### PR TITLE
Return aborted error on link failure

### DIFF
--- a/pkg/applicationserver/linking.go
+++ b/pkg/applicationserver/linking.go
@@ -247,7 +247,7 @@ func (as *ApplicationServer) link(ctx context.Context, ids ttnpb.ApplicationIden
 
 var (
 	errNotLinked  = errors.DefineNotFound("not_linked", "not linked to `{application_uid}`")
-	errLinkFailed = errors.Define("link", "link failed")
+	errLinkFailed = errors.DefineAborted("link", "link failed")
 )
 
 func (as *ApplicationServer) cancelLink(ctx context.Context, ids ttnpb.ApplicationIdentifiers) error {


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

References #214 

See also https://github.com/TheThingsNetwork/lorawan-stack/pull/257#issuecomment-470960834

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Return Aborted code on any link failure