### PR TITLE
Upgrade to Go 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 conditions: v1
 if: type = pull_request OR branch =~ ^master$ OR tag IS present
 language: go
-go: 1.11.x
+go: 1.12.x
 go_import_path: go.thethings.network/lorawan-stack
 env:
   global:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@ The Things Network Stack components are primarily built in Go, while we use Node
 
 ## Development Environment
 
-The Things Network's development environment heavily relies on [`make`](https://www.gnu.org/software/make/). Under the hood, `make` calls other tools such as `git`, `go`, `yarn` etc. Recent versions are supported; Node v10.x and Go v1.11.5. Let's first make sure you have `go`, `node` and `yarn`:
+The Things Network's development environment heavily relies on [`make`](https://www.gnu.org/software/make/). Under the hood, `make` calls other tools such as `git`, `go`, `yarn` etc. Recent versions are supported; Node v10.x and Go v1.12.x. Let's first make sure you have `go`, `node` and `yarn`:
 
 On macOS using [Homebrew](https://brew.sh):
 
@@ -18,7 +18,7 @@ On Ubuntu (or on Windows [using the Windows Subsystem for Linux](https://www.mic
 curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
 sudo apt-get install -y build-essential nodejs
 
-curl -sSL https://dl.google.com/go/go1.11.5.linux-amd64.tar.gz | sudo tar -xz -C /usr/local
+curl -sSL https://dl.google.com/go/go1.12.3.linux-amd64.tar.gz | sudo tar -xz -C /usr/local
 sudo ln -s /usr/local/go/bin/* /usr/local/bin
 ```
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR is a new attempt at #192: upgrading to Go 1.12.

**Changes:**
<!-- What are the changes made in this pull request? -->

- Upgrade the Go version in documentation and Travis. I'm not bumping the minimum version requirement in our Mage files, as Go 1.11 can still be used for development.

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Bumped our Go version to 1.12
