### PR TITLE
Add pkg/pfconfig to generate packet forwarder config

### DIFF
--- a/pkg/errors/definitions.go
+++ b/pkg/errors/definitions.go
@@ -210,7 +210,11 @@ func DefineAborted(name, messageFormat string, publicAttributes ...string) Defin
 
 // OutOfRange - not used for now
 
-// Unimplemented - not used for now
+// Unimplemented defines a registered error of type Unimplemented.
+func DefineUnimplemented(name, messageFormat string, publicAttributes ...string) Definition {
+	def := define(uint32(codes.Unimplemented), name, messageFormat, publicAttributes...)
+	return def
+}
 
 // DefineInternal defines a registered error of type Internal.
 func DefineInternal(name, messageFormat string, publicAttributes ...string) Definition {

--- a/pkg/pfconfig/conversion.go
+++ b/pkg/pfconfig/conversion.go
@@ -1,0 +1,150 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pfconfig
+
+import (
+	"fmt"
+	"math"
+	"net"
+	"strconv"
+	"time"
+
+	"go.thethings.network/lorawan-stack/pkg/band"
+	"go.thethings.network/lorawan-stack/pkg/frequencyplans"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+)
+
+func formatFrequency(frequency uint64) string {
+	freq := float64(frequency) / 1000000
+	if freq*10 == math.Floor(freq*10) {
+		return fmt.Sprintf("%.1f", freq)
+	}
+	return fmt.Sprintf("%g", freq)
+}
+
+// Build builds a packet forwarder configuration for the given gateway, using the given frequency plan store.
+func Build(gateway *ttnpb.Gateway, store *frequencyplans.Store) (*Config, error) {
+	var c Config
+
+	host, portStr, err := net.SplitHostPort(gateway.GatewayServerAddress)
+	if err != nil {
+		host = gateway.GatewayServerAddress
+		portStr = "1700"
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return nil, err
+	}
+	c.GatewayConf.ServerAddress, c.GatewayConf.ServerPortUp, c.GatewayConf.ServerPortDown = host, uint32(port), uint32(port)
+	server := c.GatewayConf
+	server.Enabled = true
+	c.GatewayConf.Servers = append(c.GatewayConf.Servers, server)
+
+	frequencyPlan, err := store.GetByID(gateway.FrequencyPlanID)
+	if err != nil {
+		return nil, err
+	}
+	band, err := band.GetByID(frequencyPlan.BandID)
+	if err != nil {
+		return nil, err
+	}
+
+	c.SX1301Conf.LoRaWANPublic = true
+	c.SX1301Conf.ClockSource = frequencyPlan.ClockSource
+
+	if frequencyPlan.LBT != nil {
+		lbtConfig := &LBTConfig{
+			Enable:     true,
+			RSSITarget: frequencyPlan.LBT.RSSITarget,
+			RSSIOffset: frequencyPlan.LBT.RSSIOffset,
+		}
+		for i, channel := range frequencyPlan.DownlinkChannels {
+			if i > 7 {
+				break
+			}
+			lbtConfig.ChannelConfigs = append(lbtConfig.ChannelConfigs, LBTChannelConfig{
+				Frequency:            channel.Frequency,
+				ScanTimeMicroseconds: uint32(frequencyPlan.LBT.ScanTime / time.Microsecond),
+			})
+		}
+		c.SX1301Conf.LBTConfig = lbtConfig
+	}
+
+	c.SX1301Conf.Radios = make([]RFConfig, len(frequencyPlan.Radios))
+	for i, radio := range frequencyPlan.Radios {
+		rfConfig := RFConfig{
+			Enable:     radio.Enable,
+			Type:       radio.ChipType,
+			Frequency:  radio.Frequency,
+			RSSIOffset: radio.RSSIOffset,
+		}
+		if radio.TxConfiguration != nil {
+			rfConfig.TxEnable = true
+			rfConfig.TxFreqMin = radio.TxConfiguration.MinFrequency
+			rfConfig.TxFreqMax = radio.TxConfiguration.MaxFrequency
+			if radio.TxConfiguration.NotchFrequency != nil {
+				rfConfig.TxNotchFreq = *radio.TxConfiguration.NotchFrequency
+			}
+		}
+		c.SX1301Conf.Radios[i] = rfConfig
+	}
+
+	numChannels := len(frequencyPlan.UplinkChannels)
+	if numChannels < 8 {
+		numChannels = 8
+	}
+	c.SX1301Conf.Channels = make([]IFConfig, numChannels)
+	for i, channel := range frequencyPlan.UplinkChannels {
+		ifConfig := IFConfig{
+			Description: fmt.Sprintf("Lora MAC, 125kHz, all SF, %s MHz", formatFrequency(channel.Frequency)),
+			Enable:      true,
+			Radio:       channel.Radio,
+			IFValue:     int32(int64(channel.Frequency) - int64(c.SX1301Conf.Radios[channel.Radio].Frequency)),
+		}
+		c.SX1301Conf.Channels[i] = ifConfig
+	}
+
+	c.SX1301Conf.LoRaStandardChannel = &IFConfig{Enable: false}
+	if channel := frequencyPlan.LoRaStandardChannel; channel != nil {
+		if lora := band.DataRates[channel.DataRate].Rate.GetLoRa(); lora != nil {
+			c.SX1301Conf.LoRaStandardChannel = &IFConfig{
+				Description:  fmt.Sprintf("Lora MAC, %dkHz, SF%d, %s MHz", lora.Bandwidth/1000, lora.SpreadingFactor, formatFrequency(channel.Frequency)),
+				Enable:       true,
+				Radio:        channel.Radio,
+				IFValue:      int32(int64(channel.Frequency) - int64(c.SX1301Conf.Radios[channel.Radio].Frequency)),
+				Bandwidth:    lora.Bandwidth,
+				SpreadFactor: uint8(lora.SpreadingFactor),
+			}
+		}
+	}
+
+	c.SX1301Conf.FSKChannel = &IFConfig{Enable: false}
+	if channel := frequencyPlan.FSKChannel; channel != nil {
+		if fsk := band.DataRates[channel.DataRate].Rate.GetFSK(); fsk != nil {
+			c.SX1301Conf.FSKChannel = &IFConfig{
+				Description: fmt.Sprintf("FSK %dkbps, %s MHz", fsk.BitRate/1000, formatFrequency(channel.Frequency)),
+				Enable:      true,
+				Radio:       channel.Radio,
+				IFValue:     int32(int64(channel.Frequency) - int64(c.SX1301Conf.Radios[channel.Radio].Frequency)),
+				Bandwidth:   125000,
+				Datarate:    fsk.BitRate,
+			}
+		}
+	}
+
+	c.SX1301Conf.TxLUTConfigs = defaultTxLUTConfigs
+
+	return &c, nil
+}

--- a/pkg/pfconfig/conversion_test.go
+++ b/pkg/pfconfig/conversion_test.go
@@ -1,0 +1,129 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pfconfig
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/kr/pretty"
+	"github.com/smartystreets/assertions"
+	"github.com/smartystreets/assertions/should"
+	"go.thethings.network/lorawan-stack/pkg/fetch"
+	"go.thethings.network/lorawan-stack/pkg/frequencyplans"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+)
+
+func TestBuild(t *testing.T) {
+	var fetcher fetch.Interface
+	localPath := os.ExpandEnv("$GOPATH/src/github.com/TheThingsNetwork/lorawan-frequency-plans")
+	if _, err := os.Stat(localPath); err == nil {
+		fetcher = fetch.FromFilesystem(localPath)
+	} else {
+		fetcher = fetch.FromHTTP("https://raw.githubusercontent.com/TheThingsNetwork/lorawan-frequency-plans/master", true)
+	}
+	store := frequencyplans.NewStore(fetcher)
+
+	var referenceFetcher fetch.Interface
+	referenceLocalPath := os.ExpandEnv("$GOPATH/src/github.com/TheThingsNetwork/gateway-conf")
+	if _, err := os.Stat(referenceLocalPath); err == nil {
+		referenceFetcher = fetch.FromFilesystem(referenceLocalPath)
+	} else {
+		referenceFetcher = fetch.FromHTTP("https://raw.githubusercontent.com/TheThingsNetwork/gateway-conf/master", true)
+	}
+
+	var shouldResembleReference = func(actual interface{}, expected ...interface{}) string {
+		referenceBytes, err := referenceFetcher.File(expected[0].(string))
+		if err != nil {
+			panic(err)
+		}
+		var expectedMap map[string]interface{}
+		err = json.Unmarshal(referenceBytes, &expectedMap)
+		if err != nil {
+			panic(err)
+		}
+		configJSON, _ := json.Marshal(actual.(*Config))
+		var actualMap map[string]interface{}
+		json.Unmarshal(configJSON, &actualMap)
+		return should.BeEmpty(pretty.Diff(actualMap, expectedMap))
+	}
+
+	for _, tt := range []struct {
+		Name    string
+		Gateway *ttnpb.Gateway
+		Assert  func(a *assertions.Assertion, config *Config)
+	}{
+		{
+			Name: "Reference: EU global_conf",
+			Gateway: &ttnpb.Gateway{
+				FrequencyPlanID:      "EU_863_870_TTN",
+				GatewayServerAddress: "router.eu.thethings.network",
+			},
+			Assert: func(a *assertions.Assertion, config *Config) {
+				a.So(config, shouldResembleReference, "EU-global_conf.json")
+			},
+		},
+		{
+			Name: "Reference: US global_conf",
+			Gateway: &ttnpb.Gateway{
+				FrequencyPlanID:      "US_902_928_FSB_2",
+				GatewayServerAddress: "router.us.thethings.network",
+			},
+			Assert: func(a *assertions.Assertion, config *Config) {
+				a.So(config, shouldResembleReference, "US-global_conf.json")
+			},
+		},
+		{
+			Name: "Reference: AU global_conf",
+			Gateway: &ttnpb.Gateway{
+				FrequencyPlanID:      "AU_915_928_FSB_2",
+				GatewayServerAddress: "router.au.thethings.network",
+			},
+			Assert: func(a *assertions.Assertion, config *Config) {
+				a.So(config, shouldResembleReference, "AU-global_conf.json")
+			},
+		},
+		{
+			Name: "Reference: AS1 global_conf",
+			Gateway: &ttnpb.Gateway{
+				FrequencyPlanID:      "AS_920_923_LBT",
+				GatewayServerAddress: "router.as1.thethings.network",
+			},
+			Assert: func(a *assertions.Assertion, config *Config) {
+				a.So(config, shouldResembleReference, "AS1-global_conf.json")
+			},
+		},
+		{
+			Name: "Reference: KR global_conf",
+			Gateway: &ttnpb.Gateway{
+				FrequencyPlanID:      "KR_920_923_TTN",
+				GatewayServerAddress: "router.kr.thethings.network",
+			},
+			Assert: func(a *assertions.Assertion, config *Config) {
+				a.So(config, shouldResembleReference, "KR-global_conf.json")
+			},
+		},
+	} {
+		t.Run(tt.Name, func(t *testing.T) {
+			a := assertions.New(t)
+			config, err := Build(tt.Gateway, store)
+			if a.So(err, should.BeNil) {
+				tt.Assert(a, config)
+			}
+		})
+	}
+
+}

--- a/pkg/pfconfig/pfconfig.go
+++ b/pkg/pfconfig/pfconfig.go
@@ -1,0 +1,225 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pfconfig implements the JSON configuration of Semtech's reference Packet Forwarder.
+package pfconfig
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"go.thethings.network/lorawan-stack/pkg/errors"
+)
+
+// Config represents the full configuration for Semtech's reference Packet Forwarder.
+type Config struct {
+	SX1301Conf  SX1301Config `json:"SX1301_conf"`
+	GatewayConf GatewayConf  `json:"gateway_conf"`
+}
+
+// SX1301Config contains the configuration for the SX1301 concentrator.
+// It marshals to compliant JSON, but does currently **not** unmarshal from it.
+type SX1301Config struct {
+	LoRaWANPublic       bool
+	ClockSource         uint8
+	AntennaGain         float32
+	LBTConfig           *LBTConfig
+	Radios              []RFConfig
+	Channels            []IFConfig
+	LoRaStandardChannel *IFConfig
+	FSKChannel          *IFConfig
+	TxLUTConfigs        []TxLUTConfig
+}
+
+type kv struct {
+	key   string
+	value interface{}
+}
+
+type orderedMap struct {
+	kv []kv
+}
+
+func (m *orderedMap) add(k string, v interface{}) {
+	m.kv = append(m.kv, kv{key: k, value: v})
+}
+
+func (m orderedMap) MarshalJSON() ([]byte, error) {
+	var b bytes.Buffer
+	b.WriteString("{")
+	for i, kv := range m.kv {
+		if i != 0 {
+			b.WriteString(",")
+		}
+		key, err := json.Marshal(kv.key)
+		if err != nil {
+			return nil, err
+		}
+		b.Write(key)
+		b.WriteString(":")
+		val, err := json.Marshal(kv.value)
+		if err != nil {
+			return nil, err
+		}
+		b.Write(val)
+	}
+	b.WriteString("}")
+	return b.Bytes(), nil
+}
+
+// MarshalJSON implements json.Marshaler.
+func (c SX1301Config) MarshalJSON() ([]byte, error) {
+	var m orderedMap
+	m.add("lorawan_public", c.LoRaWANPublic)
+	m.add("clksrc", c.ClockSource)
+	m.add("clksrc_desc", "radio_1 provides clock to concentrator for most devices except MultiTech. For MultiTech set to 0.")
+	m.add("antenna_gain", c.AntennaGain)
+	m.add("antenna_gain_desc", "antenna gain, in dBi")
+	if c.LBTConfig != nil {
+		m.add("lbt_cfg", *c.LBTConfig)
+	}
+	for i, radio := range c.Radios {
+		m.add(fmt.Sprintf("radio_%d", i), radio)
+	}
+	for i, channel := range c.Channels {
+		m.add(fmt.Sprintf("chan_multiSF_%d", i), channel)
+	}
+	if c.LoRaStandardChannel != nil {
+		m.add("chan_Lora_std", *c.LoRaStandardChannel)
+	}
+	if c.FSKChannel != nil {
+		m.add("chan_FSK", *c.FSKChannel)
+	}
+	for i, lut := range c.TxLUTConfigs {
+		m.add(fmt.Sprintf("tx_lut_%d", i), lut)
+	}
+	return json.Marshal(m)
+}
+
+var errUnmarshalNotImplemented = errors.DefineUnimplemented(
+	"unmarshal_not_implemented",
+	"unmarshaling SX1301 config is not implemented",
+)
+
+// UnmarshalJSON implements json.Unmarshaler. It currently just errors because
+// unmarshaling is not supported.
+func (c *SX1301Config) UnmarshalJSON(_ []byte) error {
+	return errUnmarshalNotImplemented
+}
+
+// LBTConfig contains the configuration for listen-before-talk.
+type LBTConfig struct {
+	Enable         bool               `json:"enable"`
+	RSSITarget     float32            `json:"rssi_target"`
+	ChannelConfigs []LBTChannelConfig `json:"chan_cfg"`
+	RSSIOffset     float32            `json:"sx127x_rssi_offset"`
+}
+
+// LBTChannelConfig contains the listen-before-talk configuration for a channel.
+type LBTChannelConfig struct {
+	Frequency            uint64 `json:"freq_hz"`
+	ScanTimeMicroseconds uint32 `json:"scan_time_us"`
+}
+
+// RFConfig contains the configuration for one of the radios.
+type RFConfig struct {
+	Enable      bool    `json:"enable"`
+	Type        string  `json:"type"`
+	Frequency   uint64  `json:"freq"`
+	RSSIOffset  float32 `json:"rssi_offset"`
+	TxEnable    bool    `json:"tx_enable"`
+	TxFreqMin   uint64  `json:"tx_freq_min,omitempty"`
+	TxFreqMax   uint64  `json:"tx_freq_max,omitempty"`
+	TxNotchFreq uint64  `json:"tx_notch_freq,omitempty"`
+}
+
+// IFConfig contains the configuration for one of the channels.
+type IFConfig struct {
+	Description  string `json:"desc"`
+	Enable       bool   `json:"enable"`
+	Radio        uint8  `json:"radio"`
+	IFValue      int32  `json:"if"`
+	Bandwidth    uint32 `json:"bandwidth,omitempty"`
+	SpreadFactor uint8  `json:"spread_factor,omitempty"`
+	Datarate     uint32 `json:"datarate,omitempty"`
+}
+
+// MarshalJSON implements json.Marshaler
+func (c IFConfig) MarshalJSON() ([]byte, error) {
+	if !c.Enable {
+		return []byte(`{"desc": "disabled","enable": false}`), nil
+	}
+	return json.Marshal(struct {
+		Description  string `json:"desc"`
+		Enable       bool   `json:"enable"`
+		Radio        uint8  `json:"radio"`
+		IFValue      int32  `json:"if"`
+		Bandwidth    uint32 `json:"bandwidth,omitempty"`
+		SpreadFactor uint8  `json:"spread_factor,omitempty"`
+		Datarate     uint32 `json:"datarate,omitempty"`
+	}{
+		Description:  c.Description,
+		Enable:       c.Enable,
+		Radio:        c.Radio,
+		IFValue:      c.IFValue,
+		Bandwidth:    c.Bandwidth,
+		SpreadFactor: c.SpreadFactor,
+		Datarate:     c.Datarate,
+	})
+}
+
+// TxLUTConfig contains the configuration for the TX LUT ind
+type TxLUTConfig struct {
+	Description string `json:"desc"`
+	PAGain      int    `json:"pa_gain"`
+	MixGain     int    `json:"mix_gain"`
+	RFPower     int    `json:"rf_power"`
+	DigGain     int    `json:"dig_gain"`
+}
+
+var defaultTxLUTConfigs = []TxLUTConfig{
+	{PAGain: 0, MixGain: 8, RFPower: -6},
+	{PAGain: 0, MixGain: 10, RFPower: -3},
+	{PAGain: 0, MixGain: 12, RFPower: 0},
+	{PAGain: 1, MixGain: 8, RFPower: 3},
+	{PAGain: 1, MixGain: 10, RFPower: 6},
+	{PAGain: 1, MixGain: 12, RFPower: 10},
+	{PAGain: 1, MixGain: 13, RFPower: 11},
+	{PAGain: 2, MixGain: 9, RFPower: 12},
+	{PAGain: 1, MixGain: 15, RFPower: 13},
+	{PAGain: 2, MixGain: 10, RFPower: 14},
+	{PAGain: 2, MixGain: 11, RFPower: 16},
+	{PAGain: 3, MixGain: 9, RFPower: 20},
+	{PAGain: 3, MixGain: 10, RFPower: 23},
+	{PAGain: 3, MixGain: 11, RFPower: 25},
+	{PAGain: 3, MixGain: 12, RFPower: 26},
+	{PAGain: 3, MixGain: 14, RFPower: 27},
+}
+
+func init() {
+	for i, config := range defaultTxLUTConfigs {
+		config.Description = fmt.Sprintf("TX gain table, index %d", i)
+		defaultTxLUTConfigs[i] = config
+	}
+}
+
+// GatewayConf contains the configuration for the gateway's server connection.
+type GatewayConf struct {
+	ServerAddress  string        `json:"server_address"`
+	ServerPortUp   uint32        `json:"serv_port_up"`
+	ServerPortDown uint32        `json:"serv_port_down"`
+	Enabled        bool          `json:"serv_enabled,omitempty"` // only used inside servers
+	Servers        []GatewayConf `json:"servers,omitempty"`
+}


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR introduces `pkg/pfconfig` that generates packet forwarder config for a `*ttnpb.Gateway` and the frequency plan that it uses. This package is needed for #68 and #74. 
 
<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Define data structures that match the config JSON for Semtech's reference packet forwarder, with adaptations to make the output consistent with existing config in https://github.com/TheThingsNetwork/gateway-conf
- Add a func to build the config from a gateway and frequency plan store.
- Tested against some of the configs in https://github.com/TheThingsNetwork/gateway-conf.

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

As this package isn't yet imported by the stack, the error messages defined in it aren't collected by `make messages` yet.
