### PR TITLE
Select and merge allowed bottom level fields from devices

### DIFF
--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -581,21 +581,21 @@ var (
 
 func init() {
 	util.FieldMaskFlags(&ttnpb.EndDevice{}).VisitAll(func(flag *pflag.Flag) {
-		if selectPath(flag.Name, getEndDeviceFromIS) {
+		if ttnpb.ContainsField(flag.Name, getEndDeviceFromIS) {
 			selectEndDeviceListFlags.AddFlag(flag)
 			selectEndDeviceFlags.AddFlag(flag)
-		} else if selectPath(flag.Name, getEndDeviceFromNS) ||
-			selectPath(flag.Name, getEndDeviceFromAS) ||
-			selectPath(flag.Name, getEndDeviceFromJS) {
+		} else if ttnpb.ContainsField(flag.Name, getEndDeviceFromNS) ||
+			ttnpb.ContainsField(flag.Name, getEndDeviceFromAS) ||
+			ttnpb.ContainsField(flag.Name, getEndDeviceFromJS) {
 			selectEndDeviceFlags.AddFlag(flag)
 		}
 	})
 
 	util.FieldFlags(&ttnpb.EndDevice{}).VisitAll(func(flag *pflag.Flag) {
-		if selectPath(flag.Name, setEndDeviceToIS) ||
-			selectPath(flag.Name, setEndDeviceToNS) ||
-			selectPath(flag.Name, setEndDeviceToAS) ||
-			selectPath(flag.Name, setEndDeviceToJS) {
+		if ttnpb.ContainsField(flag.Name, setEndDeviceToIS) ||
+			ttnpb.ContainsField(flag.Name, setEndDeviceToNS) ||
+			ttnpb.ContainsField(flag.Name, setEndDeviceToAS) ||
+			ttnpb.ContainsField(flag.Name, setEndDeviceToJS) {
 			setEndDeviceFlags.AddFlag(flag)
 		}
 	})

--- a/cmd/ttn-lw-cli/commands/end_devices_split.go
+++ b/cmd/ttn-lw-cli/commands/end_devices_split.go
@@ -23,15 +23,6 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 )
 
-func selectPath(path string, allowedPaths []string) bool {
-	for _, allowedPath := range allowedPaths {
-		if path == allowedPath {
-			return true
-		}
-	}
-	return false
-}
-
 var (
 	getEndDeviceFromIS = ttnpb.AllowedFieldMaskPathsForRPC["/ttn.lorawan.v3.EndDeviceRegistry/Get"]
 	getEndDeviceFromNS = ttnpb.AllowedFieldMaskPathsForRPC["/ttn.lorawan.v3.NsEndDeviceRegistry/Get"]
@@ -43,31 +34,20 @@ var (
 	setEndDeviceToJS   = ttnpb.AllowedFieldMaskPathsForRPC["/ttn.lorawan.v3.JsEndDeviceRegistry/Set"]
 )
 
-func selectPaths(paths []string, allowedPaths []string) []string {
-	selectedPaths := make([]string, 0, len(paths))
-	for _, path := range paths {
-		if selectPath(path, allowedPaths) {
-			selectedPaths = append(selectedPaths, path)
-			continue
-		}
-	}
-	return selectedPaths
-}
-
 func splitEndDeviceGetPaths(paths ...string) (is, ns, as, js []string) {
-	is = selectPaths(paths, getEndDeviceFromIS)
-	ns = selectPaths(paths, getEndDeviceFromNS)
-	as = selectPaths(paths, getEndDeviceFromAS)
-	js = selectPaths(paths, getEndDeviceFromJS)
+	is = ttnpb.AllowedBottomLevelFields(paths, getEndDeviceFromIS)
+	ns = ttnpb.AllowedBottomLevelFields(paths, getEndDeviceFromNS)
+	as = ttnpb.AllowedBottomLevelFields(paths, getEndDeviceFromAS)
+	js = ttnpb.AllowedBottomLevelFields(paths, getEndDeviceFromJS)
 	return
 }
 
 func splitEndDeviceSetPaths(supportsJoin bool, paths ...string) (is, ns, as, js []string) {
-	is = selectPaths(paths, setEndDeviceToIS)
-	ns = selectPaths(paths, setEndDeviceToNS)
-	as = selectPaths(paths, setEndDeviceToAS)
+	is = ttnpb.AllowedFields(paths, setEndDeviceToIS)
+	ns = ttnpb.AllowedFields(paths, setEndDeviceToNS)
+	as = ttnpb.AllowedFields(paths, setEndDeviceToAS)
 	if supportsJoin {
-		js = selectPaths(paths, setEndDeviceToJS)
+		js = ttnpb.AllowedFields(paths, setEndDeviceToJS)
 	}
 	return
 }

--- a/config/messages.json
+++ b/config/messages.json
@@ -4420,7 +4420,7 @@
   },
   "error:pkg/ttnpb:missing_field": {
     "translations": {
-      "en": "field {field} is missing"
+      "en": "field `{field}` is missing"
     },
     "description": {
       "package": "pkg/ttnpb",
@@ -4456,7 +4456,7 @@
   },
   "error:pkg/ttnpb:prohibited_field": {
     "translations": {
-      "en": "field {field} is prohibited"
+      "en": "field `{field}` is prohibited"
     },
     "description": {
       "package": "pkg/ttnpb",

--- a/pkg/applicationserver/grpc_deviceregistry.go
+++ b/pkg/applicationserver/grpc_deviceregistry.go
@@ -31,7 +31,6 @@ func (r *deviceRegistryRPC) Get(ctx context.Context, req *ttnpb.GetEndDeviceRequ
 	if err := rights.RequireApplication(ctx, req.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_DEVICES_READ); err != nil {
 		return nil, err
 	}
-	// TODO: Validate field mask (https://github.com/TheThingsNetwork/lorawan-stack/issues/39)
 	return r.registry.Get(ctx, req.EndDeviceIdentifiers, req.FieldMask.Paths)
 }
 
@@ -40,7 +39,6 @@ func (r *deviceRegistryRPC) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequ
 	if err := rights.RequireApplication(ctx, req.EndDevice.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_DEVICES_WRITE); err != nil {
 		return nil, err
 	}
-	// TODO: Validate field mask (https://github.com/TheThingsNetwork/lorawan-stack/issues/39)
 	return r.registry.Set(ctx, req.EndDevice.EndDeviceIdentifiers, req.FieldMask.Paths, func(dev *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
 		return &req.EndDevice, req.FieldMask.Paths, nil
 	})
@@ -51,7 +49,6 @@ func (r *deviceRegistryRPC) Delete(ctx context.Context, ids *ttnpb.EndDeviceIden
 	if err := rights.RequireApplication(ctx, ids.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_DEVICES_WRITE); err != nil {
 		return nil, err
 	}
-	// TODO: Validate field mask (https://github.com/TheThingsNetwork/lorawan-stack/issues/39)
 	_, err := r.registry.Set(ctx, *ids, nil, func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
 		return nil, nil, nil
 	})

--- a/pkg/ttnpb/fieldmask_utils.go
+++ b/pkg/ttnpb/fieldmask_utils.go
@@ -83,7 +83,7 @@ func FlattenPaths(paths, flatten []string) []string {
 	return res
 }
 
-var errMissingField = errors.Define("missing_field", "field {field} is missing")
+var errMissingField = errors.Define("missing_field", "field `{field}` is missing")
 
 // RequireFields returns nil if the given requested paths contain all of the given fields and error otherwise.
 // The requested fields (i.e. `a.b`) may be of a higher level than the search path (i.e. `a.b.c`).
@@ -96,7 +96,7 @@ func RequireFields(requested []string, search ...string) error {
 	return nil
 }
 
-var errProhibitedField = errors.Define("prohibited_field", "field {field} is prohibited")
+var errProhibitedField = errors.Define("prohibited_field", "field `{field}` is prohibited")
 
 // ProhibitFields returns nil if the given requested paths contain none of the given fields and error otherwise.
 // The requested fields (i.e. `a.b`) may be of a higher level than the search path (i.e. `a.b.c`).

--- a/pkg/ttnpb/fieldmask_utils_test.go
+++ b/pkg/ttnpb/fieldmask_utils_test.go
@@ -33,6 +33,27 @@ func TestTopLevelFields(t *testing.T) {
 	a.So(ttnpb.TopLevelFields(paths), should.Resemble, []string{"a", "b"})
 }
 
+func TestBottomLevelFields(t *testing.T) {
+	a := assertions.New(t)
+	paths := []string{
+		"a",
+		"b",
+		"b.c",
+		"d.e",
+		"f.g.h",
+		"f.g.h.i",
+		"f.g.h.i.j",
+		"f.g.h.i.k",
+	}
+	a.So(ttnpb.BottomLevelFields(paths), should.HaveSameElementsDeep, []string{
+		"a",
+		"b.c",
+		"d.e",
+		"f.g.h.i.j",
+		"f.g.h.i.k",
+	})
+}
+
 func TestHasOnlyAllowedFields(t *testing.T) {
 	a := assertions.New(t)
 	allowed := []string{
@@ -92,4 +113,40 @@ func TestFlattenPaths(t *testing.T) {
 		"e.f",
 	}
 	a.So(ttnpb.FlattenPaths(paths, []string{"a.b"}), should.Resemble, []string{"a", "a.b", "e.f"})
+}
+
+func TestContainsField(t *testing.T) {
+	a := assertions.New(t)
+	a.So(ttnpb.ContainsField("a.b", []string{"a.b", "c"}), should.BeTrue)
+	a.So(ttnpb.ContainsField("x", []string{"a.b", "c"}), should.BeFalse)
+}
+
+func TestAllowedFields(t *testing.T) {
+	a := assertions.New(t)
+	paths := []string{
+		"x",
+		"c.d",
+	}
+	allowedPaths := []string{
+		"a",
+		"a.b",
+		"c.d",
+	}
+	a.So(ttnpb.AllowedFields(paths, allowedPaths), should.Resemble, []string{"c.d"})
+}
+
+func TestAllowedBottomLevelFields(t *testing.T) {
+	a := assertions.New(t)
+	paths := []string{
+		"x",
+		"c",
+	}
+	allowedPaths := []string{
+		"a",
+		"a.b",
+		"c",
+		"c.d",
+		"c.e",
+	}
+	a.So(ttnpb.AllowedBottomLevelFields(paths, allowedPaths), should.HaveSameElementsDeep, []string{"c.d", "c.e"})
 }


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Fixes #288 

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- When selecting fields from components, select the allowed bottom level fields. Before, if you select `session` from NS and AS (both allowed), when merging the fields, the NS `session` would override the AS `session`. Now, since bottom level fields are selected only, replacement of parents doesn't happen anymore
- Extend utilities for field masks for the above
- Use utilities in CLI where a local func was otherwise used