### PR TITLE
Gateway Server gateway configuration endpoint

### DIFF
--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -212,6 +212,27 @@ func (gs *GatewayServer) FillGatewayContext(ctx context.Context, ids ttnpb.Gatew
 	return ctx, ids, nil
 }
 
+// GetGateway gets the specified gateway by the gateway identifiers.
+func (gs *GatewayServer) GetGateway(ctx context.Context, ids ttnpb.GatewayIdentifiers, fieldmask types.FieldMask) (*ttnpb.Gateway, error) {
+	ctx = gs.FillContext(ctx)
+	if ids.IsZero() {
+		return nil, errEmptyIdentifiers
+	}
+	er := gs.GetPeer(ctx, ttnpb.PeerInfo_ENTITY_REGISTRY, nil)
+	if er == nil {
+		return nil, errEntityRegistryNotFound
+	}
+	gtw, err := ttnpb.NewGatewayRegistryClient(er.Conn()).Get(ctx, &ttnpb.GetGatewayRequest{
+		GatewayIdentifiers: ids,
+		FieldMask:          fieldmask,
+	}, gs.WithClusterAuth())
+	if err != nil {
+		return nil, err
+	}
+
+	return gtw, nil
+}
+
 var (
 	errGatewayNotRegistered = errors.DefineNotFound(
 		"gateway_not_registered",

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -94,6 +94,9 @@ func New(c *component.Component, conf *Config) (gs *GatewayServer, err error) {
 		udp.Start(lisCtx, gs, conn, conf.UDP.Config)
 	}
 
+	web := udp.StartWeb(gs.FillContext(gs.Context()), gs, conf.UDP.Config)
+	c.RegisterWeb(web)
+
 	for _, version := range []struct {
 		Format mqtt.Format
 		Config MQTTConfig
@@ -229,7 +232,6 @@ func (gs *GatewayServer) GetGateway(ctx context.Context, ids ttnpb.GatewayIdenti
 	if err != nil {
 		return nil, err
 	}
-
 	return gtw, nil
 }
 

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -20,6 +20,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/gogo/protobuf/types"
 	"go.thethings.network/lorawan-stack/pkg/band"
 	"go.thethings.network/lorawan-stack/pkg/errorcontext"
 	"go.thethings.network/lorawan-stack/pkg/errors"
@@ -35,6 +36,8 @@ const bufferSize = 10
 type Server interface {
 	// FillGatewayContext fills the given context and identifiers.
 	FillGatewayContext(ctx context.Context, ids ttnpb.GatewayIdentifiers) (context.Context, ttnpb.GatewayIdentifiers, error)
+	// GetGateway gets the specified gateway by the gateway identifiers.
+	GetGateway(ctx context.Context, ids ttnpb.GatewayIdentifiers, fieldmask types.FieldMask) (*ttnpb.Gateway, error)
 	// Connect connects a gateway by its identifiers to the Gateway Server, and returns a Connection for traffic and
 	// control.
 	Connect(ctx context.Context, protocol string, ids ttnpb.GatewayIdentifiers) (*Connection, error)

--- a/pkg/gatewayserver/io/mock/server.go
+++ b/pkg/gatewayserver/io/mock/server.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/gogo/protobuf/types"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/frequencyplans"
@@ -68,6 +69,18 @@ func (s *server) FillGatewayContext(ctx context.Context, ids ttnpb.GatewayIdenti
 	}
 	ids.GatewayID = fmt.Sprintf("eui-%v", strings.ToLower(ids.EUI.String()))
 	return ctx, ids, nil
+}
+
+// GetGateway implements io.Server.
+func (s *server) GetGateway(ctx context.Context, ids ttnpb.GatewayIdentifiers, fieldmask types.FieldMask) (*ttnpb.Gateway, error) {
+	if ids.IsZero() {
+		return nil, errors.New("the identifiers are zero")
+	}
+	gtw, ok := s.gateways[unique.ID(ctx, ids)]
+	if !ok {
+		return nil, errors.New("gateway not found")
+	}
+	return gtw, nil
 }
 
 // Connect implements io.Server.

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -52,6 +52,8 @@ type Config struct {
 	ScheduleLateTime time.Duration `name:"schedule-late-time" description:"Time in advance to send downlink to the gateway when scheduling late"`
 	// AddrChangeBlock defines the time to block traffic when the address changes.
 	AddrChangeBlock time.Duration `name:"addr-change-block" description:"Time to block traffic when a gateway's address changes"`
+	// RequreAuth defines if the HTTP endpoints should require authentication or not.
+	RequireAuth bool `name:"require-auth" description:"Require authentication for the HTTP endpoints."`
 }
 
 // DefaultConfig contains the default configuration.
@@ -62,6 +64,7 @@ var DefaultConfig = Config{
 	ConnectionExpires:   5 * time.Minute,
 	ScheduleLateTime:    800 * time.Millisecond,
 	AddrChangeBlock:     5 * time.Minute,
+	RequireAuth:         true,
 }
 
 type srv struct {

--- a/pkg/gatewayserver/io/udp/udp_test.go
+++ b/pkg/gatewayserver/io/udp/udp_test.go
@@ -48,6 +48,7 @@ var (
 		DownlinkPathExpires: 5 * timeout,
 		ConnectionExpires:   12 * timeout,
 		ScheduleLateTime:    0,
+		RequireAuth:         true,
 	}
 )
 

--- a/pkg/gatewayserver/io/udp/web.go
+++ b/pkg/gatewayserver/io/udp/web.go
@@ -1,0 +1,150 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package udp
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/gogo/protobuf/types"
+	echo "github.com/labstack/echo/v4"
+	"go.thethings.network/lorawan-stack/pkg/auth/rights"
+	web_errors "go.thethings.network/lorawan-stack/pkg/errors/web"
+	"go.thethings.network/lorawan-stack/pkg/gatewayserver/io"
+	"go.thethings.network/lorawan-stack/pkg/log"
+	"go.thethings.network/lorawan-stack/pkg/pfconfig/semtechudp"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	ttnweb "go.thethings.network/lorawan-stack/pkg/web"
+	"google.golang.org/grpc/metadata"
+)
+
+// WebServer is an interface for registering the UDP web frontend.
+type WebServer interface {
+	ttnweb.Registerer
+}
+
+type webSrv struct {
+	ctx    context.Context
+	config Config
+
+	server io.Server
+}
+
+// RegisterRoutes registers the UDP web frontend routes.
+func (s *webSrv) RegisterRoutes(server *ttnweb.Server) {
+	middleware := []echo.MiddlewareFunc{
+		s.handleError(),
+		s.validateAndFillIDs(),
+	}
+	if s.config.RequireAuth {
+		middleware = append(middleware, s.requireGatewayRights(ttnpb.RIGHT_GATEWAY_INFO))
+	}
+	group := server.Group(ttnpb.HTTPAPIPrefix+"/gs/gateways/:gateway_id", middleware...)
+	group.GET("/global_conf.json", func(c echo.Context) error {
+		return s.handleGet(c)
+	})
+}
+
+// StartWeb starts the UDP web frontend.
+func StartWeb(ctx context.Context, server io.Server, config Config) WebServer {
+	s := &webSrv{
+		ctx:    ctx,
+		server: server,
+		config: config,
+	}
+
+	return s
+}
+
+func (s *webSrv) handleGet(c echo.Context) error {
+	ctx := s.ctx
+	gtwID := c.Get(gatewayIDKey).(ttnpb.GatewayIdentifiers)
+	gtw, err := s.server.GetGateway(ctx, gtwID, types.FieldMask{
+		Paths: []string{
+			"gateway_server_address",
+		},
+	})
+	if err != nil {
+		return err
+	}
+	frequencyPlan, err := s.server.GetFrequencyPlan(ctx, gtwID)
+	if err != nil {
+		return err
+	}
+	config, err := semtechudp.BuildSimple(gtw, frequencyPlan)
+	if err != nil {
+		return err
+	}
+	return c.JSONPretty(http.StatusOK, config, "\t")
+}
+
+func (s *webSrv) handleError() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			err := next(c)
+			if err == nil || c.Response().Committed {
+				return err
+			}
+			log.FromContext(s.ctx).WithError(err).Debug("HTTP request failed")
+			statusCode, err := web_errors.ProcessError(err)
+			if strings.Contains(c.Request().Header.Get(echo.HeaderAccept), "application/json") {
+				return c.JSON(statusCode, err)
+			}
+			return c.String(statusCode, err.Error())
+		}
+	}
+}
+
+const (
+	gatewayIDKey = "gateway_id"
+)
+
+func (s *webSrv) validateAndFillIDs() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			gtwID := ttnpb.GatewayIdentifiers{
+				GatewayID: c.Param(gatewayIDKey),
+			}
+			if err := gtwID.ValidateContext(s.ctx); err != nil {
+				return err
+			}
+			c.Set(gatewayIDKey, gtwID)
+
+			return next(c)
+		}
+	}
+}
+
+func (s *webSrv) requireGatewayRights(required ...ttnpb.Right) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			ctx := s.ctx
+			gtwID := c.Get(gatewayIDKey).(ttnpb.GatewayIdentifiers)
+			md := metadata.New(map[string]string{
+				"id":            gtwID.GatewayID,
+				"authorization": c.Request().Header.Get(echo.HeaderAuthorization),
+			})
+			if ctxMd, ok := metadata.FromIncomingContext(ctx); ok {
+				md = metadata.Join(ctxMd, md)
+			}
+			ctx = metadata.NewIncomingContext(ctx, md)
+			if err := rights.RequireGateway(ctx, gtwID, required...); err != nil {
+				return err
+			}
+			return next(c)
+		}
+	}
+}

--- a/pkg/gatewayserver/io/udp/web_test.go
+++ b/pkg/gatewayserver/io/udp/web_test.go
@@ -1,0 +1,129 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package udp_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/pkg/auth/rights"
+	"go.thethings.network/lorawan-stack/pkg/component"
+	"go.thethings.network/lorawan-stack/pkg/config"
+	"go.thethings.network/lorawan-stack/pkg/gatewayserver/io/mock"
+	. "go.thethings.network/lorawan-stack/pkg/gatewayserver/io/udp"
+	"go.thethings.network/lorawan-stack/pkg/log"
+	"go.thethings.network/lorawan-stack/pkg/rpcmetadata"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/pkg/unique"
+	"go.thethings.network/lorawan-stack/pkg/util/test"
+	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
+)
+
+func TestWeb(t *testing.T) {
+	ctx := log.NewContext(test.Context(), test.GetLogger(t))
+	t.Run("GetGateway", func(t *testing.T) {
+		httpAddress := "0.0.0.0:8098"
+		gs := mock.NewServer()
+		gtw := &ttnpb.Gateway{
+			GatewayIdentifiers:   registeredGatewayID,
+			FrequencyPlanID:      "EXAMPLE",
+			GatewayServerAddress: "localhost",
+		}
+		gs.RegisterGateway(ctx, registeredGatewayID, gtw)
+		s := StartWeb(newContextWithRightsFetcher(ctx), gs, testConfig)
+		conf := &component.Config{
+			ServiceBase: config.ServiceBase{
+				HTTP: config.HTTP{
+					Listen: httpAddress,
+				},
+			},
+		}
+		c := component.MustNew(test.GetLogger(t), conf)
+		c.RegisterWeb(s)
+		test.Must(nil, c.Start())
+		defer c.Close()
+
+		t.Run("Authorization", func(t *testing.T) {
+			for _, tc := range []struct {
+				Name       string
+				ID         ttnpb.GatewayIdentifiers
+				Key        string
+				ExpectCode int
+			}{
+				{
+					Name:       "Valid",
+					ID:         registeredGatewayID,
+					Key:        registeredGatewayKey,
+					ExpectCode: http.StatusOK,
+				},
+				{
+					Name:       "InvalidKey",
+					ID:         registeredGatewayID,
+					Key:        "invalid key",
+					ExpectCode: http.StatusForbidden,
+				},
+				{
+					Name:       "InvalidIDAndKey",
+					ID:         ttnpb.GatewayIdentifiers{GatewayID: "--invalid-id"},
+					Key:        "invalid key",
+					ExpectCode: http.StatusBadRequest,
+				},
+			} {
+				t.Run(tc.Name, func(t *testing.T) {
+					a := assertions.New(t)
+					url := fmt.Sprintf("http://%s/api/v3/gs/gateways/%s/global_conf.json",
+						httpAddress, tc.ID.GatewayID,
+					)
+					body := bytes.NewReader([]byte(`{"downlinks":[]}`))
+					req, err := http.NewRequest(http.MethodGet, url, body)
+					if !a.So(err, should.BeNil) {
+						t.FailNow()
+					}
+					req.Header.Set("Content-Type", "application/json")
+					req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tc.Key))
+					res, err := http.DefaultClient.Do(req)
+					if !a.So(err, should.BeNil) {
+						t.FailNow()
+					}
+					a.So(res.StatusCode, should.Equal, tc.ExpectCode)
+				})
+			}
+		})
+	})
+}
+
+func newContextWithRightsFetcher(ctx context.Context) context.Context {
+	return rights.NewContextWithFetcher(
+		ctx,
+		rights.FetcherFunc(func(ctx context.Context, ids ttnpb.Identifiers) (set *ttnpb.Rights, err error) {
+			uid := unique.ID(ctx, ids)
+			if uid != registeredGatewayUID {
+				return
+			}
+			md := rpcmetadata.FromIncomingContext(ctx)
+			if md.AuthType != "Bearer" || md.AuthValue != registeredGatewayKey {
+				return
+			}
+			set = ttnpb.RightsFrom(
+				ttnpb.RIGHT_GATEWAY_INFO,
+			)
+			return
+		}),
+	)
+}

--- a/pkg/pfconfig/semtechudp/semtechudp.go
+++ b/pkg/pfconfig/semtechudp/semtechudp.go
@@ -41,6 +41,16 @@ type GatewayConf struct {
 
 // Build builds a packet forwarder configuration for the given gateway, using the given frequency plan store.
 func Build(gateway *ttnpb.Gateway, store *frequencyplans.Store) (*Config, error) {
+	frequencyPlan, err := store.GetByID(gateway.FrequencyPlanID)
+	if err != nil {
+		return nil, err
+	}
+
+	return BuildSimple(gateway, frequencyPlan)
+}
+
+// BuildSimple builds a packet forwarder configuration for the given gateway, using the given frequency plan.
+func BuildSimple(gateway *ttnpb.Gateway, frequencyPlan *frequencyplans.FrequencyPlan) (*Config, error) {
 	var c Config
 
 	host, portStr, err := net.SplitHostPort(gateway.GatewayServerAddress)
@@ -57,10 +67,6 @@ func Build(gateway *ttnpb.Gateway, store *frequencyplans.Store) (*Config, error)
 	server.Enabled = true
 	c.GatewayConf.Servers = append(c.GatewayConf.Servers, server)
 
-	frequencyPlan, err := store.GetByID(gateway.FrequencyPlanID)
-	if err != nil {
-		return nil, err
-	}
 	sx1301Config, err := shared.BuildSX1301Config(frequencyPlan)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #64

**Changes:**
<!-- What are the changes made in this pull request? -->

- Added the `/api/v3/gs/gateways/:gateway_id/global_conf.json` that generates the gateway configuration.
- Added `GetGateway` to `io.Server` in the GS UDP frontend package.

**Notes for Reviewers:**
<!--
Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Non-registered gateways cannot be retrieved.

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Added the `/api/v3/gs/gateways/<gateway ID>/global_conf.json` that generates the gateway configuration in the JSON format based on the frequency plan.
