### PR TITLE
Improve getting started with TLS

### DIFF
--- a/doc/gettingstarted.md
+++ b/doc/gettingstarted.md
@@ -53,15 +53,23 @@ If your operating system or package manager is not mentioned, please [download b
 
 By default, the stack requires a `cert.pem` and `key.pem`, in order to to serve content over TLS.
 
-+ To generate self-signed certificates for `localhost`, use the following commands. This requires a [Go environment setup](../DEVELOPMENT.md#development-environment).
+Typically you'll get these from a trusted Certificate Authority. We recommend [Let's Encrypt](https://letsencrypt.org/getting-started/) for free and trusted TLS certificates for your server. Use the "full chain" for `cert.pem` and the "private key" for `key.pem`.
+
+For local (development) deployments, you can generate self-signed certificates. If you have your [Go environment](../DEVELOPMENT.md#development-environment) set up, you can run the following command to generate a key and certificate for `localhost`:
 
 ```bash
-$ go run $(go env GOROOT)/src/crypto/tls/generate_cert.go -ca -host localhost 
-# The following command is not required on Windows.
-$ chmod 0444 ./key.pem
+$ go run $(go env GOROOT)/src/crypto/tls/generate_cert.go -ca -host localhost
 ```
 
-Keep in mind that self-signed certificates are not trusted by browsers and operating systems, resulting in warnings and sometimes in errors. Consider [Let's Encrypt](https://letsencrypt.org/getting-started/) for free and trusted TLS certificates for your server.
+In order for the user in our Docker container to read these files, you have to change the ownership of the certificate and key:
+
+```bash
+$ chown 886:886 ./cert.pem ./key.pem
+```
+
+> If you don't do this, you'll get an error saying something like `/run/secrets/key.pem: permission denied`.
+
+Keep in mind that self-signed certificates are not trusted by browsers and operating systems, resulting in warnings and errors such as `certificate signed by unknown authority` or `ERR_CERT_AUTHORITY_INVALID`. In most browsers you can add an exception for your self-signed certificate. You can configure the CLI to trust the certificate as well.
 
 ## <a name="configuration">Configuration</a>
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR should resolve #484 by extending the "Certificates" section with more details for both Let's Encrypt certificates and self-signed certificates.

**Changes:**
<!-- What are the changes made in this pull request? -->

- Explain which files from Let's Encrypt to use
- Explain how to chown the cert/key to the user in our Docker container (instead of using chmod)
- Add error messages (I think it helps to be able to search for errors)
- Explain that you need to manually trust self-signed certificates.

**Notes for Reviewers:**
<!--
Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

> You can configure the CLI to trust the certificate as well

This will become clear in the PR for #483.
