### PR TITLE
Insert namespace for EUIs in Redis device registry

### DIFF
--- a/pkg/joinserver/redis/registry.go
+++ b/pkg/joinserver/redis/registry.go
@@ -28,6 +28,7 @@ import (
 )
 
 const (
+	euiKey         = "eui"
 	provisionerKey = "provisioner"
 )
 
@@ -71,7 +72,7 @@ func (r *DeviceRegistry) GetByEUI(ctx context.Context, joinEUI types.EUI64, devE
 	}
 
 	pb := &ttnpb.EndDevice{}
-	if err := ttnredis.GetProto(r.Redis, r.Redis.Key(joinEUI.String(), devEUI.String())).ScanProto(pb); err != nil {
+	if err := ttnredis.GetProto(r.Redis, r.Redis.Key(euiKey, joinEUI.String(), devEUI.String())).ScanProto(pb); err != nil {
 		return nil, err
 	}
 	return applyDeviceFieldMask(&ttnpb.EndDevice{}, pb, paths...)
@@ -83,7 +84,7 @@ func (r *DeviceRegistry) SetByEUI(ctx context.Context, joinEUI types.EUI64, devE
 		return nil, errInvalidIdentifiers
 	}
 
-	k := r.Redis.Key(joinEUI.String(), devEUI.String())
+	k := r.Redis.Key(euiKey, joinEUI.String(), devEUI.String())
 
 	var pb *ttnpb.EndDevice
 	err := r.Redis.Watch(func(tx *redis.Tx) error {


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #173 

Fixes discrepancy introduced in #123 

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Insert `eui` namespace for EUIs in JS device registry, like NS

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
What are the functional or behavioral changes? API Changes? New features?
Any changes in configuration? Added/changed/removed flags?
Are there any database migrations required?
-->

Breaking change in the device registry storage of the Join Server; devices in stored in the Join Server should be recreated.