### PR TITLE
CLI command cancelation and rollback

### DIFF
--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"context"
 	stdio "io"
 	"os"
 	"strings"
@@ -364,7 +365,7 @@ var (
 			res, err := setEndDevice(&device, nil, nsPaths, asPaths, jsPaths, true)
 			if err != nil {
 				logger.WithError(err).Error("Could not create end device, rolling back...")
-				return deleteEndDevice(&device.EndDeviceIdentifiers)
+				return deleteEndDevice(context.Background(), &device.EndDeviceIdentifiers)
 			}
 
 			device.SetFields(res, append(append(nsPaths, asPaths...), jsPaths...)...)
@@ -591,7 +592,7 @@ var (
 
 			compareServerAddresses(existingDevice, config)
 
-			return deleteEndDevice(devID)
+			return deleteEndDevice(ctx, devID)
 		},
 	}
 )

--- a/cmd/ttn-lw-cli/commands/end_devices_split.go
+++ b/cmd/ttn-lw-cli/commands/end_devices_split.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"context"
 	"strings"
 
 	"github.com/gogo/protobuf/types"
@@ -501,10 +502,10 @@ func setEndDevice(device *ttnpb.EndDevice, isPaths, nsPaths, asPaths, jsPaths []
 		res.SetFields(asRes, asPaths...)
 	}
 
-	return &res, nil
+	return &res, ctx.Err()
 }
 
-func deleteEndDevice(devID *ttnpb.EndDeviceIdentifiers) error {
+func deleteEndDevice(ctx context.Context, devID *ttnpb.EndDeviceIdentifiers) error {
 	as, err := api.Dial(ctx, config.ApplicationServerAddress)
 	if err != nil {
 		return err

--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -41,7 +41,7 @@ var (
 	mgr          = conf.InitializeWithDefaults(name, "ttn_lw", DefaultConfig)
 	config       = &Config{}
 	oauth2Config *oauth2.Config
-	ctx          = context.Background()
+	ctx          = newContext(context.Background())
 	cache        util.Cache
 
 	inputDecoder io.Decoder
@@ -146,7 +146,7 @@ var (
 				logger.Warn("No access token present")
 			}
 
-			return nil
+			return ctx.Err()
 		},
 		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
 			// clean up the API
@@ -157,7 +157,7 @@ var (
 				return err
 			}
 
-			return nil
+			return ctx.Err()
 		},
 	}
 )

--- a/cmd/ttn-lw-cli/internal/api/grpc.go
+++ b/cmd/ttn-lw-cli/internal/api/grpc.go
@@ -71,6 +71,7 @@ func SetAuth(authType, authValue string) {
 
 // GetDialOptions gets the dial options for a gRPC connection.
 func GetDialOptions() (opts []grpc.DialOption) {
+	opts = append(opts, grpc.FailOnNonTempDialError(true), grpc.WithBlock())
 	if withInsecure {
 		opts = append(opts, grpc.WithInsecure())
 		if auth != nil {


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR closes #146 by making interrupts (ctrl-c) cancel the context (instead of immediately exiting) so that it can be caught as `context.Canceled` errors and we can roll back device creates.

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->
