### PR TITLE
Account for NbTrans in ADR loss rate calculation

### DIFF
--- a/pkg/networkserver/adr.go
+++ b/pkg/networkserver/adr.go
@@ -108,6 +108,11 @@ loop:
 			fCntTrans++
 
 		default:
+			if v < fCnt {
+				// FCnt reset encountered
+				return lossRate(nbTrans, ups[i:]...)
+			}
+
 			if fCntTrans < nbTrans {
 				d := nbTrans - fCntTrans
 				lost += d

--- a/pkg/networkserver/adr.go
+++ b/pkg/networkserver/adr.go
@@ -85,6 +85,48 @@ func deviceADRMargin(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings) float32 {
 	return DefaultADRMargin
 }
 
+func lossRate(nbTrans uint32, ups ...*ttnpb.UplinkMessage) float32 {
+	if len(ups) < 2 {
+		return 0
+	}
+
+	min := ups[0].Payload.GetMACPayload().FHDR.FCnt
+	max := ups[len(ups)-1].Payload.GetMACPayload().FHDR.FCnt
+
+	fCnt := min + 1
+	var fCntTrans uint32
+	var lost uint32
+	n := uint32(len(ups))
+
+loop:
+	for i := 0; i < len(ups); i++ {
+		switch v := ups[i].Payload.GetMACPayload().FHDR.FCnt; v {
+		case min:
+			continue
+
+		case fCnt:
+			fCntTrans++
+
+		default:
+			if fCntTrans < nbTrans {
+				d := nbTrans - fCntTrans
+				lost += d
+				n += d
+			}
+			d := (v - fCnt - 1) * nbTrans
+			lost += d
+			n += d
+
+			if v == max {
+				break loop
+			}
+			fCnt = v
+			fCntTrans = 1
+		}
+	}
+	return float32(lost) / float32(n)
+}
+
 func adaptDataRate(dev *ttnpb.EndDevice, fps *frequencyplans.Store, defaults ttnpb.MACSettings) error {
 	ups := dev.RecentADRUplinks
 	if len(ups) == 0 {
@@ -157,13 +199,11 @@ func adaptDataRate(dev *ttnpb.EndDevice, fps *frequencyplans.Store, defaults ttn
 	}
 
 	if len(ups) >= 2 {
-		lossRate := float32(up.Payload.GetMACPayload().FHDR.FCnt-ups[0].Payload.GetMACPayload().FHDR.FCnt-uint32(len(ups))) /
-			float32(up.Payload.GetMACPayload().FHDR.FCnt-ups[0].Payload.GetMACPayload().FHDR.FCnt)
-		switch {
-		case lossRate < 0.05:
+		switch r := lossRate(dev.MACState.CurrentParameters.ADRNbTrans, ups...); {
+		case r < 0.05:
 			dev.MACState.DesiredParameters.ADRNbTrans = 1 + dev.MACState.DesiredParameters.ADRNbTrans/3
-		case lossRate < 0.10:
-		case lossRate < 0.30:
+		case r < 0.10:
+		case r < 0.30:
 			dev.MACState.DesiredParameters.ADRNbTrans = 2 + dev.MACState.DesiredParameters.ADRNbTrans/2
 		default:
 			dev.MACState.DesiredParameters.ADRNbTrans = maxNbTrans

--- a/pkg/networkserver/adr_test.go
+++ b/pkg/networkserver/adr_test.go
@@ -204,6 +204,18 @@ func TestLossRate(t *testing.T) {
 			NbTrans: 3,
 			Rate:    1. / 7.,
 		},
+		{
+			Uplinks: adrMatrixToUplinks([]adrMatrixRow{
+				{FCnt: 11},
+				{FCnt: 12},
+				{FCnt: 1},
+				{FCnt: 1},
+				{FCnt: 3},
+				{FCnt: 3},
+			}),
+			NbTrans: 3,
+			Rate:    3. / 7.,
+		},
 	} {
 		t.Run(func() string {
 			var ss []string

--- a/pkg/networkserver/adr_test.go
+++ b/pkg/networkserver/adr_test.go
@@ -15,8 +15,10 @@
 package networkserver
 
 import (
+	"fmt"
 	"math"
 	"math/rand"
+	"strings"
 	"testing"
 
 	pbtypes "github.com/gogo/protobuf/types"
@@ -27,7 +29,10 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 )
 
-func newADRUplink(fCnt uint32, maxSNR float32, gtwCount uint, tx ttnpb.TxSettings) *ttnpb.UplinkMessage {
+func newADRUplink(fCnt uint32, maxSNR float32, gtwCount uint, confirmed bool, tx ttnpb.TxSettings) *ttnpb.UplinkMessage {
+	if gtwCount == 0 {
+		gtwCount = 1 + uint(rand.Int()%100)
+	}
 	mds := make([]*ttnpb.RxMetadata, 0, gtwCount)
 	for i := uint(0); i < gtwCount; i++ {
 		mds = append(mds, &ttnpb.RxMetadata{
@@ -37,7 +42,7 @@ func newADRUplink(fCnt uint32, maxSNR float32, gtwCount uint, tx ttnpb.TxSetting
 	mds[rand.Intn(len(mds))].SNR = maxSNR
 
 	mType := ttnpb.MType_UNCONFIRMED_UP
-	if rand.Int()%2 == 0 {
+	if confirmed {
 		mType = ttnpb.MType_CONFIRMED_UP
 	}
 
@@ -66,19 +71,150 @@ type adrMatrixRow struct {
 	FCnt         uint32
 	MaxSNR       float32
 	GtwDiversity uint
+	Confirmed    bool
 	TxSettings   ttnpb.TxSettings
 }
 
-func adrMatrixToUplinks(m []adrMatrixRow) (ups []*ttnpb.UplinkMessage) {
+func adrMatrixToUplinks(m []adrMatrixRow) []*ttnpb.UplinkMessage {
 	if len(m) > 20 {
 		panic("ADR matrix contains more than 20 rows")
 	}
 
-	ups = make([]*ttnpb.UplinkMessage, 0, 20)
+	ups := make([]*ttnpb.UplinkMessage, 0, 20)
 	for _, r := range m {
-		ups = append(ups, newADRUplink(r.FCnt, r.MaxSNR, r.GtwDiversity, r.TxSettings))
+		ups = append(ups, newADRUplink(r.FCnt, r.MaxSNR, r.GtwDiversity, r.Confirmed, r.TxSettings))
 	}
-	return
+	return ups
+}
+
+func TestLossRate(t *testing.T) {
+	for _, tc := range []struct {
+		Name    string
+		Uplinks []*ttnpb.UplinkMessage
+		NbTrans uint32
+		Rate    float32
+	}{
+		{
+			Uplinks: adrMatrixToUplinks([]adrMatrixRow{
+				{FCnt: 11},
+				{FCnt: 12},
+				{FCnt: 13},
+			}),
+			NbTrans: 1,
+		},
+		{
+			Uplinks: adrMatrixToUplinks([]adrMatrixRow{
+				{FCnt: 11},
+				{FCnt: 11},
+				{FCnt: 12},
+				{FCnt: 12},
+				{FCnt: 13},
+				{FCnt: 13},
+			}),
+			NbTrans: 2,
+		},
+		{
+			Uplinks: adrMatrixToUplinks([]adrMatrixRow{
+				{FCnt: 11},
+				{FCnt: 11},
+				{FCnt: 11},
+				{FCnt: 12},
+				{FCnt: 12},
+				{FCnt: 12},
+				{FCnt: 13},
+				{FCnt: 13},
+				{FCnt: 13},
+			}),
+			NbTrans: 3,
+		},
+		{
+			Uplinks: adrMatrixToUplinks([]adrMatrixRow{
+				{FCnt: 11},
+				{FCnt: 12},
+				{FCnt: 12},
+				{FCnt: 13},
+			}),
+			NbTrans: 2,
+		},
+		{
+			Uplinks: adrMatrixToUplinks([]adrMatrixRow{
+				{FCnt: 11},
+				{FCnt: 11},
+				{FCnt: 12},
+				{FCnt: 12},
+				{FCnt: 12},
+				{FCnt: 13},
+			}),
+			NbTrans: 3,
+		},
+		{
+			Uplinks: adrMatrixToUplinks([]adrMatrixRow{
+				{FCnt: 11},
+				{FCnt: 13},
+			}),
+			NbTrans: 1,
+			Rate:    1. / 3.,
+		},
+		{
+			Uplinks: adrMatrixToUplinks([]adrMatrixRow{
+				{FCnt: 11},
+				{FCnt: 14},
+			}),
+			NbTrans: 1,
+			Rate:    2. / 4.,
+		},
+		{
+			Uplinks: adrMatrixToUplinks([]adrMatrixRow{
+				{FCnt: 11},
+				{FCnt: 13},
+				{FCnt: 15},
+			}),
+			NbTrans: 1,
+			Rate:    2. / 5.,
+		},
+		{
+			Uplinks: adrMatrixToUplinks([]adrMatrixRow{
+				{FCnt: 11},
+				{FCnt: 11},
+				{FCnt: 12},
+				{FCnt: 13},
+				{FCnt: 13},
+			}),
+			NbTrans: 2,
+			Rate:    1. / 6.,
+		},
+		{
+			Uplinks: adrMatrixToUplinks([]adrMatrixRow{
+				{FCnt: 11},
+				{FCnt: 12},
+				{FCnt: 13},
+			}),
+			NbTrans: 2,
+			Rate:    1. / 4.,
+		},
+		{
+			Uplinks: adrMatrixToUplinks([]adrMatrixRow{
+				{FCnt: 11},
+				{FCnt: 12},
+				{FCnt: 12},
+				{FCnt: 13},
+				{FCnt: 13},
+				{FCnt: 13},
+			}),
+			NbTrans: 3,
+			Rate:    1. / 7.,
+		},
+	} {
+		t.Run(func() string {
+			var ss []string
+			for _, up := range tc.Uplinks {
+				ss = append(ss, fmt.Sprintf("%d", up.Payload.GetMACPayload().FHDR.FCnt))
+			}
+			return fmt.Sprintf("NbTrans %d/%s", tc.NbTrans, strings.Join(ss, ","))
+		}(), func(t *testing.T) {
+			assertions.New(t).So(lossRate(tc.NbTrans, tc.Uplinks...), should.Equal, tc.Rate)
+		})
+	}
 }
 
 func TestAdaptDataRate(t *testing.T) {

--- a/pkg/networkserver/mac_link_adr.go
+++ b/pkg/networkserver/mac_link_adr.go
@@ -136,8 +136,9 @@ func handleLinkADRAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACC
 			panic("Network Server scheduled an invalid LinkADR command")
 		}
 
-		if req.NbTrans > 0 {
+		if req.NbTrans > 0 && dev.MACState.CurrentParameters.ADRNbTrans != req.NbTrans {
 			dev.MACState.CurrentParameters.ADRNbTrans = req.NbTrans
+			dev.RecentADRUplinks = nil
 		}
 
 		var mask [16]bool
@@ -168,7 +169,10 @@ func handleLinkADRAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACC
 		return nil
 	}
 
-	dev.MACState.CurrentParameters.ADRDataRateIndex = req.DataRateIndex
-	dev.MACState.CurrentParameters.ADRTxPowerIndex = req.TxPowerIndex
+	if dev.MACState.CurrentParameters.ADRDataRateIndex != req.DataRateIndex || dev.MACState.CurrentParameters.ADRTxPowerIndex != req.TxPowerIndex {
+		dev.MACState.CurrentParameters.ADRDataRateIndex = req.DataRateIndex
+		dev.MACState.CurrentParameters.ADRTxPowerIndex = req.TxPowerIndex
+		dev.RecentADRUplinks = nil
+	}
 	return nil
 }

--- a/pkg/networkserver/mac_link_adr_test.go
+++ b/pkg/networkserver/mac_link_adr_test.go
@@ -36,13 +36,48 @@ func TestHandleLinkADRAns(t *testing.T) {
 		Error            error
 	}{
 		{
-			Name:     "nil payload",
-			DupCount: 0,
+			Name: "nil payload",
 			Device: &ttnpb.EndDevice{
 				FrequencyPlanID:   test.EUFrequencyPlanID,
 				LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 				MACState: &ttnpb.MACState{
 					LoRaWANVersion: ttnpb.MAC_V1_1,
+				},
+				RecentADRUplinks: []*ttnpb.UplinkMessage{
+					{
+						Payload: &ttnpb.Message{
+							MHDR: ttnpb.MHDR{
+								MType: ttnpb.MType_UNCONFIRMED_UP,
+							},
+							Payload: &ttnpb.Message_MACPayload{
+								MACPayload: &ttnpb.MACPayload{
+									FHDR: ttnpb.FHDR{
+										FCtrl: ttnpb.FCtrl{
+											ADR: true,
+										},
+										FCnt: 42,
+									},
+								},
+							},
+						},
+					},
+					{
+						Payload: &ttnpb.Message{
+							MHDR: ttnpb.MHDR{
+								MType: ttnpb.MType_UNCONFIRMED_UP,
+							},
+							Payload: &ttnpb.Message_MACPayload{
+								MACPayload: &ttnpb.MACPayload{
+									FHDR: ttnpb.FHDR{
+										FCtrl: ttnpb.FCtrl{
+											ADR: true,
+										},
+										FCnt: 43,
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 			Expected: &ttnpb.EndDevice{
@@ -51,21 +86,91 @@ func TestHandleLinkADRAns(t *testing.T) {
 				MACState: &ttnpb.MACState{
 					LoRaWANVersion: ttnpb.MAC_V1_1,
 				},
+				RecentADRUplinks: []*ttnpb.UplinkMessage{
+					{
+						Payload: &ttnpb.Message{
+							MHDR: ttnpb.MHDR{
+								MType: ttnpb.MType_UNCONFIRMED_UP,
+							},
+							Payload: &ttnpb.Message_MACPayload{
+								MACPayload: &ttnpb.MACPayload{
+									FHDR: ttnpb.FHDR{
+										FCtrl: ttnpb.FCtrl{
+											ADR: true,
+										},
+										FCnt: 42,
+									},
+								},
+							},
+						},
+					},
+					{
+						Payload: &ttnpb.Message{
+							MHDR: ttnpb.MHDR{
+								MType: ttnpb.MType_UNCONFIRMED_UP,
+							},
+							Payload: &ttnpb.Message_MACPayload{
+								MACPayload: &ttnpb.MACPayload{
+									FHDR: ttnpb.FHDR{
+										FCtrl: ttnpb.FCtrl{
+											ADR: true,
+										},
+										FCnt: 43,
+									},
+								},
+							},
+						},
+					},
+				},
 			},
-			Payload: nil,
 			AssertEvents: func(t *testing.T, evs ...events.Event) bool {
 				return assertions.New(t).So(evs, should.BeEmpty)
 			},
 			Error: errNoPayload,
 		},
 		{
-			Name:     "no request",
-			DupCount: 0,
+			Name: "no request",
 			Device: &ttnpb.EndDevice{
 				FrequencyPlanID:   test.EUFrequencyPlanID,
 				LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 				MACState: &ttnpb.MACState{
 					LoRaWANVersion: ttnpb.MAC_V1_1,
+				},
+				RecentADRUplinks: []*ttnpb.UplinkMessage{
+					{
+						Payload: &ttnpb.Message{
+							MHDR: ttnpb.MHDR{
+								MType: ttnpb.MType_UNCONFIRMED_UP,
+							},
+							Payload: &ttnpb.Message_MACPayload{
+								MACPayload: &ttnpb.MACPayload{
+									FHDR: ttnpb.FHDR{
+										FCtrl: ttnpb.FCtrl{
+											ADR: true,
+										},
+										FCnt: 42,
+									},
+								},
+							},
+						},
+					},
+					{
+						Payload: &ttnpb.Message{
+							MHDR: ttnpb.MHDR{
+								MType: ttnpb.MType_UNCONFIRMED_UP,
+							},
+							Payload: &ttnpb.Message_MACPayload{
+								MACPayload: &ttnpb.MACPayload{
+									FHDR: ttnpb.FHDR{
+										FCtrl: ttnpb.FCtrl{
+											ADR: true,
+										},
+										FCnt: 43,
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 			Expected: &ttnpb.EndDevice{
@@ -73,6 +178,42 @@ func TestHandleLinkADRAns(t *testing.T) {
 				LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 				MACState: &ttnpb.MACState{
 					LoRaWANVersion: ttnpb.MAC_V1_1,
+				},
+				RecentADRUplinks: []*ttnpb.UplinkMessage{
+					{
+						Payload: &ttnpb.Message{
+							MHDR: ttnpb.MHDR{
+								MType: ttnpb.MType_UNCONFIRMED_UP,
+							},
+							Payload: &ttnpb.Message_MACPayload{
+								MACPayload: &ttnpb.MACPayload{
+									FHDR: ttnpb.FHDR{
+										FCtrl: ttnpb.FCtrl{
+											ADR: true,
+										},
+										FCnt: 42,
+									},
+								},
+							},
+						},
+					},
+					{
+						Payload: &ttnpb.Message{
+							MHDR: ttnpb.MHDR{
+								MType: ttnpb.MType_UNCONFIRMED_UP,
+							},
+							Payload: &ttnpb.Message_MACPayload{
+								MACPayload: &ttnpb.MACPayload{
+									FHDR: ttnpb.FHDR{
+										FCtrl: ttnpb.FCtrl{
+											ADR: true,
+										},
+										FCnt: 43,
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 			Payload: &ttnpb.MACCommand_LinkADRAns{
@@ -93,8 +234,7 @@ func TestHandleLinkADRAns(t *testing.T) {
 			Error: errMACRequestNotFound,
 		},
 		{
-			Name:     "1 request/all ack",
-			DupCount: 0,
+			Name: "1 request/all ack",
 			Device: &ttnpb.EndDevice{
 				FrequencyPlanID:   test.EUFrequencyPlanID,
 				LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
@@ -120,6 +260,11 @@ func TestHandleLinkADRAns(t *testing.T) {
 							},
 						}).MACCommand(),
 					},
+				},
+				RecentADRUplinks: []*ttnpb.UplinkMessage{
+					newADRUplink(42, -2, 2, true, ttnpb.TxSettings{}),
+					newADRUplink(43, -2, 2, false, ttnpb.TxSettings{}),
+					newADRUplink(44, -3, 2, false, ttnpb.TxSettings{}),
 				},
 			},
 			Expected: &ttnpb.EndDevice{
@@ -163,8 +308,7 @@ func TestHandleLinkADRAns(t *testing.T) {
 			},
 		},
 		{
-			Name:     "1.1/2 requests/all ack",
-			DupCount: 0,
+			Name: "1.1/2 requests/all ack",
 			Device: &ttnpb.EndDevice{
 				FrequencyPlanID:   test.EUFrequencyPlanID,
 				LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
@@ -211,6 +355,11 @@ func TestHandleLinkADRAns(t *testing.T) {
 							},
 						}).MACCommand(),
 					},
+				},
+				RecentADRUplinks: []*ttnpb.UplinkMessage{
+					newADRUplink(42, -2, 2, true, ttnpb.TxSettings{}),
+					newADRUplink(43, -2, 2, false, ttnpb.TxSettings{}),
+					newADRUplink(44, -3, 2, false, ttnpb.TxSettings{}),
 				},
 			},
 			Expected: &ttnpb.EndDevice{
@@ -308,6 +457,11 @@ func TestHandleLinkADRAns(t *testing.T) {
 						}).MACCommand(),
 					},
 				},
+				RecentADRUplinks: []*ttnpb.UplinkMessage{
+					newADRUplink(42, -2, 2, true, ttnpb.TxSettings{}),
+					newADRUplink(43, -2, 2, false, ttnpb.TxSettings{}),
+					newADRUplink(44, -3, 2, false, ttnpb.TxSettings{}),
+				},
 			},
 			Expected: &ttnpb.EndDevice{
 				FrequencyPlanID:   test.EUFrequencyPlanID,
@@ -355,8 +509,7 @@ func TestHandleLinkADRAns(t *testing.T) {
 			},
 		},
 		{
-			Name:     "1.0/2 requests/all ack",
-			DupCount: 0,
+			Name: "1.0/2 requests/all ack",
 			Device: &ttnpb.EndDevice{
 				FrequencyPlanID:   test.EUFrequencyPlanID,
 				LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
@@ -403,6 +556,11 @@ func TestHandleLinkADRAns(t *testing.T) {
 							},
 						}).MACCommand(),
 					},
+				},
+				RecentADRUplinks: []*ttnpb.UplinkMessage{
+					newADRUplink(42, -2, 2, true, ttnpb.TxSettings{}),
+					newADRUplink(43, -2, 2, false, ttnpb.TxSettings{}),
+					newADRUplink(44, -3, 2, false, ttnpb.TxSettings{}),
 				},
 			},
 			Expected: &ttnpb.EndDevice{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #269 

**Changes:**
<!-- What are the changes made in this pull request? -->

- Account for `NbTrans` when counting loss rate of packets for ADR
- Reset `RecentADRUplinks` on each ADR parameter change
- Fix `UseADR` handling

**Release Notes: _(optional)_**
<!--
Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Improved ADR algorithm performance
