### PR TITLE
Fix `make deps` ordering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ docs:
 
 dev-deps: go.deps js.dev-deps
 
-deps: go.deps js.deps sdk.deps sdk.js.build
+deps: go.deps sdk.deps sdk.js.build js.deps # NOTE: js.deps needs to be AFTER sdk.js.build
 
 test: go.test js.test sdk.test
 


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Refs #220 https://github.com/TheThingsNetwork/lorawan-stack/issues/157#issuecomment-464900724

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Fix `make deps` ordering