### PR TITLE
doc: Generate MD and Man docs for ttn-lw-stack and ttn-lw-cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,15 @@ include .make/sdk/main.make
 messages:
 	@$(GO) run ./cmd/internal/generate_i18n.go
 
+docs:
+	@rm -f doc/ttn-lw-{stack,cli}/*.{md,1,yaml}
+	@$(GO) run ./cmd/ttn-lw-stack gen-man-pages --log.level=error -o doc/ttn-lw-stack
+	@$(GO) run ./cmd/ttn-lw-stack gen-md-doc --log.level=error -o doc/ttn-lw-stack
+	@$(GO) run ./cmd/ttn-lw-stack gen-yaml-doc --log.level=error -o doc/ttn-lw-stack
+	@$(GO) run ./cmd/ttn-lw-cli gen-man-pages --log.level=error -o doc/ttn-lw-cli
+	@$(GO) run ./cmd/ttn-lw-cli gen-md-doc --log.level=error -o doc/ttn-lw-cli
+	@$(GO) run ./cmd/ttn-lw-cli gen-yaml-doc --log.level=error -o doc/ttn-lw-cli
+
 dev-deps: go.deps js.dev-deps
 
 deps: go.deps sdk.deps sdk.js.build js.deps

--- a/cmd/internal/commands/doc.go
+++ b/cmd/internal/commands/doc.go
@@ -1,0 +1,99 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+)
+
+func disableAutoGenTag(cmd *cobra.Command) {
+	cmd.DisableAutoGenTag = true
+	for _, sub := range cmd.Commands() {
+		disableAutoGenTag(sub)
+	}
+}
+
+// GenManPages generates man pages for the given root command.
+func GenManPages(root *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "gen-man-pages",
+		Hidden: true,
+		Short:  fmt.Sprintf("Generate man pages for %s", root.Name()),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir, _ := cmd.Flags().GetString("out")
+			if _, err := os.Stat(dir); os.IsNotExist(err) {
+				if err := os.MkdirAll(dir, 0755); err != nil {
+					return err
+				}
+			}
+			disableAutoGenTag(root)
+			return doc.GenManTree(root, &doc.GenManHeader{
+				Title:   strings.ToUpper(root.Name()),
+				Section: "1",
+				Manual:  "The Things Network Stack for LoRaWAN",
+				Source:  "TTN",
+			}, dir)
+		},
+	}
+	cmd.Flags().StringP("out", "o", "doc", "output directory")
+	return cmd
+}
+
+// GenMDDoc generates markdown documentation for the given root command.
+func GenMDDoc(root *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "gen-md-doc",
+		Hidden: true,
+		Short:  fmt.Sprintf("Generate markdown documentation for %s", root.Name()),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir, _ := cmd.Flags().GetString("out")
+			if _, err := os.Stat(dir); os.IsNotExist(err) {
+				if err := os.MkdirAll(dir, 0755); err != nil {
+					return err
+				}
+			}
+			disableAutoGenTag(root)
+			return doc.GenMarkdownTree(root, dir)
+		},
+	}
+	cmd.Flags().StringP("out", "o", "doc", "output directory")
+	return cmd
+}
+
+// GenYAMLDoc generates yaml documentation for the given root command.
+func GenYAMLDoc(root *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "gen-yaml-doc",
+		Hidden: true,
+		Short:  fmt.Sprintf("Generate yaml documentation for %s", root.Name()),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir, _ := cmd.Flags().GetString("out")
+			if _, err := os.Stat(dir); os.IsNotExist(err) {
+				if err := os.MkdirAll(dir, 0755); err != nil {
+					return err
+				}
+			}
+			disableAutoGenTag(root)
+			return doc.GenYamlTree(root, dir)
+		},
+	}
+	cmd.Flags().StringP("out", "o", "doc", "output directory")
+	return cmd
+}

--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"go.thethings.network/lorawan-stack/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/cmd/internal/shared/version"
 	"go.thethings.network/lorawan-stack/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/cmd/ttn-lw-cli/internal/io"
@@ -192,11 +193,22 @@ func requireAuth() error {
 	return errUnauthenticated
 }
 
-var versionCommand = version.Print(name)
+var (
+	versionCommand     = version.Print(name)
+	genManPagesCommand = commands.GenManPages(Root)
+	genMDDocCommand    = commands.GenMDDoc(Root)
+	ganYAMLDocCommand  = commands.GenYAMLDoc(Root)
+)
 
 func init() {
 	Root.SetGlobalNormalizationFunc(util.NormalizeFlags)
 	Root.PersistentFlags().AddFlagSet(mgr.Flags())
 	versionCommand.PersistentPreRunE = preRun()
 	Root.AddCommand(versionCommand)
+	genManPagesCommand.PersistentPreRunE = preRun()
+	Root.AddCommand(genManPagesCommand)
+	genMDDocCommand.PersistentPreRunE = preRun()
+	Root.AddCommand(genMDDocCommand)
+	ganYAMLDocCommand.PersistentPreRunE = preRun()
+	Root.AddCommand(ganYAMLDocCommand)
 }

--- a/cmd/ttn-lw-stack/commands/root.go
+++ b/cmd/ttn-lw-stack/commands/root.go
@@ -19,6 +19,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"go.thethings.network/lorawan-stack/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/cmd/internal/shared"
 	"go.thethings.network/lorawan-stack/cmd/internal/shared/version"
 	conf "go.thethings.network/lorawan-stack/pkg/config"
@@ -71,4 +72,7 @@ var (
 func init() {
 	Root.PersistentFlags().AddFlagSet(mgr.Flags())
 	Root.AddCommand(version.Print(name))
+	Root.AddCommand(commands.GenManPages(Root))
+	Root.AddCommand(commands.GenMDDoc(Root))
+	Root.AddCommand(commands.GenYAMLDoc(Root))
 }

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,0 +1,3 @@
+/ttn-lw-*/ttn-lw-*.md
+/ttn-lw-*/ttn-lw-*.yaml
+/ttn-lw-*/ttn-lw-*.1

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/certifi/gocertifi v0.0.0-20190105021004-abcd57078448 // indirect
 	github.com/client9/misspell v0.3.4
+	github.com/cpuguy83/go-md2man v1.0.8 // indirect
 	github.com/denisenkom/go-mssqldb v0.0.0-20190204142019-df6d76eb9289 // indirect
 	github.com/disintegration/imaging v1.6.0
 	github.com/eclipse/paho.mqtt.golang v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8Nz
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cpuguy83/go-md2man v1.0.8 h1:DwoNytLphI8hzS2Af4D0dfaEaiSq2bN05mEm4R6vf8M=
+github.com/cpuguy83/go-md2man v1.0.8/go.mod h1:N6JayAiVKtlHSnuTCeuLSQVs75hb8q+dYQLjr7cDsKY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -319,6 +321,7 @@ github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a h1:9a8MnZMP0X2nL
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190209105433-f8d8b3f739bd h1:pi7bGw6n4tfgHQtWDxJBBLYVdFr1GlfQEsDOyCDDFMM=
 github.com/prometheus/procfs v0.0.0-20190209105433-f8d8b3f739bd/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR is a proposal for generating documentation for our binaries. Although the `--help` flag displays the exact same information, people do often prefer reading documentation in man pages, or online. This PR adds commands shared by `ttn-lw-stack` and `ttn-lw-cli` that can generate both man pages and markdown files.

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Add hidden `gen-man` and `gen-md` commands to both binaries that generate man/md docs.
- Generate docs into `docs/ttn-lw-*`.

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

I'm not quite sure if we should keep generated docs in the repository. Perhaps we should only keep the markdown files in the repository, so that they can be used for the documentation site. Then the release process would make sure that release packages contain the generated man pages. What do you think? @rvolosatovs @Sypheos?

Tip: use the "file filter" in the review to filter by extension