### PR TITLE
Key devices by UID and EUIs

### DIFF
--- a/pkg/joinserver/grpc_nsjs_test.go
+++ b/pkg/joinserver/grpc_nsjs_test.go
@@ -1092,7 +1092,7 @@ func TestHandleJoin(t *testing.T) {
 
 			start := time.Now()
 
-			ret, err := devReg.SetByEUI(authorizedCtx, *pb.JoinEUI, *pb.DevEUI,
+			ret, err := devReg.SetByID(authorizedCtx, pb.ApplicationIdentifiers, pb.DeviceID,
 				[]string{
 					"created_at",
 					"last_dev_nonce",

--- a/pkg/joinserver/joinserver_internal_test.go
+++ b/pkg/joinserver/joinserver_internal_test.go
@@ -40,7 +40,9 @@ type JsDeviceServer = jsEndDeviceRegistryServer
 
 type MockDeviceRegistry struct {
 	GetByEUIFunc func(context.Context, types.EUI64, types.EUI64, []string) (*ttnpb.EndDevice, error)
+	GetByIDFunc  func(context.Context, ttnpb.ApplicationIdentifiers, string, []string) (*ttnpb.EndDevice, error)
 	SetByEUIFunc func(context.Context, types.EUI64, types.EUI64, []string, func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error)
+	SetByIDFunc  func(context.Context, ttnpb.ApplicationIdentifiers, string, []string, func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error)
 }
 
 func (r *MockDeviceRegistry) GetByEUI(ctx context.Context, joinEUI types.EUI64, devEUI types.EUI64, paths []string) (*ttnpb.EndDevice, error) {
@@ -50,11 +52,25 @@ func (r *MockDeviceRegistry) GetByEUI(ctx context.Context, joinEUI types.EUI64, 
 	return r.GetByEUIFunc(ctx, joinEUI, devEUI, paths)
 }
 
+func (r *MockDeviceRegistry) GetByID(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, paths []string) (*ttnpb.EndDevice, error) {
+	if r.GetByIDFunc == nil {
+		return nil, errors.New("Not implemented")
+	}
+	return r.GetByIDFunc(ctx, appID, devID, paths)
+}
+
 func (r *MockDeviceRegistry) SetByEUI(ctx context.Context, joinEUI types.EUI64, devEUI types.EUI64, paths []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
 	if r.SetByEUIFunc == nil {
 		return nil, errors.New("Not implemented")
 	}
 	return r.SetByEUIFunc(ctx, joinEUI, devEUI, paths, f)
+}
+
+func (r *MockDeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, paths []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+	if r.SetByIDFunc == nil {
+		return nil, errors.New("Not implemented")
+	}
+	return r.SetByIDFunc(ctx, appID, devID, paths, f)
 }
 
 type MockKeyRegistry struct {

--- a/pkg/joinserver/registry.go
+++ b/pkg/joinserver/registry.go
@@ -24,12 +24,14 @@ import (
 // DeviceRegistry is a registry, containing devices.
 type DeviceRegistry interface {
 	GetByEUI(ctx context.Context, joinEUI types.EUI64, devEUI types.EUI64, paths []string) (*ttnpb.EndDevice, error)
+	GetByID(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, paths []string) (*ttnpb.EndDevice, error)
 	SetByEUI(ctx context.Context, joinEUI types.EUI64, devEUI types.EUI64, paths []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error)
+	SetByID(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, paths []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error)
 }
 
 // DeleteDevice deletes device identified by joinEUI, devEUI from r.
-func DeleteDevice(ctx context.Context, r DeviceRegistry, joinEUI types.EUI64, devEUI types.EUI64) error {
-	_, err := r.SetByEUI(ctx, joinEUI, devEUI, nil, func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) { return nil, nil, nil })
+func DeleteDevice(ctx context.Context, r DeviceRegistry, appID ttnpb.ApplicationIdentifiers, devID string) error {
+	_, err := r.SetByID(ctx, appID, devID, nil, func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) { return nil, nil, nil })
 	return err
 }
 

--- a/pkg/networkserver/redis/registry.go
+++ b/pkg/networkserver/redis/registry.go
@@ -60,7 +60,7 @@ func (r *DeviceRegistry) addrKey(addr types.DevAddr) string {
 	return r.Redis.Key("addr", addr.String())
 }
 
-func (r *DeviceRegistry) euiKey(devEUI, joinEUI types.EUI64) string {
+func (r *DeviceRegistry) euiKey(joinEUI, devEUI types.EUI64) string {
 	return r.Redis.Key("eui", joinEUI.String(), devEUI.String())
 }
 


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #260 

Key devices by UID and EUIs.

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Use UID as primary key and EUIs as secondary key for devices; this is consistent with NS and AS device registries