### PR TITLE
Component health checks support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.8
 
 RUN addgroup -g 886 thethings && adduser -u 886 -S -G thethings thethings
 
-RUN apk --update --no-cache add ca-certificates
+RUN apk --update --no-cache add ca-certificates curl
 
 COPY ttn-lw-stack /bin/ttn-lw-stack
 RUN ln -s /bin/ttn-lw-stack /bin/stack
@@ -22,6 +22,9 @@ VOLUME ["/srv/ttn-lorawan/public/blob"]
 
 ENV TTN_LW_BLOB_LOCAL_DIRECTORY=/srv/ttn-lorawan/public/blob \
     TTN_LW_IS_DATABASE_URI=postgres://root@cockroach:26257/ttn_lorawan?sslmode=disable \
-    TTN_LW_REDIS_ADDRESS=redis:6379
+    TTN_LW_REDIS_ADDRESS=redis:6379 \
+    TTN_LW_HEALTHCHECK_URL=http://localhost:1885/healthz/live
+
+HEALTHCHECK --interval=1m --timeout=5s CMD curl -f $TTN_LW_HEALTHCHECK_URL || exit 1
 
 USER thethings:thethings

--- a/cmd/internal/shared/config.go
+++ b/cmd/internal/shared/config.go
@@ -54,6 +54,9 @@ var DefaultHTTPConfig = config.HTTP{
 	Metrics: config.Metrics{
 		Enable: true,
 	},
+	Health: config.Health{
+		Enable: true,
+	},
 }
 
 // DefaultGRPCConfig is the default config for GRPC.

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway v1.7.0
+	github.com/heptiolabs/healthcheck v0.0.0-20180807145615-6ff867650f40
 	github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -178,6 +178,8 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92Bcuy
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/heptiolabs/healthcheck v0.0.0-20180807145615-6ff867650f40 h1:GT4RsKmHh1uZyhmTkWJTDALRjSHYQp6FRKrotf0zhAs=
+github.com/heptiolabs/healthcheck v0.0.0-20180807145615-6ff867650f40/go.mod h1:NtmN9h8vrTveVQRLHcX2HQ5wIPBDCsZ351TGbZWgg38=
 github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c h1:kQWxfPIHVLbgLzphqk3QUflDy9QdksZR4ygR807bpy0=
 github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -23,7 +23,8 @@ import (
 	"sort"
 	"syscall"
 
-	raven "github.com/getsentry/raven-go"
+	"github.com/getsentry/raven-go"
+	"github.com/heptiolabs/healthcheck"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/config"
@@ -62,6 +63,8 @@ type Component struct {
 
 	web           *web.Server
 	webSubsystems []web.Registerer
+
+	healthHandler healthcheck.Handler
 
 	loopback *grpc.ClientConn
 
@@ -113,6 +116,8 @@ func New(logger log.Stack, config *Config, opts ...Option) (*Component, error) {
 
 		config: config,
 		logger: logger,
+
+		healthHandler: healthcheck.NewHandler(),
 
 		tcpListeners: make(map[string]*listener),
 

--- a/pkg/component/web_test.go
+++ b/pkg/component/web_test.go
@@ -29,6 +29,7 @@ const (
 	httpAddress     = "0.0.0.0:8097"
 	metricsPassword = "secret-metrics-test-password"
 	pprofPassword   = "secret-pprof-test-password"
+	healthPassword  = "secret-health-test-password"
 )
 
 func TestPProf(t *testing.T) {
@@ -46,6 +47,10 @@ func TestPProf(t *testing.T) {
 					Enable:   true,
 					Password: pprofPassword,
 				},
+				Health: config.Health{
+					Enable:   true,
+					Password: healthPassword,
+				},
 			},
 		},
 	}
@@ -62,7 +67,7 @@ func TestPProf(t *testing.T) {
 		username, password string
 	}{
 		{
-			path:     "/debug/pprof",
+			path:     "debug/pprof",
 			username: pprofUsername,
 			password: pprofPassword,
 		},
@@ -70,6 +75,16 @@ func TestPProf(t *testing.T) {
 			path:     "metrics",
 			username: metricsUsername,
 			password: metricsPassword,
+		},
+		{
+			path:     "healthz/live",
+			username: healthUsername,
+			password: healthPassword,
+		},
+		{
+			path:     "healthz/ready",
+			username: healthUsername,
+			password: healthPassword,
 		},
 	} {
 		t.Run(fmt.Sprintf("%s endpoint", tc.path), func(t *testing.T) {

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -84,6 +84,11 @@ type Metrics struct {
 	Password string `name:"password" description:"Password to protect metrics endpoint (username is metrics)"`
 }
 
+type Health struct {
+	Enable   bool   `name:"enable" description:"Enable health check endpoint on HTTP server"`
+	Password string `name:"password" description:"Password to protect health endpoint (username is health)"`
+}
+
 // HTTPStaticConfig represents the HTTP static file server configuration.
 type HTTPStaticConfig struct {
 	Mount      string   `name:"mount" description:"Path on the server where static assets will be served"`
@@ -98,6 +103,7 @@ type HTTP struct {
 	Cookie    Cookie           `name:"cookie"`
 	PProf     PProf            `name:"pprof"`
 	Metrics   Metrics          `name:"metrics"`
+	Health    Health           `name:"health"`
 }
 
 // Redis represents Redis configuration.


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #165, #166. 

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

[heptiolabs/healtcheck](https://github.com/heptiolabs/healthcheck) has been used instead of [gocloud.dev/health](https://godoc.org/gocloud.dev/health) since it supports both readiness and liveness checks, instead of general health checks.

**Changes:**
<!-- What are the changes made in this pull request? -->

- Added the `/health/live` and `/health/ready` endpoints that execute the liveness, respectively the readiness checks of the running component
- Add readiness and liveness checks in the Identity Server
- Added `HEALTHCHECK` section to the `Dockerfile` using the `/health/live` endpoint

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

This PR introduces the groundwork for the liveness and readiness probes. After this is merged the other maintainers can add their own checks to the specific components (issues to be added after the merge).

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
What are the functional or behavioral changes? API Changes? New features?
Any changes in configuration? Added/changed/removed flags?
Are there any database migrations required?
-->

- The `/health/live` and `/health/ready` endpoints  have been aded. They execute the liveness, respectively the readiness checks of the running component
- Added `HEALTHCHECK` support to the docker image