### PR TITLE
Make CLI args usage consistent and document

### DIFF
--- a/cmd/ttn-lw-cli/commands/applications.go
+++ b/cmd/ttn-lw-cli/commands/applications.go
@@ -110,7 +110,7 @@ var (
 		},
 	}
 	applicationsGetCommand = &cobra.Command{
-		Use:     "get",
+		Use:     "get [application-id]",
 		Aliases: []string{"info"},
 		Short:   "Get an application",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -136,7 +136,7 @@ var (
 		},
 	}
 	applicationsCreateCommand = &cobra.Command{
-		Use:     "create",
+		Use:     "create [application-id]",
 		Aliases: []string{"add", "register"},
 		Short:   "Create an application",
 		RunE: asBulk(func(cmd *cobra.Command, args []string) (err error) {
@@ -179,7 +179,7 @@ var (
 		}),
 	}
 	applicationsUpdateCommand = &cobra.Command{
-		Use:     "update",
+		Use:     "update [application-id]",
 		Aliases: []string{"set"},
 		Short:   "Update an application",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -216,7 +216,7 @@ var (
 		},
 	}
 	applicationsDeleteCommand = &cobra.Command{
-		Use:   "delete",
+		Use:   "delete [application-id]",
 		Short: "Delete an application",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			appID := getApplicationID(cmd.Flags(), args)

--- a/cmd/ttn-lw-cli/commands/applications.go
+++ b/cmd/ttn-lw-cli/commands/applications.go
@@ -236,8 +236,8 @@ var (
 			return nil
 		},
 	}
-	applicationsContactInfoCommand = contactInfoCommands("application", func(cmd *cobra.Command) (*ttnpb.EntityIdentifiers, error) {
-		appID := getApplicationID(cmd.Flags(), nil)
+	applicationsContactInfoCommand = contactInfoCommands("application", func(cmd *cobra.Command, args []string) (*ttnpb.EntityIdentifiers, error) {
+		appID := getApplicationID(cmd.Flags(), args)
 		if appID == nil {
 			return nil, errNoApplicationID
 		}

--- a/cmd/ttn-lw-cli/commands/applications_access.go
+++ b/cmd/ttn-lw-cli/commands/applications_access.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	applicationRights = &cobra.Command{
-		Use:   "rights",
+		Use:   "rights [application-id]",
 		Short: "List the rights to an application",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			appID := getApplicationID(cmd.Flags(), args)
@@ -52,7 +52,7 @@ var (
 		Short:   "Manage application collaborators",
 	}
 	applicationCollaboratorsList = &cobra.Command{
-		Use:     "list",
+		Use:     "list [application-id]",
 		Aliases: []string{"ls"},
 		Short:   "List application collaborators",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -150,7 +150,7 @@ var (
 		Short:   "Manage application API keys",
 	}
 	applicationAPIKeysList = &cobra.Command{
-		Use:     "list",
+		Use:     "list [application-id]",
 		Aliases: []string{"ls"},
 		Short:   "List application API keys",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/ttn-lw-cli/commands/applications_access.go
+++ b/cmd/ttn-lw-cli/commands/applications_access.go
@@ -217,7 +217,7 @@ var (
 		Aliases: []string{"set"},
 		Short:   "Update an application API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			appID := getApplicationID(cmd.Flags(), args[:1])
+			appID := getApplicationID(cmd.Flags(), firstArgs(1, args...))
 			if appID == nil {
 				return errNoApplicationID
 			}
@@ -256,7 +256,7 @@ var (
 		Aliases: []string{"remove"},
 		Short:   "Delete an application API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			appID := getApplicationID(cmd.Flags(), args[:1])
+			appID := getApplicationID(cmd.Flags(), firstArgs(1, args...))
 			if appID == nil {
 				return errNoApplicationID
 			}

--- a/cmd/ttn-lw-cli/commands/applications_access.go
+++ b/cmd/ttn-lw-cli/commands/applications_access.go
@@ -213,17 +213,17 @@ var (
 		},
 	}
 	applicationAPIKeysUpdate = &cobra.Command{
-		Use:     "update",
+		Use:     "update [application-id] [api-key-id]",
 		Aliases: []string{"set"},
 		Short:   "Update an application API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			id := getAPIKeyID(cmd.Flags(), args)
-			if id == "" {
-				return errNoAPIKeyID
-			}
-			appID := getApplicationID(cmd.Flags(), nil)
+			appID := getApplicationID(cmd.Flags(), args[:1])
 			if appID == nil {
 				return errNoApplicationID
+			}
+			id := getAPIKeyID(cmd.Flags(), args, 1)
+			if id == "" {
+				return errNoAPIKeyID
 			}
 			name, _ := cmd.Flags().GetString("name")
 
@@ -252,17 +252,17 @@ var (
 		},
 	}
 	applicationAPIKeysDelete = &cobra.Command{
-		Use:     "delete",
+		Use:     "delete [application-id] [api-key-id]",
 		Aliases: []string{"remove"},
 		Short:   "Delete an application API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			id := getAPIKeyID(cmd.Flags(), args)
-			if id == "" {
-				return errNoAPIKeyID
-			}
-			appID := getApplicationID(cmd.Flags(), nil)
+			appID := getApplicationID(cmd.Flags(), args[:1])
 			if appID == nil {
 				return errNoApplicationID
+			}
+			id := getAPIKeyID(cmd.Flags(), args, 1)
+			if id == "" {
+				return errNoAPIKeyID
 			}
 
 			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)

--- a/cmd/ttn-lw-cli/commands/applications_access.go
+++ b/cmd/ttn-lw-cli/commands/applications_access.go
@@ -176,11 +176,11 @@ var (
 		},
 	}
 	applicationAPIKeysCreate = &cobra.Command{
-		Use:     "create",
+		Use:     "create [application-id]",
 		Aliases: []string{"add", "generate"},
 		Short:   "Create an application API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			appID := getApplicationID(cmd.Flags(), nil)
+			appID := getApplicationID(cmd.Flags(), args)
 			if appID == nil {
 				return errNoApplicationID
 			}

--- a/cmd/ttn-lw-cli/commands/applications_downlink.go
+++ b/cmd/ttn-lw-cli/commands/applications_downlink.go
@@ -34,7 +34,7 @@ var (
 		Short: "Application downlink commands",
 	}
 	applicationsDownlinkPushCommand = &cobra.Command{
-		Use:   "push",
+		Use:   "push [application-id] [device-id]",
 		Short: "Push to the application downlink queue",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			devID, err := getEndDeviceID(cmd.Flags(), args, true)
@@ -63,7 +63,7 @@ var (
 		},
 	}
 	applicationsDownlinkReplaceCommand = &cobra.Command{
-		Use:   "replace",
+		Use:   "replace [application-id] [device-id]",
 		Short: "Replace the application downlink queue",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			devID, err := getEndDeviceID(cmd.Flags(), args, true)
@@ -92,7 +92,7 @@ var (
 		},
 	}
 	applicationsDownlinkClearCommand = &cobra.Command{
-		Use:   "clear",
+		Use:   "clear [application-id] [device-id]",
 		Short: "Clear the application downlink queue",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			devID, err := getEndDeviceID(cmd.Flags(), args, true)
@@ -115,7 +115,7 @@ var (
 		},
 	}
 	applicationsDownlinkListCommand = &cobra.Command{
-		Use:   "list",
+		Use:   "list [application-id] [device-id]",
 		Short: "List the application downlink queue",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			devID, err := getEndDeviceID(cmd.Flags(), args, true)

--- a/cmd/ttn-lw-cli/commands/applications_link.go
+++ b/cmd/ttn-lw-cli/commands/applications_link.go
@@ -41,7 +41,7 @@ var (
 		Short: "Application link commands",
 	}
 	applicationsLinkGetCommand = &cobra.Command{
-		Use:     "get",
+		Use:     "get [application-id]",
 		Aliases: []string{"info"},
 		Short:   "Get the properties of an application link",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -73,7 +73,7 @@ var (
 		},
 	}
 	applicationsLinkSetCommand = &cobra.Command{
-		Use:     "set",
+		Use:     "set [application-id]",
 		Aliases: []string{"update"},
 		Short:   "Set the properties of an application link",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -108,7 +108,7 @@ var (
 		},
 	}
 	applicationsLinkDeleteCommand = &cobra.Command{
-		Use:   "delete",
+		Use:   "delete [application-id]",
 		Short: "Delete an application link",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			appID := getApplicationID(cmd.Flags(), args)

--- a/cmd/ttn-lw-cli/commands/applications_subscribe.go
+++ b/cmd/ttn-lw-cli/commands/applications_subscribe.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	applicationsSubscribeCommand = &cobra.Command{
-		Use:     "subscribe",
+		Use:     "subscribe [application-id]",
 		Aliases: []string{"sub"},
 		Short:   "Subscribe to application uplink",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/ttn-lw-cli/commands/applications_webhooks.go
+++ b/cmd/ttn-lw-cli/commands/applications_webhooks.go
@@ -125,7 +125,7 @@ var (
 		},
 	}
 	applicationsWebhooksListCommand = &cobra.Command{
-		Use:     "list",
+		Use:     "list [application-id]",
 		Aliases: []string{"ls"},
 		Short:   "List application webhooks",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/ttn-lw-cli/commands/applications_webhooks.go
+++ b/cmd/ttn-lw-cli/commands/applications_webhooks.go
@@ -93,7 +93,7 @@ var (
 		},
 	}
 	applicationsWebhooksGetCommand = &cobra.Command{
-		Use:     "get",
+		Use:     "get [application-id] [webhook-id]",
 		Aliases: []string{"info"},
 		Short:   "Get the properties of an application webhook",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -157,7 +157,7 @@ var (
 		},
 	}
 	applicationsWebhooksSetCommand = &cobra.Command{
-		Use:     "set",
+		Use:     "set [application-id] [webhook-id]",
 		Aliases: []string{"update"},
 		Short:   "Set the properties of an application webhook",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -189,7 +189,7 @@ var (
 		},
 	}
 	applicationsWebhooksDeleteCommand = &cobra.Command{
-		Use:   "delete",
+		Use:   "delete [application-id] [webhook-id]",
 		Short: "Delete an application webhook",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			webhookID, err := getApplicationWebhookID(cmd.Flags(), args)

--- a/cmd/ttn-lw-cli/commands/clients.go
+++ b/cmd/ttn-lw-cli/commands/clients.go
@@ -240,8 +240,8 @@ var (
 			return nil
 		},
 	}
-	clientsContactInfoCommand = contactInfoCommands("client", func(cmd *cobra.Command) (*ttnpb.EntityIdentifiers, error) {
-		cliID := getClientID(cmd.Flags(), nil)
+	clientsContactInfoCommand = contactInfoCommands("client", func(cmd *cobra.Command, args []string) (*ttnpb.EntityIdentifiers, error) {
+		cliID := getClientID(cmd.Flags(), args)
 		if cliID == nil {
 			return nil, errNoClientID
 		}

--- a/cmd/ttn-lw-cli/commands/clients.go
+++ b/cmd/ttn-lw-cli/commands/clients.go
@@ -110,7 +110,7 @@ var (
 		},
 	}
 	clientsGetCommand = &cobra.Command{
-		Use:     "get",
+		Use:     "get [client-id]",
 		Aliases: []string{"info"},
 		Short:   "Get a client",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -136,7 +136,7 @@ var (
 		},
 	}
 	clientsCreateCommand = &cobra.Command{
-		Use:     "create",
+		Use:     "create [client-id]",
 		Aliases: []string{"add", "register"},
 		Short:   "Create a client",
 		RunE: asBulk(func(cmd *cobra.Command, args []string) (err error) {
@@ -183,7 +183,7 @@ var (
 		}),
 	}
 	clientsUpdateCommand = &cobra.Command{
-		Use:     "update",
+		Use:     "update [client-id]",
 		Aliases: []string{"set"},
 		Short:   "Update a client",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -220,7 +220,7 @@ var (
 		},
 	}
 	clientsDeleteCommand = &cobra.Command{
-		Use:   "delete",
+		Use:   "delete [client-id]",
 		Short: "Delete a client",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliID := getClientID(cmd.Flags(), args)

--- a/cmd/ttn-lw-cli/commands/clients_access.go
+++ b/cmd/ttn-lw-cli/commands/clients_access.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	clientRights = &cobra.Command{
-		Use:   "rights",
+		Use:   "rights [client-id]",
 		Short: "List the rights to a client",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliID := getClientID(cmd.Flags(), args)
@@ -52,7 +52,7 @@ var (
 		Short:   "Manage client collaborators",
 	}
 	clientCollaboratorsList = &cobra.Command{
-		Use:     "list",
+		Use:     "list [client-id]",
 		Aliases: []string{"ls"},
 		Short:   "List client collaborators",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/ttn-lw-cli/commands/contact_info.go
+++ b/cmd/ttn-lw-cli/commands/contact_info.go
@@ -111,15 +111,15 @@ var (
 	errMatchingContactInfoNotFound = errors.DefineAlreadyExists("contact_info_not_found", "matching contact info not found")
 )
 
-func contactInfoCommands(entity string, getID func(cmd *cobra.Command) (*ttnpb.EntityIdentifiers, error)) *cobra.Command {
+func contactInfoCommands(entity string, getID func(cmd *cobra.Command, args []string) (*ttnpb.EntityIdentifiers, error)) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "contact-info",
 		Short: fmt.Sprintf("Manage %s contact info", entity),
 	}
 	add := &cobra.Command{
-		Use: "add",
+		Use: fmt.Sprintf("add [%s-id]", entity),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			id, err := getID(cmd)
+			id, err := getID(cmd, args)
 			if err != nil {
 				return err
 			}
@@ -142,9 +142,9 @@ func contactInfoCommands(entity string, getID func(cmd *cobra.Command) (*ttnpb.E
 		},
 	}
 	remove := &cobra.Command{
-		Use: "remove",
+		Use: fmt.Sprintf("remove [%s-id]", entity),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			id, err := getID(cmd)
+			id, err := getID(cmd, args)
 			if err != nil {
 				return err
 			}

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -194,7 +194,7 @@ var (
 		},
 	}
 	endDevicesGetCommand = &cobra.Command{
-		Use:     "get",
+		Use:     "get [application-id] [device-id]",
 		Aliases: []string{"info"},
 		Short:   "Get an end device",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -266,7 +266,7 @@ var (
 		},
 	}
 	endDevicesCreateCommand = &cobra.Command{
-		Use:     "create",
+		Use:     "create [application-id] [device-id]",
 		Aliases: []string{"add", "register"},
 		Short:   "Create an end device",
 		RunE: asBulk(func(cmd *cobra.Command, args []string) (err error) {
@@ -439,7 +439,7 @@ var (
 		}),
 	}
 	endDevicesUpdateCommand = &cobra.Command{
-		Use:     "update",
+		Use:     "update [application-id] [device-id]",
 		Aliases: []string{"set"},
 		Short:   "Update an end device",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -618,7 +618,7 @@ var (
 		},
 	}
 	endDevicesDeleteCommand = &cobra.Command{
-		Use:   "delete",
+		Use:   "delete [application-id] [device-id]",
 		Short: "Delete an end device",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			devID, err := getEndDeviceID(cmd.Flags(), args, true)

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -162,7 +162,7 @@ var (
 		},
 	}
 	endDevicesListCommand = &cobra.Command{
-		Use:     "list",
+		Use:     "list [application-id]",
 		Aliases: []string{"ls"},
 		Short:   "List end devices",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -526,7 +526,7 @@ var (
 		Use:   "provision",
 		Short: "Provision end devices using vendor-specific data",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			appID := getApplicationID(cmd.Flags(), args)
+			appID := getApplicationID(cmd.Flags(), nil)
 			if appID == nil {
 				return errNoApplicationID
 			}

--- a/cmd/ttn-lw-cli/commands/flags.go
+++ b/cmd/ttn-lw-cli/commands/flags.go
@@ -99,13 +99,13 @@ var (
 	errNoAPIKeyRights = errors.DefineInvalidArgument("no_api_key_rights", "no API key rights set")
 )
 
-func getAPIKeyID(flagSet *pflag.FlagSet, args []string) string {
+func getAPIKeyID(flagSet *pflag.FlagSet, args []string, i int) string {
 	var apiKeyID string
-	if len(args) > 0 {
-		if len(args) > 1 {
-			logger.Warn("multiple IDs found in arguments, considering only the first")
+	if len(args) > 0+i {
+		if len(args) > 1+i {
+			logger.Warn("multiple API key IDs found in arguments, considering only the first")
 		}
-		apiKeyID = args[0]
+		apiKeyID = args[0+i]
 	} else {
 		apiKeyID, _ = flagSet.GetString("api-key-id")
 	}

--- a/cmd/ttn-lw-cli/commands/flags.go
+++ b/cmd/ttn-lw-cli/commands/flags.go
@@ -23,6 +23,13 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 )
 
+func firstArgs(i int, args ...string) []string {
+	if i > len(args) {
+		i = len(args)
+	}
+	return args[:i]
+}
+
 func collaboratorFlags() *pflag.FlagSet {
 	flagSet := &pflag.FlagSet{}
 	flagSet.String("user-id", "", "")

--- a/cmd/ttn-lw-cli/commands/gateways.go
+++ b/cmd/ttn-lw-cli/commands/gateways.go
@@ -350,8 +350,8 @@ var (
 			return io.Write(os.Stdout, config.OutputFormat, res)
 		},
 	}
-	gatewaysContactInfoCommand = contactInfoCommands("gateway", func(cmd *cobra.Command) (*ttnpb.EntityIdentifiers, error) {
-		gtwID, err := getGatewayID(cmd.Flags(), nil, true)
+	gatewaysContactInfoCommand = contactInfoCommands("gateway", func(cmd *cobra.Command, args []string) (*ttnpb.EntityIdentifiers, error) {
+		gtwID, err := getGatewayID(cmd.Flags(), args, true)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/ttn-lw-cli/commands/gateways.go
+++ b/cmd/ttn-lw-cli/commands/gateways.go
@@ -145,7 +145,7 @@ var (
 		},
 	}
 	gatewaysGetCommand = &cobra.Command{
-		Use:     "get",
+		Use:     "get [gateway-id]",
 		Aliases: []string{"info"},
 		Short:   "Get a gateway",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -183,7 +183,7 @@ var (
 		},
 	}
 	gatewaysCreateCommand = &cobra.Command{
-		Use:     "create",
+		Use:     "create [gateway-id]",
 		Aliases: []string{"add", "register"},
 		Short:   "Create a gateway",
 		RunE: asBulk(func(cmd *cobra.Command, args []string) (err error) {
@@ -242,7 +242,7 @@ var (
 	}
 	errAntennaIndex       = errors.DefineInvalidArgument("antenna_index", "index of antenna to update out of bounds")
 	gatewaysUpdateCommand = &cobra.Command{
-		Use:     "update",
+		Use:     "update [gateway-id]",
 		Aliases: []string{"set"},
 		Short:   "Update a gateway",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -309,7 +309,7 @@ var (
 		},
 	}
 	gatewaysDeleteCommand = &cobra.Command{
-		Use:   "delete",
+		Use:   "delete [gateway-id]",
 		Short: "Delete a gateway",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			gtwID, err := getGatewayID(cmd.Flags(), args, true)
@@ -330,7 +330,7 @@ var (
 		},
 	}
 	gatewaysConnectionStats = &cobra.Command{
-		Use:   "connection-stats",
+		Use:   "connection-stats [gateway-id]",
 		Short: "Get connection stats for a gateway",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			gtwID, err := getGatewayID(cmd.Flags(), args, true)

--- a/cmd/ttn-lw-cli/commands/gateways_access.go
+++ b/cmd/ttn-lw-cli/commands/gateways_access.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	gatewayRights = &cobra.Command{
-		Use:   "rights",
+		Use:   "rights [gateway-id]",
 		Short: "List the rights to a gateway",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			gtwID, err := getGatewayID(cmd.Flags(), args, true)
@@ -52,7 +52,7 @@ var (
 		Short:   "Manage gateway collaborators",
 	}
 	gatewayCollaboratorsList = &cobra.Command{
-		Use:     "list",
+		Use:     "list [gateway-id]",
 		Aliases: []string{"ls"},
 		Short:   "List gateway collaborators",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -81,7 +81,7 @@ var (
 		Use:   "set",
 		Short: "Set a gateway collaborator",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			gtwID, err := getGatewayID(cmd.Flags(), args, true)
+			gtwID, err := getGatewayID(cmd.Flags(), nil, true)
 			if err != nil {
 				return err
 			}
@@ -117,7 +117,7 @@ var (
 		Aliases: []string{"remove"},
 		Short:   "Delete a gateway collaborator",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			gtwID, err := getGatewayID(cmd.Flags(), args, true)
+			gtwID, err := getGatewayID(cmd.Flags(), nil, true)
 			if err != nil {
 				return err
 			}
@@ -150,7 +150,7 @@ var (
 		Short:   "Manage gateway API keys",
 	}
 	gatewayAPIKeysList = &cobra.Command{
-		Use:     "list",
+		Use:     "list [gateway-id]",
 		Aliases: []string{"ls"},
 		Short:   "List gateway API keys",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -180,7 +180,7 @@ var (
 		Aliases: []string{"add", "generate"},
 		Short:   "Create a gateway API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			gtwID, err := getGatewayID(cmd.Flags(), args, true)
+			gtwID, err := getGatewayID(cmd.Flags(), nil, true)
 			if err != nil {
 				return err
 			}
@@ -221,7 +221,7 @@ var (
 			if id == "" {
 				return errNoAPIKeyID
 			}
-			gtwID, err := getGatewayID(cmd.Flags(), args, true)
+			gtwID, err := getGatewayID(cmd.Flags(), nil, true)
 			if err != nil {
 				return err
 			}
@@ -260,7 +260,7 @@ var (
 			if id == "" {
 				return errNoAPIKeyID
 			}
-			gtwID, err := getGatewayID(cmd.Flags(), args, true)
+			gtwID, err := getGatewayID(cmd.Flags(), nil, true)
 			if err != nil {
 				return err
 			}

--- a/cmd/ttn-lw-cli/commands/gateways_access.go
+++ b/cmd/ttn-lw-cli/commands/gateways_access.go
@@ -217,7 +217,7 @@ var (
 		Aliases: []string{"set"},
 		Short:   "Update a gateway API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			gtwID, err := getGatewayID(cmd.Flags(), args[:1], true)
+			gtwID, err := getGatewayID(cmd.Flags(), firstArgs(1, args...), true)
 			if err != nil {
 				return err
 			}
@@ -256,7 +256,7 @@ var (
 		Aliases: []string{"remove"},
 		Short:   "Delete a gateway API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			gtwID, err := getGatewayID(cmd.Flags(), args[:1], true)
+			gtwID, err := getGatewayID(cmd.Flags(), firstArgs(1, args...), true)
 			if err != nil {
 				return err
 			}

--- a/cmd/ttn-lw-cli/commands/gateways_access.go
+++ b/cmd/ttn-lw-cli/commands/gateways_access.go
@@ -176,11 +176,11 @@ var (
 		},
 	}
 	gatewayAPIKeysCreate = &cobra.Command{
-		Use:     "create",
+		Use:     "create [gateway-id]",
 		Aliases: []string{"add", "generate"},
 		Short:   "Create a gateway API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			gtwID, err := getGatewayID(cmd.Flags(), nil, true)
+			gtwID, err := getGatewayID(cmd.Flags(), args, true)
 			if err != nil {
 				return err
 			}

--- a/cmd/ttn-lw-cli/commands/gateways_access.go
+++ b/cmd/ttn-lw-cli/commands/gateways_access.go
@@ -213,17 +213,17 @@ var (
 		},
 	}
 	gatewayAPIKeysUpdate = &cobra.Command{
-		Use:     "update",
+		Use:     "update [gateway-id] [api-key-id]",
 		Aliases: []string{"set"},
 		Short:   "Update a gateway API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			id := getAPIKeyID(cmd.Flags(), args)
-			if id == "" {
-				return errNoAPIKeyID
-			}
-			gtwID, err := getGatewayID(cmd.Flags(), nil, true)
+			gtwID, err := getGatewayID(cmd.Flags(), args[:1], true)
 			if err != nil {
 				return err
+			}
+			id := getAPIKeyID(cmd.Flags(), args, 1)
+			if id == "" {
+				return errNoAPIKeyID
 			}
 			name, _ := cmd.Flags().GetString("name")
 
@@ -252,17 +252,17 @@ var (
 		},
 	}
 	gatewayAPIKeysDelete = &cobra.Command{
-		Use:     "delete",
+		Use:     "delete [gateway-id] [api-key-id]",
 		Aliases: []string{"remove"},
 		Short:   "Delete a gateway API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			id := getAPIKeyID(cmd.Flags(), args)
-			if id == "" {
-				return errNoAPIKeyID
-			}
-			gtwID, err := getGatewayID(cmd.Flags(), nil, true)
+			gtwID, err := getGatewayID(cmd.Flags(), args[:1], true)
 			if err != nil {
 				return err
+			}
+			id := getAPIKeyID(cmd.Flags(), args, 1)
+			if id == "" {
+				return errNoAPIKeyID
 			}
 
 			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)

--- a/cmd/ttn-lw-cli/commands/login.go
+++ b/cmd/ttn-lw-cli/commands/login.go
@@ -65,7 +65,7 @@ func logout() error {
 			}
 		}
 	}
-	if _, ok := cache.Get("api_key").(string); ok {
+	if key, ok := cache.Get("api_key").(string); ok && key != "" {
 		logger.Info("Removing API key from cache")
 		logger.Warn("Delete the API key if it was compromised")
 	}

--- a/cmd/ttn-lw-cli/commands/organizations.go
+++ b/cmd/ttn-lw-cli/commands/organizations.go
@@ -110,7 +110,7 @@ var (
 		},
 	}
 	organizationsGetCommand = &cobra.Command{
-		Use:     "get",
+		Use:     "get [organization-id]",
 		Aliases: []string{"info"},
 		Short:   "Get an organization",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -136,7 +136,7 @@ var (
 		},
 	}
 	organizationsCreateCommand = &cobra.Command{
-		Use:     "create",
+		Use:     "create [organization-id]",
 		Aliases: []string{"add", "register"},
 		Short:   "Create an organization",
 		RunE: asBulk(func(cmd *cobra.Command, args []string) (err error) {
@@ -179,7 +179,7 @@ var (
 		}),
 	}
 	organizationsUpdateCommand = &cobra.Command{
-		Use:     "update",
+		Use:     "update [organization-id]",
 		Aliases: []string{"set"},
 		Short:   "Update an organization",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -216,7 +216,7 @@ var (
 		},
 	}
 	organizationsDeleteCommand = &cobra.Command{
-		Use:   "delete",
+		Use:   "delete [organization-id]",
 		Short: "Delete an organization",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			orgID := getOrganizationID(cmd.Flags(), args)

--- a/cmd/ttn-lw-cli/commands/organizations.go
+++ b/cmd/ttn-lw-cli/commands/organizations.go
@@ -236,8 +236,8 @@ var (
 			return nil
 		},
 	}
-	organizationsContactInfoCommand = contactInfoCommands("organization", func(cmd *cobra.Command) (*ttnpb.EntityIdentifiers, error) {
-		orgID := getOrganizationID(cmd.Flags(), nil)
+	organizationsContactInfoCommand = contactInfoCommands("organization", func(cmd *cobra.Command, args []string) (*ttnpb.EntityIdentifiers, error) {
+		orgID := getOrganizationID(cmd.Flags(), args)
 		if orgID == nil {
 			return nil, errNoOrganizationID
 		}

--- a/cmd/ttn-lw-cli/commands/organizations_access.go
+++ b/cmd/ttn-lw-cli/commands/organizations_access.go
@@ -213,17 +213,17 @@ var (
 		},
 	}
 	organizationAPIKeysUpdate = &cobra.Command{
-		Use:     "update",
+		Use:     "update [organization-id] [api-key-id]",
 		Aliases: []string{"set"},
 		Short:   "Update an organization API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			id := getAPIKeyID(cmd.Flags(), args)
-			if id == "" {
-				return errNoAPIKeyID
-			}
-			orgID := getOrganizationID(cmd.Flags(), nil)
+			orgID := getOrganizationID(cmd.Flags(), args[:1])
 			if orgID == nil {
 				return errNoOrganizationID
+			}
+			id := getAPIKeyID(cmd.Flags(), args, 1)
+			if id == "" {
+				return errNoAPIKeyID
 			}
 			name, _ := cmd.Flags().GetString("name")
 
@@ -252,17 +252,17 @@ var (
 		},
 	}
 	organizationAPIKeysDelete = &cobra.Command{
-		Use:     "delete",
+		Use:     "delete [organization-id] [api-key-id]",
 		Aliases: []string{"remove"},
 		Short:   "Delete an organization API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			id := getAPIKeyID(cmd.Flags(), args)
-			if id == "" {
-				return errNoAPIKeyID
-			}
-			orgID := getOrganizationID(cmd.Flags(), nil)
+			orgID := getOrganizationID(cmd.Flags(), args[:1])
 			if orgID == nil {
 				return errNoOrganizationID
+			}
+			id := getAPIKeyID(cmd.Flags(), args, 1)
+			if id == "" {
+				return errNoAPIKeyID
 			}
 
 			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)

--- a/cmd/ttn-lw-cli/commands/organizations_access.go
+++ b/cmd/ttn-lw-cli/commands/organizations_access.go
@@ -176,11 +176,11 @@ var (
 		},
 	}
 	organizationAPIKeysCreate = &cobra.Command{
-		Use:     "create",
+		Use:     "create [organization-id]",
 		Aliases: []string{"add", "generate"},
 		Short:   "Create an organization API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			orgID := getOrganizationID(cmd.Flags(), nil)
+			orgID := getOrganizationID(cmd.Flags(), args)
 			if orgID == nil {
 				return errNoOrganizationID
 			}

--- a/cmd/ttn-lw-cli/commands/organizations_access.go
+++ b/cmd/ttn-lw-cli/commands/organizations_access.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	organizationRights = &cobra.Command{
-		Use:   "rights",
+		Use:   "rights [organization-id]",
 		Short: "List the rights to an organization",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			orgID := getOrganizationID(cmd.Flags(), args)
@@ -52,7 +52,7 @@ var (
 		Short:   "Manage organization collaborators",
 	}
 	organizationCollaboratorsList = &cobra.Command{
-		Use:     "list",
+		Use:     "list [organization-id]",
 		Aliases: []string{"ls"},
 		Short:   "List organization collaborators",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -150,7 +150,7 @@ var (
 		Short:   "Manage organization API keys",
 	}
 	organizationAPIKeysList = &cobra.Command{
-		Use:     "list",
+		Use:     "list [organization-id]",
 		Aliases: []string{"ls"},
 		Short:   "List organization API keys",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/ttn-lw-cli/commands/organizations_access.go
+++ b/cmd/ttn-lw-cli/commands/organizations_access.go
@@ -217,7 +217,7 @@ var (
 		Aliases: []string{"set"},
 		Short:   "Update an organization API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			orgID := getOrganizationID(cmd.Flags(), args[:1])
+			orgID := getOrganizationID(cmd.Flags(), firstArgs(1, args...))
 			if orgID == nil {
 				return errNoOrganizationID
 			}
@@ -256,7 +256,7 @@ var (
 		Aliases: []string{"remove"},
 		Short:   "Delete an organization API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			orgID := getOrganizationID(cmd.Flags(), args[:1])
+			orgID := getOrganizationID(cmd.Flags(), firstArgs(1, args...))
 			if orgID == nil {
 				return errNoOrganizationID
 			}

--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -176,7 +176,7 @@ func optionalAuth() error {
 }
 
 func requireAuth() error {
-	if apiKey, ok := cache.Get("api_key").(string); ok {
+	if apiKey, ok := cache.Get("api_key").(string); ok && apiKey != "" {
 		logger.Debug("Using API key")
 		api.SetAuth("bearer", apiKey)
 		return nil

--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -154,7 +154,7 @@ func preRun(tasks ...func() error) func(cmd *cobra.Command, args []string) error
 func refreshToken() error {
 	if token, ok := cache.Get("oauth_token").(*oauth2.Token); ok && token != nil {
 		freshToken, err := oauth2Config.TokenSource(ctx, token).Token()
-		if freshToken != token {
+		if err == nil && freshToken != token {
 			cache.Set("oauth_token", freshToken)
 			if err := util.SaveCache(cache); err != nil {
 				return err

--- a/cmd/ttn-lw-cli/commands/users.go
+++ b/cmd/ttn-lw-cli/commands/users.go
@@ -305,8 +305,8 @@ var (
 			return nil
 		},
 	}
-	usersContactInfoCommand = contactInfoCommands("user", func(cmd *cobra.Command) (*ttnpb.EntityIdentifiers, error) {
-		usrID := getUserID(cmd.Flags(), nil)
+	usersContactInfoCommand = contactInfoCommands("user", func(cmd *cobra.Command, args []string) (*ttnpb.EntityIdentifiers, error) {
+		usrID := getUserID(cmd.Flags(), args)
 		if usrID == nil {
 			return nil, errNoUserID
 		}

--- a/cmd/ttn-lw-cli/commands/users.go
+++ b/cmd/ttn-lw-cli/commands/users.go
@@ -88,7 +88,7 @@ var (
 		},
 	}
 	usersGetCommand = &cobra.Command{
-		Use:     "get",
+		Use:     "get [user-id]",
 		Aliases: []string{"info"},
 		Short:   "Get a user",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -114,7 +114,7 @@ var (
 		},
 	}
 	usersCreateCommand = &cobra.Command{
-		Use:               "create",
+		Use:               "create [user-id]",
 		Aliases:           []string{"add", "register"},
 		Short:             "Create a user",
 		PersistentPreRunE: preRun(optionalAuth),
@@ -175,7 +175,7 @@ var (
 		}),
 	}
 	usersUpdateCommand = &cobra.Command{
-		Use:     "update",
+		Use:     "update [user-id]",
 		Aliases: []string{"set"},
 		Short:   "Update a user",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -219,7 +219,7 @@ var (
 		},
 	}
 	usersForgotPasswordCommand = &cobra.Command{
-		Use:   "forgot-password",
+		Use:   "forgot-password [user-id]",
 		Short: "Request a temporary user password",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			usrID := getUserID(cmd.Flags(), args)
@@ -241,7 +241,7 @@ var (
 		},
 	}
 	usersUpdatePasswordCommand = &cobra.Command{
-		Use:     "update-password",
+		Use:     "update-password [user-id]",
 		Aliases: []string{"change-password"},
 		Short:   "Update a user password",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -285,7 +285,7 @@ var (
 		},
 	}
 	usersDeleteCommand = &cobra.Command{
-		Use:   "delete",
+		Use:   "delete [user-id]",
 		Short: "Delete a user",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			usrID := getUserID(cmd.Flags(), args)

--- a/cmd/ttn-lw-cli/commands/users_access.go
+++ b/cmd/ttn-lw-cli/commands/users_access.go
@@ -115,17 +115,17 @@ var (
 		},
 	}
 	userAPIKeysUpdate = &cobra.Command{
-		Use:     "update",
+		Use:     "update [user-id] [api-key-id]",
 		Aliases: []string{"set"},
 		Short:   "Update a user API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			id := getAPIKeyID(cmd.Flags(), args)
-			if id == "" {
-				return errNoAPIKeyID
-			}
-			usrID := getUserID(cmd.Flags(), nil)
+			usrID := getUserID(cmd.Flags(), args[:1])
 			if usrID == nil {
 				return errNoUserID
+			}
+			id := getAPIKeyID(cmd.Flags(), args, 1)
+			if id == "" {
+				return errNoAPIKeyID
 			}
 			name, _ := cmd.Flags().GetString("name")
 
@@ -154,17 +154,17 @@ var (
 		},
 	}
 	userAPIKeysDelete = &cobra.Command{
-		Use:     "delete",
+		Use:     "delete [user-id] [api-key-id]",
 		Aliases: []string{"remove"},
 		Short:   "Delete a user API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			id := getAPIKeyID(cmd.Flags(), args)
-			if id == "" {
-				return errNoAPIKeyID
-			}
-			usrID := getUserID(cmd.Flags(), nil)
+			usrID := getUserID(cmd.Flags(), args[:1])
 			if usrID == nil {
 				return errNoUserID
+			}
+			id := getAPIKeyID(cmd.Flags(), args, 1)
+			if id == "" {
+				return errNoAPIKeyID
 			}
 
 			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)

--- a/cmd/ttn-lw-cli/commands/users_access.go
+++ b/cmd/ttn-lw-cli/commands/users_access.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	userRights = &cobra.Command{
-		Use:   "rights",
+		Use:   "rights [user-id]",
 		Short: "List the rights to a user",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			usrID := getUserID(cmd.Flags(), args)
@@ -52,7 +52,7 @@ var (
 		Short:   "Manage user API keys",
 	}
 	userAPIKeysList = &cobra.Command{
-		Use:     "list",
+		Use:     "list [user-id]",
 		Aliases: []string{"ls"},
 		Short:   "List user API keys",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/ttn-lw-cli/commands/users_access.go
+++ b/cmd/ttn-lw-cli/commands/users_access.go
@@ -119,7 +119,7 @@ var (
 		Aliases: []string{"set"},
 		Short:   "Update a user API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			usrID := getUserID(cmd.Flags(), args[:1])
+			usrID := getUserID(cmd.Flags(), firstArgs(1, args...))
 			if usrID == nil {
 				return errNoUserID
 			}
@@ -158,7 +158,7 @@ var (
 		Aliases: []string{"remove"},
 		Short:   "Delete a user API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			usrID := getUserID(cmd.Flags(), args[:1])
+			usrID := getUserID(cmd.Flags(), firstArgs(1, args...))
 			if usrID == nil {
 				return errNoUserID
 			}

--- a/cmd/ttn-lw-cli/commands/users_access.go
+++ b/cmd/ttn-lw-cli/commands/users_access.go
@@ -78,11 +78,11 @@ var (
 		},
 	}
 	userAPIKeysCreate = &cobra.Command{
-		Use:     "create",
+		Use:     "create [user-id]",
 		Aliases: []string{"add", "generate"},
 		Short:   "Create a user API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			usrID := getUserID(cmd.Flags(), nil)
+			usrID := getUserID(cmd.Flags(), args)
 			if usrID == nil {
 				return errNoUserID
 			}

--- a/cmd/ttn-lw-cli/commands/users_invitations.go
+++ b/cmd/ttn-lw-cli/commands/users_invitations.go
@@ -69,7 +69,7 @@ var (
 		},
 	}
 	userInvitationsCreate = &cobra.Command{
-		Use:   "create",
+		Use:   "create [email]",
 		Short: "Create a user invitation",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			email := getEmail(cmd.Flags(), args)
@@ -90,7 +90,7 @@ var (
 		},
 	}
 	userInvitationsDelete = &cobra.Command{
-		Use:   "delete",
+		Use:   "delete [email]",
 		Short: "Delete a user invitation",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			email := getEmail(cmd.Flags(), args)

--- a/cmd/ttn-lw-cli/commands/users_oauth.go
+++ b/cmd/ttn-lw-cli/commands/users_oauth.go
@@ -51,7 +51,7 @@ var errNoTokenID = errors.DefineInvalidArgument("no_token_id", "no token ID set"
 var (
 	oauthCommand = &cobra.Command{
 		Use:   "oauth",
-		Short: "Manage OAuth authorizations and tokens",
+		Short: "Manage OAuth authorizations and access tokens",
 	}
 	oauthAuthorizationsCommand = &cobra.Command{
 		Use:   "authorizations",
@@ -85,7 +85,7 @@ var (
 	}
 	oauthAuthorizationsDeleteCommand = &cobra.Command{
 		Use:   "delete",
-		Short: "Delete an OAuth authorization and all tokens",
+		Short: "Delete an OAuth authorization and all access tokens",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			usrID, cliID := getUserAndClientID(cmd.Flags(), args)
 			if usrID == nil {
@@ -123,14 +123,15 @@ var (
 			return err
 		},
 	}
-	oauthTokensCommand = &cobra.Command{
-		Use:   "tokens",
-		Short: "Manage OAuth tokens",
+	oauthAccessTokensCommand = &cobra.Command{
+		Use:     "access-tokens",
+		Aliases: []string{"tokens"},
+		Short:   "Manage OAuth tokens",
 	}
-	oauthTokensListCommand = &cobra.Command{
+	oauthAccessTokensListCommand = &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"ls"},
-		Short:   "List OAuth tokens",
+		Short:   "List OAuth access tokens",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			usrID, cliID := getUserAndClientID(cmd.Flags(), args)
 			if usrID == nil {
@@ -159,9 +160,9 @@ var (
 			return io.Write(os.Stdout, config.OutputFormat, res)
 		},
 	}
-	oauthTokensDeleteCommand = &cobra.Command{
+	oauthAccessTokensDeleteCommand = &cobra.Command{
 		Use:   "delete",
-		Short: "Delete an OAuth token",
+		Short: "Delete an OAuth access token",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			usrID, cliID := getUserAndClientID(cmd.Flags(), args)
 			if usrID == nil {
@@ -190,3 +191,21 @@ var (
 		},
 	}
 )
+
+func init() {
+	oauthAuthorizationsListCommand.Flags().AddFlagSet(userIDFlags())
+	oauthAuthorizationsCommand.AddCommand(oauthAuthorizationsListCommand)
+	oauthAuthorizationsDeleteCommand.Flags().AddFlagSet(userIDFlags())
+	oauthAuthorizationsDeleteCommand.Flags().AddFlagSet(clientIDFlags())
+	oauthAuthorizationsCommand.AddCommand(oauthAuthorizationsDeleteCommand)
+	oauthCommand.AddCommand(oauthAuthorizationsCommand)
+	oauthAccessTokensListCommand.Flags().AddFlagSet(userIDFlags())
+	oauthAccessTokensListCommand.Flags().AddFlagSet(clientIDFlags())
+	oauthAccessTokensCommand.AddCommand(oauthAccessTokensListCommand)
+	oauthAccessTokensDeleteCommand.Flags().AddFlagSet(userIDFlags())
+	oauthAccessTokensDeleteCommand.Flags().AddFlagSet(clientIDFlags())
+	oauthAccessTokensDeleteCommand.Flags().String("token-id", "", "")
+	oauthAccessTokensCommand.AddCommand(oauthAccessTokensDeleteCommand)
+	oauthCommand.AddCommand(oauthAccessTokensCommand)
+	usersCommand.AddCommand(oauthCommand)
+}

--- a/cmd/ttn-lw-cli/commands/users_oauth.go
+++ b/cmd/ttn-lw-cli/commands/users_oauth.go
@@ -58,7 +58,7 @@ var (
 		Short: "Manage OAuth authorizations",
 	}
 	oauthAuthorizationsListCommand = &cobra.Command{
-		Use:     "list",
+		Use:     "list [user-id]",
 		Aliases: []string{"ls"},
 		Short:   "List OAuth authorizations",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/ttn-lw-cli/commands/users_oauth.go
+++ b/cmd/ttn-lw-cli/commands/users_oauth.go
@@ -84,7 +84,7 @@ var (
 		},
 	}
 	oauthAuthorizationsDeleteCommand = &cobra.Command{
-		Use:   "delete",
+		Use:   "delete [user-id] [client-id]",
 		Short: "Delete an OAuth authorization and all access tokens",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			usrID, cliID := getUserAndClientID(cmd.Flags(), args)
@@ -129,7 +129,7 @@ var (
 		Short:   "Manage OAuth tokens",
 	}
 	oauthAccessTokensListCommand = &cobra.Command{
-		Use:     "list",
+		Use:     "list [user-id] [client-id]",
 		Aliases: []string{"ls"},
 		Short:   "List OAuth access tokens",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -161,7 +161,7 @@ var (
 		},
 	}
 	oauthAccessTokensDeleteCommand = &cobra.Command{
-		Use:   "delete",
+		Use:   "delete [user-id] [client-id]",
 		Short: "Delete an OAuth access token",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			usrID, cliID := getUserAndClientID(cmd.Flags(), args)

--- a/config/messages.json
+++ b/config/messages.json
@@ -3104,6 +3104,15 @@
       "file": "contact_info_store.go"
     }
   },
+  "error:pkg/identityserver:access_token_mismatch": {
+    "translations": {
+      "en": "access token ID did not match user or client identifiers"
+    },
+    "description": {
+      "package": "pkg/identityserver",
+      "file": "oauth_registry.go"
+    }
+  },
   "error:pkg/identityserver:api_key_not_found": {
     "translations": {
       "en": "API key not found"

--- a/pkg/identityserver/identityserver.go
+++ b/pkg/identityserver/identityserver.go
@@ -160,6 +160,7 @@ func New(c *component.Component, config *Config) (is *IdentityServer, err error)
 		hooks.RegisterUnaryHook("/ttn.lorawan.v3.UserAccess", hook.name, hook.middleware)
 	}
 	hooks.RegisterUnaryHook("/ttn.lorawan.v3.EntityAccess", cluster.HookName, c.ClusterAuthUnaryHook())
+	hooks.RegisterUnaryHook("/ttn.lorawan.v3.OAuthAuthorizationRegistry", rights.HookName, rights.Hook)
 
 	c.RegisterGRPC(is)
 	c.RegisterWeb(is.oauth)
@@ -187,6 +188,7 @@ func (is *IdentityServer) RegisterServices(s *grpc.Server) {
 	ttnpb.RegisterUserAccessServer(s, &userAccess{IdentityServer: is})
 	ttnpb.RegisterUserInvitationRegistryServer(s, &invitationRegistry{IdentityServer: is})
 	ttnpb.RegisterEntityRegistrySearchServer(s, &registrySearch{IdentityServer: is, adminOnly: true})
+	ttnpb.RegisterOAuthAuthorizationRegistryServer(s, &oauthRegistry{IdentityServer: is})
 	ttnpb.RegisterContactInfoRegistryServer(s, &contactInfoRegistry{IdentityServer: is})
 }
 
@@ -206,6 +208,7 @@ func (is *IdentityServer) RegisterHandlers(s *runtime.ServeMux, conn *grpc.Clien
 	ttnpb.RegisterUserAccessHandler(is.Context(), s, conn)
 	ttnpb.RegisterUserInvitationRegistryHandler(is.Context(), s, conn)
 	ttnpb.RegisterEntityRegistrySearchHandler(is.Context(), s, conn)
+	ttnpb.RegisterOAuthAuthorizationRegistryHandler(is.Context(), s, conn)
 	ttnpb.RegisterContactInfoRegistryHandler(is.Context(), s, conn)
 }
 

--- a/pkg/identityserver/oauth_registry.go
+++ b/pkg/identityserver/oauth_registry.go
@@ -1,0 +1,142 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package identityserver
+
+import (
+	"context"
+
+	"github.com/gogo/protobuf/types"
+	"github.com/jinzhu/gorm"
+	"go.thethings.network/lorawan-stack/pkg/auth/rights"
+	"go.thethings.network/lorawan-stack/pkg/errors"
+	"go.thethings.network/lorawan-stack/pkg/identityserver/store"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+)
+
+func (is *IdentityServer) listOAuthClientAuthorizations(ctx context.Context, req *ttnpb.ListOAuthClientAuthorizationsRequest) (authorizations *ttnpb.OAuthClientAuthorizations, err error) {
+	if err := rights.RequireUser(ctx, req.UserIdentifiers, ttnpb.RIGHT_USER_ALL); err != nil {
+		return nil, err
+	}
+	var total uint64
+	ctx = store.WithPagination(ctx, req.Limit, req.Page, &total)
+	defer func() {
+		if err == nil {
+			setTotalHeader(ctx, total)
+		}
+	}()
+	authorizations = &ttnpb.OAuthClientAuthorizations{}
+	err = is.withDatabase(ctx, func(db *gorm.DB) (err error) {
+		authorizations.Authorizations, err = store.GetOAuthStore(db).ListAuthorizations(ctx, &req.UserIdentifiers)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return authorizations, nil
+}
+
+func (is *IdentityServer) listOAuthAccessTokens(ctx context.Context, req *ttnpb.ListOAuthAccessTokensRequest) (tokens *ttnpb.OAuthAccessTokens, err error) {
+	authInfo, err := is.authInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	accessToken := authInfo.GetOAuthAccessToken()
+	if accessToken == nil || accessToken.UserIDs.UserID != req.UserIDs.UserID || accessToken.ClientIDs.ClientID != req.ClientIDs.ClientID {
+		if err := rights.RequireUser(ctx, req.UserIDs, ttnpb.RIGHT_USER_ALL); err != nil {
+			return nil, err
+		}
+	}
+	var total uint64
+	ctx = store.WithPagination(ctx, req.Limit, req.Page, &total)
+	defer func() {
+		if err == nil {
+			setTotalHeader(ctx, total)
+		}
+	}()
+	tokens = &ttnpb.OAuthAccessTokens{}
+	err = is.withDatabase(ctx, func(db *gorm.DB) (err error) {
+		tokens.Tokens, err = store.GetOAuthStore(db).ListAccessTokens(ctx, &req.UserIDs, &req.ClientIDs)
+		return err
+	})
+	for _, token := range tokens.Tokens {
+		token.AccessToken, token.RefreshToken = "", ""
+	}
+	if err != nil {
+		return nil, err
+	}
+	return tokens, nil
+}
+
+func (is *IdentityServer) deleteOAuthAuthorization(ctx context.Context, req *ttnpb.OAuthClientAuthorizationIdentifiers) (*types.Empty, error) {
+	if err := rights.RequireUser(ctx, req.UserIDs, ttnpb.RIGHT_USER_ALL); err != nil {
+		return nil, err
+	}
+	err := is.withDatabase(ctx, func(db *gorm.DB) (err error) {
+		return store.GetOAuthStore(db).DeleteAuthorization(ctx, &req.UserIDs, &req.ClientIDs)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ttnpb.Empty, nil
+}
+
+var errAccessTokenMismatch = errors.DefineInvalidArgument("access_token_mismatch", "access token ID did not match user or client identifiers")
+
+func (is *IdentityServer) deleteOAuthAccessToken(ctx context.Context, req *ttnpb.OAuthAccessTokenIdentifiers) (*types.Empty, error) {
+	authInfo, err := is.authInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	accessToken := authInfo.GetOAuthAccessToken()
+	if accessToken == nil || accessToken.UserIDs.UserID != req.UserIDs.UserID || accessToken.ClientIDs.ClientID != req.ClientIDs.ClientID {
+		if err := rights.RequireUser(ctx, req.UserIDs, ttnpb.RIGHT_USER_ALL); err != nil {
+			return nil, err
+		}
+	}
+	err = is.withDatabase(ctx, func(db *gorm.DB) (err error) {
+		oauthStore := store.GetOAuthStore(db)
+		if accessToken != nil && accessToken.ID != req.ID {
+			accessToken, err := oauthStore.GetAccessToken(ctx, req.ID)
+			if err != nil {
+				return err
+			}
+			if accessToken.UserIDs.UserID != req.UserIDs.UserID || accessToken.ClientIDs.ClientID != req.ClientIDs.ClientID {
+				return errAccessTokenMismatch
+			}
+		}
+		return oauthStore.DeleteAccessToken(ctx, req.ID)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ttnpb.Empty, nil
+}
+
+type oauthRegistry struct {
+	*IdentityServer
+}
+
+func (or *oauthRegistry) List(ctx context.Context, req *ttnpb.ListOAuthClientAuthorizationsRequest) (*ttnpb.OAuthClientAuthorizations, error) {
+	return or.listOAuthClientAuthorizations(ctx, req)
+}
+func (or *oauthRegistry) ListTokens(ctx context.Context, req *ttnpb.ListOAuthAccessTokensRequest) (*ttnpb.OAuthAccessTokens, error) {
+	return or.listOAuthAccessTokens(ctx, req)
+}
+func (or *oauthRegistry) Delete(ctx context.Context, req *ttnpb.OAuthClientAuthorizationIdentifiers) (*types.Empty, error) {
+	return or.deleteOAuthAuthorization(ctx, req)
+}
+func (or *oauthRegistry) DeleteToken(ctx context.Context, req *ttnpb.OAuthAccessTokenIdentifiers) (*types.Empty, error) {
+	return or.deleteOAuthAccessToken(ctx, req)
+}

--- a/pkg/identityserver/oauth_registry_test.go
+++ b/pkg/identityserver/oauth_registry_test.go
@@ -1,0 +1,111 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package identityserver
+
+import (
+	"testing"
+
+	"github.com/smartystreets/assertions"
+	"github.com/smartystreets/assertions/should"
+	"go.thethings.network/lorawan-stack/pkg/identityserver/store"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/pkg/util/test"
+	"google.golang.org/grpc"
+)
+
+func TestOAuthRegistry(t *testing.T) {
+	ctx := test.Context()
+	a := assertions.New(t)
+
+	testWithIdentityServer(t, func(is *IdentityServer, cc *grpc.ClientConn) {
+		oauthStore := store.GetOAuthStore(is.db)
+		user, creds := defaultUser, userCreds(defaultUserIdx)
+		client := population.Clients[0]
+
+		_, err := oauthStore.Authorize(ctx, &ttnpb.OAuthClientAuthorization{
+			UserIDs:   user.UserIdentifiers,
+			ClientIDs: client.ClientIdentifiers,
+			Rights:    client.Rights,
+		})
+		if err != nil {
+			panic(err)
+		}
+
+		err = oauthStore.CreateAccessToken(ctx, &ttnpb.OAuthAccessToken{
+			UserIDs:      user.UserIdentifiers,
+			ClientIDs:    client.ClientIdentifiers,
+			ID:           "access_token_id",
+			Rights:       client.Rights,
+			AccessToken:  "access_token",
+			RefreshToken: "refresh_token",
+		}, "")
+		if err != nil {
+			panic(err)
+		}
+
+		reg := ttnpb.NewOAuthAuthorizationRegistryClient(cc)
+
+		authorizations, err := reg.List(ctx, &ttnpb.ListOAuthClientAuthorizationsRequest{
+			UserIdentifiers: user.UserIdentifiers,
+		}, creds)
+
+		a.So(err, should.BeNil)
+		a.So(authorizations, should.NotBeNil)
+		if a.So(authorizations.Authorizations, should.HaveLength, 1) {
+			a.So(authorizations.Authorizations[0].ClientIDs.ClientID, should.Equal, client.ClientID)
+		}
+
+		tokens, err := reg.ListTokens(ctx, &ttnpb.ListOAuthAccessTokensRequest{
+			UserIDs:   user.UserIdentifiers,
+			ClientIDs: client.ClientIdentifiers,
+		}, creds)
+
+		a.So(err, should.BeNil)
+		a.So(tokens, should.NotBeNil)
+		if a.So(tokens.Tokens, should.HaveLength, 1) {
+			a.So(tokens.Tokens[0].ID, should.Equal, "access_token_id")
+		}
+
+		_, err = reg.DeleteToken(ctx, &ttnpb.OAuthAccessTokenIdentifiers{
+			UserIDs:   user.UserIdentifiers,
+			ClientIDs: client.ClientIdentifiers,
+			ID:        "access_token_id",
+		}, creds)
+		a.So(err, should.BeNil)
+
+		tokens, err = reg.ListTokens(ctx, &ttnpb.ListOAuthAccessTokensRequest{
+			UserIDs:   user.UserIdentifiers,
+			ClientIDs: client.ClientIdentifiers,
+		}, creds)
+
+		a.So(err, should.BeNil)
+		a.So(tokens, should.NotBeNil)
+		a.So(tokens.Tokens, should.BeEmpty)
+
+		_, err = reg.Delete(ctx, &ttnpb.OAuthClientAuthorizationIdentifiers{
+			UserIDs:   user.UserIdentifiers,
+			ClientIDs: client.ClientIdentifiers,
+		}, creds)
+		a.So(err, should.BeNil)
+
+		authorizations, err = reg.List(ctx, &ttnpb.ListOAuthClientAuthorizationsRequest{
+			UserIdentifiers: user.UserIdentifiers,
+		}, creds)
+
+		a.So(err, should.BeNil)
+		a.So(authorizations, should.NotBeNil)
+		a.So(authorizations.Authorizations, should.BeEmpty)
+	})
+}

--- a/pkg/identityserver/store/oauth_store_test.go
+++ b/pkg/identityserver/store/oauth_store_test.go
@@ -26,7 +26,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/util/test"
 )
 
-func TestOauthStore(t *testing.T) {
+func TestOAuthStore(t *testing.T) {
 	ctx := test.Context()
 
 	WithDB(t, func(t *testing.T, db *gorm.DB) {
@@ -80,6 +80,14 @@ func TestOauthStore(t *testing.T) {
 			a.So(created.ClientIDs.ClientID, should.Equal, "test-client")
 			a.So(got.CreatedAt, should.HappenAfter, start)
 			a.So(got.UpdatedAt, should.HappenAfter, start)
+
+			list, err := store.ListAuthorizations(ctx, userIDs)
+
+			a.So(list, should.NotBeNil)
+			a.So(err, should.BeNil)
+			if a.So(list, should.HaveLength, 1) {
+				a.So(list[0], should.Resemble, got)
+			}
 
 			err = store.DeleteAuthorization(ctx, userIDs, clientIDs)
 
@@ -208,6 +216,14 @@ func TestOauthStore(t *testing.T) {
 
 			for _, right := range rights {
 				a.So(got.Rights, should.Contain, right)
+			}
+
+			list, err := store.ListAccessTokens(ctx, userIDs, clientIDs)
+
+			a.So(list, should.NotBeNil)
+			a.So(err, should.BeNil)
+			if a.So(list, should.HaveLength, 1) {
+				a.So(list[0], should.Resemble, got)
 			}
 
 			err = store.DeleteAccessToken(ctx, tokenID)

--- a/pkg/identityserver/store/store_interfaces.go
+++ b/pkg/identityserver/store/store_interfaces.go
@@ -142,6 +142,7 @@ type APIKeyStore interface {
 //
 // For internal use (by the OAuth server) only.
 type OAuthStore interface {
+	ListAuthorizations(ctx context.Context, userIDs *ttnpb.UserIdentifiers) ([]*ttnpb.OAuthClientAuthorization, error)
 	GetAuthorization(ctx context.Context, userIDs *ttnpb.UserIdentifiers, clientIDs *ttnpb.ClientIdentifiers) (*ttnpb.OAuthClientAuthorization, error)
 	Authorize(ctx context.Context, req *ttnpb.OAuthClientAuthorization) (authorization *ttnpb.OAuthClientAuthorization, err error)
 	DeleteAuthorization(ctx context.Context, userIDs *ttnpb.UserIdentifiers, clientIDs *ttnpb.ClientIdentifiers) error
@@ -151,6 +152,7 @@ type OAuthStore interface {
 	DeleteAuthorizationCode(ctx context.Context, code string) error
 
 	CreateAccessToken(ctx context.Context, token *ttnpb.OAuthAccessToken, previousID string) error
+	ListAccessTokens(ctx context.Context, userIDs *ttnpb.UserIdentifiers, clientIDs *ttnpb.ClientIdentifiers) ([]*ttnpb.OAuthAccessToken, error)
 	GetAccessToken(ctx context.Context, id string) (*ttnpb.OAuthAccessToken, error)
 	DeleteAccessToken(ctx context.Context, id string) error
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR closes #489 by documenting the places where users can use CLI args instead of flags. It also adds extra places where args can be used.

**Notes for Reviewers:**
<!--
Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This includes commits from https://github.com/TheThingsNetwork/lorawan-stack/pull/500. Review commits starting with `5c33fa2`.

The api-key commands had undocumented behavior of accepting the API key ID (without the entity). Not sure if we consider these kind of undocumented things API. @johanstokking?

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Documented places in the CLI where users can use arguments instead of flags
