### PR TITLE
all: Make Application/Device separator a dot

### DIFF
--- a/pkg/applicationserver/io/grpc/grpc_test.go
+++ b/pkg/applicationserver/io/grpc/grpc_test.go
@@ -28,13 +28,14 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/pkg/unique"
 	"go.thethings.network/lorawan-stack/pkg/util/test"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 )
 
 var (
-	registeredApplicationUID = "test-app"
 	registeredApplicationID  = ttnpb.ApplicationIdentifiers{ApplicationID: "test-app"}
+	registeredApplicationUID = unique.ID(test.Context(), registeredApplicationID)
 	registeredApplicationKey = "test-key"
 
 	timeout = 10 * test.Delay

--- a/pkg/applicationserver/io/mqtt/mqtt_test.go
+++ b/pkg/applicationserver/io/mqtt/mqtt_test.go
@@ -35,8 +35,8 @@ import (
 )
 
 var (
-	registeredApplicationUID = "test-app"
 	registeredApplicationID  = ttnpb.ApplicationIdentifiers{ApplicationID: "test-app"}
+	registeredApplicationUID = unique.ID(test.Context(), registeredApplicationID)
 	registeredApplicationKey = "test-key"
 	registeredDeviceID       = ttnpb.EndDeviceIdentifiers{
 		ApplicationIdentifiers: registeredApplicationID,

--- a/pkg/applicationserver/io/web/util_test.go
+++ b/pkg/applicationserver/io/web/util_test.go
@@ -28,10 +28,8 @@ import (
 )
 
 var (
-	registeredApplicationUID = "foo-app"
-	registeredApplicationID  = ttnpb.ApplicationIdentifiers{
-		ApplicationID: "foo-app",
-	}
+	registeredApplicationID  = ttnpb.ApplicationIdentifiers{ApplicationID: "foo-app"}
+	registeredApplicationUID = unique.ID(test.Context(), registeredApplicationID)
 	registeredApplicationKey = "secret"
 	registeredDeviceID       = ttnpb.EndDeviceIdentifiers{
 		ApplicationIdentifiers: registeredApplicationID,

--- a/pkg/basicstation/cups/server_test.go
+++ b/pkg/basicstation/cups/server_test.go
@@ -311,7 +311,8 @@ func TestServer(t *testing.T) {
 				WithAuth(mockAuthFunc),
 				WithRegistries(store, store),
 			}, tt.Options...)...)
-			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(updateInfoRequest))
+			req := httptest.NewRequest(http.MethodPost, "/update-info", strings.NewReader(updateInfoRequest))
+			req = req.WithContext(test.Context())
 			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 			req.Header.Set(echo.HeaderAuthorization, "random string")
 			if tt.RequestSetup != nil {

--- a/pkg/gatewayconfigurationserver/gatewayconfigurationserver_test.go
+++ b/pkg/gatewayconfigurationserver/gatewayconfigurationserver_test.go
@@ -36,8 +36,8 @@ import (
 )
 
 var (
-	registeredGatewayUID = "test-gateway"
 	registeredGatewayID  = ttnpb.GatewayIdentifiers{GatewayID: "test-gateway"}
+	registeredGatewayUID = unique.ID(test.Context(), registeredGatewayID)
 	registeredGatewayKey = "test-key"
 
 	testConfig = &Config{

--- a/pkg/gatewayconfigurationserver/gatewayconfigurationserver_test.go
+++ b/pkg/gatewayconfigurationserver/gatewayconfigurationserver_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -114,20 +115,18 @@ func TestWeb(t *testing.T) {
 		} {
 			t.Run(tc.Name, func(t *testing.T) {
 				a := assertions.New(t)
-				url := fmt.Sprintf("http://%s/api/v3/gcs/gateways/%s/semtechudp/global_conf.json",
-					httpAddress, tc.ID.GatewayID,
+				url := fmt.Sprintf(
+					"/api/v3/gcs/gateways/%s/semtechudp/global_conf.json",
+					tc.ID.GatewayID,
 				)
 				body := bytes.NewReader([]byte(`{"downlinks":[]}`))
-				req, err := http.NewRequest(http.MethodGet, url, body)
-				if !a.So(err, should.BeNil) {
-					t.FailNow()
-				}
+				req := httptest.NewRequest(http.MethodGet, url, body)
+				req = req.WithContext(test.Context())
 				req.Header.Set("Content-Type", "application/json")
 				req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tc.Key))
-				res, err := http.DefaultClient.Do(req)
-				if !a.So(err, should.BeNil) {
-					t.FailNow()
-				}
+				rec := httptest.NewRecorder()
+				c.ServeHTTP(rec, req)
+				res := rec.Result()
 				a.So(res.StatusCode, should.Equal, tc.ExpectCode)
 			})
 		}

--- a/pkg/gatewayserver/io/grpc/grpc_test.go
+++ b/pkg/gatewayserver/io/grpc/grpc_test.go
@@ -30,13 +30,14 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/types"
+	"go.thethings.network/lorawan-stack/pkg/unique"
 	"go.thethings.network/lorawan-stack/pkg/util/test"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 )
 
 var (
-	registeredGatewayUID = "test-gateway"
 	registeredGatewayID  = ttnpb.GatewayIdentifiers{GatewayID: "test-gateway"}
+	registeredGatewayUID = unique.ID(test.Context(), registeredGatewayID)
 	registeredGatewayKey = "test-key"
 
 	timeout = 10 * test.Delay

--- a/pkg/gatewayserver/io/mqtt/mqtt_test.go
+++ b/pkg/gatewayserver/io/mqtt/mqtt_test.go
@@ -30,13 +30,14 @@ import (
 	. "go.thethings.network/lorawan-stack/pkg/gatewayserver/io/mqtt"
 	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/pkg/unique"
 	"go.thethings.network/lorawan-stack/pkg/util/test"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 )
 
 var (
-	registeredGatewayUID = "test-gateway"
 	registeredGatewayID  = ttnpb.GatewayIdentifiers{GatewayID: "test-gateway"}
+	registeredGatewayUID = unique.ID(test.Context(), registeredGatewayID)
 	registeredGatewayKey = "test-key"
 
 	timeout = 10 * test.Delay

--- a/pkg/gatewayserver/io/udp/udp_test.go
+++ b/pkg/gatewayserver/io/udp/udp_test.go
@@ -31,13 +31,14 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	encoding "go.thethings.network/lorawan-stack/pkg/ttnpb/udp"
 	"go.thethings.network/lorawan-stack/pkg/types"
+	"go.thethings.network/lorawan-stack/pkg/unique"
 	"go.thethings.network/lorawan-stack/pkg/util/test"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 )
 
 var (
-	registeredGatewayUID = "test-gateway"
 	registeredGatewayID  = ttnpb.GatewayIdentifiers{GatewayID: "test-gateway"}
+	registeredGatewayUID = unique.ID(test.Context(), registeredGatewayID)
 	registeredGatewayKey = "test-key"
 
 	timeout = (1 << 4) * test.Delay

--- a/pkg/ttnpb/identifiers.go
+++ b/pkg/ttnpb/identifiers.go
@@ -94,7 +94,7 @@ func (ids EntityIdentifiers) IDString() string {
 	case *EntityIdentifiers_ClientIDs:
 		return oneof.ClientIDs.GetClientID()
 	case *EntityIdentifiers_DeviceIDs:
-		return fmt.Sprintf("%s:%s", oneof.DeviceIDs.GetApplicationID(), oneof.DeviceIDs.GetDeviceID())
+		return fmt.Sprintf("%s.%s", oneof.DeviceIDs.GetApplicationID(), oneof.DeviceIDs.GetDeviceID())
 	case *EntityIdentifiers_GatewayIDs:
 		return oneof.GatewayIDs.GetGatewayID()
 	case *EntityIdentifiers_OrganizationIDs:

--- a/pkg/unique/unique.go
+++ b/pkg/unique/unique.go
@@ -74,7 +74,7 @@ func ToClientID(uid string) (id ttnpb.ClientIdentifiers, err error) {
 func ToDeviceID(uid string) (id ttnpb.EndDeviceIdentifiers, err error) {
 	sepIdx := strings.Index(uid, ".")
 	if sepIdx == -1 {
-		return ttnpb.EndDeviceIdentifiers{}, errFormat.WithAttributes("uid", uid)
+		return ttnpb.EndDeviceIdentifiers{}, errFormat.WithAttributes("value", uid)
 	}
 	id.ApplicationIdentifiers.ApplicationID = uid[:sepIdx]
 	id.DeviceID = uid[sepIdx+1:]


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a small PR that changes the separator of AppID/DevID from a colon to a dot. The reason to do this is that our Redis namespacing already uses colons, which could become confusing. 

Refs https://github.com/TheThingsIndustries/lorawan-stack/issues/1441

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- Nothing is actually changing, as the IDString function wasn't actually called (at least, not for EndDevices). It's just a precaution.
- There are some other changes in here related to how unique IDs are constructed in tests.