### PR TITLE
Publish messages as event payload

### DIFF
--- a/pkg/applicationserver/linking.go
+++ b/pkg/applicationserver/linking.go
@@ -227,12 +227,6 @@ func (as *ApplicationServer) link(ctx context.Context, ids ttnpb.ApplicationIden
 			return err
 		}
 
-		if handleUpErr != nil {
-			logger.WithError(err).Warn("Failed to process upstream message")
-			registerDropUp(ctx, up, err)
-			continue
-		}
-
 		switch p := up.Up.(type) {
 		case *ttnpb.ApplicationUp_JoinAccept:
 			p.JoinAccept.AppSKey = nil
@@ -240,6 +234,13 @@ func (as *ApplicationServer) link(ctx context.Context, ids ttnpb.ApplicationIden
 		case *ttnpb.ApplicationUp_DownlinkQueueInvalidated:
 			continue
 		}
+
+		if handleUpErr != nil {
+			logger.WithError(err).Warn("Failed to process upstream message")
+			registerDropUp(ctx, up, err)
+			continue
+		}
+
 		l.upCh <- up
 		registerForwardUp(ctx, up)
 	}

--- a/pkg/applicationserver/observability.go
+++ b/pkg/applicationserver/observability.go
@@ -239,9 +239,9 @@ func registerReceiveUp(ctx context.Context, msg *ttnpb.ApplicationUp, ns string)
 func registerForwardUp(ctx context.Context, msg *ttnpb.ApplicationUp) {
 	switch msg.Up.(type) {
 	case *ttnpb.ApplicationUp_JoinAccept:
-		events.Publish(evtForwardJoinAccept(ctx, msg.EndDeviceIdentifiers, nil))
+		events.Publish(evtForwardJoinAccept(ctx, msg.EndDeviceIdentifiers, msg))
 	case *ttnpb.ApplicationUp_UplinkMessage:
-		events.Publish(evtForwardDataUp(ctx, msg.EndDeviceIdentifiers, nil))
+		events.Publish(evtForwardDataUp(ctx, msg.EndDeviceIdentifiers, msg))
 	}
 	asMetrics.uplinkForwarded.WithLabelValues(ctx, msg.ApplicationID).Inc()
 }
@@ -249,9 +249,9 @@ func registerForwardUp(ctx context.Context, msg *ttnpb.ApplicationUp) {
 func registerDropUp(ctx context.Context, msg *ttnpb.ApplicationUp, err error) {
 	switch msg.Up.(type) {
 	case *ttnpb.ApplicationUp_JoinAccept:
-		events.Publish(evtDropJoinAccept(ctx, msg.EndDeviceIdentifiers, nil))
+		events.Publish(evtDropJoinAccept(ctx, msg.EndDeviceIdentifiers, err))
 	case *ttnpb.ApplicationUp_UplinkMessage:
-		events.Publish(evtDropDataUp(ctx, msg.EndDeviceIdentifiers, nil))
+		events.Publish(evtDropDataUp(ctx, msg.EndDeviceIdentifiers, err))
 	}
 	if ttnErr, ok := errors.From(err); ok {
 		asMetrics.uplinkDropped.WithLabelValues(ctx, ttnErr.String()).Inc()
@@ -261,17 +261,17 @@ func registerDropUp(ctx context.Context, msg *ttnpb.ApplicationUp, err error) {
 }
 
 func registerReceiveDownlink(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, msg *ttnpb.ApplicationDownlink) {
-	events.Publish(evtReceiveDataDown(ctx, ids, nil))
+	events.Publish(evtReceiveDataDown(ctx, ids, msg))
 	asMetrics.downlinkReceived.WithLabelValues(ctx, ids.ApplicationID).Inc()
 }
 
 func registerForwardDownlink(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, msg *ttnpb.ApplicationDownlink, ns string) {
-	events.Publish(evtForwardDataDown(ctx, ids, nil))
+	events.Publish(evtForwardDataDown(ctx, ids, msg))
 	asMetrics.downlinkForwarded.WithLabelValues(ctx, ns).Inc()
 }
 
 func registerDropDownlink(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, msg *ttnpb.ApplicationDownlink, err error) {
-	events.Publish(evtDropDataDown(ctx, ids, nil))
+	events.Publish(evtDropDataDown(ctx, ids, err))
 	if ttnErr, ok := errors.From(err); ok {
 		asMetrics.downlinkDropped.WithLabelValues(ctx, ttnErr.String()).Inc()
 	} else {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #504 

**Changes:**
<!-- What are the changes made in this pull request? -->

- Publish event payload in `as.up.{forward|drop}` and `as.down.{receive|forward|drop}`

**Notes for Reviewers:**
<!--
Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

See #504 why `as.up.receive` doesn't get payload

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Added event payload to `as.up.forward`, `as.up.drop`, `as.down.receive`, `as.down.forward` and `as.down.drop` events