### PR TITLE
Fix root keys retrieval in device overview

### DIFF
--- a/pkg/webui/console/views/device/index.js
+++ b/pkg/webui/console/views/device/index.js
@@ -70,7 +70,7 @@ export default class Device extends React.Component {
     const { dispatch, devId, match } = this.props
     const { appId } = match.params
 
-    dispatch(getDevice(appId, devId, 'name,description,session,version_ids', { ignoreNotFound: true }))
+    dispatch(getDevice(appId, devId, 'name,description,session,version_ids,root_keys', { ignoreNotFound: true }))
   }
 
   handleTabChange () {


### PR DESCRIPTION
**Summary:**
Closes #571 

**Changes:**
- Add `root_keys` to the selectors in the get device API call

**Notes for Reviewers:**
One line fix to properly show `root_key` info in the device overview.
