### PR TITLE
Refuse to delete applications that still have devices

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -3131,6 +3131,15 @@
       "file": "entity_access.go"
     }
   },
+  "error:pkg/identityserver:application_has_devices": {
+    "translations": {
+      "en": "application still has `{count}` devices"
+    },
+    "description": {
+      "package": "pkg/identityserver",
+      "file": "application_registry.go"
+    }
+  },
   "error:pkg/identityserver:client_update_admin_field": {
     "translations": {
       "en": "only admins can update the `{field}` field"

--- a/pkg/identityserver/application_registry.go
+++ b/pkg/identityserver/application_registry.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/jinzhu/gorm"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
+	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/events"
 	"go.thethings.network/lorawan-stack/pkg/identityserver/blacklist"
 	"go.thethings.network/lorawan-stack/pkg/identityserver/store"
@@ -218,11 +219,20 @@ func (is *IdentityServer) updateApplication(ctx context.Context, req *ttnpb.Upda
 	return app, nil
 }
 
+var errApplicationHasDevices = errors.DefineFailedPrecondition("application_has_devices", "application still has `{count}` devices")
+
 func (is *IdentityServer) deleteApplication(ctx context.Context, ids *ttnpb.ApplicationIdentifiers) (*types.Empty, error) {
 	if err := rights.RequireApplication(ctx, *ids, ttnpb.RIGHT_APPLICATION_DELETE); err != nil {
 		return nil, err
 	}
 	err := is.withDatabase(ctx, func(db *gorm.DB) error {
+		total, err := store.GetEndDeviceStore(db).CountEndDevices(ctx, ids)
+		if err != nil {
+			return err
+		}
+		if total > 0 {
+			return errApplicationHasDevices.WithAttributes("count", int(total))
+		}
 		return store.GetApplicationStore(db).DeleteApplication(ctx, ids)
 	})
 	if err != nil {

--- a/pkg/identityserver/store/end_device_store.go
+++ b/pkg/identityserver/store/end_device_store.go
@@ -105,6 +105,13 @@ func (s *deviceStore) findEndDevices(ctx context.Context, query *gorm.DB, fieldM
 	return devProtos, nil
 }
 
+func (s *deviceStore) CountEndDevices(ctx context.Context, ids *ttnpb.ApplicationIdentifiers) (total uint64, err error) {
+	defer trace.StartRegion(ctx, "count end devices").End()
+	query := s.db.Model(EndDevice{}).Scopes(withContext(ctx), withApplicationID(ids.GetApplicationID()))
+	err = query.Count(&total).Error
+	return
+}
+
 func (s *deviceStore) ListEndDevices(ctx context.Context, ids *ttnpb.ApplicationIdentifiers, fieldMask *types.FieldMask) ([]*ttnpb.EndDevice, error) {
 	// NOTE: tracing done in s.findEndDevices.
 	query := s.db.Scopes(withContext(ctx), withApplicationID(ids.GetApplicationID()))

--- a/pkg/identityserver/store/end_device_store_test.go
+++ b/pkg/identityserver/store/end_device_store_test.go
@@ -125,6 +125,10 @@ func TestEndDeviceStore(t *testing.T) {
 		a.So(got.CreatedAt, should.Equal, created.CreatedAt)
 		a.So(got.UpdatedAt, should.Equal, updated.UpdatedAt)
 
+		count, err := store.CountEndDevices(ctx, &deviceID.ApplicationIdentifiers)
+		a.So(err, should.BeNil)
+		a.So(count, should.Equal, 1)
+
 		list, err := store.ListEndDevices(ctx,
 			&deviceID.ApplicationIdentifiers,
 			&ptypes.FieldMask{Paths: []string{"name"}},
@@ -164,6 +168,10 @@ func TestEndDeviceStore(t *testing.T) {
 		a.So(createdNew.CreatedAt, should.HappenAfter, time.Now().Add(-1*time.Hour))
 		a.So(createdNew.UpdatedAt, should.HappenAfter, time.Now().Add(-1*time.Hour))
 
+		count, err = store.CountEndDevices(ctx, &deviceID.ApplicationIdentifiers)
+		a.So(err, should.BeNil)
+		a.So(count, should.Equal, 2)
+
 		list, err = store.ListEndDevices(ctx,
 			&deviceID.ApplicationIdentifiers,
 			nil,
@@ -199,6 +207,10 @@ func TestEndDeviceStore(t *testing.T) {
 		if a.So(err, should.NotBeNil) {
 			a.So(errors.IsNotFound(err), should.BeTrue)
 		}
+
+		count, err = store.CountEndDevices(ctx, &deviceID.ApplicationIdentifiers)
+		a.So(err, should.BeNil)
+		a.So(count, should.Equal, 0)
 
 		list, err = store.ListEndDevices(ctx, &deviceID.ApplicationIdentifiers, nil)
 		a.So(err, should.BeNil)

--- a/pkg/identityserver/store/store_interfaces.go
+++ b/pkg/identityserver/store/store_interfaces.go
@@ -51,6 +51,7 @@ type ClientStore interface {
 // sufficient rights to perform the action.
 type EndDeviceStore interface {
 	CreateEndDevice(ctx context.Context, dev *ttnpb.EndDevice) (*ttnpb.EndDevice, error)
+	CountEndDevices(ctx context.Context, ids *ttnpb.ApplicationIdentifiers) (uint64, error)
 	ListEndDevices(ctx context.Context, ids *ttnpb.ApplicationIdentifiers, fieldMask *types.FieldMask) ([]*ttnpb.EndDevice, error)
 	FindEndDevices(ctx context.Context, ids []*ttnpb.EndDeviceIdentifiers, fieldMask *types.FieldMask) ([]*ttnpb.EndDevice, error)
 	GetEndDevice(ctx context.Context, id *ttnpb.EndDeviceIdentifiers, fieldMask *types.FieldMask) (*ttnpb.EndDevice, error)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR modifies the Identity Server's implementation of the `ApplicationRegistry/Delete` to check that the application does not contain any devices before deleting it.

Closes #369

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Added a check to the Identity Server that prevents users from deleting applications that still contain end devices.
