### PR TITLE
Don't consider organization ID for organization collaborator in CLI

### DIFF
--- a/cmd/ttn-lw-cli/commands/organizations.go
+++ b/cmd/ttn-lw-cli/commands/organizations.go
@@ -75,7 +75,7 @@ var (
 			}
 			limit, page, opt, getTotal := withPagination(cmd.Flags())
 			res, err := ttnpb.NewOrganizationRegistryClient(is).List(ctx, &ttnpb.ListOrganizationsRequest{
-				Collaborator: getCollaborator(cmd.Flags()),
+				Collaborator: getUserID(cmd.Flags(), nil).OrganizationOrUserIdentifiers(),
 				FieldMask:    types.FieldMask{Paths: paths},
 				Limit:        limit,
 				Page:         page,
@@ -141,7 +141,7 @@ var (
 		Short:   "Create an organization",
 		RunE: asBulk(func(cmd *cobra.Command, args []string) (err error) {
 			orgID := getOrganizationID(cmd.Flags(), args)
-			collaborator := getCollaborator(cmd.Flags())
+			collaborator := getUserID(cmd.Flags(), nil).OrganizationOrUserIdentifiers()
 			if collaborator == nil {
 				return errNoCollaborator
 			}

--- a/cmd/ttn-lw-cli/commands/organizations_access.go
+++ b/cmd/ttn-lw-cli/commands/organizations_access.go
@@ -85,7 +85,7 @@ var (
 			if orgID == nil {
 				return errNoOrganizationID
 			}
-			collaborator := getCollaborator(cmd.Flags())
+			collaborator := getUserID(cmd.Flags(), nil).OrganizationOrUserIdentifiers()
 			if collaborator == nil {
 				return errNoCollaborator
 			}
@@ -121,7 +121,7 @@ var (
 			if orgID == nil {
 				return errNoOrganizationID
 			}
-			collaborator := getCollaborator(cmd.Flags())
+			collaborator := getUserID(cmd.Flags(), nil).OrganizationOrUserIdentifiers()
 			if collaborator == nil {
 				return errNoCollaborator
 			}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

With this PR we stop considering Organization IDs when getting the collaborator for organizations. Organizations can not collaborate on other organizations, so it didn't make sense in the first place.

This PR resolves #490. 
