### PR TITLE
Filter Tx acknowledgements on upstream socket

### DIFF
--- a/pkg/gatewayserver/io/udp/firewall.go
+++ b/pkg/gatewayserver/io/udp/firewall.go
@@ -68,10 +68,8 @@ func (v *memoryFirewall) filter(packet encoding.Packet, store *sync.Map) bool {
 	val, ok := store.Load(eui)
 	if ok {
 		a := val.(addrTime)
-		if a.UDPAddr.String() != packet.GatewayAddr.String() {
-			if a.lastSeen.Add(v.addrChangeBlock).After(now) {
-				return false
-			}
+		if a.UDPAddr.String() != packet.GatewayAddr.String() && a.lastSeen.Add(v.addrChangeBlock).After(now) {
+			return false
 		}
 	}
 	store.Store(eui, addrTime{
@@ -83,9 +81,9 @@ func (v *memoryFirewall) filter(packet encoding.Packet, store *sync.Map) bool {
 
 func (v *memoryFirewall) Filter(packet encoding.Packet) bool {
 	switch packet.PacketType {
-	case encoding.PullData, encoding.TxAck:
+	case encoding.PullData:
 		return v.filter(packet, &v.pull)
-	case encoding.PushData:
+	case encoding.PushData, encoding.TxAck:
 		return v.filter(packet, &v.push)
 	}
 	return false


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Small fix that fixes the UDP firewall that caused Tx acknowledgements to get filtered out. Apparently they're sent on the upstream socket and not on the downstream socket.

#### Changes
<!-- What are the changes made in this pull request? -->

- Filter Tx acknowledgement on upstream socket