### PR TITLE
Fix console redirect URI

### DIFF
--- a/.make/dev.make
+++ b/.make/dev.make
@@ -55,6 +55,6 @@ dev.stack.init: dev.databases.start
 	@$(DEV_DOCKER_COMPOSE) run --rm stack is-db init
 	@$(DEV_DOCKER_COMPOSE) run --rm stack is-db create-admin-user --id admin --email admin@localhost --password admin
 	@$(DEV_DOCKER_COMPOSE) run --rm stack is-db create-oauth-client --id cli --name "Command Line Interface" --owner admin --no-secret --redirect-uri 'http://localhost:11885/oauth/callback' --redirect-uri '/oauth/code'
-	@$(DEV_DOCKER_COMPOSE) run --rm stack is-db create-oauth-client --id console --name "Console" --owner admin --secret console --redirect-uri 'https://localhost:8885/console/oauth/callback' --redirect-uri 'http://localhost:1885/console/oauth/callback'
+	@$(DEV_DOCKER_COMPOSE) run --rm stack is-db create-oauth-client --id console --name "Console" --owner admin --secret console --redirect-uri 'https://localhost:8885/console/oauth/callback' --redirect-uri 'http://localhost:1885/console/oauth/callback' --redirect-uri '/console/oauth/callback'
 
 # vim: ft=make

--- a/.make/dev.make
+++ b/.make/dev.make
@@ -52,9 +52,9 @@ dev.databases.redis-cli: dev.databases.start
 # Binaries
 
 dev.stack.init: dev.databases.start
-	go run ./cmd/ttn-lw-stack is-db init
-	go run ./cmd/ttn-lw-stack is-db create-admin-user --id admin --email admin@localhost --password admin
-	go run ./cmd/ttn-lw-stack is-db create-oauth-client --id cli --name "Command Line Interface" --owner admin --no-secret --redirect-uri 'http://localhost:11885/oauth/callback' --redirect-uri '/oauth/code'
-	go run ./cmd/ttn-lw-stack is-db create-oauth-client --id console --name "Console" --owner admin --secret console --redirect-uri 'http://localhost:1885/console/oauth/callback'
+	@$(DEV_DOCKER_COMPOSE) run --rm stack is-db init
+	@$(DEV_DOCKER_COMPOSE) run --rm stack is-db create-admin-user --id admin --email admin@localhost --password admin
+	@$(DEV_DOCKER_COMPOSE) run --rm stack is-db create-oauth-client --id cli --name "Command Line Interface" --owner admin --no-secret --redirect-uri 'http://localhost:11885/oauth/callback' --redirect-uri '/oauth/code'
+	@$(DEV_DOCKER_COMPOSE) run --rm stack is-db create-oauth-client --id console --name "Console" --owner admin --secret console --redirect-uri 'https://localhost:8885/console/oauth/callback' --redirect-uri 'http://localhost:1885/console/oauth/callback'
 
 # vim: ft=make

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ The easiest way to set up a private network is with the provided [`docker-compos
       --id console --name "Console" \
       --owner admin \
       --redirect-uri 'http://example.com:1885/console/oauth/callback' \
-      --redirect-uri 'https://example.com:8885/console/oauth/callback'
+      --redirect-uri 'https://example.com:8885/console/oauth/callback' \
+      --redirect-uri '/console/oauth/callback'
     ```
     Make sure to copy the value of the `secret` that is printed by this command.
 6. Export the Console's OAuth client secret or replace it in your `docker-compose.yml`:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR closes #337 by adding a redirect URI for the console's HTTPS callback.

**Changes:**
<!-- What are the changes made in this pull request? -->

- Add `https://<console-domain>/console/oauth/callback` redirect to Make and docs
- Additionally add a relative redirect URI for future use
- Update `make dev.stack.init` to use the development docker-compose instead of `go run`

**Notes for Reviewers:**
<!--
Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Using the development docker-compose command instead of `go run` ensures that we're not accidentally using the wrong database.
