### PR TITLE
Use modulo for downlink channels

### DIFF
--- a/pkg/networkserver/utils_internal_test.go
+++ b/pkg/networkserver/utils_internal_test.go
@@ -172,13 +172,6 @@ func TestResetMACState(t *testing.T) {
 								MaxDataRateIndex:  ttnpb.DATA_RATE_5,
 								EnableUplink:      true,
 							},
-							{
-								UplinkFrequency:   869525000,
-								DownlinkFrequency: 869525000,
-								MinDataRateIndex:  ttnpb.DATA_RATE_0,
-								MaxDataRateIndex:  ttnpb.DATA_RATE_5,
-								EnableUplink:      true,
-							},
 						},
 					},
 				}
@@ -215,8 +208,8 @@ func TestResetMACState(t *testing.T) {
 						EnableUplink:     true,
 					})
 				}
-				for i := 0; i < 8; i++ {
-					bandChannels[i].DownlinkFrequency = uint64(923300000 + 600000*i)
+				for i := 0; i < 72; i++ {
+					bandChannels[i].DownlinkFrequency = uint64(923300000 + 600000*(i%8))
 				}
 
 				return func(dev *ttnpb.EndDevice) {

--- a/pkg/util/test/frequencyplans.go
+++ b/pkg/util/test/frequencyplans.go
@@ -40,6 +40,15 @@ const (
 	EUFrequencyPlanID = "EU_863_870"
 	euFrequencyPlan   = `band-id: EU_863_870
 uplink-channels:
+- frequency: 868100000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 868300000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 868500000
+  min-data-rate: 0
+  max-data-rate: 5
 - frequency: 867100000
   min-data-rate: 0
   max-data-rate: 5
@@ -53,21 +62,18 @@ uplink-channels:
   min-data-rate: 0
   max-data-rate: 5
 - frequency: 867900000
-  min-data-rate: 0
-  max-data-rate: 5
-- frequency: 868100000
-  min-data-rate: 0
-  max-data-rate: 5
-- frequency: 868300000
-  min-data-rate: 0
-  max-data-rate: 5
-- frequency: 868500000
-  min-data-rate: 0
-  max-data-rate: 5
-- frequency: 869525000
   min-data-rate: 0
   max-data-rate: 5
 downlink-channels:
+- frequency: 868100000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 868300000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 868500000
+  min-data-rate: 0
+  max-data-rate: 5
 - frequency: 867100000
   min-data-rate: 0
   max-data-rate: 5
@@ -83,20 +89,8 @@ downlink-channels:
 - frequency: 867900000
   min-data-rate: 0
   max-data-rate: 5
-- frequency: 868100000
-  min-data-rate: 0
-  max-data-rate: 5
-- frequency: 868300000
-  min-data-rate: 0
-  max-data-rate: 5
-- frequency: 868500000
-  min-data-rate: 0
-  max-data-rate: 5
-- frequency: 869525000
-  min-data-rate: 0
-  max-data-rate: 5
 lora-standard-channel:
-  frequency: 863000000
+  frequency: 868300000
   data-rate: 6
 fsk-channel:
   frequency: 868800000


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR resolves #528 by always using the modulo for determining the downlink channel. This fixes the channel resets for US-like bands and frequency plans (because it's spec) and it also works for EU-like bands and frequency plans (because `len(uplinkCh)==len(downlinkCh)`).

**Changes:**
<!-- What are the changes made in this pull request? -->

- Fix channel reset code in `resetMACState`
- Fix test frequency plan for EU
- Adapt unit test to use modulo and disregard EU RX2 channel

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Fix downlink channel handling for US, AU and CN bands
