### PR TITLE
Set device class to B/C on session confirmation

### DIFF
--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -262,9 +262,6 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 		}
 		sets = append(sets, "mac_state")
 
-		addDownlinkTask = req.EndDevice.MACState.DeviceClass != ttnpb.CLASS_A &&
-			(len(req.EndDevice.QueuedApplicationDownlinks) > 0 || !req.EndDevice.MACState.CurrentParameters.Equal(req.EndDevice.MACState.DesiredParameters))
-
 		return &req.EndDevice, sets, nil
 	})
 	if err != nil {

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -58,11 +58,9 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 	var addDownlinkTask bool
 	dev, err := ns.devices.SetByID(ctx, req.EndDevice.EndDeviceIdentifiers.ApplicationIdentifiers, req.EndDevice.EndDeviceIdentifiers.DeviceID, gets, func(dev *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
 		if dev != nil {
-			addDownlinkTask = ttnpb.HasAnyField(req.FieldMask.Paths,
-				"mac_state.device_class",
-				"queued_application_downlinks",
-			) && req.EndDevice.MACState.DeviceClass != ttnpb.CLASS_A &&
-				(len(req.EndDevice.QueuedApplicationDownlinks) > 0 || !req.EndDevice.MACState.CurrentParameters.Equal(req.EndDevice.MACState.DesiredParameters))
+			addDownlinkTask = ttnpb.HasAnyField(req.FieldMask.Paths, "mac_state.device_class") &&
+				req.EndDevice.MACState.DeviceClass != ttnpb.CLASS_A &&
+				(len(dev.QueuedApplicationDownlinks) > 0 || !dev.MACState.CurrentParameters.Equal(dev.MACState.DesiredParameters))
 			return &req.EndDevice, req.FieldMask.Paths, nil
 		}
 

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -481,6 +481,8 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 			"pending_session",
 			"recent_uplinks",
 			"session",
+			"supports_class_b",
+			"supports_class_c",
 			"supports_join",
 		},
 		func(stored *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
@@ -527,6 +529,13 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 					panic("Pending session does not match the join request")
 				}
 				stored.EndDeviceIdentifiers.DevAddr = &stored.MACState.PendingJoinRequest.DevAddr
+				if stored.SupportsClassC {
+					stored.MACState.DeviceClass = ttnpb.CLASS_C
+				} else if stored.SupportsClassB {
+					stored.MACState.DeviceClass = ttnpb.CLASS_B
+				} else {
+					stored.MACState.DeviceClass = ttnpb.CLASS_A
+				}
 				stored.MACState.CurrentParameters.Rx1Delay = stored.MACState.PendingJoinRequest.RxDelay
 				stored.MACState.CurrentParameters.Rx1DataRateOffset = stored.MACState.PendingJoinRequest.DownlinkSettings.Rx1DROffset
 				stored.MACState.CurrentParameters.Rx2DataRateIndex = stored.MACState.PendingJoinRequest.DownlinkSettings.Rx2DR

--- a/pkg/networkserver/utils.go
+++ b/pkg/networkserver/utils.go
@@ -66,13 +66,7 @@ func resetMACState(dev *ttnpb.EndDevice, fps *frequencyplans.Store, defaults ttn
 
 	dev.MACState = &ttnpb.MACState{
 		LoRaWANVersion: dev.LoRaWANVersion,
-	}
-	if dev.SupportsClassC {
-		dev.MACState.DeviceClass = ttnpb.CLASS_C
-	} else if dev.SupportsClassB {
-		dev.MACState.DeviceClass = ttnpb.CLASS_B
-	} else {
-		dev.MACState.DeviceClass = ttnpb.CLASS_A
+		DeviceClass:    ttnpb.CLASS_A,
 	}
 
 	dev.MACState.CurrentParameters.MaxEIRP = band.DefaultMaxEIRP


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #313 
Closes #404 

**Changes:**
<!-- What are the changes made in this pull request? -->

- Do not set class B/C directly on join-accept; the device has to confirm the pending session via an uplink
- On uplink, set the desired device class