### PR TITLE
CLI credentials management

### DIFF
--- a/cmd/ttn-lw-cli/commands/config.go
+++ b/cmd/ttn-lw-cli/commands/config.go
@@ -29,7 +29,7 @@ var (
 // Config for the ttn-lw-cli binary.
 type Config struct {
 	conf.Base                    `name:",squash"`
-	ConfigID                     string `name:"config-id" description:"Configuration ID (if using multiple configurations)"`
+	CredentialsID                string `name:"credentials-id" description:"Credentials ID (if using multiple configurations)"`
 	InputFormat                  string `name:"input-format" description:"Input format"`
 	OutputFormat                 string `name:"output-format" description:"Output format"`
 	AllowUnknownHosts            bool   `name:"allow-unknown-hosts" description:"Allow sending credentials to unknown hosts"`

--- a/cmd/ttn-lw-cli/commands/config.go
+++ b/cmd/ttn-lw-cli/commands/config.go
@@ -41,6 +41,17 @@ type Config struct {
 	CA                           string `name:"ca" description:"CA certificate file"`
 }
 
+func (c Config) getHosts() []string {
+	return getHosts(
+		c.OAuthServerAddress,
+		c.IdentityServerGRPCAddress,
+		c.GatewayServerGRPCAddress,
+		c.NetworkServerGRPCAddress,
+		c.ApplicationServerGRPCAddress,
+		c.JoinServerGRPCAddress,
+	)
+}
+
 // DefaultConfig contains the default config for the ttn-lw-cli binary.
 var DefaultConfig = Config{
 	Base: conf.Base{

--- a/cmd/ttn-lw-cli/commands/config.go
+++ b/cmd/ttn-lw-cli/commands/config.go
@@ -29,6 +29,7 @@ var (
 // Config for the ttn-lw-cli binary.
 type Config struct {
 	conf.Base                    `name:",squash"`
+	ConfigID                     string `name:"config-id" description:"Configuration ID (if using multiple configurations)"`
 	InputFormat                  string `name:"input-format" description:"Input format"`
 	OutputFormat                 string `name:"output-format" description:"Output format"`
 	OAuthServerAddress           string `name:"oauth-server-address" description:"OAuth Server Address"`

--- a/cmd/ttn-lw-cli/commands/config.go
+++ b/cmd/ttn-lw-cli/commands/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	ConfigID                     string `name:"config-id" description:"Configuration ID (if using multiple configurations)"`
 	InputFormat                  string `name:"input-format" description:"Input format"`
 	OutputFormat                 string `name:"output-format" description:"Output format"`
+	AllowUnknownHosts            bool   `name:"allow-unknown-hosts" description:"Allow sending credentials to unknown hosts"`
 	OAuthServerAddress           string `name:"oauth-server-address" description:"OAuth Server Address"`
 	IdentityServerGRPCAddress    string `name:"identity-server-grpc-address" description:"Identity Server Address"`
 	GatewayServerGRPCAddress     string `name:"gateway-server-grpc-address" description:"Gateway Server Address"`

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -17,10 +17,7 @@ package commands
 import (
 	"context"
 	stdio "io"
-	"net"
-	"net/url"
 	"os"
-	"strings"
 
 	pbtypes "github.com/gogo/protobuf/types"
 	"github.com/spf13/cobra"
@@ -733,22 +730,6 @@ func init() {
 	endDevicesCommand.AddCommand(applicationsDownlinkCommand)
 
 	Root.AddCommand(endDevicesCommand)
-}
-
-func getHost(address string) string {
-	if strings.Contains(address, "://") {
-		url, err := url.Parse(address)
-		if err == nil {
-			address = url.Host
-		}
-	}
-	if strings.Contains(address, ":") {
-		host, _, err := net.SplitHostPort(address)
-		if err == nil {
-			return host
-		}
-	}
-	return address
 }
 
 var errAddressMismatch = errors.DefineAborted("address_mismatch", "server address mismatch")

--- a/cmd/ttn-lw-cli/commands/login.go
+++ b/cmd/ttn-lw-cli/commands/login.go
@@ -34,8 +34,7 @@ import (
 
 func logout() error {
 	defer func() {
-		cache.Set("oauth_token", (*oauth2.Token)(nil))
-		cache.Set("api_key", "")
+		cache.Unset("oauth_token", "api_key", "hosts")
 	}()
 	refreshToken() // NOTE: ignore errors.
 	optionalAuth()
@@ -79,6 +78,8 @@ var (
 		PersistentPreRunE: preRun(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logout()
+
+			cache.Set("hosts", config.getHosts())
 
 			ctx, done := context.WithCancel(ctx)
 			defer done()

--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -97,7 +97,7 @@ func preRun(tasks ...func() error) func(cmd *cobra.Command, args []string) error
 		if err != nil {
 			return err
 		}
-		cache = cache.ForID(config.ConfigID)
+		cache = cache.ForID(config.CredentialsID)
 
 		// create logger
 		logger, err = log.NewLogger(

--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -44,7 +44,7 @@ var (
 	config       = &Config{}
 	oauth2Config *oauth2.Config
 	ctx          = newContext(context.Background())
-	cache        util.Cache
+	cache        util.AuthCache
 
 	inputDecoder io.Decoder
 
@@ -59,7 +59,7 @@ var (
 			// clean up the API
 			api.CloseAll()
 
-			err := util.SaveCache(cache)
+			err := util.SaveAuthCache(cache)
 			if err != nil {
 				return err
 			}
@@ -93,7 +93,7 @@ func preRun(tasks ...func() error) func(cmd *cobra.Command, args []string) error
 		}
 
 		// get cache
-		cache, err = util.GetCache()
+		cache, err = util.GetAuthCache()
 		if err != nil {
 			return err
 		}
@@ -156,7 +156,7 @@ func refreshToken() error {
 		freshToken, err := oauth2Config.TokenSource(ctx, token).Token()
 		if err == nil && freshToken != token {
 			cache.Set("oauth_token", freshToken)
-			if err := util.SaveCache(cache); err != nil {
+			if err := util.SaveAuthCache(cache); err != nil {
 				return err
 			}
 		}

--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -155,6 +155,9 @@ func preRun(tasks ...func() error) func(cmd *cobra.Command, args []string) error
 var errUnknownHost = errors.DefineUnauthenticated("unknown_host", "unknown host `{host}` for current credentials", "known")
 
 func checkAuth() error {
+	if config.AllowUnknownHosts {
+		return nil
+	}
 	if knownHosts, ok := cache.Get("hosts").([]string); ok && len(knownHosts) > 0 {
 	nextHost:
 		for _, host := range config.getHosts() {
@@ -163,6 +166,8 @@ func checkAuth() error {
 					continue nextHost
 				}
 			}
+			logger.Errorf("Found an unknown host `%s` that was not configured when you logged in", host)
+			logger.Error("You may want to check your configuration, login/logout or use the --allow-unknown-hosts flag")
 			return errUnknownHost.WithAttributes("host", host, "known", knownHosts)
 		}
 	}

--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -97,6 +97,7 @@ func preRun(tasks ...func() error) func(cmd *cobra.Command, args []string) error
 		if err != nil {
 			return err
 		}
+		cache = cache.ForID(config.ConfigID)
 
 		// create logger
 		logger, err = log.NewLogger(

--- a/cmd/ttn-lw-cli/commands/utils.go
+++ b/cmd/ttn-lw-cli/commands/utils.go
@@ -1,0 +1,49 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"net"
+	"net/url"
+	"strings"
+)
+
+func getHost(address string) string {
+	if strings.Contains(address, "://") {
+		url, err := url.Parse(address)
+		if err == nil {
+			address = url.Host
+		}
+	}
+	if strings.Contains(address, ":") {
+		host, _, err := net.SplitHostPort(address)
+		if err == nil {
+			return host
+		}
+	}
+	return address
+}
+
+func getHosts(addresses ...string) []string {
+	hostmap := make(map[string]struct{})
+	for _, address := range addresses {
+		hostmap[getHost(address)] = struct{}{}
+	}
+	hosts := make([]string, 0, len(hostmap))
+	for host := range hostmap {
+		hosts = append(hosts, host)
+	}
+	return hosts
+}

--- a/config/messages.json
+++ b/config/messages.json
@@ -1349,6 +1349,15 @@
       "file": "root.go"
     }
   },
+  "error:cmd/ttn-lw-cli/commands:unknown_host": {
+    "translations": {
+      "en": "unknown host `{host}` for current credentials"
+    },
+    "description": {
+      "package": "cmd/ttn-lw-cli/commands",
+      "file": "root.go"
+    }
+  },
   "error:cmd/ttn-lw-cli/internal/util:flag_value": {
     "translations": {
       "en": "invalid flag value"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR adds checks for "known hosts" to the CLI and adds support for caching credentials for multiple server configurations. This PR closes #515.

**Changes:**
<!-- What are the changes made in this pull request? -->

- Make the CLI refuse to send credentials to hosts that were not configured when the user signed in (unless circumvented)
- Add a `credentials-id` option to the CLI's config to select the credentials to use (if not using default credentials)

**Notes for Reviewers:**
<!--
Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

We're using 

```go
data struct {
	AuthData
	ByID map[string]*AuthData `json:"by_id"`
}
```

to not break on existing credential cache files.

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Add `--credentials-id` flag to CLI that allows users to be logged in with mulitple credentials and switch between them.
