### PR TITLE
Add radio buttons and corresponding Field/FieldGroup enhancements 

### DIFF
--- a/pkg/webui/components/checkbox/checkbox.styl
+++ b/pkg/webui/components/checkbox/checkbox.styl
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 .container
-  display: block
+  display: flex
   position: relative
   padding-left: 1rem + $cs.xs
   margin-bottom: 12px
@@ -49,7 +49,7 @@
   border-input()
   border-radius: $br.s
   position: absolute
-  top: 0
+  top: 4px
   left: 0
   width: 1.08rem
   height: 1.08rem

--- a/pkg/webui/components/field/field.styl
+++ b/pkg/webui/components/field/field.styl
@@ -15,7 +15,6 @@
 +media-query-min($bp.xxs)
   .horizontal.field
     flex-direction: row
-    width: 100%
 
     .title
       font-weight: normal

--- a/pkg/webui/components/field/field.styl
+++ b/pkg/webui/components/field/field.styl
@@ -26,10 +26,12 @@
     .label
       width: 30%
       line-height: 2.2
-      margin-bottom: 0
 
     .description, .err, .warn
       margin-left: 30%
+
+    &.radio, &.checkbox
+      margin-bottom: 0
 
 .field
   margin-bottom: $cs.l
@@ -37,7 +39,11 @@
   flex-wrap: wrap
   width: 100%
 
-  &.checkbox
+  &:not(.horizontal)
+    .label
+      font-weight: 600
+
+  &.checkbox, &.radio
     .component
       order: 1
       width: .8rem
@@ -46,6 +52,7 @@
     .label
       one-liner()
       nudge('down')
+      font-weight: normal
       order: 2
       padding-left: $cs.xxs
       width: auto
@@ -56,9 +63,6 @@
       order: 3
       display: block
       width: 100%
-
-.title
-  font-weight: 600
 
 .reqicon
   display: none
@@ -75,6 +79,7 @@
   width:  100%
   flex-shrink: 0
   line-height: 1
+  user-select: none
 
 .description
   font-weight: normal

--- a/pkg/webui/components/field/field.styl
+++ b/pkg/webui/components/field/field.styl
@@ -14,22 +14,22 @@
 
 +media-query-min($bp.xxs)
   .horizontal.field
-      flex-direction: row
-      width: 100%
+    flex-direction: row
+    width: 100%
 
-      .title
-        font-weight: normal
+    .title
+      font-weight: normal
 
-      .component
-        width: 70%
+    .component
+      width: 70%
 
-      .label
-        width: 30%
-        line-height: 2.2
-        margin-bottom: 0
+    .label
+      width: 30%
+      line-height: 2.2
+      margin-bottom: 0
 
-      .description, .err, .warn
-        margin-left: 30%
+    .description, .err, .warn
+      margin-left: 30%
 
 .field
   margin-bottom: $cs.l

--- a/pkg/webui/components/field/field.styl
+++ b/pkg/webui/components/field/field.styl
@@ -25,13 +25,9 @@
 
     .label
       width: 30%
-      line-height: 2.2
 
     .description, .err, .warn
       margin-left: 30%
-
-    &.radio, &.checkbox
-      margin-bottom: 0
 
 .field
   margin-bottom: $cs.l
@@ -50,8 +46,9 @@
       flex-grow: 0
 
     .label
-      one-liner()
       nudge('down')
+      flex: 1 1
+      display: flex
       font-weight: normal
       order: 2
       padding-left: $cs.xxs
@@ -75,10 +72,8 @@
 
 .label
   display: block
-  margin-bottom: $cs.xs
   width:  100%
   flex-shrink: 0
-  line-height: 1
   user-select: none
 
 .description

--- a/pkg/webui/components/field/group/group.styl
+++ b/pkg/webui/components/field/group/group.styl
@@ -12,12 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-.header
+.container
   display: flex
-  justify-content: flex-start
-  align-items: center
+  margin-bottom: $cs.l
+  flex-direction: column
+  &.horizontal
+    flex-direction: row
+    .header-title
+      width: 30%
+    .fields
+      width: 70%
+
+.container:not(.horizontal)
+  span.header-title
+    font-weight: 600
+
+.header-title
+  line-height: 2.2
+  margin-bottom: 0
+  flex-shrink: 0
+
+.fields
+  display: flex
   flex-wrap: wrap
+  margin-top: $cs.xs
+  margin-bottom: $cs.l * -1
 
-  &-title
-    margin-right: $ls.xxs
-
+  .field
+    margin-bottom: $cs.m

--- a/pkg/webui/components/field/group/group.styl
+++ b/pkg/webui/components/field/group/group.styl
@@ -22,6 +22,8 @@
       width: 30%
     .fields
       width: 70%
+      margin-top: $cs.xs
+      margin-bottom: $cs.l * -1
 
 .container:not(.horizontal)
   span.header-title
@@ -35,8 +37,6 @@
 .fields
   display: flex
   flex-wrap: wrap
-  margin-top: $cs.xs
-  margin-bottom: $cs.l * -1
 
   .field
     margin-bottom: $cs.m

--- a/pkg/webui/components/field/group/group.styl
+++ b/pkg/webui/components/field/group/group.styl
@@ -44,3 +44,6 @@
 .columns
   width: auto
   margin-right: $cs.l
+
+.error
+  margin-bottom: $cs.m

--- a/pkg/webui/components/field/group/group.styl
+++ b/pkg/webui/components/field/group/group.styl
@@ -40,3 +40,7 @@
 
   .field
     margin-bottom: $cs.m
+
+.columns
+  width: auto
+  margin-right: $cs.l

--- a/pkg/webui/components/field/group/index.js
+++ b/pkg/webui/components/field/group/index.js
@@ -89,11 +89,12 @@ class FieldGroup extends React.Component {
           component={titleComponent}
           content={title}
         />
-        {error && touched && <FieldError name={name} error={error} />}
         <div
           className={style.fields}
-          children={fields}
-        />
+        >
+          {fields}
+          {error && touched && <FieldError className={style.error} name={name} error={error} />}
+        </div>
       </div>
     )
   }

--- a/pkg/webui/components/field/group/index.js
+++ b/pkg/webui/components/field/group/index.js
@@ -25,7 +25,7 @@ import style from './group.styl'
 class FieldGroup extends React.Component {
   render () {
     const {
-      className,
+      className: groupClassName,
       children,
       name: groupName,
       title,
@@ -42,7 +42,7 @@ class FieldGroup extends React.Component {
     } = this.props
     const fields = React.Children.map(children, function (Child) {
       if (React.isValidElement(Child) && Child.type === Field || Child.type === PureField) {
-        const { type, value: fieldValue, name: fieldName } = Child.props
+        const { type, value: fieldValue, name: fieldName, className: fieldClassName } = Child.props
         const appliedProps = {}
         if (type === 'checkbox') {
           appliedProps.id = `${groupName}.${fieldName}`
@@ -57,7 +57,7 @@ class FieldGroup extends React.Component {
             appliedProps.checked = value === fieldValue
           }
         }
-        const classNames = classnames(style.field, className, {
+        const classNames = classnames(style.field, fieldClassName, {
           [style.columns]: columns,
         })
 
@@ -77,7 +77,7 @@ class FieldGroup extends React.Component {
       return Child
     })
 
-    const classNames = classnames(style.container, className, {
+    const classNames = classnames(style.container, groupClassName, {
       [style.horizontal]: horizontal,
     })
 

--- a/pkg/webui/components/field/group/index.js
+++ b/pkg/webui/components/field/group/index.js
@@ -37,6 +37,7 @@ class FieldGroup extends React.Component {
       setFieldTouched,
       horizontal,
       touched,
+      columns,
     } = this.props
 
     const fields = React.Children.map(children, function (Child) {
@@ -54,7 +55,10 @@ class FieldGroup extends React.Component {
           id = `${name}.${fieldValue}`
           mapValues.checked = value === fieldValue
         }
-        const classNames = classnames(style.field, className)
+        const classNames = classnames(style.field, className, {
+          [style.columns]: columns,
+        })
+
         return React.cloneElement(Child, {
           ...Child.props,
           ...mapValues,
@@ -99,6 +103,8 @@ FieldGroup.propTypes = {
   name: PropTypes.string.isRequired,
   title: PropTypes.message,
   errors: PropTypes.object,
+  horizontal: PropTypes.bool,
+  columns: PropTypes.bool,
 }
 
 export default FieldGroup

--- a/pkg/webui/components/field/group/index.js
+++ b/pkg/webui/components/field/group/index.js
@@ -102,7 +102,7 @@ class FieldGroup extends React.Component {
 FieldGroup.propTypes = {
   name: PropTypes.string.isRequired,
   title: PropTypes.message,
-  errors: PropTypes.object,
+  error: PropTypes.error,
   horizontal: PropTypes.bool,
   columns: PropTypes.bool,
 }

--- a/pkg/webui/components/field/index.js
+++ b/pkg/webui/components/field/index.js
@@ -174,10 +174,11 @@ const Field = function (props) {
     rest.onBlur = handleBlur
     _error = touched && rest.error
 
-    // Dismiss non boolean values for checkboxes
-    if (type === 'checkbox' || type === 'radio') {
-      rest.value = typeof rest.value === 'boolean' ? rest.value : false
-    }
+  }
+
+  // Dismiss non boolean values for checkboxes
+  if (type === 'checkbox') {
+    rest.value = typeof rest.value === 'boolean' ? rest.value : false
   }
 
   // restore the rest object for future per component filtering

--- a/pkg/webui/components/field/index.js
+++ b/pkg/webui/components/field/index.js
@@ -288,6 +288,7 @@ const Err = function (props) {
     error,
     warning,
     name,
+    className,
   } = props
 
   const content = error || warning || ''
@@ -295,7 +296,7 @@ const Err = function (props) {
 
   const icon = error ? 'error' : 'warning'
 
-  const classname = classnames(style.message, {
+  const classname = classnames(style.message, className, {
     [style.show]: content && content !== '',
     [style.hide]: !content || content === '',
     [style.err]: error,

--- a/pkg/webui/components/field/index.js
+++ b/pkg/webui/components/field/index.js
@@ -24,6 +24,7 @@ import Icon from '../icon'
 import Input from '../input'
 import Checkbox from '../checkbox'
 import Select from '../select'
+import RadioButton from '../radio-button'
 import Message from '../../lib/components/message'
 
 import style from './field.styl'
@@ -58,6 +59,8 @@ const checkboxAllowedProps = [
   'onBlur',
   'onChange',
   'disabled',
+  'name',
+  'checked',
 ]
 
 const selectAllowedProps = [
@@ -82,6 +85,7 @@ const selectAllowedProps = [
 const getAllowedPropsByType = function (type) {
   switch (type) {
   case 'checkbox':
+  case 'radio':
     return checkboxAllowedProps
   case 'select':
     return selectAllowedProps
@@ -107,7 +111,8 @@ const component = function (type) {
   switch (type) {
   case 'checkbox':
     return Checkbox
-
+  case 'radio':
+    return RadioButton
   case 'text':
   case 'number':
   case 'password':
@@ -162,17 +167,15 @@ const Field = function (props) {
 
   // Underscored assignment due to naming conflict
   let _error = rest.error
+  const id = props.id || name
   const formatMessage = content => typeof content === 'object' ? props.intl.formatMessage(content) : content
-
   if (form) {
-    // preserve default values for different inputs
-    rest.value = rest.value || ''
-    rest.onChange = rest.onChange || handleChange
+    rest.onChange = handleChange
     rest.onBlur = handleBlur
     _error = touched && rest.error
 
     // Dismiss non boolean values for checkboxes
-    if (type === 'checkbox') {
+    if (type === 'checkbox' || type === 'radio') {
       rest.value = typeof rest.value === 'boolean' ? rest.value : false
     }
   }
@@ -201,13 +204,13 @@ const Field = function (props) {
 
   return (
     <div className={classname}>
-      <label className={style.label} htmlFor={name}>
+      <label className={style.label} htmlFor={id}>
         <Message content={title} className={style.title} />
         <span className={style.reqicon}>&middot;</span>
       </label>
       <Component
         className={style.component}
-        id={name}
+        id={id}
         {...filterPropsByType(type, rest)}
       />
       {hasMessages
@@ -273,6 +276,10 @@ Field.propTypes = {
   setFieldValue: PropTypes.func,
   /** The passed (formik) function to set the touch value of a form data property */
   setFieldTouched: PropTypes.func,
+  /** Optional hook for change events of the field, handy for arbitrary actions
+   * connected to field changes.
+   */
+  onChange: PropTypes.func,
 }
 
 const Err = function (props) {

--- a/pkg/webui/components/field/index.js
+++ b/pkg/webui/components/field/index.js
@@ -156,6 +156,9 @@ const Field = function (props) {
     if (validateOnChange) {
       setFieldTouched(touches, true)
     }
+    if (props.onChange) {
+      props.onChange(value)
+    }
   }
 
   const handleBlur = function (e) {

--- a/pkg/webui/components/field/story.js
+++ b/pkg/webui/components/field/story.js
@@ -16,15 +16,37 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { withInfo } from '@storybook/addon-info'
 
+import FieldGroup from './group'
 import { Field } from '.'
 
-storiesOf('Field', module)
-  .addDecorator((story, context) => withInfo({
-    inline: true,
-    header: false,
-    source: false,
-    propTables: [ Field ],
-  })(story)(context))
+const info = {
+  inline: true,
+  header: false,
+  source: false,
+  propTables: [ Field ],
+}
+
+const checkboxFields = [
+  <Field
+    type="radio"
+    value="foo"
+    title="Foo"
+    name="radio-story"
+    form={false}
+    key="one"
+  />,
+  <Field
+    type="radio"
+    value="bar"
+    title="Bar"
+    name="radio-story"
+    form={false}
+    key="two"
+  />,
+]
+
+storiesOf('Fields', module)
+  .addDecorator((story, context) => withInfo(info)(story)(context))
   .add('Default', () => (
     <Field
       title="Foo"
@@ -118,5 +140,49 @@ storiesOf('Field', module)
       warning="Insecure password"
       touched
       form={false}
+    />
+  ))
+
+storiesOf('Fields/Radio Buttons', module)
+  .addDecorator((story, context) => withInfo(info)(story)(context))
+  .add('Default', () => (
+    <FieldGroup
+      name="radio-story"
+      title="Radio Buttons"
+      children={checkboxFields}
+    />
+  ))
+  .add('Horizontal', () => (
+    <FieldGroup
+      name="radio-story"
+      title="Radio Buttons"
+      horizontal
+      children={checkboxFields}
+    />
+  ))
+  .add('Columns', () => (
+    <FieldGroup
+      name="radio-story"
+      title="Radio Buttons"
+      columns
+      children={checkboxFields}
+    />
+  ))
+  .add('Horizontal & Columns', () => (
+    <FieldGroup
+      name="radio-story"
+      title="Radio Buttons"
+      horizontal
+      columns
+      children={checkboxFields}
+    />
+  ))
+  .add('Horizontal & Error', () => (
+    <FieldGroup
+      name="radio-story"
+      title="Radio Buttons"
+      errors={{ 'radio-story': 'Test Error' }}
+      horizontal
+      children={checkboxFields}
     />
   ))

--- a/pkg/webui/components/field/story.js
+++ b/pkg/webui/components/field/story.js
@@ -181,7 +181,8 @@ storiesOf('Fields/Radio Buttons', module)
     <FieldGroup
       name="radio-story"
       title="Radio Buttons"
-      errors={{ 'radio-story': 'Test Error' }}
+      error="Test Error!"
+      touched
       horizontal
       children={checkboxFields}
     />

--- a/pkg/webui/components/form/index.js
+++ b/pkg/webui/components/form/index.js
@@ -123,6 +123,7 @@ class InnerForm extends React.Component {
             submitEnabledWhenInvalid,
             validateOnBlur,
             validateOnChange,
+            form: true,
             ...Child.props,
           })
         } else if (Child.type === Button) {

--- a/pkg/webui/components/form/story.js
+++ b/pkg/webui/components/form/story.js
@@ -18,6 +18,7 @@ import { action } from '@storybook/addon-actions'
 import { withInfo } from '@storybook/addon-info'
 
 import Field from '../field'
+import FieldGroup from '../field/group'
 import Button from '../button'
 import Form from '.'
 
@@ -29,6 +30,11 @@ const handleSubmit = function (data, { setSubmitting }) {
 const containerStyles = {
   maxWidth: '300px',
 }
+
+const containerHorizontalStyles = {
+  maxWidth: '600px',
+}
+
 
 storiesOf('Form', module)
   .addDecorator((story, context) => withInfo({
@@ -51,48 +57,76 @@ storiesOf('Form', module)
           title="Username or Email"
           name="user_id"
           type="text"
-          form
         />
         <Field
           title="Password"
           name="password"
           type="password"
-          form
         />
         <Button type="submit" message="Login" />
         <Button naked message="Create an account" />
       </Form>
     </div>
   ))
-  .add('Rights selection', () => (
-    <div style={containerStyles}>
+  .add('Field Groups', () => (
+    <div style={containerHorizontalStyles}>
       <Form
         onSubmit={handleSubmit}
         initialValues={{
-          APPLICATION_RIGHT_READ: true,
-          APPLICATION_RIGHT_WRITE: false,
-          APPLICATION_RIGHT_DEVICE_READ: false,
+          'radio-story': 'foo',
+          'checkbox-story': { foo: true },
         }}
         submitEnabledWhenInvalid
+        horizontal
       >
-        <Field
-          type="checkbox"
-          title="Application Read"
-          name="APPLICATION_RIGHT_READ"
-          form
-        />
-        <Field
-          type="checkbox"
-          title="Application Write"
-          name="APPLICATION_RIGHT_WRITE"
-          form
-        />
-        <Field
-          type="checkbox"
-          title="Application Device Read"
-          name="APPLICATION_RIGHT_DEVICE_READ"
-          form
-        />
+        <FieldGroup
+          name="radio-story"
+          title="Radio Buttons"
+          columns
+        >
+          <Field
+            type="radio"
+            title="Foo"
+            value="foo"
+            name="foo"
+          />
+          <Field
+            type="radio"
+            title="Bar"
+            value="bar"
+            name="foo"
+          />
+          <Field
+            type="radio"
+            title="Baz"
+            value="baz"
+            name="foo"
+          />
+        </FieldGroup>
+        <FieldGroup
+          name="checkbox-story"
+          title="Checkboxes"
+          columns
+        >
+          <Field
+            type="checkbox"
+            title="Foo"
+            name="foo"
+            form
+          />
+          <Field
+            type="checkbox"
+            title="Bar"
+            name="bar"
+            form
+          />
+          <Field
+            type="checkbox"
+            title="Baz"
+            name="baz"
+            form
+          />
+        </FieldGroup>
         <Button type="submit" message="Save" />
       </Form>
     </div>

--- a/pkg/webui/components/radio-button/index.js
+++ b/pkg/webui/components/radio-button/index.js
@@ -1,0 +1,58 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import PropTypes from 'prop-types'
+import bind from 'autobind-decorator'
+
+import style from './radio-button.styl'
+
+@bind
+class RadioButton extends React.PureComponent {
+
+  onChange (evt) {
+    this.props.onChange(evt.target.value)
+  }
+
+  render () {
+    const { onChange, ...rest } = this.props
+
+    return (
+      <label className={style.container}>
+        <input
+          className={style.input}
+          type="radio"
+          onChange={this.onChange}
+          {...rest}
+        />
+        <span className={style.dot} />
+      </label>
+    )
+  }
+}
+
+RadioButton.propTypes = {
+  value: PropTypes.string,
+  name: PropTypes.string,
+  onFocus: PropTypes.func,
+  onBlur: PropTypes.func,
+  onChange: PropTypes.func,
+  disabled: PropTypes.bool,
+}
+
+RadioButton.defaultProps = {
+  onChange: () => null,
+}
+
+export default RadioButton

--- a/pkg/webui/components/radio-button/radio-button.styl
+++ b/pkg/webui/components/radio-button/radio-button.styl
@@ -1,0 +1,68 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.container
+  display: flex
+  position: relative
+  padding-left: 1rem + $cs.xs
+  margin-bottom: 12px
+  cursor: pointer
+  user-select: none
+
+  // Hide default radio button
+  input
+    position: absolute
+    opacity: 0
+    cursor: pointer
+
+  &:hover input ~ span
+    background-color: $c-backdrop
+
+  & input:checked ~ span
+    border-color: $c-input-border
+
+  &:hover input:checked ~ span, input:checked:focus ~ span
+      border-color: lighter($c-active-blue)
+
+  // Show the dot when checked
+  input:checked ~ span:after
+    display: block
+
+  input:focus ~ span
+    border-color: $c-active-blue
+
+// Custom radio button
+.dot
+  border-input()
+  border-radius: 1.08rem
+  position: absolute
+  top: 4px
+  left: 0
+  width: 1.08rem
+  height: 1.08rem
+
+  // Style the select-dot
+  &:after
+    content: ''
+    box-sizing: content-box
+    position: absolute
+    background-color: lighter($c-active-blue)
+    border-radius: 100%
+    display: none
+    left: 4px
+    top: 4px
+    width: 7px
+    height: 7px
+
+

--- a/pkg/webui/console/views/application-api-key-add/application-api-key-add.styl
+++ b/pkg/webui/console/views/application-api-key-add/application-api-key-add.styl
@@ -20,6 +20,6 @@
   padding: $cs.m
 
 .right-label
-  label::first-letter
+  span::first-letter
     text-transform: uppercase
 

--- a/pkg/webui/console/views/application-api-key-edit/application-api-key-edit.styl
+++ b/pkg/webui/console/views/application-api-key-edit/application-api-key-edit.styl
@@ -16,5 +16,5 @@
   h2()
 
 .right-label
-  label::first-letter
+  span::first-letter
     text-transform: uppercase


### PR DESCRIPTION
**Summary:**
Closes #353, as well as some additional changes necessary for #332 (see below).

**Changes:**
- Add `RadioButton` component
- Setup `Field` component to support radio buttons
- Setup `FieldGroup` component to support radio buttons
- Fixes for proper `horizontal` display of `FieldGroup`
- `column` option for `FieldGroup`
- Styling fixes
- Add a change handler prop to `Field` to hook into field changes (we'll need that for #332)
- Add corresponding stories to `Field` and `Form`

**Notes for Reviewers:**
The `FieldGroup` will handle the radio-buttons values and map it's `name` prop