### PR TITLE
Add CORS headers to expose necessary custom headers

### DIFF
--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/getsentry/raven-go"
+	"github.com/golang/protobuf/proto"
 	"github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/grpc-ecosystem/go-grpc-middleware/recovery"
 	"github.com/grpc-ecosystem/go-grpc-middleware/tags"
@@ -183,6 +184,10 @@ func New(ctx context.Context, opts ...Option) *Server {
 	}
 	server.Server = grpc.NewServer(append(baseOptions, options.serverOptions...)...)
 	server.ServeMux = runtime.NewServeMux(
+		runtime.WithForwardResponseOption(func(ctx context.Context, w http.ResponseWriter, resp proto.Message) error {
+			w.Header().Set("Access-Control-Expose-Headers", "Link, Date, Content-Length, X-Total-Count")
+			return nil
+		}),
 		runtime.WithMarshalerOption("*", jsonpb.TTN()),
 		runtime.WithProtoErrorHandler(runtime.DefaultHTTPProtoErrorHandler),
 		runtime.WithMetadata(func(ctx context.Context, req *http.Request) metadata.MD {


### PR DESCRIPTION
**Summary:**
Closes #280.
This PR adds a setting to the rpc server that will add a `Access-Control-Expose-Headers` entry to the response header in the http bridge. This will enable us to access header properties like `X-Total-Count` in cross origin API calls, which we need to properly enable pagination.

More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers

**Changes:**
- Add an option to the rpc server to include `Access-Control-Expose-Headers` with headers that should be possible to be accessed also from other origins (`Link, Date, Content-Length, X-Total-Count`)

**Notes for Reviewers:**
Might be that we will need to include other headers in the future, I can however not think of any atm.