### PR TITLE
Display of empty config slices

### DIFF
--- a/cmd/internal/commands/config.go
+++ b/cmd/internal/commands/config.go
@@ -104,7 +104,7 @@ func Config(mgr *config.Manager) *cobra.Command {
 					}
 				}
 				if empty {
-					continue
+					val = ""
 				}
 				if useEnv {
 					fmt.Fprintf(cmd.OutOrStdout(), "%s=\"%v\"\n", flagOrEnv, val)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

**Summary:**
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #576 

**Changes:**
<!-- What are the changes made in this pull request? -->

- Added empty string print in case a config with a certain flag is empty

I don't have rights to add reviewers and assign myself etc., so:
cc @htdvisser @johanstokking 
