### PR TITLE
Set device's dev_addr from NS

### DIFF
--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -254,6 +254,7 @@ var (
 				return err
 			}
 
+			device.SetFields(res, "ids.dev_addr")
 			device.SetFields(res, append(append(nsPaths, asPaths...), jsPaths...)...)
 			if device.CreatedAt.IsZero() || (!res.CreatedAt.IsZero() && res.CreatedAt.Before(res.CreatedAt)) {
 				device.CreatedAt = res.CreatedAt

--- a/cmd/ttn-lw-cli/commands/end_devices_split.go
+++ b/cmd/ttn-lw-cli/commands/end_devices_split.go
@@ -148,6 +148,7 @@ func getEndDevice(ids ttnpb.EndDeviceIdentifiers, nsPaths, asPaths, jsPaths []st
 				}
 				logger.WithError(err).Error("Could not get end device from Network Server")
 			} else {
+				res.SetFields(nsRes, "ids.dev_addr")
 				res.SetFields(nsRes, ttnpb.AllowedBottomLevelFields(nsPaths, getEndDeviceFromNS)...)
 				if res.CreatedAt.IsZero() || (!nsRes.CreatedAt.IsZero() && nsRes.CreatedAt.Before(res.CreatedAt)) {
 					res.CreatedAt = nsRes.CreatedAt

--- a/pkg/networkserver/redis/registry.go
+++ b/pkg/networkserver/redis/registry.go
@@ -179,9 +179,9 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIde
 			"created_at",
 			"ids.application_ids",
 			"ids.dev_addr",
+			"ids.dev_eui",
 			"ids.device_id",
 			"ids.join_eui",
-			"ids.dev_eui",
 			"updated_at",
 		)
 
@@ -234,9 +234,9 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIde
 				sets = append(sets,
 					"ids.application_ids",
 					"ids.dev_addr",
+					"ids.dev_eui",
 					"ids.device_id",
 					"ids.join_eui",
-					"ids.dev_eui",
 				)
 
 				pb.CreatedAt = pb.UpdatedAt


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #516 

**Changes:**
<!-- What are the changes made in this pull request? -->

- Set device's `dev_addr` from NS
- Validate the fields also for a device update
- Set device's `dev_addr` when the `session.dev_addr` changes (typical for ABP – in OTAA this happens on session switch)

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Added `dev_addr` to device fetched from the Network Server
- Update device's `dev_addr` when the session's `dev_addr` is updated