### PR TITLE
Gateway API Keys List page

### DIFF
--- a/pkg/webui/console/api/index.js
+++ b/pkg/webui/console/api/index.js
@@ -115,6 +115,12 @@ export default {
     update: ttnClient.Gateways.updateById.bind(ttnClient.Gateways),
     stats: ttnClient.Gateways.getStatisticsById.bind(ttnClient.Gateways),
     eventsSubscribe: ttnClient.Gateways.openStream.bind(ttnClient.Gateways),
+    apiKeys: {
+      list: ttnClient.Gateways.ApiKeys.getAll.bind(ttnClient.Gateways.ApiKeys),
+      update: ttnClient.Gateways.ApiKeys.updateById.bind(ttnClient.Gateways.ApiKeys),
+      'delete': ttnClient.Gateways.ApiKeys.deleteById.bind(ttnClient.Gateways.ApiKeys),
+      create: ttnClient.Gateways.ApiKeys.create.bind(ttnClient.Gateways.ApiKeys),
+    },
   },
   rights: {
     applications: ttnClient.Applications.getRightsById.bind(ttnClient.Applications),

--- a/pkg/webui/console/containers/api-keys-table/index.js
+++ b/pkg/webui/console/containers/api-keys-table/index.js
@@ -77,6 +77,7 @@ export default class ApiKeysTable extends Component {
       pageSize,
       baseDataSelector,
       getItemsAction,
+      entityId,
     } = this.props
 
     return (
@@ -88,6 +89,7 @@ export default class ApiKeysTable extends Component {
         pageSize={pageSize}
         baseDataSelector={baseDataSelector}
         getItemsAction={getItemsAction}
+        id={entityId}
       />
     )
   }
@@ -97,4 +99,5 @@ ApiKeysTable.propTypes = {
   pageSize: PropTypes.number.isRequired,
   baseDataSelector: PropTypes.func.isRequired,
   getItemsAction: PropTypes.func.isRequired,
+  entityId: PropTypes.string,
 }

--- a/pkg/webui/console/containers/api-keys-table/index.js
+++ b/pkg/webui/console/containers/api-keys-table/index.js
@@ -18,6 +18,7 @@ import { defineMessages } from 'react-intl'
 import Tag from '../../../components/tag'
 import TagGroup from '../../../components/tag/group'
 import FetchTable from '../fetch-table'
+import PropTypes from '../../../lib/prop-types'
 
 import sharedMessages from '../../../lib/shared-messages'
 import style from './api-keys-table.styl'
@@ -72,15 +73,28 @@ const headers = [
 
 export default class ApiKeysTable extends Component {
   render () {
+    const {
+      pageSize,
+      baseDataSelector,
+      getItemsAction,
+    } = this.props
+
     return (
       <FetchTable
         entity="keys"
         headers={headers}
         addMessage={sharedMessages.addApiKey}
         handlesPagination
-        {...this.props}
+        pageSize={pageSize}
+        baseDataSelector={baseDataSelector}
+        getItemsAction={getItemsAction}
       />
     )
   }
 }
 
+ApiKeysTable.propTypes = {
+  pageSize: PropTypes.number.isRequired,
+  baseDataSelector: PropTypes.func.isRequired,
+  getItemsAction: PropTypes.func.isRequired,
+}

--- a/pkg/webui/console/containers/fetch-table/index.js
+++ b/pkg/webui/console/containers/fetch-table/index.js
@@ -60,7 +60,8 @@ const filterValidator = function (filters) {
 }
 
 @connect(function (state, props) {
-  const base = props.baseDataSelector(state)
+  const base = props.baseDataSelector(state, props)
+
   return {
     items: base[props.entity] || [],
     totalCount: base.totalCount || 0,

--- a/pkg/webui/console/store/actions/gateway.js
+++ b/pkg/webui/console/store/actions/gateway.js
@@ -13,6 +13,15 @@
 // limitations under the License.
 
 import {
+  getApiKeysList,
+  createGetApiKeysListActionType,
+  getApiKeysListFailure,
+  createGetApiKeysListFailureActionType,
+  getApiKeysListSuccess,
+  createGetApiKeysListSuccessActionType,
+} from '../actions/api-keys'
+
+import {
   startEventsStream,
   createStartEventsStreamActionType,
   startEventsStreamSuccess,
@@ -41,6 +50,9 @@ export const START_GTW_EVENT_STREAM_SUCCESS = createStartEventsStreamSuccessActi
 export const START_GTW_EVENT_STREAM_FAILURE = createStartEventsStreamFailureActionType(SHARED_NAME)
 export const STOP_GTW_EVENT_STREAM = createStopEventsStreamActionType(SHARED_NAME)
 export const CLEAR_GTW_EVENTS = createClearEventsActionType(SHARED_NAME)
+export const GET_GTW_API_KEYS_LIST = createGetApiKeysListActionType(SHARED_NAME)
+export const GET_GTW_API_KEYS_LIST_SUCCESS = createGetApiKeysListSuccessActionType(SHARED_NAME)
+export const GET_GTW_API_KEYS_LIST_FAILURE = createGetApiKeysListFailureActionType(SHARED_NAME)
 
 export const getGateway = (id, meta) => (
   { type: GET_GTW, id, meta }
@@ -87,3 +99,10 @@ export const startGatewayEventsStreamFailure = startEventsStreamFailure(SHARED_N
 export const stopGatewayEventsStream = stopEventsStream(SHARED_NAME)
 
 export const clearGatewayEventsStream = clearEvents(SHARED_NAME)
+
+export const getGatewayApiKeysList = getApiKeysList(SHARED_NAME)
+
+export const getGatewayApiKeysListSuccess = getApiKeysListSuccess(SHARED_NAME)
+
+export const getGatewayApiKeysListFailure = getApiKeysListFailure(SHARED_NAME)
+

--- a/pkg/webui/console/store/middleware/gateway.js
+++ b/pkg/webui/console/store/middleware/gateway.js
@@ -110,9 +110,31 @@ const updateGatewayStatisticsLogic = createLogic({
   },
 })
 
+const getGatewayApiKeysLogic = createLogic({
+  type: gateway.GET_GTW_API_KEYS_LIST,
+  async process ({ action }, dispatch, done) {
+    const { id, params } = action
+    try {
+      const res = await api.gateway.apiKeys.list(id, params)
+      dispatch(
+        gateway.getGatewayApiKeysListSuccess(
+          id,
+          res.api_keys,
+          res.totalCount
+        )
+      )
+    } catch (e) {
+      dispatch(gateway.getGatewayApiKeysListFailure(id, e))
+    }
+
+    done()
+  },
+})
+
 export default [
   getGatewayLogic,
   startGatewayStatisticsLogic,
   updateGatewayStatisticsLogic,
   ...createEventsConnectLogics(gateway.SHARED_NAME, 'gateway'),
+  getGatewayApiKeysLogic,
 ]

--- a/pkg/webui/console/store/reducers/index.js
+++ b/pkg/webui/console/store/reducers/index.js
@@ -44,6 +44,7 @@ export default combineReducers({
   configuration,
   apiKeys: combineReducers({
     applications: createNamedApiKeysReducer(APPLICATION_SHARED_NAME),
+    gateways: createNamedApiKeysReducer(GATEWAY_SHARED_NAME),
   }),
   rights: combineReducers({
     applications: createNamedRightsReducer(APPLICATIONS_SHARED_NAME),

--- a/pkg/webui/console/store/selectors/api-keys.js
+++ b/pkg/webui/console/store/selectors/api-keys.js
@@ -1,0 +1,43 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const storeSelector = (state, props) => state[props.id]
+
+export const apiKeysStoreSelector = entity => (state, props) => (
+  storeSelector(state.apiKeys[entity], props) || {}
+)
+
+export const apiKeysSelector = entity => function (state, props) {
+  const store = storeSelector(state.apiKeys[entity], props)
+
+  return store ? store.keys : []
+}
+
+export const totalCountSelector = entity => function (state, props) {
+  const store = storeSelector(state.totalCount[entity], props)
+
+  return store.totalCount
+}
+
+export const fetchingSelector = entity => function (state, props) {
+  const store = storeSelector(state.apiKeys[entity], props)
+
+  return store.fetching
+}
+
+export const errorSelector = entity => function (state, props) {
+  const store = storeSelector(state.apiKeys[entity], props)
+
+  return store.error
+}

--- a/pkg/webui/console/store/selectors/gateway.js
+++ b/pkg/webui/console/store/selectors/gateway.js
@@ -18,6 +18,13 @@ import {
   statusSelector as eventsStatusSelector,
 } from './events'
 
+import {
+  apiKeysStoreSelector,
+  fetchingSelector as apiKeysFetchingSelector,
+  errorSelector as apiKeysErrorSelector,
+  totalCountSelector as apiKeysTotalCountSelector,
+} from './api-keys'
+
 const ENTITY = 'gateways'
 
 const storeSelector = state => state.gateway
@@ -71,3 +78,11 @@ export const gatewayEventsSelector = eventsSelector(ENTITY)
 export const gatewayEventsErrorSelector = eventsErrorSelector(ENTITY)
 
 export const gatewayEventsStatusSelector = eventsStatusSelector(ENTITY)
+
+export const gatewayApiKeysStoreSelector = apiKeysStoreSelector(ENTITY)
+
+export const gatewayTotalCountSelector = apiKeysTotalCountSelector(ENTITY)
+
+export const gatewayErrorSelector = apiKeysErrorSelector(ENTITY)
+
+export const gatewayFetchingSelector = apiKeysFetchingSelector(ENTITY)

--- a/pkg/webui/console/views/gateway-api-keys-list/index.js
+++ b/pkg/webui/console/views/gateway-api-keys-list/index.js
@@ -1,0 +1,56 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import { Container, Row, Col } from 'react-grid-system'
+import bind from 'autobind-decorator'
+
+import IntlHelmet from '../../../lib/components/intl-helmet'
+import ApiKeysTable from '../../containers/api-keys-table'
+import { getGatewayApiKeysList } from '../../store/actions/gateway'
+import { gatewayApiKeysStoreSelector } from '../../store/selectors/gateway'
+import sharedMessages from '../../../lib/shared-messages'
+
+const API_KEYS_TABLE_SIZE = 10
+
+@bind
+export default class GatewayApiKeys extends React.Component {
+
+  constructor (props) {
+    super(props)
+
+    const { gtwId } = props.match.params
+    this.getGatewayApiKeysList = filters => getGatewayApiKeysList(gtwId, filters)
+  }
+
+  render () {
+    const { gtwId } = this.props.match.params
+
+    return (
+      <Container>
+        <Row>
+          <IntlHelmet title={sharedMessages.apiKeys} />
+          <Col sm={12}>
+            <ApiKeysTable
+              entityId={gtwId}
+              pageSize={API_KEYS_TABLE_SIZE}
+              baseDataSelector={gatewayApiKeysStoreSelector}
+              getItemsAction={this.getGatewayApiKeysList}
+            />
+          </Col>
+        </Row>
+      </Container>
+    )
+  }
+}

--- a/pkg/webui/console/views/gateway-api-keys/index.js
+++ b/pkg/webui/console/views/gateway-api-keys/index.js
@@ -1,0 +1,46 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import { Switch, Route } from 'react-router'
+
+import sharedMessages from '../../../lib/shared-messages'
+import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
+import { withBreadcrumb } from '../../../components/breadcrumbs/context'
+
+import GatewayApiKeysList from '../gateway-api-keys-list'
+
+@withBreadcrumb('gateways.single.api-keys', function (props) {
+  const gtwId = props.match.params.gtwId
+
+  return (
+    <Breadcrumb
+      path={`/console/gateways/${gtwId}/api-keys`}
+      icon="api_keys"
+      content={sharedMessages.apiKeys}
+    />
+  )
+})
+export default class GatewayApiKeys extends React.Component {
+
+  render () {
+    const { match } = this.props
+
+    return (
+      <Switch>
+        <Route exact path={`${match.path}`} component={GatewayApiKeysList} />
+      </Switch>
+    )
+  }
+}

--- a/pkg/webui/console/views/gateway/index.js
+++ b/pkg/webui/console/views/gateway/index.js
@@ -24,6 +24,7 @@ import Spinner from '../../../components/spinner'
 import Message from '../../../lib/components/message'
 
 import GatewayOverview from '../gateway-overview'
+import GatewayApiKeys from '../gateway-api-keys'
 
 import {
   getGateway,
@@ -63,11 +64,18 @@ dispatch => ({
         path: matchedUrl,
         icon: 'overview',
       },
+      {
+        title: sharedMessages.apiKeys,
+        path: `${matchedUrl}/api-keys`,
+        icon: 'api_keys',
+        exact: false,
+      },
     ],
   }
 })
-@withBreadcrumb('gtws.single', function (props) {
+@withBreadcrumb('gateways.single', function (props) {
   const { gtwId } = props
+
   return (
     <Breadcrumb
       path={`/console/gateways/${gtwId}`}
@@ -120,6 +128,7 @@ export default class Gateway extends React.Component {
     return (
       <Switch>
         <Route exact path={`${match.path}`} component={GatewayOverview} />
+        <Route exact path={`${match.path}/api-keys`} component={GatewayApiKeys} />
       </Switch>
     )
   }

--- a/sdk/js/src/service/gateways.js
+++ b/sdk/js/src/service/gateways.js
@@ -14,12 +14,20 @@
 
 import Marshaler from '../util/marshaler'
 import stream from '../api/stream/stream-node'
+import ApiKeys from './api-keys'
 
 class Gateways {
   constructor (api, { defaultUserId, stackConfig, proxy = true }) {
     this._api = api
     this._defaultUserId = defaultUserId
     this._stackConfig = stackConfig
+    this.ApiKeys = new ApiKeys(api.GatewayAccess, {
+      parentRoutes: {
+        list: 'gateway_ids.gateway_id',
+        create: 'gateway_ids.gateway_id',
+        update: 'gateway_ids.gateway_id',
+      },
+    })
   }
 
   // Retrieval


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR adds the Gateway API List page and some ground work for the rest of the api keys management for gateways.
References: https://github.com/TheThingsNetwork/lorawan-stack/issues/649

<img width="1221" alt="Screenshot 2019-05-08 at 14 29 16" src="https://user-images.githubusercontent.com/16374166/57375669-49e49780-719e-11e9-9c3b-d6c0a096a293.png">

#### Changes
<!-- What are the changes made in this pull request? -->

- Add the `ApiKeys` service to gateways
- Add Gateway API Keys List page

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

for quick test:
```
curl -v -H "Authorization: Bearer $access_token" -XPOST --data '{"gateway": {"ids": {"gateway_id": "my-gtw"},"frequency_plan_id": "EU_863_870"}}' http://localhost:1885/api/v3/users/admin/gateways
curl -v -H "Authorization: Bearer $access_token" -XPOST --data '{"name": "my-gtw-api-key", "rights": ["RIGHT_GATEWAY_INFO", "RIGHT_GATEWAY_LINK"]}' http://localhost:1885/api/v3/gateways/my-gtw/api-keys
```
