### PR TITLE
Add Application Link method to js sdk

### DIFF
--- a/sdk/js/src/service/applications.js
+++ b/sdk/js/src/service/applications.js
@@ -16,6 +16,7 @@ import Marshaler from '../util/marshaler'
 import Device from '../entity/device'
 import Application from '../entity/application'
 import ApiKeys from './api-keys'
+import Link from './link'
 
 /**
  * Applications Class provides an abstraction on all applications and manages
@@ -41,6 +42,7 @@ class Applications {
       create: 'application_ids.application_id',
       update: 'application_ids.application_id',
     })
+    this.Link = new Link(api.As)
 
     this.getAll = this.getAll.bind(this)
     this.getById = this.getById.bind(this)
@@ -188,6 +190,18 @@ class Applications {
       },
       async addCollaborator (collaborator) {
         return api.ApplicationAccess.SetCollaborator(idMask, collaborator)
+      },
+      async createLink (link) {
+        return this.Link.create(id, link)
+      },
+      async setLink (link, mask) {
+        return this.Link.set(id, link, mask)
+      },
+      async deleteLink () {
+        return this.Link.delete(id)
+      },
+      async getLinkStats () {
+        return this.Link.getStats(id)
       },
     }
   }

--- a/sdk/js/src/service/link.js
+++ b/sdk/js/src/service/link.js
@@ -1,0 +1,65 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Marshaler from '../util/marshaler'
+
+class Link {
+  constructor (registry) {
+    this._api = registry
+
+    this.get = this.get.bind(this)
+    this.set = this.set.bind(this)
+    this.delete = this.delete.bind(this)
+    this.getStats = this.getStats.bind(this)
+  }
+
+  async get (appId, fieldMask) {
+    const result = await this._api.GetLink({
+      route: { 'application_ids.application_id': appId },
+      query: Marshaler.queryFieldMask(fieldMask),
+    })
+
+    return Marshaler.payloadSingleResponse(result)
+  }
+
+  async set (appId, data, mask = Marshaler.fieldMaskFromPatch(data)) {
+    const result = await this._api.SetLink({
+      route: { 'application_ids.application_id': appId },
+    },
+    {
+      link: data,
+      field_mask: Marshaler.fieldMask(mask),
+    })
+
+    return Marshaler.payloadSingleResponse(result)
+  }
+
+  async delete (appId) {
+    const result = await this._api.DeleteLink({
+      route: { application_id: appId },
+    })
+
+    return Marshaler.payloadSingleResponse(result)
+  }
+
+  async getStats (appId) {
+    const result = await this._api.GetLinkStats({
+      route: { application_id: appId },
+    })
+
+    return Marshaler.payloadSingleResponse(result)
+  }
+}
+
+export default Link

--- a/sdk/js/src/util/marshaler.js
+++ b/sdk/js/src/util/marshaler.js
@@ -89,6 +89,10 @@ class Marshaler {
   static fieldMask (fieldMask) {
     return { paths: fieldMask }
   }
+
+  static queryFieldMask (fields = []) {
+    return { 'field_mask.paths': fields }
+  }
 }
 
 export default Marshaler


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR adds the Application Link methods to the javascript sdk.
References https://github.com/TheThingsNetwork/lorawan-stack/issues/214.


<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Implement Application Link methods
- Add support for field masks url queries

