### PR TITLE
The Things Gateway CUPS

### DIFF
--- a/cmd/internal/shared/gatewayconfigurationserver/config.go
+++ b/cmd/internal/shared/gatewayconfigurationserver/config.go
@@ -1,0 +1,27 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared
+
+import (
+	"go.thethings.network/lorawan-stack/pkg/gatewayconfigurationserver"
+)
+
+// DefaultGatewayConfigurationServerConfig is the default configuration for the Application Server.
+var DefaultGatewayConfigurationServerConfig = gatewayconfigurationserver.Config{}
+
+func init() {
+	DefaultGatewayConfigurationServerConfig.TheThingsGateway.Default.UpdateChannel = "stable"
+	DefaultGatewayConfigurationServerConfig.TheThingsGateway.Default.FirmwareURL = "https://thethingsproducts.blob.core.windows.net/the-things-gateway/v1"
+}

--- a/cmd/ttn-lw-stack/commands/config.go
+++ b/cmd/ttn-lw-stack/commands/config.go
@@ -19,6 +19,7 @@ import (
 	"go.thethings.network/lorawan-stack/cmd/internal/shared"
 	shared_applicationserver "go.thethings.network/lorawan-stack/cmd/internal/shared/applicationserver"
 	shared_console "go.thethings.network/lorawan-stack/cmd/internal/shared/console"
+	shared_gatewayconfigurationserver "go.thethings.network/lorawan-stack/cmd/internal/shared/gatewayconfigurationserver"
 	shared_gatewayserver "go.thethings.network/lorawan-stack/cmd/internal/shared/gatewayserver"
 	shared_identityserver "go.thethings.network/lorawan-stack/cmd/internal/shared/identityserver"
 	shared_joinserver "go.thethings.network/lorawan-stack/cmd/internal/shared/joinserver"
@@ -54,6 +55,7 @@ var DefaultConfig = Config{
 	AS:          shared_applicationserver.DefaultApplicationServerConfig,
 	JS:          shared_joinserver.DefaultJoinServerConfig,
 	Console:     shared_console.DefaultConsoleConfig,
+	GCS:         shared_gatewayconfigurationserver.DefaultGatewayConfigurationServerConfig,
 }
 
 func init() {

--- a/config/messages.json
+++ b/config/messages.json
@@ -4445,6 +4445,24 @@
       "file": "javascript.go"
     }
   },
+  "error:pkg/thethingsgateway/cups:no_default_firmware_path": {
+    "translations": {
+      "en": "no default firmware path specified"
+    },
+    "description": {
+      "package": "pkg/thethingsgateway/cups",
+      "file": "server.go"
+    }
+  },
+  "error:pkg/thethingsgateway/cups:no_default_update_channel": {
+    "translations": {
+      "en": "no default update channel specified"
+    },
+    "description": {
+      "package": "pkg/thethingsgateway/cups",
+      "file": "server.go"
+    }
+  },
   "error:pkg/thethingsgateway/cups:unauthenticated": {
     "translations": {
       "en": "call was not authenticated"

--- a/config/messages.json
+++ b/config/messages.json
@@ -4445,6 +4445,15 @@
       "file": "javascript.go"
     }
   },
+  "error:pkg/thethingsgateway/cups:unauthenticated": {
+    "translations": {
+      "en": "call was not authenticated"
+    },
+    "description": {
+      "package": "pkg/thethingsgateway/cups",
+      "file": "middleware.go"
+    }
+  },
   "error:pkg/ttnpb/udp:bandwidth": {
     "translations": {
       "en": "failed to parse bandwidth"

--- a/pkg/gatewayconfigurationserver/gatewayconfigurationserver.go
+++ b/pkg/gatewayconfigurationserver/gatewayconfigurationserver.go
@@ -23,6 +23,7 @@ import (
 	bs_cups "go.thethings.network/lorawan-stack/pkg/basicstation/cups"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	"go.thethings.network/lorawan-stack/pkg/pfconfig/semtechudp"
+	ttg_cups "go.thethings.network/lorawan-stack/pkg/thethingsgateway/cups"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/web"
 	"google.golang.org/grpc/metadata"
@@ -30,8 +31,10 @@ import (
 
 // Config contains the Gateway Configuration Server configuration.
 type Config struct {
-	// BasicStation defines the configuration for the BasicStation CUPS server.
-	BasicStation bs_cups.ServerConfig `name:"basic-station" description:"BasicStation CUPS server configuration."`
+	// BasicStation defines the configuration for the BasicStation CUPS.
+	BasicStation bs_cups.ServerConfig `name:"basic-station" description:"BasicStation CUPS configuration."`
+	// TheThingsGateway defines the configuration for The Things Gateway CUPS.
+	TheThingsGateway ttg_cups.Config `name:"the-things-gateway" description:"The Things Gateway CUPS configuration."`
 	// RequreAuth defines if the HTTP endpoints should require authentication or not.
 	RequireAuth bool `name:"require-auth" description:"Require authentication for the HTTP endpoints."`
 }
@@ -69,8 +72,14 @@ func New(c *component.Component, conf *Config, opts ...Option) (*GatewayConfigur
 		opt(gcs)
 	}
 
-	cups := conf.BasicStation.NewServer(c)
-	_ = cups
+	bsCUPS := conf.BasicStation.NewServer(c)
+	_ = bsCUPS
+
+	ttgCUPS, err := conf.TheThingsGateway.NewServer(c)
+	if err != nil {
+		return nil, err
+	}
+	_ = ttgCUPS
 
 	c.RegisterWeb(gcs)
 	return gcs, nil

--- a/pkg/gatewayconfigurationserver/gatewayconfigurationserver_test.go
+++ b/pkg/gatewayconfigurationserver/gatewayconfigurationserver_test.go
@@ -147,3 +147,8 @@ func newContextWithRightsFetcher(ctx context.Context) context.Context {
 		}),
 	)
 }
+
+func init() {
+	testConfig.TheThingsGateway.Default.FirmwareURL = "http://example.com"
+	testConfig.TheThingsGateway.Default.UpdateChannel = "stable"
+}

--- a/pkg/thethingsgateway/cups/handlers.go
+++ b/pkg/thethingsgateway/cups/handlers.go
@@ -17,6 +17,7 @@ package cups
 import (
 	"context"
 	"fmt"
+	"github.com/gogo/protobuf/types"
 	"net"
 	"net/http"
 	"net/url"
@@ -46,6 +47,12 @@ func (s *Server) handleGatewayInfo(c echo.Context) error {
 	gatewayIDs := c.Get(gatewayIDKey).(ttnpb.GatewayIdentifiers)
 	if gateway, err := s.getRegistry(ctx, &gatewayIDs).Get(ctx, &ttnpb.GetGatewayRequest{
 		GatewayIdentifiers: gatewayIDs,
+		FieldMask: types.FieldMask{Paths: []string{
+			"frequency_plan_id",
+			"gateway_server_address",
+			"update_channel",
+			"auto_update",
+		}},
 	}, s.getAuth(c)); err != nil {
 		return err
 	} else {

--- a/pkg/thethingsgateway/cups/handlers.go
+++ b/pkg/thethingsgateway/cups/handlers.go
@@ -1,0 +1,156 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cups
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	echo "github.com/labstack/echo/v4"
+	"go.thethings.network/lorawan-stack/pkg/pfconfig/shared"
+	"go.thethings.network/lorawan-stack/pkg/rpcmetadata"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// gatewayInfoResponse represents a minimal gateway info response for The Things Gateway.
+type gatewayInfoResponse struct {
+	FrequencyPlanID  string `json:"frequency_plan"`
+	FrequencyPlanURL string `json:"frequency_plan_url"`
+	FirmwareURL      string `json:"firmware_url"`
+	Router           struct {
+		MQTTAddress string `json:"mqtt_address"`
+	} `json:"router"`
+	AutoUpdate bool `json:"auto_update"`
+}
+
+func (s *Server) handleGatewayInfo(c echo.Context) error {
+	ctx := s.getContext(c)
+	gatewayIDs := c.Get(gatewayIDKey).(ttnpb.GatewayIdentifiers)
+	if gateway, err := s.getRegistry(ctx, &gatewayIDs).Get(ctx, &ttnpb.GetGatewayRequest{
+		GatewayIdentifiers: gatewayIDs,
+	}, s.getAuth(c)); err != nil {
+		return err
+	} else {
+		freqPlanURL := &url.URL{
+			Scheme: c.Scheme(),
+			Host:   c.Request().Host,
+			Path:   fmt.Sprintf("%v/frequency-plans/%v", compatAPIPrefix, gateway.FrequencyPlanID),
+		}
+		response := &gatewayInfoResponse{
+			FrequencyPlanID:  gateway.FrequencyPlanID,
+			FrequencyPlanURL: freqPlanURL.String(),
+			FirmwareURL:      adaptUpdateChannel(gateway.UpdateChannel),
+			AutoUpdate:       gateway.AutoUpdate,
+		}
+		response.Router.MQTTAddress, err = adaptGatewayAddress(gateway.GatewayServerAddress)
+		if err != nil {
+			return err
+		}
+		return c.JSON(http.StatusOK, response)
+	}
+}
+
+func (s *Server) handleFreqPlanInfo(c echo.Context) error {
+	freqPlanID := c.Param(frequencyPlanIDKey)
+	plan, err := s.component.FrequencyPlans.GetByID(freqPlanID)
+	if err != nil {
+		return err
+	}
+	config, err := shared.BuildSX1301Config(plan)
+	if err != nil {
+		return err
+	}
+	config.TxLUTConfigs = config.TxLUTConfigs[:0]
+	return c.JSON(http.StatusOK, struct {
+		SX1301Conf *shared.SX1301Config `json:"SX1301_conf"`
+	}{
+		SX1301Conf: config,
+	})
+}
+
+const defaultFirmwarePath = "https://thethingsproducts.blob.core.windows.net/the-things-gateway/v1"
+
+// adaptUpdateChannel prepends the default firmware path if the channel itself is not an URL.
+func adaptUpdateChannel(channel string) string {
+	if channel == "" {
+		return ""
+	}
+	if _, err := url.ParseRequestURI(channel); err != nil {
+		return fmt.Sprintf("%v/%v", defaultFirmwarePath, channel)
+	}
+	return channel
+}
+
+// adaptGatewayAddress prepends the gateway address with the scheme "mqtts" and appends
+// the port "8882" if they have not been mentioned. If the scheme has been given, no
+// changes are done to the address.
+func adaptGatewayAddress(address string) (result string, err error) {
+	if address == "" {
+		return address, nil
+	}
+	if strings.Contains(address, "://") {
+		return address, nil
+	}
+	var host, port string
+	if strings.Contains(address, ":") {
+		host, port, err = net.SplitHostPort(address)
+		if err != nil {
+			return "", err
+		}
+	} else {
+		host = address
+	}
+	if port == "" {
+		port = "8882"
+	}
+	return fmt.Sprintf("mqtts://%v:%v", host, port), nil
+}
+
+// adaptAuthorization removes the Authorization prefix.
+func adaptAuthorization(originalAuth string) string {
+	if originalAuth == "" {
+		return originalAuth
+	}
+	var prefix, key string
+	if _, err := fmt.Sscanf(originalAuth, "%v %v", &prefix, &key); err != nil {
+		return originalAuth
+	}
+	return key
+}
+
+func (s *Server) getContext(c echo.Context) context.Context {
+	ctx := c.Request().Context()
+	md := metadata.New(map[string]string{
+		"authorization": c.Request().Header.Get(echo.HeaderAuthorization),
+	})
+	if ctxMd, ok := metadata.FromIncomingContext(ctx); ok {
+		md = metadata.Join(ctxMd, md)
+	}
+	return metadata.NewIncomingContext(ctx, md)
+}
+
+func (s *Server) getAuth(c echo.Context) grpc.CallOption {
+	return grpc.PerRPCCredentials(rpcmetadata.MD{
+		AuthType:      "bearer",
+		AuthValue:     adaptAuthorization(c.Request().Header.Get(echo.HeaderAuthorization)),
+		AllowInsecure: s.component.AllowInsecureForCredentials(),
+	})
+}

--- a/pkg/thethingsgateway/cups/handlers.go
+++ b/pkg/thethingsgateway/cups/handlers.go
@@ -17,12 +17,12 @@ package cups
 import (
 	"context"
 	"fmt"
-	"github.com/gogo/protobuf/types"
 	"net"
 	"net/http"
 	"net/url"
 	"strings"
 
+	"github.com/gogo/protobuf/types"
 	echo "github.com/labstack/echo/v4"
 	"go.thethings.network/lorawan-stack/pkg/pfconfig/shared"
 	"go.thethings.network/lorawan-stack/pkg/rpcmetadata"

--- a/pkg/thethingsgateway/cups/handlers.go
+++ b/pkg/thethingsgateway/cups/handlers.go
@@ -57,7 +57,7 @@ func (s *Server) handleGatewayInfo(c echo.Context) error {
 		response := &gatewayInfoResponse{
 			FrequencyPlanID:  gateway.FrequencyPlanID,
 			FrequencyPlanURL: freqPlanURL.String(),
-			FirmwareURL:      adaptUpdateChannel(gateway.UpdateChannel),
+			FirmwareURL:      s.adaptUpdateChannel(gateway.UpdateChannel),
 			AutoUpdate:       gateway.AutoUpdate,
 		}
 		response.Router.MQTTAddress, err = adaptGatewayAddress(gateway.GatewayServerAddress)
@@ -86,15 +86,13 @@ func (s *Server) handleFreqPlanInfo(c echo.Context) error {
 	})
 }
 
-const defaultFirmwarePath = "https://thethingsproducts.blob.core.windows.net/the-things-gateway/v1"
-
 // adaptUpdateChannel prepends the default firmware path if the channel itself is not an URL.
-func adaptUpdateChannel(channel string) string {
+func (s *Server) adaptUpdateChannel(channel string) string {
 	if channel == "" {
-		return ""
+		channel = s.config.Default.UpdateChannel
 	}
 	if _, err := url.ParseRequestURI(channel); err != nil {
-		return fmt.Sprintf("%v/%v", defaultFirmwarePath, channel)
+		return fmt.Sprintf("%v/%v", s.config.Default.FirmwareURL, channel)
 	}
 	return channel
 }

--- a/pkg/thethingsgateway/cups/handlers_test.go
+++ b/pkg/thethingsgateway/cups/handlers_test.go
@@ -1,0 +1,182 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cups
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/smartystreets/assertions"
+)
+
+func TestAdaptUpdateChannel(t *testing.T) {
+	for _, tt := range []struct {
+		Name            string
+		Channel         string
+		ExpectedChannel string
+	}{
+		{
+			Name:            "Empty channel",
+			Channel:         "",
+			ExpectedChannel: "",
+		},
+		{
+			Name:            "Default stable channel",
+			Channel:         "stable",
+			ExpectedChannel: fmt.Sprintf("%v/%v", defaultFirmwarePath, "stable"),
+		},
+		{
+			Name:            "Default beta channel",
+			Channel:         "beta",
+			ExpectedChannel: fmt.Sprintf("%v/%v", defaultFirmwarePath, "beta"),
+		},
+		{
+			Name:            "Custom update channel",
+			Channel:         "http://example.com/fake-firmware",
+			ExpectedChannel: "http://example.com/fake-firmware",
+		},
+		{
+			Name:            "Channel URL misspell",
+			Channel:         "htp://example.com/stable",
+			ExpectedChannel: "htp://example.com/stable",
+		},
+	} {
+		t.Run(tt.Name, func(t *testing.T) {
+			a := assertions.New(t)
+			a.So(adaptUpdateChannel(tt.Channel), assertions.ShouldEqual, tt.ExpectedChannel)
+		})
+	}
+}
+
+func TestAdaptGatewayAddress(t *testing.T) {
+	for _, tt := range []struct {
+		Name    string
+		Address string
+		Assert  func(*assertions.Assertion, string, error)
+	}{
+		{
+			Name:    "Empty address",
+			Address: "",
+			Assert: func(a *assertions.Assertion, address string, err error) {
+				a.So(err, assertions.ShouldBeNil)
+				a.So(address, assertions.ShouldEqual, "")
+			},
+		},
+		{
+			Name:    "Only host, no port or scheme",
+			Address: "localhost",
+			Assert: func(a *assertions.Assertion, address string, err error) {
+				a.So(err, assertions.ShouldBeNil)
+				a.So(address, assertions.ShouldEqual, "mqtts://localhost:8882")
+			},
+		},
+		{
+			Name:    "Host and port, no scheme",
+			Address: "localhost:8881",
+			Assert: func(a *assertions.Assertion, address string, err error) {
+				a.So(err, assertions.ShouldBeNil)
+				a.So(address, assertions.ShouldEqual, "mqtts://localhost:8881")
+			},
+		},
+		{
+			Name:    "Full mqtts address",
+			Address: "mqtts://localhost:8882",
+			Assert: func(a *assertions.Assertion, address string, err error) {
+				a.So(err, assertions.ShouldBeNil)
+				a.So(address, assertions.ShouldEqual, "mqtts://localhost:8882")
+			},
+		},
+		{
+			Name:    "Full mqtt address",
+			Address: "mqtt://localhost:1882",
+			Assert: func(a *assertions.Assertion, address string, err error) {
+				a.So(err, assertions.ShouldBeNil)
+				a.So(address, assertions.ShouldEqual, "mqtt://localhost:1882")
+			},
+		},
+		{
+			Name:    "Full http address",
+			Address: "http://localhost",
+			Assert: func(a *assertions.Assertion, address string, err error) {
+				a.So(err, assertions.ShouldBeNil)
+				a.So(address, assertions.ShouldEqual, "http://localhost")
+			},
+		},
+		{
+			Name:    "Invalid port format",
+			Address: "localhost::zzz",
+			Assert: func(a *assertions.Assertion, address string, err error) {
+				a.So(err, assertions.ShouldNotBeNil)
+				a.So(address, assertions.ShouldEqual, "")
+			},
+		},
+	} {
+		t.Run(tt.Name, func(t *testing.T) {
+			a := assertions.New(t)
+			address, err := adaptGatewayAddress(tt.Address)
+			tt.Assert(a, address, err)
+		})
+	}
+}
+
+func TestAdaptAuthorization(t *testing.T) {
+	for _, tt := range []struct {
+		Name          string
+		Authorization string
+		Assert        func(*assertions.Assertion, string)
+	}{
+		{
+			Name:          "Empty Authorization",
+			Authorization: "",
+			Assert: func(a *assertions.Assertion, auth string) {
+				a.So(auth, assertions.ShouldEqual, "")
+			},
+		},
+		{
+			Name:          "Key formatted authorization",
+			Authorization: "Key asd",
+			Assert: func(a *assertions.Assertion, auth string) {
+				a.So(auth, assertions.ShouldEqual, "asd")
+			},
+		},
+		{
+			Name:          "Bearer formatted authorization",
+			Authorization: "Bearer efg",
+			Assert: func(a *assertions.Assertion, auth string) {
+				a.So(auth, assertions.ShouldEqual, "efg")
+			},
+		},
+		{
+			Name:          "Invalid authorization",
+			Authorization: "InvalidKeyFormat",
+			Assert: func(a *assertions.Assertion, auth string) {
+				a.So(auth, assertions.ShouldEqual, "")
+			},
+		},
+		{
+			Name:          "Esoteric authorization",
+			Authorization: "APIKey asd",
+			Assert: func(a *assertions.Assertion, auth string) {
+				a.So(auth, assertions.ShouldEqual, "asd")
+			},
+		},
+	} {
+		t.Run(tt.Name, func(t *testing.T) {
+			a := assertions.New(t)
+			auth := adaptAuthorization(tt.Authorization)
+			tt.Assert(a, auth)
+		})
+	}
+}

--- a/pkg/thethingsgateway/cups/handlers_test.go
+++ b/pkg/thethingsgateway/cups/handlers_test.go
@@ -19,9 +19,18 @@ import (
 	"testing"
 
 	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/pkg/component"
+	"go.thethings.network/lorawan-stack/pkg/util/test"
 )
 
+const defaultFirmwarePath = "https://thethingsproducts.blob.core.windows.net/the-things-gateway/v1"
+
 func TestAdaptUpdateChannel(t *testing.T) {
+	var conf Config
+	conf.Default.UpdateChannel = "stable"
+	conf.Default.FirmwareURL = defaultFirmwarePath
+	s := conf.NewServer(component.MustNew(test.GetLogger(t), &component.Config{}))
+
 	for _, tt := range []struct {
 		Name            string
 		Channel         string
@@ -30,7 +39,7 @@ func TestAdaptUpdateChannel(t *testing.T) {
 		{
 			Name:            "Empty channel",
 			Channel:         "",
-			ExpectedChannel: "",
+			ExpectedChannel: fmt.Sprintf("%v/%v", defaultFirmwarePath, "stable"),
 		},
 		{
 			Name:            "Default stable channel",
@@ -55,7 +64,7 @@ func TestAdaptUpdateChannel(t *testing.T) {
 	} {
 		t.Run(tt.Name, func(t *testing.T) {
 			a := assertions.New(t)
-			a.So(adaptUpdateChannel(tt.Channel), assertions.ShouldEqual, tt.ExpectedChannel)
+			a.So(s.adaptUpdateChannel(tt.Channel), assertions.ShouldEqual, tt.ExpectedChannel)
 		})
 	}
 }
@@ -159,10 +168,10 @@ func TestAdaptAuthorization(t *testing.T) {
 			},
 		},
 		{
-			Name:          "Invalid authorization",
+			Name:          "Direct API Key",
 			Authorization: "InvalidKeyFormat",
 			Assert: func(a *assertions.Assertion, auth string) {
-				a.So(auth, assertions.ShouldEqual, "")
+				a.So(auth, assertions.ShouldEqual, "InvalidKeyFormat")
 			},
 		},
 		{

--- a/pkg/thethingsgateway/cups/handlers_test.go
+++ b/pkg/thethingsgateway/cups/handlers_test.go
@@ -23,8 +23,6 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/util/test"
 )
 
-const defaultFirmwarePath = "https://thethingsproducts.blob.core.windows.net/the-things-gateway/v1"
-
 func TestAdaptUpdateChannel(t *testing.T) {
 	var conf Config
 	conf.Default.UpdateChannel = "stable"

--- a/pkg/thethingsgateway/cups/handlers_test.go
+++ b/pkg/thethingsgateway/cups/handlers_test.go
@@ -23,11 +23,19 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/util/test"
 )
 
+const (
+	testFirmwarePath  = "https://thethingsproducts.blob.core.windows.net/the-things-gateway/v1"
+	testUpdateChannel = "stable"
+)
+
 func TestAdaptUpdateChannel(t *testing.T) {
 	var conf Config
-	conf.Default.UpdateChannel = "stable"
-	conf.Default.FirmwareURL = defaultFirmwarePath
-	s := conf.NewServer(component.MustNew(test.GetLogger(t), &component.Config{}))
+	conf.Default.UpdateChannel = testUpdateChannel
+	conf.Default.FirmwareURL = testFirmwarePath
+	s, err := conf.NewServer(component.MustNew(test.GetLogger(t), &component.Config{}))
+	if err != nil {
+		t.Error(err)
+	}
 
 	for _, tt := range []struct {
 		Name            string
@@ -37,17 +45,17 @@ func TestAdaptUpdateChannel(t *testing.T) {
 		{
 			Name:            "Empty channel",
 			Channel:         "",
-			ExpectedChannel: fmt.Sprintf("%v/%v", defaultFirmwarePath, "stable"),
+			ExpectedChannel: fmt.Sprintf("%v/%v", testFirmwarePath, "stable"),
 		},
 		{
 			Name:            "Default stable channel",
 			Channel:         "stable",
-			ExpectedChannel: fmt.Sprintf("%v/%v", defaultFirmwarePath, "stable"),
+			ExpectedChannel: fmt.Sprintf("%v/%v", testFirmwarePath, "stable"),
 		},
 		{
 			Name:            "Default beta channel",
 			Channel:         "beta",
-			ExpectedChannel: fmt.Sprintf("%v/%v", defaultFirmwarePath, "beta"),
+			ExpectedChannel: fmt.Sprintf("%v/%v", testFirmwarePath, "beta"),
 		},
 		{
 			Name:            "Custom update channel",

--- a/pkg/thethingsgateway/cups/middleware.go
+++ b/pkg/thethingsgateway/cups/middleware.go
@@ -1,0 +1,42 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cups
+
+import (
+	echo "github.com/labstack/echo/v4"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+)
+
+const (
+	gatewayIDKey       = "gateway_id"
+	frequencyPlanIDKey = "frequency_plan_id"
+)
+
+// validateAndFillGatewayIDs checks if the request contains a valid gateway ID.
+func (s *Server) validateAndFillGatewayIDs() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			gatewayIDs := ttnpb.GatewayIdentifiers{
+				GatewayID: c.Param(gatewayIDKey),
+			}
+			if err := gatewayIDs.ValidateContext(c.Request().Context()); err != nil {
+				return err
+			}
+			c.Set(gatewayIDKey, gatewayIDs)
+
+			return next(c)
+		}
+	}
+}

--- a/pkg/thethingsgateway/cups/server.go
+++ b/pkg/thethingsgateway/cups/server.go
@@ -23,6 +23,8 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/web"
 )
 
+const defaultFirmwarePath = "https://thethingsproducts.blob.core.windows.net/the-things-gateway/v1"
+
 // Config is the configuration of the The Things Gateay CUPS.
 type Config struct {
 	Default struct {
@@ -35,9 +37,10 @@ type Config struct {
 // NewServer returns a new CUPS from this config on top of the component.
 func (conf Config) NewServer(c *component.Component, customOpts ...Option) *Server {
 	opts := []Option{
-		WithDefaultUpdateChannel(conf.Default.UpdateChannel),
-		WithDefaultFirmwareURL(conf.Default.FirmwareURL),
-		WithDefaultMQTTServer(conf.Default.MQTTServer),
+		WithConfig(conf),
+	}
+	if conf.Default.FirmwareURL == "" {
+		opts = append(opts, WithDefaultFirmwareURL(defaultFirmwarePath))
 	}
 	s := NewServer(c, append(opts, customOpts...)...)
 	c.RegisterWeb(s)
@@ -105,7 +108,10 @@ func (s *Server) RegisterRoutes(srv *web.Server) {
 	group := srv.Group(compatAPIPrefix)
 	group.GET("/gateways/:gateway_id", func(c echo.Context) error {
 		return s.handleGatewayInfo(c)
-	}, s.validateAndFillGatewayIDs())
+	}, []echo.MiddlewareFunc{
+		s.validateAndFillGatewayIDs(),
+		s.checkAuthPresence(),
+	}...)
 	group.GET("/frequency-plans/:frequency_plan_id", func(c echo.Context) error {
 		return s.handleFreqPlanInfo(c)
 	})

--- a/pkg/thethingsgateway/cups/server.go
+++ b/pkg/thethingsgateway/cups/server.go
@@ -1,0 +1,69 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cups
+
+import (
+	"context"
+
+	echo "github.com/labstack/echo/v4"
+	"go.thethings.network/lorawan-stack/pkg/component"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/pkg/types"
+	"go.thethings.network/lorawan-stack/pkg/web"
+	"google.golang.org/grpc"
+)
+
+// Config is the configuration of the The Things Gateay CUPS server.
+type Config struct {
+	//TODO: Add default configuration here.
+}
+
+// NewServer returns a new CUPS server from this config on top of the component.
+func (conf Config) NewServer(c *component.Component) *Server {
+	s := NewServer(c)
+	c.RegisterWeb(s)
+	return s
+}
+
+// Server implements the CUPS endpoints used by The Things Gateway.
+type Server struct {
+	component *component.Component
+
+	auth func(context.Context, types.EUI64, string) grpc.CallOption
+}
+
+const compatAPIPrefix = "/api/v2"
+
+func (s *Server) getRegistry(ctx context.Context, ids *ttnpb.GatewayIdentifiers) ttnpb.GatewayRegistryClient {
+	return ttnpb.NewGatewayRegistryClient(s.component.GetPeer(ctx, ttnpb.PeerInfo_ENTITY_REGISTRY, ids).Conn())
+}
+
+// RegisterRoutes implements the web.Registerer interface.
+func (s *Server) RegisterRoutes(srv *web.Server) {
+	group := srv.Group(compatAPIPrefix)
+	group.GET("/gateways/:gateway_id", func(c echo.Context) error {
+		return s.handleGatewayInfo(c)
+	}, s.validateAndFillGatewayIDs())
+	group.GET("/frequency-plans/:frequency_plan_id", func(c echo.Context) error {
+		return s.handleFreqPlanInfo(c)
+	})
+}
+
+// NewServer returns a new CUPS server on top of the given gateway registry.
+func NewServer(c *component.Component) *Server {
+	return &Server{
+		component: c,
+	}
+}

--- a/pkg/thethingsgateway/cups/server.go
+++ b/pkg/thethingsgateway/cups/server.go
@@ -20,19 +20,21 @@ import (
 	echo "github.com/labstack/echo/v4"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
-	"go.thethings.network/lorawan-stack/pkg/types"
 	"go.thethings.network/lorawan-stack/pkg/web"
-	"google.golang.org/grpc"
 )
 
 // Config is the configuration of the The Things Gateay CUPS server.
 type Config struct {
-	//TODO: Add default configuration here.
+	Default struct {
+		UpdateChannel string `name:"update-channel" description:"The default update channel that the gateways should use"`
+		MQTTServer    string `name:"mqtt-server" description:"The default MQTT server that the gateways should use"`
+		FirmwareURL   string `name:"firmware-url" description:"The default URL to the firmware storage"`
+	} `name:"default" description:"Default gateway settings"`
 }
 
 // NewServer returns a new CUPS server from this config on top of the component.
 func (conf Config) NewServer(c *component.Component) *Server {
-	s := NewServer(c)
+	s := NewServer(c, conf)
 	c.RegisterWeb(s)
 	return s
 }
@@ -41,7 +43,7 @@ func (conf Config) NewServer(c *component.Component) *Server {
 type Server struct {
 	component *component.Component
 
-	auth func(context.Context, types.EUI64, string) grpc.CallOption
+	config Config
 }
 
 const compatAPIPrefix = "/api/v2"
@@ -62,8 +64,9 @@ func (s *Server) RegisterRoutes(srv *web.Server) {
 }
 
 // NewServer returns a new CUPS server on top of the given gateway registry.
-func NewServer(c *component.Component) *Server {
+func NewServer(c *component.Component, conf Config) *Server {
 	return &Server{
 		component: c,
+		config:    conf,
 	}
 }

--- a/pkg/thethingsgateway/cups/server.go
+++ b/pkg/thethingsgateway/cups/server.go
@@ -23,7 +23,10 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/web"
 )
 
-const defaultFirmwarePath = "https://thethingsproducts.blob.core.windows.net/the-things-gateway/v1"
+const (
+	defaultFirmwarePath  = "https://thethingsproducts.blob.core.windows.net/the-things-gateway/v1"
+	defaultUpdateChannel = "stable"
+)
 
 // Config is the configuration of the The Things Gateay CUPS.
 type Config struct {
@@ -41,6 +44,9 @@ func (conf Config) NewServer(c *component.Component, customOpts ...Option) *Serv
 	}
 	if conf.Default.FirmwareURL == "" {
 		opts = append(opts, WithDefaultFirmwareURL(defaultFirmwarePath))
+	}
+	if conf.Default.UpdateChannel == "" {
+		opts = append(opts, WithDefaultUpdateChannel(defaultUpdateChannel))
 	}
 	s := NewServer(c, append(opts, customOpts...)...)
 	c.RegisterWeb(s)

--- a/pkg/thethingsgateway/cups/server_test.go
+++ b/pkg/thethingsgateway/cups/server_test.go
@@ -1,0 +1,1 @@
+package cups

--- a/pkg/thethingsgateway/cups/server_test.go
+++ b/pkg/thethingsgateway/cups/server_test.go
@@ -151,7 +151,8 @@ func TestServer(t *testing.T) {
 
 			s := NewServer(component.MustNew(test.GetLogger(t), &component.Config{}), append([]Option{
 				WithRegistry(store),
-				WithDefaultFirmwareURL(defaultFirmwarePath),
+				WithDefaultFirmwareURL(testFirmwarePath),
+				WithDefaultUpdateChannel(testUpdateChannel),
 			}, tt.Options...)...)
 			req := httptest.NewRequest(http.MethodGet, "/api/v2/gateway/test-gateway", nil)
 			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)

--- a/pkg/thethingsgateway/cups/server_test.go
+++ b/pkg/thethingsgateway/cups/server_test.go
@@ -1,1 +1,177 @@
 package cups
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo"
+	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/pkg/component"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/pkg/util/test"
+	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+var (
+	mockGatewayID   = "test-gateway"
+	mockErrNotFound = grpc.Errorf(codes.NotFound, "not found")
+)
+
+type mockGatewayClientData struct {
+	ctx struct {
+		Get context.Context
+	}
+	req struct {
+		Get *ttnpb.GetGatewayRequest
+	}
+	opts struct {
+		Get []grpc.CallOption
+	}
+	res struct {
+		Get *ttnpb.Gateway
+	}
+	err struct {
+		Get error
+	}
+}
+
+type mockGatewayClient struct {
+	mockGatewayClientData
+	ttnpb.GatewayRegistryClient
+}
+
+func (m *mockGatewayClient) reset() {
+	m.mockGatewayClientData = mockGatewayClientData{}
+}
+
+func (m *mockGatewayClient) Get(ctx context.Context, in *ttnpb.GetGatewayRequest, opts ...grpc.CallOption) (*ttnpb.Gateway, error) {
+	m.ctx.Get, m.req.Get, m.opts.Get = ctx, in, opts
+	return m.res.Get, m.err.Get
+}
+
+func mockGateway() *ttnpb.Gateway {
+	return &ttnpb.Gateway{
+		GatewayIdentifiers: ttnpb.GatewayIdentifiers{
+			GatewayID: mockGatewayID,
+		},
+		UpdateChannel:        "stable",
+		FrequencyPlanID:      "EU_863_870",
+		GatewayServerAddress: "mqtts://localhost:8883",
+	}
+}
+
+func TestServer(t *testing.T) {
+	e := echo.New()
+
+	for _, tt := range []struct {
+		Name           string
+		StoreSetup     func(*mockGatewayClient)
+		Options        []Option
+		RequestSetup   func(*http.Request)
+		ContextSetup   func(echo.Context)
+		AssertError    func(actual interface{}, expected ...interface{}) string
+		AssertStore    func(*assertions.Assertion, *mockGatewayClient)
+		AssertResponse func(*assertions.Assertion, *httptest.ResponseRecorder)
+	}{
+		{
+			Name: "No Auth",
+			RequestSetup: func(req *http.Request) {
+				req.Header.Del(echo.HeaderAuthorization)
+			},
+			AssertError: should.NotBeNil,
+		},
+		{
+			Name: "No GatewayID",
+			ContextSetup: func(c echo.Context) {
+				c.SetParamValues()
+			},
+			AssertError: should.NotBeNil,
+		},
+		{
+			Name: "Not Found",
+			StoreSetup: func(c *mockGatewayClient) {
+				c.err.Get = mockErrNotFound
+			},
+			AssertError: should.NotBeNil,
+			AssertStore: func(a *assertions.Assertion, c *mockGatewayClient) {
+				a.So(c.req.Get.GatewayID, should.Equal, mockGatewayID)
+			},
+		},
+		{
+			Name: "Found",
+			StoreSetup: func(c *mockGatewayClient) {
+				c.res.Get = mockGateway()
+			},
+			AssertError: should.BeNil,
+			AssertStore: func(a *assertions.Assertion, c *mockGatewayClient) {
+				a.So(c.req.Get.GatewayID, should.Equal, mockGatewayID)
+			},
+			AssertResponse: func(a *assertions.Assertion, rc *httptest.ResponseRecorder) {
+				a.So(rc.Code, should.Equal, http.StatusOK)
+				body := rc.Body
+				a.So(body, should.NotBeEmpty)
+				var resp map[string]interface{}
+				err := json.NewDecoder(rc.Body).Decode(&resp)
+				a.So(err, should.BeNil)
+				a.So(resp["frequency_plan"], should.Equal, "EU_863_870")
+				a.So(resp["frequency_plan_url"], should.Equal, "http://example.com/api/v2/frequency-plans/EU_863_870")
+				a.So(resp["firmware_url"], should.Equal, "https://thethingsproducts.blob.core.windows.net/the-things-gateway/v1/stable")
+				a.So(resp["router"], should.Resemble, map[string]interface{}{
+					"mqtt_address": "mqtts://localhost:8883",
+				})
+				a.So(resp["auto_update"], should.Equal, false)
+			},
+		},
+	} {
+		t.Run(tt.Name, func(t *testing.T) {
+			a := assertions.New(t)
+			store := &mockGatewayClient{}
+			if tt.StoreSetup != nil {
+				tt.StoreSetup(store)
+			}
+
+			s := NewServer(component.MustNew(test.GetLogger(t), &component.Config{}), append([]Option{
+				WithRegistry(store),
+				WithDefaultFirmwareURL(defaultFirmwarePath),
+			}, tt.Options...)...)
+			req := httptest.NewRequest(http.MethodGet, "/api/v2/gateway/test-gateway", nil)
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			req.Header.Set(echo.HeaderAuthorization, "random string")
+			if tt.RequestSetup != nil {
+				tt.RequestSetup(req)
+			}
+
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetParamNames(gatewayIDKey)
+			c.SetParamValues(mockGatewayID)
+			if tt.ContextSetup != nil {
+				tt.ContextSetup(c)
+			}
+			middleware := []echo.MiddlewareFunc{
+				s.validateAndFillGatewayIDs(),
+				s.checkAuthPresence(),
+			}
+
+			handler := s.handleGatewayInfo
+			for _, m := range middleware {
+				handler = m(handler)
+			}
+			err := handler(c)
+			if tt.AssertError != nil {
+				a.So(err, tt.AssertError)
+			}
+			if tt.AssertResponse != nil {
+				tt.AssertResponse(a, rec)
+			}
+			if tt.AssertStore != nil {
+				tt.AssertStore(a, store)
+			}
+		})
+	}
+}

--- a/pkg/thethingsgateway/cups/server_test.go
+++ b/pkg/thethingsgateway/cups/server_test.go
@@ -1,3 +1,17 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cups
 
 import (
@@ -7,7 +21,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/labstack/echo"
+	echo "github.com/labstack/echo/v4"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #68.

**Changes:**
<!-- What are the changes made in this pull request? -->


- Add the `/api/v2/gateways/<gateway_id>` endpoint which renders the gateway information using the v2 format. The result is minimal and renders only the fields which are actually being used by The Things Gateway.
- Added `/api/v2/frequency-plans/<fp_id>` endpoint which the renders the frequency plan information using the v2 format.

**Notes for Reviewers:**
<!--
Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->


There is still an ongoing bug regarding the `frequency_plan_url` field, which I've been unable to correctly implement. The current implementation uses the `echo.Context.Request().Host` field in order to derive the host and the port of the current request, and derive the frequency plan URL. 

However, `Request().Host` is just an wrapper around the `Host` header sent by the HTTP client, and The Things Gateway sends only the host, without the port. As such, the URL generated does not contain the port, and the gateway cannot download the frequency plan if the IS is not listening on port 80. I've also attempted to use `Request().URL`, but again it does not contain the host / port.

One way to deal with this, which I'm not very fond of, is to add a setting for the `scheme://host:port` part of the generated URL.

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Added support for The Things Gateway.
