### PR TITLE
Use sub-band EIRP for transmission

### DIFF
--- a/api/api.md
+++ b/api/api.md
@@ -4236,7 +4236,7 @@ On downlink, this is a scheduled transmission.
 | data_rate_index | [DataRateIndex](#ttn.lorawan.v3.DataRateIndex) |  | LoRaWAN data rate index. |
 | coding_rate | [string](#string) |  | LoRa coding rate. |
 | frequency | [uint64](#uint64) |  | Frequency (Hz). |
-| tx_power | [int32](#int32) |  | Transmission power (dBm). Only on downlink. |
+| tx_power | [float](#float) |  | Transmission power (dBm). Only on downlink. |
 | invert_polarization | [bool](#bool) |  | Invert LoRa polarization; false for LoRaWAN uplink, true for downlink. |
 | gateway_channel_index | [uint32](#uint32) |  | Index of the gateway channel that received the message. Set by Gateway Server. |
 | device_channel_index | [uint32](#uint32) |  | Index of the device channel that received the message. Set by Network Server. |

--- a/api/api.swagger.json
+++ b/api/api.swagger.json
@@ -8514,8 +8514,8 @@
           "description": "Frequency (Hz)."
         },
         "tx_power": {
-          "type": "integer",
-          "format": "int32",
+          "type": "number",
+          "format": "float",
           "description": "Transmission power (dBm). Only on downlink."
         },
         "invert_polarization": {

--- a/api/lorawan.proto
+++ b/api/lorawan.proto
@@ -255,7 +255,7 @@ message TxSettings {
   // Frequency (Hz).
   uint64 frequency = 4;
   // Transmission power (dBm). Only on downlink.
-  int32 tx_power = 5;
+  float tx_power = 5;
   // Invert LoRa polarization; false for LoRaWAN uplink, true for downlink.
   bool invert_polarization = 6;
   // Index of the gateway channel that received the message.

--- a/pkg/band/as_923.go
+++ b/pkg/band/as_923.go
@@ -47,7 +47,7 @@ func init() {
 				MinFrequency: 923000000,
 				MaxFrequency: 923500000,
 				DutyCycle:    0.01,
-				MaxTxPower:   14.0,
+				MaxEIRP:      14.0 + eirpDelta,
 			},
 		},
 

--- a/pkg/band/au_915_928.go
+++ b/pkg/band/au_915_928.go
@@ -68,7 +68,7 @@ func init() {
 				MinFrequency: 902000000,
 				MaxFrequency: 928000000,
 				DutyCycle:    1,
-				MaxTxPower:   14.0,
+				MaxEIRP:      14.0 + eirpDelta,
 			},
 		},
 

--- a/pkg/band/band.go
+++ b/pkg/band/band.go
@@ -270,6 +270,16 @@ func (b Band) Versions() []ttnpb.PHYVersion {
 	return versions
 }
 
+// FindSubBand returns the sub-band by frequency, if any.
+func (b Band) FindSubBand(frequency uint64) (SubBandParameters, bool) {
+	for _, sb := range b.SubBands {
+		if sb.Comprises(frequency) {
+			return sb, true
+		}
+	}
+	return SubBandParameters{}, false
+}
+
 func beaconChannelFromFrequencies(frequencies [8]uint32) func(float64) uint32 {
 	return func(beaconTime float64) uint32 {
 		floor := math.Floor(beaconTime / float64(128))

--- a/pkg/band/band.go
+++ b/pkg/band/band.go
@@ -23,6 +23,9 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 )
 
+// eirpDelta is the delta between EIRP and ERP.
+const eirpDelta = 2.15
+
 // PayloadSizer abstracts the acceptable payload size depending on contextual parameters.
 type PayloadSizer interface {
 	PayloadSize(dwellTime bool) uint16
@@ -197,7 +200,7 @@ type SubBandParameters struct {
 	MinFrequency uint64
 	MaxFrequency uint64
 	DutyCycle    float32
-	MaxTxPower   float32
+	MaxEIRP      float32
 }
 
 // Comprises returns whether the duty cycle applies to the given frequency.

--- a/pkg/band/band_test.go
+++ b/pkg/band/band_test.go
@@ -137,3 +137,16 @@ func TestGenerateChMasksBands(t *testing.T) {
 		}
 	}
 }
+
+func TestFindSubBand(t *testing.T) {
+	a := assertions.New(t)
+
+	for _, b := range band.All {
+		for _, ch := range b.UplinkChannels {
+			sb, ok := b.FindSubBand(ch.Frequency)
+			a.So(ok, should.BeTrue)
+			a.So(sb.MinFrequency, should.BeLessThanOrEqualTo, ch.Frequency)
+			a.So(sb.MaxFrequency, should.BeGreaterThan, ch.Frequency)
+		}
+	}
+}

--- a/pkg/band/cn_470_510.go
+++ b/pkg/band/cn_470_510.go
@@ -61,7 +61,7 @@ func init() {
 				MinFrequency: 470000000,
 				MaxFrequency: 510000000,
 				DutyCycle:    1,
-				MaxTxPower:   17.0,
+				MaxEIRP:      17.0 + eirpDelta,
 			},
 		},
 

--- a/pkg/band/cn_779_787.go
+++ b/pkg/band/cn_779_787.go
@@ -52,7 +52,7 @@ func init() {
 				MinFrequency: 779000000,
 				MaxFrequency: 787000000,
 				DutyCycle:    0.01,
-				MaxTxPower:   10.0,
+				MaxEIRP:      10.0 + eirpDelta,
 			},
 		},
 

--- a/pkg/band/eu_433.go
+++ b/pkg/band/eu_433.go
@@ -49,7 +49,7 @@ func init() {
 				MinFrequency: 433175000,
 				MaxFrequency: 434665000,
 				DutyCycle:    0.1,
-				MaxTxPower:   10.0,
+				MaxEIRP:      10.0 + eirpDelta,
 			},
 		},
 

--- a/pkg/band/eu_863_870.go
+++ b/pkg/band/eu_863_870.go
@@ -50,28 +50,28 @@ func init() {
 				MinFrequency: 863000000,
 				MaxFrequency: 865000000,
 				DutyCycle:    0.001,
-				MaxTxPower:   14.0,
+				MaxEIRP:      14.0 + eirpDelta,
 			},
 			{
 				// Band L
 				MinFrequency: 865000000,
 				MaxFrequency: 868000000,
 				DutyCycle:    0.01,
-				MaxTxPower:   14.0,
+				MaxEIRP:      14.0 + eirpDelta,
 			},
 			{
 				// Band M
 				MinFrequency: 868000000,
 				MaxFrequency: 868600000,
 				DutyCycle:    0.01,
-				MaxTxPower:   14.0,
+				MaxEIRP:      14.0 + eirpDelta,
 			},
 			{
 				// Band N
 				MinFrequency: 868700000,
 				MaxFrequency: 869200000,
 				DutyCycle:    0.001,
-				MaxTxPower:   14.0,
+				MaxEIRP:      14.0 + eirpDelta,
 			},
 			// Band O is skipped intentionally
 			{
@@ -79,14 +79,14 @@ func init() {
 				MinFrequency: 869400000,
 				MaxFrequency: 869650000,
 				DutyCycle:    0.1,
-				MaxTxPower:   27.0,
+				MaxEIRP:      27.0 + eirpDelta,
 			},
 			{
 				// Band R
 				MinFrequency: 869700000,
 				MaxFrequency: 870000000,
 				DutyCycle:    0.01,
-				MaxTxPower:   14.0,
+				MaxEIRP:      14.0 + eirpDelta,
 			},
 		},
 

--- a/pkg/band/in_865_867.go
+++ b/pkg/band/in_865_867.go
@@ -48,7 +48,7 @@ func init() {
 				MinFrequency: 865000000,
 				MaxFrequency: 867000000,
 				DutyCycle:    1,
-				MaxTxPower:   14.0,
+				MaxEIRP:      14.0 + eirpDelta,
 			},
 		},
 

--- a/pkg/band/kr_920_923.go
+++ b/pkg/band/kr_920_923.go
@@ -48,7 +48,7 @@ func init() {
 				MinFrequency: 920000000,
 				MaxFrequency: 923000000,
 				DutyCycle:    1,
-				MaxTxPower:   14.0,
+				MaxEIRP:      14.0 + eirpDelta,
 			},
 		},
 

--- a/pkg/band/ru_864_870.go
+++ b/pkg/band/ru_864_870.go
@@ -47,7 +47,7 @@ func init() {
 				MinFrequency: 864000000,
 				MaxFrequency: 870000000,
 				DutyCycle:    0.01,
-				MaxTxPower:   20.0,
+				MaxEIRP:      20.0 + eirpDelta,
 			},
 		},
 

--- a/pkg/band/us_902_928.go
+++ b/pkg/band/us_902_928.go
@@ -68,7 +68,7 @@ func init() {
 				MinFrequency: 902000000,
 				MaxFrequency: 928000000,
 				DutyCycle:    1,
-				MaxTxPower:   30.0,
+				MaxEIRP:      30.0 + eirpDelta,
 			},
 		},
 

--- a/pkg/frequencyplans/frequencyplans.go
+++ b/pkg/frequencyplans/frequencyplans.go
@@ -309,7 +309,8 @@ type FrequencyPlan struct {
 	// Rx2Channel overrides the default band settings for Rx2.
 	Rx2Channel         *Channel `yaml:"rx2-channel,omitempty"`
 	DefaultRx2DataRate *uint8   `yaml:"rx2-default-data-rate,omitempty"`
-	MaxEIRP            *float32 `yaml:"max-eirp,omitempty"`
+	// MaxEIRP is the maximum EIRP as ceiling for any (sub-)band value.
+	MaxEIRP *float32 `yaml:"max-eirp,omitempty"`
 }
 
 // Extend returns the same frequency plan, with values overridden by the passed frequency plan.

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -271,10 +271,10 @@ func (c *Connection) SendDown(path *ttnpb.DownlinkPath, msg *ttnpb.DownlinkMessa
 			settings := ttnpb.TxSettings{
 				DataRateIndex: rx.dataRateIndex,
 				Frequency:     rx.frequency,
-				TxPower:       int32(maxEIRP),
+				TxPower:       maxEIRP,
 			}
 			if int(ids.AntennaIndex) < len(c.gateway.Antennas) {
-				settings.TxPower -= int32(c.gateway.Antennas[ids.AntennaIndex].Gain)
+				settings.TxPower -= c.gateway.Antennas[ids.AntennaIndex].Gain
 			}
 			settings.DataRate = dataRate
 			if dr := dataRate.GetLoRa(); dr != nil {

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -262,16 +262,18 @@ func (c *Connection) SendDown(path *ttnpb.DownlinkPath, msg *ttnpb.DownlinkMessa
 					"data_rate_index", rx.dataRateIndex,
 				)
 			}
-			var maxEIRP float32
-			if c.fp.MaxEIRP != nil {
-				maxEIRP = *c.fp.MaxEIRP
-			} else {
-				maxEIRP = band.DefaultMaxEIRP
+			eirp := band.DefaultMaxEIRP
+			if sb, ok := band.FindSubBand(rx.frequency); ok {
+				eirp = sb.MaxEIRP
+			}
+			// TODO: Override with frequency plan's sub-band MaxEIRP (https://github.com/TheThingsNetwork/lorawan-stack/issues/300)
+			if c.fp.MaxEIRP != nil && *c.fp.MaxEIRP < eirp {
+				eirp = *c.fp.MaxEIRP
 			}
 			settings := ttnpb.TxSettings{
 				DataRateIndex: rx.dataRateIndex,
 				Frequency:     rx.frequency,
-				TxPower:       maxEIRP,
+				TxPower:       eirp,
 			}
 			if int(ids.AntennaIndex) < len(c.gateway.Antennas) {
 				settings.TxPower -= c.gateway.Antennas[ids.AntennaIndex].Gain

--- a/pkg/gatewayserver/io/mqtt/format_protobufv2.go
+++ b/pkg/gatewayserver/io/mqtt/format_protobufv2.go
@@ -27,8 +27,8 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/ttnpb/udp"
 )
 
-// eirpDelta is the integer-rounded delta between EIRP and ERP.
-const eirpDelta = 2
+// eirpDelta is the delta between EIRP and ERP.
+const eirpDelta = 2.15
 
 var (
 	sourceToV3 = map[legacyttnpb.LocationMetadata_LocationSource]ttnpb.LocationSource{
@@ -90,7 +90,7 @@ func (protobufv2) FromDownlink(down *ttnpb.DownlinkMessage, _ ttnpb.GatewayIdent
 		Payload: down.RawPayload,
 		GatewayConfiguration: legacyttnpb.GatewayTxConfiguration{
 			Frequency:             settings.Frequency,
-			Power:                 settings.TxPower - eirpDelta,
+			Power:                 int32(settings.TxPower - eirpDelta),
 			PolarizationInversion: true,
 			RfChain:               0,
 			Timestamp:             settings.Timestamp,

--- a/pkg/gatewayserver/io/mqtt/format_protobufv2_test.go
+++ b/pkg/gatewayserver/io/mqtt/format_protobufv2_test.go
@@ -50,7 +50,7 @@ func TestProtobufV2Downlink(t *testing.T) {
 				CodingRate:    "4/5",
 				DataRateIndex: 0,
 				Frequency:     863000000,
-				TxPower:       15,
+				TxPower:       16.15,
 				Timestamp:     12000,
 			},
 		},
@@ -64,7 +64,7 @@ func TestProtobufV2Downlink(t *testing.T) {
 		Payload: pld,
 		GatewayConfiguration: legacyttnpb.GatewayTxConfiguration{
 			Frequency:             863000000,
-			Power:                 13,
+			Power:                 14,
 			PolarizationInversion: true,
 			Timestamp:             12000,
 		},

--- a/pkg/ttnpb/lorawan.pb.go
+++ b/pkg/ttnpb/lorawan.pb.go
@@ -18,6 +18,7 @@ import strconv "strconv"
 
 import bytes "bytes"
 
+import encoding_binary "encoding/binary"
 import github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
 
 import strings "strings"
@@ -73,7 +74,7 @@ var MType_value = map[string]int32{
 }
 
 func (MType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{0}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{0}
 }
 
 type Major int32
@@ -90,7 +91,7 @@ var Major_value = map[string]int32{
 }
 
 func (Major) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{1}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{1}
 }
 
 type MACVersion int32
@@ -119,7 +120,7 @@ var MACVersion_value = map[string]int32{
 }
 
 func (MACVersion) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{2}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{2}
 }
 
 type PHYVersion int32
@@ -154,7 +155,7 @@ var PHYVersion_value = map[string]int32{
 }
 
 func (PHYVersion) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{3}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{3}
 }
 
 type DataRateIndex int32
@@ -216,7 +217,7 @@ var DataRateIndex_value = map[string]int32{
 }
 
 func (DataRateIndex) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{4}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{4}
 }
 
 type RejoinType int32
@@ -239,7 +240,7 @@ var RejoinType_value = map[string]int32{
 }
 
 func (RejoinType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{5}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{5}
 }
 
 type CFListType int32
@@ -259,7 +260,7 @@ var CFListType_value = map[string]int32{
 }
 
 func (CFListType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{6}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{6}
 }
 
 type Class int32
@@ -282,7 +283,7 @@ var Class_value = map[string]int32{
 }
 
 func (Class) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{7}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{7}
 }
 
 type TxSchedulePriority int32
@@ -317,7 +318,7 @@ var TxSchedulePriority_value = map[string]int32{
 }
 
 func (TxSchedulePriority) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{8}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{8}
 }
 
 type MACCommandIdentifier int32
@@ -394,7 +395,7 @@ var MACCommandIdentifier_value = map[string]int32{
 }
 
 func (MACCommandIdentifier) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{9}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{9}
 }
 
 type AggregatedDutyCycle int32
@@ -456,7 +457,7 @@ var AggregatedDutyCycle_value = map[string]int32{
 }
 
 func (AggregatedDutyCycle) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{10}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{10}
 }
 
 type PingSlotPeriod int32
@@ -494,7 +495,7 @@ var PingSlotPeriod_value = map[string]int32{
 }
 
 func (PingSlotPeriod) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{11}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{11}
 }
 
 type RejoinCountExponent int32
@@ -556,7 +557,7 @@ var RejoinCountExponent_value = map[string]int32{
 }
 
 func (RejoinCountExponent) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{12}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{12}
 }
 
 type RejoinTimeExponent int32
@@ -618,7 +619,7 @@ var RejoinTimeExponent_value = map[string]int32{
 }
 
 func (RejoinTimeExponent) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{13}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{13}
 }
 
 type RejoinPeriodExponent int32
@@ -656,7 +657,7 @@ var RejoinPeriodExponent_value = map[string]int32{
 }
 
 func (RejoinPeriodExponent) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{14}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{14}
 }
 
 type DeviceEIRP int32
@@ -718,7 +719,7 @@ var DeviceEIRP_value = map[string]int32{
 }
 
 func (DeviceEIRP) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{15}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{15}
 }
 
 type ADRAckLimitExponent int32
@@ -780,7 +781,7 @@ var ADRAckLimitExponent_value = map[string]int32{
 }
 
 func (ADRAckLimitExponent) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{16}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{16}
 }
 
 type ADRAckDelayExponent int32
@@ -842,7 +843,7 @@ var ADRAckDelayExponent_value = map[string]int32{
 }
 
 func (ADRAckDelayExponent) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{17}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{17}
 }
 
 type RxDelay int32
@@ -904,7 +905,7 @@ var RxDelay_value = map[string]int32{
 }
 
 func (RxDelay) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18}
 }
 
 type Minor int32
@@ -966,7 +967,7 @@ var Minor_value = map[string]int32{
 }
 
 func (Minor) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{19}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{19}
 }
 
 type Message struct {
@@ -991,7 +992,7 @@ type Message struct {
 func (m *Message) Reset()      { *m = Message{} }
 func (*Message) ProtoMessage() {}
 func (*Message) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{0}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{0}
 }
 func (m *Message) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1209,7 +1210,7 @@ type MHDR struct {
 func (m *MHDR) Reset()      { *m = MHDR{} }
 func (*MHDR) ProtoMessage() {}
 func (*MHDR) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{1}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{1}
 }
 func (m *MHDR) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1264,7 +1265,7 @@ type MACPayload struct {
 func (m *MACPayload) Reset()      { *m = MACPayload{} }
 func (*MACPayload) ProtoMessage() {}
 func (*MACPayload) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{2}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{2}
 }
 func (m *MACPayload) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1326,7 +1327,7 @@ type FHDR struct {
 func (m *FHDR) Reset()      { *m = FHDR{} }
 func (*FHDR) ProtoMessage() {}
 func (*FHDR) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{3}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{3}
 }
 func (m *FHDR) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1382,7 +1383,7 @@ type FCtrl struct {
 func (m *FCtrl) Reset()      { *m = FCtrl{} }
 func (*FCtrl) ProtoMessage() {}
 func (*FCtrl) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{4}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{4}
 }
 func (m *FCtrl) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1457,7 +1458,7 @@ type JoinRequestPayload struct {
 func (m *JoinRequestPayload) Reset()      { *m = JoinRequestPayload{} }
 func (*JoinRequestPayload) ProtoMessage() {}
 func (*JoinRequestPayload) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{5}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{5}
 }
 func (m *JoinRequestPayload) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1499,7 +1500,7 @@ type RejoinRequestPayload struct {
 func (m *RejoinRequestPayload) Reset()      { *m = RejoinRequestPayload{} }
 func (*RejoinRequestPayload) ProtoMessage() {}
 func (*RejoinRequestPayload) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{6}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{6}
 }
 func (m *RejoinRequestPayload) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1557,7 +1558,7 @@ type JoinAcceptPayload struct {
 func (m *JoinAcceptPayload) Reset()      { *m = JoinAcceptPayload{} }
 func (*JoinAcceptPayload) ProtoMessage() {}
 func (*JoinAcceptPayload) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{7}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{7}
 }
 func (m *JoinAcceptPayload) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1619,7 +1620,7 @@ type DLSettings struct {
 func (m *DLSettings) Reset()      { *m = DLSettings{} }
 func (*DLSettings) ProtoMessage() {}
 func (*DLSettings) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{8}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{8}
 }
 func (m *DLSettings) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1686,7 +1687,7 @@ type CFList struct {
 func (m *CFList) Reset()      { *m = CFList{} }
 func (*CFList) ProtoMessage() {}
 func (*CFList) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{9}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{9}
 }
 func (m *CFList) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1747,7 +1748,7 @@ type LoRaDataRate struct {
 func (m *LoRaDataRate) Reset()      { *m = LoRaDataRate{} }
 func (*LoRaDataRate) ProtoMessage() {}
 func (*LoRaDataRate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{10}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{10}
 }
 func (m *LoRaDataRate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1800,7 +1801,7 @@ type FSKDataRate struct {
 func (m *FSKDataRate) Reset()      { *m = FSKDataRate{} }
 func (*FSKDataRate) ProtoMessage() {}
 func (*FSKDataRate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{11}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{11}
 }
 func (m *FSKDataRate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -1848,7 +1849,7 @@ type DataRate struct {
 func (m *DataRate) Reset()      { *m = DataRate{} }
 func (*DataRate) ProtoMessage() {}
 func (*DataRate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{12}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{12}
 }
 func (m *DataRate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2002,7 +2003,7 @@ type TxSettings struct {
 	// Frequency (Hz).
 	Frequency uint64 `protobuf:"varint,4,opt,name=frequency,proto3" json:"frequency,omitempty"`
 	// Transmission power (dBm). Only on downlink.
-	TxPower int32 `protobuf:"varint,5,opt,name=tx_power,json=txPower,proto3" json:"tx_power,omitempty"`
+	TxPower float32 `protobuf:"fixed32,5,opt,name=tx_power,json=txPower,proto3" json:"tx_power,omitempty"`
 	// Invert LoRa polarization; false for LoRaWAN uplink, true for downlink.
 	InvertPolarization bool `protobuf:"varint,6,opt,name=invert_polarization,json=invertPolarization,proto3" json:"invert_polarization,omitempty"`
 	// Index of the gateway channel that received the message.
@@ -2026,7 +2027,7 @@ type TxSettings struct {
 func (m *TxSettings) Reset()      { *m = TxSettings{} }
 func (*TxSettings) ProtoMessage() {}
 func (*TxSettings) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{13}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{13}
 }
 func (m *TxSettings) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2083,7 +2084,7 @@ func (m *TxSettings) GetFrequency() uint64 {
 	return 0
 }
 
-func (m *TxSettings) GetTxPower() int32 {
+func (m *TxSettings) GetTxPower() float32 {
 	if m != nil {
 		return m.TxPower
 	}
@@ -2142,7 +2143,7 @@ type GatewayAntennaIdentifiers struct {
 func (m *GatewayAntennaIdentifiers) Reset()      { *m = GatewayAntennaIdentifiers{} }
 func (*GatewayAntennaIdentifiers) ProtoMessage() {}
 func (*GatewayAntennaIdentifiers) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{14}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{14}
 }
 func (m *GatewayAntennaIdentifiers) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2188,7 +2189,7 @@ type UplinkToken struct {
 func (m *UplinkToken) Reset()      { *m = UplinkToken{} }
 func (*UplinkToken) ProtoMessage() {}
 func (*UplinkToken) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{15}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{15}
 }
 func (m *UplinkToken) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2239,7 +2240,7 @@ type DownlinkPath struct {
 func (m *DownlinkPath) Reset()      { *m = DownlinkPath{} }
 func (*DownlinkPath) ProtoMessage() {}
 func (*DownlinkPath) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{16}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{16}
 }
 func (m *DownlinkPath) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2416,7 +2417,7 @@ type TxRequest struct {
 func (m *TxRequest) Reset()      { *m = TxRequest{} }
 func (*TxRequest) ProtoMessage() {}
 func (*TxRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{17}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{17}
 }
 func (m *TxRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -2557,7 +2558,7 @@ type MACCommand struct {
 func (m *MACCommand) Reset()      { *m = MACCommand{} }
 func (*MACCommand) ProtoMessage() {}
 func (*MACCommand) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18}
 }
 func (m *MACCommand) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3580,7 +3581,7 @@ type MACCommand_ResetInd struct {
 func (m *MACCommand_ResetInd) Reset()      { *m = MACCommand_ResetInd{} }
 func (*MACCommand_ResetInd) ProtoMessage() {}
 func (*MACCommand_ResetInd) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 0}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 0}
 }
 func (m *MACCommand_ResetInd) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3625,7 +3626,7 @@ type MACCommand_ResetConf struct {
 func (m *MACCommand_ResetConf) Reset()      { *m = MACCommand_ResetConf{} }
 func (*MACCommand_ResetConf) ProtoMessage() {}
 func (*MACCommand_ResetConf) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 1}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 1}
 }
 func (m *MACCommand_ResetConf) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3672,7 +3673,7 @@ type MACCommand_LinkCheckAns struct {
 func (m *MACCommand_LinkCheckAns) Reset()      { *m = MACCommand_LinkCheckAns{} }
 func (*MACCommand_LinkCheckAns) ProtoMessage() {}
 func (*MACCommand_LinkCheckAns) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 2}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 2}
 }
 func (m *MACCommand_LinkCheckAns) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3728,7 +3729,7 @@ type MACCommand_LinkADRReq struct {
 func (m *MACCommand_LinkADRReq) Reset()      { *m = MACCommand_LinkADRReq{} }
 func (*MACCommand_LinkADRReq) ProtoMessage() {}
 func (*MACCommand_LinkADRReq) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 3}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 3}
 }
 func (m *MACCommand_LinkADRReq) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3803,7 +3804,7 @@ type MACCommand_LinkADRAns struct {
 func (m *MACCommand_LinkADRAns) Reset()      { *m = MACCommand_LinkADRAns{} }
 func (*MACCommand_LinkADRAns) ProtoMessage() {}
 func (*MACCommand_LinkADRAns) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 4}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 4}
 }
 func (m *MACCommand_LinkADRAns) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3862,7 +3863,7 @@ type MACCommand_DutyCycleReq struct {
 func (m *MACCommand_DutyCycleReq) Reset()      { *m = MACCommand_DutyCycleReq{} }
 func (*MACCommand_DutyCycleReq) ProtoMessage() {}
 func (*MACCommand_DutyCycleReq) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 5}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 5}
 }
 func (m *MACCommand_DutyCycleReq) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3909,7 +3910,7 @@ type MACCommand_RxParamSetupReq struct {
 func (m *MACCommand_RxParamSetupReq) Reset()      { *m = MACCommand_RxParamSetupReq{} }
 func (*MACCommand_RxParamSetupReq) ProtoMessage() {}
 func (*MACCommand_RxParamSetupReq) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 6}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 6}
 }
 func (m *MACCommand_RxParamSetupReq) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -3970,7 +3971,7 @@ type MACCommand_RxParamSetupAns struct {
 func (m *MACCommand_RxParamSetupAns) Reset()      { *m = MACCommand_RxParamSetupAns{} }
 func (*MACCommand_RxParamSetupAns) ProtoMessage() {}
 func (*MACCommand_RxParamSetupAns) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 7}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 7}
 }
 func (m *MACCommand_RxParamSetupAns) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4035,7 +4036,7 @@ type MACCommand_DevStatusAns struct {
 func (m *MACCommand_DevStatusAns) Reset()      { *m = MACCommand_DevStatusAns{} }
 func (*MACCommand_DevStatusAns) ProtoMessage() {}
 func (*MACCommand_DevStatusAns) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 8}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 8}
 }
 func (m *MACCommand_DevStatusAns) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4090,7 +4091,7 @@ type MACCommand_NewChannelReq struct {
 func (m *MACCommand_NewChannelReq) Reset()      { *m = MACCommand_NewChannelReq{} }
 func (*MACCommand_NewChannelReq) ProtoMessage() {}
 func (*MACCommand_NewChannelReq) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 9}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 9}
 }
 func (m *MACCommand_NewChannelReq) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4157,7 +4158,7 @@ type MACCommand_NewChannelAns struct {
 func (m *MACCommand_NewChannelAns) Reset()      { *m = MACCommand_NewChannelAns{} }
 func (*MACCommand_NewChannelAns) ProtoMessage() {}
 func (*MACCommand_NewChannelAns) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 10}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 10}
 }
 func (m *MACCommand_NewChannelAns) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4210,7 +4211,7 @@ type MACCommand_DLChannelReq struct {
 func (m *MACCommand_DLChannelReq) Reset()      { *m = MACCommand_DLChannelReq{} }
 func (*MACCommand_DLChannelReq) ProtoMessage() {}
 func (*MACCommand_DLChannelReq) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 11}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 11}
 }
 func (m *MACCommand_DLChannelReq) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4263,7 +4264,7 @@ type MACCommand_DLChannelAns struct {
 func (m *MACCommand_DLChannelAns) Reset()      { *m = MACCommand_DLChannelAns{} }
 func (*MACCommand_DLChannelAns) ProtoMessage() {}
 func (*MACCommand_DLChannelAns) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 12}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 12}
 }
 func (m *MACCommand_DLChannelAns) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4315,7 +4316,7 @@ type MACCommand_RxTimingSetupReq struct {
 func (m *MACCommand_RxTimingSetupReq) Reset()      { *m = MACCommand_RxTimingSetupReq{} }
 func (*MACCommand_RxTimingSetupReq) ProtoMessage() {}
 func (*MACCommand_RxTimingSetupReq) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 13}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 13}
 }
 func (m *MACCommand_RxTimingSetupReq) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4364,7 +4365,7 @@ type MACCommand_TxParamSetupReq struct {
 func (m *MACCommand_TxParamSetupReq) Reset()      { *m = MACCommand_TxParamSetupReq{} }
 func (*MACCommand_TxParamSetupReq) ProtoMessage() {}
 func (*MACCommand_TxParamSetupReq) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 14}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 14}
 }
 func (m *MACCommand_TxParamSetupReq) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4423,7 +4424,7 @@ type MACCommand_RekeyInd struct {
 func (m *MACCommand_RekeyInd) Reset()      { *m = MACCommand_RekeyInd{} }
 func (*MACCommand_RekeyInd) ProtoMessage() {}
 func (*MACCommand_RekeyInd) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 15}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 15}
 }
 func (m *MACCommand_RekeyInd) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4468,7 +4469,7 @@ type MACCommand_RekeyConf struct {
 func (m *MACCommand_RekeyConf) Reset()      { *m = MACCommand_RekeyConf{} }
 func (*MACCommand_RekeyConf) ProtoMessage() {}
 func (*MACCommand_RekeyConf) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 16}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 16}
 }
 func (m *MACCommand_RekeyConf) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4516,7 +4517,7 @@ type MACCommand_ADRParamSetupReq struct {
 func (m *MACCommand_ADRParamSetupReq) Reset()      { *m = MACCommand_ADRParamSetupReq{} }
 func (*MACCommand_ADRParamSetupReq) ProtoMessage() {}
 func (*MACCommand_ADRParamSetupReq) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 17}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 17}
 }
 func (m *MACCommand_ADRParamSetupReq) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4568,7 +4569,7 @@ type MACCommand_DeviceTimeAns struct {
 func (m *MACCommand_DeviceTimeAns) Reset()      { *m = MACCommand_DeviceTimeAns{} }
 func (*MACCommand_DeviceTimeAns) ProtoMessage() {}
 func (*MACCommand_DeviceTimeAns) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 18}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 18}
 }
 func (m *MACCommand_DeviceTimeAns) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4617,7 +4618,7 @@ type MACCommand_ForceRejoinReq struct {
 func (m *MACCommand_ForceRejoinReq) Reset()      { *m = MACCommand_ForceRejoinReq{} }
 func (*MACCommand_ForceRejoinReq) ProtoMessage() {}
 func (*MACCommand_ForceRejoinReq) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 19}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 19}
 }
 func (m *MACCommand_ForceRejoinReq) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4686,7 +4687,7 @@ type MACCommand_RejoinParamSetupReq struct {
 func (m *MACCommand_RejoinParamSetupReq) Reset()      { *m = MACCommand_RejoinParamSetupReq{} }
 func (*MACCommand_RejoinParamSetupReq) ProtoMessage() {}
 func (*MACCommand_RejoinParamSetupReq) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 20}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 20}
 }
 func (m *MACCommand_RejoinParamSetupReq) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4738,7 +4739,7 @@ type MACCommand_RejoinParamSetupAns struct {
 func (m *MACCommand_RejoinParamSetupAns) Reset()      { *m = MACCommand_RejoinParamSetupAns{} }
 func (*MACCommand_RejoinParamSetupAns) ProtoMessage() {}
 func (*MACCommand_RejoinParamSetupAns) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 21}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 21}
 }
 func (m *MACCommand_RejoinParamSetupAns) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4783,7 +4784,7 @@ type MACCommand_PingSlotInfoReq struct {
 func (m *MACCommand_PingSlotInfoReq) Reset()      { *m = MACCommand_PingSlotInfoReq{} }
 func (*MACCommand_PingSlotInfoReq) ProtoMessage() {}
 func (*MACCommand_PingSlotInfoReq) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 22}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 22}
 }
 func (m *MACCommand_PingSlotInfoReq) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4829,7 +4830,7 @@ type MACCommand_PingSlotChannelReq struct {
 func (m *MACCommand_PingSlotChannelReq) Reset()      { *m = MACCommand_PingSlotChannelReq{} }
 func (*MACCommand_PingSlotChannelReq) ProtoMessage() {}
 func (*MACCommand_PingSlotChannelReq) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 23}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 23}
 }
 func (m *MACCommand_PingSlotChannelReq) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4882,7 +4883,7 @@ type MACCommand_PingSlotChannelAns struct {
 func (m *MACCommand_PingSlotChannelAns) Reset()      { *m = MACCommand_PingSlotChannelAns{} }
 func (*MACCommand_PingSlotChannelAns) ProtoMessage() {}
 func (*MACCommand_PingSlotChannelAns) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 24}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 24}
 }
 func (m *MACCommand_PingSlotChannelAns) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4935,7 +4936,7 @@ type MACCommand_BeaconTimingAns struct {
 func (m *MACCommand_BeaconTimingAns) Reset()      { *m = MACCommand_BeaconTimingAns{} }
 func (*MACCommand_BeaconTimingAns) ProtoMessage() {}
 func (*MACCommand_BeaconTimingAns) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 25}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 25}
 }
 func (m *MACCommand_BeaconTimingAns) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -4987,7 +4988,7 @@ type MACCommand_BeaconFreqReq struct {
 func (m *MACCommand_BeaconFreqReq) Reset()      { *m = MACCommand_BeaconFreqReq{} }
 func (*MACCommand_BeaconFreqReq) ProtoMessage() {}
 func (*MACCommand_BeaconFreqReq) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 26}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 26}
 }
 func (m *MACCommand_BeaconFreqReq) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -5032,7 +5033,7 @@ type MACCommand_BeaconFreqAns struct {
 func (m *MACCommand_BeaconFreqAns) Reset()      { *m = MACCommand_BeaconFreqAns{} }
 func (*MACCommand_BeaconFreqAns) ProtoMessage() {}
 func (*MACCommand_BeaconFreqAns) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 27}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 27}
 }
 func (m *MACCommand_BeaconFreqAns) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -5077,7 +5078,7 @@ type MACCommand_DeviceModeInd struct {
 func (m *MACCommand_DeviceModeInd) Reset()      { *m = MACCommand_DeviceModeInd{} }
 func (*MACCommand_DeviceModeInd) ProtoMessage() {}
 func (*MACCommand_DeviceModeInd) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 28}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 28}
 }
 func (m *MACCommand_DeviceModeInd) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -5122,7 +5123,7 @@ type MACCommand_DeviceModeConf struct {
 func (m *MACCommand_DeviceModeConf) Reset()      { *m = MACCommand_DeviceModeConf{} }
 func (*MACCommand_DeviceModeConf) ProtoMessage() {}
 func (*MACCommand_DeviceModeConf) Descriptor() ([]byte, []int) {
-	return fileDescriptor_lorawan_53bfbc964216b229, []int{18, 29}
+	return fileDescriptor_lorawan_ef9f9edda3306a56, []int{18, 29}
 }
 func (m *MACCommand_DeviceModeConf) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -8497,9 +8498,10 @@ func (m *TxSettings) MarshalTo(dAtA []byte) (int, error) {
 		i = encodeVarintLorawan(dAtA, i, m.Frequency)
 	}
 	if m.TxPower != 0 {
-		dAtA[i] = 0x28
+		dAtA[i] = 0x2d
 		i++
-		i = encodeVarintLorawan(dAtA, i, uint64(m.TxPower))
+		encoding_binary.LittleEndian.PutUint32(dAtA[i:], math.Float32bits(float32(m.TxPower)))
+		i += 4
 	}
 	if m.InvertPolarization {
 		dAtA[i] = 0x30
@@ -10842,7 +10844,7 @@ func (m *TxSettings) Size() (n int) {
 		n += 1 + sovLorawan(m.Frequency)
 	}
 	if m.TxPower != 0 {
-		n += 1 + sovLorawan(uint64(m.TxPower))
+		n += 5
 	}
 	if m.InvertPolarization {
 		n += 2
@@ -14871,24 +14873,16 @@ func (m *TxSettings) Unmarshal(dAtA []byte) error {
 				}
 			}
 		case 5:
-			if wireType != 0 {
+			if wireType != 5 {
 				return fmt.Errorf("proto: wrong wireType = %d for field TxPower", wireType)
 			}
-			m.TxPower = 0
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowLorawan
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				m.TxPower |= (int32(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
+			var v uint32
+			if (iNdEx + 4) > l {
+				return io.ErrUnexpectedEOF
 			}
+			v = encoding_binary.LittleEndian.Uint32(dAtA[iNdEx:])
+			iNdEx += 4
+			m.TxPower = float32(math.Float32frombits(v))
 		case 6:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field InvertPolarization", wireType)
@@ -19472,13 +19466,13 @@ var (
 )
 
 func init() {
-	proto.RegisterFile("lorawan-stack/api/lorawan.proto", fileDescriptor_lorawan_53bfbc964216b229)
+	proto.RegisterFile("lorawan-stack/api/lorawan.proto", fileDescriptor_lorawan_ef9f9edda3306a56)
 }
 func init() {
-	golang_proto.RegisterFile("lorawan-stack/api/lorawan.proto", fileDescriptor_lorawan_53bfbc964216b229)
+	golang_proto.RegisterFile("lorawan-stack/api/lorawan.proto", fileDescriptor_lorawan_ef9f9edda3306a56)
 }
 
-var fileDescriptor_lorawan_53bfbc964216b229 = []byte{
+var fileDescriptor_lorawan_ef9f9edda3306a56 = []byte{
 	// 5395 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x5b, 0x4d, 0x6c, 0x23, 0xc9,
 	0x75, 0x66, 0xf3, 0x47, 0xa4, 0x1e, 0x49, 0xb1, 0xa7, 0xa4, 0x9d, 0xd1, 0xca, 0x6b, 0x6a, 0x56,
@@ -19577,7 +19571,7 @@ var fileDescriptor_lorawan_53bfbc964216b229 = []byte{
 	0x7a, 0x47, 0xfc, 0x3a, 0xe4, 0x86, 0x64, 0xf4, 0x36, 0xfa, 0xd1, 0xf9, 0x9c, 0x4d, 0xb4, 0x78,
 	0xd6, 0x14, 0xa7, 0xc8, 0x2c, 0xa4, 0x9b, 0x3d, 0x6a, 0x14, 0x2a, 0x1b, 0xfa, 0xdb, 0xb8, 0x06,
 	0x0c, 0xf2, 0xcc, 0xda, 0xa2, 0x77, 0x70, 0xbb, 0x79, 0x42, 0x53, 0x4a, 0x5c, 0xf3, 0x01, 0x34,
-	0x8e, 0x7b, 0xac, 0xf7, 0x7b, 0x8f, 0x2d, 0x87, 0xe6, 0x84, 0x84, 0x96, 0x74, 0x8f, 0xb7, 0x71,
+	0x8e, 0x7b, 0xac, 0xf7, 0x7b, 0x8f, 0x2d, 0x87, 0xe6, 0x84, 0xa8, 0x96, 0x74, 0x8f, 0xb7, 0x71,
 	0x48, 0x6e, 0xc2, 0x64, 0xdb, 0x7e, 0x64, 0x39, 0xae, 0xde, 0xef, 0x75, 0x0c, 0xa7, 0xfd, 0x6d,
 	0xaa, 0x20, 0x1a, 0xeb, 0x29, 0x8d, 0xb0, 0xa9, 0x6d, 0x61, 0x86, 0x7c, 0x0d, 0x5e, 0xda, 0x37,
 	0x5c, 0xeb, 0xb1, 0x71, 0xa2, 0x37, 0x0f, 0x0c, 0xdb, 0xb6, 0x3a, 0xfc, 0x8c, 0xc9, 0xd0, 0xed,
@@ -19816,6 +19810,6 @@ var fileDescriptor_lorawan_53bfbc964216b229 = []byte{
 	0xef, 0x3c, 0xcb, 0x47, 0xde, 0x7b, 0x96, 0x57, 0xbe, 0xff, 0x2c, 0x1f, 0xf9, 0xe1, 0xb3, 0xbc,
 	0xf2, 0x93, 0x67, 0xf9, 0xc8, 0x4f, 0x9f, 0xe5, 0x23, 0x3f, 0x7b, 0x96, 0x57, 0xde, 0x7f, 0x96,
 	0x57, 0x3e, 0x78, 0x96, 0x57, 0xde, 0xf9, 0xd2, 0x79, 0xff, 0xad, 0x9d, 0x6b, 0xf7, 0xf7, 0xf6,
-	0xc6, 0xe8, 0xd7, 0x84, 0xa5, 0xff, 0x0f, 0x00, 0x00, 0xff, 0xff, 0x1a, 0xb5, 0xa1, 0xe7, 0x60,
+	0xc6, 0xe8, 0xd7, 0x84, 0xa5, 0xff, 0x0f, 0x00, 0x00, 0xff, 0xff, 0x7b, 0x03, 0xa6, 0x58, 0x60,
 	0x41, 0x00, 0x00,
 }

--- a/pkg/ttnpb/lorawan.pb.setters.fm.go
+++ b/pkg/ttnpb/lorawan.pb.setters.fm.go
@@ -842,7 +842,7 @@ func (dst *TxSettings) SetFields(src *TxSettings, paths ...string) error {
 			if src != nil {
 				dst.TxPower = src.TxPower
 			} else {
-				var zero int32
+				var zero float32
 				dst.TxPower = zero
 			}
 		case "invert_polarization":

--- a/pkg/ttnpb/lorawan_populate.go
+++ b/pkg/ttnpb/lorawan_populate.go
@@ -335,11 +335,8 @@ func NewPopulatedTxSettings(r randyLorawan, easy bool) *TxSettings {
 		out.CodingRate = fmt.Sprintf("4/%d", r.Intn(4)+5)
 	}
 	out.Frequency = uint64(r.Uint32())
-	out.TxPower = r.Int31()
+	out.TxPower = float32(r.Int31())
 	out.CodingRate = fmt.Sprintf("4/%d", r.Intn(4)+5)
-	if r.Intn(2) == 0 {
-		out.TxPower *= -1
-	}
 	out.InvertPolarization = r.Intn(2) == 0
 	out.GatewayChannelIndex = r.Uint32() % 255
 	out.DataRateIndex = NewPopulatedDataRateIndex(r, false) % 6

--- a/pkg/ttnpb/udp/translation.go
+++ b/pkg/ttnpb/udp/translation.go
@@ -30,7 +30,8 @@ const (
 	lora  = "LORA"
 	fsk   = "FSK"
 
-	eirpDelta int32 = 2
+	// eirpDelta is the delta between EIRP and ERP.
+	eirpDelta = 2.15
 )
 
 var (
@@ -296,7 +297,7 @@ func ToDownlinkMessage(tx *TxPacket) (*ttnpb.DownlinkMessage, error) {
 		DataRate:           tx.DatR.DataRate,
 		Frequency:          uint64(tx.Freq * 1000000),
 		InvertPolarization: tx.IPol,
-		TxPower:            int32(tx.Powe) + eirpDelta,
+		TxPower:            float32(tx.Powe) + eirpDelta,
 		Timestamp:          tx.Tmst,
 	}
 	if lora := scheduled.DataRate.GetLoRa(); lora != nil {
@@ -328,7 +329,7 @@ func FromDownlinkMessage(msg *ttnpb.DownlinkMessage) (*TxPacket, error) {
 	tx := &TxPacket{
 		Freq: float64(scheduled.Frequency) / 1000000,
 		IPol: scheduled.InvertPolarization,
-		Powe: uint8(scheduled.TxPower) - uint8(eirpDelta),
+		Powe: uint8(scheduled.TxPower - eirpDelta),
 		Size: uint16(len(payload)),
 		Data: base64.StdEncoding.EncodeToString(payload),
 		Tmst: scheduled.Timestamp,

--- a/pkg/ttnpb/udp/translation_test.go
+++ b/pkg/ttnpb/udp/translation_test.go
@@ -302,7 +302,7 @@ func TestDownlinkRoundtrip(t *testing.T) {
 						},
 					},
 				},
-				TxPower:            20,
+				TxPower:            16.15,
 				InvertPolarization: true,
 				Timestamp:          188700000,
 			},


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #55 

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Use sub-band's maximum EIRP, and use band's maximum EIRP as default
- The frequency plan's maximum EIRP is now a ceiling for all frequencies. Further work is having sub-band overrides in frequency plans (#300)
- Change Tx power to EIRP in sub-band definitions
- Use EIRP as float; i.e. convert to integer as late as possible