### PR TITLE
Use implicit field mask paths in IS

### DIFF
--- a/cmd/ttn-lw-cli/commands/applications.go
+++ b/cmd/ttn-lw-cli/commands/applications.go
@@ -68,10 +68,6 @@ var (
 		Short:   "List applications",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			paths := util.SelectFieldMask(cmd.Flags(), selectApplicationFlags)
-			if len(paths) == 0 {
-				logger.Warnf("No fields selected, selecting %v", defaultGetPaths)
-				paths = append(paths, defaultGetPaths...)
-			}
 
 			is, err := api.Dial(ctx, config.IdentityServerAddress)
 			if err != nil {
@@ -93,10 +89,7 @@ var (
 		Short: "Search for applications",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			paths := util.SelectFieldMask(cmd.Flags(), selectApplicationFlags)
-			if len(paths) == 0 {
-				logger.Warnf("No fields selected, selecting %v", defaultGetPaths)
-				paths = append(paths, defaultGetPaths...)
-			}
+
 			req := getSearchEntitiesRequest(cmd.Flags())
 			req.FieldMask.Paths = paths
 
@@ -122,10 +115,6 @@ var (
 				return errNoApplicationID
 			}
 			paths := util.SelectFieldMask(cmd.Flags(), selectApplicationFlags)
-			if len(paths) == 0 {
-				logger.Warnf("No fields selected, selecting %v", defaultGetPaths)
-				paths = append(paths, defaultGetPaths...)
-			}
 
 			is, err := api.Dial(ctx, config.IdentityServerAddress)
 			if err != nil {

--- a/cmd/ttn-lw-cli/commands/clients.go
+++ b/cmd/ttn-lw-cli/commands/clients.go
@@ -68,10 +68,6 @@ var (
 		Short:   "List clients",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			paths := util.SelectFieldMask(cmd.Flags(), selectClientFlags)
-			if len(paths) == 0 {
-				logger.Warnf("No fields selected, selecting %v", defaultGetPaths)
-				paths = append(paths, defaultGetPaths...)
-			}
 
 			is, err := api.Dial(ctx, config.IdentityServerAddress)
 			if err != nil {
@@ -93,10 +89,7 @@ var (
 		Short: "Search for clients",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			paths := util.SelectFieldMask(cmd.Flags(), selectClientFlags)
-			if len(paths) == 0 {
-				logger.Warnf("No fields selected, selecting %v", defaultGetPaths)
-				paths = append(paths, defaultGetPaths...)
-			}
+
 			req := getSearchEntitiesRequest(cmd.Flags())
 			req.FieldMask.Paths = paths
 
@@ -122,10 +115,6 @@ var (
 				return errNoClientID
 			}
 			paths := util.SelectFieldMask(cmd.Flags(), selectClientFlags)
-			if len(paths) == 0 {
-				logger.Warnf("No fields selected, selecting %v", defaultGetPaths)
-				paths = append(paths, defaultGetPaths...)
-			}
 
 			is, err := api.Dial(ctx, config.IdentityServerAddress)
 			if err != nil {

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -131,10 +131,6 @@ var (
 				return errNoApplicationID
 			}
 			paths := util.SelectFieldMask(cmd.Flags(), selectEndDeviceListFlags)
-			if len(paths) == 0 {
-				logger.Warnf("No fields selected, selecting %v", defaultGetPaths)
-				paths = append(paths, defaultGetPaths...)
-			}
 
 			is, err := api.Dial(ctx, config.IdentityServerAddress)
 			if err != nil {
@@ -161,10 +157,6 @@ var (
 				return err
 			}
 			paths := util.SelectFieldMask(cmd.Flags(), selectEndDeviceFlags)
-			if len(paths) == 0 {
-				logger.Warnf("No fields selected, selecting %v", defaultGetPaths)
-				paths = append(paths, defaultGetPaths...)
-			}
 
 			isPaths, nsPaths, asPaths, jsPaths := splitEndDeviceGetPaths(paths...)
 

--- a/cmd/ttn-lw-cli/commands/flags.go
+++ b/cmd/ttn-lw-cli/commands/flags.go
@@ -23,8 +23,6 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 )
 
-var defaultGetPaths = []string{"name"}
-
 func collaboratorFlags() *pflag.FlagSet {
 	flagSet := &pflag.FlagSet{}
 	flagSet.String("user-id", "", "")

--- a/cmd/ttn-lw-cli/commands/gateways.go
+++ b/cmd/ttn-lw-cli/commands/gateways.go
@@ -84,10 +84,6 @@ var (
 		Short:   "List gateways",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			paths := util.SelectFieldMask(cmd.Flags(), selectGatewayFlags)
-			if len(paths) == 0 {
-				logger.Warnf("No fields selected, selecting %v", defaultGetPaths)
-				paths = append(paths, defaultGetPaths...)
-			}
 
 			is, err := api.Dial(ctx, config.IdentityServerAddress)
 			if err != nil {
@@ -109,10 +105,7 @@ var (
 		Short: "Search for gateways",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			paths := util.SelectFieldMask(cmd.Flags(), selectGatewayFlags)
-			if len(paths) == 0 {
-				logger.Warnf("No fields selected, selecting %v", defaultGetPaths)
-				paths = append(paths, defaultGetPaths...)
-			}
+
 			req := getSearchEntitiesRequest(cmd.Flags())
 			req.FieldMask.Paths = paths
 
@@ -138,10 +131,6 @@ var (
 				return err
 			}
 			paths := util.SelectFieldMask(cmd.Flags(), selectGatewayFlags)
-			if len(paths) == 0 {
-				logger.Warnf("No fields selected, selecting %v", defaultGetPaths)
-				paths = append(paths, defaultGetPaths...)
-			}
 
 			is, err := api.Dial(ctx, config.IdentityServerAddress)
 			if err != nil {

--- a/cmd/ttn-lw-cli/commands/organizations.go
+++ b/cmd/ttn-lw-cli/commands/organizations.go
@@ -68,10 +68,6 @@ var (
 		Short:   "List organizations",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			paths := util.SelectFieldMask(cmd.Flags(), selectOrganizationFlags)
-			if len(paths) == 0 {
-				logger.Warnf("No fields selected, selecting %v", defaultGetPaths)
-				paths = append(paths, defaultGetPaths...)
-			}
 
 			is, err := api.Dial(ctx, config.IdentityServerAddress)
 			if err != nil {
@@ -93,10 +89,7 @@ var (
 		Short: "Search for organizations",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			paths := util.SelectFieldMask(cmd.Flags(), selectOrganizationFlags)
-			if len(paths) == 0 {
-				logger.Warnf("No fields selected, selecting %v", defaultGetPaths)
-				paths = append(paths, defaultGetPaths...)
-			}
+
 			req := getSearchEntitiesRequest(cmd.Flags())
 			req.FieldMask.Paths = paths
 
@@ -122,10 +115,6 @@ var (
 				return errNoOrganizationID
 			}
 			paths := util.SelectFieldMask(cmd.Flags(), selectOrganizationFlags)
-			if len(paths) == 0 {
-				logger.Warnf("No fields selected, selecting %v", defaultGetPaths)
-				paths = append(paths, defaultGetPaths...)
-			}
 
 			is, err := api.Dial(ctx, config.IdentityServerAddress)
 			if err != nil {

--- a/cmd/ttn-lw-cli/commands/users.go
+++ b/cmd/ttn-lw-cli/commands/users.go
@@ -71,10 +71,7 @@ var (
 		Short: "Search for users",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			paths := util.SelectFieldMask(cmd.Flags(), selectUserFlags)
-			if len(paths) == 0 {
-				logger.Warnf("No fields selected, selecting %v", defaultGetPaths)
-				paths = append(paths, defaultGetPaths...)
-			}
+
 			req := getSearchEntitiesRequest(cmd.Flags())
 			req.FieldMask.Paths = paths
 
@@ -100,10 +97,6 @@ var (
 				return errNoUserID
 			}
 			paths := util.SelectFieldMask(cmd.Flags(), selectUserFlags)
-			if len(paths) == 0 {
-				logger.Warnf("No fields selected, selecting %v", defaultGetPaths)
-				paths = append(paths, defaultGetPaths...)
-			}
 
 			is, err := api.Dial(ctx, config.IdentityServerAddress)
 			if err != nil {

--- a/pkg/identityserver/application_registry.go
+++ b/pkg/identityserver/application_registry.go
@@ -189,6 +189,9 @@ func (is *IdentityServer) updateApplication(ctx context.Context, req *ttnpb.Upda
 		return nil, err
 	}
 	req.FieldMask.Paths = cleanFieldMaskPaths(ttnpb.ApplicationFieldPathsNested, req.FieldMask.Paths, nil, getPaths)
+	if len(req.FieldMask.Paths) == 0 {
+		req.FieldMask.Paths = updatePaths
+	}
 	if ttnpb.HasAnyField(req.FieldMask.Paths, "contact_info") {
 		if err := validateContactInfo(req.Application.ContactInfo); err != nil {
 			return nil, err

--- a/pkg/identityserver/application_registry.go
+++ b/pkg/identityserver/application_registry.go
@@ -83,6 +83,7 @@ func (is *IdentityServer) getApplication(ctx context.Context, req *ttnpb.GetAppl
 	if err = is.RequireAuthenticated(ctx); err != nil {
 		return nil, err
 	}
+	req.FieldMask.Paths = cleanFieldMaskPaths(ttnpb.ApplicationFieldPathsNested, req.FieldMask.Paths, getPaths, nil)
 	if err = rights.RequireApplication(ctx, req.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_INFO); err != nil {
 		if ttnpb.HasOnlyAllowedFields(req.FieldMask.Paths, ttnpb.PublicApplicationFields...) {
 			defer func() { app = app.PublicSafe() }()
@@ -110,6 +111,7 @@ func (is *IdentityServer) getApplication(ctx context.Context, req *ttnpb.GetAppl
 }
 
 func (is *IdentityServer) listApplications(ctx context.Context, req *ttnpb.ListApplicationsRequest) (apps *ttnpb.Applications, err error) {
+	req.FieldMask.Paths = cleanFieldMaskPaths(ttnpb.ApplicationFieldPathsNested, req.FieldMask.Paths, getPaths, nil)
 	var appRights map[string]*ttnpb.Rights
 	if req.Collaborator == nil {
 		callerRights, _, err := is.getRights(ctx)
@@ -186,8 +188,11 @@ func (is *IdentityServer) updateApplication(ctx context.Context, req *ttnpb.Upda
 	if err = rights.RequireApplication(ctx, req.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_SETTINGS_BASIC); err != nil {
 		return nil, err
 	}
-	if err := validateContactInfo(req.Application.ContactInfo); err != nil {
-		return nil, err
+	req.FieldMask.Paths = cleanFieldMaskPaths(ttnpb.ApplicationFieldPathsNested, req.FieldMask.Paths, nil, getPaths)
+	if ttnpb.HasAnyField(req.FieldMask.Paths, "contact_info") {
+		if err := validateContactInfo(req.Application.ContactInfo); err != nil {
+			return nil, err
+		}
 	}
 	err = is.withDatabase(ctx, func(db *gorm.DB) (err error) {
 		app, err = store.GetApplicationStore(db).UpdateApplication(ctx, &req.Application, &req.FieldMask)

--- a/pkg/identityserver/client_registry.go
+++ b/pkg/identityserver/client_registry.go
@@ -221,6 +221,9 @@ func (is *IdentityServer) updateClient(ctx context.Context, req *ttnpb.UpdateCli
 		return nil, err
 	}
 	req.FieldMask.Paths = cleanFieldMaskPaths(ttnpb.ClientFieldPathsNested, req.FieldMask.Paths, nil, getPaths)
+	if len(req.FieldMask.Paths) == 0 {
+		req.FieldMask.Paths = updatePaths
+	}
 	if ttnpb.HasAnyField(req.FieldMask.Paths, "contact_info") {
 		if err := validateContactInfo(req.Client.ContactInfo); err != nil {
 			return nil, err

--- a/pkg/identityserver/end_device_registry.go
+++ b/pkg/identityserver/end_device_registry.go
@@ -57,6 +57,7 @@ func (is *IdentityServer) getEndDevice(ctx context.Context, req *ttnpb.GetEndDev
 	if err = rights.RequireApplication(ctx, req.EndDeviceIdentifiers.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_DEVICES_READ); err != nil {
 		return nil, err
 	}
+	req.FieldMask.Paths = cleanFieldMaskPaths(ttnpb.EndDeviceFieldPathsNested, req.FieldMask.Paths, getPaths, nil)
 	err = is.withDatabase(ctx, func(db *gorm.DB) (err error) {
 		dev, err = store.GetEndDeviceStore(db).GetEndDevice(ctx, &req.EndDeviceIdentifiers, &req.FieldMask)
 		return err
@@ -71,6 +72,7 @@ func (is *IdentityServer) listEndDevices(ctx context.Context, req *ttnpb.ListEnd
 	if err = rights.RequireApplication(ctx, req.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_DEVICES_READ); err != nil {
 		return nil, err
 	}
+	req.FieldMask.Paths = cleanFieldMaskPaths(ttnpb.EndDeviceFieldPathsNested, req.FieldMask.Paths, getPaths, nil)
 	var total uint64
 	ctx = store.SetTotalCount(ctx, &total)
 	defer func() {
@@ -96,6 +98,7 @@ func (is *IdentityServer) updateEndDevice(ctx context.Context, req *ttnpb.Update
 	if err = rights.RequireApplication(ctx, req.EndDeviceIdentifiers.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_DEVICES_WRITE); err != nil {
 		return nil, err
 	}
+	req.FieldMask.Paths = cleanFieldMaskPaths(ttnpb.EndDeviceFieldPathsNested, req.FieldMask.Paths, nil, getPaths)
 	err = is.withDatabase(ctx, func(db *gorm.DB) (err error) {
 		dev, err = store.GetEndDeviceStore(db).UpdateEndDevice(ctx, &req.EndDevice, &req.FieldMask)
 		return err

--- a/pkg/identityserver/end_device_registry.go
+++ b/pkg/identityserver/end_device_registry.go
@@ -99,6 +99,9 @@ func (is *IdentityServer) updateEndDevice(ctx context.Context, req *ttnpb.Update
 		return nil, err
 	}
 	req.FieldMask.Paths = cleanFieldMaskPaths(ttnpb.EndDeviceFieldPathsNested, req.FieldMask.Paths, nil, getPaths)
+	if len(req.FieldMask.Paths) == 0 {
+		req.FieldMask.Paths = updatePaths
+	}
 	err = is.withDatabase(ctx, func(db *gorm.DB) (err error) {
 		dev, err = store.GetEndDeviceStore(db).UpdateEndDevice(ctx, &req.EndDevice, &req.FieldMask)
 		return err

--- a/pkg/identityserver/gateway_registry.go
+++ b/pkg/identityserver/gateway_registry.go
@@ -209,6 +209,9 @@ func (is *IdentityServer) updateGateway(ctx context.Context, req *ttnpb.UpdateGa
 		return nil, err
 	}
 	req.FieldMask.Paths = cleanFieldMaskPaths(ttnpb.GatewayFieldPathsNested, req.FieldMask.Paths, nil, getPaths)
+	if len(req.FieldMask.Paths) == 0 {
+		req.FieldMask.Paths = updatePaths
+	}
 	if ttnpb.HasAnyField(req.FieldMask.Paths, "contact_info") {
 		if err := validateContactInfo(req.Gateway.ContactInfo); err != nil {
 			return nil, err

--- a/pkg/identityserver/organization_registry.go
+++ b/pkg/identityserver/organization_registry.go
@@ -188,6 +188,9 @@ func (is *IdentityServer) updateOrganization(ctx context.Context, req *ttnpb.Upd
 		return nil, err
 	}
 	req.FieldMask.Paths = cleanFieldMaskPaths(ttnpb.OrganizationFieldPathsNested, req.FieldMask.Paths, nil, getPaths)
+	if len(req.FieldMask.Paths) == 0 {
+		req.FieldMask.Paths = updatePaths
+	}
 	if ttnpb.HasAnyField(req.FieldMask.Paths, "contact_info") {
 		if err := validateContactInfo(req.Organization.ContactInfo); err != nil {
 			return nil, err

--- a/pkg/identityserver/registry_search.go
+++ b/pkg/identityserver/registry_search.go
@@ -46,6 +46,7 @@ func (rs *registrySearch) SearchApplications(ctx context.Context, req *ttnpb.Sea
 	if err := rs.SearchAllowed(ctx); err != nil {
 		return nil, err
 	}
+	req.FieldMask.Paths = cleanFieldMaskPaths(ttnpb.ApplicationFieldPathsNested, req.FieldMask.Paths, getPaths, nil)
 	res := &ttnpb.Applications{}
 	err := rs.withDatabase(ctx, func(db *gorm.DB) error {
 		entityIDs, err := store.GetEntitySearch(db).FindEntities(ctx, req, "application")
@@ -78,6 +79,7 @@ func (rs *registrySearch) SearchClients(ctx context.Context, req *ttnpb.SearchEn
 	if err := rs.SearchAllowed(ctx); err != nil {
 		return nil, err
 	}
+	req.FieldMask.Paths = cleanFieldMaskPaths(ttnpb.ClientFieldPathsNested, req.FieldMask.Paths, getPaths, nil)
 	res := &ttnpb.Clients{}
 	err := rs.withDatabase(ctx, func(db *gorm.DB) error {
 		entityIDs, err := store.GetEntitySearch(db).FindEntities(ctx, req, "client")
@@ -110,6 +112,7 @@ func (rs *registrySearch) SearchGateways(ctx context.Context, req *ttnpb.SearchE
 	if err := rs.SearchAllowed(ctx); err != nil {
 		return nil, err
 	}
+	req.FieldMask.Paths = cleanFieldMaskPaths(ttnpb.GatewayFieldPathsNested, req.FieldMask.Paths, getPaths, nil)
 	res := &ttnpb.Gateways{}
 	err := rs.withDatabase(ctx, func(db *gorm.DB) error {
 		entityIDs, err := store.GetEntitySearch(db).FindEntities(ctx, req, "gateway")
@@ -142,6 +145,7 @@ func (rs *registrySearch) SearchOrganizations(ctx context.Context, req *ttnpb.Se
 	if err := rs.SearchAllowed(ctx); err != nil {
 		return nil, err
 	}
+	req.FieldMask.Paths = cleanFieldMaskPaths(ttnpb.OrganizationFieldPathsNested, req.FieldMask.Paths, getPaths, nil)
 	res := &ttnpb.Organizations{}
 	err := rs.withDatabase(ctx, func(db *gorm.DB) error {
 		entityIDs, err := store.GetEntitySearch(db).FindEntities(ctx, req, "organization")
@@ -174,6 +178,7 @@ func (rs *registrySearch) SearchUsers(ctx context.Context, req *ttnpb.SearchEnti
 	if err := rs.SearchAllowed(ctx); err != nil {
 		return nil, err
 	}
+	req.FieldMask.Paths = cleanFieldMaskPaths(ttnpb.UserFieldPathsNested, req.FieldMask.Paths, getPaths, nil)
 	res := &ttnpb.Users{}
 	err := rs.withDatabase(ctx, func(db *gorm.DB) error {
 		entityIDs, err := store.GetEntitySearch(db).FindEntities(ctx, req, "user")

--- a/pkg/identityserver/user_registry.go
+++ b/pkg/identityserver/user_registry.go
@@ -196,6 +196,7 @@ func (is *IdentityServer) getUser(ctx context.Context, req *ttnpb.GetUserRequest
 	if err = is.RequireAuthenticated(ctx); err != nil {
 		return nil, err
 	}
+	req.FieldMask.Paths = cleanFieldMaskPaths(ttnpb.UserFieldPathsNested, req.FieldMask.Paths, getPaths, nil)
 	if err = rights.RequireUser(ctx, req.UserIdentifiers, ttnpb.RIGHT_USER_INFO); err != nil {
 		if ttnpb.HasOnlyAllowedFields(req.FieldMask.Paths, ttnpb.PublicUserFields...) {
 			defer func() { usr = usr.PublicSafe() }()
@@ -261,6 +262,7 @@ func (is *IdentityServer) updateUser(ctx context.Context, req *ttnpb.UpdateUserR
 	if err = rights.RequireUser(ctx, req.UserIdentifiers, ttnpb.RIGHT_USER_SETTINGS_BASIC); err != nil {
 		return nil, err
 	}
+	req.FieldMask.Paths = cleanFieldMaskPaths(ttnpb.UserFieldPathsNested, req.FieldMask.Paths, nil, getPaths)
 	updatedByAdmin := is.UniversalRights(ctx).IncludesAll(ttnpb.RIGHT_USER_ALL)
 
 	if ttnpb.HasAnyField(req.FieldMask.Paths, "password", "password_updated_at") {

--- a/pkg/identityserver/user_registry.go
+++ b/pkg/identityserver/user_registry.go
@@ -263,6 +263,9 @@ func (is *IdentityServer) updateUser(ctx context.Context, req *ttnpb.UpdateUserR
 		return nil, err
 	}
 	req.FieldMask.Paths = cleanFieldMaskPaths(ttnpb.UserFieldPathsNested, req.FieldMask.Paths, nil, getPaths)
+	if len(req.FieldMask.Paths) == 0 {
+		req.FieldMask.Paths = updatePaths
+	}
 	updatedByAdmin := is.UniversalRights(ctx).IncludesAll(ttnpb.RIGHT_USER_ALL)
 
 	if ttnpb.HasAnyField(req.FieldMask.Paths, "password", "password_updated_at") {

--- a/pkg/identityserver/utils.go
+++ b/pkg/identityserver/utils.go
@@ -24,7 +24,10 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-var getPaths = []string{"ids", "created_at", "updated_at"}
+var (
+	getPaths    = []string{"ids", "created_at", "updated_at"}
+	updatePaths = []string{"updated_at"}
+)
 
 func cleanFieldMaskPaths(allowedPaths, requestedPaths, addPaths, removePaths []string) []string {
 	selected := make(map[string]struct{})

--- a/pkg/identityserver/utils.go
+++ b/pkg/identityserver/utils.go
@@ -24,6 +24,28 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
+var getPaths = []string{"ids", "created_at", "updated_at"}
+
+func cleanFieldMaskPaths(allowedPaths, requestedPaths, addPaths, removePaths []string) []string {
+	selected := make(map[string]struct{})
+	for _, path := range addPaths {
+		selected[path] = struct{}{}
+	}
+	for _, path := range requestedPaths {
+		selected[path] = struct{}{}
+	}
+	for _, path := range removePaths {
+		delete(selected, path)
+	}
+	out := make([]string, 0, len(selected))
+	for _, path := range allowedPaths {
+		if _, ok := selected[path]; ok {
+			out = append(out, path)
+		}
+	}
+	return out
+}
+
 func cleanContactInfo(info []*ttnpb.ContactInfo) {
 	for _, info := range info {
 		info.ValidatedAt = nil

--- a/pkg/ttnpb/public.go
+++ b/pkg/ttnpb/public.go
@@ -32,6 +32,7 @@ func onlyPublicContactInfo(info []*ContactInfo) []*ContactInfo {
 var PublicEntityFields = []string{
 	"ids",
 	"created_at",
+	"updated_at",
 	"contact_info", // Note that this is filtered.
 }
 


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Since #69 (specifically the decisions in https://github.com/TheThingsNetwork/lorawan-stack/issues/69#issuecomment-465184422 and related meeting) we now allow empty field masks. This PR makes sure that the Identity Server handles such requests accordingly.

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Field Mask paths on IS requests are "cleaned" according to a set of possible/allowed fields, as well as fields to add (default fields on Get-like requests) or remove (ignored fields on Set-like requests)
- CLI is updated to no longer implicitly select the "name" field.

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

@rvolosatovs if you think it could be useful in other places (end device registries), we can move the `cleanFieldMaskPaths` utility to `ttnpb`.

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
What are the functional or behavioral changes? API Changes? New features?
Any changes in configuration? Added/changed/removed flags?
Are there any database migrations required?
-->

The Identity Server now treats empty field masks as if ids and created/updated times were requested.