### PR TITLE
Pass stackConfig to device service

### DIFF
--- a/sdk/js/src/service/applications.js
+++ b/sdk/js/src/service/applications.js
@@ -43,7 +43,7 @@ class Applications {
       },
     })
     this.Link = new Link(api.As)
-    this.Devices = new Devices(api, { proxy })
+    this.Devices = new Devices(api, { proxy, stackConfig })
   }
 
   _responseTransform (response, single = true) {


### PR DESCRIPTION
**Summary:**
Closes #381 

**Changes:**
- Pass `stackConfig` object to the device service

**Notes for Reviewers:**
One line fix
