### PR TITLE
ID uniqueness, harmonization and namespacing in Redis registries

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -1394,6 +1394,15 @@
       "file": "mqtt.go"
     }
   },
+  "error:pkg/applicationserver/io/web/redis:invalid_identifiers": {
+    "translations": {
+      "en": "invalid identifiers"
+    },
+    "description": {
+      "package": "pkg/applicationserver/io/web/redis",
+      "file": "registry.go"
+    }
+  },
   "error:pkg/applicationserver/io/web:format_not_found": {
     "translations": {
       "en": "format `{format}` not found"
@@ -1451,6 +1460,24 @@
   "error:pkg/applicationserver/redis:application_uid": {
     "translations": {
       "en": "invalid application UID `{application_uid}`"
+    },
+    "description": {
+      "package": "pkg/applicationserver/redis",
+      "file": "registry.go"
+    }
+  },
+  "error:pkg/applicationserver/redis:duplicate_identifiers": {
+    "translations": {
+      "en": "duplicate identifiers"
+    },
+    "description": {
+      "package": "pkg/applicationserver/redis",
+      "file": "registry.go"
+    }
+  },
+  "error:pkg/applicationserver/redis:invalid_identifiers": {
+    "translations": {
+      "en": "invalid identifiers"
     },
     "description": {
       "package": "pkg/applicationserver/redis",
@@ -3206,6 +3233,15 @@
   "error:pkg/joinserver/redis:already_provisioned": {
     "translations": {
       "en": "device already provisioned"
+    },
+    "description": {
+      "package": "pkg/joinserver/redis",
+      "file": "registry.go"
+    }
+  },
+  "error:pkg/joinserver/redis:duplicate_identifiers": {
+    "translations": {
+      "en": "duplicate identifiers"
     },
     "description": {
       "package": "pkg/joinserver/redis",

--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -100,7 +100,7 @@ func TestApplicationServer(t *testing.T) {
 	defer linksFlush()
 	defer linksRedisClient.Close()
 	linkRegistry := &redis.LinkRegistry{Redis: linksRedisClient}
-	linkRegistry.Set(ctx, registeredApplicationID, nil, func(_ *ttnpb.ApplicationLink) (*ttnpb.ApplicationLink, []string, error) {
+	_, err := linkRegistry.Set(ctx, registeredApplicationID, nil, func(_ *ttnpb.ApplicationLink) (*ttnpb.ApplicationLink, []string, error) {
 		return &ttnpb.ApplicationLink{
 			APIKey: registeredApplicationKey,
 			DefaultFormatters: &ttnpb.MessagePayloadFormatters{
@@ -109,6 +109,9 @@ func TestApplicationServer(t *testing.T) {
 			},
 		}, []string{"api_key", "default_formatters"}, nil
 	})
+	if err != nil {
+		t.Fatalf("Failed to set link in registry: %s", err)
+	}
 
 	webhooksRedisClient, webhooksFlush := test.NewRedis(t, "applicationserver_test", "webhooks")
 	defer webhooksFlush()

--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -1329,30 +1329,31 @@ func TestApplicationServer(t *testing.T) {
 						}
 					}
 					res, err := as.DownlinkQueueList(ctx, registeredDevice.EndDeviceIdentifiers)
-					a.So(err, should.BeNil)
-					a.So(res, should.Resemble, []*ttnpb.ApplicationDownlink{
-						{
-							SessionKeyID:   []byte{0x11},
-							FPort:          11,
-							FCnt:           1,
-							FRMPayload:     []byte{0x1, 0x1, 0x1},
-							CorrelationIDs: res[0].CorrelationIDs,
-						},
-						{
-							SessionKeyID:   []byte{0x11},
-							FPort:          22,
-							FCnt:           2,
-							FRMPayload:     []byte{0x2, 0x2, 0x2},
-							CorrelationIDs: res[1].CorrelationIDs,
-						},
-						{
-							SessionKeyID:   []byte{0x11},
-							FPort:          33,
-							FCnt:           3,
-							FRMPayload:     []byte{0x1, 0x1, 0x1, 0x1, 0x1, 0x1},
-							CorrelationIDs: res[2].CorrelationIDs,
-						},
-					})
+					if a.So(err, should.BeNil) && a.So(res, should.HaveLength, 3) {
+						a.So(res, should.Resemble, []*ttnpb.ApplicationDownlink{
+							{
+								SessionKeyID:   []byte{0x11},
+								FPort:          11,
+								FCnt:           1,
+								FRMPayload:     []byte{0x1, 0x1, 0x1},
+								CorrelationIDs: res[0].CorrelationIDs,
+							},
+							{
+								SessionKeyID:   []byte{0x11},
+								FPort:          22,
+								FCnt:           2,
+								FRMPayload:     []byte{0x2, 0x2, 0x2},
+								CorrelationIDs: res[1].CorrelationIDs,
+							},
+							{
+								SessionKeyID:   []byte{0x11},
+								FPort:          33,
+								FCnt:           3,
+								FRMPayload:     []byte{0x1, 0x1, 0x1, 0x1, 0x1, 0x1},
+								CorrelationIDs: res[2].CorrelationIDs,
+							},
+						})
+					}
 				})
 				t.Run("RegisteredDevice/Replace", func(t *testing.T) {
 					a := assertions.New(t)
@@ -1378,23 +1379,24 @@ func TestApplicationServer(t *testing.T) {
 						t.Fatal("Expected downlink error timeout")
 					}
 					res, err := as.DownlinkQueueList(ctx, registeredDevice.EndDeviceIdentifiers)
-					a.So(err, should.BeNil)
-					a.So(res, should.Resemble, []*ttnpb.ApplicationDownlink{
-						{
-							SessionKeyID:   []byte{0x11},
-							FPort:          11,
-							FCnt:           4,
-							FRMPayload:     []byte{0x1, 0x1, 0x1},
-							CorrelationIDs: res[0].CorrelationIDs,
-						},
-						{
-							SessionKeyID:   []byte{0x11},
-							FPort:          22,
-							FCnt:           5,
-							FRMPayload:     []byte{0x2, 0x2, 0x2},
-							CorrelationIDs: res[1].CorrelationIDs,
-						},
-					})
+					if a.So(err, should.BeNil) && a.So(res, should.HaveLength, 2) {
+						a.So(res, should.Resemble, []*ttnpb.ApplicationDownlink{
+							{
+								SessionKeyID:   []byte{0x11},
+								FPort:          11,
+								FCnt:           4,
+								FRMPayload:     []byte{0x1, 0x1, 0x1},
+								CorrelationIDs: res[0].CorrelationIDs,
+							},
+							{
+								SessionKeyID:   []byte{0x11},
+								FPort:          22,
+								FCnt:           5,
+								FRMPayload:     []byte{0x2, 0x2, 0x2},
+								CorrelationIDs: res[1].CorrelationIDs,
+							},
+						})
+					}
 				})
 			})
 

--- a/pkg/applicationserver/grpc_deviceregistry_test.go
+++ b/pkg/applicationserver/grpc_deviceregistry_test.go
@@ -150,17 +150,23 @@ func TestDeviceRegistry(t *testing.T) {
 				Paths: []string{"ids", "version_ids", "formatters"},
 			},
 		}, creds)
-		a.So(err, should.BeNil)
+		if !a.So(err, should.BeNil) {
+			t.FailNow()
+		}
 		dev, err := client.Get(ctx, &ttnpb.GetEndDeviceRequest{
 			EndDeviceIdentifiers: registeredDevice.EndDeviceIdentifiers,
 			FieldMask: pbtypes.FieldMask{
 				Paths: []string{"ids", "version_ids", "formatters"},
 			},
 		}, creds)
-		a.So(err, should.BeNil)
+		if !a.So(err, should.BeNil) {
+			t.FailNow()
+		}
 		registeredDevice.CreatedAt = dev.CreatedAt
 		registeredDevice.UpdatedAt = dev.UpdatedAt
-		a.So(dev, should.HaveEmptyDiff, registeredDevice)
+		if !a.So(dev, should.HaveEmptyDiff, registeredDevice) {
+			t.FailNow()
+		}
 
 		// Update and assert new value.
 		registeredDevice.Formatters.UpFormatter = ttnpb.PayloadFormatter_FORMATTER_NONE
@@ -170,21 +176,29 @@ func TestDeviceRegistry(t *testing.T) {
 				Paths: []string{"formatters"},
 			},
 		}, creds)
-		a.So(err, should.BeNil)
+		if !a.So(err, should.BeNil) {
+			t.FailNow()
+		}
 		dev, err = client.Get(ctx, &ttnpb.GetEndDeviceRequest{
 			EndDeviceIdentifiers: registeredDevice.EndDeviceIdentifiers,
 			FieldMask: pbtypes.FieldMask{
 				Paths: []string{"ids", "version_ids", "formatters"},
 			},
 		}, creds)
-		a.So(err, should.BeNil)
+		if !a.So(err, should.BeNil) {
+			t.FailNow()
+		}
 		registeredDevice.CreatedAt = dev.CreatedAt
 		registeredDevice.UpdatedAt = dev.UpdatedAt
-		a.So(dev, should.HaveEmptyDiff, registeredDevice)
+		if !a.So(dev, should.HaveEmptyDiff, registeredDevice) {
+			t.FailNow()
+		}
 
 		// Delete and assert it's gone.
 		_, err = client.Delete(ctx, &registeredDevice.EndDeviceIdentifiers, creds)
-		a.So(err, should.BeNil)
+		if !a.So(err, should.BeNil) {
+			t.FailNow()
+		}
 		_, err = client.Get(ctx, &ttnpb.GetEndDeviceRequest{
 			EndDeviceIdentifiers: registeredDevice.EndDeviceIdentifiers,
 			FieldMask: pbtypes.FieldMask{

--- a/pkg/applicationserver/io/web/redis/registry.go
+++ b/pkg/applicationserver/io/web/redis/registry.go
@@ -28,6 +28,10 @@ import (
 
 const webhookKey = "webhook"
 
+var (
+	errInvalidIdentifiers = errors.DefineInvalidArgument("invalid_identifiers", "invalid identifiers")
+)
+
 func applyWebhookFieldMask(dst, src *ttnpb.ApplicationWebhook, paths ...string) (*ttnpb.ApplicationWebhook, error) {
 	if dst == nil {
 		dst = &ttnpb.ApplicationWebhook{}
@@ -42,9 +46,8 @@ type WebhookRegistry struct {
 
 // Get implements WebhookRegistry.
 func (r WebhookRegistry) Get(ctx context.Context, ids ttnpb.ApplicationWebhookIdentifiers, paths []string) (*ttnpb.ApplicationWebhook, error) {
-	k := r.Redis.Key(webhookKey, unique.ID(ctx, ids.ApplicationIdentifiers), ids.WebhookID)
 	pb := &ttnpb.ApplicationWebhook{}
-	if err := ttnredis.GetProto(r.Redis, k).ScanProto(pb); err != nil {
+	if err := ttnredis.GetProto(r.Redis, r.Redis.Key(webhookKey, unique.ID(ctx, ids.ApplicationIdentifiers), ids.WebhookID)).ScanProto(pb); err != nil {
 		return nil, err
 	}
 	return applyWebhookFieldMask(nil, pb, paths...)
@@ -53,11 +56,8 @@ func (r WebhookRegistry) Get(ctx context.Context, ids ttnpb.ApplicationWebhookId
 // List implements WebhookRegistry.
 func (r WebhookRegistry) List(ctx context.Context, ids ttnpb.ApplicationIdentifiers, paths []string) ([]*ttnpb.ApplicationWebhook, error) {
 	var pbs []*ttnpb.ApplicationWebhook
-	k := r.Redis.Key(webhookKey, unique.ID(ctx, ids))
-	keyCmd := func(ks ...string) string {
-		return r.Redis.Key(append([]string{webhookKey, unique.ID(ctx, ids)}, ks...)...)
-	}
-	err := ttnredis.FindProtos(r.Redis, k, keyCmd).Range(func() (proto.Message, func() (bool, error)) {
+	appUID := unique.ID(ctx, ids)
+	err := ttnredis.FindProtos(r.Redis, r.Redis.Key(webhookKey, appUID), func(id string) string { return r.Redis.Key(webhookKey, appUID, id) }).Range(func() (proto.Message, func() (bool, error)) {
 		pb := &ttnpb.ApplicationWebhook{}
 		return pb, func() (bool, error) {
 			pb, err := applyWebhookFieldMask(nil, pb, paths...)
@@ -76,14 +76,13 @@ func (r WebhookRegistry) List(ctx context.Context, ids ttnpb.ApplicationIdentifi
 
 // Set implements WebhookRegistry.
 func (r WebhookRegistry) Set(ctx context.Context, ids ttnpb.ApplicationWebhookIdentifiers, gets []string, f func(*ttnpb.ApplicationWebhook) (*ttnpb.ApplicationWebhook, []string, error)) (*ttnpb.ApplicationWebhook, error) {
-	k := r.Redis.Key(webhookKey, unique.ID(ctx, ids.ApplicationIdentifiers), ids.WebhookID)
+	appUID := unique.ID(ctx, ids.ApplicationIdentifiers)
+	uk := r.Redis.Key(webhookKey, appUID, ids.WebhookID)
 	var pb *ttnpb.ApplicationWebhook
 	err := r.Redis.Watch(func(tx *redis.Tx) error {
-		var create bool
-		cmd := ttnredis.GetProto(tx, k)
+		cmd := ttnredis.GetProto(tx, uk)
 		stored := &ttnpb.ApplicationWebhook{}
 		if err := cmd.ScanProto(stored); errors.IsNotFound(err) {
-			create = true
 			stored = nil
 		} else if err != nil {
 			return err
@@ -91,7 +90,11 @@ func (r WebhookRegistry) Set(ctx context.Context, ids ttnpb.ApplicationWebhookId
 
 		var err error
 		if stored != nil {
-			pb, err = applyWebhookFieldMask(nil, stored, gets...)
+			pb = &ttnpb.ApplicationWebhook{}
+			if err := cmd.ScanProto(pb); err != nil {
+				return err
+			}
+			pb, err = applyWebhookFieldMask(nil, pb, gets...)
 			if err != nil {
 				return err
 			}
@@ -109,42 +112,58 @@ func (r WebhookRegistry) Set(ctx context.Context, ids ttnpb.ApplicationWebhookId
 		var f func(redis.Pipeliner) error
 		if pb == nil {
 			f = func(p redis.Pipeliner) error {
-				p.Del(k)
-				p.SRem(r.Redis.Key(webhookKey, unique.ID(ctx, ids.ApplicationIdentifiers)), ids.WebhookID)
+				p.Del(uk)
+				p.SRem(r.Redis.Key(webhookKey, appUID), stored.WebhookID)
 				return nil
 			}
 		} else {
-			pb.ApplicationWebhookIdentifiers = ids
+			if pb.ApplicationWebhookIdentifiers != ids {
+				return errInvalidIdentifiers
+			}
+
 			pb.UpdatedAt = time.Now().UTC()
 			sets = append(sets, "updated_at")
-			if create {
+
+			updated := &ttnpb.ApplicationWebhook{}
+			if stored == nil {
 				pb.CreatedAt = pb.UpdatedAt
 				sets = append(sets, "created_at")
-			}
-			stored = &ttnpb.ApplicationWebhook{}
-			if err := cmd.ScanProto(stored); err != nil && !errors.IsNotFound(err) {
-				return err
-			}
-			stored, err = applyWebhookFieldMask(stored, pb, sets...)
-			if err != nil {
-				return err
-			}
-			pb, err = applyWebhookFieldMask(nil, stored, gets...)
-			if err != nil {
-				return err
-			}
-			f = func(p redis.Pipeliner) error {
-				_, err := ttnredis.SetProto(p, k, stored, 0)
+
+				updated, err = applyWebhookFieldMask(updated, pb, sets...)
 				if err != nil {
 					return err
 				}
-				p.SAdd(r.Redis.Key(webhookKey, unique.ID(ctx, ids.ApplicationIdentifiers)), ids.WebhookID)
+			} else {
+				if err := cmd.ScanProto(updated); err != nil {
+					return err
+				}
+				updated, err = applyWebhookFieldMask(updated, pb, sets...)
+				if err != nil {
+					return err
+				}
+				if stored.ApplicationWebhookIdentifiers != updated.ApplicationWebhookIdentifiers {
+					return errInvalidIdentifiers
+				}
+			}
+			pb, err = applyWebhookFieldMask(nil, updated, gets...)
+			if err != nil {
+				return err
+			}
+
+			f = func(p redis.Pipeliner) error {
+				if _, err := ttnredis.SetProto(p, uk, updated, 0); err != nil {
+					return err
+				}
+				p.SAdd(r.Redis.Key(webhookKey, appUID), updated.WebhookID)
 				return nil
 			}
 		}
 		_, err = tx.Pipelined(f)
-		return err
-	}, k)
+		if err != nil {
+			return err
+		}
+		return nil
+	}, uk)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/applicationserver/io/web/webhooks_test.go
+++ b/pkg/applicationserver/io/web/webhooks_test.go
@@ -48,53 +48,56 @@ func TestWebhooks(t *testing.T) {
 		ApplicationIdentifiers: registeredApplicationID,
 		WebhookID:              registeredWebhookID,
 	}
-	registry.Set(ctx, ids, nil, func(_ *ttnpb.ApplicationWebhook) (*ttnpb.ApplicationWebhook, []string, error) {
-		hook := &ttnpb.ApplicationWebhook{
-			BaseURL: "https://myapp.com/api/ttn/v3",
-			Headers: map[string]string{
-				"Authorization": "key secret",
+	_, err := registry.Set(ctx, ids, nil, func(_ *ttnpb.ApplicationWebhook) (*ttnpb.ApplicationWebhook, []string, error) {
+		return &ttnpb.ApplicationWebhook{
+				ApplicationWebhookIdentifiers: ids,
+				BaseURL:                       "https://myapp.com/api/ttn/v3",
+				Headers: map[string]string{
+					"Authorization": "key secret",
+				},
+				Format: "json",
+				UplinkMessage: &ttnpb.ApplicationWebhook_Message{
+					Path: "up",
+				},
+				JoinAccept: &ttnpb.ApplicationWebhook_Message{
+					Path: "join",
+				},
+				DownlinkAck: &ttnpb.ApplicationWebhook_Message{
+					Path: "down/ack",
+				},
+				DownlinkNack: &ttnpb.ApplicationWebhook_Message{
+					Path: "down/nack",
+				},
+				DownlinkSent: &ttnpb.ApplicationWebhook_Message{
+					Path: "down/sent",
+				},
+				DownlinkQueued: &ttnpb.ApplicationWebhook_Message{
+					Path: "down/queued",
+				},
+				DownlinkFailed: &ttnpb.ApplicationWebhook_Message{
+					Path: "down/failed",
+				},
+				LocationSolved: &ttnpb.ApplicationWebhook_Message{
+					Path: "location",
+				},
 			},
-			Format: "json",
-			UplinkMessage: &ttnpb.ApplicationWebhook_Message{
-				Path: "up",
-			},
-			JoinAccept: &ttnpb.ApplicationWebhook_Message{
-				Path: "join",
-			},
-			DownlinkAck: &ttnpb.ApplicationWebhook_Message{
-				Path: "down/ack",
-			},
-			DownlinkNack: &ttnpb.ApplicationWebhook_Message{
-				Path: "down/nack",
-			},
-			DownlinkSent: &ttnpb.ApplicationWebhook_Message{
-				Path: "down/sent",
-			},
-			DownlinkQueued: &ttnpb.ApplicationWebhook_Message{
-				Path: "down/queued",
-			},
-			DownlinkFailed: &ttnpb.ApplicationWebhook_Message{
-				Path: "down/failed",
-			},
-			LocationSolved: &ttnpb.ApplicationWebhook_Message{
-				Path: "location",
-			},
-		}
-		paths := []string{
-			"base_url",
-			"headers",
-			"format",
-			"uplink_message",
-			"join_accept",
-			"downlink_ack",
-			"downlink_nack",
-			"downlink_sent",
-			"downlink_failed",
-			"downlink_queued",
-			"location_solved",
-		}
-		return hook, paths, nil
+			[]string{
+				"base_url",
+				"headers",
+				"format",
+				"uplink_message",
+				"join_accept",
+				"downlink_ack",
+				"downlink_nack",
+				"downlink_sent",
+				"downlink_failed",
+				"downlink_queued",
+				"location_solved",
+			}, nil
 	})
+	if err != nil {
+		t.Fatalf("Failed to set webhook in registry: %s", err)
+	}
 
 	t.Run("Upstream", func(t *testing.T) {
 		testSink := &mockSink{

--- a/pkg/networkserver/redis/registry.go
+++ b/pkg/networkserver/redis/registry.go
@@ -27,12 +27,6 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/unique"
 )
 
-const (
-	addrKey = "addr"
-	euiKey  = "eui"
-	uidKey  = "uid"
-)
-
 var (
 	errInvalidIdentifiers   = errors.DefineInvalidArgument("invalid_identifiers", "invalid identifiers")
 	errDuplicateIdentifiers = errors.DefineAlreadyExists("duplicate_identifiers", "duplicate identifiers")
@@ -56,6 +50,18 @@ type DeviceRegistry struct {
 	Redis *ttnredis.Client
 }
 
+func (r *DeviceRegistry) uidKey(uid string) string {
+	return r.Redis.Key("uid", uid)
+}
+
+func (r *DeviceRegistry) addrKey(addr types.DevAddr) string {
+	return r.Redis.Key("addr", addr.String())
+}
+
+func (r *DeviceRegistry) euiKey(devEUI, joinEUI types.EUI64) string {
+	return r.Redis.Key("eui", joinEUI.String(), devEUI.String())
+}
+
 // GetByID gets device by appID, devID.
 func (r *DeviceRegistry) GetByID(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, paths []string) (*ttnpb.EndDevice, error) {
 	ids := ttnpb.EndDeviceIdentifiers{
@@ -67,10 +73,7 @@ func (r *DeviceRegistry) GetByID(ctx context.Context, appID ttnpb.ApplicationIde
 	}
 
 	pb := &ttnpb.EndDevice{}
-	if err := ttnredis.GetProto(
-		r.Redis,
-		r.Redis.Key(uidKey, unique.ID(ctx, ids)),
-	).ScanProto(pb); err != nil {
+	if err := ttnredis.GetProto(r.Redis, r.uidKey(unique.ID(ctx, ids))).ScanProto(pb); err != nil {
 		return nil, err
 	}
 	return applyDeviceFieldMask(nil, pb, paths...)
@@ -79,7 +82,7 @@ func (r *DeviceRegistry) GetByID(ctx context.Context, appID ttnpb.ApplicationIde
 // GetByEUI gets device by joinEUI, devEUI.
 func (r *DeviceRegistry) GetByEUI(_ context.Context, joinEUI, devEUI types.EUI64, paths []string) (*ttnpb.EndDevice, error) {
 	pb := &ttnpb.EndDevice{}
-	if err := ttnredis.FindProto(r.Redis, r.Redis.Key(euiKey, joinEUI.String(), devEUI.String()), func(uid string) string { return r.Redis.Key(uidKey, uid) }).ScanProto(pb); err != nil {
+	if err := ttnredis.FindProto(r.Redis, r.euiKey(joinEUI, devEUI), r.uidKey).ScanProto(pb); err != nil {
 		return nil, err
 	}
 	return applyDeviceFieldMask(nil, pb, paths...)
@@ -87,7 +90,7 @@ func (r *DeviceRegistry) GetByEUI(_ context.Context, joinEUI, devEUI types.EUI64
 
 // RangeByAddr ranges over devices by addr.
 func (r *DeviceRegistry) RangeByAddr(addr types.DevAddr, paths []string, f func(*ttnpb.EndDevice) bool) error {
-	return ttnredis.FindProtos(r.Redis, r.Redis.Key(addrKey, addr.String()), func(uid string) string { return r.Redis.Key(uidKey, uid) }).Range(func() (proto.Message, func() (bool, error)) {
+	return ttnredis.FindProtos(r.Redis, r.addrKey(addr), r.uidKey).Range(func() (proto.Message, func() (bool, error)) {
 		pb := &ttnpb.EndDevice{}
 		return pb, func() (bool, error) {
 			pb, err := applyDeviceFieldMask(nil, pb, paths...)
@@ -141,7 +144,7 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIde
 		return nil, err
 	}
 	uid := unique.ID(ctx, ids)
-	uk := r.Redis.Key(uidKey, uid)
+	uk := r.uidKey(uid)
 
 	var pb *ttnpb.EndDevice
 	err := r.Redis.Watch(func(tx *redis.Tx) error {
@@ -181,13 +184,13 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIde
 			f = func(p redis.Pipeliner) error {
 				p.Del(uk)
 				if stored.JoinEUI != nil && stored.DevEUI != nil {
-					p.Del(r.Redis.Key(euiKey, stored.JoinEUI.String(), stored.DevEUI.String()))
+					p.Del(r.euiKey(*stored.JoinEUI, *stored.DevEUI))
 				}
 				if storedAddrs.pending != nil {
-					p.SRem(r.Redis.Key(addrKey, storedAddrs.pending.String()), uid)
+					p.SRem(r.addrKey(*storedAddrs.pending), uid)
 				}
 				if storedAddrs.current != nil {
-					p.SRem(r.Redis.Key(addrKey, storedAddrs.current.String()), uid)
+					p.SRem(r.addrKey(*storedAddrs.current), uid)
 				}
 				return nil
 			}
@@ -230,7 +233,7 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIde
 
 			f = func(p redis.Pipeliner) error {
 				if stored == nil && updated.JoinEUI != nil && updated.DevEUI != nil {
-					ek := r.Redis.Key(euiKey, pb.JoinEUI.String(), pb.DevEUI.String())
+					ek := r.euiKey(*pb.JoinEUI, *pb.DevEUI)
 					if err := tx.Watch(ek).Err(); err != nil {
 						return err
 					}
@@ -250,16 +253,16 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIde
 				}
 
 				if storedAddrs.pending != nil && !equalAddr(storedAddrs.pending, updatedAddrs.pending) && !equalAddr(storedAddrs.pending, updatedAddrs.current) {
-					p.SRem(r.Redis.Key(addrKey, storedAddrs.pending.String()), uid)
+					p.SRem(r.addrKey(*storedAddrs.pending), uid)
 				}
 				if storedAddrs.current != nil && !equalAddr(storedAddrs.current, updatedAddrs.pending) && !equalAddr(storedAddrs.current, updatedAddrs.current) {
-					p.SRem(r.Redis.Key(addrKey, storedAddrs.current.String()), uid)
+					p.SRem(r.addrKey(*storedAddrs.current), uid)
 				}
 				if updatedAddrs.pending != nil && !equalAddr(updatedAddrs.pending, storedAddrs.pending) && !equalAddr(updatedAddrs.pending, storedAddrs.current) {
-					p.SAdd(r.Redis.Key(addrKey, updatedAddrs.pending.String()), uid)
+					p.SAdd(r.addrKey(*updatedAddrs.pending), uid)
 				}
 				if updatedAddrs.current != nil && !equalAddr(updatedAddrs.current, storedAddrs.pending) && !equalAddr(updatedAddrs.current, storedAddrs.current) {
-					p.SAdd(r.Redis.Key(addrKey, updatedAddrs.current.String()), uid)
+					p.SAdd(r.addrKey(*updatedAddrs.current), uid)
 				}
 				return nil
 			}

--- a/pkg/redis/redis.go
+++ b/pkg/redis/redis.go
@@ -127,7 +127,7 @@ func SetProto(r redis.Cmdable, k string, pb proto.Message, expiration time.Durat
 
 // FindProto finds the protocol buffer stored under the key stored under k.
 // The external key is constructed using keyCmd.
-func FindProto(r WatchCmdable, k string, keyCmd func(...string) string) *ProtoCmd {
+func FindProto(r WatchCmdable, k string, keyCmd func(string) string) *ProtoCmd {
 	var result func() (string, error)
 	if err := r.Watch(func(tx *redis.Tx) error {
 		id, err := tx.Get(k).Result()
@@ -174,7 +174,7 @@ func (cmd ProtosCmd) Range(f func() (proto.Message, func() (bool, error))) error
 }
 
 // FindProtos gets protos stored under keys in k.
-func FindProtos(r redis.Cmdable, k string, keyCmd func(...string) string) *ProtosCmd {
+func FindProtos(r redis.Cmdable, k string, keyCmd func(string) string) *ProtosCmd {
 	return &ProtosCmd{
 		result: r.Sort(k, &redis.Sort{
 			Alpha: true,


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #175 
I noticed that registry implementations diverged quite a bit, included a bunch of redundant actions, weren't clear and had possible memory leaks.
<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Harmonized Redis registry implementations(not the signatures) - essentially I cleaned up NS registry implementation and then used that as the base for all other Redis registry implementations
- AS tests were throwing `panic`s on failing testcases, gave a bunch of useless output after a test failure, and did not handle registry errors, which I fixed(it was impossible to debug otherwise)
- Validate that the entity set in the registry has the same identifiers, as the ones passed to the setter.
- Ensure uniqueness of identifiers in registries

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

I duplicated `equalEUI` in `NS`, `JS` and `AS` - changing the signature of `types.EUI64` to pointer received does not work, as generated code in `ttnpb` expect the method to use value types. 
The functions are very small, so I don't think it's a big deal, but if you disagree - please propose a better solution.