### PR TITLE
Gather common IS store logic together

### DIFF
--- a/pkg/identityserver/store/account.go
+++ b/pkg/identityserver/store/account.go
@@ -38,6 +38,10 @@ func init() {
 	registerModel(&Account{})
 }
 
+func (s *store) findAccount(ctx context.Context, id *ttnpb.OrganizationOrUserIdentifiers) (*Account, error) {
+	return findAccount(ctx, s.DB, id)
+}
+
 func findAccount(ctx context.Context, db *gorm.DB, id *ttnpb.OrganizationOrUserIdentifiers) (*Account, error) {
 	entityID := id.EntityIdentifiers()
 	var account Account

--- a/pkg/identityserver/store/api_key_store_test.go
+++ b/pkg/identityserver/store/api_key_store_test.go
@@ -36,18 +36,20 @@ func TestAPIKeyStore(t *testing.T) {
 			&Account{}, &User{}, &Organization{},
 			&Application{}, &Client{}, &Gateway{},
 		)
+
+		s := newStore(db)
 		store := GetAPIKeyStore(db)
 
-		db.Create(&User{Account: Account{UID: "test-user"}})
+		s.createEntity(ctx, &User{Account: Account{UID: "test-user"}})
 		userIDs := &ttnpb.UserIdentifiers{UserID: "test-user"}
 
-		db.Create(&Organization{Account: Account{UID: "test-org"}})
+		s.createEntity(ctx, &Organization{Account: Account{UID: "test-org"}})
 		orgIDs := &ttnpb.OrganizationIdentifiers{OrganizationID: "test-org"}
 
-		db.Create(&Application{ApplicationID: "test-app"})
+		s.createEntity(ctx, &Application{ApplicationID: "test-app"})
 		appIDs := &ttnpb.ApplicationIdentifiers{ApplicationID: "test-app"}
 
-		db.Create(&Gateway{GatewayID: "test-gtw"})
+		s.createEntity(ctx, &Gateway{GatewayID: "test-gtw"})
 		gtwIDs := &ttnpb.GatewayIdentifiers{GatewayID: "test-gtw"}
 
 		for _, tt := range []struct {

--- a/pkg/identityserver/store/attribute_store.go
+++ b/pkg/identityserver/store/attribute_store.go
@@ -21,6 +21,10 @@ import (
 	"github.com/jinzhu/gorm"
 )
 
+func (s *store) replaceAttributes(ctx context.Context, entityType, entityUUID string, old []Attribute, new []Attribute) (err error) {
+	return replaceAttributes(ctx, s.DB, entityType, entityUUID, old, new)
+}
+
 func replaceAttributes(ctx context.Context, db *gorm.DB, entityType, entityUUID string, old []Attribute, new []Attribute) (err error) {
 	defer trace.StartRegion(ctx, "update attributes").End()
 	oldByUUID := make(map[string]Attribute, len(old))

--- a/pkg/identityserver/store/end_device_location_store.go
+++ b/pkg/identityserver/store/end_device_location_store.go
@@ -21,6 +21,10 @@ import (
 	"github.com/jinzhu/gorm"
 )
 
+func (s *store) replaceEndDeviceLocations(ctx context.Context, endDeviceUUID string, old []EndDeviceLocation, new []EndDeviceLocation) error {
+	return replaceEndDeviceLocations(ctx, s.DB, endDeviceUUID, old, new)
+}
+
 func replaceEndDeviceLocations(ctx context.Context, db *gorm.DB, endDeviceUUID string, old []EndDeviceLocation, new []EndDeviceLocation) (err error) {
 	defer trace.StartRegion(ctx, "update end device locations").End()
 	oldByUUID := make(map[string]EndDeviceLocation, len(old))

--- a/pkg/identityserver/store/entity_search_test.go
+++ b/pkg/identityserver/store/entity_search_test.go
@@ -32,10 +32,11 @@ func TestEntitySearch(t *testing.T) {
 	WithDB(t, func(t *testing.T, db *gorm.DB) {
 		prepareTest(db, &Attribute{}, &Application{}, &Client{}, &Gateway{}, &Account{}, &User{}, &Organization{})
 
+		store := newStore(db)
 		s := GetEntitySearch(db)
 
 		for _, name := range []string{"foo", "bar"} {
-			db.Create(&Application{
+			store.createEntity(ctx, &Application{
 				ApplicationID: fmt.Sprintf("the-%s-app", name),
 				Name:          fmt.Sprintf("The %s application", name),
 				Description:   fmt.Sprintf("This application does %s stuff", name),
@@ -44,7 +45,7 @@ func TestEntitySearch(t *testing.T) {
 				},
 			})
 
-			db.Create(&Client{
+			store.createEntity(ctx, &Client{
 				ClientID:    fmt.Sprintf("the-%s-cli", name),
 				Name:        fmt.Sprintf("The %s client", name),
 				Description: fmt.Sprintf("This client does %s stuff", name),
@@ -53,7 +54,7 @@ func TestEntitySearch(t *testing.T) {
 				},
 			})
 
-			db.Create(&Gateway{
+			store.createEntity(ctx, &Gateway{
 				GatewayID:   fmt.Sprintf("the-%s-gtw", name),
 				Name:        fmt.Sprintf("The %s gateway", name),
 				Description: fmt.Sprintf("This gateway does %s stuff", name),
@@ -62,7 +63,7 @@ func TestEntitySearch(t *testing.T) {
 				},
 			})
 
-			db.Create(&User{
+			store.createEntity(ctx, &User{
 				Account: Account{
 					UID: fmt.Sprintf("the-%s-usr", name),
 				},
@@ -74,7 +75,7 @@ func TestEntitySearch(t *testing.T) {
 				PrimaryEmailAddress: fmt.Sprintf("%s@example.com", name),
 			})
 
-			db.Create(&Organization{
+			store.createEntity(ctx, &Organization{
 				Account: Account{
 					UID: fmt.Sprintf("the-%s-org", name),
 				},

--- a/pkg/identityserver/store/gateway_antenna_store.go
+++ b/pkg/identityserver/store/gateway_antenna_store.go
@@ -21,6 +21,10 @@ import (
 	"github.com/jinzhu/gorm"
 )
 
+func (s *store) replaceGatewayAntennas(ctx context.Context, gatewayUUID string, old []GatewayAntenna, new []GatewayAntenna) error {
+	return replaceGatewayAntennas(ctx, s.DB, gatewayUUID, old, new)
+}
+
 func replaceGatewayAntennas(ctx context.Context, db *gorm.DB, gatewayUUID string, old []GatewayAntenna, new []GatewayAntenna) (err error) {
 	defer trace.StartRegion(ctx, "update gateway antennas").End()
 	db = db.Where(GatewayAntenna{GatewayID: gatewayUUID})

--- a/pkg/identityserver/store/membership_store_test.go
+++ b/pkg/identityserver/store/membership_store_test.go
@@ -34,25 +34,27 @@ func TestMembershipStore(t *testing.T) {
 			&Account{}, &User{}, &Organization{},
 			&Application{}, &Client{}, &Gateway{},
 		)
+
+		s := newStore(db)
 		store := GetMembershipStore(db)
 
 		usr := &User{Account: Account{UID: "test-user"}}
-		db.Create(usr)
+		s.createEntity(ctx, usr)
 		usrIDs := usr.Account.OrganizationOrUserIdentifiers()
 
 		org := &Organization{Account: Account{UID: "test-org"}}
-		db.Create(org)
+		s.createEntity(ctx, org)
 		orgIDs := org.Account.OrganizationOrUserIdentifiers()
 
-		db.Create(&Application{ApplicationID: "test-app"})
-		db.Create(&Client{ClientID: "test-cli"})
-		db.Create(&Gateway{GatewayID: "test-gtw"})
+		s.createEntity(ctx, &Application{ApplicationID: "test-app"})
+		s.createEntity(ctx, &Client{ClientID: "test-cli"})
+		s.createEntity(ctx, &Gateway{GatewayID: "test-gtw"})
 
-		db.Create(&User{Account: Account{UID: "other-user"}})
-		db.Create(&Organization{Account: Account{UID: "other-org"}})
-		db.Create(&Application{ApplicationID: "other-app"})
-		db.Create(&Client{ClientID: "other-cli"})
-		db.Create(&Gateway{GatewayID: "other-gtw"})
+		s.createEntity(ctx, &User{Account: Account{UID: "other-user"}})
+		s.createEntity(ctx, &Organization{Account: Account{UID: "other-org"}})
+		s.createEntity(ctx, &Application{ApplicationID: "other-app"})
+		s.createEntity(ctx, &Client{ClientID: "other-cli"})
+		s.createEntity(ctx, &Gateway{GatewayID: "other-gtw"})
 
 		for _, tt := range []struct {
 			Name              string

--- a/pkg/identityserver/store/oauth_store_test.go
+++ b/pkg/identityserver/store/oauth_store_test.go
@@ -38,12 +38,14 @@ func TestOAuthStore(t *testing.T) {
 			&Client{},
 			&Account{},
 		)
+
+		s := newStore(db)
 		store := GetOAuthStore(db)
 
-		db.Create(&User{Account: Account{UID: "test-user"}})
+		s.createEntity(ctx, &User{Account: Account{UID: "test-user"}})
 		userIDs := &ttnpb.UserIdentifiers{UserID: "test-user"}
 
-		db.Create(&Client{ClientID: "test-client"})
+		s.createEntity(ctx, &Client{ClientID: "test-client"})
 		clientIDs := &ttnpb.ClientIdentifiers{ClientID: "test-client"}
 
 		rights := []ttnpb.Right{ttnpb.RIGHT_ALL}

--- a/pkg/identityserver/store/store.go
+++ b/pkg/identityserver/store/store.go
@@ -30,6 +30,61 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 )
 
+func newStore(db *gorm.DB) *store { return &store{DB: db} }
+
+type store struct {
+	DB *gorm.DB
+}
+
+func (s *store) query(ctx context.Context, model interface{}, funcs ...func(*gorm.DB) *gorm.DB) *gorm.DB {
+	query := s.DB.Model(model).Scopes(withContext(ctx))
+	if len(funcs) > 0 {
+		query = query.Scopes(funcs...)
+	}
+	return query
+}
+
+func (s *store) findEntity(ctx context.Context, entityID *ttnpb.EntityIdentifiers, fields ...string) (modelInterface, error) {
+	model := modelForID(entityID)
+	query := s.query(ctx, model, withID(entityID))
+	if len(fields) == 1 && fields[0] == "id" {
+		fields[0] = s.DB.NewScope(model).TableName() + ".id"
+	}
+	if len(fields) > 0 {
+		query = query.Select(fields)
+	}
+	if err := query.First(model).Error; err != nil {
+		if gorm.IsRecordNotFoundError(err) {
+			return nil, errNotFoundForID(entityID)
+		}
+		return nil, convertError(err)
+	}
+	return model, nil
+}
+
+func (s *store) createEntity(ctx context.Context, model interface{}) error {
+	if model, ok := model.(modelInterface); ok {
+		model.SetContext(ctx)
+	}
+	return s.DB.Create(model).Error
+}
+
+func (s *store) updateEntity(ctx context.Context, model interface{}, columns ...string) error {
+	query := s.query(ctx, model)
+	if len(columns) > 0 {
+		query = query.Select(append(columns, "updated_at"))
+	}
+	return query.Save(model).Error
+}
+
+func (s *store) deleteEntity(ctx context.Context, entityID *ttnpb.EntityIdentifiers) error {
+	model, err := s.findEntity(ctx, entityID, "id")
+	if err != nil {
+		return err
+	}
+	return s.DB.Delete(model).Error
+}
+
 var (
 	errDatabase      = errors.DefineInternal("database", "database error")
 	errAlreadyExists = errors.DefineAlreadyExists("already_exists", "entity already exists", "field", "value")
@@ -126,24 +181,6 @@ func modelForID(id *ttnpb.EntityIdentifiers) modelInterface {
 	}
 }
 
-func findEntity(ctx context.Context, db *gorm.DB, entityID *ttnpb.EntityIdentifiers, fields ...string) (modelInterface, error) {
-	query := db.Scopes(withContext(ctx), withID(entityID))
-	entity := modelForID(entityID)
-	if len(fields) == 1 && fields[0] == "id" {
-		fields[0] = entityTypeForID(entityID) + "s.id"
-	}
-	if len(fields) > 0 {
-		query = query.Select(fields)
-	}
-	if err := query.First(entity).Error; err != nil {
-		if gorm.IsRecordNotFoundError(err) {
-			return nil, errNotFoundForID(entityID)
-		}
-		return nil, convertError(err)
-	}
-	return entity, nil
-}
-
 var (
 	errApplicationNotFound  = errors.DefineNotFound("application_not_found", "application `{application_id}` not found")
 	errClientNotFound       = errors.DefineNotFound("client_not_found", "client `{client_id}` not found")
@@ -177,14 +214,6 @@ func errNotFoundForID(entityID *ttnpb.EntityIdentifiers) error {
 	default:
 		panic(fmt.Sprintf("can't find errNotFound for id type %T", id))
 	}
-}
-
-func deleteEntity(ctx context.Context, db *gorm.DB, entityID *ttnpb.EntityIdentifiers) error {
-	err := db.Scopes(withContext(ctx), withID(entityID)).Delete(modelForID(entityID)).Error
-	if gorm.IsRecordNotFoundError(err) {
-		return errNotFoundForID(entityID)
-	}
-	return err
 }
 
 // SetLogger sets the database logger.

--- a/pkg/identityserver/store/user_session_store_test.go
+++ b/pkg/identityserver/store/user_session_store_test.go
@@ -43,7 +43,7 @@ func TestUserSessionStore(t *testing.T) {
 		userIDs := ttnpb.UserIdentifiers{UserID: "test"}
 		doesNotExistIDs := ttnpb.UserIdentifiers{UserID: "does_not_exist"}
 
-		if err := db.Create(user).Error; err != nil {
+		if err := newStore(db).createEntity(ctx, user); err != nil {
 			panic(err)
 		}
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR does some preparation for https://github.com/TheThingsIndustries/lorawan-stack/issues/1441 by moving common store logic in the identity server (like query building) to a generic "store" struct.

**Changes:**
<!-- What are the changes made in this pull request? -->

- Implement new generic `*store.store` with common logic shared between the different entity stores
- Use this new `*store` in entity stores
- Use this new `*store` in unit tests
