### PR TITLE
Redefine ttnpb.Identifiers

### DIFF
--- a/pkg/auth/rights/hook.go
+++ b/pkg/auth/rights/hook.go
@@ -55,7 +55,9 @@ func Hook(next grpc.UnaryHandler) grpc.UnaryHandler {
 		if !ok {
 			panic(errNoFetcher)
 		}
-		ids, ok := req.(ttnpb.Identifiers)
+		ids, ok := req.(interface {
+			CombinedIdentifiers() *ttnpb.CombinedIdentifiers
+		})
 		if !ok {
 			return next(ctx, req)
 		}

--- a/pkg/events/default.go
+++ b/pkg/events/default.go
@@ -14,11 +14,7 @@
 
 package events
 
-import (
-	"context"
-
-	"go.thethings.network/lorawan-stack/pkg/ttnpb"
-)
+import "context"
 
 // DefaultPubSub is the default event pubsub.
 var DefaultPubSub = NewPubSub(DefaultBufferSize)
@@ -43,7 +39,7 @@ func Publish(evt Event) {
 // Event identifiers identify the TTN entities that are related to the event.
 // System events have nil identifiers.
 // Event data will in most cases be marshaled to JSON, but ideally is a proto message.
-func PublishEvent(ctx context.Context, name string, identifiers ttnpb.Identifiers, data interface{}) {
+func PublishEvent(ctx context.Context, name string, identifiers CombinedIdentifiers, data interface{}) {
 	localEvent := local(New(ctx, name, identifiers, data))
 	localEvent = localEvent.withCaller()
 	Publish(localEvent)

--- a/pkg/events/definitions.go
+++ b/pkg/events/definitions.go
@@ -19,13 +19,12 @@ import (
 	"fmt"
 
 	"go.thethings.network/lorawan-stack/pkg/i18n"
-	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 )
 
 const i18nPrefix = "event"
 
 // Definition of a registered event.
-type Definition func(ctx context.Context, identifiers ttnpb.Identifiers, data interface{}) Event
+type Definition func(ctx context.Context, identifiers CombinedIdentifiers, data interface{}) Event
 
 // Definitions of registered events.
 // Events that are defined in init() funcs will be collected for translation.
@@ -40,7 +39,7 @@ func defineSkip(name, description string, skip uint) Definition {
 	i18n.Define(fmt.Sprintf("%s:%s", i18nPrefix, name), description).SetSource(1 + skip)
 	Definitions[name] = description
 	initMetrics(name)
-	return func(ctx context.Context, identifiers ttnpb.Identifiers, data interface{}) Event {
+	return func(ctx context.Context, identifiers CombinedIdentifiers, data interface{}) Event {
 		return New(ctx, name, identifiers, data)
 	}
 }

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -133,7 +133,7 @@ func init() {
 // Event identifiers identify the TTN entities that are related to the event.
 // System events have nil identifiers.
 // Event data will in most cases be marshaled to JSON, but ideally is a proto message.
-func New(ctx context.Context, name string, identifiers ttnpb.Identifiers, data interface{}) Event {
+func New(ctx context.Context, name string, identifiers CombinedIdentifiers, data interface{}) Event {
 	evt := &event{
 		ctx: ctx,
 		innerEvent: ttnpb.Event{

--- a/pkg/events/identifiers.go
+++ b/pkg/events/identifiers.go
@@ -22,12 +22,16 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/unique"
 )
 
+type CombinedIdentifiers interface {
+	CombinedIdentifiers() *ttnpb.CombinedIdentifiers
+}
+
 // IdentifierFilter can be used as a layer on top of a PubSub to filter events
 // based on the identifiers they contain.
 type IdentifierFilter interface {
 	Handler
-	Subscribe(ctx context.Context, ids ttnpb.Identifiers, handler Handler)
-	Unsubscribe(ctx context.Context, ids ttnpb.Identifiers, handler Handler)
+	Subscribe(ctx context.Context, ids CombinedIdentifiers, handler Handler)
+	Unsubscribe(ctx context.Context, ids CombinedIdentifiers, handler Handler)
 }
 
 // NewIdentifierFilter returns a new IdentifierFilter (see interface).
@@ -61,7 +65,7 @@ type identifierFilter struct {
 	userIDs         map[string][]Handler
 }
 
-func (f *identifierFilter) Subscribe(ctx context.Context, ids ttnpb.Identifiers, handler Handler) {
+func (f *identifierFilter) Subscribe(ctx context.Context, ids CombinedIdentifiers, handler Handler) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	for _, entityIDs := range ids.CombinedIdentifiers().GetEntityIdentifiers() {
@@ -94,7 +98,7 @@ func removeHandler(handlers []Handler, toRemove Handler) []Handler {
 	return updated
 }
 
-func (f *identifierFilter) Unsubscribe(ctx context.Context, ids ttnpb.Identifiers, handler Handler) {
+func (f *identifierFilter) Unsubscribe(ctx context.Context, ids CombinedIdentifiers, handler Handler) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	for _, entityIDs := range ids.CombinedIdentifiers().GetEntityIdentifiers() {

--- a/pkg/identityserver/application_access.go
+++ b/pkg/identityserver/application_access.go
@@ -63,7 +63,7 @@ func (is *IdentityServer) createApplicationAPIKey(ctx context.Context, req *ttnp
 		return nil, err
 	}
 	err = is.withDatabase(ctx, func(db *gorm.DB) error {
-		return store.GetAPIKeyStore(db).CreateAPIKey(ctx, req.ApplicationIdentifiers.EntityIdentifiers(), key)
+		return store.GetAPIKeyStore(db).CreateAPIKey(ctx, req.ApplicationIdentifiers, key)
 	})
 	if err != nil {
 		return nil, err
@@ -93,7 +93,7 @@ func (is *IdentityServer) listApplicationAPIKeys(ctx context.Context, req *ttnpb
 	}()
 	keys = &ttnpb.APIKeys{}
 	err = is.withDatabase(ctx, func(db *gorm.DB) (err error) {
-		keys.APIKeys, err = store.GetAPIKeyStore(db).FindAPIKeys(ctx, req.EntityIdentifiers())
+		keys.APIKeys, err = store.GetAPIKeyStore(db).FindAPIKeys(ctx, req.ApplicationIdentifiers)
 		return err
 	})
 	if err != nil {
@@ -135,7 +135,7 @@ func (is *IdentityServer) updateApplicationAPIKey(ctx context.Context, req *ttnp
 		return nil, err
 	}
 	err = is.withDatabase(ctx, func(db *gorm.DB) (err error) {
-		key, err = store.GetAPIKeyStore(db).UpdateAPIKey(ctx, req.ApplicationIdentifiers.EntityIdentifiers(), &req.APIKey)
+		key, err = store.GetAPIKeyStore(db).UpdateAPIKey(ctx, req.ApplicationIdentifiers, &req.APIKey)
 		return err
 	})
 	if err != nil {
@@ -173,7 +173,7 @@ func (is *IdentityServer) setApplicationCollaborator(ctx context.Context, req *t
 		return store.GetMembershipStore(db).SetMember(
 			ctx,
 			&req.Collaborator.OrganizationOrUserIdentifiers,
-			req.ApplicationIdentifiers.EntityIdentifiers(),
+			req.ApplicationIdentifiers,
 			ttnpb.RightsFrom(req.Collaborator.Rights...),
 		)
 	})
@@ -208,7 +208,7 @@ func (is *IdentityServer) listApplicationCollaborators(ctx context.Context, req 
 		}
 	}()
 	err = is.withDatabase(ctx, func(db *gorm.DB) error {
-		memberRights, err := store.GetMembershipStore(db).FindMembers(ctx, req.EntityIdentifiers())
+		memberRights, err := store.GetMembershipStore(db).FindMembers(ctx, req.ApplicationIdentifiers)
 		if err != nil {
 			return err
 		}

--- a/pkg/identityserver/application_registry.go
+++ b/pkg/identityserver/application_registry.go
@@ -121,7 +121,7 @@ func (is *IdentityServer) listApplications(ctx context.Context, req *ttnpb.ListA
 		}
 		appRights = make(map[string]*ttnpb.Rights, len(callerRights))
 		for ids, rights := range callerRights {
-			if ids := ids.GetApplicationIDs(); ids != nil {
+			if ids.EntityType() == "application" {
 				appRights[unique.ID(ctx, ids)] = rights
 			}
 		}

--- a/pkg/identityserver/application_registry.go
+++ b/pkg/identityserver/application_registry.go
@@ -58,14 +58,14 @@ func (is *IdentityServer) createApplication(ctx context.Context, req *ttnpb.Crea
 		if err = store.GetMembershipStore(db).SetMember(
 			ctx,
 			&req.Collaborator,
-			app.ApplicationIdentifiers.EntityIdentifiers(),
+			app.ApplicationIdentifiers,
 			ttnpb.RightsFrom(ttnpb.RIGHT_ALL),
 		); err != nil {
 			return err
 		}
 		if len(req.ContactInfo) > 0 {
 			cleanContactInfo(req.ContactInfo)
-			app.ContactInfo, err = store.GetContactInfoStore(db).SetContactInfo(ctx, app.EntityIdentifiers(), req.ContactInfo)
+			app.ContactInfo, err = store.GetContactInfoStore(db).SetContactInfo(ctx, app.ApplicationIdentifiers, req.ContactInfo)
 			if err != nil {
 				return err
 			}
@@ -98,7 +98,7 @@ func (is *IdentityServer) getApplication(ctx context.Context, req *ttnpb.GetAppl
 			return err
 		}
 		if ttnpb.HasAnyField(req.FieldMask.Paths, "contact_info") {
-			app.ContactInfo, err = store.GetContactInfoStore(db).GetContactInfo(ctx, app.EntityIdentifiers())
+			app.ContactInfo, err = store.GetContactInfoStore(db).GetContactInfo(ctx, app.ApplicationIdentifiers)
 			if err != nil {
 				return err
 			}
@@ -205,7 +205,7 @@ func (is *IdentityServer) updateApplication(ctx context.Context, req *ttnpb.Upda
 		}
 		if ttnpb.HasAnyField(req.FieldMask.Paths, "contact_info") {
 			cleanContactInfo(req.ContactInfo)
-			app.ContactInfo, err = store.GetContactInfoStore(db).SetContactInfo(ctx, app.EntityIdentifiers(), req.ContactInfo)
+			app.ContactInfo, err = store.GetContactInfoStore(db).SetContactInfo(ctx, app.ApplicationIdentifiers, req.ContactInfo)
 			if err != nil {
 				return err
 			}

--- a/pkg/identityserver/application_registry_test.go
+++ b/pkg/identityserver/application_registry_test.go
@@ -31,9 +31,9 @@ func init() {
 	userID := paginationUser.UserIdentifiers
 	for _, app := range population.Applications {
 		for id, collaborators := range population.Memberships {
-			if app.EntityIdentifiers().IDString() == id.IDString() {
+			if app.IDString() == id.IDString() {
 				for i, collaborator := range collaborators {
-					if collaborator.EntityIdentifiers().IDString() == userID.GetUserID() {
+					if collaborator.IDString() == userID.GetUserID() {
 						collaborators = collaborators[:i+copy(collaborators[i:], collaborators[i+1:])]
 					}
 				}

--- a/pkg/identityserver/client_access.go
+++ b/pkg/identityserver/client_access.go
@@ -59,7 +59,7 @@ func (is *IdentityServer) setClientCollaborator(ctx context.Context, req *ttnpb.
 		return store.GetMembershipStore(db).SetMember(
 			ctx,
 			&req.Collaborator.OrganizationOrUserIdentifiers,
-			req.ClientIdentifiers.EntityIdentifiers(),
+			req.ClientIdentifiers,
 			ttnpb.RightsFrom(req.Collaborator.Rights...),
 		)
 	})
@@ -94,7 +94,7 @@ func (is *IdentityServer) listClientCollaborators(ctx context.Context, req *ttnp
 		}
 	}()
 	err = is.withDatabase(ctx, func(db *gorm.DB) error {
-		memberRights, err := store.GetMembershipStore(db).FindMembers(ctx, req.EntityIdentifiers())
+		memberRights, err := store.GetMembershipStore(db).FindMembers(ctx, req.ClientIdentifiers)
 		if err != nil {
 			return err
 		}

--- a/pkg/identityserver/client_registry.go
+++ b/pkg/identityserver/client_registry.go
@@ -81,14 +81,14 @@ func (is *IdentityServer) createClient(ctx context.Context, req *ttnpb.CreateCli
 		if err = store.GetMembershipStore(db).SetMember(
 			ctx,
 			&req.Collaborator,
-			cli.ClientIdentifiers.EntityIdentifiers(),
+			cli.ClientIdentifiers,
 			ttnpb.RightsFrom(ttnpb.RIGHT_ALL),
 		); err != nil {
 			return err
 		}
 		if len(req.ContactInfo) > 0 {
 			cleanContactInfo(req.ContactInfo)
-			cli.ContactInfo, err = store.GetContactInfoStore(db).SetContactInfo(ctx, cli.EntityIdentifiers(), req.ContactInfo)
+			cli.ContactInfo, err = store.GetContactInfoStore(db).SetContactInfo(ctx, cli.ClientIdentifiers, req.ContactInfo)
 			if err != nil {
 				return err
 			}
@@ -124,7 +124,7 @@ func (is *IdentityServer) getClient(ctx context.Context, req *ttnpb.GetClientReq
 			return err
 		}
 		if ttnpb.HasAnyField(req.FieldMask.Paths, "contact_info") {
-			cli.ContactInfo, err = store.GetContactInfoStore(db).GetContactInfo(ctx, cli.EntityIdentifiers())
+			cli.ContactInfo, err = store.GetContactInfoStore(db).GetContactInfo(ctx, cli.ClientIdentifiers)
 			if err != nil {
 				return err
 			}
@@ -241,7 +241,7 @@ func (is *IdentityServer) updateClient(ctx context.Context, req *ttnpb.UpdateCli
 		}
 		if ttnpb.HasAnyField(req.FieldMask.Paths, "contact_info") {
 			cleanContactInfo(req.ContactInfo)
-			cli.ContactInfo, err = store.GetContactInfoStore(db).SetContactInfo(ctx, cli.EntityIdentifiers(), req.ContactInfo)
+			cli.ContactInfo, err = store.GetContactInfoStore(db).SetContactInfo(ctx, cli.ClientIdentifiers, req.ContactInfo)
 			if err != nil {
 				return err
 			}

--- a/pkg/identityserver/client_registry.go
+++ b/pkg/identityserver/client_registry.go
@@ -147,7 +147,7 @@ func (is *IdentityServer) listClients(ctx context.Context, req *ttnpb.ListClient
 		}
 		cliRights = make(map[string]*ttnpb.Rights, len(callerRights))
 		for ids, rights := range callerRights {
-			if ids := ids.GetClientIDs(); ids != nil {
+			if ids.EntityType() == "client" {
 				cliRights[unique.ID(ctx, ids)] = rights
 			}
 		}

--- a/pkg/identityserver/client_registry_test.go
+++ b/pkg/identityserver/client_registry_test.go
@@ -31,9 +31,9 @@ func init() {
 	userID := paginationUser.UserIdentifiers
 	for _, client := range population.Clients {
 		for id, collaborators := range population.Memberships {
-			if client.EntityIdentifiers().IDString() == id.IDString() {
+			if client.IDString() == id.IDString() {
 				for i, collaborator := range collaborators {
-					if collaborator.EntityIdentifiers().IDString() == userID.GetUserID() {
+					if collaborator.IDString() == userID.GetUserID() {
 						collaborators = collaborators[:i+copy(collaborators[i:], collaborators[i+1:])]
 					}
 				}

--- a/pkg/identityserver/entity_access_cache.go
+++ b/pkg/identityserver/entity_access_cache.go
@@ -24,7 +24,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/unique"
 )
 
-func (is *IdentityServer) cachedMembershipsForAccount(ctx context.Context, ouIDs *ttnpb.OrganizationOrUserIdentifiers) map[*ttnpb.EntityIdentifiers]*ttnpb.Rights {
+func (is *IdentityServer) cachedMembershipsForAccount(ctx context.Context, ouIDs *ttnpb.OrganizationOrUserIdentifiers) map[ttnpb.Identifiers]*ttnpb.Rights {
 	if is.redis == nil || is.config.AuthCache.MembershipTTL == 0 {
 		return nil
 	}
@@ -39,7 +39,7 @@ func (is *IdentityServer) cachedMembershipsForAccount(ctx context.Context, ouIDs
 	if len(hash) == 0 {
 		return nil
 	}
-	entityRights := make(map[*ttnpb.EntityIdentifiers]*ttnpb.Rights, len(hash))
+	entityRights := make(map[ttnpb.Identifiers]*ttnpb.Rights, len(hash))
 	for k, v := range hash {
 		var entity ttnpb.EntityIdentifiers
 		var rights ttnpb.Rights
@@ -49,7 +49,7 @@ func (is *IdentityServer) cachedMembershipsForAccount(ctx context.Context, ouIDs
 		if err = ttnredis.UnmarshalProto(v, &rights); err != nil {
 			return nil
 		}
-		entityRights[&entity] = &rights
+		entityRights[entity.Identifiers()] = &rights
 	}
 	return entityRights
 }
@@ -64,7 +64,7 @@ func (is *IdentityServer) invalidateCachedMembershipsForAccount(ctx context.Cont
 	}
 }
 
-func (is *IdentityServer) cacheMembershipsForAccount(ctx context.Context, ouIDs *ttnpb.OrganizationOrUserIdentifiers, entityRights map[*ttnpb.EntityIdentifiers]*ttnpb.Rights) {
+func (is *IdentityServer) cacheMembershipsForAccount(ctx context.Context, ouIDs *ttnpb.OrganizationOrUserIdentifiers, entityRights map[ttnpb.Identifiers]*ttnpb.Rights) {
 	if is.redis == nil || is.config.AuthCache.MembershipTTL == 0 {
 		return
 	}
@@ -73,7 +73,7 @@ func (is *IdentityServer) cacheMembershipsForAccount(ctx context.Context, ouIDs 
 	}
 	hash := make(map[string]interface{}, len(entityRights))
 	for entity, rights := range entityRights {
-		k, err := ttnredis.MarshalProto(entity)
+		k, err := ttnredis.MarshalProto(entity.EntityIdentifiers())
 		if err != nil {
 			return
 		}

--- a/pkg/identityserver/entity_access_test.go
+++ b/pkg/identityserver/entity_access_test.go
@@ -99,10 +99,10 @@ func TestEntityAccess(t *testing.T) {
 
 			ctx := log.NewContext(ctx, is.Logger())
 
-			entityRights, err := is.memberRights(ctx, adminUser.EntityIdentifiers())
+			entityRights, err := is.memberRights(ctx, adminUser)
 			a.So(err, should.BeNil)
 
-			cachedEntityRights, err := is.memberRights(ctx, adminUser.EntityIdentifiers())
+			cachedEntityRights, err := is.memberRights(ctx, adminUser)
 			a.So(err, should.BeNil)
 
 			a.So(len(cachedEntityRights), should.Equal, len(entityRights))

--- a/pkg/identityserver/gateway_access.go
+++ b/pkg/identityserver/gateway_access.go
@@ -63,7 +63,7 @@ func (is *IdentityServer) createGatewayAPIKey(ctx context.Context, req *ttnpb.Cr
 		return nil, err
 	}
 	err = is.withDatabase(ctx, func(db *gorm.DB) error {
-		return store.GetAPIKeyStore(db).CreateAPIKey(ctx, req.GatewayIdentifiers.EntityIdentifiers(), key)
+		return store.GetAPIKeyStore(db).CreateAPIKey(ctx, req.GatewayIdentifiers, key)
 	})
 	if err != nil {
 		return nil, err
@@ -93,7 +93,7 @@ func (is *IdentityServer) listGatewayAPIKeys(ctx context.Context, req *ttnpb.Lis
 	}()
 	keys = &ttnpb.APIKeys{}
 	err = is.withDatabase(ctx, func(db *gorm.DB) (err error) {
-		keys.APIKeys, err = store.GetAPIKeyStore(db).FindAPIKeys(ctx, req.EntityIdentifiers())
+		keys.APIKeys, err = store.GetAPIKeyStore(db).FindAPIKeys(ctx, req.GatewayIdentifiers)
 		return err
 	})
 	if err != nil {
@@ -135,7 +135,7 @@ func (is *IdentityServer) updateGatewayAPIKey(ctx context.Context, req *ttnpb.Up
 		return nil, err
 	}
 	err = is.withDatabase(ctx, func(db *gorm.DB) (err error) {
-		key, err = store.GetAPIKeyStore(db).UpdateAPIKey(ctx, req.GatewayIdentifiers.EntityIdentifiers(), &req.APIKey)
+		key, err = store.GetAPIKeyStore(db).UpdateAPIKey(ctx, req.GatewayIdentifiers, &req.APIKey)
 		return err
 	})
 	if err != nil {
@@ -173,7 +173,7 @@ func (is *IdentityServer) setGatewayCollaborator(ctx context.Context, req *ttnpb
 		return store.GetMembershipStore(db).SetMember(
 			ctx,
 			&req.Collaborator.OrganizationOrUserIdentifiers,
-			req.GatewayIdentifiers.EntityIdentifiers(),
+			req.GatewayIdentifiers,
 			ttnpb.RightsFrom(req.Collaborator.Rights...),
 		)
 	})
@@ -208,7 +208,7 @@ func (is *IdentityServer) listGatewayCollaborators(ctx context.Context, req *ttn
 		}
 	}()
 	err = is.withDatabase(ctx, func(db *gorm.DB) error {
-		memberRights, err := store.GetMembershipStore(db).FindMembers(ctx, req.EntityIdentifiers())
+		memberRights, err := store.GetMembershipStore(db).FindMembers(ctx, req.GatewayIdentifiers)
 		if err != nil {
 			return err
 		}

--- a/pkg/identityserver/gateway_registry.go
+++ b/pkg/identityserver/gateway_registry.go
@@ -57,14 +57,14 @@ func (is *IdentityServer) createGateway(ctx context.Context, req *ttnpb.CreateGa
 		if err = store.GetMembershipStore(db).SetMember(
 			ctx,
 			&req.Collaborator,
-			gtw.GatewayIdentifiers.EntityIdentifiers(),
+			gtw.GatewayIdentifiers,
 			ttnpb.RightsFrom(ttnpb.RIGHT_ALL),
 		); err != nil {
 			return err
 		}
 		if len(req.ContactInfo) > 0 {
 			cleanContactInfo(req.ContactInfo)
-			gtw.ContactInfo, err = store.GetContactInfoStore(db).SetContactInfo(ctx, gtw.EntityIdentifiers(), req.ContactInfo)
+			gtw.ContactInfo, err = store.GetContactInfoStore(db).SetContactInfo(ctx, gtw.GatewayIdentifiers, req.ContactInfo)
 			if err != nil {
 				return err
 			}
@@ -97,7 +97,7 @@ func (is *IdentityServer) getGateway(ctx context.Context, req *ttnpb.GetGatewayR
 			return err
 		}
 		if ttnpb.HasAnyField(req.FieldMask.Paths, "contact_info") {
-			gtw.ContactInfo, err = store.GetContactInfoStore(db).GetContactInfo(ctx, gtw.EntityIdentifiers())
+			gtw.ContactInfo, err = store.GetContactInfoStore(db).GetContactInfo(ctx, gtw.GatewayIdentifiers)
 			if err != nil {
 				return err
 			}
@@ -224,7 +224,7 @@ func (is *IdentityServer) updateGateway(ctx context.Context, req *ttnpb.UpdateGa
 		}
 		if ttnpb.HasAnyField(req.FieldMask.Paths, "contact_info") {
 			cleanContactInfo(req.ContactInfo)
-			gtw.ContactInfo, err = store.GetContactInfoStore(db).SetContactInfo(ctx, gtw.EntityIdentifiers(), req.ContactInfo)
+			gtw.ContactInfo, err = store.GetContactInfoStore(db).SetContactInfo(ctx, gtw.GatewayIdentifiers, req.ContactInfo)
 			if err != nil {
 				return err
 			}

--- a/pkg/identityserver/gateway_registry.go
+++ b/pkg/identityserver/gateway_registry.go
@@ -140,7 +140,7 @@ func (is *IdentityServer) listGateways(ctx context.Context, req *ttnpb.ListGatew
 		}
 		gtwRights = make(map[string]*ttnpb.Rights, len(callerRights))
 		for ids, rights := range callerRights {
-			if ids := ids.GetGatewayIDs(); ids != nil {
+			if ids.EntityType() == "gateway" {
 				gtwRights[unique.ID(ctx, ids)] = rights
 			}
 		}

--- a/pkg/identityserver/gateway_registry_test.go
+++ b/pkg/identityserver/gateway_registry_test.go
@@ -32,9 +32,9 @@ func init() {
 	userID := paginationUser.UserIdentifiers
 	for _, gw := range population.Gateways {
 		for id, collaborators := range population.Memberships {
-			if gw.EntityIdentifiers().IDString() == id.IDString() {
+			if gw.IDString() == id.IDString() {
 				for i, collaborator := range collaborators {
-					if collaborator.EntityIdentifiers().IDString() == userID.GetUserID() {
+					if collaborator.IDString() == userID.GetUserID() {
 						collaborators = collaborators[:i+copy(collaborators[i:], collaborators[i+1:])]
 					}
 				}

--- a/pkg/identityserver/identityserver_test.go
+++ b/pkg/identityserver/identityserver_test.go
@@ -185,9 +185,9 @@ func userApplications(userID *ttnpb.UserIdentifiers) ttnpb.Applications {
 	applications := []*ttnpb.Application{}
 	for _, app := range population.Applications {
 		for id, collaborators := range population.Memberships {
-			if app.EntityIdentifiers().IDString() == id.IDString() {
+			if app.IDString() == id.IDString() {
 				for _, collaborator := range collaborators {
-					if collaborator.EntityIdentifiers().IDString() == userID.GetUserID() {
+					if collaborator.IDString() == userID.GetUserID() {
 						applications = append(applications, app)
 					}
 				}
@@ -204,9 +204,9 @@ func userClients(userID *ttnpb.UserIdentifiers) ttnpb.Clients {
 	clients := []*ttnpb.Client{}
 	for _, client := range population.Clients {
 		for id, collaborators := range population.Memberships {
-			if client.EntityIdentifiers().IDString() == id.IDString() {
+			if client.IDString() == id.IDString() {
 				for _, collaborator := range collaborators {
-					if collaborator.EntityIdentifiers().IDString() == userID.GetUserID() {
+					if collaborator.IDString() == userID.GetUserID() {
 						clients = append(clients, client)
 					}
 				}
@@ -223,9 +223,9 @@ func userGateways(userID *ttnpb.UserIdentifiers) ttnpb.Gateways {
 	gateways := []*ttnpb.Gateway{}
 	for _, gateway := range population.Gateways {
 		for id, collaborators := range population.Memberships {
-			if gateway.EntityIdentifiers().IDString() == id.IDString() {
+			if gateway.IDString() == id.IDString() {
 				for _, collaborator := range collaborators {
-					if collaborator.EntityIdentifiers().IDString() == userID.GetUserID() {
+					if collaborator.IDString() == userID.GetUserID() {
 						gateways = append(gateways, gateway)
 					}
 				}
@@ -242,9 +242,9 @@ func userOrganizations(userID *ttnpb.UserIdentifiers) ttnpb.Organizations {
 	organizations := []*ttnpb.Organization{}
 	for _, organization := range population.Organizations {
 		for id, collaborators := range population.Memberships {
-			if organization.EntityIdentifiers().IDString() == id.IDString() {
+			if organization.IDString() == id.IDString() {
 				for _, collaborator := range collaborators {
-					if collaborator.EntityIdentifiers().IDString() == userID.GetUserID() {
+					if collaborator.IDString() == userID.GetUserID() {
 						organizations = append(organizations, organization)
 					}
 				}

--- a/pkg/identityserver/organization_access.go
+++ b/pkg/identityserver/organization_access.go
@@ -63,7 +63,7 @@ func (is *IdentityServer) createOrganizationAPIKey(ctx context.Context, req *ttn
 		return nil, err
 	}
 	err = is.withDatabase(ctx, func(db *gorm.DB) error {
-		return store.GetAPIKeyStore(db).CreateAPIKey(ctx, req.OrganizationIdentifiers.EntityIdentifiers(), key)
+		return store.GetAPIKeyStore(db).CreateAPIKey(ctx, req.OrganizationIdentifiers, key)
 	})
 	if err != nil {
 		return nil, err
@@ -93,7 +93,7 @@ func (is *IdentityServer) listOrganizationAPIKeys(ctx context.Context, req *ttnp
 	}()
 	keys = &ttnpb.APIKeys{}
 	err = is.withDatabase(ctx, func(db *gorm.DB) (err error) {
-		keys.APIKeys, err = store.GetAPIKeyStore(db).FindAPIKeys(ctx, req.EntityIdentifiers())
+		keys.APIKeys, err = store.GetAPIKeyStore(db).FindAPIKeys(ctx, req.OrganizationIdentifiers)
 		return err
 	})
 	if err != nil {
@@ -135,7 +135,7 @@ func (is *IdentityServer) updateOrganizationAPIKey(ctx context.Context, req *ttn
 		return nil, err
 	}
 	err = is.withDatabase(ctx, func(db *gorm.DB) (err error) {
-		key, err = store.GetAPIKeyStore(db).UpdateAPIKey(ctx, req.OrganizationIdentifiers.EntityIdentifiers(), &req.APIKey)
+		key, err = store.GetAPIKeyStore(db).UpdateAPIKey(ctx, req.OrganizationIdentifiers, &req.APIKey)
 		return err
 	})
 	if err != nil {
@@ -173,7 +173,7 @@ func (is *IdentityServer) setOrganizationCollaborator(ctx context.Context, req *
 		return store.GetMembershipStore(db).SetMember(
 			ctx,
 			&req.Collaborator.OrganizationOrUserIdentifiers,
-			req.OrganizationIdentifiers.EntityIdentifiers(),
+			req.OrganizationIdentifiers,
 			ttnpb.RightsFrom(req.Collaborator.Rights...),
 		)
 	})
@@ -207,7 +207,7 @@ func (is *IdentityServer) listOrganizationCollaborators(ctx context.Context, req
 		}
 	}()
 	err = is.withDatabase(ctx, func(db *gorm.DB) (err error) {
-		memberRights, err := store.GetMembershipStore(db).FindMembers(ctx, req.EntityIdentifiers())
+		memberRights, err := store.GetMembershipStore(db).FindMembers(ctx, req.OrganizationIdentifiers)
 		if err != nil {
 			return err
 		}

--- a/pkg/identityserver/organization_registry.go
+++ b/pkg/identityserver/organization_registry.go
@@ -121,7 +121,7 @@ func (is *IdentityServer) listOrganizations(ctx context.Context, req *ttnpb.List
 		}
 		orgRights = make(map[string]*ttnpb.Rights, len(callerRights))
 		for ids, rights := range callerRights {
-			if ids := ids.GetOrganizationIDs(); ids != nil {
+			if ids.EntityType() == "organization" {
 				orgRights[unique.ID(ctx, ids)] = rights
 			}
 		}

--- a/pkg/identityserver/organization_registry.go
+++ b/pkg/identityserver/organization_registry.go
@@ -58,14 +58,14 @@ func (is *IdentityServer) createOrganization(ctx context.Context, req *ttnpb.Cre
 		if err = store.GetMembershipStore(db).SetMember(
 			ctx,
 			&req.Collaborator,
-			org.OrganizationIdentifiers.EntityIdentifiers(),
+			org.OrganizationIdentifiers,
 			ttnpb.RightsFrom(ttnpb.RIGHT_ALL),
 		); err != nil {
 			return err
 		}
 		if len(req.ContactInfo) > 0 {
 			cleanContactInfo(req.ContactInfo)
-			org.ContactInfo, err = store.GetContactInfoStore(db).SetContactInfo(ctx, org.EntityIdentifiers(), req.ContactInfo)
+			org.ContactInfo, err = store.GetContactInfoStore(db).SetContactInfo(ctx, org.OrganizationIdentifiers, req.ContactInfo)
 			if err != nil {
 				return err
 			}
@@ -98,7 +98,7 @@ func (is *IdentityServer) getOrganization(ctx context.Context, req *ttnpb.GetOrg
 			return err
 		}
 		if ttnpb.HasAnyField(req.FieldMask.Paths, "contact_info") {
-			org.ContactInfo, err = store.GetContactInfoStore(db).GetContactInfo(ctx, org.EntityIdentifiers())
+			org.ContactInfo, err = store.GetContactInfoStore(db).GetContactInfo(ctx, org.OrganizationIdentifiers)
 			if err != nil {
 				return err
 			}
@@ -203,7 +203,7 @@ func (is *IdentityServer) updateOrganization(ctx context.Context, req *ttnpb.Upd
 		}
 		if ttnpb.HasAnyField(req.FieldMask.Paths, "contact_info") {
 			cleanContactInfo(req.ContactInfo)
-			org.ContactInfo, err = store.GetContactInfoStore(db).SetContactInfo(ctx, org.EntityIdentifiers(), req.ContactInfo)
+			org.ContactInfo, err = store.GetContactInfoStore(db).SetContactInfo(ctx, org.OrganizationIdentifiers, req.ContactInfo)
 			if err != nil {
 				return err
 			}

--- a/pkg/identityserver/organization_registry_test.go
+++ b/pkg/identityserver/organization_registry_test.go
@@ -32,9 +32,9 @@ func init() {
 	// remove organizations assigned to the user by the populator
 	for _, organization := range population.Organizations {
 		for id, collaborators := range population.Memberships {
-			if organization.EntityIdentifiers().IDString() == id.IDString() {
+			if organization.IDString() == id.IDString() {
 				for i, collaborator := range collaborators {
-					if collaborator.EntityIdentifiers().IDString() == userID.GetUserID() {
+					if collaborator.IDString() == userID.GetUserID() {
 						population.Memberships[id] = collaborators[:i+copy(collaborators[i:], collaborators[i+1:])]
 					}
 				}

--- a/pkg/identityserver/registry_search.go
+++ b/pkg/identityserver/registry_search.go
@@ -55,7 +55,7 @@ func (rs *registrySearch) SearchApplications(ctx context.Context, req *ttnpb.Sea
 		}
 		var ids []*ttnpb.ApplicationIdentifiers
 		for _, id := range entityIDs {
-			id := id.GetApplicationIDs()
+			id := id.Identifiers().(*ttnpb.ApplicationIdentifiers)
 			if rights.RequireApplication(ctx, *id, ttnpb.RIGHT_APPLICATION_INFO) == nil {
 				ids = append(ids, id)
 			}
@@ -88,7 +88,7 @@ func (rs *registrySearch) SearchClients(ctx context.Context, req *ttnpb.SearchEn
 		}
 		var ids []*ttnpb.ClientIdentifiers
 		for _, id := range entityIDs {
-			id := id.GetClientIDs()
+			id := id.Identifiers().(*ttnpb.ClientIdentifiers)
 			if rights.RequireClient(ctx, *id, ttnpb.RIGHT_CLIENT_ALL) == nil {
 				ids = append(ids, id)
 			}
@@ -121,7 +121,7 @@ func (rs *registrySearch) SearchGateways(ctx context.Context, req *ttnpb.SearchE
 		}
 		var ids []*ttnpb.GatewayIdentifiers
 		for _, id := range entityIDs {
-			id := id.GetGatewayIDs()
+			id := id.Identifiers().(*ttnpb.GatewayIdentifiers)
 			if rights.RequireGateway(ctx, *id, ttnpb.RIGHT_GATEWAY_INFO) == nil {
 				ids = append(ids, id)
 			}
@@ -154,7 +154,7 @@ func (rs *registrySearch) SearchOrganizations(ctx context.Context, req *ttnpb.Se
 		}
 		var ids []*ttnpb.OrganizationIdentifiers
 		for _, id := range entityIDs {
-			id := id.GetOrganizationIDs()
+			id := id.Identifiers().(*ttnpb.OrganizationIdentifiers)
 			if rights.RequireOrganization(ctx, *id, ttnpb.RIGHT_ORGANIZATION_INFO) == nil {
 				ids = append(ids, id)
 			}
@@ -187,7 +187,7 @@ func (rs *registrySearch) SearchUsers(ctx context.Context, req *ttnpb.SearchEnti
 		}
 		var ids []*ttnpb.UserIdentifiers
 		for _, id := range entityIDs {
-			id := id.GetUserIDs()
+			id := id.Identifiers().(*ttnpb.UserIdentifiers)
 			if rights.RequireUser(ctx, *id, ttnpb.RIGHT_USER_INFO) == nil {
 				ids = append(ids, id)
 			}

--- a/pkg/identityserver/rights.go
+++ b/pkg/identityserver/rights.go
@@ -23,7 +23,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 )
 
-func (is *IdentityServer) getRights(ctx context.Context) (entity map[*ttnpb.EntityIdentifiers]*ttnpb.Rights, universal *ttnpb.Rights, err error) {
+func (is *IdentityServer) getRights(ctx context.Context) (entity map[ttnpb.Identifiers]*ttnpb.Rights, universal *ttnpb.Rights, err error) {
 	authInfo, err := is.authInfo(ctx)
 	if err != nil {
 		return nil, nil, err
@@ -43,7 +43,7 @@ func (is *IdentityServer) ApplicationRights(ctx context.Context, appIDs ttnpb.Ap
 		return nil, err
 	}
 	for ids, rights := range entity {
-		if ids := ids.GetApplicationIDs(); ids != nil && ids.ApplicationID == appIDs.ApplicationID {
+		if ids.EntityType() == "application" && ids.IDString() == appIDs.IDString() {
 			return rights.Union(universal), nil
 		}
 	}
@@ -67,7 +67,7 @@ func (is *IdentityServer) ClientRights(ctx context.Context, cliIDs ttnpb.ClientI
 		return nil, err
 	}
 	for ids, rights := range entity {
-		if ids := ids.GetClientIDs(); ids != nil && ids.ClientID == cliIDs.ClientID {
+		if ids.EntityType() == "client" && ids.IDString() == cliIDs.IDString() {
 			return rights.Union(universal), nil
 		}
 	}
@@ -91,7 +91,7 @@ func (is *IdentityServer) GatewayRights(ctx context.Context, gtwIDs ttnpb.Gatewa
 		return nil, err
 	}
 	for ids, rights := range entity {
-		if ids := ids.GetGatewayIDs(); ids != nil && ids.GatewayID == gtwIDs.GatewayID {
+		if ids.EntityType() == "gateway" && ids.IDString() == gtwIDs.IDString() {
 			return rights.Union(universal), nil
 		}
 	}
@@ -115,7 +115,7 @@ func (is *IdentityServer) OrganizationRights(ctx context.Context, orgIDs ttnpb.O
 		return nil, err
 	}
 	for ids, rights := range entity {
-		if ids := ids.GetOrganizationIDs(); ids != nil && ids.OrganizationID == orgIDs.OrganizationID {
+		if ids.EntityType() == "organization" && ids.IDString() == orgIDs.IDString() {
 			return rights.Union(universal), nil
 		}
 	}
@@ -139,7 +139,7 @@ func (is *IdentityServer) UserRights(ctx context.Context, userIDs ttnpb.UserIden
 		return nil, err
 	}
 	for ids, rights := range entity {
-		if ids := ids.GetUserIDs(); ids != nil && ids.UserID == userIDs.UserID {
+		if ids.EntityType() == "user" && ids.IDString() == userIDs.IDString() {
 			return rights.Union(universal), nil
 		}
 	}

--- a/pkg/identityserver/store/account.go
+++ b/pkg/identityserver/store/account.go
@@ -43,14 +43,13 @@ func (s *store) findAccount(ctx context.Context, id *ttnpb.OrganizationOrUserIde
 }
 
 func findAccount(ctx context.Context, db *gorm.DB, id *ttnpb.OrganizationOrUserIdentifiers) (*Account, error) {
-	entityID := id.EntityIdentifiers()
 	var account Account
 	err := db.Scopes(withContext(ctx)).Where(Account{
-		UID: entityID.IDString(),
+		UID: id.IDString(),
 	}).Find(&account).Error
 	if err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return nil, errNotFoundForID(entityID)
+			return nil, errNotFoundForID(id)
 		}
 		return nil, err
 	}

--- a/pkg/identityserver/store/api_key_store.go
+++ b/pkg/identityserver/store/api_key_store.go
@@ -32,7 +32,7 @@ type apiKeyStore struct {
 	*store
 }
 
-func (s *apiKeyStore) CreateAPIKey(ctx context.Context, entityID *ttnpb.EntityIdentifiers, key *ttnpb.APIKey) error {
+func (s *apiKeyStore) CreateAPIKey(ctx context.Context, entityID ttnpb.Identifiers, key *ttnpb.APIKey) error {
 	defer trace.StartRegion(ctx, "create api key").End()
 	entity, err := s.findEntity(ctx, entityID, "id")
 	if err != nil {
@@ -49,7 +49,7 @@ func (s *apiKeyStore) CreateAPIKey(ctx context.Context, entityID *ttnpb.EntityId
 	return s.createEntity(ctx, model)
 }
 
-func (s *apiKeyStore) FindAPIKeys(ctx context.Context, entityID *ttnpb.EntityIdentifiers) ([]*ttnpb.APIKey, error) {
+func (s *apiKeyStore) FindAPIKeys(ctx context.Context, entityID ttnpb.Identifiers) ([]*ttnpb.APIKey, error) {
 	defer trace.StartRegion(ctx, "find api keys").End()
 	entity, err := s.findEntity(ctx, entityID, "id")
 	if err != nil {
@@ -77,7 +77,7 @@ func (s *apiKeyStore) FindAPIKeys(ctx context.Context, entityID *ttnpb.EntityIde
 
 var errAPIKeyEntity = errors.DefineCorruption("api_key_entity", "API key not linked to an entity")
 
-func (s *apiKeyStore) GetAPIKey(ctx context.Context, id string) (*ttnpb.EntityIdentifiers, *ttnpb.APIKey, error) {
+func (s *apiKeyStore) GetAPIKey(ctx context.Context, id string) (ttnpb.Identifiers, *ttnpb.APIKey, error) {
 	defer trace.StartRegion(ctx, "get api key").End()
 	query := s.query(ctx, APIKey{})
 	var keyModel APIKey
@@ -102,7 +102,7 @@ func (s *apiKeyStore) GetAPIKey(ctx context.Context, id string) (*ttnpb.EntityId
 	return ids, keyModel.toPB(), nil
 }
 
-func (s *apiKeyStore) UpdateAPIKey(ctx context.Context, entityID *ttnpb.EntityIdentifiers, key *ttnpb.APIKey) (*ttnpb.APIKey, error) {
+func (s *apiKeyStore) UpdateAPIKey(ctx context.Context, entityID ttnpb.Identifiers, key *ttnpb.APIKey) (*ttnpb.APIKey, error) {
 	defer trace.StartRegion(ctx, "update api key").End()
 	entity, err := s.findEntity(ctx, entityID, "id")
 	if err != nil {

--- a/pkg/identityserver/store/api_key_store_test.go
+++ b/pkg/identityserver/store/api_key_store_test.go
@@ -41,40 +41,40 @@ func TestAPIKeyStore(t *testing.T) {
 		store := GetAPIKeyStore(db)
 
 		s.createEntity(ctx, &User{Account: Account{UID: "test-user"}})
-		userIDs := &ttnpb.UserIdentifiers{UserID: "test-user"}
+		userIDs := ttnpb.UserIdentifiers{UserID: "test-user"}
 
 		s.createEntity(ctx, &Organization{Account: Account{UID: "test-org"}})
-		orgIDs := &ttnpb.OrganizationIdentifiers{OrganizationID: "test-org"}
+		orgIDs := ttnpb.OrganizationIdentifiers{OrganizationID: "test-org"}
 
 		s.createEntity(ctx, &Application{ApplicationID: "test-app"})
-		appIDs := &ttnpb.ApplicationIdentifiers{ApplicationID: "test-app"}
+		appIDs := ttnpb.ApplicationIdentifiers{ApplicationID: "test-app"}
 
 		s.createEntity(ctx, &Gateway{GatewayID: "test-gtw"})
-		gtwIDs := &ttnpb.GatewayIdentifiers{GatewayID: "test-gtw"}
+		gtwIDs := ttnpb.GatewayIdentifiers{GatewayID: "test-gtw"}
 
 		for _, tt := range []struct {
 			Name        string
-			Identifiers *ttnpb.EntityIdentifiers
+			Identifiers ttnpb.Identifiers
 			Rights      []ttnpb.Right
 		}{
 			{
 				Name:        "Application",
-				Identifiers: appIDs.EntityIdentifiers(),
+				Identifiers: appIDs,
 				Rights:      []ttnpb.Right{ttnpb.RIGHT_APPLICATION_ALL},
 			},
 			{
 				Name:        "Gateway",
-				Identifiers: gtwIDs.EntityIdentifiers(),
+				Identifiers: gtwIDs,
 				Rights:      []ttnpb.Right{ttnpb.RIGHT_GATEWAY_ALL},
 			},
 			{
 				Name:        "Organization",
-				Identifiers: orgIDs.EntityIdentifiers(),
+				Identifiers: orgIDs,
 				Rights:      []ttnpb.Right{ttnpb.RIGHT_APPLICATION_ALL, ttnpb.RIGHT_GATEWAY_ALL},
 			},
 			{
 				Name:        "User",
-				Identifiers: userIDs.EntityIdentifiers(),
+				Identifiers: userIDs,
 				Rights:      []ttnpb.Right{ttnpb.RIGHT_APPLICATION_ALL, ttnpb.RIGHT_GATEWAY_ALL},
 			},
 		} {

--- a/pkg/identityserver/store/application_store.go
+++ b/pkg/identityserver/store/application_store.go
@@ -111,7 +111,7 @@ func (s *applicationStore) GetApplication(ctx context.Context, id *ttnpb.Applica
 	var appModel Application
 	if err := query.First(&appModel).Error; err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return nil, errNotFoundForID(id.EntityIdentifiers())
+			return nil, errNotFoundForID(id)
 		}
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func (s *applicationStore) UpdateApplication(ctx context.Context, app *ttnpb.App
 	var appModel Application
 	if err = query.First(&appModel).Error; err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return nil, errNotFoundForID(app.ApplicationIdentifiers.EntityIdentifiers())
+			return nil, errNotFoundForID(app.ApplicationIdentifiers)
 		}
 		return nil, err
 	}
@@ -151,5 +151,5 @@ func (s *applicationStore) UpdateApplication(ctx context.Context, app *ttnpb.App
 
 func (s *applicationStore) DeleteApplication(ctx context.Context, id *ttnpb.ApplicationIdentifiers) error {
 	defer trace.StartRegion(ctx, "delete application").End()
-	return s.deleteEntity(ctx, id.EntityIdentifiers())
+	return s.deleteEntity(ctx, id)
 }

--- a/pkg/identityserver/store/client_store.go
+++ b/pkg/identityserver/store/client_store.go
@@ -111,7 +111,7 @@ func (s *clientStore) GetClient(ctx context.Context, id *ttnpb.ClientIdentifiers
 	var cliModel Client
 	if err := query.First(&cliModel).Error; err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return nil, errNotFoundForID(id.EntityIdentifiers())
+			return nil, errNotFoundForID(id)
 		}
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func (s *clientStore) UpdateClient(ctx context.Context, cli *ttnpb.Client, field
 	var cliModel Client
 	if err = query.First(&cliModel).Error; err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return nil, errNotFoundForID(cli.ClientIdentifiers.EntityIdentifiers())
+			return nil, errNotFoundForID(cli.ClientIdentifiers)
 		}
 		return nil, err
 	}
@@ -151,5 +151,5 @@ func (s *clientStore) UpdateClient(ctx context.Context, cli *ttnpb.Client, field
 
 func (s *clientStore) DeleteClient(ctx context.Context, id *ttnpb.ClientIdentifiers) error {
 	defer trace.StartRegion(ctx, "delete client").End()
-	return s.deleteEntity(ctx, id.EntityIdentifiers())
+	return s.deleteEntity(ctx, id)
 }

--- a/pkg/identityserver/store/contact_info_store.go
+++ b/pkg/identityserver/store/contact_info_store.go
@@ -33,7 +33,7 @@ type contactInfoStore struct {
 	*store
 }
 
-func (s *contactInfoStore) GetContactInfo(ctx context.Context, entityID *ttnpb.EntityIdentifiers) ([]*ttnpb.ContactInfo, error) {
+func (s *contactInfoStore) GetContactInfo(ctx context.Context, entityID ttnpb.Identifiers) ([]*ttnpb.ContactInfo, error) {
 	defer trace.StartRegion(ctx, "get contact info").End()
 	entity, err := s.findEntity(ctx, entityID, "id")
 	if err != nil {
@@ -54,7 +54,7 @@ func (s *contactInfoStore) GetContactInfo(ctx context.Context, entityID *ttnpb.E
 	return pb, nil
 }
 
-func (s *contactInfoStore) SetContactInfo(ctx context.Context, entityID *ttnpb.EntityIdentifiers, pb []*ttnpb.ContactInfo) ([]*ttnpb.ContactInfo, error) {
+func (s *contactInfoStore) SetContactInfo(ctx context.Context, entityID ttnpb.Identifiers, pb []*ttnpb.ContactInfo) ([]*ttnpb.ContactInfo, error) {
 	defer trace.StartRegion(ctx, "update contact info").End()
 	entity, err := s.findEntity(ctx, entityID, "id")
 	if err != nil {

--- a/pkg/identityserver/store/contact_info_store_test.go
+++ b/pkg/identityserver/store/contact_info_store_test.go
@@ -43,21 +43,21 @@ func TestContactInfoStore(t *testing.T) {
 
 		s := GetContactInfoStore(db)
 
-		contactInfo, err := s.GetContactInfo(ctx, app.EntityIdentifiers())
+		contactInfo, err := s.GetContactInfo(ctx, app.ApplicationIdentifiers)
 		a.So(err, should.BeNil)
 		a.So(contactInfo, should.BeEmpty)
 
-		_, err = s.SetContactInfo(ctx, app.EntityIdentifiers(), []*ttnpb.ContactInfo{
+		_, err = s.SetContactInfo(ctx, app.ApplicationIdentifiers, []*ttnpb.ContactInfo{
 			{ContactType: ttnpb.CONTACT_TYPE_TECHNICAL, ContactMethod: ttnpb.CONTACT_METHOD_EMAIL, Value: "foo@example.com", ValidatedAt: &now},
 			{ContactType: ttnpb.CONTACT_TYPE_BILLING, ContactMethod: ttnpb.CONTACT_METHOD_EMAIL, Value: "admin@example.com"},
 		})
 		a.So(err, should.BeNil)
 
-		contactInfo, err = s.GetContactInfo(ctx, app.EntityIdentifiers())
+		contactInfo, err = s.GetContactInfo(ctx, app.ApplicationIdentifiers)
 		a.So(err, should.BeNil)
 		a.So(contactInfo, should.HaveLength, 2)
 
-		_, err = s.SetContactInfo(ctx, app.EntityIdentifiers(), []*ttnpb.ContactInfo{
+		_, err = s.SetContactInfo(ctx, app.ApplicationIdentifiers, []*ttnpb.ContactInfo{
 			{ContactType: ttnpb.CONTACT_TYPE_TECHNICAL, ContactMethod: ttnpb.CONTACT_METHOD_EMAIL, Value: "bar@example.com"},
 			{ContactType: ttnpb.CONTACT_TYPE_TECHNICAL, ContactMethod: ttnpb.CONTACT_METHOD_EMAIL, Value: "foo@example.com"},
 			{ContactType: ttnpb.CONTACT_TYPE_ABUSE, ContactMethod: ttnpb.CONTACT_METHOD_EMAIL, Value: "foo@example.com"},
@@ -66,7 +66,7 @@ func TestContactInfoStore(t *testing.T) {
 		})
 		a.So(err, should.BeNil)
 
-		contactInfo, err = s.GetContactInfo(ctx, app.EntityIdentifiers())
+		contactInfo, err = s.GetContactInfo(ctx, app.ApplicationIdentifiers)
 		a.So(err, should.BeNil)
 		a.So(contactInfo, should.HaveLength, 5)
 
@@ -94,7 +94,7 @@ func TestContactInfoValidation(t *testing.T) {
 
 		s := GetContactInfoStore(db)
 
-		info, err := s.SetContactInfo(ctx, usr.EntityIdentifiers(), []*ttnpb.ContactInfo{
+		info, err := s.SetContactInfo(ctx, usr.UserIdentifiers, []*ttnpb.ContactInfo{
 			{ContactMethod: ttnpb.CONTACT_METHOD_EMAIL, Value: "foo@example.com"},
 		})
 		a.So(err, should.BeNil)
@@ -116,7 +116,7 @@ func TestContactInfoValidation(t *testing.T) {
 		})
 		a.So(err, should.BeNil)
 
-		info, err = s.GetContactInfo(ctx, usr.EntityIdentifiers())
+		info, err = s.GetContactInfo(ctx, usr)
 		a.So(err, should.BeNil)
 		if a.So(info, should.HaveLength, 1) {
 			a.So(info[0].ValidatedAt, should.NotBeNil)

--- a/pkg/identityserver/store/end_device_store.go
+++ b/pkg/identityserver/store/end_device_store.go
@@ -139,7 +139,7 @@ func (s *deviceStore) GetEndDevice(ctx context.Context, id *ttnpb.EndDeviceIdent
 	var devModel EndDevice
 	if err := query.First(&devModel).Error; err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return nil, errNotFoundForID(id.EntityIdentifiers())
+			return nil, errNotFoundForID(id)
 		}
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func (s *deviceStore) UpdateEndDevice(ctx context.Context, dev *ttnpb.EndDevice,
 	var devModel EndDevice
 	if err = query.First(&devModel).Error; err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return nil, errNotFoundForID(dev.EndDeviceIdentifiers.EntityIdentifiers())
+			return nil, errNotFoundForID(dev.EndDeviceIdentifiers)
 		}
 		return nil, err
 	}
@@ -182,5 +182,5 @@ func (s *deviceStore) UpdateEndDevice(ctx context.Context, dev *ttnpb.EndDevice,
 
 func (s *deviceStore) DeleteEndDevice(ctx context.Context, id *ttnpb.EndDeviceIdentifiers) error {
 	defer trace.StartRegion(ctx, "delete end device").End()
-	return s.deleteEntity(ctx, id.EntityIdentifiers())
+	return s.deleteEntity(ctx, id)
 }

--- a/pkg/identityserver/store/entity_search.go
+++ b/pkg/identityserver/store/entity_search.go
@@ -32,7 +32,7 @@ type entitySearch struct {
 	db *gorm.DB
 }
 
-func (s *entitySearch) FindEntities(ctx context.Context, req *ttnpb.SearchEntitiesRequest, entityType string) ([]*ttnpb.EntityIdentifiers, error) {
+func (s *entitySearch) FindEntities(ctx context.Context, req *ttnpb.SearchEntitiesRequest, entityType string) ([]ttnpb.Identifiers, error) {
 	defer trace.StartRegion(ctx, "find entities").End()
 
 	table := entityType + "s"
@@ -71,19 +71,19 @@ func (s *entitySearch) FindEntities(ctx context.Context, req *ttnpb.SearchEntiti
 		return nil, nil
 	}
 
-	identifiers := make([]*ttnpb.EntityIdentifiers, len(entities))
+	identifiers := make([]ttnpb.Identifiers, len(entities))
 	for i, entity := range entities {
 		switch entityType {
 		case "application":
-			identifiers[i] = ttnpb.ApplicationIdentifiers{ApplicationID: entity.ID}.EntityIdentifiers()
+			identifiers[i] = ttnpb.ApplicationIdentifiers{ApplicationID: entity.ID}
 		case "client":
-			identifiers[i] = ttnpb.ClientIdentifiers{ClientID: entity.ID}.EntityIdentifiers()
+			identifiers[i] = ttnpb.ClientIdentifiers{ClientID: entity.ID}
 		case "gateway":
-			identifiers[i] = ttnpb.GatewayIdentifiers{GatewayID: entity.ID}.EntityIdentifiers()
+			identifiers[i] = ttnpb.GatewayIdentifiers{GatewayID: entity.ID}
 		case "organization":
-			identifiers[i] = ttnpb.OrganizationIdentifiers{OrganizationID: entity.ID}.EntityIdentifiers()
+			identifiers[i] = ttnpb.OrganizationIdentifiers{OrganizationID: entity.ID}
 		case "user":
-			identifiers[i] = ttnpb.UserIdentifiers{UserID: entity.ID}.EntityIdentifiers()
+			identifiers[i] = ttnpb.UserIdentifiers{UserID: entity.ID}
 		}
 	}
 

--- a/pkg/identityserver/store/gateway_store.go
+++ b/pkg/identityserver/store/gateway_store.go
@@ -116,7 +116,7 @@ func (s *gatewayStore) GetGateway(ctx context.Context, id *ttnpb.GatewayIdentifi
 	var gtwModel Gateway
 	if err := query.First(&gtwModel).Error; err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return nil, errNotFoundForID(id.EntityIdentifiers())
+			return nil, errNotFoundForID(id)
 		}
 		return nil, err
 	}
@@ -132,7 +132,7 @@ func (s *gatewayStore) UpdateGateway(ctx context.Context, gtw *ttnpb.Gateway, fi
 	var gtwModel Gateway
 	if err = query.First(&gtwModel).Error; err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return nil, errNotFoundForID(gtw.GatewayIdentifiers.EntityIdentifiers())
+			return nil, errNotFoundForID(gtw.GatewayIdentifiers)
 		}
 		return nil, err
 	}
@@ -161,5 +161,5 @@ func (s *gatewayStore) UpdateGateway(ctx context.Context, gtw *ttnpb.Gateway, fi
 
 func (s *gatewayStore) DeleteGateway(ctx context.Context, id *ttnpb.GatewayIdentifiers) error {
 	defer trace.StartRegion(ctx, "delete gateway").End()
-	return s.deleteEntity(ctx, id.EntityIdentifiers())
+	return s.deleteEntity(ctx, id)
 }

--- a/pkg/identityserver/store/invitation_store.go
+++ b/pkg/identityserver/store/invitation_store.go
@@ -96,7 +96,7 @@ func (s *invitationStore) SetInvitationAcceptedBy(ctx context.Context, token str
 		return err
 	}
 
-	user, err := s.findEntity(ctx, acceptedByID.EntityIdentifiers(), "id")
+	user, err := s.findEntity(ctx, acceptedByID, "id")
 	if err != nil {
 		return err
 	}

--- a/pkg/identityserver/store/membership.go
+++ b/pkg/identityserver/store/membership.go
@@ -66,13 +66,13 @@ type polymorphicEntity struct {
 	EntityType string
 }
 
-func (s *store) findIdentifiers(entities ...polymorphicEntity) (map[polymorphicEntity]*ttnpb.EntityIdentifiers, error) {
+func (s *store) findIdentifiers(entities ...polymorphicEntity) (map[polymorphicEntity]ttnpb.Identifiers, error) {
 	return findIdentifiers(s.DB, entities...)
 }
 
-func findIdentifiers(db *gorm.DB, entities ...polymorphicEntity) (map[polymorphicEntity]*ttnpb.EntityIdentifiers, error) {
+func findIdentifiers(db *gorm.DB, entities ...polymorphicEntity) (map[polymorphicEntity]ttnpb.Identifiers, error) {
 	var err error
-	identifiers := make(map[polymorphicEntity]*ttnpb.EntityIdentifiers, len(entities))
+	identifiers := make(map[polymorphicEntity]ttnpb.Identifiers, len(entities))
 	for _, entityType := range []string{"application", "client", "gateway", "organization", "user"} {
 		uuids := make([]string, 0, len(entities))
 		for _, entity := range entities {
@@ -104,26 +104,26 @@ func findIdentifiers(db *gorm.DB, entities ...polymorphicEntity) (map[polymorphi
 			entity := polymorphicEntity{EntityType: entityType, EntityUUID: result.UUID}
 			switch entityType {
 			case "application":
-				identifiers[entity] = ttnpb.ApplicationIdentifiers{ApplicationID: result.FriendlyID}.EntityIdentifiers()
+				identifiers[entity] = ttnpb.ApplicationIdentifiers{ApplicationID: result.FriendlyID}
 			case "client":
-				identifiers[entity] = ttnpb.ClientIdentifiers{ClientID: result.FriendlyID}.EntityIdentifiers()
+				identifiers[entity] = ttnpb.ClientIdentifiers{ClientID: result.FriendlyID}
 			case "gateway":
-				identifiers[entity] = ttnpb.GatewayIdentifiers{GatewayID: result.FriendlyID}.EntityIdentifiers()
+				identifiers[entity] = ttnpb.GatewayIdentifiers{GatewayID: result.FriendlyID}
 			case "organization":
-				identifiers[entity] = ttnpb.OrganizationIdentifiers{OrganizationID: result.FriendlyID}.EntityIdentifiers()
+				identifiers[entity] = ttnpb.OrganizationIdentifiers{OrganizationID: result.FriendlyID}
 			case "user":
-				identifiers[entity] = ttnpb.UserIdentifiers{UserID: result.FriendlyID}.EntityIdentifiers()
+				identifiers[entity] = ttnpb.UserIdentifiers{UserID: result.FriendlyID}
 			}
 		}
 	}
 	return identifiers, nil
 }
 
-func (s *store) identifierRights(entityRights map[polymorphicEntity]Rights) (map[*ttnpb.EntityIdentifiers]*ttnpb.Rights, error) {
+func (s *store) identifierRights(entityRights map[polymorphicEntity]Rights) (map[ttnpb.Identifiers]*ttnpb.Rights, error) {
 	return identifierRights(s.DB, entityRights)
 }
 
-func identifierRights(db *gorm.DB, entityRights map[polymorphicEntity]Rights) (map[*ttnpb.EntityIdentifiers]*ttnpb.Rights, error) {
+func identifierRights(db *gorm.DB, entityRights map[polymorphicEntity]Rights) (map[ttnpb.Identifiers]*ttnpb.Rights, error) {
 	entities := make([]polymorphicEntity, 0, len(entityRights))
 	for entity := range entityRights {
 		entities = append(entities, entity)
@@ -132,7 +132,7 @@ func identifierRights(db *gorm.DB, entityRights map[polymorphicEntity]Rights) (m
 	if err != nil {
 		return nil, err
 	}
-	identifierRights := make(map[*ttnpb.EntityIdentifiers]*ttnpb.Rights, len(entityRights))
+	identifierRights := make(map[ttnpb.Identifiers]*ttnpb.Rights, len(entityRights))
 	for entity, rights := range entityRights {
 		ids, ok := identifiers[entity]
 		if !ok {

--- a/pkg/identityserver/store/membership_store.go
+++ b/pkg/identityserver/store/membership_store.go
@@ -33,7 +33,7 @@ type membershipStore struct {
 	*store
 }
 
-func (s *membershipStore) FindMembers(ctx context.Context, entityID *ttnpb.EntityIdentifiers) (map[*ttnpb.OrganizationOrUserIdentifiers]*ttnpb.Rights, error) {
+func (s *membershipStore) FindMembers(ctx context.Context, entityID ttnpb.Identifiers) (map[*ttnpb.OrganizationOrUserIdentifiers]*ttnpb.Rights, error) {
 	defer trace.StartRegion(ctx, fmt.Sprintf("find members of %s", entityID.EntityType())).End()
 	entity, err := s.findEntity(ctx, entityID, "id")
 	if err != nil {
@@ -61,12 +61,12 @@ func (s *membershipStore) FindMembers(ctx context.Context, entityID *ttnpb.Entit
 	return membershipRights, nil
 }
 
-func (s *membershipStore) FindMemberRights(ctx context.Context, id *ttnpb.OrganizationOrUserIdentifiers, entityType string) (map[*ttnpb.EntityIdentifiers]*ttnpb.Rights, error) {
+func (s *membershipStore) FindMemberRights(ctx context.Context, id *ttnpb.OrganizationOrUserIdentifiers, entityType string) (map[ttnpb.Identifiers]*ttnpb.Rights, error) {
 	entityTypeForTrace := entityType
 	if entityTypeForTrace == "" {
 		entityTypeForTrace = "all"
 	}
-	defer trace.StartRegion(ctx, fmt.Sprintf("find %s memberships for %s", entityTypeForTrace, id.EntityIdentifiers().EntityType())).End()
+	defer trace.StartRegion(ctx, fmt.Sprintf("find %s memberships for %s", entityTypeForTrace, id.EntityType())).End()
 	account, err := s.findAccount(ctx, id)
 	if err != nil {
 		return nil, err
@@ -89,7 +89,7 @@ var errAccountType = errors.DefineInvalidArgument(
 	"account of type `{account_type}` can not collaborate on `{entity_type}`",
 )
 
-func (s *membershipStore) SetMember(ctx context.Context, id *ttnpb.OrganizationOrUserIdentifiers, entityID *ttnpb.EntityIdentifiers, rights *ttnpb.Rights) (err error) {
+func (s *membershipStore) SetMember(ctx context.Context, id *ttnpb.OrganizationOrUserIdentifiers, entityID ttnpb.Identifiers, rights *ttnpb.Rights) (err error) {
 	defer trace.StartRegion(ctx, "update membership").End()
 	account, err := s.findAccount(ctx, id)
 	if err != nil {

--- a/pkg/identityserver/store/membership_store_test.go
+++ b/pkg/identityserver/store/membership_store_test.go
@@ -59,7 +59,7 @@ func TestMembershipStore(t *testing.T) {
 		for _, tt := range []struct {
 			Name              string
 			Identifiers       *ttnpb.OrganizationOrUserIdentifiers
-			MemberIdentifiers *ttnpb.EntityIdentifiers
+			MemberIdentifiers ttnpb.Identifiers
 			Rights            []ttnpb.Right
 			RightsUpdated     []ttnpb.Right
 			EntityType        string
@@ -67,7 +67,7 @@ func TestMembershipStore(t *testing.T) {
 			{
 				Name:              "User-Application",
 				Identifiers:       usrIDs,
-				MemberIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app"}.EntityIdentifiers(),
+				MemberIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app"},
 				Rights:            []ttnpb.Right{ttnpb.RIGHT_APPLICATION_SETTINGS_BASIC},
 				RightsUpdated: []ttnpb.Right{
 					ttnpb.RIGHT_APPLICATION_INFO,
@@ -78,7 +78,7 @@ func TestMembershipStore(t *testing.T) {
 			{
 				Name:              "User-Client",
 				Identifiers:       usrIDs,
-				MemberIdentifiers: ttnpb.ClientIdentifiers{ClientID: "test-cli"}.EntityIdentifiers(),
+				MemberIdentifiers: ttnpb.ClientIdentifiers{ClientID: "test-cli"},
 				Rights:            []ttnpb.Right{ttnpb.RIGHT_CLIENT_ALL},
 				RightsUpdated: []ttnpb.Right{
 					ttnpb.RIGHT_CLIENT_ALL,
@@ -89,7 +89,7 @@ func TestMembershipStore(t *testing.T) {
 			{
 				Name:              "User-Gateway",
 				Identifiers:       usrIDs,
-				MemberIdentifiers: ttnpb.GatewayIdentifiers{GatewayID: "test-gtw"}.EntityIdentifiers(),
+				MemberIdentifiers: ttnpb.GatewayIdentifiers{GatewayID: "test-gtw"},
 				Rights:            []ttnpb.Right{ttnpb.RIGHT_GATEWAY_SETTINGS_BASIC},
 				RightsUpdated: []ttnpb.Right{
 					ttnpb.RIGHT_GATEWAY_INFO,
@@ -100,7 +100,7 @@ func TestMembershipStore(t *testing.T) {
 			{
 				Name:              "User-Organization",
 				Identifiers:       usrIDs,
-				MemberIdentifiers: ttnpb.OrganizationIdentifiers{OrganizationID: "test-org"}.EntityIdentifiers(),
+				MemberIdentifiers: ttnpb.OrganizationIdentifiers{OrganizationID: "test-org"},
 				Rights: []ttnpb.Right{
 					ttnpb.RIGHT_APPLICATION_ALL,
 					ttnpb.RIGHT_GATEWAY_ALL,
@@ -117,7 +117,7 @@ func TestMembershipStore(t *testing.T) {
 			{
 				Name:              "Organization-Application",
 				Identifiers:       orgIDs,
-				MemberIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app"}.EntityIdentifiers(),
+				MemberIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app"},
 				Rights:            []ttnpb.Right{ttnpb.RIGHT_APPLICATION_INFO},
 				RightsUpdated: []ttnpb.Right{
 					ttnpb.RIGHT_APPLICATION_INFO,
@@ -128,7 +128,7 @@ func TestMembershipStore(t *testing.T) {
 			{
 				Name:              "Organization-Client",
 				Identifiers:       orgIDs,
-				MemberIdentifiers: ttnpb.ClientIdentifiers{ClientID: "test-cli"}.EntityIdentifiers(),
+				MemberIdentifiers: ttnpb.ClientIdentifiers{ClientID: "test-cli"},
 				Rights:            []ttnpb.Right{ttnpb.RIGHT_CLIENT_ALL},
 				RightsUpdated: []ttnpb.Right{
 					ttnpb.RIGHT_CLIENT_ALL,
@@ -139,7 +139,7 @@ func TestMembershipStore(t *testing.T) {
 			{
 				Name:              "Organization-Gateway",
 				Identifiers:       orgIDs,
-				MemberIdentifiers: ttnpb.GatewayIdentifiers{GatewayID: "test-gtw"}.EntityIdentifiers(),
+				MemberIdentifiers: ttnpb.GatewayIdentifiers{GatewayID: "test-gtw"},
 				Rights:            []ttnpb.Right{ttnpb.RIGHT_GATEWAY_INFO},
 				RightsUpdated: []ttnpb.Right{
 					ttnpb.RIGHT_GATEWAY_INFO,
@@ -220,7 +220,7 @@ func TestMembershipStore(t *testing.T) {
 
 			err := store.SetMember(ctx,
 				orgIDs,
-				ttnpb.OrganizationIdentifiers{OrganizationID: "other-org"}.EntityIdentifiers(),
+				ttnpb.OrganizationIdentifiers{OrganizationID: "other-org"},
 				ttnpb.RightsFrom([]ttnpb.Right{ttnpb.RIGHT_ORGANIZATION_ALL}...),
 			)
 
@@ -234,49 +234,49 @@ func TestMembershipStore(t *testing.T) {
 		for _, tt := range []struct {
 			Name              string
 			Identifiers       *ttnpb.OrganizationOrUserIdentifiers
-			MemberIdentifiers *ttnpb.EntityIdentifiers
+			MemberIdentifiers ttnpb.Identifiers
 			EntityType        string
 		}{
 			{
 				Name:              "User-Application - user not found",
 				Identifiers:       userNotFoundIDs,
-				MemberIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app"}.EntityIdentifiers(),
+				MemberIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app"},
 				EntityType:        "application",
 			},
 			{
 				Name:              "User-Client - user not found",
 				Identifiers:       userNotFoundIDs,
-				MemberIdentifiers: ttnpb.ClientIdentifiers{ClientID: "test-cli"}.EntityIdentifiers(),
+				MemberIdentifiers: ttnpb.ClientIdentifiers{ClientID: "test-cli"},
 				EntityType:        "client",
 			},
 			{
 				Name:              "User-Gateway - user not found",
 				Identifiers:       userNotFoundIDs,
-				MemberIdentifiers: ttnpb.GatewayIdentifiers{GatewayID: "test-gtw"}.EntityIdentifiers(),
+				MemberIdentifiers: ttnpb.GatewayIdentifiers{GatewayID: "test-gtw"},
 				EntityType:        "gateway",
 			},
 			{
 				Name:              "User-Organization - user not found",
 				Identifiers:       userNotFoundIDs,
-				MemberIdentifiers: ttnpb.OrganizationIdentifiers{OrganizationID: "test-org"}.EntityIdentifiers(),
+				MemberIdentifiers: ttnpb.OrganizationIdentifiers{OrganizationID: "test-org"},
 				EntityType:        "organization",
 			},
 			{
 				Name:              "Organization-Application - organization not found",
 				Identifiers:       organizationNotFoundIDs,
-				MemberIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app"}.EntityIdentifiers(),
+				MemberIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app"},
 				EntityType:        "application",
 			},
 			{
 				Name:              "Organization-Client - organization not found",
 				Identifiers:       organizationNotFoundIDs,
-				MemberIdentifiers: ttnpb.ClientIdentifiers{ClientID: "test-cli"}.EntityIdentifiers(),
+				MemberIdentifiers: ttnpb.ClientIdentifiers{ClientID: "test-cli"},
 				EntityType:        "client",
 			},
 			{
 				Name:              "Organization-Gateway - organization not found",
 				Identifiers:       organizationNotFoundIDs,
-				MemberIdentifiers: ttnpb.GatewayIdentifiers{GatewayID: "test-gtw"}.EntityIdentifiers(),
+				MemberIdentifiers: ttnpb.GatewayIdentifiers{GatewayID: "test-gtw"},
 				EntityType:        "gateway",
 			},
 		} {
@@ -302,49 +302,49 @@ func TestMembershipStore(t *testing.T) {
 		for _, tt := range []struct {
 			Name              string
 			Identifiers       *ttnpb.OrganizationOrUserIdentifiers
-			MemberIdentifiers *ttnpb.EntityIdentifiers
+			MemberIdentifiers ttnpb.Identifiers
 			EntityType        string
 		}{
 			{
 				Name:              "User-Application - application not found",
 				Identifiers:       usrIDs,
-				MemberIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-not-found"}.EntityIdentifiers(),
+				MemberIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-not-found"},
 				EntityType:        "application",
 			},
 			{
 				Name:              "User-Client - client not found",
 				Identifiers:       usrIDs,
-				MemberIdentifiers: ttnpb.ClientIdentifiers{ClientID: "test-cli-not-found"}.EntityIdentifiers(),
+				MemberIdentifiers: ttnpb.ClientIdentifiers{ClientID: "test-cli-not-found"},
 				EntityType:        "client",
 			},
 			{
 				Name:              "User-Gateway - gateway not found",
 				Identifiers:       usrIDs,
-				MemberIdentifiers: ttnpb.GatewayIdentifiers{GatewayID: "test-gtw-not-found"}.EntityIdentifiers(),
+				MemberIdentifiers: ttnpb.GatewayIdentifiers{GatewayID: "test-gtw-not-found"},
 				EntityType:        "gateway",
 			},
 			{
 				Name:              "User-Organization - organization not found",
 				Identifiers:       usrIDs,
-				MemberIdentifiers: ttnpb.OrganizationIdentifiers{OrganizationID: "test-org-not-found"}.EntityIdentifiers(),
+				MemberIdentifiers: ttnpb.OrganizationIdentifiers{OrganizationID: "test-org-not-found"},
 				EntityType:        "organization",
 			},
 			{
 				Name:              "Organization-Application - application not found",
 				Identifiers:       orgIDs,
-				MemberIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-not-found"}.EntityIdentifiers(),
+				MemberIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-not-found"},
 				EntityType:        "application",
 			},
 			{
 				Name:              "Organization-Client - client not found",
 				Identifiers:       orgIDs,
-				MemberIdentifiers: ttnpb.ClientIdentifiers{ClientID: "test-cli-not-found"}.EntityIdentifiers(),
+				MemberIdentifiers: ttnpb.ClientIdentifiers{ClientID: "test-cli-not-found"},
 				EntityType:        "client",
 			},
 			{
 				Name:              "Organization-Gateway - gateway not found",
 				Identifiers:       orgIDs,
-				MemberIdentifiers: ttnpb.GatewayIdentifiers{GatewayID: "test-gtw-not-found"}.EntityIdentifiers(),
+				MemberIdentifiers: ttnpb.GatewayIdentifiers{GatewayID: "test-gtw-not-found"},
 				EntityType:        "gateway",
 			},
 		} {

--- a/pkg/identityserver/store/oauth_store.go
+++ b/pkg/identityserver/store/oauth_store.go
@@ -33,7 +33,7 @@ type oauthStore struct {
 
 func (s *oauthStore) ListAuthorizations(ctx context.Context, userIDs *ttnpb.UserIdentifiers) ([]*ttnpb.OAuthClientAuthorization, error) {
 	defer trace.StartRegion(ctx, "list authorizations").End()
-	user, err := s.findEntity(ctx, userIDs.EntityIdentifiers(), "id")
+	user, err := s.findEntity(ctx, userIDs, "id")
 	if err != nil {
 		return nil, err
 	}
@@ -55,11 +55,11 @@ func (s *oauthStore) ListAuthorizations(ctx context.Context, userIDs *ttnpb.User
 
 func (s *oauthStore) GetAuthorization(ctx context.Context, userIDs *ttnpb.UserIdentifiers, clientIDs *ttnpb.ClientIdentifiers) (*ttnpb.OAuthClientAuthorization, error) {
 	defer trace.StartRegion(ctx, "get authorization").End()
-	client, err := s.findEntity(ctx, clientIDs.EntityIdentifiers(), "id")
+	client, err := s.findEntity(ctx, clientIDs, "id")
 	if err != nil {
 		return nil, err
 	}
-	user, err := s.findEntity(ctx, userIDs.EntityIdentifiers(), "id")
+	user, err := s.findEntity(ctx, userIDs, "id")
 	if err != nil {
 		return nil, err
 	}
@@ -82,11 +82,11 @@ func (s *oauthStore) GetAuthorization(ctx context.Context, userIDs *ttnpb.UserId
 
 func (s *oauthStore) Authorize(ctx context.Context, authorization *ttnpb.OAuthClientAuthorization) (*ttnpb.OAuthClientAuthorization, error) {
 	defer trace.StartRegion(ctx, "create or update authorization").End()
-	client, err := s.findEntity(ctx, authorization.ClientIDs.EntityIdentifiers(), "id")
+	client, err := s.findEntity(ctx, authorization.ClientIDs, "id")
 	if err != nil {
 		return nil, err
 	}
-	user, err := s.findEntity(ctx, authorization.UserIDs.EntityIdentifiers(), "id")
+	user, err := s.findEntity(ctx, authorization.UserIDs, "id")
 	if err != nil {
 		return nil, err
 	}
@@ -118,11 +118,11 @@ func (s *oauthStore) Authorize(ctx context.Context, authorization *ttnpb.OAuthCl
 
 func (s *oauthStore) DeleteAuthorization(ctx context.Context, userIDs *ttnpb.UserIdentifiers, clientIDs *ttnpb.ClientIdentifiers) error {
 	defer trace.StartRegion(ctx, "delete authorization").End()
-	client, err := s.findEntity(ctx, clientIDs.EntityIdentifiers(), "id")
+	client, err := s.findEntity(ctx, clientIDs, "id")
 	if err != nil {
 		return err
 	}
-	user, err := s.findEntity(ctx, userIDs.EntityIdentifiers(), "id")
+	user, err := s.findEntity(ctx, userIDs, "id")
 	if err != nil {
 		return err
 	}
@@ -135,11 +135,11 @@ func (s *oauthStore) DeleteAuthorization(ctx context.Context, userIDs *ttnpb.Use
 
 func (s *oauthStore) CreateAuthorizationCode(ctx context.Context, code *ttnpb.OAuthAuthorizationCode) error {
 	defer trace.StartRegion(ctx, "create authorization code").End()
-	client, err := s.findEntity(ctx, code.ClientIDs.EntityIdentifiers(), "id")
+	client, err := s.findEntity(ctx, code.ClientIDs, "id")
 	if err != nil {
 		return err
 	}
-	user, err := s.findEntity(ctx, code.UserIDs.EntityIdentifiers(), "id")
+	user, err := s.findEntity(ctx, code.UserIDs, "id")
 	if err != nil {
 		return err
 	}
@@ -194,11 +194,11 @@ func (s *oauthStore) DeleteAuthorizationCode(ctx context.Context, code string) e
 
 func (s *oauthStore) CreateAccessToken(ctx context.Context, token *ttnpb.OAuthAccessToken, previousID string) error {
 	defer trace.StartRegion(ctx, "create access token").End()
-	client, err := s.findEntity(ctx, token.ClientIDs.EntityIdentifiers(), "id")
+	client, err := s.findEntity(ctx, token.ClientIDs, "id")
 	if err != nil {
 		return err
 	}
-	user, err := s.findEntity(ctx, token.UserIDs.EntityIdentifiers(), "id")
+	user, err := s.findEntity(ctx, token.UserIDs, "id")
 	if err != nil {
 		return err
 	}
@@ -220,11 +220,11 @@ func (s *oauthStore) CreateAccessToken(ctx context.Context, token *ttnpb.OAuthAc
 
 func (s *oauthStore) ListAccessTokens(ctx context.Context, userIDs *ttnpb.UserIdentifiers, clientIDs *ttnpb.ClientIdentifiers) ([]*ttnpb.OAuthAccessToken, error) {
 	defer trace.StartRegion(ctx, "list access tokens").End()
-	client, err := s.findEntity(ctx, clientIDs.EntityIdentifiers(), "id")
+	client, err := s.findEntity(ctx, clientIDs, "id")
 	if err != nil {
 		return nil, err
 	}
-	user, err := s.findEntity(ctx, userIDs.EntityIdentifiers(), "id")
+	user, err := s.findEntity(ctx, userIDs, "id")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/identityserver/store/organization_store.go
+++ b/pkg/identityserver/store/organization_store.go
@@ -115,7 +115,7 @@ func (s *organizationStore) GetOrganization(ctx context.Context, id *ttnpb.Organ
 	var orgModel Organization
 	if err := query.Preload("Account").First(&orgModel).Error; err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return nil, errNotFoundForID(id.EntityIdentifiers())
+			return nil, errNotFoundForID(id)
 		}
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func (s *organizationStore) UpdateOrganization(ctx context.Context, org *ttnpb.O
 	var orgModel Organization
 	if err = query.Preload("Account").First(&orgModel).Error; err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return nil, errNotFoundForID(org.OrganizationIdentifiers.EntityIdentifiers())
+			return nil, errNotFoundForID(org.OrganizationIdentifiers)
 		}
 		return nil, err
 	}
@@ -155,5 +155,5 @@ func (s *organizationStore) UpdateOrganization(ctx context.Context, org *ttnpb.O
 
 func (s *organizationStore) DeleteOrganization(ctx context.Context, id *ttnpb.OrganizationIdentifiers) (err error) {
 	defer trace.StartRegion(ctx, "delete organization").End()
-	return s.deleteEntity(ctx, id.EntityIdentifiers())
+	return s.deleteEntity(ctx, id)
 }

--- a/pkg/identityserver/store/store_interfaces.go
+++ b/pkg/identityserver/store/store_interfaces.go
@@ -119,24 +119,24 @@ type UserSessionStore interface {
 //   for (entity_type,entity_id) and (account_id,[entityType]).
 type MembershipStore interface {
 	// Find direct members and rights of the given entity.
-	FindMembers(ctx context.Context, entityID *ttnpb.EntityIdentifiers) (map[*ttnpb.OrganizationOrUserIdentifiers]*ttnpb.Rights, error)
+	FindMembers(ctx context.Context, entityID ttnpb.Identifiers) (map[*ttnpb.OrganizationOrUserIdentifiers]*ttnpb.Rights, error)
 	// Find direct member rights of the given organization or user. The entityType may be omitted.
-	FindMemberRights(ctx context.Context, id *ttnpb.OrganizationOrUserIdentifiers, entityType string) (map[*ttnpb.EntityIdentifiers]*ttnpb.Rights, error)
+	FindMemberRights(ctx context.Context, id *ttnpb.OrganizationOrUserIdentifiers, entityType string) (map[ttnpb.Identifiers]*ttnpb.Rights, error)
 	// Set member rights on an entity. Rights can be deleted by not passing any rights.
-	SetMember(ctx context.Context, id *ttnpb.OrganizationOrUserIdentifiers, entityID *ttnpb.EntityIdentifiers, rights *ttnpb.Rights) error
+	SetMember(ctx context.Context, id *ttnpb.OrganizationOrUserIdentifiers, entityID ttnpb.Identifiers, rights *ttnpb.Rights) error
 }
 
 // APIKeyStore interface for storing API keys for entities (applications,
 // clients, gateways, organizations or users).
 type APIKeyStore interface {
 	// Create a new API key for the given entity.
-	CreateAPIKey(ctx context.Context, entityID *ttnpb.EntityIdentifiers, key *ttnpb.APIKey) error
+	CreateAPIKey(ctx context.Context, entityID ttnpb.Identifiers, key *ttnpb.APIKey) error
 	// Find API keys of the given entity.
-	FindAPIKeys(ctx context.Context, entityID *ttnpb.EntityIdentifiers) ([]*ttnpb.APIKey, error)
+	FindAPIKeys(ctx context.Context, entityID ttnpb.Identifiers) ([]*ttnpb.APIKey, error)
 	// Get an API key by its ID.
-	GetAPIKey(ctx context.Context, id string) (*ttnpb.EntityIdentifiers, *ttnpb.APIKey, error)
+	GetAPIKey(ctx context.Context, id string) (ttnpb.Identifiers, *ttnpb.APIKey, error)
 	// Update key rights on an entity. Rights can be deleted by not passing any rights, in which case the returned API key will be nil.
-	UpdateAPIKey(ctx context.Context, entityID *ttnpb.EntityIdentifiers, key *ttnpb.APIKey) (*ttnpb.APIKey, error)
+	UpdateAPIKey(ctx context.Context, entityID ttnpb.Identifiers, key *ttnpb.APIKey) (*ttnpb.APIKey, error)
 }
 
 // OAuthStore interface for the OAuth server.
@@ -169,13 +169,13 @@ type InvitationStore interface {
 
 // EntitySearch interface for searching entities.
 type EntitySearch interface {
-	FindEntities(ctx context.Context, req *ttnpb.SearchEntitiesRequest, entityType string) ([]*ttnpb.EntityIdentifiers, error)
+	FindEntities(ctx context.Context, req *ttnpb.SearchEntitiesRequest, entityType string) ([]ttnpb.Identifiers, error)
 }
 
 // ContactInfoStore interface for contact info validation.
 type ContactInfoStore interface {
-	GetContactInfo(ctx context.Context, entityID *ttnpb.EntityIdentifiers) ([]*ttnpb.ContactInfo, error)
-	SetContactInfo(ctx context.Context, entityID *ttnpb.EntityIdentifiers, contactInfo []*ttnpb.ContactInfo) ([]*ttnpb.ContactInfo, error)
+	GetContactInfo(ctx context.Context, entityID ttnpb.Identifiers) ([]*ttnpb.ContactInfo, error)
+	SetContactInfo(ctx context.Context, entityID ttnpb.Identifiers, contactInfo []*ttnpb.ContactInfo) ([]*ttnpb.ContactInfo, error)
 	CreateValidation(ctx context.Context, validation *ttnpb.ContactInfoValidation) (*ttnpb.ContactInfoValidation, error)
 	// Confirm a validation. Only the ID and Token need to be set.
 	Validate(ctx context.Context, validation *ttnpb.ContactInfoValidation) error

--- a/pkg/identityserver/store/user_session_store.go
+++ b/pkg/identityserver/store/user_session_store.go
@@ -33,7 +33,7 @@ type userSessionStore struct {
 
 func (s *userSessionStore) CreateSession(ctx context.Context, sess *ttnpb.UserSession) (*ttnpb.UserSession, error) {
 	defer trace.StartRegion(ctx, "create user session").End()
-	user, err := s.findEntity(ctx, sess.UserIdentifiers.EntityIdentifiers(), "id")
+	user, err := s.findEntity(ctx, sess.UserIdentifiers, "id")
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +51,7 @@ func (s *userSessionStore) CreateSession(ctx context.Context, sess *ttnpb.UserSe
 
 func (s *userSessionStore) FindSessions(ctx context.Context, userIDs *ttnpb.UserIdentifiers) ([]*ttnpb.UserSession, error) {
 	defer trace.StartRegion(ctx, "find user sessions").End()
-	user, err := s.findEntity(ctx, userIDs.EntityIdentifiers(), "id")
+	user, err := s.findEntity(ctx, userIDs, "id")
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func (s *userSessionStore) FindSessions(ctx context.Context, userIDs *ttnpb.User
 
 func (s *userSessionStore) GetSession(ctx context.Context, userIDs *ttnpb.UserIdentifiers, sessionID string) (*ttnpb.UserSession, error) {
 	defer trace.StartRegion(ctx, "get user session").End()
-	user, err := s.findEntity(ctx, userIDs.EntityIdentifiers(), "id")
+	user, err := s.findEntity(ctx, userIDs, "id")
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (s *userSessionStore) GetSession(ctx context.Context, userIDs *ttnpb.UserId
 
 func (s *userSessionStore) UpdateSession(ctx context.Context, sess *ttnpb.UserSession) (*ttnpb.UserSession, error) {
 	defer trace.StartRegion(ctx, "update user session").End()
-	user, err := s.findEntity(ctx, sess.UserIdentifiers.EntityIdentifiers(), "id")
+	user, err := s.findEntity(ctx, sess.UserIdentifiers, "id")
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func (s *userSessionStore) UpdateSession(ctx context.Context, sess *ttnpb.UserSe
 
 func (s *userSessionStore) DeleteSession(ctx context.Context, userIDs *ttnpb.UserIdentifiers, sessionID string) error {
 	defer trace.StartRegion(ctx, "delete user session").End()
-	user, err := s.findEntity(ctx, userIDs.EntityIdentifiers(), "id")
+	user, err := s.findEntity(ctx, userIDs, "id")
 	if err != nil {
 		return err
 	}

--- a/pkg/identityserver/store/user_store.go
+++ b/pkg/identityserver/store/user_store.go
@@ -119,7 +119,7 @@ func (s *userStore) GetUser(ctx context.Context, id *ttnpb.UserIdentifiers, fiel
 	var userModel User
 	if err := query.Preload("Account").First(&userModel).Error; err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return nil, errNotFoundForID(id.EntityIdentifiers())
+			return nil, errNotFoundForID(id)
 		}
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func (s *userStore) UpdateUser(ctx context.Context, usr *ttnpb.User, fieldMask *
 	var userModel User
 	if err = query.First(&userModel).Error; err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return nil, errNotFoundForID(usr.UserIdentifiers.EntityIdentifiers())
+			return nil, errNotFoundForID(usr.UserIdentifiers)
 		}
 		return nil, err
 	}
@@ -175,5 +175,5 @@ func (s *userStore) UpdateUser(ctx context.Context, usr *ttnpb.User, fieldMask *
 
 func (s *userStore) DeleteUser(ctx context.Context, id *ttnpb.UserIdentifiers) (err error) {
 	defer trace.StartRegion(ctx, "delete user").End()
-	return s.deleteEntity(ctx, id.EntityIdentifiers())
+	return s.deleteEntity(ctx, id)
 }

--- a/pkg/identityserver/user_access.go
+++ b/pkg/identityserver/user_access.go
@@ -60,7 +60,7 @@ func (is *IdentityServer) createUserAPIKey(ctx context.Context, req *ttnpb.Creat
 		return nil, err
 	}
 	err = is.withDatabase(ctx, func(db *gorm.DB) error {
-		return store.GetAPIKeyStore(db).CreateAPIKey(ctx, req.UserIdentifiers.EntityIdentifiers(), key)
+		return store.GetAPIKeyStore(db).CreateAPIKey(ctx, req.UserIdentifiers, key)
 	})
 	if err != nil {
 		return nil, err
@@ -90,7 +90,7 @@ func (is *IdentityServer) listUserAPIKeys(ctx context.Context, req *ttnpb.ListUs
 	}()
 	keys = &ttnpb.APIKeys{}
 	err = is.withDatabase(ctx, func(db *gorm.DB) (err error) {
-		keys.APIKeys, err = store.GetAPIKeyStore(db).FindAPIKeys(ctx, req.EntityIdentifiers())
+		keys.APIKeys, err = store.GetAPIKeyStore(db).FindAPIKeys(ctx, req.UserIdentifiers)
 		return err
 	})
 	if err != nil {
@@ -132,7 +132,7 @@ func (is *IdentityServer) updateUserAPIKey(ctx context.Context, req *ttnpb.Updat
 		return nil, err
 	}
 	err = is.withDatabase(ctx, func(db *gorm.DB) (err error) {
-		key, err = store.GetAPIKeyStore(db).UpdateAPIKey(ctx, req.UserIdentifiers.EntityIdentifiers(), &req.APIKey)
+		key, err = store.GetAPIKeyStore(db).UpdateAPIKey(ctx, req.UserIdentifiers, &req.APIKey)
 		return err
 	})
 	if err != nil {

--- a/pkg/identityserver/user_registry.go
+++ b/pkg/identityserver/user_registry.go
@@ -164,7 +164,7 @@ func (is *IdentityServer) createUser(ctx context.Context, req *ttnpb.CreateUserR
 		}
 
 		if len(req.ContactInfo) > 0 {
-			usr.ContactInfo, err = store.GetContactInfoStore(db).SetContactInfo(ctx, usr.EntityIdentifiers(), req.ContactInfo)
+			usr.ContactInfo, err = store.GetContactInfoStore(db).SetContactInfo(ctx, usr.UserIdentifiers, req.ContactInfo)
 			if err != nil {
 				return err
 			}
@@ -227,7 +227,7 @@ func (is *IdentityServer) getUser(ctx context.Context, req *ttnpb.GetUserRequest
 			return err
 		}
 		if ttnpb.HasAnyField(req.FieldMask.Paths, "contact_info") {
-			usr.ContactInfo, err = store.GetContactInfoStore(db).GetContactInfo(ctx, usr.EntityIdentifiers())
+			usr.ContactInfo, err = store.GetContactInfoStore(db).GetContactInfo(ctx, usr.UserIdentifiers)
 			if err != nil {
 				return err
 			}
@@ -313,7 +313,7 @@ func (is *IdentityServer) updateUser(ctx context.Context, req *ttnpb.UpdateUserR
 		updatingPrimaryEmailAddress := ttnpb.HasAnyField(req.FieldMask.Paths, "primary_email_address")
 		if updatingContactInfo || updatingPrimaryEmailAddress {
 			if updatingContactInfo {
-				contactInfo, err = store.GetContactInfoStore(db).SetContactInfo(ctx, req.User.EntityIdentifiers(), req.ContactInfo)
+				contactInfo, err = store.GetContactInfoStore(db).SetContactInfo(ctx, req.User.UserIdentifiers, req.ContactInfo)
 				if err != nil {
 					return err
 				}
@@ -321,7 +321,7 @@ func (is *IdentityServer) updateUser(ctx context.Context, req *ttnpb.UpdateUserR
 			}
 			if updatingPrimaryEmailAddress {
 				if !updatingContactInfo {
-					contactInfo, err = store.GetContactInfoStore(db).GetContactInfo(ctx, req.User.EntityIdentifiers())
+					contactInfo, err = store.GetContactInfoStore(db).GetContactInfo(ctx, req.User.UserIdentifiers)
 					if err != nil {
 						return err
 					}

--- a/pkg/ttnpb/identifiers.go
+++ b/pkg/ttnpb/identifiers.go
@@ -16,7 +16,6 @@ package ttnpb
 
 import (
 	"context"
-	"fmt"
 
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/types"
@@ -56,153 +55,11 @@ func (ids UserIdentifiers) IsZero() bool {
 	return ids.UserID == "" && ids.Email == ""
 }
 
-// Identifiers interface for Entity Identifiers.
-type Identifiers interface {
-	CombinedIdentifiers() *CombinedIdentifiers
-}
-
-// CombinedIdentifiers returns the EntityIdentifiers as a CombinedIdentifiers type.
-func (ids EntityIdentifiers) CombinedIdentifiers() *CombinedIdentifiers {
-	return &CombinedIdentifiers{EntityIdentifiers: []*EntityIdentifiers{&ids}}
-}
-
-// Identifiers returns the actual Identifiers inside the oneof.
-func (ids EntityIdentifiers) Identifiers() Identifiers {
-	switch oneof := ids.Ids.(type) {
-	case *EntityIdentifiers_ApplicationIDs:
-		return oneof.ApplicationIDs
-	case *EntityIdentifiers_ClientIDs:
-		return oneof.ClientIDs
-	case *EntityIdentifiers_DeviceIDs:
-		return oneof.DeviceIDs
-	case *EntityIdentifiers_GatewayIDs:
-		return oneof.GatewayIDs
-	case *EntityIdentifiers_OrganizationIDs:
-		return oneof.OrganizationIDs
-	case *EntityIdentifiers_UserIDs:
-		return oneof.UserIDs
-	default:
-		panic("missed oneof type in EntityIdentifiers.Identifiers()")
-	}
-}
-
-// IDString returns the ID string of the Identifiers inside the oneof.
-func (ids EntityIdentifiers) IDString() string {
-	switch oneof := ids.Ids.(type) {
-	case *EntityIdentifiers_ApplicationIDs:
-		return oneof.ApplicationIDs.GetApplicationID()
-	case *EntityIdentifiers_ClientIDs:
-		return oneof.ClientIDs.GetClientID()
-	case *EntityIdentifiers_DeviceIDs:
-		return fmt.Sprintf("%s.%s", oneof.DeviceIDs.GetApplicationID(), oneof.DeviceIDs.GetDeviceID())
-	case *EntityIdentifiers_GatewayIDs:
-		return oneof.GatewayIDs.GetGatewayID()
-	case *EntityIdentifiers_OrganizationIDs:
-		return oneof.OrganizationIDs.GetOrganizationID()
-	case *EntityIdentifiers_UserIDs:
-		return oneof.UserIDs.GetUserID()
-	default:
-		panic("missed oneof type in EntityIdentifiers.IDString()")
-	}
-}
-
-// EntityType returns the entity type for the Identifiers inside the oneof.
-func (ids EntityIdentifiers) EntityType() string {
-	switch ids.Ids.(type) {
-	case *EntityIdentifiers_ApplicationIDs:
-		return "application"
-	case *EntityIdentifiers_ClientIDs:
-		return "client"
-	case *EntityIdentifiers_DeviceIDs:
-		return "end device"
-	case *EntityIdentifiers_GatewayIDs:
-		return "gateway"
-	case *EntityIdentifiers_OrganizationIDs:
-		return "organization"
-	case *EntityIdentifiers_UserIDs:
-		return "user"
-	default:
-		panic("missed oneof type in EntityIdentifiers.EntityType()")
-	}
-}
-
-// EntityIdentifiers returns the ApplicationIdentifiers as EntityIdentifiers.
-func (ids ApplicationIdentifiers) EntityIdentifiers() *EntityIdentifiers {
-	return &EntityIdentifiers{Ids: &EntityIdentifiers_ApplicationIDs{
-		ApplicationIDs: &ids,
-	}}
-}
-
-// CombinedIdentifiers returns the ApplicationIdentifiers as CombinedIdentifiers.
-func (ids ApplicationIdentifiers) CombinedIdentifiers() *CombinedIdentifiers {
-	return ids.EntityIdentifiers().CombinedIdentifiers()
-}
-
-// EntityIdentifiers returns the ClientIdentifiers as EntityIdentifiers.
-func (ids ClientIdentifiers) EntityIdentifiers() *EntityIdentifiers {
-	return &EntityIdentifiers{Ids: &EntityIdentifiers_ClientIDs{
-		ClientIDs: &ids,
-	}}
-}
-
-// CombinedIdentifiers returns the ClientIdentifiers as CombinedIdentifiers.
-func (ids ClientIdentifiers) CombinedIdentifiers() *CombinedIdentifiers {
-	return ids.EntityIdentifiers().CombinedIdentifiers()
-}
-
-// EntityIdentifiers returns the EndDeviceIdentifiers as EntityIdentifiers.
-func (ids EndDeviceIdentifiers) EntityIdentifiers() *EntityIdentifiers {
-	return &EntityIdentifiers{Ids: &EntityIdentifiers_DeviceIDs{
-		DeviceIDs: &ids,
-	}}
-}
-
-// CombinedIdentifiers returns the EndDeviceIdentifiers as CombinedIdentifiers.
-func (ids EndDeviceIdentifiers) CombinedIdentifiers() *CombinedIdentifiers {
-	return ids.EntityIdentifiers().CombinedIdentifiers()
-}
-
-// EntityIdentifiers returns the GatewayIdentifiers as EntityIdentifiers.
-func (ids GatewayIdentifiers) EntityIdentifiers() *EntityIdentifiers {
-	return &EntityIdentifiers{Ids: &EntityIdentifiers_GatewayIDs{
-		GatewayIDs: &ids,
-	}}
-}
-
-// CombinedIdentifiers returns the GatewayIdentifiers as CombinedIdentifiers.
-func (ids GatewayIdentifiers) CombinedIdentifiers() *CombinedIdentifiers {
-	return ids.EntityIdentifiers().CombinedIdentifiers()
-}
-
-// EntityIdentifiers implements returns theOrganizationIdentifiers as EntityIdentifiers.
-func (ids OrganizationIdentifiers) EntityIdentifiers() *EntityIdentifiers {
-	return &EntityIdentifiers{Ids: &EntityIdentifiers_OrganizationIDs{
-		OrganizationIDs: &ids,
-	}}
-}
-
-// CombinedIdentifiers returns the OrganizationIdentifiers as CombinedIdentifiers.
-func (ids OrganizationIdentifiers) CombinedIdentifiers() *CombinedIdentifiers {
-	return ids.EntityIdentifiers().CombinedIdentifiers()
-}
-
 // OrganizationOrUserIdentifiers returns the OrganizationIdentifiers as *OrganizationOrUserIdentifiers.
 func (ids OrganizationIdentifiers) OrganizationOrUserIdentifiers() *OrganizationOrUserIdentifiers {
 	return &OrganizationOrUserIdentifiers{Ids: &OrganizationOrUserIdentifiers_OrganizationIDs{
 		OrganizationIDs: &ids,
 	}}
-}
-
-// EntityIdentifiers returns the UserIdentifiers as EntityIdentifiers.
-func (ids UserIdentifiers) EntityIdentifiers() *EntityIdentifiers {
-	return &EntityIdentifiers{Ids: &EntityIdentifiers_UserIDs{
-		UserIDs: &ids,
-	}}
-}
-
-// CombinedIdentifiers returns the UserIdentifiers as CombinedIdentifiers.
-func (ids UserIdentifiers) CombinedIdentifiers() *CombinedIdentifiers {
-	return ids.EntityIdentifiers().CombinedIdentifiers()
 }
 
 // OrganizationOrUserIdentifiers returns the UserIdentifiers as *OrganizationOrUserIdentifiers.
@@ -212,40 +69,11 @@ func (ids UserIdentifiers) OrganizationOrUserIdentifiers() *OrganizationOrUserId
 	}}
 }
 
-// Identifiers returns the OrganizationOrUserIdentifiers as Identifiers.
-func (ids OrganizationOrUserIdentifiers) Identifiers() Identifiers {
-	switch oneof := ids.Ids.(type) {
-	case *OrganizationOrUserIdentifiers_OrganizationIDs:
-		return oneof.OrganizationIDs
-	case *OrganizationOrUserIdentifiers_UserIDs:
-		return oneof.UserIDs
-	default:
-		panic("missed oneof type in OrganizationOrUserIdentifiers.Identifiers()")
-	}
-}
-
-// EntityIdentifiers returns the OrganizationOrUserIdentifiers as EntityIdentifiers.
-func (ids OrganizationOrUserIdentifiers) EntityIdentifiers() *EntityIdentifiers {
-	switch oneof := ids.Ids.(type) {
-	case *OrganizationOrUserIdentifiers_OrganizationIDs:
-		return oneof.OrganizationIDs.EntityIdentifiers()
-	case *OrganizationOrUserIdentifiers_UserIDs:
-		return oneof.UserIDs.EntityIdentifiers()
-	default:
-		panic("missed oneof type in OrganizationOrUserIdentifiers.EntityIdentifiers()")
-	}
-}
-
-// CombinedIdentifiers returns the OrganizationOrUserIdentifiers as CombinedIdentifiers.
-func (ids OrganizationOrUserIdentifiers) CombinedIdentifiers() *CombinedIdentifiers {
-	return ids.EntityIdentifiers().CombinedIdentifiers()
-}
-
 // CombineIdentifiers merges the identifiers of the multiple entities.
 func CombineIdentifiers(ids ...Identifiers) *CombinedIdentifiers {
 	combined := &CombinedIdentifiers{}
 	for _, id := range ids {
-		combined.EntityIdentifiers = append(combined.EntityIdentifiers, id.CombinedIdentifiers().GetEntityIdentifiers()...)
+		combined.EntityIdentifiers = append(combined.EntityIdentifiers, id.EntityIdentifiers())
 	}
 	return combined
 }

--- a/pkg/ttnpb/identifiers_combined.go
+++ b/pkg/ttnpb/identifiers_combined.go
@@ -1,0 +1,55 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ttnpb
+
+// CombinedIdentifiers returns the ApplicationIdentifiers as CombinedIdentifiers.
+func (ids ApplicationIdentifiers) CombinedIdentifiers() *CombinedIdentifiers {
+	return ids.EntityIdentifiers().CombinedIdentifiers()
+}
+
+// CombinedIdentifiers returns the ClientIdentifiers as CombinedIdentifiers.
+func (ids ClientIdentifiers) CombinedIdentifiers() *CombinedIdentifiers {
+	return ids.EntityIdentifiers().CombinedIdentifiers()
+}
+
+// CombinedIdentifiers returns the EndDeviceIdentifiers as CombinedIdentifiers.
+func (ids EndDeviceIdentifiers) CombinedIdentifiers() *CombinedIdentifiers {
+	return ids.EntityIdentifiers().CombinedIdentifiers()
+}
+
+// CombinedIdentifiers returns the GatewayIdentifiers as CombinedIdentifiers.
+func (ids GatewayIdentifiers) CombinedIdentifiers() *CombinedIdentifiers {
+	return ids.EntityIdentifiers().CombinedIdentifiers()
+}
+
+// CombinedIdentifiers returns the OrganizationIdentifiers as CombinedIdentifiers.
+func (ids OrganizationIdentifiers) CombinedIdentifiers() *CombinedIdentifiers {
+	return ids.EntityIdentifiers().CombinedIdentifiers()
+}
+
+// CombinedIdentifiers returns the UserIdentifiers as CombinedIdentifiers.
+func (ids UserIdentifiers) CombinedIdentifiers() *CombinedIdentifiers {
+	return ids.EntityIdentifiers().CombinedIdentifiers()
+}
+
+// CombinedIdentifiers returns the EntityIdentifiers as a CombinedIdentifiers type.
+func (ids EntityIdentifiers) CombinedIdentifiers() *CombinedIdentifiers {
+	return &CombinedIdentifiers{EntityIdentifiers: []*EntityIdentifiers{&ids}}
+}
+
+// CombinedIdentifiers returns the OrganizationOrUserIdentifiers as CombinedIdentifiers.
+func (ids OrganizationOrUserIdentifiers) CombinedIdentifiers() *CombinedIdentifiers {
+	return ids.EntityIdentifiers().CombinedIdentifiers()
+}

--- a/pkg/ttnpb/identifiers_polymorphism.go
+++ b/pkg/ttnpb/identifiers_polymorphism.go
@@ -1,0 +1,237 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ttnpb
+
+import "fmt"
+
+// Identifiers is the interface implemented by all (single) identifiers.
+type Identifiers interface {
+	EntityType() string
+	IDString() string
+	Identifiers() Identifiers
+	EntityIdentifiers() *EntityIdentifiers
+	CombinedIdentifiers() *CombinedIdentifiers
+}
+
+// EntityIdentifiers returns the ApplicationIdentifiers as EntityIdentifiers.
+func (ids ApplicationIdentifiers) EntityIdentifiers() *EntityIdentifiers {
+	return &EntityIdentifiers{Ids: &EntityIdentifiers_ApplicationIDs{
+		ApplicationIDs: &ids,
+	}}
+}
+
+// EntityIdentifiers returns the ClientIdentifiers as EntityIdentifiers.
+func (ids ClientIdentifiers) EntityIdentifiers() *EntityIdentifiers {
+	return &EntityIdentifiers{Ids: &EntityIdentifiers_ClientIDs{
+		ClientIDs: &ids,
+	}}
+}
+
+// EntityIdentifiers returns the EndDeviceIdentifiers as EntityIdentifiers.
+func (ids EndDeviceIdentifiers) EntityIdentifiers() *EntityIdentifiers {
+	return &EntityIdentifiers{Ids: &EntityIdentifiers_DeviceIDs{
+		DeviceIDs: &ids,
+	}}
+}
+
+// EntityIdentifiers returns the GatewayIdentifiers as EntityIdentifiers.
+func (ids GatewayIdentifiers) EntityIdentifiers() *EntityIdentifiers {
+	return &EntityIdentifiers{Ids: &EntityIdentifiers_GatewayIDs{
+		GatewayIDs: &ids,
+	}}
+}
+
+// EntityIdentifiers implements returns theOrganizationIdentifiers as EntityIdentifiers.
+func (ids OrganizationIdentifiers) EntityIdentifiers() *EntityIdentifiers {
+	return &EntityIdentifiers{Ids: &EntityIdentifiers_OrganizationIDs{
+		OrganizationIDs: &ids,
+	}}
+}
+
+// EntityIdentifiers returns the UserIdentifiers as EntityIdentifiers.
+func (ids UserIdentifiers) EntityIdentifiers() *EntityIdentifiers {
+	return &EntityIdentifiers{Ids: &EntityIdentifiers_UserIDs{
+		UserIDs: &ids,
+	}}
+}
+
+// EntityIdentifiers returns itself.
+func (ids EntityIdentifiers) EntityIdentifiers() *EntityIdentifiers {
+	return &ids
+}
+
+// EntityIdentifiers returns the Identifiers inside the oneof as EntityIdentifiers.
+func (ids OrganizationOrUserIdentifiers) EntityIdentifiers() *EntityIdentifiers {
+	switch oneof := ids.Ids.(type) {
+	case *OrganizationOrUserIdentifiers_OrganizationIDs:
+		return oneof.OrganizationIDs.EntityIdentifiers()
+	case *OrganizationOrUserIdentifiers_UserIDs:
+		return oneof.UserIDs.EntityIdentifiers()
+	default:
+		panic("missed oneof type in OrganizationOrUserIdentifiers.EntityIdentifiers()")
+	}
+}
+
+// Identifiers returns itself.
+func (ids ApplicationIdentifiers) Identifiers() Identifiers { return &ids }
+
+// Identifiers returns itself.
+func (ids ClientIdentifiers) Identifiers() Identifiers { return &ids }
+
+// Identifiers returns itself.
+func (ids EndDeviceIdentifiers) Identifiers() Identifiers { return &ids }
+
+// Identifiers returns itself.
+func (ids GatewayIdentifiers) Identifiers() Identifiers { return &ids }
+
+// Identifiers returns itself.
+func (ids OrganizationIdentifiers) Identifiers() Identifiers { return &ids }
+
+// Identifiers returns itself.
+func (ids UserIdentifiers) Identifiers() Identifiers { return &ids }
+
+// Identifiers returns the concrete identifiers inside the oneof.
+func (ids EntityIdentifiers) Identifiers() Identifiers {
+	switch oneof := ids.Ids.(type) {
+	case *EntityIdentifiers_ApplicationIDs:
+		return oneof.ApplicationIDs
+	case *EntityIdentifiers_ClientIDs:
+		return oneof.ClientIDs
+	case *EntityIdentifiers_DeviceIDs:
+		return oneof.DeviceIDs
+	case *EntityIdentifiers_GatewayIDs:
+		return oneof.GatewayIDs
+	case *EntityIdentifiers_OrganizationIDs:
+		return oneof.OrganizationIDs
+	case *EntityIdentifiers_UserIDs:
+		return oneof.UserIDs
+	default:
+		panic("missed oneof type in EntityIdentifiers.Identifiers()")
+	}
+}
+
+// Identifiers returns the concrete identifiers inside the oneof.
+func (ids OrganizationOrUserIdentifiers) Identifiers() Identifiers {
+	switch oneof := ids.Ids.(type) {
+	case *OrganizationOrUserIdentifiers_OrganizationIDs:
+		return oneof.OrganizationIDs
+	case *OrganizationOrUserIdentifiers_UserIDs:
+		return oneof.UserIDs
+	default:
+		panic("missed oneof type in OrganizationOrUserIdentifiers.Identifiers()")
+	}
+}
+
+// IDString returns the ID string of this Identifier.
+func (ids ApplicationIdentifiers) IDString() string { return ids.ApplicationID }
+
+// IDString returns the ID string of this Identifier.
+func (ids ClientIdentifiers) IDString() string { return ids.ClientID }
+
+// IDString returns the ID string of this Identifier.
+func (ids EndDeviceIdentifiers) IDString() string {
+	return fmt.Sprintf("%s.%s", ids.ApplicationIdentifiers.IDString(), ids.DeviceID)
+}
+
+// IDString returns the ID string of this Identifier.
+func (ids GatewayIdentifiers) IDString() string { return ids.GatewayID }
+
+// IDString returns the ID string of this Identifier.
+func (ids OrganizationIdentifiers) IDString() string { return ids.OrganizationID }
+
+// IDString returns the ID string of this Identifier.
+func (ids UserIdentifiers) IDString() string { return ids.UserID }
+
+// IDString returns the ID string of the Identifiers inside the oneof.
+func (ids EntityIdentifiers) IDString() string {
+	switch oneof := ids.Ids.(type) {
+	case *EntityIdentifiers_ApplicationIDs:
+		return oneof.ApplicationIDs.IDString()
+	case *EntityIdentifiers_ClientIDs:
+		return oneof.ClientIDs.IDString()
+	case *EntityIdentifiers_DeviceIDs:
+		return oneof.DeviceIDs.IDString()
+	case *EntityIdentifiers_GatewayIDs:
+		return oneof.GatewayIDs.IDString()
+	case *EntityIdentifiers_OrganizationIDs:
+		return oneof.OrganizationIDs.IDString()
+	case *EntityIdentifiers_UserIDs:
+		return oneof.UserIDs.IDString()
+	default:
+		panic("missed oneof type in EntityIdentifiers.IDString()")
+	}
+}
+
+// IDString returns the ID string of the Identifiers inside the oneof.
+func (ids OrganizationOrUserIdentifiers) IDString() string {
+	switch oneof := ids.Ids.(type) {
+	case *OrganizationOrUserIdentifiers_OrganizationIDs:
+		return oneof.OrganizationIDs.IDString()
+	case *OrganizationOrUserIdentifiers_UserIDs:
+		return oneof.UserIDs.IDString()
+	default:
+		panic("missed oneof type in OrganizationOrUserIdentifiers.IDString()")
+	}
+}
+
+// EntityType returns the entity type for this ID (application).
+func (ApplicationIdentifiers) EntityType() string { return "application" }
+
+// EntityType returns the entity type for this ID (client).
+func (ClientIdentifiers) EntityType() string { return "client" }
+
+// EntityType returns the entity type for this ID (end device).
+func (EndDeviceIdentifiers) EntityType() string { return "end device" }
+
+// EntityType returns the entity type for this ID (gateway).
+func (GatewayIdentifiers) EntityType() string { return "gateway" }
+
+// EntityType returns the entity type for this ID (organization).
+func (OrganizationIdentifiers) EntityType() string { return "organization" }
+
+// EntityType returns the entity type for this ID (user).
+func (UserIdentifiers) EntityType() string { return "user" }
+
+// EntityType returns the entity type for the Identifiers inside the oneof.
+func (ids EntityIdentifiers) EntityType() string {
+	switch oneof := ids.Ids.(type) {
+	case *EntityIdentifiers_ApplicationIDs:
+		return oneof.ApplicationIDs.EntityType()
+	case *EntityIdentifiers_ClientIDs:
+		return oneof.ClientIDs.EntityType()
+	case *EntityIdentifiers_DeviceIDs:
+		return oneof.DeviceIDs.EntityType()
+	case *EntityIdentifiers_GatewayIDs:
+		return oneof.GatewayIDs.EntityType()
+	case *EntityIdentifiers_OrganizationIDs:
+		return oneof.OrganizationIDs.EntityType()
+	case *EntityIdentifiers_UserIDs:
+		return oneof.UserIDs.EntityType()
+	default:
+		panic("missed oneof type in EntityIdentifiers.EntityType()")
+	}
+}
+
+// EntityType returns the entity type for the Identifiers inside the oneof.
+func (ids OrganizationOrUserIdentifiers) EntityType() string {
+	switch oneof := ids.Ids.(type) {
+	case *OrganizationOrUserIdentifiers_OrganizationIDs:
+		return oneof.OrganizationIDs.EntityType()
+	case *OrganizationOrUserIdentifiers_UserIDs:
+		return oneof.UserIDs.EntityType()
+	default:
+		panic("missed oneof type in OrganizationOrUserIdentifiers.EntityType()")
+	}
+}

--- a/pkg/ttnpb/identifiers_polymorphism_test.go
+++ b/pkg/ttnpb/identifiers_polymorphism_test.go
@@ -1,0 +1,91 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ttnpb_test
+
+import (
+	"testing"
+
+	"github.com/smartystreets/assertions"
+	. "go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
+)
+
+func TestEntityType(t *testing.T) {
+	a := assertions.New(t)
+
+	applicationID := ApplicationIdentifiers{ApplicationID: "foo"}
+	clientID := ClientIdentifiers{ClientID: "foo"}
+	endDeviceID := EndDeviceIdentifiers{DeviceID: "foo", ApplicationIdentifiers: applicationID}
+	gatewayID := GatewayIdentifiers{GatewayID: "foo"}
+	organizationID := OrganizationIdentifiers{OrganizationID: "foo"}
+	userID := UserIdentifiers{UserID: "foo"}
+
+	a.So(applicationID.EntityType(), should.Equal, "application")
+	a.So(applicationID.IDString(), should.Equal, "foo")
+
+	a.So(clientID.EntityType(), should.Equal, "client")
+	a.So(clientID.IDString(), should.Equal, "foo")
+
+	a.So(endDeviceID.EntityType(), should.Equal, "end device")
+	a.So(endDeviceID.IDString(), should.Equal, "foo.foo")
+
+	a.So(gatewayID.EntityType(), should.Equal, "gateway")
+	a.So(gatewayID.IDString(), should.Equal, "foo")
+
+	a.So(organizationID.EntityType(), should.Equal, "organization")
+	a.So(organizationID.IDString(), should.Equal, "foo")
+
+	a.So(userID.EntityType(), should.Equal, "user")
+	a.So(userID.IDString(), should.Equal, "foo")
+
+	for _, id := range []Identifiers{
+		&applicationID,
+		&clientID,
+		&endDeviceID,
+		&gatewayID,
+		&organizationID,
+		&userID,
+	} {
+		a.So(id.Identifiers(), should.Resemble, id)
+		a.So(id.EntityIdentifiers().Identifiers(), should.Resemble, id)
+
+		a.So(id.Identifiers().EntityType(), should.Equal, id.EntityType())
+		a.So(id.EntityIdentifiers().EntityType(), should.Equal, id.EntityType())
+		a.So(id.EntityIdentifiers().Identifiers().EntityType(), should.Equal, id.EntityType())
+
+		a.So(id.Identifiers().IDString(), should.Equal, id.IDString())
+		a.So(id.EntityIdentifiers().IDString(), should.Equal, id.IDString())
+		a.So(id.EntityIdentifiers().Identifiers().IDString(), should.Equal, id.IDString())
+
+		if orgOrUsr, ok := id.(interface {
+			OrganizationOrUserIdentifiers() *OrganizationOrUserIdentifiers
+		}); ok {
+			ouid := orgOrUsr.OrganizationOrUserIdentifiers()
+			a.So(ouid.EntityType(), should.Equal, id.EntityType())
+			a.So(ouid.IDString(), should.Equal, id.IDString())
+
+			a.So(ouid.Identifiers(), should.Resemble, id)
+			a.So(ouid.EntityIdentifiers().Identifiers(), should.Resemble, id)
+
+			a.So(ouid.Identifiers().EntityType(), should.Equal, id.EntityType())
+			a.So(ouid.EntityIdentifiers().EntityType(), should.Equal, id.EntityType())
+			a.So(ouid.EntityIdentifiers().Identifiers().EntityType(), should.Equal, id.EntityType())
+
+			a.So(ouid.Identifiers().IDString(), should.Equal, id.IDString())
+			a.So(ouid.EntityIdentifiers().IDString(), should.Equal, id.IDString())
+			a.So(ouid.EntityIdentifiers().Identifiers().IDString(), should.Equal, id.IDString())
+		}
+	}
+}

--- a/pkg/ttnpb/identifiers_test.go
+++ b/pkg/ttnpb/identifiers_test.go
@@ -65,7 +65,7 @@ func TestIdentifiersIsZero(t *testing.T) {
 func TestCombinedIdentifiers(t *testing.T) {
 	a := assertions.New(t)
 
-	for _, msg := range []Identifiers{
+	for _, msg := range []interface{ CombinedIdentifiers() *CombinedIdentifiers }{
 		NewPopulatedApplicationIdentifiers(test.Randy, true),
 		NewPopulatedClientIdentifiers(test.Randy, true),
 		NewPopulatedEndDeviceIdentifiers(test.Randy, true),

--- a/pkg/unique/unique.go
+++ b/pkg/unique/unique.go
@@ -32,15 +32,7 @@ var errFormat = errors.DefineInvalidArgument("format", "invalid format in value 
 // The reason for panicking is that taking the unique identifier of a nil or
 // zero value may result in unexpected and potentially harmful behavior.
 func ID(ctx context.Context, id ttnpb.Identifiers) (res string) {
-	if idStringer, ok := id.(interface{ IDString() string }); ok {
-		res = idStringer.IDString()
-	} else {
-		eids := id.CombinedIdentifiers().EntityIdentifiers
-		if len(eids) != 1 {
-			panic(fmt.Errorf("failed to determine unique ID: invalid number of identifiers for unique ID"))
-		}
-		res = eids[0].IDString()
-	}
+	res = id.IDString()
 	if res == "" || strings.HasPrefix(res, ".") || strings.HasSuffix(res, ".") {
 		panic(fmt.Errorf("failed to determine unique ID: the primary identifier is invalid"))
 	}

--- a/pkg/unique/unique_test.go
+++ b/pkg/unique/unique_test.go
@@ -27,15 +27,6 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 )
 
-type customIdentifiers struct {
-}
-
-func (c customIdentifiers) IsZero() bool { return false }
-
-func (c customIdentifiers) CombinedIdentifiers() *ttnpb.CombinedIdentifiers {
-	return &ttnpb.CombinedIdentifiers{}
-}
-
 func TestValidity(t *testing.T) {
 	eui := types.EUI64{0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01}
 	for _, tc := range []ttnpb.Identifiers{
@@ -66,8 +57,6 @@ func TestValidity(t *testing.T) {
 		ttnpb.OrganizationIdentifiers{},
 		(*ttnpb.UserIdentifiers)(nil),
 		ttnpb.UserIdentifiers{},
-		customIdentifiers{},
-		&customIdentifiers{},
 	} {
 		t.Run(fmt.Sprintf("%T", tc), func(t *testing.T) {
 			a := assertions.New(t)
@@ -167,7 +156,7 @@ func TestRoundtrip(t *testing.T) {
 			if tc.Parser != nil {
 				parsed, err := tc.Parser(tc.Expected)
 				if a.So(err, should.BeNil) {
-					a.So(parsed.CombinedIdentifiers(), should.Resemble, tc.ID.CombinedIdentifiers())
+					a.So(parsed.EntityIdentifiers(), should.Resemble, tc.ID.EntityIdentifiers())
 				}
 			}
 		})


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR redefines `ttnpb.Identifiers`

#### Changes
<!-- What are the changes made in this pull request? -->

- Make the rights hook and events system only depend on CombinedIdentifiers
- Remove CombinedIdentifiers from normal Identifiers interface
- Remove conversions of anything to `.EntityIdentifiers()` in Identity Server
- Refactor Identity Server rights handling to use ttnpb.Identifiers

Refs https://github.com/TheThingsIndustries/lorawan-stack/issues/1441