### PR TITLE
cli: Avoid closing the listener on error

### DIFF
--- a/cmd/ttn-lw-cli/commands/login.go
+++ b/cmd/ttn-lw-cli/commands/login.go
@@ -70,10 +70,11 @@ var (
 				}))
 
 				lis, err := net.Listen("tcp", ":11885")
-				defer lis.Close()
 				if err != nil {
+					logger.WithError(err).Error("Could not listen for OAuth callback. Try re-running this command with --callback=false")
 					return err
 				}
+				defer lis.Close()
 				go http.Serve(lis, nil)
 			} else {
 				oauth2Config.RedirectURL = "/oauth/code"


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #227.

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Close the listener only if it was actually open.
- Return an error when this occurs.

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

Implemented as mentioned in the original issue.