### PR TITLE
OAuth Authorization and Access Token management

### DIFF
--- a/cmd/ttn-lw-cli/commands/login.go
+++ b/cmd/ttn-lw-cli/commands/login.go
@@ -65,7 +65,7 @@ func logout() error {
 			}
 		}
 	}
-	if _, ok := cache.Get("api_key").(string); ok {
+	if key, ok := cache.Get("api_key").(string); ok && key != "" {
 		logger.Info("Removing API key from cache")
 		logger.Warn("Delete the API key if it was compromised")
 	}

--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -176,7 +176,7 @@ func optionalAuth() error {
 }
 
 func requireAuth() error {
-	if apiKey, ok := cache.Get("api_key").(string); ok {
+	if apiKey, ok := cache.Get("api_key").(string); ok && apiKey != "" {
 		logger.Debug("Using API key")
 		api.SetAuth("bearer", apiKey)
 		return nil

--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -154,7 +154,7 @@ func preRun(tasks ...func() error) func(cmd *cobra.Command, args []string) error
 func refreshToken() error {
 	if token, ok := cache.Get("oauth_token").(*oauth2.Token); ok && token != nil {
 		freshToken, err := oauth2Config.TokenSource(ctx, token).Token()
-		if freshToken != token {
+		if err == nil && freshToken != token {
 			cache.Set("oauth_token", freshToken)
 			if err := util.SaveCache(cache); err != nil {
 				return err

--- a/cmd/ttn-lw-cli/commands/users_oauth.go
+++ b/cmd/ttn-lw-cli/commands/users_oauth.go
@@ -51,7 +51,7 @@ var errNoTokenID = errors.DefineInvalidArgument("no_token_id", "no token ID set"
 var (
 	oauthCommand = &cobra.Command{
 		Use:   "oauth",
-		Short: "Manage OAuth authorizations and tokens",
+		Short: "Manage OAuth authorizations and access tokens",
 	}
 	oauthAuthorizationsCommand = &cobra.Command{
 		Use:   "authorizations",
@@ -85,7 +85,7 @@ var (
 	}
 	oauthAuthorizationsDeleteCommand = &cobra.Command{
 		Use:   "delete",
-		Short: "Delete an OAuth authorization and all tokens",
+		Short: "Delete an OAuth authorization and all access tokens",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			usrID, cliID := getUserAndClientID(cmd.Flags(), args)
 			if usrID == nil {
@@ -123,14 +123,15 @@ var (
 			return err
 		},
 	}
-	oauthTokensCommand = &cobra.Command{
-		Use:   "tokens",
-		Short: "Manage OAuth tokens",
+	oauthAccessTokensCommand = &cobra.Command{
+		Use:     "access-tokens",
+		Aliases: []string{"tokens"},
+		Short:   "Manage OAuth tokens",
 	}
-	oauthTokensListCommand = &cobra.Command{
+	oauthAccessTokensListCommand = &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "List OAuth tokens",
+		Short:   "List OAuth access tokens",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			usrID, cliID := getUserAndClientID(cmd.Flags(), args)
 			if usrID == nil {
@@ -159,9 +160,9 @@ var (
 			return io.Write(os.Stdout, config.OutputFormat, res)
 		},
 	}
-	oauthTokensDeleteCommand = &cobra.Command{
+	oauthAccessTokensDeleteCommand = &cobra.Command{
 		Use:   "delete",
-		Short: "Delete an OAuth token",
+		Short: "Delete an OAuth access token",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			usrID, cliID := getUserAndClientID(cmd.Flags(), args)
 			if usrID == nil {
@@ -190,3 +191,21 @@ var (
 		},
 	}
 )
+
+func init() {
+	oauthAuthorizationsListCommand.Flags().AddFlagSet(userIDFlags())
+	oauthAuthorizationsCommand.AddCommand(oauthAuthorizationsListCommand)
+	oauthAuthorizationsDeleteCommand.Flags().AddFlagSet(userIDFlags())
+	oauthAuthorizationsDeleteCommand.Flags().AddFlagSet(clientIDFlags())
+	oauthAuthorizationsCommand.AddCommand(oauthAuthorizationsDeleteCommand)
+	oauthCommand.AddCommand(oauthAuthorizationsCommand)
+	oauthAccessTokensListCommand.Flags().AddFlagSet(userIDFlags())
+	oauthAccessTokensListCommand.Flags().AddFlagSet(clientIDFlags())
+	oauthAccessTokensCommand.AddCommand(oauthAccessTokensListCommand)
+	oauthAccessTokensDeleteCommand.Flags().AddFlagSet(userIDFlags())
+	oauthAccessTokensDeleteCommand.Flags().AddFlagSet(clientIDFlags())
+	oauthAccessTokensDeleteCommand.Flags().String("token-id", "", "")
+	oauthAccessTokensCommand.AddCommand(oauthAccessTokensDeleteCommand)
+	oauthCommand.AddCommand(oauthAccessTokensCommand)
+	usersCommand.AddCommand(oauthCommand)
+}

--- a/config/messages.json
+++ b/config/messages.json
@@ -3104,6 +3104,15 @@
       "file": "contact_info_store.go"
     }
   },
+  "error:pkg/identityserver:access_token_mismatch": {
+    "translations": {
+      "en": "access token ID did not match user or client identifiers"
+    },
+    "description": {
+      "package": "pkg/identityserver",
+      "file": "oauth_registry.go"
+    }
+  },
   "error:pkg/identityserver:api_key_not_found": {
     "translations": {
       "en": "API key not found"

--- a/pkg/identityserver/identityserver.go
+++ b/pkg/identityserver/identityserver.go
@@ -160,6 +160,7 @@ func New(c *component.Component, config *Config) (is *IdentityServer, err error)
 		hooks.RegisterUnaryHook("/ttn.lorawan.v3.UserAccess", hook.name, hook.middleware)
 	}
 	hooks.RegisterUnaryHook("/ttn.lorawan.v3.EntityAccess", cluster.HookName, c.ClusterAuthUnaryHook())
+	hooks.RegisterUnaryHook("/ttn.lorawan.v3.OAuthAuthorizationRegistry", rights.HookName, rights.Hook)
 
 	c.RegisterGRPC(is)
 	c.RegisterWeb(is.oauth)
@@ -187,6 +188,7 @@ func (is *IdentityServer) RegisterServices(s *grpc.Server) {
 	ttnpb.RegisterUserAccessServer(s, &userAccess{IdentityServer: is})
 	ttnpb.RegisterUserInvitationRegistryServer(s, &invitationRegistry{IdentityServer: is})
 	ttnpb.RegisterEntityRegistrySearchServer(s, &registrySearch{IdentityServer: is, adminOnly: true})
+	ttnpb.RegisterOAuthAuthorizationRegistryServer(s, &oauthRegistry{IdentityServer: is})
 	ttnpb.RegisterContactInfoRegistryServer(s, &contactInfoRegistry{IdentityServer: is})
 }
 
@@ -206,6 +208,7 @@ func (is *IdentityServer) RegisterHandlers(s *runtime.ServeMux, conn *grpc.Clien
 	ttnpb.RegisterUserAccessHandler(is.Context(), s, conn)
 	ttnpb.RegisterUserInvitationRegistryHandler(is.Context(), s, conn)
 	ttnpb.RegisterEntityRegistrySearchHandler(is.Context(), s, conn)
+	ttnpb.RegisterOAuthAuthorizationRegistryHandler(is.Context(), s, conn)
 	ttnpb.RegisterContactInfoRegistryHandler(is.Context(), s, conn)
 }
 

--- a/pkg/identityserver/oauth_registry.go
+++ b/pkg/identityserver/oauth_registry.go
@@ -1,0 +1,142 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package identityserver
+
+import (
+	"context"
+
+	"github.com/gogo/protobuf/types"
+	"github.com/jinzhu/gorm"
+	"go.thethings.network/lorawan-stack/pkg/auth/rights"
+	"go.thethings.network/lorawan-stack/pkg/errors"
+	"go.thethings.network/lorawan-stack/pkg/identityserver/store"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+)
+
+func (is *IdentityServer) listOAuthClientAuthorizations(ctx context.Context, req *ttnpb.ListOAuthClientAuthorizationsRequest) (authorizations *ttnpb.OAuthClientAuthorizations, err error) {
+	if err := rights.RequireUser(ctx, req.UserIdentifiers, ttnpb.RIGHT_USER_ALL); err != nil {
+		return nil, err
+	}
+	var total uint64
+	ctx = store.WithPagination(ctx, req.Limit, req.Page, &total)
+	defer func() {
+		if err == nil {
+			setTotalHeader(ctx, total)
+		}
+	}()
+	authorizations = &ttnpb.OAuthClientAuthorizations{}
+	err = is.withDatabase(ctx, func(db *gorm.DB) (err error) {
+		authorizations.Authorizations, err = store.GetOAuthStore(db).ListAuthorizations(ctx, &req.UserIdentifiers)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return authorizations, nil
+}
+
+func (is *IdentityServer) listOAuthAccessTokens(ctx context.Context, req *ttnpb.ListOAuthAccessTokensRequest) (tokens *ttnpb.OAuthAccessTokens, err error) {
+	authInfo, err := is.authInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	accessToken := authInfo.GetOAuthAccessToken()
+	if accessToken == nil || accessToken.UserIDs.UserID != req.UserIDs.UserID || accessToken.ClientIDs.ClientID != req.ClientIDs.ClientID {
+		if err := rights.RequireUser(ctx, req.UserIDs, ttnpb.RIGHT_USER_ALL); err != nil {
+			return nil, err
+		}
+	}
+	var total uint64
+	ctx = store.WithPagination(ctx, req.Limit, req.Page, &total)
+	defer func() {
+		if err == nil {
+			setTotalHeader(ctx, total)
+		}
+	}()
+	tokens = &ttnpb.OAuthAccessTokens{}
+	err = is.withDatabase(ctx, func(db *gorm.DB) (err error) {
+		tokens.Tokens, err = store.GetOAuthStore(db).ListAccessTokens(ctx, &req.UserIDs, &req.ClientIDs)
+		return err
+	})
+	for _, token := range tokens.Tokens {
+		token.AccessToken, token.RefreshToken = "", ""
+	}
+	if err != nil {
+		return nil, err
+	}
+	return tokens, nil
+}
+
+func (is *IdentityServer) deleteOAuthAuthorization(ctx context.Context, req *ttnpb.OAuthClientAuthorizationIdentifiers) (*types.Empty, error) {
+	if err := rights.RequireUser(ctx, req.UserIDs, ttnpb.RIGHT_USER_ALL); err != nil {
+		return nil, err
+	}
+	err := is.withDatabase(ctx, func(db *gorm.DB) (err error) {
+		return store.GetOAuthStore(db).DeleteAuthorization(ctx, &req.UserIDs, &req.ClientIDs)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ttnpb.Empty, nil
+}
+
+var errAccessTokenMismatch = errors.DefineInvalidArgument("access_token_mismatch", "access token ID did not match user or client identifiers")
+
+func (is *IdentityServer) deleteOAuthAccessToken(ctx context.Context, req *ttnpb.OAuthAccessTokenIdentifiers) (*types.Empty, error) {
+	authInfo, err := is.authInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	accessToken := authInfo.GetOAuthAccessToken()
+	if accessToken == nil || accessToken.UserIDs.UserID != req.UserIDs.UserID || accessToken.ClientIDs.ClientID != req.ClientIDs.ClientID {
+		if err := rights.RequireUser(ctx, req.UserIDs, ttnpb.RIGHT_USER_ALL); err != nil {
+			return nil, err
+		}
+	}
+	err = is.withDatabase(ctx, func(db *gorm.DB) (err error) {
+		oauthStore := store.GetOAuthStore(db)
+		if accessToken != nil && accessToken.ID != req.ID {
+			accessToken, err := oauthStore.GetAccessToken(ctx, req.ID)
+			if err != nil {
+				return err
+			}
+			if accessToken.UserIDs.UserID != req.UserIDs.UserID || accessToken.ClientIDs.ClientID != req.ClientIDs.ClientID {
+				return errAccessTokenMismatch
+			}
+		}
+		return oauthStore.DeleteAccessToken(ctx, req.ID)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ttnpb.Empty, nil
+}
+
+type oauthRegistry struct {
+	*IdentityServer
+}
+
+func (or *oauthRegistry) List(ctx context.Context, req *ttnpb.ListOAuthClientAuthorizationsRequest) (*ttnpb.OAuthClientAuthorizations, error) {
+	return or.listOAuthClientAuthorizations(ctx, req)
+}
+func (or *oauthRegistry) ListTokens(ctx context.Context, req *ttnpb.ListOAuthAccessTokensRequest) (*ttnpb.OAuthAccessTokens, error) {
+	return or.listOAuthAccessTokens(ctx, req)
+}
+func (or *oauthRegistry) Delete(ctx context.Context, req *ttnpb.OAuthClientAuthorizationIdentifiers) (*types.Empty, error) {
+	return or.deleteOAuthAuthorization(ctx, req)
+}
+func (or *oauthRegistry) DeleteToken(ctx context.Context, req *ttnpb.OAuthAccessTokenIdentifiers) (*types.Empty, error) {
+	return or.deleteOAuthAccessToken(ctx, req)
+}

--- a/pkg/identityserver/oauth_registry_test.go
+++ b/pkg/identityserver/oauth_registry_test.go
@@ -1,0 +1,111 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package identityserver
+
+import (
+	"testing"
+
+	"github.com/smartystreets/assertions"
+	"github.com/smartystreets/assertions/should"
+	"go.thethings.network/lorawan-stack/pkg/identityserver/store"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/pkg/util/test"
+	"google.golang.org/grpc"
+)
+
+func TestOAuthRegistry(t *testing.T) {
+	ctx := test.Context()
+	a := assertions.New(t)
+
+	testWithIdentityServer(t, func(is *IdentityServer, cc *grpc.ClientConn) {
+		oauthStore := store.GetOAuthStore(is.db)
+		user, creds := defaultUser, userCreds(defaultUserIdx)
+		client := population.Clients[0]
+
+		_, err := oauthStore.Authorize(ctx, &ttnpb.OAuthClientAuthorization{
+			UserIDs:   user.UserIdentifiers,
+			ClientIDs: client.ClientIdentifiers,
+			Rights:    client.Rights,
+		})
+		if err != nil {
+			panic(err)
+		}
+
+		err = oauthStore.CreateAccessToken(ctx, &ttnpb.OAuthAccessToken{
+			UserIDs:      user.UserIdentifiers,
+			ClientIDs:    client.ClientIdentifiers,
+			ID:           "access_token_id",
+			Rights:       client.Rights,
+			AccessToken:  "access_token",
+			RefreshToken: "refresh_token",
+		}, "")
+		if err != nil {
+			panic(err)
+		}
+
+		reg := ttnpb.NewOAuthAuthorizationRegistryClient(cc)
+
+		authorizations, err := reg.List(ctx, &ttnpb.ListOAuthClientAuthorizationsRequest{
+			UserIdentifiers: user.UserIdentifiers,
+		}, creds)
+
+		a.So(err, should.BeNil)
+		a.So(authorizations, should.NotBeNil)
+		if a.So(authorizations.Authorizations, should.HaveLength, 1) {
+			a.So(authorizations.Authorizations[0].ClientIDs.ClientID, should.Equal, client.ClientID)
+		}
+
+		tokens, err := reg.ListTokens(ctx, &ttnpb.ListOAuthAccessTokensRequest{
+			UserIDs:   user.UserIdentifiers,
+			ClientIDs: client.ClientIdentifiers,
+		}, creds)
+
+		a.So(err, should.BeNil)
+		a.So(tokens, should.NotBeNil)
+		if a.So(tokens.Tokens, should.HaveLength, 1) {
+			a.So(tokens.Tokens[0].ID, should.Equal, "access_token_id")
+		}
+
+		_, err = reg.DeleteToken(ctx, &ttnpb.OAuthAccessTokenIdentifiers{
+			UserIDs:   user.UserIdentifiers,
+			ClientIDs: client.ClientIdentifiers,
+			ID:        "access_token_id",
+		}, creds)
+		a.So(err, should.BeNil)
+
+		tokens, err = reg.ListTokens(ctx, &ttnpb.ListOAuthAccessTokensRequest{
+			UserIDs:   user.UserIdentifiers,
+			ClientIDs: client.ClientIdentifiers,
+		}, creds)
+
+		a.So(err, should.BeNil)
+		a.So(tokens, should.NotBeNil)
+		a.So(tokens.Tokens, should.BeEmpty)
+
+		_, err = reg.Delete(ctx, &ttnpb.OAuthClientAuthorizationIdentifiers{
+			UserIDs:   user.UserIdentifiers,
+			ClientIDs: client.ClientIdentifiers,
+		}, creds)
+		a.So(err, should.BeNil)
+
+		authorizations, err = reg.List(ctx, &ttnpb.ListOAuthClientAuthorizationsRequest{
+			UserIdentifiers: user.UserIdentifiers,
+		}, creds)
+
+		a.So(err, should.BeNil)
+		a.So(authorizations, should.NotBeNil)
+		a.So(authorizations.Authorizations, should.BeEmpty)
+	})
+}

--- a/pkg/identityserver/store/oauth_store_test.go
+++ b/pkg/identityserver/store/oauth_store_test.go
@@ -26,7 +26,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/util/test"
 )
 
-func TestOauthStore(t *testing.T) {
+func TestOAuthStore(t *testing.T) {
 	ctx := test.Context()
 
 	WithDB(t, func(t *testing.T, db *gorm.DB) {
@@ -80,6 +80,14 @@ func TestOauthStore(t *testing.T) {
 			a.So(created.ClientIDs.ClientID, should.Equal, "test-client")
 			a.So(got.CreatedAt, should.HappenAfter, start)
 			a.So(got.UpdatedAt, should.HappenAfter, start)
+
+			list, err := store.ListAuthorizations(ctx, userIDs)
+
+			a.So(list, should.NotBeNil)
+			a.So(err, should.BeNil)
+			if a.So(list, should.HaveLength, 1) {
+				a.So(list[0], should.Resemble, got)
+			}
 
 			err = store.DeleteAuthorization(ctx, userIDs, clientIDs)
 
@@ -208,6 +216,14 @@ func TestOauthStore(t *testing.T) {
 
 			for _, right := range rights {
 				a.So(got.Rights, should.Contain, right)
+			}
+
+			list, err := store.ListAccessTokens(ctx, userIDs, clientIDs)
+
+			a.So(list, should.NotBeNil)
+			a.So(err, should.BeNil)
+			if a.So(list, should.HaveLength, 1) {
+				a.So(list[0], should.Resemble, got)
 			}
 
 			err = store.DeleteAccessToken(ctx, tokenID)

--- a/pkg/identityserver/store/store_interfaces.go
+++ b/pkg/identityserver/store/store_interfaces.go
@@ -142,6 +142,7 @@ type APIKeyStore interface {
 //
 // For internal use (by the OAuth server) only.
 type OAuthStore interface {
+	ListAuthorizations(ctx context.Context, userIDs *ttnpb.UserIdentifiers) ([]*ttnpb.OAuthClientAuthorization, error)
 	GetAuthorization(ctx context.Context, userIDs *ttnpb.UserIdentifiers, clientIDs *ttnpb.ClientIdentifiers) (*ttnpb.OAuthClientAuthorization, error)
 	Authorize(ctx context.Context, req *ttnpb.OAuthClientAuthorization) (authorization *ttnpb.OAuthClientAuthorization, err error)
 	DeleteAuthorization(ctx context.Context, userIDs *ttnpb.UserIdentifiers, clientIDs *ttnpb.ClientIdentifiers) error
@@ -151,6 +152,7 @@ type OAuthStore interface {
 	DeleteAuthorizationCode(ctx context.Context, code string) error
 
 	CreateAccessToken(ctx context.Context, token *ttnpb.OAuthAccessToken, previousID string) error
+	ListAccessTokens(ctx context.Context, userIDs *ttnpb.UserIdentifiers, clientIDs *ttnpb.ClientIdentifiers) ([]*ttnpb.OAuthAccessToken, error)
 	GetAccessToken(ctx context.Context, id string) (*ttnpb.OAuthAccessToken, error)
 	DeleteAccessToken(ctx context.Context, id string) error
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR closes #264 by adding OAuth Authorization and Access Token management to the IS stores, IS RPC server and by hooking up the management commands in the CLI.

**Changes:**
<!-- What are the changes made in this pull request? -->

- Add listing of Authorizations and Access Tokens to store interface and implementation
- Implement OAuth registry RPCs in the IS
- Hook up CLI's OAuth commands (that were previously dead code)
- Also do logout procedure on `ttn-lw-cli login` (to revoke old access token)
- Fix incorrect handling of API keys in the CLI (once used, you could never switch back to OAuth)

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Implemented OAuth management in the Identity Server
- Added `ttn-lw-cli users oauth` commands
