### PR TITLE
Fix preserving priority and class B/C settings in application downlink

### DIFF
--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -725,6 +725,7 @@ func (as *ApplicationServer) recalculateDownlinkQueue(ctx context.Context, dev *
 			FCnt:           newSession.LastAFCntDown + 1,
 			Confirmed:      oldItem.Confirmed,
 			ClassBC:        oldItem.ClassBC,
+			Priority:       oldItem.Priority,
 			CorrelationIDs: oldItem.CorrelationIDs,
 		}
 		newItem.FRMPayload, err = crypto.EncryptDownlink(newAppSKey, newSession.DevAddr, newItem.FCnt, frmPayload)

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -329,13 +329,13 @@ func (as *ApplicationServer) downlinkQueueOp(ctx context.Context, ids ttnpb.EndD
 // DownlinkQueuePush pushes the given downlink messages to the end device's application downlink queue.
 // This operation changes FRMPayload in the given items.
 func (as *ApplicationServer) DownlinkQueuePush(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, items []*ttnpb.ApplicationDownlink) error {
-	return as.downlinkQueueOp(ctx, ids, items, ttnpb.AsNsClient.DownlinkQueuePush)
+	return as.downlinkQueueOp(ctx, ids, io.CleanDownlinks(items), ttnpb.AsNsClient.DownlinkQueuePush)
 }
 
 // DownlinkQueueReplace replaces the end device's application downlink queue with the given downlink messages.
 // This operation changes FRMPayload in the given items.
 func (as *ApplicationServer) DownlinkQueueReplace(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, items []*ttnpb.ApplicationDownlink) error {
-	return as.downlinkQueueOp(ctx, ids, items, ttnpb.AsNsClient.DownlinkQueueReplace)
+	return as.downlinkQueueOp(ctx, ids, io.CleanDownlinks(items), ttnpb.AsNsClient.DownlinkQueueReplace)
 }
 
 var errNoAppSKey = errors.DefineCorruption("no_app_s_key", "no AppSKey")

--- a/pkg/applicationserver/io/grpc/grpc.go
+++ b/pkg/applicationserver/io/grpc/grpc.go
@@ -73,24 +73,11 @@ func (s *impl) Subscribe(ids *ttnpb.ApplicationIdentifiers, stream ttnpb.AppAs_S
 	}
 }
 
-func clean(items []*ttnpb.ApplicationDownlink) []*ttnpb.ApplicationDownlink {
-	res := make([]*ttnpb.ApplicationDownlink, 0, len(items))
-	for _, item := range items {
-		res = append(res, &ttnpb.ApplicationDownlink{
-			FPort:          item.FPort,
-			FRMPayload:     item.FRMPayload,
-			DecodedPayload: item.DecodedPayload,
-			Confirmed:      item.Confirmed,
-		})
-	}
-	return res
-}
-
 func (s *impl) DownlinkQueuePush(ctx context.Context, req *ttnpb.DownlinkQueueRequest) (*pbtypes.Empty, error) {
 	if err := rights.RequireApplication(ctx, req.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_TRAFFIC_DOWN_WRITE); err != nil {
 		return nil, err
 	}
-	if err := s.server.DownlinkQueuePush(ctx, req.EndDeviceIdentifiers, clean(req.Downlinks)); err != nil {
+	if err := s.server.DownlinkQueuePush(ctx, req.EndDeviceIdentifiers, req.Downlinks); err != nil {
 		return nil, err
 	}
 	return ttnpb.Empty, nil
@@ -100,7 +87,7 @@ func (s *impl) DownlinkQueueReplace(ctx context.Context, req *ttnpb.DownlinkQueu
 	if err := rights.RequireApplication(ctx, req.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_TRAFFIC_DOWN_WRITE); err != nil {
 		return nil, err
 	}
-	if err := s.server.DownlinkQueueReplace(ctx, req.EndDeviceIdentifiers, clean(req.Downlinks)); err != nil {
+	if err := s.server.DownlinkQueueReplace(ctx, req.EndDeviceIdentifiers, req.Downlinks); err != nil {
 		return nil, err
 	}
 	return ttnpb.Empty, nil

--- a/pkg/applicationserver/io/grpc/grpc_test.go
+++ b/pkg/applicationserver/io/grpc/grpc_test.go
@@ -208,7 +208,7 @@ func TestTraffic(t *testing.T) {
 						FCnt:           100, // This gets discarded.
 						FRMPayload:     []byte{0x01, 0x01, 0x01},
 						Confirmed:      true,
-						CorrelationIDs: []string{"test"}, // This gets discarded.
+						CorrelationIDs: []string{"test"},
 					},
 					{
 						FPort:      2,
@@ -236,9 +236,10 @@ func TestTraffic(t *testing.T) {
 			a.So(res.Downlinks, should.HaveLength, 3)
 			a.So(res.Downlinks, should.Resemble, []*ttnpb.ApplicationDownlink{
 				{
-					FPort:      1,
-					Confirmed:  true,
-					FRMPayload: []byte{0x01, 0x01, 0x01},
+					FPort:          1,
+					Confirmed:      true,
+					FRMPayload:     []byte{0x01, 0x01, 0x01},
+					CorrelationIDs: []string{"test"},
 				},
 				{
 					FPort:      2,

--- a/pkg/applicationserver/io/io.go
+++ b/pkg/applicationserver/io/io.go
@@ -95,3 +95,20 @@ func (s *Subscription) SendUp(up *ttnpb.ApplicationUp) error {
 func (s *Subscription) Up() <-chan *ttnpb.ApplicationUp {
 	return s.upCh
 }
+
+// CleanDownlinks returns a copy of the given downlink items with only the fields that can be set by the application.
+func CleanDownlinks(items []*ttnpb.ApplicationDownlink) []*ttnpb.ApplicationDownlink {
+	res := make([]*ttnpb.ApplicationDownlink, 0, len(items))
+	for _, item := range items {
+		res = append(res, &ttnpb.ApplicationDownlink{
+			FPort:          item.FPort,
+			FRMPayload:     item.FRMPayload,
+			DecodedPayload: item.DecodedPayload,
+			ClassBC:        item.ClassBC,
+			Priority:       item.Priority,
+			Confirmed:      item.Confirmed,
+			CorrelationIDs: item.CorrelationIDs,
+		})
+	}
+	return res
+}

--- a/pkg/applicationserver/io/mock/server.go
+++ b/pkg/applicationserver/io/mock/server.go
@@ -67,7 +67,7 @@ func (s *server) Subscribe(ctx context.Context, protocol string, ids ttnpb.Appli
 func (s *server) DownlinkQueuePush(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, items []*ttnpb.ApplicationDownlink) error {
 	s.downlinkQueueMu.Lock()
 	uid := unique.ID(ctx, ids)
-	s.downlinkQueue[uid] = append(s.downlinkQueue[uid], items...)
+	s.downlinkQueue[uid] = append(s.downlinkQueue[uid], io.CleanDownlinks(items)...)
 	s.downlinkQueueMu.Unlock()
 	return nil
 }
@@ -75,7 +75,7 @@ func (s *server) DownlinkQueuePush(ctx context.Context, ids ttnpb.EndDeviceIdent
 // DownlinkQueueReplace implements io.Server.
 func (s *server) DownlinkQueueReplace(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, items []*ttnpb.ApplicationDownlink) error {
 	s.downlinkQueueMu.Lock()
-	s.downlinkQueue[unique.ID(ctx, ids)] = items
+	s.downlinkQueue[unique.ID(ctx, ids)] = io.CleanDownlinks(items)
 	s.downlinkQueueMu.Unlock()
 	return nil
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #625 

#### Changes
<!-- What are the changes made in this pull request? -->

- Promote `clean()` from gRPC frontend to AS-level, so it also gets done for UDP and gRPC frontends. Also make sure that the user defined fields are allowed there (i.e. `ClassBC` and `Priority` got discarded)
- Preserve priority in downlink queue recalculation

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Fixed preserving user defined priority for application downlink
- Made sure that non-user definable fields of downlink messages get discarded across all Application Server frontends