### PR TITLE
Add toast notification

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -105,7 +105,6 @@ export default {
           name: 'styles',
           test: /\.css$/,
           chunks: 'all',
-          enforce: true,
         },
       },
     },

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "react-router": "~4.3.1",
     "react-router-dom": "^4.2.2",
     "react-text-mask": "^5.0.2",
+    "react-toastify": "^4.5.2",
     "redux": "^3.7.2",
     "redux-logic": "^0.15.0",
     "ttn-lw": "file:sdk/js",

--- a/pkg/webui/components/notification/index.js
+++ b/pkg/webui/components/notification/index.js
@@ -53,7 +53,7 @@ const Notification = function ({
 
   return (
     <div className={classname}>
-      <Icon className={style.icon} icon={icon} />
+      <Icon className={style.icon} icon={icon} large={!small} />
       <div className={style.content}>
         { title && (
           <Message

--- a/pkg/webui/components/notification/index.js
+++ b/pkg/webui/components/notification/index.js
@@ -24,6 +24,7 @@ import style from './notification.styl'
 
 const Notification = function ({
   className,
+  title,
   error,
   warning,
   info,
@@ -50,7 +51,17 @@ const Notification = function ({
 
   return (
     <div className={classname}>
-      <Icon nudgeUp icon={icon} /><Component content={content} />
+      <Icon className={style.icon} icon={icon} />
+      <div className={style.content}>
+        { title && (
+          <Message
+            className={style.title}
+            content={title}
+            component="h4"
+          />
+        )}
+        <Component content={content} />
+      </div>
     </div>
   )
 }
@@ -61,6 +72,7 @@ Notification.propTypes = {
   warning: PropTypes.message,
   info: PropTypes.message,
   small: PropTypes.bool,
+  title: PropTypes.message,
 }
 
 export default Notification

--- a/pkg/webui/components/notification/index.js
+++ b/pkg/webui/components/notification/index.js
@@ -30,6 +30,7 @@ const Notification = function ({
   info,
   small,
   message,
+  success,
 }) {
 
   const classname = classnames(style.notification, className, {
@@ -37,6 +38,7 @@ const Notification = function ({
     [style.warning]: warning,
     [style.info]: info,
     [style.small]: small,
+    [style.success]: success,
   })
 
   let icon = 'info'
@@ -46,7 +48,7 @@ const Notification = function ({
     icon = 'warning'
   }
 
-  const content = message || error || warning || info
+  const content = message || error || warning || info || success
   const Component = error ? ErrorMessage : Message
 
   return (
@@ -73,6 +75,7 @@ Notification.propTypes = {
   info: PropTypes.message,
   small: PropTypes.bool,
   title: PropTypes.message,
+  success: PropTypes.message,
 }
 
 export default Notification

--- a/pkg/webui/components/notification/notification.styl
+++ b/pkg/webui/components/notification/notification.styl
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+$border-width = $cs.xxs
+
 left-border($color)
   background: linear-gradient(left, $color, 5px $color, 5px white)
 
@@ -21,15 +23,18 @@ left-border($color)
   border-right: 1px solid $c-divider
   border-color: $c-divider-subtle
   border-radius: $br.m
-  padding: $cs.xl $cs.l
+  padding: $cs.xl $cs.l $cs.xl $cs.xl
   margin-bottom: $ls.xxs
   box-shadow: 0 1px 1px 0 $c-divider-dark
   display: flex
   flex-wrap: nowrap
 
   &.small
-    padding: $cs.s
-    border-left-width: 4px
+    padding: $cs.s $cs.s $cs.s $cs.l
+    border-left-width: $border-width
+
+    .icon
+      margin-right: $cs.l - $border-width
 
   &.error
     left-border($c-error)
@@ -52,8 +57,9 @@ left-border($color)
     font-weight: 600
 
   .content
-    margin-left: $cs.xs
     display: inline-block
+    color: $tc-deep-gray
 
   .icon
     display: flex
+    margin-right: $cs.xl - $border-width

--- a/pkg/webui/components/notification/notification.styl
+++ b/pkg/webui/components/notification/notification.styl
@@ -43,6 +43,10 @@ left-border($color)
     left-border($c-active-blue)
     color: $c-active-blue
 
+  &.success
+    left-border($c-success)
+    color: $c-success
+
   .title
     margin: 0
     font-weight: 600

--- a/pkg/webui/components/notification/notification.styl
+++ b/pkg/webui/components/notification/notification.styl
@@ -24,6 +24,8 @@ left-border($color)
   padding: $cs.xl $cs.l
   margin-bottom: $ls.xxs
   box-shadow: 0 1px 1px 0 $c-divider-dark
+  display: flex
+  flex-wrap: nowrap
 
   &.small
     padding: $cs.s
@@ -41,5 +43,13 @@ left-border($color)
     left-border($c-active-blue)
     color: $c-active-blue
 
-  span:last-child
+  .title
+    margin: 0
+    font-weight: 600
+
+  .content
     margin-left: $cs.xs
+    display: inline-block
+
+  .icon
+    display: flex

--- a/pkg/webui/components/notification/story.js
+++ b/pkg/webui/components/notification/story.js
@@ -19,20 +19,85 @@ import Notification from '.'
 
 storiesOf('Notification', module)
   .add('Default', () => (
-    <Notification message="This is an example message" />
+    <div>
+      <Notification
+        title="example message title"
+        message="This is an example message"
+      />
+      <Notification message="This is an example message" />
+      <Notification
+        title="example message title"
+        message="This is an example message"
+        small
+      />
+      <Notification message="This is an example message" small />
+    </div>
   ))
   .add('Info', () => (
-    <Notification
-      info="This message is good to know"
-    />
+    <div>
+      <Notification
+        title="example message title"
+        info="This message is good to know"
+      />
+      <Notification
+        info="This message is good to know"
+      />
+      <Notification
+        title="example message title"
+        info="This message is good to know"
+        small
+      />
+      <Notification info="This message is good to know" small />
+    </div>
   ))
   .add('Warning', () => (
-    <Notification
-      warning="This issue should be addressed!"
-    />
+    <div>
+      <Notification
+        title="example message title"
+        warning="This issue should be addressed!"
+      />
+      <Notification
+        warning="This issue should be addressed!"
+      />
+      <Notification
+        title="example message title"
+        warning="This issue should be addressed!"
+        small
+      />
+      <Notification warning="This issue should be addressed!" small />
+    </div>
   ))
   .add('Error', () => (
-    <Notification
-      error="We got a problem here!"
-    />
+    <div>
+      <Notification
+        title="example message title"
+        error="We got a problem here!"
+      />
+      <Notification
+        error="We got a problem here!"
+      />
+      <Notification
+        title="example message title"
+        error="We got a problem here!"
+        small
+      />
+      <Notification error="We got a problem here!" small />
+    </div>
+  ))
+  .add('Success', () => (
+    <div>
+      <Notification
+        title="example message title"
+        success="Successful action!"
+      />
+      <Notification
+        success="Successful action!"
+      />
+      <Notification
+        title="example message title"
+        success="Successful action!"
+        small
+      />
+      <Notification success="Successful action!" small />
+    </div>
   ))

--- a/pkg/webui/components/toast/index.js
+++ b/pkg/webui/components/toast/index.js
@@ -1,0 +1,68 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import { ToastContainer as Container, Slide } from 'react-toastify'
+import 'react-toastify/dist/ReactToastify.css'
+
+import PropTypes from '../../lib/prop-types'
+import createToast from './toast'
+
+import style from './toast.styl'
+
+class ToastContainer extends React.Component {
+  render () {
+    return (
+      <Container
+        toastClassName={style.toast}
+        bodyClassName={style.body}
+        {...this.props}
+      />
+    )
+  }
+}
+
+ToastContainer.propTypes = {
+  position: PropTypes.oneOf([
+    'bottom-right',
+    'bottom-left',
+    'top-right',
+    'top-left',
+    'top-center',
+    'bottom-center',
+  ]),
+  autoClose: PropTypes.oneOfType([ PropTypes.bool, PropTypes.number ]),
+  closeButton: PropTypes.oneOfType([ PropTypes.bool, PropTypes.element ]),
+  hideProgressBar: PropTypes.bool,
+  pauseOnHover: PropTypes.bool,
+  closeOnClick: PropTypes.bool,
+  pauseOnFocusLoss: PropTypes.bool,
+  transition: PropTypes.element,
+}
+
+ToastContainer.defaultProps = {
+  position: 'bottom-right',
+  autoClose: 4000,
+  closeButton: false,
+  hideProgressBar: true,
+  pauseOnHover: true,
+  closeOnClick: true,
+  pauseOnFocusLoss: true,
+  transition: Slide,
+}
+
+const toast = createToast()
+
+export { toast as default, ToastContainer }
+

--- a/pkg/webui/components/toast/story.js
+++ b/pkg/webui/components/toast/story.js
@@ -1,0 +1,71 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import bind from 'autobind-decorator'
+
+import Button from '../button'
+import toast, { ToastContainer } from '.'
+
+const TOAST_TITLE = 'Toast title'
+const TOAST_CONTENT = 'Toast content'
+
+@bind
+class Example extends React.Component {
+
+  showToast (evt) {
+    let type = null
+    switch (evt.currentTarget.name) {
+    case 'success':
+      type = toast.types.SUCCESS
+      break
+    case 'info':
+      type = toast.types.INFO
+      break
+    case 'warning':
+      type = toast.types.WARNING
+      break
+    case 'error':
+      type = toast.types.ERROR
+      break
+    default:
+      type = toast.types.DEFAULT
+    }
+
+    toast({
+      type,
+      title: TOAST_TITLE,
+      message: TOAST_CONTENT,
+    })
+  }
+
+  render () {
+    return (
+      <div style={{ width: '100%', height: '100%' }}>
+        <ToastContainer />
+        <Button onClick={this.showToast} message="Show Default Toast" name="default" />
+        <Button onClick={this.showToast} message="Show Success Toast" name="success" />
+        <Button onClick={this.showToast} message="Show Error Toast" name="error" />
+        <Button onClick={this.showToast} message="Show Warning Toast" name="warning" />
+        <Button onClick={this.showToast} message="Show Info Toast" name="info" />
+      </div>
+    )
+  }
+}
+
+storiesOf('Toast', module)
+  .add('Default', () => (
+    <Example />
+  ))

--- a/pkg/webui/components/toast/toast.js
+++ b/pkg/webui/components/toast/toast.js
@@ -1,0 +1,75 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import { toast as t } from 'react-toastify'
+
+import Notification from '../notification'
+
+import style from './toast.styl'
+
+const createToast = function () {
+  const queue = []
+  let toastId = null
+
+  const show = function (toastOptions) {
+    const { INFO, SUCCESS, ERROR, WARNING, DEFAULT } = toast.types
+    const { title, message, type = DEFAULT, ...rest } = toastOptions
+
+    toastId = t(
+      <Notification
+        className={style.notification}
+        small
+        title={title}
+        success={type === SUCCESS ? message : undefined}
+        info={type === INFO ? message : undefined}
+        error={type === ERROR ? message : undefined}
+        warning={type === WARNING ? message : undefined}
+        message={type === DEFAULT ? message : undefined}
+      />,
+      {
+        onClose: () => next(),
+        ...rest,
+      }
+    )
+  }
+
+  const next = function () {
+    if (queue.length) {
+      const options = queue.pop()
+      show(options)
+    }
+  }
+
+  const toast = function (options) {
+    queue.push(options)
+
+    if (!t.isActive(toastId)) {
+      next()
+    }
+  }
+
+  toast.types = {
+    INFO: 'info',
+    SUCCESS: 'success',
+    ERROR: 'error',
+    WARNING: 'warning',
+    DEFAULT: 'default',
+  }
+
+  return toast
+
+}
+
+export default createToast

--- a/pkg/webui/components/toast/toast.styl
+++ b/pkg/webui/components/toast/toast.styl
@@ -1,0 +1,24 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.toast
+  padding: 0
+  background: transparent
+  bottom: 2.5rem
+  border-radius: $br.m
+  min-height: 2rem
+  font-family: $font-family
+
+  .notification
+    margin: 0

--- a/pkg/webui/console/views/application-general-settings/index.js
+++ b/pkg/webui/console/views/application-general-settings/index.js
@@ -29,6 +29,7 @@ import Field from '../../../components/field'
 import Button from '../../../components/button'
 import ModalButton from '../../../components/button/modal-button'
 import diff from '../../../lib/diff'
+import toast from '../../../components/toast'
 
 import api from '../../api'
 
@@ -39,6 +40,7 @@ const m = defineMessages({
   deleteApp: 'Delete application',
   modalWarning: 'Are you sure you want to delete "{appName}"? Deleting an application cannot be undone!',
   generalSettings: 'General Settings',
+  updateSuccess: 'Successfully updated application',
 })
 
 const validationSchema = Yup.object().shape({
@@ -74,15 +76,21 @@ export default class ApplicationGeneralSettings extends React.Component {
     error: '',
   }
 
-  async handleSubmit (values, { setSubmitting, resetForm }) {
+  async handleSubmit (values, { resetForm }) {
     const { application } = this.props
 
     await this.setState({ error: '' })
 
     const changed = diff(application, values)
     try {
-      await api.application.update(application.ids.application_id, changed)
+      const { ids: { application_id }} = application
+      await api.application.update(application_id, changed)
       resetForm({ ...values })
+      toast({
+        title: application_id,
+        message: m.updateSuccess,
+        type: toast.types.SUCCESS,
+      })
     } catch (error) {
       resetForm({ ...values })
       await this.setState(error)

--- a/pkg/webui/console/views/landing/index.js
+++ b/pkg/webui/console/views/landing/index.js
@@ -22,6 +22,7 @@ import Overview from '../overview'
 import Applications from '../applications'
 import Gateways from '../gateways'
 import Organizations from '../organizations'
+import { ToastContainer } from '../../../components/toast'
 
 import style from './landing.styl'
 
@@ -31,6 +32,7 @@ export default class Landing extends React.PureComponent {
     const { path } = this.props.match
     return (
       <div className={style.container}>
+        <ToastContainer />
         <div className={style.breadcrumbsContainer}>
           <Container>
             <Breadcrumbs />

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -31,6 +31,7 @@
   "console.views.application-general-settings.index.deleteApp": "Delete application",
   "console.views.application-general-settings.index.modalWarning": "Are you sure you want to delete \"{appName}\"? Deleting an application cannot be undone!",
   "console.views.application-general-settings.index.generalSettings": "General Settings",
+  "console.views.application-general-settings.index.updateSuccess": "Successfully updated application",
   "console.views.login.index.welcome": "Welcome to {stackConsole}",
   "console.views.login.index.login": "You need to be logged in to use this site",
   "console.views.login.index.loginWithStackAccount": "Login with your TTN Stack Account",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -31,6 +31,7 @@
   "console.views.application-general-settings.index.deleteApp": "Xxxxxx xxxxxxxxxxx",
   "console.views.application-general-settings.index.modalWarning": "Xxx xxx xxxx xxx xxxx xx xxxxxx \"{appName}\"? Xxxxxxxx xx xxxxxxxxxxx xxxxxx xx xxxxxx!",
   "console.views.application-general-settings.index.generalSettings": "Xxxxxxx Xxxxxxxx",
+  "console.views.application-general-settings.index.updateSuccess": "Xxxxxxxxxxxx xxxxxxx xxxxxxxxxxx",
   "console.views.login.index.welcome": "Xxxxxxx xx {stackConsole}",
   "console.views.login.index.login": "Xxx xxxx xx xx xxxxxx xx xx xxx xxxx xxxx",
   "console.views.login.index.loginWithStackAccount": "Xxxxx xxxx xxxx XXX Xxxxx Xxxxxxx",

--- a/pkg/webui/styles/variables.styl
+++ b/pkg/webui/styles/variables.styl
@@ -35,6 +35,7 @@ $c-input-border = #BBB
 
 // ## Alerts
 
+$c-success = #24C833
 $c-error = #FF5C5C
 $c-warning = #FFC464
 $c-info = $c-active-blue

--- a/yarn.lock
+++ b/yarn.lock
@@ -3436,7 +3436,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5:
+classnames@^2.2.5, classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -9414,10 +9414,29 @@ react-textarea-autosize@^7.0.4:
   dependencies:
     prop-types "^15.6.0"
 
+react-toastify@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-4.5.2.tgz#a75b5f8b6219f62d4aacd0455d578a53341e37ca"
+  integrity sha512-KymDDhkcX5EvFht17nO0MCsegM/Kdhyfxhi+WQl2tE3IxJrueOhY6TUnALTfvz7eDRUjPYBGb+ywWqWrGyvBnw==
+  dependencies:
+    classnames "^2.2.6"
+    prop-types "^15.6.0"
+    react-transition-group "^2.4.0"
+
 react-transition-group@^2.0.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.5.0.tgz#70bca0e3546102c4dc5cf3f5f57f73447cce6874"
   integrity sha512-qYB3JBF+9Y4sE4/Mg/9O6WFpdoYjeeYqx0AFb64PTazVy8RPMiE3A47CG9QmM4WJ/mzDiZYslV+Uly6O1Erlgw==
+  dependencies:
+    dom-helpers "^3.3.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
+    react-lifecycles-compat "^3.0.4"
+
+react-transition-group@^2.4.0:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.5.3.tgz#26de363cab19e5c88ae5dbae105c706cf953bb92"
+  integrity sha512-2DGFck6h99kLNr8pOFk+z4Soq3iISydwOFeeEVPjTN6+Y01CmvbWmnN02VuTWyFdnRtIDPe+wy2q6Ui8snBPZg==
   dependencies:
     dom-helpers "^3.3.1"
     loose-envify "^1.4.0"


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/126
This PR adds the toast component

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Add `react-toastify` dependency
- Add the success notification type
- Extend notification storybook
- Add the toast component
- Include the toast notification in the app general settings page

Some features of the toast:
- Pause the times on hover and screen focus loss(this can be problematic on queuing too many toasts)
- Animated
- Close on click and swipe
- Support for mobile devices

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

Turned off the default `optimization` setup in webpack config. Lets come back to this once we are done with external deps, and then we can define the chunk sizes and etc.


