### PR TITLE
Implicit Redis registry fieldmasks

### DIFF
--- a/pkg/applicationserver/util_test.go
+++ b/pkg/applicationserver/util_test.go
@@ -72,7 +72,7 @@ func startMockNS(ctx context.Context, validateAuth func(rpcmetadata.MD) bool) (*
 	}
 	srv := rpcserver.New(ctx)
 	ttnpb.RegisterAsNsServer(srv.Server, ns)
-	lis, err := net.Listen("tcp", ":0")
+	lis, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/joinserver/grpc_nsjs_test.go
+++ b/pkg/joinserver/grpc_nsjs_test.go
@@ -1095,6 +1095,8 @@ func TestHandleJoin(t *testing.T) {
 			ret, err := devReg.SetByID(authorizedCtx, pb.ApplicationIdentifiers, pb.DeviceID,
 				[]string{
 					"created_at",
+					"ids.dev_eui",
+					"ids.join_eui",
 					"last_dev_nonce",
 					"last_join_nonce",
 					"lorawan_version",
@@ -1110,6 +1112,8 @@ func TestHandleJoin(t *testing.T) {
 						t.Fatal("Registry is not empty")
 					}
 					return CopyEndDevice(pb), []string{
+						"ids.dev_eui",
+						"ids.join_eui",
 						"last_dev_nonce",
 						"last_join_nonce",
 						"lorawan_version",

--- a/pkg/joinserver/redis/registry.go
+++ b/pkg/joinserver/redis/registry.go
@@ -38,18 +38,10 @@ var (
 )
 
 func applyDeviceFieldMask(dst, src *ttnpb.EndDevice, paths ...string) (*ttnpb.EndDevice, error) {
-	paths = append(paths, "ids")
-
 	if dst == nil {
 		dst = &ttnpb.EndDevice{}
 	}
-	if err := dst.SetFields(src, paths...); err != nil {
-		return nil, err
-	}
-	if err := dst.ValidateFields(paths...); err != nil {
-		return nil, err
-	}
-	return dst, nil
+	return dst, dst.SetFields(src, paths...)
 }
 
 // DeviceRegistry is an implementation of joinserver.DeviceRegistry.
@@ -96,11 +88,14 @@ func (r *DeviceRegistry) GetByID(ctx context.Context, appID ttnpb.ApplicationIde
 	if err := ttnredis.GetProto(r.Redis, r.uidKey(unique.ID(ctx, ids))).ScanProto(pb); err != nil {
 		return nil, err
 	}
-	return applyDeviceFieldMask(nil, pb, paths...)
+	return applyDeviceFieldMask(nil, pb, append(paths,
+		"ids.application_ids",
+		"ids.device_id",
+	)...)
 }
 
 // GetByEUI gets device by joinEUI, devEUI.
-func (r *DeviceRegistry) GetByEUI(ctx context.Context, joinEUI types.EUI64, devEUI types.EUI64, paths []string) (*ttnpb.EndDevice, error) {
+func (r *DeviceRegistry) GetByEUI(ctx context.Context, joinEUI, devEUI types.EUI64, paths []string) (*ttnpb.EndDevice, error) {
 	if joinEUI.IsZero() || devEUI.IsZero() {
 		return nil, errInvalidIdentifiers
 	}
@@ -111,7 +106,12 @@ func (r *DeviceRegistry) GetByEUI(ctx context.Context, joinEUI types.EUI64, devE
 	if err := ttnredis.FindProto(r.Redis, r.euiKey(joinEUI, devEUI), r.uidKey).ScanProto(pb); err != nil {
 		return nil, err
 	}
-	return applyDeviceFieldMask(&ttnpb.EndDevice{}, pb, paths...)
+	return applyDeviceFieldMask(nil, pb, append(paths,
+		"ids.application_ids",
+		"ids.dev_eui",
+		"ids.device_id",
+		"ids.join_eui",
+	)...)
 }
 
 func equalEUI(x, y *types.EUI64) bool {
@@ -131,6 +131,13 @@ func (r *DeviceRegistry) set(tx *redis.Tx, uid string, gets []string, f func(pb 
 	} else if err != nil {
 		return nil, err
 	}
+
+	gets = append(gets,
+		"created_at",
+		"ids.application_ids",
+		"ids.device_id",
+		"updated_at",
+	)
 
 	var pb *ttnpb.EndDevice
 	var err error
@@ -181,6 +188,13 @@ func (r *DeviceRegistry) set(tx *redis.Tx, uid string, gets []string, f func(pb 
 		updated := &ttnpb.EndDevice{}
 		var updatedPID string
 		if stored == nil {
+			sets = append(sets,
+				"ids.application_ids",
+				"ids.dev_eui",
+				"ids.device_id",
+				"ids.join_eui",
+			)
+
 			pb.CreatedAt = pb.UpdatedAt
 			sets = append(sets, "created_at")
 
@@ -214,14 +228,13 @@ func (r *DeviceRegistry) set(tx *redis.Tx, uid string, gets []string, f func(pb 
 				return nil, errInvalidIdentifiers
 			}
 		}
-		pb, err = applyDeviceFieldMask(nil, updated, gets...)
-		if err != nil {
+		if err := updated.ValidateFields(sets...); err != nil {
 			return nil, err
 		}
 
 		pipelined = func(p redis.Pipeliner) error {
 			if stored == nil {
-				ek := r.euiKey(*pb.JoinEUI, *pb.DevEUI)
+				ek := r.euiKey(*updated.JoinEUI, *updated.DevEUI)
 				if err := tx.Watch(ek).Err(); err != nil {
 					return err
 				}
@@ -254,8 +267,11 @@ func (r *DeviceRegistry) set(tx *redis.Tx, uid string, gets []string, f func(pb 
 			if err != nil {
 				return err
 			}
-
 			return nil
+		}
+		pb, err = applyDeviceFieldMask(nil, updated, gets...)
+		if err != nil {
+			return nil, err
 		}
 	}
 	_, err = tx.Pipelined(pipelined)
@@ -283,7 +299,10 @@ func (r *DeviceRegistry) SetByEUI(ctx context.Context, joinEUI types.EUI64, devE
 		if err := tx.Watch(r.uidKey(uid)).Err(); err != nil {
 			return ttnredis.ConvertError(err)
 		}
-		pb, err = r.set(tx, uid, gets, f)
+		pb, err = r.set(tx, uid, append(gets,
+			"ids.dev_eui",
+			"ids.join_eui",
+		), f)
 		return err
 	}, ek)
 	if err != nil {
@@ -327,15 +346,10 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIde
 }
 
 func applyKeyFieldMask(dst, src *ttnpb.SessionKeys, paths ...string) (*ttnpb.SessionKeys, error) {
-	paths = append(paths, "session_key_id")
-
 	if dst == nil {
 		dst = &ttnpb.SessionKeys{}
 	}
 	if err := dst.SetFields(src, paths...); err != nil {
-		return nil, err
-	}
-	if err := dst.ValidateFields(paths...); err != nil {
 		return nil, err
 	}
 	return dst, nil
@@ -362,7 +376,7 @@ func (r *KeyRegistry) GetByID(ctx context.Context, devEUI types.EUI64, id []byte
 	if err := ttnredis.GetProto(r.Redis, r.idKey(devEUI, id)).ScanProto(pb); err != nil {
 		return nil, err
 	}
-	return applyKeyFieldMask(&ttnpb.SessionKeys{}, pb, paths...)
+	return applyKeyFieldMask(&ttnpb.SessionKeys{}, pb, append(paths, "session_key_id")...)
 }
 
 // SetByID sets session keys by devEUI, id.
@@ -383,6 +397,8 @@ func (r *KeyRegistry) SetByID(ctx context.Context, devEUI types.EUI64, id []byte
 		} else if err != nil {
 			return err
 		}
+
+		gets = append(gets, "session_key_id")
 
 		var err error
 		if stored != nil {
@@ -405,9 +421,9 @@ func (r *KeyRegistry) SetByID(ctx context.Context, devEUI types.EUI64, id []byte
 			return nil
 		}
 
-		var f func(redis.Pipeliner) error
+		var pipelined func(redis.Pipeliner) error
 		if pb == nil {
-			f = func(p redis.Pipeliner) error {
+			pipelined = func(p redis.Pipeliner) error {
 				p.Del(ik)
 				return nil
 			}
@@ -417,29 +433,41 @@ func (r *KeyRegistry) SetByID(ctx context.Context, devEUI types.EUI64, id []byte
 			}
 
 			updated := &ttnpb.SessionKeys{}
-			if stored != nil {
+			if stored == nil {
+				sets = append(sets, "session_key_id")
+				updated, err = applyKeyFieldMask(updated, pb, sets...)
+				if err != nil {
+					return err
+				}
+			} else {
 				if err := cmd.ScanProto(updated); err != nil {
 					return err
 				}
+				updated, err = applyKeyFieldMask(updated, pb, sets...)
+				if err != nil {
+					return err
+				}
+				if !bytes.Equal(updated.SessionKeyID, stored.SessionKeyID) {
+					return errInvalidIdentifiers
+				}
 			}
-			updated, err = applyKeyFieldMask(updated, pb, sets...)
-			if err != nil {
+			if err := updated.ValidateFields(sets...); err != nil {
 				return err
 			}
 
-			pb, err = applyKeyFieldMask(nil, updated, gets...)
-			if err != nil {
-				return err
-			}
-			f = func(p redis.Pipeliner) error {
+			pipelined = func(p redis.Pipeliner) error {
 				_, err := ttnredis.SetProto(p, ik, updated, 0)
 				if err != nil {
 					return err
 				}
 				return nil
 			}
+			pb, err = applyKeyFieldMask(nil, updated, gets...)
+			if err != nil {
+				return err
+			}
 		}
-		_, err = tx.Pipelined(f)
+		_, err = tx.Pipelined(pipelined)
 		if err != nil {
 			return err
 		}

--- a/pkg/joinserver/registry_test.go
+++ b/pkg/joinserver/registry_test.go
@@ -70,16 +70,18 @@ func handleDeviceRegistryTest(t *testing.T, reg DeviceRegistry) {
 
 	ret, err = reg.SetByID(ctx, pb.ApplicationIdentifiers, pb.DeviceID,
 		[]string{
-			"created_at",
+			"ids.dev_eui",
+			"ids.join_eui",
 			"provisioner_id",
 			"provisioning_data",
-			"updated_at",
 		},
 		func(stored *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
 			if !a.So(stored, should.BeNil) {
 				t.Fatal("Registry is not empty")
 			}
 			return CopyEndDevice(pb), []string{
+				"ids.dev_eui",
+				"ids.join_eui",
 				"provisioner_id",
 				"provisioning_data",
 			}, nil
@@ -113,16 +115,18 @@ func handleDeviceRegistryTest(t *testing.T, reg DeviceRegistry) {
 
 	ret, err = reg.SetByID(ctx, pbOther.ApplicationIdentifiers, pbOther.DeviceID,
 		[]string{
-			"created_at",
+			"ids.dev_eui",
+			"ids.join_eui",
 			"provisioner_id",
 			"provisioning_data",
-			"updated_at",
 		},
 		func(stored *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
 			if !a.So(stored, should.BeNil) {
 				t.Fatal("Registry is not empty")
 			}
 			return CopyEndDevice(pbOther), []string{
+				"ids.dev_eui",
+				"ids.join_eui",
 				"provisioner_id",
 				"provisioning_data",
 			}, nil
@@ -145,16 +149,18 @@ func handleDeviceRegistryTest(t *testing.T, reg DeviceRegistry) {
 
 	ret, err = reg.SetByID(ctx, pbOther.ApplicationIdentifiers, pbOther.DeviceID,
 		[]string{
-			"created_at",
+			"ids.dev_eui",
+			"ids.join_eui",
 			"provisioner_id",
 			"provisioning_data",
-			"updated_at",
 		},
 		func(stored *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
 			if !a.So(stored, should.BeNil) {
 				t.Fatal("Registry is not empty")
 			}
 			return CopyEndDevice(pbOther), []string{
+				"ids.dev_eui",
+				"ids.join_eui",
 				"provisioner_id",
 				"provisioning_data",
 			}, nil
@@ -257,7 +263,6 @@ func handleKeyRegistryTest(t *testing.T, reg KeyRegistry) {
 
 	ret, err = reg.SetByID(ctx, devEUI, pb.SessionKeyID,
 		[]string{
-			"session_key_id",
 			"f_nwk_s_int_key",
 			"s_nwk_s_int_key",
 			"nwk_s_enc_key",
@@ -268,7 +273,6 @@ func handleKeyRegistryTest(t *testing.T, reg KeyRegistry) {
 				t.Fatal("Registry is not empty")
 			}
 			return CopySessionKeys(pb), []string{
-				"session_key_id",
 				"f_nwk_s_int_key",
 				"s_nwk_s_int_key",
 				"nwk_s_enc_key",
@@ -296,7 +300,6 @@ func handleKeyRegistryTest(t *testing.T, reg KeyRegistry) {
 
 	ret, err = reg.SetByID(ctx, devEUIOther, pbOther.SessionKeyID,
 		[]string{
-			"session_key_id",
 			"f_nwk_s_int_key",
 			"s_nwk_s_int_key",
 			"nwk_s_enc_key",
@@ -307,7 +310,6 @@ func handleKeyRegistryTest(t *testing.T, reg KeyRegistry) {
 				t.Fatal("Registry is not empty")
 			}
 			return CopySessionKeys(pbOther), []string{
-				"session_key_id",
 				"f_nwk_s_int_key",
 				"s_nwk_s_int_key",
 				"nwk_s_enc_key",

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -101,6 +101,8 @@ func (ns *NetworkServer) matchDevice(ctx context.Context, up *ttnpb.UplinkMessag
 	if err := ns.devices.RangeByAddr(ctx, pld.DevAddr,
 		[]string{
 			"frequency_plan_id",
+			"ids.dev_eui",
+			"ids.join_eui",
 			"lorawan_phy_version",
 			"mac_settings.resets_f_cnt",
 			"mac_settings.supports_32_bit_f_cnt",
@@ -481,9 +483,12 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 		[]string{
 			"downlink_margin",
 			"frequency_plan_id",
+			"ids.dev_addr",
+			"ids.dev_eui",
+			"ids.join_eui",
 			"last_dev_status_received_at",
-			"lorawan_version",
 			"lorawan_phy_version",
+			"lorawan_version",
 			"mac_settings",
 			"mac_state",
 			"pending_session",
@@ -536,7 +541,10 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 				if stored.PendingSession.DevAddr != stored.MACState.PendingJoinRequest.DevAddr {
 					panic("Pending session does not match the join request")
 				}
+
 				stored.EndDeviceIdentifiers.DevAddr = &stored.MACState.PendingJoinRequest.DevAddr
+				paths = append(paths, "ids.dev_addr")
+
 				if stored.SupportsClassC {
 					stored.MACState.DeviceClass = ttnpb.CLASS_C
 				} else if stored.SupportsClassB {
@@ -544,6 +552,7 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 				} else {
 					stored.MACState.DeviceClass = ttnpb.CLASS_A
 				}
+
 				stored.MACState.CurrentParameters.Rx1Delay = stored.MACState.PendingJoinRequest.RxDelay
 				stored.MACState.CurrentParameters.Rx1DataRateOffset = stored.MACState.PendingJoinRequest.DownlinkSettings.Rx1DROffset
 				stored.MACState.CurrentParameters.Rx2DataRateIndex = stored.MACState.PendingJoinRequest.DownlinkSettings.Rx2DR
@@ -880,6 +889,8 @@ func (ns *NetworkServer) handleJoin(ctx context.Context, up *ttnpb.UplinkMessage
 	dev, err = ns.devices.SetByID(ctx, dev.EndDeviceIdentifiers.ApplicationIdentifiers, dev.EndDeviceIdentifiers.DeviceID,
 		[]string{
 			"frequency_plan_id",
+			"ids.dev_eui",
+			"ids.join_eui",
 			"lorawan_phy_version",
 			"lorawan_version",
 			"mac_settings",

--- a/pkg/networkserver/grpc_gsns_test.go
+++ b/pkg/networkserver/grpc_gsns_test.go
@@ -223,12 +223,13 @@ func handleUplinkTest() func(t *testing.T) {
 
 			ret, err := devReg.SetByID(authorizedCtx, pb.ApplicationIdentifiers, pb.DeviceID,
 				[]string{
-					"created_at",
 					"frequency_plan_id",
+					"ids.dev_addr",
+					"ids.dev_eui",
+					"ids.join_eui",
 					"lorawan_phy_version",
 					"lorawan_version",
 					"session",
-					"updated_at",
 				},
 				func(stored *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
 					if !a.So(stored, should.BeNil) {
@@ -236,6 +237,9 @@ func handleUplinkTest() func(t *testing.T) {
 					}
 					return CopyEndDevice(pb), []string{
 						"frequency_plan_id",
+						"ids.dev_addr",
+						"ids.dev_eui",
+						"ids.join_eui",
 						"lorawan_phy_version",
 						"lorawan_version",
 						"session",
@@ -307,6 +311,9 @@ func handleUplinkTest() func(t *testing.T) {
 				[]string{
 					"created_at",
 					"frequency_plan_id",
+					"ids.dev_addr",
+					"ids.dev_eui",
+					"ids.join_eui",
 					"lorawan_phy_version",
 					"lorawan_version",
 					"session",
@@ -318,6 +325,9 @@ func handleUplinkTest() func(t *testing.T) {
 					}
 					return CopyEndDevice(pb), []string{
 						"frequency_plan_id",
+						"ids.dev_addr",
+						"ids.dev_eui",
+						"ids.join_eui",
 						"lorawan_phy_version",
 						"lorawan_version",
 						"session",
@@ -1361,6 +1371,9 @@ func handleUplinkTest() func(t *testing.T) {
 						[]string{
 							"created_at",
 							"frequency_plan_id",
+							"ids.dev_addr",
+							"ids.dev_eui",
+							"ids.join_eui",
 							"lorawan_phy_version",
 							"lorawan_version",
 							"mac_state",
@@ -1374,6 +1387,9 @@ func handleUplinkTest() func(t *testing.T) {
 							}
 							return CopyEndDevice(pb), []string{
 								"frequency_plan_id",
+								"ids.dev_addr",
+								"ids.dev_eui",
+								"ids.join_eui",
 								"lorawan_phy_version",
 								"lorawan_version",
 								"mac_state",
@@ -1455,6 +1471,9 @@ func handleUplinkTest() func(t *testing.T) {
 					[]string{
 						"created_at",
 						"frequency_plan_id",
+						"ids.dev_addr",
+						"ids.dev_eui",
+						"ids.join_eui",
 						"lorawan_phy_version",
 						"lorawan_version",
 						"mac_settings",
@@ -1470,6 +1489,9 @@ func handleUplinkTest() func(t *testing.T) {
 						}
 						return CopyEndDevice(tc.Device), []string{
 							"frequency_plan_id",
+							"ids.dev_addr",
+							"ids.dev_eui",
+							"ids.join_eui",
 							"lorawan_phy_version",
 							"lorawan_version",
 							"mac_settings",
@@ -1958,6 +1980,9 @@ func handleJoinTest() func(t *testing.T) {
 						[]string{
 							"created_at",
 							"frequency_plan_id",
+							"ids.dev_addr",
+							"ids.dev_eui",
+							"ids.join_eui",
 							"lorawan_phy_version",
 							"lorawan_version",
 							"mac_state",
@@ -1971,6 +1996,9 @@ func handleJoinTest() func(t *testing.T) {
 							}
 							return CopyEndDevice(pb), []string{
 								"frequency_plan_id",
+								"ids.dev_addr",
+								"ids.dev_eui",
+								"ids.join_eui",
 								"lorawan_phy_version",
 								"lorawan_version",
 								"mac_state",
@@ -2072,6 +2100,9 @@ func handleJoinTest() func(t *testing.T) {
 					[]string{
 						"created_at",
 						"frequency_plan_id",
+						"ids.dev_addr",
+						"ids.dev_eui",
+						"ids.join_eui",
 						"lorawan_phy_version",
 						"lorawan_version",
 						"mac_settings",
@@ -2087,6 +2118,9 @@ func handleJoinTest() func(t *testing.T) {
 						}
 						return CopyEndDevice(tc.Device), []string{
 							"frequency_plan_id",
+							"ids.dev_addr",
+							"ids.dev_eui",
+							"ids.join_eui",
 							"lorawan_phy_version",
 							"lorawan_version",
 							"mac_settings",

--- a/pkg/networkserver/redis/registry.go
+++ b/pkg/networkserver/redis/registry.go
@@ -37,13 +37,7 @@ func applyDeviceFieldMask(dst, src *ttnpb.EndDevice, paths ...string) (*ttnpb.En
 	if dst == nil {
 		dst = &ttnpb.EndDevice{}
 	}
-	if err := dst.SetFields(src, paths...); err != nil {
-		return nil, err
-	}
-	if err := dst.ValidateFields(paths...); err != nil {
-		return nil, err
-	}
-	return dst, nil
+	return dst, dst.SetFields(src, paths...)
 }
 
 // DeviceRegistry is an implementation of networkserver.DeviceRegistry.
@@ -232,13 +226,15 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIde
 
 			updated := &ttnpb.EndDevice{}
 			if stored == nil {
+				sets = append(sets,
+					"ids.application_ids",
+					"ids.device_id",
+				)
+
 				pb.CreatedAt = pb.UpdatedAt
 				sets = append(sets, "created_at")
 
-				updated, err = applyDeviceFieldMask(updated, pb, append(sets,
-					"ids.application_ids",
-					"ids.device_id",
-				)...)
+				updated, err = applyDeviceFieldMask(updated, pb, sets...)
 				if err != nil {
 					return err
 				}
@@ -254,6 +250,9 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIde
 					stored.ApplicationIdentifiers != updated.ApplicationIdentifiers || stored.DeviceID != updated.DeviceID {
 					return errInvalidIdentifiers
 				}
+			}
+			if err := updated.ValidateFields(sets...); err != nil {
+				return err
 			}
 			pb, err = applyDeviceFieldMask(nil, updated, gets...)
 			if err != nil {

--- a/pkg/networkserver/registry_test.go
+++ b/pkg/networkserver/registry_test.go
@@ -83,18 +83,20 @@ func handleRegistryTest(t *testing.T, reg DeviceRegistry) {
 
 	ret, err = reg.SetByID(ctx, pb.ApplicationIdentifiers, pb.DeviceID,
 		[]string{
-			"created_at",
+			"ids.dev_eui",
+			"ids.join_eui",
 			"pending_session",
 			"session",
-			"updated_at",
 		},
 		func(stored *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
 			if !a.So(stored, should.BeNil) {
 				t.Fatal("Registry is not empty")
 			}
 			return pb, []string{
-				"session",
+				"ids.dev_eui",
+				"ids.join_eui",
 				"pending_session",
+				"session",
 			}, nil
 		},
 	)
@@ -149,18 +151,20 @@ func handleRegistryTest(t *testing.T, reg DeviceRegistry) {
 
 	ret, err = reg.SetByID(ctx, pbOther.ApplicationIdentifiers, pbOther.DeviceID,
 		[]string{
-			"created_at",
+			"ids.dev_eui",
+			"ids.join_eui",
 			"pending_session",
 			"session",
-			"updated_at",
 		},
 		func(stored *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
 			if !a.So(stored, should.BeNil) {
 				t.Fatal("Registry is not empty")
 			}
 			return pbOther, []string{
-				"session",
+				"ids.dev_eui",
+				"ids.join_eui",
 				"pending_session",
+				"session",
 			}, nil
 		},
 	)


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #315 

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Handle implicit fieldmasks in a saner way
- Only validate the entities actually stored in the registries, instead of performing validation every time we apply the fieldmask
- Actually perform validation in AS registries

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

@johanstokking 	please fix the invalid AS tests
I suppose this is not going to be finished before my holiday, so assigning you

```
go run ./cmd/ttn-lw-cli login && go run ./cmd/ttn-lw-cli end-devices create --application-id test-app  --device-id test-sim --dev-eui 4200000000000000 --join-eui 4200000000000000 --frequency_plan_id EU_863_870 --root_keys.app_key.key 42000000000000000000000000000000 --lorawan_phy_version "1.0.2-b" --lorawan-version '1.0.2' --supports_class_c && go run ./cmd/ttn-lw-cli app create test-app --user-id admin && go run ./cmd/ttn-lw-cli app api-keys create --application-id test-app --right-application-all
```
 now returns this:
```
  INFO Please go to http://localhost:1885/oauth/authorize?client_id=cli&redirect_uri=http%3A%2F%2Flocalhost%3A11885%2Foauth%2Fcallback&response_type=code
  INFO Waiting for your authorization...       
  INFO Got OAuth access token                  
 DEBUG Using access token (valid until 9:39AM) 
 DEBUG pickfirstBalancer: HandleSubConnStateChange: 0xc0001fc670, CONNECTING
 DEBUG pickfirstBalancer: HandleSubConnStateChange: 0xc0001fc670, READY
 DEBUG Finished unary call                      duration=53.37822ms grpc_method=Create grpc_service=ttn.lorawan.v3.EndDeviceRegistry namespace=grpc
 DEBUG Finished unary call                      duration=35.907081ms grpc_method=Update grpc_service=ttn.lorawan.v3.EndDeviceRegistry namespace=grpc
 DEBUG Finished unary call                      duration=34.080964ms grpc_method=Set grpc_service=ttn.lorawan.v3.JsEndDeviceRegistry namespace=grpc
 DEBUG Finished unary call                      duration=35.692605ms grpc_method=Set grpc_service=ttn.lorawan.v3.NsEndDeviceRegistry namespace=grpc
 DEBUG Finished unary call                      duration=33.308143ms grpc_method=Set grpc_service=ttn.lorawan.v3.AsEndDeviceRegistry namespace=grpc
{
  "ids": {
    "device_id": "test-sim",
    "application_ids": {
      "application_id": "test-app"
    },
    "dev_eui": "4200000000000000",
    "join_eui": "4200000000000000"
  },
  "created_at": "2019-03-22T07:40:02.371Z",
  "updated_at": "2019-03-22T07:40:02.371Z",
  "attributes": {
  },
  "network_server_address": "localhost:8884",
  "application_server_address": "localhost:8884",
  "join_server_address": "localhost:8884",
  "supports_class_c": true,
  "lorawan_version": "1.0.2",
  "lorawan_phy_version": "1.0.2-b",
  "frequency_plan_id": "EU_863_870",
  "supports_join": true,
  "root_keys": {
    "app_key": {
      "key": "QgAAAAAAAAAAAAAAAAAAAA=="
    }
  }
}
 DEBUG Using access token (valid until 9:39AM) 
 DEBUG pickfirstBalancer: HandleSubConnStateChange: 0xc000269830, CONNECTING
 DEBUG pickfirstBalancer: HandleSubConnStateChange: 0xc000269830, READY
 DEBUG Finished unary call                      duration=62.69133ms grpc_method=Create grpc_service=ttn.lorawan.v3.ApplicationRegistry namespace=grpc
{
  "ids": {
    "application_id": "test-app"
  },
  "created_at": "2019-03-22T07:40:04.587Z",
  "updated_at": "2019-03-22T07:40:04.587Z"
}
 DEBUG Using access token (valid until 9:39AM) 
 DEBUG pickfirstBalancer: HandleSubConnStateChange: 0xc000312ea0, CONNECTING
 DEBUG pickfirstBalancer: HandleSubConnStateChange: 0xc000312ea0, READY
 DEBUG Finished unary call                      duration=83.533954ms grpc_method=CreateAPIKey grpc_service=ttn.lorawan.v3.ApplicationAccess namespace=grpc
  INFO API key ID: KBSF326EKRUX2DJKRZ76ZF65KR4DR4YJAKZRJVQ
  INFO API key value: NNSXS.KBSF326EKRUX2DJKRZ76ZF65KR4DR4YJAKZRJVQ.H33MKQ6F4WKNSG24V5DO7TRMYLRV3V3A6FFZTG5PS5MEXB5FIVDA
  WARN The API key value will never be shown again
  WARN Make sure to copy it to a safe place    
{
  "id": "KBSF326EKRUX2DJKRZ76ZF65KR4DR4YJAKZRJVQ",
  "key": "NNSXS.KBSF326EKRUX2DJKRZ76ZF65KR4DR4YJAKZRJVQ.H33MKQ6F4WKNSG24V5DO7TRMYLRV3V3A6FFZTG5PS5MEXB5FIVDA",
  "rights": [
    "RIGHT_APPLICATION_ALL"
  ]
}
```