### PR TITLE
Fix x-total-count header for API Keys and Collaborators

### DIFF
--- a/pkg/identityserver/store/api_key_store.go
+++ b/pkg/identityserver/store/api_key_store.go
@@ -67,6 +67,7 @@ func (s *apiKeyStore) FindAPIKeys(ctx context.Context, entityID *ttnpb.EntityIde
 	if err = query.Find(&keyModels).Error; err != nil {
 		return nil, err
 	}
+	setTotal(ctx, uint64(len(keyModels)))
 	keyProtos := make([]*ttnpb.APIKey, len(keyModels))
 	for i, apiKey := range keyModels {
 		keyProtos[i] = apiKey.toPB()

--- a/pkg/identityserver/store/membership_store.go
+++ b/pkg/identityserver/store/membership_store.go
@@ -51,6 +51,7 @@ func (s *membershipStore) FindMembers(ctx context.Context, entityID *ttnpb.Entit
 	if err = query.Find(&memberships).Error; err != nil {
 		return nil, err
 	}
+	setTotal(ctx, uint64(len(memberships)))
 	membershipRights := make(map[*ttnpb.OrganizationOrUserIdentifiers]*ttnpb.Rights, len(memberships))
 	for _, membership := range memberships {
 		ids := membership.Account.OrganizationOrUserIdentifiers()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes the `x-total-count` header for API keys and collaborators.
Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/679

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Fixed the `x-total-count` header value for API Keys and collaborators 
