### PR TITLE
Add DevAddrPrefix to DevAddr generation function 

### DIFF
--- a/pkg/networkserver/config.go
+++ b/pkg/networkserver/config.go
@@ -26,7 +26,8 @@ import (
 type Config struct {
 	Devices             DeviceRegistry         `name:"-"`
 	DownlinkTasks       DownlinkTaskQueue      `name:"-"`
-	NetID               types.NetID            `name:"net_id" description:"NetID of this Network Server"`
+	NetID               types.NetID            `name:"net-id" description:"NetID of this Network Server"`
+	DevAddrPrefixes     []types.DevAddrPrefix  `name:"dev-addr-prefixes" description:""` // TODO
 	DeduplicationWindow time.Duration          `name:"deduplication-window" description:"Time window during which, duplicate messages are collected for metadata"`
 	CooldownWindow      time.Duration          `name:"cooldown-window" description:"Time window starting right after deduplication window, during which, duplicate messages are discarded"`
 	DownlinkPriorities  DownlinkPriorityConfig `name:"downlink-priorities" description:"Downlink message priorities"`

--- a/pkg/networkserver/config.go
+++ b/pkg/networkserver/config.go
@@ -27,7 +27,7 @@ type Config struct {
 	Devices             DeviceRegistry         `name:"-"`
 	DownlinkTasks       DownlinkTaskQueue      `name:"-"`
 	NetID               types.NetID            `name:"net-id" description:"NetID of this Network Server"`
-	DevAddrPrefixes     []types.DevAddrPrefix  `name:"dev-addr-prefixes" description:""` // TODO
+	DevAddrPrefixes     []types.DevAddrPrefix  `name:"dev-addr-prefixes" description:"DevAddrPrefixes of this Network Server"`
 	DeduplicationWindow time.Duration          `name:"deduplication-window" description:"Time window during which, duplicate messages are collected for metadata"`
 	CooldownWindow      time.Duration          `name:"cooldown-window" description:"Time window starting right after deduplication window, during which, duplicate messages are discarded"`
 	DownlinkPriorities  DownlinkPriorityConfig `name:"downlink-priorities" description:"Downlink message priorities"`

--- a/pkg/networkserver/config.go
+++ b/pkg/networkserver/config.go
@@ -27,7 +27,7 @@ type Config struct {
 	Devices             DeviceRegistry         `name:"-"`
 	DownlinkTasks       DownlinkTaskQueue      `name:"-"`
 	NetID               types.NetID            `name:"net-id" description:"NetID of this Network Server"`
-	DevAddrPrefixes     []types.DevAddrPrefix  `name:"dev-addr-prefixes" description:"DevAddrPrefixes of this Network Server"`
+	DevAddrPrefixes     []types.DevAddrPrefix  `name:"dev-addr-prefixes" description:"Device address prefixes of this Network Server"`
 	DeduplicationWindow time.Duration          `name:"deduplication-window" description:"Time window during which, duplicate messages are collected for metadata"`
 	CooldownWindow      time.Duration          `name:"cooldown-window" description:"Time window starting right after deduplication window, during which, duplicate messages are discarded"`
 	DownlinkPriorities  DownlinkPriorityConfig `name:"downlink-priorities" description:"Downlink message priorities"`

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -781,16 +781,15 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 
 // newDevAddr generates a DevAddr for specified EndDevice.
 func (ns *NetworkServer) newDevAddr(context.Context, *ttnpb.EndDevice) types.DevAddr {
-	// TODO: Allow generating DevAddr from a prefix. (https://github.com/TheThingsNetwork/lorawan-stack/issues/130)
-
-	// TODO: Randomly choose a ns.devAddrPrefixes
-	// TODO: Generate a random DevAddr within the chosen DevAddrPrefix
 	// TODO: Add tests
-
 	nwkAddr := make([]byte, types.NwkAddrLength(ns.netID))
 	random.Read(nwkAddr)
 	nwkAddr[0] &= 0xff >> (8 - types.NwkAddrBits(ns.netID)%8)
+
+	prefix := ns.devAddrPrefixes[random.Intn(len(ns.devAddrPrefixes))]
+
 	devAddr, err := types.NewDevAddr(ns.netID, nwkAddr)
+	devAddr = devAddr.WithPrefix(prefix)
 	if err != nil {
 		panic(errors.New("failed to create new DevAddr").WithCause(err))
 	}

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -29,7 +29,6 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/crypto"
 	"go.thethings.network/lorawan-stack/pkg/crypto/cryptoutil"
 	"go.thethings.network/lorawan-stack/pkg/encoding/lorawan"
-	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/events"
 	"go.thethings.network/lorawan-stack/pkg/frequencyplans"
 	"go.thethings.network/lorawan-stack/pkg/log"
@@ -781,19 +780,10 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 
 // newDevAddr generates a DevAddr for specified EndDevice.
 func (ns *NetworkServer) newDevAddr(context.Context, *ttnpb.EndDevice) types.DevAddr {
-	// TODO: Add tests
-	nwkAddr := make([]byte, types.NwkAddrLength(ns.netID))
-	random.Read(nwkAddr)
-	nwkAddr[0] &= 0xff >> (8 - types.NwkAddrBits(ns.netID)%8)
-
+	var devAddr types.DevAddr
+	random.Read(devAddr[:])
 	prefix := ns.devAddrPrefixes[random.Intn(len(ns.devAddrPrefixes))]
-
-	devAddr, err := types.NewDevAddr(ns.netID, nwkAddr)
-	devAddr = devAddr.WithPrefix(prefix)
-	if err != nil {
-		panic(errors.New("failed to create new DevAddr").WithCause(err))
-	}
-	return devAddr
+	return devAddr.WithPrefix(prefix)
 }
 
 func (ns *NetworkServer) handleJoin(ctx context.Context, up *ttnpb.UplinkMessage, acc *metadataAccumulator) (err error) {

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -782,6 +782,11 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 // newDevAddr generates a DevAddr for specified EndDevice.
 func (ns *NetworkServer) newDevAddr(context.Context, *ttnpb.EndDevice) types.DevAddr {
 	// TODO: Allow generating DevAddr from a prefix. (https://github.com/TheThingsNetwork/lorawan-stack/issues/130)
+
+	// TODO: Randomly choose a ns.devAddrPrefixes
+	// TODO: Generate a random DevAddr within the chosen DevAddrPrefix
+	// TODO: Add tests
+
 	nwkAddr := make([]byte, types.NwkAddrLength(ns.netID))
 	random.Read(nwkAddr)
 	nwkAddr[0] &= 0xff >> (8 - types.NwkAddrBits(ns.netID)%8)

--- a/pkg/networkserver/grpc_gsns_internal_test.go
+++ b/pkg/networkserver/grpc_gsns_internal_test.go
@@ -1,0 +1,92 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkserver
+
+import (
+	"testing"
+
+	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/pkg/component"
+	"go.thethings.network/lorawan-stack/pkg/types"
+	"go.thethings.network/lorawan-stack/pkg/util/test"
+	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
+)
+
+func TestNewDevAddr(t *testing.T) {
+	a := assertions.New(t)
+
+	// Use DevAddr prefix from NetID.
+	{
+		ns := test.Must(New(
+			component.MustNew(test.GetLogger(t), &component.Config{}),
+			&Config{
+				NetID:               types.NetID{0x00, 0x00, 0x13},
+				DeduplicationWindow: 42,
+				CooldownWindow:      42,
+				DownlinkTasks:       &MockDownlinkTaskQueue{},
+			})).(*NetworkServer)
+
+		if !a.So(ns.devAddrPrefixes, should.HaveLength, 1) {
+			t.FailNow()
+		}
+		a.So(ns.devAddrPrefixes[0], should.Resemble, types.DevAddrPrefix{
+			DevAddr: types.DevAddr{0x26, 0, 0, 0},
+			Length:  7,
+		})
+
+		devAddr := ns.newDevAddr(test.Context(), nil)
+		a.So(devAddr.HasPrefix(ns.devAddrPrefixes[0]), should.BeTrue)
+	}
+
+	// Configured DevAddr prefixes.
+	{
+		ns := test.Must(New(
+			component.MustNew(test.GetLogger(t), &component.Config{}),
+			&Config{
+				NetID: types.NetID{0x00, 0x00, 0x13},
+				DevAddrPrefixes: []types.DevAddrPrefix{
+					{
+						DevAddr: types.DevAddr{0x26, 0x01, 0x00, 0x00},
+						Length:  16,
+					},
+					{
+						DevAddr: types.DevAddr{0x26, 0xff, 0x01, 0x00},
+						Length:  24,
+					},
+					{
+						DevAddr: types.DevAddr{0x27, 0x00, 0x00, 0x00},
+						Length:  8,
+					},
+				},
+				DeduplicationWindow: 42,
+				CooldownWindow:      42,
+				DownlinkTasks:       &MockDownlinkTaskQueue{},
+			})).(*NetworkServer)
+
+		seen := map[types.DevAddrPrefix]int{}
+		for i := 0; i < 100; i++ {
+			devAddr := ns.newDevAddr(test.Context(), nil)
+			for _, prefix := range ns.devAddrPrefixes {
+				if devAddr.HasPrefix(prefix) {
+					seen[prefix]++
+					break
+				}
+			}
+		}
+		a.So(seen[ns.devAddrPrefixes[0]], should.BeGreaterThan, 0)
+		a.So(seen[ns.devAddrPrefixes[1]], should.BeGreaterThan, 0)
+		a.So(seen[ns.devAddrPrefixes[2]], should.BeGreaterThan, 0)
+	}
+}

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -113,6 +113,8 @@ type NetworkServer struct {
 	devices DeviceRegistry
 
 	netID types.NetID
+	// TODO: Read from configuration
+	devAddrPrefixes []types.DevAddrPrefix
 
 	applicationServersMu *sync.RWMutex
 	applicationServers   map[string]*applicationUpStream
@@ -201,6 +203,7 @@ func New(c *component.Component, conf *Config, opts ...Option) (*NetworkServer, 
 		Component:               c,
 		devices:                 conf.Devices,
 		netID:                   conf.NetID,
+		devAddrPrefixes:         conf.DevAddrPrefixes,
 		applicationServersMu:    &sync.RWMutex{},
 		applicationServers:      make(map[string]*applicationUpStream),
 		metadataAccumulators:    &sync.Map{},

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -112,8 +112,7 @@ type NetworkServer struct {
 
 	devices DeviceRegistry
 
-	netID types.NetID
-	// TODO: Read from configuration
+	netID           types.NetID
 	devAddrPrefixes []types.DevAddrPrefix
 
 	applicationServersMu *sync.RWMutex


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #130 

**Changes:**
<!-- What are the changes made in this pull request? -->

- Add random prefix choice from the network server slice of devAddrPrefixes
- Apply prefix to already generated DevAddr
- Make the network server create a prefix from NetID in case []types.DevAddrPrefixes is empty
- Add internal tests (grpc_gsns_internal_test.go)

**Notes for Reviewers:**
<!--
Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

#222 is closely related. Should be considered next.
