### PR TITLE
Component logging namespaces

### DIFF
--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -143,7 +143,7 @@ var (
 				if err != nil {
 					return shared.ErrInitializeNetworkServer.WithCause(err)
 				}
-				ns.Component.RegisterTask("queue_downlink", nsDownlinkTasks.Run, component.TaskRestartOnFailure)
+				ns.Component.RegisterTask(ns.Context(), "queue_downlink", nsDownlinkTasks.Run, component.TaskRestartOnFailure)
 			}
 
 			if start.ApplicationServer || startDefault {

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -49,6 +49,7 @@ import (
 // The Application Server exposes the As, AppAs and AsEndDeviceRegistry services.
 type ApplicationServer struct {
 	*component.Component
+	ctx context.Context
 
 	linkMode       LinkMode
 	linkRegistry   LinkRegistry
@@ -59,6 +60,11 @@ type ApplicationServer struct {
 	links              sync.Map
 	linkErrors         sync.Map
 	defaultSubscribers []*io.Subscription
+}
+
+// Context returns the context of the Application Server.
+func (as *ApplicationServer) Context() context.Context {
+	return as.ctx
 }
 
 var (
@@ -76,6 +82,7 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 	}
 	as = &ApplicationServer{
 		Component:      c,
+		ctx:            log.NewContextWithField(c.Context(), "namespace", "applicationserver"),
 		linkMode:       linkMode,
 		linkRegistry:   conf.Links,
 		deviceRegistry: conf.Devices,
@@ -92,7 +99,7 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 		},
 	}
 
-	ctx, cancel := context.WithCancel(c.Context())
+	ctx, cancel := context.WithCancel(as.Context())
 	defer func() {
 		if err != nil {
 			cancel()

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -160,7 +160,7 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 
 	c.RegisterGRPC(as)
 	if as.linkMode == LinkAll {
-		c.RegisterTask("link_all", as.linkAll, component.TaskRestartOnFailure)
+		c.RegisterTask(as.Context(), "link_all", as.linkAll, component.TaskRestartOnFailure)
 	}
 	return as, nil
 }

--- a/pkg/component/tasks.go
+++ b/pkg/component/tasks.go
@@ -45,6 +45,7 @@ var defaultTaskBackoff = [...]time.Duration{
 }
 
 type task struct {
+	ctx     context.Context
 	id      string
 	fn      TaskFunc
 	restart TaskRestart
@@ -52,8 +53,9 @@ type task struct {
 }
 
 // RegisterTask registers a task, optionally with restart policy and backoff, to be started after the component started.
-func (c *Component) RegisterTask(id string, fn TaskFunc, restart TaskRestart, backoff ...time.Duration) {
+func (c *Component) RegisterTask(ctx context.Context, id string, fn TaskFunc, restart TaskRestart, backoff ...time.Duration) {
 	c.tasks = append(c.tasks, task{
+		ctx:     ctx,
 		id:      id,
 		fn:      fn,
 		restart: restart,
@@ -104,6 +106,6 @@ func (c *Component) StartTask(ctx context.Context, id string, fn TaskFunc, resta
 
 func (c *Component) startTasks() {
 	for _, t := range c.tasks {
-		c.StartTask(c.ctx, t.id, t.fn, t.restart, 0.1, t.backoff...)
+		c.StartTask(t.ctx, t.id, t.fn, t.restart, 0.1, t.backoff...)
 	}
 }

--- a/pkg/component/tasks_test.go
+++ b/pkg/component/tasks_test.go
@@ -37,6 +37,7 @@ func init() {
 
 func TestTasks(t *testing.T) {
 	a := assertions.New(t)
+	ctx := test.Context()
 
 	c, err := New(test.GetLogger(t), &Config{})
 	a.So(err, should.BeNil)
@@ -44,7 +45,7 @@ func TestTasks(t *testing.T) {
 	// Register a one-off task.
 	oneOffWg := sync.WaitGroup{}
 	oneOffWg.Add(1)
-	c.RegisterTask("one_off", func(_ context.Context) error {
+	c.RegisterTask(ctx, "one_off", func(_ context.Context) error {
 		oneOffWg.Done()
 		return nil
 	}, TaskRestartNever)
@@ -52,7 +53,7 @@ func TestTasks(t *testing.T) {
 	restartingWg := sync.WaitGroup{}
 	restartingWg.Add(5)
 	i := 0
-	c.RegisterTask("restarts", func(_ context.Context) error {
+	c.RegisterTask(ctx, "restarts", func(_ context.Context) error {
 		i++
 		if i <= 5 {
 			restartingWg.Done()
@@ -64,7 +65,7 @@ func TestTasks(t *testing.T) {
 	failingWg := sync.WaitGroup{}
 	failingWg.Add(1)
 	j := 0
-	c.RegisterTask("restarts_on_failure", func(_ context.Context) error {
+	c.RegisterTask(ctx, "restarts_on_failure", func(_ context.Context) error {
 		j++
 		if j < 5 {
 			return errors.New("failed")

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -53,11 +53,17 @@ var connConcurrentUplinks = 16
 // The Gateway Server exposes the Gs, GtwGs and NsGs services and MQTT and UDP frontends for gateways.
 type GatewayServer struct {
 	*component.Component
+	ctx context.Context
 	io.Server
 
 	config *Config
 
 	connections sync.Map
+}
+
+// Context returns the context of the Gateway Server.
+func (gs *GatewayServer) Context() context.Context {
+	return gs.ctx
 }
 
 var (
@@ -72,10 +78,11 @@ var (
 func New(c *component.Component, conf *Config) (gs *GatewayServer, err error) {
 	gs = &GatewayServer{
 		Component: c,
+		ctx:       log.NewContextWithField(c.Context(), "namespace", "gatewayserver"),
 		config:    conf,
 	}
 
-	ctx, cancel := context.WithCancel(c.Context())
+	ctx, cancel := context.WithCancel(gs.Context())
 	defer func() {
 		if err != nil {
 			cancel()

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -39,6 +39,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/rpcmetadata"
 	"go.thethings.network/lorawan-stack/pkg/rpcmiddleware/hooks"
+	"go.thethings.network/lorawan-stack/pkg/rpcmiddleware/rpclog"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/unique"
 	"google.golang.org/grpc"
@@ -145,6 +146,7 @@ func New(c *component.Component, conf *Config) (gs *GatewayServer, err error) {
 		}
 	}
 
+	hooks.RegisterUnaryHook("/ttn.lorawan.v3.NsGs", rpclog.NamespaceHook, rpclog.UnaryNamespaceHook("gs"))
 	hooks.RegisterUnaryHook("/ttn.lorawan.v3.NsGs", cluster.HookName, c.ClusterAuthUnaryHook())
 
 	c.RegisterGRPC(gs)

--- a/pkg/identityserver/identityserver.go
+++ b/pkg/identityserver/identityserver.go
@@ -31,6 +31,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/oauth"
 	"go.thethings.network/lorawan-stack/pkg/redis"
 	"go.thethings.network/lorawan-stack/pkg/rpcmiddleware/hooks"
+	"go.thethings.network/lorawan-stack/pkg/rpcmiddleware/rpclog"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"google.golang.org/grpc"
 )
@@ -144,6 +145,7 @@ func New(c *component.Component, config *Config) (is *IdentityServer, err error)
 		name       string
 		middleware hooks.UnaryHandlerMiddleware
 	}{
+		{rpclog.NamespaceHook, rpclog.UnaryNamespaceHook("identityserver")},
 		{cluster.HookName, c.ClusterAuthUnaryHook()},
 		{rights.HookName, rights.Hook},
 	} {
@@ -159,7 +161,9 @@ func New(c *component.Component, config *Config) (is *IdentityServer, err error)
 		hooks.RegisterUnaryHook("/ttn.lorawan.v3.UserRegistry", hook.name, hook.middleware)
 		hooks.RegisterUnaryHook("/ttn.lorawan.v3.UserAccess", hook.name, hook.middleware)
 	}
+	hooks.RegisterUnaryHook("/ttn.lorawan.v3.EntityAccess", rpclog.NamespaceHook, rpclog.UnaryNamespaceHook("identityserver"))
 	hooks.RegisterUnaryHook("/ttn.lorawan.v3.EntityAccess", cluster.HookName, c.ClusterAuthUnaryHook())
+	hooks.RegisterUnaryHook("/ttn.lorawan.v3.OAuthAuthorizationRegistry", rpclog.NamespaceHook, rpclog.UnaryNamespaceHook("identityserver"))
 	hooks.RegisterUnaryHook("/ttn.lorawan.v3.OAuthAuthorizationRegistry", rights.HookName, rights.Hook)
 
 	c.RegisterGRPC(is)

--- a/pkg/identityserver/identityserver.go
+++ b/pkg/identityserver/identityserver.go
@@ -28,6 +28,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/email/sendgrid"
 	"go.thethings.network/lorawan-stack/pkg/email/smtp"
 	"go.thethings.network/lorawan-stack/pkg/identityserver/store"
+	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/oauth"
 	"go.thethings.network/lorawan-stack/pkg/redis"
 	"go.thethings.network/lorawan-stack/pkg/rpcmiddleware/hooks"
@@ -79,11 +80,17 @@ type Config struct {
 // OAuth clients, Gateways, Organizations and Users.
 type IdentityServer struct {
 	*component.Component
+	ctx    context.Context
 	config *Config
 	db     *gorm.DB
 	oauth  oauth.Server
 
 	redis *redis.Client
+}
+
+// Context returns the context of the Identity Server.
+func (is *IdentityServer) Context() context.Context {
+	return is.ctx
 }
 
 // SetRedisCache configures the given redis instance for caching.
@@ -106,6 +113,7 @@ func (is *IdentityServer) configFromContext(ctx context.Context) *Config {
 func New(c *component.Component, config *Config) (is *IdentityServer, err error) {
 	is = &IdentityServer{
 		Component: c,
+		ctx:       log.NewContextWithField(c.Context(), "namespace", "identityserver"),
 		config:    config,
 	}
 	is.db, err = store.Open(is.Context(), is.config.DatabaseURI)

--- a/pkg/joinserver/joinserver.go
+++ b/pkg/joinserver/joinserver.go
@@ -26,6 +26,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	"go.thethings.network/lorawan-stack/pkg/rpcmiddleware/hooks"
+	"go.thethings.network/lorawan-stack/pkg/rpcmiddleware/rpclog"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/types"
 	"google.golang.org/grpc"
@@ -78,6 +79,8 @@ func New(c *component.Component, conf *Config) (*JoinServer, error) {
 	js.grpc.nsJs = nsJsServer{JS: js}
 
 	// TODO: Support authentication from non-cluster-local NS and AS (https://github.com/TheThingsNetwork/lorawan-stack/issues/4).
+	hooks.RegisterUnaryHook("/ttn.lorawan.v3.NsJs", rpclog.NamespaceHook, rpclog.UnaryNamespaceHook("joinserver"))
+	hooks.RegisterUnaryHook("/ttn.lorawan.v3.AsJs", rpclog.NamespaceHook, rpclog.UnaryNamespaceHook("joinserver"))
 	hooks.RegisterUnaryHook("/ttn.lorawan.v3.NsJs", cluster.HookName, c.ClusterAuthUnaryHook())
 	hooks.RegisterUnaryHook("/ttn.lorawan.v3.AsJs", cluster.HookName, c.ClusterAuthUnaryHook())
 

--- a/pkg/joinserver/joinserver.go
+++ b/pkg/joinserver/joinserver.go
@@ -16,6 +16,7 @@
 package joinserver
 
 import (
+	"context"
 	"io"
 	"math/rand"
 	"sync"
@@ -25,6 +26,7 @@ import (
 	"github.com/oklog/ulid"
 	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/rpcmiddleware/hooks"
 	"go.thethings.network/lorawan-stack/pkg/rpcmiddleware/rpclog"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
@@ -44,6 +46,7 @@ type Config struct {
 // The Join Server exposes the NsJs and DeviceRegistry services.
 type JoinServer struct {
 	*component.Component
+	ctx context.Context
 
 	devices DeviceRegistry
 	keys    KeyRegistry
@@ -60,10 +63,16 @@ type JoinServer struct {
 	}
 }
 
+// Context returns the context of the Join Server.
+func (js *JoinServer) Context() context.Context {
+	return js.ctx
+}
+
 // New returns new *JoinServer.
 func New(c *component.Component, conf *Config) (*JoinServer, error) {
 	js := &JoinServer{
 		Component: c,
+		ctx:       log.NewContextWithField(c.Context(), "namespace", "joinserver"),
 
 		devices: conf.Devices,
 		keys:    conf.Keys,

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -28,6 +28,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/component"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/rpcmiddleware/hooks"
+	"go.thethings.network/lorawan-stack/pkg/rpcmiddleware/rpclog"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/types"
 	"go.thethings.network/lorawan-stack/pkg/unique"
@@ -296,6 +297,9 @@ func New(c *component.Component, conf *Config, opts ...Option) (*NetworkServer, 
 		}
 	}
 
+	hooks.RegisterUnaryHook("/ttn.lorawan.v3.GsNs", rpclog.NamespaceHook, rpclog.UnaryNamespaceHook("networkserver"))
+	hooks.RegisterStreamHook("/ttn.lorawan.v3.AsNs", rpclog.NamespaceHook, rpclog.StreamNamespaceHook("networkserver"))
+	hooks.RegisterUnaryHook("/ttn.lorawan.v3.AsNs", rpclog.NamespaceHook, rpclog.UnaryNamespaceHook("networkserver"))
 	hooks.RegisterUnaryHook("/ttn.lorawan.v3.GsNs", cluster.HookName, c.ClusterAuthUnaryHook())
 	hooks.RegisterStreamHook("/ttn.lorawan.v3.AsNs", cluster.HookName, c.ClusterAuthStreamHook())
 	hooks.RegisterUnaryHook("/ttn.lorawan.v3.AsNs", cluster.HookName, c.ClusterAuthUnaryHook())

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -312,7 +312,7 @@ func New(c *component.Component, conf *Config, opts ...Option) (*NetworkServer, 
 	hooks.RegisterStreamHook("/ttn.lorawan.v3.AsNs", cluster.HookName, c.ClusterAuthStreamHook())
 	hooks.RegisterUnaryHook("/ttn.lorawan.v3.AsNs", cluster.HookName, c.ClusterAuthUnaryHook())
 
-	ns.RegisterTask("process_downlink", func(ctx context.Context) error {
+	ns.RegisterTask(ns.Context(), "process_downlink", func(ctx context.Context) error {
 		for {
 			select {
 			case <-ctx.Done():

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -27,6 +27,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	"go.thethings.network/lorawan-stack/pkg/errors"
+	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/rpcmiddleware/hooks"
 	"go.thethings.network/lorawan-stack/pkg/rpcmiddleware/rpclog"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
@@ -110,6 +111,7 @@ type DownlinkPriorities struct {
 // The Network Server exposes the GsNs, AsNs, DeviceRegistry and ApplicationDownlinkQueue services.
 type NetworkServer struct {
 	*component.Component
+	ctx context.Context
 
 	devices DeviceRegistry
 
@@ -136,6 +138,11 @@ type NetworkServer struct {
 	handleASUplink func(ctx context.Context, ids ttnpb.ApplicationIdentifiers, up *ttnpb.ApplicationUp) (bool, error)
 
 	defaultMACSettings ttnpb.MACSettings
+}
+
+// Context returns the context of the Network Server.
+func (ns *NetworkServer) Context() context.Context {
+	return ns.ctx
 }
 
 // Option configures the NetworkServer.
@@ -214,6 +221,7 @@ func New(c *component.Component, conf *Config, opts ...Option) (*NetworkServer, 
 	}
 	ns := &NetworkServer{
 		Component:               c,
+		ctx:                     log.NewContextWithField(c.Context(), "namespace", "networkserver"),
 		devices:                 conf.Devices,
 		netID:                   conf.NetID,
 		devAddrPrefixes:         devAddrPrefixes,

--- a/pkg/rpcmiddleware/rpclog/namespaces.go
+++ b/pkg/rpcmiddleware/rpclog/namespaces.go
@@ -1,0 +1,47 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpclog
+
+import (
+	"context"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware"
+	"go.thethings.network/lorawan-stack/pkg/log"
+	"go.thethings.network/lorawan-stack/pkg/rpcmiddleware/hooks"
+	"google.golang.org/grpc"
+)
+
+const NamespaceHook = "namespace"
+
+// UnaryNamespaceHook adds the component namespace to the context of the unary call.
+func UnaryNamespaceHook(namespace string) hooks.UnaryHandlerMiddleware {
+	return func(h grpc.UnaryHandler) grpc.UnaryHandler {
+		return func(ctx context.Context, req interface{}) (interface{}, error) {
+			ctx = log.NewContextWithField(ctx, "namespace", namespace)
+			return h(ctx, req)
+		}
+	}
+}
+
+// StreamNamespaceHook adds the component namespace to the context of the stream.
+func StreamNamespaceHook(namespace string) hooks.StreamHandlerMiddleware {
+	return func(h grpc.StreamHandler) grpc.StreamHandler {
+		return func(srv interface{}, stream grpc.ServerStream) error {
+			wrapped := grpc_middleware.WrapServerStream(stream)
+			wrapped.WrappedContext = log.NewContextWithField(stream.Context(), "namespace", namespace)
+			return h(srv, wrapped)
+		}
+	}
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #334

**Changes:**
<!-- What are the changes made in this pull request? -->

- Added the component namespaces logging hooks to `rpcmiddleware/rpclog`
- Added said hooks to GS/NS/IS/JS

**Notes for Reviewers:**
<!--
Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I've implemented it based on @htdvisser suggestion, with a slight change in component names (`GsNs` instead of simply `Ns` and so forth).

**Release Notes:**
<!--
Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Added logging namespaces to the gRPC calls.
