### PR TITLE
CLI API-Key and collaborator deletion

### DIFF
--- a/cmd/ttn-lw-cli/commands/applications.go
+++ b/cmd/ttn-lw-cli/commands/applications.go
@@ -38,10 +38,7 @@ func applicationIDFlags() *pflag.FlagSet {
 	return flagSet
 }
 
-var (
-	errNoApplicationID = errors.DefineInvalidArgument("no_application_id", "no application ID set")
-	errNoAPIKeyRights  = errors.DefineInvalidArgument("no_api_key_rights", "no API key rights set")
-)
+var errNoApplicationID = errors.DefineInvalidArgument("no_application_id", "no application ID set")
 
 func getApplicationID(flagSet *pflag.FlagSet, args []string) *ttnpb.ApplicationIdentifiers {
 	var applicationID string

--- a/cmd/ttn-lw-cli/commands/applications.go
+++ b/cmd/ttn-lw-cli/commands/applications.go
@@ -38,7 +38,10 @@ func applicationIDFlags() *pflag.FlagSet {
 	return flagSet
 }
 
-var errNoApplicationID = errors.DefineInvalidArgument("no_application_id", "no application ID set")
+var (
+	errNoApplicationID = errors.DefineInvalidArgument("no_application_id", "no application ID set")
+	errNoAPIKeyRights  = errors.DefineInvalidArgument("no_api_key_rights", "no API key rights set")
+)
 
 func getApplicationID(flagSet *pflag.FlagSet, args []string) *ttnpb.ApplicationIdentifiers {
 	var applicationID string

--- a/cmd/ttn-lw-cli/commands/applications_access.go
+++ b/cmd/ttn-lw-cli/commands/applications_access.go
@@ -180,8 +180,7 @@ var (
 
 			rights := getRights(cmd.Flags())
 			if len(rights) == 0 {
-				logger.Info("No rights selected, won't create API key")
-				return nil
+				return errNoAPIKeyRights
 			}
 
 			is, err := api.Dial(ctx, config.IdentityServerAddress)

--- a/cmd/ttn-lw-cli/commands/applications_access.go
+++ b/cmd/ttn-lw-cli/commands/applications_access.go
@@ -190,7 +190,7 @@ var (
 
 			rights := getRights(cmd.Flags())
 			if len(rights) == 0 {
-				logger.Info("No rights selected, will remove API key")
+				return errNoAPIKeyRights
 			}
 
 			is, err := api.Dial(ctx, config.IdentityServerAddress)
@@ -203,6 +203,38 @@ var (
 					ID:     id,
 					Name:   name,
 					Rights: rights,
+				},
+			})
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+	applicationAPIKeysDelete = &cobra.Command{
+		Use:     "delete",
+		Aliases: []string{"remove"},
+		Short:   "Delete an application API key",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := getAPIKeyID(cmd.Flags(), args)
+			if id == "" {
+				return errNoAPIKeyID
+			}
+			appID := getApplicationID(cmd.Flags(), nil)
+			if appID == nil {
+				return errNoApplicationID
+			}
+
+			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			if err != nil {
+				return err
+			}
+			_, err = ttnpb.NewApplicationAccessClient(is).UpdateAPIKey(ctx, &ttnpb.UpdateApplicationAPIKeyRequest{
+				ApplicationIdentifiers: *appID,
+				APIKey: ttnpb.APIKey{
+					ID:     id,
+					Rights: nil,
 				},
 			})
 			if err != nil {
@@ -237,6 +269,8 @@ func init() {
 	applicationAPIKeysUpdate.Flags().String("name", "", "")
 	applicationAPIKeysUpdate.Flags().AddFlagSet(applicationRightsFlags)
 	applicationAPIKeys.AddCommand(applicationAPIKeysUpdate)
+	applicationAPIKeysDelete.Flags().String("api-key-id", "", "")
+	applicationAPIKeys.AddCommand(applicationAPIKeysDelete)
 	applicationAPIKeys.PersistentFlags().AddFlagSet(applicationIDFlags())
 	applicationsCommand.AddCommand(applicationAPIKeys)
 }

--- a/cmd/ttn-lw-cli/commands/flags.go
+++ b/cmd/ttn-lw-cli/commands/flags.go
@@ -32,7 +32,10 @@ func collaboratorFlags() *pflag.FlagSet {
 	return flagSet
 }
 
-var errNoCollaborator = errors.DefineInvalidArgument("no_collaborator", "no collaborator set")
+var (
+	errNoCollaborator       = errors.DefineInvalidArgument("no_collaborator", "no collaborator set")
+	errNoCollaboratorRights = errors.DefineInvalidArgument("no_collaborator_rights", "no collaborator rights set")
+)
 
 func getCollaborator(flagSet *pflag.FlagSet) *ttnpb.OrganizationOrUserIdentifiers {
 	organizationID, _ := flagSet.GetString("organization-id")
@@ -93,7 +96,10 @@ func getRights(flagSet *pflag.FlagSet) (rights []ttnpb.Right) {
 	return
 }
 
-var errNoAPIKeyID = errors.DefineInvalidArgument("no_api_key_id", "no API key ID set")
+var (
+	errNoAPIKeyID     = errors.DefineInvalidArgument("no_api_key_id", "no API key ID set")
+	errNoAPIKeyRights = errors.DefineInvalidArgument("no_api_key_rights", "no API key rights set")
+)
 
 func getAPIKeyID(flagSet *pflag.FlagSet, args []string) string {
 	var apiKeyID string

--- a/cmd/ttn-lw-cli/commands/gateways_access.go
+++ b/cmd/ttn-lw-cli/commands/gateways_access.go
@@ -180,8 +180,7 @@ var (
 
 			rights := getRights(cmd.Flags())
 			if len(rights) == 0 {
-				logger.Info("No rights selected, won't create API key")
-				return nil
+				return errNoAPIKeyRights
 			}
 
 			is, err := api.Dial(ctx, config.IdentityServerAddress)

--- a/cmd/ttn-lw-cli/commands/organizations_access.go
+++ b/cmd/ttn-lw-cli/commands/organizations_access.go
@@ -180,8 +180,7 @@ var (
 
 			rights := getRights(cmd.Flags())
 			if len(rights) == 0 {
-				logger.Info("No rights selected, won't create API key")
-				return nil
+				return errNoAPIKeyRights
 			}
 
 			is, err := api.Dial(ctx, config.IdentityServerAddress)

--- a/cmd/ttn-lw-cli/commands/users_access.go
+++ b/cmd/ttn-lw-cli/commands/users_access.go
@@ -86,8 +86,7 @@ var (
 
 			rights := getRights(cmd.Flags())
 			if len(rights) == 0 {
-				logger.Info("No rights selected, won't create API key")
-				return nil
+				return errNoAPIKeyRights
 			}
 
 			is, err := api.Dial(ctx, config.IdentityServerAddress)

--- a/cmd/ttn-lw-cli/commands/users_access.go
+++ b/cmd/ttn-lw-cli/commands/users_access.go
@@ -128,7 +128,7 @@ var (
 
 			rights := getRights(cmd.Flags())
 			if len(rights) == 0 {
-				logger.Info("No rights selected, will remove API key")
+				return errNoAPIKeyRights
 			}
 
 			is, err := api.Dial(ctx, config.IdentityServerAddress)
@@ -141,6 +141,38 @@ var (
 					ID:     id,
 					Name:   name,
 					Rights: rights,
+				},
+			})
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+	userAPIKeysDelete = &cobra.Command{
+		Use:     "delete",
+		Aliases: []string{"remove"},
+		Short:   "Delete a user API key",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := getAPIKeyID(cmd.Flags(), args)
+			if id == "" {
+				return errNoAPIKeyID
+			}
+			usrID := getUserID(cmd.Flags(), nil)
+			if usrID == nil {
+				return errNoUserID
+			}
+
+			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			if err != nil {
+				return err
+			}
+			_, err = ttnpb.NewUserAccessClient(is).UpdateAPIKey(ctx, &ttnpb.UpdateUserAPIKeyRequest{
+				UserIdentifiers: *usrID,
+				APIKey: ttnpb.APIKey{
+					ID:     id,
+					Rights: nil,
 				},
 			})
 			if err != nil {
@@ -168,6 +200,8 @@ func init() {
 	userAPIKeysUpdate.Flags().String("name", "", "")
 	userAPIKeysUpdate.Flags().AddFlagSet(userRightsFlags)
 	userAPIKeys.AddCommand(userAPIKeysUpdate)
+	userAPIKeysDelete.Flags().String("api-key-id", "", "")
+	userAPIKeys.AddCommand(userAPIKeysDelete)
 	userAPIKeys.PersistentFlags().AddFlagSet(userIDFlags())
 	usersCommand.AddCommand(userAPIKeys)
 }

--- a/config/messages.json
+++ b/config/messages.json
@@ -1187,6 +1187,15 @@
       "file": "flags.go"
     }
   },
+  "error:cmd/ttn-lw-cli/commands:no_api_key_rights": {
+    "translations": {
+      "en": "no API key rights set"
+    },
+    "description": {
+      "package": "cmd/ttn-lw-cli/commands",
+      "file": "flags.go"
+    }
+  },
   "error:cmd/ttn-lw-cli/commands:no_application_id": {
     "translations": {
       "en": "no application ID set"
@@ -1217,6 +1226,15 @@
   "error:cmd/ttn-lw-cli/commands:no_collaborator": {
     "translations": {
       "en": "no collaborator set"
+    },
+    "description": {
+      "package": "cmd/ttn-lw-cli/commands",
+      "file": "flags.go"
+    }
+  },
+  "error:cmd/ttn-lw-cli/commands:no_collaborator_rights": {
+    "translations": {
+      "en": "no collaborator rights set"
     },
     "description": {
       "package": "cmd/ttn-lw-cli/commands",


### PR DESCRIPTION
**Summary:**
Closes #172

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Added the `delete` command for `api-keys`
- Added the `delete` command for `collaborators`
- The set command for both API-keys and the collaborators no longer deletes the entity if no rights are set

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

As discussed, set no longer deletes the entity since it would be counter-intuitive, given that the delete command exists separately.