### PR TITLE
Use concurrency for upstream handling per connection

### DIFF
--- a/pkg/gatewayserver/gatewayserver_internal_test.go
+++ b/pkg/gatewayserver/gatewayserver_internal_test.go
@@ -17,3 +17,7 @@ package gatewayserver
 var (
 	ErrSchedule = errSchedule
 )
+
+func init() {
+	connConcurrentUplinks = 1
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #462 

**Changes:**
<!-- What are the changes made in this pull request? -->

- Use concurrency of 16 per gateway connection for upstream handling

This will not scale in the 1000s of gateways per GS instance, but we'll have (proprietary) solutions for that.