### PR TITLE
Fix error equals/not-equals in CLI

### DIFF
--- a/cmd/ttn-lw-cli/commands/login.go
+++ b/cmd/ttn-lw-cli/commands/login.go
@@ -95,7 +95,7 @@ var (
 					}
 					code = strings.TrimSpace(code)
 					tokenType, _, _, err := auth.SplitToken(code)
-					if err == nil {
+					if err != nil {
 						logger.WithError(err).Warn("Could not parse authorization code")
 						continue
 					}


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes https://github.com/TheThingsNetwork/lorawan-stack/pull/128#issuecomment-464384292. No idea how that one slipped through...

