### PR TITLE
Restore gzip Middleware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/jinzhu/now v1.0.0 // indirect
 	github.com/kamilsk/retry/v4 v4.0.2 // indirect
 	github.com/kr/pretty v0.1.0
-	github.com/labstack/echo v3.3.10+incompatible
+	github.com/labstack/echo/v4 v4.0.0
 	github.com/labstack/gommon v0.2.8
 	github.com/lib/pq v1.0.0
 	github.com/lyft/protoc-gen-validate v0.0.13

--- a/go.sum
+++ b/go.sum
@@ -409,8 +409,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/labstack/echo v3.3.10+incompatible h1:pGRcYk231ExFAyoAjAfD85kQzRJCRI8bbnE7CX5OEgg=
-github.com/labstack/echo v3.3.10+incompatible/go.mod h1:0INS7j/VjnFxD4E2wkz67b8cVwCLbBmJyDaka6Cmk1s=
+github.com/labstack/echo/v4 v4.0.0 h1:q1GH+caIXPP7H2StPIdzy/ez9CO0EepqYeUg6vi9SWM=
+github.com/labstack/echo/v4 v4.0.0/go.mod h1:tZv7nai5buKSg5h/8E6zz4LsD/Dqh9/91Mvs7Z5Zyno=
 github.com/labstack/gommon v0.2.8 h1:JvRqmeZcfrHC5u6uVleB4NxxNbzx6gpbJiQknDbKQu0=
 github.com/labstack/gommon v0.2.8/go.mod h1:/tj9csK2iPSBvn+3NLM9e52usepMtrd5ilFYA+wQNJ4=
 github.com/lib/pq v1.0.0 h1:X5PMW56eZitiTeO7tKzZxFCSpbFZJtkMMooicw2us9A=
@@ -641,6 +641,7 @@ github.com/ugorji/go/codec v0.0.0-20181012064053-8333dd449516/go.mod h1:VFNgLljT
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4/go.mod h1:50wTf68f99/Zt14pr046Tgt3Lp2vLyFZKzbFXTOabXw=
 github.com/valyala/fasttemplate v1.0.1 h1:tY9CJiPnMXf1ERmG2EyK7gNUd+c6RKGD0IfU8WdUSz8=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/willf/bitset v1.1.9/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
@@ -673,6 +674,7 @@ golang.org/x/crypto v0.0.0-20181001203147-e3636079e1a4/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190122013713-64072686203f/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20190130090550-b01c7a725664/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a h1:YX8ljsm6wXlHZO+aRz9Exqr0evNhKRNe5K/gi+zKh4U=
 golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -732,6 +734,7 @@ golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181218192612-074acd46bca6/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181228144115-9a3f9b0469bb/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190129075346-302c3dd5f1cc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190316082340-a2f829d7f35f h1:yCrMx/EeIue0+Qca57bWZS7VX6ymEoypmhWyPhz0NHM=

--- a/pkg/applicationserver/io/web/webhooks.go
+++ b/pkg/applicationserver/io/web/webhooks.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/pkg/errors"

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	"go.thethings.network/lorawan-stack/pkg/config"

--- a/pkg/component/grpc.go
+++ b/pkg/component/grpc.go
@@ -20,8 +20,8 @@ import (
 	"net/http"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware"
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/middleware"
+	echo "github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/rpcmiddleware/hooks"
 	"go.thethings.network/lorawan-stack/pkg/rpcmiddleware/rpclog"

--- a/pkg/component/web.go
+++ b/pkg/component/web.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 
 	"github.com/heptiolabs/healthcheck"
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/middleware"
+	echo "github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
 	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/metrics"
 	"go.thethings.network/lorawan-stack/pkg/web"

--- a/pkg/console/callback.go
+++ b/pkg/console/callback.go
@@ -17,7 +17,7 @@ package console
 import (
 	"net/http"
 
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 )
 
 // Callback is the OAuth callback that accepts the authorization code

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -19,8 +19,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/middleware"
+	echo "github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	web_errors "go.thethings.network/lorawan-stack/pkg/errors/web"

--- a/pkg/console/cookie_auth.go
+++ b/pkg/console/cookie_auth.go
@@ -19,7 +19,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 	"go.thethings.network/lorawan-stack/pkg/web/cookie"
 )
 

--- a/pkg/console/cookie_state.go
+++ b/pkg/console/cookie_state.go
@@ -19,7 +19,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 	"go.thethings.network/lorawan-stack/pkg/random"
 	"go.thethings.network/lorawan-stack/pkg/web/cookie"
 )

--- a/pkg/console/login.go
+++ b/pkg/console/login.go
@@ -17,7 +17,7 @@ package console
 import (
 	"net/http"
 
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 )
 
 // Login logs in the user by redirecting to the OAuth flow.

--- a/pkg/console/logout.go
+++ b/pkg/console/logout.go
@@ -17,7 +17,7 @@ package console
 import (
 	"net/http"
 
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 )
 
 // Logout logs out the user.

--- a/pkg/console/refresh.go
+++ b/pkg/console/refresh.go
@@ -18,7 +18,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 	"golang.org/x/oauth2"
 )
 

--- a/pkg/console/token.go
+++ b/pkg/console/token.go
@@ -17,7 +17,7 @@ package console
 import (
 	"net/http"
 
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 )
 
 // Token is the handler that allows the user to get their OAuth token.

--- a/pkg/errors/web/middleware.go
+++ b/pkg/errors/web/middleware.go
@@ -20,7 +20,7 @@ import (
 	"sort"
 
 	"github.com/golang/gddo/httputil"
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	_ "go.thethings.network/lorawan-stack/pkg/ttnpb" // imported for side-effect of correct TTN error rendering.
 )

--- a/pkg/errors/web/middleware_test.go
+++ b/pkg/errors/web/middleware_test.go
@@ -20,7 +20,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 	"github.com/smartystreets/assertions"
 	"github.com/smartystreets/assertions/should"
 	"go.thethings.network/lorawan-stack/pkg/errors"

--- a/pkg/oauth/middleware.go
+++ b/pkg/oauth/middleware.go
@@ -20,7 +20,7 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 )
 

--- a/pkg/oauth/oauth.go
+++ b/pkg/oauth/oauth.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 	"github.com/openshift/osin"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/events"

--- a/pkg/oauth/server.go
+++ b/pkg/oauth/server.go
@@ -19,8 +19,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/middleware"
+	echo "github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
 	"github.com/openshift/osin"
 	web_errors "go.thethings.network/lorawan-stack/pkg/errors/web"
 	"go.thethings.network/lorawan-stack/pkg/identityserver/store"

--- a/pkg/oauth/user.go
+++ b/pkg/oauth/user.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/types"
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 	"go.thethings.network/lorawan-stack/pkg/auth"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/events"

--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -46,6 +46,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/rpcmiddleware/validator"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"google.golang.org/grpc"
+	_ "google.golang.org/grpc/encoding/gzip" // Register gzip compression.
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 )

--- a/pkg/web/cookie/cookie.go
+++ b/pkg/web/cookie/cookie.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/gorilla/securecookie"
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 )
 
 const (

--- a/pkg/web/cookie/cookie_test.go
+++ b/pkg/web/cookie/cookie_test.go
@@ -20,7 +20,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/random"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"

--- a/pkg/web/error_handler.go
+++ b/pkg/web/error_handler.go
@@ -15,7 +15,7 @@
 package web
 
 import (
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 	"go.thethings.network/lorawan-stack/pkg/errors/web"
 )
 

--- a/pkg/web/error_handler_test.go
+++ b/pkg/web/error_handler_test.go
@@ -20,7 +20,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"

--- a/pkg/web/middleware/id.go
+++ b/pkg/web/middleware/id.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 	"github.com/oklog/ulid"
 )
 

--- a/pkg/web/middleware/id_test.go
+++ b/pkg/web/middleware/id_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 )

--- a/pkg/web/middleware/immutable.go
+++ b/pkg/web/middleware/immutable.go
@@ -14,7 +14,7 @@
 
 package middleware
 
-import "github.com/labstack/echo"
+import echo "github.com/labstack/echo/v4"
 
 // Immutable set the Cache-Control header to make the resource immutable. This means the
 // client will never try to revalidate the resource.

--- a/pkg/web/middleware/immutable_test.go
+++ b/pkg/web/middleware/immutable_test.go
@@ -18,7 +18,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 )

--- a/pkg/web/middleware/log.go
+++ b/pkg/web/middleware/log.go
@@ -17,7 +17,7 @@ package middleware
 import (
 	"time"
 
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 	"go.thethings.network/lorawan-stack/pkg/errors/web"
 	"go.thethings.network/lorawan-stack/pkg/log"
 )

--- a/pkg/web/middleware/log_test.go
+++ b/pkg/web/middleware/log_test.go
@@ -20,7 +20,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"

--- a/pkg/web/middleware/noop.go
+++ b/pkg/web/middleware/noop.go
@@ -14,7 +14,7 @@
 
 package middleware
 
-import "github.com/labstack/echo"
+import echo "github.com/labstack/echo/v4"
 
 // Noop is middleware that does nothing.
 func Noop(next echo.HandlerFunc) echo.HandlerFunc {

--- a/pkg/web/middleware/normalize.go
+++ b/pkg/web/middleware/normalize.go
@@ -19,7 +19,7 @@ import (
 	"net/url"
 
 	"github.com/PuerkitoBio/purell"
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 )
 
 // redirect are are the normalization flags that warrant a redirect.

--- a/pkg/web/middleware/normalize_test.go
+++ b/pkg/web/middleware/normalize_test.go
@@ -19,7 +19,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 )

--- a/pkg/web/middleware/recover.go
+++ b/pkg/web/middleware/recover.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"runtime/debug"
 
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 )
 

--- a/pkg/web/redirect.go
+++ b/pkg/web/redirect.go
@@ -15,7 +15,7 @@
 package web
 
 import (
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 )
 
 type redirector struct {

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -21,8 +21,8 @@ import (
 	"path"
 	"strings"
 
-	"github.com/labstack/echo"
-	echomiddleware "github.com/labstack/echo/middleware"
+	echo "github.com/labstack/echo/v4"
+	echomiddleware "github.com/labstack/echo/v4/middleware"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/log"

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -80,6 +80,7 @@ func New(ctx context.Context, config config.HTTP) (*Server, error) {
 		middleware.ID(""),
 		echomiddleware.BodyLimit("16M"),
 		echomiddleware.Secure(),
+		echomiddleware.Gzip(),
 		middleware.Recover(),
 		cookie.Cookies(blockKey, hashKey),
 	)
@@ -144,11 +145,7 @@ func (s *Server) RootGroup(prefix string, middleware ...echo.MiddlewareFunc) *ec
 func (s *Server) Static(prefix string, fs http.FileSystem, middleware ...echo.MiddlewareFunc) {
 	t := strings.TrimSuffix(prefix, "/")
 	path := path.Join(t, "*")
-	fileServer := http.StripPrefix(t, http.FileServer(fs))
-	handler := func(c echo.Context) error {
-		fileServer.ServeHTTP(c.Response().Writer, c.Request())
-		return nil
-	}
+	handler := echo.WrapHandler(http.StripPrefix(t, http.FileServer(fs)))
 	s.GET(path, handler, middleware...)
 	s.HEAD(path, handler, middleware...)
 }

--- a/pkg/web/web_test.go
+++ b/pkg/web/web_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/random"

--- a/pkg/webui/template.go
+++ b/pkg/webui/template.go
@@ -22,7 +22,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 )
 
 // Data contains data to render templates.


### PR DESCRIPTION
**Summary:**
<!--
A summary, always referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR closes #94 by restoring the Gzip middleware after fixing the problem that caused it to break in the first place.

Refs #83 #84 #93 

<!--
Please motivate briefly why it is implemented this way, if that deviates
from the implementation proposal in the referenced issues.
-->

**Changes:**
<!-- What are the changes made in this pull request? -->

- Fixed the broken Static handler and restored gzip middleware
- Additionally added server-side support for gzip in gRPC

**Notes for Reviewers:**
<!--
How should your reviewers approach this pull request?
Any special requests or questions for specific reviewers?
-->

The commit `all: Update Echo module to v4` can be completely ignored.
