### PR TITLE
doc: Add separate release details

### DIFF
--- a/doc/gettingstarted.md
+++ b/doc/gettingstarted.md
@@ -25,16 +25,30 @@ In this guide we will get everything up and running on a server using Docker.
 
 For now, the web interface Console is not available; in this tutorial, we use the command-line interface (CLI) to manage the network.
 
-Get the latest packages or binaries for your operating system from the [releases](https://github.com/TheThingsNetwork/lorawan-stack/releases) page on GitHub.
+In this tutorial, the stack will run in Docker on the server, and you manage the stack either using the CLI on your local machine or on the server.
+
+#### Package managers (recommended)
+
+##### macOS
+
+```bash
+$ brew install TheThingsNetwork/lorawan-stack/ttn-lw-stack
+```
+
+#### Binaries
+
+If your operating system or package manager is not mentioned, please [download binaries](https://github.com/TheThingsNetwork/lorawan-stack/releases) for your operating system and processor architecture.
 
 ### Certificates
 
 By default, the Stack requires a `cert.pem` and `key.pem`, in order to to serve content over TLS.
 
-+ To generate self-signed certificates for `localhost`, use the following command. This requires a [Go environment setup](../DEVELOPMENT.md#development-environment).
++ To generate self-signed certificates for `localhost`, use the following commands. This requires a [Go environment setup](../DEVELOPMENT.md#development-environment).
 
 ```bash
-go run $(go env GOROOT)/src/crypto/tls/generate_cert.go -ca -host localhost && chmod 0444 ./key.pem
+$ go run $(go env GOROOT)/src/crypto/tls/generate_cert.go -ca -host localhost 
+# The following command is not required on Windows.
+$ chmod 0444 ./key.pem
 ```
 
 Keep in mind that self-signed certificates are not trusted by browsers and operating systems, resulting oftentimes in warnings and sometimes in errors. Consider [Let's Encrypt](https://letsencrypt.org/getting-started/) for free and trusted TLS certificates for your server.


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #218

This PR adds separate instructions for each operating system based on the currently supported package managers (only `brew`) and manually downloading the binaries.

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Adds `brew` instructions for MacOS
- Adds manually downloading the binaries instruction for Linux and Windows.

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

As requested, the manual installation instructions for the debian packages has not been added yet.