### PR TITLE
Uplink-less Class C Downlink and Queue Invalidation

### DIFF
--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -433,6 +433,7 @@ func (ns *NetworkServer) scheduleDownlinkByPaths(ctx context.Context, req *ttnpb
 			errs = append(errs, err)
 			continue
 		}
+		logger.WithField("delay", res.Delay).Debug("Scheduled downlink")
 		return down, time.Now().Add(res.Delay), nil
 	}
 
@@ -854,9 +855,11 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 			return err
 
 		case err != nil && errors.Resemble(err, errNoDownlink):
+			logger.Debug("No downlink to send, skipping downlink slot...")
 			return nil
 
 		case err != nil && errors.Resemble(err, errScheduleTooSoon):
+			logger.Debug("Downlink scheduled too soon, skipping downlink slot...")
 			break
 
 		case err != nil:
@@ -868,6 +871,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 		if nextDownlinkAt.IsZero() {
 			return nil
 		}
+		logger.WithField("schedule_at", nextDownlinkAt).Debug("Adding device to downlink schedule...")
 		if err := ns.downlinkTasks.Add(ctx, devID, nextDownlinkAt, true); err != nil {
 			addErr = true
 			logger.WithError(err).Error("Failed to add device to downlink schedule")

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -147,6 +147,7 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 	cmdBuf := make([]byte, 0, maxDownLen)
 	for _, cmd := range cmds {
 		var err error
+		logger.WithField("cid", cmd.CID).Debug("Adding MAC command to buffer...")
 		cmdBuf, err = spec.AppendDownlink(cmdBuf, *cmd)
 
 		if err != nil {
@@ -478,12 +479,11 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 	var addErr bool
 	err := ns.downlinkTasks.Pop(ctx, func(ctx context.Context, devID ttnpb.EndDeviceIdentifiers, t time.Time) error {
 		logger := log.FromContext(ctx).WithFields(log.Fields(
-			"delay", time.Now().Sub(t),
 			"device_uid", unique.ID(ctx, devID),
-			"start_at", t,
+			"started_at", time.Now().UTC(),
 		))
 		ctx = log.NewContext(ctx, logger)
-		logger.Debug("Processing downlink task...")
+		logger.WithField("start_at", t).Debug("Processing downlink task...")
 
 		var sendInvalidation func() (bool, error)
 		var nextDownlinkAt time.Time
@@ -882,7 +882,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 		}
 
 		if !nextDownlinkAt.IsZero() {
-			logger.WithField("schedule_at", nextDownlinkAt).Debug("Adding device to downlink schedule...")
+			logger.WithField("start_at", nextDownlinkAt).Debug("Adding downlink task...")
 			if err := ns.downlinkTasks.Add(ctx, devID, nextDownlinkAt, true); err != nil {
 				addErr = true
 				logger.WithError(err).Error("Failed to add device to downlink schedule")

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -306,7 +306,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 				rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 				rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-				payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+				genDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 					band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
@@ -322,7 +322,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				expected.MACState.RxWindowsAvailable = false
 				expected.QueuedApplicationDownlinks = []*ttnpb.ApplicationDownlink{}
 				expected.RecentDownlinks = append(expected.RecentDownlinks, &ttnpb.DownlinkMessage{
-					RawPayload:     payload,
+					RawPayload:     genDown.Payload,
 					CorrelationIDs: ret.RecentDownlinks[0].CorrelationIDs,
 					EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -380,7 +380,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					if rx1DRIdx < drIdx {
 						drIdx = rx1DRIdx
 					}
-					payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					genDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[drIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
@@ -415,7 +415,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 									a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 									a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 									a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-										RawPayload:     payload,
+										RawPayload:     genDown.Payload,
 										CorrelationIDs: msg.CorrelationIDs,
 										EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 											ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -453,7 +453,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 							a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 							a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 							a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-								RawPayload:     payload,
+								RawPayload:     genDown.Payload,
 								CorrelationIDs: msg.CorrelationIDs,
 								EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 									ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -500,7 +500,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     payload,
+									RawPayload:     genDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -732,7 +732,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 				rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 				rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-				payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+				genDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 					band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
@@ -748,7 +748,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				expected.MACState.RxWindowsAvailable = false
 				expected.QueuedApplicationDownlinks = []*ttnpb.ApplicationDownlink{}
 				expected.RecentDownlinks = append(expected.RecentDownlinks, &ttnpb.DownlinkMessage{
-					RawPayload:     payload,
+					RawPayload:     genDown.Payload,
 					CorrelationIDs: ret.RecentDownlinks[0].CorrelationIDs,
 					EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -802,7 +802,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 					rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 					rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-					payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					genDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
@@ -822,7 +822,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     payload,
+									RawPayload:     genDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -863,7 +863,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     payload,
+									RawPayload:     genDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -917,7 +917,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     payload,
+									RawPayload:     genDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1145,7 +1145,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Fatal("Invalid context")
 				}
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
-				rx2Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+				rx2GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 					band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
@@ -1161,7 +1161,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				expected.MACState.RxWindowsAvailable = false
 				expected.QueuedApplicationDownlinks = []*ttnpb.ApplicationDownlink{}
 				expected.RecentDownlinks = append(expected.RecentDownlinks, &ttnpb.DownlinkMessage{
-					RawPayload:     rx2Payload,
+					RawPayload:     rx2GenDown.Payload,
 					CorrelationIDs: ret.RecentDownlinks[0].CorrelationIDs,
 					EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1217,14 +1217,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 					fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 					rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 					rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-					rx1Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					rx1GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
 					if !a.So(err, should.BeNil) {
 						t.Fatalf("Failed to generate Rx1 payload: %s", err)
 					}
-					rx2Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					rx2GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
@@ -1244,7 +1244,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx1Payload,
+									RawPayload:     rx1GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1280,7 +1280,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx2Payload,
+									RawPayload:     rx2GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1317,7 +1317,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx1Payload,
+									RawPayload:     rx1GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1358,7 +1358,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx1Payload,
+									RawPayload:     rx1GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1395,7 +1395,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx2Payload,
+									RawPayload:     rx2GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1435,7 +1435,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx2Payload,
+									RawPayload:     rx2GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1724,7 +1724,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Fatal("Invalid context")
 				}
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
-				rx2Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+				rx2GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 					band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
@@ -1740,7 +1740,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				expected.MACState.RxWindowsAvailable = false
 				expected.QueuedApplicationDownlinks = []*ttnpb.ApplicationDownlink{}
 				expected.RecentDownlinks = append(expected.RecentDownlinks, &ttnpb.DownlinkMessage{
-					RawPayload:     rx2Payload,
+					RawPayload:     rx2GenDown.Payload,
 					CorrelationIDs: ret.RecentDownlinks[0].CorrelationIDs,
 					EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1799,14 +1799,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 					fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 					rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 					rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-					rx1Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					rx1GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
 					if !a.So(err, should.BeNil) {
 						t.Fatalf("Failed to generate Rx1 payload: %s", err)
 					}
-					rx2Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					rx2GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
@@ -1826,7 +1826,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx1Payload,
+									RawPayload:     rx1GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1865,7 +1865,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx2Payload,
+									RawPayload:     rx2GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1905,7 +1905,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx1Payload,
+									RawPayload:     rx1GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1952,7 +1952,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx1Payload,
+									RawPayload:     rx1GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1992,7 +1992,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx2Payload,
+									RawPayload:     rx2GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -2038,7 +2038,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx2Payload,
+									RawPayload:     rx2GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -3519,17 +3519,22 @@ func TestGenerateDownlink(t *testing.T) {
 
 			dev := CopyEndDevice(tc.Device)
 
-			b, _, appDown, err := ns.generateDownlink(tc.Context, dev, math.MaxUint16, math.MaxUint16)
-			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
-				tc.Error == nil && !a.So(err, should.BeNil) {
+			genDown, err := ns.generateDownlink(tc.Context, dev, math.MaxUint16, math.MaxUint16)
+			if tc.Error != nil {
+				a.So(err, should.EqualErrorOrDefinition, tc.Error)
+				a.So(genDown, should.BeNil)
+				return
+			}
+
+			if !a.So(err, should.BeNil) || !a.So(genDown, should.NotBeNil) {
 				t.FailNow()
 			}
 
-			a.So(b, should.Resemble, tc.Bytes)
+			a.So(genDown.Payload, should.Resemble, tc.Bytes)
 			if tc.ApplicationDownlinkAssertion != nil {
-				a.So(tc.ApplicationDownlinkAssertion(t, appDown), should.BeTrue)
+				a.So(tc.ApplicationDownlinkAssertion(t, genDown.ApplicationDownlink), should.BeTrue)
 			} else {
-				a.So(appDown, should.BeNil)
+				a.So(genDown.ApplicationDownlink, should.BeNil)
 			}
 
 			if tc.DeviceAssertion != nil {

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -268,6 +268,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					"lorawan_phy_version",
 					"mac_settings",
 					"mac_state",
+					"pending_session",
 					"queued_application_downlinks",
 					"recent_downlinks",
 					"recent_uplinks",
@@ -305,7 +306,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 				rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 				rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-				payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+				payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 					band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
@@ -379,7 +380,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					if rx1DRIdx < drIdx {
 						drIdx = rx1DRIdx
 					}
-					payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[drIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
@@ -692,6 +693,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					"lorawan_phy_version",
 					"mac_settings",
 					"mac_state",
+					"pending_session",
 					"queued_application_downlinks",
 					"recent_downlinks",
 					"recent_uplinks",
@@ -709,6 +711,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				a.So(err, should.BeNil)
 				a.So(paths, should.HaveSameElementsDeep, []string{
 					"mac_state",
+					"pending_session",
 					"queued_application_downlinks",
 					"recent_downlinks",
 					"session",
@@ -729,7 +732,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 				rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 				rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-				payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+				payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 					band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
@@ -799,7 +802,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 					rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 					rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-					payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
@@ -1105,6 +1108,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					"lorawan_phy_version",
 					"mac_settings",
 					"mac_state",
+					"pending_session",
 					"queued_application_downlinks",
 					"recent_downlinks",
 					"recent_uplinks",
@@ -1122,6 +1126,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				a.So(err, should.BeNil)
 				a.So(paths, should.HaveSameElementsDeep, []string{
 					"mac_state",
+					"pending_session",
 					"queued_application_downlinks",
 					"recent_downlinks",
 					"session",
@@ -1140,7 +1145,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Fatal("Invalid context")
 				}
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
-				rx2Payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+				rx2Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 					band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
@@ -1212,14 +1217,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 					fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 					rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 					rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-					rx1Payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					rx1Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
 					if !a.So(err, should.BeNil) {
 						t.Fatalf("Failed to generate Rx1 payload: %s", err)
 					}
-					rx2Payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					rx2Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
@@ -1682,6 +1687,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					"lorawan_phy_version",
 					"mac_settings",
 					"mac_state",
+					"pending_session",
 					"queued_application_downlinks",
 					"recent_downlinks",
 					"recent_uplinks",
@@ -1699,6 +1705,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				a.So(err, should.BeNil)
 				a.So(paths, should.HaveSameElementsDeep, []string{
 					"mac_state",
+					"pending_session",
 					"queued_application_downlinks",
 					"recent_downlinks",
 					"session",
@@ -1717,7 +1724,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Fatal("Invalid context")
 				}
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
-				rx2Payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+				rx2Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 					band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
@@ -1792,14 +1799,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 					fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 					rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 					rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-					rx1Payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					rx1Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
 					if !a.So(err, should.BeNil) {
 						t.Fatalf("Failed to generate Rx1 payload: %s", err)
 					}
-					rx2Payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					rx2Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
@@ -2263,6 +2270,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					"lorawan_phy_version",
 					"mac_settings",
 					"mac_state",
+					"pending_session",
 					"queued_application_downlinks",
 					"recent_downlinks",
 					"recent_uplinks",
@@ -3511,7 +3519,7 @@ func TestGenerateDownlink(t *testing.T) {
 
 			dev := CopyEndDevice(tc.Device)
 
-			b, appDown, err := ns.generateDownlink(tc.Context, dev, math.MaxUint16, math.MaxUint16)
+			b, _, appDown, err := ns.generateDownlink(tc.Context, dev, math.MaxUint16, math.MaxUint16)
 			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
 				tc.Error == nil && !a.So(err, should.BeNil) {
 				t.FailNow()

--- a/pkg/networkserver/grpc_asns.go
+++ b/pkg/networkserver/grpc_asns.go
@@ -124,8 +124,9 @@ func (ns *NetworkServer) DownlinkQueueReplace(ctx context.Context, req *ttnpb.Do
 
 	logger.Debug("Replaced application downlink queue")
 	if dev.MACState != nil && dev.MACState.DeviceClass != ttnpb.CLASS_A && len(dev.QueuedApplicationDownlinks) > 0 {
-		logger.Debug("Adding downlink task...")
-		return ttnpb.Empty, ns.downlinkTasks.Add(ctx, req.EndDeviceIdentifiers, time.Now(), false)
+		scheduleAt := time.Now().UTC()
+		logger.WithField("start_at", scheduleAt).Debug("Adding downlink task...")
+		return ttnpb.Empty, ns.downlinkTasks.Add(ctx, req.EndDeviceIdentifiers, scheduleAt, false)
 	}
 	return ttnpb.Empty, nil
 }
@@ -162,8 +163,9 @@ func (ns *NetworkServer) DownlinkQueuePush(ctx context.Context, req *ttnpb.Downl
 
 	logger.Debug("Pushed application downlink to queue")
 	if dev.MACState != nil && dev.MACState.DeviceClass != ttnpb.CLASS_A {
-		logger.Debug("Adding downlink task...")
-		return ttnpb.Empty, ns.downlinkTasks.Add(ctx, req.EndDeviceIdentifiers, time.Now(), false)
+		scheduleAt := time.Now().UTC()
+		logger.WithField("start_at", scheduleAt).Debug("Adding downlink task...")
+		return ttnpb.Empty, ns.downlinkTasks.Add(ctx, req.EndDeviceIdentifiers, scheduleAt, false)
 	}
 	return ttnpb.Empty, nil
 }

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -271,7 +271,9 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 		return nil, err
 	}
 	if addDownlinkTask {
-		if err = ns.downlinkTasks.Add(ctx, dev.EndDeviceIdentifiers, time.Now(), false); err != nil {
+		scheduleAt := time.Now().UTC()
+		log.FromContext(ctx).WithField("start_at", scheduleAt).Debug("Adding downlink task...")
+		if err = ns.downlinkTasks.Add(ctx, dev.EndDeviceIdentifiers, scheduleAt, false); err != nil {
 			log.FromContext(ctx).WithError(err).Warn("Failed to add downlink task for device after set")
 		}
 	}

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -732,7 +732,9 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 	} else {
 		registerForwardDataUplink(ctx, &matched.EndDeviceIdentifiers, up)
 	}
-	return ns.downlinkTasks.Add(ctx, matched.EndDeviceIdentifiers, time.Now().UTC(), true)
+	scheduleAt := time.Now().UTC()
+	logger.WithField("start_at", scheduleAt).Debug("Adding downlink task...")
+	return ns.downlinkTasks.Add(ctx, matched.EndDeviceIdentifiers, scheduleAt, true)
 }
 
 // newDevAddr generates a DevAddr for specified EndDevice.
@@ -931,7 +933,9 @@ func (ns *NetworkServer) handleJoin(ctx context.Context, up *ttnpb.UplinkMessage
 		return err
 	}
 
-	if err := ns.downlinkTasks.Add(ctx, dev.EndDeviceIdentifiers, time.Now().UTC(), true); err != nil {
+	scheduleAt := time.Now().UTC()
+	logger.WithField("start_at", scheduleAt).Debug("Adding downlink task...")
+	if err := ns.downlinkTasks.Add(ctx, dev.EndDeviceIdentifiers, scheduleAt, true); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -764,7 +764,7 @@ func (ns *NetworkServer) handleJoin(ctx context.Context, up *ttnpb.UplinkMessage
 			"lorawan_version",
 			"mac_settings",
 			"mac_state",
-			"session",
+			"session.dev_addr",
 		},
 	)
 	if err != nil {
@@ -849,7 +849,6 @@ func (ns *NetworkServer) handleJoin(ctx context.Context, up *ttnpb.UplinkMessage
 			"lorawan_version",
 			"mac_settings",
 			"mac_state",
-			"pending_session",
 			"queued_application_downlinks",
 			"recent_uplinks",
 			"supports_class_b",

--- a/pkg/networkserver/mac_dev_status.go
+++ b/pkg/networkserver/mac_dev_status.go
@@ -53,7 +53,7 @@ func deviceStatusTimePeriodicity(dev *ttnpb.EndDevice, defaults ttnpb.MACSetting
 	return DefaultStatusTimePeriodicity
 }
 
-func enqueueDevStatusReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16, defaults ttnpb.MACSettings) (uint16, uint16, bool) {
+func enqueueDevStatusReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16, ses *ttnpb.Session, defaults ttnpb.MACSettings) (uint16, uint16, bool) {
 	cp := deviceStatusCountPeriodicity(dev, defaults)
 	tp := deviceStatusTimePeriodicity(dev, defaults)
 
@@ -61,7 +61,7 @@ func enqueueDevStatusReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, 
 		return maxDownLen, maxUpLen, true
 	}
 	if dev.LastDevStatusReceivedAt != nil &&
-		(cp == 0 || dev.MACState.LastDevStatusFCntUp+cp > dev.Session.LastFCntUp) &&
+		(cp == 0 || dev.MACState.LastDevStatusFCntUp+cp > ses.LastFCntUp) &&
 		(tp == 0 || dev.LastDevStatusReceivedAt.Add(tp).After(time.Now())) {
 		return maxDownLen, maxUpLen, true
 	}

--- a/pkg/ttnpb/end_device_populate.go
+++ b/pkg/ttnpb/end_device_populate.go
@@ -174,7 +174,7 @@ func NewPopulatedMACParameters(r randyEndDevice, easy bool) *MACParameters {
 	out.ADRAckLimit = 1 + r.Uint32()%32768
 	out.ADRAckDelay = 1 + r.Uint32()%32768
 	out.MaxDutyCycle = AggregatedDutyCycle([]int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}[r.Intn(16)])
-	out.Channels = make([]*MACParameters_Channel, r.Intn(255))
+	out.Channels = make([]*MACParameters_Channel, 1+r.Intn(254))
 	for i := range out.Channels {
 		out.Channels[i] = NewPopulatedMACParameters_Channel(r, easy)
 	}


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #313 
Closes #317 

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Add support for uplink-less downlinks(#313) - note, that it will only work for 1st join of the device. If a device has joined and sent an uplink, after a new join-request is received and answered by Network Server, the downlinks will be sent assuming device still uses the old session until an uplink is received using the new session.
- Only send queue invalidation to AS after `FPort=0` downlink is actually successfully scheduled