### PR TITLE
Validate LoRaWAN MAC/PHY versions

### DIFF
--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -66,11 +66,13 @@ func forwardDeprecatedDeviceFlags(flagSet *pflag.FlagSet) {
 }
 
 var (
-	errNoEndDeviceID                = errors.DefineInvalidArgument("no_end_device_id", "no end device ID set")
-	errNoEndDeviceEUI               = errors.DefineInvalidArgument("no_end_device_eui", "no end device EUIs set")
-	errInconsistentEndDeviceEUI     = errors.DefineInvalidArgument("inconsistent_end_device_eui", "given end device EUIs do not match registered EUIs")
 	errEndDeviceEUIUpdate           = errors.DefineInvalidArgument("end_device_eui_update", "end device EUIs can not be updated")
 	errEndDeviceKeysWithProvisioner = errors.DefineInvalidArgument("end_device_keys_provisioner", "end device ABP or OTAA keys cannot be set when there is a provisioner")
+	errInconsistentEndDeviceEUI     = errors.DefineInvalidArgument("inconsistent_end_device_eui", "given end device EUIs do not match registered EUIs")
+	errInvalidMACVerson             = errors.DefineInvalidArgument("mac_version", "LoRaWAN MAC version is invalid")
+	errInvalidPHYVerson             = errors.DefineInvalidArgument("phy_version", "LoRaWAN PHY version is invalid")
+	errNoEndDeviceEUI               = errors.DefineInvalidArgument("no_end_device_eui", "no end device EUIs set")
+	errNoEndDeviceID                = errors.DefineInvalidArgument("no_end_device_id", "no end device ID set")
 )
 
 func getEndDeviceID(flagSet *pflag.FlagSet, args []string, requireID bool) (*ttnpb.EndDeviceIdentifiers, error) {
@@ -297,8 +299,12 @@ var (
 			if err != nil {
 				return err
 			}
+
 			if err := macVersion.UnmarshalText([]byte(s)); err != nil {
 				return err
+			}
+			if err := macVersion.Validate(); err != nil {
+				return errInvalidMACVerson
 			}
 
 			setDefaults, _ := cmd.Flags().GetBool("defaults")

--- a/cmd/ttn-lw-cli/commands/simulate.go
+++ b/cmd/ttn-lw-cli/commands/simulate.go
@@ -405,6 +405,14 @@ var (
 				return err
 			}
 
+			if err := uplinkParams.LoRaWANVersion.Validate(); err != nil {
+				return errInvalidMACVerson
+			}
+
+			if err := uplinkParams.LoRaWANPHYVersion.Validate(); err != nil {
+				return errInvalidPHYVerson
+			}
+
 			processDownlink := processDownlink(&ttnpb.EndDevice{
 				LoRaWANVersion:    uplinkParams.LoRaWANVersion,
 				LoRaWANPHYVersion: uplinkParams.LoRaWANPHYVersion,
@@ -481,6 +489,14 @@ var (
 			var dataUplinkParams simulateDataUplinkParams
 			if err := util.SetFields(&dataUplinkParams, simulateDataUplinkFlags); err != nil {
 				return err
+			}
+
+			if err := uplinkParams.LoRaWANVersion.Validate(); err != nil {
+				return errInvalidMACVerson
+			}
+
+			if err := uplinkParams.LoRaWANPHYVersion.Validate(); err != nil {
+				return errInvalidPHYVerson
 			}
 
 			processDownlink := processDownlink(&ttnpb.EndDevice{

--- a/config/messages.json
+++ b/config/messages.json
@@ -1187,6 +1187,15 @@
       "file": "end_devices.go"
     }
   },
+  "error:cmd/ttn-lw-cli/commands:mac_version": {
+    "translations": {
+      "en": "LoRaWAN MAC version is invalid"
+    },
+    "description": {
+      "package": "cmd/ttn-lw-cli/commands",
+      "file": "end_devices.go"
+    }
+  },
   "error:cmd/ttn-lw-cli/commands:no_api_key_id": {
     "translations": {
       "en": "no API key ID set"
@@ -1338,6 +1347,15 @@
     "description": {
       "package": "cmd/ttn-lw-cli/commands",
       "file": "users.go"
+    }
+  },
+  "error:cmd/ttn-lw-cli/commands:phy_version": {
+    "translations": {
+      "en": "LoRaWAN PHY version is invalid"
+    },
+    "description": {
+      "package": "cmd/ttn-lw-cli/commands",
+      "file": "end_devices.go"
     }
   },
   "error:cmd/ttn-lw-cli/commands:unauthenticated": {

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -168,8 +168,8 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 		if err := req.EndDevice.LoRaWANVersion.Validate(); err != nil {
 			return nil, nil, errInvalidFieldValue.WithAttributes("field", "lorawan_version").WithCause(err)
 		}
-		if req.EndDevice.LoRaWANPHYVersion == ttnpb.PHY_UNKNOWN {
-			return nil, nil, errInvalidFieldValue.WithAttributes("field", "lorawan_phy_version")
+		if err := req.EndDevice.LoRaWANPHYVersion.Validate(); err != nil {
+			return nil, nil, errInvalidFieldValue.WithAttributes("field", "lorawan_phy_version").WithCause(err)
 		}
 
 		if ttnpb.HasAnyField(sets, "supports_class_b") && req.EndDevice.SupportsClassB {

--- a/pkg/ttnpb/lorawan.go
+++ b/pkg/ttnpb/lorawan.go
@@ -690,6 +690,19 @@ func (v MACVersion) HasMaxFCntGap() bool {
 	return v.Compare(MAC_V1_1) < 0
 }
 
+// Validate reports whether v represents a valid PHYVersion.
+func (v PHYVersion) Validate() error {
+	if v < 1 || v >= PHYVersion(len(PHYVersion_name)) {
+		return errExpectedBetween("PHYVersion", 1, len(PHYVersion_name)-1)(v)
+	}
+
+	_, err := semver.Parse(v.String())
+	if err != nil {
+		return errParsingSemanticVersion(v.String()).WithCause(err)
+	}
+	return nil
+}
+
 // String implements fmt.Stringer.
 func (v PHYVersion) String() string {
 	switch v {
@@ -709,6 +722,17 @@ func (v PHYVersion) String() string {
 		return "1.1.0-b"
 	}
 	return "unknown"
+}
+
+// Compare compares PHYVersions v to o:
+// -1 == v is less than o
+// 0 == v is equal to o
+// 1 == v is greater than o
+// Compare panics, if v.Validate() returns non-nil error.
+func (v PHYVersion) Compare(o PHYVersion) int {
+	return semver.MustParse(v.String()).Compare(
+		semver.MustParse(o.String()),
+	)
 }
 
 func init() {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/564

**Changes:**
<!-- What are the changes made in this pull request? -->

- Validate PHY version specified in NS device registry
- Validate MAC version before using `Compare`