### PR TITLE
Fix/63 spinner issue

### DIFF
--- a/pkg/webui/components/input/input.styl
+++ b/pkg/webui/components/input/input.styl
@@ -70,6 +70,7 @@
   flex-grow: 2
   z-index: $zi.slight
   height: 2.3rem
+  min-width: 0
 
   &[type='password']
     letter-spacing: 1px

--- a/pkg/webui/components/input/story.js
+++ b/pkg/webui/components/input/story.js
@@ -85,3 +85,6 @@ storiesOf('Input', module)
   .add('Textarea', () => (
     <Example component="textarea" />
   ))
+  .add('With Spinner', () => (
+    <Example icon="search" loading />
+  ))


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #63 
When the input field gets shrinked (to somewhere around 50%), the size of the field cannot be shrinked anymore and the spinner gets overflown by div on the right. This happens in Firefox, while in Chrome the input field continues shrinking accordingly. This is fixed by setting the minimum width property to 0.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add input field with a spinner to storybook (to replicate the issue)
- Add `min-width: 0` to `.input` class such that the input field is shrinking properly

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- ...
