### PR TITLE
Publish gateway status and message uplink/downlink event payload

### DIFF
--- a/pkg/gatewayserver/observability.go
+++ b/pkg/gatewayserver/observability.go
@@ -161,12 +161,12 @@ func registerGatewayDisconnect(ctx context.Context, ids ttnpb.GatewayIdentifiers
 }
 
 func registerReceiveStatus(ctx context.Context, gtw *ttnpb.Gateway, status *ttnpb.GatewayStatus) {
-	events.Publish(evtReceiveStatus(ctx, gtw, nil))
+	events.Publish(evtReceiveStatus(ctx, gtw, status))
 	gsMetrics.statusReceived.WithLabelValues(ctx, gtw.GatewayID).Inc()
 }
 
 func registerReceiveUplink(ctx context.Context, gtw *ttnpb.Gateway, msg *ttnpb.UplinkMessage) {
-	events.Publish(evtReceiveUp(ctx, gtw, nil))
+	events.Publish(evtReceiveUp(ctx, gtw, msg))
 	gsMetrics.uplinkReceived.WithLabelValues(ctx, gtw.GatewayID).Inc()
 }
 
@@ -185,7 +185,7 @@ func registerDropUplink(ctx context.Context, devIDs ttnpb.EndDeviceIdentifiers, 
 }
 
 func registerSendDownlink(ctx context.Context, gtw *ttnpb.Gateway, msg *ttnpb.DownlinkMessage) {
-	events.Publish(evtSendDown(ctx, gtw, nil))
+	events.Publish(evtSendDown(ctx, gtw, msg))
 	gsMetrics.downlinkSent.WithLabelValues(ctx, gtw.GatewayID).Inc()
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #495 

**Changes:**
<!-- What are the changes made in this pull request? -->

- Publish gateway status and message uplink/downlink event payload

**Notes for Reviewers:**
<!--
Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This is only affecting `gs.status.receive`, `gs.up.receive`, `gs.down.send`

Related events, like `gs.up.{forward|drop}` and `gs.down.tx.{success|fail}` do not publish the payload. For now, we expect clients to use correlation IDs as authorization for these event types will be similar to their `gs.up.receive` and `gs.down.send` counterparts. We may add them later for stateless processing by clients.

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Added event payload to `gs.status.receive`, `gs.up.receive` and `gs.down.send` events