### PR TITLE
Add configuration service to JS SDK

### DIFF
--- a/sdk/js/src/api/http.js
+++ b/sdk/js/src/api/http.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import axios from 'axios'
+import { STACK_COMPONENTS } from '../util/constants'
 
 /**
  * Http Class is a connector for the API that uses the HTTP bridge to connect.
@@ -58,10 +59,10 @@ class Http {
     }
   }
 
-  async handleRequest (method, endpoint, payload = {}, config) {
-    const component = this._parseStackComponent(endpoint)
+  async handleRequest (method, endpoint, component, payload = {}, config) {
+    const parsedComponent = component || this._parseStackComponent(endpoint)
     try {
-      return await this[component]({
+      return await this[parsedComponent]({
         method,
         url: endpoint,
         data: payload,
@@ -76,7 +77,7 @@ class Http {
     }
   }
 
-  async get (endpoint, params) {
+  async get (endpoint, component, params) {
     // Convert payload to query params (should usually be field_mask only)
     const config = {}
     if (params && Object.keys(params).length > 0) {
@@ -87,23 +88,23 @@ class Http {
       config.params = params
     }
 
-    return this.handleRequest('get', endpoint, undefined, config)
+    return this.handleRequest('get', endpoint, component, undefined, config)
   }
 
-  async post (endpoint, payload) {
-    return this.handleRequest('post', endpoint, payload)
+  async post (endpoint, component, payload) {
+    return this.handleRequest('post', endpoint, component, payload)
   }
 
-  async patch (endpoint, payload) {
-    return this.handleRequest('patch', endpoint, payload)
+  async patch (endpoint, component, payload) {
+    return this.handleRequest('patch', endpoint, component, payload)
   }
 
-  async put (endpoint, payload) {
-    return this.handleRequest('put', endpoint, payload)
+  async put (endpoint, component, payload) {
+    return this.handleRequest('put', endpoint, component, payload)
   }
 
-  async delete (endpoint) {
-    return this.handleRequest('delete', endpoint)
+  async delete (endpoint, component) {
+    return this.handleRequest('delete', component, endpoint)
   }
 
   /**
@@ -114,15 +115,7 @@ class Http {
   _parseStackComponent (endpoint) {
     try {
       const component = endpoint.split('/')[1]
-      switch (component) {
-      case 'as':
-      case 'gs':
-      case 'js':
-      case 'ns':
-        return component
-      default:
-        return 'is'
-      }
+      return STACK_COMPONENTS.includes(component) ? component : 'is'
     } catch (err) {
       throw new Error('Unable to extract the stack component:', endpoint)
     }

--- a/sdk/js/src/api/index.test.js
+++ b/sdk/js/src/api/index.test.js
@@ -69,7 +69,7 @@ describe('API', function () {
     api.ApplicationRegistry.Create({ routeParams: { 'collaborator.user_ids.user_id': 'test' }}, { name: 'test-name' })
 
     expect(api._connector.post).toHaveBeenCalledTimes(1)
-    expect(api._connector.post).toHaveBeenCalledWith('/users/test/applications', { name: 'test-name' })
+    expect(api._connector.post).toHaveBeenCalledWith('/users/test/applications', undefined, { name: 'test-name' })
   })
 
   test('it throws when parameters mismatch', function () {
@@ -82,6 +82,6 @@ describe('API', function () {
     api.ApplicationRegistry.List(undefined, { limit: 2, page: 1 })
 
     expect(api._connector.get).toHaveBeenCalledTimes(1)
-    expect(api._connector.get).toHaveBeenCalledWith('/applications', { limit: 2, page: 1 })
+    expect(api._connector.get).toHaveBeenCalledWith('/applications', undefined, { limit: 2, page: 1 })
   })
 })

--- a/sdk/js/src/index.js
+++ b/sdk/js/src/index.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Applications from './service/applications'
+import Configuration from './service/configuration'
 import Application from './entity/application'
 import Api from './api'
 import Token from './util/token'
@@ -31,6 +32,8 @@ class TtnLw {
 
     this.Applications = new Applications(this.api, { defaultUserId, proxy, stackConfig })
     this.Application = Application.bind(null, this.Applications)
+
+    this.Configuration = new Configuration(this.api.Configuration)
   }
 }
 

--- a/sdk/js/src/service/configuration.js
+++ b/sdk/js/src/service/configuration.js
@@ -1,0 +1,35 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Marshaler from '../util/marshaler'
+
+class Configuration {
+  constructor (service) {
+    this._api = service
+  }
+
+  async listNsFrequencyPlans (appId) {
+    const result = await this._api.ListFrequencyPlans({ component: 'ns' })
+
+    return Marshaler.payloadListResponse('frequency_plans', result)
+  }
+
+  async listGsFrequencyPlans (appId) {
+    const result = await this._api.ListFrequencyPlans({ component: 'gs' })
+
+    return Marshaler.payloadListResponse('frequency_plans', result)
+  }
+}
+
+export default Configuration

--- a/sdk/js/src/util/constants.js
+++ b/sdk/js/src/util/constants.js
@@ -1,0 +1,21 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable import/prefer-default-export */
+
+const STACK_COMPONENTS = [ 'as', 'is', 'ns', 'js', 'gs' ]
+
+export {
+  STACK_COMPONENTS,
+}


### PR DESCRIPTION
#### Summary
Closes #588
References: #573 

#### Changes
- Add a module with constants used throughout
- Add functionality to the api/http class to choose which component to query with an RPC based on the `config.component` value passed to the service function
  - The `Configuration.ListFrequencyPlans` rpc is exposed globally, but can return different values depending on what component it is queried against (NS gives frequency plans for device, GS for gateways)
- Add the configuration service

#### Release Notes
- Added configuration service to JS SDK
