### PR TITLE
Identity Server notification and registration emails

### DIFF
--- a/cmd/internal/shared/identityserver/config.go
+++ b/cmd/internal/shared/identityserver/config.go
@@ -48,6 +48,9 @@ func init() {
 	DefaultIdentityServerConfig.UserRegistration.PasswordRequirements.MinLength = 8
 	DefaultIdentityServerConfig.UserRegistration.PasswordRequirements.MinUppercase = 1
 	DefaultIdentityServerConfig.UserRegistration.PasswordRequirements.MinDigits = 1
+	DefaultIdentityServerConfig.Email.Network.Name = DefaultIdentityServerConfig.OAuth.UI.SiteName
+	DefaultIdentityServerConfig.Email.Network.IdentityServerURL = shared.DefaultOAuthPublicURL
+	DefaultIdentityServerConfig.Email.Network.ConsoleURL = shared.DefaultConsolePublicURL
 	DefaultIdentityServerConfig.ProfilePicture.Bucket = "profile_pictures"
 	DefaultIdentityServerConfig.ProfilePicture.BucketURL = path.Join(shared.DefaultAssetsBaseURL, "blob", "profile_pictures")
 	DefaultIdentityServerConfig.ProfilePicture.UseGravatar = true

--- a/config/messages.json
+++ b/config/messages.json
@@ -2078,6 +2078,15 @@
       "file": "devicerepository.go"
     }
   },
+  "error:pkg/email/sendgrid:email_not_sent": {
+    "translations": {
+      "en": "email was not sent"
+    },
+    "description": {
+      "package": "pkg/email/sendgrid",
+      "file": "sendgrid.go"
+    }
+  },
   "error:pkg/encoding/lorawan:decode": {
     "translations": {
       "en": "could not decode `{lorawan_field}`"

--- a/pkg/email/email.go
+++ b/pkg/email/email.go
@@ -25,4 +25,9 @@ type Config struct {
 	SenderName    string `name:"sender-name" description:"The name of the sender"`
 	SenderAddress string `name:"sender-address" description:"The address of the sender"`
 	Provider      string `name:"provider" description:"Email provider to use"`
+	Network       struct {
+		Name              string `name:"name" description:"The name of the network"`
+		IdentityServerURL string `name:"identity-server-url" description:"The URL of the Identity Server"`
+		ConsoleURL        string `name:"console-url" description:"The URL of the Console"`
+	} `name:"network" description:"The network of the sender"`
 }

--- a/pkg/email/email.go
+++ b/pkg/email/email.go
@@ -22,7 +22,7 @@ type Sender interface {
 
 // Config for sending emails
 type Config struct {
-	SenderName    string `name:"sender.name" description:"The name of the sender"`
-	SenderAddress string `name:"sender.address" description:"The address of the sender"`
+	SenderName    string `name:"sender-name" description:"The name of the sender"`
+	SenderAddress string `name:"sender-address" description:"The address of the sender"`
 	Provider      string `name:"provider" description:"Email provider to use"`
 }

--- a/pkg/email/registry.go
+++ b/pkg/email/registry.go
@@ -57,8 +57,8 @@ type registeredTemplate struct {
 
 func (r *TemplateRegistry) getTemplate(data MessageData) (m *MessageTemplate, err error) {
 	name := data.TemplateName()
-	registeredI, ok := r.registry.LoadOrStore(name, registeredTemplate{ready: make(chan struct{})})
-	registered := registeredI.(registeredTemplate)
+	registeredI, ok := r.registry.LoadOrStore(name, &registeredTemplate{ready: make(chan struct{})})
+	registered := registeredI.(*registeredTemplate)
 	if ok {
 		<-registered.ready
 		return registered.m, registered.err

--- a/pkg/email/sendgrid/sendgrid.go
+++ b/pkg/email/sendgrid/sendgrid.go
@@ -16,6 +16,8 @@
 package sendgrid
 
 import (
+	"context"
+
 	"github.com/sendgrid/sendgrid-go"
 	"github.com/sendgrid/sendgrid-go/helpers/mail"
 	"go.thethings.network/lorawan-stack/pkg/email"
@@ -38,9 +40,9 @@ type SendGrid struct {
 }
 
 // New creates a SendGrid email provider.
-func New(logger log.Interface, emailConfig email.Config, sgConfig Config) (email.Sender, error) {
+func New(ctx context.Context, emailConfig email.Config, sgConfig Config) (email.Sender, error) {
 	provider := &SendGrid{
-		logger:    logger.WithField("email_provider", "SendGrid"),
+		logger:    log.FromContext(ctx).WithField("email_provider", "SendGrid"),
 		config:    sgConfig,
 		client:    sendgrid.NewSendClient(sgConfig.APIKey),
 		fromEmail: mail.NewEmail(emailConfig.SenderName, emailConfig.SenderAddress),

--- a/pkg/email/sendgrid/sendgrid_test.go
+++ b/pkg/email/sendgrid/sendgrid_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/email"
+	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/util/test"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 )
@@ -30,7 +31,7 @@ func TestSendGrid(t *testing.T) {
 	apiKey := os.Getenv("SENDGRID_API_KEY")
 
 	sg, err := New(
-		test.GetLogger(t),
+		log.NewContext(test.Context(), test.GetLogger(t)),
 		email.Config{
 			SenderName:    "Unit Test",
 			SenderAddress: "unit@test.local",

--- a/pkg/identityserver/application_access.go
+++ b/pkg/identityserver/application_access.go
@@ -120,7 +120,13 @@ func (is *IdentityServer) updateApplicationAPIKey(ctx context.Context, req *ttnp
 	key.Key = ""
 	if len(req.Rights) > 0 {
 		events.Publish(evtUpdateApplicationAPIKey(ctx, req.ApplicationIdentifiers, nil))
-		// TODO: Send notification email (https://github.com/TheThingsNetwork/lorawan-stack/issues/72).
+		err = is.SendContactsEmail(ctx, req.EntityIdentifiers(), func(data emails.Data) email.MessageData {
+			data.SetEntity(req.EntityIdentifiers())
+			return &emails.APIKeyChanged{Data: data, Identifier: key.PrettyName(), Rights: key.Rights}
+		})
+		if err != nil {
+			log.FromContext(ctx).WithError(err).Error("Could not send API key update notification email")
+		}
 	} else {
 		events.Publish(evtDeleteApplicationAPIKey(ctx, req.ApplicationIdentifiers, nil))
 	}

--- a/pkg/identityserver/application_access.go
+++ b/pkg/identityserver/application_access.go
@@ -155,7 +155,13 @@ func (is *IdentityServer) setApplicationCollaborator(ctx context.Context, req *t
 	}
 	if len(req.Collaborator.Rights) > 0 {
 		events.Publish(evtUpdateApplicationCollaborator(ctx, req.ApplicationIdentifiers, nil))
-		// TODO: Send notification email (https://github.com/TheThingsNetwork/lorawan-stack/issues/72).
+		err = is.SendContactsEmail(ctx, req.EntityIdentifiers(), func(data emails.Data) email.MessageData {
+			data.SetEntity(req.EntityIdentifiers())
+			return &emails.CollaboratorChanged{Data: data, Collaborator: req.Collaborator}
+		})
+		if err != nil {
+			log.FromContext(ctx).WithError(err).Error("Could not send collaborator updated notification email")
+		}
 	} else {
 		events.Publish(evtDeleteApplicationCollaborator(ctx, req.ApplicationIdentifiers, nil))
 	}

--- a/pkg/identityserver/application_access.go
+++ b/pkg/identityserver/application_access.go
@@ -20,8 +20,11 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/jinzhu/gorm"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
+	"go.thethings.network/lorawan-stack/pkg/email"
 	"go.thethings.network/lorawan-stack/pkg/events"
+	"go.thethings.network/lorawan-stack/pkg/identityserver/emails"
 	"go.thethings.network/lorawan-stack/pkg/identityserver/store"
+	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/unique"
 )
@@ -67,7 +70,13 @@ func (is *IdentityServer) createApplicationAPIKey(ctx context.Context, req *ttnp
 	}
 	key.Key = token
 	events.Publish(evtCreateApplicationAPIKey(ctx, req.ApplicationIdentifiers, nil))
-	// TODO: Send notification email (https://github.com/TheThingsNetwork/lorawan-stack/issues/72).
+	err = is.SendContactsEmail(ctx, req.EntityIdentifiers(), func(data emails.Data) email.MessageData {
+		data.SetEntity(req.EntityIdentifiers())
+		return &emails.APIKeyCreated{Data: data, Identifier: key.PrettyName(), Rights: key.Rights}
+	})
+	if err != nil {
+		log.FromContext(ctx).WithError(err).Error("Could not send API key creation notification email")
+	}
 	return key, nil
 }
 

--- a/pkg/identityserver/email.go
+++ b/pkg/identityserver/email.go
@@ -16,8 +16,6 @@ package identityserver
 
 import (
 	"context"
-	"net/url"
-
 	"github.com/gogo/protobuf/types"
 	"github.com/jinzhu/gorm"
 	"go.thethings.network/lorawan-stack/pkg/email"
@@ -51,11 +49,9 @@ func (is *IdentityServer) SendEmail(ctx context.Context, f func(emails.Data) ema
 		return err
 	}
 	var data emails.Data
-	data.Network.Name = isConfig.OAuth.UI.SiteName // TODO: Should this be separate config?
-	url, _ := url.Parse(isConfig.OAuth.UI.CanonicalURL)
-	url.Path = "/"
-	data.Network.IdentityServerURL = url.String() // TODO: Should this be separate config?
-	data.Network.ConsoleURL = url.String()        // TODO: Should this be separate config?
+	data.Network.Name = isConfig.Email.Network.Name
+	data.Network.IdentityServerURL = isConfig.Email.Network.IdentityServerURL
+	data.Network.ConsoleURL = isConfig.Email.Network.ConsoleURL
 	messageData := f(data)
 	if messageData == nil {
 		return nil

--- a/pkg/identityserver/email.go
+++ b/pkg/identityserver/email.go
@@ -1,0 +1,127 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package identityserver
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/gogo/protobuf/types"
+	"github.com/jinzhu/gorm"
+	"go.thethings.network/lorawan-stack/pkg/email"
+	"go.thethings.network/lorawan-stack/pkg/email/sendgrid"
+	"go.thethings.network/lorawan-stack/pkg/email/smtp"
+	"go.thethings.network/lorawan-stack/pkg/identityserver/emails"
+	"go.thethings.network/lorawan-stack/pkg/identityserver/store"
+	"go.thethings.network/lorawan-stack/pkg/log"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+)
+
+var globalEmailTemplateRegistry = email.NewTemplateRegistry(nil)
+
+func (is *IdentityServer) getEmailTemplates(_ context.Context) *email.TemplateRegistry {
+	// TODO: Get email template fetcher from config (https://github.com/TheThingsNetwork/lorawan-stack/issues/148).
+	// Re-use existing registry for same fetcher (to avoid re-compiling templates).
+	return globalEmailTemplateRegistry
+}
+
+// SendEmail sends an email.
+func (is *IdentityServer) SendEmail(ctx context.Context, f func(emails.Data) email.MessageData) (err error) {
+	isConfig := is.configFromContext(ctx)
+	var sender email.Sender
+	switch isConfig.Email.Provider {
+	case "sendgrid":
+		sender, err = sendgrid.New(ctx, isConfig.Email.Config, isConfig.Email.SendGrid)
+	case "smtp":
+		sender, err = smtp.New(ctx, isConfig.Email.Config, isConfig.Email.SMTP)
+	}
+	if err != nil {
+		return err
+	}
+	var data emails.Data
+	data.Network.Name = isConfig.OAuth.UI.SiteName // TODO: Should this be separate config?
+	url, _ := url.Parse(isConfig.OAuth.UI.CanonicalURL)
+	url.Path = "/"
+	data.Network.IdentityServerURL = url.String() // TODO: Should this be separate config?
+	data.Network.ConsoleURL = url.String()        // TODO: Should this be separate config?
+	messageData := f(data)
+	if messageData == nil {
+		return nil
+	}
+	message, err := is.getEmailTemplates(ctx).Render(messageData)
+	if err != nil {
+		return err
+	}
+	if sender == nil {
+		log.FromContext(ctx).WithFields(log.Fields(
+			"to", message.RecipientAddress,
+			"subject", message.Subject,
+			"body", message.TextBody,
+		)).Warn("Could not send email without email provider")
+		return nil
+	}
+	return sender.Send(message)
+}
+
+// SendUserEmail sends an email to the given user.
+func (is *IdentityServer) SendUserEmail(ctx context.Context, userIDs *ttnpb.UserIdentifiers, makeMessage func(emails.Data) email.MessageData) error {
+	var usr *ttnpb.User
+	err := is.withDatabase(ctx, func(db *gorm.DB) (err error) {
+		usr, err = store.GetUserStore(db).GetUser(ctx, userIDs, &types.FieldMask{
+			Paths: []string{"name", "primary_email_address"},
+		})
+		if err != nil {
+			return err
+		}
+		return err
+	})
+	if err != nil {
+		return err
+	}
+	err = is.SendEmail(ctx, func(data emails.Data) email.MessageData {
+		data.SetUser(usr)
+		return makeMessage(data)
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// SendContactsEmail sends an email to the contacts of the given entity.
+func (is *IdentityServer) SendContactsEmail(ctx context.Context, ids *ttnpb.EntityIdentifiers, makeMessage func(emails.Data) email.MessageData) error {
+	var contacts []*ttnpb.ContactInfo
+	err := is.withDatabase(ctx, func(db *gorm.DB) (err error) {
+		contacts, err = store.GetContactInfoStore(db).GetContactInfo(ctx, ids)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+	for _, contactInfo := range contacts {
+		if contactInfo.ContactMethod != ttnpb.CONTACT_METHOD_EMAIL {
+			continue
+		}
+		err := is.SendEmail(ctx, func(data emails.Data) email.MessageData {
+			data.SetEntity(ids)
+			data.SetContact(contactInfo)
+			return makeMessage(data)
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/identityserver/emails/api_key_changed.go
+++ b/pkg/identityserver/emails/api_key_changed.go
@@ -1,0 +1,41 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package emails
+
+import "go.thethings.network/lorawan-stack/pkg/ttnpb"
+
+// APIKeyChanged is the email that is sent when users updates an API key
+type APIKeyChanged struct {
+	Data
+	Identifier string
+	Rights     []ttnpb.Right
+}
+
+// TemplateName returns the name of the template to use for this email.
+func (APIKeyChanged) TemplateName() string { return "api_key_changed" }
+
+const apiKeyChangedSubject = `An API key has been changed`
+
+const apiKeyChangedText = `Dear {{.User.Name}},
+
+The API key "{{.Identifier}}" for {{.Entity.Type}} "{{.Entity.ID}}" on {{.Network.Name}} has been updated with the following rights:
+{{range $right := .Rights}} 
+{{$right}} {{end}}
+`
+
+// DefaultTemplates returns the default templates for this email.
+func (APIKeyChanged) DefaultTemplates() (subject, html, text string) {
+	return apiKeyChangedSubject, "", apiKeyChangedText
+}

--- a/pkg/identityserver/emails/api_key_created.go
+++ b/pkg/identityserver/emails/api_key_created.go
@@ -1,0 +1,41 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package emails
+
+import "go.thethings.network/lorawan-stack/pkg/ttnpb"
+
+// APIKeyCreated is the email that is sent when users creates a new API key
+type APIKeyCreated struct {
+	Data
+	Identifier string
+	Rights     []ttnpb.Right
+}
+
+// TemplateName returns the name of the template to use for this email.
+func (APIKeyCreated) TemplateName() string { return "api_key_created" }
+
+const apiKeyCreatedSubject = `An API key has been created`
+
+const apiKeyCreatedText = `Dear {{.User.Name}},
+
+A new API key "{{.Identifier}}" has been created for {{.Entity.Type}} "{{.Entity.ID}}" on {{.Network.Name}} with the following rights:
+{{range $right := .Rights}} 
+{{$right}} {{end}}
+`
+
+// DefaultTemplates returns the default templates for this email.
+func (APIKeyCreated) DefaultTemplates() (subject, html, text string) {
+	return apiKeyCreatedSubject, "", apiKeyCreatedText
+}

--- a/pkg/identityserver/emails/collaborator_changed.go
+++ b/pkg/identityserver/emails/collaborator_changed.go
@@ -1,0 +1,40 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package emails
+
+import "go.thethings.network/lorawan-stack/pkg/ttnpb"
+
+// CollaboratorChanged is the email that is sent when a collaborator is changed
+type CollaboratorChanged struct {
+	Data
+	Collaborator ttnpb.Collaborator
+}
+
+// TemplateName returns the name of the template to use for this email.
+func (CollaboratorChanged) TemplateName() string { return "collaborator_added" }
+
+const collaboratorChangedSubject = `A collaborator has been changed`
+
+const collaboratorChangedBody = `Dear {{.User.Name}},
+
+The collaborator "{{.Collaborator.EntityIdentifiers.IDString}}" of {{.Entity.Type}} "{{.Entity.ID}}" on {{.Network.Name}} now has the following rights:
+{{range $right := .Collaborator.Rights}} 
+{{$right}} {{end}}
+`
+
+// DefaultTemplates returns the default templates for this email.
+func (CollaboratorChanged) DefaultTemplates() (subject, html, text string) {
+	return collaboratorChangedSubject, "", collaboratorChangedBody
+}

--- a/pkg/identityserver/emails/emails.go
+++ b/pkg/identityserver/emails/emails.go
@@ -1,0 +1,81 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package emails
+
+import "go.thethings.network/lorawan-stack/pkg/ttnpb"
+
+// Data for emails.
+type Data struct {
+	// User we're sending this email to. We need at least an Email.
+	User struct {
+		ID    string
+		Name  string
+		Email string
+	}
+
+	// Network information to fill into the template.
+	Network struct {
+		Name              string
+		IdentityServerURL string
+		ConsoleURL        string
+	}
+
+	// Entity this is concerning
+	Entity struct {
+		Type string
+		ID   string
+	}
+
+	// Contact details used to inform the user why they are receiving an email.
+	// For example:
+	//     You are receiving this because you are {{.Contact.Type}} contact on {{.Entity.Type}} {{.Entity.ID}}.
+	Contact struct {
+		Type string // contact type: technical, billing, abuse; see *ttnpb.ContactInfo
+	}
+}
+
+// SetUser sets the user's ID, name and primary email address to the email data.
+// If the user's name is unknown, its ID is used as name.
+func (d *Data) SetUser(user *ttnpb.User) {
+	d.User.ID = user.UserID
+	if user.Name != "" {
+		d.User.Name = user.Name
+	} else {
+		d.User.Name = user.UserID
+	}
+	d.User.Email = user.PrimaryEmailAddress
+}
+
+// SetEntity sets the entity that the email is about.
+func (d *Data) SetEntity(ids *ttnpb.EntityIdentifiers) {
+	d.Entity.Type = ids.EntityType()
+	d.Entity.ID = ids.IDString()
+}
+
+// SetContact sets the contact info as recipient of the email.
+func (d *Data) SetContact(contact *ttnpb.ContactInfo) {
+	d.Contact.Type = contact.ContactType.String()
+	if contact.ContactMethod == ttnpb.CONTACT_METHOD_EMAIL {
+		d.User.Email = contact.Value
+	}
+	if d.User.Name == "" {
+		d.User.Name = "user"
+	}
+}
+
+// Recipient returns the recipient info of the email.
+func (d Data) Recipient() (name, address string) {
+	return d.User.Name, d.User.Email
+}

--- a/pkg/identityserver/emails/password_changed.go
+++ b/pkg/identityserver/emails/password_changed.go
@@ -14,27 +14,24 @@
 
 package emails
 
-// TemporaryPassword is the email that is sent when users request a temporary password.
-type TemporaryPassword struct {
+// PasswordChanged is the email that is sent when users change their password.
+type PasswordChanged struct {
 	Data
-	TemporaryPassword string
 }
 
 // TemplateName returns the name of the template to use for this email.
-func (TemporaryPassword) TemplateName() string { return "temporary_password" }
+func (PasswordChanged) TemplateName() string { return "password_changed" }
 
-const temporaryPasswordSubject = `Your temporary password`
+const passwordChangedSubject = `Your password for {{.User.ID}} was changed`
 
-const temporaryPasswordText = `Dear {{.User.Name}},
+const passwordChangedText = `Dear {{.User.Name}},
 
-A temporary password was requested for your user "{{.User.ID}}" on {{.Network.Name}}.
+The password of your user "{{.User.ID}}" on {{.Network.Name}} was just changed.
 
-This temporary password can only be used once, and only to change the password of your account.
-
-Temporary Password: {{.TemporaryPassword}}
+If this was not done by you, please contact us as soon as possible.
 `
 
 // DefaultTemplates returns the default templates for this email.
-func (TemporaryPassword) DefaultTemplates() (subject, html, text string) {
-	return temporaryPasswordSubject, "", temporaryPasswordText
+func (PasswordChanged) DefaultTemplates() (subject, html, text string) {
+	return passwordChangedSubject, "", passwordChangedText
 }

--- a/pkg/identityserver/emails/temporary_password.go
+++ b/pkg/identityserver/emails/temporary_password.go
@@ -1,0 +1,40 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package emails
+
+// TemporaryPassword is the email that is sent when users request a temporary password.
+type TemporaryPassword struct {
+	Data
+	TemporaryPassword string
+}
+
+// TemplateName returns the name of the template to use for this email.
+func (TemporaryPassword) TemplateName() string { return "temporary_password" }
+
+const temporaryPasswordSubject = `Your temporary password for {{.Network.Name}}`
+
+const temporaryPasswordText = `Dear {{.User.Name}},
+
+A temporary password was requested for your user "{{.User.ID}}" on {{.Network.Name}}.
+
+This temporary password can only be used once, and only to change the password of your account.
+
+Temporary Password: {{.TemporaryPassword}}
+`
+
+// DefaultTemplates returns the default templates for this email.
+func (TemporaryPassword) DefaultTemplates() (subject, html, text string) {
+	return temporaryPasswordSubject, "", temporaryPasswordText
+}

--- a/pkg/identityserver/emails/validate.go
+++ b/pkg/identityserver/emails/validate.go
@@ -1,0 +1,40 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package emails
+
+// Validate is the validation email.
+type Validate struct {
+	Data
+	ID    string
+	Token string
+}
+
+// TemplateName returns the name of the template to use for this email.
+func (Validate) TemplateName() string { return "validate" }
+
+const validateSubject = `Please confirm your email address for {{.Network.Name}}`
+
+const validateText = `Please confirm your email address for {{.Network.Name}}.
+
+Your email address will be used as contact for {{.Entity.Type}} "{{.Entity.ID}}".
+
+Reference: {{.ID}}
+Confirmation Token: {{.Token}}
+`
+
+// DefaultTemplates returns the default templates for this email.
+func (Validate) DefaultTemplates() (subject, html, text string) {
+	return validateSubject, "", validateText
+}

--- a/pkg/identityserver/gateway_access.go
+++ b/pkg/identityserver/gateway_access.go
@@ -155,7 +155,13 @@ func (is *IdentityServer) setGatewayCollaborator(ctx context.Context, req *ttnpb
 	}
 	if len(req.Collaborator.Rights) > 0 {
 		events.Publish(evtUpdateGatewayCollaborator(ctx, req.GatewayIdentifiers, nil))
-		// TODO: Send notification email (https://github.com/TheThingsNetwork/lorawan-stack/issues/72).
+		err = is.SendContactsEmail(ctx, req.EntityIdentifiers(), func(data emails.Data) email.MessageData {
+			data.SetEntity(req.EntityIdentifiers())
+			return &emails.CollaboratorChanged{Data: data, Collaborator: req.Collaborator}
+		})
+		if err != nil {
+			log.FromContext(ctx).WithError(err).Error("Could not send collaborator updated notification email")
+		}
 	} else {
 		events.Publish(evtDeleteGatewayCollaborator(ctx, req.GatewayIdentifiers, nil))
 	}

--- a/pkg/identityserver/gateway_access.go
+++ b/pkg/identityserver/gateway_access.go
@@ -20,8 +20,11 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/jinzhu/gorm"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
+	"go.thethings.network/lorawan-stack/pkg/email"
 	"go.thethings.network/lorawan-stack/pkg/events"
+	"go.thethings.network/lorawan-stack/pkg/identityserver/emails"
 	"go.thethings.network/lorawan-stack/pkg/identityserver/store"
+	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/unique"
 )
@@ -67,7 +70,13 @@ func (is *IdentityServer) createGatewayAPIKey(ctx context.Context, req *ttnpb.Cr
 	}
 	key.Key = token
 	events.Publish(evtCreateGatewayAPIKey(ctx, req.GatewayIdentifiers, nil))
-	// TODO: Send notification email (https://github.com/TheThingsNetwork/lorawan-stack/issues/72).
+	err = is.SendContactsEmail(ctx, req.EntityIdentifiers(), func(data emails.Data) email.MessageData {
+		data.SetEntity(req.EntityIdentifiers())
+		return &emails.APIKeyCreated{Data: data, Identifier: key.PrettyName(), Rights: key.Rights}
+	})
+	if err != nil {
+		log.FromContext(ctx).WithError(err).Error("Could not send API key creation notification email")
+	}
 	return key, nil
 }
 

--- a/pkg/identityserver/gateway_access.go
+++ b/pkg/identityserver/gateway_access.go
@@ -120,7 +120,13 @@ func (is *IdentityServer) updateGatewayAPIKey(ctx context.Context, req *ttnpb.Up
 	key.Key = ""
 	if len(req.Rights) > 0 {
 		events.Publish(evtUpdateGatewayAPIKey(ctx, req.GatewayIdentifiers, nil))
-		// TODO: Send notification email (https://github.com/TheThingsNetwork/lorawan-stack/issues/72).
+		err = is.SendContactsEmail(ctx, req.EntityIdentifiers(), func(data emails.Data) email.MessageData {
+			data.SetEntity(req.EntityIdentifiers())
+			return &emails.APIKeyChanged{Data: data, Identifier: key.PrettyName(), Rights: key.Rights}
+		})
+		if err != nil {
+			log.FromContext(ctx).WithError(err).Error("Could not send API key update notification email")
+		}
 	} else {
 		events.Publish(evtDeleteGatewayAPIKey(ctx, req.GatewayIdentifiers, nil))
 	}

--- a/pkg/identityserver/identityserver.go
+++ b/pkg/identityserver/identityserver.go
@@ -24,6 +24,9 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	"go.thethings.network/lorawan-stack/pkg/email"
+	"go.thethings.network/lorawan-stack/pkg/email/sendgrid"
+	"go.thethings.network/lorawan-stack/pkg/email/smtp"
 	"go.thethings.network/lorawan-stack/pkg/identityserver/store"
 	"go.thethings.network/lorawan-stack/pkg/oauth"
 	"go.thethings.network/lorawan-stack/pkg/redis"
@@ -62,6 +65,11 @@ type Config struct {
 		Bucket      string `name:"bucket" description:"Bucket used for storing profile pictures"`
 		BucketURL   string `name:"bucket-url" description:"Base URL for public bucket access"`
 	} `name:"profile-picture"`
+	Email struct {
+		email.Config `name:",squash"`
+		SendGrid     sendgrid.Config `name:"sendgrid"`
+		SMTP         smtp.Config     `name:"smtp"`
+	} `name:"email"`
 }
 
 // IdentityServer implements the Identity Server component.

--- a/pkg/identityserver/organization_access.go
+++ b/pkg/identityserver/organization_access.go
@@ -20,8 +20,11 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/jinzhu/gorm"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
+	"go.thethings.network/lorawan-stack/pkg/email"
 	"go.thethings.network/lorawan-stack/pkg/events"
+	"go.thethings.network/lorawan-stack/pkg/identityserver/emails"
 	"go.thethings.network/lorawan-stack/pkg/identityserver/store"
+	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/unique"
 )
@@ -67,7 +70,13 @@ func (is *IdentityServer) createOrganizationAPIKey(ctx context.Context, req *ttn
 	}
 	key.Key = token
 	events.Publish(evtCreateOrganizationAPIKey(ctx, req.OrganizationIdentifiers, nil))
-	// TODO: Send notification email (https://github.com/TheThingsNetwork/lorawan-stack/issues/72).
+	err = is.SendContactsEmail(ctx, req.EntityIdentifiers(), func(data emails.Data) email.MessageData {
+		data.SetEntity(req.EntityIdentifiers())
+		return &emails.APIKeyCreated{Data: data, Identifier: key.PrettyName(), Rights: key.Rights}
+	})
+	if err != nil {
+		log.FromContext(ctx).WithError(err).Error("Could not send API key creation notification email")
+	}
 	return key, nil
 }
 

--- a/pkg/identityserver/user_access.go
+++ b/pkg/identityserver/user_access.go
@@ -19,8 +19,11 @@ import (
 
 	"github.com/jinzhu/gorm"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
+	"go.thethings.network/lorawan-stack/pkg/email"
 	"go.thethings.network/lorawan-stack/pkg/events"
+	"go.thethings.network/lorawan-stack/pkg/identityserver/emails"
 	"go.thethings.network/lorawan-stack/pkg/identityserver/store"
+	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/unique"
 )
@@ -108,7 +111,13 @@ func (is *IdentityServer) updateUserAPIKey(ctx context.Context, req *ttnpb.Updat
 	key.Key = ""
 	if len(req.Rights) > 0 {
 		events.Publish(evtUpdateUserAPIKey(ctx, req.UserIdentifiers, nil))
-		// TODO: Send notification email (https://github.com/TheThingsNetwork/lorawan-stack/issues/72).
+		err = is.SendUserEmail(ctx, &req.UserIdentifiers, func(data emails.Data) email.MessageData {
+			data.SetEntity(req.EntityIdentifiers())
+			return &emails.APIKeyChanged{Data: data, Identifier: key.PrettyName(), Rights: key.Rights}
+		})
+		if err != nil {
+			log.FromContext(ctx).WithError(err).Error("Could not send API key update notification email")
+		}
 	} else {
 		events.Publish(evtDeleteUserAPIKey(ctx, req.UserIdentifiers, nil))
 	}

--- a/pkg/identityserver/user_registry.go
+++ b/pkg/identityserver/user_registry.go
@@ -420,7 +420,12 @@ func (is *IdentityServer) updateUserPassword(ctx context.Context, req *ttnpb.Upd
 		return nil, err
 	}
 	events.Publish(evtUpdateUser(ctx, req.UserIdentifiers, updateMask))
-	// TODO: Send password update email (https://github.com/TheThingsNetwork/lorawan-stack/issues/72).
+	err = is.SendUserEmail(ctx, &req.UserIdentifiers, func(data emails.Data) email.MessageData {
+		return &emails.PasswordChanged{Data: data}
+	})
+	if err != nil {
+		log.FromContext(ctx).WithError(err).Error("Could not send password change notification email")
+	}
 	return ttnpb.Empty, nil
 }
 

--- a/pkg/ttnpb/identifiers.go
+++ b/pkg/ttnpb/identifiers.go
@@ -104,6 +104,26 @@ func (ids EntityIdentifiers) IDString() string {
 	}
 }
 
+// EntityType returns the entity type for the Identifiers inside the oneof.
+func (ids EntityIdentifiers) EntityType() string {
+	switch ids.Ids.(type) {
+	case *EntityIdentifiers_ApplicationIDs:
+		return "application"
+	case *EntityIdentifiers_ClientIDs:
+		return "client"
+	case *EntityIdentifiers_DeviceIDs:
+		return "end device"
+	case *EntityIdentifiers_GatewayIDs:
+		return "gateway"
+	case *EntityIdentifiers_OrganizationIDs:
+		return "organization"
+	case *EntityIdentifiers_UserIDs:
+		return "user"
+	default:
+		panic("missed oneof type in EntityIdentifiers.EntityType()")
+	}
+}
+
 // EntityIdentifiers returns the ApplicationIdentifiers as EntityIdentifiers.
 func (ids ApplicationIdentifiers) EntityIdentifiers() *EntityIdentifiers {
 	return &EntityIdentifiers{Ids: &EntityIdentifiers_ApplicationIDs{

--- a/pkg/ttnpb/rights.go
+++ b/pkg/ttnpb/rights.go
@@ -15,6 +15,7 @@
 package ttnpb
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 )
@@ -171,3 +172,12 @@ func (r *Rights) IncludesAll(search ...Right) bool {
 
 // RightsFrom returns a Rights message from a list of rights.
 func RightsFrom(rights ...Right) *Rights { return &Rights{Rights: rights} }
+
+// PrettyName returns the key ID (Name if present)
+func (m *APIKey) PrettyName() string {
+	identifier := m.GetID()
+	if name := m.GetName(); name != "" {
+		identifier = fmt.Sprintf("%v (%v)", identifier, name)
+	}
+	return identifier
+}


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #72.

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Fix the Sendgrid initialization
- Fix the `email` package config
- Fix the template registry
- Sending the actual emails requested in #72

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

None.

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
What are the functional or behavioral changes? API Changes? New features?
Any changes in configuration? Added/changed/removed flags?
Are there any database migrations required?
-->

- Account registration, password recovery and contact info validation emails have been added.
- Email notifications on password change, email change, collaborator changes and API key changes have been added.