### PR TITLE
Don't close test stream in rpctest, but let the context cancelation do its job

### DIFF
--- a/pkg/util/rpctest/server_test.go
+++ b/pkg/util/rpctest/server_test.go
@@ -80,7 +80,7 @@ func TestFooBarExampleServer(t *testing.T) {
 			err = stream.Send(&rpctest.Foo{Message: "foo"})
 			a.So(err, should.BeNil)
 			cancel()
-			_, err = stream.CloseAndRecv()
+			err = stream.RecvMsg(&rpctest.Bar{})
 			a.So(grpc.Code(err), should.Equal, codes.Canceled)
 		}
 


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR closes #347 by making the problematic test not close the stream (which should result in an OK), but wait for the cancel to propagate to the server.

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

Don't don't end the stream

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

Looks like Travis got faster :joy:

