### PR TITLE
Various Device creation fixes in JS SDK

### DIFF
--- a/sdk/js/src/service/devices/index.js
+++ b/sdk/js/src/service/devices/index.js
@@ -94,6 +94,11 @@ class Devices {
       delete requestTree.is
     }
 
+    // Do not query JS when the device is ABP
+    if (!device.supports_join) {
+      delete requestTree.js
+    }
+
     // Write the device id param based on either the id of the newly created
     // device, or the passed id argument
     params.routeParams['end_device.ids.device_id'] = 'data' in isResult ? isResult.ids.device_id : devId

--- a/sdk/js/src/service/devices/index.js
+++ b/sdk/js/src/service/devices/index.js
@@ -205,29 +205,34 @@ class Devices {
         keys: {
           session_key_id: randomByteString(16),
           f_nwk_s_int_key: {
-            key: randomByteString(16, 'base64'),
-            kek_label: '',
+            key: randomByteString(32),
           },
           app_s_key: {
-            key: randomByteString(16),
-            kek_label: '',
+            key: randomByteString(32),
           },
         },
       }
       if (parseInt(device.lorawan_version.replace(/\D/g, '').padEnd(3, 0)) >= 110) {
         session.keys.s_nwk_s_int_key = {
-          key: randomByteString(16, 'base64'),
-          kek_label: '',
+          key: randomByteString(32),
         }
         session.keys.nwk_s_enc_key = {
-          key: randomByteString(16, 'base64'),
-          kek_label: '',
+          key: randomByteString(32),
         }
+      }
+
+      let providedKeys = {}
+      if (dev.session && dev.session.keys) {
+        providedKeys = dev.session.keys
       }
 
       dev.session = {
         ...session,
         ...dev.session,
+        keys: {
+          ...session.keys,
+          ...providedKeys,
+        },
       }
 
       dev.supports_join = false
@@ -241,12 +246,10 @@ class Devices {
         root_keys = {
           root_key_id: 'ttn-lw-js-sdk-generated',
           app_key: {
-            key: randomByteString(16),
-            kek_label: 'default',
+            key: randomByteString(32),
           },
           nwk_key: {
-            key: randomByteString(16),
-            kek_label: 'default',
+            key: randomByteString(32),
           },
         }
       }

--- a/sdk/js/src/service/devices/index.js
+++ b/sdk/js/src/service/devices/index.js
@@ -188,12 +188,13 @@ class Devices {
 
   async create (applicationId, device, { abp = false, setDefaults = true, withRootKeys = false } = {}) {
     let dev = device
+    const Url = URL ? URL : window.URL
 
     if (setDefaults) {
       dev = {
-        application_server_address: new URL(this._stackConfig.as).host,
-        join_server_address: new URL(this._stackConfig.js).host,
-        network_server_address: new URL(this._stackConfig.ns).host,
+        application_server_address: new Url(this._stackConfig.as).host,
+        join_server_address: new Url(this._stackConfig.js).host,
+        network_server_address: new Url(this._stackConfig.ns).host,
         ...device,
       }
     }


### PR DESCRIPTION
**Summary:**
Closes #566 
Closes #567 
Closes #568

Referencing #332 

**Changes:**
- Change encoding of keys to hex in device key generation
- Fix usage of `URL` class in browsers
- Prevent rpc calls to JS when the device has `supports_join` set to `false`
- Fix faulty composition of default values with provided values

**Notes for Reviewers:**
It's a couple of quick fixes. See the respective issues. These are all necessary for #332 to work properly.

**Release Notes: _(optional)_**
- Change encoding of keys to hex in device key generation (JS SDK)
- Fix usage of `URL` class in browsers (JS SDK)
- Prevent rpc calls to JS when the device has `supports_join` set to `false` (JS SDK)
- Fix faulty composition of default values with provided values during device creation (JS SDK)
