### PR TITLE
Add script to regenerate SDK API definitions

### DIFF
--- a/sdk/js/generated/api.json
+++ b/sdk/js/generated/api.json
@@ -7269,6 +7269,16 @@
               "fullType": "ttn.lorawan.v3.Rights",
               "ismap": false,
               "defaultValue": ""
+            },
+            {
+              "name": "is_admin",
+              "description": "",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "defaultValue": ""
             }
           ]
         },

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -7,10 +7,11 @@
   "license": "Apache-2.0",
   "private": false,
   "scripts": {
-    "build": "babel src -d dist",
-    "build:watch": "babel -w src -d dist",
+    "build": "rm -rf dist; babel src -d dist",
+    "build:watch": "rm -rf dist; babel -w src -d dist",
     "test": "node_modules/.bin/jest --testPathIgnorePatterns=/dist/",
-    "test:watch": "node_modules/.bin/jest --testPathIgnorePatterns=/dist/ --watch"
+    "test:watch": "node_modules/.bin/jest --testPathIgnorePatterns=/dist/ --watch",
+    "definitions": "mkdir -p ../../.cache; (cd ../.. && docker run --rm -v $PWD:$PWD -w $PWD htdvisser/protocontainer -I $(dirname $PWD) -I $PWD/vendor --doc_out=$PWD/sdk/js/generated --doc_opt=json,api.json --swagger_out=$PWD/.cache $PWD/api/*.proto); node dist/util/http-mapper.js"
   },
   "devDependencies": {
     "babel": "^6.23.0",


### PR DESCRIPTION
**Summary:**
Closes #430. This is a small PR, adding a `definitions` script to the JS SDK's `package.json` that will regenerate the API definitions. I have not added any make targets, as we would likely replace them soon. We can hook the command into mage rather but I think it's better to do this within #377.

**Changes:**
<!-- What are the changes made in this pull request? -->
- Update `sdk/js/package.json` to have a `definitions` script
- I've also added updated the build scripts to remove the `dist` folder before building, as we had trouble caused by not doing so recently
- Update the definitions while at it. (There seemed to be a minor API change recently)

**Notes for Reviewers:**
To test this, try `yarn run definitions` inside `sdk/js`
