### PR TITLE
Make frequency multiplier band-configurable

### DIFF
--- a/pkg/band/as_923.go
+++ b/pkg/band/as_923.go
@@ -105,6 +105,7 @@ func init() {
 		},
 		MaxTxPowerIndex: 7,
 
+		FreqMultiplier:   100,
 		ImplementsCFList: true,
 		CFListType:       ttnpb.CFListType_FREQUENCIES,
 

--- a/pkg/band/au_915_928.go
+++ b/pkg/band/au_915_928.go
@@ -150,6 +150,7 @@ func init() {
 		}(),
 		MaxTxPowerIndex: 14,
 
+		FreqMultiplier:   100,
 		ImplementsCFList: true,
 		CFListType:       ttnpb.CFListType_CHANNEL_MASKS,
 

--- a/pkg/band/band.go
+++ b/pkg/band/band.go
@@ -139,6 +139,7 @@ type Band struct {
 
 	DataRates [16]DataRate
 
+	FreqMultiplier   uint64
 	ImplementsCFList bool
 	CFListType       ttnpb.CFListType
 

--- a/pkg/band/cn_470_510.go
+++ b/pkg/band/cn_470_510.go
@@ -143,6 +143,7 @@ func init() {
 			PingSlotChannels: cn470BeaconFrequencies[:],
 		},
 
+		FreqMultiplier:   100,
 		ImplementsCFList: true,
 		CFListType:       ttnpb.CFListType_CHANNEL_MASKS,
 

--- a/pkg/band/cn_779_787.go
+++ b/pkg/band/cn_779_787.go
@@ -132,6 +132,7 @@ func init() {
 		GenerateChMasks: generateChMask16,
 		ParseChMask:     parseChMask16,
 
+		FreqMultiplier:   100,
 		ImplementsCFList: true,
 		CFListType:       ttnpb.CFListType_FREQUENCIES,
 

--- a/pkg/band/eu_433.go
+++ b/pkg/band/eu_433.go
@@ -129,6 +129,7 @@ func init() {
 		GenerateChMasks: generateChMask16,
 		ParseChMask:     parseChMask16,
 
+		FreqMultiplier:   100,
 		ImplementsCFList: true,
 		CFListType:       ttnpb.CFListType_FREQUENCIES,
 

--- a/pkg/band/eu_863_870.go
+++ b/pkg/band/eu_863_870.go
@@ -166,6 +166,7 @@ func init() {
 		GenerateChMasks: generateChMask16,
 		ParseChMask:     parseChMask16,
 
+		FreqMultiplier:   100,
 		ImplementsCFList: true,
 		CFListType:       ttnpb.CFListType_FREQUENCIES,
 

--- a/pkg/band/in_865_867.go
+++ b/pkg/band/in_865_867.go
@@ -130,6 +130,7 @@ func init() {
 		GenerateChMasks: generateChMask16,
 		ParseChMask:     parseChMask16,
 
+		FreqMultiplier:   100,
 		ImplementsCFList: true,
 		CFListType:       ttnpb.CFListType_FREQUENCIES,
 

--- a/pkg/band/kr_920_923.go
+++ b/pkg/band/kr_920_923.go
@@ -118,6 +118,7 @@ func init() {
 		GenerateChMasks: generateChMask16,
 		ParseChMask:     parseChMask16,
 
+		FreqMultiplier:   100,
 		ImplementsCFList: true,
 		CFListType:       ttnpb.CFListType_FREQUENCIES,
 

--- a/pkg/band/ru_864_870.go
+++ b/pkg/band/ru_864_870.go
@@ -124,6 +124,7 @@ func init() {
 		GenerateChMasks: generateChMask16,
 		ParseChMask:     parseChMask16,
 
+		FreqMultiplier:   100,
 		ImplementsCFList: true,
 		CFListType:       ttnpb.CFListType_FREQUENCIES,
 

--- a/pkg/band/us_902_928.go
+++ b/pkg/band/us_902_928.go
@@ -164,6 +164,7 @@ func init() {
 		GenerateChMasks: makeGenerateChMask72(true),
 		ParseChMask:     parseChMask72,
 
+		FreqMultiplier:   100,
 		ImplementsCFList: true,
 		CFListType:       ttnpb.CFListType_CHANNEL_MASKS,
 

--- a/pkg/encoding/lorawan/mac.go
+++ b/pkg/encoding/lorawan/mac.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"time"
 
+	"go.thethings.network/lorawan-stack/pkg/band"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/gpstime"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
@@ -38,17 +39,17 @@ type MACCommandDescriptor struct {
 	ExpectAnswer      bool
 	UplinkLength      uint16
 	DownlinkLength    uint16
-	AppendUplink      func(b []byte, cmd ttnpb.MACCommand) ([]byte, error)
-	UnmarshalUplink   func(b []byte, cmd *ttnpb.MACCommand) error
-	AppendDownlink    func(b []byte, cmd ttnpb.MACCommand) ([]byte, error)
-	UnmarshalDownlink func(b []byte, cmd *ttnpb.MACCommand) error
+	AppendUplink      func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error)
+	UnmarshalUplink   func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error
+	AppendDownlink    func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error)
+	UnmarshalDownlink func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error
 }
 
 // MACCommandSpec maps the ttnpb.CID of MACCommand to a *MACCommandDescriptor.
 type MACCommandSpec map[ttnpb.MACCommandIdentifier]*MACCommandDescriptor
 
-func newMACUnmarshaler(cid ttnpb.MACCommandIdentifier, name string, n uint8, f func([]byte, *ttnpb.MACCommand) error) func(b []byte, cmd *ttnpb.MACCommand) error {
-	return func(b []byte, cmd *ttnpb.MACCommand) error {
+func newMACUnmarshaler(cid ttnpb.MACCommandIdentifier, name string, n uint8, f func(band.Band, []byte, *ttnpb.MACCommand) error) func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
+	return func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 		if len(b) != int(n) {
 			return errExpectedLengthEqual(name, int(n))(len(b))
 		}
@@ -56,7 +57,7 @@ func newMACUnmarshaler(cid ttnpb.MACCommandIdentifier, name string, n uint8, f f
 		if f == nil {
 			return nil
 		}
-		return f(b, cmd)
+		return f(phy, b, cmd)
 	}
 }
 
@@ -67,7 +68,7 @@ var DefaultMACCommands = MACCommandSpec{
 		ExpectAnswer:      true,
 
 		UplinkLength: 1,
-		AppendUplink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendUplink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetResetInd()
 			if pld.MinorVersion > 15 {
 				return nil, errExpectedLowerOrEqual("MinorVersion", 15)(pld.MinorVersion)
@@ -75,7 +76,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = append(b, byte(pld.MinorVersion))
 			return b, nil
 		},
-		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_RESET, "ResetInd", 1, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_RESET, "ResetInd", 1, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_ResetInd_{
 				ResetInd: &ttnpb.MACCommand_ResetInd{
 					MinorVersion: ttnpb.Minor(b[0] & 0xf),
@@ -85,7 +86,7 @@ var DefaultMACCommands = MACCommandSpec{
 		}),
 
 		DownlinkLength: 1,
-		AppendDownlink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendDownlink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetResetConf()
 			if pld.MinorVersion > 15 {
 				return nil, errExpectedLowerOrEqual("MinorVersion", 15)(pld.MinorVersion)
@@ -93,7 +94,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = append(b, byte(pld.MinorVersion))
 			return b, nil
 		},
-		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_RESET, "ResetConf", 1, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_RESET, "ResetConf", 1, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_ResetConf_{
 				ResetConf: &ttnpb.MACCommand_ResetConf{
 					MinorVersion: ttnpb.Minor(b[0] & 0xf),
@@ -108,13 +109,13 @@ var DefaultMACCommands = MACCommandSpec{
 		ExpectAnswer:      true,
 
 		UplinkLength: 0,
-		AppendUplink: func(b []byte, _ ttnpb.MACCommand) ([]byte, error) {
+		AppendUplink: func(phy band.Band, b []byte, _ ttnpb.MACCommand) ([]byte, error) {
 			return b, nil
 		},
 		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_LINK_CHECK, "LinkCheckReq", 0, nil),
 
 		DownlinkLength: 2,
-		AppendDownlink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendDownlink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetLinkCheckAns()
 			if pld.Margin > 254 {
 				return nil, errExpectedLowerOrEqual("Margin", 254)(pld.Margin)
@@ -125,7 +126,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = append(b, byte(pld.Margin), byte(pld.GatewayCount))
 			return b, nil
 		},
-		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_LINK_CHECK, "LinkCheckAns", 2, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_LINK_CHECK, "LinkCheckAns", 2, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_LinkCheckAns_{
 				LinkCheckAns: &ttnpb.MACCommand_LinkCheckAns{
 					Margin:       uint32(b[0]),
@@ -141,7 +142,7 @@ var DefaultMACCommands = MACCommandSpec{
 		ExpectAnswer:      true,
 
 		UplinkLength: 1,
-		AppendUplink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendUplink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetLinkADRAns()
 			var status byte
 			if pld.ChannelMaskAck {
@@ -156,7 +157,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = append(b, status)
 			return b, nil
 		},
-		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_LINK_ADR, "LinkADRAns", 1, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_LINK_ADR, "LinkADRAns", 1, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_LinkADRAns_{
 				LinkADRAns: &ttnpb.MACCommand_LinkADRAns{
 					ChannelMaskAck:   b[0]&1 == 1,
@@ -168,7 +169,7 @@ var DefaultMACCommands = MACCommandSpec{
 		}),
 
 		DownlinkLength: 4,
-		AppendDownlink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendDownlink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetLinkADRReq()
 			if pld.DataRateIndex > 15 {
 				return nil, errExpectedLowerOrEqual("DataRateIndex", 15)(pld.DataRateIndex)
@@ -194,7 +195,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = append(b, byte((pld.ChannelMaskControl&0x7)<<4)^byte(pld.NbTrans&0xf))
 			return b, nil
 		},
-		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_LINK_ADR, "LinkADRReq", 4, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_LINK_ADR, "LinkADRReq", 4, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			var chMask [16]bool
 			for i := uint8(0); i < 16; i++ {
 				if (b[1+i/8]>>(i%8))&1 == 1 {
@@ -219,13 +220,13 @@ var DefaultMACCommands = MACCommandSpec{
 		ExpectAnswer:      true,
 
 		UplinkLength: 0,
-		AppendUplink: func(b []byte, _ ttnpb.MACCommand) ([]byte, error) {
+		AppendUplink: func(phy band.Band, b []byte, _ ttnpb.MACCommand) ([]byte, error) {
 			return b, nil
 		},
 		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_DUTY_CYCLE, "DutyCycleAns", 0, nil),
 
 		DownlinkLength: 1,
-		AppendDownlink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendDownlink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetDutyCycleReq()
 			if pld.MaxDutyCycle > 15 {
 				return nil, errExpectedLowerOrEqual("MaxDutyCycle", 15)(pld.MaxDutyCycle)
@@ -233,7 +234,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = append(b, byte(pld.MaxDutyCycle))
 			return b, nil
 		},
-		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_DUTY_CYCLE, "DutyCycleReq", 1, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_DUTY_CYCLE, "DutyCycleReq", 1, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_DutyCycleReq_{
 				DutyCycleReq: &ttnpb.MACCommand_DutyCycleReq{
 					MaxDutyCycle: ttnpb.AggregatedDutyCycle(b[0] & 0xf),
@@ -248,7 +249,7 @@ var DefaultMACCommands = MACCommandSpec{
 		ExpectAnswer:      true,
 
 		UplinkLength: 1,
-		AppendUplink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendUplink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetRxParamSetupAns()
 			var v byte
 			if pld.Rx2FrequencyAck {
@@ -263,7 +264,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = append(b, v)
 			return b, nil
 		},
-		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_RX_PARAM_SETUP, "RxParamSetupAns", 1, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_RX_PARAM_SETUP, "RxParamSetupAns", 1, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_RxParamSetupAns_{
 				RxParamSetupAns: &ttnpb.MACCommand_RxParamSetupAns{
 					Rx2FrequencyAck:      b[0]&1 == 1,
@@ -275,7 +276,7 @@ var DefaultMACCommands = MACCommandSpec{
 		}),
 
 		DownlinkLength: 4,
-		AppendDownlink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendDownlink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetRxParamSetupReq()
 			if pld.Rx1DataRateOffset > 7 {
 				return nil, errExpectedLowerOrEqual("Rx1DROffset", 7)(pld.Rx1DataRateOffset)
@@ -290,7 +291,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = appendUint64(b, pld.Rx2Frequency/100, 3)
 			return b, nil
 		},
-		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_RX_PARAM_SETUP, "RxParamSetupReq", 4, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_RX_PARAM_SETUP, "RxParamSetupReq", 4, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_RxParamSetupReq_{
 				RxParamSetupReq: &ttnpb.MACCommand_RxParamSetupReq{
 					Rx1DataRateOffset: uint32((b[0] >> 4) & 0x7),
@@ -307,7 +308,7 @@ var DefaultMACCommands = MACCommandSpec{
 		ExpectAnswer:      true,
 
 		UplinkLength: 2,
-		AppendUplink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendUplink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetDevStatusAns()
 			if pld.Battery > math.MaxUint8 {
 				return nil, errExpectedLowerOrEqual("Battery", math.MaxUint8)(math.MaxUint8)
@@ -323,7 +324,7 @@ var DefaultMACCommands = MACCommandSpec{
 			}
 			return b, nil
 		},
-		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_DEV_STATUS, "DevStatusAns", 2, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_DEV_STATUS, "DevStatusAns", 2, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			margin := int32(b[1] & 0x1f)
 			if (b[1]>>5)&1 == 1 {
 				margin = -margin - 1
@@ -338,7 +339,7 @@ var DefaultMACCommands = MACCommandSpec{
 		}),
 
 		DownlinkLength: 0,
-		AppendDownlink: func(b []byte, _ ttnpb.MACCommand) ([]byte, error) {
+		AppendDownlink: func(phy band.Band, b []byte, _ ttnpb.MACCommand) ([]byte, error) {
 			return b, nil
 		},
 		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_DEV_STATUS, "DevStatusReq", 0, nil),
@@ -349,7 +350,7 @@ var DefaultMACCommands = MACCommandSpec{
 		ExpectAnswer:      true,
 
 		UplinkLength: 1,
-		AppendUplink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendUplink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetNewChannelAns()
 			var v byte
 			if pld.FrequencyAck {
@@ -361,7 +362,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = append(b, v)
 			return b, nil
 		},
-		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_NEW_CHANNEL, "NewChannelAns", 1, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_NEW_CHANNEL, "NewChannelAns", 1, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_NewChannelAns_{
 				NewChannelAns: &ttnpb.MACCommand_NewChannelAns{
 					FrequencyAck: b[0]&1 == 1,
@@ -372,7 +373,7 @@ var DefaultMACCommands = MACCommandSpec{
 		}),
 
 		DownlinkLength: 5,
-		AppendDownlink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendDownlink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetNewChannelReq()
 			if pld.ChannelIndex > math.MaxUint8 {
 				return nil, errExpectedLowerOrEqual("ChannelIndex", math.MaxUint8)(pld.ChannelIndex)
@@ -396,7 +397,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = append(b, v)
 			return b, nil
 		},
-		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_NEW_CHANNEL, "NewChannelReq", 5, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_NEW_CHANNEL, "NewChannelReq", 5, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_NewChannelReq_{
 				NewChannelReq: &ttnpb.MACCommand_NewChannelReq{
 					ChannelIndex:     uint32(b[0]),
@@ -414,13 +415,13 @@ var DefaultMACCommands = MACCommandSpec{
 		ExpectAnswer:      true,
 
 		UplinkLength: 0,
-		AppendUplink: func(b []byte, _ ttnpb.MACCommand) ([]byte, error) {
+		AppendUplink: func(phy band.Band, b []byte, _ ttnpb.MACCommand) ([]byte, error) {
 			return b, nil
 		},
 		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_RX_TIMING_SETUP, "RxTimingSetupAns", 0, nil),
 
 		DownlinkLength: 1,
-		AppendDownlink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendDownlink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetRxTimingSetupReq()
 			if pld.Delay > 15 {
 				return nil, errExpectedLowerOrEqual("Delay", 15)(pld.Delay)
@@ -428,7 +429,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = append(b, byte(pld.Delay))
 			return b, nil
 		},
-		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_RX_TIMING_SETUP, "RxTimingSetupReq", 1, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_RX_TIMING_SETUP, "RxTimingSetupReq", 1, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_RxTimingSetupReq_{
 				RxTimingSetupReq: &ttnpb.MACCommand_RxTimingSetupReq{
 					Delay: ttnpb.RxDelay(b[0] & 0xf),
@@ -443,13 +444,13 @@ var DefaultMACCommands = MACCommandSpec{
 		ExpectAnswer:      true,
 
 		UplinkLength: 0,
-		AppendUplink: func(b []byte, _ ttnpb.MACCommand) ([]byte, error) {
+		AppendUplink: func(phy band.Band, b []byte, _ ttnpb.MACCommand) ([]byte, error) {
 			return b, nil
 		},
 		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_TX_PARAM_SETUP, "TxParamSetupAns", 0, nil),
 
 		DownlinkLength: 1,
-		AppendDownlink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendDownlink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetTxParamSetupReq()
 
 			v := byte(pld.MaxEIRPIndex)
@@ -462,7 +463,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = append(b, v)
 			return b, nil
 		},
-		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_TX_PARAM_SETUP, "TxParamSetupReq", 1, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_TX_PARAM_SETUP, "TxParamSetupReq", 1, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_TxParamSetupReq_{
 				TxParamSetupReq: &ttnpb.MACCommand_TxParamSetupReq{
 					MaxEIRPIndex:      ttnpb.DeviceEIRP(b[0] & 0xf),
@@ -479,7 +480,7 @@ var DefaultMACCommands = MACCommandSpec{
 		ExpectAnswer:      true,
 
 		UplinkLength: 1,
-		AppendUplink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendUplink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetDLChannelAns()
 			var v byte
 			if pld.ChannelIndexAck {
@@ -491,7 +492,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = append(b, v)
 			return b, nil
 		},
-		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_DL_CHANNEL, "DLChannelAns", 1, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_DL_CHANNEL, "DLChannelAns", 1, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_DLChannelAns_{
 				DLChannelAns: &ttnpb.MACCommand_DLChannelAns{
 					ChannelIndexAck: b[0]&1 == 1,
@@ -502,7 +503,7 @@ var DefaultMACCommands = MACCommandSpec{
 		}),
 
 		DownlinkLength: 4,
-		AppendDownlink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendDownlink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetDLChannelReq()
 			if pld.ChannelIndex > math.MaxUint8 {
 				return nil, errExpectedLowerOrEqual("ChannelIndex", math.MaxUint8)(pld.ChannelIndex)
@@ -515,7 +516,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = appendUint64(b, pld.Frequency/100, 3)
 			return b, nil
 		},
-		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_DL_CHANNEL, "DLChannelReq", 4, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_DL_CHANNEL, "DLChannelReq", 4, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_DLChannelReq_{
 				DLChannelReq: &ttnpb.MACCommand_DLChannelReq{
 					ChannelIndex: uint32(b[0]),
@@ -531,7 +532,7 @@ var DefaultMACCommands = MACCommandSpec{
 		ExpectAnswer:      true,
 
 		UplinkLength: 1,
-		AppendUplink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendUplink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetRekeyInd()
 			if pld.MinorVersion > 15 {
 				return nil, errExpectedLowerOrEqual("MinorVersion", 15)(pld.MinorVersion)
@@ -539,7 +540,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = append(b, byte(pld.MinorVersion))
 			return b, nil
 		},
-		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_REKEY, "RekeyInd", 1, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_REKEY, "RekeyInd", 1, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_RekeyInd_{
 				RekeyInd: &ttnpb.MACCommand_RekeyInd{
 					MinorVersion: ttnpb.Minor(b[0] & 0xf),
@@ -549,7 +550,7 @@ var DefaultMACCommands = MACCommandSpec{
 		}),
 
 		DownlinkLength: 1,
-		AppendDownlink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendDownlink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetRekeyConf()
 			if pld.MinorVersion > 15 {
 				return nil, errExpectedLowerOrEqual("MinorVersion", 15)(pld.MinorVersion)
@@ -557,7 +558,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = append(b, byte(pld.MinorVersion))
 			return b, nil
 		},
-		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_REKEY, "RekeyConf", 1, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_REKEY, "RekeyConf", 1, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_RekeyConf_{
 				RekeyConf: &ttnpb.MACCommand_RekeyConf{
 					MinorVersion: ttnpb.Minor(b[0] & 0xf),
@@ -572,13 +573,13 @@ var DefaultMACCommands = MACCommandSpec{
 		ExpectAnswer:      true,
 
 		UplinkLength: 0,
-		AppendUplink: func(b []byte, _ ttnpb.MACCommand) ([]byte, error) {
+		AppendUplink: func(phy band.Band, b []byte, _ ttnpb.MACCommand) ([]byte, error) {
 			return b, nil
 		},
 		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_ADR_PARAM_SETUP, "ADRParamSetupAns", 0, nil),
 
 		DownlinkLength: 1,
-		AppendDownlink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendDownlink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetADRParamSetupReq()
 			if 1 > pld.ADRAckDelayExponent || pld.ADRAckDelayExponent > 32768 {
 				return nil, errExpectedBetween("ADRAckDelay", 1, 32768)(pld.ADRAckDelayExponent)
@@ -593,7 +594,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = append(b, v)
 			return b, nil
 		},
-		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_ADR_PARAM_SETUP, "ADRParamSetupReq", 1, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_ADR_PARAM_SETUP, "ADRParamSetupReq", 1, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_ADRParamSetupReq_{
 				ADRParamSetupReq: &ttnpb.MACCommand_ADRParamSetupReq{
 					ADRAckDelayExponent: ttnpb.ADRAckDelayExponent(b[0] & 0xf),
@@ -609,13 +610,13 @@ var DefaultMACCommands = MACCommandSpec{
 		ExpectAnswer:      true,
 
 		UplinkLength: 0,
-		AppendUplink: func(b []byte, _ ttnpb.MACCommand) ([]byte, error) {
+		AppendUplink: func(phy band.Band, b []byte, _ ttnpb.MACCommand) ([]byte, error) {
 			return b, nil
 		},
 		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_DEVICE_TIME, "DeviceTimeReq", 0, nil),
 
 		DownlinkLength: 5,
-		AppendDownlink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendDownlink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetDeviceTimeAns()
 
 			sec := gpstime.ToGPS(pld.Time)
@@ -626,7 +627,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = append(b, byte(time.Duration(pld.Time.Nanosecond())/fractStep))
 			return b, nil
 		},
-		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_DEVICE_TIME, "DeviceTimeAns", 5, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_DEVICE_TIME, "DeviceTimeAns", 5, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_DeviceTimeAns_{
 				DeviceTimeAns: &ttnpb.MACCommand_DeviceTimeAns{
 					Time: gpstime.Parse(int64(parseUint32(b[0:4]))).Add(time.Duration(b[4]) * fractStep),
@@ -641,7 +642,7 @@ var DefaultMACCommands = MACCommandSpec{
 		ExpectAnswer:      false,
 
 		DownlinkLength: 2,
-		AppendDownlink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendDownlink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetForceRejoinReq()
 
 			if pld.PeriodExponent > 7 {
@@ -669,7 +670,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = append(b, v)
 			return b, nil
 		},
-		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_FORCE_REJOIN, "ForceRejoinReq", 2, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_FORCE_REJOIN, "ForceRejoinReq", 2, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_ForceRejoinReq_{
 				ForceRejoinReq: &ttnpb.MACCommand_ForceRejoinReq{
 					PeriodExponent: ttnpb.RejoinPeriodExponent(uint32(b[0] >> 3)),
@@ -687,7 +688,7 @@ var DefaultMACCommands = MACCommandSpec{
 		ExpectAnswer:      true,
 
 		UplinkLength: 1,
-		AppendUplink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendUplink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetRejoinParamSetupAns()
 
 			var v byte
@@ -697,7 +698,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = append(b, v)
 			return b, nil
 		},
-		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_REJOIN_PARAM_SETUP, "RejoinParamSetupAns", 1, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_REJOIN_PARAM_SETUP, "RejoinParamSetupAns", 1, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_RejoinParamSetupAns_{
 				RejoinParamSetupAns: &ttnpb.MACCommand_RejoinParamSetupAns{
 					MaxTimeExponentAck: b[0]&1 == 1,
@@ -707,7 +708,7 @@ var DefaultMACCommands = MACCommandSpec{
 		}),
 
 		DownlinkLength: 1,
-		AppendDownlink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendDownlink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetRejoinParamSetupReq()
 
 			if pld.MaxTimeExponent > 15 {
@@ -722,7 +723,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = append(b, v)
 			return b, nil
 		},
-		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_REJOIN_PARAM_SETUP, "RejoinParamSetupReq", 1, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_REJOIN_PARAM_SETUP, "RejoinParamSetupReq", 1, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_RejoinParamSetupReq_{
 				RejoinParamSetupReq: &ttnpb.MACCommand_RejoinParamSetupReq{
 					MaxTimeExponent:  ttnpb.RejoinTimeExponent(uint32(b[0] >> 4)),
@@ -738,7 +739,7 @@ var DefaultMACCommands = MACCommandSpec{
 		ExpectAnswer:      true,
 
 		UplinkLength: 1,
-		AppendUplink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendUplink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetPingSlotInfoReq()
 
 			if pld.Period > 7 {
@@ -747,7 +748,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = append(b, byte(pld.Period))
 			return b, nil
 		},
-		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_PING_SLOT_INFO, "PingSlotInfoReq", 1, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_PING_SLOT_INFO, "PingSlotInfoReq", 1, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_PingSlotInfoReq_{
 				PingSlotInfoReq: &ttnpb.MACCommand_PingSlotInfoReq{
 					Period: ttnpb.PingSlotPeriod(b[0] & 0x7),
@@ -757,7 +758,7 @@ var DefaultMACCommands = MACCommandSpec{
 		}),
 
 		DownlinkLength: 0,
-		AppendDownlink: func(b []byte, _ ttnpb.MACCommand) ([]byte, error) {
+		AppendDownlink: func(phy band.Band, b []byte, _ ttnpb.MACCommand) ([]byte, error) {
 			return b, nil
 		},
 		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_PING_SLOT_INFO, "PingSlotInfoAns", 0, nil),
@@ -768,7 +769,7 @@ var DefaultMACCommands = MACCommandSpec{
 		ExpectAnswer:      true,
 
 		UplinkLength: 1,
-		AppendUplink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendUplink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetPingSlotChannelAns()
 
 			var v byte
@@ -781,7 +782,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = append(b, v)
 			return b, nil
 		},
-		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_PING_SLOT_CHANNEL, "PingSlotChannelAns", 1, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_PING_SLOT_CHANNEL, "PingSlotChannelAns", 1, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_PingSlotChannelAns_{
 				PingSlotChannelAns: &ttnpb.MACCommand_PingSlotChannelAns{
 					FrequencyAck:     b[0]&1 == 1,
@@ -792,7 +793,7 @@ var DefaultMACCommands = MACCommandSpec{
 		}),
 
 		DownlinkLength: 4,
-		AppendDownlink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendDownlink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetPingSlotChannelReq()
 
 			if pld.Frequency < 100000 || pld.Frequency > maxUint24*100 {
@@ -806,7 +807,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = append(b, byte(pld.DataRateIndex))
 			return b, nil
 		},
-		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_PING_SLOT_CHANNEL, "PingSlotChannelReq", 4, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_PING_SLOT_CHANNEL, "PingSlotChannelReq", 4, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_PingSlotChannelReq_{
 				PingSlotChannelReq: &ttnpb.MACCommand_PingSlotChannelReq{
 					Frequency:     parseUint64(b[0:3]) * 100,
@@ -822,13 +823,13 @@ var DefaultMACCommands = MACCommandSpec{
 		ExpectAnswer:      true,
 
 		UplinkLength: 0,
-		AppendUplink: func(b []byte, _ ttnpb.MACCommand) ([]byte, error) {
+		AppendUplink: func(phy band.Band, b []byte, _ ttnpb.MACCommand) ([]byte, error) {
 			return b, nil
 		},
 		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_BEACON_TIMING, "BeaconTimingReq", 0, nil),
 
 		DownlinkLength: 3,
-		AppendDownlink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendDownlink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetBeaconTimingAns()
 
 			if pld.Delay > math.MaxUint16 {
@@ -843,7 +844,7 @@ var DefaultMACCommands = MACCommandSpec{
 
 			return b, nil
 		},
-		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_BEACON_TIMING, "BeaconTimingAns", 3, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_BEACON_TIMING, "BeaconTimingAns", 3, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_BeaconTimingAns_{
 				BeaconTimingAns: &ttnpb.MACCommand_BeaconTimingAns{
 					Delay:        parseUint32(b[0:2]),
@@ -859,7 +860,7 @@ var DefaultMACCommands = MACCommandSpec{
 		ExpectAnswer:      true,
 
 		UplinkLength: 1,
-		AppendUplink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendUplink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetBeaconFreqAns()
 			var v byte
 			if pld.FrequencyAck {
@@ -868,7 +869,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = append(b, v)
 			return b, nil
 		},
-		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_BEACON_FREQ, "BeaconFreqAns", 1, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_BEACON_FREQ, "BeaconFreqAns", 1, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_BeaconFreqAns_{
 				BeaconFreqAns: &ttnpb.MACCommand_BeaconFreqAns{
 					FrequencyAck: b[0]&1 == 1,
@@ -878,7 +879,7 @@ var DefaultMACCommands = MACCommandSpec{
 		}),
 
 		DownlinkLength: 3,
-		AppendDownlink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendDownlink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetBeaconFreqReq()
 			if pld.Frequency < 100000 || pld.Frequency > maxUint24*100 {
 				return nil, errExpectedBetween("Frequency", 100000, maxUint24*100)(pld.Frequency)
@@ -886,7 +887,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = appendUint64(b, pld.Frequency/100, 3)
 			return b, nil
 		},
-		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_BEACON_FREQ, "BeaconFreqReq", 3, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_BEACON_FREQ, "BeaconFreqReq", 3, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_BeaconFreqReq_{
 				BeaconFreqReq: &ttnpb.MACCommand_BeaconFreqReq{
 					Frequency: parseUint64(b[0:3]) * 100,
@@ -901,12 +902,12 @@ var DefaultMACCommands = MACCommandSpec{
 		ExpectAnswer:      true,
 
 		UplinkLength: 1,
-		AppendUplink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendUplink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetDeviceModeInd()
 			b = append(b, byte(pld.Class))
 			return b, nil
 		},
-		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_DEVICE_MODE, "DeviceModeInd", 1, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalUplink: newMACUnmarshaler(ttnpb.CID_DEVICE_MODE, "DeviceModeInd", 1, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_DeviceModeInd_{
 				DeviceModeInd: &ttnpb.MACCommand_DeviceModeInd{
 					Class: ttnpb.Class(b[0]),
@@ -916,12 +917,12 @@ var DefaultMACCommands = MACCommandSpec{
 		}),
 
 		DownlinkLength: 1,
-		AppendDownlink: func(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+		AppendDownlink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetDeviceModeConf()
 			b = append(b, byte(pld.Class))
 			return b, nil
 		},
-		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_DEVICE_MODE, "DeviceModeConf", 1, func(b []byte, cmd *ttnpb.MACCommand) error {
+		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_DEVICE_MODE, "DeviceModeConf", 1, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_DeviceModeConf_{
 				DeviceModeConf: &ttnpb.MACCommand_DeviceModeConf{
 					Class: ttnpb.Class(b[0]),
@@ -934,7 +935,7 @@ var DefaultMACCommands = MACCommandSpec{
 
 var errDecodingMACCommand = errors.DefineInvalidArgument("decoding_mac_command", "could not decode MAC command with CID `{cid}`")
 
-func (spec MACCommandSpec) read(r io.Reader, isUplink bool, cmd *ttnpb.MACCommand) error {
+func (spec MACCommandSpec) read(phy band.Band, r io.Reader, isUplink bool, cmd *ttnpb.MACCommand) error {
 	b := make([]byte, 1)
 	_, err := r.Read(b)
 	if err != nil {
@@ -960,7 +961,7 @@ func (spec MACCommandSpec) read(r io.Reader, isUplink bool, cmd *ttnpb.MACComman
 	}
 
 	var n uint16
-	var unmarshaler func(b []byte, cmd *ttnpb.MACCommand) error
+	var unmarshaler func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error
 	if isUplink {
 		n = desc.UplinkLength
 		unmarshaler = desc.UnmarshalUplink
@@ -978,20 +979,20 @@ func (spec MACCommandSpec) read(r io.Reader, isUplink bool, cmd *ttnpb.MACComman
 			return err
 		}
 	}
-	if err := unmarshaler(b, cmd); err != nil {
+	if err := unmarshaler(phy, b, cmd); err != nil {
 		return errDecodingMACCommand.WithAttributes("cid", fmt.Sprintf("0x%X", int32(ret.CID))).WithCause(err)
 	}
 	return nil
 }
 
 // ReadUplink reads an uplink MACCommand from r into cmd and returns any errors encountered.
-func (spec MACCommandSpec) ReadUplink(r io.Reader, cmd *ttnpb.MACCommand) error {
-	return spec.read(r, true, cmd)
+func (spec MACCommandSpec) ReadUplink(phy band.Band, r io.Reader, cmd *ttnpb.MACCommand) error {
+	return spec.read(phy, r, true, cmd)
 }
 
 // ReadDownlink reads a downlink MACCommand from r into cmd and returns any errors encountered.
-func (spec MACCommandSpec) ReadDownlink(r io.Reader, cmd *ttnpb.MACCommand) error {
-	return spec.read(r, false, cmd)
+func (spec MACCommandSpec) ReadDownlink(phy band.Band, r io.Reader, cmd *ttnpb.MACCommand) error {
+	return spec.read(phy, r, false, cmd)
 }
 
 var (
@@ -1001,14 +1002,14 @@ var (
 	errMACCommandDownlink = errors.DefineInvalidArgument("mac_command_downlink", "invalid downlink MAC command CID `{cid}`")
 )
 
-func (spec MACCommandSpec) append(b []byte, isUplink bool, cmd ttnpb.MACCommand) ([]byte, error) {
+func (spec MACCommandSpec) append(phy band.Band, b []byte, isUplink bool, cmd ttnpb.MACCommand) ([]byte, error) {
 	desc, ok := spec[cmd.CID]
 	if !ok || desc == nil {
 		return nil, errUnknownMACCommand.WithAttributes("cid", fmt.Sprintf("0x%X", int32(cmd.CID)))
 	}
 	b = append(b, byte(cmd.CID))
 
-	var appender func(b []byte, cmd ttnpb.MACCommand) ([]byte, error)
+	var appender func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error)
 	if isUplink {
 		appender = desc.AppendUplink
 		if appender == nil {
@@ -1021,7 +1022,7 @@ func (spec MACCommandSpec) append(b []byte, isUplink bool, cmd ttnpb.MACCommand)
 		}
 	}
 
-	b, err := appender(b, cmd)
+	b, err := appender(phy, b, cmd)
 	if err != nil {
 		return nil, errEncodingMACCommand.WithAttributes("cid", fmt.Sprintf("0x%X", int32(cmd.CID))).WithCause(err)
 	}
@@ -1029,11 +1030,11 @@ func (spec MACCommandSpec) append(b []byte, isUplink bool, cmd ttnpb.MACCommand)
 }
 
 // AppendUplink encodes uplink MAC command cmd, appends it to b and returns any errors encountered.
-func (spec MACCommandSpec) AppendUplink(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
-	return spec.append(b, true, cmd)
+func (spec MACCommandSpec) AppendUplink(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+	return spec.append(phy, b, true, cmd)
 }
 
 // AppendDownlink encodes downlink MAC command cmd, appends it to b and returns any errors encountered.
-func (spec MACCommandSpec) AppendDownlink(b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
-	return spec.append(b, false, cmd)
+func (spec MACCommandSpec) AppendDownlink(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
+	return spec.append(phy, b, false, cmd)
 }

--- a/pkg/encoding/lorawan/mac.go
+++ b/pkg/encoding/lorawan/mac.go
@@ -285,10 +285,10 @@ var DefaultMACCommands = MACCommandSpec{
 				return nil, errExpectedLowerOrEqual("Rx2DR", 15)(pld.Rx2DataRateIndex)
 			}
 			b = append(b, byte(pld.Rx2DataRateIndex)|byte(pld.Rx1DataRateOffset<<4))
-			if pld.Rx2Frequency < 100000 || pld.Rx2Frequency > maxUint24*100 {
-				return nil, errExpectedBetween("Rx2Frequency", 100000, maxUint24*100)(pld.Rx2Frequency)
+			if pld.Rx2Frequency < 100000 || pld.Rx2Frequency > maxUint24*phy.FreqMultiplier {
+				return nil, errExpectedBetween("Rx2Frequency", 100000, maxUint24*phy.FreqMultiplier)(pld.Rx2Frequency)
 			}
-			b = appendUint64(b, pld.Rx2Frequency/100, 3)
+			b = appendUint64(b, pld.Rx2Frequency/phy.FreqMultiplier, 3)
 			return b, nil
 		},
 		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_RX_PARAM_SETUP, "RxParamSetupReq", 4, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
@@ -296,7 +296,7 @@ var DefaultMACCommands = MACCommandSpec{
 				RxParamSetupReq: &ttnpb.MACCommand_RxParamSetupReq{
 					Rx1DataRateOffset: uint32((b[0] >> 4) & 0x7),
 					Rx2DataRateIndex:  ttnpb.DataRateIndex(b[0] & 0xf),
-					Rx2Frequency:      parseUint64(b[1:4]) * 100,
+					Rx2Frequency:      parseUint64(b[1:4]) * phy.FreqMultiplier,
 				},
 			}
 			return nil
@@ -380,10 +380,10 @@ var DefaultMACCommands = MACCommandSpec{
 			}
 			b = append(b, byte(pld.ChannelIndex))
 
-			if pld.Frequency > maxUint24*100 {
-				return nil, errExpectedLowerOrEqual("Frequency", maxUint24*100)(pld.Frequency)
+			if pld.Frequency > maxUint24*phy.FreqMultiplier {
+				return nil, errExpectedLowerOrEqual("Frequency", maxUint24*phy.FreqMultiplier)(pld.Frequency)
 			}
-			b = appendUint64(b, pld.Frequency/100, 3)
+			b = appendUint64(b, pld.Frequency/phy.FreqMultiplier, 3)
 
 			if pld.MinDataRateIndex > 15 {
 				return nil, errExpectedLowerOrEqual("MinDataRateIndex", 15)(pld.MinDataRateIndex)
@@ -401,7 +401,7 @@ var DefaultMACCommands = MACCommandSpec{
 			cmd.Payload = &ttnpb.MACCommand_NewChannelReq_{
 				NewChannelReq: &ttnpb.MACCommand_NewChannelReq{
 					ChannelIndex:     uint32(b[0]),
-					Frequency:        parseUint64(b[1:4]) * 100,
+					Frequency:        parseUint64(b[1:4]) * phy.FreqMultiplier,
 					MinDataRateIndex: ttnpb.DataRateIndex(b[4] & 0xf),
 					MaxDataRateIndex: ttnpb.DataRateIndex(b[4] >> 4),
 				},
@@ -510,17 +510,17 @@ var DefaultMACCommands = MACCommandSpec{
 			}
 			b = append(b, byte(pld.ChannelIndex))
 
-			if pld.Frequency < 100000 || pld.Frequency > maxUint24*100 {
-				return nil, errExpectedBetween("Frequency", 100000, maxUint24*100)(pld.Frequency)
+			if pld.Frequency < 100000 || pld.Frequency > maxUint24*phy.FreqMultiplier {
+				return nil, errExpectedBetween("Frequency", 100000, maxUint24*phy.FreqMultiplier)(pld.Frequency)
 			}
-			b = appendUint64(b, pld.Frequency/100, 3)
+			b = appendUint64(b, pld.Frequency/phy.FreqMultiplier, 3)
 			return b, nil
 		},
 		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_DL_CHANNEL, "DLChannelReq", 4, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_DLChannelReq_{
 				DLChannelReq: &ttnpb.MACCommand_DLChannelReq{
 					ChannelIndex: uint32(b[0]),
-					Frequency:    parseUint64(b[1:4]) * 100,
+					Frequency:    parseUint64(b[1:4]) * phy.FreqMultiplier,
 				},
 			}
 			return nil
@@ -796,10 +796,10 @@ var DefaultMACCommands = MACCommandSpec{
 		AppendDownlink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetPingSlotChannelReq()
 
-			if pld.Frequency < 100000 || pld.Frequency > maxUint24*100 {
-				return nil, errExpectedBetween("Frequency", 100000, maxUint24*100)(pld.Frequency)
+			if pld.Frequency < 100000 || pld.Frequency > maxUint24*phy.FreqMultiplier {
+				return nil, errExpectedBetween("Frequency", 100000, maxUint24*phy.FreqMultiplier)(pld.Frequency)
 			}
-			b = appendUint64(b, pld.Frequency/100, 3)
+			b = appendUint64(b, pld.Frequency/phy.FreqMultiplier, 3)
 
 			if pld.DataRateIndex > 15 {
 				return nil, errExpectedLowerOrEqual("DataRateIndex", 15)(pld.DataRateIndex)
@@ -810,7 +810,7 @@ var DefaultMACCommands = MACCommandSpec{
 		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_PING_SLOT_CHANNEL, "PingSlotChannelReq", 4, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_PingSlotChannelReq_{
 				PingSlotChannelReq: &ttnpb.MACCommand_PingSlotChannelReq{
-					Frequency:     parseUint64(b[0:3]) * 100,
+					Frequency:     parseUint64(b[0:3]) * phy.FreqMultiplier,
 					DataRateIndex: ttnpb.DataRateIndex(b[3] & 0xf),
 				},
 			}
@@ -881,16 +881,16 @@ var DefaultMACCommands = MACCommandSpec{
 		DownlinkLength: 3,
 		AppendDownlink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {
 			pld := cmd.GetBeaconFreqReq()
-			if pld.Frequency < 100000 || pld.Frequency > maxUint24*100 {
-				return nil, errExpectedBetween("Frequency", 100000, maxUint24*100)(pld.Frequency)
+			if pld.Frequency < 100000 || pld.Frequency > maxUint24*phy.FreqMultiplier {
+				return nil, errExpectedBetween("Frequency", 100000, maxUint24*phy.FreqMultiplier)(pld.Frequency)
 			}
-			b = appendUint64(b, pld.Frequency/100, 3)
+			b = appendUint64(b, pld.Frequency/phy.FreqMultiplier, 3)
 			return b, nil
 		},
 		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_BEACON_FREQ, "BeaconFreqReq", 3, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			cmd.Payload = &ttnpb.MACCommand_BeaconFreqReq_{
 				BeaconFreqReq: &ttnpb.MACCommand_BeaconFreqReq{
-					Frequency: parseUint64(b[0:3]) * 100,
+					Frequency: parseUint64(b[0:3]) * phy.FreqMultiplier,
 				},
 			}
 			return nil

--- a/pkg/encoding/lorawan/mac_test.go
+++ b/pkg/encoding/lorawan/mac_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/pkg/band"
 	. "go.thethings.network/lorawan-stack/pkg/encoding/lorawan"
 	"go.thethings.network/lorawan-stack/pkg/gpstime"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
@@ -28,6 +29,11 @@ import (
 )
 
 func TestLoRaWANEncodingMAC(t *testing.T) {
+	phy, err := band.GetByID("EU_863_870")
+	if err != nil {
+		panic(err)
+	}
+
 	for _, tc := range []struct {
 		Name    string
 		Payload interface {
@@ -388,13 +394,13 @@ func TestLoRaWANEncodingMAC(t *testing.T) {
 				reader = DefaultMACCommands.ReadDownlink
 			}
 
-			b, err := appender([]byte{}, *cmd)
+			b, err := appender(phy, []byte{}, *cmd)
 			if a.So(err, should.BeNil) {
 				a.So(b, should.Resemble, tc.Bytes)
 			}
 
 			cmd = &ttnpb.MACCommand{}
-			err = reader(bytes.NewReader(tc.Bytes), cmd)
+			err = reader(phy, bytes.NewReader(tc.Bytes), cmd)
 			if pld := cmd.GetDeviceTimeAns(); pld != nil {
 				pld.Time = pld.Time.UTC()
 			}

--- a/pkg/encoding/lorawan/mac_test.go
+++ b/pkg/encoding/lorawan/mac_test.go
@@ -25,14 +25,12 @@ import (
 	. "go.thethings.network/lorawan-stack/pkg/encoding/lorawan"
 	"go.thethings.network/lorawan-stack/pkg/gpstime"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/pkg/util/test"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 )
 
 func TestLoRaWANEncodingMAC(t *testing.T) {
-	phy, err := band.GetByID("EU_863_870")
-	if err != nil {
-		panic(err)
-	}
+	phy := test.Must(test.Must(band.GetByID(band.EU_863_870)).(band.Band).Version(ttnpb.PHY_V1_1_REV_B)).(band.Band)
 
 	for _, tc := range []struct {
 		Name    string

--- a/pkg/frequencyplans/cflist.go
+++ b/pkg/frequencyplans/cflist.go
@@ -23,37 +23,37 @@ import (
 // This function returns nil if the CFList could not be computed, or if the
 // device does not support CFLists.
 func CFList(fp FrequencyPlan, version ttnpb.PHYVersion) *ttnpb.CFList {
-	band, err := band.GetByID(fp.BandID)
+	phy, err := band.GetByID(fp.BandID)
 	if err != nil {
 		return nil
 	}
 
-	band, err = band.Version(version)
+	phy, err = phy.Version(version)
 	if err != nil {
 		return nil
 	}
 
-	if !band.ImplementsCFList {
+	if !phy.ImplementsCFList {
 		return nil
 	}
 
-	switch band.CFListType {
+	switch phy.CFListType {
 	case ttnpb.CFListType_CHANNEL_MASKS:
-		return chMaskCFList(fp, band)
+		return chMaskCFList(fp, phy)
 	case ttnpb.CFListType_FREQUENCIES:
-		return frequenciesCFList(fp, band)
+		return frequenciesCFList(fp, phy)
 	default:
 		return nil
 	}
 }
 
-func chMaskCFList(fp FrequencyPlan, band band.Band) *ttnpb.CFList {
+func chMaskCFList(fp FrequencyPlan, phy band.Band) *ttnpb.CFList {
 	cfList := &ttnpb.CFList{
 		Type:    ttnpb.CFListType_CHANNEL_MASKS,
 		ChMasks: []bool{},
 	}
 
-	for _, bandChannel := range band.UplinkChannels {
+	for _, bandChannel := range phy.UplinkChannels {
 		var channelEnabled bool
 		for _, fpChannel := range fp.UplinkChannels {
 			if fpChannel.Frequency == bandChannel.Frequency {
@@ -66,12 +66,12 @@ func chMaskCFList(fp FrequencyPlan, band band.Band) *ttnpb.CFList {
 	return cfList
 }
 
-func frequenciesCFList(fp FrequencyPlan, band band.Band) *ttnpb.CFList {
+func frequenciesCFList(fp FrequencyPlan, phy band.Band) *ttnpb.CFList {
 	cfList := &ttnpb.CFList{Type: ttnpb.CFListType_FREQUENCIES}
 
 outer:
 	for _, fpChannel := range fp.UplinkChannels {
-		for _, bandChannel := range band.UplinkChannels {
+		for _, bandChannel := range phy.UplinkChannels {
 			if fpChannel.Frequency == bandChannel.Frequency {
 				continue outer
 			}

--- a/pkg/frequencyplans/cflist.go
+++ b/pkg/frequencyplans/cflist.go
@@ -76,7 +76,7 @@ outer:
 				continue outer
 			}
 		}
-		cfList.Freq = append(cfList.Freq, uint32(fpChannel.Frequency/100))
+		cfList.Freq = append(cfList.Freq, uint32(fpChannel.Frequency/phy.FreqMultiplier))
 		if len(cfList.Freq) == 5 {
 			break
 		}

--- a/pkg/frequencyplans/cflist_test.go
+++ b/pkg/frequencyplans/cflist_test.go
@@ -48,7 +48,7 @@ func TestFrequenciesCFList(t *testing.T) {
 	cfList := frequencyplans.CFList(euFP, ttnpb.PHY_V1_1_REV_B)
 	a.So(cfList.Type, should.Equal, ttnpb.CFListType_FREQUENCIES)
 
-	euBand, err := band.GetByID(euFP.BandID)
+	phy, err := band.GetByID(euFP.BandID)
 	if !a.So(err, should.BeNil) {
 		t.FailNow()
 	}
@@ -57,7 +57,7 @@ func TestFrequenciesCFList(t *testing.T) {
 	var seen int
 outer:
 	for _, channel := range euFP.UplinkChannels {
-		for _, bandChannel := range euBand.UplinkChannels {
+		for _, bandChannel := range phy.UplinkChannels {
 			if bandChannel.Frequency == channel.Frequency {
 				continue outer
 			}

--- a/pkg/frequencyplans/cflist_test.go
+++ b/pkg/frequencyplans/cflist_test.go
@@ -65,7 +65,7 @@ outer:
 
 		var found bool
 		for _, cfListFrequency := range cfList.Freq {
-			if uint64(cfListFrequency)*100 == channel.Frequency {
+			if uint64(cfListFrequency)*phy.FreqMultiplier == channel.Frequency {
 				found = true
 			}
 		}

--- a/pkg/networkserver/adr.go
+++ b/pkg/networkserver/adr.go
@@ -100,7 +100,7 @@ func adaptDataRate(dev *ttnpb.EndDevice, fps *frequencyplans.Store, defaults ttn
 		}
 	}
 
-	_, band, err := getDeviceBandVersion(dev, fps)
+	_, phy, err := getDeviceBandVersion(dev, fps)
 	if err != nil {
 		return err
 	}
@@ -131,7 +131,7 @@ func adaptDataRate(dev *ttnpb.EndDevice, fps *frequencyplans.Store, defaults ttn
 
 	// As long as we have enough margin to increase the data rate, we do that.
 	// If we change the DR, we reset the Tx power.
-	for int(dev.MACState.DesiredParameters.ADRDataRateIndex) < int(band.MaxADRDataRateIndex) {
+	for int(dev.MACState.DesiredParameters.ADRDataRateIndex) < int(phy.MaxADRDataRateIndex) {
 		newMargin := margin - drStep
 		if newMargin < 0 {
 			break
@@ -142,8 +142,8 @@ func adaptDataRate(dev *ttnpb.EndDevice, fps *frequencyplans.Store, defaults ttn
 	}
 
 	// If we still have margin left, we decrease the Tx power (increase the index).
-	for int(dev.MACState.DesiredParameters.ADRTxPowerIndex) < int(band.MaxTxPowerIndex) {
-		newMargin := margin - (band.TxOffset[dev.MACState.DesiredParameters.ADRTxPowerIndex] - band.TxOffset[dev.MACState.DesiredParameters.ADRTxPowerIndex+1])
+	for int(dev.MACState.DesiredParameters.ADRTxPowerIndex) < int(phy.MaxTxPowerIndex) {
+		newMargin := margin - (phy.TxOffset[dev.MACState.DesiredParameters.ADRTxPowerIndex] - phy.TxOffset[dev.MACState.DesiredParameters.ADRTxPowerIndex+1])
 		if newMargin < 0 {
 			break
 		}

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/mohae/deepcopy"
+	"go.thethings.network/lorawan-stack/pkg/band"
 	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/crypto"
 	"go.thethings.network/lorawan-stack/pkg/crypto/cryptoutil"
@@ -81,7 +82,7 @@ type generatedDownlink struct {
 // For example, a sequence of 'NewChannel' MAC commands could be generated for a
 // device operating in a region where a fixed channel plan is defined in case
 // dev.MACState.CurrentParameters.Channels is not equal to dev.MACState.DesiredParameters.Channels.
-func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16) (*generatedDownlink, error) {
+func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDevice, phy band.Band, maxDownLen, maxUpLen uint16) (*generatedDownlink, error) {
 	if dev.MACState == nil {
 		return nil, errUnknownMACState
 	}
@@ -153,7 +154,7 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 		logger := logger.WithField("cid", cmd.CID)
 		logger.Debug("Add MAC command to buffer")
 		var err error
-		cmdBuf, err = spec.AppendDownlink(cmdBuf, *cmd)
+		cmdBuf, err = spec.AppendDownlink(phy, cmdBuf, *cmd)
 		if err != nil {
 			return nil, errEncodeMAC.WithCause(err)
 		}
@@ -565,7 +566,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 				}
 				logger = logger.WithField("device_class", dev.MACState.DeviceClass)
 
-				fp, band, err := getDeviceBandVersion(dev, ns.FrequencyPlans)
+				fp, phy, err := getDeviceBandVersion(dev, ns.FrequencyPlans)
 				if err != nil {
 					return nil, nil, errUnknownBand.WithCause(err)
 				}
@@ -584,7 +585,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 						break loop
 					}
 				}
-				maxUpLength := band.DataRates[maxUpDRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks())
+				maxUpLength := phy.DataRates[maxUpDRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks())
 
 				if dev.MACState.RxWindowsAvailable {
 					if len(dev.RecentUplinks) == 0 {
@@ -596,7 +597,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 					if up.DeviceChannelIndex > math.MaxUint8 {
 						return nil, nil, errInvalidChannelIndex
 					}
-					rx1ChIdx, err := band.Rx1Channel(uint8(up.DeviceChannelIndex))
+					rx1ChIdx, err := phy.Rx1Channel(uint8(up.DeviceChannelIndex))
 					if err != nil {
 						return nil, nil, err
 					}
@@ -605,7 +606,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 						dev.MACState.CurrentParameters.Channels[int(rx1ChIdx)].DownlinkFrequency == 0 {
 						return nil, nil, errCorruptedMACState
 					}
-					rx1DRIdx, err := band.Rx1DataRate(up.Settings.DataRateIndex, dev.MACState.CurrentParameters.Rx1DataRateOffset, dev.MACState.CurrentParameters.DownlinkDwellTime)
+					rx1DRIdx, err := phy.Rx1DataRate(up.Settings.DataRateIndex, dev.MACState.CurrentParameters.Rx1DataRateOffset, dev.MACState.CurrentParameters.DownlinkDwellTime)
 					if err != nil {
 						return nil, nil, err
 					}
@@ -617,9 +618,9 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 					switch {
 					case dev.MACState.QueuedJoinAccept != nil:
 						// Join-accept downlink for Class A/B/C in Rx1/Rx2
-						req.Rx1Delay = ttnpb.RxDelay(band.JoinAcceptDelay1 / time.Second)
+						req.Rx1Delay = ttnpb.RxDelay(phy.JoinAcceptDelay1 / time.Second)
 						rx1, rx2, paths := downlinkPathsForClassA(
-							ttnpb.RxDelay(band.JoinAcceptDelay1/time.Second),
+							ttnpb.RxDelay(phy.JoinAcceptDelay1/time.Second),
 							dev.RecentUplinks...,
 						)
 						if rx1 {
@@ -695,8 +696,8 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 						if req.Rx2DataRateIndex < minDR {
 							minDR = req.Rx2DataRateIndex
 						}
-						genDown, err = ns.generateDownlink(ctx, dev,
-							band.DataRates[minDR].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
+						genDown, err = ns.generateDownlink(ctx, dev, phy,
+							phy.DataRates[minDR].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 							maxUpLength,
 						)
 						if err != nil {
@@ -756,8 +757,8 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 						// we need to create a deep copy for the first call.
 						devCopy := deepcopy.Copy(dev).(*ttnpb.EndDevice)
 
-						genDown, err = ns.generateDownlink(ctx, dev,
-							band.DataRates[req.Rx1DataRateIndex].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
+						genDown, err = ns.generateDownlink(ctx, dev, phy,
+							phy.DataRates[req.Rx1DataRateIndex].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 							maxUpLength,
 						)
 						if err != nil {
@@ -837,8 +838,8 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 						Rx2Frequency:     dev.MACState.CurrentParameters.Rx2Frequency,
 					}
 
-					genDown, err = ns.generateDownlink(ctx, dev,
-						band.DataRates[req.Rx2DataRateIndex].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
+					genDown, err = ns.generateDownlink(ctx, dev, phy,
+						phy.DataRates[req.Rx2DataRateIndex].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 						maxUpLength,
 					)
 					if err != nil {

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -85,9 +85,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 	}
 
-	// NOTE: This is only valid under assumption that test.EUFrequencyPlanID uses 868,
-	// and that all devices in test cases use test.EUFrequencyPlanID as the frequency plan.
-	band := test.Must(test.Must(band.GetByID(band.EU_863_870)).(band.Band).Version(ttnpb.PHY_V1_1_REV_B)).(band.Band)
+	phy := test.Must(test.Must(band.GetByID(band.EU_863_870)).(band.Band).Version(ttnpb.PHY_V1_1_REV_B)).(band.Band)
 
 	channels := [16]*ttnpb.MACParameters_Channel{
 		ttnpb.NewPopulatedMACParameters_Channel(test.Randy, false),
@@ -306,11 +304,11 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Fatal("Invalid context")
 				}
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
-				rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
-				rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-				genDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
-					band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
-					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
+				rx1DRIdx := test.Must(phy.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
+				rx1Freq := channels[int(test.Must(phy.Rx1Channel(3)).(uint8))].DownlinkFrequency
+				genDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb), phy,
+					phy.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
+					phy.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
 				if !a.So(err, should.BeNil) {
 					t.Fatalf("Failed to generate Rx2 payload: %s", err)
@@ -377,15 +375,15 @@ func TestProcessDownlinkTask(t *testing.T) {
 					}
 
 					fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
-					rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
-					rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
+					rx1DRIdx := test.Must(phy.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
+					rx1Freq := channels[int(test.Must(phy.Rx1Channel(3)).(uint8))].DownlinkFrequency
 					drIdx := ttnpb.DATA_RATE_1
 					if rx1DRIdx < drIdx {
 						drIdx = rx1DRIdx
 					}
-					genDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
-						band.DataRates[drIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
-						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
+					genDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb), phy,
+						phy.DataRates[drIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
+						phy.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
 					if !a.So(err, should.BeNil) {
 						t.Fatalf("Failed to generate Rx2 payload: %s", err)
@@ -742,15 +740,15 @@ func TestProcessDownlinkTask(t *testing.T) {
 					}
 
 					fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
-					rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
-					rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
+					rx1DRIdx := test.Must(phy.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
+					rx1Freq := channels[int(test.Must(phy.Rx1Channel(3)).(uint8))].DownlinkFrequency
 					drIdx := ttnpb.DATA_RATE_1
 					if rx1DRIdx < drIdx {
 						drIdx = rx1DRIdx
 					}
-					genDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
-						band.DataRates[drIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
-						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
+					genDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb), phy,
+						phy.DataRates[drIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
+						phy.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
 					if !a.So(err, should.BeNil) {
 						t.Fatalf("Failed to generate Rx2 payload: %s", err)
@@ -1100,11 +1098,11 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Fatal("Invalid context")
 				}
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
-				rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
-				rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-				genDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
-					band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
-					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
+				rx1DRIdx := test.Must(phy.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
+				rx1Freq := channels[int(test.Must(phy.Rx1Channel(3)).(uint8))].DownlinkFrequency
+				genDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb), phy,
+					phy.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
+					phy.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
 				if !a.So(err, should.BeNil) {
 					t.Fatalf("Failed to generate Rx1 payload: %s", err)
@@ -1171,11 +1169,11 @@ func TestProcessDownlinkTask(t *testing.T) {
 						t.Fatal("Invalid context")
 					}
 					fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
-					rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
-					rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-					genDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
-						band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
-						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
+					rx1DRIdx := test.Must(phy.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
+					rx1Freq := channels[int(test.Must(phy.Rx1Channel(3)).(uint8))].DownlinkFrequency
+					genDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb), phy,
+						phy.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
+						phy.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
 					if !a.So(err, should.BeNil) {
 						t.Fatalf("Failed to generate Rx1 payload: %s", err)
@@ -1517,9 +1515,9 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Fatal("Invalid context")
 				}
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
-				rx2GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
-					band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
-					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
+				rx2GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb), phy,
+					phy.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
+					phy.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
 				if !a.So(err, should.BeNil) {
 					t.Fatalf("Failed to generate Rx2 payload: %s", err)
@@ -1587,18 +1585,18 @@ func TestProcessDownlinkTask(t *testing.T) {
 						t.Fatal("Invalid context")
 					}
 					fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
-					rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
-					rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
-					rx1GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
-						band.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
-						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
+					rx1DRIdx := test.Must(phy.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
+					rx1Freq := channels[int(test.Must(phy.Rx1Channel(3)).(uint8))].DownlinkFrequency
+					rx1GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb), phy,
+						phy.DataRates[rx1DRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
+						phy.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
 					if !a.So(err, should.BeNil) {
 						t.Fatalf("Failed to generate Rx1 payload: %s", err)
 					}
-					rx2GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
-						band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
-						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
+					rx2GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb), phy,
+						phy.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
+						phy.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
 					if !a.So(err, should.BeNil) {
 						t.Fatalf("Failed to generate Rx2 payload: %s", err)
@@ -2019,9 +2017,9 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Fatal("Invalid context")
 				}
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
-				rx2GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
-					band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
-					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
+				rx2GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb), phy,
+					phy.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
+					phy.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
 				if !a.So(err, should.BeNil) {
 					t.Fatalf("Failed to generate Rx2 payload: %s", err)
@@ -2090,9 +2088,9 @@ func TestProcessDownlinkTask(t *testing.T) {
 						t.Fatal("Invalid context")
 					}
 					fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
-					rx2GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
-						band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
-						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
+					rx2GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb), phy,
+						phy.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
+						phy.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
 					if !a.So(err, should.BeNil) {
 						t.Fatalf("Failed to generate Rx2 payload: %s", err)
@@ -2363,9 +2361,9 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Fatal("Invalid context")
 				}
 				fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
-				rx2GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
-					band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
-					band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
+				rx2GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb), phy,
+					phy.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
+					phy.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 				)
 				if !a.So(err, should.BeNil) {
 					t.Fatalf("Failed to generate Rx2 payload: %s", err)
@@ -2435,9 +2433,9 @@ func TestProcessDownlinkTask(t *testing.T) {
 						t.Fatal("Invalid context")
 					}
 					fp := test.Must(ns.FrequencyPlans.GetByID(test.EUFrequencyPlanID)).(*frequencyplans.FrequencyPlan)
-					rx2GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb),
-						band.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
-						band.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
+					rx2GenDown, err := ns.generateDownlink(ctx, CopyEndDevice(pb), phy,
+						phy.DataRates[ttnpb.DATA_RATE_1].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
+						phy.DataRates[ttnpb.DATA_RATE_0].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks()),
 					)
 					if !a.So(err, should.BeNil) {
 						t.Fatalf("Failed to generate Rx2 payload: %s", err)
@@ -2821,8 +2819,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 				a.So(ret.RecentDownlinks[0].CorrelationIDs, should.Contain, "testCorrelationUpID1")
 				a.So(ret.RecentDownlinks[0].CorrelationIDs, should.Contain, "testCorrelationUpID2")
 
-				rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
-				rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
+				rx1DRIdx := test.Must(phy.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
+				rx1Freq := channels[int(test.Must(phy.Rx1Channel(3)).(uint8))].DownlinkFrequency
 
 				expected := CopyEndDevice(pb)
 				expected.MACState.PendingJoinRequest = &expected.MACState.QueuedJoinAccept.Request
@@ -2847,7 +2845,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 						Request: &ttnpb.TxRequest{
 							Class:            ttnpb.CLASS_A,
 							Rx1DataRateIndex: rx1DRIdx,
-							Rx1Delay:         ttnpb.RxDelay(band.JoinAcceptDelay1 / time.Second),
+							Rx1Delay:         ttnpb.RxDelay(phy.JoinAcceptDelay1 / time.Second),
 							Rx1Frequency:     rx1Freq,
 							Rx2DataRateIndex: ttnpb.DATA_RATE_1,
 							Rx2Frequency:     42,
@@ -2878,8 +2876,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 					defer test.MustIncrementContextCounter(ctx, getPeerCallKey{}, 1)
 
-					rx1DRIdx := test.Must(band.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
-					rx1Freq := channels[int(test.Must(band.Rx1Channel(3)).(uint8))].DownlinkFrequency
+					rx1DRIdx := test.Must(phy.Rx1DataRate(ttnpb.DATA_RATE_0, 2, false)).(ttnpb.DataRateIndex)
+					rx1Freq := channels[int(test.Must(phy.Rx1Channel(3)).(uint8))].DownlinkFrequency
 
 					switch uid := unique.ID(ctx, ids); uid {
 					case unique.ID(ctx, gateways[0]):
@@ -2917,7 +2915,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 											Request: &ttnpb.TxRequest{
 												Class:            ttnpb.CLASS_A,
 												Rx1DataRateIndex: rx1DRIdx,
-												Rx1Delay:         ttnpb.RxDelay(band.JoinAcceptDelay1 / time.Second),
+												Rx1Delay:         ttnpb.RxDelay(phy.JoinAcceptDelay1 / time.Second),
 												Rx1Frequency:     rx1Freq,
 												Rx2DataRateIndex: ttnpb.DATA_RATE_1,
 												Rx2Frequency:     42,
@@ -2954,7 +2952,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 									Request: &ttnpb.TxRequest{
 										Class:            ttnpb.CLASS_A,
 										Rx1DataRateIndex: rx1DRIdx,
-										Rx1Delay:         ttnpb.RxDelay(band.JoinAcceptDelay1 / time.Second),
+										Rx1Delay:         ttnpb.RxDelay(phy.JoinAcceptDelay1 / time.Second),
 										Rx1Frequency:     rx1Freq,
 										Rx2DataRateIndex: ttnpb.DATA_RATE_1,
 										Rx2Frequency:     42,
@@ -3000,7 +2998,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 										Request: &ttnpb.TxRequest{
 											Class:            ttnpb.CLASS_A,
 											Rx1DataRateIndex: rx1DRIdx,
-											Rx1Delay:         ttnpb.RxDelay(band.JoinAcceptDelay1 / time.Second),
+											Rx1Delay:         ttnpb.RxDelay(phy.JoinAcceptDelay1 / time.Second),
 											Rx1Frequency:     rx1Freq,
 											Rx2DataRateIndex: ttnpb.DATA_RATE_1,
 											Priority:         ttnpb.TxSchedulePriority_HIGH,
@@ -3110,6 +3108,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 }
 
 func TestGenerateDownlink(t *testing.T) {
+	phy := test.Must(test.Must(band.GetByID(band.EU_863_870)).(band.Band).Version(ttnpb.PHY_V1_1_REV_B)).(band.Band)
+
 	encodeMessage := func(msg *ttnpb.Message, ver ttnpb.MACVersion, confFCnt uint32) []byte {
 		msg = deepcopy.Copy(msg).(*ttnpb.Message)
 		mac := msg.GetMACPayload()
@@ -3154,9 +3154,9 @@ func TestGenerateDownlink(t *testing.T) {
 		return append(b, mic[:]...)
 	}
 
-	encodeMAC := func(cmds ...*ttnpb.MACCommand) (b []byte) {
+	encodeMAC := func(phy band.Band, cmds ...*ttnpb.MACCommand) (b []byte) {
 		for _, cmd := range cmds {
-			b = test.Must(lorawan.DefaultMACCommands.AppendDownlink(b, *cmd)).([]byte)
+			b = test.Must(lorawan.DefaultMACCommands.AppendDownlink(phy, b, *cmd)).([]byte)
 		}
 		return
 	}
@@ -3184,6 +3184,7 @@ func TestGenerateDownlink(t *testing.T) {
 				},
 				Session:           ttnpb.NewPopulatedSession(test.Randy, false),
 				LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
+				FrequencyPlanID:   band.EU_863_870,
 				RecentUplinks: []*ttnpb.UplinkMessage{{
 					Payload: &ttnpb.Message{
 						MHDR: ttnpb.MHDR{
@@ -3215,6 +3216,7 @@ func TestGenerateDownlink(t *testing.T) {
 					LastFCntUp: 4,
 				},
 				LoRaWANPHYVersion:       ttnpb.PHY_V1_1_REV_B,
+				FrequencyPlanID:         band.EU_863_870,
 				LastDevStatusReceivedAt: TimePtr(time.Unix(42, 0)),
 				RecentUplinks: []*ttnpb.UplinkMessage{{
 					Payload: &ttnpb.Message{
@@ -3243,6 +3245,7 @@ func TestGenerateDownlink(t *testing.T) {
 					LoRaWANVersion: ttnpb.MAC_V1_1,
 				},
 				LoRaWANPHYVersion:       ttnpb.PHY_V1_1_REV_B,
+				FrequencyPlanID:         band.EU_863_870,
 				LastDevStatusReceivedAt: TimePtr(time.Now()),
 				Session:                 ttnpb.NewPopulatedSession(test.Randy, false),
 				RecentUplinks: []*ttnpb.UplinkMessage{{
@@ -3282,6 +3285,7 @@ func TestGenerateDownlink(t *testing.T) {
 					},
 				},
 				LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
+				FrequencyPlanID:   band.EU_863_870,
 				RecentUplinks: []*ttnpb.UplinkMessage{{
 					Payload: &ttnpb.Message{
 						MHDR: ttnpb.MHDR{
@@ -3338,6 +3342,7 @@ func TestGenerateDownlink(t *testing.T) {
 						},
 					},
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
+					FrequencyPlanID:   band.EU_863_870,
 					RecentUplinks: []*ttnpb.UplinkMessage{{
 						Payload: &ttnpb.Message{
 							MHDR: ttnpb.MHDR{
@@ -3388,6 +3393,7 @@ func TestGenerateDownlink(t *testing.T) {
 					},
 				},
 				LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
+				FrequencyPlanID:   band.EU_863_870,
 				RecentUplinks: []*ttnpb.UplinkMessage{{
 					Payload: &ttnpb.Message{
 						MHDR: ttnpb.MHDR{
@@ -3447,6 +3453,7 @@ func TestGenerateDownlink(t *testing.T) {
 						},
 					},
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
+					FrequencyPlanID:   band.EU_863_870,
 					RecentUplinks: []*ttnpb.UplinkMessage{{
 						Payload: &ttnpb.Message{
 							MHDR: ttnpb.MHDR{
@@ -3492,6 +3499,7 @@ func TestGenerateDownlink(t *testing.T) {
 					},
 				},
 				LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
+				FrequencyPlanID:   band.EU_863_870,
 				RecentUplinks: []*ttnpb.UplinkMessage{{
 					Payload: &ttnpb.Message{
 						MHDR: ttnpb.MHDR{
@@ -3557,6 +3565,7 @@ func TestGenerateDownlink(t *testing.T) {
 						},
 					},
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
+					FrequencyPlanID:   band.EU_863_870,
 					RecentUplinks: []*ttnpb.UplinkMessage{{
 						Payload: &ttnpb.Message{
 							MHDR: ttnpb.MHDR{
@@ -3607,6 +3616,7 @@ func TestGenerateDownlink(t *testing.T) {
 					},
 				},
 				LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
+				FrequencyPlanID:   band.EU_863_870,
 				RecentUplinks: []*ttnpb.UplinkMessage{{
 					Payload: &ttnpb.Message{
 						MHDR: ttnpb.MHDR{
@@ -3679,6 +3689,7 @@ func TestGenerateDownlink(t *testing.T) {
 						},
 					},
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
+					FrequencyPlanID:   band.EU_863_870,
 					RecentUplinks: []*ttnpb.UplinkMessage{{
 						Payload: &ttnpb.Message{
 							MHDR: ttnpb.MHDR{
@@ -3716,6 +3727,7 @@ func TestGenerateDownlink(t *testing.T) {
 					},
 				},
 				LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
+				FrequencyPlanID:   band.EU_863_870,
 				QueuedApplicationDownlinks: []*ttnpb.ApplicationDownlink{
 					{
 						Confirmed:  true,
@@ -3803,6 +3815,7 @@ func TestGenerateDownlink(t *testing.T) {
 						},
 					},
 					LoRaWANPHYVersion:          ttnpb.PHY_V1_1_REV_B,
+					FrequencyPlanID:            band.EU_863_870,
 					QueuedApplicationDownlinks: []*ttnpb.ApplicationDownlink{},
 					RecentUplinks: []*ttnpb.UplinkMessage{{
 						Payload: &ttnpb.Message{
@@ -3850,6 +3863,8 @@ func TestGenerateDownlink(t *testing.T) {
 						},
 					},
 				},
+				LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
+				FrequencyPlanID:   band.EU_863_870,
 				RecentUplinks: []*ttnpb.UplinkMessage{{
 					Payload: &ttnpb.Message{
 						MHDR: ttnpb.MHDR{
@@ -3875,6 +3890,7 @@ func TestGenerateDownlink(t *testing.T) {
 						},
 						FPort: 0,
 						FRMPayload: encodeMAC(
+							phy,
 							ttnpb.CID_DEV_STATUS.MACCommand(),
 						),
 					},
@@ -3917,6 +3933,8 @@ func TestGenerateDownlink(t *testing.T) {
 							},
 						},
 					},
+					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
+					FrequencyPlanID:   band.EU_863_870,
 					RecentUplinks: []*ttnpb.UplinkMessage{{
 						Payload: &ttnpb.Message{
 							MHDR: ttnpb.MHDR{
@@ -3955,6 +3973,8 @@ func TestGenerateDownlink(t *testing.T) {
 						},
 					},
 				},
+				LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
+				FrequencyPlanID:   band.EU_863_870,
 				RecentUplinks: []*ttnpb.UplinkMessage{{
 					Payload: &ttnpb.Message{
 						MHDR: ttnpb.MHDR{
@@ -3980,6 +4000,7 @@ func TestGenerateDownlink(t *testing.T) {
 						},
 						FPort: 0,
 						FRMPayload: encodeMAC(
+							phy,
 							ttnpb.CID_DEV_STATUS.MACCommand(),
 						),
 					},
@@ -4020,6 +4041,8 @@ func TestGenerateDownlink(t *testing.T) {
 							},
 						},
 					},
+					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
+					FrequencyPlanID:   band.EU_863_870,
 					RecentUplinks: []*ttnpb.UplinkMessage{{
 						Payload: &ttnpb.Message{
 							MHDR: ttnpb.MHDR{
@@ -4055,8 +4078,12 @@ func TestGenerateDownlink(t *testing.T) {
 			defer ns.Close()
 
 			dev := CopyEndDevice(tc.Device)
+			_, phy, err := getDeviceBandVersion(dev, ns.FrequencyPlans)
+			if !a.So(err, should.BeNil) {
+				t.FailNow()
+			}
 
-			genDown, err := ns.generateDownlink(tc.Context, dev, math.MaxUint16, math.MaxUint16)
+			genDown, err := ns.generateDownlink(tc.Context, dev, phy, math.MaxUint16, math.MaxUint16)
 			if tc.Error != nil {
 				a.So(err, should.EqualErrorOrDefinition, tc.Error)
 				a.So(genDown, should.BeNil)

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -143,8 +143,8 @@ func (ns *NetworkServer) matchDevice(ctx context.Context, up *ttnpb.UplinkMessag
 								break
 							}
 							dev.MACState.CurrentParameters.Channels = append(dev.MACState.CurrentParameters.Channels, &ttnpb.MACParameters_Channel{
-								UplinkFrequency:   uint64(freq * 100),
-								DownlinkFrequency: uint64(freq * 100),
+								UplinkFrequency:   uint64(freq) * phy.FreqMultiplier,
+								DownlinkFrequency: uint64(freq) * phy.FreqMultiplier,
 								MaxDataRateIndex:  ttnpb.DataRateIndex(phy.MaxADRDataRateIndex),
 								EnableUplink:      true,
 							})
@@ -577,8 +577,8 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 								break
 							}
 							stored.MACState.CurrentParameters.Channels = append(stored.MACState.CurrentParameters.Channels, &ttnpb.MACParameters_Channel{
-								UplinkFrequency:   uint64(freq * 100),
-								DownlinkFrequency: uint64(freq * 100),
+								UplinkFrequency:   uint64(freq) * phy.FreqMultiplier,
+								DownlinkFrequency: uint64(freq) * phy.FreqMultiplier,
 								MaxDataRateIndex:  ttnpb.DataRateIndex(phy.MaxADRDataRateIndex),
 								EnableUplink:      true,
 							})

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -130,7 +130,7 @@ func (ns *NetworkServer) matchDevice(ctx context.Context, up *ttnpb.UplinkMessag
 				}
 
 				if dev.MACState.GetPendingJoinRequest().GetCFList() != nil {
-					_, band, err := getDeviceBandVersion(dev, ns.FrequencyPlans)
+					_, phy, err := getDeviceBandVersion(dev, ns.FrequencyPlans)
 					if err != nil {
 						logger.WithError(err).Warn("Failed to get device's versioned band, skip")
 						return true
@@ -145,7 +145,7 @@ func (ns *NetworkServer) matchDevice(ctx context.Context, up *ttnpb.UplinkMessag
 							dev.MACState.CurrentParameters.Channels = append(dev.MACState.CurrentParameters.Channels, &ttnpb.MACParameters_Channel{
 								UplinkFrequency:   uint64(freq * 100),
 								DownlinkFrequency: uint64(freq * 100),
-								MaxDataRateIndex:  ttnpb.DataRateIndex(band.MaxADRDataRateIndex),
+								MaxDataRateIndex:  ttnpb.DataRateIndex(phy.MaxADRDataRateIndex),
 								EnableUplink:      true,
 							})
 						}
@@ -227,12 +227,12 @@ outer:
 			gap = fCnt - dev.matchedSession.LastFCntUp
 
 			if dev.MACState.LoRaWANVersion.HasMaxFCntGap() {
-				_, band, err := getDeviceBandVersion(dev.EndDevice, ns.FrequencyPlans)
+				_, phy, err := getDeviceBandVersion(dev.EndDevice, ns.FrequencyPlans)
 				if err != nil {
 					logger.WithError(err).Warn("Failed to get device's versioned band, skip")
 					continue
 				}
-				if gap > uint32(band.MaxFCntGap) {
+				if gap > uint32(phy.MaxFCntGap) {
 					logger.Debug("FCnt gap too high, skip")
 					continue outer
 				}
@@ -451,8 +451,12 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 
 	var cmds []*ttnpb.MACCommand
 	for r := bytes.NewReader(mac); r.Len() > 0; {
+		_, phy, err := getDeviceBandVersion(matched, ns.FrequencyPlans)
+		if err != nil {
+			return errUnknownBand.WithCause(err)
+		}
 		cmd := &ttnpb.MACCommand{}
-		if err := lorawan.DefaultMACCommands.ReadUplink(r, cmd); err != nil {
+		if err := lorawan.DefaultMACCommands.ReadUplink(phy, r, cmd); err != nil {
 			logger.WithFields(log.Fields(
 				"bytes_left", r.Len(),
 				"mac_count", len(cmds),
@@ -561,7 +565,7 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 					stored.MACState.LoRaWANVersion = ttnpb.MAC_V1_1
 				}
 				if stored.MACState.PendingJoinRequest.CFList != nil {
-					_, band, err := getDeviceBandVersion(stored, ns.FrequencyPlans)
+					_, phy, err := getDeviceBandVersion(stored, ns.FrequencyPlans)
 					if err != nil {
 						return nil, nil, err
 					}
@@ -575,7 +579,7 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 							stored.MACState.CurrentParameters.Channels = append(stored.MACState.CurrentParameters.Channels, &ttnpb.MACParameters_Channel{
 								UplinkFrequency:   uint64(freq * 100),
 								DownlinkFrequency: uint64(freq * 100),
-								MaxDataRateIndex:  ttnpb.DataRateIndex(band.MaxADRDataRateIndex),
+								MaxDataRateIndex:  ttnpb.DataRateIndex(phy.MaxADRDataRateIndex),
 								EnableUplink:      true,
 							})
 						}

--- a/pkg/networkserver/mac_link_adr.go
+++ b/pkg/networkserver/mac_link_adr.go
@@ -41,20 +41,20 @@ func enqueueLinkADRReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, ma
 		return maxDownLen, maxUpLen, true, nil
 	}
 
-	_, band, err := getDeviceBandVersion(dev, fps)
+	_, phy, err := getDeviceBandVersion(dev, fps)
 	if err != nil {
 		return maxDownLen, maxUpLen, false, err
 	}
 
-	if len(dev.MACState.DesiredParameters.Channels) > int(band.MaxUplinkChannels) {
+	if len(dev.MACState.DesiredParameters.Channels) > int(phy.MaxUplinkChannels) {
 		return maxDownLen, maxUpLen, false, errCorruptedMACState
 	}
 
-	desiredChs := make([]bool, band.MaxUplinkChannels)
+	desiredChs := make([]bool, phy.MaxUplinkChannels)
 	for i, ch := range dev.MACState.DesiredParameters.Channels {
 		desiredChs[i] = ch.EnableUplink
 	}
-	desiredMasks, err := band.GenerateChMasks(desiredChs)
+	desiredMasks, err := phy.GenerateChMasks(desiredChs)
 	if err != nil {
 		return maxDownLen, maxUpLen, false, err
 	}
@@ -104,7 +104,7 @@ func handleLinkADRAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACC
 		events.Publish(evtReceiveLinkADRAccept(ctx, dev.EndDeviceIdentifiers, pld))
 	}
 
-	_, band, err := getDeviceBandVersion(dev, fps)
+	_, phy, err := getDeviceBandVersion(dev, fps)
 	if err != nil {
 		return err
 	}
@@ -145,7 +145,7 @@ func handleLinkADRAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACC
 			mask[i] = v
 		}
 
-		m, err := band.ParseChMask(mask, uint8(req.ChannelMaskControl))
+		m, err := phy.ParseChMask(mask, uint8(req.ChannelMaskControl))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/issues/1649

**Changes:**
<!-- What are the changes made in this pull request? -->

- Rename variable `band` to `phy` to avoid conflict with `pkg/band` import
- Add `FreqMultiplier` to band definitions and use these in MAC encoding/decoding