### PR TITLE
Add OAuth flow with Authorization Code copy-paste for CLI

### DIFF
--- a/.make/dev.make
+++ b/.make/dev.make
@@ -54,7 +54,7 @@ dev.databases.redis-cli: dev.databases.start
 dev.stack.init: dev.databases.start
 	go run ./cmd/ttn-lw-stack is-db init
 	go run ./cmd/ttn-lw-stack is-db create-admin-user --id admin --email admin@localhost --password admin
-	go run ./cmd/ttn-lw-stack is-db create-oauth-client --id cli --name "Command Line Interface" --owner admin --no-secret --redirect-uri 'http://localhost:11885/oauth/callback'
+	go run ./cmd/ttn-lw-stack is-db create-oauth-client --id cli --name "Command Line Interface" --owner admin --no-secret --redirect-uri 'http://localhost:11885/oauth/callback' --redirect-uri '/oauth/code'
 	go run ./cmd/ttn-lw-stack is-db create-oauth-client --id console --name "Console" --owner admin --secret console --redirect-uri 'http://localhost:1885/console/oauth/callback'
 
 # vim: ft=make

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ The easiest way to set up a private network is with the provided [`docker-compos
     docker-compose run --rm stack is-db create-oauth-client \
       --id cli --name "Command Line Interface" --no-secret \
       --owner admin \
-      --redirect-uri 'http://localhost:11885/oauth/callback'
+      --redirect-uri 'http://localhost:11885/oauth/callback' \
+      --redirect-uri '/oauth/code'
     ```
 5. Register the Console as an OAuth client:
     ```sh

--- a/cmd/ttn-lw-cli/commands/login.go
+++ b/cmd/ttn-lw-cli/commands/login.go
@@ -15,9 +15,13 @@
 package commands
 
 import (
+	"bufio"
+	"context"
+	"fmt"
 	"net"
 	"net/http"
-	"sync"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -31,40 +35,76 @@ var (
 		Use:   "login",
 		Short: "Login",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			lis, err := net.Listen("tcp", ":11885")
+			ctx, done := context.WithCancel(ctx)
+			defer done()
+
+			callback, err := cmd.Flags().GetBool("callback")
 			if err != nil {
 				return err
 			}
-			var (
-				once    sync.Once
-				tokenCh = make(chan *oauth2.Token)
-			)
-			go http.Serve(lis, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.Method != http.MethodGet || r.URL.Path != "/oauth/callback" {
-					http.NotFound(w, r)
-					return
-				}
-				token, err := oauth2Config.Exchange(ctx, r.URL.Query().Get("code"))
-				if err != nil {
-					msg := "Could not exchange OAuth access token"
-					logger.WithError(err).Error(msg)
-					w.WriteHeader(http.StatusUnauthorized)
+
+			var token *oauth2.Token
+
+			if callback {
+				oauth2Config.RedirectURL = "http://localhost:11885/oauth/callback"
+
+				http.HandleFunc("/oauth/callback", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.Method != http.MethodGet {
+						http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+						return
+					}
+					token, err = oauth2Config.Exchange(ctx, r.URL.Query().Get("code"))
+					if err != nil {
+						msg := "Could not exchange OAuth access token"
+						logger.WithError(err).Error(msg)
+						w.WriteHeader(http.StatusUnauthorized)
+						w.Write([]byte(msg))
+						return
+					}
+					msg := "Got OAuth access token"
+					logger.Info(msg)
 					w.Write([]byte(msg))
-					return
+					done()
+				}))
+
+				lis, err := net.Listen("tcp", ":11885")
+				defer lis.Close()
+				if err != nil {
+					return err
 				}
-				msg := "Got OAuth access token"
-				logger.Info(msg)
-				w.Write([]byte(msg))
-				once.Do(func() {
-					tokenCh <- token
-				})
-			}))
+				go http.Serve(lis, nil)
+			} else {
+				oauth2Config.RedirectURL = "/oauth/code"
+			}
 
 			logger.Infof("Please go to %s", oauth2Config.AuthCodeURL(""))
-			logger.Info("Waiting for your authorization...")
 
-			token := <-tokenCh
-			lis.Close()
+			if callback {
+				logger.Info("Waiting for your authorization...")
+				<-ctx.Done()
+			} else {
+				logger.Info("Then paste the authorization code and press enter")
+				var code string
+				for {
+					fmt.Fprint(os.Stderr, "> ")
+					r := bufio.NewReader(os.Stdin)
+					code, err = r.ReadString('\n')
+					if err != nil {
+						return err
+					}
+					code = strings.TrimSpace(code)
+					if code != "" {
+						break
+					}
+					logger.Info("Please paste the authorization code and press enter")
+				}
+				token, err = oauth2Config.Exchange(ctx, code)
+				if err != nil {
+					logger.WithError(err).Error("Could not exchange OAuth access token")
+					return err
+				}
+				logger.Info("Got OAuth access token")
+			}
 
 			cache.Set("oauth_token", token)
 
@@ -116,6 +156,7 @@ var (
 )
 
 func init() {
+	loginCommand.Flags().Bool("callback", true, "use local OAuth callback endpoint")
 	Root.AddCommand(loginCommand)
 	Root.AddCommand(logoutCommand)
 }

--- a/doc/gettingstarted.md
+++ b/doc/gettingstarted.md
@@ -64,7 +64,7 @@ You can run it using Docker, or container orchestration solutions. An example [D
 $ docker-compose pull
 $ docker-compose run --rm stack is-db init
 $ docker-compose run --rm stack is-db create-admin-user --id admin --email admin@localhost
-$ docker-compose run --rm stack is-db create-oauth-client --id cli --name "Command Line Interface" --owner admin --no-secret --redirect-uri 'http://localhost:11885/oauth/callback'
+$ docker-compose run --rm stack is-db create-oauth-client --id cli --name "Command Line Interface" --owner admin --no-secret --redirect-uri 'http://localhost:11885/oauth/callback' --redirect-uri '/oauth/code'
 $ docker-compose up
 ```
 

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -84,6 +84,7 @@
   "oauth.views.authorize.index.loginInfo": "You are logged in as {userId}.",
   "oauth.views.authorize.index.redirectInfo": "You will be redirected to {redirectUri}",
   "oauth.views.authorize.index.authorize": "Authorize",
+  "oauth.views.code.index.code": "Your Authorization Code",
   "oauth.views.create-account.index.createAccount": "Create TTN Stack Account",
   "oauth.views.create-account.index.register": "Register",
   "oauth.views.create-account.index.goToLogin": "Go to login",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -84,6 +84,7 @@
   "oauth.views.authorize.index.loginInfo": "Xxx xxx xxxxxx xx xx {userId}.",
   "oauth.views.authorize.index.redirectInfo": "Xxx xxxx xx xxxxxxxxxx xx {redirectUri}",
   "oauth.views.authorize.index.authorize": "Xxxxxxxxx",
+  "oauth.views.code.index.code": "Xxxx Xxxxxxxxxxxxx Xxxx",
   "oauth.views.create-account.index.createAccount": "Xxxxxx XXX Xxxxx Xxxxxxx",
   "oauth.views.create-account.index.register": "Xxxxxxxx",
   "oauth.views.create-account.index.goToLogin": "Xx xx xxxxx",

--- a/pkg/webui/oauth/views/app/index.js
+++ b/pkg/webui/oauth/views/app/index.js
@@ -28,6 +28,7 @@ import Authorize from '../authorize'
 import CreateAccount from '../create-account'
 import createStore from '../../store'
 import Init from '../../../lib/components/init'
+import Code from '../code'
 
 const history = createBrowserHistory()
 const store = createStore(history)
@@ -55,6 +56,7 @@ export default class OAuthApp extends React.PureComponent {
                   <Route path="/oauth/login" component={Login} />
                   <Route path="/oauth/authorize" component={Authorize} />
                   <Route path="/oauth/register" component={CreateAccount} />
+                  <Route path="/oauth/code" component={Code} />
                 </Switch>
               </ConnectedRouter>
             </WithLocale>

--- a/pkg/webui/oauth/views/code/index.js
+++ b/pkg/webui/oauth/views/code/index.js
@@ -1,0 +1,56 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import Query from 'query-string'
+import { Redirect } from 'react-router-dom'
+import { defineMessages } from 'react-intl'
+import { Container, Col, Row } from 'react-grid-system'
+
+import Message from '../../../lib/components/message'
+import SafeInspector from '../../../components/safe-inspector'
+
+const m = defineMessages({
+  code: 'Your Authorization Code',
+})
+
+export default class Code extends React.Component {
+
+  render () {
+    const { location } = this.props
+    const { query } = Query.parseUrl(location.search)
+
+    if (!query.code) {
+      return (
+        <Redirect to="/oauth/login" />
+      )
+    }
+
+    return (
+      <Container>
+        <Row>
+          <Col xs={12}>
+            <Message component="h2" content={m.code} />
+            <SafeInspector
+              data={query.code}
+              initiallyVisible
+              hideable={false}
+              isBytes={false}
+            />
+          </Col>
+        </Row>
+      </Container>
+    )
+  }
+}


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR is intended to resolve #99 by letting users disable the CLI's OAuth callback endpoint with `--callback=false`, which will make the OAuth flow redirect to a new page on the OAuth server that simply displays the authorization code for copy-paste.

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

Added a `--callback=false` flag to the CLI that changes the Redirect URI and asks for the authorization code:

<img width="877" alt="screen shot 2019-02-11 at 17 10 56" src="https://user-images.githubusercontent.com/181308/52576488-777ca780-2e20-11e9-8b05-96e25ab23627.png">

Added web UI that allows users to copy the authorization code:

<img width="926" alt="screen shot 2019-02-11 at 17 11 42" src="https://user-images.githubusercontent.com/181308/52576542-8bc0a480-2e20-11e9-897a-cf3f8f8c46c5.png">

And finish the OAuth flow with the usual token exchange:

<img width="877" alt="screen shot 2019-02-11 at 17 11 59" src="https://user-images.githubusercontent.com/181308/52576553-924f1c00-2e20-11e9-96e0-f1baa9cc3267.png">

The docs and initialization commands have been updated accordingly.

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

1. The typo in the screenshot above has already been fixed.
2. @kschiffer we may need to improve the design of the `/oauth/code` page, as it's very minimal right now. Do you think this MUST be done right now or can it wait?
3. @rvolosatovs does this resolve your issue in #99?

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
What are the functional or behavioral changes? API Changes? New features?
Any changes in configuration? Added/changed/removed flags?
Are there any database migrations required?
-->

Add an OAuth flow for the CLI that does not expose a local endpoint for the OAuth callback, but allows the user to copy-paste the authorization code. 

For this to work, an existing `cli` OAuth client will need to be updated as follows: 

```sh
ttn-lw-cli cli set cli --redirect-uris "http://localhost:11885/oauth/callback,/oauth/code"
```
