### PR TITLE
Wrap validation errors

### DIFF
--- a/cmd/internal/errors/print_stack.go
+++ b/cmd/internal/errors/print_stack.go
@@ -28,7 +28,7 @@ func PrintStack(w io.Writer, err error) {
 		if i == 0 {
 			fmt.Fprintln(w, err)
 		} else {
-			fmt.Fprintf(w, "--- %s", err)
+			fmt.Fprintf(w, "--- %s\n", err)
 		}
 		for k, v := range errors.Attributes(err) {
 			fmt.Fprintf(os.Stderr, "    %s=%v\n", k, v)

--- a/config/messages.json
+++ b/config/messages.json
@@ -2402,6 +2402,15 @@
       "file": "attributes.go"
     }
   },
+  "error:pkg/errors:validation": {
+    "translations": {
+      "en": "invalid `{field}`: {reason}"
+    },
+    "description": {
+      "package": "pkg/errors",
+      "file": "validation.go"
+    }
+  },
   "error:pkg/fetch:fetch_file": {
     "translations": {
       "en": "could not fetch file `{filename}`"

--- a/pkg/errors/validation.go
+++ b/pkg/errors/validation.go
@@ -1,0 +1,25 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+type validationError interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+}
+
+var errValidation = DefineInvalidArgument("validation", "invalid `{field}`: {reason}", "name")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR wraps the validation errors introduced in #194 so that they can be communicated over gRPC.

**Changes:**
<!-- What are the changes made in this pull request? -->

As an additional change, I fixed the formatting of error cause stacks in the CLI

**Notes for Reviewers:**
<!--
Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This is technically an API change, because we now start communicating these errors over GRPC if they are the cause of an RPC to fail. However, these causes are only informative, so I didn't attach the compat/api label.

```
% go run ./cmd/ttn-lw-cli app create admin_app --user-id admin
error:pkg/ttnpb:identifiers (invalid identifiers)
    correlation_id=50b56c3f59654d68b5f52edb37302f32
--- error:pkg/errors:validation (invalid `application_id`: value does not match regex pattern "^[a-z0-9](?:[-]?[a-z0-9]){2,}$")
    name=ApplicationIdentifiersValidationError
    field=application_id
    reason=value does not match regex pattern "^[a-z0-9](?:[-]?[a-z0-9]){2,}$"
exit status 255
```