### PR TITLE
Gateway Configuration Server configuration endpoint

### DIFF
--- a/cmd/internal/shared/errors.go
+++ b/cmd/internal/shared/errors.go
@@ -18,11 +18,12 @@ import "go.thethings.network/lorawan-stack/pkg/errors"
 
 // Errors returned by component initialization.
 var (
-	ErrInitializeBaseComponent     = errors.Define("initialize_base_component", "could not initialize base component")
-	ErrInitializeIdentityServer    = errors.Define("initialize_identity_server", "could not initialize Identity Server")
-	ErrInitializeGatewayServer     = errors.Define("initialize_gateway_server", "could not initialize Gateway Server")
-	ErrInitializeNetworkServer     = errors.Define("initialize_network_server", "could not initialize Network Server")
-	ErrInitializeApplicationServer = errors.Define("initialize_application_server", "could not initialize Application Server")
-	ErrInitializeJoinServer        = errors.Define("initialize_join_server", "could not initialize Join Server")
-	ErrInitializeConsole           = errors.Define("initialize_console", "could not initialize Console")
+	ErrInitializeBaseComponent              = errors.Define("initialize_base_component", "could not initialize base component")
+	ErrInitializeIdentityServer             = errors.Define("initialize_identity_server", "could not initialize Identity Server")
+	ErrInitializeGatewayServer              = errors.Define("initialize_gateway_server", "could not initialize Gateway Server")
+	ErrInitializeNetworkServer              = errors.Define("initialize_network_server", "could not initialize Network Server")
+	ErrInitializeApplicationServer          = errors.Define("initialize_application_server", "could not initialize Application Server")
+	ErrInitializeJoinServer                 = errors.Define("initialize_join_server", "could not initialize Join Server")
+	ErrInitializeConsole                    = errors.Define("initialize_console", "could not initialize Console")
+	ErrInitializeGatewayConfigurationServer = errors.Define("initialize_gateway_configuration_server", "could not initialize Gateway Configuration Server")
 )

--- a/cmd/internal/shared/gatewayconfigurationserver/config.go
+++ b/cmd/internal/shared/gatewayconfigurationserver/config.go
@@ -19,7 +19,9 @@ import (
 )
 
 // DefaultGatewayConfigurationServerConfig is the default configuration for the Application Server.
-var DefaultGatewayConfigurationServerConfig = gatewayconfigurationserver.Config{}
+var DefaultGatewayConfigurationServerConfig = gatewayconfigurationserver.Config{
+	RequireAuth: true,
+}
 
 func init() {
 	DefaultGatewayConfigurationServerConfig.TheThingsGateway.Default.UpdateChannel = "stable"

--- a/cmd/internal/shared/gatewayconfigurationserver/config.go
+++ b/cmd/internal/shared/gatewayconfigurationserver/config.go
@@ -1,0 +1,27 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared
+
+import (
+	"go.thethings.network/lorawan-stack/pkg/gatewayconfigurationserver"
+)
+
+// DefaultGatewayConfigurationServerConfig is the default configuration for the Application Server.
+var DefaultGatewayConfigurationServerConfig = gatewayconfigurationserver.Config{}
+
+func init() {
+	DefaultGatewayConfigurationServerConfig.TheThingsGateway.Default.UpdateChannel = "stable"
+	DefaultGatewayConfigurationServerConfig.TheThingsGateway.Default.FirmwareURL = "https://thethingsproducts.blob.core.windows.net/the-things-gateway/v1"
+}

--- a/cmd/ttn-lw-stack/commands/config.go
+++ b/cmd/ttn-lw-stack/commands/config.go
@@ -24,9 +24,9 @@ import (
 	shared_joinserver "go.thethings.network/lorawan-stack/cmd/internal/shared/joinserver"
 	shared_networkserver "go.thethings.network/lorawan-stack/cmd/internal/shared/networkserver"
 	"go.thethings.network/lorawan-stack/pkg/applicationserver"
-	"go.thethings.network/lorawan-stack/pkg/basicstation/cups"
 	conf "go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/console"
+	"go.thethings.network/lorawan-stack/pkg/gatewayconfigurationserver"
 	"go.thethings.network/lorawan-stack/pkg/gatewayserver"
 	"go.thethings.network/lorawan-stack/pkg/identityserver"
 	"go.thethings.network/lorawan-stack/pkg/joinserver"
@@ -36,15 +36,13 @@ import (
 // Config for the ttn-lw-stack binary.
 type Config struct {
 	conf.ServiceBase `name:",squash"`
-	IS               identityserver.Config    `name:"is"`
-	GS               gatewayserver.Config     `name:"gs"`
-	NS               networkserver.Config     `name:"ns"`
-	AS               applicationserver.Config `name:"as"`
-	JS               joinserver.Config        `name:"js"`
-	Console          console.Config           `name:"console"`
-	GCS              struct {
-		BasicStation cups.ServerConfig `name:"basic-station"`
-	} `name:"gcs"`
+	IS               identityserver.Config             `name:"is"`
+	GS               gatewayserver.Config              `name:"gs"`
+	NS               networkserver.Config              `name:"ns"`
+	AS               applicationserver.Config          `name:"as"`
+	JS               joinserver.Config                 `name:"js"`
+	Console          console.Config                    `name:"console"`
+	GCS              gatewayconfigurationserver.Config `name:"gcs"`
 }
 
 // DefaultConfig contains the default config for the ttn-lw-stack binary.

--- a/cmd/ttn-lw-stack/commands/config.go
+++ b/cmd/ttn-lw-stack/commands/config.go
@@ -19,6 +19,7 @@ import (
 	"go.thethings.network/lorawan-stack/cmd/internal/shared"
 	shared_applicationserver "go.thethings.network/lorawan-stack/cmd/internal/shared/applicationserver"
 	shared_console "go.thethings.network/lorawan-stack/cmd/internal/shared/console"
+	shared_gatewayconfigurationserver "go.thethings.network/lorawan-stack/cmd/internal/shared/gatewayconfigurationserver"
 	shared_gatewayserver "go.thethings.network/lorawan-stack/cmd/internal/shared/gatewayserver"
 	shared_identityserver "go.thethings.network/lorawan-stack/cmd/internal/shared/identityserver"
 	shared_joinserver "go.thethings.network/lorawan-stack/cmd/internal/shared/joinserver"
@@ -54,6 +55,7 @@ var DefaultConfig = Config{
 	AS:          shared_applicationserver.DefaultApplicationServerConfig,
 	JS:          shared_joinserver.DefaultJoinServerConfig,
 	Console:     shared_console.DefaultConsoleConfig,
+	GCS:         shared_gatewayconfigurationserver.DefaultGatewayConfigurationServerConfig,
 }
 
 func init() {

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -30,6 +30,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/events"
 	events_grpc "go.thethings.network/lorawan-stack/pkg/events/grpc"
+	"go.thethings.network/lorawan-stack/pkg/gatewayconfigurationserver"
 	"go.thethings.network/lorawan-stack/pkg/gatewayserver"
 	"go.thethings.network/lorawan-stack/pkg/identityserver"
 	"go.thethings.network/lorawan-stack/pkg/joinserver"
@@ -197,9 +198,12 @@ var (
 			}
 
 			if start.GCS {
-				logger.Info("Setting up GCS")
-				cups := config.GCS.BasicStation.NewServer(c)
-				_ = cups
+				logger.Info("Setting up Gateway Configuration Server")
+				gcs, err := gatewayconfigurationserver.New(c, &config.GCS)
+				if err != nil {
+					return shared.ErrInitializeGatewayConfigurationServer.WithCause(err)
+				}
+				_ = gcs
 			}
 
 			if rootRedirect != nil {

--- a/config/messages.json
+++ b/config/messages.json
@@ -4391,6 +4391,15 @@
       "file": "storage.go"
     }
   },
+  "error:pkg/pfconfig/shared:unmarshal_not_implemented": {
+    "translations": {
+      "en": "unmarshaling SX1301 config is not implemented"
+    },
+    "description": {
+      "package": "pkg/pfconfig/shared",
+      "file": "shared.go"
+    }
+  },
   "error:pkg/redis:not_found": {
     "translations": {
       "en": "entity not found"

--- a/config/messages.json
+++ b/config/messages.json
@@ -4481,6 +4481,33 @@
       "file": "javascript.go"
     }
   },
+  "error:pkg/thethingsgateway/cups:no_default_firmware_path": {
+    "translations": {
+      "en": "no default firmware path specified"
+    },
+    "description": {
+      "package": "pkg/thethingsgateway/cups",
+      "file": "server.go"
+    }
+  },
+  "error:pkg/thethingsgateway/cups:no_default_update_channel": {
+    "translations": {
+      "en": "no default update channel specified"
+    },
+    "description": {
+      "package": "pkg/thethingsgateway/cups",
+      "file": "server.go"
+    }
+  },
+  "error:pkg/thethingsgateway/cups:unauthenticated": {
+    "translations": {
+      "en": "call was not authenticated"
+    },
+    "description": {
+      "package": "pkg/thethingsgateway/cups",
+      "file": "middleware.go"
+    }
+  },
   "error:pkg/toa:bandwidth": {
     "translations": {
       "en": "invalid bandwidth"

--- a/config/messages.json
+++ b/config/messages.json
@@ -1088,6 +1088,15 @@
       "file": "errors.go"
     }
   },
+  "error:cmd/internal/shared:initialize_gateway_configuration_server": {
+    "translations": {
+      "en": "could not initialize Gateway Configuration Server"
+    },
+    "description": {
+      "package": "cmd/internal/shared",
+      "file": "errors.go"
+    }
+  },
   "error:cmd/internal/shared:initialize_gateway_server": {
     "translations": {
       "en": "could not initialize Gateway Server"

--- a/pkg/gatewayconfigurationserver/gatewayconfigurationserver.go
+++ b/pkg/gatewayconfigurationserver/gatewayconfigurationserver.go
@@ -23,6 +23,7 @@ import (
 	bs_cups "go.thethings.network/lorawan-stack/pkg/basicstation/cups"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	"go.thethings.network/lorawan-stack/pkg/pfconfig/semtechudp"
+	ttg_cups "go.thethings.network/lorawan-stack/pkg/thethingsgateway/cups"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/web"
 	"google.golang.org/grpc/metadata"
@@ -30,8 +31,10 @@ import (
 
 // Config contains the Gateway Configuration Server configuration.
 type Config struct {
-	// BasicStation defines the configuration for the BasicStation CUPS server.
-	BasicStation bs_cups.ServerConfig `name:"basic-station" description:"BasicStation CUPS server configuration."`
+	// BasicStation defines the configuration for the BasicStation CUPS.
+	BasicStation bs_cups.ServerConfig `name:"basic-station" description:"BasicStation CUPS configuration."`
+	// TheThingsGateway defines the configuration for The Things Gateway CUPS.
+	TheThingsGateway ttg_cups.Config `name:"the-things-gateway" description:"The Things Gateway CUPS configuration."`
 	// RequreAuth defines if the HTTP endpoints should require authentication or not.
 	RequireAuth bool `name:"require-auth" description:"Require authentication for the HTTP endpoints."`
 }
@@ -69,8 +72,14 @@ func New(c *component.Component, conf *Config, opts ...Option) (*GatewayConfigur
 		opt(gcs)
 	}
 
-	cups := conf.BasicStation.NewServer(c)
-	_ = cups
+	bsCUPS := conf.BasicStation.NewServer(c)
+	_ = bsCUPS
+
+	ttgCUPS, err := conf.TheThingsGateway.NewServer(c)
+	if err != nil {
+		return nil, err
+	}
+	_ = ttgCUPS
 
 	c.RegisterWeb(gcs)
 	return gcs, nil

--- a/pkg/gatewayconfigurationserver/gatewayconfigurationserver.go
+++ b/pkg/gatewayconfigurationserver/gatewayconfigurationserver.go
@@ -1,0 +1,129 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gatewayconfigurationserver
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gogo/protobuf/types"
+	echo "github.com/labstack/echo/v4"
+	"go.thethings.network/lorawan-stack/pkg/component"
+	"go.thethings.network/lorawan-stack/pkg/errors"
+	"go.thethings.network/lorawan-stack/pkg/pfconfig/semtechudp"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/pkg/web"
+	"google.golang.org/grpc/metadata"
+)
+
+// Config contains the Gateway Configuration Server configuration.
+type Config struct {
+	// RequreAuth defines if the HTTP endpoints should require authentication or not.
+	RequireAuth bool `name:"require-auth" description:"Require authentication for the HTTP endpoints."`
+}
+
+// GatewayConfigurationServer implements the Gateway Configuration Server component.
+type GatewayConfigurationServer struct {
+	*component.Component
+	config *Config
+
+	registry ttnpb.GatewayRegistryClient
+
+	ctx context.Context
+}
+
+// RegisterRoutes registers the web frontend routes.
+func (gcs *GatewayConfigurationServer) RegisterRoutes(server *web.Server) {
+	middleware := []echo.MiddlewareFunc{
+		gcs.validateAndFillIDs(),
+	}
+	if gcs.config.RequireAuth {
+		middleware = append(middleware, gcs.requireGatewayRights(ttnpb.RIGHT_GATEWAY_INFO))
+	}
+	group := server.Group(ttnpb.HTTPAPIPrefix+"/gcs/gateways/:gateway_id", middleware...)
+	group.GET("/global_conf.json", gcs.handleGetGlobalConfig)
+}
+
+// New returns new *GatewayConfigurationServer.
+func New(c *component.Component, conf *Config, opts ...Option) (*GatewayConfigurationServer, error) {
+	gcs := &GatewayConfigurationServer{
+		Component: c,
+		config:    conf,
+		ctx:       c.Context(),
+	}
+	for _, opt := range opts {
+		opt(gcs)
+	}
+	c.RegisterWeb(gcs)
+	return gcs, nil
+}
+
+// Option represents a Gateway Configuration Server option.
+type Option func(gcs *GatewayConfigurationServer)
+
+// WithRegistry sets the gateway registry for the given server.
+func WithRegistry(registry ttnpb.GatewayRegistryClient) Option {
+	return func(gcs *GatewayConfigurationServer) {
+		gcs.registry = registry
+	}
+}
+
+// WithContext sets the context for the given server.
+func WithContext(ctx context.Context) Option {
+	return func(gcs *GatewayConfigurationServer) {
+		gcs.ctx = ctx
+	}
+}
+
+func (gcs *GatewayConfigurationServer) handleGetGlobalConfig(c echo.Context) error {
+	ctx := gcs.getContext(c)
+	gtwID := c.Get(gatewayIDKey).(ttnpb.GatewayIdentifiers)
+	gtw, err := gcs.getRegistry(ctx).Get(ctx, &ttnpb.GetGatewayRequest{
+		GatewayIdentifiers: gtwID,
+		FieldMask: types.FieldMask{
+			Paths: []string{
+				"gateway_server_address",
+				"frequency_plan_id",
+			},
+		},
+	}, gcs.WithClusterAuth())
+	if err != nil {
+		return err
+	}
+	config, err := semtechudp.Build(gtw, gcs.FrequencyPlans)
+	if err != nil {
+		return err
+	}
+	return c.JSONPretty(http.StatusOK, config, "\t")
+}
+
+func (gcs *GatewayConfigurationServer) getContext(c echo.Context) context.Context {
+	ctx := c.Request().Context()
+	ctx = gcs.FillContext(ctx)
+	md := metadata.New(map[string]string{
+		"authorization": c.Request().Header.Get(echo.HeaderAuthorization),
+	})
+	if ctxMd, ok := metadata.FromIncomingContext(ctx); ok {
+		md = metadata.Join(ctxMd, md)
+	}
+	return metadata.NewIncomingContext(ctx, md)
+}
+
+func (gcs *GatewayConfigurationServer) getRegistry(ctx context.Context) ttnpb.GatewayRegistryClient {
+	if gcs.registry != nil {
+		return gcs.registry
+	}
+	return ttnpb.NewGatewayRegistryClient(gcs.GetPeer(ctx, ttnpb.PeerInfo_ENTITY_REGISTRY, nil).Conn())
+}

--- a/pkg/gatewayconfigurationserver/gatewayconfigurationserver.go
+++ b/pkg/gatewayconfigurationserver/gatewayconfigurationserver.go
@@ -20,10 +20,10 @@ import (
 
 	"github.com/gogo/protobuf/types"
 	echo "github.com/labstack/echo/v4"
-	bs_cups "go.thethings.network/lorawan-stack/pkg/basicstation/cups"
+	bscups "go.thethings.network/lorawan-stack/pkg/basicstation/cups"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	"go.thethings.network/lorawan-stack/pkg/pfconfig/semtechudp"
-	ttg_cups "go.thethings.network/lorawan-stack/pkg/thethingsgateway/cups"
+	ttgcups "go.thethings.network/lorawan-stack/pkg/thethingsgateway/cups"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/web"
 	"google.golang.org/grpc/metadata"
@@ -32,9 +32,9 @@ import (
 // Config contains the Gateway Configuration Server configuration.
 type Config struct {
 	// BasicStation defines the configuration for the BasicStation CUPS.
-	BasicStation bs_cups.ServerConfig `name:"basic-station" description:"BasicStation CUPS configuration."`
+	BasicStation bscups.ServerConfig `name:"basic-station" description:"BasicStation CUPS configuration."`
 	// TheThingsGateway defines the configuration for The Things Gateway CUPS.
-	TheThingsGateway ttg_cups.Config `name:"the-things-gateway" description:"The Things Gateway CUPS configuration."`
+	TheThingsGateway ttgcups.Config `name:"the-things-gateway" description:"The Things Gateway CUPS configuration."`
 	// RequreAuth defines if the HTTP endpoints should require authentication or not.
 	RequireAuth bool `name:"require-auth" description:"Require authentication for the HTTP endpoints."`
 }
@@ -54,7 +54,7 @@ func (gcs *GatewayConfigurationServer) RegisterRoutes(server *web.Server) {
 		middleware = append(middleware, gcs.requireGatewayRights(ttnpb.RIGHT_GATEWAY_INFO))
 	}
 	group := server.Group(ttnpb.HTTPAPIPrefix+"/gcs/gateways/:gateway_id", middleware...)
-	group.GET("/global_conf.json", gcs.handleGetGlobalConfig)
+	group.GET("/semtechudp/global_conf.json", gcs.handleGetGlobalConfig)
 }
 
 // New returns new *GatewayConfigurationServer.

--- a/pkg/gatewayconfigurationserver/gatewayconfigurationserver.go
+++ b/pkg/gatewayconfigurationserver/gatewayconfigurationserver.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/gogo/protobuf/types"
 	echo "github.com/labstack/echo/v4"
+	bs_cups "go.thethings.network/lorawan-stack/pkg/basicstation/cups"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/pfconfig/semtechudp"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/web"
@@ -30,6 +30,8 @@ import (
 
 // Config contains the Gateway Configuration Server configuration.
 type Config struct {
+	// BasicStation defines the configuration for the BasicStation CUPS server.
+	BasicStation bs_cups.ServerConfig `name:"basic-station" description:"BasicStation CUPS server configuration."`
 	// RequreAuth defines if the HTTP endpoints should require authentication or not.
 	RequireAuth bool `name:"require-auth" description:"Require authentication for the HTTP endpoints."`
 }
@@ -66,6 +68,10 @@ func New(c *component.Component, conf *Config, opts ...Option) (*GatewayConfigur
 	for _, opt := range opts {
 		opt(gcs)
 	}
+
+	cups := conf.BasicStation.NewServer(c)
+	_ = cups
+
 	c.RegisterWeb(gcs)
 	return gcs, nil
 }

--- a/pkg/gatewayconfigurationserver/gatewayconfigurationserver_test.go
+++ b/pkg/gatewayconfigurationserver/gatewayconfigurationserver_test.go
@@ -114,7 +114,7 @@ func TestWeb(t *testing.T) {
 		} {
 			t.Run(tc.Name, func(t *testing.T) {
 				a := assertions.New(t)
-				url := fmt.Sprintf("http://%s/api/v3/gcs/gateways/%s/global_conf.json",
+				url := fmt.Sprintf("http://%s/api/v3/gcs/gateways/%s/semtechudp/global_conf.json",
 					httpAddress, tc.ID.GatewayID,
 				)
 				body := bytes.NewReader([]byte(`{"downlinks":[]}`))

--- a/pkg/gatewayconfigurationserver/gatewayconfigurationserver_test.go
+++ b/pkg/gatewayconfigurationserver/gatewayconfigurationserver_test.go
@@ -1,0 +1,149 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gatewayconfigurationserver_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/pkg/auth/rights"
+	"go.thethings.network/lorawan-stack/pkg/component"
+	"go.thethings.network/lorawan-stack/pkg/config"
+	. "go.thethings.network/lorawan-stack/pkg/gatewayconfigurationserver"
+	"go.thethings.network/lorawan-stack/pkg/log"
+	"go.thethings.network/lorawan-stack/pkg/rpcmetadata"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/pkg/unique"
+	"go.thethings.network/lorawan-stack/pkg/util/test"
+	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
+)
+
+var (
+	registeredGatewayUID = "test-gateway"
+	registeredGatewayID  = ttnpb.GatewayIdentifiers{GatewayID: "test-gateway"}
+	registeredGatewayKey = "test-key"
+
+	testConfig = &Config{
+		RequireAuth: true,
+	}
+)
+
+func TestWeb(t *testing.T) {
+	a := assertions.New(t)
+	ctx := log.NewContext(test.Context(), test.GetLogger(t))
+
+	gs := &mockGatewayClient{}
+	gs.res.Get = &ttnpb.Gateway{
+		GatewayIdentifiers:   registeredGatewayID,
+		FrequencyPlanID:      "EU_863_870",
+		GatewayServerAddress: "localhost",
+	}
+
+	httpAddress := "0.0.0.0:8098"
+	conf := &component.Config{
+		ServiceBase: config.ServiceBase{
+			HTTP: config.HTTP{
+				Listen: httpAddress,
+			},
+			FrequencyPlans: config.FrequencyPlansConfig{
+				URL: "https://raw.githubusercontent.com/TheThingsNetwork/lorawan-frequency-plans/master",
+			},
+		},
+	}
+	c := component.MustNew(test.GetLogger(t), conf)
+	ctx = c.FillContext(ctx)
+
+	gcs, err := New(c, testConfig, []Option{
+		WithRegistry(gs),
+		WithContext(newContextWithRightsFetcher(ctx)),
+	}...)
+	a.So(err, should.BeNil)
+	a.So(gcs, should.NotBeNil)
+
+	err = c.Start()
+	a.So(err, should.BeNil)
+	defer c.Close()
+
+	t.Run("Authorization", func(t *testing.T) {
+		for _, tc := range []struct {
+			Name       string
+			ID         ttnpb.GatewayIdentifiers
+			Key        string
+			ExpectCode int
+		}{
+			{
+				Name:       "Valid",
+				ID:         registeredGatewayID,
+				Key:        registeredGatewayKey,
+				ExpectCode: http.StatusOK,
+			},
+			{
+				Name:       "InvalidKey",
+				ID:         registeredGatewayID,
+				Key:        "invalid key",
+				ExpectCode: http.StatusForbidden,
+			},
+			{
+				Name:       "InvalidIDAndKey",
+				ID:         ttnpb.GatewayIdentifiers{GatewayID: "--invalid-id"},
+				Key:        "invalid key",
+				ExpectCode: http.StatusBadRequest,
+			},
+		} {
+			t.Run(tc.Name, func(t *testing.T) {
+				a := assertions.New(t)
+				url := fmt.Sprintf("http://%s/api/v3/gcs/gateways/%s/global_conf.json",
+					httpAddress, tc.ID.GatewayID,
+				)
+				body := bytes.NewReader([]byte(`{"downlinks":[]}`))
+				req, err := http.NewRequest(http.MethodGet, url, body)
+				if !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tc.Key))
+				res, err := http.DefaultClient.Do(req)
+				if !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
+				a.So(res.StatusCode, should.Equal, tc.ExpectCode)
+			})
+		}
+	})
+}
+
+func newContextWithRightsFetcher(ctx context.Context) context.Context {
+	return rights.NewContextWithFetcher(
+		ctx,
+		rights.FetcherFunc(func(ctx context.Context, ids ttnpb.Identifiers) (set *ttnpb.Rights, err error) {
+			uid := unique.ID(ctx, ids)
+			if uid != registeredGatewayUID {
+				return
+			}
+			md := rpcmetadata.FromIncomingContext(ctx)
+			if md.AuthType != "Bearer" || md.AuthValue != registeredGatewayKey {
+				return
+			}
+			set = ttnpb.RightsFrom(
+				ttnpb.RIGHT_GATEWAY_INFO,
+			)
+			return
+		}),
+	)
+}

--- a/pkg/gatewayconfigurationserver/gatewayconfigurationserver_test.go
+++ b/pkg/gatewayconfigurationserver/gatewayconfigurationserver_test.go
@@ -147,3 +147,8 @@ func newContextWithRightsFetcher(ctx context.Context) context.Context {
 		}),
 	)
 }
+
+func init() {
+	testConfig.TheThingsGateway.Default.FirmwareURL = "http://example.com"
+	testConfig.TheThingsGateway.Default.UpdateChannel = "stable"
+}

--- a/pkg/gatewayconfigurationserver/middleware.go
+++ b/pkg/gatewayconfigurationserver/middleware.go
@@ -1,0 +1,86 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gatewayconfigurationserver
+
+import (
+	"strings"
+
+	echo "github.com/labstack/echo/v4"
+	"go.thethings.network/lorawan-stack/pkg/auth/rights"
+	web_errors "go.thethings.network/lorawan-stack/pkg/errors/web"
+	"go.thethings.network/lorawan-stack/pkg/log"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"google.golang.org/grpc/metadata"
+)
+
+func (gcs *GatewayConfigurationServer) handleError() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			ctx := gcs.ctx
+			err := next(c)
+			if err == nil || c.Response().Committed {
+				return err
+			}
+			log.FromContext(ctx).WithError(err).Debug("HTTP request failed")
+			statusCode, err := web_errors.ProcessError(err)
+			if strings.Contains(c.Request().Header.Get(echo.HeaderAccept), "application/json") {
+				return c.JSON(statusCode, err)
+			}
+			return c.String(statusCode, err.Error())
+		}
+	}
+}
+
+const (
+	gatewayIDKey = "gateway_id"
+)
+
+func (gcs *GatewayConfigurationServer) validateAndFillIDs() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			ctx := gcs.ctx
+			gtwID := ttnpb.GatewayIdentifiers{
+				GatewayID: c.Param(gatewayIDKey),
+			}
+			if err := gtwID.ValidateContext(ctx); err != nil {
+				return err
+			}
+			c.Set(gatewayIDKey, gtwID)
+
+			return next(c)
+		}
+	}
+}
+
+func (gcs *GatewayConfigurationServer) requireGatewayRights(required ...ttnpb.Right) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			ctx := gcs.ctx
+			gtwID := c.Get(gatewayIDKey).(ttnpb.GatewayIdentifiers)
+			md := metadata.New(map[string]string{
+				"id":            gtwID.GatewayID,
+				"authorization": c.Request().Header.Get(echo.HeaderAuthorization),
+			})
+			if ctxMd, ok := metadata.FromIncomingContext(ctx); ok {
+				md = metadata.Join(ctxMd, md)
+			}
+			ctx = metadata.NewIncomingContext(ctx, md)
+			if err := rights.RequireGateway(ctx, gtwID, required...); err != nil {
+				return err
+			}
+			return next(c)
+		}
+	}
+}

--- a/pkg/gatewayconfigurationserver/middleware.go
+++ b/pkg/gatewayconfigurationserver/middleware.go
@@ -28,7 +28,7 @@ import (
 func (gcs *GatewayConfigurationServer) handleError() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			ctx := gcs.ctx
+			ctx := gcs.getContext(c)
 			err := next(c)
 			if err == nil || c.Response().Committed {
 				return err
@@ -50,7 +50,7 @@ const (
 func (gcs *GatewayConfigurationServer) validateAndFillIDs() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			ctx := gcs.ctx
+			ctx := gcs.getContext(c)
 			gtwID := ttnpb.GatewayIdentifiers{
 				GatewayID: c.Param(gatewayIDKey),
 			}
@@ -67,7 +67,7 @@ func (gcs *GatewayConfigurationServer) validateAndFillIDs() echo.MiddlewareFunc 
 func (gcs *GatewayConfigurationServer) requireGatewayRights(required ...ttnpb.Right) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			ctx := gcs.ctx
+			ctx := gcs.getContext(c)
 			gtwID := c.Get(gatewayIDKey).(ttnpb.GatewayIdentifiers)
 			md := metadata.New(map[string]string{
 				"id":            gtwID.GatewayID,

--- a/pkg/gatewayconfigurationserver/store_util_test.go
+++ b/pkg/gatewayconfigurationserver/store_util_test.go
@@ -1,0 +1,104 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gatewayconfigurationserver_test
+
+import (
+	"context"
+
+	"github.com/gogo/protobuf/types"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"google.golang.org/grpc"
+)
+
+type mockGatewayClientData struct {
+	ctx struct {
+		GetIdentifiersForEUI context.Context
+		Create               context.Context
+		Get                  context.Context
+		Update               context.Context
+		List                 context.Context
+		Delete               context.Context
+	}
+	req struct {
+		GetIdentifiersForEUI *ttnpb.GetGatewayIdentifiersForEUIRequest
+		Create               *ttnpb.CreateGatewayRequest
+		Get                  *ttnpb.GetGatewayRequest
+		Update               *ttnpb.UpdateGatewayRequest
+		List                 *ttnpb.ListGatewaysRequest
+		Delete               *ttnpb.GatewayIdentifiers
+	}
+	opts struct {
+		GetIdentifiersForEUI []grpc.CallOption
+		Create               []grpc.CallOption
+		Get                  []grpc.CallOption
+		Update               []grpc.CallOption
+		List                 []grpc.CallOption
+		Delete               []grpc.CallOption
+	}
+	res struct {
+		GetIdentifiersForEUI *ttnpb.GatewayIdentifiers
+		Create               *ttnpb.Gateway
+		Get                  *ttnpb.Gateway
+		Update               *ttnpb.Gateway
+		List                 *ttnpb.Gateways
+		Delete               *types.Empty
+	}
+	err struct {
+		GetIdentifiersForEUI error
+		Create               error
+		Get                  error
+		Update               error
+		List                 error
+		Delete               error
+	}
+}
+
+type mockGatewayClient struct {
+	mockGatewayClientData
+}
+
+func (m *mockGatewayClient) reset() {
+	m.mockGatewayClientData = mockGatewayClientData{}
+}
+
+func (m *mockGatewayClient) GetIdentifiersForEUI(ctx context.Context, in *ttnpb.GetGatewayIdentifiersForEUIRequest, opts ...grpc.CallOption) (*ttnpb.GatewayIdentifiers, error) {
+	m.ctx.GetIdentifiersForEUI, m.req.GetIdentifiersForEUI, m.opts.GetIdentifiersForEUI = ctx, in, opts
+	return m.res.GetIdentifiersForEUI, m.err.GetIdentifiersForEUI
+}
+
+func (m *mockGatewayClient) Create(ctx context.Context, in *ttnpb.CreateGatewayRequest, opts ...grpc.CallOption) (*ttnpb.Gateway, error) {
+	m.ctx.Create, m.req.Create, m.opts.Create = ctx, in, opts
+	return m.res.Create, m.err.Create
+}
+
+func (m *mockGatewayClient) Get(ctx context.Context, in *ttnpb.GetGatewayRequest, opts ...grpc.CallOption) (*ttnpb.Gateway, error) {
+	m.ctx.Get, m.req.Get, m.opts.Get = ctx, in, opts
+	return m.res.Get, m.err.Get
+}
+
+func (m *mockGatewayClient) Update(ctx context.Context, in *ttnpb.UpdateGatewayRequest, opts ...grpc.CallOption) (*ttnpb.Gateway, error) {
+	m.ctx.Update, m.req.Update, m.opts.Update = ctx, in, opts
+	return m.res.Update, m.err.Update
+}
+
+func (m *mockGatewayClient) Delete(ctx context.Context, ids *ttnpb.GatewayIdentifiers, opts ...grpc.CallOption) (*types.Empty, error) {
+	m.ctx.Delete, m.req.Delete, m.opts.Delete = ctx, ids, opts
+	return m.res.Delete, m.err.Delete
+}
+
+func (m *mockGatewayClient) List(ctx context.Context, in *ttnpb.ListGatewaysRequest, opts ...grpc.CallOption) (*ttnpb.Gateways, error) {
+	m.ctx.List, m.req.List, m.opts.List = ctx, in, opts
+	return m.res.List, m.err.List
+}

--- a/pkg/thethingsgateway/cups/handlers.go
+++ b/pkg/thethingsgateway/cups/handlers.go
@@ -17,6 +17,7 @@ package cups
 import (
 	"context"
 	"fmt"
+	"github.com/gogo/protobuf/types"
 	"net"
 	"net/http"
 	"net/url"
@@ -46,6 +47,12 @@ func (s *Server) handleGatewayInfo(c echo.Context) error {
 	gatewayIDs := c.Get(gatewayIDKey).(ttnpb.GatewayIdentifiers)
 	if gateway, err := s.getRegistry(ctx, &gatewayIDs).Get(ctx, &ttnpb.GetGatewayRequest{
 		GatewayIdentifiers: gatewayIDs,
+		FieldMask: types.FieldMask{Paths: []string{
+			"frequency_plan_id",
+			"gateway_server_address",
+			"update_channel",
+			"auto_update",
+		}},
 	}, s.getAuth(c)); err != nil {
 		return err
 	} else {

--- a/pkg/thethingsgateway/cups/handlers.go
+++ b/pkg/thethingsgateway/cups/handlers.go
@@ -1,0 +1,156 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cups
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	echo "github.com/labstack/echo/v4"
+	"go.thethings.network/lorawan-stack/pkg/pfconfig/shared"
+	"go.thethings.network/lorawan-stack/pkg/rpcmetadata"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// gatewayInfoResponse represents a minimal gateway info response for The Things Gateway.
+type gatewayInfoResponse struct {
+	FrequencyPlanID  string `json:"frequency_plan"`
+	FrequencyPlanURL string `json:"frequency_plan_url"`
+	FirmwareURL      string `json:"firmware_url"`
+	Router           struct {
+		MQTTAddress string `json:"mqtt_address"`
+	} `json:"router"`
+	AutoUpdate bool `json:"auto_update"`
+}
+
+func (s *Server) handleGatewayInfo(c echo.Context) error {
+	ctx := s.getContext(c)
+	gatewayIDs := c.Get(gatewayIDKey).(ttnpb.GatewayIdentifiers)
+	if gateway, err := s.getRegistry(ctx, &gatewayIDs).Get(ctx, &ttnpb.GetGatewayRequest{
+		GatewayIdentifiers: gatewayIDs,
+	}, s.getAuth(c)); err != nil {
+		return err
+	} else {
+		freqPlanURL := &url.URL{
+			Scheme: c.Scheme(),
+			Host:   c.Request().Host,
+			Path:   fmt.Sprintf("%v/frequency-plans/%v", compatAPIPrefix, gateway.FrequencyPlanID),
+		}
+		response := &gatewayInfoResponse{
+			FrequencyPlanID:  gateway.FrequencyPlanID,
+			FrequencyPlanURL: freqPlanURL.String(),
+			FirmwareURL:      adaptUpdateChannel(gateway.UpdateChannel),
+			AutoUpdate:       gateway.AutoUpdate,
+		}
+		response.Router.MQTTAddress, err = adaptGatewayAddress(gateway.GatewayServerAddress)
+		if err != nil {
+			return err
+		}
+		return c.JSON(http.StatusOK, response)
+	}
+}
+
+func (s *Server) handleFreqPlanInfo(c echo.Context) error {
+	freqPlanID := c.Param(frequencyPlanIDKey)
+	plan, err := s.component.FrequencyPlans.GetByID(freqPlanID)
+	if err != nil {
+		return err
+	}
+	config, err := shared.BuildSX1301Config(plan)
+	if err != nil {
+		return err
+	}
+	config.TxLUTConfigs = config.TxLUTConfigs[:0]
+	return c.JSON(http.StatusOK, struct {
+		SX1301Conf *shared.SX1301Config `json:"SX1301_conf"`
+	}{
+		SX1301Conf: config,
+	})
+}
+
+const defaultFirmwarePath = "https://thethingsproducts.blob.core.windows.net/the-things-gateway/v1"
+
+// adaptUpdateChannel prepends the default firmware path if the channel itself is not an URL.
+func adaptUpdateChannel(channel string) string {
+	if channel == "" {
+		return ""
+	}
+	if _, err := url.ParseRequestURI(channel); err != nil {
+		return fmt.Sprintf("%v/%v", defaultFirmwarePath, channel)
+	}
+	return channel
+}
+
+// adaptGatewayAddress prepends the gateway address with the scheme "mqtts" and appends
+// the port "8882" if they have not been mentioned. If the scheme has been given, no
+// changes are done to the address.
+func adaptGatewayAddress(address string) (result string, err error) {
+	if address == "" {
+		return address, nil
+	}
+	if strings.Contains(address, "://") {
+		return address, nil
+	}
+	var host, port string
+	if strings.Contains(address, ":") {
+		host, port, err = net.SplitHostPort(address)
+		if err != nil {
+			return "", err
+		}
+	} else {
+		host = address
+	}
+	if port == "" {
+		port = "8882"
+	}
+	return fmt.Sprintf("mqtts://%v:%v", host, port), nil
+}
+
+// adaptAuthorization removes the Authorization prefix.
+func adaptAuthorization(originalAuth string) string {
+	if originalAuth == "" {
+		return originalAuth
+	}
+	var prefix, key string
+	if _, err := fmt.Sscanf(originalAuth, "%v %v", &prefix, &key); err != nil {
+		return originalAuth
+	}
+	return key
+}
+
+func (s *Server) getContext(c echo.Context) context.Context {
+	ctx := c.Request().Context()
+	md := metadata.New(map[string]string{
+		"authorization": c.Request().Header.Get(echo.HeaderAuthorization),
+	})
+	if ctxMd, ok := metadata.FromIncomingContext(ctx); ok {
+		md = metadata.Join(ctxMd, md)
+	}
+	return metadata.NewIncomingContext(ctx, md)
+}
+
+func (s *Server) getAuth(c echo.Context) grpc.CallOption {
+	return grpc.PerRPCCredentials(rpcmetadata.MD{
+		AuthType:      "bearer",
+		AuthValue:     adaptAuthorization(c.Request().Header.Get(echo.HeaderAuthorization)),
+		AllowInsecure: s.component.AllowInsecureForCredentials(),
+	})
+}

--- a/pkg/thethingsgateway/cups/handlers.go
+++ b/pkg/thethingsgateway/cups/handlers.go
@@ -17,12 +17,12 @@ package cups
 import (
 	"context"
 	"fmt"
-	"github.com/gogo/protobuf/types"
 	"net"
 	"net/http"
 	"net/url"
 	"strings"
 
+	"github.com/gogo/protobuf/types"
 	echo "github.com/labstack/echo/v4"
 	"go.thethings.network/lorawan-stack/pkg/pfconfig/shared"
 	"go.thethings.network/lorawan-stack/pkg/rpcmetadata"

--- a/pkg/thethingsgateway/cups/handlers.go
+++ b/pkg/thethingsgateway/cups/handlers.go
@@ -57,7 +57,7 @@ func (s *Server) handleGatewayInfo(c echo.Context) error {
 		response := &gatewayInfoResponse{
 			FrequencyPlanID:  gateway.FrequencyPlanID,
 			FrequencyPlanURL: freqPlanURL.String(),
-			FirmwareURL:      adaptUpdateChannel(gateway.UpdateChannel),
+			FirmwareURL:      s.adaptUpdateChannel(gateway.UpdateChannel),
 			AutoUpdate:       gateway.AutoUpdate,
 		}
 		response.Router.MQTTAddress, err = adaptGatewayAddress(gateway.GatewayServerAddress)
@@ -86,15 +86,13 @@ func (s *Server) handleFreqPlanInfo(c echo.Context) error {
 	})
 }
 
-const defaultFirmwarePath = "https://thethingsproducts.blob.core.windows.net/the-things-gateway/v1"
-
 // adaptUpdateChannel prepends the default firmware path if the channel itself is not an URL.
-func adaptUpdateChannel(channel string) string {
+func (s *Server) adaptUpdateChannel(channel string) string {
 	if channel == "" {
-		return ""
+		channel = s.config.Default.UpdateChannel
 	}
 	if _, err := url.ParseRequestURI(channel); err != nil {
-		return fmt.Sprintf("%v/%v", defaultFirmwarePath, channel)
+		return fmt.Sprintf("%v/%v", s.config.Default.FirmwareURL, channel)
 	}
 	return channel
 }

--- a/pkg/thethingsgateway/cups/handlers_test.go
+++ b/pkg/thethingsgateway/cups/handlers_test.go
@@ -1,0 +1,182 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cups
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/smartystreets/assertions"
+)
+
+func TestAdaptUpdateChannel(t *testing.T) {
+	for _, tt := range []struct {
+		Name            string
+		Channel         string
+		ExpectedChannel string
+	}{
+		{
+			Name:            "Empty channel",
+			Channel:         "",
+			ExpectedChannel: "",
+		},
+		{
+			Name:            "Default stable channel",
+			Channel:         "stable",
+			ExpectedChannel: fmt.Sprintf("%v/%v", defaultFirmwarePath, "stable"),
+		},
+		{
+			Name:            "Default beta channel",
+			Channel:         "beta",
+			ExpectedChannel: fmt.Sprintf("%v/%v", defaultFirmwarePath, "beta"),
+		},
+		{
+			Name:            "Custom update channel",
+			Channel:         "http://example.com/fake-firmware",
+			ExpectedChannel: "http://example.com/fake-firmware",
+		},
+		{
+			Name:            "Channel URL misspell",
+			Channel:         "htp://example.com/stable",
+			ExpectedChannel: "htp://example.com/stable",
+		},
+	} {
+		t.Run(tt.Name, func(t *testing.T) {
+			a := assertions.New(t)
+			a.So(adaptUpdateChannel(tt.Channel), assertions.ShouldEqual, tt.ExpectedChannel)
+		})
+	}
+}
+
+func TestAdaptGatewayAddress(t *testing.T) {
+	for _, tt := range []struct {
+		Name    string
+		Address string
+		Assert  func(*assertions.Assertion, string, error)
+	}{
+		{
+			Name:    "Empty address",
+			Address: "",
+			Assert: func(a *assertions.Assertion, address string, err error) {
+				a.So(err, assertions.ShouldBeNil)
+				a.So(address, assertions.ShouldEqual, "")
+			},
+		},
+		{
+			Name:    "Only host, no port or scheme",
+			Address: "localhost",
+			Assert: func(a *assertions.Assertion, address string, err error) {
+				a.So(err, assertions.ShouldBeNil)
+				a.So(address, assertions.ShouldEqual, "mqtts://localhost:8882")
+			},
+		},
+		{
+			Name:    "Host and port, no scheme",
+			Address: "localhost:8881",
+			Assert: func(a *assertions.Assertion, address string, err error) {
+				a.So(err, assertions.ShouldBeNil)
+				a.So(address, assertions.ShouldEqual, "mqtts://localhost:8881")
+			},
+		},
+		{
+			Name:    "Full mqtts address",
+			Address: "mqtts://localhost:8882",
+			Assert: func(a *assertions.Assertion, address string, err error) {
+				a.So(err, assertions.ShouldBeNil)
+				a.So(address, assertions.ShouldEqual, "mqtts://localhost:8882")
+			},
+		},
+		{
+			Name:    "Full mqtt address",
+			Address: "mqtt://localhost:1882",
+			Assert: func(a *assertions.Assertion, address string, err error) {
+				a.So(err, assertions.ShouldBeNil)
+				a.So(address, assertions.ShouldEqual, "mqtt://localhost:1882")
+			},
+		},
+		{
+			Name:    "Full http address",
+			Address: "http://localhost",
+			Assert: func(a *assertions.Assertion, address string, err error) {
+				a.So(err, assertions.ShouldBeNil)
+				a.So(address, assertions.ShouldEqual, "http://localhost")
+			},
+		},
+		{
+			Name:    "Invalid port format",
+			Address: "localhost::zzz",
+			Assert: func(a *assertions.Assertion, address string, err error) {
+				a.So(err, assertions.ShouldNotBeNil)
+				a.So(address, assertions.ShouldEqual, "")
+			},
+		},
+	} {
+		t.Run(tt.Name, func(t *testing.T) {
+			a := assertions.New(t)
+			address, err := adaptGatewayAddress(tt.Address)
+			tt.Assert(a, address, err)
+		})
+	}
+}
+
+func TestAdaptAuthorization(t *testing.T) {
+	for _, tt := range []struct {
+		Name          string
+		Authorization string
+		Assert        func(*assertions.Assertion, string)
+	}{
+		{
+			Name:          "Empty Authorization",
+			Authorization: "",
+			Assert: func(a *assertions.Assertion, auth string) {
+				a.So(auth, assertions.ShouldEqual, "")
+			},
+		},
+		{
+			Name:          "Key formatted authorization",
+			Authorization: "Key asd",
+			Assert: func(a *assertions.Assertion, auth string) {
+				a.So(auth, assertions.ShouldEqual, "asd")
+			},
+		},
+		{
+			Name:          "Bearer formatted authorization",
+			Authorization: "Bearer efg",
+			Assert: func(a *assertions.Assertion, auth string) {
+				a.So(auth, assertions.ShouldEqual, "efg")
+			},
+		},
+		{
+			Name:          "Invalid authorization",
+			Authorization: "InvalidKeyFormat",
+			Assert: func(a *assertions.Assertion, auth string) {
+				a.So(auth, assertions.ShouldEqual, "")
+			},
+		},
+		{
+			Name:          "Esoteric authorization",
+			Authorization: "APIKey asd",
+			Assert: func(a *assertions.Assertion, auth string) {
+				a.So(auth, assertions.ShouldEqual, "asd")
+			},
+		},
+	} {
+		t.Run(tt.Name, func(t *testing.T) {
+			a := assertions.New(t)
+			auth := adaptAuthorization(tt.Authorization)
+			tt.Assert(a, auth)
+		})
+	}
+}

--- a/pkg/thethingsgateway/cups/handlers_test.go
+++ b/pkg/thethingsgateway/cups/handlers_test.go
@@ -19,9 +19,18 @@ import (
 	"testing"
 
 	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/pkg/component"
+	"go.thethings.network/lorawan-stack/pkg/util/test"
 )
 
+const defaultFirmwarePath = "https://thethingsproducts.blob.core.windows.net/the-things-gateway/v1"
+
 func TestAdaptUpdateChannel(t *testing.T) {
+	var conf Config
+	conf.Default.UpdateChannel = "stable"
+	conf.Default.FirmwareURL = defaultFirmwarePath
+	s := conf.NewServer(component.MustNew(test.GetLogger(t), &component.Config{}))
+
 	for _, tt := range []struct {
 		Name            string
 		Channel         string
@@ -30,7 +39,7 @@ func TestAdaptUpdateChannel(t *testing.T) {
 		{
 			Name:            "Empty channel",
 			Channel:         "",
-			ExpectedChannel: "",
+			ExpectedChannel: fmt.Sprintf("%v/%v", defaultFirmwarePath, "stable"),
 		},
 		{
 			Name:            "Default stable channel",
@@ -55,7 +64,7 @@ func TestAdaptUpdateChannel(t *testing.T) {
 	} {
 		t.Run(tt.Name, func(t *testing.T) {
 			a := assertions.New(t)
-			a.So(adaptUpdateChannel(tt.Channel), assertions.ShouldEqual, tt.ExpectedChannel)
+			a.So(s.adaptUpdateChannel(tt.Channel), assertions.ShouldEqual, tt.ExpectedChannel)
 		})
 	}
 }
@@ -159,10 +168,10 @@ func TestAdaptAuthorization(t *testing.T) {
 			},
 		},
 		{
-			Name:          "Invalid authorization",
+			Name:          "Direct API Key",
 			Authorization: "InvalidKeyFormat",
 			Assert: func(a *assertions.Assertion, auth string) {
-				a.So(auth, assertions.ShouldEqual, "")
+				a.So(auth, assertions.ShouldEqual, "InvalidKeyFormat")
 			},
 		},
 		{

--- a/pkg/thethingsgateway/cups/handlers_test.go
+++ b/pkg/thethingsgateway/cups/handlers_test.go
@@ -23,8 +23,6 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/util/test"
 )
 
-const defaultFirmwarePath = "https://thethingsproducts.blob.core.windows.net/the-things-gateway/v1"
-
 func TestAdaptUpdateChannel(t *testing.T) {
 	var conf Config
 	conf.Default.UpdateChannel = "stable"

--- a/pkg/thethingsgateway/cups/handlers_test.go
+++ b/pkg/thethingsgateway/cups/handlers_test.go
@@ -23,11 +23,19 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/util/test"
 )
 
+const (
+	testFirmwarePath  = "https://thethingsproducts.blob.core.windows.net/the-things-gateway/v1"
+	testUpdateChannel = "stable"
+)
+
 func TestAdaptUpdateChannel(t *testing.T) {
 	var conf Config
-	conf.Default.UpdateChannel = "stable"
-	conf.Default.FirmwareURL = defaultFirmwarePath
-	s := conf.NewServer(component.MustNew(test.GetLogger(t), &component.Config{}))
+	conf.Default.UpdateChannel = testUpdateChannel
+	conf.Default.FirmwareURL = testFirmwarePath
+	s, err := conf.NewServer(component.MustNew(test.GetLogger(t), &component.Config{}))
+	if err != nil {
+		t.Error(err)
+	}
 
 	for _, tt := range []struct {
 		Name            string
@@ -37,17 +45,17 @@ func TestAdaptUpdateChannel(t *testing.T) {
 		{
 			Name:            "Empty channel",
 			Channel:         "",
-			ExpectedChannel: fmt.Sprintf("%v/%v", defaultFirmwarePath, "stable"),
+			ExpectedChannel: fmt.Sprintf("%v/%v", testFirmwarePath, "stable"),
 		},
 		{
 			Name:            "Default stable channel",
 			Channel:         "stable",
-			ExpectedChannel: fmt.Sprintf("%v/%v", defaultFirmwarePath, "stable"),
+			ExpectedChannel: fmt.Sprintf("%v/%v", testFirmwarePath, "stable"),
 		},
 		{
 			Name:            "Default beta channel",
 			Channel:         "beta",
-			ExpectedChannel: fmt.Sprintf("%v/%v", defaultFirmwarePath, "beta"),
+			ExpectedChannel: fmt.Sprintf("%v/%v", testFirmwarePath, "beta"),
 		},
 		{
 			Name:            "Custom update channel",

--- a/pkg/thethingsgateway/cups/middleware.go
+++ b/pkg/thethingsgateway/cups/middleware.go
@@ -1,0 +1,42 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cups
+
+import (
+	echo "github.com/labstack/echo/v4"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+)
+
+const (
+	gatewayIDKey       = "gateway_id"
+	frequencyPlanIDKey = "frequency_plan_id"
+)
+
+// validateAndFillGatewayIDs checks if the request contains a valid gateway ID.
+func (s *Server) validateAndFillGatewayIDs() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			gatewayIDs := ttnpb.GatewayIdentifiers{
+				GatewayID: c.Param(gatewayIDKey),
+			}
+			if err := gatewayIDs.ValidateContext(c.Request().Context()); err != nil {
+				return err
+			}
+			c.Set(gatewayIDKey, gatewayIDs)
+
+			return next(c)
+		}
+	}
+}

--- a/pkg/thethingsgateway/cups/middleware.go
+++ b/pkg/thethingsgateway/cups/middleware.go
@@ -44,8 +44,8 @@ func (s *Server) validateAndFillGatewayIDs() echo.MiddlewareFunc {
 	}
 }
 
-// checkAuthPresence checks if the request contains the Authorization header.
-func (s *Server) checkAuthPresence() echo.MiddlewareFunc {
+// requireAuth checks if the request contains the Authorization header.
+func (s *Server) requireAuth() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			authHeader := c.Request().Header.Get(echo.HeaderAuthorization)

--- a/pkg/thethingsgateway/cups/server.go
+++ b/pkg/thethingsgateway/cups/server.go
@@ -23,6 +23,8 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/web"
 )
 
+const defaultFirmwarePath = "https://thethingsproducts.blob.core.windows.net/the-things-gateway/v1"
+
 // Config is the configuration of the The Things Gateay CUPS.
 type Config struct {
 	Default struct {
@@ -35,9 +37,10 @@ type Config struct {
 // NewServer returns a new CUPS from this config on top of the component.
 func (conf Config) NewServer(c *component.Component, customOpts ...Option) *Server {
 	opts := []Option{
-		WithDefaultUpdateChannel(conf.Default.UpdateChannel),
-		WithDefaultFirmwareURL(conf.Default.FirmwareURL),
-		WithDefaultMQTTServer(conf.Default.MQTTServer),
+		WithConfig(conf),
+	}
+	if conf.Default.FirmwareURL == "" {
+		opts = append(opts, WithDefaultFirmwareURL(defaultFirmwarePath))
 	}
 	s := NewServer(c, append(opts, customOpts...)...)
 	c.RegisterWeb(s)
@@ -105,7 +108,10 @@ func (s *Server) RegisterRoutes(srv *web.Server) {
 	group := srv.Group(compatAPIPrefix)
 	group.GET("/gateways/:gateway_id", func(c echo.Context) error {
 		return s.handleGatewayInfo(c)
-	}, s.validateAndFillGatewayIDs())
+	}, []echo.MiddlewareFunc{
+		s.validateAndFillGatewayIDs(),
+		s.checkAuthPresence(),
+	}...)
 	group.GET("/frequency-plans/:frequency_plan_id", func(c echo.Context) error {
 		return s.handleFreqPlanInfo(c)
 	})

--- a/pkg/thethingsgateway/cups/server.go
+++ b/pkg/thethingsgateway/cups/server.go
@@ -117,7 +117,7 @@ func (s *Server) RegisterRoutes(srv *web.Server) {
 		return s.handleGatewayInfo(c)
 	}, []echo.MiddlewareFunc{
 		s.validateAndFillGatewayIDs(),
-		s.checkAuthPresence(),
+		s.requireAuth(),
 	}...)
 	group.GET("/frequency-plans/:frequency_plan_id", func(c echo.Context) error {
 		return s.handleFreqPlanInfo(c)

--- a/pkg/thethingsgateway/cups/server.go
+++ b/pkg/thethingsgateway/cups/server.go
@@ -1,0 +1,69 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cups
+
+import (
+	"context"
+
+	echo "github.com/labstack/echo/v4"
+	"go.thethings.network/lorawan-stack/pkg/component"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/pkg/types"
+	"go.thethings.network/lorawan-stack/pkg/web"
+	"google.golang.org/grpc"
+)
+
+// Config is the configuration of the The Things Gateay CUPS server.
+type Config struct {
+	//TODO: Add default configuration here.
+}
+
+// NewServer returns a new CUPS server from this config on top of the component.
+func (conf Config) NewServer(c *component.Component) *Server {
+	s := NewServer(c)
+	c.RegisterWeb(s)
+	return s
+}
+
+// Server implements the CUPS endpoints used by The Things Gateway.
+type Server struct {
+	component *component.Component
+
+	auth func(context.Context, types.EUI64, string) grpc.CallOption
+}
+
+const compatAPIPrefix = "/api/v2"
+
+func (s *Server) getRegistry(ctx context.Context, ids *ttnpb.GatewayIdentifiers) ttnpb.GatewayRegistryClient {
+	return ttnpb.NewGatewayRegistryClient(s.component.GetPeer(ctx, ttnpb.PeerInfo_ENTITY_REGISTRY, ids).Conn())
+}
+
+// RegisterRoutes implements the web.Registerer interface.
+func (s *Server) RegisterRoutes(srv *web.Server) {
+	group := srv.Group(compatAPIPrefix)
+	group.GET("/gateways/:gateway_id", func(c echo.Context) error {
+		return s.handleGatewayInfo(c)
+	}, s.validateAndFillGatewayIDs())
+	group.GET("/frequency-plans/:frequency_plan_id", func(c echo.Context) error {
+		return s.handleFreqPlanInfo(c)
+	})
+}
+
+// NewServer returns a new CUPS server on top of the given gateway registry.
+func NewServer(c *component.Component) *Server {
+	return &Server{
+		component: c,
+	}
+}

--- a/pkg/thethingsgateway/cups/server.go
+++ b/pkg/thethingsgateway/cups/server.go
@@ -20,19 +20,21 @@ import (
 	echo "github.com/labstack/echo/v4"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
-	"go.thethings.network/lorawan-stack/pkg/types"
 	"go.thethings.network/lorawan-stack/pkg/web"
-	"google.golang.org/grpc"
 )
 
 // Config is the configuration of the The Things Gateay CUPS server.
 type Config struct {
-	//TODO: Add default configuration here.
+	Default struct {
+		UpdateChannel string `name:"update-channel" description:"The default update channel that the gateways should use"`
+		MQTTServer    string `name:"mqtt-server" description:"The default MQTT server that the gateways should use"`
+		FirmwareURL   string `name:"firmware-url" description:"The default URL to the firmware storage"`
+	} `name:"default" description:"Default gateway settings"`
 }
 
 // NewServer returns a new CUPS server from this config on top of the component.
 func (conf Config) NewServer(c *component.Component) *Server {
-	s := NewServer(c)
+	s := NewServer(c, conf)
 	c.RegisterWeb(s)
 	return s
 }
@@ -41,7 +43,7 @@ func (conf Config) NewServer(c *component.Component) *Server {
 type Server struct {
 	component *component.Component
 
-	auth func(context.Context, types.EUI64, string) grpc.CallOption
+	config Config
 }
 
 const compatAPIPrefix = "/api/v2"
@@ -62,8 +64,9 @@ func (s *Server) RegisterRoutes(srv *web.Server) {
 }
 
 // NewServer returns a new CUPS server on top of the given gateway registry.
-func NewServer(c *component.Component) *Server {
+func NewServer(c *component.Component, conf Config) *Server {
 	return &Server{
 		component: c,
+		config:    conf,
 	}
 }

--- a/pkg/thethingsgateway/cups/server.go
+++ b/pkg/thethingsgateway/cups/server.go
@@ -23,7 +23,10 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/web"
 )
 
-const defaultFirmwarePath = "https://thethingsproducts.blob.core.windows.net/the-things-gateway/v1"
+const (
+	defaultFirmwarePath  = "https://thethingsproducts.blob.core.windows.net/the-things-gateway/v1"
+	defaultUpdateChannel = "stable"
+)
 
 // Config is the configuration of the The Things Gateay CUPS.
 type Config struct {
@@ -41,6 +44,9 @@ func (conf Config) NewServer(c *component.Component, customOpts ...Option) *Serv
 	}
 	if conf.Default.FirmwareURL == "" {
 		opts = append(opts, WithDefaultFirmwareURL(defaultFirmwarePath))
+	}
+	if conf.Default.UpdateChannel == "" {
+		opts = append(opts, WithDefaultUpdateChannel(defaultUpdateChannel))
 	}
 	s := NewServer(c, append(opts, customOpts...)...)
 	c.RegisterWeb(s)

--- a/pkg/thethingsgateway/cups/server_test.go
+++ b/pkg/thethingsgateway/cups/server_test.go
@@ -1,0 +1,1 @@
+package cups

--- a/pkg/thethingsgateway/cups/server_test.go
+++ b/pkg/thethingsgateway/cups/server_test.go
@@ -151,7 +151,8 @@ func TestServer(t *testing.T) {
 
 			s := NewServer(component.MustNew(test.GetLogger(t), &component.Config{}), append([]Option{
 				WithRegistry(store),
-				WithDefaultFirmwareURL(defaultFirmwarePath),
+				WithDefaultFirmwareURL(testFirmwarePath),
+				WithDefaultUpdateChannel(testUpdateChannel),
 			}, tt.Options...)...)
 			req := httptest.NewRequest(http.MethodGet, "/api/v2/gateway/test-gateway", nil)
 			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)

--- a/pkg/thethingsgateway/cups/server_test.go
+++ b/pkg/thethingsgateway/cups/server_test.go
@@ -1,1 +1,177 @@
 package cups
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo"
+	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/pkg/component"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/pkg/util/test"
+	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+var (
+	mockGatewayID   = "test-gateway"
+	mockErrNotFound = grpc.Errorf(codes.NotFound, "not found")
+)
+
+type mockGatewayClientData struct {
+	ctx struct {
+		Get context.Context
+	}
+	req struct {
+		Get *ttnpb.GetGatewayRequest
+	}
+	opts struct {
+		Get []grpc.CallOption
+	}
+	res struct {
+		Get *ttnpb.Gateway
+	}
+	err struct {
+		Get error
+	}
+}
+
+type mockGatewayClient struct {
+	mockGatewayClientData
+	ttnpb.GatewayRegistryClient
+}
+
+func (m *mockGatewayClient) reset() {
+	m.mockGatewayClientData = mockGatewayClientData{}
+}
+
+func (m *mockGatewayClient) Get(ctx context.Context, in *ttnpb.GetGatewayRequest, opts ...grpc.CallOption) (*ttnpb.Gateway, error) {
+	m.ctx.Get, m.req.Get, m.opts.Get = ctx, in, opts
+	return m.res.Get, m.err.Get
+}
+
+func mockGateway() *ttnpb.Gateway {
+	return &ttnpb.Gateway{
+		GatewayIdentifiers: ttnpb.GatewayIdentifiers{
+			GatewayID: mockGatewayID,
+		},
+		UpdateChannel:        "stable",
+		FrequencyPlanID:      "EU_863_870",
+		GatewayServerAddress: "mqtts://localhost:8883",
+	}
+}
+
+func TestServer(t *testing.T) {
+	e := echo.New()
+
+	for _, tt := range []struct {
+		Name           string
+		StoreSetup     func(*mockGatewayClient)
+		Options        []Option
+		RequestSetup   func(*http.Request)
+		ContextSetup   func(echo.Context)
+		AssertError    func(actual interface{}, expected ...interface{}) string
+		AssertStore    func(*assertions.Assertion, *mockGatewayClient)
+		AssertResponse func(*assertions.Assertion, *httptest.ResponseRecorder)
+	}{
+		{
+			Name: "No Auth",
+			RequestSetup: func(req *http.Request) {
+				req.Header.Del(echo.HeaderAuthorization)
+			},
+			AssertError: should.NotBeNil,
+		},
+		{
+			Name: "No GatewayID",
+			ContextSetup: func(c echo.Context) {
+				c.SetParamValues()
+			},
+			AssertError: should.NotBeNil,
+		},
+		{
+			Name: "Not Found",
+			StoreSetup: func(c *mockGatewayClient) {
+				c.err.Get = mockErrNotFound
+			},
+			AssertError: should.NotBeNil,
+			AssertStore: func(a *assertions.Assertion, c *mockGatewayClient) {
+				a.So(c.req.Get.GatewayID, should.Equal, mockGatewayID)
+			},
+		},
+		{
+			Name: "Found",
+			StoreSetup: func(c *mockGatewayClient) {
+				c.res.Get = mockGateway()
+			},
+			AssertError: should.BeNil,
+			AssertStore: func(a *assertions.Assertion, c *mockGatewayClient) {
+				a.So(c.req.Get.GatewayID, should.Equal, mockGatewayID)
+			},
+			AssertResponse: func(a *assertions.Assertion, rc *httptest.ResponseRecorder) {
+				a.So(rc.Code, should.Equal, http.StatusOK)
+				body := rc.Body
+				a.So(body, should.NotBeEmpty)
+				var resp map[string]interface{}
+				err := json.NewDecoder(rc.Body).Decode(&resp)
+				a.So(err, should.BeNil)
+				a.So(resp["frequency_plan"], should.Equal, "EU_863_870")
+				a.So(resp["frequency_plan_url"], should.Equal, "http://example.com/api/v2/frequency-plans/EU_863_870")
+				a.So(resp["firmware_url"], should.Equal, "https://thethingsproducts.blob.core.windows.net/the-things-gateway/v1/stable")
+				a.So(resp["router"], should.Resemble, map[string]interface{}{
+					"mqtt_address": "mqtts://localhost:8883",
+				})
+				a.So(resp["auto_update"], should.Equal, false)
+			},
+		},
+	} {
+		t.Run(tt.Name, func(t *testing.T) {
+			a := assertions.New(t)
+			store := &mockGatewayClient{}
+			if tt.StoreSetup != nil {
+				tt.StoreSetup(store)
+			}
+
+			s := NewServer(component.MustNew(test.GetLogger(t), &component.Config{}), append([]Option{
+				WithRegistry(store),
+				WithDefaultFirmwareURL(defaultFirmwarePath),
+			}, tt.Options...)...)
+			req := httptest.NewRequest(http.MethodGet, "/api/v2/gateway/test-gateway", nil)
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			req.Header.Set(echo.HeaderAuthorization, "random string")
+			if tt.RequestSetup != nil {
+				tt.RequestSetup(req)
+			}
+
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetParamNames(gatewayIDKey)
+			c.SetParamValues(mockGatewayID)
+			if tt.ContextSetup != nil {
+				tt.ContextSetup(c)
+			}
+			middleware := []echo.MiddlewareFunc{
+				s.validateAndFillGatewayIDs(),
+				s.checkAuthPresence(),
+			}
+
+			handler := s.handleGatewayInfo
+			for _, m := range middleware {
+				handler = m(handler)
+			}
+			err := handler(c)
+			if tt.AssertError != nil {
+				a.So(err, tt.AssertError)
+			}
+			if tt.AssertResponse != nil {
+				tt.AssertResponse(a, rec)
+			}
+			if tt.AssertStore != nil {
+				tt.AssertStore(a, store)
+			}
+		})
+	}
+}

--- a/pkg/thethingsgateway/cups/server_test.go
+++ b/pkg/thethingsgateway/cups/server_test.go
@@ -170,7 +170,7 @@ func TestServer(t *testing.T) {
 			}
 			middleware := []echo.MiddlewareFunc{
 				s.validateAndFillGatewayIDs(),
-				s.checkAuthPresence(),
+				s.requireAuth(),
 			}
 
 			handler := s.handleGatewayInfo

--- a/pkg/thethingsgateway/cups/server_test.go
+++ b/pkg/thethingsgateway/cups/server_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cups
 
 import (
@@ -7,7 +21,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #64
References #68 

**Changes:**
<!-- What are the changes made in this pull request? -->

- Added the `/api/v3/gcs/gateways/:gateway_id/global_conf.json` that generates the gateway configuration.

**Notes for Reviewers:**
<!--
Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Unregistered gateways cannot be retrieved.

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Added the `/api/v3/gcs/gateways/<gateway ID>/global_conf.json` that generates the gateway configuration in the JSON format based on the frequency plan.
