### PR TITLE
Fix errors in events

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -166,11 +166,11 @@ func Proto(e Event) (*ttnpb.Event, error) {
 		var err error
 		if protoMessage, ok := evt.data.(proto.Message); ok {
 			pb.Data, err = types.MarshalAny(protoMessage)
-		} else if err, ok := evt.data.(error); ok {
-			if ttnErr, ok := errors.From(err); ok {
-				pb.Data, err = types.MarshalAny(ttnErr.GRPCStatus().Proto())
+		} else if errData, ok := evt.data.(error); ok {
+			if ttnErrData, ok := errors.From(errData); ok {
+				pb.Data, err = types.MarshalAny(ttnpb.ErrorDetailsToProto(ttnErrData))
 			} else {
-				pb.Data, err = types.MarshalAny(&types.StringValue{Value: err.Error()})
+				pb.Data, err = types.MarshalAny(&types.StringValue{Value: errData.Error()})
 			}
 		} else {
 			value, err := gogoproto.Value(evt.data)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes #502 by using `ttnpb.ErrorDetailsToProto` instead of the statuspb. Additionally it skips marshaling empty maps.
