### PR TITLE
Improve error handling

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -4634,6 +4634,15 @@
       "file": "lorawan.go"
     }
   },
+  "error:pkg/web/middleware:http_recovered": {
+    "translations": {
+      "en": "Internal Server Error"
+    },
+    "description": {
+      "package": "pkg/web/middleware",
+      "file": "recover.go"
+    }
+  },
   "event:application.api-key.create": {
     "translations": {
       "en": "Create application API key"

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -34,6 +34,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/log/middleware/sentry"
 	"go.thethings.network/lorawan-stack/pkg/rpcserver"
+	"go.thethings.network/lorawan-stack/pkg/version"
 	"go.thethings.network/lorawan-stack/pkg/web"
 	"google.golang.org/grpc"
 )
@@ -128,6 +129,7 @@ func New(logger log.Stack, config *Config, opts ...Option) (*Component, error) {
 	if config.Sentry.DSN != "" {
 		c.sentry, _ = raven.New(config.Sentry.DSN)
 		c.sentry.SetIncludePaths([]string{"go.thethings.network/lorawan-stack"})
+		c.sentry.SetRelease(version.String())
 		c.logger.Use(sentry.New(c.sentry))
 	}
 

--- a/pkg/rpcclient/rpcclient.go
+++ b/pkg/rpcclient/rpcclient.go
@@ -23,7 +23,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware"
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	"go.opencensus.io/plugin/ocgrpc"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/metrics"
@@ -50,18 +50,13 @@ func DefaultDialOptions(ctx context.Context) []grpc.DialOption {
 		warning.UnaryClientInterceptor,
 	}
 
-	ttnVersion := strings.TrimPrefix(version.TTN, "v")
-	if version.GitCommit != "" && version.BuildDate != "" {
-		ttnVersion += fmt.Sprintf("(%s, %s)", version.GitCommit, version.BuildDate)
-	}
-
 	return []grpc.DialOption{
 		grpc.WithStatsHandler(rpcmiddleware.StatsHandlers{new(ocgrpc.ClientHandler), metrics.StatsHandler}),
 		grpc.WithUserAgent(fmt.Sprintf(
 			"%s go/%s ttn/%s",
 			filepath.Base(os.Args[0]),
 			strings.TrimPrefix(runtime.Version(), "go"),
-			ttnVersion,
+			version.String(),
 		)),
 		grpc.WithStreamInterceptor(grpc_middleware.ChainStreamClient(streamInterceptors...)),
 		grpc.WithUnaryInterceptor(grpc_middleware.ChainUnaryClient(unaryInterceptors...)),

--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -17,8 +17,11 @@ package rpcserver
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"net/http"
+	"os"
+	"runtime/debug"
 	"strconv"
 	"time"
 
@@ -123,6 +126,8 @@ func New(ctx context.Context, opts ...Option) *Server {
 	}
 	recoveryOpts := []grpc_recovery.Option{
 		grpc_recovery.WithRecoveryHandler(func(p interface{}) (err error) {
+			fmt.Fprintln(os.Stderr, p)
+			os.Stderr.Write(debug.Stack())
 			return ErrRPCRecovered.WithAttributes("panic", p)
 		}),
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,3 +14,17 @@
 
 // Package version contains version and build variables set by the CI process.
 package version
+
+import (
+	"fmt"
+	"strings"
+)
+
+// String returns the version string.
+func String() string {
+	version := strings.TrimPrefix(TTN, "v")
+	if GitCommit != "" && BuildDate != "" {
+		version += fmt.Sprintf(" (%s, %s)", GitCommit, BuildDate)
+	}
+	return version
+}

--- a/pkg/web/middleware/recover.go
+++ b/pkg/web/middleware/recover.go
@@ -1,0 +1,43 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"fmt"
+	"os"
+	"runtime/debug"
+
+	"github.com/labstack/echo"
+	"go.thethings.network/lorawan-stack/pkg/errors"
+)
+
+// ErrHTTPRecovered is returned when a panic is caught from an HTTP handler.
+var ErrHTTPRecovered = errors.DefineInternal("http_recovered", "Internal Server Error")
+
+// Recover returns Echo middleware that recovers from panics.
+func Recover() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) (err error) {
+			defer func() {
+				if p := recover(); p != nil {
+					fmt.Fprintln(os.Stderr, p)
+					os.Stderr.Write(debug.Stack())
+					err = ErrHTTPRecovered.WithAttributes("panic", p)
+				}
+			}()
+			return next(c)
+		}
+	}
+}

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -80,7 +80,7 @@ func New(ctx context.Context, config config.HTTP) (*Server, error) {
 		middleware.ID(""),
 		echomiddleware.BodyLimit("16M"),
 		echomiddleware.Secure(),
-		echomiddleware.Recover(),
+		middleware.Recover(),
 		cookie.Cookies(blockKey, hashKey),
 	)
 


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR, related to #169 improves error handling even more by including the release version in Sentry reports, and by changing panic recovery middleware to print call stacks to Stderr.

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Add release version string to Sentry reports
- Write panics and call stacks to Stderr
