### PR TITLE
Remove CODEOWNERS from release archive

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,7 +53,6 @@ builds:
 
 archive:
   files:
-    - CODEOWNERS
     - LICENSE
     - README.md
     - doc/**/*


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/223

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Remove `CODEOWNERS` from release archive