### PR TITLE
Improve formatting of byte arrays

### DIFF
--- a/pkg/webui/components/safe-inspector/index.js
+++ b/pkg/webui/components/safe-inspector/index.js
@@ -49,7 +49,7 @@ const m = defineMessages({
   copied: 'Copied to clipboard!',
   toggleVisibility: 'Toggle visibility',
   copyClipboard: 'Copy to clipboard',
-  cStyle: 'Toggle C-Style formatting',
+  arrayFormatting: 'Toggle array formatting',
   byteOrder: 'Switch byte order',
 })
 
@@ -148,7 +148,7 @@ export class SafeInspector extends Component {
       const chunks = chunkArray(data.toUpperCase().split(''), 2)
       if (!byteStyle) {
         const orderedChunks = msb ? chunks : chunks.reverse()
-        formattedData = display = `{ ${orderedChunks.map(chunk => ` 0x${chunk.join('')}`)} }`
+        formattedData = display = `${orderedChunks.map(chunk => ` 0x${chunk.join('')}`)}`
       } else {
         display = chunks.map((chunk, index) => (<span key={`${data}_chunk_${index}`}>{hidden ? '••' : chunk}</span>))
       }
@@ -184,7 +184,7 @@ export class SafeInspector extends Component {
           )}
           {!hidden && isBytes && (
             <button
-              title={m.cStyle}
+              title={m.arrayFormatting}
               className={style.buttonTransform}
               onClick={this.handleTransformToggle}
             >

--- a/pkg/webui/components/safe-inspector/index.js
+++ b/pkg/webui/components/safe-inspector/index.js
@@ -50,7 +50,7 @@ const m = defineMessages({
   toggleVisibility: 'Toggle visibility',
   copyClipboard: 'Copy to clipboard',
   cStyle: 'Toggle C-Style formatting',
-  byteSignificance: 'Swap byte significance',
+  byteOrder: 'Switch byte order',
 })
 
 @bind
@@ -174,7 +174,7 @@ export class SafeInspector extends Component {
             <React.Fragment>
               <span>{ msb ? 'msb' : 'lsb' }</span>
               <button
-                title={m.byteSignificance}
+                title={m.byteOrder}
                 className={style.buttonSwap}
                 onClick={this.handleSwapToggle}
               >

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -5,7 +5,7 @@
   "components.safe-inspector.index.toggleVisibility": "Toggle visibility",
   "components.safe-inspector.index.copyClipboard": "Copy to clipboard",
   "components.safe-inspector.index.cStyle": "Toggle C-Style formatting",
-  "components.safe-inspector.index.byteSignificance": "Swap byte significance",
+  "components.safe-inspector.index.byteOrder": "Switch byte order",
   "console.containers.api-keys-table.index.keyId": "Key ID",
   "console.containers.api-keys-table.index.grantedRights": "Granted Rights",
   "console.containers.api-keys-table.index.add": "Add Access Key",

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -4,7 +4,7 @@
   "components.safe-inspector.index.copied": "Copied to clipboard!",
   "components.safe-inspector.index.toggleVisibility": "Toggle visibility",
   "components.safe-inspector.index.copyClipboard": "Copy to clipboard",
-  "components.safe-inspector.index.cStyle": "Toggle C-Style formatting",
+  "components.safe-inspector.index.arrayFormatting": "Toggle array formatting",
   "components.safe-inspector.index.byteOrder": "Switch byte order",
   "console.containers.api-keys-table.index.keyId": "Key ID",
   "console.containers.api-keys-table.index.grantedRights": "Granted Rights",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -5,7 +5,7 @@
   "components.safe-inspector.index.toggleVisibility": "Xxxxxx xxxxxxxxxx",
   "components.safe-inspector.index.copyClipboard": "Xxxx xx xxxxxxxxx",
   "components.safe-inspector.index.cStyle": "Xxxxxx X-Xxxxx xxxxxxxxxx",
-  "components.safe-inspector.index.byteSignificance": "Xxxx xxxx xxxxxxxxxxxx",
+  "components.safe-inspector.index.byteOrder": "Xxxxxx xxxx xxxxx",
   "console.containers.api-keys-table.index.keyId": "Xxx XX",
   "console.containers.api-keys-table.index.grantedRights": "Xxxxxxx Xxxxxx",
   "console.containers.api-keys-table.index.add": "Xxx Xxxxxx Xxx",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -4,7 +4,7 @@
   "components.safe-inspector.index.copied": "Xxxxxx xx xxxxxxxxx!",
   "components.safe-inspector.index.toggleVisibility": "Xxxxxx xxxxxxxxxx",
   "components.safe-inspector.index.copyClipboard": "Xxxx xx xxxxxxxxx",
-  "components.safe-inspector.index.cStyle": "Xxxxxx X-Xxxxx xxxxxxxxxx",
+  "components.safe-inspector.index.arrayFormatting": "Xxxxxx xxxxx xxxxxxxxxx",
   "components.safe-inspector.index.byteOrder": "Xxxxxx xxxx xxxxx",
   "console.containers.api-keys-table.index.keyId": "Xxx XX",
   "console.containers.api-keys-table.index.grantedRights": "Xxxxxxx Xxxxxx",


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

This Pull Request makes some small improvements the bytes field (safe inspector).

Refs https://github.com/TheThingsNetwork/ttn/issues/749

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Remove the curly braces around the array formatting so that we don't need a separate format for languages that write arrays with `[]` instead of `{}`
- Rename "c-style" to "array" formatting
- Rename "byte significance" to "byte order"
