### PR TITLE
Add device event streaming

### DIFF
--- a/pkg/webui/console/api/index.js
+++ b/pkg/webui/console/api/index.js
@@ -104,6 +104,7 @@ export default {
     get: ttnClient.Applications.Devices.getById.bind(ttnClient.Applications.Devices),
     create: ttnClient.Applications.Devices.create.bind(ttnClient.Applications.Devices),
     update: ttnClient.Applications.Devices.updateById.bind(ttnClient.Applications.Devices),
+    eventsSubscribe: ttnClient.Applications.Devices.openStream.bind(ttnClient.Applications.Devices),
   },
   gateways: {
     list: ttnClient.Gateways.getAll.bind(ttnClient.Gateways),

--- a/pkg/webui/console/containers/device-events/index.js
+++ b/pkg/webui/console/containers/device-events/index.js
@@ -1,0 +1,71 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import { connect } from 'react-redux'
+import bind from 'autobind-decorator'
+
+import PropTypes from '../../../lib/prop-types'
+import { getApplicationId, getDeviceId } from '../../../lib/selectors/id'
+import EventsSubscription from '../../containers/events-subscription'
+
+import {
+  clearDeviceEventsStream,
+} from '../../store/actions/device'
+
+import {
+  deviceEventsSelector,
+  deviceEventsStatusSelector,
+} from '../../store/selectors/device'
+
+@connect(
+  null,
+  (dispatch, ownProps) => ({
+    onClear: () => dispatch(clearDeviceEventsStream(ownProps.devIds)),
+  }))
+@bind
+class DeviceEvents extends React.Component {
+  render () {
+    const {
+      devIds,
+      widget,
+      onClear,
+    } = this.props
+
+    const devId = getDeviceId(devIds)
+    const appId = getApplicationId(devIds)
+
+    return (
+      <EventsSubscription
+        id={devId}
+        widget={widget}
+        eventsSelector={deviceEventsSelector}
+        statusSelector={deviceEventsStatusSelector}
+        onClear={onClear}
+        toAllUrl={`/console/applications/${appId}/devices/${devId}/data`}
+      />
+    )
+  }
+}
+
+DeviceEvents.propTypes = {
+  devIds: PropTypes.object.isRequired,
+  widget: PropTypes.bool,
+}
+
+DeviceEvents.defaultProps = {
+  widget: false,
+}
+
+export default DeviceEvents

--- a/pkg/webui/console/containers/gateway-events/index.js
+++ b/pkg/webui/console/containers/gateway-events/index.js
@@ -44,7 +44,7 @@ class GatewayEvents extends React.Component {
         eventsSelector={gatewayEventsSelector}
         statusSelector={gatewayEventsStatusSelector}
         onClear={onClear}
-        toAllUrl={`/console/gatways/${gtwId}/data`}
+        toAllUrl={`/console/gateways/${gtwId}/data`}
       />
     )
   }

--- a/pkg/webui/console/store/actions/device.js
+++ b/pkg/webui/console/store/actions/device.js
@@ -12,9 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import {
+  startEventsStream,
+  createStartEventsStreamActionType,
+  startEventsStreamSuccess,
+  createStartEventsStreamSuccessActionType,
+  startEventsStreamFailure,
+  createStartEventsStreamFailureActionType,
+  stopEventsStream,
+  createStopEventsStreamActionType,
+  clearEvents,
+  createClearEventsActionType,
+} from '../actions/events'
+
+export const SHARED_NAME = 'DEVICE'
+
 export const GET_DEV = 'GET_DEVICE'
 export const GET_DEV_SUCCESS = 'GET_DEVICE_SUCCESS'
 export const GET_DEV_FAILURE = 'GET_DEVICE_FAILURE'
+export const START_DEVICE_EVENT_STREAM = createStartEventsStreamActionType(SHARED_NAME)
+export const START_DEVICE_EVENT_STREAM_SUCCESS = createStartEventsStreamSuccessActionType(SHARED_NAME)
+export const START_DEVICE_EVENT_STREAM_FAILURE = createStartEventsStreamFailureActionType(SHARED_NAME)
+export const STOP_DEVICE_EVENT_STREAM = createStopEventsStreamActionType(SHARED_NAME)
+export const CLEAR_DEVICE_EVENTS = createClearEventsActionType(SHARED_NAME)
 
 export const getDevice = (appId, deviceId, selector, options) => (
   { type: GET_DEV, appId, deviceId, selector, options }
@@ -27,3 +47,13 @@ export const getDeviceSuccess = device => (
 export const getDeviceFailure = error => (
   { type: GET_DEV_FAILURE, error }
 )
+
+export const startDeviceEventsStream = startEventsStream(SHARED_NAME)
+
+export const startDeviceEventsStreamSuccess = startEventsStreamSuccess(SHARED_NAME)
+
+export const startDeviceEventsStreamFailure = startEventsStreamFailure(SHARED_NAME)
+
+export const stopDeviceEventsStream = stopEventsStream(SHARED_NAME)
+
+export const clearDeviceEventsStream = clearEvents(SHARED_NAME)

--- a/pkg/webui/console/store/middleware/device.js
+++ b/pkg/webui/console/store/middleware/device.js
@@ -16,6 +16,7 @@ import { createLogic } from 'redux-logic'
 
 import api from '../../api'
 import * as device from '../actions/device'
+import createEventsConnectLogics from './events'
 
 const getDeviceLogic = createLogic({
   type: [ device.GET_DEV ],
@@ -23,6 +24,7 @@ const getDeviceLogic = createLogic({
     const { appId, deviceId, selector, options } = action
     try {
       const dev = await api.device.get(appId, deviceId, selector, options)
+      dispatch(device.startDeviceEventsStream(dev.ids))
       dispatch(device.getDeviceSuccess(dev))
     } catch (e) {
       dispatch(device.getDeviceFailure(e))
@@ -34,4 +36,5 @@ const getDeviceLogic = createLogic({
 
 export default [
   getDeviceLogic,
+  ...createEventsConnectLogics(device.SHARED_NAME, 'device'),
 ]

--- a/pkg/webui/console/store/reducers/events.js
+++ b/pkg/webui/console/store/reducers/events.js
@@ -23,6 +23,8 @@ import {
   createClearEventsActionType,
 } from '../actions/events'
 
+import { getDeviceId } from '../../../lib/selectors/id'
+
 const defaultState = {
   events: [],
   error: false,
@@ -93,6 +95,10 @@ const createNamedEventsReducer = function (reducerName = '') {
       return state
     }
 
+    const id = typeof action.id === 'object'
+      ? getDeviceId(action.id)
+      : action.id
+
     switch (action.type) {
     case START_EVENTS:
     case START_EVENTS_FAILURE:
@@ -103,7 +109,7 @@ const createNamedEventsReducer = function (reducerName = '') {
     case CLEAR_EVENTS:
       return {
         ...state,
-        [action.id]: event(state[action.id], action),
+        [id]: event(state[id], action),
       }
     default:
       return state

--- a/pkg/webui/console/store/reducers/index.js
+++ b/pkg/webui/console/store/reducers/index.js
@@ -17,6 +17,7 @@ import { SHARED_NAME as APPLICATION_SHARED_NAME } from '../actions/application'
 import { SHARED_NAME as APPLICATIONS_SHARED_NAME } from '../actions/applications'
 import { SHARED_NAME as GATEWAY_SHARED_NAME } from '../actions/gateway'
 import { SHARED_NAME as GATEWAYS_SHARED_NAME } from '../actions/gateways'
+import { SHARED_NAME as DEVICE_SHARED_NAME } from '../actions/device'
 import user from './user'
 import client from './client'
 import init from './init'
@@ -56,6 +57,7 @@ export default combineReducers({
   }),
   events: combineReducers({
     applications: createNamedEventsReducer(APPLICATION_SHARED_NAME),
+    devices: createNamedEventsReducer(DEVICE_SHARED_NAME),
     gateways: createNamedEventsReducer(GATEWAY_SHARED_NAME),
   }),
 })

--- a/pkg/webui/console/store/selectors/device.js
+++ b/pkg/webui/console/store/selectors/device.js
@@ -1,0 +1,43 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  eventsSelector,
+  errorSelector as eventsErrorSelector,
+  statusSelector as eventsStatusSelector,
+} from './events'
+
+const ENTITY = 'devices'
+
+const storeSelector = store => store.device
+
+export const deviceSelector = state => storeSelector(state).device
+
+export const fetchingSelector = function (state) {
+  const store = storeSelector(state)
+
+  return store.fetching || false
+}
+
+export const errorSelector = function (state) {
+  const store = storeSelector(state)
+
+  return store.error
+}
+
+export const deviceEventsSelector = eventsSelector(ENTITY)
+
+export const deviceEventsErrorSelector = eventsErrorSelector(ENTITY)
+
+export const deviceEventsStatusSelector = eventsStatusSelector(ENTITY)

--- a/pkg/webui/console/views/device-data/index.js
+++ b/pkg/webui/console/views/device-data/index.js
@@ -1,0 +1,66 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import { connect } from 'react-redux'
+import { Col, Row, Container } from 'react-grid-system'
+import bind from 'autobind-decorator'
+
+import IntlHelmet from '../../../lib/components/intl-helmet'
+import sharedMessages from '../../../lib/shared-messages'
+import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
+import { withBreadcrumb } from '../../../components/breadcrumbs/context'
+import DeviceEvents from '../../containers/device-events'
+
+import { getDeviceId } from '../../../lib/selectors/id'
+
+@connect(function ({ device, application }, props) {
+  return {
+    device: device.device,
+    devId: getDeviceId(device.device),
+    devIds: device.device && device.device.ids,
+  }
+})
+@withBreadcrumb('device.single.data', function (props) {
+  const { devId } = props
+  const { appId } = props.match.params
+  return (
+    <Breadcrumb
+      path={`/console/applications/${appId}/devices/${devId}/data`}
+      icon="data"
+      content={sharedMessages.data}
+    />
+  )
+})
+@bind
+export default class DeviceGeneralSettings extends React.Component {
+  render () {
+    const { devIds } = this.props
+
+    return (
+      <Container>
+        <IntlHelmet
+          title={sharedMessages.data}
+        />
+        <Row>
+          <Col sm={12} md={12} lg={8} xl={8}>
+            <DeviceEvents
+              devIds={devIds}
+            />
+          </Col>
+        </Row>
+      </Container>
+    )
+  }
+}

--- a/pkg/webui/console/views/device-overview/device-overview.styl
+++ b/pkg/webui/console/views/device-overview/device-overview.styl
@@ -56,28 +56,3 @@
     border-normal('bottom')
     box-sizing: border-box
     padding-bottom: 2.55rem
-
-.locationPlaceholder, .activityPlaceholder
-  h4
-    one-liner(block)
-    height: 1rem
-    margin: 0
-
-  div
-    border-normal()
-    box-sizing: border-box
-    display: flex
-    align-items: center
-    justify-content: center
-    width: 100%
-    height: 16rem
-    margin-top: $ls.xxs
-    text-align: center
-    font-style: italic
-    color: $tc-subtle-gray
-
-.activityPlaceholder
-  margin-top: $ls.s
-
-.locationPlaceholder
-  margin-top: $ls.m

--- a/pkg/webui/console/views/device-overview/index.js
+++ b/pkg/webui/console/views/device-overview/index.js
@@ -147,10 +147,6 @@ class DeviceOverview extends React.Component {
           </Col>
           <Col md={12} lg={6}>
             <DeviceEvents devIds={devIds} widget />
-            <div className={style.locationPlaceholder}>
-              <h4><Message content={sharedMessages.location} /></h4>
-              <div>Location Map Placeholder</div>
-            </div>
           </Col>
         </Row>
       </Container>

--- a/pkg/webui/console/views/device-overview/index.js
+++ b/pkg/webui/console/views/device-overview/index.js
@@ -24,6 +24,9 @@ import IntlHelmet from '../../../lib/components/intl-helmet'
 import Message from '../../../lib/components/message'
 import DataSheet from '../../../components/data-sheet'
 import DateTime from '../../../lib/components/date-time'
+import DeviceEvents from '../../containers/device-events'
+
+import { getDeviceId } from '../../../lib/selectors/id'
 
 import style from './device-overview.styl'
 
@@ -132,6 +135,9 @@ class DeviceOverview extends React.Component {
   }
 
   render () {
+    const { device } = this.props
+    const devId = getDeviceId(device)
+
     return (
       <Container>
         <IntlHelmet
@@ -142,10 +148,7 @@ class DeviceOverview extends React.Component {
             {this.deviceInfo}
           </Col>
           <Col md={12} lg={6}>
-            <div className={style.activityPlaceholder}>
-              <h4><Message content={m.latestData} /></h4>
-              <div>Activity Panel Placeholder</div>
-            </div>
+            <DeviceEvents devId={devId} widget />
             <div className={style.locationPlaceholder}>
               <h4><Message content={sharedMessages.location} /></h4>
               <div>Location Map Placeholder</div>

--- a/pkg/webui/console/views/device-overview/index.js
+++ b/pkg/webui/console/views/device-overview/index.js
@@ -26,8 +26,6 @@ import DataSheet from '../../../components/data-sheet'
 import DateTime from '../../../lib/components/date-time'
 import DeviceEvents from '../../containers/device-events'
 
-import { getDeviceId } from '../../../lib/selectors/id'
-
 import style from './device-overview.styl'
 
 const m = defineMessages({
@@ -136,7 +134,7 @@ class DeviceOverview extends React.Component {
 
   render () {
     const { device } = this.props
-    const devId = getDeviceId(device)
+    const devIds = device && device.ids
 
     return (
       <Container>
@@ -148,7 +146,7 @@ class DeviceOverview extends React.Component {
             {this.deviceInfo}
           </Col>
           <Col md={12} lg={6}>
-            <DeviceEvents devId={devId} widget />
+            <DeviceEvents devIds={devIds} widget />
             <div className={style.locationPlaceholder}>
               <h4><Message content={sharedMessages.location} /></h4>
               <div>Location Map Placeholder</div>

--- a/pkg/webui/console/views/device/index.js
+++ b/pkg/webui/console/views/device/index.js
@@ -27,6 +27,7 @@ import Tabs from '../../../components/tabs'
 import IntlHelmet from '../../../lib/components/intl-helmet'
 
 import DeviceOverview from '../device-overview'
+import DeviceData from '../device-data'
 import DeviceGeneralSettings from '../device-general-settings'
 
 import {
@@ -119,7 +120,7 @@ export default class Device extends React.Component {
 
     const tabs = [
       { title: sharedMessages.overview, name: 'overview', link: basePath },
-      { title: sharedMessages.data, name: 'data' },
+      { title: sharedMessages.data, name: 'data', link: `${basePath}/data` },
       { title: sharedMessages.location, name: 'location' },
       { title: sharedMessages.payloadFormats, name: 'develop' },
       { title: sharedMessages.generalSettings, name: 'general-settings', link: `${basePath}/general-settings` },
@@ -144,6 +145,7 @@ export default class Device extends React.Component {
         </Container>
         <Switch>
           <Route exact path={basePath} component={DeviceOverview} />
+          <Route exact path={`${basePath}/data`} component={DeviceData} />
           <Route exact path={`${basePath}/general-settings`} component={DeviceGeneralSettings} />
         </Switch>
       </React.Fragment>

--- a/pkg/webui/console/views/device/index.js
+++ b/pkg/webui/console/views/device/index.js
@@ -134,7 +134,7 @@ export default class Device extends React.Component {
         <Container>
           <Row>
             <Col lg={12}>
-              <h2 className={style.title}>{devId}</h2>
+              <h2 className={style.title}>{deviceName || devId}</h2>
               <Tabs
                 narrow
                 tabs={tabs}

--- a/pkg/webui/lib/selectors/id.js
+++ b/pkg/webui/lib/selectors/id.js
@@ -22,6 +22,7 @@ export const getApplicationId = function (application = {}) {
 
 export const getDeviceId = function (device = {}) {
   return getByPath(device, 'device_id')
+    || getByPath(device, 'ids.device_id')
     || getByPath(device, 'device_ids.device_id')
 }
 

--- a/sdk/js/src/service/devices/index.js
+++ b/sdk/js/src/service/devices/index.js
@@ -18,6 +18,7 @@ import { URL } from 'url'
 import traverse from 'traverse'
 import Marshaler from '../../util/marshaler'
 import Device from '../../entity/device'
+import stream from '../../api/stream/stream-node'
 import randomByteString from '../../util/random-bytes'
 import { splitSetPaths, splitGetPaths, makeRequests } from './split'
 import mergeDevice from './merge'
@@ -297,6 +298,21 @@ class Devices {
     const result = this._deleteDevice(applicationId, deviceId)
 
     return result
+  }
+
+  // Events Stream
+
+  async openStream (identifiers, tail, after) {
+    const eventsUrl = `${this._stackConfig.as}/events`
+    const payload = {
+      identifiers: identifiers.map(ids => ({
+        device_ids: ids,
+      })),
+      tail,
+      after,
+    }
+
+    return stream(payload, eventsUrl)
   }
 }
 


### PR DESCRIPTION
#### Summary
Closes #691 
References #25, #28 
This PR adds functionality to view device event data, as widget in the overview and as dedicated "Data" view.

![image](https://user-images.githubusercontent.com/5710611/57840660-533ab900-77c9-11e9-8863-ea7f8b3c663d.png)
![image](https://user-images.githubusercontent.com/5710611/57840692-66e61f80-77c9-11e9-917d-19edafcd027e.png)

#### Changes
- Add streaming to device service in JS SDK
- Add redux primitives for event streaming of devices
- Add `<DeviceData />` container
- Add event widget to device overview
- Add "Data" view to devices with full event component
- Minor semi-related fixes
- Remove placeholders in device overview

#### Notes for Reviewers
The action for opening the stream is now dispatched inside the action to retrieve the device, as the stream endpoint needs the whole id object of the device, which is only available after successful retrieval. We should do a similar thing for the other entities as this also fixes #662.
Likewise, it is not possible to key the reducer by the device ID, because in the case of devices it is an object. Hence, I added a check to extract the actual device id string, in case this is necessary.

#### Release Notes
- Added event streaming views for end devices
