### PR TITLE
dev: Add commitBump target to Mage

### DIFF
--- a/.mage/version.go
+++ b/.mage/version.go
@@ -139,6 +139,11 @@ func (Version) BumpPatch() error { return bumpVersion("patch") }
 // BumpRC bumps a release candidate version.
 func (Version) BumpRC() error { return bumpVersion("rc") }
 
+// CommitBump creates a git commit for the version bump.
+func (Version) CommitBump() error {
+	return git.Commit(fmt.Sprintf("all: Bump to version %s", strings.TrimPrefix(currentVersion, "v")))
+}
+
 // Tag creates a git tag for the current version.
 func (Version) Tag() error {
 	version, err := semver.Parse(strings.TrimPrefix(currentVersion, "v"))


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR adds a Mage target `commitBump` that commits a version bump to Git.

Example: `mage version:bumpRelease version:files version:commitBump version:tag`

This bumps the current rc to a release (so v3.0.0-rcN to v3.0.0), generates the version files, commits those with a "bump" commit and tags a new version.

Note that this needs to be executed by a repo admin from the master branch.

Follow-up of #141 