### PR TITLE
Fix class C downlink on new session

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -2330,6 +2330,24 @@
       "file": "errors.go"
     }
   },
+  "error:pkg/encoding/lorawan:mac_command_downlink": {
+    "translations": {
+      "en": "invalid downlink MAC command CID `{cid}`"
+    },
+    "description": {
+      "package": "pkg/encoding/lorawan",
+      "file": "mac.go"
+    }
+  },
+  "error:pkg/encoding/lorawan:mac_command_uplink": {
+    "translations": {
+      "en": "invalid uplink MAC command CID `{cid}`"
+    },
+    "description": {
+      "package": "pkg/encoding/lorawan",
+      "file": "mac.go"
+    }
+  },
   "error:pkg/encoding/lorawan:max_cflist_frequency": {
     "translations": {
       "en": "expected CFList frequency to be less or equal to 0xFFFFFF"
@@ -2339,15 +2357,6 @@
       "file": "messages.go"
     }
   },
-  "error:pkg/encoding/lorawan:unknown_cmd": {
-    "translations": {
-      "en": "unknown MAC command CID `{cid}`"
-    },
-    "description": {
-      "package": "pkg/encoding/lorawan",
-      "file": "mac.go"
-    }
-  },
   "error:pkg/encoding/lorawan:unknown_field": {
     "translations": {
       "en": "unknown `{lorawan_field}`"
@@ -2355,6 +2364,15 @@
     "description": {
       "package": "pkg/encoding/lorawan",
       "file": "errors.go"
+    }
+  },
+  "error:pkg/encoding/lorawan:unknown_mac_command": {
+    "translations": {
+      "en": "unknown MAC command CID `{cid}`"
+    },
+    "description": {
+      "package": "pkg/encoding/lorawan",
+      "file": "mac.go"
     }
   },
   "error:pkg/errors/web:http": {

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -263,7 +263,7 @@ func (as *ApplicationServer) downlinkQueueOp(ctx context.Context, ids ttnpb.EndD
 				encryptedItem := *item
 				encryptedItem.SessionKeyID = session.SessionKeyID
 				encryptedItem.FCnt = session.LastAFCntDown + 1
-				if err := as.encodeAndEncrypt(ctx, dev, &encryptedItem, link.DefaultFormatters); err != nil {
+				if err := as.encodeAndEncrypt(ctx, dev, session, &encryptedItem, link.DefaultFormatters); err != nil {
 					logger.WithError(err).Warn("Dropping downlink message; encoding and encryption failed")
 					return nil, nil, err
 				}

--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -652,6 +652,45 @@ hardware_versions:
 						},
 					},
 					{
+						Name: "RegisteredDevice/UplinkMessage/PendingSession",
+						IDs:  registeredDevice.EndDeviceIdentifiers,
+						Message: &ttnpb.ApplicationUp{
+							EndDeviceIdentifiers: withDevAddr(registeredDevice.EndDeviceIdentifiers, types.DevAddr{0x22, 0x22, 0x22, 0x22}),
+							Up: &ttnpb.ApplicationUp_UplinkMessage{
+								UplinkMessage: &ttnpb.ApplicationUplink{
+									SessionKeyID: []byte{0x22},
+									FPort:        22,
+									FCnt:         22,
+									FRMPayload:   []byte{0x01},
+								},
+							},
+						},
+						AssertUp: func(t *testing.T, up *ttnpb.ApplicationUp) {
+							a := assertions.New(t)
+							a.So(up, should.Resemble, &ttnpb.ApplicationUp{
+								EndDeviceIdentifiers: withDevAddr(registeredDevice.EndDeviceIdentifiers, types.DevAddr{0x22, 0x22, 0x22, 0x22}),
+								Up: &ttnpb.ApplicationUp_UplinkMessage{
+									UplinkMessage: &ttnpb.ApplicationUplink{
+										SessionKeyID: []byte{0x22},
+										FPort:        22,
+										FCnt:         22,
+										FRMPayload:   []byte{0xc1},
+										DecodedPayload: &pbtypes.Struct{
+											Fields: map[string]*pbtypes.Value{
+												"sum": {
+													Kind: &pbtypes.Value_NumberValue{
+														NumberValue: 193, // Payload formatter sums the bytes in FRMPayload.
+													},
+												},
+											},
+										},
+									},
+								},
+								CorrelationIDs: up.CorrelationIDs,
+							})
+						},
+					},
+					{
 						Name: "RegisteredDevice/JoinAccept/WithAppSKey/WithQueue",
 						IDs:  registeredDevice.EndDeviceIdentifiers,
 						Message: &ttnpb.ApplicationUp{
@@ -663,6 +702,20 @@ hardware_versions:
 										// AppSKey is []byte{0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33}
 										Key:      []byte{0x5, 0x81, 0xe1, 0x15, 0x8a, 0xc3, 0x13, 0x68, 0x5e, 0x8d, 0x15, 0xc0, 0x11, 0x92, 0x14, 0x49, 0x9f, 0xa0, 0xc6, 0xf1, 0xdb, 0x95, 0xff, 0xbd},
 										KEKLabel: "test",
+									},
+									InvalidatedDownlinks: []*ttnpb.ApplicationDownlink{
+										{
+											SessionKeyID: []byte{0x22},
+											FPort:        11,
+											FCnt:         11,
+											FRMPayload:   []byte{0x69, 0x65, 0x9f, 0x8f},
+										},
+										{
+											SessionKeyID: []byte{0x22},
+											FPort:        22,
+											FCnt:         22,
+											FRMPayload:   []byte{0xb, 0x8f, 0x94, 0xe6},
+										},
 									},
 								},
 							},
@@ -681,7 +734,18 @@ hardware_versions:
 						},
 						AssertDevice: func(t *testing.T, dev *ttnpb.EndDevice, queue []*ttnpb.ApplicationDownlink) {
 							a := assertions.New(t)
-							a.So(dev.Session, should.BeNil)
+							a.So(dev.Session, should.Resemble, &ttnpb.Session{
+								DevAddr: types.DevAddr{0x22, 0x22, 0x22, 0x22},
+								SessionKeys: ttnpb.SessionKeys{
+									SessionKeyID: []byte{0x22},
+									AppSKey: &ttnpb.KeyEnvelope{
+										Key:      []byte{0x39, 0x11, 0x40, 0x98, 0xa1, 0x5d, 0x6f, 0x92, 0xd7, 0xf0, 0x13, 0x21, 0x5b, 0x5b, 0x41, 0xa8, 0x98, 0x2d, 0xac, 0x59, 0x34, 0x76, 0x36, 0x18},
+										KEKLabel: "test",
+									},
+								},
+								LastAFCntDown: 2,
+								StartedAt:     dev.Session.StartedAt,
+							})
 							a.So(dev.PendingSession, should.Resemble, &ttnpb.Session{
 								DevAddr: types.DevAddr{0x33, 0x33, 0x33, 0x33},
 								SessionKeys: ttnpb.SessionKeys{
@@ -694,7 +758,20 @@ hardware_versions:
 								LastAFCntDown: 0,
 								StartedAt:     dev.PendingSession.StartedAt,
 							})
-							a.So(queue, should.BeEmpty)
+							a.So(queue, should.Resemble, []*ttnpb.ApplicationDownlink{
+								{
+									SessionKeyID: []byte{0x22},
+									FPort:        11,
+									FCnt:         1,
+									FRMPayload:   []byte{0x1, 0x1, 0x1, 0x1},
+								},
+								{
+									SessionKeyID: []byte{0x22},
+									FPort:        22,
+									FCnt:         2,
+									FRMPayload:   []byte{0x2, 0x2, 0x2, 0x2},
+								},
+							})
 						},
 					},
 					{

--- a/pkg/encoding/lorawan/mac.go
+++ b/pkg/encoding/lorawan/mac.go
@@ -56,7 +56,6 @@ func newMACUnmarshaler(cid ttnpb.MACCommandIdentifier, name string, n uint8, f f
 			return nil
 		}
 		return f(b, cmd)
-
 	}
 }
 
@@ -335,7 +334,7 @@ var DefaultMACCommands = MACCommandSpec{
 		AppendDownlink: func(b []byte, _ ttnpb.MACCommand) ([]byte, error) {
 			return b, nil
 		},
-		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_DEV_STATUS, "NewChannelReq", 0, nil),
+		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_DEV_STATUS, "DevStatusReq", 0, nil),
 	},
 
 	ttnpb.CID_NEW_CHANNEL: &MACCommandDescriptor{
@@ -625,12 +624,6 @@ var DefaultMACCommands = MACCommandSpec{
 
 	ttnpb.CID_FORCE_REJOIN: &MACCommandDescriptor{
 		InitiatedByDevice: false,
-
-		UplinkLength: 0,
-		AppendUplink: func(b []byte, _ ttnpb.MACCommand) ([]byte, error) {
-			return b, nil
-		},
-		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_FORCE_REJOIN, "ForceRejoinAns", 0, nil),
 
 		DownlinkLength: 2,
 		AppendDownlink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
@@ -980,21 +973,31 @@ func (spec MACCommandSpec) ReadDownlink(r io.Reader, cmd *ttnpb.MACCommand) erro
 	return spec.read(r, false, cmd)
 }
 
-var errEncodingMACCommand = errors.DefineInvalidArgument("encoding_mac_command", "could not encode MAC command with CID `{cid}`")
-var errUnknownCID = errors.DefineInvalidArgument("unknown_cmd", "unknown MAC command CID `{cid}`")
+var (
+	errEncodingMACCommand = errors.DefineInvalidArgument("encoding_mac_command", "could not encode MAC command with CID `{cid}`")
+	errUnknownMACCommand  = errors.DefineInvalidArgument("unknown_mac_command", "unknown MAC command CID `{cid}`")
+	errMACCommandUplink   = errors.DefineInvalidArgument("mac_command_uplink", "invalid uplink MAC command CID `{cid}`")
+	errMACCommandDownlink = errors.DefineInvalidArgument("mac_command_downlink", "invalid downlink MAC command CID `{cid}`")
+)
 
 func (spec MACCommandSpec) append(b []byte, isUplink bool, cmd ttnpb.MACCommand) ([]byte, error) {
 	desc, ok := spec[cmd.CID]
 	if !ok || desc == nil {
-		return nil, errUnknownCID.WithAttributes("cid", fmt.Sprintf("0x%X", int32(cmd.CID)))
+		return nil, errUnknownMACCommand.WithAttributes("cid", fmt.Sprintf("0x%X", int32(cmd.CID)))
 	}
 	b = append(b, byte(cmd.CID))
 
 	var appender func(b []byte, cmd ttnpb.MACCommand) ([]byte, error)
 	if isUplink {
 		appender = desc.AppendUplink
+		if appender == nil {
+			return nil, errMACCommandUplink.WithAttributes("cid", fmt.Sprintf("0x%X", int32(cmd.CID)))
+		}
 	} else {
 		appender = desc.AppendDownlink
+		if appender == nil {
+			return nil, errMACCommandDownlink.WithAttributes("cid", fmt.Sprintf("0x%X", int32(cmd.CID)))
+		}
 	}
 
 	b, err := appender(b, cmd)

--- a/pkg/encoding/lorawan/mac.go
+++ b/pkg/encoding/lorawan/mac.go
@@ -35,6 +35,7 @@ const maxGPSTime int64 = 1<<32 - 1
 // MACCommandDescriptor descibes a MAC command.
 type MACCommandDescriptor struct {
 	InitiatedByDevice bool
+	ExpectAnswer      bool
 	UplinkLength      uint16
 	DownlinkLength    uint16
 	AppendUplink      func(b []byte, cmd ttnpb.MACCommand) ([]byte, error)
@@ -63,6 +64,7 @@ func newMACUnmarshaler(cid ttnpb.MACCommandIdentifier, name string, n uint8, f f
 var DefaultMACCommands = MACCommandSpec{
 	ttnpb.CID_RESET: &MACCommandDescriptor{
 		InitiatedByDevice: true,
+		ExpectAnswer:      true,
 
 		UplinkLength: 1,
 		AppendUplink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
@@ -103,6 +105,7 @@ var DefaultMACCommands = MACCommandSpec{
 
 	ttnpb.CID_LINK_CHECK: &MACCommandDescriptor{
 		InitiatedByDevice: true,
+		ExpectAnswer:      true,
 
 		UplinkLength: 0,
 		AppendUplink: func(b []byte, _ ttnpb.MACCommand) ([]byte, error) {
@@ -135,6 +138,7 @@ var DefaultMACCommands = MACCommandSpec{
 
 	ttnpb.CID_LINK_ADR: &MACCommandDescriptor{
 		InitiatedByDevice: false,
+		ExpectAnswer:      true,
 
 		UplinkLength: 1,
 		AppendUplink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
@@ -212,6 +216,7 @@ var DefaultMACCommands = MACCommandSpec{
 
 	ttnpb.CID_DUTY_CYCLE: &MACCommandDescriptor{
 		InitiatedByDevice: false,
+		ExpectAnswer:      true,
 
 		UplinkLength: 0,
 		AppendUplink: func(b []byte, _ ttnpb.MACCommand) ([]byte, error) {
@@ -240,6 +245,7 @@ var DefaultMACCommands = MACCommandSpec{
 
 	ttnpb.CID_RX_PARAM_SETUP: &MACCommandDescriptor{
 		InitiatedByDevice: false,
+		ExpectAnswer:      true,
 
 		UplinkLength: 1,
 		AppendUplink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
@@ -298,6 +304,7 @@ var DefaultMACCommands = MACCommandSpec{
 
 	ttnpb.CID_DEV_STATUS: &MACCommandDescriptor{
 		InitiatedByDevice: false,
+		ExpectAnswer:      true,
 
 		UplinkLength: 2,
 		AppendUplink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
@@ -339,6 +346,7 @@ var DefaultMACCommands = MACCommandSpec{
 
 	ttnpb.CID_NEW_CHANNEL: &MACCommandDescriptor{
 		InitiatedByDevice: false,
+		ExpectAnswer:      true,
 
 		UplinkLength: 1,
 		AppendUplink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
@@ -403,6 +411,7 @@ var DefaultMACCommands = MACCommandSpec{
 
 	ttnpb.CID_RX_TIMING_SETUP: &MACCommandDescriptor{
 		InitiatedByDevice: false,
+		ExpectAnswer:      true,
 
 		UplinkLength: 0,
 		AppendUplink: func(b []byte, _ ttnpb.MACCommand) ([]byte, error) {
@@ -431,6 +440,7 @@ var DefaultMACCommands = MACCommandSpec{
 
 	ttnpb.CID_TX_PARAM_SETUP: &MACCommandDescriptor{
 		InitiatedByDevice: false,
+		ExpectAnswer:      true,
 
 		UplinkLength: 0,
 		AppendUplink: func(b []byte, _ ttnpb.MACCommand) ([]byte, error) {
@@ -466,6 +476,7 @@ var DefaultMACCommands = MACCommandSpec{
 
 	ttnpb.CID_DL_CHANNEL: &MACCommandDescriptor{
 		InitiatedByDevice: false,
+		ExpectAnswer:      true,
 
 		UplinkLength: 1,
 		AppendUplink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
@@ -517,6 +528,7 @@ var DefaultMACCommands = MACCommandSpec{
 
 	ttnpb.CID_REKEY: &MACCommandDescriptor{
 		InitiatedByDevice: true,
+		ExpectAnswer:      true,
 
 		UplinkLength: 1,
 		AppendUplink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
@@ -557,6 +569,7 @@ var DefaultMACCommands = MACCommandSpec{
 
 	ttnpb.CID_ADR_PARAM_SETUP: &MACCommandDescriptor{
 		InitiatedByDevice: false,
+		ExpectAnswer:      true,
 
 		UplinkLength: 0,
 		AppendUplink: func(b []byte, _ ttnpb.MACCommand) ([]byte, error) {
@@ -593,6 +606,7 @@ var DefaultMACCommands = MACCommandSpec{
 
 	ttnpb.CID_DEVICE_TIME: &MACCommandDescriptor{
 		InitiatedByDevice: true,
+		ExpectAnswer:      true,
 
 		UplinkLength: 0,
 		AppendUplink: func(b []byte, _ ttnpb.MACCommand) ([]byte, error) {
@@ -624,6 +638,7 @@ var DefaultMACCommands = MACCommandSpec{
 
 	ttnpb.CID_FORCE_REJOIN: &MACCommandDescriptor{
 		InitiatedByDevice: false,
+		ExpectAnswer:      false,
 
 		DownlinkLength: 2,
 		AppendDownlink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
@@ -669,6 +684,7 @@ var DefaultMACCommands = MACCommandSpec{
 
 	ttnpb.CID_REJOIN_PARAM_SETUP: &MACCommandDescriptor{
 		InitiatedByDevice: false,
+		ExpectAnswer:      true,
 
 		UplinkLength: 1,
 		AppendUplink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
@@ -719,6 +735,7 @@ var DefaultMACCommands = MACCommandSpec{
 
 	ttnpb.CID_PING_SLOT_INFO: &MACCommandDescriptor{
 		InitiatedByDevice: false,
+		ExpectAnswer:      true,
 
 		UplinkLength: 1,
 		AppendUplink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
@@ -748,6 +765,7 @@ var DefaultMACCommands = MACCommandSpec{
 
 	ttnpb.CID_PING_SLOT_CHANNEL: &MACCommandDescriptor{
 		InitiatedByDevice: false,
+		ExpectAnswer:      true,
 
 		UplinkLength: 1,
 		AppendUplink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
@@ -801,6 +819,7 @@ var DefaultMACCommands = MACCommandSpec{
 
 	ttnpb.CID_BEACON_TIMING: &MACCommandDescriptor{
 		InitiatedByDevice: false,
+		ExpectAnswer:      true,
 
 		UplinkLength: 0,
 		AppendUplink: func(b []byte, _ ttnpb.MACCommand) ([]byte, error) {
@@ -837,6 +856,7 @@ var DefaultMACCommands = MACCommandSpec{
 
 	ttnpb.CID_BEACON_FREQ: &MACCommandDescriptor{
 		InitiatedByDevice: false,
+		ExpectAnswer:      true,
 
 		UplinkLength: 1,
 		AppendUplink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
@@ -878,6 +898,7 @@ var DefaultMACCommands = MACCommandSpec{
 
 	ttnpb.CID_DEVICE_MODE: &MACCommandDescriptor{
 		InitiatedByDevice: false,
+		ExpectAnswer:      true,
 
 		UplinkLength: 1,
 		AppendUplink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -249,12 +249,6 @@ func (c *Connection) SendDown(path *ttnpb.DownlinkPath, msg *ttnpb.DownlinkMessa
 				delay:         time.Second,
 			},
 		} {
-			logger := logger.WithFields(log.Fields(
-				"rx_window", i+1,
-				"frequency", rx.frequency,
-				"data_rate", rx.dataRateIndex,
-			))
-			logger.Debug("Attempting to schedule downlink in receive window")
 			rx1Delay := time.Duration(request.Rx1Delay) * time.Second
 			if rx1Delay == 0 {
 				rx1Delay = time.Second // RX_DELAY_0 is valid, and 1 second.
@@ -264,6 +258,12 @@ func (c *Connection) SendDown(path *ttnpb.DownlinkPath, msg *ttnpb.DownlinkMessa
 				errRxDetails = append(errRxDetails, errRxEmpty)
 				continue
 			}
+			logger := logger.WithFields(log.Fields(
+				"rx_window", i+1,
+				"frequency", rx.frequency,
+				"data_rate_index", rx.dataRateIndex,
+			))
+			logger.Debug("Attempting to schedule downlink in receive window")
 			dataRate := band.DataRates[rx.dataRateIndex].Rate
 			if dataRate == (ttnpb.DataRate{}) {
 				return 0, errDataRate.WithAttributes("index", rx.dataRateIndex)
@@ -333,6 +333,7 @@ func (c *Connection) SendDown(path *ttnpb.DownlinkPath, msg *ttnpb.DownlinkMessa
 			logger.WithFields(log.Fields(
 				"starts", em.Starts(),
 				"duration", em.Duration(),
+				"raw_payload", msg.RawPayload,
 			)).Debug("Scheduled downlink")
 			break
 		}

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -376,6 +376,24 @@ func downlinkPathsFromMetadata(mds ...*ttnpb.RxMetadata) []downlinkPath {
 	return append(head, tail...)
 }
 
+// downlinkPathsForClassA returns the last paths, if any, of the given uplink messages.
+// This function returns whether class A downlink can be made in either window considering the given Rx delay.
+func downlinkPathsForClassA(rxDelay ttnpb.RxDelay, ups ...*ttnpb.UplinkMessage) (rx1, rx2 bool, paths []downlinkPath) {
+	if rxDelay == ttnpb.RX_DELAY_0 {
+		rxDelay = ttnpb.RX_DELAY_1
+	}
+	maxDelta := time.Duration(rxDelay) * time.Second
+	for i := len(ups) - 1; i >= 0; i-- {
+		up := ups[i]
+		delta := time.Now().Sub(up.ReceivedAt)
+		rx1, rx2 := delta < maxDelta, delta < maxDelta+time.Second
+		if paths := downlinkPathsFromMetadata(up.RxMetadata...); len(paths) > 0 {
+			return rx1, rx2, paths
+		}
+	}
+	return false, false, nil
+}
+
 func downlinkPathsFromRecentUplinks(ups ...*ttnpb.UplinkMessage) []downlinkPath {
 	for i := len(ups) - 1; i >= 0; i-- {
 		if paths := downlinkPathsFromMetadata(ups[i].RxMetadata...); len(paths) > 0 {
@@ -560,30 +578,39 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 						dev.MACState.CurrentParameters.Channels[int(rx1ChIdx)].DownlinkFrequency == 0 {
 						return nil, nil, errCorruptedMACState
 					}
-
 					rx1DRIdx, err := band.Rx1DataRate(up.Settings.DataRateIndex, dev.MACState.CurrentParameters.Rx1DataRateOffset, dev.MACState.CurrentParameters.DownlinkDwellTime)
 					if err != nil {
 						return nil, nil, err
 					}
+					rx1Freq := dev.MACState.CurrentParameters.Channels[int(rx1ChIdx)].DownlinkFrequency
 
 					req := &ttnpb.TxRequest{
-						Class:            ttnpb.CLASS_A,
-						Rx1Delay:         dev.MACState.CurrentParameters.Rx1Delay,
-						Rx1Frequency:     dev.MACState.CurrentParameters.Channels[int(rx1ChIdx)].DownlinkFrequency,
-						Rx1DataRateIndex: rx1DRIdx,
+						Class: ttnpb.CLASS_A,
 					}
-
 					switch {
 					case dev.MACState.QueuedJoinAccept != nil:
 						// Join-accept downlink for Class A/B/C in Rx1/Rx2
 						req.Rx1Delay = ttnpb.RxDelay(band.JoinAcceptDelay1 / time.Second)
-						req.Rx2DataRateIndex = dev.MACState.CurrentParameters.Rx2DataRateIndex
-						req.Rx2Frequency = dev.MACState.CurrentParameters.Rx2Frequency
+						rx1, rx2, paths := downlinkPathsForClassA(
+							ttnpb.RxDelay(band.JoinAcceptDelay1/time.Second),
+							dev.RecentUplinks...,
+						)
+						if rx1 {
+							req.Rx1Frequency = rx1Freq
+							req.Rx1DataRateIndex = rx1DRIdx
+						}
+						if rx2 {
+							req.Rx2Frequency = dev.MACState.CurrentParameters.Rx2Frequency
+							req.Rx2DataRateIndex = dev.MACState.CurrentParameters.Rx2DataRateIndex
+						}
+						if !rx1 && !rx2 {
+							return nil, nil, errNoPath
+						}
 
 						down, _, err := ns.scheduleDownlinkByPaths(
 							log.NewContext(ctx, logger.WithFields(log.Fields(
-								"attempt_rx1", true,
-								"attempt_rx2", true,
+								"attempt_rx1", rx1,
+								"attempt_rx2", rx2,
 								"downlink_class", req.Class,
 								"downlink_type", "join-accept",
 								"rx1_delay", req.Rx1Delay,
@@ -594,7 +621,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 							req,
 							dev.EndDeviceIdentifiers,
 							dev.MACState.QueuedJoinAccept.Payload,
-							downlinkPathsFromRecentUplinks(dev.RecentUplinks...)...,
+							paths...,
 						)
 						if err != nil {
 							scheduleErr = true
@@ -622,8 +649,23 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 
 					case dev.MACState.DeviceClass == ttnpb.CLASS_A:
 						// Data downlink for Class A in Rx1/Rx2
-						req.Rx2DataRateIndex = dev.MACState.CurrentParameters.Rx2DataRateIndex
-						req.Rx2Frequency = dev.MACState.CurrentParameters.Rx2Frequency
+						req.Rx1Delay = dev.MACState.CurrentParameters.Rx1Delay
+						rx1, rx2, paths := downlinkPathsForClassA(
+							dev.MACState.CurrentParameters.Rx1Delay,
+							dev.RecentUplinks...,
+						)
+						if rx1 {
+							req.Rx1Frequency = rx1Freq
+							req.Rx1DataRateIndex = rx1DRIdx
+						}
+						if rx2 {
+							req.Rx2Frequency = dev.MACState.CurrentParameters.Rx2Frequency
+							req.Rx2DataRateIndex = dev.MACState.CurrentParameters.Rx2DataRateIndex
+						}
+						if !rx1 && !rx2 {
+							return nil, nil, errNoPath
+						}
+
 						minDR := req.Rx1DataRateIndex
 						if req.Rx2DataRateIndex < minDR {
 							minDR = req.Rx2DataRateIndex
@@ -641,8 +683,8 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 
 						down, _, err := ns.scheduleDownlinkByPaths(
 							log.NewContext(ctx, logger.WithFields(log.Fields(
-								"attempt_rx1", true,
-								"attempt_rx2", true,
+								"attempt_rx1", rx1,
+								"attempt_rx2", rx2,
 								"downlink_class", req.Class,
 								"downlink_type", "data",
 								"rx1_delay", req.Rx1Delay,
@@ -653,7 +695,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 							req,
 							dev.EndDeviceIdentifiers,
 							genDown.Payload,
-							downlinkPathsFromRecentUplinks(dev.RecentUplinks...)...,
+							paths...,
 						)
 						if err != nil {
 							scheduleErr = true
@@ -676,6 +718,9 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 
 					default:
 						// Data downlink for Class B/C in Rx1
+						req.Rx1Delay = dev.MACState.CurrentParameters.Rx1Delay
+						req.Rx1Frequency = rx1Freq
+						req.Rx1DataRateIndex = rx1DRIdx
 
 						// NOTE: generateDownlink mutates the device, and since we may need to call it twice(Rx1/Rx2),
 						// we need to create a deep copy for the first call.
@@ -720,7 +765,13 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 								})
 							}
 						} else if genDown.ApplicationDownlink == nil || genDown.ApplicationDownlink.ClassBC == nil {
-							paths = downlinkPathsFromRecentUplinks(dev.RecentUplinks...)
+							rx1, _, classAPaths := downlinkPathsForClassA(
+								dev.MACState.CurrentParameters.Rx1Delay,
+								dev.RecentUplinks...,
+							)
+							if rx1 {
+								paths = classAPaths
+							}
 						}
 						// NOTE: We must skip Rx1 if genDown.ApplicationDownlink.ClassBC.AbsoluteTime is set
 

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -163,27 +163,16 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 
 	var needsDownlink bool
 	var up *ttnpb.UplinkMessage
-	if dev.MACState.RxWindowsAvailable {
-	outer:
-		for i := len(dev.RecentUplinks) - 1; i >= 0; i-- {
-			switch dev.RecentUplinks[i].Payload.MHDR.MType {
-			case ttnpb.MType_UNCONFIRMED_UP:
-				up = dev.RecentUplinks[i]
-				if needsDownlink = up.Payload.GetMACPayload().FCtrl.ADRAckReq; needsDownlink {
-					logger.Debug("Need downlink for ADRAckReq")
-				}
-				break outer
-			case ttnpb.MType_CONFIRMED_UP:
-				up = dev.RecentUplinks[i]
-				needsDownlink = true
-				logger.Debug("Need downlink for confirmed uplink")
-				break outer
-			case ttnpb.MType_JOIN_REQUEST, ttnpb.MType_REJOIN_REQUEST:
-				up = dev.RecentUplinks[i]
-				break outer
-			default:
-				logger.WithField("m_type", up.Payload.MHDR.MType).Warn("Unknown MType stored in RecentUplinks")
+	if dev.MACState.RxWindowsAvailable && len(dev.RecentUplinks) > 0 {
+		up = dev.RecentUplinks[len(dev.RecentUplinks)-1]
+		switch up.Payload.MHDR.MType {
+		case ttnpb.MType_UNCONFIRMED_UP:
+			if needsDownlink = up.Payload.GetMACPayload().FCtrl.ADRAckReq; needsDownlink {
+				logger.Debug("Need downlink for ADRAckReq")
 			}
+		case ttnpb.MType_CONFIRMED_UP:
+			needsDownlink = true
+			logger.Debug("Need downlink for confirmed uplink")
 		}
 	}
 	if !needsDownlink &&

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -433,6 +433,7 @@ func (ns *NetworkServer) scheduleDownlinkByPaths(ctx context.Context, req *ttnpb
 			errs = append(errs, err)
 			continue
 		}
+		logger.WithField("delay", res.Delay).Debug("Scheduled downlink")
 		return down, time.Now().Add(res.Delay), nil
 	}
 
@@ -854,9 +855,11 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 			return err
 
 		case err != nil && errors.Resemble(err, errNoDownlink):
+			logger.Debug("No downlink to send, skipping downlink slot...")
 			return nil
 
 		case err != nil && errors.Resemble(err, errScheduleTooSoon):
+			logger.Debug("Downlink scheduled too soon, skipping downlink slot...")
 			break
 
 		case err != nil:
@@ -868,6 +871,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 		if nextDownlinkAt.IsZero() {
 			return nil
 		}
+		logger.WithField("schedule_at", nextDownlinkAt).Debug("Adding device to downlink schedule...")
 		if err := ns.downlinkTasks.Add(ctx, devID, nextDownlinkAt, true); err != nil {
 			addErr = true
 			logger.WithError(err).Error("Failed to add device to downlink schedule")

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -72,13 +72,12 @@ var errNoDownlink = errors.Define("no_downlink", "no downlink to send")
 // For example, a sequence of 'NewChannel' MAC commands could be generated for a
 // device operating in a region where a fixed channel plan is defined in case
 // dev.MACState.CurrentParameters.Channels is not equal to dev.MACState.DesiredParameters.Channels.
-func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16) ([]byte, *ttnpb.ApplicationDownlink, error) {
+func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16) ([]byte, uint32, *ttnpb.ApplicationDownlink, error) {
 	if dev.MACState == nil {
-		return nil, nil, errUnknownMACState
+		return nil, 0, nil, errUnknownMACState
 	}
-
 	if dev.Session == nil {
-		return nil, nil, errEmptySession
+		return nil, 0, nil, errEmptySession
 	}
 
 	ctx = log.NewContextWithField(ctx, "device_uid", unique.ID(ctx, dev.EndDeviceIdentifiers))
@@ -109,7 +108,7 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 
 	maxDownLen, maxUpLen, ok, err := enqueueLinkADRReq(ctx, dev, maxDownLen, maxUpLen, ns.FrequencyPlans)
 	if err != nil {
-		return nil, nil, err
+		return nil, 0, nil, err
 	}
 	fPending := !ok
 	for _, f := range []func(context.Context, *ttnpb.EndDevice, uint16, uint16) (uint16, uint16, bool){
@@ -145,7 +144,7 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 		cmdBuf, err = spec.AppendDownlink(cmdBuf, *cmd)
 
 		if err != nil {
-			return nil, nil, errEncodeMAC.WithCause(err)
+			return nil, 0, nil, errEncodeMAC.WithCause(err)
 		}
 	}
 	logger = logger.WithField("mac_count", len(cmds))
@@ -173,7 +172,7 @@ outer:
 	if !needsDownlink &&
 		len(cmdBuf) == 0 &&
 		len(dev.QueuedApplicationDownlinks) == 0 {
-		return nil, nil, errNoDownlink
+		return nil, 0, nil, errNoDownlink
 	}
 
 	pld := &ttnpb.MACPayload{
@@ -212,7 +211,7 @@ outer:
 			}
 
 			if !needsDownlink && len(cmdBuf) == 0 {
-				return nil, nil, errNoDownlink
+				return nil, 0, nil, errNoDownlink
 			}
 		} else {
 			appDown = down
@@ -235,17 +234,17 @@ outer:
 
 	if len(cmdBuf) > 0 && (pld.FPort == 0 || dev.MACState.LoRaWANVersion.EncryptFOpts()) {
 		if dev.Session.NwkSEncKey == nil || len(dev.Session.NwkSEncKey.Key) == 0 {
-			return nil, nil, errUnknownNwkSEncKey
+			return nil, 0, nil, errUnknownNwkSEncKey
 		}
 		key, err := cryptoutil.UnwrapAES128Key(*dev.Session.NwkSEncKey, ns.KeyVault)
 		if err != nil {
 			logger.WithField("kek_label", dev.Session.NwkSEncKey.KEKLabel).WithError(err).Warn("Failed to unwrap NwkSEncKey")
-			return nil, nil, err
+			return nil, 0, nil, err
 		}
 
 		cmdBuf, err = crypto.EncryptDownlink(key, dev.Session.DevAddr, pld.FHDR.FCnt, cmdBuf)
 		if err != nil {
-			return nil, nil, errEncryptMAC.WithCause(err)
+			return nil, 0, nil, errEncryptMAC.WithCause(err)
 		}
 	}
 
@@ -270,7 +269,7 @@ outer:
 	case dev.MACState.DeviceClass == ttnpb.CLASS_C &&
 		dev.MACState.LastConfirmedDownlinkAt != nil &&
 		dev.MACState.LastConfirmedDownlinkAt.Add(deviceClassCTimeout(dev, ns.defaultMACSettings)).After(time.Now()):
-		return nil, nil, errScheduleTooSoon
+		return nil, 0, nil, errScheduleTooSoon
 
 	default:
 		dev.MACState.LastConfirmedDownlinkAt = timePtr(time.Now().UTC())
@@ -286,17 +285,17 @@ outer:
 		},
 	})
 	if err != nil {
-		return nil, nil, errEncodePayload.WithCause(err)
+		return nil, 0, nil, errEncodePayload.WithCause(err)
 	}
 	// NOTE: It is assumed, that b does not contain MIC.
 
 	if dev.Session.SNwkSIntKey == nil || len(dev.Session.SNwkSIntKey.Key) == 0 {
-		return nil, nil, errUnknownSNwkSIntKey
+		return nil, 0, nil, errUnknownSNwkSIntKey
 	}
 	key, err := cryptoutil.UnwrapAES128Key(*dev.Session.SNwkSIntKey, ns.KeyVault)
 	if err != nil {
 		logger.WithField("kek_label", dev.Session.SNwkSIntKey.KEKLabel).WithError(err).Warn("Failed to unwrap SNwkSIntKey")
-		return nil, nil, err
+		return nil, 0, nil, err
 	}
 
 	var mic [4]byte
@@ -321,12 +320,12 @@ outer:
 		)
 	}
 	if err != nil {
-		return nil, nil, errComputeMIC
+		return nil, 0, nil, errComputeMIC
 	}
 	b = append(b, mic[:]...)
 
 	logger.WithField("payload_length", len(b)).Debug("Generated downlink")
-	return b, appDown, nil
+	return b, pld.FHDR.FCnt, appDown, nil
 }
 
 type downlinkPath struct {
@@ -446,14 +445,14 @@ func (ns *NetworkServer) scheduleDownlinkByPaths(ctx context.Context, req *ttnpb
 	return nil, time.Time{}, errSchedule
 }
 
-func (ns *NetworkServer) sendQueueInvalidationToAS(ctx context.Context, dev *ttnpb.EndDevice) (bool, error) {
+func (ns *NetworkServer) sendQueueInvalidationToAS(ctx context.Context, dev *ttnpb.EndDevice, fCnt uint32) (bool, error) {
 	ok, err := ns.handleASUplink(ctx, dev.EndDeviceIdentifiers.ApplicationIdentifiers, &ttnpb.ApplicationUp{
 		EndDeviceIdentifiers: dev.EndDeviceIdentifiers,
 		CorrelationIDs:       events.CorrelationIDsFromContext(ctx),
 		Up: &ttnpb.ApplicationUp_DownlinkQueueInvalidated{
 			DownlinkQueueInvalidated: &ttnpb.ApplicationInvalidatedDownlinks{
 				Downlinks:    dev.QueuedApplicationDownlinks,
-				LastFCntDown: dev.Session.LastNFCntDown,
+				LastFCntDown: fCnt,
 			},
 		},
 	})
@@ -480,6 +479,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 		ctx = log.NewContext(ctx, logger)
 		logger.Debug("Processing downlink task...")
 
+		var sendInvalidation func() (bool, error)
 		var nextDownlinkAt time.Time
 		_, err := ns.devices.SetByID(ctx, devID.ApplicationIdentifiers, devID.DeviceID,
 			[]string{
@@ -618,7 +618,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 						if req.Rx2DataRateIndex < minDR {
 							minDR = req.Rx2DataRateIndex
 						}
-						b, appDown, err := ns.generateDownlink(ctx, dev,
+						b, fCnt, appDown, err := ns.generateDownlink(ctx, dev,
 							band.DataRates[minDR].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 							maxUpLength,
 						)
@@ -649,7 +649,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 							scheduleErr = true
 						} else {
 							if appDown == nil && len(dev.QueuedApplicationDownlinks) > 0 && dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 {
-								go ns.sendQueueInvalidationToAS(ctx, dev)
+								sendInvalidation = func() (bool, error) { return ns.sendQueueInvalidationToAS(ctx, dev, fCnt) }
 							}
 							dev.MACState.RxWindowsAvailable = false
 							dev.RecentDownlinks = append(dev.RecentDownlinks, down)
@@ -671,7 +671,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 						// we need to create a deep copy for the first call.
 						devCopy := deepcopy.Copy(dev).(*ttnpb.EndDevice)
 
-						b, appDown, err := ns.generateDownlink(ctx, dev,
+						b, fCnt, appDown, err := ns.generateDownlink(ctx, dev,
 							band.DataRates[req.Rx1DataRateIndex].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 							maxUpLength,
 						)
@@ -738,7 +738,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 								}
 
 								if appDown == nil && len(dev.QueuedApplicationDownlinks) > 0 && dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 {
-									go ns.sendQueueInvalidationToAS(ctx, dev)
+									sendInvalidation = func() (bool, error) { return ns.sendQueueInvalidationToAS(ctx, dev, fCnt) }
 								}
 								dev.MACState.RxWindowsAvailable = false
 								dev.RecentDownlinks = append(dev.RecentDownlinks, down)
@@ -770,7 +770,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 						Rx2Frequency:     dev.MACState.CurrentParameters.Rx2Frequency,
 					}
 
-					b, appDown, err := ns.generateDownlink(ctx, dev,
+					b, fCnt, appDown, err := ns.generateDownlink(ctx, dev,
 						band.DataRates[req.Rx2DataRateIndex].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						maxUpLength,
 					)
@@ -833,7 +833,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 						}
 
 						if appDown == nil && len(dev.QueuedApplicationDownlinks) > 0 && dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 {
-							go ns.sendQueueInvalidationToAS(ctx, dev)
+							sendInvalidation = func() (bool, error) { return ns.sendQueueInvalidationToAS(ctx, dev, fCnt) }
 						}
 						dev.RecentDownlinks = append(dev.RecentDownlinks, down)
 						if len(dev.RecentDownlinks) > recentDownlinkCount {
@@ -848,7 +848,8 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 					}
 				}
 				return nil, nil, errSchedule
-			})
+			},
+		)
 
 		switch {
 		case scheduleErr:
@@ -857,25 +858,27 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 		case err != nil && errors.Resemble(err, errNoDownlink):
 			logger.Debug("No downlink to send, skipping downlink slot...")
 			return nil
+		}
 
-		case err != nil && errors.Resemble(err, errScheduleTooSoon):
+		if err != nil && errors.Resemble(err, errScheduleTooSoon) {
 			logger.Debug("Downlink scheduled too soon, skipping downlink slot...")
-			break
-
-		case err != nil:
+		} else if err != nil {
 			setErr = true
 			logger.WithError(err).Warn("Failed to update device in registry")
 			return err
 		}
 
-		if nextDownlinkAt.IsZero() {
-			return nil
+		if sendInvalidation != nil {
+			go sendInvalidation()
 		}
-		logger.WithField("schedule_at", nextDownlinkAt).Debug("Adding device to downlink schedule...")
-		if err := ns.downlinkTasks.Add(ctx, devID, nextDownlinkAt, true); err != nil {
-			addErr = true
-			logger.WithError(err).Error("Failed to add device to downlink schedule")
-			return err
+
+		if !nextDownlinkAt.IsZero() {
+			logger.WithField("schedule_at", nextDownlinkAt).Debug("Adding device to downlink schedule...")
+			if err := ns.downlinkTasks.Add(ctx, devID, nextDownlinkAt, true); err != nil {
+				addErr = true
+				logger.WithError(err).Error("Failed to add device to downlink schedule")
+				return err
+			}
 		}
 		return nil
 	})

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -61,6 +61,12 @@ func deviceClassCTimeout(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings) time.
 var errApplicationDownlinkTooLong = errors.DefineInvalidArgument("application_downlink_too_long", "application downlink payload is too long")
 var errNoDownlink = errors.Define("no_downlink", "no downlink to send")
 
+type generatedDownlink struct {
+	Payload             []byte
+	FCnt                uint32
+	ApplicationDownlink *ttnpb.ApplicationDownlink
+}
+
 // generateDownlink attempts to generate a downlink.
 // generateDownlink returns the marshaled payload of the downlink, application downlink, if included in the payload and error, if any.
 // generateDownlink may mutate the device in order to record the downlink generated.
@@ -72,12 +78,12 @@ var errNoDownlink = errors.Define("no_downlink", "no downlink to send")
 // For example, a sequence of 'NewChannel' MAC commands could be generated for a
 // device operating in a region where a fixed channel plan is defined in case
 // dev.MACState.CurrentParameters.Channels is not equal to dev.MACState.DesiredParameters.Channels.
-func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16) ([]byte, uint32, *ttnpb.ApplicationDownlink, error) {
+func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16) (*generatedDownlink, error) {
 	if dev.MACState == nil {
-		return nil, 0, nil, errUnknownMACState
+		return nil, errUnknownMACState
 	}
 	if dev.Session == nil {
-		return nil, 0, nil, errEmptySession
+		return nil, errEmptySession
 	}
 
 	ctx = log.NewContextWithField(ctx, "device_uid", unique.ID(ctx, dev.EndDeviceIdentifiers))
@@ -108,7 +114,7 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 
 	maxDownLen, maxUpLen, ok, err := enqueueLinkADRReq(ctx, dev, maxDownLen, maxUpLen, ns.FrequencyPlans)
 	if err != nil {
-		return nil, 0, nil, err
+		return nil, err
 	}
 	fPending := !ok
 	for _, f := range []func(context.Context, *ttnpb.EndDevice, uint16, uint16) (uint16, uint16, bool){
@@ -145,7 +151,7 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 		cmdBuf, err = spec.AppendDownlink(cmdBuf, *cmd)
 
 		if err != nil {
-			return nil, 0, nil, errEncodeMAC.WithCause(err)
+			return nil, errEncodeMAC.WithCause(err)
 		}
 	}
 	logger = logger.WithField("mac_count", len(cmds))
@@ -173,7 +179,7 @@ outer:
 	if !needsDownlink &&
 		len(cmdBuf) == 0 &&
 		len(dev.QueuedApplicationDownlinks) == 0 {
-		return nil, 0, nil, errNoDownlink
+		return nil, errNoDownlink
 	}
 
 	pld := &ttnpb.MACPayload{
@@ -212,7 +218,7 @@ outer:
 			}
 
 			if !needsDownlink && len(cmdBuf) == 0 {
-				return nil, 0, nil, errNoDownlink
+				return nil, errNoDownlink
 			}
 		} else {
 			appDown = down
@@ -235,17 +241,17 @@ outer:
 
 	if len(cmdBuf) > 0 && (pld.FPort == 0 || dev.MACState.LoRaWANVersion.EncryptFOpts()) {
 		if dev.Session.NwkSEncKey == nil || len(dev.Session.NwkSEncKey.Key) == 0 {
-			return nil, 0, nil, errUnknownNwkSEncKey
+			return nil, errUnknownNwkSEncKey
 		}
 		key, err := cryptoutil.UnwrapAES128Key(*dev.Session.NwkSEncKey, ns.KeyVault)
 		if err != nil {
 			logger.WithField("kek_label", dev.Session.NwkSEncKey.KEKLabel).WithError(err).Warn("Failed to unwrap NwkSEncKey")
-			return nil, 0, nil, err
+			return nil, err
 		}
 
 		cmdBuf, err = crypto.EncryptDownlink(key, dev.Session.DevAddr, pld.FHDR.FCnt, cmdBuf)
 		if err != nil {
-			return nil, 0, nil, errEncryptMAC.WithCause(err)
+			return nil, errEncryptMAC.WithCause(err)
 		}
 	}
 
@@ -270,7 +276,7 @@ outer:
 	case dev.MACState.DeviceClass == ttnpb.CLASS_C &&
 		dev.MACState.LastConfirmedDownlinkAt != nil &&
 		dev.MACState.LastConfirmedDownlinkAt.Add(deviceClassCTimeout(dev, ns.defaultMACSettings)).After(time.Now()):
-		return nil, 0, nil, errScheduleTooSoon
+		return nil, errScheduleTooSoon
 
 	default:
 		dev.MACState.LastConfirmedDownlinkAt = timePtr(time.Now().UTC())
@@ -286,17 +292,17 @@ outer:
 		},
 	})
 	if err != nil {
-		return nil, 0, nil, errEncodePayload.WithCause(err)
+		return nil, errEncodePayload.WithCause(err)
 	}
 	// NOTE: It is assumed, that b does not contain MIC.
 
 	if dev.Session.SNwkSIntKey == nil || len(dev.Session.SNwkSIntKey.Key) == 0 {
-		return nil, 0, nil, errUnknownSNwkSIntKey
+		return nil, errUnknownSNwkSIntKey
 	}
 	key, err := cryptoutil.UnwrapAES128Key(*dev.Session.SNwkSIntKey, ns.KeyVault)
 	if err != nil {
 		logger.WithField("kek_label", dev.Session.SNwkSIntKey.KEKLabel).WithError(err).Warn("Failed to unwrap SNwkSIntKey")
-		return nil, 0, nil, err
+		return nil, err
 	}
 
 	var mic [4]byte
@@ -321,12 +327,16 @@ outer:
 		)
 	}
 	if err != nil {
-		return nil, 0, nil, errComputeMIC
+		return nil, errComputeMIC
 	}
 	b = append(b, mic[:]...)
 
 	logger.WithField("payload_length", len(b)).Debug("Generated downlink")
-	return b, pld.FHDR.FCnt, appDown, nil
+	return &generatedDownlink{
+		Payload:             b,
+		FCnt:                pld.FHDR.FCnt,
+		ApplicationDownlink: appDown,
+	}, nil
 }
 
 type downlinkPath struct {
@@ -618,15 +628,15 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 						if req.Rx2DataRateIndex < minDR {
 							minDR = req.Rx2DataRateIndex
 						}
-						b, fCnt, appDown, err := ns.generateDownlink(ctx, dev,
+						genDown, err := ns.generateDownlink(ctx, dev,
 							band.DataRates[minDR].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 							maxUpLength,
 						)
 						if err != nil {
 							return nil, nil, err
 						}
-						if appDown != nil {
-							ctx = events.ContextWithCorrelationID(ctx, appDown.CorrelationIDs...)
+						if genDown.ApplicationDownlink != nil {
+							ctx = events.ContextWithCorrelationID(ctx, genDown.ApplicationDownlink.CorrelationIDs...)
 						}
 
 						down, _, err := ns.scheduleDownlinkByPaths(
@@ -642,14 +652,14 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 							))),
 							req,
 							dev.EndDeviceIdentifiers,
-							b,
+							genDown.Payload,
 							downlinkPathsFromRecentUplinks(dev.RecentUplinks...)...,
 						)
 						if err != nil {
 							scheduleErr = true
 						} else {
-							if appDown == nil && len(dev.QueuedApplicationDownlinks) > 0 && dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 {
-								sendInvalidation = func() (bool, error) { return ns.sendQueueInvalidationToAS(ctx, dev, fCnt) }
+							if genDown.ApplicationDownlink == nil && len(dev.QueuedApplicationDownlinks) > 0 && dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 {
+								sendInvalidation = func() (bool, error) { return ns.sendQueueInvalidationToAS(ctx, dev, genDown.FCnt) }
 							}
 							dev.MACState.RxWindowsAvailable = false
 							dev.RecentDownlinks = append(dev.RecentDownlinks, down)
@@ -671,7 +681,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 						// we need to create a deep copy for the first call.
 						devCopy := deepcopy.Copy(dev).(*ttnpb.EndDevice)
 
-						b, fCnt, appDown, err := ns.generateDownlink(ctx, dev,
+						genDown, err := ns.generateDownlink(ctx, dev,
 							band.DataRates[req.Rx1DataRateIndex].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 							maxUpLength,
 						)
@@ -689,14 +699,14 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 							}
 						}
 
-						if appDown != nil {
-							ctx = events.ContextWithCorrelationID(ctx, appDown.CorrelationIDs...)
+						if genDown.ApplicationDownlink != nil {
+							ctx = events.ContextWithCorrelationID(ctx, genDown.ApplicationDownlink.CorrelationIDs...)
 						}
 
 						var paths []downlinkPath
-						if appDown != nil && appDown.ClassBC != nil && appDown.ClassBC.AbsoluteTime == nil {
-							paths = make([]downlinkPath, 0, len(appDown.ClassBC.Gateways))
-							for _, gtw := range appDown.ClassBC.Gateways {
+						if genDown.ApplicationDownlink != nil && genDown.ApplicationDownlink.ClassBC != nil && genDown.ApplicationDownlink.ClassBC.AbsoluteTime == nil {
+							paths = make([]downlinkPath, 0, len(genDown.ApplicationDownlink.ClassBC.Gateways))
+							for _, gtw := range genDown.ApplicationDownlink.ClassBC.Gateways {
 								if gtw == nil || gtw.IsZero() {
 									continue
 								}
@@ -709,10 +719,10 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 									},
 								})
 							}
-						} else if appDown == nil || appDown.ClassBC == nil {
+						} else if genDown.ApplicationDownlink == nil || genDown.ApplicationDownlink.ClassBC == nil {
 							paths = downlinkPathsFromRecentUplinks(dev.RecentUplinks...)
 						}
-						// NOTE: We must skip Rx1 if appDown.ClassBC.AbsoluteTime is set
+						// NOTE: We must skip Rx1 if genDown.ApplicationDownlink.ClassBC.AbsoluteTime is set
 
 						if len(paths) > 0 {
 							down, downAt, err := ns.scheduleDownlinkByPaths(
@@ -726,7 +736,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 								))),
 								req,
 								dev.EndDeviceIdentifiers,
-								b,
+								genDown.Payload,
 								paths...,
 							)
 							if err != nil {
@@ -737,8 +747,8 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 									nextDownlinkAt = downAt
 								}
 
-								if appDown == nil && len(dev.QueuedApplicationDownlinks) > 0 && dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 {
-									sendInvalidation = func() (bool, error) { return ns.sendQueueInvalidationToAS(ctx, dev, fCnt) }
+								if genDown.ApplicationDownlink == nil && len(dev.QueuedApplicationDownlinks) > 0 && dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 {
+									sendInvalidation = func() (bool, error) { return ns.sendQueueInvalidationToAS(ctx, dev, genDown.FCnt) }
 								}
 								dev.MACState.RxWindowsAvailable = false
 								dev.RecentDownlinks = append(dev.RecentDownlinks, down)
@@ -770,7 +780,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 						Rx2Frequency:     dev.MACState.CurrentParameters.Rx2Frequency,
 					}
 
-					b, fCnt, appDown, err := ns.generateDownlink(ctx, dev,
+					genDown, err := ns.generateDownlink(ctx, dev,
 						band.DataRates[req.Rx2DataRateIndex].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						maxUpLength,
 					)
@@ -788,14 +798,14 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 						}
 					}
 
-					if appDown != nil {
-						ctx = events.ContextWithCorrelationID(ctx, appDown.CorrelationIDs...)
+					if genDown.ApplicationDownlink != nil {
+						ctx = events.ContextWithCorrelationID(ctx, genDown.ApplicationDownlink.CorrelationIDs...)
 					}
 
 					var paths []downlinkPath
-					if appDown != nil && appDown.ClassBC != nil {
-						paths = make([]downlinkPath, 0, len(appDown.ClassBC.Gateways))
-						for _, gtw := range appDown.ClassBC.Gateways {
+					if genDown.ApplicationDownlink != nil && genDown.ApplicationDownlink.ClassBC != nil {
+						paths = make([]downlinkPath, 0, len(genDown.ApplicationDownlink.ClassBC.Gateways))
+						for _, gtw := range genDown.ApplicationDownlink.ClassBC.Gateways {
 							paths = append(paths, downlinkPath{
 								GatewayIdentifiers: gtw.GatewayIdentifiers,
 								DownlinkPath: &ttnpb.DownlinkPath{
@@ -822,7 +832,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 						))),
 						req,
 						dev.EndDeviceIdentifiers,
-						b,
+						genDown.Payload,
 						paths...,
 					)
 					if err != nil {
@@ -832,8 +842,8 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 							nextDownlinkAt = downAt
 						}
 
-						if appDown == nil && len(dev.QueuedApplicationDownlinks) > 0 && dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 {
-							sendInvalidation = func() (bool, error) { return ns.sendQueueInvalidationToAS(ctx, dev, fCnt) }
+						if genDown.ApplicationDownlink == nil && len(dev.QueuedApplicationDownlinks) > 0 && dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 {
+							sendInvalidation = func() (bool, error) { return ns.sendQueueInvalidationToAS(ctx, dev, genDown.FCnt) }
 						}
 						dev.RecentDownlinks = append(dev.RecentDownlinks, down)
 						if len(dev.RecentDownlinks) > recentDownlinkCount {

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -496,6 +496,14 @@ func (ns *NetworkServer) sendQueueInvalidationToAS(ctx context.Context, dev *ttn
 	return ok, err
 }
 
+func appendRecentDownlink(recent []*ttnpb.DownlinkMessage, down *ttnpb.DownlinkMessage, window int) []*ttnpb.DownlinkMessage {
+	recent = append(recent, down)
+	if len(recent) > window {
+		recent = recent[len(recent)-window:]
+	}
+	return recent
+}
+
 // processDownlinkTask processes the most recent downlink task ready for execution, if such is available or wait until it is before processing it.
 // NOTE: ctx.Done() is not guaranteed to be respected by processDownlinkTask.
 func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
@@ -637,10 +645,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 								SessionKeys: dev.MACState.QueuedJoinAccept.Keys,
 							}
 							dev.MACState.QueuedJoinAccept = nil
-							dev.RecentDownlinks = append(dev.RecentDownlinks, down)
-							if len(dev.RecentDownlinks) > recentDownlinkCount {
-								dev.RecentDownlinks = append(dev.RecentDownlinks[:0], dev.RecentDownlinks[len(dev.RecentDownlinks)-recentDownlinkCount:]...)
-							}
+							dev.RecentDownlinks = appendRecentDownlink(dev.RecentDownlinks, down, recentDownlinkCount)
 							return dev, []string{
 								"ids.dev_addr",
 								"mac_state.pending_join_request",
@@ -708,10 +713,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 								sendInvalidation = func() (bool, error) { return ns.sendQueueInvalidationToAS(ctx, dev, genDown.FCnt) }
 							}
 							dev.MACState.RxWindowsAvailable = false
-							dev.RecentDownlinks = append(dev.RecentDownlinks, down)
-							if len(dev.RecentDownlinks) > recentDownlinkCount {
-								dev.RecentDownlinks = append(dev.RecentDownlinks[:0], dev.RecentDownlinks[len(dev.RecentDownlinks)-recentDownlinkCount:]...)
-							}
+							dev.RecentDownlinks = appendRecentDownlink(dev.RecentDownlinks, down, recentDownlinkCount)
 							return dev, []string{
 								"mac_state",
 								"queued_application_downlinks",
@@ -806,10 +808,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 									sendInvalidation = func() (bool, error) { return ns.sendQueueInvalidationToAS(ctx, dev, genDown.FCnt) }
 								}
 								dev.MACState.RxWindowsAvailable = false
-								dev.RecentDownlinks = append(dev.RecentDownlinks, down)
-								if len(dev.RecentDownlinks) > recentDownlinkCount {
-									dev.RecentDownlinks = append(dev.RecentDownlinks[:0], dev.RecentDownlinks[len(dev.RecentDownlinks)-recentDownlinkCount:]...)
-								}
+								dev.RecentDownlinks = appendRecentDownlink(dev.RecentDownlinks, down, recentDownlinkCount)
 								return dev, []string{
 									"mac_state",
 									"queued_application_downlinks",
@@ -900,10 +899,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 						if genDown.ApplicationDownlink == nil && len(dev.QueuedApplicationDownlinks) > 0 && dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 {
 							sendInvalidation = func() (bool, error) { return ns.sendQueueInvalidationToAS(ctx, dev, genDown.FCnt) }
 						}
-						dev.RecentDownlinks = append(dev.RecentDownlinks, down)
-						if len(dev.RecentDownlinks) > recentDownlinkCount {
-							dev.RecentDownlinks = append(dev.RecentDownlinks[:0], dev.RecentDownlinks[len(dev.RecentDownlinks)-recentDownlinkCount:]...)
-						}
+						dev.RecentDownlinks = appendRecentDownlink(dev.RecentDownlinks, down, recentDownlinkCount)
 						return dev, []string{
 							"mac_state",
 							"queued_application_downlinks",

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -144,14 +144,19 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 	}
 	cmds = append(cmds, dev.MACState.PendingRequests...)
 
+	mType := ttnpb.MType_UNCONFIRMED_DOWN
 	cmdBuf := make([]byte, 0, maxDownLen)
 	for _, cmd := range cmds {
+		logger := logger.WithField("cid", cmd.CID)
+		logger.Debug("Adding MAC command to buffer...")
 		var err error
-		logger.WithField("cid", cmd.CID).Debug("Adding MAC command to buffer...")
 		cmdBuf, err = spec.AppendDownlink(cmdBuf, *cmd)
-
 		if err != nil {
 			return nil, errEncodeMAC.WithCause(err)
+		}
+		if mType == ttnpb.MType_UNCONFIRMED_DOWN && spec[cmd.CID].ExpectAnswer && dev.MACState.DeviceClass == ttnpb.CLASS_C {
+			logger.Debug("Using confirmed downlink to get immediate answer")
+			mType = ttnpb.MType_CONFIRMED_DOWN
 		}
 	}
 	logger = logger.WithField("mac_count", len(cmds))
@@ -194,7 +199,6 @@ outer:
 	logger = logger.WithField("ack", pld.FHDR.FCtrl.Ack)
 
 	var appDown *ttnpb.ApplicationDownlink
-	mType := ttnpb.MType_UNCONFIRMED_DOWN
 	if len(cmdBuf) <= fOptsCapacity && len(dev.QueuedApplicationDownlinks) > 0 {
 		var down *ttnpb.ApplicationDownlink
 		down, dev.QueuedApplicationDownlinks = dev.QueuedApplicationDownlinks[0], dev.QueuedApplicationDownlinks[1:]
@@ -227,7 +231,6 @@ outer:
 			pld.FRMPayload = down.FRMPayload
 			if down.Confirmed {
 				mType = ttnpb.MType_CONFIRMED_DOWN
-
 				dev.MACState.PendingApplicationDownlink = down
 				dev.Session.LastConfFCntDown = pld.FCnt
 			}

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -937,7 +937,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 		}
 
 		if !nextDownlinkAt.IsZero() {
-			logger.WithField("start_at", nextDownlinkAt.UTC()).Debug("Adding downlink task...")
+			logger.WithField("start_at", nextDownlinkAt.UTC()).Debug("Adding downlink task after downlink...")
 			if err := ns.downlinkTasks.Add(ctx, devID, nextDownlinkAt, true); err != nil {
 				addErr = true
 				logger.WithError(err).Error("Failed to add downlink task after downlink")

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -305,7 +305,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 				rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 				rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-				payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+				genDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 					band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
@@ -321,7 +321,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				expected.MACState.RxWindowsAvailable = false
 				expected.QueuedApplicationDownlinks = []*ttnpb.ApplicationDownlink{}
 				expected.RecentDownlinks = append(expected.RecentDownlinks, &ttnpb.DownlinkMessage{
-					RawPayload:     payload,
+					RawPayload:     genDown.Payload,
 					CorrelationIDs: ret.RecentDownlinks[0].CorrelationIDs,
 					EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -379,7 +379,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					if rx1DRIdx < drIdx {
 						drIdx = rx1DRIdx
 					}
-					payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					genDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[drIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
@@ -414,7 +414,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 									a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 									a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 									a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-										RawPayload:     payload,
+										RawPayload:     genDown.Payload,
 										CorrelationIDs: msg.CorrelationIDs,
 										EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 											ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -452,7 +452,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 							a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 							a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 							a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-								RawPayload:     payload,
+								RawPayload:     genDown.Payload,
 								CorrelationIDs: msg.CorrelationIDs,
 								EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 									ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -499,7 +499,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     payload,
+									RawPayload:     genDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -729,7 +729,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 				rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 				rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-				payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+				genDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 					band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
@@ -745,7 +745,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				expected.MACState.RxWindowsAvailable = false
 				expected.QueuedApplicationDownlinks = []*ttnpb.ApplicationDownlink{}
 				expected.RecentDownlinks = append(expected.RecentDownlinks, &ttnpb.DownlinkMessage{
-					RawPayload:     payload,
+					RawPayload:     genDown.Payload,
 					CorrelationIDs: ret.RecentDownlinks[0].CorrelationIDs,
 					EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -799,7 +799,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 					rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 					rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-					payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					genDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
@@ -819,7 +819,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     payload,
+									RawPayload:     genDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -860,7 +860,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     payload,
+									RawPayload:     genDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -914,7 +914,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     payload,
+									RawPayload:     genDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1140,7 +1140,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Fatal("Invalid context")
 				}
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
-				rx2Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+				rx2GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 					band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
@@ -1156,7 +1156,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				expected.MACState.RxWindowsAvailable = false
 				expected.QueuedApplicationDownlinks = []*ttnpb.ApplicationDownlink{}
 				expected.RecentDownlinks = append(expected.RecentDownlinks, &ttnpb.DownlinkMessage{
-					RawPayload:     rx2Payload,
+					RawPayload:     rx2GenDown.Payload,
 					CorrelationIDs: ret.RecentDownlinks[0].CorrelationIDs,
 					EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1212,14 +1212,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 					fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 					rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 					rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-					rx1Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					rx1GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
 					if !a.So(err, should.BeNil) {
 						t.Fatalf("Failed to generate Rx1 payload: %s", err)
 					}
-					rx2Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					rx2GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
@@ -1239,7 +1239,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx1Payload,
+									RawPayload:     rx1GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1275,7 +1275,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx2Payload,
+									RawPayload:     rx2GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1312,7 +1312,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx1Payload,
+									RawPayload:     rx1GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1353,7 +1353,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx1Payload,
+									RawPayload:     rx1GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1390,7 +1390,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx2Payload,
+									RawPayload:     rx2GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1430,7 +1430,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx2Payload,
+									RawPayload:     rx2GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1717,7 +1717,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Fatal("Invalid context")
 				}
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
-				rx2Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+				rx2GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 					band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
@@ -1733,7 +1733,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				expected.MACState.RxWindowsAvailable = false
 				expected.QueuedApplicationDownlinks = []*ttnpb.ApplicationDownlink{}
 				expected.RecentDownlinks = append(expected.RecentDownlinks, &ttnpb.DownlinkMessage{
-					RawPayload:     rx2Payload,
+					RawPayload:     rx2GenDown.Payload,
 					CorrelationIDs: ret.RecentDownlinks[0].CorrelationIDs,
 					EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1792,14 +1792,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 					fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 					rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 					rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-					rx1Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					rx1GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
 					if !a.So(err, should.BeNil) {
 						t.Fatalf("Failed to generate Rx1 payload: %s", err)
 					}
-					rx2Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					rx2GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
@@ -1819,7 +1819,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx1Payload,
+									RawPayload:     rx1GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1858,7 +1858,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx2Payload,
+									RawPayload:     rx2GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1898,7 +1898,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx1Payload,
+									RawPayload:     rx1GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1945,7 +1945,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx1Payload,
+									RawPayload:     rx1GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1985,7 +1985,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx2Payload,
+									RawPayload:     rx2GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -2031,7 +2031,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx2Payload,
+									RawPayload:     rx2GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -3511,17 +3511,22 @@ func TestGenerateDownlink(t *testing.T) {
 
 			dev := CopyEndDevice(tc.Device)
 
-			b, _, appDown, err := ns.generateDownlink(tc.Context, dev, math.MaxUint16, math.MaxUint16)
-			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
-				tc.Error == nil && !a.So(err, should.BeNil) {
+			genDown, err := ns.generateDownlink(tc.Context, dev, math.MaxUint16, math.MaxUint16)
+			if tc.Error != nil {
+				a.So(err, should.EqualErrorOrDefinition, tc.Error)
+				a.So(genDown, should.BeNil)
+				return
+			}
+
+			if !a.So(err, should.BeNil) || !a.So(genDown, should.NotBeNil) {
 				t.FailNow()
 			}
 
-			a.So(b, should.Resemble, tc.Bytes)
+			a.So(genDown.Payload, should.Resemble, tc.Bytes)
 			if tc.ApplicationDownlinkAssertion != nil {
-				a.So(tc.ApplicationDownlinkAssertion(t, appDown), should.BeTrue)
+				a.So(tc.ApplicationDownlinkAssertion(t, genDown.ApplicationDownlink), should.BeTrue)
 			} else {
-				a.So(appDown, should.BeNil)
+				a.So(genDown.ApplicationDownlink, should.BeNil)
 			}
 
 			if tc.DeviceAssertion != nil {

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -305,7 +305,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 				rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 				rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-				payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+				payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 					band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
@@ -379,7 +379,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					if rx1DRIdx < drIdx {
 						drIdx = rx1DRIdx
 					}
-					payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[drIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
@@ -729,7 +729,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 				rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 				rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-				payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+				payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 					band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
@@ -799,7 +799,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 					rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 					rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-					payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
@@ -1140,7 +1140,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Fatal("Invalid context")
 				}
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
-				rx2Payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+				rx2Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 					band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
@@ -1212,14 +1212,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 					fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 					rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 					rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-					rx1Payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					rx1Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
 					if !a.So(err, should.BeNil) {
 						t.Fatalf("Failed to generate Rx1 payload: %s", err)
 					}
-					rx2Payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					rx2Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
@@ -1717,7 +1717,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Fatal("Invalid context")
 				}
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
-				rx2Payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+				rx2Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 					band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
@@ -1792,14 +1792,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 					fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 					rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 					rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-					rx1Payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					rx1Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
 					if !a.So(err, should.BeNil) {
 						t.Fatalf("Failed to generate Rx1 payload: %s", err)
 					}
-					rx2Payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					rx2Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
@@ -3511,7 +3511,7 @@ func TestGenerateDownlink(t *testing.T) {
 
 			dev := CopyEndDevice(tc.Device)
 
-			b, appDown, err := ns.generateDownlink(tc.Context, dev, math.MaxUint16, math.MaxUint16)
+			b, _, appDown, err := ns.generateDownlink(tc.Context, dev, math.MaxUint16, math.MaxUint16)
 			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
 				tc.Error == nil && !a.So(err, should.BeNil) {
 				t.FailNow()

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -639,7 +639,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								DeviceChannelIndex: 3,
 							},
 							CorrelationIDs: []string{"testCorrelationUpID1", "testCorrelationUpID2"},
-							ReceivedAt:     time.Now().Add(time.Hour),
+							ReceivedAt:     time.Now().Add(-time.Second),
 							Payload: &ttnpb.Message{
 								MHDR: ttnpb.MHDR{
 									MType: ttnpb.MType_UNCONFIRMED_UP,
@@ -1052,7 +1052,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								DeviceChannelIndex: 3,
 							},
 							CorrelationIDs: []string{"testCorrelationUpID1", "testCorrelationUpID2"},
-							ReceivedAt:     time.Now().Add(time.Hour),
+							ReceivedAt:     time.Now().Add(-time.Second),
 							Payload: &ttnpb.Message{
 								MHDR: ttnpb.MHDR{
 									MType: ttnpb.MType_UNCONFIRMED_UP,

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -2729,7 +2729,8 @@ func TestGenerateDownlink(t *testing.T) {
 					DevAddr:                &DevAddr,
 				},
 				MACState: &ttnpb.MACState{
-					LoRaWANVersion: ttnpb.MAC_V1_1,
+					LoRaWANVersion:     ttnpb.MAC_V1_1,
+					RxWindowsAvailable: true,
 				},
 				Session: &ttnpb.Session{
 					DevAddr:       DevAddr,
@@ -2784,7 +2785,8 @@ func TestGenerateDownlink(t *testing.T) {
 						DevAddr:                &DevAddr,
 					},
 					MACState: &ttnpb.MACState{
-						LoRaWANVersion: ttnpb.MAC_V1_1,
+						LoRaWANVersion:     ttnpb.MAC_V1_1,
+						RxWindowsAvailable: true,
 					},
 					Session: &ttnpb.Session{
 						DevAddr:       DevAddr,
@@ -2826,7 +2828,8 @@ func TestGenerateDownlink(t *testing.T) {
 					DevAddr:                &DevAddr,
 				},
 				MACState: &ttnpb.MACState{
-					LoRaWANVersion: ttnpb.MAC_V1_1,
+					LoRaWANVersion:     ttnpb.MAC_V1_1,
+					RxWindowsAvailable: true,
 				},
 				Session: &ttnpb.Session{
 					DevAddr: DevAddr,
@@ -2892,7 +2895,8 @@ func TestGenerateDownlink(t *testing.T) {
 						DevAddr:                &DevAddr,
 					},
 					MACState: &ttnpb.MACState{
-						LoRaWANVersion: ttnpb.MAC_V1_1,
+						LoRaWANVersion:     ttnpb.MAC_V1_1,
+						RxWindowsAvailable: true,
 					},
 					Session: &ttnpb.Session{
 						DevAddr: DevAddr,
@@ -2928,7 +2932,8 @@ func TestGenerateDownlink(t *testing.T) {
 					DevAddr:                &DevAddr,
 				},
 				MACState: &ttnpb.MACState{
-					LoRaWANVersion: ttnpb.MAC_V1_1,
+					LoRaWANVersion:     ttnpb.MAC_V1_1,
+					RxWindowsAvailable: true,
 				},
 				Session: &ttnpb.Session{
 					DevAddr: DevAddr,
@@ -3000,7 +3005,8 @@ func TestGenerateDownlink(t *testing.T) {
 						DevAddr:                &DevAddr,
 					},
 					MACState: &ttnpb.MACState{
-						LoRaWANVersion: ttnpb.MAC_V1_1,
+						LoRaWANVersion:     ttnpb.MAC_V1_1,
+						RxWindowsAvailable: true,
 					},
 					Session: &ttnpb.Session{
 						DevAddr: DevAddr,
@@ -3158,7 +3164,8 @@ func TestGenerateDownlink(t *testing.T) {
 					DevAddr:                &DevAddr,
 				},
 				MACState: &ttnpb.MACState{
-					LoRaWANVersion: ttnpb.MAC_V1_1,
+					LoRaWANVersion:     ttnpb.MAC_V1_1,
+					RxWindowsAvailable: true,
 				},
 				Session: &ttnpb.Session{
 					DevAddr: DevAddr,
@@ -3237,6 +3244,7 @@ func TestGenerateDownlink(t *testing.T) {
 					},
 					MACState: &ttnpb.MACState{
 						LoRaWANVersion:          ttnpb.MAC_V1_1,
+						RxWindowsAvailable:      true,
 						LastConfirmedDownlinkAt: dev.MACState.LastConfirmedDownlinkAt,
 						PendingApplicationDownlink: &ttnpb.ApplicationDownlink{
 							Confirmed:  true,

--- a/pkg/networkserver/grpc_asns.go
+++ b/pkg/networkserver/grpc_asns.go
@@ -124,8 +124,9 @@ func (ns *NetworkServer) DownlinkQueueReplace(ctx context.Context, req *ttnpb.Do
 
 	logger.Debug("Replaced application downlink queue")
 	if dev.MACState != nil && dev.MACState.DeviceClass != ttnpb.CLASS_A && len(dev.QueuedApplicationDownlinks) > 0 {
-		logger.Debug("Adding downlink task...")
-		return ttnpb.Empty, ns.downlinkTasks.Add(ctx, req.EndDeviceIdentifiers, time.Now(), false)
+		startAt := time.Now().UTC()
+		logger.WithField("start_at", startAt).Debug("Adding downlink task...")
+		return ttnpb.Empty, ns.downlinkTasks.Add(ctx, req.EndDeviceIdentifiers, startAt, false)
 	}
 	return ttnpb.Empty, nil
 }
@@ -162,8 +163,9 @@ func (ns *NetworkServer) DownlinkQueuePush(ctx context.Context, req *ttnpb.Downl
 
 	logger.Debug("Pushed application downlink to queue")
 	if dev.MACState != nil && dev.MACState.DeviceClass != ttnpb.CLASS_A {
-		logger.Debug("Adding downlink task...")
-		return ttnpb.Empty, ns.downlinkTasks.Add(ctx, req.EndDeviceIdentifiers, time.Now(), false)
+		startAt := time.Now().UTC()
+		logger.WithField("start_at", startAt).Debug("Adding downlink task...")
+		return ttnpb.Empty, ns.downlinkTasks.Add(ctx, req.EndDeviceIdentifiers, startAt, false)
 	}
 	return ttnpb.Empty, nil
 }

--- a/pkg/networkserver/grpc_asns.go
+++ b/pkg/networkserver/grpc_asns.go
@@ -125,7 +125,7 @@ func (ns *NetworkServer) DownlinkQueueReplace(ctx context.Context, req *ttnpb.Do
 	logger.Debug("Replaced application downlink queue")
 	if dev.MACState != nil && dev.MACState.DeviceClass != ttnpb.CLASS_A && len(dev.QueuedApplicationDownlinks) > 0 {
 		startAt := time.Now().UTC()
-		logger.WithField("start_at", startAt).Debug("Adding downlink task...")
+		logger.WithField("start_at", startAt).Debug("Adding downlink task with application downlink pending...")
 		return ttnpb.Empty, ns.downlinkTasks.Add(ctx, req.EndDeviceIdentifiers, startAt, false)
 	}
 	return ttnpb.Empty, nil
@@ -164,7 +164,7 @@ func (ns *NetworkServer) DownlinkQueuePush(ctx context.Context, req *ttnpb.Downl
 	logger.Debug("Pushed application downlink to queue")
 	if dev.MACState != nil && dev.MACState.DeviceClass != ttnpb.CLASS_A {
 		startAt := time.Now().UTC()
-		logger.WithField("start_at", startAt).Debug("Adding downlink task...")
+		logger.WithField("start_at", startAt).Debug("Adding downlink task with application downlink pending...")
 		return ttnpb.Empty, ns.downlinkTasks.Add(ctx, req.EndDeviceIdentifiers, startAt, false)
 	}
 	return ttnpb.Empty, nil

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -262,9 +262,6 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 		}
 		sets = append(sets, "mac_state")
 
-		addDownlinkTask = req.EndDevice.MACState.DeviceClass != ttnpb.CLASS_A &&
-			(len(req.EndDevice.QueuedApplicationDownlinks) > 0 || !req.EndDevice.MACState.CurrentParameters.Equal(req.EndDevice.MACState.DesiredParameters))
-
 		return &req.EndDevice, sets, nil
 	})
 	if err != nil {

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -271,7 +271,9 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 		return nil, err
 	}
 	if addDownlinkTask {
-		if err = ns.downlinkTasks.Add(ctx, dev.EndDeviceIdentifiers, time.Now(), false); err != nil {
+		startAt := time.Now().UTC()
+		log.FromContext(ctx).WithField("start_at", startAt).Debug("Adding downlink task...")
+		if err = ns.downlinkTasks.Add(ctx, dev.EndDeviceIdentifiers, startAt, false); err != nil {
 			log.FromContext(ctx).WithError(err).Warn("Failed to add downlink task for device after set")
 		}
 	}

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -58,11 +58,9 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 	var addDownlinkTask bool
 	dev, err := ns.devices.SetByID(ctx, req.EndDevice.EndDeviceIdentifiers.ApplicationIdentifiers, req.EndDevice.EndDeviceIdentifiers.DeviceID, gets, func(dev *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
 		if dev != nil {
-			addDownlinkTask = ttnpb.HasAnyField(req.FieldMask.Paths,
-				"mac_state.device_class",
-				"queued_application_downlinks",
-			) && req.EndDevice.MACState.DeviceClass != ttnpb.CLASS_A &&
-				(len(req.EndDevice.QueuedApplicationDownlinks) > 0 || !req.EndDevice.MACState.CurrentParameters.Equal(req.EndDevice.MACState.DesiredParameters))
+			addDownlinkTask = ttnpb.HasAnyField(req.FieldMask.Paths, "mac_state.device_class") &&
+				req.EndDevice.MACState.DeviceClass != ttnpb.CLASS_A &&
+				(len(dev.QueuedApplicationDownlinks) > 0 || !dev.MACState.CurrentParameters.Equal(dev.MACState.DesiredParameters))
 			return &req.EndDevice, req.FieldMask.Paths, nil
 		}
 

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -481,6 +481,8 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 			"pending_session",
 			"recent_uplinks",
 			"session",
+			"supports_class_b",
+			"supports_class_c",
 			"supports_join",
 		},
 		func(stored *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
@@ -527,6 +529,13 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 					panic("Pending session does not match the join request")
 				}
 				stored.EndDeviceIdentifiers.DevAddr = &stored.MACState.PendingJoinRequest.DevAddr
+				if stored.SupportsClassC {
+					stored.MACState.DeviceClass = ttnpb.CLASS_C
+				} else if stored.SupportsClassB {
+					stored.MACState.DeviceClass = ttnpb.CLASS_B
+				} else {
+					stored.MACState.DeviceClass = ttnpb.CLASS_A
+				}
 				stored.MACState.CurrentParameters.Rx1Delay = stored.MACState.PendingJoinRequest.RxDelay
 				stored.MACState.CurrentParameters.Rx1DataRateOffset = stored.MACState.PendingJoinRequest.DownlinkSettings.Rx1DROffset
 				stored.MACState.CurrentParameters.Rx2DataRateIndex = stored.MACState.PendingJoinRequest.DownlinkSettings.Rx2DR

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -87,11 +87,7 @@ func (ns *NetworkServer) matchDevice(ctx context.Context, up *ttnpb.UplinkMessag
 
 	pld := up.Payload.GetMACPayload()
 
-	logger := log.FromContext(ctx).WithFields(log.Fields(
-		"dev_addr", pld.DevAddr,
-		"uplink_f_cnt", pld.FCnt,
-		"payload_length", len(macPayloadBytes),
-	))
+	logger := log.FromContext(ctx)
 
 	type device struct {
 		*ttnpb.EndDevice
@@ -199,11 +195,10 @@ outer:
 			fCnt |= (dev.matchedSession.LastFCntUp + 0x10000) &^ 0xffff
 		}
 
-		logger = logger.WithFields(log.Fields(
+		logger := logger.WithFields(log.Fields(
 			"device_uid", unique.ID(ctx, dev.EndDeviceIdentifiers),
 			"full_f_cnt_up", fCnt,
 			"last_f_cnt_up", dev.matchedSession.LastFCntUp,
-			"uplink_f_cnt_up", pld.FCnt,
 		))
 
 		resetsFCnt := false
@@ -359,7 +354,15 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 	pld := up.Payload.GetMACPayload()
 
 	logger := log.FromContext(ctx).WithFields(log.Fields(
+		"ack", pld.Ack,
+		"adr", pld.ADR,
+		"adr_ack_req", pld.ADRAckReq,
+		"class_b", pld.ClassB,
 		"dev_addr", pld.DevAddr,
+		"f_cnt", pld.FCnt,
+		"f_opts_len", len(pld.FOpts),
+		"f_port", pld.FPort,
+		"frm_payload_len", len(pld.FRMPayload),
 	))
 	ctx = log.NewContext(ctx, logger)
 
@@ -426,7 +429,6 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 			logger.WithField("kek_label", ses.NwkSEncKey.KEKLabel).WithError(err).Warn("Failed to unwrap NwkSEncKey")
 			return err
 		}
-
 		mac, err = crypto.DecryptUplink(key, pld.DevAddr, pld.FCnt, mac)
 		if err != nil {
 			return errDecrypt.WithCause(err)
@@ -437,15 +439,19 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 	for r := bytes.NewReader(mac); r.Len() > 0; {
 		cmd := &ttnpb.MACCommand{}
 		if err := lorawan.DefaultMACCommands.ReadUplink(r, cmd); err != nil {
-			logger.
-				WithField("unmarshaled", len(cmds)).
-				WithError(err).
-				Warn("Failed to unmarshal MAC commands")
+			logger.WithFields(log.Fields(
+				"bytes_left", r.Len(),
+				"mac_count", len(cmds),
+			)).WithError(err).Warn("Failed to unmarshal MAC command")
 			break
 		}
+		logger.WithField("cid", cmd.CID).Debug("Read MAC command")
 		cmds = append(cmds, cmd)
 	}
+	logger = logger.WithField("mac_count", len(cmds))
+	ctx = log.NewContext(ctx, logger)
 
+	logger.Debug("Waiting for deduplication window to close...")
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -453,7 +459,10 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 	}
 
 	up.RxMetadata = acc.Accumulated()
+	ctx = log.NewContextWithField("metadata_count", len(up.RxMetadata))
 	registerMergeMetadata(ctx, &matched.EndDeviceIdentifiers, up)
+	logger = log.FromContext(ctx)
+	logger.Debug("Merged metadata")
 
 	var handleErr bool
 	stored, err := ns.devices.SetByID(ctx, matched.EndDeviceIdentifiers.ApplicationIdentifiers, matched.EndDeviceIdentifiers.DeviceID,
@@ -508,6 +517,7 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 				stored.Session = ses
 			} else if ses == matched.PendingSession {
 				// Device switched the session.
+				logger.Debug("Switching to pending session")
 				stored.PendingSession = ses
 				if stored.PendingSession.DevAddr != stored.MACState.PendingJoinRequest.DevAddr {
 					panic("Pending session does not match the join request")
@@ -586,6 +596,8 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 			for len(cmds) > 0 {
 				var cmd *ttnpb.MACCommand
 				cmd, cmds = cmds[0], cmds[1:]
+				logger := logger.WithField("cid", cmd.CID)
+				logger.Debug("Handling MAC command...")
 				switch cmd.CID {
 				case ttnpb.CID_RESET:
 					err = handleResetInd(ctx, stored, cmd.GetResetInd(), ns.FrequencyPlans, ns.defaultMACSettings)
@@ -595,6 +607,7 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 					pld := cmd.GetLinkADRAns()
 					dupCount := 0
 					if stored.MACState.LoRaWANVersion == ttnpb.MAC_V1_0_2 {
+						logger.Debug("Counting duplicates...")
 						for _, dup := range cmds {
 							if dup.CID != ttnpb.CID_LINK_ADR {
 								break
@@ -605,6 +618,7 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 							}
 							dupCount++
 						}
+						logger.WithField("duplicate_count", dupCount).Debug("Counted duplicates")
 					}
 					if err != nil {
 						break
@@ -713,6 +727,7 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 	asCtx, cancel := context.WithTimeout(ctx, appQueueUpdateTimeout)
 	defer cancel()
 
+	logger.Debug("Sending uplink to Application Server...")
 	ok, err := ns.handleASUplink(asCtx, matched.EndDeviceIdentifiers.ApplicationIdentifiers, &ttnpb.ApplicationUp{
 		EndDeviceIdentifiers: matched.EndDeviceIdentifiers,
 		CorrelationIDs:       up.CorrelationIDs,
@@ -732,7 +747,9 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 	} else {
 		registerForwardDataUplink(ctx, &matched.EndDeviceIdentifiers, up)
 	}
-	return ns.downlinkTasks.Add(ctx, matched.EndDeviceIdentifiers, time.Now().UTC(), true)
+	startAt := time.Now().UTC()
+	logger.WithField("start_at", startAt).Debug("Adding downlink task...")
+	return ns.downlinkTasks.Add(ctx, matched.EndDeviceIdentifiers, startAt, true)
 }
 
 // newDevAddr generates a DevAddr for specified EndDevice.
@@ -932,7 +949,9 @@ func (ns *NetworkServer) handleJoin(ctx context.Context, up *ttnpb.UplinkMessage
 		return err
 	}
 
-	if err := ns.downlinkTasks.Add(ctx, dev.EndDeviceIdentifiers, time.Now().UTC(), true); err != nil {
+	startAt := time.Now().UTC()
+	logger.WithField("start_at", startAt).Debug("Adding downlink task...")
+	if err := ns.downlinkTasks.Add(ctx, dev.EndDeviceIdentifiers, startAt, true); err != nil {
 		return err
 	}
 	return nil
@@ -959,11 +978,7 @@ func (ns *NetworkServer) HandleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 		fmt.Sprintf("ns:uplink:%s", events.NewCorrelationID()),
 	)...)
 	up.CorrelationIDs = events.CorrelationIDsFromContext(ctx)
-
 	up.ReceivedAt = time.Now().UTC()
-
-	logger := log.FromContext(ctx)
-
 	up.Payload = &ttnpb.Message{}
 	if err := lorawan.UnmarshalMessage(up.RawPayload, up.Payload); err != nil {
 		return nil, errDecodePayload.WithCause(err)
@@ -974,6 +989,13 @@ func (ns *NetworkServer) HandleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 			"major", up.Payload.Major,
 		)
 	}
+
+	logger := log.FromContext(ctx).WithFields(log.Fields(
+		"m_type", up.Payload.MType,
+		"major", up.Payload.Major,
+		"received_at", up.ReceivedAt,
+	))
+	ctx = log.NewContext(ctx, logger)
 
 	logger.Debug("Deduplicating uplink...")
 	acc, stopDedup, ok := ns.deduplicateUplink(ctx, up)

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -761,7 +761,7 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 		registerForwardDataUplink(ctx, &matched.EndDeviceIdentifiers, up)
 	}
 	startAt := time.Now().UTC()
-	logger.WithField("start_at", startAt).Debug("Adding downlink task...")
+	logger.WithField("start_at", startAt).Debug("Adding downlink task for class A downlink...")
 	return ns.downlinkTasks.Add(ctx, matched.EndDeviceIdentifiers, startAt, true)
 }
 
@@ -963,7 +963,7 @@ func (ns *NetworkServer) handleJoin(ctx context.Context, up *ttnpb.UplinkMessage
 	}
 
 	startAt := time.Now().UTC()
-	logger.WithField("start_at", startAt).Debug("Adding downlink task...")
+	logger.WithField("start_at", startAt).Debug("Adding downlink task for join-accept...")
 	if err := ns.downlinkTasks.Add(ctx, dev.EndDeviceIdentifiers, startAt, true); err != nil {
 		return err
 	}

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -188,7 +188,7 @@ outer:
 
 		fCnt := pld.FCnt
 		switch {
-		case !supports32BitFCnt, fCnt > dev.matchedSession.LastFCntUp, fCnt == 0:
+		case !supports32BitFCnt, fCnt >= dev.matchedSession.LastFCntUp, fCnt == 0:
 		case fCnt > dev.matchedSession.LastFCntUp&0xffff:
 			fCnt |= dev.matchedSession.LastFCntUp &^ 0xffff
 		case dev.matchedSession.LastFCntUp < 0xffff0000:
@@ -213,7 +213,11 @@ outer:
 			(len(dev.RecentUplinks) == 0 || dev.PendingSession != nil) {
 			gap = 0
 		} else if !resetsFCnt {
-			if fCnt <= dev.matchedSession.LastFCntUp {
+			if fCnt == dev.matchedSession.LastFCntUp {
+				// TODO: Handle accordingly (https://github.com/TheThingsNetwork/lorawan-stack/issues/356)
+				logger.Debug("Possible uplink retransmission encountered, skipping...")
+				continue outer
+			} else if fCnt < dev.matchedSession.LastFCntUp {
 				logger.Debug("FCnt too low, skipping...")
 				continue outer
 			}
@@ -459,7 +463,7 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 	}
 
 	up.RxMetadata = acc.Accumulated()
-	ctx = log.NewContextWithField("metadata_count", len(up.RxMetadata))
+	ctx = log.NewContextWithField(ctx, "metadata_count", len(up.RxMetadata))
 	registerMergeMetadata(ctx, &matched.EndDeviceIdentifiers, up)
 	logger = log.FromContext(ctx)
 	logger.Debug("Merged metadata")

--- a/pkg/networkserver/mac_new_channel.go
+++ b/pkg/networkserver/mac_new_channel.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"go.thethings.network/lorawan-stack/pkg/events"
+	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 )
 
@@ -50,6 +51,12 @@ func enqueueNewChannelReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen,
 				MinDataRateIndex: ch.MinDataRateIndex,
 				MaxDataRateIndex: ch.MaxDataRateIndex,
 			}
+			log.FromContext(ctx).WithFields(log.Fields(
+				"index", pld.ChannelIndex,
+				"frequency", pld.Frequency,
+				"min_data_rate_index", pld.MinDataRateIndex,
+				"max_data_rate_index", pld.MaxDataRateIndex,
+			)).Debug("Enqueued NewChannelReq")
 			cmds = append(cmds, pld.MACCommand())
 
 			events.Publish(evtEnqueueNewChannelRequest(ctx, dev.EndDeviceIdentifiers, pld))

--- a/pkg/networkserver/utils.go
+++ b/pkg/networkserver/utils.go
@@ -66,13 +66,7 @@ func resetMACState(dev *ttnpb.EndDevice, fps *frequencyplans.Store, defaults ttn
 
 	dev.MACState = &ttnpb.MACState{
 		LoRaWANVersion: dev.LoRaWANVersion,
-	}
-	if dev.SupportsClassC {
-		dev.MACState.DeviceClass = ttnpb.CLASS_C
-	} else if dev.SupportsClassB {
-		dev.MACState.DeviceClass = ttnpb.CLASS_B
-	} else {
-		dev.MACState.DeviceClass = ttnpb.CLASS_A
+		DeviceClass: ttnpb.CLASS_A,
 	}
 
 	dev.MACState.CurrentParameters.MaxEIRP = band.DefaultMaxEIRP


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Replaces #318 
Closes #313 
Closes #317 
Closes #389
Closes #404 
Closes #406 

**Changes:**
<!-- What are the changes made in this pull request? -->

- NS fails downlink when the `pending_session` is set, i.e. the session has to be confirmed through uplink before class C downlink is accepted
- Improve logging