### PR TITLE
Document CLI's config.yml

### DIFF
--- a/doc/gettingstarted.md
+++ b/doc/gettingstarted.md
@@ -73,6 +73,27 @@ Refer to the [networking documentation](networking.md) for the endpoints and por
 
 By default, frequency plans are fetched by the stack from a [public GitHub repository](https://github.com/TheThingsNetwork/lorawan-frequency-plans). To configure a local directory in offline environments, see the [configuration documentation](config.md) for more information.
 
+### <a name="cli-config">Command-line interface</a>
+
+The command-line interface has some built-in defaults, but you'll want to create a config file or set some environment variables to point it at your deployment.
+
+The recommended way to configure the CLI is with a `.ttn-lw-cli.yml` in your `$XDG_CONFIG_HOME` or `$HOME` directory. You can also put the config file in a different location, and pass it to the CLI as `-c path/to/config.yml`. In this guide we will use the following configuration file:
+
+```yml
+oauth-server-address: https://localhost:8885/oauth
+
+identity-server-grpc-address: localhost:8884
+gateway-server-grpc-address: localhost:8884
+network-server-grpc-address: localhost:8884
+application-server-grpc-address: localhost:8884
+join-server-grpc-address: localhost:8884
+
+ca: /path/to/your/cert.pem
+
+log:
+  level: info
+```
+
 ## <a name="running">Running the stack</a>
 
 You can run the stack using Docker or container orchestration solutions using Docker. An example [Docker Compose configuration](../docker-compose.yml) is available to get started quickly.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR resolves #483 by adding a section to the getting started that explains how to use a config.yml with the CLI. It also adds the config yml that is used in the rest of the getting started guide.

**Changes:**
<!-- What are the changes made in this pull request? -->

- Add command-line interface configuration section to Getting Started
- Add `--yml` flag to `ttn-lw-cli config` that renders the config as yml.

**Notes for Reviewers:**
<!--
Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The `ttn-lw-cli config --yml` command is for future use.
