### PR TITLE
Fix double-Update and add debugging of CLI's EndDevice RPCs

### DIFF
--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -225,6 +225,7 @@ var (
 			if err != nil {
 				return err
 			}
+			logger.WithField("paths", isPaths).Debug("Get EndDevice from Identity Server")
 			device, err := ttnpb.NewEndDeviceRegistryClient(is).Get(ctx, &ttnpb.GetEndDeviceRequest{
 				EndDeviceIdentifiers: *devID,
 				FieldMask:            pbtypes.FieldMask{Paths: isPaths},
@@ -485,6 +486,7 @@ var (
 			if err != nil {
 				return err
 			}
+			logger.WithField("paths", isPaths).Debug("Get EndDevice from Identity Server")
 			existingDevice, err := ttnpb.NewEndDeviceRegistryClient(is).Get(ctx, &ttnpb.GetEndDeviceRequest{
 				EndDeviceIdentifiers: *devID,
 				FieldMask:            pbtypes.FieldMask{Paths: isPaths},

--- a/cmd/ttn-lw-cli/commands/end_devices_split.go
+++ b/cmd/ttn-lw-cli/commands/end_devices_split.go
@@ -167,7 +167,7 @@ func setEndDevice(device *ttnpb.EndDevice, isPaths, nsPaths, asPaths, jsPaths []
 	var res ttnpb.EndDevice
 	res.SetFields(device, "ids", "created_at", "updated_at")
 
-	if len(isPaths) > 0 || isCreate {
+	if len(isPaths) > 0 && !isCreate {
 		is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 		if err != nil {
 			return nil, err

--- a/cmd/ttn-lw-cli/commands/end_devices_split.go
+++ b/cmd/ttn-lw-cli/commands/end_devices_split.go
@@ -80,6 +80,7 @@ func getEndDevice(ids ttnpb.EndDeviceIdentifiers, nsPaths, asPaths, jsPaths []st
 			}
 			logger.WithError(err).Error("Could not connect to Join Server")
 		} else {
+			logger.WithField("paths", jsPaths).Debug("Get EndDevice from Join Server")
 			jsRes, err := ttnpb.NewJsEndDeviceRegistryClient(js).Get(ctx, &ttnpb.GetEndDeviceRequest{
 				EndDeviceIdentifiers: ids,
 				FieldMask:            types.FieldMask{Paths: jsPaths},
@@ -109,6 +110,7 @@ func getEndDevice(ids ttnpb.EndDeviceIdentifiers, nsPaths, asPaths, jsPaths []st
 			}
 			logger.WithError(err).Error("Could not connect to Application Server")
 		} else {
+			logger.WithField("paths", asPaths).Debug("Get EndDevice from Application Server")
 			asRes, err := ttnpb.NewAsEndDeviceRegistryClient(as).Get(ctx, &ttnpb.GetEndDeviceRequest{
 				EndDeviceIdentifiers: ids,
 				FieldMask:            types.FieldMask{Paths: asPaths},
@@ -138,6 +140,7 @@ func getEndDevice(ids ttnpb.EndDeviceIdentifiers, nsPaths, asPaths, jsPaths []st
 			}
 			logger.WithError(err).Error("Could not connect to Network Server")
 		} else {
+			logger.WithField("paths", nsPaths).Debug("Get EndDevice from Network Server")
 			nsRes, err := ttnpb.NewNsEndDeviceRegistryClient(ns).Get(ctx, &ttnpb.GetEndDeviceRequest{
 				EndDeviceIdentifiers: ids,
 				FieldMask:            types.FieldMask{Paths: nsPaths},
@@ -173,6 +176,7 @@ func setEndDevice(device *ttnpb.EndDevice, isPaths, nsPaths, asPaths, jsPaths []
 			return nil, err
 		}
 		var isDevice ttnpb.EndDevice
+		logger.WithField("paths", isPaths).Debug("Set EndDevice on Identity Server")
 		isDevice.SetFields(device, append(isPaths, "ids")...)
 		isRes, err := ttnpb.NewEndDeviceRegistryClient(is).Update(ctx, &ttnpb.UpdateEndDeviceRequest{
 			EndDevice: isDevice,
@@ -196,6 +200,7 @@ func setEndDevice(device *ttnpb.EndDevice, isPaths, nsPaths, asPaths, jsPaths []
 			return nil, err
 		}
 		var jsDevice ttnpb.EndDevice
+		logger.WithField("paths", jsPaths).Debug("Set EndDevice on Join Server")
 		jsDevice.SetFields(device, append(jsPaths, "ids")...)
 		jsRes, err := ttnpb.NewJsEndDeviceRegistryClient(js).Set(ctx, &ttnpb.SetEndDeviceRequest{
 			EndDevice: jsDevice,
@@ -219,6 +224,7 @@ func setEndDevice(device *ttnpb.EndDevice, isPaths, nsPaths, asPaths, jsPaths []
 			return nil, err
 		}
 		var nsDevice ttnpb.EndDevice
+		logger.WithField("paths", nsPaths).Debug("Set EndDevice on Network Server")
 		nsDevice.SetFields(device, append(nsPaths, "ids")...)
 		nsRes, err := ttnpb.NewNsEndDeviceRegistryClient(ns).Set(ctx, &ttnpb.SetEndDeviceRequest{
 			EndDevice: nsDevice,
@@ -242,6 +248,7 @@ func setEndDevice(device *ttnpb.EndDevice, isPaths, nsPaths, asPaths, jsPaths []
 			return nil, err
 		}
 		var asDevice ttnpb.EndDevice
+		logger.WithField("paths", asPaths).Debug("Set EndDevice on Application Server")
 		asDevice.SetFields(device, append(asPaths, "ids")...)
 		asRes, err := ttnpb.NewAsEndDeviceRegistryClient(as).Set(ctx, &ttnpb.SetEndDeviceRequest{
 			EndDevice: asDevice,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR closes #547 (possible Update call on Create) with the first commit, and adds some debugging of paths->server mappings in the second commit.

**Notes for Reviewers:**
<!--
Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Small stuff
