### PR TITLE
Events pub-sub with go-cloud

### DIFF
--- a/cmd/internal/shared/events.go
+++ b/cmd/internal/shared/events.go
@@ -15,15 +15,17 @@
 package shared
 
 import (
+	"context"
 	"fmt"
 
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/events"
+	"go.thethings.network/lorawan-stack/pkg/events/cloud"
 	"go.thethings.network/lorawan-stack/pkg/events/redis"
 )
 
 // InitializeEvents initializes the event system.
-func InitializeEvents(config config.ServiceBase) error {
+func InitializeEvents(ctx context.Context, config config.ServiceBase) (err error) {
 	switch config.Events.Backend {
 	case "internal":
 		return nil // this is the default.
@@ -32,6 +34,12 @@ func InitializeEvents(config config.ServiceBase) error {
 			events.DefaultPubSub = redis.NewPubSub(config.Events.Redis)
 		} else {
 			events.DefaultPubSub = redis.NewPubSub(config.Redis)
+		}
+		return nil
+	case "cloud":
+		events.DefaultPubSub, err = cloud.NewPubSub(ctx, config.Events.Cloud.PublishURL, config.Events.Cloud.SubscribeURL)
+		if err != nil {
+			return err
 		}
 		return nil
 	default:

--- a/cmd/internal/shared/events.go
+++ b/cmd/internal/shared/events.go
@@ -22,6 +22,8 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/events"
 	"go.thethings.network/lorawan-stack/pkg/events/cloud"
 	"go.thethings.network/lorawan-stack/pkg/events/redis"
+	_ "gocloud.dev/pubsub/awssnssqs" // AWS backend for PubSub.
+	_ "gocloud.dev/pubsub/gcppubsub" // GCP backend for PubSub.
 )
 
 // InitializeEvents initializes the event system.

--- a/cmd/internal/shared/init.go
+++ b/cmd/internal/shared/init.go
@@ -14,11 +14,15 @@
 
 package shared
 
-import "go.thethings.network/lorawan-stack/pkg/config"
+import (
+	"context"
+
+	"go.thethings.network/lorawan-stack/pkg/config"
+)
 
 // Initialize global packages.
-func Initialize(config config.ServiceBase) error {
-	if err := InitializeEvents(config); err != nil {
+func Initialize(ctx context.Context, config config.ServiceBase) error {
+	if err := InitializeEvents(ctx, config); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/ttn-lw-stack/commands/root.go
+++ b/cmd/ttn-lw-stack/commands/root.go
@@ -16,6 +16,7 @@
 package commands
 
 import (
+	"context"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -30,6 +31,7 @@ import (
 var errMissingFlag = errors.DefineInvalidArgument("missing_flag", "missing CLI flag `{flag}`")
 
 var (
+	ctx    = context.Background()
 	logger *log.Logger
 	name   = "ttn-lw-stack"
 	mgr    = conf.InitializeWithDefaults(name, "ttn_lw", DefaultConfig)
@@ -59,8 +61,10 @@ var (
 				log.WithHandler(log.NewCLI(os.Stdout)),
 			)
 
+			ctx = log.NewContext(ctx, logger)
+
 			// initialize shared packages
-			if err := shared.Initialize(config.ServiceBase); err != nil {
+			if err := shared.Initialize(ctx, config.ServiceBase); err != nil {
 				return err
 			}
 

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -117,10 +117,17 @@ type Redis struct {
 // IsZero returns whether the Redis configuration is empty.
 func (r Redis) IsZero() bool { return r.Address == "" && r.Database == 0 && len(r.Namespace) == 0 }
 
+// CloudEvents represents configuration for the cloud events backend.
+type CloudEvents struct {
+	PublishURL   string `name:"publish-url" description:"URL for the topic to send events"`
+	SubscribeURL string `name:"subscribe-url" description:"URL for the subscription to receiving events"`
+}
+
 // Events represents configuration for the events system.
 type Events struct {
-	Backend string `name:"backend" description:"Backend to use for events (internal, redis)"`
-	Redis   Redis  `name:"redis"`
+	Backend string      `name:"backend" description:"Backend to use for events (internal, redis, cloud)"`
+	Redis   Redis       `name:"redis"`
+	Cloud   CloudEvents `name:"cloud"`
 }
 
 // Rights represents the configuration to apply when fetching entity rights.

--- a/pkg/events/cloud/cloud.go
+++ b/pkg/events/cloud/cloud.go
@@ -1,0 +1,124 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cloud implements an events.PubSub implementation that uses Go Cloud PubSub.
+package cloud
+
+import (
+	"context"
+	"encoding/json"
+
+	"go.thethings.network/lorawan-stack/pkg/events"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"gocloud.dev/pubsub"
+)
+
+// WrapPubSub wraps an existing PubSub and publishes all events received from Go Cloud to that PubSub.
+// If the subURL is an empty string, this PubSub will only publish to Go Cloud.
+func WrapPubSub(ctx context.Context, wrapped events.PubSub, pubURL, subURL string) (ps *PubSub, err error) {
+	ps = &PubSub{
+		PubSub:      wrapped,
+		ctx:         ctx,
+		contentType: "application/protobuf",
+	}
+	ps.topic, err = pubsub.OpenTopic(ctx, pubURL)
+	if err != nil {
+		return nil, err
+	}
+	if subURL != "" {
+		ps.subscription, err = pubsub.OpenSubscription(ctx, subURL)
+		if err != nil {
+			return nil, err
+		}
+		go func() {
+			for ctx.Err() == nil {
+				msg, err := ps.subscription.Receive(ctx)
+				if err != nil {
+					return
+				}
+				switch msg.Metadata["content-type"] {
+				case "application/protobuf":
+					var evtpb ttnpb.Event
+					if err = evtpb.Unmarshal(msg.Body); err == nil {
+						if evt, err := events.FromProto(&evtpb); err == nil {
+							ps.PubSub.Publish(evt)
+						}
+					}
+				case "application/json":
+					if evt, err := events.UnmarshalJSON(msg.Body); err == nil {
+						ps.PubSub.Publish(evt)
+					}
+				}
+				msg.Ack()
+			}
+		}()
+	}
+	return ps, nil
+}
+
+// NewPubSub creates a new PubSub that publishes and subscribes to Go Cloud.
+// If the subURL is an empty string, this PubSub will only publish to Go Cloud.
+func NewPubSub(ctx context.Context, pubURL, subURL string) (*PubSub, error) {
+	return WrapPubSub(ctx, events.NewPubSub(events.DefaultBufferSize), pubURL, subURL)
+}
+
+// PubSub with Go Cloud backend.
+type PubSub struct {
+	events.PubSub
+
+	ctx          context.Context
+	contentType  string
+	topic        *pubsub.Topic
+	subscription *pubsub.Subscription
+}
+
+// Close the Go Cloud publisher.
+func (ps *PubSub) Close() (err error) {
+	if ps.subscription != nil {
+		err = ps.subscription.Shutdown(ps.ctx)
+	}
+	pubShutdownErr := ps.topic.Shutdown(ps.ctx)
+	if err == nil {
+		err = pubShutdownErr
+	}
+	return err
+}
+
+// Publish an event to Go Cloud.
+func (ps *PubSub) Publish(evt events.Event) {
+	var body []byte
+	switch ps.contentType {
+	case "application/protobuf":
+		evtpb, err := events.Proto(evt)
+		if err != nil {
+			return
+		}
+		body, err = evtpb.Marshal()
+		if err != nil {
+			return
+		}
+	case "application/json":
+		var err error
+		body, err = json.Marshal(evt)
+		if err != nil {
+			return
+		}
+	}
+	ps.topic.Send(evt.Context(), &pubsub.Message{
+		Metadata: map[string]string{
+			"content-type": ps.contentType,
+		},
+		Body: body,
+	})
+}

--- a/pkg/events/cloud/cloud_internal_test.go
+++ b/pkg/events/cloud/cloud_internal_test.go
@@ -1,0 +1,19 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloud
+
+func SetContentType(ps *PubSub, contentType string) {
+	ps.contentType = contentType
+}

--- a/pkg/events/cloud/cloud_test.go
+++ b/pkg/events/cloud/cloud_test.go
@@ -1,0 +1,96 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloud_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/pkg/events"
+	"go.thethings.network/lorawan-stack/pkg/events/cloud"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/pkg/util/test"
+	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
+	_ "gocloud.dev/pubsub/mempubsub"
+)
+
+func Example() {
+	// Import the desired cloud pub-sub drivers (see godoc.org/gocloud.dev).
+	// In this example we use "gocloud.dev/pubsub/mempubsub".
+
+	// This sends all events received from a Go Cloud pub sub to the default pubsub.
+	cloudPubSub, err := cloud.WrapPubSub(context.TODO(), events.DefaultPubSub, "mem://events", "mem://events")
+	if err != nil {
+		// Handle error.
+	}
+
+	// Replace the default pubsub so that we will now publish to a Go Cloud pub sub.
+	events.DefaultPubSub = cloudPubSub
+}
+
+func TestCloudPubSub(t *testing.T) {
+	a := assertions.New(t)
+
+	events.IncludeCaller = true
+
+	var eventCh = make(chan events.Event)
+	handler := events.HandlerFunc(func(e events.Event) {
+		t.Logf("Received event %v", e)
+		a.So(e.Time().IsZero(), should.BeFalse)
+		a.So(e.Context(), should.NotBeNil)
+		eventCh <- e
+	})
+
+	pubsub, err := cloud.NewPubSub(test.Context(), "mem://events_test", "mem://events_test")
+	a.So(err, should.BeNil)
+
+	defer pubsub.Close()
+
+	pubsub.Subscribe("cloud.**", handler)
+
+	ctx := events.ContextWithCorrelationID(test.Context(), t.Name())
+
+	appID := &ttnpb.ApplicationIdentifiers{ApplicationID: "test-app"}
+
+	cloud.SetContentType(pubsub, "application/json")
+
+	pubsub.Publish(events.New(ctx, "cloud.test.evt0", appID, nil))
+	select {
+	case e := <-eventCh:
+		a.So(e.Name(), should.Equal, "cloud.test.evt0")
+		if a.So(e.Identifiers(), should.NotBeNil) && a.So(e.Identifiers(), should.HaveLength, 1) {
+			a.So(e.Identifiers()[0].GetApplicationIDs(), should.Resemble, appID)
+		}
+	case <-time.After(time.Second):
+		t.Error("Did not receive expected event")
+		t.FailNow()
+	}
+
+	cloud.SetContentType(pubsub, "application/protobuf")
+
+	pubsub.Publish(events.New(ctx, "cloud.test.evt1", appID, nil))
+	select {
+	case e := <-eventCh:
+		a.So(e.Name(), should.Equal, "cloud.test.evt1")
+		if a.So(e.Identifiers(), should.NotBeNil) && a.So(e.Identifiers(), should.HaveLength, 1) {
+			a.So(e.Identifiers()[0].GetApplicationIDs(), should.Resemble, appID)
+		}
+	case <-time.After(time.Second):
+		t.Error("Did not receive expected event")
+		t.FailNow()
+	}
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR adds a backend for the events package that uses go-cloud, which in turn has configurable drivers, such as AWS SQS and GCP PubSub. 

Refs https://github.com/TheThingsIndustries/lorawan-stack/issues/394

**Changes:**
<!-- What are the changes made in this pull request? -->

- Implemented interfacing with `gocloud.dev/pubsub`
- Added config options for setting it up
- Imported drivers for AWS SQS and GCP PubSub

**Notes for Reviewers:**
<!--
Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@adriansmares this can also be used for #85 

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Added support for the value `cloud` for the `--events.backend` flag. When this flag is set, the `--events.cloud.publish-url` and `--events.cloud.subscribe-url` are used to set up a cloud pub-sub for events.