### PR TITLE
Fix GatewayServer MQTTv2 support

### DIFF
--- a/pkg/gatewayserver/io/mqtt/format.go
+++ b/pkg/gatewayserver/io/mqtt/format.go
@@ -24,10 +24,10 @@ import (
 type Format interface {
 	topics.Layout
 
-	FromDownlink(down *ttnpb.DownlinkMessage) ([]byte, error)
-	ToUplink(message []byte) (*ttnpb.UplinkMessage, error)
-	ToStatus(message []byte) (*ttnpb.GatewayStatus, error)
-	ToTxAck(message []byte) (*ttnpb.TxAcknowledgment, error)
+	FromDownlink(down *ttnpb.DownlinkMessage, ids ttnpb.GatewayIdentifiers) ([]byte, error)
+	ToUplink(message []byte, ids ttnpb.GatewayIdentifiers) (*ttnpb.UplinkMessage, error)
+	ToStatus(message []byte, ids ttnpb.GatewayIdentifiers) (*ttnpb.GatewayStatus, error)
+	ToTxAck(message []byte, ids ttnpb.GatewayIdentifiers) (*ttnpb.TxAcknowledgment, error)
 }
 
 var errNotSupported = errors.DefineFailedPrecondition("not_supported", "not supported")

--- a/pkg/gatewayserver/io/mqtt/format_protobuf.go
+++ b/pkg/gatewayserver/io/mqtt/format_protobuf.go
@@ -23,14 +23,14 @@ type protobuf struct {
 	topics.Layout
 }
 
-func (protobuf) FromDownlink(down *ttnpb.DownlinkMessage) ([]byte, error) {
+func (protobuf) FromDownlink(down *ttnpb.DownlinkMessage, _ ttnpb.GatewayIdentifiers) ([]byte, error) {
 	gwDown := &ttnpb.GatewayDown{
 		DownlinkMessage: down,
 	}
 	return gwDown.Marshal()
 }
 
-func (protobuf) ToUplink(message []byte) (*ttnpb.UplinkMessage, error) {
+func (protobuf) ToUplink(message []byte, _ ttnpb.GatewayIdentifiers) (*ttnpb.UplinkMessage, error) {
 	uplink := &ttnpb.UplinkMessage{}
 	if err := uplink.Unmarshal(message); err != nil {
 		return nil, err
@@ -38,7 +38,7 @@ func (protobuf) ToUplink(message []byte) (*ttnpb.UplinkMessage, error) {
 	return uplink, nil
 }
 
-func (protobuf) ToStatus(message []byte) (*ttnpb.GatewayStatus, error) {
+func (protobuf) ToStatus(message []byte, _ ttnpb.GatewayIdentifiers) (*ttnpb.GatewayStatus, error) {
 	status := &ttnpb.GatewayStatus{}
 	if err := status.Unmarshal(message); err != nil {
 		return nil, err
@@ -46,7 +46,7 @@ func (protobuf) ToStatus(message []byte) (*ttnpb.GatewayStatus, error) {
 	return status, nil
 }
 
-func (protobuf) ToTxAck(message []byte) (*ttnpb.TxAcknowledgment, error) {
+func (protobuf) ToTxAck(message []byte, _ ttnpb.GatewayIdentifiers) (*ttnpb.TxAcknowledgment, error) {
 	ack := &ttnpb.TxAcknowledgment{}
 	if err := ack.Unmarshal(message); err != nil {
 		return nil, err

--- a/pkg/gatewayserver/io/mqtt/format_protobufv2.go
+++ b/pkg/gatewayserver/io/mqtt/format_protobufv2.go
@@ -71,7 +71,7 @@ func (protobufv2) FromDownlink(down *ttnpb.DownlinkMessage) ([]byte, error) {
 		return nil, errNotScheduled
 	}
 	lorawan := &legacyttnpb.LoRaWANTxConfiguration{}
-	if pld, ok := down.Payload.Payload.(*ttnpb.Message_MACPayload); ok {
+	if pld, ok := down.GetPayload().GetPayload().(*ttnpb.Message_MACPayload); ok {
 		lorawan.FCnt = pld.MACPayload.FHDR.FCnt
 	}
 	switch dr := settings.DataRate.Modulation.(type) {

--- a/pkg/gatewayserver/io/mqtt/format_protobufv2.go
+++ b/pkg/gatewayserver/io/mqtt/format_protobufv2.go
@@ -65,13 +65,13 @@ type protobufv2 struct {
 	topics.Layout
 }
 
-func (protobufv2) FromDownlink(down *ttnpb.DownlinkMessage) ([]byte, error) {
+func (protobufv2) FromDownlink(down *ttnpb.DownlinkMessage, _ ttnpb.GatewayIdentifiers) ([]byte, error) {
 	settings := down.GetScheduled()
 	if settings == nil {
 		return nil, errNotScheduled
 	}
 	lorawan := &legacyttnpb.LoRaWANTxConfiguration{}
-	if pld, ok := down.GetPayload().GetPayload().(*ttnpb.Message_MACPayload); ok {
+	if pld, ok := down.GetPayload().GetPayload().(*ttnpb.Message_MACPayload); ok && pld != nil {
 		lorawan.FCnt = pld.MACPayload.FHDR.FCnt
 	}
 	switch dr := settings.DataRate.Modulation.(type) {
@@ -102,7 +102,7 @@ func (protobufv2) FromDownlink(down *ttnpb.DownlinkMessage) ([]byte, error) {
 	return v2downlink.Marshal()
 }
 
-func (protobufv2) ToUplink(message []byte) (*ttnpb.UplinkMessage, error) {
+func (protobufv2) ToUplink(message []byte, ids ttnpb.GatewayIdentifiers) (*ttnpb.UplinkMessage, error) {
 	v2uplink := &legacyttnpb.UplinkMessage{}
 	err := v2uplink.Unmarshal(message)
 	if err != nil {
@@ -162,9 +162,6 @@ func (protobufv2) ToUplink(message []byte) (*ttnpb.UplinkMessage, error) {
 		return nil, errModulation.WithAttributes("modulation", lorawanMetadata.Modulation)
 	}
 
-	ids := ttnpb.GatewayIdentifiers{
-		GatewayID: gwMetadata.GatewayID,
-	}
 	mdTime := time.Unix(0, gwMetadata.Time)
 	if antennas := gwMetadata.Antennas; len(antennas) > 0 {
 		for _, antenna := range antennas {
@@ -195,7 +192,7 @@ func (protobufv2) ToUplink(message []byte) (*ttnpb.UplinkMessage, error) {
 	return uplink, nil
 }
 
-func (protobufv2) ToStatus(message []byte) (*ttnpb.GatewayStatus, error) {
+func (protobufv2) ToStatus(message []byte, _ ttnpb.GatewayIdentifiers) (*ttnpb.GatewayStatus, error) {
 	v2status := &legacyttnpb.StatusMessage{}
 	err := v2status.Unmarshal(message)
 	if err != nil {
@@ -254,7 +251,7 @@ func (protobufv2) ToStatus(message []byte) (*ttnpb.GatewayStatus, error) {
 	}, nil
 }
 
-func (protobufv2) ToTxAck(message []byte) (*ttnpb.TxAcknowledgment, error) {
+func (protobufv2) ToTxAck(message []byte, _ ttnpb.GatewayIdentifiers) (*ttnpb.TxAcknowledgment, error) {
 	return nil, errNotSupported
 }
 

--- a/pkg/gatewayserver/io/mqtt/format_protobufv2_test.go
+++ b/pkg/gatewayserver/io/mqtt/format_protobufv2_test.go
@@ -31,6 +31,9 @@ import (
 func TestProtobufV2Downlink(t *testing.T) {
 	a := assertions.New(t)
 	pld, _ := base64.RawStdEncoding.DecodeString("YHBhYUoAAgABj9/clY414A")
+	ids := ttnpb.GatewayIdentifiers{
+		GatewayID: "gateway-id",
+	}
 	input := &ttnpb.DownlinkMessage{
 		RawPayload: pld,
 		Payload:    &ttnpb.Message{},
@@ -79,7 +82,7 @@ func TestProtobufV2Downlink(t *testing.T) {
 		t.Fatal("Could not marshal the v2 struct")
 	}
 
-	actualBuf, err := mqtt.ProtobufV2.FromDownlink(input)
+	actualBuf, err := mqtt.ProtobufV2.FromDownlink(input, ids)
 	if !a.So(err, should.BeNil) {
 		t.Fatal("Could not marshal the input v3 struct")
 	}
@@ -124,9 +127,12 @@ func TestProtobufV2Uplinks(t *testing.T) {
 		Timestamp: validV2Metadata.Timestamp,
 	}
 	nilTime := time.Unix(0, 0)
+	ids := ttnpb.GatewayIdentifiers{
+		GatewayID: "gateway-id",
+	}
 	validV3Metadata := []*ttnpb.RxMetadata{
 		{
-			GatewayIdentifiers: ttnpb.GatewayIdentifiers{GatewayID: "gateway-id"},
+			GatewayIdentifiers: ids,
 			RSSI:               -2,
 			SNR:                -75,
 			Time:               &nilTime,
@@ -211,7 +217,7 @@ func TestProtobufV2Uplinks(t *testing.T) {
 			if !a.So(err, should.BeNil) {
 				t.FailNow()
 			}
-			res, err := mqtt.ProtobufV2.ToUplink(buf)
+			res, err := mqtt.ProtobufV2.ToUplink(buf, ids)
 			if tc.ErrorAssertion != nil {
 				if !a.So(tc.ErrorAssertion(err), should.BeTrue) {
 					t.FailNow()
@@ -230,6 +236,9 @@ func TestProtobufV2Uplinks(t *testing.T) {
 }
 
 func TestProtobufV2Status(t *testing.T) {
+	ids := ttnpb.GatewayIdentifiers{
+		GatewayID: "gateway-id",
+	}
 	for _, tc := range []struct {
 		Name           string
 		input          *legacyttnpb.StatusMessage
@@ -361,7 +370,7 @@ func TestProtobufV2Status(t *testing.T) {
 			if !a.So(err, should.BeNil) {
 				t.FailNow()
 			}
-			res, err := mqtt.ProtobufV2.ToStatus(buf)
+			res, err := mqtt.ProtobufV2.ToStatus(buf, ids)
 			if tc.ErrorAssertion != nil {
 				if !a.So(tc.ErrorAssertion(err), should.BeTrue) {
 					t.FailNow()

--- a/pkg/gatewayserver/io/mqtt/mqtt.go
+++ b/pkg/gatewayserver/io/mqtt/mqtt.go
@@ -123,7 +123,7 @@ func (c *connection) setup(ctx context.Context) error {
 				logger.WithError(c.io.Context().Err()).Debug("Done sending downlink")
 				return
 			case down := <-c.io.Down():
-				buf, err := c.format.FromDownlink(down)
+				buf, err := c.format.FromDownlink(down, c.io.Gateway().GatewayIdentifiers)
 				if err != nil {
 					logger.WithError(err).Warn("Failed to marshal downlink message")
 					continue
@@ -270,7 +270,7 @@ func (c *connection) deliver(pkt *packet.PublishPacket) {
 	logger := log.FromContext(c.io.Context()).WithField("topic", pkt.TopicName)
 	switch {
 	case c.format.IsUplinkTopic(pkt.TopicParts):
-		up, err := c.format.ToUplink(pkt.Message)
+		up, err := c.format.ToUplink(pkt.Message, c.io.Gateway().GatewayIdentifiers)
 		if err != nil {
 			logger.WithError(err).Warn("Failed to unmarshal uplink message")
 			return
@@ -280,7 +280,7 @@ func (c *connection) deliver(pkt *packet.PublishPacket) {
 			logger.WithError(err).Warn("Failed to handle uplink message")
 		}
 	case c.format.IsStatusTopic(pkt.TopicParts):
-		status, err := c.format.ToStatus(pkt.Message)
+		status, err := c.format.ToStatus(pkt.Message, c.io.Gateway().GatewayIdentifiers)
 		if err != nil {
 			logger.WithError(err).Warn("Failed to unmarshal status message")
 			return
@@ -289,7 +289,7 @@ func (c *connection) deliver(pkt *packet.PublishPacket) {
 			logger.WithError(err).Warn("Failed to handle status message")
 		}
 	case c.format.IsTxAckTopic(pkt.TopicParts):
-		ack, err := c.format.ToTxAck(pkt.Message)
+		ack, err := c.format.ToTxAck(pkt.Message, c.io.Gateway().GatewayIdentifiers)
 		if err != nil {
 			logger.WithError(err).Warn("Failed to unmarshal Tx acknowledgment message")
 			return


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #255 .
Closes #256.

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Use payload getters when formatting the v2 downlink in the MQTT frontend.
- Manually inject the gateway ID in the uplinks during parsing.