### PR TITLE
Add application events to js sdk

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -5192,6 +5192,24 @@
       "file": "end_device_registry.go"
     }
   },
+  "event:events.stream.start": {
+    "translations": {
+      "en": "event stream start"
+    },
+    "description": {
+      "package": "pkg/events/grpc",
+      "file": "grpc.go"
+    }
+  },
+  "event:events.stream.stop": {
+    "translations": {
+      "en": "event stream stop"
+    },
+    "description": {
+      "package": "pkg/events/grpc",
+      "file": "grpc.go"
+    }
+  },
   "event:gateway.api-key.create": {
     "translations": {
       "en": "Create gateway API key"

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -54,6 +54,7 @@ export default {
   mode: production ? 'production' : 'development',
   externals: [ filterLocales ],
   stats: 'minimal',
+  target: 'web',
   node: {
     fs: 'empty',
     module: 'empty',

--- a/pkg/jsonpb/ttn.go
+++ b/pkg/jsonpb/ttn.go
@@ -14,6 +14,8 @@
 
 package jsonpb
 
+import "github.com/grpc-ecosystem/grpc-gateway/runtime"
+
 // TTN returns the default TTN JSONPb marshaler.
 func TTN() *GoGoJSONPb {
 	return &GoGoJSONPb{
@@ -21,3 +23,16 @@ func TTN() *GoGoJSONPb {
 		EnumsAsInts: true,
 	}
 }
+
+// TTNEventStream returns a TTN JsonPb marshaler with double newlines for
+// text/event-stream compatibility.
+func TTNEventStream() runtime.Marshaler {
+	return &ttnEventStream{GoGoJSONPb: TTN()}
+}
+
+type ttnEventStream struct {
+	*GoGoJSONPb
+}
+
+func (s *ttnEventStream) ContentType() string { return "text/event-stream" }
+func (s *ttnEventStream) Delimiter() []byte   { return []byte{'\n', '\n'} }

--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -193,6 +193,7 @@ func New(ctx context.Context, opts ...Option) *Server {
 			return nil
 		}),
 		runtime.WithMarshalerOption("*", jsonpb.TTN()),
+		runtime.WithMarshalerOption("text/event-stream", jsonpb.TTNEventStream()),
 		runtime.WithProtoErrorHandler(runtime.DefaultHTTPProtoErrorHandler),
 		runtime.WithMetadata(func(ctx context.Context, req *http.Request) metadata.MD {
 			md := rpcmetadata.MD{

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -4,6 +4,10 @@
   "description": "The Things Network Stack for LoRaWAN JavaScript SDK",
   "url": "https://github.com/TheThingsNetwork/lorawan-stack/tree/master/sdk/js",
   "main": "dist/index.js",
+  "browser": {
+    "./dist/api/stream/stream-node.js": "./dist/api/stream/stream.js",
+    "./src/api/stream/stream-node.js": "./src/api/stream/stream.js"
+  },
   "license": "Apache-2.0",
   "private": false,
   "scripts": {

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -46,10 +46,11 @@
     "preset": "jest-preset-ttn"
   },
   "dependencies": {
+    "arraybuffer-to-string": "^1.0.2",
     "axios": "^0.18.0",
     "proxy-polyfill": "^0.3.0",
     "query-string": "^6.2.0",
     "traverse": "^0.6.6",
-    "arraybuffer-to-string": "^1.0.2"
+    "web-streams-polyfill": "^2.0.3"
   }
 }

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -49,6 +49,7 @@
     "axios": "^0.18.0",
     "proxy-polyfill": "^0.3.0",
     "query-string": "^6.2.0",
-    "traverse": "^0.6.6"
+    "traverse": "^0.6.6",
+    "arraybuffer-to-string": "^1.0.2"
   }
 }

--- a/sdk/js/src/api/http.js
+++ b/sdk/js/src/api/http.js
@@ -20,8 +20,8 @@ import axios from 'axios'
 class Http {
   constructor (token, stackConfig, axiosConfig = {}) {
     const headers = axiosConfig.headers || {}
-    let Authorization = null
 
+    let Authorization = null
     if (typeof token === 'string') {
       Authorization = `Bearer ${token}`
     }

--- a/sdk/js/src/api/index.js
+++ b/sdk/js/src/api/index.js
@@ -23,7 +23,6 @@ import Http from './http'
 class Api {
   constructor (connectionType = 'http', stackConfig, axiosConfig, token) {
     this.connectionType = connectionType
-    this.token = token
 
     if (this.connectionType !== 'http') {
       throw new Error('Only http connection type is supported')

--- a/sdk/js/src/api/stream/shared.js
+++ b/sdk/js/src/api/stream/shared.js
@@ -1,0 +1,26 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export const notify = function (listener, ...args) {
+  if (listener !== null) {
+    listener(...args)
+  }
+}
+
+export const EVENTS = Object.freeze({
+  START: 'start',
+  EVENT: 'event',
+  ERROR: 'error',
+  CLOSE: 'close',
+})

--- a/sdk/js/src/api/stream/stream-node.js
+++ b/sdk/js/src/api/stream/stream-node.js
@@ -1,0 +1,106 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import axios from 'axios'
+import Token from '../../util/token'
+import { notify, EVENTS } from './shared'
+
+/**
+ * Opens a new stream.
+ *
+ * @param {Object} payload  - The body of the initial request.
+ * @param {string} url - The stream endpoint.
+ *
+ * @example
+ * (async () => {
+ *    const stream = await stream(
+ *      { identifiers: [{ application_ids: { application_id: 'my-app' }}]},
+ *      'http://localhost:1885/api/v3/events',
+ *    )
+ *
+ *    // add listeners to the stream
+ *    stream
+ *      .on('start', () => console.log('conn opened'));
+ *      .on('event', message => console.log('received event message', message));
+ *      .on('error', error => console.log(error));
+ *      .on('close', () => console.log('conn closed'))
+ *
+ *    // close the stream after 20 s
+ *    setTimeout(() => stream.close(), 20000)
+ * })()
+ *
+ * @returns {Object} The stream subscription object with the `on` function for
+ * attaching listeners and the `close` function to close the stream.
+ */
+export default async function (payload, url) {
+  let listeners = Object.values(EVENTS)
+    .reduce((acc, curr) => ({ ...acc, [curr]: null }), {})
+  const token = new Token().get()
+
+  let Authorization = null
+  if (typeof token === 'function') {
+    Authorization = `Bearer ${(await token()).access_token}`
+  } else {
+    Authorization = `Bearer ${token}`
+  }
+
+  let reader = null
+  axios({
+    url,
+    data: JSON.stringify(payload),
+    method: 'POST',
+    responseType: 'stream',
+    headers: {
+      Authorization,
+    },
+  })
+    .then(response => response.data)
+    .then(function (stream) {
+      reader = stream
+      notify(listeners[EVENTS.START])
+
+      stream.on('data', function (data) {
+        const parsed = data.toString('utf8')
+        const result = JSON.parse(parsed).result
+        notify(listeners[EVENTS.EVENT], result)
+      })
+      stream.on('end', function () {
+        notify(listeners[EVENTS.CLOSE])
+        listeners = null
+      })
+      stream.on('error', function (error) {
+        notify(listeners[EVENTS.ERROR], error)
+        listeners = null
+      })
+    })
+
+  return {
+    on (eventName, callback) {
+      if (listeners[eventName] === undefined) {
+        throw new Error(
+          `${eventName} event is not supported. Should be one of: start, error, event or close`
+        )
+      }
+
+      listeners[eventName] = callback
+
+      return this
+    },
+    close () {
+      if (reader) {
+        reader.cancel()
+      }
+    },
+  }
+}

--- a/sdk/js/src/api/stream/stream.js
+++ b/sdk/js/src/api/stream/stream.js
@@ -1,0 +1,119 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import ArrayBufferToString from 'arraybuffer-to-string'
+import Token from '../../util/token'
+import { notify, EVENTS } from './shared'
+
+/**
+ * Opens a new stream.
+ *
+ * @param {Object} payload  - The body of the initial request.
+ * @param {string} url - The stream endpoint, defaults to `/api/v3/events`.
+ *
+ * @example
+ * (async () => {
+ *    const stream = await stream(
+ *      { identifiers: [{ application_ids: { application_id: 'my-app' }}]},
+ *      '/api/v3/events',
+ *    )
+ *
+ *    // add listeners to the stream
+ *    stream
+ *      .on('start', () => console.log('conn opened'));
+ *      .on('event', message => console.log('received event message', message));
+ *      .on('error', error => console.log(error));
+ *      .on('close', () => console.log('conn closed'))
+ *
+ *    // close the stream after 20 s
+ *    setTimeout(() => stream.close(), 20000)
+ * })()
+ *
+ * @returns {Object} The stream subscription object with the `on` function for
+ * attaching listeners and the `close` function to close the stream.
+ */
+export default async function (payload, url = '/api/v3/events') {
+  let listeners = Object.values(EVENTS)
+    .reduce((acc, curr) => ({ ...acc, [curr]: null }), {})
+  const token = new Token().get()
+
+  let Authorization = null
+  if (typeof token === 'function') {
+    Authorization = `Bearer ${(await token()).access_token}`
+  } else {
+    Authorization = `Bearer ${token}`
+  }
+
+  let reader = null
+  fetch(url, {
+    body: JSON.stringify(payload),
+    method: 'POST',
+    headers: {
+      Authorization,
+    },
+  })
+    .then(async function (response) {
+      if (response.status !== 200) {
+        const err = await response.json()
+
+        throw err
+      }
+
+      return response.body
+    })
+    .then(function (body) {
+      notify(listeners[EVENTS.START])
+
+      reader = body.getReader()
+      reader.read()
+        .then(function onChunk ({ done, value }) {
+
+          if (done) {
+            notify(listeners[EVENTS.CLOSE])
+            listeners = null
+            return
+          }
+
+          const parsed = ArrayBufferToString(value)
+          const result = JSON.parse(parsed).result
+          notify(listeners[EVENTS.EVENT], result)
+
+          return reader.read().then(onChunk)
+        })
+        .catch(function (error) {
+          notify(listeners[EVENTS.ERROR], error)
+          listeners = null
+        })
+
+    })
+
+  return {
+    on (eventName, callback) {
+      if (listeners[eventName] === undefined) {
+        throw new Error(
+          `${eventName} event is not supported. Should be one of: start, error, event or close`
+        )
+      }
+
+      listeners[eventName] = callback
+
+      return this
+    },
+    close () {
+      if (reader) {
+        reader.cancel()
+      }
+    },
+  }
+}

--- a/sdk/js/src/api/stream/stream.js
+++ b/sdk/js/src/api/stream/stream.js
@@ -15,6 +15,7 @@
 import ArrayBufferToString from 'arraybuffer-to-string'
 import Token from '../../util/token'
 import { notify, EVENTS } from './shared'
+import 'web-streams-polyfill/dist/polyfill.js'
 
 /**
  * Opens a new stream.

--- a/sdk/js/src/api/stream/stream.js
+++ b/sdk/js/src/api/stream/stream.js
@@ -95,7 +95,6 @@ export default async function (payload, url = '/api/v3/events') {
           notify(listeners[EVENTS.ERROR], error)
           listeners = null
         })
-
     })
 
   return {

--- a/sdk/js/src/service/applications.js
+++ b/sdk/js/src/service/applications.js
@@ -15,6 +15,7 @@
 import Marshaler from '../util/marshaler'
 import Devices from '../service/devices'
 import Application from '../entity/application'
+import stream from '../api/stream/stream-node'
 import ApiKeys from './api-keys'
 import Link from './link'
 import Collaborators from './collaborators'
@@ -35,6 +36,7 @@ class Applications {
     this._defaultUserId = defaultUserId
     this._api = api
     this._proxy = proxy
+    this._stackConfig = stackConfig
 
     this.ApiKeys = new ApiKeys(api.ApplicationAccess, {
       parentRoutes: {
@@ -145,6 +147,21 @@ class Applications {
     })
 
     return Marshaler.unwrapRights(result)
+  }
+
+  // Events Stream
+
+  async openStream (identifiers, tail, after) {
+    const eventsUrl = `${this._stackConfig.as}/events`
+    const payload = {
+      identifiers: identifiers.map(id => ({
+        application_ids: { application_id: id },
+      })),
+      tail,
+      after,
+    }
+
+    return stream(payload, eventsUrl)
   }
 }
 

--- a/sdk/js/src/util/token.js
+++ b/sdk/js/src/util/token.js
@@ -12,26 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Applications from './service/applications'
-import Application from './entity/application'
-import Api from './api'
-import Token from './util/token'
+class Token {
 
-class TtnLw {
-  constructor (token, {
-    stackConfig,
-    connectionType,
-    defaultUserId,
-    proxy,
-    axiosConfig,
-  }) {
-    const tokenInstance = new Token(token)
-    this.config = arguments.config
-    this.api = new Api(connectionType, stackConfig, axiosConfig, tokenInstance.get())
+  constructor (token) {
+    /**
+     * Make sure it is possible to instantiate an instance
+     * of the class only once.
+     */
+    if (!!Token.instance) {
+      return Token.instance
+    }
 
-    this.Applications = new Applications(this.api, { defaultUserId, proxy, stackConfig })
-    this.Application = Application.bind(null, this.Applications)
+    if (this.token) {
+      return Token.instance
+    }
+
+    Token.instance = this
+    this.token = token
+
+    return this
+  }
+
+  get () {
+    return this.token
   }
 }
 
-export default TtnLw
+export default Token

--- a/sdk/js/yarn.lock
+++ b/sdk/js/yarn.lock
@@ -4512,6 +4512,11 @@ watch@~0.18.0:
     exec-sh "^0.2.0"
     minimist "^1.2.0"
 
+web-streams-polyfill@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-2.0.3.tgz#0c396f069a5eedc96c711393b12f2c67cf283a00"
+  integrity sha512-pOqiHmL3RBAGS+SgOR42RbPU6nc8/n15N2rsOXFYHLnTfs2Z8QHs8AizOeOaYEnhwPN4+hu3M2D9XvAqzvt6MA==
+
 webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"

--- a/sdk/js/yarn.lock
+++ b/sdk/js/yarn.lock
@@ -179,6 +179,11 @@ array-unique@^0.3.2:
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
+arraybuffer-to-string@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/arraybuffer-to-string/-/arraybuffer-to-string-1.0.2.tgz#c373aa7bb0e6844d9a2bc9654c8889a9570a26e2"
+  integrity sha512-WbIYlLVmvIAyUBdQRRuyGOJRriOQy9OAsWcyURmsRQp9+g647hdMSS2VFKXbJLVw0daUu06hqwLXm9etVrXI9A==
+
 arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1662,6 +1662,11 @@ array.prototype.flatmap@^1.2.1:
     es-abstract "^1.10.0"
     function-bind "^1.1.1"
 
+arraybuffer-to-string@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/arraybuffer-to-string/-/arraybuffer-to-string-1.0.2.tgz#c373aa7bb0e6844d9a2bc9654c8889a9570a26e2"
+  integrity sha512-WbIYlLVmvIAyUBdQRRuyGOJRriOQy9OAsWcyURmsRQp9+g647hdMSS2VFKXbJLVw0daUu06hqwLXm9etVrXI9A==
+
 arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
@@ -11057,12 +11062,14 @@ tslib@^1.9.0:
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
 "ttn-lw@file:sdk/js":
-  version "3.0.0-rc1"
+  version "3.0.2"
   dependencies:
+    arraybuffer-to-string "^1.0.2"
     axios "^0.18.0"
     proxy-polyfill "^0.3.0"
     query-string "^6.2.0"
     traverse "^0.6.6"
+    web-streams-polyfill "^2.0.3"
 
 tty-browserify@0.0.0:
   version "0.0.0"
@@ -11455,6 +11462,11 @@ wcwidth@^1.0.0:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
+
+web-streams-polyfill@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-2.0.3.tgz#0c396f069a5eedc96c711393b12f2c67cf283a00"
+  integrity sha512-pOqiHmL3RBAGS+SgOR42RbPU6nc8/n15N2rsOXFYHLnTfs2Z8QHs8AizOeOaYEnhwPN4+hu3M2D9XvAqzvt6MA==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->
This PR adds applications events support to the Javascript SDK.
References https://github.com/TheThingsNetwork/lorawan-stack/issues/28
~~Blocked by https://github.com/TheThingsNetwork/lorawan-stack/issues/28#issuecomment-481238500, https://github.com/TheThingsNetwork/lorawan-stack/pull/525~~

**Changes:**
<!-- What are the changes made in this pull request? -->

- Add the `Stream` service for node and browser.
- Add token singleton to distribute the access token easier in the sdk

**Notes for Reviewers:**
<!--
Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->
- Two implementations of the stream service are needed since I was not able to find a single solution that fits well for both environments.

@htdvisser  please make sure your commits are fine
@kschiffer please review the sdk part
