### PR TITLE
Get and set dev_addr from device registry

### DIFF
--- a/pkg/networkserver/redis/registry.go
+++ b/pkg/networkserver/redis/registry.go
@@ -75,6 +75,7 @@ func (r *DeviceRegistry) GetByID(ctx context.Context, appID ttnpb.ApplicationIde
 	}
 	return applyDeviceFieldMask(nil, pb, append(paths,
 		"ids.application_ids",
+		"ids.dev_addr",
 		"ids.device_id",
 	)...)
 }
@@ -89,6 +90,7 @@ func (r *DeviceRegistry) GetByEUI(ctx context.Context, joinEUI, devEUI types.EUI
 	}
 	return applyDeviceFieldMask(nil, pb, append(paths,
 		"ids.application_ids",
+		"ids.dev_addr",
 		"ids.dev_eui",
 		"ids.device_id",
 		"ids.join_eui",
@@ -176,6 +178,7 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIde
 		gets = append(gets,
 			"created_at",
 			"ids.application_ids",
+			"ids.dev_addr",
 			"ids.device_id",
 			"ids.join_eui",
 			"ids.dev_eui",
@@ -230,6 +233,7 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIde
 			if stored == nil {
 				sets = append(sets,
 					"ids.application_ids",
+					"ids.dev_addr",
 					"ids.device_id",
 					"ids.join_eui",
 					"ids.dev_eui",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #503 

**Changes:**
<!-- What are the changes made in this pull request? -->

- Fix regression from #344 where `dev_addr` is not get/set from/to registry

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Fixed `dev_addr` not being present in upstream messages