### PR TITLE
Refactor CLI OAuth again

### DIFF
--- a/.make/dev.make
+++ b/.make/dev.make
@@ -54,7 +54,7 @@ dev.databases.redis-cli: dev.databases.start
 dev.stack.init: dev.databases.start
 	@$(DEV_DOCKER_COMPOSE) run --rm stack is-db init
 	@$(DEV_DOCKER_COMPOSE) run --rm stack is-db create-admin-user --id admin --email admin@localhost --password admin
-	@$(DEV_DOCKER_COMPOSE) run --rm stack is-db create-oauth-client --id cli --name "Command Line Interface" --owner admin --no-secret --redirect-uri 'http://localhost:11885/oauth/callback' --redirect-uri 'code'
+	@$(DEV_DOCKER_COMPOSE) run --rm stack is-db create-oauth-client --id cli --name "Command Line Interface" --owner admin --no-secret --redirect-uri 'local-callback' --redirect-uri 'code'
 	@$(DEV_DOCKER_COMPOSE) run --rm stack is-db create-oauth-client --id console --name "Console" --owner admin --secret console --redirect-uri 'https://localhost:8885/console/oauth/callback' --redirect-uri 'http://localhost:1885/console/oauth/callback' --redirect-uri '/console/oauth/callback'
 
 # vim: ft=make

--- a/.make/dev.make
+++ b/.make/dev.make
@@ -54,7 +54,7 @@ dev.databases.redis-cli: dev.databases.start
 dev.stack.init: dev.databases.start
 	@$(DEV_DOCKER_COMPOSE) run --rm stack is-db init
 	@$(DEV_DOCKER_COMPOSE) run --rm stack is-db create-admin-user --id admin --email admin@localhost --password admin
-	@$(DEV_DOCKER_COMPOSE) run --rm stack is-db create-oauth-client --id cli --name "Command Line Interface" --owner admin --no-secret --redirect-uri 'http://localhost:11885/oauth/callback' --redirect-uri '/oauth/code'
+	@$(DEV_DOCKER_COMPOSE) run --rm stack is-db create-oauth-client --id cli --name "Command Line Interface" --owner admin --no-secret --redirect-uri 'http://localhost:11885/oauth/callback' --redirect-uri 'code'
 	@$(DEV_DOCKER_COMPOSE) run --rm stack is-db create-oauth-client --id console --name "Console" --owner admin --secret console --redirect-uri 'https://localhost:8885/console/oauth/callback' --redirect-uri 'http://localhost:1885/console/oauth/callback' --redirect-uri '/console/oauth/callback'
 
 # vim: ft=make

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The easiest way to set up a private network is with the provided [`docker-compos
       --id cli --name "Command Line Interface" --no-secret \
       --owner admin \
       --redirect-uri 'http://localhost:11885/oauth/callback' \
-      --redirect-uri '/oauth/code'
+      --redirect-uri 'code'
     ```
 5. Register the Console as an OAuth client:
     ```sh

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The easiest way to set up a private network is with the provided [`docker-compos
     docker-compose run --rm stack is-db create-oauth-client \
       --id cli --name "Command Line Interface" --no-secret \
       --owner admin \
-      --redirect-uri 'http://localhost:11885/oauth/callback' \
+      --redirect-uri 'local-callback' \
       --redirect-uri 'code'
     ```
 5. Register the Console as an OAuth client:

--- a/cmd/ttn-lw-cli/commands/config.go
+++ b/cmd/ttn-lw-cli/commands/config.go
@@ -50,7 +50,7 @@ var DefaultConfig = Config{
 	},
 	InputFormat:                  "json",
 	OutputFormat:                 "json",
-	OAuthServerAddress:           clusterHTTPAddress,
+	OAuthServerAddress:           clusterHTTPAddress + "/oauth",
 	IdentityServerGRPCAddress:    clusterGRPCAddress,
 	GatewayServerGRPCAddress:     clusterGRPCAddress,
 	NetworkServerGRPCAddress:     clusterGRPCAddress,

--- a/cmd/ttn-lw-cli/commands/login.go
+++ b/cmd/ttn-lw-cli/commands/login.go
@@ -77,7 +77,7 @@ var (
 				defer lis.Close()
 				go http.Serve(lis, nil)
 			} else {
-				oauth2Config.RedirectURL = "/oauth/code"
+				oauth2Config.RedirectURL = "code"
 			}
 
 			logger.Infof("Please go to %s", oauth2Config.AuthCodeURL(""))

--- a/cmd/ttn-lw-cli/commands/login.go
+++ b/cmd/ttn-lw-cli/commands/login.go
@@ -51,24 +51,22 @@ var (
 			if callback {
 				oauth2Config.RedirectURL = "local-callback" // NOTE: The "?port=11885" is implicit.
 
-				http.HandleFunc("/oauth/callback", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.HandleFunc("/oauth/callback", func(w http.ResponseWriter, r *http.Request) {
 					if r.Method != http.MethodGet {
 						http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 						return
 					}
 					token, err = oauth2Config.Exchange(ctx, r.URL.Query().Get("code"))
 					if err != nil {
-						msg := "Could not exchange OAuth access token"
-						logger.WithError(err).Error(msg)
+						logger.WithError(err).Error("Could not exchange OAuth access token")
 						w.WriteHeader(http.StatusUnauthorized)
-						w.Write([]byte(msg))
+						fmt.Fprintf(w, "The CLI could not exchange the OAuth access token: %v.\n", err)
 						return
 					}
-					msg := "Got OAuth access token"
-					logger.Info(msg)
-					w.Write([]byte(msg))
+					logger.Info("Successfully got an access token.")
+					fmt.Fprintln(w, "The CLI successfully got an access token. You can now close this window and return to the CLI.")
 					done()
-				}))
+				})
 
 				lis, err := net.Listen("tcp", ":11885")
 				if err != nil {

--- a/cmd/ttn-lw-cli/commands/login.go
+++ b/cmd/ttn-lw-cli/commands/login.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 	"go.thethings.network/lorawan-stack/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/pkg/auth"
@@ -80,7 +81,12 @@ var (
 				oauth2Config.RedirectURL = "code"
 			}
 
-			logger.Infof("Please go to %s", oauth2Config.AuthCodeURL(""))
+			authCodeURL := oauth2Config.AuthCodeURL("")
+			logger.Infof("Opening your browser on %s", authCodeURL)
+			if err = browser.OpenURL(authCodeURL); err != nil {
+				logger.WithError(err).Warn("Could not open your browser, you'll have to go there yourself")
+			}
+			logger.Info("After logging in and authorizing the CLI, we'll get an access token for future commands.")
 
 			if callback {
 				logger.Info("Waiting for your authorization...")

--- a/cmd/ttn-lw-cli/commands/login.go
+++ b/cmd/ttn-lw-cli/commands/login.go
@@ -48,7 +48,7 @@ var (
 			var token *oauth2.Token
 
 			if callback {
-				oauth2Config.RedirectURL = "http://localhost:11885/oauth/callback"
+				oauth2Config.RedirectURL = "local-callback" // NOTE: The "?port=11885" is implicit.
 
 				http.HandleFunc("/oauth/callback", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					if r.Method != http.MethodGet {

--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -136,8 +136,8 @@ func preRun(tasks ...func() error) func(cmd *cobra.Command, args []string) error
 		oauth2Config = &oauth2.Config{
 			ClientID: "cli",
 			Endpoint: oauth2.Endpoint{
-				AuthURL:   fmt.Sprintf("%s/oauth/authorize", config.OAuthServerAddress),
-				TokenURL:  fmt.Sprintf("%s/oauth/token", config.OAuthServerAddress),
+				AuthURL:   fmt.Sprintf("%s/authorize", config.OAuthServerAddress),
+				TokenURL:  fmt.Sprintf("%s/token", config.OAuthServerAddress),
 				AuthStyle: oauth2.AuthStyleInParams,
 			},
 		}

--- a/doc/gettingstarted.md
+++ b/doc/gettingstarted.md
@@ -77,7 +77,7 @@ With the `docker-compose.yml` file in the directory of your terminal prompt, ent
 $ docker-compose pull
 $ docker-compose run --rm stack is-db init
 $ docker-compose run --rm stack is-db create-admin-user --id admin --email admin@localhost
-$ docker-compose run --rm stack is-db create-oauth-client --id cli --name "Command Line Interface" --owner admin --no-secret --redirect-uri 'http://localhost:11885/oauth/callback' --redirect-uri '/oauth/code'
+$ docker-compose run --rm stack is-db create-oauth-client --id cli --name "Command Line Interface" --owner admin --no-secret --redirect-uri 'http://localhost:11885/oauth/callback' --redirect-uri 'code'
 $ docker-compose up
 ```
 

--- a/doc/gettingstarted.md
+++ b/doc/gettingstarted.md
@@ -77,7 +77,7 @@ With the `docker-compose.yml` file in the directory of your terminal prompt, ent
 $ docker-compose pull
 $ docker-compose run --rm stack is-db init
 $ docker-compose run --rm stack is-db create-admin-user --id admin --email admin@localhost
-$ docker-compose run --rm stack is-db create-oauth-client --id cli --name "Command Line Interface" --owner admin --no-secret --redirect-uri 'http://localhost:11885/oauth/callback' --redirect-uri 'code'
+$ docker-compose run --rm stack is-db create-oauth-client --id cli --name "Command Line Interface" --owner admin --no-secret --redirect-uri 'local-callback' --redirect-uri 'code'
 $ docker-compose up
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,7 @@ require (
 	github.com/onsi/ginkgo v1.8.0 // indirect
 	github.com/onsi/gomega v1.5.0 // indirect
 	github.com/openshift/osin v1.0.1
+	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 // indirect

--- a/go.sum
+++ b/go.sum
@@ -518,6 +518,8 @@ github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4 h1:49lOXmGaUpV9Fz3gd7TFZY106KVlPVa5jcYD1gaQf98=
+github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/oauth/callback.go
+++ b/pkg/oauth/callback.go
@@ -1,0 +1,46 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauth
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	echo "github.com/labstack/echo/v4"
+)
+
+func (s *server) redirectToLocal(c echo.Context) error {
+	port, err := strconv.Atoi(c.QueryParam("port"))
+	if err != nil {
+		port = 11885
+	}
+
+	params := make(url.Values)
+	for k, v := range c.QueryParams() {
+		params[k] = v
+	}
+	delete(params, "port")
+
+	url := url.URL{
+		Scheme:   "http",
+		Host:     fmt.Sprintf("localhost:%d", port),
+		Path:     "/oauth/callback",
+		RawQuery: params.Encode(),
+	}
+
+	return c.Redirect(http.StatusFound, url.String())
+}

--- a/pkg/oauth/server.go
+++ b/pkg/oauth/server.go
@@ -17,6 +17,7 @@ package oauth
 import (
 	"context"
 	"net/http"
+	"strings"
 	"time"
 
 	echo "github.com/labstack/echo/v4"
@@ -141,6 +142,10 @@ func (s *server) output(c echo.Context, resp *osin.Response) error {
 		location, err := resp.GetRedirectUrl()
 		if err != nil {
 			return err
+		}
+		uiMount := strings.TrimSuffix(s.config.UI.MountPath(), "/") + "/"
+		if strings.HasPrefix(location, "/") && !strings.HasPrefix(location, uiMount) {
+			location = uiMount + location
 		}
 		return c.Redirect(http.StatusFound, location)
 	}

--- a/pkg/oauth/server.go
+++ b/pkg/oauth/server.go
@@ -190,5 +190,7 @@ func (s *server) RegisterRoutes(server *web.Server) {
 	}
 	group.GET("/*", webui.Template.Handler, middleware.CSRF())
 
-	group.POST("/token", s.Token) // No CSRF here.
+	// No CSRF here:
+	group.GET("/code", webui.Template.Handler)
+	group.POST("/token", s.Token)
 }

--- a/pkg/oauth/server.go
+++ b/pkg/oauth/server.go
@@ -192,5 +192,6 @@ func (s *server) RegisterRoutes(server *web.Server) {
 
 	// No CSRF here:
 	group.GET("/code", webui.Template.Handler)
+	group.GET("/local-callback", s.redirectToLocal)
 	group.POST("/token", s.Token)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR closes #432

**Changes:**
<!-- What are the changes made in this pull request? -->

- Replace `http://localhost:11885/oauth/callback` with a relative `local-callback` route on the OAuth server that subsequently redirects to localhost.
- Improve messages for CLI's OAuth flow
- Make `ttn-lw-cli login` open browser (only relying on copy-pasting the URL if we can't), similar to how `gcloud login` does it.

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Replace the default CLI's OAuth callback with a relative callback that redirects to localhost. With an existing database you have to update the CLI's registration with `ttn-lw-cli cli set cli --redirect-uris "local-callback,code"` or by updating the registration manually in the database.
