### PR TITLE
make: Fix sdk dependencies

### DIFF
--- a/.make/sdk/main.make
+++ b/.make/sdk/main.make
@@ -21,9 +21,11 @@ sdk.deps: sdk.js.deps
 
 # JS SDK make rules
 
-sdk.js.deps:
+sdk.js.deps: $(YARN)
 	@$(log) "Fetching JS SDK dependencies"
 	@$(YARN_SDK) install $(YARN_FLAGS) --production=false
 
 include .make/sdk/build.make
 include .make/sdk/quality.make
+
+# vim: ft=make

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ docs:
 
 dev-deps: go.deps js.dev-deps
 
-deps: go.deps sdk.deps sdk.js.build js.deps
+deps: go.deps js.deps sdk.deps sdk.js.build
 
 test: go.test js.test sdk.test
 


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #219 

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Specify `$(YARN)` as dependency to SDK
- Reorder the `deps` target dependencies in an ordering that makes more sense