### PR TITLE
Fix CLI OAuth and make OAuth server better handle clients without secret

### DIFF
--- a/cmd/ttn-lw-cli/commands/config.go
+++ b/cmd/ttn-lw-cli/commands/config.go
@@ -58,6 +58,9 @@ var DefaultConfig = Config{
 	JoinServerAddress:        clusterGRPCAddress,
 }
 
+var configCommand = commands.Config(mgr)
+
 func init() {
-	Root.AddCommand(commands.Config(mgr))
+	versionCommand.PersistentPreRunE = preRun()
+	Root.AddCommand(configCommand)
 }

--- a/cmd/ttn-lw-cli/commands/login.go
+++ b/cmd/ttn-lw-cli/commands/login.go
@@ -33,8 +33,9 @@ import (
 
 var (
 	loginCommand = &cobra.Command{
-		Use:   "login",
-		Short: "Login",
+		Use:               "login",
+		Short:             "Login",
+		PersistentPreRunE: preRun(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, done := context.WithCancel(ctx)
 			defer done()

--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -166,6 +166,14 @@ func refreshToken() error {
 
 var errUnauthenticated = errors.DefineUnauthenticated("unauthenticated", "not authenticated with either API key or OAuth access token")
 
+func optionalAuth() error {
+	err := requireAuth()
+	if err != nil && !errors.IsUnauthenticated(err) {
+		return err
+	}
+	return nil
+}
+
 func requireAuth() error {
 	if apiKey, ok := cache.Get("api_key").(string); ok {
 		logger.Debug("Using API key")
@@ -184,8 +192,11 @@ func requireAuth() error {
 	return errUnauthenticated
 }
 
+var versionCommand = version.Print(name)
+
 func init() {
 	Root.SetGlobalNormalizationFunc(util.NormalizeFlags)
 	Root.PersistentFlags().AddFlagSet(mgr.Flags())
-	Root.AddCommand(version.Print(name))
+	versionCommand.PersistentPreRunE = preRun()
+	Root.AddCommand(versionCommand)
 }

--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -118,8 +118,9 @@ var (
 			oauth2Config = &oauth2.Config{
 				ClientID: "cli",
 				Endpoint: oauth2.Endpoint{
-					AuthURL:  fmt.Sprintf("%s/oauth/authorize", config.OAuthServerAddress),
-					TokenURL: fmt.Sprintf("%s/oauth/token", config.OAuthServerAddress),
+					AuthURL:   fmt.Sprintf("%s/oauth/authorize", config.OAuthServerAddress),
+					TokenURL:  fmt.Sprintf("%s/oauth/token", config.OAuthServerAddress),
+					AuthStyle: oauth2.AuthStyleInParams,
 				},
 			}
 

--- a/cmd/ttn-lw-cli/commands/users.go
+++ b/cmd/ttn-lw-cli/commands/users.go
@@ -121,12 +121,10 @@ var (
 		},
 	}
 	usersCreateCommand = &cobra.Command{
-		Use:     "create",
-		Aliases: []string{"add", "register"},
-		Short:   "Create a user",
-		PreRun: func(cmd *cobra.Command, args []string) {
-			api.SetAuth("", "") // Unset auth on this call
-		},
+		Use:               "create",
+		Aliases:           []string{"add", "register"},
+		Short:             "Create a user",
+		PersistentPreRunE: preRun(optionalAuth),
 		RunE: asBulk(func(cmd *cobra.Command, args []string) (err error) {
 			usrID := getUserID(cmd.Flags(), args)
 			var user ttnpb.User

--- a/config/messages.json
+++ b/config/messages.json
@@ -1331,6 +1331,15 @@
       "file": "users.go"
     }
   },
+  "error:cmd/ttn-lw-cli/commands:unauthenticated": {
+    "translations": {
+      "en": "not authenticated with either API key or OAuth access token"
+    },
+    "description": {
+      "package": "cmd/ttn-lw-cli/commands",
+      "file": "root.go"
+    }
+  },
   "error:cmd/ttn-lw-cli/internal/util:flag_value": {
     "translations": {
       "en": "invalid flag value"

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/Azure/azure-storage-blob-go v0.0.0-20190123011202-457680cc0804 // indirect
 	github.com/PuerkitoBio/purell v1.1.0
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
-	github.com/RangelReale/osin v1.0.1
 	github.com/TheThingsIndustries/magepkg v0.0.0-20190214092847-6c0299b7c3ed
 	github.com/TheThingsIndustries/mystique v0.0.0-20181023142449-f12a32cee6d6
 	github.com/TheThingsNetwork/go-cayenne-lib v1.0.0
@@ -81,6 +80,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.1 // indirect
 	github.com/onsi/ginkgo v1.7.0 // indirect
 	github.com/onsi/gomega v1.4.3 // indirect
+	github.com/openshift/osin v1.0.1
 	github.com/pborman/uuid v1.2.0 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.2

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,6 @@ github.com/PuerkitoBio/purell v1.1.0 h1:rmGxhojJlM0tuKtfdvliR84CFHljx9ag64t2xmVk
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/RangelReale/osin v1.0.1 h1:JcqBe8ljQq9WQJPtioXGxBWyIcfuVMw0BX6yJ9E4HKw=
-github.com/RangelReale/osin v1.0.1/go.mod h1:k/PH1SjZDitJDtK3zHm/XZRi+bRz6i3rhx9qE9p54CY=
 github.com/TheThingsIndustries/magepkg v0.0.0-20190214092847-6c0299b7c3ed h1:rsGbnyV9cP0ocol1W17uTbZ1iWcEeg+gp3ivzW6NQ6Q=
 github.com/TheThingsIndustries/magepkg v0.0.0-20190214092847-6c0299b7c3ed/go.mod h1:InVSk9cxzZR1y4QaHF4CbDQ/uFeoTnbJfnwiKM04UNo=
 github.com/TheThingsIndustries/mystique v0.0.0-20181023142449-f12a32cee6d6 h1:bU/mzNwvlF6Rn/5Qk9g8+/bSWmK2Iz+9XaemmJo4nBk=
@@ -286,6 +284,8 @@ github.com/onsi/ginkgo v1.7.0 h1:WSHQ+IS43OoUrWtD1/bbclrwK8TTH5hzp+umCiuxHgs=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3 h1:RE1xgDvH7imwFD45h+u2SgIfERHlS2yNG4DObb5BSKU=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/openshift/osin v1.0.1 h1:2hYushQtTLGVfnKAmz1+/ln5GZD0ykJCavs2JIwVEfQ=
+github.com/openshift/osin v1.0.1/go.mod h1:/gGuqQHvGNST0GB+Pomi3398FTdcM+9UaXafpqHvfDM=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/openzipkin/zipkin-go v0.1.3/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=

--- a/pkg/oauth/oauth.go
+++ b/pkg/oauth/oauth.go
@@ -21,8 +21,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/RangelReale/osin"
 	"github.com/labstack/echo"
+	"github.com/openshift/osin"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/events"
 	"go.thethings.network/lorawan-stack/pkg/jsonpb"

--- a/pkg/oauth/oauth.go
+++ b/pkg/oauth/oauth.go
@@ -161,12 +161,8 @@ func (r tokenRequest) Values() (values url.Values) {
 	if r.RedirectURI != "" {
 		values.Set("redirect_uri", r.RedirectURI)
 	}
-	if r.ClientID != "" {
-		values.Set("client_id", r.ClientID)
-	}
-	if r.ClientSecret != "" {
-		values.Set("client_secret", r.ClientSecret)
-	}
+	values.Set("client_id", r.ClientID)
+	values.Set("client_secret", r.ClientSecret)
 	return
 }
 

--- a/pkg/oauth/server.go
+++ b/pkg/oauth/server.go
@@ -19,9 +19,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/RangelReale/osin"
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
+	"github.com/openshift/osin"
 	web_errors "go.thethings.network/lorawan-stack/pkg/errors/web"
 	"go.thethings.network/lorawan-stack/pkg/identityserver/store"
 	"go.thethings.network/lorawan-stack/pkg/log"

--- a/pkg/oauth/storage.go
+++ b/pkg/oauth/storage.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/RangelReale/osin"
+	"github.com/openshift/osin"
 	"go.thethings.network/lorawan-stack/pkg/auth"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/identityserver/store"

--- a/pkg/oauth/token_generators.go
+++ b/pkg/oauth/token_generators.go
@@ -15,7 +15,7 @@
 package oauth
 
 import (
-	"github.com/RangelReale/osin"
+	"github.com/openshift/osin"
 	"go.thethings.network/lorawan-stack/pkg/auth"
 )
 


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes #212 by making the CLI explicitly specify the auth method, and by changing the way the OAuth server forwards the ClientID and ClientSecret to the OAuth library in token exchanges.

This PR additionally switches forks of the OAuth library, as the old one doesn't seem to be maintained anymore.

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->


