### PR TITLE
Fix error attribute when scheduled payload is too long

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -2620,7 +2620,7 @@
   },
   "error:pkg/gatewayserver/io:too_long": {
     "translations": {
-      "en": "the payload length `{payload_length}` exceeds maximum `{maximum_payload}` at data rate index `{data_rate_index}`"
+      "en": "the payload length `{payload_length}` exceeds maximum `{maximum_length}` at data rate index `{data_rate_index}`"
     },
     "description": {
       "package": "pkg/gatewayserver/io",

--- a/pkg/fetch/http_test.go
+++ b/pkg/fetch/http_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/fetch"
+	"go.thethings.network/lorawan-stack/pkg/util/test"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 	httpmock "gopkg.in/jarcoal/httpmock.v1"
 )
@@ -86,7 +87,7 @@ func TestHTTPCache(t *testing.T) {
 	go s.ListenAndServe()
 	defer s.Close()
 
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(10 * test.Delay)
 
 	fetcher := fetch.FromHTTP(fmt.Sprintf("http://%s", s.Addr), true)
 

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -178,7 +178,7 @@ var (
 	errRxEmpty          = errors.DefineFailedPrecondition("rx_empty", "settings empty")
 	errRxWindowSchedule = errors.Define("rx_window_schedule", "schedule in Rx window `{window}` failed")
 	errDataRate         = errors.DefineInvalidArgument("data_rate", "no data rate with index `{index}`")
-	errTooLong          = errors.DefineInvalidArgument("too_long", "the payload length `{payload_length}` exceeds maximum `{maximum_payload}` at data rate index `{data_rate_index}`")
+	errTooLong          = errors.DefineInvalidArgument("too_long", "the payload length `{payload_length}` exceeds maximum `{maximum_length}` at data rate index `{data_rate_index}`")
 	errTxSchedule       = errors.DefineAborted("tx_schedule", "failed to schedule")
 )
 


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

References #271 

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Fix error attribute