### PR TITLE
GS UDP late scheduling and encoding fixes

### DIFF
--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -356,14 +356,14 @@ func (s *srv) handleDown(ctx context.Context, state *state) error {
 				}
 			}
 			canImmediate := atomic.LoadUint32(&state.receivedTxAck) == 1
-			preferLate := state.io.Gateway().ScheduleDownlinkLate
-			if canImmediate || !preferLate {
+			forceLate := state.io.Gateway().ScheduleDownlinkLate
+			if canImmediate && !forceLate {
 				write()
 				break
 			}
 			gatewayTime, err := state.clock(tx.Tmst)
 			if err != nil {
-				logger.Warn("Schedule late preferred but no gateway clock available")
+				logger.Warn("Schedule late forced but no gateway clock available")
 				write()
 				break
 			}

--- a/pkg/ttnpb/udp/packet_data.go
+++ b/pkg/ttnpb/udp/packet_data.go
@@ -64,8 +64,8 @@ type TxPacket struct {
 	Tmms *uint64      `json:"tmms,omitempty"` // Send packet at a certain GPS time (GPS synchronization required)
 	Time *CompactTime `json:"time,omitempty"` // Send packet at a certain time (GPS synchronization required)
 	Freq float64      `json:"freq"`           // Tx central frequency in MHz (unsigned float, Hz precision)
-	Brd  uint8        `json:"brd"`            // Concentrator board used for Tx (unsigned integer)
-	Ant  uint8        `json:"ant"`            // Concentrator antenna used for Tx (unsigned integer)
+	Brd  uint8        `json:"brd,omitempty"`  // Concentrator board used for Tx (unsigned integer)
+	Ant  uint8        `json:"ant,omitempty"`  // Concentrator antenna used for Tx (unsigned integer)
 	RFCh uint8        `json:"rfch"`           // Concentrator "RF chain" used for Tx (unsigned integer)
 	Powe uint8        `json:"powe"`           // Tx output power in dBm (unsigned integer, dBm precision)
 	Modu string       `json:"modu"`           // Modulation identifier "LORA" or "FSK"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #608 
Closes #609 

#### Changes
<!-- What are the changes made in this pull request? -->

- Schedule late is now default; setting it to false has no effect if there's no JIT queue
- Remove fields that some UDP compatible forwarders don't understand

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Made late scheduling default for gateways connected over UDP to avoid overwriting queued downlink
- Fixed UDP downlink format for older forwarders