### PR TITLE
Device Support for JS SDK

### DIFF
--- a/sdk/js/generated/device-entity-map.json
+++ b/sdk/js/generated/device-entity-map.json
@@ -1,0 +1,77 @@
+{
+  "ids": ["is", "is"],
+  "name": ["is", "is"],
+  "description": ["is", "is"],
+  "attributes": ["is", "is"],
+  "locations": ["is", "is"],
+  "version_ids": ["is", "is"],
+  "service_profile_id": ["is", "is"],
+  "application_server_address": ["is", ["is", "js"]],
+  "join_server_address": ["is", "is"],
+  "network_server_address": ["is", ["is", "js"]],
+  "battery_percentage": ["ns", "read_only"],
+  "default_class": ["ns", "ns"],
+  "default_mac_parameters": ["ns", "ns"],
+  "downlink_margin": ["ns", "read_only"],
+  "frequency_plan_id": ["ns", "ns"],
+  "last_dev_status_received_at": ["ns", "read_only"],
+  "lorawan_phy_version": ["ns", "ns"],
+  "lorawan_version": ["ns", "ns"],
+  "mac_settings": ["ns", "ns"],
+  "mac_state": ["ns", "read_only"],
+  "max_frequency": ["ns", "ns"],
+  "min_frequency": ["ns", "ns"],
+  "power_state": ["ns", "read_only"],
+  "recent_downlinks": ["ns", "read_only"],
+  "recent_uplinks": ["ns", "read_only"],
+  "resets_f_cnt": ["ns", "ns"],
+  "resets_join_nonces": ["js", "js"],
+  "supports_class_b": ["ns", "ns"],
+  "supports_class_c": ["ns", "ns"],
+  "supports_join": ["ns", "ns"],
+  "uses_32_bit_f_cnt": ["ns", "ns"],
+  "session": {
+    "_root": [["ns", "as"], "read_only"],
+    "dev_addr": ["ns", "ns"],
+    "last_f_cnt_down": ["ns", "ns"],
+    "last_f_cnt_up": ["ns", "ns"],
+    "last_conf_f_cnt_down": ["ns", "ns"],
+    "last_a_f_cnt_down": ["as", "as"],
+    "started_at": ["ns", "ns"],
+    "keys": {
+      "_root": [["ns", "as"], "read_only"],
+      "f_nwk_s_int_key": {
+        "_root": ["ns", "read_only"],
+        "key": ["ns", "ns"],
+        "label": ["ns", "read_only"]
+      },
+      "nwk_s_enc_key": {
+        "_root": ["ns", "read_only"],
+        "key": ["ns", "ns"],
+        "label": ["ns", "read_only"]
+      },
+      "s_nwk_s_int_key": {
+        "_root": ["ns", "read_only"],
+        "key": ["ns", "ns"],
+        "label": ["ns", "read_only"]
+      },
+      "app_s_key": {
+        "_root": ["as", "read_only"],
+        "key": ["as", "as"],
+        "label": ["as", "read_only"]
+      }
+    }
+  },
+  "formatters": ["as", "as"],
+  "queued_application_downlinks": ["ns", "read_only"],
+  "last_dev_nonce": ["js", "js"],
+  "last_join_nonce": ["js", "js"],
+  "last_rj_count_0": ["js", "js"],
+  "last_rj_count_1": ["js", "js"],
+  "net_id": ["js", "js"],
+  "provisioner_id": ["js", "js"],
+  "provisioning_data": ["js", "js"],
+  "resets_join_nonces": ["js", "js"],
+  "root_keys": ["js", "js"],
+  "used_dev_nonces": ["js", "js"]
+}

--- a/sdk/js/src/api/http.js
+++ b/sdk/js/src/api/http.js
@@ -79,9 +79,18 @@ class Http {
 
   async get (endpoint, ...rest) {
     const { fieldMask, queryParams } = rest[rest.length - 1]
-    const config = {}
+    let fieldMaskPath
     if (fieldMask) {
-      config.params = { field_mask: fieldMask.paths.join(',') || fieldMask.join(',') }
+      if (typeof fieldMask === 'string') {
+        fieldMaskPath = fieldMask.paths.join(',')
+      } else if ('paths' in fieldMask && typeof fieldMask.paths === 'string') {
+        fieldMaskPath = fieldMask.join(',')
+      }
+    }
+
+    const config = {}
+    if (fieldMaskPath) {
+      config.params = { field_mask: fieldMaskPath }
     }
     if (queryParams) {
       config.params = {

--- a/sdk/js/src/api/http.js
+++ b/sdk/js/src/api/http.js
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import axios from 'axios'
-import Marshaler from '../util/marshaler'
 
 /**
  * Http Class is a connector for the API that uses the HTTP bridge to connect.
@@ -101,18 +100,15 @@ class Http {
     return this.handleRequest('get', endpoint, undefined, config)
   }
 
-  async post (endpoint, rawPayload) {
-    const payload = Marshaler.payload(rawPayload, 'end_device')
+  async post (endpoint, payload) {
     return this.handleRequest('post', endpoint, payload)
   }
 
-  async patch (endpoint, rawPayload) {
-    const payload = Marshaler.payload(rawPayload, 'end_device')
+  async patch (endpoint, payload) {
     return this.handleRequest('patch', endpoint, payload)
   }
 
-  async put (endpoint, rawPayload, { fieldMask }) {
-    const payload = Marshaler.payload(rawPayload, 'end_device')
+  async put (endpoint, payload, { fieldMask }) {
     if (fieldMask) {
       payload.field_mask = fieldMask
     }

--- a/sdk/js/src/api/http.js
+++ b/sdk/js/src/api/http.js
@@ -76,26 +76,15 @@ class Http {
     }
   }
 
-  async get (endpoint, { fieldMask, queryParams }) {
+  async get (endpoint, params) {
+    // Convert payload to query params (should usually be field_mask only)
     const config = {}
-
-    let fieldMaskPath
-    if (fieldMask) {
-      if (typeof fieldMask === 'string') {
-        fieldMaskPath = fieldMask.join(',')
-      } else if ('paths' in fieldMask) {
-        fieldMaskPath = fieldMask.paths.join(',')
+    if (params && Object.keys(params).length > 0) {
+      if ('field_mask' in params) {
+        // Convert field mask prop to a query param friendly format
+        params.field_mask = params.field_mask.paths.join(',')
       }
-    }
-
-    if (fieldMaskPath) {
-      config.params = { field_mask: fieldMaskPath }
-    }
-    if (queryParams) {
-      config.params = {
-        ...config.params,
-        ...queryParams,
-      }
+      config.params = params
     }
 
     return this.handleRequest('get', endpoint, undefined, config)
@@ -109,10 +98,7 @@ class Http {
     return this.handleRequest('patch', endpoint, payload)
   }
 
-  async put (endpoint, payload, { fieldMask }) {
-    if (fieldMask) {
-      payload.field_mask = fieldMask
-    }
+  async put (endpoint, payload) {
     return this.handleRequest('put', endpoint, payload)
   }
 

--- a/sdk/js/src/api/http.js
+++ b/sdk/js/src/api/http.js
@@ -76,18 +76,18 @@ class Http {
     }
   }
 
-  async get (endpoint, ...rest) {
-    const { fieldMask, queryParams } = rest[rest.length - 1]
+  async get (endpoint, { fieldMask, queryParams }) {
+    const config = {}
+
     let fieldMaskPath
     if (fieldMask) {
       if (typeof fieldMask === 'string') {
-        fieldMaskPath = fieldMask.paths.join(',')
-      } else if ('paths' in fieldMask && typeof fieldMask.paths === 'string') {
         fieldMaskPath = fieldMask.join(',')
+      } else if ('paths' in fieldMask) {
+        fieldMaskPath = fieldMask.paths.join(',')
       }
     }
 
-    const config = {}
     if (fieldMaskPath) {
       config.params = { field_mask: fieldMaskPath }
     }
@@ -97,6 +97,7 @@ class Http {
         ...queryParams,
       }
     }
+
     return this.handleRequest('get', endpoint, undefined, config)
   }
 

--- a/sdk/js/src/api/index.js
+++ b/sdk/js/src/api/index.js
@@ -40,7 +40,7 @@ class Api {
       for (const rpcName of Object.keys(service)) {
         const rpc = service[rpcName]
 
-        this[serviceName][rpcName] = function ({ routeParams = {}, queryParams = {}, fieldMask = []} = {}, payload) {
+        this[serviceName][rpcName] = function ({ routeParams = {}} = {}, payload) {
 
           const paramSignature = Object.keys(routeParams).sort().join()
           const endpoint = rpc.http.find(function (prospect) {
@@ -59,15 +59,7 @@ Signature tried: ${paramSignature}`)
             route = route.replace(`{${parameter}}`, routeParams[parameter])
           }
 
-          if (endpoint.method === 'delete') {
-            return connector.delete(route)
-          }
-
-          if (endpoint.method === 'get') {
-            return connector.get(route, { queryParams, fieldMask })
-          }
-
-          return connector[endpoint.method](route, payload, { queryParams, fieldMask })
+          return connector[endpoint.method](route, payload)
         }
       }
     }

--- a/sdk/js/src/api/index.js
+++ b/sdk/js/src/api/index.js
@@ -59,6 +59,14 @@ Signature tried: ${paramSignature}`)
             route = route.replace(`{${parameter}}`, routeParams[parameter])
           }
 
+          if (endpoint.method === 'delete') {
+            return connector.delete(route)
+          }
+
+          if (endpoint.method === 'get') {
+            return connector.get(route, { queryParams, fieldMask })
+          }
+
           return connector[endpoint.method](route, payload, { queryParams, fieldMask })
         }
       }

--- a/sdk/js/src/api/index.js
+++ b/sdk/js/src/api/index.js
@@ -40,7 +40,7 @@ class Api {
       for (const rpcName of Object.keys(service)) {
         const rpc = service[rpcName]
 
-        this[serviceName][rpcName] = function ({ routeParams = {}, queryParams = {}, fieldMask = []}, payload) {
+        this[serviceName][rpcName] = function ({ routeParams = {}, queryParams = {}, fieldMask = []} = {}, payload) {
 
           const paramSignature = Object.keys(routeParams).sort().join()
           const endpoint = rpc.http.find(function (prospect) {

--- a/sdk/js/src/api/index.test.js
+++ b/sdk/js/src/api/index.test.js
@@ -66,10 +66,10 @@ describe('API', function () {
   })
 
   test('it applies parameters correctly', function () {
-    api.ApplicationRegistry.Create({ route: { 'collaborator.user_ids.user_id': 'test' }})
+    api.ApplicationRegistry.Create({ routeParams: { 'collaborator.user_ids.user_id': 'test' }}, { name: 'test-name' })
 
     expect(api._connector.post).toHaveBeenCalledTimes(1)
-    expect(api._connector.post).toHaveBeenCalledWith('/users/test/applications', undefined)
+    expect(api._connector.post).toHaveBeenCalledWith('/users/test/applications', { name: 'test-name' })
   })
 
   test('it throws when parameters mismatch', function () {
@@ -79,9 +79,9 @@ describe('API', function () {
   })
 
   test('it respects the search query', function () {
-    api.ApplicationRegistry.List({ query: { limit: 2, page: 1 }})
+    api.ApplicationRegistry.List(undefined, { limit: 2, page: 1 })
 
     expect(api._connector.get).toHaveBeenCalledTimes(1)
-    expect(api._connector.get).toHaveBeenCalledWith('/applications?limit=2&page=1', undefined)
+    expect(api._connector.get).toHaveBeenCalledWith('/applications', { limit: 2, page: 1 })
   })
 })

--- a/sdk/js/src/entity/application.js
+++ b/sdk/js/src/entity/application.js
@@ -34,34 +34,24 @@ class Application extends Entity {
     this.Devices = new Devices(parent._api, this._id)
   }
 
-  // Collaborators
-
-  async getCollaborators () {
-    return this._parent.withId(this._id).getCollaborators()
-  }
-
-  async addCollaborator (collaborator) {
-    return this._parent.withId(this._id).setCollaborator(collaborator)
-  }
-
   // API Keys
 
-  async getApiKeys () {
-    return this._parent.withId(this._id).getApiKeys()
+  async getApiKeys (params) {
+    return this._parent.ApiKeys.getAll(this._id, params)
   }
 
   async addApiKey (key) {
-    return this._parent.withId(this._id).addApiKey(key)
+    return this._parent.ApiKeys.getAll(this._id, key)
   }
 
   // Devices
 
   async getDevice (deviceId) {
-    return this._parent.withId(this._id).getDevice(deviceId)
+    return this._parent.Devices.getById(this._id, deviceId)
   }
 
-  async getDevices () {
-    return this._parent.withId(this._id).getDevices()
+  async getDevices (params) {
+    return this._parent.Devices.getAll(this._id, params)
   }
 
   async save (userId) {

--- a/sdk/js/src/index.js
+++ b/sdk/js/src/index.js
@@ -14,7 +14,6 @@
 
 import Applications from './service/applications'
 import Application from './entity/application'
-import Devices from './service/devices'
 import Api from './api'
 
 class TtnLw {
@@ -28,10 +27,8 @@ class TtnLw {
     this.config = arguments.config
     this.api = new Api(connectionType, stackConfig, axiosConfig, token)
 
-    this.Applications = new Applications(this.api, { defaultUserId, proxy })
+    this.Applications = new Applications(this.api, { defaultUserId, proxy, stackConfig })
     this.Application = Application.bind(null, this.Applications)
-
-    this.Devices = new Devices(this.api, { defaultUserId, proxy })
   }
 }
 

--- a/sdk/js/src/index.js
+++ b/sdk/js/src/index.js
@@ -14,6 +14,7 @@
 
 import Applications from './service/applications'
 import Application from './entity/application'
+import Devices from './service/devices'
 import Api from './api'
 
 class TtnLw {
@@ -29,6 +30,8 @@ class TtnLw {
 
     this.Applications = new Applications(this.api, { defaultUserId, proxy })
     this.Application = Application.bind(null, this.Applications)
+
+    this.Devices = new Devices(this.api, { defaultUserId, proxy })
   }
 }
 

--- a/sdk/js/src/index.test.js
+++ b/sdk/js/src/index.test.js
@@ -92,7 +92,7 @@ describe('SDK class', function () {
 
   test('retrieves device via app instance correctly', async function () {
     const app = await ttn.Applications.getById('test')
-    const device = await app.Devices.getById('test', 'test-device', 'ids')
+    const device = await app.Devices.getById('test', 'test-device')
 
     expect(app.Devices).toBeInstanceOf(Devices)
     expect(device).toBeDefined()

--- a/sdk/js/src/index.test.js
+++ b/sdk/js/src/index.test.js
@@ -65,7 +65,7 @@ jest.mock('./api', function () {
         }),
       },
       EndDeviceRegistry: {
-        Get: jest.fn().mockResolvedValue(mockDeviceData),
+        Get: jest.fn().mockResolvedValue({ data: mockDeviceData }),
       },
     }
   })
@@ -92,18 +92,10 @@ describe('SDK class', function () {
 
   test('retrieves device via app instance correctly', async function () {
     const app = await ttn.Applications.getById('test')
-    const device = await app.Devices.getById('test-device')
+    const device = await app.Devices.getById('test', 'test-device', 'ids')
 
     expect(app.Devices).toBeInstanceOf(Devices)
     expect(device).toBeDefined()
     expect(device).toBeInstanceOf(Device)
   })
-
-  test('retrieves device via shorthand correctly', async function () {
-    const device = await ttn.Applications.withId('test').getDevice('test-device')
-
-    expect(device).toBeDefined()
-    expect(device).toBeInstanceOf(Device)
-  })
-
 })

--- a/sdk/js/src/service/api-keys.js
+++ b/sdk/js/src/service/api-keys.js
@@ -23,9 +23,8 @@ class ApiKeys {
   async getAll (entityId, params) {
     const entityIdRoute = this._parentRoutes.list
     const result = await this._api.ListAPIKeys({
-      route: { [entityIdRoute]: entityId },
-      query: params,
-    })
+      routeParams: { [entityIdRoute]: entityId },
+    }, params)
 
     return Marshaler.payloadListResponse('api_keys', result)
   }
@@ -33,7 +32,7 @@ class ApiKeys {
   async create (entityId, key) {
     const entityIdRoute = this._parentRoutes.create
     const result = await this._api.CreateAPIKey({
-      route: { [entityIdRoute]: entityId },
+      routeParams: { [entityIdRoute]: entityId },
     },
     {
       ...key,
@@ -51,7 +50,7 @@ class ApiKeys {
   async updateById (entityId, id, patch) {
     const entityIdRoute = this._parentRoutes.update
     const result = await this._api.UpdateAPIKey({
-      route: {
+      routeParams: {
         [entityIdRoute]: entityId,
         'api_key.id': id,
       },

--- a/sdk/js/src/service/api-keys.js
+++ b/sdk/js/src/service/api-keys.js
@@ -15,7 +15,7 @@
 import Marshaler from '../util/marshaler'
 
 class ApiKeys {
-  constructor (registry, parentRoutes) {
+  constructor (registry, { parentRoutes }) {
     this._api = registry
     this._parentRoutes = parentRoutes
   }

--- a/sdk/js/src/service/applications.js
+++ b/sdk/js/src/service/applications.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import Marshaler from '../util/marshaler'
-import Device from '../entity/device'
+import Devices from '../service/devices'
 import Application from '../entity/application'
 import ApiKeys from './api-keys'
 import Link from './link'
@@ -43,20 +43,8 @@ class Applications {
       },
     })
     this.Link = new Link(api.As)
-<<<<<<< HEAD
-=======
-    this.Device = new Device(api, { proxy })
+    this.Devices = new Devices(api, { proxy })
 
-    this.getAll = this.getAll.bind(this)
-    this.getById = this.getById.bind(this)
-    this.getByOrganization = this.getByOrganization.bind(this)
-    this.getByCollaborator = this.getByCollaborator.bind(this)
-    this.search = this.search.bind(this)
-    this.updateById = this.updateById.bind(this)
-    this.create = this.create.bind(this)
-    this.deleteById = this.deleteById.bind(this)
-    this.getRightsById = this.getRightsById.bind(this)
->>>>>>> 34741e7f7... util: Remove withId shorthand
   }
 
   _responseTransform (response) {

--- a/sdk/js/src/service/applications.js
+++ b/sdk/js/src/service/applications.js
@@ -36,9 +36,11 @@ class Applications {
     this._proxy = proxy
 
     this.ApiKeys = new ApiKeys(api.ApplicationAccess, {
-      list: 'application_id',
-      create: 'application_ids.application_id',
-      update: 'application_ids.application_id',
+      parentRoutes: {
+        list: 'application_id',
+        create: 'application_ids.application_id',
+        update: 'application_ids.application_id',
+      },
     })
     this.Link = new Link(api.As)
 <<<<<<< HEAD
@@ -70,14 +72,14 @@ class Applications {
   // Retrieval
 
   async getAll (params) {
-    const response = await this._api.ApplicationRegistry.List({ query: params })
+    const response = await this._api.ApplicationRegistry.List({ queryParams: params })
 
     return this._responseTransform(response)
   }
 
   async getById (id) {
     const response = await this._api.ApplicationRegistry.Get({
-      route: { 'application_ids.application_id': id },
+      routeParams: { 'application_ids.application_id': id },
     })
 
     return this._responseTransform(response)
@@ -85,7 +87,7 @@ class Applications {
 
   async getByOrganization (organizationId) {
     const response = this._api.ApplicationRegistry.List({
-      route: { 'collaborator.organization_ids.organization_id': organizationId },
+      routeParams: { 'collaborator.organization_ids.organization_id': organizationId },
     })
 
     return this._responseTransform(response)
@@ -93,7 +95,7 @@ class Applications {
 
   async getByCollaborator (userId) {
     const response = this._api.ApplicationRegistry.List({
-      route: { 'collaborator.user_ids.user_id': userId },
+      routeParams: { 'collaborator.user_ids.user_id': userId },
     })
 
     return this._responseTransform(response)
@@ -101,7 +103,7 @@ class Applications {
 
   async search (params) {
     const response = await this._api.EntityRegistrySearch.SearchApplications({
-      query: params,
+      queryParams: params,
     })
 
     return this._responseTransform(response)
@@ -111,7 +113,7 @@ class Applications {
 
   async updateById (id, patch, mask = Marshaler.fieldMaskFromPatch(patch)) {
     const response = await this._api.ApplicationRegistry.Update({
-      route: {
+      routeParams: {
         'application.ids.application_id': id,
       },
     },
@@ -119,14 +121,17 @@ class Applications {
       application: patch,
       field_mask: Marshaler.fieldMask(mask),
     })
-    return this._responseTransform(response)
+    return Marshaler.unwrapApplication(
+      response,
+      this._applicationTransform
+    )
   }
 
   // Create
 
   async create (userId = this._defaultUserId, application) {
     const response = await this._api.ApplicationRegistry.Create({
-      route: { 'collaborator.user_ids.user_id': userId },
+      routeParams: { 'collaborator.user_ids.user_id': userId },
     },
     { application })
     return this._responseTransform(response)
@@ -136,13 +141,13 @@ class Applications {
 
   async deleteById (applicationId) {
     return this._api.ApplicationRegistry.Delete({
-      route: { application_id: applicationId },
+      routeParams: { application_id: applicationId },
     })
   }
 
   async getRightsById (applicationId) {
     const result = await this._api.ApplicationAccess.ListRights({
-      route: { application_id: applicationId },
+      routeParams: { application_id: applicationId },
     })
 
     return Marshaler.unwrapRights(result)

--- a/sdk/js/src/service/applications.js
+++ b/sdk/js/src/service/applications.js
@@ -43,6 +43,20 @@ class Applications {
       update: 'application_ids.application_id',
     })
     this.Link = new Link(api.As)
+<<<<<<< HEAD
+=======
+    this.Device = new Device(api, { proxy })
+
+    this.getAll = this.getAll.bind(this)
+    this.getById = this.getById.bind(this)
+    this.getByOrganization = this.getByOrganization.bind(this)
+    this.getByCollaborator = this.getByCollaborator.bind(this)
+    this.search = this.search.bind(this)
+    this.updateById = this.updateById.bind(this)
+    this.create = this.create.bind(this)
+    this.deleteById = this.deleteById.bind(this)
+    this.getRightsById = this.getRightsById.bind(this)
+>>>>>>> 34741e7f7... util: Remove withId shorthand
   }
 
   // Retrieval
@@ -144,55 +158,6 @@ class Applications {
     })
 
     return Marshaler.unwrapRights(result)
-  }
-
-  // Shorthand to methods of single application
-  withId (id) {
-    const parent = this
-    const api = parent._api
-    const idMask = { 'application_ids.application_id': id }
-    return {
-      async getDevices () {
-        return api.EndDeviceRegistry.List(idMask)
-      },
-      async getDevice (deviceId) {
-        const result = await api.EndDeviceRegistry.Get({
-          'end_device_ids.application_ids.application_id': id,
-          device_id: deviceId,
-        })
-        return new Device(result, api)
-      },
-      async getApiKeys (params) {
-        return this.ApiKeys.getAll(id, params)
-      },
-      async getCollaborators () {
-        return api.ApplicationAccess.ListCollaborators({ application_id: id })
-      },
-      async addApiKey (key) {
-        return this.ApiKeys.create(id, key)
-      },
-      async deleteApiKey (keyId) {
-        return this.ApiKeys.deleteById(id, keyId)
-      },
-      async updateApikey (keyId, patch) {
-        return this.ApiKeys.updateById(id, keyId, patch)
-      },
-      async addCollaborator (collaborator) {
-        return api.ApplicationAccess.SetCollaborator(idMask, collaborator)
-      },
-      async createLink (link) {
-        return this.Link.create(id, link)
-      },
-      async setLink (link, mask) {
-        return this.Link.set(id, link, mask)
-      },
-      async deleteLink () {
-        return this.Link.delete(id)
-      },
-      async getLinkStats () {
-        return this.Link.getStats(id)
-      },
-    }
   }
 }
 

--- a/sdk/js/src/service/applications.js
+++ b/sdk/js/src/service/applications.js
@@ -58,15 +58,16 @@ class Applications {
   // Retrieval
 
   async getAll (params) {
-    const response = await this._api.ApplicationRegistry.List({ queryParams: params })
+    const response = await this._api.ApplicationRegistry.List(undefined, params)
 
     return this._responseTransform(response, false)
   }
 
-  async getById (id) {
+  async getById (id, selector) {
+    const fieldMask = Marshaler.selectorToFieldMask(selector)
     const response = await this._api.ApplicationRegistry.Get({
       routeParams: { 'application_ids.application_id': id },
-    })
+    }, fieldMask)
 
     return this._responseTransform(response)
   }

--- a/sdk/js/src/service/applications.js
+++ b/sdk/js/src/service/applications.js
@@ -30,7 +30,7 @@ import Link from './link'
  *  should be proxied with the wrapper objects.
  */
 class Applications {
-  constructor (api, { defaultUserId, proxy = true }) {
+  constructor (api, { defaultUserId, stackConfig, proxy = true }) {
     this._defaultUserId = defaultUserId
     this._api = api
     this._proxy = proxy
@@ -44,7 +44,6 @@ class Applications {
     })
     this.Link = new Link(api.As)
     this.Devices = new Devices(api, { proxy })
-
   }
 
   _responseTransform (response) {

--- a/sdk/js/src/service/applications.js
+++ b/sdk/js/src/service/applications.js
@@ -46,9 +46,8 @@ class Applications {
     this.Devices = new Devices(api, { proxy })
   }
 
-  _responseTransform (response) {
-    const isList = response instanceof Array
-    return Marshaler[isList ? 'unwrapApplications' : 'unwrapApplication'](
+  _responseTransform (response, single = true) {
+    return Marshaler[single ? 'unwrapApplication' : 'unwrapApplications'](
       response,
       this._proxy
         ? app => new Application(this, app, false)
@@ -61,7 +60,7 @@ class Applications {
   async getAll (params) {
     const response = await this._api.ApplicationRegistry.List({ queryParams: params })
 
-    return this._responseTransform(response)
+    return this._responseTransform(response, false)
   }
 
   async getById (id) {
@@ -93,7 +92,7 @@ class Applications {
       queryParams: params,
     })
 
-    return this._responseTransform(response)
+    return this._responseTransform(response, false)
   }
 
   // Update

--- a/sdk/js/src/service/devices.js
+++ b/sdk/js/src/service/devices.js
@@ -12,8 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/* eslint-disable no-invalid-this */
+
+import traverse from 'traverse'
 import Marshaler from '../util/marshaler'
 import Device from '../entity/device'
+import deviceEntityMap from '../../generated/device-entity-map.json'
 
 /**
  * Devices Class provides an abstraction on all devices and manages data
@@ -28,6 +32,50 @@ class Devices {
     this._entityTransform = proxy
       ? app => new Device(this, app, false)
       : undefined
+  }
+
+  _splitEntitySetPaths (paths, base = {}) {
+    return this._splitEntityPaths(paths, 'set', base)
+  }
+
+  _splitEntityGetPaths (paths, base = {}) {
+    return this._splitEntityPaths(paths, 'get', base)
+  }
+
+  _splitEntityPaths (paths, direction, base = {}) {
+    const result = base
+    const retrieveIndex = direction === 'get' ? 0 : 1
+
+    for (const path of paths) {
+      const subtree =
+        traverse(deviceEntityMap).get(path)
+        || traverse(deviceEntityMap).get([ path[0] ])
+
+      const definition = '_root' in subtree ? subtree._root[retrieveIndex] : subtree[retrieveIndex]
+
+      if (definition) {
+        if (definition instanceof Array) {
+          for (const component of definition) {
+            result[component] = !result[component] ? [ path ] : [ ...result[component], path ]
+          }
+        } else {
+          result[definition] = !result[definition] ? [ path ] : [ ...result[definition], path ]
+        }
+      }
+    }
+    return result
+  }
+
+  _mergeEntity (parts, base = {}) {
+    const result = base
+
+    for (const part of parts) {
+      for (const path of part.paths) {
+        traverse(result).set(path, traverse(part.record).get(path))
+      }
+    }
+
+    return result
   }
 
   async getById (deviceId) {
@@ -47,10 +95,69 @@ class Devices {
   }
 
   async create (device, applicationId = this._applicationId) {
-    const result = await this._api.EndDeviceRegistry.Create(
+    const paths = traverse(device).reduce(function (acc, node) {
+      if (this.isLeaf) {
+        acc.push(this.path)
+      }
+      return acc
+    }, [])
+
+    const requestTree = this._splitEntitySetPaths(paths, {
+      ns: [[ 'ids' ], [ 'created_at' ], [ 'updated_at' ]],
+      as: [[ 'ids' ], [ 'created_at' ], [ 'updated_at' ]],
+      js: [[ 'ids' ], [ 'created_at' ], [ 'updated_at' ]],
+    })
+
+    const isResult = await this._api.EndDeviceRegistry.Create(
       { route: { 'end_device.ids.application_ids.application_id': applicationId }},
       { end_device: device }
     )
+
+    let nsResult = {}
+    let asResult = {}
+    let jsResult = {}
+
+    if ('ns' in requestTree) {
+      nsResult = await this._api.NsDeviceRegistry.Set({
+        route: {
+          'device.ids.application_ids.application_id': applicationId,
+        },
+      },
+      {
+        device,
+        field_mask: Marshaler.fieldMask(requestTree.ns),
+      })
+    }
+    if ('as' in requestTree) {
+      asResult = await this._api.AsDeviceRegistry.Set({
+        route: {
+          'device.ids.application_ids.application_id': applicationId,
+        },
+      },
+      {
+        device,
+        field_mask: Marshaler.fieldMask(requestTree.as),
+      })
+    }
+    if ('js' in requestTree) {
+      jsResult = await this._api.JsDeviceRegistry.Set({
+        route: {
+          'device.ids.application_ids.application_id': applicationId,
+        },
+      },
+      {
+        device,
+        field_mask: Marshaler.fieldMask(requestTree.js),
+      })
+    }
+
+    const result = this._mergeEntity([
+      { record: isResult.data, paths: requestTree.is },
+      { record: nsResult.data, paths: requestTree.ns },
+      { record: asResult.data, paths: requestTree.as },
+      { record: jsResult.data, paths: requestTree.js },
+    ])
+
     return Marshaler.unwrapDevice(
       result,
       this._entityTransform

--- a/sdk/js/src/service/devices.js
+++ b/sdk/js/src/service/devices.js
@@ -173,29 +173,29 @@ class Devices {
     const requests = new Array(3)
 
     if (!create && 'is' in requestTree) {
-      isResult = await this._api.EndDeviceRegistry.Update({
-        ...params,
+      isResult = await this._api.EndDeviceRegistry.Update(params, {
+        ...devicePayload,
         ...Marshaler.pathsToFieldMask(requestTree.is),
-      }, devicePayload)
+      })
     }
 
     if ('ns' in requestTree) {
-      requests[0] = this._api.NsEndDeviceRegistry.Set({
-        ...params,
+      requests[0] = this._api.NsEndDeviceRegistry.Set(params, {
+        ...devicePayload,
         ...Marshaler.pathsToFieldMask(requestTree.ns),
-      }, devicePayload)
+      })
     }
     if ('as' in requestTree) {
-      requests[1] = this._api.AsEndDeviceRegistry.Set({
-        ...params,
+      requests[1] = this._api.AsEndDeviceRegistry.Set(params, {
+        ...devicePayload,
         ...Marshaler.pathsToFieldMask(requestTree.as),
-      }, devicePayload)
+      })
     }
     if ('js' in requestTree) {
-      requests[2] = this._api.JsEndDeviceRegistry.Set({
-        ...params,
+      requests[2] = this._api.JsEndDeviceRegistry.Set(params, {
+        ...devicePayload,
         ...Marshaler.pathsToFieldMask(requestTree.js),
-      }, devicePayload)
+      })
     }
 
     try {
@@ -238,29 +238,29 @@ class Devices {
     const requests = new Array(3)
 
     if ('is' in requestTree) {
-      isResult = await this._api.EndDeviceRegistry.Get({
-        ...params,
-        ...Marshaler.pathsToFieldMask(requestTree.is),
-      })
+      isResult = await this._api.EndDeviceRegistry.Get(
+        params,
+        Marshaler.pathsToFieldMask(requestTree.is),
+      )
     }
 
     if ('ns' in requestTree) {
-      requests[0] = this._api.NsEndDeviceRegistry.Get({
-        ...params,
-        ...Marshaler.pathsToFieldMask(requestTree.ns),
-      })
+      requests[0] = this._api.NsEndDeviceRegistry.Get(
+        params,
+        Marshaler.pathsToFieldMask(requestTree.ns),
+      )
     }
     if ('as' in requestTree) {
-      requests[1] = this._api.AsEndDeviceRegistry.Get({
-        ...params,
-        ...Marshaler.pathsToFieldMask(requestTree.as),
-      })
+      requests[1] = this._api.AsEndDeviceRegistry.Get(
+        params,
+        Marshaler.pathsToFieldMask(requestTree.as),
+      )
     }
     if ('js' in requestTree) {
-      requests[2] = this._api.JsEndDeviceRegistry.Get({
-        ...params,
-        ...Marshaler.pathsToFieldMask(requestTree.js),
-      })
+      requests[2] = this._api.JsEndDeviceRegistry.Get(
+        params,
+        Marshaler.pathsToFieldMask(requestTree.js),
+      )
     }
 
     const getResults = (await Promise.all(requests))
@@ -306,7 +306,8 @@ class Devices {
   async getAll (applicationId, params, selector) {
     const response = await this._api.EndDeviceRegistry.List({
       routeParams: { 'application_ids.application_id': applicationId },
-      queryParams: params,
+    }, {
+      ...params,
       ...Marshaler.selectorToFieldMask(selector),
     })
 

--- a/sdk/js/src/service/devices.js
+++ b/sdk/js/src/service/devices.js
@@ -25,24 +25,25 @@ import deviceEntityMap from '../../generated/device-entity-map.json'
  * device data.
  */
 class Devices {
-  constructor (api, { applicationId, proxy = true }) {
+  constructor (api, { proxy = true }) {
+    if (!api) {
+      throw new Error('Cannot initialize device service without api object.')
+    }
     this._api = api
-    this._applicationId = applicationId
-    this._idMask = { route: { 'end_device.ids.application_ids.application_id': this._applicationId }}
     this._entityTransform = proxy
       ? app => new Device(this, app, false)
       : undefined
   }
 
-  _splitEntitySetPaths (paths, base = {}) {
+  _splitEntitySetPaths (paths, base) {
     return this._splitEntityPaths(paths, 'set', base)
   }
 
-  _splitEntityGetPaths (paths, base = {}) {
+  _splitEntityGetPaths (paths, base) {
     return this._splitEntityPaths(paths, 'get', base)
   }
 
-  _splitEntityPaths (paths, direction, base = {}) {
+  _splitEntityPaths (paths = [], direction, base = {}) {
     const result = base
     const retrieveIndex = direction === 'get' ? 0 : 1
 
@@ -50,6 +51,10 @@ class Devices {
       const subtree =
         traverse(deviceEntityMap).get(path)
         || traverse(deviceEntityMap).get([ path[0] ])
+
+      if (!subtree) {
+        throw new Error(`Invalid or unknown field mask path used: ${path}`)
+      }
 
       const definition = '_root' in subtree ? subtree._root[retrieveIndex] : subtree[retrieveIndex]
 
@@ -70,31 +75,41 @@ class Devices {
     const result = base
 
     for (const part of parts) {
-      for (const path of part.paths) {
-        traverse(result).set(path, traverse(part.record).get(path))
+      for (const path of part.paths || []) {
+        const val = traverse(part.record).get(path)
+        if (val) {
+          traverse(result).set(path, val)
+        }
       }
     }
 
     return result
   }
 
-  async getById (deviceId) {
-    const res = await this._api.EndDeviceRegistry.Get({
-      ...this._idMask,
-      device_id: deviceId,
-    })
+  async _setDevice (applicationId, device, create = false) {
+    const ids = device.ids
+    const deviceId = 'device_id' in ids && ids.device_id
+    const appId = applicationId || 'application_ids' in ids && ids.application_ids.application_id
 
-    return new Device(res, this)
-  }
+    if (!create && !deviceId) {
+      throw new Error('Missing device_id for update operation.')
+    }
 
-  async updateById (deviceId) {
-    return this._api.EndDeviceRegistry.Get({
-      ...this._idMask,
-      device_id: deviceId,
-    })
-  }
+    if (!appId) {
+      throw new Error('Missing application_id for device.')
+    }
 
-  async create (device, applicationId = this._applicationId) {
+    const mergeBase = create ? {
+      ns: [[ 'ids' ]],
+      as: [[ 'ids' ]],
+      js: [[ 'ids' ]],
+    } : {}
+
+    const params = {
+      routeParams: { 'end_device.ids.application_ids.application_id': appId },
+    }
+
+    // Extract the paths from the patch
     const paths = traverse(device).reduce(function (acc, node) {
       if (this.isLeaf) {
         acc.push(this.path)
@@ -102,66 +117,131 @@ class Devices {
       return acc
     }, [])
 
-    const requestTree = this._splitEntitySetPaths(paths, {
-      ns: [[ 'ids' ], [ 'created_at' ], [ 'updated_at' ]],
-      as: [[ 'ids' ], [ 'created_at' ], [ 'updated_at' ]],
-      js: [[ 'ids' ], [ 'created_at' ], [ 'updated_at' ]],
-    })
+    const requestTree = this._splitEntitySetPaths(paths, mergeBase)
 
-    const isResult = await this._api.EndDeviceRegistry.Create(
-      { route: { 'end_device.ids.application_ids.application_id': applicationId }},
-      { end_device: device }
-    )
+    let isResult = {}
+    if (create) {
+      isResult = await this._api.EndDeviceRegistry.Create(params, device)
+    }
 
-    let nsResult = {}
-    let asResult = {}
-    let jsResult = {}
+    params.routeParams['end_device.ids.device_id'] = 'data' in isResult ? isResult.data.ids.device_id : deviceId
+
+    const requests = new Array(3)
+
+    if (!create && 'is' in requestTree) {
+      isResult = await this._api.EndDeviceRegistry.Update({
+        ...params,
+        ...Marshaler.pathsToFieldMask(requestTree.is),
+      }, device)
+    }
 
     if ('ns' in requestTree) {
-      nsResult = await this._api.NsDeviceRegistry.Set({
-        route: {
-          'device.ids.application_ids.application_id': applicationId,
-        },
+      requests[0] = this._api.NsEndDeviceRegistry.Set({
+        ...params,
+        ...Marshaler.pathsToFieldMask(requestTree.ns),
+      }, device)
+    }
+    if ('as' in requestTree) {
+      requests[1] = this._api.AsEndDeviceRegistry.Set({
+        ...params,
+        ...Marshaler.pathsToFieldMask(requestTree.as),
+      }, device)
+    }
+    if ('js' in requestTree) {
+      requests[2] = this._api.JsEndDeviceRegistry.Set({
+        ...params,
+        ...Marshaler.pathsToFieldMask(requestTree.js),
+      }, device)
+    }
+
+    // TODO: Error handling
+    const setResults = (await Promise.all(requests))
+      .map(e => e ? Marshaler.payloadSingleResponse(e) : undefined)
+
+    const result = this._mergeEntity([
+      { record: Marshaler.payloadSingleResponse(isResult), paths: requestTree.is },
+      { record: setResults[0], paths: requestTree.ns },
+      { record: setResults[1], paths: requestTree.as },
+      { record: setResults[2], paths: requestTree.js },
+    ])
+
+    return result
+  }
+
+  async _getDevice (applicationId, deviceId, paths) {
+
+    if (!applicationId) {
+      throw new Error('Missing application_id for device.')
+    }
+
+    const requestTree = this._splitEntityGetPaths(paths)
+
+    const params = {
+      routeParams: {
+        'end_device_ids.application_ids.application_id': applicationId,
+        'end_device_ids.device_id': deviceId,
       },
-      {
-        device,
-        field_mask: Marshaler.fieldMask(requestTree.ns),
+    }
+
+    let isResult = {}
+    const requests = new Array(3)
+
+    if ('is' in requestTree) {
+      isResult = await this._api.EndDeviceRegistry.Get({
+        ...params,
+        ...Marshaler.pathsToFieldMask(requestTree.is),
+      })
+    }
+
+    if ('ns' in requestTree) {
+      requests[0] = this._api.NsEndDeviceRegistry.Get({
+        ...params,
+        ...Marshaler.pathsToFieldMask(requestTree.ns),
       })
     }
     if ('as' in requestTree) {
-      asResult = await this._api.AsDeviceRegistry.Set({
-        route: {
-          'device.ids.application_ids.application_id': applicationId,
-        },
-      },
-      {
-        device,
-        field_mask: Marshaler.fieldMask(requestTree.as),
+      requests[1] = this._api.AsEndDeviceRegistry.Get({
+        ...params,
+        ...Marshaler.pathsToFieldMask(requestTree.as),
       })
     }
     if ('js' in requestTree) {
-      jsResult = await this._api.JsDeviceRegistry.Set({
-        route: {
-          'device.ids.application_ids.application_id': applicationId,
-        },
-      },
-      {
-        device,
-        field_mask: Marshaler.fieldMask(requestTree.js),
+      requests[2] = this._api.JsEndDeviceRegistry.Get({
+        ...params,
+        ...Marshaler.pathsToFieldMask(requestTree.js),
       })
     }
 
+    // TODO: Error handling
+    const getResults = (await Promise.all(requests))
+      .map(e => e ? Marshaler.payloadSingleResponse(e) : undefined)
+
     const result = this._mergeEntity([
-      { record: isResult.data, paths: requestTree.is },
-      { record: nsResult.data, paths: requestTree.ns },
-      { record: asResult.data, paths: requestTree.as },
-      { record: jsResult.data, paths: requestTree.js },
+      { record: Marshaler.payloadSingleResponse(isResult), paths: requestTree.is },
+      { record: getResults[0], paths: requestTree.ns },
+      { record: getResults[1], paths: requestTree.as },
+      { record: getResults[2], paths: requestTree.js },
     ])
 
-    return Marshaler.unwrapDevice(
-      result,
-      this._entityTransform
-    )
+    return result
+  }
+
+  async getById (applicationId, deviceId, selector) {
+    const result = await this._getDevice(applicationId, deviceId, Marshaler.selectorToPaths(selector))
+
+    return result
+  }
+
+  async updateById (applicationId, deviceId, patch) {
+    const result = await this._setDevice(applicationId, patch, true)
+
+    return result
+  }
+
+  async create (applicationId, device) {
+    const result = await this._setDevice(applicationId, device, true)
+
+    return result
   }
 }
 

--- a/sdk/js/src/service/devices.js
+++ b/sdk/js/src/service/devices.js
@@ -160,10 +160,11 @@ class Devices {
     }, [])
 
     const requestTree = this._splitEntitySetPaths(paths, mergeBase)
+    const devicePayload = Marshaler.payload(device, 'end_device')
 
     let isResult = {}
     if (create) {
-      isResult = await this._api.EndDeviceRegistry.Create(params, device)
+      isResult = await this._api.EndDeviceRegistry.Create(params, devicePayload)
     }
 
     params.routeParams['end_device.ids.device_id'] = 'data' in isResult ? isResult.data.ids.device_id : deviceId
@@ -174,26 +175,26 @@ class Devices {
       isResult = await this._api.EndDeviceRegistry.Update({
         ...params,
         ...Marshaler.pathsToFieldMask(requestTree.is),
-      }, device)
+      }, devicePayload)
     }
 
     if ('ns' in requestTree) {
       requests[0] = this._api.NsEndDeviceRegistry.Set({
         ...params,
         ...Marshaler.pathsToFieldMask(requestTree.ns),
-      }, device)
+      }, devicePayload)
     }
     if ('as' in requestTree) {
       requests[1] = this._api.AsEndDeviceRegistry.Set({
         ...params,
         ...Marshaler.pathsToFieldMask(requestTree.as),
-      }, device)
+      }, devicePayload)
     }
     if ('js' in requestTree) {
       requests[2] = this._api.JsEndDeviceRegistry.Set({
         ...params,
         ...Marshaler.pathsToFieldMask(requestTree.js),
-      }, device)
+      }, devicePayload)
     }
 
     try {

--- a/sdk/js/src/service/devices.js
+++ b/sdk/js/src/service/devices.js
@@ -311,7 +311,7 @@ class Devices {
     return this._responseTransform(response, false)
   }
 
-  async getById (applicationId, deviceId, selector) {
+  async getById (applicationId, deviceId, selector = [[ 'ids' ]]) {
     const response = await this._getDevice(applicationId, deviceId, Marshaler.selectorToPaths(selector))
 
     return this._responseTransform(response)

--- a/sdk/js/src/service/devices.js
+++ b/sdk/js/src/service/devices.js
@@ -32,14 +32,14 @@ class Devices {
     }
     this._api = api
     this._stackConfig = stackConfig
+    this._proxy = proxy
   }
 
-  _responseTransform (response) {
-    const isList = response instanceof Array
-    return Marshaler[isList ? 'unwrapDevices' : 'unwrapDevice'](
+  _responseTransform (response, single = true) {
+    return Marshaler[single ? 'unwrapDevice' : 'unwrapDevices'](
       response,
       this._proxy
-        ? app => new Device(this, app, false)
+        ? device => new Device(device, this._api)
         : undefined
     )
   }
@@ -308,7 +308,7 @@ class Devices {
       ...Marshaler.selectorToFieldMask(selector),
     })
 
-    return this._responseTransform(response)
+    return this._responseTransform(response, false)
   }
 
   async getById (applicationId, deviceId, selector) {

--- a/sdk/js/src/service/devices.js
+++ b/sdk/js/src/service/devices.js
@@ -14,6 +14,7 @@
 
 /* eslint-disable no-invalid-this */
 
+import { URL } from 'url'
 import traverse from 'traverse'
 import Marshaler from '../util/marshaler'
 import Device from '../entity/device'
@@ -212,7 +213,7 @@ class Devices {
     } catch (err) {
       // Roll back changes
       if (create) {
-        this._deleteDevice(appId, deviceId, Object.keys(requestTree))
+        this._deleteDevice(appId, devId, Object.keys(requestTree))
       }
       throw new Error('Could not create device.')
     }
@@ -333,9 +334,9 @@ class Devices {
 
     if (setDefaults) {
       dev = {
-        application_server_address: this._stackConfig.as,
-        join_server_address: this._stackConfig.js,
-        network_server_address: this._stackConfig.ns,
+        application_server_address: new URL(this._stackConfig.as).host,
+        join_server_address: new URL(this._stackConfig.js).host,
+        network_server_address: new URL(this._stackConfig.ns).host,
         ...device,
       }
     }
@@ -400,7 +401,6 @@ class Devices {
       dev.supports_join = true
 
     }
-
     const response = await this._setDevice(applicationId, undefined, dev, true)
 
     return this._responseTransform(response)

--- a/sdk/js/src/service/devices/index.js
+++ b/sdk/js/src/service/devices/index.js
@@ -16,10 +16,10 @@
 
 import { URL } from 'url'
 import traverse from 'traverse'
-import Marshaler from '../util/marshaler'
-import Device from '../entity/device'
-import deviceEntityMap from '../../generated/device-entity-map.json'
-import randomByteString from '../util/random-bytes'
+import Marshaler from '../../util/marshaler'
+import Device from '../../entity/device'
+import deviceEntityMap from '../../../generated/device-entity-map.json'
+import randomByteString from '../../util/random-bytes'
 
 /**
  * Devices Class provides an abstraction on all devices and manages data

--- a/sdk/js/src/service/devices/index.js
+++ b/sdk/js/src/service/devices/index.js
@@ -19,8 +19,8 @@ import traverse from 'traverse'
 import Marshaler from '../../util/marshaler'
 import Device from '../../entity/device'
 import randomByteString from '../../util/random-bytes'
-import { splitSetPath, splitGetPath } from './split'
-import { mergeDevice } from './merge'
+import { splitSetPaths, splitGetPaths, makeRequests } from './split'
+import mergeDevice from './merge'
 
 /**
  * Devices Class provides an abstraction on all devices and manages data
@@ -87,62 +87,28 @@ class Devices {
       return acc
     }, [])
 
-    const requestTree = splitSetPath(paths, mergeBase)
+    const requestTree = splitSetPaths(paths, mergeBase)
     const devicePayload = Marshaler.payload(device, 'end_device')
 
     let isResult = {}
     if (create) {
       isResult = await this._api.EndDeviceRegistry.Create(params, devicePayload)
+      isResult = Marshaler.payloadSingleResponse(isResult)
+      delete requestTree.is
     }
 
-    params.routeParams['end_device.ids.device_id'] = 'data' in isResult ? isResult.data.ids.device_id : deviceId
-
-    const requests = new Array(3)
-
-    if (!create && 'is' in requestTree) {
-      isResult = await this._api.EndDeviceRegistry.Update(params, {
-        ...devicePayload,
-        ...Marshaler.pathsToFieldMask(requestTree.is),
-      })
-    }
-
-    if ('ns' in requestTree) {
-      requests[0] = this._api.NsEndDeviceRegistry.Set(params, {
-        ...devicePayload,
-        ...Marshaler.pathsToFieldMask(requestTree.ns),
-      })
-    }
-    if ('as' in requestTree) {
-      requests[1] = this._api.AsEndDeviceRegistry.Set(params, {
-        ...devicePayload,
-        ...Marshaler.pathsToFieldMask(requestTree.as),
-      })
-    }
-    if ('js' in requestTree) {
-      requests[2] = this._api.JsEndDeviceRegistry.Set(params, {
-        ...devicePayload,
-        ...Marshaler.pathsToFieldMask(requestTree.js),
-      })
-    }
+    params.routeParams['end_device.ids.device_id'] = 'data' in isResult ? isResult.ids.device_id : devId
 
     try {
-      const setResults = (await Promise.all(requests))
-        .map(e => e ? Marshaler.payloadSingleResponse(e) : undefined)
-
-      const result = mergeDevice([
-        { record: setResults[0], paths: requestTree.ns },
-        { record: setResults[1], paths: requestTree.as },
-        { record: setResults[2], paths: requestTree.js },
-        { record: Marshaler.payloadSingleResponse(isResult), paths: requestTree.is },
-      ])
-
+      const setParts = await makeRequests(this._api, 'set', requestTree, params, devicePayload)
+      const result = mergeDevice(setParts, isResult)
       return result
     } catch (err) {
       // Roll back changes
       if (create) {
         this._deleteDevice(appId, devId, Object.keys(requestTree))
       }
-      throw new Error('Could not create device.')
+      throw new Error(`Could not ${create ? 'create' : 'update'} device.`)
     }
   }
 
@@ -161,67 +127,13 @@ class Devices {
       },
     }
 
-    let isResult = {}
-    const requests = new Array(3)
-
-    // Wrap the request to allow ignoring not found errors
-    const requestWrapper = async function (call, params, paths) {
-      try {
-        const res = await call(params, Marshaler.pathsToFieldMask(paths))
-        return res
-      } catch (err) {
-        if (ignoreNotFound && err.code === 5) {
-          return { end_device: {}}
-        }
-        throw err
-      }
-    }
-
-    if ('is' in requestTree) {
-      isResult = await this._api.EndDeviceRegistry.Get(
-        params,
-        Marshaler.pathsToFieldMask(requestTree.is),
-      )
-    }
-
-    if ('ns' in requestTree) {
-      requests[0] = await requestWrapper(
-        this._api.NsEndDeviceRegistry.Get,
-        params,
-        requestTree.ns,
-      )
-    }
-    if ('as' in requestTree) {
-      requests[1] = await requestWrapper(
-        this._api.AsEndDeviceRegistry.Get,
-        params,
-        requestTree.as,
-      )
-    }
-    if ('js' in requestTree) {
-      requests[2] = await requestWrapper(
-        this._api.NsEndDeviceRegistry.Get,
-        params,
-        requestTree.js,
-      )
-    }
-
-    const getResults = (await Promise.all(requests))
-      .map(e => e ? Marshaler.payloadSingleResponse(e) : undefined)
-
-    const result = mergeDevice([
-      { record: getResults[0], paths: requestTree.ns },
-      { record: getResults[1], paths: requestTree.as },
-      { record: getResults[2], paths: requestTree.js },
-      { record: Marshaler.payloadSingleResponse(isResult), paths: requestTree.is },
-    ])
+    const deviceParts = await makeRequests(this._api, 'get', requestTree, params, undefined, ignoreNotFound)
+    const result = mergeDevice(deviceParts)
 
     return result
   }
 
   async _deleteDevice (applicationId, deviceId, components = [ 'is', 'ns', 'as', 'js' ]) {
-    const requests = Array(4)
-
     const params = {
       routeParams: {
         'application_ids.application_id': applicationId,
@@ -229,21 +141,14 @@ class Devices {
       },
     }
 
-    if (components.includes('is')) {
-      requests[0] = this._api.EndDeviceRegistry.Delete(params)
-    }
-    if (components.includes('ns')) {
-      requests[1] = this._api.NsEndDeviceRegistry.Delete(params)
-    }
-    if (components.includes('as')) {
-      requests[2] = this._api.AsEndDeviceRegistry.Delete(params)
-    }
-    if (components.includes('js')) {
-      requests[3] = this._api.JsEndDeviceRegistry.Delete(params)
-    }
+    // Compose a request tree
+    const requestTree = components.reduce(function (acc, val) {
+      acc[val] = undefined
+      return acc
+    }, {})
 
-    const deleteResults = (await Promise.all(requests)).map(e => e ? e.status : false)
-    return deleteResults
+    const deleteParts = await makeRequests(this._api, 'delete', requestTree, params)
+    return deleteParts.every(e => Object.keys(e.device).length === 0) ? {} : deleteParts
   }
 
   async getAll (applicationId, params, selector) {

--- a/sdk/js/src/service/devices/index.js
+++ b/sdk/js/src/service/devices/index.js
@@ -63,6 +63,7 @@ class Devices {
       throw new Error('Missing application_id for device.')
     }
 
+    // Make sure to write at least the ids, in case of creation
     const mergeBase = create ? {
       ns: [[ 'ids' ]],
       as: [[ 'ids' ]],
@@ -73,10 +74,6 @@ class Devices {
       routeParams: {
         'end_device.ids.application_ids.application_id': appId,
       },
-    }
-
-    if (!create) {
-      params.routeParams['end_device.ids.device_id'] = devId
     }
 
     // Extract the paths from the patch
@@ -97,6 +94,8 @@ class Devices {
       delete requestTree.is
     }
 
+    // Write the device id param based on either the id of the newly created
+    // device, or the passed id argument
     params.routeParams['end_device.ids.device_id'] = 'data' in isResult ? isResult.ids.device_id : devId
 
     try {
@@ -116,6 +115,10 @@ class Devices {
 
     if (!applicationId) {
       throw new Error('Missing application_id for device.')
+    }
+
+    if (!deviceId) {
+      throw new Error('Missing device_id for device.')
     }
 
     const requestTree = splitGetPaths(paths)

--- a/sdk/js/src/service/devices/merge.js
+++ b/sdk/js/src/service/devices/merge.js
@@ -20,7 +20,7 @@ import traverse from 'traverse'
 * single entity record.
 * @param {Object} parts - An object containing the device record responded from
 * the registry and the paths that were requested from the component.
-* Shape: { record: …, paths: … }
+* Shape: { device: …, paths: … }
 * @param {string} base - An optional base device record, that the merge will
 * take as base
 * @param {Object} minimum - Paths that will always be merged for all records
@@ -35,7 +35,7 @@ export default function mergeDevice (
 
   for (const part of parts) {
     for (const path of part.paths ? [ ...minimum, ...part.paths ] : []) {
-      const val = traverse(part.record).get(path)
+      const val = traverse(part.device).get(path)
       if (val) {
         if (typeof val === 'object') {
           // In case of a whole sub-object being selected, write each leaf node

--- a/sdk/js/src/service/devices/merge.js
+++ b/sdk/js/src/service/devices/merge.js
@@ -33,15 +33,17 @@ export default function mergeDevice (
 ) {
   const result = base
 
+  // Cycle through all responses
   for (const part of parts) {
     for (const path of part.paths ? [ ...minimum, ...part.paths ] : []) {
+      // For each path requested, get the corresponding value of the device record
       const val = traverse(part.device).get(path)
       if (val) {
         if (typeof val === 'object') {
           // In case of a whole sub-object being selected, write each leaf node
-          // explicitly to achieve a deep merge instead of object overrides
+          // explicitly to achieve a deep merge instead of whole object overrides
           if (Object.keys(val).length === 0) {
-            // Ignore empty object values
+            // Ignore empty object values, as they might override legitimate values
             continue
           }
           traverse(val).forEach(function (e) {
@@ -50,10 +52,12 @@ export default function mergeDevice (
                 // Ignore empty object values
                 return
               }
+              // Write the sub object leaf into the result
               traverse(result).set([ ...path, ...this.path ], e)
             }
           })
         } else {
+          // In case of a simple leaf, just write it into the result
           traverse(result).set(path, val)
         }
       }

--- a/sdk/js/src/service/devices/split.js
+++ b/sdk/js/src/service/devices/split.js
@@ -1,0 +1,76 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import traverse from 'traverse'
+import deviceEntityMap from '../../../generated/device-entity-map.json'
+
+
+/** Takes the requested paths of the device and returns a request tree. The
+* splitting is achieved by looking up path responsibilities as defined in the
+* generated device entity map json.
+* @param {Object} paths - The requested paths (from the field mask) of the device
+* @param {string} direction - The direction, either 'set' or 'get'
+* @param {Object} base - An optional base value for the returned request tree
+* @returns {Object} A request tree object, consisting of resulting paths for each
+* component eg: { is: ['ids'], as: ['session'], js: ['root_keys'] }
+*/
+function splitPaths (paths = [], direction, base = {}) {
+  const result = base
+  const retrieveIndex = direction === 'get' ? 0 : 1
+
+  for (const path of paths) {
+    // Look up the current path in the device entity map
+    const subtree =
+      traverse(deviceEntityMap).get(path)
+      || traverse(deviceEntityMap).get([ path[0] ])
+
+    if (!subtree) {
+      throw new Error(`Invalid or unknown field mask path used: ${path}`)
+    }
+
+    const definition = '_root' in subtree ? subtree._root[retrieveIndex] : subtree[retrieveIndex]
+
+    if (definition) {
+      if (definition instanceof Array) {
+        for (const component of definition) {
+          result[component] = !result[component] ? [ path ] : [ ...result[component], path ]
+        }
+      } else {
+        result[definition] = !result[definition] ? [ path ] : [ ...result[definition], path ]
+      }
+    }
+  }
+  return result
+}
+
+/** A wrapper function to obtain a request tree for writing values to a device
+* @param {Object} paths - The requested paths (from the field mask) of the device
+* @param {Object} base - An optional base value for the returned request tree
+* @returns {Object} A request tree object, consisting of resulting paths for each
+* component eg: { is: ['ids'], as: ['session'], js: ['root_keys'] }
+*/
+export function splitSetPaths (paths, base) {
+  return splitPaths(paths, 'set', base)
+}
+
+/** A wrapper function to obtain a request tree for reading values to a device
+* @param {Object} paths - The requested paths (from the field mask) of the device
+* @param {Object} base - An optional base value for the returned request tree
+* @returns {Object} A request tree object, consisting of resulting paths for each
+* component eg: { is: ['ids'], as: ['session'], js: ['root_keys'] }
+*/
+export function splitGetPaths (paths, base) {
+  return splitPaths(paths, 'get', base)
+}
+

--- a/sdk/js/src/service/link.js
+++ b/sdk/js/src/service/link.js
@@ -21,16 +21,15 @@ class Link {
 
   async get (appId, fieldMask) {
     const result = await this._api.GetLink({
-      route: { 'application_ids.application_id': appId },
-      query: Marshaler.queryFieldMask(fieldMask),
-    })
+      routeParams: { 'application_ids.application_id': appId },
+    }, Marshaler.selectorToFieldMask(fieldMask))
 
     return Marshaler.payloadSingleResponse(result)
   }
 
   async set (appId, data, mask = Marshaler.fieldMaskFromPatch(data)) {
     const result = await this._api.SetLink({
-      route: { 'application_ids.application_id': appId },
+      routeParams: { 'application_ids.application_id': appId },
     },
     {
       link: data,
@@ -42,7 +41,7 @@ class Link {
 
   async delete (appId) {
     const result = await this._api.DeleteLink({
-      route: { application_id: appId },
+      routeParams: { application_id: appId },
     })
 
     return Marshaler.payloadSingleResponse(result)
@@ -50,7 +49,7 @@ class Link {
 
   async getStats (appId) {
     const result = await this._api.GetLinkStats({
-      route: { application_id: appId },
+      routeParams: { application_id: appId },
     })
 
     return Marshaler.payloadSingleResponse(result)

--- a/sdk/js/src/util/marshaler.js
+++ b/sdk/js/src/util/marshaler.js
@@ -110,7 +110,7 @@ class Marshaler {
     if (!paths) {
       return
     }
-    return { fieldMask: { paths: paths.map(e => e.join('.')) }}
+    return { field_mask: { paths: paths.map(e => e.join('.')) }}
   }
 
   /** This function will convert a selector parameter and convert it to a

--- a/sdk/js/src/util/marshaler.js
+++ b/sdk/js/src/util/marshaler.js
@@ -90,6 +90,14 @@ class Marshaler {
     return this.payloadSingleResponse(result, transform)
   }
 
+  static unwrapDevices (result, transform) {
+    return this.payloadListResponse('end_devices', result, transform)
+  }
+
+  static unwrapDevice (result, transform) {
+    return this.payloadSingleResponse(result, transform)
+  }
+
   static fieldMaskFromPatch (patch) {
     return traverse(patch).paths().slice(1).map( e => e.join('.') )
   }

--- a/sdk/js/src/util/random-bytes.js
+++ b/sdk/js/src/util/random-bytes.js
@@ -1,0 +1,21 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import crypto from 'crypto'
+
+export default function randomByteString (len, type = 'hex') {
+  return crypto
+    .randomBytes(type === 'hex' ? Math.floor(len / 2) : len)
+    .toString(type)
+}


### PR DESCRIPTION
**Summary:**
Closes #131.
This PR adds the first implementation for supporting device crud in the SDK. It follows the logic of the cli commands for doing device CRUD, including merging of entity parts from different components, based on the field mask paths.
It also simplifies the SDK implementation and streamlines marshaling of field masks and unwrapping of api responses, along with other improvements.

**Changes:**
- Decorating the device service
  - Handling device entities
  - proper request logic (resolving requests to component endpoints based on responsibility)
  - merging entities (combining parts of the end device structure coming from different components)
  - device creation
    - settings defaults based on flags (setDefaults, abp/otaa)
    - rolling back fragmented entries when device creation fails
  - updating devices
  - deleting devices (throughout all components or selective)
  - listing devices (entity registry only)
- marshaling of field masks from path strings or arrays (called selectors)
- component responsibility map for devices in `get` and `set/update`
- removal of `withId()` shorthand
- simplification of entity transformation logic (proxied or not)
- improving request parameter logic (passing fieldmasks, query and route parameters explicitly to the api handler)

**Notes for Reviewers:**
- due to timing issues, I have skipped unit tests for now
- I submit this as a draft PR so you can start reviewing, but I still have to integrate this branch to the console API to check for any issues, which I think makes sense to do before merging this
- I have, however, obviously checked the new functions to be operative using test scripts

**Release Notes: _(optional)_**
Added Device support to JS SDK.
