### PR TITLE
Fix error codes for failed auth

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -2969,6 +2969,15 @@
       "file": "contact_info_store.go"
     }
   },
+  "error:pkg/identityserver:api_key_not_found": {
+    "translations": {
+      "en": "API key not found"
+    },
+    "description": {
+      "package": "pkg/identityserver",
+      "file": "entity_access.go"
+    }
+  },
   "error:pkg/identityserver:client_update_admin_field": {
     "translations": {
       "en": "only admins can update the `{field}` field"
@@ -3125,6 +3134,15 @@
   "error:pkg/identityserver:token_expired": {
     "translations": {
       "en": "access token expired"
+    },
+    "description": {
+      "package": "pkg/identityserver",
+      "file": "entity_access.go"
+    }
+  },
+  "error:pkg/identityserver:token_not_found": {
+    "translations": {
+      "en": "access token not found"
     },
     "description": {
       "package": "pkg/identityserver",

--- a/pkg/identityserver/entity_access.go
+++ b/pkg/identityserver/entity_access.go
@@ -35,7 +35,7 @@ var (
 	errUnauthenticated          = errors.DefineUnauthenticated("unauthenticated", "unauthenticated")
 	errUnsupportedAuthorization = errors.DefineUnauthenticated("unsupported_authorization", "Unsupported authorization method")
 	errAPIKeyNotFound           = errors.DefineUnauthenticated("api_key_not_found", "API key not found")
-	errInvalidAuthorization     = errors.DefinePermissionDenied("invalid_authorization", "invalid authorization")
+	errInvalidAuthorization     = errors.DefineUnauthenticated("invalid_authorization", "invalid authorization")
 	errTokenNotFound            = errors.DefineUnauthenticated("token_not_found", "access token not found")
 	errTokenExpired             = errors.DefineUnauthenticated("token_expired", "access token expired")
 	errOAuthClientRejected      = errors.DefinePermissionDenied("oauth_client_rejected", "OAuth client was rejected")

--- a/pkg/identityserver/user_registry_test.go
+++ b/pkg/identityserver/user_registry_test.go
@@ -315,6 +315,18 @@ func TestUsersCRUD(t *testing.T) {
 
 		a.So(empty, should.BeNil)
 		a.So(err, should.NotBeNil)
+
+		// NOTE: For other entities, this would be a NotFound, but in this case
+		// the user's credentials become invalid when the user is deleted.
+		a.So(errors.IsUnauthenticated(err), should.BeTrue)
+
+		empty, err = reg.Get(ctx, &ttnpb.GetUserRequest{
+			UserIdentifiers: user.UserIdentifiers,
+			FieldMask:       types.FieldMask{Paths: []string{"name"}},
+		}, userCreds(adminUserIdx))
+
+		a.So(empty, should.BeNil)
+		a.So(err, should.NotBeNil)
 		a.So(errors.IsNotFound(err), should.BeTrue)
 	})
 }


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR closes #197 by returning `Unauthenticated` error types if API keys, OAuth tokens or their corresponding user/client is not found.

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Return `Unauthenticated` errors if entities were not found during Auth procedure
- Return `Unauthenticated` errors if hash validation fails (instead of `PermissionDenied`)