### PR TITLE
Add trace regions

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -503,6 +503,7 @@ github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zM
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/openshift/osin v1.0.1 h1:2hYushQtTLGVfnKAmz1+/ln5GZD0ykJCavs2JIwVEfQ=
 github.com/openshift/osin v1.0.1/go.mod h1:/gGuqQHvGNST0GB+Pomi3398FTdcM+9UaXafpqHvfDM=
+github.com/opentracing/opentracing-go v1.0.2 h1:3jA2P6O1F9UOrWVpwrIo17pu01KWvNWg4X946/Y5Zwg=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/openzipkin/zipkin-go v0.1.3/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=

--- a/pkg/auth/rights/hook.go
+++ b/pkg/auth/rights/hook.go
@@ -16,6 +16,7 @@ package rights
 
 import (
 	"context"
+	"runtime/trace"
 
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
@@ -49,6 +50,7 @@ const HookName = "rights-fetcher"
 // argument that implements the ttnpb.Identifiers interface.
 func Hook(next grpc.UnaryHandler) grpc.UnaryHandler {
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
+		defer trace.StartRegion(ctx, "fetch rights").End()
 		fetcher, ok := fetcherFromContext(ctx)
 		if !ok {
 			panic(errNoFetcher)

--- a/pkg/gatewayserver/scheduling/scheduler.go
+++ b/pkg/gatewayserver/scheduling/scheduler.go
@@ -17,6 +17,7 @@ package scheduling
 import (
 	"context"
 	"math"
+	"runtime/trace"
 	"sync"
 	"time"
 
@@ -124,6 +125,8 @@ var (
 
 // ScheduleAt attempts to schedule the given Tx settings with the given priority.
 func (s *Scheduler) ScheduleAt(ctx context.Context, payloadSize int, settings ttnpb.TxSettings, priority ttnpb.TxSchedulePriority) (Emission, error) {
+	defer trace.StartRegion(ctx, "schedule transmission").End()
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.clock.IsSynced() {
@@ -164,6 +167,8 @@ func (s *Scheduler) ScheduleAt(ctx context.Context, payloadSize int, settings tt
 // emission time is unknown. Therefore, when the time is set to Immediate, the estimated current concentrator time plus
 // ScheduleDelayLong will be used.
 func (s *Scheduler) ScheduleAnytime(ctx context.Context, payloadSize int, settings ttnpb.TxSettings, priority ttnpb.TxSchedulePriority) (Emission, error) {
+	defer trace.StartRegion(ctx, "schedule transmission at any time").End()
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.clock.IsSynced() {

--- a/pkg/identityserver/entity_access.go
+++ b/pkg/identityserver/entity_access.go
@@ -17,6 +17,7 @@ package identityserver
 import (
 	"context"
 	"fmt"
+	"runtime/trace"
 	"strings"
 	"time"
 
@@ -106,7 +107,9 @@ func (is *IdentityServer) authInfo(ctx context.Context) (info *ttnpb.AuthInfoRes
 				}
 				return err
 			}
+			region := trace.StartRegion(ctx, "validate api key")
 			valid, err := auth.Password(apiKey.GetKey()).Validate(tokenKey)
+			region.End()
 			if err != nil {
 				return err
 			}
@@ -142,7 +145,9 @@ func (is *IdentityServer) authInfo(ctx context.Context) (info *ttnpb.AuthInfoRes
 				}
 				return err
 			}
+			region := trace.StartRegion(ctx, "validate access token")
 			valid, err := auth.Password(accessToken.GetAccessToken()).Validate(tokenKey)
+			region.End()
 			if err != nil {
 				return err
 			}

--- a/pkg/identityserver/store/api_key_store.go
+++ b/pkg/identityserver/store/api_key_store.go
@@ -16,6 +16,7 @@ package store
 
 import (
 	"context"
+	"runtime/trace"
 
 	"github.com/jinzhu/gorm"
 	"go.thethings.network/lorawan-stack/pkg/errors"
@@ -32,6 +33,7 @@ type apiKeyStore struct {
 }
 
 func (s *apiKeyStore) CreateAPIKey(ctx context.Context, entityID *ttnpb.EntityIdentifiers, key *ttnpb.APIKey) error {
+	defer trace.StartRegion(ctx, "create api key").End()
 	entity, err := findEntity(ctx, s.db, entityID, "id")
 	if err != nil {
 		return err
@@ -49,6 +51,7 @@ func (s *apiKeyStore) CreateAPIKey(ctx context.Context, entityID *ttnpb.EntityId
 }
 
 func (s *apiKeyStore) FindAPIKeys(ctx context.Context, entityID *ttnpb.EntityIdentifiers) ([]*ttnpb.APIKey, error) {
+	defer trace.StartRegion(ctx, "find api keys").End()
 	entity, err := findEntity(ctx, s.db, entityID, "id")
 	if err != nil {
 		return nil, err
@@ -67,6 +70,7 @@ func (s *apiKeyStore) FindAPIKeys(ctx context.Context, entityID *ttnpb.EntityIde
 var errAPIKeyEntity = errors.DefineCorruption("api_key_entity", "API key not linked to an entity")
 
 func (s *apiKeyStore) GetAPIKey(ctx context.Context, id string) (*ttnpb.EntityIdentifiers, *ttnpb.APIKey, error) {
+	defer trace.StartRegion(ctx, "get api key").End()
 	var keyModel APIKey
 	if err := s.db.Scopes(withContext(ctx)).Where(APIKey{APIKeyID: id}).First(&keyModel).Error; err != nil {
 		if gorm.IsRecordNotFoundError(err) {
@@ -90,6 +94,7 @@ func (s *apiKeyStore) GetAPIKey(ctx context.Context, id string) (*ttnpb.EntityId
 }
 
 func (s *apiKeyStore) UpdateAPIKey(ctx context.Context, entityID *ttnpb.EntityIdentifiers, key *ttnpb.APIKey) (*ttnpb.APIKey, error) {
+	defer trace.StartRegion(ctx, "update api key").End()
 	entity, err := findEntity(ctx, s.db, entityID, "id")
 	if err != nil {
 		return nil, err

--- a/pkg/identityserver/store/attribute_store.go
+++ b/pkg/identityserver/store/attribute_store.go
@@ -14,9 +14,15 @@
 
 package store
 
-import "github.com/jinzhu/gorm"
+import (
+	"context"
+	"runtime/trace"
 
-func replaceAttributes(db *gorm.DB, entityType, entityUUID string, old []Attribute, new []Attribute) (err error) {
+	"github.com/jinzhu/gorm"
+)
+
+func replaceAttributes(ctx context.Context, db *gorm.DB, entityType, entityUUID string, old []Attribute, new []Attribute) (err error) {
+	defer trace.StartRegion(ctx, "update attributes").End()
 	oldByUUID := make(map[string]Attribute, len(old))
 	for _, attr := range old {
 		oldByUUID[attr.ID] = attr

--- a/pkg/identityserver/store/contact_info_store.go
+++ b/pkg/identityserver/store/contact_info_store.go
@@ -16,6 +16,7 @@ package store
 
 import (
 	"context"
+	"runtime/trace"
 	"time"
 
 	"github.com/jinzhu/gorm"
@@ -33,6 +34,7 @@ type contactInfoStore struct {
 }
 
 func (s *contactInfoStore) GetContactInfo(ctx context.Context, entityID *ttnpb.EntityIdentifiers) ([]*ttnpb.ContactInfo, error) {
+	defer trace.StartRegion(ctx, "get contact info").End()
 	entity, err := findEntity(ctx, s.db, entityID, "id")
 	if err != nil {
 		return nil, err
@@ -53,6 +55,7 @@ func (s *contactInfoStore) GetContactInfo(ctx context.Context, entityID *ttnpb.E
 }
 
 func (s *contactInfoStore) SetContactInfo(ctx context.Context, entityID *ttnpb.EntityIdentifiers, pb []*ttnpb.ContactInfo) ([]*ttnpb.ContactInfo, error) {
+	defer trace.StartRegion(ctx, "update contact info").End()
 	entity, err := findEntity(ctx, s.db, entityID, "id")
 	if err != nil {
 		return nil, err
@@ -142,6 +145,7 @@ func (s *contactInfoStore) SetContactInfo(ctx context.Context, entityID *ttnpb.E
 }
 
 func (s *contactInfoStore) CreateValidation(ctx context.Context, validation *ttnpb.ContactInfoValidation) (*ttnpb.ContactInfoValidation, error) {
+	defer trace.StartRegion(ctx, "create contact info validation").End()
 	var (
 		contactMethod ttnpb.ContactMethod
 		value         string
@@ -185,6 +189,7 @@ var (
 )
 
 func (s *contactInfoStore) Validate(ctx context.Context, validation *ttnpb.ContactInfoValidation) error {
+	defer trace.StartRegion(ctx, "validate contact info").End()
 	now := cleanTime(time.Now())
 
 	var model ContactInfoValidation

--- a/pkg/identityserver/store/end_device_location_store.go
+++ b/pkg/identityserver/store/end_device_location_store.go
@@ -14,9 +14,15 @@
 
 package store
 
-import "github.com/jinzhu/gorm"
+import (
+	"context"
+	"runtime/trace"
 
-func replaceEndDeviceLocations(db *gorm.DB, endDeviceUUID string, old []EndDeviceLocation, new []EndDeviceLocation) (err error) {
+	"github.com/jinzhu/gorm"
+)
+
+func replaceEndDeviceLocations(ctx context.Context, db *gorm.DB, endDeviceUUID string, old []EndDeviceLocation, new []EndDeviceLocation) (err error) {
+	defer trace.StartRegion(ctx, "update end device locations").End()
 	oldByUUID := make(map[string]EndDeviceLocation, len(old))
 	for _, loc := range old {
 		oldByUUID[loc.ID] = loc

--- a/pkg/identityserver/store/entity_search.go
+++ b/pkg/identityserver/store/entity_search.go
@@ -17,6 +17,7 @@ package store
 import (
 	"context"
 	"fmt"
+	"runtime/trace"
 
 	"github.com/jinzhu/gorm"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
@@ -32,6 +33,8 @@ type entitySearch struct {
 }
 
 func (s *entitySearch) FindEntities(ctx context.Context, req *ttnpb.SearchEntitiesRequest, entityType string) ([]*ttnpb.EntityIdentifiers, error) {
+	defer trace.StartRegion(ctx, "find entities").End()
+
 	table := entityType + "s"
 	db := s.db.Scopes(withContext(ctx)).Table(table)
 	idField := fmt.Sprintf("%s_id", entityType)

--- a/pkg/identityserver/store/gateway_antenna_store.go
+++ b/pkg/identityserver/store/gateway_antenna_store.go
@@ -15,10 +15,14 @@
 package store
 
 import (
+	"context"
+	"runtime/trace"
+
 	"github.com/jinzhu/gorm"
 )
 
-func replaceGatewayAntennas(db *gorm.DB, gatewayUUID string, old []GatewayAntenna, new []GatewayAntenna) (err error) {
+func replaceGatewayAntennas(ctx context.Context, db *gorm.DB, gatewayUUID string, old []GatewayAntenna, new []GatewayAntenna) (err error) {
+	defer trace.StartRegion(ctx, "update gateway antennas").End()
 	db = db.Where(GatewayAntenna{GatewayID: gatewayUUID})
 	if len(new) < len(old) {
 		if err = db.Where("\"index\" >= ?", len(new)).Delete(&GatewayAntenna{}).Error; err != nil {

--- a/pkg/identityserver/store/invitation_store.go
+++ b/pkg/identityserver/store/invitation_store.go
@@ -16,6 +16,7 @@ package store
 
 import (
 	"context"
+	"runtime/trace"
 	"time"
 
 	"github.com/jinzhu/gorm"
@@ -35,6 +36,7 @@ type invitationStore struct {
 var errInvitationAlreadySent = errors.DefineAlreadyExists("invitation_already_sent", "invitation already sent")
 
 func (s *invitationStore) CreateInvitation(ctx context.Context, invitation *ttnpb.Invitation) (*ttnpb.Invitation, error) {
+	defer trace.StartRegion(ctx, "create invitation").End()
 	model := Invitation{
 		Email:     invitation.Email,
 		Token:     invitation.Token,
@@ -52,6 +54,7 @@ func (s *invitationStore) CreateInvitation(ctx context.Context, invitation *ttnp
 }
 
 func (s *invitationStore) FindInvitations(ctx context.Context) ([]*ttnpb.Invitation, error) {
+	defer trace.StartRegion(ctx, "find invitations").End()
 	var invitationModels []Invitation
 	if err := s.db.Scopes(withContext(ctx)).Find(&invitationModels).Error; err != nil {
 		return nil, err
@@ -66,6 +69,7 @@ func (s *invitationStore) FindInvitations(ctx context.Context) ([]*ttnpb.Invitat
 var errInvitationNotFound = errors.DefineNotFound("invitation_not_found", "invitation not found")
 
 func (s *invitationStore) GetInvitation(ctx context.Context, token string) (*ttnpb.Invitation, error) {
+	defer trace.StartRegion(ctx, "get invitation").End()
 	var invitationModel Invitation
 	if err := s.db.Scopes(withContext(ctx)).Where(Invitation{Token: token}).First(&invitationModel).Error; err != nil {
 		if gorm.IsRecordNotFoundError(err) {
@@ -79,6 +83,7 @@ func (s *invitationStore) GetInvitation(ctx context.Context, token string) (*ttn
 var errInvitationAlreadyAccepted = errors.DefineAlreadyExists("invitation_already_accepted", "invitation already accepted")
 
 func (s *invitationStore) SetInvitationAcceptedBy(ctx context.Context, token string, acceptedByID *ttnpb.UserIdentifiers) error {
+	defer trace.StartRegion(ctx, "update invitation").End()
 	var invitationModel Invitation
 	if err := s.db.Scopes(withContext(ctx)).Where(Invitation{Token: token}).First(&invitationModel).Error; err != nil {
 		if gorm.IsRecordNotFoundError(err) {
@@ -105,6 +110,7 @@ func (s *invitationStore) SetInvitationAcceptedBy(ctx context.Context, token str
 }
 
 func (s *invitationStore) DeleteInvitation(ctx context.Context, email string) error {
+	defer trace.StartRegion(ctx, "delete invitation").End()
 	var invitationModel Invitation
 	if err := s.db.Scopes(withContext(ctx)).Where(Invitation{Email: email}).First(&invitationModel).Error; err != nil {
 		if gorm.IsRecordNotFoundError(err) {

--- a/pkg/identityserver/store/oauth_store.go
+++ b/pkg/identityserver/store/oauth_store.go
@@ -16,6 +16,7 @@ package store
 
 import (
 	"context"
+	"runtime/trace"
 
 	"github.com/jinzhu/gorm"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
@@ -31,6 +32,7 @@ type oauthStore struct {
 }
 
 func (s *oauthStore) GetAuthorization(ctx context.Context, userIDs *ttnpb.UserIdentifiers, clientIDs *ttnpb.ClientIdentifiers) (*ttnpb.OAuthClientAuthorization, error) {
+	defer trace.StartRegion(ctx, "get authorization").End()
 	client, err := findEntity(ctx, s.db, clientIDs.EntityIdentifiers(), "id")
 	if err != nil {
 		return nil, err
@@ -56,6 +58,7 @@ func (s *oauthStore) GetAuthorization(ctx context.Context, userIDs *ttnpb.UserId
 }
 
 func (s *oauthStore) Authorize(ctx context.Context, authorization *ttnpb.OAuthClientAuthorization) (*ttnpb.OAuthClientAuthorization, error) {
+	defer trace.StartRegion(ctx, "create or update authorization").End()
 	client, err := findEntity(ctx, s.db, authorization.ClientIDs.EntityIdentifiers(), "id")
 	if err != nil {
 		return nil, err
@@ -91,6 +94,7 @@ func (s *oauthStore) Authorize(ctx context.Context, authorization *ttnpb.OAuthCl
 }
 
 func (s *oauthStore) DeleteAuthorization(ctx context.Context, userIDs *ttnpb.UserIdentifiers, clientIDs *ttnpb.ClientIdentifiers) error {
+	defer trace.StartRegion(ctx, "delete authorization").End()
 	client, err := findEntity(ctx, s.db, clientIDs.EntityIdentifiers(), "id")
 	if err != nil {
 		return err
@@ -107,6 +111,7 @@ func (s *oauthStore) DeleteAuthorization(ctx context.Context, userIDs *ttnpb.Use
 }
 
 func (s *oauthStore) CreateAuthorizationCode(ctx context.Context, code *ttnpb.OAuthAuthorizationCode) error {
+	defer trace.StartRegion(ctx, "create authorization code").End()
 	client, err := findEntity(ctx, s.db, code.ClientIDs.EntityIdentifiers(), "id")
 	if err != nil {
 		return err
@@ -136,6 +141,7 @@ func (s *oauthStore) CreateAuthorizationCode(ctx context.Context, code *ttnpb.OA
 }
 
 func (s *oauthStore) GetAuthorizationCode(ctx context.Context, code string) (*ttnpb.OAuthAuthorizationCode, error) {
+	defer trace.StartRegion(ctx, "get authorization code").End()
 	if code == "" {
 		return nil, errAuthorizationCodeNotFound
 	}
@@ -155,6 +161,7 @@ func (s *oauthStore) DeleteAuthorizationCode(ctx context.Context, code string) e
 	if code == "" {
 		return errAuthorizationCodeNotFound
 	}
+	defer trace.StartRegion(ctx, "delete authorization code").End()
 	err := s.db.Scopes(withContext(ctx)).Where(AuthorizationCode{
 		Code: code,
 	}).Delete(&AuthorizationCode{}).Error
@@ -168,6 +175,7 @@ func (s *oauthStore) DeleteAuthorizationCode(ctx context.Context, code string) e
 }
 
 func (s *oauthStore) CreateAccessToken(ctx context.Context, token *ttnpb.OAuthAccessToken, previousID string) error {
+	defer trace.StartRegion(ctx, "create access token").End()
 	client, err := findEntity(ctx, s.db, token.ClientIDs.EntityIdentifiers(), "id")
 	if err != nil {
 		return err
@@ -201,6 +209,7 @@ func (s *oauthStore) GetAccessToken(ctx context.Context, id string) (*ttnpb.OAut
 	if id == "" {
 		return nil, errAccessTokenNotFound
 	}
+	defer trace.StartRegion(ctx, "get access token").End()
 	var tokenModel AccessToken
 	err := s.db.Scopes(withContext(ctx)).Where(AccessToken{
 		TokenID: id,
@@ -217,6 +226,7 @@ func (s *oauthStore) DeleteAccessToken(ctx context.Context, id string) error {
 	if id == "" {
 		return errAccessTokenNotFound
 	}
+	defer trace.StartRegion(ctx, "delete access token").End()
 	err := s.db.Scopes(withContext(ctx)).Where(AccessToken{
 		TokenID: id,
 	}).Delete(&AccessToken{}).Error

--- a/pkg/identityserver/store/store.go
+++ b/pkg/identityserver/store/store.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"runtime/trace"
 	"strings"
 	"time"
 
@@ -63,6 +64,7 @@ func convertError(err error) error {
 
 // Transact executes f in a db transaction.
 func Transact(ctx context.Context, db *gorm.DB, f func(db *gorm.DB) error) (err error) {
+	defer trace.StartRegion(ctx, "database transaction").End()
 	tx := db.Begin()
 	defer func() {
 		if p := recover(); p != nil {

--- a/pkg/identityserver/store/user_session_store.go
+++ b/pkg/identityserver/store/user_session_store.go
@@ -16,6 +16,7 @@ package store
 
 import (
 	"context"
+	"runtime/trace"
 
 	"github.com/jinzhu/gorm"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
@@ -31,6 +32,7 @@ type userSessionStore struct {
 }
 
 func (s *userSessionStore) CreateSession(ctx context.Context, sess *ttnpb.UserSession) (*ttnpb.UserSession, error) {
+	defer trace.StartRegion(ctx, "create user session").End()
 	user, err := findEntity(ctx, s.db, sess.UserIdentifiers.EntityIdentifiers(), "id")
 	if err != nil {
 		return nil, err
@@ -50,6 +52,7 @@ func (s *userSessionStore) CreateSession(ctx context.Context, sess *ttnpb.UserSe
 }
 
 func (s *userSessionStore) FindSessions(ctx context.Context, userIDs *ttnpb.UserIdentifiers) ([]*ttnpb.UserSession, error) {
+	defer trace.StartRegion(ctx, "find user sessions").End()
 	user, err := findEntity(ctx, s.db, userIDs.EntityIdentifiers(), "id")
 	if err != nil {
 		return nil, err
@@ -76,6 +79,7 @@ func (s *userSessionStore) FindSessions(ctx context.Context, userIDs *ttnpb.User
 }
 
 func (s *userSessionStore) GetSession(ctx context.Context, userIDs *ttnpb.UserIdentifiers, sessionID string) (*ttnpb.UserSession, error) {
+	defer trace.StartRegion(ctx, "get user session").End()
 	user, err := findEntity(ctx, s.db, userIDs.EntityIdentifiers(), "id")
 	if err != nil {
 		return nil, err
@@ -95,6 +99,7 @@ func (s *userSessionStore) GetSession(ctx context.Context, userIDs *ttnpb.UserId
 }
 
 func (s *userSessionStore) UpdateSession(ctx context.Context, sess *ttnpb.UserSession) (*ttnpb.UserSession, error) {
+	defer trace.StartRegion(ctx, "update user session").End()
 	user, err := findEntity(ctx, s.db, sess.UserIdentifiers.EntityIdentifiers(), "id")
 	if err != nil {
 		return nil, err
@@ -117,6 +122,7 @@ func (s *userSessionStore) UpdateSession(ctx context.Context, sess *ttnpb.UserSe
 }
 
 func (s *userSessionStore) DeleteSession(ctx context.Context, userIDs *ttnpb.UserIdentifiers, sessionID string) error {
+	defer trace.StartRegion(ctx, "delete user session").End()
 	user, err := findEntity(ctx, s.db, userIDs.EntityIdentifiers(), "id")
 	if err != nil {
 		return err

--- a/pkg/identityserver/user_registry.go
+++ b/pkg/identityserver/user_registry.go
@@ -17,6 +17,7 @@ package identityserver
 import (
 	"context"
 	"path"
+	"runtime/trace"
 	"strings"
 	"time"
 
@@ -390,7 +391,9 @@ func (is *IdentityServer) updateUserPassword(ctx context.Context, req *ttnpb.Upd
 		if err != nil {
 			return err
 		}
+		region := trace.StartRegion(ctx, "validate old password")
 		valid, err := auth.Password(usr.Password).Validate(req.Old)
+		region.End()
 		if err != nil {
 			return err
 		}
@@ -403,7 +406,9 @@ func (is *IdentityServer) updateUserPassword(ctx context.Context, req *ttnpb.Upd
 				events.Publish(evtUpdateUserIncorrectPassword(ctx, req.UserIdentifiers, nil))
 				return errIncorrectPassword
 			}
+			region := trace.StartRegion(ctx, "validate temporary password")
 			valid, err = auth.Password(usr.TemporaryPassword).Validate(req.Old)
+			region.End()
 			switch {
 			case err != nil:
 				return err

--- a/pkg/messageprocessors/cayennelpp/cayennelpp.go
+++ b/pkg/messageprocessors/cayennelpp/cayennelpp.go
@@ -18,6 +18,7 @@ package cayennelpp
 import (
 	"bytes"
 	"context"
+	"runtime/trace"
 
 	lpp "github.com/TheThingsNetwork/go-cayenne-lib/cayennelpp"
 	"go.thethings.network/lorawan-stack/pkg/errors"
@@ -43,6 +44,8 @@ var (
 
 // Encode encodes the message's DecodedPayload to FRMPayload using CayenneLPP encoding.
 func (h *host) Encode(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, msg *ttnpb.ApplicationDownlink, script string) error {
+	defer trace.StartRegion(ctx, "encode message").End()
+
 	decoded := msg.DecodedPayload
 	if decoded == nil {
 		return nil
@@ -70,6 +73,8 @@ func (h *host) Encode(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, versi
 
 // Decode decodes the message's FRMPayload to DecodedPayload using CayenneLPP decoding.
 func (h *host) Decode(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, msg *ttnpb.ApplicationUplink, script string) error {
+	defer trace.StartRegion(ctx, "decode message").End()
+
 	decoder := lpp.NewDecoder(bytes.NewBuffer(msg.FRMPayload))
 	m := decodedMap(make(map[string]interface{}))
 	if err := decoder.DecodeUplink(m); err != nil {

--- a/pkg/messageprocessors/javascript/javascript.go
+++ b/pkg/messageprocessors/javascript/javascript.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"runtime/trace"
 
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/gogoproto"
@@ -62,6 +63,8 @@ var (
 
 // Encode encodes the message's DecodedPayload to FRMPayload using the given script.
 func (h *host) Encode(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, msg *ttnpb.ApplicationDownlink, script string) error {
+	defer trace.StartRegion(ctx, "encode message").End()
+
 	decoded := msg.DecodedPayload
 	if decoded == nil {
 		return nil
@@ -126,6 +129,8 @@ func (h *host) Encode(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, versi
 
 // Decode decodes the message's FRMPayload to DecodedPayload using the given script.
 func (h *host) Decode(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, msg *ttnpb.ApplicationUplink, script string) error {
+	defer trace.StartRegion(ctx, "decode message").End()
+
 	env := h.createEnvironment(ids, version)
 	env["payload"] = msg.FRMPayload
 	env["f_port"] = msg.FPort

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -98,7 +98,7 @@ func (ns *NetworkServer) matchDevice(ctx context.Context, up *ttnpb.UplinkMessag
 	}
 
 	var devs []device
-	if err := ns.devices.RangeByAddr(pld.DevAddr,
+	if err := ns.devices.RangeByAddr(ctx, pld.DevAddr,
 		[]string{
 			"frequency_plan_id",
 			"lorawan_phy_version",

--- a/pkg/networkserver/networkserver_util_test.go
+++ b/pkg/networkserver/networkserver_util_test.go
@@ -96,7 +96,7 @@ var _ DeviceRegistry = MockDeviceRegistry{}
 type MockDeviceRegistry struct {
 	GetByEUIFunc    func(ctx context.Context, joinEUI, devEUI types.EUI64, paths []string) (*ttnpb.EndDevice, error)
 	GetByIDFunc     func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, paths []string) (*ttnpb.EndDevice, error)
-	RangeByAddrFunc func(devAddr types.DevAddr, paths []string, f func(*ttnpb.EndDevice) bool) error
+	RangeByAddrFunc func(ctx context.Context, devAddr types.DevAddr, paths []string, f func(*ttnpb.EndDevice) bool) error
 	SetByIDFunc     func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, paths []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error)
 }
 
@@ -117,11 +117,11 @@ func (r MockDeviceRegistry) GetByID(ctx context.Context, appID ttnpb.Application
 }
 
 // RangeByAddr calls RangeByAddrFunc if set and returns error otherwise.
-func (r MockDeviceRegistry) RangeByAddr(devAddr types.DevAddr, paths []string, f func(*ttnpb.EndDevice) bool) error {
+func (r MockDeviceRegistry) RangeByAddr(ctx context.Context, devAddr types.DevAddr, paths []string, f func(*ttnpb.EndDevice) bool) error {
 	if r.RangeByAddrFunc == nil {
 		return errors.New("RangeByAddr not set")
 	}
-	return r.RangeByAddrFunc(devAddr, paths, f)
+	return r.RangeByAddrFunc(ctx, devAddr, paths, f)
 }
 
 // SetByID calls SetByIDFunc if set and returns nil, error otherwise.

--- a/pkg/networkserver/registry.go
+++ b/pkg/networkserver/registry.go
@@ -25,7 +25,7 @@ import (
 type DeviceRegistry interface {
 	GetByEUI(ctx context.Context, joinEUI, devEUI types.EUI64, paths []string) (*ttnpb.EndDevice, error)
 	GetByID(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, paths []string) (*ttnpb.EndDevice, error)
-	RangeByAddr(devAddr types.DevAddr, paths []string, f func(*ttnpb.EndDevice) bool) error
+	RangeByAddr(ctx context.Context, devAddr types.DevAddr, paths []string, f func(*ttnpb.EndDevice) bool) error
 	SetByID(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, paths []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error)
 }
 

--- a/pkg/networkserver/registry_test.go
+++ b/pkg/networkserver/registry_test.go
@@ -64,7 +64,7 @@ func handleRegistryTest(t *testing.T, reg DeviceRegistry) {
 
 	var rets []*ttnpb.EndDevice
 	rets = nil
-	err = reg.RangeByAddr(pb.Session.DevAddr, ttnpb.EndDeviceFieldPathsTopLevel, func(dev *ttnpb.EndDevice) bool {
+	err = reg.RangeByAddr(ctx, pb.Session.DevAddr, ttnpb.EndDeviceFieldPathsTopLevel, func(dev *ttnpb.EndDevice) bool {
 		rets = append(rets, dev)
 		return true
 	})
@@ -72,7 +72,7 @@ func handleRegistryTest(t *testing.T, reg DeviceRegistry) {
 	a.So(rets, should.BeNil)
 
 	rets = nil
-	err = reg.RangeByAddr(pb.PendingSession.DevAddr, ttnpb.EndDeviceFieldPathsTopLevel, func(dev *ttnpb.EndDevice) bool {
+	err = reg.RangeByAddr(ctx, pb.PendingSession.DevAddr, ttnpb.EndDeviceFieldPathsTopLevel, func(dev *ttnpb.EndDevice) bool {
 		rets = append(rets, dev)
 		return true
 	})
@@ -116,7 +116,7 @@ func handleRegistryTest(t *testing.T, reg DeviceRegistry) {
 	a.So(err, should.BeNil)
 	a.So(ret, should.HaveEmptyDiff, pb)
 
-	err = reg.RangeByAddr(pb.Session.DevAddr, ttnpb.EndDeviceFieldPathsTopLevel, func(dev *ttnpb.EndDevice) bool {
+	err = reg.RangeByAddr(ctx, pb.Session.DevAddr, ttnpb.EndDeviceFieldPathsTopLevel, func(dev *ttnpb.EndDevice) bool {
 		rets = append(rets, dev)
 		return true
 	})
@@ -124,7 +124,7 @@ func handleRegistryTest(t *testing.T, reg DeviceRegistry) {
 	a.So(rets, should.HaveSameElementsDiff, []*ttnpb.EndDevice{pb})
 
 	rets = nil
-	err = reg.RangeByAddr(pb.PendingSession.DevAddr, ttnpb.EndDeviceFieldPathsTopLevel, func(dev *ttnpb.EndDevice) bool {
+	err = reg.RangeByAddr(ctx, pb.PendingSession.DevAddr, ttnpb.EndDeviceFieldPathsTopLevel, func(dev *ttnpb.EndDevice) bool {
 		rets = append(rets, dev)
 		return true
 	})
@@ -183,7 +183,7 @@ func handleRegistryTest(t *testing.T, reg DeviceRegistry) {
 	a.So(ret, should.Resemble, pbOther)
 
 	rets = nil
-	err = reg.RangeByAddr(pbOther.Session.DevAddr, ttnpb.EndDeviceFieldPathsTopLevel, func(dev *ttnpb.EndDevice) bool {
+	err = reg.RangeByAddr(ctx, pbOther.Session.DevAddr, ttnpb.EndDeviceFieldPathsTopLevel, func(dev *ttnpb.EndDevice) bool {
 		rets = append(rets, dev)
 		return true
 	})
@@ -191,7 +191,7 @@ func handleRegistryTest(t *testing.T, reg DeviceRegistry) {
 	a.So(rets, should.HaveSameElementsDiff, []*ttnpb.EndDevice{pb, pbOther})
 
 	rets = nil
-	err = reg.RangeByAddr(pbOther.PendingSession.DevAddr, ttnpb.EndDeviceFieldPathsTopLevel, func(dev *ttnpb.EndDevice) bool {
+	err = reg.RangeByAddr(ctx, pbOther.PendingSession.DevAddr, ttnpb.EndDeviceFieldPathsTopLevel, func(dev *ttnpb.EndDevice) bool {
 		rets = append(rets, dev)
 		return true
 	})
@@ -216,7 +216,7 @@ func handleRegistryTest(t *testing.T, reg DeviceRegistry) {
 	a.So(ret, should.BeNil)
 
 	rets = nil
-	err = reg.RangeByAddr(pb.Session.DevAddr, ttnpb.EndDeviceFieldPathsTopLevel, func(dev *ttnpb.EndDevice) bool {
+	err = reg.RangeByAddr(ctx, pb.Session.DevAddr, ttnpb.EndDeviceFieldPathsTopLevel, func(dev *ttnpb.EndDevice) bool {
 		rets = append(rets, dev)
 		return true
 	})
@@ -224,7 +224,7 @@ func handleRegistryTest(t *testing.T, reg DeviceRegistry) {
 	a.So(rets, should.HaveSameElementsDiff, []*ttnpb.EndDevice{pbOther})
 
 	rets = nil
-	err = reg.RangeByAddr(pb.PendingSession.DevAddr, ttnpb.EndDeviceFieldPathsTopLevel, func(dev *ttnpb.EndDevice) bool {
+	err = reg.RangeByAddr(ctx, pb.PendingSession.DevAddr, ttnpb.EndDeviceFieldPathsTopLevel, func(dev *ttnpb.EndDevice) bool {
 		rets = append(rets, dev)
 		return true
 	})
@@ -249,7 +249,7 @@ func handleRegistryTest(t *testing.T, reg DeviceRegistry) {
 	a.So(ret, should.BeNil)
 
 	rets = nil
-	err = reg.RangeByAddr(pbOther.Session.DevAddr, ttnpb.EndDeviceFieldPathsTopLevel, func(dev *ttnpb.EndDevice) bool {
+	err = reg.RangeByAddr(ctx, pbOther.Session.DevAddr, ttnpb.EndDeviceFieldPathsTopLevel, func(dev *ttnpb.EndDevice) bool {
 		rets = append(rets, dev)
 		return true
 	})
@@ -257,7 +257,7 @@ func handleRegistryTest(t *testing.T, reg DeviceRegistry) {
 	a.So(rets, should.BeNil)
 
 	rets = nil
-	err = reg.RangeByAddr(pbOther.PendingSession.DevAddr, ttnpb.EndDeviceFieldPathsTopLevel, func(dev *ttnpb.EndDevice) bool {
+	err = reg.RangeByAddr(ctx, pbOther.PendingSession.DevAddr, ttnpb.EndDeviceFieldPathsTopLevel, func(dev *ttnpb.EndDevice) bool {
 		rets = append(rets, dev)
 		return true
 	})

--- a/pkg/oauth/user.go
+++ b/pkg/oauth/user.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"runtime/trace"
 	"time"
 
 	"github.com/gogo/protobuf/types"
@@ -165,7 +166,9 @@ func (s *server) doLogin(ctx context.Context, userID, password string) error {
 	if err != nil {
 		return err
 	}
+	region := trace.StartRegion(ctx, "validate password")
 	ok, err := auth.Password(user.Password).Validate(password)
+	region.End()
 	if err != nil || !ok {
 		events.Publish(evtUserLoginFailed(ctx, user.UserIdentifiers, nil))
 		return errIncorrectPassword

--- a/pkg/rpcclient/rpcclient.go
+++ b/pkg/rpcclient/rpcclient.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	grpc_opentracing "github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
 	"go.opencensus.io/plugin/ocgrpc"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/metrics"
@@ -39,6 +40,7 @@ func DefaultDialOptions(ctx context.Context) []grpc.DialOption {
 	streamInterceptors := []grpc.StreamClientInterceptor{
 		errors.StreamClientInterceptor(),
 		metrics.StreamClientInterceptor,
+		grpc_opentracing.StreamClientInterceptor(),
 		rpclog.StreamClientInterceptor(ctx), // Gets logger from global context
 		warning.StreamClientInterceptor,
 	}
@@ -46,6 +48,7 @@ func DefaultDialOptions(ctx context.Context) []grpc.DialOption {
 	unaryInterceptors := []grpc.UnaryClientInterceptor{
 		errors.UnaryClientInterceptor(),
 		metrics.UnaryClientInterceptor,
+		grpc_opentracing.UnaryClientInterceptor(),
 		rpclog.UnaryClientInterceptor(ctx), // Gets logger from global context
 		warning.UnaryClientInterceptor,
 	}

--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -27,9 +27,10 @@ import (
 
 	"github.com/getsentry/raven-go"
 	"github.com/golang/protobuf/proto"
-	"github.com/grpc-ecosystem/go-grpc-middleware"
-	"github.com/grpc-ecosystem/go-grpc-middleware/recovery"
-	"github.com/grpc-ecosystem/go-grpc-middleware/tags"
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
+	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
+	grpc_opentracing "github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"go.opencensus.io/plugin/ocgrpc"
 	"go.thethings.network/lorawan-stack/pkg/errors"
@@ -141,6 +142,7 @@ func New(ctx context.Context, opts ...Option) *Server {
 		rpcfillcontext.StreamServerInterceptor(options.contextFillers...),
 		grpc_ctxtags.StreamServerInterceptor(ctxtagsOpts...),
 		rpcmiddleware.RequestIDStreamServerInterceptor(),
+		grpc_opentracing.StreamServerInterceptor(),
 		events.StreamServerInterceptor,
 		rpclog.StreamServerInterceptor(ctx),
 		metrics.StreamServerInterceptor,
@@ -154,6 +156,7 @@ func New(ctx context.Context, opts ...Option) *Server {
 		rpcfillcontext.UnaryServerInterceptor(options.contextFillers...),
 		grpc_ctxtags.UnaryServerInterceptor(ctxtagsOpts...),
 		rpcmiddleware.RequestIDUnaryServerInterceptor(),
+		grpc_opentracing.UnaryServerInterceptor(),
 		events.UnaryServerInterceptor,
 		rpclog.UnaryServerInterceptor(ctx),
 		metrics.UnaryServerInterceptor,

--- a/pkg/scripting/javascript/javascript.go
+++ b/pkg/scripting/javascript/javascript.go
@@ -17,6 +17,7 @@ package javascript
 
 import (
 	"context"
+	"runtime/trace"
 	"time"
 
 	"github.com/robertkrimen/otto"
@@ -37,6 +38,8 @@ var errRuntime = errors.Define("runtime", "runtime error")
 
 // Run executes the Javascript script in the environment env and returns the output.
 func (j *js) Run(ctx context.Context, script string, env map[string]interface{}) (val interface{}, err error) {
+	defer trace.StartRegion(ctx, "run javascript").End()
+
 	start := time.Now()
 	defer func() {
 		runLatency.Observe(time.Since(start).Seconds())


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR is part one in the process of getting #29 resolved. It adds trace middleware to our gRPC server and clients, and adds trace regions to various parts of our codebase.

**Changes:**
<!-- What are the changes made in this pull request? -->

Exactly what's in the summary. Changes in different packages are made in separate commits for your convenience.

**Notes for Reviewers:**
<!--
Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- I had to change the interface of the NS registry, because `RangeByAddr` didn't take a `context.Context`. I'll probably also have to change other interfaces (fetcher, frequencyplans, devicerepository, ...) that don't take a `context.Context`.
- I plan to work with @johanstokking (and @rvolosatovs when he's back) to add more trace regions in the GS/NS/AS/JS where it makes sense.
