### PR TITLE
all: Remove repository dirs from Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,9 @@ EXPOSE 1700/udp 1882 8882 1883 8883 1884 8884 1885 8885
 
 RUN mkdir /srv/ttn-lorawan/public/blob
 
-VOLUME ["/srv/ttn-lorawan/device-repository", "/srv/ttn-lorawan/public/blob", "/srv/ttn-lorawan/frequency-plans"]
+VOLUME ["/srv/ttn-lorawan/public/blob"]
 
-ENV TTN_LW_AS_DEVICE_REPOSITORY_DIRECTORY=/srv/ttn-lorawan/device-repository \
-    TTN_LW_BLOB_LOCAL_DIRECTORY=/srv/ttn-lorawan/public/blob \
-    TTN_LW_FREQUENCY_PLANS_DIRECTORY=/srv/ttn-lorawan/frequency-plans \
+ENV TTN_LW_BLOB_LOCAL_DIRECTORY=/srv/ttn-lorawan/public/blob \
     TTN_LW_IS_DATABASE_URI=postgres://root@cockroach:26257/ttn_lorawan?sslmode=disable \
     TTN_LW_REDIS_ADDRESS=redis:6379
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       - TTN_LW_COOKIE_BLOCKKEY
       - TTN_LW_CLUSTER_KEYS
       - TTN_LW_FREQUENCY_PLANS_URL
-      - TTN_LW_FREQUENCY_PLANS_DIRECTORY
       - TTN_LW_CONSOLE_OAUTH_CLIENT_SECRET
       - TTN_LW_IS_DATABASE_URI=postgres://root@cockroach:26257/${DEV_DATABASE_NAME:-ttn_lorawan}?sslmode=disable
       - TTN_LW_REDIS_ADDRESS=redis:6379


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR closes #149 by removing the frequency plans directory and device directory from the Docker image. The image should use the frequency plans and devices on Github by default, and not default to some volume that we don't even map in docker-compose.
