### PR TITLE
Filter traffic based on forward table

### DIFF
--- a/cmd/internal/shared/gatewayserver/config.go
+++ b/cmd/internal/shared/gatewayserver/config.go
@@ -22,6 +22,9 @@ import (
 // DefaultGatewayServerConfig is the default configuration for the GatewayServer.
 var DefaultGatewayServerConfig = gatewayserver.Config{
 	RequireRegisteredGateways: false,
+	Forward: map[string][]string{
+		"": []string{"00000000/0"},
+	},
 	UDP: gatewayserver.UDPConfig{
 		Config: udp.DefaultConfig,
 		Listeners: map[string]string{

--- a/cmd/internal/shared/gatewayserver/config.go
+++ b/cmd/internal/shared/gatewayserver/config.go
@@ -23,7 +23,7 @@ import (
 var DefaultGatewayServerConfig = gatewayserver.Config{
 	RequireRegisteredGateways: false,
 	Forward: map[string][]string{
-		"": []string{"00000000/0"},
+		"": {"00000000/0"},
 	},
 	UDP: gatewayserver.UDPConfig{
 		Config: udp.DefaultConfig,

--- a/config/messages.json
+++ b/config/messages.json
@@ -2888,6 +2888,15 @@
       "file": "gatewayserver.go"
     }
   },
+  "error:pkg/gatewayserver:host_handle": {
+    "translations": {
+      "en": "host `{host}` failed to handle message"
+    },
+    "description": {
+      "package": "pkg/gatewayserver",
+      "file": "gatewayserver.go"
+    }
+  },
   "error:pkg/gatewayserver:listen_frontend": {
     "translations": {
       "en": "failed to start frontend listener `{protocol}` on address `{address}`"
@@ -2900,6 +2909,15 @@
   "error:pkg/gatewayserver:no_fallback_frequency_plan": {
     "translations": {
       "en": "gateway `{gateway_uid}` is not registered and no fallback frequency plan defined"
+    },
+    "description": {
+      "package": "pkg/gatewayserver",
+      "file": "gatewayserver.go"
+    }
+  },
+  "error:pkg/gatewayserver:no_forward_to_host": {
+    "translations": {
+      "en": "no forward to host `{host}`"
     },
     "description": {
       "package": "pkg/gatewayserver",

--- a/config/messages.json
+++ b/config/messages.json
@@ -5453,6 +5453,15 @@
       "file": "observability.go"
     }
   },
+  "event:gs.up.fail": {
+    "translations": {
+      "en": "fail to handle uplink message"
+    },
+    "description": {
+      "package": "pkg/gatewayserver",
+      "file": "observability.go"
+    }
+  },
   "event:gs.up.forward": {
     "translations": {
       "en": "forward uplink message"

--- a/config/messages.json
+++ b/config/messages.json
@@ -2915,15 +2915,6 @@
       "file": "gatewayserver.go"
     }
   },
-  "error:pkg/gatewayserver:no_forward_to_host": {
-    "translations": {
-      "en": "no forward to host `{host}`"
-    },
-    "description": {
-      "package": "pkg/gatewayserver",
-      "file": "gatewayserver.go"
-    }
-  },
   "error:pkg/gatewayserver:no_network_server": {
     "translations": {
       "en": "no Network Server found to handle message"

--- a/pkg/gatewayserver/config_test.go
+++ b/pkg/gatewayserver/config_test.go
@@ -29,15 +29,15 @@ func TestConfig(t *testing.T) {
 	{
 		conf := gatewayserver.Config{
 			Forward: map[string][]string{
-				"":                []string{"00000000/0"},
-				"packetbroker.io": []string{"00000000/3", "26000000/7"},
+				"":                {"00000000/0"},
+				"packetbroker.io": {"00000000/3", "26000000/7"},
 			},
 		}
 		forward, err := conf.ForwardDevAddrPrefixes()
 		a.So(err, should.BeNil)
 		a.So(forward, should.HaveEmptyDiff, map[string][]types.DevAddrPrefix{
-			"": []types.DevAddrPrefix{{}},
-			"packetbroker.io": []types.DevAddrPrefix{
+			"": {{}},
+			"packetbroker.io": {
 				{DevAddr: types.DevAddr{}, Length: 3},
 				{DevAddr: types.DevAddr{0x26, 0x0, 0x0, 0x0}, Length: 7},
 			},
@@ -47,7 +47,7 @@ func TestConfig(t *testing.T) {
 	{
 		conf := gatewayserver.Config{
 			Forward: map[string][]string{
-				"packetbroker.io": []string{"00000000/3", "invalid"},
+				"packetbroker.io": {"00000000/3", "invalid"},
 			},
 		}
 		_, err := conf.ForwardDevAddrPrefixes()

--- a/pkg/gatewayserver/config_test.go
+++ b/pkg/gatewayserver/config_test.go
@@ -1,0 +1,56 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gatewayserver_test
+
+import (
+	"testing"
+
+	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/pkg/gatewayserver"
+	"go.thethings.network/lorawan-stack/pkg/types"
+	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
+)
+
+func TestConfig(t *testing.T) {
+	a := assertions.New(t)
+
+	{
+		conf := gatewayserver.Config{
+			Forward: map[string][]string{
+				"":                []string{"00000000/0"},
+				"packetbroker.io": []string{"00000000/3", "26000000/7"},
+			},
+		}
+		forward, err := conf.ForwardDevAddrPrefixes()
+		a.So(err, should.BeNil)
+		a.So(forward, should.HaveEmptyDiff, map[string][]types.DevAddrPrefix{
+			"": []types.DevAddrPrefix{{}},
+			"packetbroker.io": []types.DevAddrPrefix{
+				{DevAddr: types.DevAddr{}, Length: 3},
+				{DevAddr: types.DevAddr{0x26, 0x0, 0x0, 0x0}, Length: 7},
+			},
+		})
+	}
+
+	{
+		conf := gatewayserver.Config{
+			Forward: map[string][]string{
+				"packetbroker.io": []string{"00000000/3", "invalid"},
+			},
+		}
+		_, err := conf.ForwardDevAddrPrefixes()
+		a.So(err, should.NotBeNil)
+	}
+}

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -334,7 +334,9 @@ var (
 	// maxUpstreamHandlers is the maximum number of goroutines per gateway connection to handle upstream messages.
 	maxUpstreamHandlers = int32(1 << 5)
 	// upstreamHandlerIdleTimeout is the duration after which an idle upstream handler stops to save resources.
-	upstreamHandlerIdleTimeout = (1 << 6) * time.Millisecond
+	upstreamHandlerIdleTimeout = (1 << 7) * time.Millisecond
+	// upstreamHandlerBusyTimeout is the duration after traffic gets dropped if all upstream handlers are busy.
+	upstreamHandlerBusyTimeout = (1 << 6) * time.Millisecond
 )
 
 type upstreamHandler interface {
@@ -488,7 +490,11 @@ func (gs *GatewayServer) handleUpstream(conn *io.Connection) {
 					host.handleWg.Add(1)
 					go handleFn(host)
 				}
-				host.handleCh <- item
+				select {
+				case host.handleCh <- item:
+				case <-time.After(upstreamHandlerBusyTimeout):
+					logger.WithField("host", host).Warn("Upstream handlers busy, drop message")
+				}
 			}
 		}
 	}

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -326,7 +326,6 @@ func (gs *GatewayServer) GetConnection(ctx context.Context, ids ttnpb.GatewayIde
 
 var (
 	errNoNetworkServer = errors.DefineNotFound("no_network_server", "no Network Server found to handle message")
-	errNoForwardToHost = errors.DefineFailedPrecondition("no_forward_to_host", "no forward to host `{host}`")
 	errHostHandle      = errors.Define("host_handle", "host `{host}` failed to handle message")
 )
 
@@ -404,7 +403,6 @@ func (gs *GatewayServer) handleUpstream(conn *io.Connection) {
 					}
 					handler := item.host.handler(&ids)
 					if handler == nil {
-						drop(ids, errNoForwardToHost.WithAttributes("host", item.host.name))
 						break
 					}
 					if _, err := handler.HandleUplink(ctx, msg, item.host.callOpts...); err != nil {

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -81,6 +81,9 @@ func New(c *component.Component, conf *Config) (gs *GatewayServer, err error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(forward) == 0 {
+		forward[""] = []types.DevAddrPrefix{{}}
+	}
 	gs = &GatewayServer{
 		Component:                 c,
 		ctx:                       log.NewContextWithField(c.Context(), "namespace", "gatewayserver"),
@@ -321,7 +324,11 @@ func (gs *GatewayServer) GetConnection(ctx context.Context, ids ttnpb.GatewayIde
 	return conn.(*io.Connection), true
 }
 
-var errNoNetworkServer = errors.DefineNotFound("no_network_server", "no Network Server found to handle message")
+var (
+	errNoNetworkServer = errors.DefineNotFound("no_network_server", "no Network Server found to handle message")
+	errNoForwardToHost = errors.DefineFailedPrecondition("no_forward_to_host", "no forward to host `{host}`")
+	errHostHandle      = errors.Define("host_handle", "host `{host}` failed to handle message")
+)
 
 var (
 	// maxUpstreamHandlers is the maximum number of goroutines per gateway connection to handle upstream messages.
@@ -341,9 +348,22 @@ func (gs *GatewayServer) handleUpstream(conn *io.Connection) {
 		logger.Info("Disconnected")
 	}()
 
+	type handler interface {
+		HandleUplink(context.Context, *ttnpb.UplinkMessage, ...grpc.CallOption) (*pbtypes.Empty, error)
+	}
+	type host struct {
+		name     string
+		handler  func(ids *ttnpb.EndDeviceIdentifiers) handler
+		callOpts []grpc.CallOption
+	}
+	type item struct {
+		val  interface{}
+		host *host
+	}
+
 	wg := &sync.WaitGroup{}
 	handlers := int32(0)
-	handleCh := make(chan interface{})
+	handleCh := make(chan item)
 	handleFn := func() {
 		defer wg.Done()
 		defer atomic.AddInt32(&handlers, -1)
@@ -354,7 +374,7 @@ func (gs *GatewayServer) handleUpstream(conn *io.Connection) {
 			case <-time.After(upstreamHandlerIdleTimeout):
 				return
 			case item := <-handleCh:
-				switch msg := item.(type) {
+				switch msg := item.val.(type) {
 				case *ttnpb.UplinkMessage:
 					ctx := events.ContextWithCorrelationID(ctx, fmt.Sprintf("gs:uplink:%s", events.NewCorrelationID()))
 					msg.CorrelationIDs = append(msg.CorrelationIDs, events.CorrelationIDsFromContext(ctx)...)
@@ -378,16 +398,16 @@ func (gs *GatewayServer) handleUpstream(conn *io.Connection) {
 						drop(ttnpb.EndDeviceIdentifiers{}, err)
 						break
 					}
-					ns := gs.GetPeer(ctx, ttnpb.PeerInfo_NETWORK_SERVER, ids)
-					if ns == nil {
-						drop(ids, errNoNetworkServer)
+					handler := item.host.handler(&ids)
+					if handler == nil {
+						drop(ids, errNoForwardToHost.WithAttributes("host", item.host.name))
 						break
 					}
-					if _, err := ttnpb.NewGsNsClient(ns.Conn()).HandleUplink(ctx, msg, gs.WithClusterAuth()); err != nil {
-						drop(ids, err)
+					if _, err := handler.HandleUplink(ctx, msg, item.host.callOpts...); err != nil {
+						drop(ids, errHostHandle.WithCause(err).WithAttributes("host", item.host.name))
 						break
 					}
-					registerForwardUplink(ctx, ids, conn.Gateway(), msg, ns.Name())
+					registerForwardUplink(ctx, ids, conn.Gateway(), msg, item.host.name)
 
 				case *ttnpb.GatewayStatus:
 					ctx := events.ContextWithCorrelationID(ctx, fmt.Sprintf("gs:status:%s", events.NewCorrelationID()))
@@ -406,25 +426,64 @@ func (gs *GatewayServer) handleUpstream(conn *io.Connection) {
 		}
 	}
 
+	hosts := make([]*host, 0, len(gs.forward))
+	for name, prefixes := range gs.forward {
+		passDevAddr := func(devAddr types.DevAddr) bool {
+			for _, prefix := range prefixes {
+				if devAddr.HasPrefix(prefix) {
+					return true
+				}
+			}
+			return false
+		}
+		if name == "" {
+			// Cluster Network Server; filter based on DevAddr and pass all join-requests.
+			hosts = append(hosts, &host{
+				name: name,
+				handler: func(ids *ttnpb.EndDeviceIdentifiers) handler {
+					if ids != nil && ids.DevAddr != nil && !passDevAddr(*ids.DevAddr) {
+						return nil
+					}
+					ns := gs.GetPeer(ctx, ttnpb.PeerInfo_NETWORK_SERVER, ids)
+					if ns == nil {
+						logger.Warn("Cluster Network Server unavailable for upstream traffic")
+						return nil
+					}
+					return ttnpb.NewGsNsClient(ns.Conn())
+				},
+				callOpts: []grpc.CallOption{gs.WithClusterAuth()},
+			})
+		} else {
+			// Packet Broker; filter based on DevAddr and filter all join-requests.
+			// TODO: Offload traffic to Packet Broker (https://github.com/TheThingsNetwork/lorawan-stack/issues/671)
+		}
+	}
+
 	defer wg.Wait()
 	for {
-		var item interface{}
+		var val interface{}
 		select {
 		case <-ctx.Done():
 			return
-		case item = <-conn.Up():
-		case item = <-conn.Status():
-		case item = <-conn.TxAck():
+		case val = <-conn.Up():
+		case val = <-conn.Status():
+		case val = <-conn.TxAck():
 		}
-		select {
-		case handleCh <- item:
-		default:
-			if atomic.LoadInt32(&handlers) < maxUpstreamHandlers {
-				atomic.AddInt32(&handlers, 1)
-				wg.Add(1)
-				go handleFn()
+		for _, host := range hosts {
+			item := item{
+				val:  val,
+				host: host,
 			}
-			handleCh <- item
+			select {
+			case handleCh <- item:
+			default:
+				if atomic.LoadInt32(&handlers) < maxUpstreamHandlers {
+					atomic.AddInt32(&handlers, 1)
+					wg.Add(1)
+					go handleFn()
+				}
+				handleCh <- item
+			}
 		}
 	}
 }

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -381,7 +381,7 @@ func (gs *GatewayServer) handleUpstream(conn *io.Connection) {
 				ctx := item.ctx
 				switch msg := item.val.(type) {
 				case *ttnpb.UplinkMessage:
-					registerReceiveUplink(ctx, conn.Gateway(), msg)
+					registerReceiveUplink(ctx, conn.Gateway(), msg, host.name)
 					drop := func(ids ttnpb.EndDeviceIdentifiers, err error) {
 						logger := logger.WithError(err)
 						if ids.JoinEUI != nil && !ids.JoinEUI.IsZero() {
@@ -394,7 +394,7 @@ func (gs *GatewayServer) handleUpstream(conn *io.Connection) {
 							logger = logger.WithField("dev_addr", *ids.DevAddr)
 						}
 						logger.Debug("Drop message")
-						registerDropUplink(ctx, conn.Gateway(), msg, err)
+						registerDropUplink(ctx, conn.Gateway(), msg, host.name, err)
 					}
 					ids, err := lorawan.GetUplinkMessageIdentifiers(msg)
 					if err != nil {

--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -53,7 +53,7 @@ var (
 	unregisteredGatewayID  = "eui-bbff000000000000"
 	unregisteredGatewayEUI = types.EUI64{0xBB, 0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 
-	timeout = (1 << 4) * test.Delay
+	timeout = (1 << 5) * test.Delay
 )
 
 func TestGatewayServer(t *testing.T) {

--- a/pkg/gatewayserver/observability.go
+++ b/pkg/gatewayserver/observability.go
@@ -70,7 +70,7 @@ var gsMetrics = &messageMetrics{
 			Name:      "uplink_received_total",
 			Help:      "Total number of received uplinks",
 		},
-		[]string{gatewayID},
+		[]string{networkServer, gatewayID},
 	),
 	uplinkForwarded: metrics.NewContextualCounterVec(
 		prometheus.CounterOpts{
@@ -86,7 +86,7 @@ var gsMetrics = &messageMetrics{
 			Name:      "uplink_dropped_total",
 			Help:      "Total number of dropped uplinks",
 		},
-		[]string{"error"},
+		[]string{networkServer, "error"},
 	),
 	uplinkFailed: metrics.NewContextualCounterVec(
 		prometheus.CounterOpts{
@@ -177,9 +177,9 @@ func registerReceiveStatus(ctx context.Context, gtw *ttnpb.Gateway, status *ttnp
 	gsMetrics.statusReceived.WithLabelValues(ctx, gtw.GatewayID).Inc()
 }
 
-func registerReceiveUplink(ctx context.Context, gtw *ttnpb.Gateway, msg *ttnpb.UplinkMessage) {
+func registerReceiveUplink(ctx context.Context, gtw *ttnpb.Gateway, msg *ttnpb.UplinkMessage, ns string) {
 	events.Publish(evtReceiveUp(ctx, gtw, msg))
-	gsMetrics.uplinkReceived.WithLabelValues(ctx, gtw.GatewayID).Inc()
+	gsMetrics.uplinkReceived.WithLabelValues(ctx, ns, gtw.GatewayID).Inc()
 }
 
 func registerForwardUplink(ctx context.Context, gtw *ttnpb.Gateway, msg *ttnpb.UplinkMessage, ns string) {
@@ -187,12 +187,12 @@ func registerForwardUplink(ctx context.Context, gtw *ttnpb.Gateway, msg *ttnpb.U
 	gsMetrics.uplinkForwarded.WithLabelValues(ctx, ns).Inc()
 }
 
-func registerDropUplink(ctx context.Context, gtw *ttnpb.Gateway, msg *ttnpb.UplinkMessage, err error) {
+func registerDropUplink(ctx context.Context, gtw *ttnpb.Gateway, msg *ttnpb.UplinkMessage, ns string, err error) {
 	events.Publish(evtDropUp(ctx, gtw, err))
 	if ttnErr, ok := errors.From(err); ok {
-		gsMetrics.uplinkDropped.WithLabelValues(ctx, ttnErr.FullName()).Inc()
+		gsMetrics.uplinkDropped.WithLabelValues(ctx, ns, ttnErr.FullName()).Inc()
 	} else {
-		gsMetrics.uplinkDropped.WithLabelValues(ctx, unknown).Inc()
+		gsMetrics.uplinkDropped.WithLabelValues(ctx, ns, unknown).Inc()
 	}
 }
 

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -363,7 +363,7 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 			priority = max
 		}
 	}
-	if len(cmdBuf) > 0 && priority < ns.downlinkPriorities.MACCommands {
+	if (pld.FPort == 0 || len(cmdBuf) > 0) && priority < ns.downlinkPriorities.MACCommands {
 		priority = ns.downlinkPriorities.MACCommands
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #671; no offloading, only filtering and preparation for multiple upstream hosts and their handler goroutine pool.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add GS config for forwarding `DevAddr` prefixes to hosts
- Per gateway connection, allow for multiple upstream hosts and their handlers