### PR TITLE
Remove `this` bindings from SDK service classes

### DIFF
--- a/pkg/webui/console/api/index.js
+++ b/pkg/webui/console/api/index.js
@@ -67,25 +67,25 @@ export default {
     },
   },
   applications: {
-    list: ttnClient.Applications.getAll,
-    search: ttnClient.Applications.search,
+    list: ttnClient.Applications.getAll.bind(ttnClient.Applications),
+    search: ttnClient.Applications.search.bind(ttnClient.Applications),
   },
   application: {
-    get: ttnClient.Applications.getById,
-    'delete': ttnClient.Applications.deleteById,
-    create: ttnClient.Applications.create,
-    update: ttnClient.Applications.updateById,
+    get: ttnClient.Applications.getById.bind(ttnClient.Applications),
+    'delete': ttnClient.Applications.deleteById.bind(ttnClient.Applications),
+    create: ttnClient.Applications.create.bind(ttnClient.Applications),
+    update: ttnClient.Applications.updateById.bind(ttnClient.Applications),
     apiKeys: {
-      list: ttnClient.Applications.ApiKeys.getAll,
-      update: ttnClient.Applications.ApiKeys.updateById,
-      'delete': ttnClient.Applications.ApiKeys.deleteById,
-      create: ttnClient.Applications.ApiKeys.create,
+      list: ttnClient.Applications.ApiKeys.getAll.bind(ttnClient.Applications.ApiKeys),
+      update: ttnClient.Applications.ApiKeys.updateById.bind(ttnClient.Applications.ApiKeys),
+      'delete': ttnClient.Applications.ApiKeys.deleteById.bind(ttnClient.Applications.ApiKeys),
+      create: ttnClient.Applications.ApiKeys.create.bind(ttnClient.Applications.ApiKeys),
     },
     link: {
-      get: ttnClient.Applications.Link.get,
-      set: ttnClient.Applications.Link.set,
-      'delete': ttnClient.Applications.Link.delete,
-      stats: ttnClient.Applications.Link.getStats,
+      get: ttnClient.Applications.Link.get.bind(ttnClient.Applications.Link),
+      set: ttnClient.Applications.Link.set.bind(ttnClient.Applications.Link),
+      'delete': ttnClient.Applications.Link.delete.bind(ttnClient.Applications.Link),
+      stats: ttnClient.Applications.Link.getStats.bind(ttnClient.Applications.Link),
     },
   },
   devices: {
@@ -97,6 +97,6 @@ export default {
     search: stubs.gateways.search,
   },
   rights: {
-    applications: ttnClient.Applications.getRightsById,
+    applications: ttnClient.Applications.getRightsById.bind(ttnClient.Applications),
   },
 }

--- a/sdk/js/src/service/api-keys.js
+++ b/sdk/js/src/service/api-keys.js
@@ -18,11 +18,6 @@ class ApiKeys {
   constructor (registry, parentRoutes) {
     this._api = registry
     this._parentRoutes = parentRoutes
-
-    this.getAll = this.getAll.bind(this)
-    this.create = this.create.bind(this)
-    this.deleteById = this.deleteById.bind(this)
-    this.updateById = this.updateById.bind(this)
   }
 
   async getAll (entityId, params) {

--- a/sdk/js/src/service/applications.js
+++ b/sdk/js/src/service/applications.js
@@ -43,17 +43,6 @@ class Applications {
       update: 'application_ids.application_id',
     })
     this.Link = new Link(api.As)
-
-    this.getAll = this.getAll.bind(this)
-    this.getById = this.getById.bind(this)
-    this.getByOrganization = this.getByOrganization.bind(this)
-    this.getByCollaborator = this.getByCollaborator.bind(this)
-    this.search = this.search.bind(this)
-    this.updateById = this.updateById.bind(this)
-    this.create = this.create.bind(this)
-    this.deleteById = this.deleteById.bind(this)
-    this.withId = this.withId.bind(this)
-    this.getRightsById = this.getRightsById.bind(this)
   }
 
   // Retrieval

--- a/sdk/js/src/service/link.js
+++ b/sdk/js/src/service/link.js
@@ -17,11 +17,6 @@ import Marshaler from '../util/marshaler'
 class Link {
   constructor (registry) {
     this._api = registry
-
-    this.get = this.get.bind(this)
-    this.set = this.set.bind(this)
-    this.delete = this.delete.bind(this)
-    this.getStats = this.getStats.bind(this)
   }
 
   async get (appId, fieldMask) {


### PR DESCRIPTION
**Summary:**
Closes #281 

**Changes:**
- Remove `.bind(this)` in service class constructors
- Add instance bindings to api tree object in console

**Notes for Reviewers:**
See [issue](#281) for more info.