### PR TITLE
ci: Use proxy.golang.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ go: 1.12.x
 go_import_path: go.thethings.network/lorawan-stack
 env:
   global:
+  - GOPROXY=https://proxy.golang.org
   - YARN_CACHE_FOLDER=$HOME/.cache/yarn
   - MAGE=$HOME/.cache/mage/mage
   - TEST_SLOWDOWN=8


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Yesterday the Go team [announced](https://groups.google.com/forum/#!topic/golang-dev/go6_lZqew6g) the launch of proxy.golang.org. This PR updates our travis.yml to use the proxy for faster module downloads.
