### PR TITLE
Quickfix for release build failing on snap login file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ key.pem
 # Javascript test coverage
 /coverage
 /sdk/js/coverage
+
+# Release files
+/snap.login


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quick fix for the failed rc3 release error:

```
   • GETTING AND VALIDATING GIT STATE
      • releasing v3.0.0-rc3, commit 54934b483423059e55ef7ef34918006585b09bd2
   ⨯ release failed after 106.98s error=git is currently in a dirty state:
?? snap.login
```

By ignoring `snap.login` in git this problem should be solved