### PR TITLE
Fix javascript build

### DIFF
--- a/.mage/js.go
+++ b/.mage/js.go
@@ -46,7 +46,7 @@ func (Js) installYarn() error {
 	} else {
 		yarn = "yarn"
 	}
-	return sh.RunV("npm", "install", "--no-package-lock", "--no-save", yarn)
+	return sh.RunV("npm", "install", "--no-package-lock", "--no-save", "--production=false", yarn)
 }
 
 func (js Js) yarn() (func(args ...string) error, error) {
@@ -72,5 +72,5 @@ func (js Js) Deps() error {
 	if err != nil {
 		return err
 	}
-	return yarn("install", "--no-progress")
+	return yarn("install", "--no-progress", "--production=false")
 }

--- a/.make/js/build.make
+++ b/.make/js/build.make
@@ -55,9 +55,9 @@ js.build-watch: NODE_ENV = development
 js.build-watch: WEBPACK_FLAGS += -w
 js.build-watch: js.webpack-main
 
-js.build: sdk.js.build js.build-dll js.build-main
+js.build: js.build-dll js.build-main
 
-js.watch: sdk.js.build js.build-dll js.build-watch
+js.watch: js.build-dll js.build-watch
 
 js.serve: DEV_SERVER_BUILD = true
 js.serve: $(WEBPACK_CONFIG_BUILT) $(DEFAULT_LOCALE_FILE) $(BACKEND_LOCALES_DIR) $(DLL_OUTPUT)

--- a/.make/js/main.make
+++ b/.make/js/main.make
@@ -88,6 +88,8 @@ js.deps: $(YARN)
 js.init: $(MAGE)
 	@$(log) "Initializing js"
 	@make js.dev-deps
+	@make sdk.js.deps
+	@make sdk.js.build
 	@make js.deps
 
 INIT_RULES += js.init

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ messages:
 
 dev-deps: go.deps js.dev-deps
 
-deps: go.deps js.deps sdk.deps
+deps: go.deps sdk.deps sdk.js.build js.deps
 
 test: go.test js.test sdk.test
 


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/157
Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/150
This PR changes the order of javascript build targets, see https://github.com/TheThingsNetwork/lorawan-stack/issues/157#issuecomment-464900724

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Make sure that the javascript sdk is built before the console dependencies are fetched
- Fix javascript build in the production mode. By default both npm and yarn ignore dev dependencies when `NODE_ENV=production`. Force the development mode when installing dependencies.

With this PR the stack can be initialized with just `make init`.

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

Changes to the make files are needed only until we publish the js sdk to the registry.
