### PR TITLE
Check if entity exists before handing out rights to admins

### DIFF
--- a/pkg/identityserver/application_access_test.go
+++ b/pkg/identityserver/application_access_test.go
@@ -207,6 +207,14 @@ func TestApplicationAccessCRUD(t *testing.T) {
 		a.So(rights.Rights, should.NotBeEmpty)
 		a.So(err, should.BeNil)
 
+		modifiedApplicationID := applicationID
+		modifiedApplicationID.ApplicationID += "mod"
+
+		rights, err = reg.ListRights(ctx, &modifiedApplicationID, creds)
+		a.So(rights, should.NotBeNil)
+		a.So(rights.Rights, should.BeEmpty)
+		a.So(err, should.BeNil)
+
 		applicationAPIKeys := applicationAPIKeys(&applicationID)
 		APIKeys, err := reg.ListAPIKeys(ctx, &applicationID, creds)
 

--- a/pkg/identityserver/client_access_test.go
+++ b/pkg/identityserver/client_access_test.go
@@ -130,6 +130,14 @@ func TestClientAccessCRUD(t *testing.T) {
 		a.So(rights.Rights, should.Contain, ttnpb.RIGHT_CLIENT_ALL)
 		a.So(err, should.BeNil)
 
+		modifiedClientID := clientID
+		modifiedClientID.ClientID += "mod"
+
+		rights, err = reg.ListRights(ctx, &modifiedClientID, creds)
+		a.So(rights, should.NotBeNil)
+		a.So(rights.Rights, should.BeEmpty)
+		a.So(err, should.BeNil)
+
 		collaborators, err := reg.ListCollaborators(ctx, &clientID, creds)
 
 		a.So(collaborators, should.NotBeNil)

--- a/pkg/identityserver/gateway_access_test.go
+++ b/pkg/identityserver/gateway_access_test.go
@@ -207,6 +207,14 @@ func TestGatewayAccessCRUD(t *testing.T) {
 		a.So(rights.Rights, should.Contain, ttnpb.RIGHT_GATEWAY_ALL)
 		a.So(err, should.BeNil)
 
+		modifiedGatewayID := gatewayID
+		modifiedGatewayID.GatewayID += "mod"
+
+		rights, err = reg.ListRights(ctx, &modifiedGatewayID, userCreds)
+		a.So(rights, should.NotBeNil)
+		a.So(rights.Rights, should.BeEmpty)
+		a.So(err, should.BeNil)
+
 		gatewayAPIKeys := gatewayAPIKeys(&gatewayID)
 		APIKeys, err := reg.ListAPIKeys(ctx, &gatewayID, userCreds)
 

--- a/pkg/identityserver/organization_access_test.go
+++ b/pkg/identityserver/organization_access_test.go
@@ -207,6 +207,14 @@ func TestOrganizationAccessCRUD(t *testing.T) {
 		a.So(rights.Rights, should.Contain, ttnpb.RIGHT_ORGANIZATION_ALL)
 		a.So(err, should.BeNil)
 
+		modifiedOrganizationID := organizationID
+		modifiedOrganizationID.OrganizationID += "mod"
+
+		rights, err = reg.ListRights(ctx, &modifiedOrganizationID, creds)
+		a.So(rights, should.NotBeNil)
+		a.So(rights.Rights, should.BeEmpty)
+		a.So(err, should.BeNil)
+
 		organizationAPIKeys := organizationAPIKeys(&organizationID)
 		APIKeys, err := reg.ListAPIKeys(ctx, &organizationID, creds)
 

--- a/pkg/identityserver/rights.go
+++ b/pkg/identityserver/rights.go
@@ -17,6 +17,10 @@ package identityserver
 import (
 	"context"
 
+	"github.com/gogo/protobuf/types"
+	"github.com/jinzhu/gorm"
+	"go.thethings.network/lorawan-stack/pkg/errors"
+	"go.thethings.network/lorawan-stack/pkg/identityserver/store"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 )
 
@@ -44,6 +48,19 @@ func (is *IdentityServer) ApplicationRights(ctx context.Context, appIDs ttnpb.Ap
 			return rights.Union(universal), nil
 		}
 	}
+	if universal == nil {
+		return &ttnpb.Rights{}, nil
+	}
+	err = is.withDatabase(ctx, func(db *gorm.DB) error {
+		_, err := store.GetApplicationStore(db).GetApplication(ctx, &appIDs, &types.FieldMask{Paths: []string{"ids"}})
+		return err
+	})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return &ttnpb.Rights{}, nil
+		}
+		return nil, err
+	}
 	return universal, nil
 }
 
@@ -57,6 +74,19 @@ func (is *IdentityServer) ClientRights(ctx context.Context, cliIDs ttnpb.ClientI
 		if ids := ids.GetClientIDs(); ids != nil && ids.ClientID == cliIDs.ClientID {
 			return rights.Union(universal), nil
 		}
+	}
+	if universal == nil {
+		return &ttnpb.Rights{}, nil
+	}
+	err = is.withDatabase(ctx, func(db *gorm.DB) error {
+		_, err := store.GetClientStore(db).GetClient(ctx, &cliIDs, &types.FieldMask{Paths: []string{"ids"}})
+		return err
+	})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return &ttnpb.Rights{}, nil
+		}
+		return nil, err
 	}
 	return universal, nil
 }
@@ -72,6 +102,19 @@ func (is *IdentityServer) GatewayRights(ctx context.Context, gtwIDs ttnpb.Gatewa
 			return rights.Union(universal), nil
 		}
 	}
+	if universal == nil {
+		return &ttnpb.Rights{}, nil
+	}
+	err = is.withDatabase(ctx, func(db *gorm.DB) error {
+		_, err := store.GetGatewayStore(db).GetGateway(ctx, &gtwIDs, &types.FieldMask{Paths: []string{"ids"}})
+		return err
+	})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return &ttnpb.Rights{}, nil
+		}
+		return nil, err
+	}
 	return universal, nil
 }
 
@@ -86,6 +129,19 @@ func (is *IdentityServer) OrganizationRights(ctx context.Context, orgIDs ttnpb.O
 			return rights.Union(universal), nil
 		}
 	}
+	if universal == nil {
+		return &ttnpb.Rights{}, nil
+	}
+	err = is.withDatabase(ctx, func(db *gorm.DB) error {
+		_, err := store.GetOrganizationStore(db).GetOrganization(ctx, &orgIDs, &types.FieldMask{Paths: []string{"ids"}})
+		return err
+	})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return &ttnpb.Rights{}, nil
+		}
+		return nil, err
+	}
 	return universal, nil
 }
 
@@ -99,6 +155,19 @@ func (is *IdentityServer) UserRights(ctx context.Context, userIDs ttnpb.UserIden
 		if ids := ids.GetUserIDs(); ids != nil && ids.UserID == userIDs.UserID {
 			return rights.Union(universal), nil
 		}
+	}
+	if universal == nil {
+		return &ttnpb.Rights{}, nil
+	}
+	err = is.withDatabase(ctx, func(db *gorm.DB) error {
+		_, err := store.GetUserStore(db).GetUser(ctx, &userIDs, &types.FieldMask{Paths: []string{"ids"}})
+		return err
+	})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return &ttnpb.Rights{}, nil
+		}
+		return nil, err
 	}
 	return universal, nil
 }

--- a/pkg/identityserver/user_access_test.go
+++ b/pkg/identityserver/user_access_test.go
@@ -168,6 +168,14 @@ func TestUserAccessCRUD(t *testing.T) {
 		a.So(rights.Rights, should.NotBeEmpty)
 		a.So(err, should.BeNil)
 
+		modifiedUserID := user.UserIdentifiers
+		modifiedUserID.UserID += "mod"
+
+		rights, err = reg.ListRights(ctx, &modifiedUserID, creds)
+		a.So(rights, should.NotBeNil)
+		a.So(rights.Rights, should.BeEmpty)
+		a.So(err, should.BeNil)
+
 		userAPIKeys := userAPIKeys(&user.UserIdentifiers)
 		sort.Slice(userAPIKeys.APIKeys, func(i int, j int) bool { return userAPIKeys.APIKeys[i].Name < userAPIKeys.APIKeys[j].Name })
 		apiKeys, err := reg.ListAPIKeys(ctx, &user.UserIdentifiers, creds)


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR closes #346 by making the Rights logic in the Identity Server check if entities actually exist before returning the caller's universal (admin) rights as entity rights.

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

If the normal rights lookup (using memberships) didn't have any results, and the caller has universal (admin) rights, then we try to fetch the entity before returning those rights. If the entity does not exist, we return an empty rights list.

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
What are the functional or behavioral changes? API Changes? New features?
Any changes in configuration? Added/changed/removed flags?
Are there any database migrations required?
-->

Admins no longer have rights to entities that don't exist
