### PR TITLE
Subtract time on air from absolute time

### DIFF
--- a/pkg/gatewayserver/scheduling/scheduler.go
+++ b/pkg/gatewayserver/scheduling/scheduler.go
@@ -174,6 +174,12 @@ func (s *Scheduler) ScheduleAt(ctx context.Context, payloadSize int, settings tt
 				return Emission{}, errNoAbsoluteGatewayTime
 			}
 		}
+		// Assume that the absolute time is the time of arrival, not time of transmission.
+		toa, err := toa.Compute(payloadSize, settings)
+		if err != nil {
+			return Emission{}, err
+		}
+		starts -= ConcentratorTime(toa)
 	} else {
 		starts = s.clock.TimestampTime(settings.Timestamp)
 	}

--- a/pkg/gatewayserver/scheduling/scheduler_test.go
+++ b/pkg/gatewayserver/scheduling/scheduler_test.go
@@ -182,7 +182,7 @@ func TestScheduleAt(t *testing.T) {
 			Priority:       ttnpb.TxSchedulePriority_HIGHEST,
 			MedianRTT:      durationPtr(200 * time.Millisecond),
 			ExpectedToa:    51456 * time.Microsecond,
-			ExpectedStarts: 1000000000 - 200000000/2,
+			ExpectedStarts: 1000000000 - 200000000/2 - 51456000,
 		},
 		{
 			SyncWithGateway: true,
@@ -202,7 +202,7 @@ func TestScheduleAt(t *testing.T) {
 			},
 			Priority:       ttnpb.TxSchedulePriority_HIGHEST,
 			ExpectedToa:    51456 * time.Microsecond,
-			ExpectedStarts: 60000000000,
+			ExpectedStarts: 60000000000 - 51456000,
 		},
 		{
 			PayloadSize: 10,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #634 

#### Changes
<!-- What are the changes made in this pull request? -->

- Subtract time on air from absolute time

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Changed interpretation of absolute time in downlink messages from time of transmission to time of arrival