### PR TITLE
Get allowed fields, merge bottom level fields

### DIFF
--- a/cmd/ttn-lw-cli/commands/end_devices_split.go
+++ b/cmd/ttn-lw-cli/commands/end_devices_split.go
@@ -35,10 +35,10 @@ var (
 )
 
 func splitEndDeviceGetPaths(paths ...string) (is, ns, as, js []string) {
-	is = ttnpb.AllowedBottomLevelFields(paths, getEndDeviceFromIS)
-	ns = ttnpb.AllowedBottomLevelFields(paths, getEndDeviceFromNS)
-	as = ttnpb.AllowedBottomLevelFields(paths, getEndDeviceFromAS)
-	js = ttnpb.AllowedBottomLevelFields(paths, getEndDeviceFromJS)
+	is = ttnpb.AllowedFields(paths, getEndDeviceFromIS)
+	ns = ttnpb.AllowedFields(paths, getEndDeviceFromNS)
+	as = ttnpb.AllowedFields(paths, getEndDeviceFromAS)
+	js = ttnpb.AllowedFields(paths, getEndDeviceFromJS)
 	return
 }
 
@@ -73,7 +73,7 @@ func getEndDevice(ids ttnpb.EndDeviceIdentifiers, nsPaths, asPaths, jsPaths []st
 				}
 				logger.WithError(err).Error("Could not get end device from Join Server")
 			} else {
-				res.SetFields(jsRes, jsPaths...)
+				res.SetFields(jsRes, ttnpb.AllowedBottomLevelFields(jsPaths, getEndDeviceFromJS)...)
 			}
 		}
 	}
@@ -96,7 +96,7 @@ func getEndDevice(ids ttnpb.EndDeviceIdentifiers, nsPaths, asPaths, jsPaths []st
 				}
 				logger.WithError(err).Error("Could not get end device from Application Server")
 			} else {
-				res.SetFields(asRes, asPaths...)
+				res.SetFields(asRes, ttnpb.AllowedBottomLevelFields(asPaths, getEndDeviceFromAS)...)
 			}
 		}
 	}
@@ -119,7 +119,7 @@ func getEndDevice(ids ttnpb.EndDeviceIdentifiers, nsPaths, asPaths, jsPaths []st
 				}
 				logger.WithError(err).Error("Could not get end device from Network Server")
 			} else {
-				res.SetFields(nsRes, nsPaths...)
+				res.SetFields(nsRes, ttnpb.AllowedBottomLevelFields(nsPaths, getEndDeviceFromNS)...)
 			}
 		}
 	}


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Fixes #311 

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- CLI now gets given paths from components, not the bottom level fields. This caused multiple `oneof`s to be selected
- CLI uses bottom level fields only at merge-time