### PR TITLE
Fix reading DevAddrPrefix from config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,8 @@ script:
     make dev.databases.start
     make dev.certs
     make go.test
+    go run ./cmd/ttn-lw-stack version
+    go run ./cmd/ttn-lw-cli version
   fi
 - |
   if [[ "$RUNTYPE" == "go.lint" ]]; then

--- a/pkg/types/devaddr.go
+++ b/pkg/types/devaddr.go
@@ -450,6 +450,20 @@ func (prefix *DevAddrPrefix) Scan(src interface{}) error {
 	return prefix.UnmarshalText(data)
 }
 
+// FromConfigString implements the config.Configurable interface
+func (prefix DevAddrPrefix) FromConfigString(in string) (interface{}, error) {
+	p := new(DevAddrPrefix)
+	if err := p.UnmarshalText([]byte(in)); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+// ConfigString implements the config.Stringer interface
+func (prefix DevAddrPrefix) ConfigString() string {
+	return prefix.String()
+}
+
 // WithPrefix returns the DevAddr, but with the first length bits replaced by the Prefix.
 func (addr DevAddr) WithPrefix(prefix DevAddrPrefix) (prefixed DevAddr) {
 	k := uint(prefix.Length)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR is a hotfix for a bug introduced in #485. It ensures that the DevAddrPrefix (that was added to config) can be unmarshaled from config.

**Changes:**
<!-- What are the changes made in this pull request? -->

- Implement config.Configurable and config.Stringer interfaces on types.DevAddrPrefix
- Add "go run" commands to Travis to avoid these kind of regressions in the future.

