### PR TITLE
Fix rights filters for organizations and users

### DIFF
--- a/cmd/ttn-lw-cli/commands/organizations_access.go
+++ b/cmd/ttn-lw-cli/commands/organizations_access.go
@@ -278,7 +278,12 @@ var (
 )
 
 var organizationRightsFlags = rightsFlags(func(flag string) bool {
-	return strings.HasPrefix(flag, "right-organization")
+	for _, entity := range []string{"application", "client", "gateway", "organization"} {
+		if strings.HasPrefix(flag, "right-"+entity) {
+			return true
+		}
+	}
+	return false
 })
 
 func init() {

--- a/cmd/ttn-lw-cli/commands/users_access.go
+++ b/cmd/ttn-lw-cli/commands/users_access.go
@@ -184,7 +184,12 @@ var (
 )
 
 var userRightsFlags = rightsFlags(func(flag string) bool {
-	return strings.HasPrefix(flag, "right-user")
+	for _, entity := range []string{"application", "client", "gateway", "organization", "user"} {
+		if strings.HasPrefix(flag, "right-"+entity) {
+			return true
+		}
+	}
+	return false
 })
 
 func init() {


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes #336 by fixing the filters of rights that can be given to user/organization API keys and to organization collaborators.

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
What are the functional or behavioral changes? API Changes? New features?
Any changes in configuration? Added/changed/removed flags?
Are there any database migrations required?
-->

The CLI now allows creating API keys with all supported rights for Users and Organizations.
