### PR TITLE
dev: Add release and rc bumps to version bumping

### DIFF
--- a/.mage/version.go
+++ b/.mage/version.go
@@ -17,6 +17,7 @@ package ttnmage
 import (
 	"fmt"
 	"io/ioutil"
+	"strconv"
 	"strings"
 
 	"github.com/TheThingsIndustries/magepkg/git"
@@ -56,15 +57,12 @@ func (Version) Current() error {
 
 // Files writes the current version to files that contain version info.
 func (Version) Files() error {
-	_, _, tag, err := git.Info()
+	mg.Deps(Version.getCurrent)
+	err := ioutil.WriteFile("pkg/version/ttn.go", []byte(fmt.Sprintf(goVersionFile, currentVersion)), 0644)
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile("pkg/version/ttn.go", []byte(fmt.Sprintf(goVersionFile, tag)), 0644)
-	if err != nil {
-		return err
-	}
-	version := strings.TrimPrefix(tag, "v")
+	version := strings.TrimPrefix(currentVersion, "v")
 	for _, packageJSONFile := range []string{"package.json", "sdk/js/package.json"} {
 		err = sh.Run(
 			nodeBin("json"),
@@ -87,6 +85,11 @@ func bumpVersion(bump string) error {
 	}
 	var newVersion semver.Version
 	switch bump {
+	case "release":
+		newVersion.Major = version.Major
+		newVersion.Minor = version.Minor
+		newVersion.Patch = version.Patch
+		newVersion.Pre = nil
 	case "major":
 		newVersion.Major = version.Major + 1
 	case "minor":
@@ -96,10 +99,29 @@ func bumpVersion(bump string) error {
 		newVersion.Major = version.Major
 		newVersion.Minor = version.Minor
 		newVersion.Patch = version.Patch + 1
+	case "rc":
+		newVersion.Major = version.Major
+		newVersion.Minor = version.Minor
+		newVersion.Patch = version.Patch
+		rc := 0
+		if len(version.Pre) > 0 {
+			rc, err = strconv.Atoi(strings.TrimPrefix(version.Pre[0].VersionStr, "rc"))
+			if err != nil {
+				return err
+			}
+		}
+		pre, err := semver.NewPRVersion(fmt.Sprintf("rc%d", rc+1))
+		if err != nil {
+			return err
+		}
+		newVersion.Pre = []semver.PRVersion{pre}
 	}
 	currentVersion = fmt.Sprintf("v%s", newVersion)
 	return nil
 }
+
+// BumpRelease bumps a pre-release to a release version.
+func (Version) BumpRelease() error { return bumpVersion("release") }
 
 // BumpMajor bumps a major version.
 func (Version) BumpMajor() error { return bumpVersion("major") }
@@ -109,3 +131,6 @@ func (Version) BumpMinor() error { return bumpVersion("minor") }
 
 // BumpPatch bumps a patch version.
 func (Version) BumpPatch() error { return bumpVersion("patch") }
+
+// BumpRC bumps a release candidate version.
+func (Version) BumpRC() error { return bumpVersion("rc") }

--- a/.mage/version.go
+++ b/.mage/version.go
@@ -138,3 +138,21 @@ func (Version) BumpPatch() error { return bumpVersion("patch") }
 
 // BumpRC bumps a release candidate version.
 func (Version) BumpRC() error { return bumpVersion("rc") }
+
+// Tag creates a git tag for the current version.
+func (Version) Tag() error {
+	version, err := semver.Parse(strings.TrimPrefix(currentVersion, "v"))
+	if err != nil {
+		return err
+	}
+	versionType := "Release version"
+	if len(version.Pre) > 0 {
+		pre := version.Pre[0].VersionStr
+		versionType = "Pre-release for version"
+		if strings.HasPrefix(pre, "rc") {
+			versionType = fmt.Sprintf("Release candidate %s for version", strings.TrimPrefix(pre, "rc"))
+		}
+		version.Pre = nil
+	}
+	return git.Tag(currentVersion, fmt.Sprintf("%s %s", versionType, version))
+}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/PuerkitoBio/purell v1.1.0
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/RangelReale/osin v1.0.1
-	github.com/TheThingsIndustries/magepkg v0.0.0-20190121105130-84da34311dab
+	github.com/TheThingsIndustries/magepkg v0.0.0-20190214092847-6c0299b7c3ed
 	github.com/TheThingsIndustries/mystique v0.0.0-20181023142449-f12a32cee6d6
 	github.com/TheThingsNetwork/go-cayenne-lib v1.0.0
 	github.com/alecthomas/gometalinter v3.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/RangelReale/osin v1.0.1 h1:JcqBe8ljQq9WQJPtioXGxBWyIcfuVMw0BX6yJ9E4HKw=
 github.com/RangelReale/osin v1.0.1/go.mod h1:k/PH1SjZDitJDtK3zHm/XZRi+bRz6i3rhx9qE9p54CY=
-github.com/TheThingsIndustries/magepkg v0.0.0-20190121105130-84da34311dab h1:TACV1bRELhjK8U5EhWLKlIjoHE/TfWQXJcNE0kbetOY=
-github.com/TheThingsIndustries/magepkg v0.0.0-20190121105130-84da34311dab/go.mod h1:InVSk9cxzZR1y4QaHF4CbDQ/uFeoTnbJfnwiKM04UNo=
+github.com/TheThingsIndustries/magepkg v0.0.0-20190214092847-6c0299b7c3ed h1:rsGbnyV9cP0ocol1W17uTbZ1iWcEeg+gp3ivzW6NQ6Q=
+github.com/TheThingsIndustries/magepkg v0.0.0-20190214092847-6c0299b7c3ed/go.mod h1:InVSk9cxzZR1y4QaHF4CbDQ/uFeoTnbJfnwiKM04UNo=
 github.com/TheThingsIndustries/mystique v0.0.0-20181023142449-f12a32cee6d6 h1:bU/mzNwvlF6Rn/5Qk9g8+/bSWmK2Iz+9XaemmJo4nBk=
 github.com/TheThingsIndustries/mystique v0.0.0-20181023142449-f12a32cee6d6/go.mod h1:l1YfNoSNxng8UF9XBfDixHAQjMEMAyoEQnbKSqX/qII=
 github.com/TheThingsNetwork/go-cayenne-lib v1.0.0 h1:be7h6E/69+qaYs1iwQ2xjGjSFPXzvU3q6AWBCWayG2Y=


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

This small PR adds the `version:bumpRelease` (which bumps a pre-release to a release), the `version:bumpRC` (which bumps a release candidate) and the `version:tag` (which creates a git tag) to Mage.
