### PR TITLE
Observability Improvements (pprof, prometheus)

### DIFF
--- a/pkg/applicationserver/observability.go
+++ b/pkg/applicationserver/observability.go
@@ -254,7 +254,7 @@ func registerDropUp(ctx context.Context, msg *ttnpb.ApplicationUp, err error) {
 		events.Publish(evtDropDataUp(ctx, msg.EndDeviceIdentifiers, err))
 	}
 	if ttnErr, ok := errors.From(err); ok {
-		asMetrics.uplinkDropped.WithLabelValues(ctx, ttnErr.String()).Inc()
+		asMetrics.uplinkDropped.WithLabelValues(ctx, ttnErr.FullName()).Inc()
 	} else {
 		asMetrics.uplinkDropped.WithLabelValues(ctx, unknown).Inc()
 	}
@@ -273,7 +273,7 @@ func registerForwardDownlink(ctx context.Context, ids ttnpb.EndDeviceIdentifiers
 func registerDropDownlink(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, msg *ttnpb.ApplicationDownlink, err error) {
 	events.Publish(evtDropDataDown(ctx, ids, err))
 	if ttnErr, ok := errors.From(err); ok {
-		asMetrics.downlinkDropped.WithLabelValues(ctx, ttnErr.String()).Inc()
+		asMetrics.downlinkDropped.WithLabelValues(ctx, ttnErr.FullName()).Inc()
 	} else {
 		asMetrics.downlinkDropped.WithLabelValues(ctx, unknown).Inc()
 	}

--- a/pkg/component/grpc.go
+++ b/pkg/component/grpc.go
@@ -23,6 +23,7 @@ import (
 	echo "github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"go.thethings.network/lorawan-stack/pkg/errors"
+	"go.thethings.network/lorawan-stack/pkg/metrics"
 	"go.thethings.network/lorawan-stack/pkg/rpcmiddleware/hooks"
 	"go.thethings.network/lorawan-stack/pkg/rpcmiddleware/rpclog"
 	"go.thethings.network/lorawan-stack/pkg/rpcserver"
@@ -44,6 +45,7 @@ func (c *Component) setupGRPC() (err error) {
 	for _, sub := range c.grpcSubsystems {
 		sub.RegisterServices(c.grpc.Server)
 	}
+	metrics.InitializeServerMetrics(c.grpc.Server)
 	c.logger.Debug("Starting loopback connection")
 	c.loopback, err = rpcserver.StartLoopback(c.ctx, c.grpc.Server)
 	if err != nil {

--- a/pkg/component/web.go
+++ b/pkg/component/web.go
@@ -86,7 +86,12 @@ func (c *Component) listenWeb() (err error) {
 		}
 		g := c.web.RootGroup("/metrics", middleware...)
 		g.GET("/", func(c echo.Context) error { return c.Redirect(http.StatusFound, strings.TrimSuffix(c.Path(), "/")) })
-		g.GET("", echo.WrapHandler(metrics.Exporter))
+		g.GET("", echo.WrapHandler(metrics.Exporter), func(next echo.HandlerFunc) echo.HandlerFunc {
+			return func(c echo.Context) error {
+				c.Request().Header.Del("Accept-Encoding")
+				return next(c)
+			}
+		})
 	}
 
 	if c.config.HTTP.Health.Enable {

--- a/pkg/events/definitions.go
+++ b/pkg/events/definitions.go
@@ -39,6 +39,7 @@ func defineSkip(name, description string, skip uint) Definition {
 	}
 	i18n.Define(fmt.Sprintf("%s:%s", i18nPrefix, name), description).SetSource(1 + skip)
 	Definitions[name] = description
+	initMetrics(name)
 	return func(ctx context.Context, identifiers ttnpb.Identifiers, data interface{}) Event {
 		return New(ctx, name, identifiers, data)
 	}

--- a/pkg/events/observability.go
+++ b/pkg/events/observability.go
@@ -15,6 +15,8 @@
 package events
 
 import (
+	"context"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"go.thethings.network/lorawan-stack/pkg/metrics"
 )
@@ -47,6 +49,13 @@ var channelDropped = metrics.NewContextualCounterVec(
 	},
 	[]string{"name"},
 )
+
+func initMetrics(name string) {
+	ctx := context.Background()
+	publishes.WithLabelValues(ctx, name).Add(0)
+	subscriptions.WithLabelValues(name).Add(0)
+	channelDropped.WithLabelValues(ctx, name).Add(0)
+}
 
 func init() {
 	metrics.MustRegister(publishes, subscriptions, channelDropped)

--- a/pkg/gatewayserver/observability.go
+++ b/pkg/gatewayserver/observability.go
@@ -178,7 +178,7 @@ func registerForwardUplink(ctx context.Context, devIDs ttnpb.EndDeviceIdentifier
 func registerDropUplink(ctx context.Context, devIDs ttnpb.EndDeviceIdentifiers, gtw *ttnpb.Gateway, msg *ttnpb.UplinkMessage, err error) {
 	events.Publish(evtDropUp(ctx, gtw, err))
 	if ttnErr, ok := errors.From(err); ok {
-		gsMetrics.uplinkDropped.WithLabelValues(ctx, ttnErr.String()).Inc()
+		gsMetrics.uplinkDropped.WithLabelValues(ctx, ttnErr.FullName()).Inc()
 	} else {
 		gsMetrics.uplinkDropped.WithLabelValues(ctx, unknown).Inc()
 	}

--- a/pkg/joinserver/observability.go
+++ b/pkg/joinserver/observability.go
@@ -84,7 +84,7 @@ func registerAcceptJoin(ctx context.Context, dev *ttnpb.EndDevice, msg *ttnpb.Jo
 func registerRejectJoin(ctx context.Context, req *ttnpb.JoinRequest, err error) {
 	events.Publish(evtRejectJoin(ctx, nil, err))
 	if ttnErr, ok := errors.From(err); ok {
-		jsMetrics.joinRejected.WithLabelValues(ctx, ttnErr.String()).Inc()
+		jsMetrics.joinRejected.WithLabelValues(ctx, ttnErr.FullName()).Inc()
 	} else {
 		jsMetrics.joinRejected.WithLabelValues(ctx, unknown).Inc()
 	}

--- a/pkg/metrics/grpc.go
+++ b/pkg/metrics/grpc.go
@@ -17,6 +17,7 @@ package metrics
 import (
 	"context"
 	"net"
+	"runtime/pprof"
 
 	"github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus"
@@ -117,6 +118,9 @@ func (hdl statsHandler) Collect(ch chan<- prometheus.Metric) {
 }
 
 func (hdl statsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
+	defer pprof.SetGoroutineLabels(ctx)
+	ctx = pprof.WithLabels(ctx, pprof.Labels("grpc.method", info.FullMethodName))
+	pprof.SetGoroutineLabels(ctx)
 	return ctx
 }
 

--- a/pkg/metrics/grpc.go
+++ b/pkg/metrics/grpc.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/stats"
 )
 
@@ -28,6 +29,11 @@ var serverMetrics = grpc_prometheus.NewServerMetrics()
 func init() {
 	serverMetrics.EnableHandlingTimeHistogram()
 	MustRegister(serverMetrics)
+}
+
+// InitializeServerMetrics initializes server metrics for the given gRPC server.
+func InitializeServerMetrics(s *grpc.Server) {
+	serverMetrics.InitializeMetrics(s)
 }
 
 // Server interceptors.

--- a/pkg/metrics/grpc.go
+++ b/pkg/metrics/grpc.go
@@ -27,7 +27,6 @@ import (
 var serverMetrics = grpc_prometheus.NewServerMetrics()
 
 func init() {
-	serverMetrics.EnableHandlingTimeHistogram()
 	MustRegister(serverMetrics)
 }
 

--- a/pkg/networkserver/observability.go
+++ b/pkg/networkserver/observability.go
@@ -212,7 +212,7 @@ func registerDropDataUplink(ctx context.Context, devIDs *ttnpb.EndDeviceIdentifi
 	}
 
 	if ttnErr, ok := errors.From(err); ok {
-		nsMetrics.uplinkDropped.WithLabelValues(ctx, uplinkMTypeLabel(msg), ttnErr.String()).Inc()
+		nsMetrics.uplinkDropped.WithLabelValues(ctx, uplinkMTypeLabel(msg), ttnErr.FullName()).Inc()
 	} else {
 		nsMetrics.uplinkDropped.WithLabelValues(ctx, uplinkMTypeLabel(msg), unknown).Inc()
 	}
@@ -224,7 +224,7 @@ func registerDropJoinRequest(ctx context.Context, devIDs *ttnpb.EndDeviceIdentif
 	}
 
 	if ttnErr, ok := errors.From(err); ok {
-		nsMetrics.uplinkDropped.WithLabelValues(ctx, uplinkMTypeLabel(msg), ttnErr.String()).Inc()
+		nsMetrics.uplinkDropped.WithLabelValues(ctx, uplinkMTypeLabel(msg), ttnErr.FullName()).Inc()
 	} else {
 		nsMetrics.uplinkDropped.WithLabelValues(ctx, uplinkMTypeLabel(msg), unknown).Inc()
 	}
@@ -236,7 +236,7 @@ func registerDropRejoinRequest(ctx context.Context, devIDs *ttnpb.EndDeviceIdent
 	}
 
 	if ttnErr, ok := errors.From(err); ok {
-		nsMetrics.uplinkDropped.WithLabelValues(ctx, uplinkMTypeLabel(msg), ttnErr.String()).Inc()
+		nsMetrics.uplinkDropped.WithLabelValues(ctx, uplinkMTypeLabel(msg), ttnErr.FullName()).Inc()
 	} else {
 		nsMetrics.uplinkDropped.WithLabelValues(ctx, uplinkMTypeLabel(msg), unknown).Inc()
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR is a follow-up of #442, and resolves #29 by tagging RPCs with pprof labels. Additionally, this PR makes some improvements to our prometheus metrics.

**Changes:**
<!-- What are the changes made in this pull request? -->

- RPCs and their goroutines are now tagged with pprof labels
- Prometheus counters for RPCs and events are initialized to 0
- Disabled RPC timing histograms (they didn't add much over tracing and generated too many time series in Prometheus).
- Fixed double-gzip issue on `/metrics` endpoint.
- Use error names instead of rendered error (which may contain variables) in metrics to avoid creating too many time series in Prometheus