### PR TITLE
Add documentation for Postgres setup and make initialization+tests work

### DIFF
--- a/cmd/ttn-lw-stack/commands/is_db_create_admin_user.go
+++ b/cmd/ttn-lw-stack/commands/is_db_create_admin_user.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/howeyc/gopass"
-	"github.com/jinzhu/gorm"
 	"github.com/spf13/cobra"
 	"go.thethings.network/lorawan-stack/pkg/auth"
 	"go.thethings.network/lorawan-stack/pkg/errors"
@@ -40,12 +39,11 @@ var (
 			defer cancel()
 
 			logger.Info("Connecting to Identity Server database...")
-			db, err := gorm.Open("postgres", config.IS.DatabaseURI)
+			db, err := store.Open(ctx, config.IS.DatabaseURI)
 			if err != nil {
 				return err
 			}
 			defer db.Close()
-			store.SetLogger(db, logger)
 
 			userID, err := cmd.Flags().GetString("id")
 			if err != nil {

--- a/cmd/ttn-lw-stack/commands/is_db_create_oauth_client.go
+++ b/cmd/ttn-lw-stack/commands/is_db_create_oauth_client.go
@@ -35,12 +35,11 @@ var (
 			defer cancel()
 
 			logger.Info("Connecting to Identity Server database...")
-			db, err := gorm.Open("postgres", config.IS.DatabaseURI)
+			db, err := store.Open(ctx, config.IS.DatabaseURI)
 			if err != nil {
 				return err
 			}
 			defer db.Close()
-			store.SetLogger(db, logger)
 
 			clientID, err := cmd.Flags().GetString("id")
 			if err != nil {

--- a/cmd/ttn-lw-stack/commands/root.go
+++ b/cmd/ttn-lw-stack/commands/root.go
@@ -16,6 +16,7 @@
 package commands
 
 import (
+	"context"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -30,6 +31,7 @@ import (
 var errMissingFlag = errors.DefineInvalidArgument("missing_flag", "missing CLI flag `{flag}`")
 
 var (
+	ctx    = context.Background()
 	logger *log.Logger
 	name   = "ttn-lw-stack"
 	mgr    = conf.InitializeWithDefaults(name, "ttn_lw", DefaultConfig)
@@ -58,6 +60,8 @@ var (
 				log.WithLevel(config.Base.Log.Level),
 				log.WithHandler(log.NewCLI(os.Stdout)),
 			)
+
+			ctx = log.NewContext(ctx, logger)
 
 			// initialize shared packages
 			if err := shared.Initialize(config.ServiceBase); err != nil {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,14 +10,20 @@ services:
       - TTN_LW_CLUSTER_KEYS
       - TTN_LW_FREQUENCY_PLANS_URL
       - TTN_LW_CONSOLE_OAUTH_CLIENT_SECRET
+      # If using CockroachDB:
       - TTN_LW_IS_DATABASE_URI=postgres://root@cockroach:26257/${DEV_DATABASE_NAME:-ttn_lorawan}?sslmode=disable
+      # If using PostgreSQL:
+      # - TTN_LW_IS_DATABASE_URI=postgres://root@postgres:5432/${DEV_DATABASE_NAME:-ttn_lorawan}?sslmode=disable
       - TTN_LW_REDIS_ADDRESS=redis:6379
       - TTN_LW_TLS_CERTIFICATE=/run/secrets/cert.pem
       - TTN_LW_CA=/run/secrets/cert.pem
       - TTN_LW_TLS_KEY=/run/secrets/key.pem
     depends_on:
-      - cockroach
       - redis
+      # If using CockroachDB:
+      - cockroach
+      # If using PostgreSQL:
+      # - postgres
     ports:
       - "1882:1882"
       - "8882:8882"
@@ -31,6 +37,7 @@ services:
     secrets:
       - cert.pem
       - key.pem
+  # If using CockroachDB:
   cockroach:
     image: cockroachdb/cockroach:v2.1.1
     command: start --http-port 26256 --insecure
@@ -39,6 +46,17 @@ services:
     ports:
       - "127.0.0.1:26257:26257" # Cockroach
       - "127.0.0.1:26256:26256" # WebUI
+  # If using PostgreSQL:
+  # postgres:
+  #   image: postgres:11.2-alpine
+  #   environment:
+  #     - POSTGRES_PASSWORD=
+  #     - POSTGRES_USER=root
+  #     - POSTGRES_DB=${DEV_DATABASE_NAME:-ttn_lorawan}
+  #   volumes:
+  #     - ${DEV_DATA_DIR:-.env/data}/postgres:/var/lib/postgresql/data
+  #   ports:
+  #     - "127.0.0.1:5432:5432"
   redis:
     image: redis:5.0.1-alpine
     command: redis-server --appendonly yes

--- a/pkg/identityserver/identityserver.go
+++ b/pkg/identityserver/identityserver.go
@@ -107,7 +107,7 @@ func New(c *component.Component, config *Config) (is *IdentityServer, err error)
 		Component: c,
 		config:    config,
 	}
-	is.db, err = gorm.Open("postgres", is.config.DatabaseURI)
+	is.db, err = store.Open(is.Context(), is.config.DatabaseURI)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/identityserver/store/registry.go
+++ b/pkg/identityserver/store/registry.go
@@ -46,8 +46,10 @@ func AutoMigrate(db *gorm.DB) *gorm.DB {
 // clear database tables for the given models.
 // This should be used with caution.
 func clear(db *gorm.DB, models ...interface{}) (err error) {
-	if err = db.Exec("SET SQL_SAFE_UPDATES = FALSE").Error; err != nil {
-		return err
+	if dbKind, ok := db.Get("db:kind"); ok && dbKind == "CockroachDB" {
+		if err = db.Exec("SET SQL_SAFE_UPDATES = FALSE").Error; err != nil {
+			return err
+		}
 	}
 	for _, model := range models {
 		if err = db.Unscoped().Delete(model).Error; err != nil {

--- a/pkg/identityserver/store/store.go
+++ b/pkg/identityserver/store/store.go
@@ -17,6 +17,7 @@ package store
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"regexp"
 	"runtime/trace"
@@ -60,6 +61,53 @@ func convertError(err error) error {
 		}
 	}
 	return errDatabase.WithCause(err)
+}
+
+// Open opens a new database connection.
+func Open(ctx context.Context, dsn string) (*gorm.DB, error) {
+	dbURI, err := url.Parse(dsn)
+	if err != nil {
+		return nil, err
+	}
+	dbName := strings.TrimPrefix(dbURI.Path, "/")
+	db, err := gorm.Open("postgres", dsn)
+	if err != nil {
+		return nil, err
+	}
+	db = db.Set("db:name", dbName)
+	var dbVersion string
+	err = db.Raw("SELECT version()").Row().Scan(&dbVersion)
+	if err != nil {
+		return nil, err
+	}
+	db = db.Set("db:version", dbVersion)
+	switch {
+	case strings.Contains(dbVersion, "CockroachDB"):
+		db = db.Set("db:kind", "CockroachDB")
+	case strings.Contains(dbVersion, "PostgreSQL"):
+		db = db.Set("db:kind", "PostgreSQL")
+	}
+	SetLogger(db, log.FromContext(ctx))
+	return db, nil
+}
+
+// Initialize initializes the database.
+func Initialize(db *gorm.DB) error {
+	if dbKind, ok := db.Get("db:kind"); ok {
+		switch dbKind {
+		case "CockroachDB":
+			if dbName, ok := db.Get("db:name"); ok {
+				if err := db.Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s;", dbName)).Error; err != nil {
+					return err
+				}
+			}
+		case "PostgreSQL":
+			if err := db.Exec("CREATE EXTENSION IF NOT EXISTS pgcrypto").Error; err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // Transact executes f in a db transaction.

--- a/pkg/identityserver/store/utils_test.go
+++ b/pkg/identityserver/store/utils_test.go
@@ -17,44 +17,56 @@ package store
 import (
 	"fmt"
 	"os"
-	"strings"
+	"sync"
 	"testing"
-	"time"
 
 	"github.com/jinzhu/gorm"
+	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/util/test"
 )
 
+var (
+	setup        sync.Once
+	dbConnString string
+)
+
 func WithDB(t *testing.T, f func(t *testing.T, db *gorm.DB)) {
-	dbAddress := os.Getenv("SQL_DB_ADDRESS")
-	if dbAddress == "" {
-		dbAddress = "localhost:26257"
-	}
-	dbName := os.Getenv("TEST_DB_NAME")
-	randomDB := false
-	if dbName == "" {
-		dbName = fmt.Sprintf("%s_%d", strings.ToLower(t.Name()), time.Now().UnixNano())
-		randomDB = true
-	}
-	dbConnString := fmt.Sprintf("postgresql://root@%s/%s?sslmode=disable", dbAddress, dbName)
-	db, err := gorm.Open("postgres", dbConnString)
+	ctx := log.NewContext(test.Context(), test.GetLogger(t))
+	setup.Do(func() {
+		dbAddress := os.Getenv("SQL_DB_ADDRESS")
+		if dbAddress == "" {
+			dbAddress = "localhost:26257"
+		}
+		dbName := os.Getenv("TEST_DATABASE_NAME")
+		if dbName == "" {
+			dbName = "ttn_lorawan_test"
+		}
+		dbConnString = fmt.Sprintf("postgresql://root@%s/%s?sslmode=disable", dbAddress, dbName)
+		db, err := Open(test.Context(), dbConnString)
+		if err != nil {
+			panic(err)
+		}
+		defer db.Close()
+		if err = Initialize(db); err != nil {
+			panic(err)
+		}
+		if err = AutoMigrate(db).Error; err != nil {
+			panic(err)
+		}
+		if err = Clear(db); err != nil {
+			panic(err)
+		}
+	})
+	db, err := Open(ctx, dbConnString)
 	if err != nil {
 		panic(err)
 	}
 	defer db.Close()
-	SetLogger(db, test.GetLogger(t))
 	db = db.Debug()
-	if err := db.Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s;", dbName)).Error; err != nil {
-		panic(err)
-	}
-	if randomDB {
-		defer db.Exec(fmt.Sprintf("DROP DATABASE %s CASCADE;", dbName))
-	}
 	f(t, db)
 }
 
 func prepareTest(db *gorm.DB, models ...interface{}) {
-	db.AutoMigrate(models...)
 	if err := clear(db, models...); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR closes #549 by adding documentation to the docker-compose.yml that shows how you can run the stack with Postgres instead of Cockroach. I also updated the DB initialization to work better with Postgres.

**Changes:**
<!-- What are the changes made in this pull request? -->

- Added comments to docker-compose.yml to show how you can run the stack with Postgres instead of Cockroach
- Moved DB initialization to store package, and use that in `is-db init` and tests

**Notes for Reviewers:**
<!--
Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Running tests with Postgres works with the following env:

```
export DEV_DATABASES="postgres redis"
export SQL_DB_ADDRESS="localhost:5432"
```
