### PR TITLE
Compute EndDevice created_at and updated_at

### DIFF
--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -190,6 +190,12 @@ var (
 			}
 
 			device.SetFields(res, append(append(nsPaths, asPaths...), jsPaths...)...)
+			if device.CreatedAt.IsZero() || (!res.CreatedAt.IsZero() && res.CreatedAt.Before(res.CreatedAt)) {
+				device.CreatedAt = res.CreatedAt
+			}
+			if res.UpdatedAt.After(device.UpdatedAt) {
+				device.UpdatedAt = res.UpdatedAt
+			}
 
 			return io.Write(os.Stdout, config.OutputFormat, device)
 		},
@@ -351,6 +357,12 @@ var (
 			}
 
 			device.SetFields(res, append(append(nsPaths, asPaths...), jsPaths...)...)
+			if device.CreatedAt.IsZero() || (!res.CreatedAt.IsZero() && res.CreatedAt.Before(res.CreatedAt)) {
+				device.CreatedAt = res.CreatedAt
+			}
+			if res.UpdatedAt.After(device.UpdatedAt) {
+				device.UpdatedAt = res.UpdatedAt
+			}
 
 			return io.Write(os.Stdout, config.OutputFormat, &device)
 		}),
@@ -432,7 +444,6 @@ var (
 				return err
 			}
 
-			res.SetFields(&device, "ids")
 			return io.Write(os.Stdout, config.OutputFormat, res)
 		},
 	}


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR closes #338 by always setting the `created_at` to the earliest known `created_at` and the latest known `updated_at`.

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

The `CreatedAt` and `UpdatedAt` of every intermediate EndDevice Get/Set result are considered while constructing the final result.
