### PR TITLE
Remove duplicate api entries

### DIFF
--- a/pkg/webui/api/index.js
+++ b/pkg/webui/api/index.js
@@ -41,20 +41,13 @@ export default {
         async create (userData) {
           return axios.post(`/api/v3/users`, userData)
         },
-        async get (userId) {
-          return axios.get(`/api/v3/users/${userId}`, {
+        async authInfo () {
+          return axios.get('/api/v3/auth_info', {
             headers: {
               Authorization: `Bearer ${(await token()).access_token}`,
             },
           })
         },
-      },
-      async authInfo () {
-        return axios.get('/api/v3/auth_info', {
-          headers: {
-            Authorization: `Bearer ${(await token()).access_token}`,
-          },
-        })
       },
       applications: {
         list: stubs.applications.list,

--- a/pkg/webui/logic/init.js
+++ b/pkg/webui/logic/init.js
@@ -35,7 +35,7 @@ const consoleLogic = createLogic({
           // there is no way to retrieve the current user directly
           // within the console app, so first get the authentication info
           // and only afterwards fetch the user
-          const info = await api.v3.is.authInfo()
+          const info = await api.v3.is.users.authInfo()
           const userId = info.data.oauth_access_token.user_ids.user_id
           result = await api.v3.is.users.get(userId)
         } else {


### PR DESCRIPTION
**Summary:**
This PR removes issues from ad hoc fixes to console/oauth api's.

**Changes:**
<!-- What are the changes made in this pull request? -->

- Remove duplicate `get` functions from the `user` api group
- Move `authInfo` to the `user` api group

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->
The duplicate `get` function was introduced in the following commit - https://github.com/TheThingsNetwork/lorawan-stack/commit/a3d9aaaf58faee4fb86cd0f21b4e6793a9721d39

