### PR TITLE
Events Widget Component

### DIFF
--- a/pkg/webui/components/event/event.styl
+++ b/pkg/webui/components/event/event.styl
@@ -1,0 +1,44 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.event
+  font-family: $font-family-mono
+  font-size: $fs.s
+
+  &-header
+    display: flex
+    align-items: center
+    flex-wrap: nowrap
+
+  &-icon
+    nudge('up', 1px)
+    margin-right: $cs.xs
+    font-size: 1.1rem
+
+    &-default
+      color: $c-icon-fill
+
+  &-time
+    color: $tc-subtle-gray
+    margin-right: $cs.s
+
+  &-emitter
+    min-width: 4rem
+    white-space: nowrap
+    overflow: hidden
+    text-overflow: ellipsis
+    margin-right: $cs.s
+
+  &-content
+    display: inline-block

--- a/pkg/webui/components/event/index.js
+++ b/pkg/webui/components/event/index.js
@@ -20,6 +20,7 @@ import DateTime from '../../lib/components/date-time'
 import PropTypes from '../../lib/prop-types'
 import CRUDEvent from './types/crud'
 import DefaultEvent from './types/default'
+import MessageEvent from './types/message'
 
 import style from './event.styl'
 
@@ -91,5 +92,6 @@ Event.defaultProps = {
 
 Event.CRUD = CRUDEvent
 Event.Default = DefaultEvent
+Event.Message = MessageEvent
 
 export default Event

--- a/pkg/webui/components/event/index.js
+++ b/pkg/webui/components/event/index.js
@@ -1,0 +1,90 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import classnames from 'classnames'
+
+import Icon from '../icon'
+import DateTime from '../../lib/components/date-time'
+import PropTypes from '../../lib/prop-types'
+
+import style from './event.styl'
+
+const Event = function (props) {
+  const {
+    className,
+    icon,
+    time,
+    emitter,
+    content,
+  } = props
+
+  const eventIcon = React.isValidElement(icon)
+    ? React.cloneElement(icon, {
+      ...icon.props,
+      className: classnames(style.eventIcon, icon.props.className, {
+        [style.eventIconDefault]: !icon.props.className,
+      }),
+    })
+    : (
+      <Icon
+        className={classnames(style.eventIcon, style.eventIconDefault)}
+        icon={icon}
+      />
+    )
+
+  const eventContent = React.isValidElement(content)
+    ? React.cloneElement(content, {
+      ...content.props,
+      className: classnames(style.eventContent, content.props.className),
+    })
+    : <div className={style.eventContent}>{content}</div>
+
+  return (
+    <div className={classnames(className, style.event)}>
+      <div className={style.eventHeader}>
+        {eventIcon}
+        <DateTime
+          className={style.eventTime}
+          value={time}
+          date={false}
+        />
+        <span className={style.eventEmitter}>{emitter}</span>
+        {eventContent}
+      </div>
+    </div>
+  )
+}
+
+Event.propTypes = {
+  /** The time of the event. */
+  time: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.instanceOf(Date),
+  ]).isRequired,
+  /** The icon of the event. */
+  icon: PropTypes.node,
+  /** The entity identifier of the event. */
+  emitter: PropTypes.string.isRequired,
+  /** Custom content of the event. */
+  content: PropTypes.node.isRequired,
+}
+
+Event.defaultProps = {
+  icon: 'event',
+  content: null,
+}
+
+export default Event

--- a/pkg/webui/components/event/index.js
+++ b/pkg/webui/components/event/index.js
@@ -18,6 +18,7 @@ import classnames from 'classnames'
 import Icon from '../icon'
 import DateTime from '../../lib/components/date-time'
 import PropTypes from '../../lib/prop-types'
+import CRUDEvent from './types/crud'
 
 import style from './event.styl'
 
@@ -86,5 +87,7 @@ Event.defaultProps = {
   icon: 'event',
   content: null,
 }
+
+Event.CRUD = CRUDEvent
 
 export default Event

--- a/pkg/webui/components/event/index.js
+++ b/pkg/webui/components/event/index.js
@@ -19,6 +19,7 @@ import Icon from '../icon'
 import DateTime from '../../lib/components/date-time'
 import PropTypes from '../../lib/prop-types'
 import CRUDEvent from './types/crud'
+import DefaultEvent from './types/default'
 
 import style from './event.styl'
 
@@ -89,5 +90,6 @@ Event.defaultProps = {
 }
 
 Event.CRUD = CRUDEvent
+Event.Default = DefaultEvent
 
 export default Event

--- a/pkg/webui/components/event/types/crud/crud.styl
+++ b/pkg/webui/components/event/types/crud/crud.styl
@@ -1,0 +1,19 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.create
+  color: $c-success
+
+.delete
+  color: $c-error

--- a/pkg/webui/components/event/types/crud/index.js
+++ b/pkg/webui/components/event/types/crud/index.js
@@ -1,0 +1,70 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+
+import Event from '../..'
+import Message from '../../../../lib/components/message'
+import Icon from '../../../icon'
+import PropTypes from '../../../../lib/prop-types'
+import { getEntityId } from '../../../../lib/selectors/id'
+import { warn } from '../../../../lib/log'
+import { getEventActionByName } from '..'
+
+import style from './crud.styl'
+
+const CRUDEvent = function (props) {
+  const { className, event } = props
+
+  const entityId = getEntityId(event.identifiers[0])
+  const eventAction = getEventActionByName(event.name)
+
+  let icon = null
+
+  if (eventAction === 'create') {
+    icon = <Icon icon="event_create" className={style.create} />
+  } else if (eventAction === 'delete') {
+    icon = <Icon icon="event_delete" className={style.delete} />
+  } else if (eventAction === 'update') {
+    icon = <Icon icon="event_update" />
+  } else {
+    warn(`Unknown event name: ${event.name}`)
+    icon = <Icon icon="event" />
+  }
+
+  const content = (
+    <Message content={{ id: `event:${event.name}` }} />
+  )
+
+  return (
+    <Event
+      className={className}
+      icon={icon}
+      time={event.time}
+      emitter={entityId}
+      content={content}
+    />
+  )
+}
+
+CRUDEvent.propTypes = {
+  event: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    time: PropTypes.string.isRequired,
+    identifiers: PropTypes.array.isRequired,
+    data: PropTypes.object,
+  }).isRequired,
+}
+
+export default CRUDEvent

--- a/pkg/webui/components/event/types/default/index.js
+++ b/pkg/webui/components/event/types/default/index.js
@@ -1,0 +1,50 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+
+import Message from '../../../../lib/components/message'
+import Event from '../..'
+import PropTypes from '../../../../lib/prop-types'
+import { getEntityId } from '../../../../lib/selectors/id'
+
+const DefaultEvent = function (props) {
+  const { className, event } = props
+
+  const entityId = getEntityId(event.identifiers[0])
+
+  const content = (
+    <Message content={{ id: `event:${event.name}` }} />
+  )
+
+  return (
+    <Event
+      className={className}
+      time={event.time}
+      content={content}
+      emitter={entityId}
+    />
+  )
+}
+
+DefaultEvent.propTypes = {
+  event: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    time: PropTypes.string.isRequired,
+    identifiers: PropTypes.array.isRequired,
+    data: PropTypes.object,
+  }).isRequired,
+}
+
+export default DefaultEvent

--- a/pkg/webui/components/event/types/index.js
+++ b/pkg/webui/components/event/types/index.js
@@ -1,0 +1,46 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Event from '..'
+
+const getEventActionByName = function (name) {
+  const names = name.split('.')
+
+  return names[names.length - 1]
+}
+
+const getEventComponentByName = function (name) {
+  const action = getEventActionByName(name)
+
+  let component = null
+  let type = null
+
+  if (name.includes('.up.')) {
+    component = Event.Message
+    type = 'uplink'
+  } else if (name.includes('.down.')) {
+    component = Event.Message
+    type = 'downlink'
+  } else if ([ 'create', 'delete', 'update' ].includes(action)) {
+    component = Event.CRUD
+    type = 'crud'
+  } else {
+    component = Event.Default
+    type = 'default'
+  }
+
+  return { component, type }
+}
+
+export { getEventComponentByName as default, getEventActionByName }

--- a/pkg/webui/components/event/types/message/index.js
+++ b/pkg/webui/components/event/types/message/index.js
@@ -1,0 +1,59 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+
+import Event from '../..'
+import Message from '../../../../lib/components/message'
+import Icon from '../../../icon'
+import PropTypes from '../../../../lib/prop-types'
+import { getEntityId } from '../../../../lib/selectors/id'
+
+import style from './message.styl'
+
+const MessageEvent = function (props) {
+  const { className, event, type } = props
+
+  const entityId = getEntityId(event.identifiers[0])
+  const icon = type === 'downlink' ? 'event_downlink' : 'event_uplink'
+
+  const eventContent = (
+    <Message content={{ id: `event:${event.name}` }} />
+  )
+  const eventIcon = (
+    <Icon icon={icon} className={style.messageIcon} />
+  )
+
+  return (
+    <Event
+      className={className}
+      icon={eventIcon}
+      time={event.time}
+      emitter={entityId}
+      content={eventContent}
+    />
+  )
+}
+
+MessageEvent.propTypes = {
+  event: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    time: PropTypes.string.isRequired,
+    identifiers: PropTypes.array.isRequired,
+    data: PropTypes.object,
+  }).isRequired,
+  type: PropTypes.oneOf([ 'downlink', 'uplink' ]),
+}
+
+export default MessageEvent

--- a/pkg/webui/components/event/types/message/message.styl
+++ b/pkg/webui/components/event/types/message/message.styl
@@ -1,0 +1,16 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.message-icon
+  color: $c-active-blue

--- a/pkg/webui/components/events/index.js
+++ b/pkg/webui/components/events/index.js
@@ -1,0 +1,25 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+
+class Events extends React.PureComponent {
+
+  render () {
+    // TODO: implement the events component
+    return <div>events</div>
+  }
+}
+
+export default Events

--- a/pkg/webui/components/events/widget/index.js
+++ b/pkg/webui/components/events/widget/index.js
@@ -1,0 +1,135 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import bind from 'autobind-decorator'
+import { defineMessages } from 'react-intl'
+
+import Link from '../../link'
+import Message from '../../../lib/components/message'
+import Status from '../../status'
+import List from '../../list'
+import PropTypes from '../../../lib/prop-types'
+import getEventComponentByName from '../../event/types'
+
+import DateTime from '../../../lib/components/date-time'
+import style from './widget.styl'
+
+const m = defineMessages({
+  latestEvents: 'Latest events',
+  seeAllActivity: 'See all activity',
+  noEvents: '{entityId} has not sent any events recently',
+  unknown: 'Unknown',
+})
+
+@bind
+class EventsWidget extends React.PureComponent {
+
+  renderEvent (event) {
+    const { component: Component, type } = getEventComponentByName(event.name)
+
+    return (
+      <List.Item>
+        <Component
+          event={event}
+          type={type}
+        />
+      </List.Item>
+    )
+  }
+
+  render () {
+    const {
+      className,
+      events,
+      toAllUrl,
+      emitterId,
+      connectionStatus,
+      limit,
+    } = this.props
+
+    let latestActivityTime = null
+    if (events.length) {
+      const latestEvent = events[0]
+      latestActivityTime = <DateTime.Relative value={latestEvent.time} />
+    } else {
+      latestActivityTime = <Message content={m.unknown} />
+    }
+
+    const statusMessage = (
+      <span>
+        <Message
+          className={style.statusMessage}
+          content={m.latestEvents}
+        />
+        {latestActivityTime}
+      </span>
+    )
+
+    let truncatedEvents = events
+    if (events.length > limit) {
+      truncatedEvents = events.slice(0, limit)
+    }
+
+    return (
+      <aside className={className}>
+        <div className={style.header}>
+          <Status
+            label={statusMessage}
+            status={connectionStatus}
+          />
+          <Link to={toAllUrl}>
+            <Message
+              className={style.seeAllMessage}
+              content={m.seeAllActivity}
+            />
+            →
+          </Link>
+        </div>
+        <List
+          bordered
+          className={style.list}
+          size="small"
+          items={truncatedEvents}
+          renderItem={this.renderEvent}
+          emptyMessage={m.noEvents}
+          emptyMessageValues={{ entityId: emitterId }}
+        />
+      </aside>
+    )
+  }
+}
+
+EventsWidget.propTypes = {
+  /**
+   * A list of events to be displayed in the widget. Events are expected
+   * to be sorted in the descending order by their time.
+   */
+  events: PropTypes.array,
+  /** A url to the page with full version of the events component. */
+  toAllUrl: PropTypes.string.isRequired,
+  /** An entity identifer. */
+  emitterId: PropTypes.node.isRequired,
+  /** A current status of the network. */
+  connectionStatus: PropTypes.oneOf([ 'good', 'bad', 'mediocre', 'unknown' ]).isRequired,
+  /** The number of events to displayed in the widget. */
+  limit: PropTypes.number,
+}
+
+EventsWidget.defaultProps = {
+  events: [],
+  limit: 5,
+}
+
+export default EventsWidget

--- a/pkg/webui/components/events/widget/story.js
+++ b/pkg/webui/components/events/widget/story.js
@@ -1,0 +1,103 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import bind from 'autobind-decorator'
+import { storiesOf } from '@storybook/react'
+
+import Events from '..'
+
+const events = [
+  {
+    icon: 'add_circle',
+    identifiers: [{ application_ids: { application_id: 'admin-app' }}],
+    name: 'application.create',
+    time: '2019-03-28T13:18:13.376022Z',
+  },
+  {
+    icon: 'remove_circle',
+    identifiers: [{ application_ids: { application_id: 'admin-app' }}],
+    name: 'application.delete',
+    time: '2019-03-28T13:18:24.376022Z',
+  },
+  {
+    icon: 'edit',
+    identifiers: [{ application_ids: { application_id: 'admin-app' }}],
+    name: 'application.update',
+    time: '2019-03-28T13:18:39.376022Z',
+  },
+  {
+    icon: 'remove_circle',
+    identifiers: [{ application_ids: { application_id: 'admin-app' }}],
+    name: 'application.delete',
+    time: '2019-03-28T13:18:48.376022Z',
+  },
+]
+
+@bind
+class WidgetExample extends React.Component {
+  state = {
+    events: [],
+  }
+
+  onEventPublish () {
+    this.setState(prev => ({
+      events: [
+        {
+          name: 'application.update',
+          time: new Date().toISOString(),
+          identifiers: [{ application_ids: { application_id: 'admin-app' }}],
+        },
+        ...prev.events,
+      ],
+    }))
+  }
+
+  render () {
+    const { events } = this.state
+
+    return (
+      <div>
+        <Events.Widget
+          events={events}
+          connectionStatus="good"
+          emitterId="admin-app"
+          toAllUrl="/"
+        />
+        <button style={{ marginTop: '20px' }} onClick={this.onEventPublish}>Publish event</button>
+      </div>
+    )
+  }
+}
+
+storiesOf('Events/Widget', module)
+  .add('Empty', () => (
+    <Events.Widget
+      events={[]}
+      connectionStatus="good"
+      toAllUrl="/"
+      emitterId="admin-app"
+    />
+  ))
+  .add('Default', () => (
+    <Events.Widget
+      events={events}
+      connectionStatus="good"
+      toAllUrl="/"
+      emitterId="admin-app"
+    />
+  ))
+  .add('Publish', () => (
+    <WidgetExample />
+  ))

--- a/pkg/webui/components/events/widget/widget.styl
+++ b/pkg/webui/components/events/widget/widget.styl
@@ -12,18 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React from 'react'
+.header
+  display: flex
+  align-items: center
+  justify-content: space-between
+  margin-bottom: $cs.xs
 
-import EventsWidget from './widget'
+.see-all-message
+  padding-right: $cs.xxs
 
-class Events extends React.PureComponent {
+.list
+  min-height: 10rem
 
-  render () {
-    // TODO: implement the events component
-    return <div>events</div>
-  }
-}
-
-Events.Widget = EventsWidget
-
-export default Events
+.status-message
+  margin-right: $cs.xs

--- a/pkg/webui/components/icon/index.js
+++ b/pkg/webui/components/icon/index.js
@@ -38,6 +38,12 @@ const hardcoded = {
   general_settings: 'settings',
   location: 'place',
   user: 'person',
+  event: 'offline_bolt',
+  event_create: 'add_circle',
+  event_delete: 'delete',
+  event_update: 'edit',
+  event_uplink: 'arrow_drop_up',
+  event_downlink: 'arrow_drop_down',
 }
 
 const Icon = function ({

--- a/pkg/webui/components/list/index.js
+++ b/pkg/webui/components/list/index.js
@@ -1,0 +1,122 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import classnames from 'classnames'
+import bind from 'autobind-decorator'
+
+import PropTypes from '../../lib/prop-types'
+import Message from '../../lib/components/message'
+import sharedMessages from '../../lib/shared-messages'
+import ListItem from './item'
+
+import style from './list.styl'
+
+@bind
+class List extends React.PureComponent {
+  renderItem (item, index) {
+    const { rowKey, renderItem, size } = this.props
+
+    let actualRowKey = null
+    const rowKeyType = typeof rowKey
+    if (rowKeyType === 'function') {
+      actualRowKey = rowKey(item, index)
+    } else if (rowKeyType === 'string') {
+      actualRowKey = item[rowKey]
+    } else if (item.key) {
+      actualRowKey = item.key
+    } else {
+      actualRowKey = `list-item-${index}`
+    }
+
+    const renderedItem = renderItem(item, index)
+    return React.cloneElement(renderedItem, {
+      ...renderedItem.props,
+      key: actualRowKey,
+      className: classnames(
+        renderedItem.props.className,
+        style[`item-${size}`]
+      ),
+    })
+  }
+
+  renderItems () {
+    const {
+      items,
+      emptyMessage,
+      emptyMessageValues,
+      children,
+    } = this.props
+
+    if (children) {
+      return children
+    }
+
+    if (!items.length) {
+      return (
+        <Message
+          className={style.listEmptyMessage}
+          content={emptyMessage}
+          values={emptyMessageValues}
+        />
+      )
+    }
+
+    return items.map((item, idx) => this.renderItem(item, idx))
+  }
+
+  render () {
+    const {
+      className,
+      component: Component,
+      bordered,
+      items,
+    } = this.props
+
+    const cls = classnames(className, style.list, {
+      [style.listBordered]: bordered,
+      [style.listEmpty]: !items.length,
+    })
+
+    return (
+      <Component className={cls}>
+        {this.renderItems()}
+      </Component>
+    )
+  }
+}
+
+List.propTypes = {
+  size: PropTypes.oneOf([ 'small', 'default', 'large' ]),
+  renderItem: PropTypes.func.isRequired,
+  items: PropTypes.array,
+  rowKey: PropTypes.oneOfType([ PropTypes.func, PropTypes.string ]),
+  component: PropTypes.string,
+  bordered: PropTypes.bool,
+  emptyMessage: PropTypes.message,
+  emptyMessageValues: PropTypes.object,
+}
+
+List.defaultProps = {
+  component: 'ol',
+  size: 'default',
+  items: [],
+  bordered: false,
+  emptyMessage: sharedMessages.noMatch,
+  emptyMessageValues: {},
+}
+
+List.Item = ListItem
+
+export default List

--- a/pkg/webui/components/list/item/index.js
+++ b/pkg/webui/components/list/item/index.js
@@ -1,0 +1,44 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import PropTypes from '../../../lib/prop-types'
+
+const ListItem = function (props) {
+  const {
+    className,
+    component: Component,
+    children,
+    ...rest
+  } = props
+
+  return (
+    <Component
+      className={className}
+      {...rest}
+    >
+      {children}
+    </Component>
+  )
+}
+
+ListItem.propTypes = {
+  component: PropTypes.string,
+}
+
+ListItem.defaultProps = {
+  component: 'li',
+}
+
+export default ListItem

--- a/pkg/webui/components/list/list.styl
+++ b/pkg/webui/components/list/list.styl
@@ -1,0 +1,43 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.list
+  height: 100%
+  width: 100%
+  padding: 0
+
+  &-bordered
+    border-normal()
+    border-radius: $br.s
+
+  &-empty
+    display: flex
+    justify-content: center
+    align-items: center
+    color: $tc-subtle-gray
+
+ul.list,
+ol.list
+  list-style: none
+  margin: 0
+
+.item
+  &-small
+    padding: $cs.xxs $cs.xs
+
+  &-default
+    padding: $cs.xs $cs.s
+
+  &-large
+    padding: $cs.s $cs.m

--- a/pkg/webui/components/list/story.js
+++ b/pkg/webui/components/list/story.js
@@ -1,0 +1,67 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import bind from 'autobind-decorator'
+import { storiesOf } from '@storybook/react'
+
+import List from '.'
+
+@bind
+class DefaultList extends React.Component {
+
+  renderItem (item, index) {
+    return (
+      <List.Item key={index}>
+        {item}
+      </List.Item>
+    )
+  }
+
+  render () {
+    const { listProps } = this.props
+    return (
+      <List
+        {...listProps}
+        renderItem={this.renderItem}
+      />
+    )
+  }
+}
+
+const simpleItems = [ ...new Array(100).keys() ]
+  .map(i => `List item nr. ${i}`)
+
+storiesOf('List', module)
+  .add('Default', function () {
+    return (
+      <DefaultList
+        listProps={{ items: simpleItems }}
+      />
+    )
+  })
+  .add('Small', function () {
+    return (
+      <DefaultList
+        listProps={{ items: simpleItems, size: 'small' }}
+      />
+    )
+  })
+  .add('Large', function () {
+    return (
+      <DefaultList
+        listProps={{ items: simpleItems, size: 'large' }}
+      />
+    )
+  })

--- a/pkg/webui/components/status/index.js
+++ b/pkg/webui/components/status/index.js
@@ -1,0 +1,67 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import classnames from 'classnames'
+
+import Message from '../../lib/components/message'
+import PropTypes from '../../lib/prop-types'
+
+import style from './status.styl'
+
+const Status = function ({
+  className,
+  status,
+  label,
+  labelValues,
+  children,
+}) {
+
+  const cls = classnames(style.status, {
+    [style.statusGood]: status === 'good',
+    [style.statusBad]: status === 'bad',
+    [style.statusMediocre]: status === 'mediocre',
+    [style.statusUnknown]: status === 'unknown',
+  })
+
+  let statusLabel = null
+  if (React.isValidElement(label)) {
+    statusLabel = React.cloneElement(label, {
+      ...label.props,
+      className: classnames(label.props.className, style.statusLabel),
+    })
+  } else {
+    statusLabel = <Message className={style.statusLabel} content={label} />
+  }
+
+  return (
+    <span className={classnames(className, style.container)}>
+      {statusLabel}
+      <span className={classnames(cls)} />
+      {children}
+    </span>
+  )
+}
+
+Status.propTypes = {
+  status: PropTypes.oneOf([ 'good', 'bad', 'mediocre', 'unknown' ]),
+  label: PropTypes.message,
+  labelValues: PropTypes.object,
+}
+
+Status.defaultProps = {
+  status: 'unknown',
+}
+
+export default Status

--- a/pkg/webui/components/status/status.styl
+++ b/pkg/webui/components/status/status.styl
@@ -1,0 +1,73 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.container
+  display: flex
+  align-items: center
+
+.status
+  position: relative
+  display: inline-block
+  width: 5px
+  height: 5px
+  border-radius: 50%
+  transition: background-color $ad.m
+
+  &:after
+    content: ''
+    position: absolute
+    border-radius: 50%
+    width: 5px
+    height: 5px
+    opacity: .7
+    animation: pulse 2s infinite
+
+  &-good
+    background-color: $c-active-blue
+
+    &:after
+      animation: goodPulse 2s infinite
+
+  &-bad
+    background-color: $c-error
+
+    &:after
+      animation: badPulse 2s infinite
+
+  &-mediocre
+    background-color: $c-warning
+
+    &:after
+      animation: mediocrePulse 2s infinite
+
+  &-unknown
+    background-color: $c-icon-fill
+
+  &-label
+    padding-right: $cs.xs
+
+pulse-animation($color, $name)
+  @keyframes $name
+    0%
+      box-shadow: 0 0 0 0 alpha($color, .4)
+
+    70%
+      box-shadow: 0 0 0 5px alpha($color, 0)
+
+    100%
+      box-shadow: 0 0 0 0 alpha($color, 0)
+
+pulse-animation($c-active-blue, 'goodPulse')
+pulse-animation($c-error, 'badPulse')
+pulse-animation($c-error, 'mediocrePulse')

--- a/pkg/webui/components/status/story.js
+++ b/pkg/webui/components/status/story.js
@@ -1,0 +1,95 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import bind from 'autobind-decorator'
+import { storiesOf } from '@storybook/react'
+
+import Status from '.'
+
+const containerStyle = {
+  width: '100px',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+}
+
+@bind
+class Toggle extends React.Component {
+
+  state = {
+    status: 'unknown',
+  }
+
+  toggleStatus () {
+    const { status } = this.state
+    let nextStatus
+    switch (status) {
+    case 'unknown':
+      nextStatus = 'bad'
+      break
+    case 'bad':
+      nextStatus = 'mediocre'
+      break
+    case 'mediocre':
+      nextStatus = 'good'
+      break
+    case 'good':
+      nextStatus = 'unknown'
+      break
+    }
+
+    this.setState({ status: nextStatus })
+  }
+
+  render () {
+    const { status } = this.state
+    return (
+      <div>
+        <Status status={status} />
+        <br />
+        <button onClick={this.toggleStatus}>Toggle</button>
+      </div>
+    )
+  }
+}
+
+storiesOf('Status', module)
+  .add('All types', () => (
+    <div>
+      <div style={containerStyle}>
+        <span>Good:</span><Status status="good" />
+      </div>
+      <div style={containerStyle}>
+        <span>Bad:</span><Status status="bad" />
+      </div>
+      <div style={containerStyle}>
+        <span>Mediocre:</span><Status status="mediocre" />
+      </div>
+      <div style={containerStyle}>
+        <span>Unknown:</span><Status status="unknown" />
+      </div>
+    </div>
+  ))
+  .add('With label', () => (
+    <div>
+      <Status label="Network Status" status="good" />
+      <Status label="Network Status" status="bad" />
+      <Status label="Network Status" status="mediocre" />
+      <Status label="Network Status" status="unknown" />
+    </div>
+  ))
+  .add('Toggle', () => (
+    <Toggle />
+  ))

--- a/pkg/webui/console/lib/selectors/id.js
+++ b/pkg/webui/console/lib/selectors/id.js
@@ -1,0 +1,59 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import getByPath from '../../../lib/get-by-path'
+
+export const getEntityId = function (entity) {
+  let id
+  let selectorIndex = 0
+  while (!id) {
+    const selector = idSelectors[selectorIndex++]
+    id = selector(entity)
+  }
+
+  return id
+}
+
+export const getApplicationId = function (application = {}) {
+  return getByPath(application, 'application_id')
+    || getByPath(application, 'application_ids.application_id')
+}
+
+export const getDeviceId = function (device = {}) {
+  return getByPath(device, 'device_id')
+    || getByPath(device, 'device_ids.device_id')
+}
+
+export const getCollaboratorId = function (collaborator = {}) {
+  return getByPath(collaborator, 'ids.organization_ids.organization_id')
+    || getByPath(collaborator, 'ids.user_ids.user_id')
+}
+
+export const getGatewayId = function (gateway = {}) {
+  return getByPath(gateway, 'gateway_id')
+    || getByPath(gateway, 'gateway_ids.gateway_id')
+}
+
+export const getApiKeyId = function (key = {}) {
+  return key.id
+}
+
+const idSelectors = [
+  getApplicationId,
+  getCollaboratorId,
+  getApiKeyId,
+  getGatewayId,
+  getDeviceId,
+]
+

--- a/pkg/webui/lib/selectors/id.js
+++ b/pkg/webui/lib/selectors/id.js
@@ -12,18 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import getByPath from '../../../lib/get-by-path'
-
-export const getEntityId = function (entity) {
-  let id
-  let selectorIndex = 0
-  while (!id) {
-    const selector = idSelectors[selectorIndex++]
-    id = selector(entity)
-  }
-
-  return id
-}
+import getByPath from '../get-by-path'
 
 export const getApplicationId = function (application = {}) {
   return getByPath(application, 'application_id')
@@ -57,3 +46,13 @@ const idSelectors = [
   getDeviceId,
 ]
 
+export const getEntityId = function (entity) {
+  let id
+  let selectorIndex = 0
+  while (!id && selectorIndex < idSelectors.length) {
+    const selector = idSelectors[selectorIndex++]
+    id = selector(entity)
+  }
+
+  return id
+}

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -1,4 +1,8 @@
 {
+  "components.events.widget.index.latestEvents": "Latest events",
+  "components.events.widget.index.seeAllActivity": "See all activity",
+  "components.events.widget.index.noEvents": "{entityId} has not sent any events recently",
+  "components.events.widget.index.unknown": "Unknown",
   "components.footer.index.footer": "You are the network. Let's build this thing together.",
   "components.navigation.side.side.hideSidebar": "Hide Sidebar",
   "components.safe-inspector.index.copied": "Copied to clipboard!",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -1,4 +1,8 @@
 {
+  "components.events.widget.index.latestEvents": "Xxxxxx xxxxxx",
+  "components.events.widget.index.seeAllActivity": "Xxx xxx xxxxxxxx",
+  "components.events.widget.index.noEvents": "{entityId} xxx xxx xxxx xxx xxxxxx xxxxxxxx",
+  "components.events.widget.index.unknown": "Xxxxxxx",
   "components.footer.index.footer": "Xxx xxx xxx xxxxxxx. Xxx'x xxxxx xxxx xxxxx xxxxxxxx.",
   "components.navigation.side.side.hideSidebar": "Xxxx Xxxxxxx",
   "components.safe-inspector.index.copied": "Xxxxxx xx xxxxxxxxx!",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR adds the `<Events.Widget />` component to the console as well as some groundwork for the entity events pages.
References https://github.com/TheThingsNetwork/lorawan-stack/issues/28 and https://github.com/TheThingsNetwork/lorawan-stack/issues/553

<img width="504" alt="Screenshot 2019-04-22 at 16 36 00" src="https://user-images.githubusercontent.com/16374166/56505173-8ae47700-6523-11e9-852f-bccdc9550a8e.png">
<img width="504" alt="Screenshot 2019-04-22 at 16 42 53" src="https://user-images.githubusercontent.com/16374166/56505177-8fa92b00-6523-11e9-8ace-e5b73c7feca1.png">


**Changes:**
<!-- What are the changes made in this pull request? -->

- Add the `<Events />` (currently as a stub)  and `<Events.Widget />`  components.
- Add the `<List />` component
- Add the `<Event />` component of different types
- Add the `<Status />` component
- Add entity id selectors

cc @htdvisser 
