### PR TITLE
Improve form/field value handling

### DIFF
--- a/pkg/webui/components/field/group/index.js
+++ b/pkg/webui/components/field/group/index.js
@@ -16,6 +16,7 @@ import React from 'react'
 
 import Message from '../../../lib/components/message'
 import PropTypes from '../../../lib/prop-types'
+import getByPath from '../../../lib/get-by-path'
 import Field, { FieldError } from '..'
 
 import style from './group.styl'
@@ -29,13 +30,25 @@ class FieldGroup extends React.Component {
       title,
       titleComponent = 'h4',
       errors,
+      value,
+      disabled,
+      setFieldValue,
+      setFieldTouched,
+      horizontal,
     } = this.props
+
     const fields = React.Children.map(children, function (Child) {
       if (React.isValidElement(Child) && Child.type === Field) {
         const fieldName = `${name}.${Child.props.name}`
+        const fieldValue = getByPath(value, Child.props.name)
         return React.cloneElement(Child, {
           ...Child.props,
           name: fieldName,
+          value: fieldValue,
+          disabled,
+          setFieldValue,
+          setFieldTouched,
+          horizontal,
         })
       }
 

--- a/pkg/webui/components/field/group/index.js
+++ b/pkg/webui/components/field/group/index.js
@@ -29,7 +29,7 @@ class FieldGroup extends React.Component {
       name,
       title,
       titleComponent = 'h4',
-      errors,
+      error,
       value,
       disabled,
       setFieldValue,
@@ -55,8 +55,6 @@ class FieldGroup extends React.Component {
       return Child
     })
 
-
-    const error = errors[name]
     return (
       <div className={className}>
         <div className={style.header}>

--- a/pkg/webui/components/field/group/index.js
+++ b/pkg/webui/components/field/group/index.js
@@ -35,6 +35,7 @@ class FieldGroup extends React.Component {
       setFieldValue,
       setFieldTouched,
       horizontal,
+      touched,
     } = this.props
 
     const fields = React.Children.map(children, function (Child) {
@@ -45,9 +46,11 @@ class FieldGroup extends React.Component {
           ...Child.props,
           name: fieldName,
           value: fieldValue,
+          touches: name,
           disabled,
           setFieldValue,
           setFieldTouched,
+          validateOnChange: true,
           horizontal,
         })
       }
@@ -63,7 +66,7 @@ class FieldGroup extends React.Component {
             component={titleComponent}
             content={title}
           />
-          {error && <FieldError name={name} error={error} />}
+          {touched && error && <FieldError name={name} error={error} />}
         </div>
         {fields}
       </div>

--- a/pkg/webui/components/field/index.js
+++ b/pkg/webui/components/field/index.js
@@ -128,14 +128,14 @@ const Field = function (props) {
   const handleChange = function (value) {
     props.setFieldValue(props.name, value)
     if (props.validateOnChange) {
-      props.setFieldTouched(props.name, true)
+      props.setFieldTouched(props.touches || props.name, true)
     }
   }
 
   const handleBlur = function (e) {
     // Always regard inputs that never received a value as untouched (better UX)
     if (e.target.value !== '' && props.validateOnBlur) {
-      props.setFieldTouched(props.name, true)
+      props.setFieldTouched(props.touches || props.name, true)
     }
   }
 
@@ -147,7 +147,7 @@ const Field = function (props) {
     placeholder = props.title,
     description = null,
     warning,
-    touched,
+    touched = false,
     horizontal = false,
     disabled = false,
     readOnly = false,
@@ -158,16 +158,14 @@ const Field = function (props) {
 
   // Underscored assignment due to naming conflict
   let _error = rest.error
-  let _touched = touched
   const formatMessage = content => typeof content === 'object' ? props.intl.formatMessage(content) : content
 
   if (form) {
     // preserve default values for different inputs
     rest.value = rest.value || ''
-    _touched = touched && touched[name]
-    rest.onChange = handleChange
+    rest.onChange = rest.onChange || handleChange
     rest.onBlur = handleBlur
-    _error = _touched && rest.error
+    _error = touched && rest.error
 
     // Dismiss non boolean values for checkboxes
     if (type === 'checkbox') {
@@ -184,7 +182,7 @@ const Field = function (props) {
   rest.type = type
   rest.placeholder = placeholder ? formatMessage(placeholder) : ''
 
-  const hasMessages = _touched && (_error || warning)
+  const hasMessages = touched && (_error || warning)
 
   const classname = classnames(className, style.field, style[type], ...from(style, {
     error: rest.error,
@@ -230,7 +228,7 @@ Field.propTypes = {
     PropTypes.node,
     PropTypes.message,
   ]),
-  /** "name" prop applied to the input */
+  /** "name" prop applied to the input, mapped to the form value object */
   name: PropTypes.string.isRequired,
   /**
    * The field type (eg. text, byte, password, checkbox), thunked values are
@@ -256,6 +254,9 @@ Field.propTypes = {
    * This is necessary to map form values correctly.
    */
   form: PropTypes.bool,
+  /** The value name that the field will set to touched (defaults to 'name' prop)
+   */
+  touches: PropTypes.string,
 }
 
 const Err = function (props) {

--- a/pkg/webui/components/field/index.js
+++ b/pkg/webui/components/field/index.js
@@ -179,16 +179,16 @@ const Field = function (props) {
     if (type === 'checkbox') {
       rest.value = typeof rest.value === 'boolean' ? rest.value : false
     }
-
-    // restore the rest object for future per component filtering
-    rest.name = name
-    rest.readOnly = readOnly
-    rest.disabled = disabled
-    rest.error = _touched && Boolean(_error)
-    rest.warning = Boolean(warning)
-    rest.type = type
-    rest.placeholder = placeholder ? formatMessage(placeholder) : ''
   }
+
+  // restore the rest object for future per component filtering
+  rest.name = name
+  rest.readOnly = readOnly
+  rest.disabled = disabled
+  rest.error = _touched && Boolean(_error)
+  rest.warning = Boolean(warning)
+  rest.type = type
+  rest.placeholder = placeholder ? formatMessage(placeholder) : ''
 
   const hasMessages = _touched && (_error || warning)
 

--- a/pkg/webui/components/field/index.js
+++ b/pkg/webui/components/field/index.js
@@ -258,9 +258,21 @@ Field.propTypes = {
    * This is necessary to map form values correctly.
    */
   form: PropTypes.bool,
+  /** A flag indicating whether the field has already received any input so far */
+  touched: PropTypes.bool,
   /** The value name that the field will set to touched (defaults to 'name' prop)
    */
   touches: PropTypes.string,
+  /** A flag indicating whether the field value should be validated when the
+   * input triggered a blur event */
+  validateOnBlur: PropTypes.bool,
+  /** A flag indicating whether the field value should be validated when the
+   * input triggered a change event */
+  validateOnChange: PropTypes.bool,
+  /** The passed (formik) function to change form data */
+  setFieldValue: PropTypes.func,
+  /** The passed (formik) function to set the touch value of a form data property */
+  setFieldTouched: PropTypes.func,
 }
 
 const Err = function (props) {

--- a/pkg/webui/components/field/index.js
+++ b/pkg/webui/components/field/index.js
@@ -245,7 +245,7 @@ Field.propTypes = {
   type: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.func,
-  ]).isRequired,
+  ]),
   /** Error to be displayed next to input */
   error: PropTypes.error,
   /** Warning to be displayed next to input */

--- a/pkg/webui/components/field/index.js
+++ b/pkg/webui/components/field/index.js
@@ -124,25 +124,11 @@ const component = function (type) {
 }
 
 const Field = function (props) {
-
-  const handleChange = function (value) {
-    props.setFieldValue(props.name, value)
-    if (props.validateOnChange) {
-      props.setFieldTouched(props.touches || props.name, true)
-    }
-  }
-
-  const handleBlur = function (e) {
-    // Always regard inputs that never received a value as untouched (better UX)
-    if (e.target.value !== '' && props.validateOnBlur) {
-      props.setFieldTouched(props.touches || props.name, true)
-    }
-  }
-
   const {
     className,
     type = 'text',
     name = '',
+    touches = props.name,
     title,
     placeholder = props.title,
     description = null,
@@ -153,8 +139,26 @@ const Field = function (props) {
     readOnly = false,
     required = false,
     form = true,
+    validateOnBlur,
+    validateOnChange,
+    setFieldValue,
+    setFieldTouched,
     ...rest
   } = props
+
+  const handleChange = function (value) {
+    setFieldValue(name, value)
+    if (validateOnChange) {
+      setFieldTouched(touches, true)
+    }
+  }
+
+  const handleBlur = function (e) {
+    // Always regard inputs that never received a value as untouched (better UX)
+    if (e.target.value !== '' && validateOnBlur) {
+      setFieldTouched(touches, true)
+    }
+  }
 
   // Underscored assignment due to naming conflict
   let _error = rest.error

--- a/pkg/webui/components/field/index.js
+++ b/pkg/webui/components/field/index.js
@@ -19,7 +19,6 @@ import { injectIntl } from 'react-intl'
 import PropTypes from '../../lib/prop-types'
 import from from '../../lib/from'
 import { warn } from '../../lib/log'
-import getByPath from '../../lib/get-by-path'
 
 import Icon from '../icon'
 import Input from '../input'
@@ -147,7 +146,6 @@ const Field = function (props) {
     title,
     placeholder = props.title,
     description = null,
-    error,
     warning,
     touched,
     horizontal = false,
@@ -159,21 +157,17 @@ const Field = function (props) {
   } = props
 
   // Underscored assignment due to naming conflict
-
-  let _error = props.error
-  let _touched = props.touched
+  let _error = rest.error
+  let _touched = touched
   const formatMessage = content => typeof content === 'object' ? props.intl.formatMessage(content) : content
 
   if (form) {
-    const {
-      errors = {},
-    } = props
-
     // preserve default values for different inputs
-    _error = getByPath(errors, name)
+    rest.value = rest.value || ''
     _touched = touched && touched[name]
     rest.onChange = handleChange
     rest.onBlur = handleBlur
+    _error = _touched && rest.error
 
     // Dismiss non boolean values for checkboxes
     if (type === 'checkbox') {
@@ -185,7 +179,7 @@ const Field = function (props) {
   rest.name = name
   rest.readOnly = readOnly
   rest.disabled = disabled
-  rest.error = _touched && Boolean(_error)
+  rest.error = Boolean(_error)
   rest.warning = Boolean(warning)
   rest.type = type
   rest.placeholder = placeholder ? formatMessage(placeholder) : ''
@@ -193,7 +187,7 @@ const Field = function (props) {
   const hasMessages = _touched && (_error || warning)
 
   const classname = classnames(className, style.field, style[type], ...from(style, {
-    error: _error,
+    error: rest.error,
     warning: warning && !_error,
     horizontal,
     required,

--- a/pkg/webui/components/field/index.js
+++ b/pkg/webui/components/field/index.js
@@ -148,7 +148,6 @@ const Field = function (props) {
     placeholder = props.title,
     description = null,
     error,
-    value,
     warning,
     touched,
     horizontal = false,
@@ -161,25 +160,25 @@ const Field = function (props) {
 
   // Underscored assignment due to naming conflict
 
-  let _value = props.value
   let _error = props.error
   let _touched = props.touched
   const formatMessage = content => typeof content === 'object' ? props.intl.formatMessage(content) : content
 
   if (form) {
     const {
-      values = {},
       errors = {},
     } = props
 
     // preserve default values for different inputs
-    // make sure the checkbox component gets `false` as a falsy value
-    _value = getByPath(values, name) || (type === 'checkbox' ? false : '')
     _error = getByPath(errors, name)
-    _touched = touched[name]
-    rest.value = _value
+    _touched = touched && touched[name]
     rest.onChange = handleChange
     rest.onBlur = handleBlur
+
+    // Dismiss non boolean values for checkboxes
+    if (type === 'checkbox') {
+      rest.value = typeof rest.value === 'boolean' ? rest.value : false
+    }
 
     // restore the rest object for future per component filtering
     rest.name = name

--- a/pkg/webui/components/form/index.js
+++ b/pkg/webui/components/form/index.js
@@ -111,13 +111,14 @@ class InnerForm extends React.Component {
           const { name, value: originalValue } = Child.props
           const value = name ? getByPath(values, name) : originalValue
           const fieldError = getByPath(combinedErrors, name)
+          const fieldTouched = getByPath(touched, name)
 
           return React.cloneElement(Child, {
             setFieldValue,
             setFieldTouched,
             error: fieldError,
+            touched: fieldTouched,
             value,
-            touched,
             horizontal,
             submitEnabledWhenInvalid,
             validateOnBlur,
@@ -148,6 +149,7 @@ class InnerForm extends React.Component {
             ...Child.props,
             setFieldValue,
             setFieldTouched,
+            touched: groupTouched,
             error: groupError,
             value,
             horizontal,

--- a/pkg/webui/components/form/index.js
+++ b/pkg/webui/components/form/index.js
@@ -103,17 +103,19 @@ class InnerForm extends React.Component {
     const formError = status.formError || false
     const serverErrors = status.errors || {}
     const clientErrors = errors
+    const combinedErrors = { ...serverErrors, ...clientErrors }
 
     const decoratedChildren = recursiveMap(children,
       function (Child) {
         if (Child.type === Field) {
           const { name, value: originalValue } = Child.props
           const value = name ? getByPath(values, name) : originalValue
+          const fieldError = getByPath(combinedErrors, name)
 
           return React.cloneElement(Child, {
             setFieldValue,
             setFieldTouched,
-            errors: { ...serverErrors, ...clientErrors },
+            error: fieldError,
             value,
             touched,
             horizontal,

--- a/pkg/webui/components/form/index.js
+++ b/pkg/webui/components/form/index.js
@@ -108,8 +108,8 @@ class InnerForm extends React.Component {
     const decoratedChildren = recursiveMap(children,
       function (Child) {
         if (Child.type === Field) {
-          const { name, value: originalValue } = Child.props
-          const value = name ? getByPath(values, name) : originalValue
+          const { name } = Child.props
+          const value = getByPath(values, name)
           const fieldError = getByPath(combinedErrors, name)
           const fieldTouched = getByPath(touched, name)
 
@@ -142,7 +142,7 @@ class InnerForm extends React.Component {
           }
         } else if (Child.type === FieldGroup) {
           const { name } = Child.props
-          const value = name && getByPath(values, name)
+          const value = getByPath(values, name)
           const groupError = getByPath(combinedErrors, name)
           const groupTouched = getByPath(touched, name)
           return React.cloneElement(Child, {

--- a/pkg/webui/components/form/index.js
+++ b/pkg/webui/components/form/index.js
@@ -142,12 +142,14 @@ class InnerForm extends React.Component {
         } else if (Child.type === FieldGroup) {
           const { name } = Child.props
           const value = name && getByPath(values, name)
+          const groupError = getByPath(combinedErrors, name)
+          const groupTouched = getByPath(touched, name)
           return React.cloneElement(Child, {
             ...Child.props,
             setFieldValue,
             setFieldTouched,
+            error: groupError,
             value,
-            errors,
             horizontal,
           })
         }

--- a/pkg/webui/components/form/index.js
+++ b/pkg/webui/components/form/index.js
@@ -138,9 +138,15 @@ class InnerForm extends React.Component {
             })
           }
         } else if (Child.type === FieldGroup) {
+          const { name } = Child.props
+          const value = name && getByPath(values, name)
           return React.cloneElement(Child, {
             ...Child.props,
+            setFieldValue,
+            setFieldTouched,
+            value,
             errors,
+            horizontal,
           })
         }
 
@@ -213,7 +219,7 @@ function recursiveMap (children, fn) {
     }
 
     let child = Child
-    if (child.props.children) {
+    if (child.props.children && child.type !== FieldGroup) {
       child = React.cloneElement(child, {
         children: recursiveMap(child.props.children, fn),
       })

--- a/pkg/webui/components/form/index.js
+++ b/pkg/webui/components/form/index.js
@@ -21,6 +21,7 @@ import FieldGroup from '../field/group'
 import Button from '../button'
 import Notification from '../notification'
 import PropTypes from '../../lib/prop-types'
+import getByPath from '../../lib/get-by-path'
 
 @bind
 class InnerForm extends React.Component {
@@ -106,11 +107,14 @@ class InnerForm extends React.Component {
     const decoratedChildren = recursiveMap(children,
       function (Child) {
         if (Child.type === Field) {
+          const { name, value: originalValue } = Child.props
+          const value = name ? getByPath(values, name) : originalValue
+
           return React.cloneElement(Child, {
             setFieldValue,
             setFieldTouched,
             errors: { ...serverErrors, ...clientErrors },
-            values,
+            value,
             touched,
             horizontal,
             submitEnabledWhenInvalid,


### PR DESCRIPTION
**Summary:**
Closes #393. Additionally, it will also change the error values mapping respectively. It also makes the `FieldGroup` hold and handle the form value connected to its name. We need this for #353.

**Changes:**
- Make `<Form />` only pass the value that the field needs
- Make `<Form />` only pass the error value that the field needs
- Make `<FieldGroup />` a container of a form value and handling its children's state
- Fix a bug that would result in some input props not being passed in non form controlled fields
- Remove requiring the type prop in `<Field />`, as it is defaulting to `text` (caused warnings)

**Notes for Reviewers:**
We discussed this yesterday. 
