### PR TITLE
Fix ChannelMask in LinkADRReq mismatch with the frequency_plan

### DIFF
--- a/pkg/networkserver/mac_link_adr.go
+++ b/pkg/networkserver/mac_link_adr.go
@@ -77,13 +77,13 @@ func enqueueLinkADRReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, ma
 			return nil, 0, false
 		}
 		cmds := make([]*ttnpb.MACCommand, 0, len(desiredMasks))
-		for _, m := range desiredMasks {
+		for i, m := range desiredMasks {
 			pld := &ttnpb.MACCommand_LinkADRReq{
 				DataRateIndex:      dev.MACState.DesiredParameters.ADRDataRateIndex,
 				NbTrans:            dev.MACState.DesiredParameters.ADRNbTrans,
 				TxPowerIndex:       dev.MACState.DesiredParameters.ADRTxPowerIndex,
 				ChannelMaskControl: uint32(m.Cntl),
-				ChannelMask:        m.Mask[:],
+				ChannelMask:        desiredMasks[i].Mask[:],
 			}
 			cmds = append(cmds, pld.MACCommand())
 			events.Publish(evtEnqueueLinkADRRequest(ctx, dev.EndDeviceIdentifiers, pld))


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #586 

#### Changes
<!-- What are the changes made in this pull request? -->

- Pass the memory address of origin array to ChannelMask slice.
