### PR TITLE
Fix make INIT_RULES add order

### DIFF
--- a/.make/general.make
+++ b/.make/general.make
@@ -27,9 +27,6 @@ count = wc -w
 GENERAL_FILE = $(shell echo $(MAKEFILE_LIST) | xargs -n 1 echo | grep 'general\.make')
 MAKE_DIR = $(shell dirname $(GENERAL_FILE))
 
-# init rules are the rules to invoke to initialize the repo
-INIT_RULES ?= git.hooks
-
 .PHONY: .FORCE
 .FORCE:
 

--- a/.make/git.make
+++ b/.make/git.make
@@ -23,6 +23,8 @@
 
 .PHONY: git.hooks
 
+INIT_RULES += git.hooks
+
 GIT_TAG ?= `git describe --abbrev=0 --tags 2>/dev/null`
 
 GIT_RELATIVE_DIR=git rev-parse --show-prefix


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #198 

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

Fix adding `INIT_RULES` order.