### PR TITLE
Add Link Component

### DIFF
--- a/pkg/webui/components/button/index.js
+++ b/pkg/webui/components/button/index.js
@@ -100,6 +100,7 @@ Button.Link = function (props) {
     />
   )
 }
+Button.Link.displayName = 'Button.Link'
 
 Button.AnchorLink = function (props) {
   const { target, title, name } = props
@@ -114,6 +115,7 @@ Button.AnchorLink = function (props) {
     />
   )
 }
+Button.AnchorLink.displayName = 'Button.AnchorLink'
 
 const commonPropTypes = {
   /** The message to be displayed within the button */

--- a/pkg/webui/components/button/index.js
+++ b/pkg/webui/components/button/index.js
@@ -15,8 +15,8 @@
 import React from 'react'
 import classnames from 'classnames'
 import bind from 'autobind-decorator'
-import { Link } from 'react-router-dom'
 
+import Link from '../link'
 import PropTypes from '../../lib/prop-types'
 import Spinner from '../spinner'
 import Message from '../../lib/components/message'
@@ -106,7 +106,7 @@ Button.AnchorLink = function (props) {
   const htmlProps = { target, title, name }
   const buttonClassNames = assembleClassnames(props)
   return (
-    <a
+    <Link.Anchor
       className={buttonClassNames}
       href={props.href}
       children={buttonChildren(props)}
@@ -175,20 +175,12 @@ Button.propTypes = {
 }
 
 Button.Link.propTypes = {
-  /** The route to navigate to on click */
-  to: PropTypes.string,
   ...commonPropTypes,
+  ...Link.propTypes,
 }
 
 Button.AnchorLink.propTypes = {
-  /** The <a/>'s href prop */
-  href: PropTypes.string,
-  /** The <a/>'s title prop */
-  title: PropTypes.message,
-  /** The <a/>'s name prop */
-  name: PropTypes.string,
-  /** The <a/>'s target prop */
-  target: PropTypes.string,
   ...commonPropTypes,
+  ...Link.Anchor.propTypes,
 }
 export default Button

--- a/pkg/webui/components/link/index.js
+++ b/pkg/webui/components/link/index.js
@@ -1,0 +1,130 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import { Link as RouterLink } from 'react-router-dom'
+import classnames from 'classnames'
+import { injectIntl } from 'react-intl'
+
+import PropTypes from '../../lib/prop-types'
+
+import style from './link.styl'
+
+const formatTitle = function (content, values, formatter) {
+  if (typeof content === 'object' && content.id && content.defaultMessage) {
+    return formatter(content, values)
+  }
+
+  return content
+}
+
+const Link = function (props) {
+  const {
+    className,
+    title,
+    titleValues,
+    id,
+    children,
+    to,
+    replace,
+    target,
+    showVisited,
+    intl,
+  } = props
+
+  const formattedTitle = formatTitle(title, titleValues, intl.formatMessage)
+
+  return (
+    <RouterLink
+      className={className ? className : classnames(style.link,
+        { [style.linkVisited]: showVisited }
+      )}
+      id={id}
+      title={formattedTitle}
+      replace={replace}
+      to={to}
+      target={target}
+    >
+      {children}
+    </RouterLink>
+  )
+}
+
+Link.propTypes = {
+  title: PropTypes.message,
+  id: PropTypes.string,
+  to: PropTypes.oneOfType([ PropTypes.string, PropTypes.shape({
+    pathname: PropTypes.string,
+    search: PropTypes.string,
+    hash: PropTypes.string,
+    state: PropTypes.object,
+  }) ]).isRequired,
+  replace: PropTypes.bool,
+  target: PropTypes.string,
+  showVisited: PropTypes.bool,
+}
+
+Link.defaultProps = {
+  replace: false,
+  showVisited: false,
+}
+
+const AnchorLink = function (props) {
+  const {
+    className,
+    name,
+    title,
+    titleValues,
+    id,
+    href,
+    target,
+    children,
+    showVisited,
+    intl,
+  } = props
+
+  const formattedTitle = formatTitle(title, titleValues, intl.formatMessage)
+
+  return (
+    <a
+      className={className ? className : classnames(style.link,
+        { [style.linkVisited]: showVisited }
+      )}
+      title={formattedTitle}
+      id={id}
+      href={href}
+      target={target}
+      name={name}
+    >
+      {children}
+    </a>
+  )
+}
+
+AnchorLink.propTypes = {
+  title: PropTypes.string,
+  id: PropTypes.string,
+  href: PropTypes.string.isRequired,
+  target: PropTypes.string,
+  showVisited: PropTypes.bool,
+  name: PropTypes.string,
+}
+
+AnchorLink.defaultProps = {
+  showVisited: false,
+}
+
+Link.Anchor = injectIntl(AnchorLink)
+
+export default injectIntl(Link)

--- a/pkg/webui/components/link/link.styl
+++ b/pkg/webui/components/link/link.styl
@@ -1,0 +1,27 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.link
+  color: $tc-subtle-gray
+  text-decoration: none
+
+  &:active,
+  &:hover
+    color: $tc-deep-gray
+    text-decoration: underline
+
+  &-visited
+    &:visited
+      color: $tc-deep-gray
+

--- a/pkg/webui/components/link/story.js
+++ b/pkg/webui/components/link/story.js
@@ -1,0 +1,53 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import Link from '.'
+
+const titleStyle = { marginRight: '20px' }
+storiesOf('Link', module)
+  .add('Default', () => (
+    <div>
+      <div>
+        <span style={titleStyle}>link:</span>
+        <Link to="/">
+      Show more
+        </Link>
+      </div>
+      <div>
+        <span style={titleStyle}>anchor link:</span>
+        <Link.Anchor href="/">
+      Show more
+        </Link.Anchor>
+      </div>
+    </div>
+  ))
+  .add('Show Visited', () => (
+    <div>
+      <div>
+        <span style={titleStyle}>link:</span>
+        <Link showVisited to="/">
+      Show more
+        </Link>
+      </div>
+      <div>
+        <span style={titleStyle}>anchor link:</span>
+        <Link.Anchor showVisited href="/">
+      Show more
+        </Link.Anchor>
+      </div>
+    </div>
+  ))


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR adds a standalone `<Link />` component that act as the `react-router-dom` link and the native `<a />` tag.
Somewhat references https://github.com/TheThingsNetwork/lorawan-stack/issues/28, the events widget component has the `See all activity` link.

<img width="558" alt="Screenshot 2019-04-16 at 14 35 40" src="https://user-images.githubusercontent.com/16374166/56209944-0e4e2600-6055-11e9-8f4b-c250f8eec28e.png">


**Changes:**
<!-- What are the changes made in this pull request? -->

- Add the `<Link />` component
- Refactor `<Button.Link />` and `<Button.AnchorLink />` to use the new component
- Fix button links `displayName`
- Add support for translated link titles
