### PR TITLE
doc: Fix double slash in markdown docs

### DIFF
--- a/api/api.md
+++ b/api/api.md
@@ -575,13 +575,13 @@ where the user or organization is collaborator on.
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `ListRights` | `GET` | `/api/v3//applications/{application_id}/rights` |  |
-| `CreateAPIKey` | `POST` | `/api/v3//applications/{application_ids.application_id}/api-keys` | `*` |
-| `ListAPIKeys` | `GET` | `/api/v3//applications/{application_ids.application_id}/api-keys` |  |
-| `GetAPIKey` | `GET` | `/api/v3//applications/{application_ids.application_id}/api-keys/{key_id}` |  |
-| `UpdateAPIKey` | `PUT` | `/api/v3//applications/{application_ids.application_id}/api-keys/{api_key.id}` | `*` |
-| `SetCollaborator` | `PUT` | `/api/v3//applications/{application_ids.application_id}/collaborators` | `*` |
-| `ListCollaborators` | `GET` | `/api/v3//applications/{application_ids.application_id}/collaborators` |  |
+| `ListRights` | `GET` | `/api/v3/applications/{application_id}/rights` |  |
+| `CreateAPIKey` | `POST` | `/api/v3/applications/{application_ids.application_id}/api-keys` | `*` |
+| `ListAPIKeys` | `GET` | `/api/v3/applications/{application_ids.application_id}/api-keys` |  |
+| `GetAPIKey` | `GET` | `/api/v3/applications/{application_ids.application_id}/api-keys/{key_id}` |  |
+| `UpdateAPIKey` | `PUT` | `/api/v3/applications/{application_ids.application_id}/api-keys/{api_key.id}` | `*` |
+| `SetCollaborator` | `PUT` | `/api/v3/applications/{application_ids.application_id}/collaborators` | `*` |
+| `ListCollaborators` | `GET` | `/api/v3/applications/{application_ids.application_id}/collaborators` |  |
 
 ### <a name="ttn.lorawan.v3.ApplicationRegistry">Service `ApplicationRegistry`</a>
 
@@ -597,14 +597,14 @@ where the user or organization is collaborator on.
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `Create` | `POST` | `/api/v3//users/{collaborator.user_ids.user_id}/applications` | `*` |
-| `Create` | `POST` | `/api/v3//organizations/{collaborator.organization_ids.organization_id}/applications` | `*` |
-| `Get` | `GET` | `/api/v3//applications/{application_ids.application_id}` |  |
-| `List` | `GET` | `/api/v3//applications` |  |
-| `List` | `GET` | `/api/v3//users/{collaborator.user_ids.user_id}/applications` |  |
-| `List` | `GET` | `/api/v3//organizations/{collaborator.organization_ids.organization_id}/applications` |  |
-| `Update` | `PUT` | `/api/v3//applications/{application.ids.application_id}` | `*` |
-| `Delete` | `DELETE` | `/api/v3//applications/{application_id}` |  |
+| `Create` | `POST` | `/api/v3/users/{collaborator.user_ids.user_id}/applications` | `*` |
+| `Create` | `POST` | `/api/v3/organizations/{collaborator.organization_ids.organization_id}/applications` | `*` |
+| `Get` | `GET` | `/api/v3/applications/{application_ids.application_id}` |  |
+| `List` | `GET` | `/api/v3/applications` |  |
+| `List` | `GET` | `/api/v3/users/{collaborator.user_ids.user_id}/applications` |  |
+| `List` | `GET` | `/api/v3/organizations/{collaborator.organization_ids.organization_id}/applications` |  |
+| `Update` | `PUT` | `/api/v3/applications/{application.ids.application_id}` | `*` |
+| `Delete` | `DELETE` | `/api/v3/applications/{application_id}` |  |
 
 ## <a name="lorawan-stack/api/applicationserver.proto">File `lorawan-stack/api/applicationserver.proto`</a>
 
@@ -685,9 +685,9 @@ The AppAs service connects an application or integration to an Application Serve
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `DownlinkQueuePush` | `POST` | `/api/v3//as/applications/{end_device_ids.application_ids.application_id}/devices/{end_device_ids.device_id}/down/push` | `*` |
-| `DownlinkQueueReplace` | `POST` | `/api/v3//as/applications/{end_device_ids.application_ids.application_id}/devices/{end_device_ids.device_id}/down/replace` | `*` |
-| `DownlinkQueueList` | `GET` | `/api/v3//as/applications/{application_ids.application_id}/devices/{device_id}/down` |  |
+| `DownlinkQueuePush` | `POST` | `/api/v3/as/applications/{end_device_ids.application_ids.application_id}/devices/{end_device_ids.device_id}/down/push` | `*` |
+| `DownlinkQueueReplace` | `POST` | `/api/v3/as/applications/{end_device_ids.application_ids.application_id}/devices/{end_device_ids.device_id}/down/replace` | `*` |
+| `DownlinkQueueList` | `GET` | `/api/v3/as/applications/{application_ids.application_id}/devices/{device_id}/down` |  |
 
 ### <a name="ttn.lorawan.v3.As">Service `As`</a>
 
@@ -704,10 +704,10 @@ The As service manages the Application Server.
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `GetLink` | `GET` | `/api/v3//as/applications/{application_ids.application_id}/link` |  |
-| `SetLink` | `PUT` | `/api/v3//as/applications/{application_ids.application_id}/link` | `*` |
-| `DeleteLink` | `DELETE` | `/api/v3//as/applications/{application_id}/link` |  |
-| `GetLinkStats` | `GET` | `/api/v3//as/applications/{application_id}/link/stats` |  |
+| `GetLink` | `GET` | `/api/v3/as/applications/{application_ids.application_id}/link` |  |
+| `SetLink` | `PUT` | `/api/v3/as/applications/{application_ids.application_id}/link` | `*` |
+| `DeleteLink` | `DELETE` | `/api/v3/as/applications/{application_id}/link` |  |
+| `GetLinkStats` | `GET` | `/api/v3/as/applications/{application_id}/link/stats` |  |
 
 ### <a name="ttn.lorawan.v3.AsEndDeviceRegistry">Service `AsEndDeviceRegistry`</a>
 
@@ -723,10 +723,10 @@ The AsEndDeviceRegistry service allows clients to manage their end devices on th
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `Get` | `GET` | `/api/v3//as/applications/{end_device_ids.application_ids.application_id}/devices/{end_device_ids.device_id}` |  |
-| `Set` | `PUT` | `/api/v3//as/applications/{end_device.ids.application_ids.application_id}/devices/{end_device.ids.device_id}` | `*` |
-| `Set` | `POST` | `/api/v3//as/applications/{end_device.ids.application_ids.application_id}/devices` | `*` |
-| `Delete` | `DELETE` | `/api/v3//as/applications/{application_ids.application_id}/devices/{device_id}` |  |
+| `Get` | `GET` | `/api/v3/as/applications/{end_device_ids.application_ids.application_id}/devices/{end_device_ids.device_id}` |  |
+| `Set` | `PUT` | `/api/v3/as/applications/{end_device.ids.application_ids.application_id}/devices/{end_device.ids.device_id}` | `*` |
+| `Set` | `POST` | `/api/v3/as/applications/{end_device.ids.application_ids.application_id}/devices` | `*` |
+| `Delete` | `DELETE` | `/api/v3/as/applications/{application_ids.application_id}/devices/{device_id}` |  |
 
 ## <a name="lorawan-stack/api/applicationserver_web.proto">File `lorawan-stack/api/applicationserver_web.proto`</a>
 
@@ -855,11 +855,11 @@ The AsEndDeviceRegistry service allows clients to manage their end devices on th
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `GetFormats` | `GET` | `/api/v3//as/webhook-formats` |  |
-| `Get` | `GET` | `/api/v3//as/applications/{ids.application_ids.application_id}/webhooks/{ids.webhook_id}` |  |
-| `List` | `GET` | `/api/v3//as/applications/{application_ids.application_id}/webhooks` |  |
-| `Set` | `POST` | `/api/v3//as/applications/{webhook.ids.application_ids.application_id}/webhooks/{webhook.ids.webhook_id}` | `*` |
-| `Delete` | `DELETE` | `/api/v3//as/applications/{application_ids.application_id}/webhooks/{webhook_id}` |  |
+| `GetFormats` | `GET` | `/api/v3/as/webhook-formats` |  |
+| `Get` | `GET` | `/api/v3/as/applications/{ids.application_ids.application_id}/webhooks/{ids.webhook_id}` |  |
+| `List` | `GET` | `/api/v3/as/applications/{application_ids.application_id}/webhooks` |  |
+| `Set` | `POST` | `/api/v3/as/applications/{webhook.ids.application_ids.application_id}/webhooks/{webhook.ids.webhook_id}` | `*` |
+| `Delete` | `DELETE` | `/api/v3/as/applications/{application_ids.application_id}/webhooks/{webhook_id}` |  |
 
 ## <a name="lorawan-stack/api/client.proto">File `lorawan-stack/api/client.proto`</a>
 
@@ -1022,9 +1022,9 @@ The OAuth2 flows an OAuth client can use to get an access token.
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `ListRights` | `GET` | `/api/v3//clients/{client_id}/rights` |  |
-| `SetCollaborator` | `PUT` | `/api/v3//clients/{client_ids.client_id}/collaborators` | `*` |
-| `ListCollaborators` | `GET` | `/api/v3//clients/{client_ids.client_id}/collaborators` |  |
+| `ListRights` | `GET` | `/api/v3/clients/{client_id}/rights` |  |
+| `SetCollaborator` | `PUT` | `/api/v3/clients/{client_ids.client_id}/collaborators` | `*` |
+| `ListCollaborators` | `GET` | `/api/v3/clients/{client_ids.client_id}/collaborators` |  |
 
 ### <a name="ttn.lorawan.v3.ClientRegistry">Service `ClientRegistry`</a>
 
@@ -1040,14 +1040,14 @@ The OAuth2 flows an OAuth client can use to get an access token.
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `Create` | `POST` | `/api/v3//users/{collaborator.user_ids.user_id}/clients` | `*` |
-| `Create` | `POST` | `/api/v3//organizations/{collaborator.organization_ids.organization_id}/clients` | `*` |
-| `Get` | `GET` | `/api/v3//clients/{client_ids.client_id}` |  |
-| `List` | `GET` | `/api/v3//clients` |  |
-| `List` | `GET` | `/api/v3//users/{collaborator.user_ids.user_id}/clients` |  |
-| `List` | `GET` | `/api/v3//organizations/{collaborator.organization_ids.organization_id}/clients` |  |
-| `Update` | `PUT` | `/api/v3//clients/{client.ids.client_id}` | `*` |
-| `Delete` | `DELETE` | `/api/v3//clients/{client_id}` |  |
+| `Create` | `POST` | `/api/v3/users/{collaborator.user_ids.user_id}/clients` | `*` |
+| `Create` | `POST` | `/api/v3/organizations/{collaborator.organization_ids.organization_id}/clients` | `*` |
+| `Get` | `GET` | `/api/v3/clients/{client_ids.client_id}` |  |
+| `List` | `GET` | `/api/v3/clients` |  |
+| `List` | `GET` | `/api/v3/users/{collaborator.user_ids.user_id}/clients` |  |
+| `List` | `GET` | `/api/v3/organizations/{collaborator.organization_ids.organization_id}/clients` |  |
+| `Update` | `PUT` | `/api/v3/clients/{client.ids.client_id}` | `*` |
+| `Delete` | `DELETE` | `/api/v3/clients/{client_id}` |  |
 
 ## <a name="lorawan-stack/api/cluster.proto">File `lorawan-stack/api/cluster.proto`</a>
 
@@ -1115,7 +1115,7 @@ PeerInfo
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `ListFrequencyPlans` | `GET` | `/api/v3//configuration/frequency-plans` |  |
+| `ListFrequencyPlans` | `GET` | `/api/v3/configuration/frequency-plans` |  |
 
 ## <a name="lorawan-stack/api/contact_info.proto">File `lorawan-stack/api/contact_info.proto`</a>
 
@@ -1168,8 +1168,8 @@ PeerInfo
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `RequestValidation` | `POST` | `/api/v3//contact_info/validation` |  |
-| `Validate` | `PATCH` | `/api/v3//contact_info/validation` |  |
+| `RequestValidation` | `POST` | `/api/v3/contact_info/validation` |  |
+| `Validate` | `PATCH` | `/api/v3/contact_info/validation` |  |
 
 ## <a name="lorawan-stack/api/end_device.proto">File `lorawan-stack/api/end_device.proto`</a>
 
@@ -1648,11 +1648,11 @@ Power state of the device.
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `Create` | `POST` | `/api/v3//applications/{end_device.ids.application_ids.application_id}/devices` | `*` |
-| `Get` | `GET` | `/api/v3//applications/{end_device_ids.application_ids.application_id}/devices/{end_device_ids.device_id}` |  |
-| `List` | `GET` | `/api/v3//applications/{application_ids.application_id}/devices` |  |
-| `Update` | `PUT` | `/api/v3//applications/{end_device.ids.application_ids.application_id}/devices/{end_device.ids.device_id}` | `*` |
-| `Delete` | `DELETE` | `/api/v3//applications/{application_ids.application_id}/devices/{device_id}` |  |
+| `Create` | `POST` | `/api/v3/applications/{end_device.ids.application_ids.application_id}/devices` | `*` |
+| `Get` | `GET` | `/api/v3/applications/{end_device_ids.application_ids.application_id}/devices/{end_device_ids.device_id}` |  |
+| `List` | `GET` | `/api/v3/applications/{application_ids.application_id}/devices` |  |
+| `Update` | `PUT` | `/api/v3/applications/{end_device.ids.application_ids.application_id}/devices/{end_device.ids.device_id}` | `*` |
+| `Delete` | `DELETE` | `/api/v3/applications/{application_ids.application_id}/devices/{device_id}` |  |
 
 ## <a name="lorawan-stack/api/enums.proto">File `lorawan-stack/api/enums.proto`</a>
 
@@ -1740,7 +1740,7 @@ The Events service serves events from the cluster.
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `Stream` | `POST` | `/api/v3//events` | `*` |
+| `Stream` | `POST` | `/api/v3/events` | `*` |
 
 ## <a name="lorawan-stack/api/gateway.proto">File `lorawan-stack/api/gateway.proto`</a>
 
@@ -2141,13 +2141,13 @@ where the user or organization is collaborator on.
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `ListRights` | `GET` | `/api/v3//gateways/{gateway_id}/rights` |  |
-| `CreateAPIKey` | `POST` | `/api/v3//gateways/{gateway_ids.gateway_id}/api-keys` | `*` |
-| `ListAPIKeys` | `GET` | `/api/v3//gateways/{gateway_ids.gateway_id}/api-keys` |  |
-| `GetAPIKey` | `GET` | `/api/v3//gateways/{gateway_ids.gateway_id}/api-keys/{key_id}` |  |
-| `UpdateAPIKey` | `PUT` | `/api/v3//gateways/{gateway_ids.gateway_id}/api-keys/{api_key.id}` | `*` |
-| `SetCollaborator` | `PUT` | `/api/v3//gateways/{gateway_ids.gateway_id}/collaborators` | `*` |
-| `ListCollaborators` | `GET` | `/api/v3//gateways/{gateway_ids.gateway_id}/collaborators` |  |
+| `ListRights` | `GET` | `/api/v3/gateways/{gateway_id}/rights` |  |
+| `CreateAPIKey` | `POST` | `/api/v3/gateways/{gateway_ids.gateway_id}/api-keys` | `*` |
+| `ListAPIKeys` | `GET` | `/api/v3/gateways/{gateway_ids.gateway_id}/api-keys` |  |
+| `GetAPIKey` | `GET` | `/api/v3/gateways/{gateway_ids.gateway_id}/api-keys/{key_id}` |  |
+| `UpdateAPIKey` | `PUT` | `/api/v3/gateways/{gateway_ids.gateway_id}/api-keys/{api_key.id}` | `*` |
+| `SetCollaborator` | `PUT` | `/api/v3/gateways/{gateway_ids.gateway_id}/collaborators` | `*` |
+| `ListCollaborators` | `GET` | `/api/v3/gateways/{gateway_ids.gateway_id}/collaborators` |  |
 
 ### <a name="ttn.lorawan.v3.GatewayConfigurator">Service `GatewayConfigurator`</a>
 
@@ -2170,14 +2170,14 @@ where the user or organization is collaborator on.
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `Create` | `POST` | `/api/v3//users/{collaborator.user_ids.user_id}/gateways` | `*` |
-| `Create` | `POST` | `/api/v3//organizations/{collaborator.organization_ids.organization_id}/gateways` | `*` |
-| `Get` | `GET` | `/api/v3//gateways/{gateway_ids.gateway_id}` |  |
-| `List` | `GET` | `/api/v3//gateways` |  |
-| `List` | `GET` | `/api/v3//users/{collaborator.user_ids.user_id}/gateways` |  |
-| `List` | `GET` | `/api/v3//organizations/{collaborator.organization_ids.organization_id}/gateways` |  |
-| `Update` | `PUT` | `/api/v3//gateways/{gateway.ids.gateway_id}` | `*` |
-| `Delete` | `DELETE` | `/api/v3//gateways/{gateway_id}` |  |
+| `Create` | `POST` | `/api/v3/users/{collaborator.user_ids.user_id}/gateways` | `*` |
+| `Create` | `POST` | `/api/v3/organizations/{collaborator.organization_ids.organization_id}/gateways` | `*` |
+| `Get` | `GET` | `/api/v3/gateways/{gateway_ids.gateway_id}` |  |
+| `List` | `GET` | `/api/v3/gateways` |  |
+| `List` | `GET` | `/api/v3/users/{collaborator.user_ids.user_id}/gateways` |  |
+| `List` | `GET` | `/api/v3/organizations/{collaborator.organization_ids.organization_id}/gateways` |  |
+| `Update` | `PUT` | `/api/v3/gateways/{gateway.ids.gateway_id}` | `*` |
+| `Delete` | `DELETE` | `/api/v3/gateways/{gateway_id}` |  |
 
 ## <a name="lorawan-stack/api/gatewayserver.proto">File `lorawan-stack/api/gatewayserver.proto`</a>
 
@@ -2221,7 +2221,7 @@ GatewayUp may contain zero or more uplink messages and/or a status message for t
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `GetGatewayConnectionStats` | `GET` | `/api/v3//gs/gateways/{gateway_id}/connection/stats` |  |
+| `GetGatewayConnectionStats` | `GET` | `/api/v3/gs/gateways/{gateway_id}/connection/stats` |  |
 
 ### <a name="ttn.lorawan.v3.GtwGs">Service `GtwGs`</a>
 
@@ -2387,7 +2387,7 @@ OrganizationOrUserIdentifiers contains either organization or user identifiers.
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `AuthInfo` | `GET` | `/api/v3//auth_info` |  |
+| `AuthInfo` | `GET` | `/api/v3/auth_info` |  |
 
 ## <a name="lorawan-stack/api/join.proto">File `lorawan-stack/api/join.proto`</a>
 
@@ -2617,11 +2617,11 @@ The JsEndDeviceRegistry service allows clients to manage their end devices on th
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `Get` | `GET` | `/api/v3//js/applications/{end_device_ids.application_ids.application_id}/devices/{end_device_ids.device_id}` |  |
-| `Set` | `PUT` | `/api/v3//js/applications/{end_device.ids.application_ids.application_id}/devices/{end_device.ids.device_id}` | `*` |
-| `Set` | `POST` | `/api/v3//js/applications/{end_device.ids.application_ids.application_id}/devices` | `*` |
-| `Provision` | `PUT` | `/api/v3//js/applications/{application_ids.application_id}/provision-devices` | `*` |
-| `Delete` | `DELETE` | `/api/v3//js/applications/{application_ids.application_id}/devices/{device_id}` |  |
+| `Get` | `GET` | `/api/v3/js/applications/{end_device_ids.application_ids.application_id}/devices/{end_device_ids.device_id}` |  |
+| `Set` | `PUT` | `/api/v3/js/applications/{end_device.ids.application_ids.application_id}/devices/{end_device.ids.device_id}` | `*` |
+| `Set` | `POST` | `/api/v3/js/applications/{end_device.ids.application_ids.application_id}/devices` | `*` |
+| `Provision` | `PUT` | `/api/v3/js/applications/{application_ids.application_id}/provision-devices` | `*` |
+| `Delete` | `DELETE` | `/api/v3/js/applications/{application_ids.application_id}/devices/{device_id}` |  |
 
 ### <a name="ttn.lorawan.v3.NetworkCryptoService">Service `NetworkCryptoService`</a>
 
@@ -4091,10 +4091,10 @@ The NsEndDeviceRegistry service allows clients to manage their end devices on th
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `Get` | `GET` | `/api/v3//ns/applications/{end_device_ids.application_ids.application_id}/devices/{end_device_ids.device_id}` |  |
-| `Set` | `PUT` | `/api/v3//ns/applications/{end_device.ids.application_ids.application_id}/devices/{end_device.ids.device_id}` | `*` |
-| `Set` | `POST` | `/api/v3//ns/applications/{end_device.ids.application_ids.application_id}/devices` | `*` |
-| `Delete` | `DELETE` | `/api/v3//ns/applications/{application_ids.application_id}/devices/{device_id}` |  |
+| `Get` | `GET` | `/api/v3/ns/applications/{end_device_ids.application_ids.application_id}/devices/{end_device_ids.device_id}` |  |
+| `Set` | `PUT` | `/api/v3/ns/applications/{end_device.ids.application_ids.application_id}/devices/{end_device.ids.device_id}` | `*` |
+| `Set` | `POST` | `/api/v3/ns/applications/{end_device.ids.application_ids.application_id}/devices` | `*` |
+| `Delete` | `DELETE` | `/api/v3/ns/applications/{application_ids.application_id}/devices/{device_id}` |  |
 
 ## <a name="lorawan-stack/api/oauth.proto">File `lorawan-stack/api/oauth.proto`</a>
 
@@ -4246,10 +4246,10 @@ The NsEndDeviceRegistry service allows clients to manage their end devices on th
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `List` | `GET` | `/api/v3//users/{user_ids.user_id}/authorizations` |  |
-| `ListTokens` | `GET` | `/api/v3//users/{user_ids.user_id}/authorizations/{client_ids.client_id}/tokens` |  |
-| `Delete` | `DELETE` | `/api/v3//users/{user_ids.user_id}/authorizations/{client_ids.client_id}` |  |
-| `DeleteToken` | `DELETE` | `/api/v3//users/{user_ids.user_id}/authorizations/{client_ids.client_id}/tokens/{id}` |  |
+| `List` | `GET` | `/api/v3/users/{user_ids.user_id}/authorizations` |  |
+| `ListTokens` | `GET` | `/api/v3/users/{user_ids.user_id}/authorizations/{client_ids.client_id}/tokens` |  |
+| `Delete` | `DELETE` | `/api/v3/users/{user_ids.user_id}/authorizations/{client_ids.client_id}` |  |
+| `DeleteToken` | `DELETE` | `/api/v3/users/{user_ids.user_id}/authorizations/{client_ids.client_id}/tokens/{id}` |  |
 
 ## <a name="lorawan-stack/api/organization.proto">File `lorawan-stack/api/organization.proto`</a>
 
@@ -4452,13 +4452,13 @@ where the user or organization is collaborator on.
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `ListRights` | `GET` | `/api/v3//organizations/{organization_id}/rights` |  |
-| `CreateAPIKey` | `POST` | `/api/v3//organizations/{organization_ids.organization_id}/api-keys` | `*` |
-| `ListAPIKeys` | `GET` | `/api/v3//organizations/{organization_ids.organization_id}/api-keys` |  |
-| `GetAPIKey` | `GET` | `/api/v3//organizations/{organization_ids.organization_id}/api-keys/{key_id}` |  |
-| `UpdateAPIKey` | `PUT` | `/api/v3//organizations/{organization_ids.organization_id}/api-keys/{api_key.id}` | `*` |
-| `SetCollaborator` | `PUT` | `/api/v3//organizations/{organization_ids.organization_id}/collaborators` | `*` |
-| `ListCollaborators` | `GET` | `/api/v3//organizations/{organization_ids.organization_id}/collaborators` |  |
+| `ListRights` | `GET` | `/api/v3/organizations/{organization_id}/rights` |  |
+| `CreateAPIKey` | `POST` | `/api/v3/organizations/{organization_ids.organization_id}/api-keys` | `*` |
+| `ListAPIKeys` | `GET` | `/api/v3/organizations/{organization_ids.organization_id}/api-keys` |  |
+| `GetAPIKey` | `GET` | `/api/v3/organizations/{organization_ids.organization_id}/api-keys/{key_id}` |  |
+| `UpdateAPIKey` | `PUT` | `/api/v3/organizations/{organization_ids.organization_id}/api-keys/{api_key.id}` | `*` |
+| `SetCollaborator` | `PUT` | `/api/v3/organizations/{organization_ids.organization_id}/collaborators` | `*` |
+| `ListCollaborators` | `GET` | `/api/v3/organizations/{organization_ids.organization_id}/collaborators` |  |
 
 ### <a name="ttn.lorawan.v3.OrganizationRegistry">Service `OrganizationRegistry`</a>
 
@@ -4474,12 +4474,12 @@ where the user or organization is collaborator on.
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `Create` | `POST` | `/api/v3//users/{collaborator.user_ids.user_id}/organizations` | `*` |
-| `Get` | `GET` | `/api/v3//organizations/{organization_ids.organization_id}` |  |
-| `List` | `GET` | `/api/v3//organizations` |  |
-| `List` | `GET` | `/api/v3//users/{collaborator.user_ids.user_id}/organizations` |  |
-| `Update` | `PUT` | `/api/v3//organizations/{organization.ids.organization_id}` | `*` |
-| `Delete` | `DELETE` | `/api/v3//organizations/{organization_id}` |  |
+| `Create` | `POST` | `/api/v3/users/{collaborator.user_ids.user_id}/organizations` | `*` |
+| `Get` | `GET` | `/api/v3/organizations/{organization_ids.organization_id}` |  |
+| `List` | `GET` | `/api/v3/organizations` |  |
+| `List` | `GET` | `/api/v3/users/{collaborator.user_ids.user_id}/organizations` |  |
+| `Update` | `PUT` | `/api/v3/organizations/{organization.ids.organization_id}` | `*` |
+| `Delete` | `DELETE` | `/api/v3/organizations/{organization_id}` |  |
 
 ## <a name="lorawan-stack/api/regional.proto">File `lorawan-stack/api/regional.proto`</a>
 
@@ -4714,7 +4714,7 @@ This service is not implemented on all deployments.
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `SearchEndDevices` | `GET` | `/api/v3//search/applications/{application_ids.application_id}/devices` |  |
+| `SearchEndDevices` | `GET` | `/api/v3/search/applications/{application_ids.application_id}/devices` |  |
 
 ### <a name="ttn.lorawan.v3.EntityRegistrySearch">Service `EntityRegistrySearch`</a>
 
@@ -4734,11 +4734,11 @@ This service is not implemented on all deployments.
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `SearchApplications` | `GET` | `/api/v3//search/applications` |  |
-| `SearchClients` | `GET` | `/api/v3//search/clients` |  |
-| `SearchGateways` | `GET` | `/api/v3//search/gateways` |  |
-| `SearchOrganizations` | `GET` | `/api/v3//search/organizations` |  |
-| `SearchUsers` | `GET` | `/api/v3//search/users` |  |
+| `SearchApplications` | `GET` | `/api/v3/search/applications` |  |
+| `SearchClients` | `GET` | `/api/v3/search/clients` |  |
+| `SearchGateways` | `GET` | `/api/v3/search/gateways` |  |
+| `SearchOrganizations` | `GET` | `/api/v3/search/organizations` |  |
+| `SearchUsers` | `GET` | `/api/v3/search/users` |  |
 
 ## <a name="lorawan-stack/api/user.proto">File `lorawan-stack/api/user.proto`</a>
 
@@ -5071,11 +5071,11 @@ User is the message that defines an user on the network.
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `ListRights` | `GET` | `/api/v3//users/{user_id}/rights` |  |
-| `CreateAPIKey` | `POST` | `/api/v3//users/{user_ids.user_id}/api-keys` | `*` |
-| `ListAPIKeys` | `GET` | `/api/v3//users/{user_ids.user_id}/api-keys` |  |
-| `GetAPIKey` | `GET` | `/api/v3//users/{user_ids.user_id}/api-keys/{key_id}` |  |
-| `UpdateAPIKey` | `PUT` | `/api/v3//users/{user_ids.user_id}/api-keys/{api_key.id}` | `*` |
+| `ListRights` | `GET` | `/api/v3/users/{user_id}/rights` |  |
+| `CreateAPIKey` | `POST` | `/api/v3/users/{user_ids.user_id}/api-keys` | `*` |
+| `ListAPIKeys` | `GET` | `/api/v3/users/{user_ids.user_id}/api-keys` |  |
+| `GetAPIKey` | `GET` | `/api/v3/users/{user_ids.user_id}/api-keys/{key_id}` |  |
+| `UpdateAPIKey` | `PUT` | `/api/v3/users/{user_ids.user_id}/api-keys/{api_key.id}` | `*` |
 
 ### <a name="ttn.lorawan.v3.UserInvitationRegistry">Service `UserInvitationRegistry`</a>
 
@@ -5089,9 +5089,9 @@ User is the message that defines an user on the network.
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `Send` | `POST` | `/api/v3//invitations` | `*` |
-| `List` | `GET` | `/api/v3//invitations` |  |
-| `Delete` | `DELETE` | `/api/v3//invitations` |  |
+| `Send` | `POST` | `/api/v3/invitations` | `*` |
+| `List` | `GET` | `/api/v3/invitations` |  |
+| `Delete` | `DELETE` | `/api/v3/invitations` |  |
 
 ### <a name="ttn.lorawan.v3.UserRegistry">Service `UserRegistry`</a>
 
@@ -5108,12 +5108,12 @@ User is the message that defines an user on the network.
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `Create` | `POST` | `/api/v3//users` | `*` |
-| `Get` | `GET` | `/api/v3//users/{user_ids.user_id}` |  |
-| `Update` | `PUT` | `/api/v3//users/{user.ids.user_id}` | `*` |
-| `CreateTemporaryPassword` | `POST` | `/api/v3//users/{user_ids.user_id}/temporary_password` |  |
-| `UpdatePassword` | `PUT` | `/api/v3//users/{user_ids.user_id}/password` | `*` |
-| `Delete` | `DELETE` | `/api/v3//users/{user_id}` |  |
+| `Create` | `POST` | `/api/v3/users` | `*` |
+| `Get` | `GET` | `/api/v3/users/{user_ids.user_id}` |  |
+| `Update` | `PUT` | `/api/v3/users/{user.ids.user_id}` | `*` |
+| `CreateTemporaryPassword` | `POST` | `/api/v3/users/{user_ids.user_id}/temporary_password` |  |
+| `UpdatePassword` | `PUT` | `/api/v3/users/{user_ids.user_id}/password` | `*` |
+| `Delete` | `DELETE` | `/api/v3/users/{user_id}` |  |
 
 ### <a name="ttn.lorawan.v3.UserSessionRegistry">Service `UserSessionRegistry`</a>
 
@@ -5126,8 +5126,8 @@ User is the message that defines an user on the network.
 
 | Method Name | Method | Pattern | Body |
 | ----------- | ------ | ------- | ---- |
-| `List` | `GET` | `/api/v3//users/{user_ids.user_id}/sessions` |  |
-| `Delete` | `DELETE` | `/api/v3//users/{user_ids.user_id}/sessions/{session_id}` |  |
+| `List` | `GET` | `/api/v3/users/{user_ids.user_id}/sessions` |  |
+| `Delete` | `DELETE` | `/api/v3/users/{user_ids.user_id}/sessions/{session_id}` |  |
 
 ## Scalar Value Types
 

--- a/api/api.md.tmpl
+++ b/api/api.md.tmpl
@@ -97,7 +97,7 @@
 | ----------- | ------ | ------- | ---- |
 {{- range $service.MethodsWithOption "google.api.http" }}{{ $method := . }}
 {{- range (.Option "google.api.http").Rules }}
-| `{{ $method.Name }}` | `{{ .Method }}` | `/api/v3/{{ .Pattern }}` | {{ with .Body }}`{{ . }}`{{ end }} |
+| `{{ $method.Name }}` | `{{ .Method }}` | `/api/v3{{ .Pattern }}` | {{ with .Body }}`{{ . }}`{{ end }} |
 {{- end -}}
 {{- end -}}
 {{ end -}}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a small PR that fixes double slashes in the documented HTTP mappings for our gRPC methods.
