### PR TITLE
Update Issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,10 @@
+<!--
+Thanks for submitting an issue. Please fill the template below,
+otherwise we will not be able to process this issue.
+-->
+
 **Summary:** 
-<!-- Summarize the problem or feature in a few sentences: -->
+<!-- Summarize the issue in a few sentences: -->
 
 ...
 
@@ -10,31 +15,38 @@
 2. ...
 3. ...
 
-<!-- Please attach (or link to) configuration files if applicable -->
-
-**What do you see now?**
-<!-- Please attach (or link to) screenshots and logs if applicable -->
-
-...
-
-**What do you want to see instead?**
-<!-- Please add some examples or mock-ups if applicable -->
-
-...
-
-**How do you propose to implement this?**
 <!--
-If unsure, add the discussion label and (temporarily) assign the expert
-If you cannot assign people, please @mention the experts
+Please upload relevant configuration (as .txt).
+If you use the command "ttn-lw-stack config", you can redact sensitive config.
+-->
+
+**What is already there? What do you see now?**
+<!--
+Please paste terminal output, upload logs (as .txt) or upload screenshots.
+Describe or link to related APIs, screen designs, packages, etc.
 -->
 
 ...
 
-**Environment:**
-<!-- Your environment: OS/Browser/Gateway/Device/...? Versions? IDs/EUIs? -->
+**What is missing? What do you want to see?**
+<!-- Please add some examples or mock-ups if applicable. -->
 
 ...
 
-**What can you do yourself and what do you need help with?**
+**Environment:**
+<!--
+Your environment: OS/Browser/Gateway/Device/...? Versions? IDs/EUIs?
+Paste the output of "ttn-lw-cli version" or "ttn-lw-stack version" if applicable.
+-->
+
+...
+
+**How do you propose to implement this?**
+<!-- Please think about how this could be implemented. -->
+
+...
+
+**Can you do this yourself and submit a Pull Request?**
+<!-- You can also @mention experts if you need help with this. -->
 
 ...

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,6 +3,10 @@ name: Bug report
 about: Create a report to help us improve
 
 ---
+<!--
+Thanks for submitting a bug report. Please fill the template below,
+otherwise we will not be able to process this bug report.
+-->
 
 **Summary:** 
 <!-- Summarize the problem in a few sentences: -->
@@ -16,31 +20,37 @@ about: Create a report to help us improve
 2. ...
 3. ...
 
-<!-- Please attach (or link to) configuration files if applicable -->
+<!--
+Please upload relevant configuration (as .txt).
+If you use the command "ttn-lw-stack config", you can redact sensitive config.
+-->
 
 **What do you see now?**
-<!-- Please attach (or link to) screenshots and logs if applicable -->
-
-...
-
-**What do you want to see instead?**
-<!-- Please add some examples or mock-ups if applicable -->
-
-...
-
-**How do you propose to implement this?**
 <!--
-If unsure, add the discussion label and (temporarily) assign the expert
-If you cannot assign people, please @mention the experts
+Please paste terminal output, upload logs (as .txt) or upload screenshots.
 -->
 
 ...
 
-**Environment:**
-<!-- Your environment: OS/Browser/Gateway/Device/...? Versions? IDs/EUIs? -->
+**What do you want to see instead?**
+<!-- Please add some examples or mock-ups if applicable. -->
 
 ...
 
-**What can you do yourself and what do you need help with?**
+**Environment:**
+<!--
+Your environment: OS/Browser/Gateway/Device/...? Versions? IDs/EUIs?
+Paste the output of "ttn-lw-cli version" or "ttn-lw-stack version" if applicable.
+-->
+
+...
+
+**How do you propose to implement this?**
+<!-- Please think about how this could be fixed. -->
+
+...
+
+**Can you do this yourself and submit a Pull Request?**
+<!-- You can also @mention experts if you need help with this. -->
 
 ...

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,6 +3,10 @@ name: Feature request
 about: Suggest an idea for this project
 
 ---
+<!--
+Thanks for submitting a feature request. Please fill the template below,
+otherwise we will not be able to process this feature request.
+-->
 
 **Summary:** 
 <!-- Summarize the feature in a few sentences: -->
@@ -10,12 +14,15 @@ about: Suggest an idea for this project
 ...
 
 **Why do we need this?**
-<!-- Please explain the motivation, how it will be used, etc -->
+<!-- Please explain the motivation, how it will be used, etc. -->
 
 ...
 
 **What is already there? What do you see now?**
-<!-- Please attach (or link to) screenshots and logs if applicable -->
+<!--
+Please paste terminal output, upload logs (as .txt) or upload screenshots.
+Describe or link to related APIs, screen designs, packages, etc.
+-->
 
 ...
 
@@ -24,19 +31,20 @@ about: Suggest an idea for this project
 
 ...
 
-**How do you propose to implement this?**
+**Environment:**
 <!--
-If unsure, add the discussion label and (temporarily) assign the expert
-If you cannot assign people, please @mention the experts
+Your environment: OS/Browser/Gateway/Device/...? Versions? IDs/EUIs?
+Paste the output of "ttn-lw-cli version" or "ttn-lw-stack version" if applicable.
 -->
 
 ...
 
-**Environment:**
-<!-- Your environment: OS/Browser/Gateway/Device/...? Versions? IDs/EUIs? -->
+**How do you propose to implement this?**
+<!-- Please think about how this could be fixed. -->
 
 ...
 
-**What can you do yourself and what do you need help with?**
+**Can you do this yourself and submit a Pull Request?**
+<!-- You can also @mention experts if you need help with this. -->
 
 ...

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,15 @@
+<!--
+Thanks for submitting a pull request. Please fill the template below,
+otherwise we will not be able to process this pull request.
+-->
+
 **Summary:**
 <!--
-A summary, always referencing related issues:
+A short summary, referencing related issues:
 Closes #0000, References #0000, etc.
 -->
 
 ...
-
-<!--
-Please motivate briefly why it is implemented this way, if that deviates
-from the implementation proposal in the referenced issues.
--->
 
 **Changes:**
 <!-- What are the changes made in this pull request? -->
@@ -19,8 +19,10 @@ from the implementation proposal in the referenced issues.
 
 **Notes for Reviewers:**
 <!--
-How should your reviewers approach this pull request?
-Any special requests or questions for specific reviewers?
+Motivate briefly why it is implemented this way, if that deviates from the
+implementation proposal in the referenced issues.
+- How should your reviewers approach this pull request?
+- @mention reviewers with special requests or questions for them
 -->
 
 ...
@@ -28,9 +30,11 @@ Any special requests or questions for specific reviewers?
 **Release Notes: _(optional)_**
 <!--
 Any notes that we need to include in the Release Notes for the next release.
-What are the functional or behavioral changes? API Changes? New features?
-Any changes in configuration? Added/changed/removed flags?
-Are there any database migrations required?
+These notes are formatted as bullet points, written in past tense, and will be
+combined with the labels of this Pull Request.
+- Always mention changes in API, database models, configuration options or defaults.
+- Are there any database migrations required?
+- What are the functional or behavioral changes?
 -->
 
-...
+- ...


### PR DESCRIPTION
**Summary:**

This is a proposal to update our Issue and Pull Request templates.

**Changes:**

- Added a "header" that says thanks and tells people that we will only be able to process the issue if they actually fill the template.
- Moved "environment" section up, so that the templates first describe the situation and then move on to the next steps.
- Explain how to upload configuration (Github doesn't accept many file types)
- Mention `ttn-lw-stack config` command to extract config
- Explicitly ask to paste terminal output
- Ask to describe (or link to) APIs, screen designs, packages, etc. (as discussed with our frontend engineers)
- Mention `ttn-lw-stack version` (and cli couterpart) commands to extract version info.
- Removed assigning people and setting labels. Only the core team can do that, so only confusing for external contributors.
- Added `@mentioning` people for assistance
- Punctuation, styling, line lengths, ...

**Notes for Reviewers:**

@rvolosatovs did you want to make any more changes to the Release Notes section?