### PR TITLE
Fix GS absolute downlink timing in UDP

### DIFF
--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -332,6 +332,8 @@ func (c *Connection) SendDown(path *ttnpb.DownlinkPath, msg *ttnpb.DownlinkMessa
 				errRxDetails = append(errRxDetails, errRxWindowSchedule.WithCause(err).WithAttributes("window", i+1))
 				continue
 			}
+			settings.Time = nil
+			settings.Timestamp = uint32(time.Duration(em.Starts()) / time.Microsecond)
 			msg.Settings = &ttnpb.DownlinkMessage_Scheduled{
 				Scheduled: &settings,
 			}

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -373,7 +373,7 @@ func (s *srv) handleDown(ctx context.Context, state *state) error {
 		case <-healthCheck.C:
 			lastSeenPull := time.Unix(0, atomic.LoadInt64(&state.lastSeenPull))
 			if time.Since(lastSeenPull) > s.config.DownlinkPathExpires {
-				logger.Warn("Downlink path expired")
+				logger.Debug("Downlink path expired")
 				s.server.UnclaimDownlink(ctx, state.io.Gateway().GatewayIdentifiers)
 				state.lastDownlinkPath.Store(downlinkPath{})
 				state.startHandleDownMu.Lock()
@@ -426,7 +426,7 @@ func (s *srv) gc() {
 					if time.Since(lastSeenPush) > s.config.ConnectionExpires {
 						select {
 						case <-state.ioWait:
-							logger.WithField("gateway_eui", k.(types.EUI64)).Warn("Connection expired")
+							logger.WithField("gateway_eui", k.(types.EUI64)).Debug("Connection expired")
 							s.connections.Delete(k)
 							state.io.Disconnect(errConnectionExpired)
 						default:

--- a/pkg/gatewayserver/io/udp/udp_test.go
+++ b/pkg/gatewayserver/io/udp/udp_test.go
@@ -45,8 +45,8 @@ var (
 	testConfig = Config{
 		PacketHandlers:      2,
 		PacketBuffer:        10,
-		DownlinkPathExpires: 5 * timeout,
-		ConnectionExpires:   12 * timeout,
+		DownlinkPathExpires: 8 * timeout,
+		ConnectionExpires:   20 * timeout,
 		ScheduleLateTime:    0,
 	}
 )
@@ -355,7 +355,7 @@ func TestTraffic(t *testing.T) {
 					Path: &ttnpb.DownlinkPath_UplinkToken{
 						UplinkToken: io.MustUplinkToken(
 							ttnpb.GatewayAntennaIdentifiers{GatewayIdentifiers: registeredGatewayID},
-							uint32(150*test.Delay/time.Microsecond),
+							uint32(300*test.Delay/time.Microsecond),
 						),
 					},
 				},
@@ -381,12 +381,12 @@ func TestTraffic(t *testing.T) {
 				Packet:        generatePullData(eui2),
 				AckOK:         true,
 				ExpectConnect: false,
-				SyncClock:     1*time.Second + 150*test.Delay, // Rx1 delay + start time
+				SyncClock:     1*time.Second + 300*test.Delay, // Rx1 delay + start time
 				Path: &ttnpb.DownlinkPath{
 					Path: &ttnpb.DownlinkPath_UplinkToken{
 						UplinkToken: io.MustUplinkToken(
 							ttnpb.GatewayAntennaIdentifiers{GatewayIdentifiers: registeredGatewayID},
-							uint32(300*test.Delay/time.Microsecond),
+							uint32(600*test.Delay/time.Microsecond),
 						),
 					},
 				},
@@ -417,7 +417,7 @@ func TestTraffic(t *testing.T) {
 					Path: &ttnpb.DownlinkPath_UplinkToken{
 						UplinkToken: io.MustUplinkToken(
 							ttnpb.GatewayAntennaIdentifiers{GatewayIdentifiers: registeredGatewayID},
-							uint32((15*time.Second+150*test.Delay)/time.Microsecond),
+							uint32((15*time.Second+300*test.Delay)/time.Microsecond),
 						),
 					},
 				},
@@ -464,7 +464,7 @@ func TestTraffic(t *testing.T) {
 					t.SkipNow()
 				}
 
-				// Sync the clock at 0, i.e. approximate time.Now().
+				// Sync the clock at the given time.
 				var clockSynced time.Time
 				packet := generatePushData(eui2, false, tc.SyncClock)
 				buf, err = packet.MarshalBinary()
@@ -489,10 +489,9 @@ func TestTraffic(t *testing.T) {
 				}
 
 				// Set expected time for the pull response.
-				expectedTime := time.Now()
+				expectedTime := clockSynced
 				if tc.ScheduledLate {
 					expectedTime = expectedTime.Add(-tc.SyncClock)
-					expectedTime = expectedTime.Add(-time.Since(clockSynced))
 					expectedTime = expectedTime.Add(time.Duration(tc.Message.GetScheduled().Timestamp) * time.Microsecond)
 					expectedTime = expectedTime.Add(-testConfig.ScheduleLateTime)
 				}

--- a/pkg/gatewayserver/scheduling/clock.go
+++ b/pkg/gatewayserver/scheduling/clock.go
@@ -23,12 +23,14 @@ import (
 type Clock interface {
 	// IsSynced returns whether the clock is synchronized.
 	IsSynced() bool
-	// ServerTime returns an indication of the concentrator time at the given server time.
-	ServerTime(server time.Time) ConcentratorTime
-	// GatewayTime returns an indication of the concentrator time at the given gateway time if available.
-	GatewayTime(time.Time) (ConcentratorTime, bool)
-	// TimestampTime returns the concentrator time for the given timestamp.
-	TimestampTime(timestamp uint32) ConcentratorTime
+	// FromServerTime returns an indication of the concentrator time at the given server time.
+	FromServerTime(time.Time) ConcentratorTime
+	// ToServerTime returns an indication of the server time at the given concentrator time.
+	ToServerTime(ConcentratorTime) time.Time
+	// FromGatewayTime returns an indication of the concentrator time at the given gateway time if available.
+	FromGatewayTime(time.Time) (ConcentratorTime, bool)
+	// FromTimestampTime returns the concentrator time for the given timestamp.
+	FromTimestampTime(timestamp uint32) ConcentratorTime
 }
 
 // RolloverClock is a Clock that takes roll-over of a uint32 microsecond concentrator time into account.
@@ -45,7 +47,7 @@ func (c *RolloverClock) IsSynced() bool { return c.synced }
 
 // Sync synchronizes the clock with the given concentrator time v and the server time.
 func (c *RolloverClock) Sync(timestamp uint32, server time.Time) {
-	c.absolute = c.TimestampTime(timestamp)
+	c.absolute = c.FromTimestampTime(timestamp)
 	c.relative = timestamp
 	c.server = server
 	c.gateway = nil
@@ -59,21 +61,26 @@ func (c *RolloverClock) SyncWithGateway(timestamp uint32, server, gateway time.T
 	c.gateway = &gateway
 }
 
-// ServerTime implements Clock.
-func (c *RolloverClock) ServerTime(server time.Time) ConcentratorTime {
+// FromServerTime implements Clock.
+func (c *RolloverClock) FromServerTime(server time.Time) ConcentratorTime {
 	return c.absolute + ConcentratorTime(server.Sub(c.server))
 }
 
-// GatewayTime implements Clock.
-func (c *RolloverClock) GatewayTime(gateway time.Time) (ConcentratorTime, bool) {
+// ToServerTime implements Clock.
+func (c *RolloverClock) ToServerTime(t ConcentratorTime) time.Time {
+	return c.server.Add(time.Duration(t - c.absolute))
+}
+
+// FromGatewayTime implements Clock.
+func (c *RolloverClock) FromGatewayTime(gateway time.Time) (ConcentratorTime, bool) {
 	if c.gateway == nil {
 		return 0, false
 	}
 	return c.absolute + ConcentratorTime(gateway.Sub(*c.gateway)), true
 }
 
-// TimestampTime implements Clock.
-func (c *RolloverClock) TimestampTime(timestamp uint32) ConcentratorTime {
+// FromTimestampTime implements Clock.
+func (c *RolloverClock) FromTimestampTime(timestamp uint32) ConcentratorTime {
 	passed := int64(timestamp) - int64(c.relative)
 	if passed < 0 {
 		passed += math.MaxUint32

--- a/pkg/gatewayserver/scheduling/scheduler.go
+++ b/pkg/gatewayserver/scheduling/scheduler.go
@@ -163,19 +163,19 @@ func (s *Scheduler) ScheduleAt(ctx context.Context, payloadSize int, settings tt
 		}
 	}
 	var starts ConcentratorTime
-	now := s.clock.ServerTime(s.timeSource.Now())
+	now := s.clock.FromServerTime(s.timeSource.Now())
 	if settings.Time != nil {
 		var ok bool
-		starts, ok = s.clock.GatewayTime(*settings.Time)
+		starts, ok = s.clock.FromGatewayTime(*settings.Time)
 		if !ok {
 			if medianRTT != nil {
-				starts = s.clock.ServerTime(*settings.Time) - ConcentratorTime(*medianRTT/2)
+				starts = s.clock.FromServerTime(*settings.Time) - ConcentratorTime(*medianRTT/2)
 			} else {
 				return Emission{}, errNoAbsoluteGatewayTime
 			}
 		}
 	} else {
-		starts = s.clock.TimestampTime(settings.Timestamp)
+		starts = s.clock.FromTimestampTime(settings.Timestamp)
 	}
 	if delta := time.Duration(starts - now); delta < minScheduleTime {
 		return Emission{}, errTooLate.WithAttributes("delta", delta)
@@ -223,13 +223,13 @@ func (s *Scheduler) ScheduleAnytime(ctx context.Context, payloadSize int, settin
 		}
 	}
 	var starts ConcentratorTime
-	now := s.clock.ServerTime(s.timeSource.Now())
+	now := s.clock.FromServerTime(s.timeSource.Now())
 	if settings.Timestamp == 0 && settings.Time == nil {
 		starts = now + ConcentratorTime(ScheduleTimeLong)
 		settings.Timestamp = uint32(time.Duration(starts) / time.Microsecond)
 	} else if settings.Time != nil {
 		var ok bool
-		starts, ok = s.clock.GatewayTime(*settings.Time)
+		starts, ok = s.clock.FromGatewayTime(*settings.Time)
 		if !ok {
 			return Emission{}, errNoAbsoluteGatewayTime
 		}
@@ -239,7 +239,7 @@ func (s *Scheduler) ScheduleAnytime(ctx context.Context, payloadSize int, settin
 			settings.Time = &t
 		}
 	} else {
-		starts = s.clock.TimestampTime(settings.Timestamp)
+		starts = s.clock.FromTimestampTime(settings.Timestamp)
 		if delta := minScheduleTime - time.Duration(starts-now); delta > 0 {
 			starts += ConcentratorTime(delta)
 			settings.Timestamp += uint32(delta / time.Microsecond)
@@ -314,5 +314,5 @@ func (s *Scheduler) Now() (ConcentratorTime, bool) {
 	if !s.clock.IsSynced() {
 		return 0, false
 	}
-	return s.clock.ServerTime(s.timeSource.Now()), true
+	return s.clock.FromServerTime(s.timeSource.Now()), true
 }

--- a/pkg/gatewayserver/scheduling/scheduler.go
+++ b/pkg/gatewayserver/scheduling/scheduler.go
@@ -216,7 +216,7 @@ func (s *Scheduler) ScheduleAnytime(ctx context.Context, payloadSize int, settin
 	if !s.clock.IsSynced() {
 		return Emission{}, errNoClockSync
 	}
-	minScheduleTime := ScheduleTimeShort
+	var minScheduleTime = ScheduleTimeShort
 	if rtts != nil {
 		if _, max, _, n := rtts.Stats(); n > 0 {
 			minScheduleTime = max + QueueDelay
@@ -224,20 +224,9 @@ func (s *Scheduler) ScheduleAnytime(ctx context.Context, payloadSize int, settin
 	}
 	var starts ConcentratorTime
 	now := s.clock.FromServerTime(s.timeSource.Now())
-	if settings.Timestamp == 0 && settings.Time == nil {
+	if settings.Timestamp == 0 {
 		starts = now + ConcentratorTime(ScheduleTimeLong)
 		settings.Timestamp = uint32(time.Duration(starts) / time.Microsecond)
-	} else if settings.Time != nil {
-		var ok bool
-		starts, ok = s.clock.FromGatewayTime(*settings.Time)
-		if !ok {
-			return Emission{}, errNoAbsoluteGatewayTime
-		}
-		if delta := minScheduleTime - time.Duration(starts-now); delta > 0 {
-			starts += ConcentratorTime(delta)
-			t := settings.Time.Add(delta)
-			settings.Time = &t
-		}
 	} else {
 		starts = s.clock.FromTimestampTime(settings.Timestamp)
 		if delta := minScheduleTime - time.Duration(starts-now); delta > 0 {

--- a/pkg/gatewayserver/scheduling/scheduler_test.go
+++ b/pkg/gatewayserver/scheduling/scheduler_test.go
@@ -469,9 +469,9 @@ func TestScheduleAnytimeShort(t *testing.T) {
 		scheduler, err := scheduling.NewScheduler(ctx, fp, true, timeSource)
 		a.So(err, should.BeNil)
 		scheduler.SyncWithGateway(0, timeSource.Time, time.Unix(0, 0))
-		em, err := scheduler.ScheduleAnytime(ctx, 10, settingsAt(869525000, 7, timePtr(time.Unix(0, int64(100*time.Millisecond))), 0), nil, ttnpb.TxSchedulePriority_NORMAL)
+		em, err := scheduler.ScheduleAnytime(ctx, 10, settingsAt(869525000, 7, nil, 0), nil, ttnpb.TxSchedulePriority_NORMAL)
 		a.So(err, should.BeNil)
-		a.So(time.Duration(em.Starts()), should.Equal, scheduling.ScheduleTimeShort)
+		a.So(time.Duration(em.Starts()), should.Equal, scheduling.ScheduleTimeLong)
 	}
 
 	// Gateway time; too late (10 ms) with RTT.
@@ -486,9 +486,9 @@ func TestScheduleAnytimeShort(t *testing.T) {
 			Max:   40 * time.Millisecond,
 			Count: 1,
 		}
-		em, err := scheduler.ScheduleAnytime(ctx, 10, settingsAt(869525000, 7, timePtr(time.Unix(0, int64(10*time.Millisecond))), 0), rtts, ttnpb.TxSchedulePriority_NORMAL)
+		em, err := scheduler.ScheduleAnytime(ctx, 10, settingsAt(869525000, 7, nil, 0), rtts, ttnpb.TxSchedulePriority_NORMAL)
 		a.So(err, should.BeNil)
-		a.So(time.Duration(em.Starts()), should.Equal, 40*time.Millisecond+scheduling.QueueDelay)
+		a.So(time.Duration(em.Starts()), should.Equal, scheduling.ScheduleTimeLong)
 	}
 
 	// Timestamp; too late (100 ms) without RTT.

--- a/pkg/gatewayserver/scheduling/sub_band.go
+++ b/pkg/gatewayserver/scheduling/sub_band.go
@@ -75,7 +75,7 @@ func (sb *SubBand) gc(ctx context.Context) error {
 			ticker.Stop()
 			return ctx.Err()
 		case <-ticker.C:
-			from := sb.clock.ServerTime(time.Now()) - ConcentratorTime(DutyCycleWindow)
+			from := sb.clock.FromServerTime(time.Now()) - ConcentratorTime(DutyCycleWindow)
 			sb.mu.Lock()
 			expired := 0
 			for _, em := range sb.emissions {
@@ -103,7 +103,7 @@ func (sb *SubBand) sum(from, to ConcentratorTime) time.Duration {
 
 // DutyCycleUtilization returns the utilization as a fraction of the available duty-cycle.
 func (sb *SubBand) DutyCycleUtilization() float32 {
-	now := sb.clock.ServerTime(time.Now())
+	now := sb.clock.FromServerTime(time.Now())
 	sb.mu.RLock()
 	val := sb.sum(now-ConcentratorTime(DutyCycleWindow), now)
 	sb.mu.RUnlock()

--- a/pkg/gatewayserver/scheduling/util_test.go
+++ b/pkg/gatewayserver/scheduling/util_test.go
@@ -35,13 +35,16 @@ type mockClock struct {
 func (c *mockClock) IsSynced() bool {
 	return c.t > 0
 }
-func (c *mockClock) ServerTime(_ time.Time) scheduling.ConcentratorTime {
+func (c *mockClock) FromServerTime(_ time.Time) scheduling.ConcentratorTime {
 	return c.t
 }
-func (c *mockClock) GatewayTime(t time.Time) (scheduling.ConcentratorTime, bool) {
+func (c *mockClock) ToServerTime(t scheduling.ConcentratorTime) time.Time {
+	return time.Unix(0, 0).Add(time.Duration(t - c.t))
+}
+func (c *mockClock) FromGatewayTime(t time.Time) (scheduling.ConcentratorTime, bool) {
 	return scheduling.ConcentratorTime(t.Sub(time.Unix(0, 0))), true
 }
-func (c *mockClock) TimestampTime(timestamp uint32) scheduling.ConcentratorTime {
+func (c *mockClock) FromTimestampTime(timestamp uint32) scheduling.ConcentratorTime {
 	return c.t + scheduling.ConcentratorTime(time.Duration(timestamp)*time.Microsecond)
 }
 

--- a/pkg/ttnpb/udp/translation.go
+++ b/pkg/ttnpb/udp/translation.go
@@ -344,12 +344,11 @@ func FromDownlinkMessage(msg *ttnpb.DownlinkMessage) (*TxPacket, error) {
 		Data: base64.StdEncoding.EncodeToString(payload),
 		Tmst: scheduled.Timestamp,
 	}
-	if scheduled.Timestamp == 0 {
-		tx.Imme = true
-	}
 	if scheduled.Time != nil {
 		gpsTime := uint64(gpstime.ToGPS(*scheduled.Time))
 		tx.Tmms = &gpsTime
+	} else if scheduled.Timestamp == 0 {
+		tx.Imme = true
 	}
 
 	tx.DatR.DataRate = scheduled.DataRate


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #627 

#### Changes
<!-- What are the changes made in this pull request? -->

- UDP frontend now uses `scheduling.RolloverClock` instead of own rollover functionality
- GS I/O layer sets timestamp from scheduling so that the frontends know the right timestamp
- Reduced log levels on downlink path and connection expiry

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Fixed absolute time scheduling with UDP connected gateways