### PR TITLE
Enforce provisioner unique identifiers

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -3158,9 +3158,27 @@
       "file": "microchip.go"
     }
   },
+  "error:pkg/joinserver/redis:already_provisioned": {
+    "translations": {
+      "en": "device already provisioned"
+    },
+    "description": {
+      "package": "pkg/joinserver/redis",
+      "file": "registry.go"
+    }
+  },
   "error:pkg/joinserver/redis:invalid_identifiers": {
     "translations": {
       "en": "invalid identifiers"
+    },
+    "description": {
+      "package": "pkg/joinserver/redis",
+      "file": "registry.go"
+    }
+  },
+  "error:pkg/joinserver/redis:provisioner_not_found": {
+    "translations": {
+      "en": "provisioner `{id}` not found"
     },
     "description": {
       "package": "pkg/joinserver/redis",

--- a/pkg/applicationserver/io/web/redis/registry.go
+++ b/pkg/applicationserver/io/web/redis/registry.go
@@ -102,6 +102,9 @@ func (r WebhookRegistry) Set(ctx context.Context, ids ttnpb.ApplicationWebhookId
 		if err != nil {
 			return err
 		}
+		if stored == nil && pb == nil {
+			return nil
+		}
 
 		var f func(redis.Pipeliner) error
 		if pb == nil {

--- a/pkg/applicationserver/redis/registry.go
+++ b/pkg/applicationserver/redis/registry.go
@@ -82,6 +82,9 @@ func (r *DeviceRegistry) Set(ctx context.Context, ids ttnpb.EndDeviceIdentifiers
 		if err != nil {
 			return err
 		}
+		if stored == nil && pb == nil {
+			return nil
+		}
 
 		var f func(redis.Pipeliner) error
 		if pb == nil {

--- a/pkg/joinserver/grpc_deviceregistry.go
+++ b/pkg/joinserver/grpc_deviceregistry.go
@@ -186,7 +186,7 @@ func (srv jsEndDeviceRegistryServer) Provision(req *ttnpb.ProvisionEndDevicesReq
 					return nil, err
 				}
 			}
-			deviceID, err := provisioner.DeviceID(joinEUI, devEUI, entry)
+			deviceID, err := provisioner.DefaultDeviceID(joinEUI, devEUI, entry)
 			if err != nil {
 				return nil, err
 			}
@@ -214,7 +214,7 @@ func (srv jsEndDeviceRegistryServer) Provision(req *ttnpb.ProvisionEndDevicesReq
 			if err != nil {
 				return nil, err
 			}
-			deviceID, err := provisioner.DeviceID(joinEUI, devEUI, entry)
+			deviceID, err := provisioner.DefaultDeviceID(joinEUI, devEUI, entry)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/joinserver/grpc_deviceregistry_test.go
+++ b/pkg/joinserver/grpc_deviceregistry_test.go
@@ -1668,7 +1668,7 @@ func (p *byteToSerialNumber) DefaultDevEUI(entry *pbtypes.Struct) (types.EUI64, 
 	return devEUI, nil
 }
 
-func (p *byteToSerialNumber) DeviceID(joinEUI, devEUI types.EUI64, entry *pbtypes.Struct) (string, error) {
+func (p *byteToSerialNumber) DefaultDeviceID(joinEUI, devEUI types.EUI64, entry *pbtypes.Struct) (string, error) {
 	return fmt.Sprintf("sn-%d", int(entry.Fields["serial_number"].GetNumberValue())), nil
 }
 

--- a/pkg/joinserver/grpc_deviceregistry_test.go
+++ b/pkg/joinserver/grpc_deviceregistry_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"strconv"
 	"testing"
 
 	pbtypes "github.com/gogo/protobuf/types"
@@ -1669,6 +1670,10 @@ func (p *byteToSerialNumber) DefaultDevEUI(entry *pbtypes.Struct) (types.EUI64, 
 
 func (p *byteToSerialNumber) DeviceID(joinEUI, devEUI types.EUI64, entry *pbtypes.Struct) (string, error) {
 	return fmt.Sprintf("sn-%d", int(entry.Fields["serial_number"].GetNumberValue())), nil
+}
+
+func (p *byteToSerialNumber) UniqueID(entry *pbtypes.Struct) (string, error) {
+	return strconv.Itoa(int(entry.Fields["serial_number"].GetNumberValue())), nil
 }
 
 func (p *byteToSerialNumber) Decode(data []byte) ([]*pbtypes.Struct, error) {

--- a/pkg/joinserver/grpc_deviceregistry_test.go
+++ b/pkg/joinserver/grpc_deviceregistry_test.go
@@ -16,9 +16,6 @@ package joinserver_test
 
 import (
 	"context"
-	"encoding/binary"
-	"fmt"
-	"strconv"
 	"testing"
 
 	pbtypes "github.com/gogo/protobuf/types"
@@ -29,7 +26,6 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/crypto/cryptoutil"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	. "go.thethings.network/lorawan-stack/pkg/joinserver"
-	"go.thethings.network/lorawan-stack/pkg/joinserver/provisioning"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/types"
 	"go.thethings.network/lorawan-stack/pkg/unique"
@@ -1655,43 +1651,6 @@ func TestDeviceRegistryProvision(t *testing.T) {
 	}
 }
 
-type byteToSerialNumber struct {
-}
-
-func (p *byteToSerialNumber) DefaultJoinEUI(entry *pbtypes.Struct) (types.EUI64, error) {
-	return types.EUI64{0x42, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, nil
-}
-
-func (p *byteToSerialNumber) DefaultDevEUI(entry *pbtypes.Struct) (types.EUI64, error) {
-	var devEUI types.EUI64
-	binary.BigEndian.PutUint64(devEUI[:], uint64(entry.Fields["serial_number"].GetNumberValue()))
-	return devEUI, nil
-}
-
-func (p *byteToSerialNumber) DefaultDeviceID(joinEUI, devEUI types.EUI64, entry *pbtypes.Struct) (string, error) {
-	return fmt.Sprintf("sn-%d", int(entry.Fields["serial_number"].GetNumberValue())), nil
-}
-
-func (p *byteToSerialNumber) UniqueID(entry *pbtypes.Struct) (string, error) {
-	return strconv.Itoa(int(entry.Fields["serial_number"].GetNumberValue())), nil
-}
-
-func (p *byteToSerialNumber) Decode(data []byte) ([]*pbtypes.Struct, error) {
-	var res []*pbtypes.Struct
-	for _, b := range data {
-		res = append(res, &pbtypes.Struct{
-			Fields: map[string]*pbtypes.Value{
-				"serial_number": {
-					Kind: &pbtypes.Value_NumberValue{
-						NumberValue: float64(b),
-					},
-				},
-			},
-		})
-	}
-	return res, nil
-}
-
 type mockJsEndDeviceRegistryProvisionServer struct {
 	*test.MockServerStream
 	SendFunc func(*ttnpb.EndDevice) error
@@ -1702,8 +1661,4 @@ func (s *mockJsEndDeviceRegistryProvisionServer) Send(up *ttnpb.EndDevice) error
 		return nil
 	}
 	return s.SendFunc(up)
-}
-
-func init() {
-	provisioning.Register("mock", &byteToSerialNumber{})
 }

--- a/pkg/joinserver/provisioning/microchip.go
+++ b/pkg/joinserver/provisioning/microchip.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"strings"
 
 	pbtypes "github.com/gogo/protobuf/types"
 	"go.thethings.network/lorawan-stack/pkg/errors"
@@ -123,11 +124,20 @@ func (p *microchip) DefaultDevEUI(entry *pbtypes.Struct) (types.EUI64, error) {
 
 // DeviceID returns the device ID formatted as sn-{uniqueId}.
 func (p *microchip) DeviceID(joinEUI, devEUI types.EUI64, entry *pbtypes.Struct) (string, error) {
+	sn, err := p.UniqueID(entry)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("sn-%s", strings.ToLower(sn)), nil
+}
+
+// UniqueID returns the serial number.
+func (p *microchip) UniqueID(entry *pbtypes.Struct) (string, error) {
 	sn := entry.Fields["uniqueId"].GetStringValue()
 	if sn == "" {
 		return "", errEntry
 	}
-	return fmt.Sprintf("sn-%s", sn), nil
+	return strings.ToUpper(sn), nil
 }
 
 func init() {

--- a/pkg/joinserver/provisioning/microchip.go
+++ b/pkg/joinserver/provisioning/microchip.go
@@ -122,8 +122,8 @@ func (p *microchip) DefaultDevEUI(entry *pbtypes.Struct) (types.EUI64, error) {
 	return eui, nil
 }
 
-// DeviceID returns the device ID formatted as sn-{uniqueId}.
-func (p *microchip) DeviceID(joinEUI, devEUI types.EUI64, entry *pbtypes.Struct) (string, error) {
+// DeviceID returns the default device ID formatted as sn-{uniqueId}.
+func (p *microchip) DefaultDeviceID(joinEUI, devEUI types.EUI64, entry *pbtypes.Struct) (string, error) {
 	sn, err := p.UniqueID(entry)
 	if err != nil {
 		return "", err

--- a/pkg/joinserver/provisioning/microchip_test.go
+++ b/pkg/joinserver/provisioning/microchip_test.go
@@ -51,4 +51,8 @@ func TestMicrochip(t *testing.T) {
 	deviceID, err := provisioner.DeviceID(joinEUI, devEUI, entry)
 	a.So(err, should.BeNil)
 	a.So(deviceID, should.Equal, "sn-01237a005b08bcc527")
+
+	uniqueID, err := provisioner.UniqueID(entry)
+	a.So(err, should.BeNil)
+	a.So(uniqueID, should.Equal, "01237A005B08BCC527")
 }

--- a/pkg/joinserver/provisioning/microchip_test.go
+++ b/pkg/joinserver/provisioning/microchip_test.go
@@ -48,7 +48,7 @@ func TestMicrochip(t *testing.T) {
 	a.So(err, should.BeNil)
 	a.So(devEUI, should.Resemble, types.EUI64{0x01, 0x23, 0x7a, 0x00, 0x5b, 0x08, 0xbc, 0xc5})
 
-	deviceID, err := provisioner.DeviceID(joinEUI, devEUI, entry)
+	deviceID, err := provisioner.DefaultDeviceID(joinEUI, devEUI, entry)
 	a.So(err, should.BeNil)
 	a.So(deviceID, should.Equal, "sn-01237a005b08bcc527")
 

--- a/pkg/joinserver/provisioning/provisioning.go
+++ b/pkg/joinserver/provisioning/provisioning.go
@@ -29,8 +29,8 @@ type Provisioner interface {
 	DefaultJoinEUI(entry *pbtypes.Struct) (types.EUI64, error)
 	// DefaultDevEUI returns the default DevEUI for the given entry.
 	DefaultDevEUI(entry *pbtypes.Struct) (types.EUI64, error)
-	// DeviceID generates a device ID.
-	DeviceID(joinEUI, devEUI types.EUI64, entry *pbtypes.Struct) (string, error)
+	// DefaultDeviceID returns the default device ID.
+	DefaultDeviceID(joinEUI, devEUI types.EUI64, entry *pbtypes.Struct) (string, error)
 	// UniqueID returns the vendor-specific unique ID for the given entry.
 	UniqueID(entry *pbtypes.Struct) (string, error)
 }

--- a/pkg/joinserver/provisioning/provisioning.go
+++ b/pkg/joinserver/provisioning/provisioning.go
@@ -29,8 +29,10 @@ type Provisioner interface {
 	DefaultJoinEUI(entry *pbtypes.Struct) (types.EUI64, error)
 	// DefaultDevEUI returns the default DevEUI for the given entry.
 	DefaultDevEUI(entry *pbtypes.Struct) (types.EUI64, error)
-	// DeviceID generates a device ID
+	// DeviceID generates a device ID.
 	DeviceID(joinEUI, devEUI types.EUI64, entry *pbtypes.Struct) (string, error)
+	// UniqueID returns the vendor-specific unique ID for the given entry.
+	UniqueID(entry *pbtypes.Struct) (string, error)
 }
 
 var (

--- a/pkg/joinserver/util_test.go
+++ b/pkg/joinserver/util_test.go
@@ -1,0 +1,66 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package joinserver_test
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strconv"
+
+	pbtypes "github.com/gogo/protobuf/types"
+	"go.thethings.network/lorawan-stack/pkg/joinserver/provisioning"
+	"go.thethings.network/lorawan-stack/pkg/types"
+)
+
+type byteToSerialNumber struct {
+}
+
+func (p *byteToSerialNumber) DefaultJoinEUI(entry *pbtypes.Struct) (types.EUI64, error) {
+	return types.EUI64{0x42, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, nil
+}
+
+func (p *byteToSerialNumber) DefaultDevEUI(entry *pbtypes.Struct) (types.EUI64, error) {
+	var devEUI types.EUI64
+	binary.BigEndian.PutUint64(devEUI[:], uint64(entry.Fields["serial_number"].GetNumberValue()))
+	return devEUI, nil
+}
+
+func (p *byteToSerialNumber) DefaultDeviceID(joinEUI, devEUI types.EUI64, entry *pbtypes.Struct) (string, error) {
+	return fmt.Sprintf("sn-%d", int(entry.Fields["serial_number"].GetNumberValue())), nil
+}
+
+func (p *byteToSerialNumber) UniqueID(entry *pbtypes.Struct) (string, error) {
+	return strconv.Itoa(int(entry.Fields["serial_number"].GetNumberValue())), nil
+}
+
+func (p *byteToSerialNumber) Decode(data []byte) ([]*pbtypes.Struct, error) {
+	var res []*pbtypes.Struct
+	for _, b := range data {
+		res = append(res, &pbtypes.Struct{
+			Fields: map[string]*pbtypes.Value{
+				"serial_number": {
+					Kind: &pbtypes.Value_NumberValue{
+						NumberValue: float64(b),
+					},
+				},
+			},
+		})
+	}
+	return res, nil
+}
+
+func init() {
+	provisioning.Register("mock", &byteToSerialNumber{})
+}

--- a/pkg/networkserver/redis/registry.go
+++ b/pkg/networkserver/redis/registry.go
@@ -166,6 +166,9 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIde
 		if err != nil {
 			return err
 		}
+		if stored == nil && pb == nil {
+			return nil
+		}
 
 		var f func(redis.Pipeliner) error
 		if pb == nil {
@@ -224,7 +227,9 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIde
 					if err == nil && s != "" {
 						return errDuplicateIdentifiers
 					}
-					p.Set(ek, uid, 0)
+					if s != uid {
+						p.Set(ek, uid, 0)
+					}
 				}
 
 				if _, err := ttnredis.SetProto(p, k, stored, 0); err != nil {


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #122 

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

Enforce uniqueness by setting a key with the provisioner's unique identifier and checking if it's not set.

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

The JS Redis device registry does not use a key to prepend the EUIs. This PR claims provisioner unique identifiers in the devices namespace as it needs to be part of the transaction. So we're mixing:

- `ttn:v3:js:devices:4200000000000000:4200000000000000` 
- `ttn:v3:js:devices:provisioners:microchip:0123E8CC04ABBAA127`

This is not a problem since `provisioners` never collides with a string formatted EUI.

Alternatively, we may not pass a namespace to the JS device registry, and insert either `devices` and `provisioners` namespace in the device registry. That's less clean in my opinion and gives full access to the entire `ttn:v3:js` namespace. Introducing a `euis` prefix is not possible anymore with V3 release.

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
What are the functional or behavioral changes? API Changes? New features?
Any changes in configuration? Added/changed/removed flags?
Are there any database migrations required?
-->

Provisioner unique identifiers are now enforced; duplicate registrations of the same physical device are no longer permitted.