### PR TITLE
Change how the CLI handles the ns/as/js address config and EndDevice fields

### DIFF
--- a/cmd/ttn-lw-cli/commands/access.go
+++ b/cmd/ttn-lw-cli/commands/access.go
@@ -29,7 +29,7 @@ var (
 		Hidden: true,
 		Short:  "Get auth info",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}

--- a/cmd/ttn-lw-cli/commands/applications.go
+++ b/cmd/ttn-lw-cli/commands/applications.go
@@ -69,7 +69,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			paths := util.SelectFieldMask(cmd.Flags(), selectApplicationFlags)
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -93,7 +93,7 @@ var (
 			req := getSearchEntitiesRequest(cmd.Flags())
 			req.FieldMask.Paths = paths
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -116,7 +116,7 @@ var (
 			}
 			paths := util.SelectFieldMask(cmd.Flags(), selectApplicationFlags)
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -159,7 +159,7 @@ var (
 				return errNoApplicationID
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -195,7 +195,7 @@ var (
 			application.Attributes = mergeAttributes(application.Attributes, cmd.Flags())
 			application.ApplicationIdentifiers = *appID
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -220,7 +220,7 @@ var (
 				return errNoApplicationID
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}

--- a/cmd/ttn-lw-cli/commands/applications_access.go
+++ b/cmd/ttn-lw-cli/commands/applications_access.go
@@ -34,7 +34,7 @@ var (
 				return errNoApplicationID
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -61,7 +61,7 @@ var (
 				return errNoApplicationID
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -90,7 +90,7 @@ var (
 				return errNoCollaboratorRights
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -122,7 +122,7 @@ var (
 				return errNoCollaborator
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -155,7 +155,7 @@ var (
 				return errNoApplicationID
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -183,7 +183,7 @@ var (
 				return errNoAPIKeyRights
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -224,7 +224,7 @@ var (
 				return errNoAPIKeyRights
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -257,7 +257,7 @@ var (
 				return errNoApplicationID
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}

--- a/cmd/ttn-lw-cli/commands/applications_downlink.go
+++ b/cmd/ttn-lw-cli/commands/applications_downlink.go
@@ -47,7 +47,7 @@ var (
 				return err
 			}
 
-			as, err := api.Dial(ctx, config.ApplicationServerAddress)
+			as, err := api.Dial(ctx, config.ApplicationServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -76,7 +76,7 @@ var (
 				return err
 			}
 
-			as, err := api.Dial(ctx, config.ApplicationServerAddress)
+			as, err := api.Dial(ctx, config.ApplicationServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -100,7 +100,7 @@ var (
 				return err
 			}
 
-			as, err := api.Dial(ctx, config.ApplicationServerAddress)
+			as, err := api.Dial(ctx, config.ApplicationServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -123,7 +123,7 @@ var (
 				return err
 			}
 
-			as, err := api.Dial(ctx, config.ApplicationServerAddress)
+			as, err := api.Dial(ctx, config.ApplicationServerGRPCAddress)
 			if err != nil {
 				return err
 			}

--- a/cmd/ttn-lw-cli/commands/applications_link.go
+++ b/cmd/ttn-lw-cli/commands/applications_link.go
@@ -57,7 +57,7 @@ var (
 				})
 			}
 
-			as, err := api.Dial(ctx, config.ApplicationServerAddress)
+			as, err := api.Dial(ctx, config.ApplicationServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -91,7 +91,7 @@ var (
 				return errNoApplicationLinkAPIKey
 			}
 
-			as, err := api.Dial(ctx, config.ApplicationServerAddress)
+			as, err := api.Dial(ctx, config.ApplicationServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -116,7 +116,7 @@ var (
 				return errNoApplicationID
 			}
 
-			as, err := api.Dial(ctx, config.ApplicationServerAddress)
+			as, err := api.Dial(ctx, config.ApplicationServerGRPCAddress)
 			if err != nil {
 				return err
 			}

--- a/cmd/ttn-lw-cli/commands/applications_subscribe.go
+++ b/cmd/ttn-lw-cli/commands/applications_subscribe.go
@@ -35,7 +35,7 @@ var (
 				return errNoApplicationID
 			}
 
-			as, err := api.Dial(ctx, config.ApplicationServerAddress)
+			as, err := api.Dial(ctx, config.ApplicationServerGRPCAddress)
 			if err != nil {
 				return err
 			}

--- a/cmd/ttn-lw-cli/commands/applications_webhook.go
+++ b/cmd/ttn-lw-cli/commands/applications_webhook.go
@@ -79,7 +79,7 @@ var (
 		Aliases: []string{"formats"},
 		Short:   "Get the available formats for application webhooks",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			as, err := api.Dial(ctx, config.ApplicationServerAddress)
+			as, err := api.Dial(ctx, config.ApplicationServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -108,7 +108,7 @@ var (
 				})
 			}
 
-			as, err := api.Dial(ctx, config.ApplicationServerAddress)
+			as, err := api.Dial(ctx, config.ApplicationServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -140,7 +140,7 @@ var (
 				})
 			}
 
-			as, err := api.Dial(ctx, config.ApplicationServerAddress)
+			as, err := api.Dial(ctx, config.ApplicationServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -172,7 +172,7 @@ var (
 			}
 			webhook.ApplicationWebhookIdentifiers = *webhookID
 
-			as, err := api.Dial(ctx, config.ApplicationServerAddress)
+			as, err := api.Dial(ctx, config.ApplicationServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -196,7 +196,7 @@ var (
 				return err
 			}
 
-			as, err := api.Dial(ctx, config.ApplicationServerAddress)
+			as, err := api.Dial(ctx, config.ApplicationServerGRPCAddress)
 			if err != nil {
 				return err
 			}

--- a/cmd/ttn-lw-cli/commands/clients.go
+++ b/cmd/ttn-lw-cli/commands/clients.go
@@ -69,7 +69,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			paths := util.SelectFieldMask(cmd.Flags(), selectClientFlags)
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -93,7 +93,7 @@ var (
 			req := getSearchEntitiesRequest(cmd.Flags())
 			req.FieldMask.Paths = paths
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -116,7 +116,7 @@ var (
 			}
 			paths := util.SelectFieldMask(cmd.Flags(), selectClientFlags)
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -159,7 +159,7 @@ var (
 				return errNoClientID
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -199,7 +199,7 @@ var (
 			client.Attributes = mergeAttributes(client.Attributes, cmd.Flags())
 			client.ClientIdentifiers = *cliID
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -224,7 +224,7 @@ var (
 				return errNoClientID
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}

--- a/cmd/ttn-lw-cli/commands/clients_access.go
+++ b/cmd/ttn-lw-cli/commands/clients_access.go
@@ -34,7 +34,7 @@ var (
 				return errNoClientID
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -61,7 +61,7 @@ var (
 				return errNoClientID
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -90,7 +90,7 @@ var (
 				return errNoCollaboratorRights
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -122,7 +122,7 @@ var (
 				return errNoCollaborator
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}

--- a/cmd/ttn-lw-cli/commands/config.go
+++ b/cmd/ttn-lw-cli/commands/config.go
@@ -28,17 +28,17 @@ var (
 
 // Config for the ttn-lw-cli binary.
 type Config struct {
-	conf.Base                `name:",squash"`
-	InputFormat              string `name:"input-format" description:"Input format"`
-	OutputFormat             string `name:"output-format" description:"Output format"`
-	OAuthServerAddress       string `name:"oauth-server-address" description:"OAuth Server Address"`
-	IdentityServerAddress    string `name:"identity-server-address" description:"Identity Server Address"`
-	GatewayServerAddress     string `name:"gateway-server-address" description:"Gateway Server Address"`
-	NetworkServerAddress     string `name:"network-server-address" description:"Network Server Address"`
-	ApplicationServerAddress string `name:"application-server-address" description:"Application Server Address"`
-	JoinServerAddress        string `name:"join-server-address" description:"Join Server Address"`
-	Insecure                 bool   `name:"insecure" description:"Connect without TLS"`
-	CA                       string `name:"ca" description:"CA certificate file"`
+	conf.Base                    `name:",squash"`
+	InputFormat                  string `name:"input-format" description:"Input format"`
+	OutputFormat                 string `name:"output-format" description:"Output format"`
+	OAuthServerAddress           string `name:"oauth-server-address" description:"OAuth Server Address"`
+	IdentityServerGRPCAddress    string `name:"identity-server-grpc-address" description:"Identity Server Address"`
+	GatewayServerGRPCAddress     string `name:"gateway-server-grpc-address" description:"Gateway Server Address"`
+	NetworkServerGRPCAddress     string `name:"network-server-grpc-address" description:"Network Server Address"`
+	ApplicationServerGRPCAddress string `name:"application-server-grpc-address" description:"Application Server Address"`
+	JoinServerGRPCAddress        string `name:"join-server-grpc-address" description:"Join Server Address"`
+	Insecure                     bool   `name:"insecure" description:"Connect without TLS"`
+	CA                           string `name:"ca" description:"CA certificate file"`
 }
 
 // DefaultConfig contains the default config for the ttn-lw-cli binary.
@@ -48,19 +48,19 @@ var DefaultConfig = Config{
 			Level: log.InfoLevel,
 		},
 	},
-	InputFormat:              "json",
-	OutputFormat:             "json",
-	OAuthServerAddress:       clusterHTTPAddress,
-	IdentityServerAddress:    clusterGRPCAddress,
-	GatewayServerAddress:     clusterGRPCAddress,
-	NetworkServerAddress:     clusterGRPCAddress,
-	ApplicationServerAddress: clusterGRPCAddress,
-	JoinServerAddress:        clusterGRPCAddress,
+	InputFormat:                  "json",
+	OutputFormat:                 "json",
+	OAuthServerAddress:           clusterHTTPAddress,
+	IdentityServerGRPCAddress:    clusterGRPCAddress,
+	GatewayServerGRPCAddress:     clusterGRPCAddress,
+	NetworkServerGRPCAddress:     clusterGRPCAddress,
+	ApplicationServerGRPCAddress: clusterGRPCAddress,
+	JoinServerGRPCAddress:        clusterGRPCAddress,
 }
 
 var configCommand = commands.Config(mgr)
 
 func init() {
-	versionCommand.PersistentPreRunE = preRun()
+	configCommand.PersistentPreRunE = preRun()
 	Root.AddCommand(configCommand)
 }

--- a/cmd/ttn-lw-cli/commands/contact_info.go
+++ b/cmd/ttn-lw-cli/commands/contact_info.go
@@ -28,7 +28,7 @@ import (
 )
 
 func updateContactInfo(entityID *ttnpb.EntityIdentifiers, updater func([]*ttnpb.ContactInfo) ([]*ttnpb.ContactInfo, error)) ([]*ttnpb.ContactInfo, error) {
-	is, err := api.Dial(ctx, config.IdentityServerAddress)
+	is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -17,7 +17,10 @@ package commands
 import (
 	"context"
 	stdio "io"
+	"net"
+	"net/url"
 	"os"
+	"strings"
 
 	pbtypes "github.com/gogo/protobuf/types"
 	"github.com/spf13/cobra"
@@ -132,7 +135,7 @@ var (
 			}
 			paths := util.SelectFieldMask(cmd.Flags(), selectEndDeviceListFlags)
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -170,7 +173,7 @@ var (
 				isPaths = append(isPaths, "join_server_address")
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -183,6 +186,11 @@ var (
 			}
 
 			compareServerAddresses(device, config)
+
+			if len(jsPaths) > 0 && device.JoinServerAddress == "" {
+				logger.WithField("paths", jsPaths).Debug("No registered Join Server address, deselecting Join Server paths")
+				jsPaths = nil
+			}
 
 			res, err := getEndDevice(device.EndDeviceIdentifiers, nsPaths, asPaths, jsPaths, true)
 			if err != nil {
@@ -231,12 +239,10 @@ var (
 
 			setDefaults, _ := cmd.Flags().GetBool("defaults")
 			if setDefaults {
-				device.NetworkServerAddress = config.NetworkServerAddress
-				device.ApplicationServerAddress = config.ApplicationServerAddress
-				device.JoinServerAddress = config.JoinServerAddress
+				device.NetworkServerAddress = getHost(config.NetworkServerGRPCAddress)
+				device.ApplicationServerAddress = getHost(config.ApplicationServerGRPCAddress)
 				paths = append(paths,
 					"application_server_address",
-					"join_server_address",
 					"network_server_address",
 				)
 			}
@@ -280,6 +286,12 @@ var (
 			} else {
 				device.SupportsJoin = true
 				paths = append(paths, "supports_join")
+				if setDefaults {
+					device.JoinServerAddress = getHost(config.JoinServerGRPCAddress)
+					paths = append(paths,
+						"join_server_address",
+					)
+				}
 				if withKeys, _ := cmd.Flags().GetBool("with-root-keys"); withKeys {
 					if device.ProvisionerID != "" {
 						return errEndDeviceKeysWithProvisioner
@@ -334,7 +346,7 @@ var (
 				return errNoEndDeviceEUI
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -404,7 +416,7 @@ var (
 				isPaths = append(isPaths, "join_server_address")
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -520,7 +532,7 @@ var (
 				}
 			}
 
-			js, err := api.Dial(ctx, config.JoinServerAddress)
+			js, err := api.Dial(ctx, config.JoinServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -551,7 +563,7 @@ var (
 				return err
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -643,23 +655,40 @@ func init() {
 	Root.AddCommand(endDevicesCommand)
 }
 
+func getHost(address string) string {
+	if strings.Contains(address, "://") {
+		url, err := url.Parse(address)
+		if err == nil {
+			address = url.Host
+		}
+	}
+	if strings.Contains(address, ":") {
+		host, _, err := net.SplitHostPort(address)
+		if err == nil {
+			return host
+		}
+	}
+	return address
+}
+
 func compareServerAddresses(device *ttnpb.EndDevice, config *Config) {
-	if device.NetworkServerAddress != "" && device.NetworkServerAddress != config.NetworkServerAddress {
+	nsHost, asHost, jsHost := getHost(config.NetworkServerGRPCAddress), getHost(config.ApplicationServerGRPCAddress), getHost(config.JoinServerGRPCAddress)
+	if host := getHost(device.NetworkServerAddress); host != "" && host != nsHost {
 		logger.WithFields(log.Fields(
-			"configured", config.NetworkServerAddress,
-			"registered", device.NetworkServerAddress,
+			"configured", nsHost,
+			"registered", host,
 		)).Warn("Registered Network Server address does not match CLI configuration")
 	}
-	if device.ApplicationServerAddress != "" && device.ApplicationServerAddress != config.ApplicationServerAddress {
+	if host := getHost(device.ApplicationServerAddress); host != "" && host != asHost {
 		logger.WithFields(log.Fields(
-			"configured", config.ApplicationServerAddress,
-			"registered", device.ApplicationServerAddress,
+			"configured", asHost,
+			"registered", host,
 		)).Warn("Registered Application Server address does not match CLI configuration")
 	}
-	if device.JoinServerAddress != "" && device.JoinServerAddress != config.JoinServerAddress {
+	if host := getHost(device.JoinServerAddress); host != "" && host != jsHost {
 		logger.WithFields(log.Fields(
-			"configured", config.JoinServerAddress,
-			"registered", device.JoinServerAddress,
+			"configured", jsHost,
+			"registered", host,
 		)).Warn("Registered Join Server address does not match CLI configuration")
 	}
 }

--- a/cmd/ttn-lw-cli/commands/end_devices_split.go
+++ b/cmd/ttn-lw-cli/commands/end_devices_split.go
@@ -73,7 +73,7 @@ func getEndDevice(ids ttnpb.EndDeviceIdentifiers, nsPaths, asPaths, jsPaths []st
 	var res ttnpb.EndDevice
 
 	if len(jsPaths) > 0 {
-		js, err := api.Dial(ctx, config.JoinServerAddress)
+		js, err := api.Dial(ctx, config.JoinServerGRPCAddress)
 		if err != nil {
 			if !continueOnError {
 				return nil, err
@@ -102,7 +102,7 @@ func getEndDevice(ids ttnpb.EndDeviceIdentifiers, nsPaths, asPaths, jsPaths []st
 	}
 
 	if len(asPaths) > 0 {
-		as, err := api.Dial(ctx, config.ApplicationServerAddress)
+		as, err := api.Dial(ctx, config.ApplicationServerGRPCAddress)
 		if err != nil {
 			if !continueOnError {
 				return nil, err
@@ -131,7 +131,7 @@ func getEndDevice(ids ttnpb.EndDeviceIdentifiers, nsPaths, asPaths, jsPaths []st
 	}
 
 	if len(nsPaths) > 0 {
-		ns, err := api.Dial(ctx, config.NetworkServerAddress)
+		ns, err := api.Dial(ctx, config.NetworkServerGRPCAddress)
 		if err != nil {
 			if !continueOnError {
 				return nil, err
@@ -167,7 +167,7 @@ func setEndDevice(device *ttnpb.EndDevice, isPaths, nsPaths, asPaths, jsPaths []
 	res.SetFields(device, "ids", "created_at", "updated_at")
 
 	if len(isPaths) > 0 || isCreate {
-		is, err := api.Dial(ctx, config.IdentityServerAddress)
+		is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 		if err != nil {
 			return nil, err
 		}
@@ -190,7 +190,7 @@ func setEndDevice(device *ttnpb.EndDevice, isPaths, nsPaths, asPaths, jsPaths []
 	}
 
 	if len(jsPaths) > 0 {
-		js, err := api.Dial(ctx, config.JoinServerAddress)
+		js, err := api.Dial(ctx, config.JoinServerGRPCAddress)
 		if err != nil {
 			return nil, err
 		}
@@ -213,7 +213,7 @@ func setEndDevice(device *ttnpb.EndDevice, isPaths, nsPaths, asPaths, jsPaths []
 	}
 
 	if len(nsPaths) > 0 || isCreate {
-		ns, err := api.Dial(ctx, config.NetworkServerAddress)
+		ns, err := api.Dial(ctx, config.NetworkServerGRPCAddress)
 		if err != nil {
 			return nil, err
 		}
@@ -236,7 +236,7 @@ func setEndDevice(device *ttnpb.EndDevice, isPaths, nsPaths, asPaths, jsPaths []
 	}
 
 	if len(asPaths) > 0 || isCreate {
-		as, err := api.Dial(ctx, config.ApplicationServerAddress)
+		as, err := api.Dial(ctx, config.ApplicationServerGRPCAddress)
 		if err != nil {
 			return nil, err
 		}
@@ -262,7 +262,7 @@ func setEndDevice(device *ttnpb.EndDevice, isPaths, nsPaths, asPaths, jsPaths []
 }
 
 func deleteEndDevice(ctx context.Context, devID *ttnpb.EndDeviceIdentifiers) error {
-	as, err := api.Dial(ctx, config.ApplicationServerAddress)
+	as, err := api.Dial(ctx, config.ApplicationServerGRPCAddress)
 	if err != nil {
 		return err
 	}
@@ -273,7 +273,7 @@ func deleteEndDevice(ctx context.Context, devID *ttnpb.EndDeviceIdentifiers) err
 		return err
 	}
 
-	ns, err := api.Dial(ctx, config.NetworkServerAddress)
+	ns, err := api.Dial(ctx, config.NetworkServerGRPCAddress)
 	if err != nil {
 		return err
 	}
@@ -285,7 +285,7 @@ func deleteEndDevice(ctx context.Context, devID *ttnpb.EndDeviceIdentifiers) err
 	}
 
 	if devID.JoinEUI != nil && devID.DevEUI != nil {
-		js, err := api.Dial(ctx, config.JoinServerAddress)
+		js, err := api.Dial(ctx, config.JoinServerGRPCAddress)
 		if err != nil {
 			return err
 		}
@@ -297,7 +297,7 @@ func deleteEndDevice(ctx context.Context, devID *ttnpb.EndDeviceIdentifiers) err
 		}
 	}
 
-	is, err := api.Dial(ctx, config.IdentityServerAddress)
+	is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 	if err != nil {
 		return err
 	}

--- a/cmd/ttn-lw-cli/commands/events.go
+++ b/cmd/ttn-lw-cli/commands/events.go
@@ -33,11 +33,11 @@ var eventsCommand = &cobra.Command{
 		var wg sync.WaitGroup
 
 		addresses := make(map[string]bool)
-		addresses[config.IdentityServerAddress] = true
-		addresses[config.GatewayServerAddress] = true
-		addresses[config.NetworkServerAddress] = true
-		addresses[config.ApplicationServerAddress] = true
-		addresses[config.JoinServerAddress] = true
+		addresses[config.IdentityServerGRPCAddress] = true
+		addresses[config.GatewayServerGRPCAddress] = true
+		addresses[config.NetworkServerGRPCAddress] = true
+		addresses[config.ApplicationServerGRPCAddress] = true
+		addresses[config.JoinServerGRPCAddress] = true
 
 		ids := getCombinedIdentifiers(cmd.Flags())
 		if len(ids.GetEntityIdentifiers()) == 0 {

--- a/cmd/ttn-lw-cli/commands/gateways.go
+++ b/cmd/ttn-lw-cli/commands/gateways.go
@@ -85,7 +85,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			paths := util.SelectFieldMask(cmd.Flags(), selectGatewayFlags)
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -109,7 +109,7 @@ var (
 			req := getSearchEntitiesRequest(cmd.Flags())
 			req.FieldMask.Paths = paths
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -132,7 +132,7 @@ var (
 			}
 			paths := util.SelectFieldMask(cmd.Flags(), selectGatewayFlags)
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -202,7 +202,7 @@ var (
 			}
 			gateway.Antennas = []ttnpb.GatewayAntenna{antenna}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -240,7 +240,7 @@ var (
 			gateway.Attributes = mergeAttributes(gateway.Attributes, cmd.Flags())
 			gateway.GatewayIdentifiers = *gtwID
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -294,7 +294,7 @@ var (
 				return err
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -315,7 +315,7 @@ var (
 				return err
 			}
 
-			gs, err := api.Dial(ctx, config.GatewayServerAddress)
+			gs, err := api.Dial(ctx, config.GatewayServerGRPCAddress)
 			if err != nil {
 				return err
 			}

--- a/cmd/ttn-lw-cli/commands/gateways_access.go
+++ b/cmd/ttn-lw-cli/commands/gateways_access.go
@@ -34,7 +34,7 @@ var (
 				return err
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -61,7 +61,7 @@ var (
 				return err
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -90,7 +90,7 @@ var (
 				return errNoCollaboratorRights
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -122,7 +122,7 @@ var (
 				return errNoCollaborator
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -155,7 +155,7 @@ var (
 				return err
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -183,7 +183,7 @@ var (
 				return errNoAPIKeyRights
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -224,7 +224,7 @@ var (
 				return errNoAPIKeyRights
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -257,7 +257,7 @@ var (
 				return err
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}

--- a/cmd/ttn-lw-cli/commands/login.go
+++ b/cmd/ttn-lw-cli/commands/login.go
@@ -125,7 +125,7 @@ var (
 		Short: "Logout",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if token, ok := cache.Get("oauth_token").(*oauth2.Token); ok && token != nil {
-				is, err := api.Dial(ctx, config.IdentityServerAddress)
+				is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 				if err != nil {
 					return err
 				}

--- a/cmd/ttn-lw-cli/commands/organizations.go
+++ b/cmd/ttn-lw-cli/commands/organizations.go
@@ -69,7 +69,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			paths := util.SelectFieldMask(cmd.Flags(), selectOrganizationFlags)
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -93,7 +93,7 @@ var (
 			req := getSearchEntitiesRequest(cmd.Flags())
 			req.FieldMask.Paths = paths
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -116,7 +116,7 @@ var (
 			}
 			paths := util.SelectFieldMask(cmd.Flags(), selectOrganizationFlags)
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -159,7 +159,7 @@ var (
 				return errNoOrganizationID
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -195,7 +195,7 @@ var (
 			organization.Attributes = mergeAttributes(organization.Attributes, cmd.Flags())
 			organization.OrganizationIdentifiers = *orgID
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -220,7 +220,7 @@ var (
 				return errNoOrganizationID
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}

--- a/cmd/ttn-lw-cli/commands/organizations_access.go
+++ b/cmd/ttn-lw-cli/commands/organizations_access.go
@@ -34,7 +34,7 @@ var (
 				return errNoOrganizationID
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -61,7 +61,7 @@ var (
 				return errNoOrganizationID
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -90,7 +90,7 @@ var (
 				return errNoCollaboratorRights
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -122,7 +122,7 @@ var (
 				return errNoCollaborator
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -155,7 +155,7 @@ var (
 				return errNoOrganizationID
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -183,7 +183,7 @@ var (
 				return errNoAPIKeyRights
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -224,7 +224,7 @@ var (
 				return errNoAPIKeyRights
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -257,7 +257,7 @@ var (
 				return errNoOrganizationID
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}

--- a/cmd/ttn-lw-cli/commands/users.go
+++ b/cmd/ttn-lw-cli/commands/users.go
@@ -75,7 +75,7 @@ var (
 			req := getSearchEntitiesRequest(cmd.Flags())
 			req.FieldMask.Paths = paths
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -98,7 +98,7 @@ var (
 			}
 			paths := util.SelectFieldMask(cmd.Flags(), selectUserFlags)
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -160,7 +160,7 @@ var (
 				}
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -202,7 +202,7 @@ var (
 				paths = append(paths, "profile_picture")
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -229,7 +229,7 @@ var (
 
 			usrID.Email, _ = cmd.Flags().GetString("email")
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -268,7 +268,7 @@ var (
 				new = string(pw)
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -293,7 +293,7 @@ var (
 				return errNoUserID
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}

--- a/cmd/ttn-lw-cli/commands/users_access.go
+++ b/cmd/ttn-lw-cli/commands/users_access.go
@@ -34,7 +34,7 @@ var (
 				return errNoUserID
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -61,7 +61,7 @@ var (
 				return errNoUserID
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -89,7 +89,7 @@ var (
 				return errNoAPIKeyRights
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -130,7 +130,7 @@ var (
 				return errNoAPIKeyRights
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -163,7 +163,7 @@ var (
 				return errNoUserID
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}

--- a/cmd/ttn-lw-cli/commands/users_invitations.go
+++ b/cmd/ttn-lw-cli/commands/users_invitations.go
@@ -51,7 +51,7 @@ var (
 		Aliases: []string{"ls"},
 		Short:   "List user invitations",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -70,7 +70,7 @@ var (
 			if email == "" {
 				return errNoEmail
 			}
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -91,7 +91,7 @@ var (
 			if email == "" {
 				return errNoEmail
 			}
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}

--- a/cmd/ttn-lw-cli/commands/users_oauth.go
+++ b/cmd/ttn-lw-cli/commands/users_oauth.go
@@ -67,7 +67,7 @@ var (
 				return errNoUserID
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -90,7 +90,7 @@ var (
 				return errNoClientID
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -135,7 +135,7 @@ var (
 				return errNoClientID
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}
@@ -163,7 +163,7 @@ var (
 				return errNoTokenID
 			}
 
-			is, err := api.Dial(ctx, config.IdentityServerAddress)
+			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err
 			}

--- a/config/messages.json
+++ b/config/messages.json
@@ -1124,6 +1124,15 @@
       "file": "errors.go"
     }
   },
+  "error:cmd/ttn-lw-cli/commands:address_mismatch": {
+    "translations": {
+      "en": "server address mismatch"
+    },
+    "description": {
+      "package": "cmd/ttn-lw-cli/commands",
+      "file": "end_devices.go"
+    }
+  },
   "error:cmd/ttn-lw-cli/commands:antenna_index": {
     "translations": {
       "en": "index of antenna to update out of bounds"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR closes #145 by adding `-grpc` to the CLI's configuration flags for the NS/AS/JS address (so `--application-server-grpc-address` for example).

**Changes:**
<!-- What are the changes made in this pull request? -->

- Add "GRPC" to the field names for the CLI's NS/AS/JS address config.

Additional changes in EndDevice handling related to addresses and specifically the JS address:

1. Store only the "host" part of the addresses, not the scheme (`http(s)://`) or port (`80`/`443`/`1884`/`8884`/`1885`/`8885`)
2. Compare only the "host" part of the addresses
3. Don't register `join_server_address` if the EndDevice is an ABP device
4. Don't call the JS if there is no `join_server_address` registered
5. Warn about address mismatches in Get command
6. Return error on address mismatches in Update and Delete commands

**Notes for Reviewers:**
<!--
Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

cc to @kschiffer and @bafonins because I'm not sure what the console does with these addresses. Knowing what the CLI does might help you determine the behavior of the console.

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Changed the NS/AS/JS address config flags and environment variables for ttn-lw-cli; they now end with `-grpc-address`/`_GRPC_ADDRESS`.
- Changed how the CLI stores the NS/AS/JS addresses of EndDevices