### PR TITLE
Only send queue invalidation to AS when downlink gets scheduled

### DIFF
--- a/pkg/applicationserver/io/mqtt/mqtt.go
+++ b/pkg/applicationserver/io/mqtt/mqtt.go
@@ -112,7 +112,7 @@ func (c *connection) setup(ctx context.Context) error {
 				return
 			}
 			if pkt != nil {
-				logger.Debugf("Scheduling %s packet", packet.Name[pkt.PacketType()])
+				logger.Debugf("Schedule %s packet", packet.Name[pkt.PacketType()])
 				controlCh <- pkt
 			}
 		}
@@ -153,7 +153,7 @@ func (c *connection) setup(ctx context.Context) error {
 					logger.WithError(err).Warn("Failed to marshal upstream message")
 					continue
 				}
-				logger.Info("Publishing upstream message")
+				logger.Info("Publish upstream message")
 				c.session.Publish(&packet.PublishPacket{
 					TopicName:  topic.Join(topicParts),
 					TopicParts: topicParts,
@@ -180,7 +180,7 @@ func (c *connection) setup(ctx context.Context) error {
 				if !ok {
 					return
 				}
-				logger.Debug("Writing publish packet")
+				logger.Debug("Write publish packet")
 				err = c.mqtt.Send(pkt)
 			}
 			if err != nil {
@@ -323,7 +323,7 @@ func (c *connection) deliver(pkt *packet.PublishPacket) {
 	logger.WithFields(log.Fields(
 		"device_uid", unique.ID(c.io.Context(), ids),
 		"count", len(items.Downlinks),
-	)).Debug("Handling downlink messages")
+	)).Debug("Handle downlink messages")
 	if err := op(c.server, c.io.Context(), ids, items.Downlinks); err != nil {
 		logger.WithError(err).Warn("Failed to handle downlink messages")
 	}

--- a/pkg/applicationserver/io/web/webhooks.go
+++ b/pkg/applicationserver/io/web/webhooks.go
@@ -307,7 +307,7 @@ func (w *webhooks) handleUp(ctx context.Context, msg *ttnpb.ApplicationUp) error
 			if req == nil {
 				return
 			}
-			logger.WithField("url", req.URL).Debug("Processing message")
+			logger.WithField("url", req.URL).Debug("Process message")
 			if err := w.target.Process(req); err != nil {
 				logger.WithError(err).Warn("Failed to process message")
 			}
@@ -395,7 +395,7 @@ func (w *webhooks) handleDown(c echo.Context, op func(io.Server, context.Context
 	if err != nil {
 		return err
 	}
-	logger.Debug("Performing downlink queue operation")
+	logger.Debug("Perform downlink queue operation")
 	if err := op(w.server, ctx, devID, items.Downlinks); err != nil {
 		return err
 	}

--- a/pkg/applicationserver/linking.go
+++ b/pkg/applicationserver/linking.go
@@ -180,10 +180,10 @@ func (as *ApplicationServer) link(ctx context.Context, ids ttnpb.ApplicationIden
 	client := ttnpb.NewAsNsClient(l.conn)
 	ctx = log.NewContextWithField(ctx, "network_server", l.connName)
 	logger := log.FromContext(ctx)
-	logger.Debug("Linking")
+	logger.Debug("Link")
 	stream, err := client.LinkApplication(ctx, l.callOpts...)
 	if err != nil {
-		logger.WithError(err).Warn("Linking failed")
+		logger.WithError(err).Warn("Link setup failed")
 		return err
 	}
 	logger.Info("Linked")
@@ -254,7 +254,7 @@ func (as *ApplicationServer) cancelLink(ctx context.Context, ids ttnpb.Applicati
 	uid := unique.ID(ctx, ids)
 	if val, ok := as.links.Load(uid); ok {
 		l := val.(*link)
-		log.FromContext(ctx).WithField("application_uid", uid).Debug("Unlinking")
+		log.FromContext(ctx).WithField("application_uid", uid).Debug("Unlink")
 		l.cancel(context.Canceled)
 	} else {
 		as.linkErrors.Delete(uid)

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -265,7 +265,7 @@ func (gs *GatewayServer) Connect(ctx context.Context, protocol string, ids ttnpb
 		if !ok {
 			return nil, errNoFallbackFrequencyPlan.WithAttributes("gateway_uid", uid)
 		}
-		logger.Warn("Connecting unregistered gateway")
+		logger.Warn("Connect unregistered gateway")
 		gtw = &ttnpb.Gateway{
 			GatewayIdentifiers:     ids,
 			FrequencyPlanID:        fpID,
@@ -336,7 +336,7 @@ func (gs *GatewayServer) handleUpstream(conn *io.Connection) {
 				if ids.DevAddr != nil && !ids.DevAddr.IsZero() {
 					logger = logger.WithField("dev_addr", *ids.DevAddr)
 				}
-				logger.Debug("Dropping message")
+				logger.Debug("Drop message")
 				registerDropUplink(ctx, ids, conn.Gateway(), msg, err)
 			}
 			ids, err := lorawan.GetUplinkMessageIdentifiers(msg)

--- a/pkg/gatewayserver/io/grpc/grpc.go
+++ b/pkg/gatewayserver/io/grpc/grpc.go
@@ -85,7 +85,7 @@ func (s *impl) LinkGateway(link ttnpb.GtwGs_LinkGatewayServer) (err error) {
 				msg := &ttnpb.GatewayDown{
 					DownlinkMessage: down,
 				}
-				logger.Info("Sending downlink message")
+				logger.Info("Send downlink message")
 				if err := link.Send(msg); err != nil {
 					logger.WithError(err).Warn("Failed to send message")
 					conn.Disconnect(err)

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -223,7 +223,7 @@ func (c *Connection) SendDown(path *ttnpb.DownlinkPath, msg *ttnpb.DownlinkMessa
 	// Otherwise, scheduling is done by the Gateway Server scheduler. This converts TxRequest to TxSettings.
 	if c.scheduler != nil {
 		logger := log.FromContext(c.ctx).WithField("class", request.Class)
-		logger.Debug("Attempting to schedule downlink on gateway")
+		logger.Debug("Attempt to schedule downlink on gateway")
 		ids, uplinkTimestamp, err := getDownlinkPath(path, request.Class)
 		if err != nil {
 			return 0, err
@@ -249,12 +249,6 @@ func (c *Connection) SendDown(path *ttnpb.DownlinkPath, msg *ttnpb.DownlinkMessa
 				delay:         time.Second,
 			},
 		} {
-			logger := logger.WithFields(log.Fields(
-				"rx_window", i+1,
-				"frequency", rx.frequency,
-				"data_rate", rx.dataRateIndex,
-			))
-			logger.Debug("Attempting to schedule downlink in receive window")
 			rx1Delay := time.Duration(request.Rx1Delay) * time.Second
 			if rx1Delay == 0 {
 				rx1Delay = time.Second // RX_DELAY_0 is valid, and 1 second.
@@ -264,6 +258,12 @@ func (c *Connection) SendDown(path *ttnpb.DownlinkPath, msg *ttnpb.DownlinkMessa
 				errRxDetails = append(errRxDetails, errRxEmpty)
 				continue
 			}
+			logger := logger.WithFields(log.Fields(
+				"rx_window", i+1,
+				"frequency", rx.frequency,
+				"data_rate_index", rx.dataRateIndex,
+			))
+			logger.Debug("Attempt to schedule downlink in receive window")
 			dataRate := band.DataRates[rx.dataRateIndex].Rate
 			if dataRate == (ttnpb.DataRate{}) {
 				return 0, errDataRate.WithAttributes("index", rx.dataRateIndex)

--- a/pkg/gatewayserver/io/mqtt/mqtt.go
+++ b/pkg/gatewayserver/io/mqtt/mqtt.go
@@ -109,7 +109,7 @@ func (c *connection) setup(ctx context.Context) error {
 				return
 			}
 			if pkt != nil {
-				logger.Debugf("Scheduling %s packet", packet.Name[pkt.PacketType()])
+				logger.Debugf("Schedule %s packet", packet.Name[pkt.PacketType()])
 				controlCh <- pkt
 			}
 		}
@@ -128,7 +128,7 @@ func (c *connection) setup(ctx context.Context) error {
 					logger.WithError(err).Warn("Failed to marshal downlink message")
 					continue
 				}
-				logger.Info("Publishing downlink message")
+				logger.Info("Publish downlink message")
 				topicParts := c.format.DownlinkTopic(unique.ID(c.io.Context(), c.io.Gateway().GatewayIdentifiers))
 				c.session.Publish(&packet.PublishPacket{
 					TopicName:  topic.Join(topicParts),
@@ -156,7 +156,7 @@ func (c *connection) setup(ctx context.Context) error {
 				if !ok {
 					return
 				}
-				logger.Debug("Writing publish packet")
+				logger.Debug("Write publish packet")
 				err = c.mqtt.Send(pkt)
 			}
 			if err != nil {

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -348,7 +348,7 @@ func (s *srv) handleDown(ctx context.Context, state *state) error {
 				sent:           time.Now(),
 			})
 			write := func() {
-				logger.Debug("Writing downlink message")
+				logger.Debug("Write downlink message")
 				if err := s.write(packet); err != nil {
 					logger.WithError(err).Warn("Failed to write downlink message")
 					// TODO: Report to Network Server: https://github.com/TheThingsNetwork/lorawan-stack/issues/76
@@ -367,7 +367,7 @@ func (s *srv) handleDown(ctx context.Context, state *state) error {
 				break
 			}
 			d := time.Until(gatewayTime.Add(-s.config.ScheduleLateTime))
-			logger.WithField("duration", d).Debug("Waiting to schedule downlink message late")
+			logger.WithField("duration", d).Debug("Wait to schedule downlink message late")
 			time.AfterFunc(d, write)
 		case <-healthCheck.C:
 			lastSeenPull := time.Unix(0, atomic.LoadInt64(&state.lastSeenPull))

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -147,7 +147,7 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 	cmdBuf := make([]byte, 0, maxDownLen)
 	for _, cmd := range cmds {
 		var err error
-		logger.WithField("cid", cmd.CID).Debug("Adding MAC command to buffer...")
+		logger.WithField("cid", cmd.CID).Debug("Add MAC command to buffer")
 		cmdBuf, err = spec.AppendDownlink(cmdBuf, *cmd)
 
 		if err != nil {
@@ -200,7 +200,7 @@ outer:
 		down, dev.QueuedApplicationDownlinks = dev.QueuedApplicationDownlinks[0], dev.QueuedApplicationDownlinks[1:]
 
 		if len(down.FRMPayload) > int(maxDownLen) {
-			logger.Warn("Application downlink present, but the payload is too long, informing Application Server...")
+			logger.Warn("Application downlink present, but the payload is too long, inform Application Server")
 			ok, err := ns.handleASUplink(ctx, dev.EndDeviceIdentifiers.ApplicationIdentifiers, &ttnpb.ApplicationUp{
 				EndDeviceIdentifiers: dev.EndDeviceIdentifiers,
 				CorrelationIDs:       append(events.CorrelationIDsFromContext(ctx), down.CorrelationIDs...),
@@ -437,7 +437,7 @@ func (ns *NetworkServer) scheduleDownlinkByPaths(ctx context.Context, req *ttnpb
 			},
 		}
 
-		logger.WithField("path_count", len(req.DownlinkPaths)).Debug("Scheduling downlink...")
+		logger.WithField("path_count", len(req.DownlinkPaths)).Debug("Schedule downlink")
 		res, err := ttnpb.NewNsGsClient(a.peer.Conn()).ScheduleDownlink(ctx, down, ns.WithClusterAuth())
 		if err != nil {
 			errs = append(errs, err)
@@ -487,7 +487,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 			"started_at", time.Now().UTC(),
 		))
 		ctx = log.NewContext(ctx, logger)
-		logger.WithField("start_at", t).Debug("Processing downlink task...")
+		logger.WithField("start_at", t).Debug("Process downlink task")
 
 		var sendInvalidation func() (bool, error)
 		var nextDownlinkAt time.Time
@@ -866,12 +866,12 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 			return err
 
 		case err != nil && errors.Resemble(err, errNoDownlink):
-			logger.Debug("No downlink to send, skipping downlink slot...")
+			logger.Debug("No downlink to send, skip downlink slot")
 			return nil
 		}
 
 		if err != nil && errors.Resemble(err, errScheduleTooSoon) {
-			logger.Debug("Downlink scheduled too soon, skipping downlink slot...")
+			logger.Debug("Downlink scheduled too soon, skip downlink slot")
 		} else if err != nil {
 			setErr = true
 			logger.WithError(err).Warn("Failed to update device in registry")
@@ -883,7 +883,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 		}
 
 		if !nextDownlinkAt.IsZero() {
-			logger.WithField("start_at", nextDownlinkAt.UTC()).Debug("Adding downlink task...")
+			logger.WithField("start_at", nextDownlinkAt.UTC()).Debug("Add downlink task")
 			if err := ns.downlinkTasks.Add(ctx, devID, nextDownlinkAt, true); err != nil {
 				addErr = true
 				logger.WithError(err).Error("Failed to add downlink task after downlink")

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -433,6 +433,7 @@ func (ns *NetworkServer) scheduleDownlinkByPaths(ctx context.Context, req *ttnpb
 			errs = append(errs, err)
 			continue
 		}
+		logger.WithField("delay", res.Delay).Debug("Scheduled downlink")
 		return down, time.Now().Add(res.Delay), nil
 	}
 
@@ -854,9 +855,11 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 			return err
 
 		case err != nil && errors.Resemble(err, errNoDownlink):
+			logger.Debug("No downlink to send, skipping downlink slot...")
 			return nil
 
 		case err != nil && errors.Resemble(err, errScheduleTooSoon):
+			logger.Debug("Downlink scheduled too soon, skipping downlink slot...")
 			break
 
 		case err != nil:
@@ -868,6 +871,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 		if nextDownlinkAt.IsZero() {
 			return nil
 		}
+		logger.WithField("schedule_at", nextDownlinkAt).Debug("Adding device to downlink schedule...")
 		if err := ns.downlinkTasks.Add(ctx, devID, nextDownlinkAt, true); err != nil {
 			addErr = true
 			logger.WithError(err).Error("Failed to add device to downlink schedule")

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -72,13 +72,12 @@ var errNoDownlink = errors.Define("no_downlink", "no downlink to send")
 // For example, a sequence of 'NewChannel' MAC commands could be generated for a
 // device operating in a region where a fixed channel plan is defined in case
 // dev.MACState.CurrentParameters.Channels is not equal to dev.MACState.DesiredParameters.Channels.
-func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16) ([]byte, *ttnpb.ApplicationDownlink, error) {
+func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16) ([]byte, uint32, *ttnpb.ApplicationDownlink, error) {
 	if dev.MACState == nil {
-		return nil, nil, errUnknownMACState
+		return nil, 0, nil, errUnknownMACState
 	}
-
 	if dev.Session == nil {
-		return nil, nil, errEmptySession
+		return nil, 0, nil, errEmptySession
 	}
 
 	ctx = log.NewContextWithField(ctx, "device_uid", unique.ID(ctx, dev.EndDeviceIdentifiers))
@@ -109,7 +108,7 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 
 	maxDownLen, maxUpLen, ok, err := enqueueLinkADRReq(ctx, dev, maxDownLen, maxUpLen, ns.FrequencyPlans)
 	if err != nil {
-		return nil, nil, err
+		return nil, 0, nil, err
 	}
 	fPending := !ok
 	for _, f := range []func(context.Context, *ttnpb.EndDevice, uint16, uint16) (uint16, uint16, bool){
@@ -145,7 +144,7 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 		cmdBuf, err = spec.AppendDownlink(cmdBuf, *cmd)
 
 		if err != nil {
-			return nil, nil, errEncodeMAC.WithCause(err)
+			return nil, 0, nil, errEncodeMAC.WithCause(err)
 		}
 	}
 	logger = logger.WithField("mac_count", len(cmds))
@@ -173,7 +172,7 @@ outer:
 	if !needsDownlink &&
 		len(cmdBuf) == 0 &&
 		len(dev.QueuedApplicationDownlinks) == 0 {
-		return nil, nil, errNoDownlink
+		return nil, 0, nil, errNoDownlink
 	}
 
 	pld := &ttnpb.MACPayload{
@@ -212,7 +211,7 @@ outer:
 			}
 
 			if !needsDownlink && len(cmdBuf) == 0 {
-				return nil, nil, errNoDownlink
+				return nil, 0, nil, errNoDownlink
 			}
 		} else {
 			appDown = down
@@ -235,17 +234,17 @@ outer:
 
 	if len(cmdBuf) > 0 && (pld.FPort == 0 || dev.MACState.LoRaWANVersion.EncryptFOpts()) {
 		if dev.Session.NwkSEncKey == nil || len(dev.Session.NwkSEncKey.Key) == 0 {
-			return nil, nil, errUnknownNwkSEncKey
+			return nil, 0, nil, errUnknownNwkSEncKey
 		}
 		key, err := cryptoutil.UnwrapAES128Key(*dev.Session.NwkSEncKey, ns.KeyVault)
 		if err != nil {
 			logger.WithField("kek_label", dev.Session.NwkSEncKey.KEKLabel).WithError(err).Warn("Failed to unwrap NwkSEncKey")
-			return nil, nil, err
+			return nil, 0, nil, err
 		}
 
 		cmdBuf, err = crypto.EncryptDownlink(key, dev.Session.DevAddr, pld.FHDR.FCnt, cmdBuf)
 		if err != nil {
-			return nil, nil, errEncryptMAC.WithCause(err)
+			return nil, 0, nil, errEncryptMAC.WithCause(err)
 		}
 	}
 
@@ -270,7 +269,7 @@ outer:
 	case dev.MACState.DeviceClass == ttnpb.CLASS_C &&
 		dev.MACState.LastConfirmedDownlinkAt != nil &&
 		dev.MACState.LastConfirmedDownlinkAt.Add(deviceClassCTimeout(dev, ns.defaultMACSettings)).After(time.Now()):
-		return nil, nil, errScheduleTooSoon
+		return nil, 0, nil, errScheduleTooSoon
 
 	default:
 		dev.MACState.LastConfirmedDownlinkAt = timePtr(time.Now().UTC())
@@ -286,17 +285,17 @@ outer:
 		},
 	})
 	if err != nil {
-		return nil, nil, errEncodePayload.WithCause(err)
+		return nil, 0, nil, errEncodePayload.WithCause(err)
 	}
 	// NOTE: It is assumed, that b does not contain MIC.
 
 	if dev.Session.SNwkSIntKey == nil || len(dev.Session.SNwkSIntKey.Key) == 0 {
-		return nil, nil, errUnknownSNwkSIntKey
+		return nil, 0, nil, errUnknownSNwkSIntKey
 	}
 	key, err := cryptoutil.UnwrapAES128Key(*dev.Session.SNwkSIntKey, ns.KeyVault)
 	if err != nil {
 		logger.WithField("kek_label", dev.Session.SNwkSIntKey.KEKLabel).WithError(err).Warn("Failed to unwrap SNwkSIntKey")
-		return nil, nil, err
+		return nil, 0, nil, err
 	}
 
 	var mic [4]byte
@@ -321,12 +320,12 @@ outer:
 		)
 	}
 	if err != nil {
-		return nil, nil, errComputeMIC
+		return nil, 0, nil, errComputeMIC
 	}
 	b = append(b, mic[:]...)
 
 	logger.WithField("payload_length", len(b)).Debug("Generated downlink")
-	return b, appDown, nil
+	return b, pld.FHDR.FCnt, appDown, nil
 }
 
 type downlinkPath struct {
@@ -446,14 +445,14 @@ func (ns *NetworkServer) scheduleDownlinkByPaths(ctx context.Context, req *ttnpb
 	return nil, time.Time{}, errSchedule
 }
 
-func (ns *NetworkServer) sendQueueInvalidationToAS(ctx context.Context, dev *ttnpb.EndDevice) (bool, error) {
+func (ns *NetworkServer) sendQueueInvalidationToAS(ctx context.Context, dev *ttnpb.EndDevice, fCnt uint32) (bool, error) {
 	ok, err := ns.handleASUplink(ctx, dev.EndDeviceIdentifiers.ApplicationIdentifiers, &ttnpb.ApplicationUp{
 		EndDeviceIdentifiers: dev.EndDeviceIdentifiers,
 		CorrelationIDs:       events.CorrelationIDsFromContext(ctx),
 		Up: &ttnpb.ApplicationUp_DownlinkQueueInvalidated{
 			DownlinkQueueInvalidated: &ttnpb.ApplicationInvalidatedDownlinks{
 				Downlinks:    dev.QueuedApplicationDownlinks,
-				LastFCntDown: dev.Session.LastNFCntDown,
+				LastFCntDown: fCnt,
 			},
 		},
 	})
@@ -480,6 +479,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 		ctx = log.NewContext(ctx, logger)
 		logger.Debug("Processing downlink task...")
 
+		var sendInvalidation func() (bool, error)
 		var nextDownlinkAt time.Time
 		_, err := ns.devices.SetByID(ctx, devID.ApplicationIdentifiers, devID.DeviceID,
 			[]string{
@@ -618,7 +618,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 						if req.Rx2DataRateIndex < minDR {
 							minDR = req.Rx2DataRateIndex
 						}
-						b, appDown, err := ns.generateDownlink(ctx, dev,
+						b, fCnt, appDown, err := ns.generateDownlink(ctx, dev,
 							band.DataRates[minDR].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 							maxUpLength,
 						)
@@ -649,7 +649,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 							scheduleErr = true
 						} else {
 							if appDown == nil && len(dev.QueuedApplicationDownlinks) > 0 && dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 {
-								go ns.sendQueueInvalidationToAS(ctx, dev)
+								sendInvalidation = func() (bool, error) { return ns.sendQueueInvalidationToAS(ctx, dev, fCnt) }
 							}
 							dev.MACState.RxWindowsAvailable = false
 							dev.RecentDownlinks = append(dev.RecentDownlinks, down)
@@ -671,7 +671,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 						// we need to create a deep copy for the first call.
 						devCopy := deepcopy.Copy(dev).(*ttnpb.EndDevice)
 
-						b, appDown, err := ns.generateDownlink(ctx, dev,
+						b, fCnt, appDown, err := ns.generateDownlink(ctx, dev,
 							band.DataRates[req.Rx1DataRateIndex].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 							maxUpLength,
 						)
@@ -738,7 +738,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 								}
 
 								if appDown == nil && len(dev.QueuedApplicationDownlinks) > 0 && dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 {
-									go ns.sendQueueInvalidationToAS(ctx, dev)
+									sendInvalidation = func() (bool, error) { return ns.sendQueueInvalidationToAS(ctx, dev, fCnt) }
 								}
 								dev.MACState.RxWindowsAvailable = false
 								dev.RecentDownlinks = append(dev.RecentDownlinks, down)
@@ -770,7 +770,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 						Rx2Frequency:     dev.MACState.CurrentParameters.Rx2Frequency,
 					}
 
-					b, appDown, err := ns.generateDownlink(ctx, dev,
+					b, fCnt, appDown, err := ns.generateDownlink(ctx, dev,
 						band.DataRates[req.Rx2DataRateIndex].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						maxUpLength,
 					)
@@ -833,7 +833,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 						}
 
 						if appDown == nil && len(dev.QueuedApplicationDownlinks) > 0 && dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 {
-							go ns.sendQueueInvalidationToAS(ctx, dev)
+							sendInvalidation = func() (bool, error) { return ns.sendQueueInvalidationToAS(ctx, dev, fCnt) }
 						}
 						dev.RecentDownlinks = append(dev.RecentDownlinks, down)
 						if len(dev.RecentDownlinks) > recentDownlinkCount {
@@ -848,7 +848,8 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 					}
 				}
 				return nil, nil, errSchedule
-			})
+			},
+		)
 
 		switch {
 		case scheduleErr:
@@ -857,25 +858,27 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 		case err != nil && errors.Resemble(err, errNoDownlink):
 			logger.Debug("No downlink to send, skipping downlink slot...")
 			return nil
+		}
 
-		case err != nil && errors.Resemble(err, errScheduleTooSoon):
+		if err != nil && errors.Resemble(err, errScheduleTooSoon) {
 			logger.Debug("Downlink scheduled too soon, skipping downlink slot...")
-			break
-
-		case err != nil:
+		} else if err != nil {
 			setErr = true
 			logger.WithError(err).Warn("Failed to update device in registry")
 			return err
 		}
 
-		if nextDownlinkAt.IsZero() {
-			return nil
+		if sendInvalidation != nil {
+			go sendInvalidation()
 		}
-		logger.WithField("schedule_at", nextDownlinkAt).Debug("Adding device to downlink schedule...")
-		if err := ns.downlinkTasks.Add(ctx, devID, nextDownlinkAt, true); err != nil {
-			addErr = true
-			logger.WithError(err).Error("Failed to add device to downlink schedule")
-			return err
+
+		if !nextDownlinkAt.IsZero() {
+			logger.WithField("schedule_at", nextDownlinkAt).Debug("Adding device to downlink schedule...")
+			if err := ns.downlinkTasks.Add(ctx, devID, nextDownlinkAt, true); err != nil {
+				addErr = true
+				logger.WithError(err).Error("Failed to add device to downlink schedule")
+				return err
+			}
 		}
 		return nil
 	})

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -61,6 +61,12 @@ func deviceClassCTimeout(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings) time.
 var errApplicationDownlinkTooLong = errors.DefineInvalidArgument("application_downlink_too_long", "application downlink payload is too long")
 var errNoDownlink = errors.Define("no_downlink", "no downlink to send")
 
+type generatedDownlink struct {
+	Payload             []byte
+	FCnt                uint32
+	ApplicationDownlink *ttnpb.ApplicationDownlink
+}
+
 // generateDownlink attempts to generate a downlink.
 // generateDownlink returns the marshaled payload of the downlink, application downlink, if included in the payload and error, if any.
 // generateDownlink may mutate the device in order to record the downlink generated.
@@ -72,12 +78,12 @@ var errNoDownlink = errors.Define("no_downlink", "no downlink to send")
 // For example, a sequence of 'NewChannel' MAC commands could be generated for a
 // device operating in a region where a fixed channel plan is defined in case
 // dev.MACState.CurrentParameters.Channels is not equal to dev.MACState.DesiredParameters.Channels.
-func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16) ([]byte, uint32, *ttnpb.ApplicationDownlink, error) {
+func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16) (*generatedDownlink, error) {
 	if dev.MACState == nil {
-		return nil, 0, nil, errUnknownMACState
+		return nil, errUnknownMACState
 	}
 	if dev.Session == nil {
-		return nil, 0, nil, errEmptySession
+		return nil, errEmptySession
 	}
 
 	ctx = log.NewContextWithField(ctx, "device_uid", unique.ID(ctx, dev.EndDeviceIdentifiers))
@@ -108,7 +114,7 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 
 	maxDownLen, maxUpLen, ok, err := enqueueLinkADRReq(ctx, dev, maxDownLen, maxUpLen, ns.FrequencyPlans)
 	if err != nil {
-		return nil, 0, nil, err
+		return nil, err
 	}
 	fPending := !ok
 	for _, f := range []func(context.Context, *ttnpb.EndDevice, uint16, uint16) (uint16, uint16, bool){
@@ -145,7 +151,7 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 		cmdBuf, err = spec.AppendDownlink(cmdBuf, *cmd)
 
 		if err != nil {
-			return nil, 0, nil, errEncodeMAC.WithCause(err)
+			return nil, errEncodeMAC.WithCause(err)
 		}
 	}
 	logger = logger.WithField("mac_count", len(cmds))
@@ -173,7 +179,7 @@ outer:
 	if !needsDownlink &&
 		len(cmdBuf) == 0 &&
 		len(dev.QueuedApplicationDownlinks) == 0 {
-		return nil, 0, nil, errNoDownlink
+		return nil, errNoDownlink
 	}
 
 	pld := &ttnpb.MACPayload{
@@ -212,7 +218,7 @@ outer:
 			}
 
 			if !needsDownlink && len(cmdBuf) == 0 {
-				return nil, 0, nil, errNoDownlink
+				return nil, errNoDownlink
 			}
 		} else {
 			appDown = down
@@ -235,17 +241,17 @@ outer:
 
 	if len(cmdBuf) > 0 && (pld.FPort == 0 || dev.MACState.LoRaWANVersion.EncryptFOpts()) {
 		if dev.Session.NwkSEncKey == nil || len(dev.Session.NwkSEncKey.Key) == 0 {
-			return nil, 0, nil, errUnknownNwkSEncKey
+			return nil, errUnknownNwkSEncKey
 		}
 		key, err := cryptoutil.UnwrapAES128Key(*dev.Session.NwkSEncKey, ns.KeyVault)
 		if err != nil {
 			logger.WithField("kek_label", dev.Session.NwkSEncKey.KEKLabel).WithError(err).Warn("Failed to unwrap NwkSEncKey")
-			return nil, 0, nil, err
+			return nil, err
 		}
 
 		cmdBuf, err = crypto.EncryptDownlink(key, dev.Session.DevAddr, pld.FHDR.FCnt, cmdBuf)
 		if err != nil {
-			return nil, 0, nil, errEncryptMAC.WithCause(err)
+			return nil, errEncryptMAC.WithCause(err)
 		}
 	}
 
@@ -270,7 +276,7 @@ outer:
 	case dev.MACState.DeviceClass == ttnpb.CLASS_C &&
 		dev.MACState.LastConfirmedDownlinkAt != nil &&
 		dev.MACState.LastConfirmedDownlinkAt.Add(deviceClassCTimeout(dev, ns.defaultMACSettings)).After(time.Now()):
-		return nil, 0, nil, errScheduleTooSoon
+		return nil, errScheduleTooSoon
 
 	default:
 		dev.MACState.LastConfirmedDownlinkAt = timePtr(time.Now().UTC())
@@ -286,17 +292,17 @@ outer:
 		},
 	})
 	if err != nil {
-		return nil, 0, nil, errEncodePayload.WithCause(err)
+		return nil, errEncodePayload.WithCause(err)
 	}
 	// NOTE: It is assumed, that b does not contain MIC.
 
 	if dev.Session.SNwkSIntKey == nil || len(dev.Session.SNwkSIntKey.Key) == 0 {
-		return nil, 0, nil, errUnknownSNwkSIntKey
+		return nil, errUnknownSNwkSIntKey
 	}
 	key, err := cryptoutil.UnwrapAES128Key(*dev.Session.SNwkSIntKey, ns.KeyVault)
 	if err != nil {
 		logger.WithField("kek_label", dev.Session.SNwkSIntKey.KEKLabel).WithError(err).Warn("Failed to unwrap SNwkSIntKey")
-		return nil, 0, nil, err
+		return nil, err
 	}
 
 	var mic [4]byte
@@ -321,12 +327,16 @@ outer:
 		)
 	}
 	if err != nil {
-		return nil, 0, nil, errComputeMIC
+		return nil, errComputeMIC
 	}
 	b = append(b, mic[:]...)
 
 	logger.WithField("payload_length", len(b)).Debug("Generated downlink")
-	return b, pld.FHDR.FCnt, appDown, nil
+	return &generatedDownlink{
+		Payload:             b,
+		FCnt:                pld.FHDR.FCnt,
+		ApplicationDownlink: appDown,
+	}, nil
 }
 
 type downlinkPath struct {
@@ -618,15 +628,15 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 						if req.Rx2DataRateIndex < minDR {
 							minDR = req.Rx2DataRateIndex
 						}
-						b, fCnt, appDown, err := ns.generateDownlink(ctx, dev,
+						genDown, err := ns.generateDownlink(ctx, dev,
 							band.DataRates[minDR].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 							maxUpLength,
 						)
 						if err != nil {
 							return nil, nil, err
 						}
-						if appDown != nil {
-							ctx = events.ContextWithCorrelationID(ctx, appDown.CorrelationIDs...)
+						if genDown.ApplicationDownlink != nil {
+							ctx = events.ContextWithCorrelationID(ctx, genDown.ApplicationDownlink.CorrelationIDs...)
 						}
 
 						down, _, err := ns.scheduleDownlinkByPaths(
@@ -642,14 +652,14 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 							))),
 							req,
 							dev.EndDeviceIdentifiers,
-							b,
+							genDown.Payload,
 							downlinkPathsFromRecentUplinks(dev.RecentUplinks...)...,
 						)
 						if err != nil {
 							scheduleErr = true
 						} else {
-							if appDown == nil && len(dev.QueuedApplicationDownlinks) > 0 && dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 {
-								sendInvalidation = func() (bool, error) { return ns.sendQueueInvalidationToAS(ctx, dev, fCnt) }
+							if genDown.ApplicationDownlink == nil && len(dev.QueuedApplicationDownlinks) > 0 && dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 {
+								sendInvalidation = func() (bool, error) { return ns.sendQueueInvalidationToAS(ctx, dev, genDown.FCnt) }
 							}
 							dev.MACState.RxWindowsAvailable = false
 							dev.RecentDownlinks = append(dev.RecentDownlinks, down)
@@ -671,7 +681,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 						// we need to create a deep copy for the first call.
 						devCopy := deepcopy.Copy(dev).(*ttnpb.EndDevice)
 
-						b, fCnt, appDown, err := ns.generateDownlink(ctx, dev,
+						genDown, err := ns.generateDownlink(ctx, dev,
 							band.DataRates[req.Rx1DataRateIndex].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 							maxUpLength,
 						)
@@ -689,14 +699,14 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 							}
 						}
 
-						if appDown != nil {
-							ctx = events.ContextWithCorrelationID(ctx, appDown.CorrelationIDs...)
+						if genDown.ApplicationDownlink != nil {
+							ctx = events.ContextWithCorrelationID(ctx, genDown.ApplicationDownlink.CorrelationIDs...)
 						}
 
 						var paths []downlinkPath
-						if appDown != nil && appDown.ClassBC != nil && appDown.ClassBC.AbsoluteTime == nil {
-							paths = make([]downlinkPath, 0, len(appDown.ClassBC.Gateways))
-							for _, gtw := range appDown.ClassBC.Gateways {
+						if genDown.ApplicationDownlink != nil && genDown.ApplicationDownlink.ClassBC != nil && genDown.ApplicationDownlink.ClassBC.AbsoluteTime == nil {
+							paths = make([]downlinkPath, 0, len(genDown.ApplicationDownlink.ClassBC.Gateways))
+							for _, gtw := range genDown.ApplicationDownlink.ClassBC.Gateways {
 								if gtw == nil || gtw.IsZero() {
 									continue
 								}
@@ -709,10 +719,10 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 									},
 								})
 							}
-						} else if appDown == nil || appDown.ClassBC == nil {
+						} else if genDown.ApplicationDownlink == nil || genDown.ApplicationDownlink.ClassBC == nil {
 							paths = downlinkPathsFromRecentUplinks(dev.RecentUplinks...)
 						}
-						// NOTE: We must skip Rx1 if appDown.ClassBC.AbsoluteTime is set
+						// NOTE: We must skip Rx1 if genDown.ApplicationDownlink.ClassBC.AbsoluteTime is set
 
 						if len(paths) > 0 {
 							down, downAt, err := ns.scheduleDownlinkByPaths(
@@ -726,7 +736,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 								))),
 								req,
 								dev.EndDeviceIdentifiers,
-								b,
+								genDown.Payload,
 								paths...,
 							)
 							if err != nil {
@@ -737,8 +747,8 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 									nextDownlinkAt = downAt
 								}
 
-								if appDown == nil && len(dev.QueuedApplicationDownlinks) > 0 && dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 {
-									sendInvalidation = func() (bool, error) { return ns.sendQueueInvalidationToAS(ctx, dev, fCnt) }
+								if genDown.ApplicationDownlink == nil && len(dev.QueuedApplicationDownlinks) > 0 && dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 {
+									sendInvalidation = func() (bool, error) { return ns.sendQueueInvalidationToAS(ctx, dev, genDown.FCnt) }
 								}
 								dev.MACState.RxWindowsAvailable = false
 								dev.RecentDownlinks = append(dev.RecentDownlinks, down)
@@ -770,7 +780,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 						Rx2Frequency:     dev.MACState.CurrentParameters.Rx2Frequency,
 					}
 
-					b, fCnt, appDown, err := ns.generateDownlink(ctx, dev,
+					genDown, err := ns.generateDownlink(ctx, dev,
 						band.DataRates[req.Rx2DataRateIndex].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						maxUpLength,
 					)
@@ -788,14 +798,14 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 						}
 					}
 
-					if appDown != nil {
-						ctx = events.ContextWithCorrelationID(ctx, appDown.CorrelationIDs...)
+					if genDown.ApplicationDownlink != nil {
+						ctx = events.ContextWithCorrelationID(ctx, genDown.ApplicationDownlink.CorrelationIDs...)
 					}
 
 					var paths []downlinkPath
-					if appDown != nil && appDown.ClassBC != nil {
-						paths = make([]downlinkPath, 0, len(appDown.ClassBC.Gateways))
-						for _, gtw := range appDown.ClassBC.Gateways {
+					if genDown.ApplicationDownlink != nil && genDown.ApplicationDownlink.ClassBC != nil {
+						paths = make([]downlinkPath, 0, len(genDown.ApplicationDownlink.ClassBC.Gateways))
+						for _, gtw := range genDown.ApplicationDownlink.ClassBC.Gateways {
 							paths = append(paths, downlinkPath{
 								GatewayIdentifiers: gtw.GatewayIdentifiers,
 								DownlinkPath: &ttnpb.DownlinkPath{
@@ -822,7 +832,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 						))),
 						req,
 						dev.EndDeviceIdentifiers,
-						b,
+						genDown.Payload,
 						paths...,
 					)
 					if err != nil {
@@ -832,8 +842,8 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 							nextDownlinkAt = downAt
 						}
 
-						if appDown == nil && len(dev.QueuedApplicationDownlinks) > 0 && dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 {
-							sendInvalidation = func() (bool, error) { return ns.sendQueueInvalidationToAS(ctx, dev, fCnt) }
+						if genDown.ApplicationDownlink == nil && len(dev.QueuedApplicationDownlinks) > 0 && dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 {
+							sendInvalidation = func() (bool, error) { return ns.sendQueueInvalidationToAS(ctx, dev, genDown.FCnt) }
 						}
 						dev.RecentDownlinks = append(dev.RecentDownlinks, down)
 						if len(dev.RecentDownlinks) > recentDownlinkCount {

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -305,7 +305,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 				rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 				rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-				payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+				genDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 					band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
@@ -321,7 +321,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				expected.MACState.RxWindowsAvailable = false
 				expected.QueuedApplicationDownlinks = []*ttnpb.ApplicationDownlink{}
 				expected.RecentDownlinks = append(expected.RecentDownlinks, &ttnpb.DownlinkMessage{
-					RawPayload:     payload,
+					RawPayload:     genDown.Payload,
 					CorrelationIDs: ret.RecentDownlinks[0].CorrelationIDs,
 					EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -379,7 +379,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					if rx1DRIdx < drIdx {
 						drIdx = rx1DRIdx
 					}
-					payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					genDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[drIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
@@ -414,7 +414,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 									a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 									a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 									a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-										RawPayload:     payload,
+										RawPayload:     genDown.Payload,
 										CorrelationIDs: msg.CorrelationIDs,
 										EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 											ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -452,7 +452,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 							a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 							a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 							a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-								RawPayload:     payload,
+								RawPayload:     genDown.Payload,
 								CorrelationIDs: msg.CorrelationIDs,
 								EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 									ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -499,7 +499,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     payload,
+									RawPayload:     genDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -729,7 +729,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 				rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 				rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-				payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+				genDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 					band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
@@ -745,7 +745,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				expected.MACState.RxWindowsAvailable = false
 				expected.QueuedApplicationDownlinks = []*ttnpb.ApplicationDownlink{}
 				expected.RecentDownlinks = append(expected.RecentDownlinks, &ttnpb.DownlinkMessage{
-					RawPayload:     payload,
+					RawPayload:     genDown.Payload,
 					CorrelationIDs: ret.RecentDownlinks[0].CorrelationIDs,
 					EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -799,7 +799,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 					rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 					rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-					payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					genDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
@@ -819,7 +819,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     payload,
+									RawPayload:     genDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -860,7 +860,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     payload,
+									RawPayload:     genDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -914,7 +914,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     payload,
+									RawPayload:     genDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1140,7 +1140,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Fatal("Invalid context")
 				}
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
-				rx2Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+				rx2GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 					band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
@@ -1156,7 +1156,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				expected.MACState.RxWindowsAvailable = false
 				expected.QueuedApplicationDownlinks = []*ttnpb.ApplicationDownlink{}
 				expected.RecentDownlinks = append(expected.RecentDownlinks, &ttnpb.DownlinkMessage{
-					RawPayload:     rx2Payload,
+					RawPayload:     rx2GenDown.Payload,
 					CorrelationIDs: ret.RecentDownlinks[0].CorrelationIDs,
 					EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1212,14 +1212,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 					fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 					rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 					rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-					rx1Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					rx1GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
 					if !a.So(err, should.BeNil) {
 						t.Fatalf("Failed to generate Rx1 payload: %s", err)
 					}
-					rx2Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					rx2GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
@@ -1239,7 +1239,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx1Payload,
+									RawPayload:     rx1GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1275,7 +1275,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx2Payload,
+									RawPayload:     rx2GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1312,7 +1312,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx1Payload,
+									RawPayload:     rx1GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1353,7 +1353,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx1Payload,
+									RawPayload:     rx1GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1390,7 +1390,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx2Payload,
+									RawPayload:     rx2GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1430,7 +1430,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx2Payload,
+									RawPayload:     rx2GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1717,7 +1717,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Fatal("Invalid context")
 				}
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
-				rx2Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+				rx2GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 					band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
@@ -1733,7 +1733,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				expected.MACState.RxWindowsAvailable = false
 				expected.QueuedApplicationDownlinks = []*ttnpb.ApplicationDownlink{}
 				expected.RecentDownlinks = append(expected.RecentDownlinks, &ttnpb.DownlinkMessage{
-					RawPayload:     rx2Payload,
+					RawPayload:     rx2GenDown.Payload,
 					CorrelationIDs: ret.RecentDownlinks[0].CorrelationIDs,
 					EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1792,14 +1792,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 					fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 					rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 					rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-					rx1Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					rx1GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
 					if !a.So(err, should.BeNil) {
 						t.Fatalf("Failed to generate Rx1 payload: %s", err)
 					}
-					rx2Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					rx2GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
@@ -1819,7 +1819,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx1Payload,
+									RawPayload:     rx1GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1858,7 +1858,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx2Payload,
+									RawPayload:     rx2GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1898,7 +1898,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx1Payload,
+									RawPayload:     rx1GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1945,7 +1945,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx1Payload,
+									RawPayload:     rx1GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -1985,7 +1985,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx2Payload,
+									RawPayload:     rx2GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -2031,7 +2031,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID1")
 								a.So(msg.CorrelationIDs, should.Contain, "testCorrelationAppDownID2")
 								a.So(msg, should.Resemble, &ttnpb.DownlinkMessage{
-									RawPayload:     rx2Payload,
+									RawPayload:     rx2GenDown.Payload,
 									CorrelationIDs: msg.CorrelationIDs,
 									EndDeviceIDs: &ttnpb.EndDeviceIdentifiers{
 										ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: ApplicationID},
@@ -3511,17 +3511,22 @@ func TestGenerateDownlink(t *testing.T) {
 
 			dev := CopyEndDevice(tc.Device)
 
-			b, _, appDown, err := ns.generateDownlink(tc.Context, dev, math.MaxUint16, math.MaxUint16)
-			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
-				tc.Error == nil && !a.So(err, should.BeNil) {
+			genDown, err := ns.generateDownlink(tc.Context, dev, math.MaxUint16, math.MaxUint16)
+			if tc.Error != nil {
+				a.So(err, should.EqualErrorOrDefinition, tc.Error)
+				a.So(genDown, should.BeNil)
+				return
+			}
+
+			if !a.So(err, should.BeNil) || !a.So(genDown, should.NotBeNil) {
 				t.FailNow()
 			}
 
-			a.So(b, should.Resemble, tc.Bytes)
+			a.So(genDown.Payload, should.Resemble, tc.Bytes)
 			if tc.ApplicationDownlinkAssertion != nil {
-				a.So(tc.ApplicationDownlinkAssertion(t, appDown), should.BeTrue)
+				a.So(tc.ApplicationDownlinkAssertion(t, genDown.ApplicationDownlink), should.BeTrue)
 			} else {
-				a.So(appDown, should.BeNil)
+				a.So(genDown.ApplicationDownlink, should.BeNil)
 			}
 
 			if tc.DeviceAssertion != nil {

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -305,7 +305,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 				rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 				rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-				payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+				payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 					band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
@@ -379,7 +379,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					if rx1DRIdx < drIdx {
 						drIdx = rx1DRIdx
 					}
-					payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[drIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
@@ -729,7 +729,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 				rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 				rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-				payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+				payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 					band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
@@ -799,7 +799,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 					rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 					rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-					payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
@@ -1140,7 +1140,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Fatal("Invalid context")
 				}
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
-				rx2Payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+				rx2Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 					band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
@@ -1212,14 +1212,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 					fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 					rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 					rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-					rx1Payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					rx1Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
 					if !a.So(err, should.BeNil) {
 						t.Fatalf("Failed to generate Rx1 payload: %s", err)
 					}
-					rx2Payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					rx2Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
@@ -1717,7 +1717,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Fatal("Invalid context")
 				}
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
-				rx2Payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+				rx2Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 					band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
@@ -1792,14 +1792,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 					fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
 					rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
 					rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-					rx1Payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					rx1Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
 					if !a.So(err, should.BeNil) {
 						t.Fatalf("Failed to generate Rx1 payload: %s", err)
 					}
-					rx2Payload, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
+					rx2Payload, _, _, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
 						band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
@@ -3511,7 +3511,7 @@ func TestGenerateDownlink(t *testing.T) {
 
 			dev := CopyEndDevice(tc.Device)
 
-			b, appDown, err := ns.generateDownlink(tc.Context, dev, math.MaxUint16, math.MaxUint16)
+			b, _, appDown, err := ns.generateDownlink(tc.Context, dev, math.MaxUint16, math.MaxUint16)
 			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
 				tc.Error == nil && !a.So(err, should.BeNil) {
 				t.FailNow()

--- a/pkg/networkserver/grpc_asns.go
+++ b/pkg/networkserver/grpc_asns.go
@@ -124,8 +124,9 @@ func (ns *NetworkServer) DownlinkQueueReplace(ctx context.Context, req *ttnpb.Do
 
 	logger.Debug("Replaced application downlink queue")
 	if dev.MACState != nil && dev.MACState.DeviceClass != ttnpb.CLASS_A && len(dev.QueuedApplicationDownlinks) > 0 {
-		logger.Debug("Adding downlink task...")
-		return ttnpb.Empty, ns.downlinkTasks.Add(ctx, req.EndDeviceIdentifiers, time.Now(), false)
+		startAt := time.Now().UTC()
+		logger.WithField("start_at", startAt).Debug("Adding downlink task...")
+		return ttnpb.Empty, ns.downlinkTasks.Add(ctx, req.EndDeviceIdentifiers, startAt, false)
 	}
 	return ttnpb.Empty, nil
 }
@@ -162,8 +163,9 @@ func (ns *NetworkServer) DownlinkQueuePush(ctx context.Context, req *ttnpb.Downl
 
 	logger.Debug("Pushed application downlink to queue")
 	if dev.MACState != nil && dev.MACState.DeviceClass != ttnpb.CLASS_A {
-		logger.Debug("Adding downlink task...")
-		return ttnpb.Empty, ns.downlinkTasks.Add(ctx, req.EndDeviceIdentifiers, time.Now(), false)
+		startAt := time.Now().UTC()
+		logger.WithField("start_at", startAt).Debug("Adding downlink task...")
+		return ttnpb.Empty, ns.downlinkTasks.Add(ctx, req.EndDeviceIdentifiers, startAt, false)
 	}
 	return ttnpb.Empty, nil
 }

--- a/pkg/networkserver/grpc_asns.go
+++ b/pkg/networkserver/grpc_asns.go
@@ -125,7 +125,7 @@ func (ns *NetworkServer) DownlinkQueueReplace(ctx context.Context, req *ttnpb.Do
 	logger.Debug("Replaced application downlink queue")
 	if dev.MACState != nil && dev.MACState.DeviceClass != ttnpb.CLASS_A && len(dev.QueuedApplicationDownlinks) > 0 {
 		startAt := time.Now().UTC()
-		logger.WithField("start_at", startAt).Debug("Adding downlink task...")
+		logger.WithField("start_at", startAt).Debug("Add downlink task")
 		return ttnpb.Empty, ns.downlinkTasks.Add(ctx, req.EndDeviceIdentifiers, startAt, false)
 	}
 	return ttnpb.Empty, nil
@@ -164,7 +164,7 @@ func (ns *NetworkServer) DownlinkQueuePush(ctx context.Context, req *ttnpb.Downl
 	logger.Debug("Pushed application downlink to queue")
 	if dev.MACState != nil && dev.MACState.DeviceClass != ttnpb.CLASS_A {
 		startAt := time.Now().UTC()
-		logger.WithField("start_at", startAt).Debug("Adding downlink task...")
+		logger.WithField("start_at", startAt).Debug("Add downlink task")
 		return ttnpb.Empty, ns.downlinkTasks.Add(ctx, req.EndDeviceIdentifiers, startAt, false)
 	}
 	return ttnpb.Empty, nil

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -272,7 +272,7 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 	}
 	if addDownlinkTask {
 		startAt := time.Now().UTC()
-		log.FromContext(ctx).WithField("start_at", startAt).Debug("Adding downlink task...")
+		log.FromContext(ctx).WithField("start_at", startAt).Debug("Add downlink task")
 		if err = ns.downlinkTasks.Add(ctx, dev.EndDeviceIdentifiers, startAt, false); err != nil {
 			log.FromContext(ctx).WithError(err).Warn("Failed to add downlink task for device after set")
 		}

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -271,7 +271,9 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 		return nil, err
 	}
 	if addDownlinkTask {
-		if err = ns.downlinkTasks.Add(ctx, dev.EndDeviceIdentifiers, time.Now(), false); err != nil {
+		startAt := time.Now().UTC()
+		log.FromContext(ctx).WithField("start_at", startAt).Debug("Adding downlink task...")
+		if err = ns.downlinkTasks.Add(ctx, dev.EndDeviceIdentifiers, startAt, false); err != nil {
 			log.FromContext(ctx).WithError(err).Warn("Failed to add downlink task for device after set")
 		}
 	}

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -188,7 +188,7 @@ outer:
 
 		fCnt := pld.FCnt
 		switch {
-		case !supports32BitFCnt, fCnt > dev.matchedSession.LastFCntUp, fCnt == 0:
+		case !supports32BitFCnt, fCnt >= dev.matchedSession.LastFCntUp, fCnt == 0:
 		case fCnt > dev.matchedSession.LastFCntUp&0xffff:
 			fCnt |= dev.matchedSession.LastFCntUp &^ 0xffff
 		case dev.matchedSession.LastFCntUp < 0xffff0000:
@@ -213,7 +213,11 @@ outer:
 			(len(dev.RecentUplinks) == 0 || dev.PendingSession != nil) {
 			gap = 0
 		} else if !resetsFCnt {
-			if fCnt <= dev.matchedSession.LastFCntUp {
+			if fCnt == dev.matchedSession.LastFCntUp {
+				// TODO: Handle accordingly (https://github.com/TheThingsNetwork/lorawan-stack/issues/356)
+				logger.Debug("Possible uplink retransmission encountered, skipping...")
+				continue outer
+			} else if fCnt < dev.matchedSession.LastFCntUp {
 				logger.Debug("FCnt too low, skipping...")
 				continue outer
 			}

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -130,7 +130,7 @@ func (ns *NetworkServer) matchDevice(ctx context.Context, up *ttnpb.UplinkMessag
 				if dev.MACState.GetPendingJoinRequest().GetCFList() != nil {
 					_, band, err := getDeviceBandVersion(dev, ns.FrequencyPlans)
 					if err != nil {
-						logger.WithError(err).Warn("Failed to get device's versioned band, skipping...")
+						logger.WithError(err).Warn("Failed to get device's versioned band, skip")
 						return true
 					}
 
@@ -150,7 +150,7 @@ func (ns *NetworkServer) matchDevice(ctx context.Context, up *ttnpb.UplinkMessag
 
 					case ttnpb.CFListType_CHANNEL_MASKS:
 						if len(dev.MACState.CurrentParameters.Channels) != len(dev.MACState.PendingJoinRequest.CFList.ChMasks) {
-							logger.Warn("Mismatch in CFList mask count and configured channel count, skipping...")
+							logger.Warn("Mismatch in CFList mask count and configured channel count, skip")
 							return true
 						}
 						for i, m := range dev.MACState.PendingJoinRequest.CFList.ChMasks {
@@ -215,10 +215,10 @@ outer:
 		} else if !resetsFCnt {
 			if fCnt == dev.matchedSession.LastFCntUp {
 				// TODO: Handle accordingly (https://github.com/TheThingsNetwork/lorawan-stack/issues/356)
-				logger.Debug("Possible uplink retransmission encountered, skipping...")
+				logger.Debug("Possible uplink retransmission encountered, skip")
 				continue outer
 			} else if fCnt < dev.matchedSession.LastFCntUp {
-				logger.Debug("FCnt too low, skipping...")
+				logger.Debug("FCnt too low, skip")
 				continue outer
 			}
 
@@ -227,11 +227,11 @@ outer:
 			if dev.MACState.LoRaWANVersion.HasMaxFCntGap() {
 				_, band, err := getDeviceBandVersion(dev.EndDevice, ns.FrequencyPlans)
 				if err != nil {
-					logger.WithError(err).Warn("Failed to get device's versioned band, skipping...")
+					logger.WithError(err).Warn("Failed to get device's versioned band, skip")
 					continue
 				}
 				if gap > uint32(band.MaxFCntGap) {
-					logger.Debug("FCnt gap too high, skipping...")
+					logger.Debug("FCnt gap too high, skip")
 					continue outer
 				}
 			}
@@ -257,7 +257,7 @@ outer:
 		return matching[i].gap < matching[j].gap
 	})
 
-	logger.WithField("device_count", len(matching)).Debug("Performing MIC checks on devices with matching frame counters...")
+	logger.WithField("device_count", len(matching)).Debug("Perform MIC checks on devices with matching frame counters")
 	for _, dev := range matching {
 		logger := logger.WithFields(log.Fields(
 			"device_uid", unique.ID(ctx, dev.EndDeviceIdentifiers),
@@ -268,19 +268,19 @@ outer:
 			if len(dev.RecentDownlinks) == 0 {
 				// Uplink acknowledges a downlink, but no downlink was sent to the device,
 				// hence it must be the wrong device.
-				logger.Debug("Uplink contains ACK, but no downlink was sent to device, skipping...")
+				logger.Debug("Uplink contains ACK, but no downlink was sent to device, skip")
 				continue
 			}
 		}
 
 		if dev.matchedSession.FNwkSIntKey == nil || len(dev.matchedSession.FNwkSIntKey.Key) == 0 {
-			logger.Warn("Device missing FNwkSIntKey in registry, skipping...")
+			logger.Warn("Device missing FNwkSIntKey in registry, skip")
 			continue
 		}
 
 		fNwkSIntKey, err := cryptoutil.UnwrapAES128Key(*dev.matchedSession.FNwkSIntKey, ns.KeyVault)
 		if err != nil {
-			logger.WithField("kek_label", dev.matchedSession.FNwkSIntKey.KEKLabel).WithError(err).Warn("Failed to unwrap FNwkSIntKey, skipping...")
+			logger.WithField("kek_label", dev.matchedSession.FNwkSIntKey.KEKLabel).WithError(err).Warn("Failed to unwrap FNwkSIntKey, skip")
 			continue
 		}
 
@@ -294,13 +294,13 @@ outer:
 			)
 		} else {
 			if dev.matchedSession.SNwkSIntKey == nil || len(dev.matchedSession.SNwkSIntKey.Key) == 0 {
-				logger.Warn("Device missing SNwkSIntKey in registry, skipping...")
+				logger.Warn("Device missing SNwkSIntKey in registry, skip")
 				continue
 			}
 
 			sNwkSIntKey, err := cryptoutil.UnwrapAES128Key(*dev.matchedSession.SNwkSIntKey, ns.KeyVault)
 			if err != nil {
-				logger.WithField("kek_label", dev.matchedSession.SNwkSIntKey.KEKLabel).WithError(err).Warn("Failed to unwrap SNwkSIntKey, skipping...")
+				logger.WithField("kek_label", dev.matchedSession.SNwkSIntKey.KEKLabel).WithError(err).Warn("Failed to unwrap SNwkSIntKey, skip")
 				continue
 			}
 
@@ -370,7 +370,7 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 	))
 	ctx = log.NewContext(ctx, logger)
 
-	logger.Debug("Matching device...")
+	logger.Debug("Match device")
 	matched, ses, err := ns.matchDevice(ctx, up)
 	if err != nil {
 		registerDropDataUplink(ctx, nil, up, err)
@@ -409,7 +409,7 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 		asCtx, cancel := context.WithTimeout(ctx, appQueueUpdateTimeout)
 		defer cancel()
 
-		logger.Debug("Sending downlink (n)ack to Application Server...")
+		logger.Debug("Send downlink (n)ack to Application Server")
 		ok, err := ns.handleASUplink(asCtx, matched.EndDeviceIdentifiers.ApplicationIdentifiers, asUp)
 		if err != nil {
 			return err
@@ -455,7 +455,7 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 	logger = logger.WithField("mac_count", len(cmds))
 	ctx = log.NewContext(ctx, logger)
 
-	logger.Debug("Waiting for deduplication window to close...")
+	logger.Debug("Wait for deduplication window to close")
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -485,7 +485,7 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 		},
 		func(stored *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
 			if stored == nil {
-				logger.Warn("Device deleted during uplink handling, dropping...")
+				logger.Warn("Device deleted during uplink handling, drop")
 				handleErr = true
 				return nil, nil, errOutdatedData
 			}
@@ -497,7 +497,7 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 				storedSes = stored.PendingSession
 			}
 			if !bytes.Equal(storedSes.GetSessionKeyID(), ses.SessionKeyID) {
-				logger.Warn("Device changed session during uplink handling, dropping...")
+				logger.Warn("Device changed session during uplink handling, drop")
 				handleErr = true
 				return nil, nil, errOutdatedData
 			}
@@ -512,7 +512,7 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 				logger.WithFields(log.Fields(
 					"stored_f_cnt", storedSes.GetLastFCntUp(),
 					"got_f_cnt", ses.LastFCntUp,
-				)).Warn("A more recent uplink was received by device during uplink handling, dropping...")
+				)).Warn("A more recent uplink was received by device during uplink handling, drop")
 				handleErr = true
 				return nil, nil, errOutdatedData
 			}
@@ -521,7 +521,7 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 				stored.Session = ses
 			} else if ses == matched.PendingSession {
 				// Device switched the session.
-				logger.Debug("Switching to pending session")
+				logger.Debug("Switch to pending session")
 				stored.PendingSession = ses
 				if stored.PendingSession.DevAddr != stored.MACState.PendingJoinRequest.DevAddr {
 					panic("Pending session does not match the join request")
@@ -601,7 +601,7 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 				var cmd *ttnpb.MACCommand
 				cmd, cmds = cmds[0], cmds[1:]
 				logger := logger.WithField("cid", cmd.CID)
-				logger.Debug("Handling MAC command...")
+				logger.Debug("Handle MAC command")
 				switch cmd.CID {
 				case ttnpb.CID_RESET:
 					err = handleResetInd(ctx, stored, cmd.GetResetInd(), ns.FrequencyPlans, ns.defaultMACSettings)
@@ -611,7 +611,7 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 					pld := cmd.GetLinkADRAns()
 					dupCount := 0
 					if stored.MACState.LoRaWANVersion == ttnpb.MAC_V1_0_2 {
-						logger.Debug("Counting duplicates...")
+						logger.Debug("Count duplicates")
 						for _, dup := range cmds {
 							if dup.CID != ttnpb.CID_LINK_ADR {
 								break
@@ -670,7 +670,7 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 				default:
 					h, ok := ns.macHandlers.Load(cmd.CID)
 					if !ok {
-						logger.WithField("cid", cmd.CID).Warn("Unknown MAC command received, skipping the rest...")
+						logger.WithField("cid", cmd.CID).Warn("Unknown MAC command received, skip the rest")
 						break outer
 					}
 					err = h.(MACHandler)(ctx, stored, cmd.GetRawPayload(), up)
@@ -731,7 +731,7 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 	asCtx, cancel := context.WithTimeout(ctx, appQueueUpdateTimeout)
 	defer cancel()
 
-	logger.Debug("Sending uplink to Application Server...")
+	logger.Debug("Send uplink to Application Server")
 	ok, err := ns.handleASUplink(asCtx, matched.EndDeviceIdentifiers.ApplicationIdentifiers, &ttnpb.ApplicationUp{
 		EndDeviceIdentifiers: matched.EndDeviceIdentifiers,
 		CorrelationIDs:       up.CorrelationIDs,
@@ -752,7 +752,7 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 		registerForwardDataUplink(ctx, &matched.EndDeviceIdentifiers, up)
 	}
 	startAt := time.Now().UTC()
-	logger.WithField("start_at", startAt).Debug("Adding downlink task...")
+	logger.WithField("start_at", startAt).Debug("Add downlink task")
 	return ns.downlinkTasks.Add(ctx, matched.EndDeviceIdentifiers, startAt, true)
 }
 
@@ -842,7 +842,7 @@ func (ns *NetworkServer) handleJoin(ctx context.Context, up *ttnpb.UplinkMessage
 		return err
 	}
 
-	logger.Debug("Sending join-request to Join Server...")
+	logger.Debug("Send join-request to Join Server")
 	resp, err := js.HandleJoin(ctx, req, ns.WithClusterAuth())
 	if err != nil {
 		logger.WithError(err).Warn("Join Server failed to handle join-request")
@@ -932,7 +932,7 @@ func (ns *NetworkServer) handleJoin(ctx context.Context, up *ttnpb.UplinkMessage
 	logger = logger.WithField(
 		"application_uid", unique.ID(ctx, dev.EndDeviceIdentifiers.ApplicationIdentifiers),
 	)
-	logger.Debug("Sending join-accept to AS...")
+	logger.Debug("Send join-accept to AS")
 	_, err = ns.handleASUplink(ctx, dev.EndDeviceIdentifiers.ApplicationIdentifiers, &ttnpb.ApplicationUp{
 		EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
 			ApplicationIdentifiers: dev.EndDeviceIdentifiers.ApplicationIdentifiers,
@@ -954,7 +954,7 @@ func (ns *NetworkServer) handleJoin(ctx context.Context, up *ttnpb.UplinkMessage
 	}
 
 	startAt := time.Now().UTC()
-	logger.WithField("start_at", startAt).Debug("Adding downlink task...")
+	logger.WithField("start_at", startAt).Debug("Add downlink task")
 	if err := ns.downlinkTasks.Add(ctx, dev.EndDeviceIdentifiers, startAt, true); err != nil {
 		return err
 	}
@@ -1001,7 +1001,7 @@ func (ns *NetworkServer) HandleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 	))
 	ctx = log.NewContext(ctx, logger)
 
-	logger.Debug("Deduplicating uplink...")
+	logger.Debug("Deduplicate uplink")
 	acc, stopDedup, ok := ns.deduplicateUplink(ctx, up)
 	if ok {
 		logger.Debug("Dropped duplicate uplink")
@@ -1011,7 +1011,7 @@ func (ns *NetworkServer) HandleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 	registerReceiveUplink(ctx, up)
 
 	defer func(up *ttnpb.UplinkMessage) {
-		logger.Debug("Waiting for collection window to be closed...")
+		logger.Debug("Wait for collection window to be closed")
 		<-ns.collectionDone(ctx, up)
 		stopDedup()
 		logger.Debug("Collection window closed, stopped deduplication")
@@ -1020,13 +1020,13 @@ func (ns *NetworkServer) HandleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 	up = deepcopy.Copy(up).(*ttnpb.UplinkMessage)
 	switch up.Payload.MType {
 	case ttnpb.MType_CONFIRMED_UP, ttnpb.MType_UNCONFIRMED_UP:
-		logger.Debug("Handling data uplink...")
+		logger.Debug("Handle data uplink")
 		return ttnpb.Empty, ns.handleUplink(ctx, up, acc)
 	case ttnpb.MType_JOIN_REQUEST:
-		logger.Debug("Handling join-request...")
+		logger.Debug("Handle join-request")
 		return ttnpb.Empty, ns.handleJoin(ctx, up, acc)
 	case ttnpb.MType_REJOIN_REQUEST:
-		logger.Debug("Handling rejoin-request...")
+		logger.Debug("Handle rejoin-request")
 		return ttnpb.Empty, ns.handleRejoin(ctx, up, acc)
 	default:
 		logger.Warn("Unmatched MType")

--- a/pkg/networkserver/mac_new_channel.go
+++ b/pkg/networkserver/mac_new_channel.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"go.thethings.network/lorawan-stack/pkg/events"
+	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 )
 
@@ -50,6 +51,12 @@ func enqueueNewChannelReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen,
 				MinDataRateIndex: ch.MinDataRateIndex,
 				MaxDataRateIndex: ch.MaxDataRateIndex,
 			}
+			log.FromContext(ctx).WithFields(log.Fields(
+				"index", pld.ChannelIndex,
+				"frequency", pld.Frequency,
+				"min_data_rate_index", pld.MinDataRateIndex,
+				"max_data_rate_index", pld.MaxDataRateIndex,
+			)).Debug("Enqueued NewChannelReq")
 			cmds = append(cmds, pld.MACCommand())
 
 			events.Publish(evtEnqueueNewChannelRequest(ctx, dev.EndDeviceIdentifiers, pld))


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #416 

**Changes:**
<!-- What are the changes made in this pull request? -->

- NS only sends the queue invalidation to AS when downlink actually gets scheduled
- Extended logging

**Notes for Reviewers:**
<!--
Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- Except for https://github.com/TheThingsNetwork/lorawan-stack/commit/862f06fe69b26f8949f41df3700f6cbdd1a1f155, the changes are only related to extending debug logs
- I have reviewed @rvolosatovs commits already; please sanity check