### PR TITLE
Implement explicit enum marshalers and unmarshalers

### DIFF
--- a/pkg/ttnpb/contact_info.go
+++ b/pkg/ttnpb/contact_info.go
@@ -1,0 +1,88 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ttnpb
+
+import (
+	"strconv"
+	"strings"
+)
+
+// MarshalText implements encoding.TextMarshaler interface.
+func (v ContactType) MarshalText() ([]byte, error) {
+	return []byte(v.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *ContactType) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := ContactType_value[s]; ok {
+		*v = ContactType(i)
+		return nil
+	}
+	if !strings.HasPrefix(s, "CONTACT_TYPE_") {
+		if i, ok := ContactType_value["CONTACT_TYPE_"+s]; ok {
+			*v = ContactType(i)
+			return nil
+		}
+	}
+	return errCouldNotParse("ContactType")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *ContactType) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("ContactType")(string(b)).WithCause(err)
+	}
+	*v = ContactType(i)
+	return nil
+}
+
+// MarshalText implements encoding.TextMarshaler interface.
+func (v ContactMethod) MarshalText() ([]byte, error) {
+	return []byte(v.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *ContactMethod) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := ContactMethod_value[s]; ok {
+		*v = ContactMethod(i)
+		return nil
+	}
+	if !strings.HasPrefix(s, "CONTACT_METHOD_") {
+		if i, ok := ContactMethod_value["CONTACT_METHOD_"+s]; ok {
+			*v = ContactMethod(i)
+			return nil
+		}
+	}
+	return errCouldNotParse("ContactMethod")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *ContactMethod) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("ContactMethod")(string(b)).WithCause(err)
+	}
+	*v = ContactMethod(i)
+	return nil
+}

--- a/pkg/ttnpb/end_device.go
+++ b/pkg/ttnpb/end_device.go
@@ -14,7 +14,45 @@
 
 package ttnpb
 
-import "context"
+import (
+	"context"
+	"strconv"
+	"strings"
+)
+
+// MarshalText implements encoding.TextMarshaler interface.
+func (v PowerState) MarshalText() ([]byte, error) {
+	return []byte(v.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *PowerState) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := PowerState_value[s]; ok {
+		*v = PowerState(i)
+		return nil
+	}
+	if !strings.HasPrefix(s, "POWER_") {
+		if i, ok := PowerState_value["POWER_"+s]; ok {
+			*v = PowerState(i)
+			return nil
+		}
+	}
+	return errCouldNotParse("PowerState")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *PowerState) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("PowerState")(string(b)).WithCause(err)
+	}
+	*v = PowerState(i)
+	return nil
+}
 
 // ValidateContext wraps the generated validator with (optionally context-based) custom checks.
 func (m *UpdateEndDeviceRequest) ValidateContext(context.Context) error {

--- a/pkg/ttnpb/enums.go
+++ b/pkg/ttnpb/enums.go
@@ -1,0 +1,88 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ttnpb
+
+import (
+	"strconv"
+	"strings"
+)
+
+// MarshalText implements encoding.TextMarshaler interface.
+func (v DownlinkPathConstraint) MarshalText() ([]byte, error) {
+	return []byte(v.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *DownlinkPathConstraint) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := DownlinkPathConstraint_value[s]; ok {
+		*v = DownlinkPathConstraint(i)
+		return nil
+	}
+	if !strings.HasPrefix(s, "DOWNLINK_PATH_CONSTRAINT_") {
+		if i, ok := DownlinkPathConstraint_value["DOWNLINK_PATH_CONSTRAINT_"+s]; ok {
+			*v = DownlinkPathConstraint(i)
+			return nil
+		}
+	}
+	return errCouldNotParse("DownlinkPathConstraint")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *DownlinkPathConstraint) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("DownlinkPathConstraint")(string(b)).WithCause(err)
+	}
+	*v = DownlinkPathConstraint(i)
+	return nil
+}
+
+// MarshalText implements encoding.TextMarshaler interface.
+func (v State) MarshalText() ([]byte, error) {
+	return []byte(v.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *State) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := State_value[s]; ok {
+		*v = State(i)
+		return nil
+	}
+	if !strings.HasPrefix(s, "STATE_") {
+		if i, ok := State_value["STATE_"+s]; ok {
+			*v = State(i)
+			return nil
+		}
+	}
+	return errCouldNotParse("State")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *State) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("State")(string(b)).WithCause(err)
+	}
+	*v = State(i)
+	return nil
+}

--- a/pkg/ttnpb/lorawan.go
+++ b/pkg/ttnpb/lorawan.go
@@ -16,10 +16,616 @@ package ttnpb
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/blang/semver"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 )
+
+// MarshalText implements encoding.TextMarshaler interface.
+func (v MType) MarshalText() ([]byte, error) {
+	return []byte(v.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *MType) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := MType_value[s]; ok {
+		*v = MType(i)
+		return nil
+	}
+	return errCouldNotParse("MType")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *MType) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("MType")(string(b)).WithCause(err)
+	}
+	*v = MType(i)
+	return nil
+}
+
+// MarshalText implements encoding.TextMarshaler interface.
+func (v Major) MarshalText() ([]byte, error) {
+	return []byte(v.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *Major) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := Major_value[s]; ok {
+		*v = Major(i)
+		return nil
+	}
+	return errCouldNotParse("Major")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *Major) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("Major")(string(b)).WithCause(err)
+	}
+	*v = Major(i)
+	return nil
+}
+
+// MarshalText implements encoding.TextMarshaler interface.
+func (v MACVersion) MarshalText() ([]byte, error) {
+	return []byte(v.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *MACVersion) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := MACVersion_value[s]; ok {
+		*v = MACVersion(i)
+		return nil
+	}
+	if !strings.HasPrefix(s, "MAC_") {
+		if i, ok := MACVersion_value["MAC_"+s]; ok {
+			*v = MACVersion(i)
+			return nil
+		}
+	}
+	return errCouldNotParse("MACVersion")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *MACVersion) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("MACVersion")(string(b)).WithCause(err)
+	}
+	*v = MACVersion(i)
+	return nil
+}
+
+// MarshalText implements encoding.TextMarshaler interface.
+func (v PHYVersion) MarshalText() ([]byte, error) {
+	return []byte(v.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *PHYVersion) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := PHYVersion_value[s]; ok {
+		*v = PHYVersion(i)
+		return nil
+	}
+	if !strings.HasPrefix(s, "PHY_") {
+		if i, ok := PHYVersion_value["PHY_"+s]; ok {
+			*v = PHYVersion(i)
+			return nil
+		}
+	}
+	return errCouldNotParse("PHYVersion")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *PHYVersion) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("PHYVersion")(string(b)).WithCause(err)
+	}
+	*v = PHYVersion(i)
+	return nil
+}
+
+// MarshalText implements encoding.TextMarshaler interface.
+func (v DataRateIndex) MarshalText() ([]byte, error) {
+	return []byte(v.String()), nil
+}
+
+// MarshalJSON implements json.Marshaler interface.
+func (v DataRateIndex) MarshalJSON() ([]byte, error) {
+	return v.MarshalText()
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *DataRateIndex) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := DataRateIndex_value[s]; ok {
+		*v = DataRateIndex(i)
+		return nil
+	}
+	if !strings.HasPrefix(s, "DATA_RATE_") {
+		if i, ok := DataRateIndex_value["DATA_RATE_"+s]; ok {
+			*v = DataRateIndex(i)
+			return nil
+		}
+	}
+	return errCouldNotParse("DataRateIndex")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *DataRateIndex) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("DataRateIndex")(string(b)).WithCause(err)
+	}
+	*v = DataRateIndex(i)
+	return nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *RejoinType) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := RejoinType_value[s]; ok {
+		*v = RejoinType(i)
+		return nil
+	}
+	return errCouldNotParse("RejoinType")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *RejoinType) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("RejoinType")(string(b)).WithCause(err)
+	}
+	*v = RejoinType(i)
+	return nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *CFListType) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := CFListType_value[s]; ok {
+		*v = CFListType(i)
+		return nil
+	}
+	return errCouldNotParse("CFListType")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *CFListType) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("CFListType")(string(b)).WithCause(err)
+	}
+	*v = CFListType(i)
+	return nil
+}
+
+// MarshalText implements encoding.TextMarshaler interface.
+func (v Class) MarshalText() ([]byte, error) {
+	return []byte(v.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *Class) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := Class_value[s]; ok {
+		*v = Class(i)
+		return nil
+	}
+	if !strings.HasPrefix(s, "CLASS_") {
+		if i, ok := Class_value["CLASS_"+s]; ok {
+			*v = Class(i)
+			return nil
+		}
+	}
+	return errCouldNotParse("Class")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *Class) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("Class")(string(b)).WithCause(err)
+	}
+	*v = Class(i)
+	return nil
+}
+
+// MarshalText implements encoding.TextMarshaler interface.
+func (v TxSchedulePriority) MarshalText() ([]byte, error) {
+	return []byte(v.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *TxSchedulePriority) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := TxSchedulePriority_value[s]; ok {
+		*v = TxSchedulePriority(i)
+		return nil
+	}
+	return errCouldNotParse("TxSchedulePriority")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *TxSchedulePriority) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("TxSchedulePriority")(string(b)).WithCause(err)
+	}
+	*v = TxSchedulePriority(i)
+	return nil
+}
+
+// MarshalText implements encoding.TextMarshaler interface.
+func (v MACCommandIdentifier) MarshalText() ([]byte, error) {
+	return []byte(v.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *MACCommandIdentifier) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := MACCommandIdentifier_value[s]; ok {
+		*v = MACCommandIdentifier(i)
+		return nil
+	}
+	if !strings.HasPrefix(s, "CID_") {
+		if i, ok := MACCommandIdentifier_value["CID_"+s]; ok {
+			*v = MACCommandIdentifier(i)
+			return nil
+		}
+	}
+	return errCouldNotParse("MACCommandIdentifier")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *MACCommandIdentifier) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("MACCommandIdentifier")(string(b)).WithCause(err)
+	}
+	*v = MACCommandIdentifier(i)
+	return nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *AggregatedDutyCycle) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := AggregatedDutyCycle_value[s]; ok {
+		*v = AggregatedDutyCycle(i)
+		return nil
+	}
+	if !strings.HasPrefix(s, "DUTY_CYCLE_") {
+		if i, ok := AggregatedDutyCycle_value["DUTY_CYCLE_"+s]; ok {
+			*v = AggregatedDutyCycle(i)
+			return nil
+		}
+	}
+	return errCouldNotParse("AggregatedDutyCycle")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *AggregatedDutyCycle) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("AggregatedDutyCycle")(string(b)).WithCause(err)
+	}
+	*v = AggregatedDutyCycle(i)
+	return nil
+}
+
+// MarshalText implements encoding.TextMarshaler interface.
+func (v PingSlotPeriod) MarshalText() ([]byte, error) {
+	return []byte(v.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *PingSlotPeriod) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := PingSlotPeriod_value[s]; ok {
+		*v = PingSlotPeriod(i)
+		return nil
+	}
+	if !strings.HasPrefix(s, "PING_EVERY_") {
+		if i, ok := PingSlotPeriod_value["PING_EVERY_"+s]; ok {
+			*v = PingSlotPeriod(i)
+			return nil
+		}
+	}
+	return errCouldNotParse("PingSlotPeriod")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *PingSlotPeriod) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("PingSlotPeriod")(string(b)).WithCause(err)
+	}
+	*v = PingSlotPeriod(i)
+	return nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *RejoinCountExponent) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := RejoinCountExponent_value[s]; ok {
+		*v = RejoinCountExponent(i)
+		return nil
+	}
+	if !strings.HasPrefix(s, "REJOIN_COUNT_") {
+		if i, ok := RejoinCountExponent_value["REJOIN_COUNT_"+s]; ok {
+			*v = RejoinCountExponent(i)
+			return nil
+		}
+	}
+	return errCouldNotParse("RejoinCountExponent")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *RejoinCountExponent) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("RejoinCountExponent")(string(b)).WithCause(err)
+	}
+	*v = RejoinCountExponent(i)
+	return nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *RejoinTimeExponent) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := RejoinTimeExponent_value[s]; ok {
+		*v = RejoinTimeExponent(i)
+		return nil
+	}
+	if !strings.HasPrefix(s, "REJOIN_TIME_") {
+		if i, ok := RejoinTimeExponent_value["REJOIN_TIME_"+s]; ok {
+			*v = RejoinTimeExponent(i)
+			return nil
+		}
+	}
+	return errCouldNotParse("RejoinTimeExponent")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *RejoinTimeExponent) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("RejoinTimeExponent")(string(b)).WithCause(err)
+	}
+	*v = RejoinTimeExponent(i)
+	return nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *RejoinPeriodExponent) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := RejoinPeriodExponent_value[s]; ok {
+		*v = RejoinPeriodExponent(i)
+		return nil
+	}
+	if !strings.HasPrefix(s, "REJOIN_PERIOD_") {
+		if i, ok := RejoinPeriodExponent_value["REJOIN_PERIOD_"+s]; ok {
+			*v = RejoinPeriodExponent(i)
+			return nil
+		}
+	}
+	return errCouldNotParse("RejoinPeriodExponent")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *RejoinPeriodExponent) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("RejoinPeriodExponent")(string(b)).WithCause(err)
+	}
+	*v = RejoinPeriodExponent(i)
+	return nil
+}
+
+// MarshalText implements encoding.TextMarshaler interface.
+func (v DeviceEIRP) MarshalText() ([]byte, error) {
+	return []byte(v.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *DeviceEIRP) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := DeviceEIRP_value[s]; ok {
+		*v = DeviceEIRP(i)
+		return nil
+	}
+	if !strings.HasPrefix(s, "DEVICE_EIRP_") {
+		if i, ok := DeviceEIRP_value["DEVICE_EIRP_"+s]; ok {
+			*v = DeviceEIRP(i)
+			return nil
+		}
+	}
+	return errCouldNotParse("DeviceEIRP")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *DeviceEIRP) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("DeviceEIRP")(string(b)).WithCause(err)
+	}
+	*v = DeviceEIRP(i)
+	return nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *ADRAckLimitExponent) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := ADRAckLimitExponent_value[s]; ok {
+		*v = ADRAckLimitExponent(i)
+		return nil
+	}
+	if !strings.HasPrefix(s, "ADR_ACK_LIMIT_") {
+		if i, ok := ADRAckLimitExponent_value["ADR_ACK_LIMIT_"+s]; ok {
+			*v = ADRAckLimitExponent(i)
+			return nil
+		}
+	}
+	return errCouldNotParse("ADRAckLimitExponent")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *ADRAckLimitExponent) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("ADRAckLimitExponent")(string(b)).WithCause(err)
+	}
+	*v = ADRAckLimitExponent(i)
+	return nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *ADRAckDelayExponent) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := ADRAckDelayExponent_value[s]; ok {
+		*v = ADRAckDelayExponent(i)
+		return nil
+	}
+	if !strings.HasPrefix(s, "ADR_ACK_DELAY_") {
+		if i, ok := ADRAckDelayExponent_value["ADR_ACK_DELAY_"+s]; ok {
+			*v = ADRAckDelayExponent(i)
+			return nil
+		}
+	}
+	return errCouldNotParse("ADRAckDelayExponent")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *ADRAckDelayExponent) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("ADRAckDelayExponent")(string(b)).WithCause(err)
+	}
+	*v = ADRAckDelayExponent(i)
+	return nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *RxDelay) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := RxDelay_value[s]; ok {
+		*v = RxDelay(i)
+		return nil
+	}
+	if !strings.HasPrefix(s, "RX_DELAY_") {
+		if i, ok := RxDelay_value["RX_DELAY_"+s]; ok {
+			*v = RxDelay(i)
+			return nil
+		}
+	}
+	return errCouldNotParse("RxDelay")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *RxDelay) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("RxDelay")(string(b)).WithCause(err)
+	}
+	*v = RxDelay(i)
+	return nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *Minor) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := Minor_value[s]; ok {
+		*v = Minor(i)
+		return nil
+	}
+	if !strings.HasPrefix(s, "MINOR_") {
+		if i, ok := Minor_value["MINOR_"+s]; ok {
+			*v = Minor(i)
+			return nil
+		}
+	}
+	return errCouldNotParse("Minor")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *Minor) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("Minor")(string(b)).WithCause(err)
+	}
+	*v = Minor(i)
+	return nil
+}
 
 var errParsingSemanticVersion = unexpectedValue(
 	errors.DefineInvalidArgument("parsing_semantic_version", "could not parse semantic version", valueKey),
@@ -55,32 +661,10 @@ func (v MACVersion) String() string {
 	return "unknown"
 }
 
-// MarshalText implements encoding.TextMarshaler interface.
-func (v MACVersion) MarshalText() ([]byte, error) {
-	return []byte(v.String()), nil
-}
-
-// UnmarshalText implements encoding.TextUnmarshaler interface.
-func (v *MACVersion) UnmarshalText(b []byte) error {
-	switch string(b) {
-	case MAC_V1_0.String():
-		*v = MAC_V1_0
-	case MAC_V1_0_1.String():
-		*v = MAC_V1_0_1
-	case MAC_V1_0_2.String():
-		*v = MAC_V1_0_2
-	case MAC_V1_0_2.String():
-		*v = MAC_V1_0_2
-	case MAC_V1_0_3.String():
-		*v = MAC_V1_0_3
-	case MAC_V1_1.String():
-		*v = MAC_V1_1
-	case MAC_UNKNOWN.String():
-		*v = MAC_UNKNOWN
-	default:
-		return errCouldNotParse("MACVersion")(string(b))
+func init() {
+	for i := range MACVersion_name {
+		MACVersion_value[MACVersion(i).String()] = i
 	}
-	return nil
 }
 
 // Compare compares MACVersions v to o:
@@ -127,34 +711,10 @@ func (v PHYVersion) String() string {
 	return "unknown"
 }
 
-// MarshalText implements encoding.TextMarshaler interface.
-func (v PHYVersion) MarshalText() ([]byte, error) {
-	return []byte(v.String()), nil
-}
-
-// UnmarshalText implements encoding.TextUnmarshaler interface.
-func (v *PHYVersion) UnmarshalText(b []byte) error {
-	switch string(b) {
-	case PHY_V1_0.String():
-		*v = PHY_V1_0
-	case PHY_V1_0_1.String():
-		*v = PHY_V1_0_1
-	case PHY_V1_0_2_REV_A.String():
-		*v = PHY_V1_0_2_REV_A
-	case PHY_V1_0_2_REV_B.String():
-		*v = PHY_V1_0_2_REV_B
-	case PHY_V1_0_3_REV_A.String():
-		*v = PHY_V1_0_3_REV_A
-	case PHY_V1_1_REV_A.String():
-		*v = PHY_V1_1_REV_A
-	case PHY_V1_1_REV_B.String():
-		*v = PHY_V1_1_REV_B
-	case PHY_UNKNOWN.String():
-		*v = PHY_UNKNOWN
-	default:
-		return errCouldNotParse("PHYVersion")(string(b))
+func init() {
+	for i := range PHYVersion_name {
+		PHYVersion_value[PHYVersion(i).String()] = i
 	}
-	return nil
 }
 
 // String implements fmt.Stringer.
@@ -162,69 +722,7 @@ func (v DataRateIndex) String() string {
 	return strconv.Itoa(int(v))
 }
 
-// MarshalText implements encoding.TextMarshaler interface.
-func (v DataRateIndex) MarshalText() ([]byte, error) {
-	return []byte(v.String()), nil
-}
-
-// UnmarshalText implements encoding.TextUnmarshaler interface.
-func (v *DataRateIndex) UnmarshalText(b []byte) error {
-	i, err := strconv.Atoi(string(b))
-	if err != nil {
-		return errCouldNotParse("DataRateIndex")(string(b)).WithCause(err)
-	}
-	if i > int(DATA_RATE_15) {
-		return errFieldHasMax.WithAttributes(
-			"lorawan_field", "DataRateIndex",
-			"max", DATA_RATE_15,
-		)
-	}
-	*v = DataRateIndex(i)
-	return nil
-}
-
-// MarshalJSON implements json.Marshaler interface.
-func (v DataRateIndex) MarshalJSON() ([]byte, error) {
-	return v.MarshalText()
-}
-
-// UnmarshalJSON implements json.Unmarshaler interface.
-func (v *DataRateIndex) UnmarshalJSON(b []byte) error {
-	return v.UnmarshalText(b)
-}
-
 // String implements fmt.Stringer.
 func (v RxDelay) String() string {
 	return strconv.Itoa(int(v))
-}
-
-// MarshalText implements encoding.TextMarshaler interface.
-func (v RxDelay) MarshalText() ([]byte, error) {
-	return []byte(v.String()), nil
-}
-
-// UnmarshalText implements encoding.TextUnmarshaler interface.
-func (v *RxDelay) UnmarshalText(b []byte) error {
-	i, err := strconv.Atoi(string(b))
-	if err != nil {
-		return errCouldNotParse("RxDelay")(string(b)).WithCause(err)
-	}
-	if i > int(RX_DELAY_15) {
-		return errFieldHasMax.WithAttributes(
-			"lorawan_field", "RxDelay",
-			"max", RX_DELAY_15,
-		)
-	}
-	*v = RxDelay(i)
-	return nil
-}
-
-// MarshalJSON implements json.Marshaler interface.
-func (v RxDelay) MarshalJSON() ([]byte, error) {
-	return v.MarshalText()
-}
-
-// UnmarshalJSON implements json.Unmarshaler interface.
-func (v *RxDelay) UnmarshalJSON(b []byte) error {
-	return v.UnmarshalText(b)
 }

--- a/pkg/ttnpb/messages.go
+++ b/pkg/ttnpb/messages.go
@@ -1,0 +1,82 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ttnpb
+
+import (
+	"strconv"
+	"strings"
+)
+
+// MarshalText implements encoding.TextMarshaler interface.
+func (v PayloadFormatter) MarshalText() ([]byte, error) {
+	return []byte(v.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *PayloadFormatter) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := PayloadFormatter_value[s]; ok {
+		*v = PayloadFormatter(i)
+		return nil
+	}
+	if !strings.HasPrefix(s, "FORMATTER_") {
+		if i, ok := PayloadFormatter_value["FORMATTER_"+s]; ok {
+			*v = PayloadFormatter(i)
+			return nil
+		}
+	}
+	return errCouldNotParse("PayloadFormatter")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *PayloadFormatter) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("PayloadFormatter")(string(b)).WithCause(err)
+	}
+	*v = PayloadFormatter(i)
+	return nil
+}
+
+// MarshalText implements encoding.TextMarshaler interface.
+func (v TxAcknowledgment_Result) MarshalText() ([]byte, error) {
+	return []byte(v.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *TxAcknowledgment_Result) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := TxAcknowledgment_Result_value[s]; ok {
+		*v = TxAcknowledgment_Result(i)
+		return nil
+	}
+	return errCouldNotParse("TxAcknowledgment_Result")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *TxAcknowledgment_Result) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("TxAcknowledgment_Result")(string(b)).WithCause(err)
+	}
+	*v = TxAcknowledgment_Result(i)
+	return nil
+}

--- a/pkg/ttnpb/metadata.go
+++ b/pkg/ttnpb/metadata.go
@@ -15,51 +15,40 @@
 package ttnpb
 
 import (
-	"context"
 	"strconv"
 	"strings"
 )
 
 // MarshalText implements encoding.TextMarshaler interface.
-func (v GrantType) MarshalText() ([]byte, error) {
+func (v LocationSource) MarshalText() ([]byte, error) {
 	return []byte(v.String()), nil
 }
 
 // UnmarshalText implements encoding.TextUnmarshaler interface.
-func (v *GrantType) UnmarshalText(b []byte) error {
+func (v *LocationSource) UnmarshalText(b []byte) error {
 	s := string(b)
-	if i, ok := GrantType_value[s]; ok {
-		*v = GrantType(i)
+	if i, ok := LocationSource_value[s]; ok {
+		*v = LocationSource(i)
 		return nil
 	}
-	if !strings.HasPrefix(s, "GRANT_") {
-		if i, ok := GrantType_value["GRANT_"+s]; ok {
-			*v = GrantType(i)
+	if !strings.HasPrefix(s, "SOURCE_") {
+		if i, ok := LocationSource_value["SOURCE_"+s]; ok {
+			*v = LocationSource(i)
 			return nil
 		}
 	}
-	return errCouldNotParse("GrantType")(string(b))
+	return errCouldNotParse("LocationSource")(string(b))
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface.
-func (v *GrantType) UnmarshalJSON(b []byte) error {
+func (v *LocationSource) UnmarshalJSON(b []byte) error {
 	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
 		return v.UnmarshalText(b[1 : len(b)-1])
 	}
 	i, err := strconv.Atoi(string(b))
 	if err != nil {
-		return errCouldNotParse("GrantType")(string(b)).WithCause(err)
+		return errCouldNotParse("LocationSource")(string(b)).WithCause(err)
 	}
-	*v = GrantType(i)
+	*v = LocationSource(i)
 	return nil
-}
-
-// ValidateContext wraps the generated validator with (optionally context-based) custom checks.
-func (m *UpdateClientRequest) ValidateContext(context.Context) error {
-	if len(m.FieldMask.Paths) == 0 {
-		return m.ValidateFields()
-	}
-	return m.ValidateFields(append(fieldsWithPrefix("client", m.FieldMask.Paths...),
-		"client.ids",
-	)...)
 }

--- a/pkg/ttnpb/rights.go
+++ b/pkg/ttnpb/rights.go
@@ -17,8 +17,43 @@ package ttnpb
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 )
+
+// MarshalText implements encoding.TextMarshaler interface.
+func (v Right) MarshalText() ([]byte, error) {
+	return []byte(v.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler interface.
+func (v *Right) UnmarshalText(b []byte) error {
+	s := string(b)
+	if i, ok := Right_value[s]; ok {
+		*v = Right(i)
+		return nil
+	}
+	if !strings.HasPrefix(s, "RIGHT_") {
+		if i, ok := Right_value["RIGHT_"+s]; ok {
+			*v = Right(i)
+			return nil
+		}
+	}
+	return errCouldNotParse("Right")(string(b))
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (v *Right) UnmarshalJSON(b []byte) error {
+	if len(b) > 2 && b[0] == '"' && b[len(b)-1] == '"' {
+		return v.UnmarshalText(b[1 : len(b)-1])
+	}
+	i, err := strconv.Atoi(string(b))
+	if err != nil {
+		return errCouldNotParse("Right")(string(b)).WithCause(err)
+	}
+	*v = Right(i)
+	return nil
+}
 
 var (
 	AllUserRights         = &Rights{}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes the JSON marshaling that was unintentionally broken in #512. This PR resolves #526.

**Changes:**
<!-- What are the changes made in this pull request? -->

- Implement `UnmarshalText` and `UnmarshalJSON` on all enums. `UnmarshalText` accepts prefixed and non-prefixed enum strings (so both `RIGHT_XXX` and `XXX`). `UnmarshalJSON` additionally accepts the integer representation.
- Implement `MarshalText` on all enums that we don't want to render as their integer representation.

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Fixed JSON marshaling and unmarshaling of enums
