### PR TITLE
Add device list view to applications

### DIFF
--- a/pkg/webui/console/containers/devices-table/index.js
+++ b/pkg/webui/console/containers/devices-table/index.js
@@ -19,6 +19,7 @@ import bind from 'autobind-decorator'
 
 import sharedMessages from '../../../lib/shared-messages'
 import Message from '../../../lib/components/message'
+import PropTypes from '../../../lib/prop-types'
 import FetchTable from '../fetch-table'
 import DateTime from '../../../lib/components/date-time'
 
@@ -55,7 +56,7 @@ const headers = [
   }
 })
 @bind
-export default class DevicesTable extends React.Component {
+class DevicesTable extends React.Component {
   constructor (props) {
     super(props)
 
@@ -68,7 +69,7 @@ export default class DevicesTable extends React.Component {
   }
 
   render () {
-    const { totalCount } = this.props
+    const { totalCount, devicePathPrefix } = this.props
     return (
       <FetchTable
         entity="devices"
@@ -77,10 +78,21 @@ export default class DevicesTable extends React.Component {
         tableTitle={<Message content={m.connectedDevices} values={{ deviceCount: totalCount }} />}
         getItemsAction={this.getDevicesList}
         searchItemsAction={this.searchDevicesList}
-        itemPathPrefix="/devices"
+        itemPathPrefix={devicePathPrefix}
         baseDataSelector={this.baseDataSelector}
         {...this.props}
       />
     )
   }
 }
+
+DevicesTable.propTypes = {
+  devicePathPrefix: PropTypes.string,
+  totalCount: PropTypes.number,
+}
+
+DevicesTable.defaultProps = {
+  totalCount: 0,
+}
+
+export default DevicesTable

--- a/pkg/webui/console/views/application-overview/index.js
+++ b/pkg/webui/console/views/application-overview/index.js
@@ -84,7 +84,7 @@ class ApplicationOverview extends React.Component {
         </Row>
         <Row>
           <Col sm={12} className={style.table}>
-            <DevicesTable pageSize={DEVICES_TABLE_SIZE} />
+            <DevicesTable pageSize={DEVICES_TABLE_SIZE} devicePathPrefix="/devices" />
           </Col>
         </Row>
       </Container>

--- a/pkg/webui/console/views/device-list/index.js
+++ b/pkg/webui/console/views/device-list/index.js
@@ -1,0 +1,45 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import { connect } from 'react-redux'
+import { Col, Row, Container } from 'react-grid-system'
+
+import IntlHelmet from '../../../lib/components/intl-helmet'
+import sharedMessages from '../../../lib/shared-messages'
+import DevicesTable from '../../containers/devices-table'
+
+const DEVICES_TABLE_SIZE = 25
+
+@connect(function ({ application }, props) {
+  return {
+    application: application.application,
+  }
+})
+class ApplicationDeviceList extends React.Component {
+  render () {
+    return (
+      <Container>
+        <Row>
+          <IntlHelmet title={sharedMessages.devices} />
+          <Col sm={12}>
+            <DevicesTable pageSize={DEVICES_TABLE_SIZE} />
+          </Col>
+        </Row>
+      </Container>
+    )
+  }
+}
+
+export default ApplicationDeviceList

--- a/pkg/webui/console/views/devices/index.js
+++ b/pkg/webui/console/views/devices/index.js
@@ -15,6 +15,7 @@
 import React from 'react'
 import { Switch, Route } from 'react-router-dom'
 
+import DeviceList from '../device-list'
 import DeviceAdd from '../device-add'
 import Device from '../device'
 
@@ -39,6 +40,7 @@ export default class Applications extends React.Component {
       <Switch>
         <Route path={`${path}/add`} component={DeviceAdd} />
         <Route path={`${path}/:devId`} component={Device} />
+        <Route path={`${path}`} component={DeviceList} />
       </Switch>
     )
   }


### PR DESCRIPTION
#### Summary
Closes #644

#### Changes
- Extend `<DevicesTable />` a little to pass `itemPathPrefix` prop
- While at it add prop types and default props
- Add device list view and routes

#### Release Notes
- Add device list page to applications in console