### PR TITLE
CLI gateway server address default and mismatch check

### DIFF
--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -241,7 +241,7 @@ var (
 				jsPaths = nil
 			}
 
-			nsMismatch, asMismatch, jsMismatch := compareServerAddresses(device, config)
+			nsMismatch, asMismatch, jsMismatch := compareServerAddressesEndDevice(device, config)
 			if len(nsPaths) > 0 && nsMismatch {
 				logger.WithField("paths", nsPaths).Warn("Deselecting Network Server paths")
 				nsPaths = nil
@@ -522,8 +522,8 @@ var (
 				return errNoEndDeviceEUI
 			}
 
-			if nsMismatch, asMismatch, jsMismatch := compareServerAddresses(existingDevice, config); nsMismatch || asMismatch || jsMismatch {
-				return errAddressMismatch
+			if nsMismatch, asMismatch, jsMismatch := compareServerAddressesEndDevice(existingDevice, config); nsMismatch || asMismatch || jsMismatch {
+				return errAddressMismatchEndDevice
 			}
 
 			res, err := setEndDevice(&device, isPaths, nsPaths, asPaths, jsPaths, false)
@@ -670,8 +670,8 @@ var (
 				devID.DevEUI = existingDevice.DevEUI
 			}
 
-			if nsMismatch, asMismatch, jsMismatch := compareServerAddresses(existingDevice, config); nsMismatch || asMismatch || jsMismatch {
-				return errAddressMismatch
+			if nsMismatch, asMismatch, jsMismatch := compareServerAddressesEndDevice(existingDevice, config); nsMismatch || asMismatch || jsMismatch {
+				return errAddressMismatchEndDevice
 			}
 
 			return deleteEndDevice(ctx, devID)
@@ -740,9 +740,9 @@ func init() {
 	Root.AddCommand(endDevicesCommand)
 }
 
-var errAddressMismatch = errors.DefineAborted("address_mismatch", "server address mismatch")
+var errAddressMismatchEndDevice = errors.DefineAborted("end_device_server_address_mismatch", "network/application/join server address mismatch")
 
-func compareServerAddresses(device *ttnpb.EndDevice, config *Config) (nsMismatch, asMismatch, jsMismatch bool) {
+func compareServerAddressesEndDevice(device *ttnpb.EndDevice, config *Config) (nsMismatch, asMismatch, jsMismatch bool) {
 	nsHost, asHost, jsHost := getHost(config.NetworkServerGRPCAddress), getHost(config.ApplicationServerGRPCAddress), getHost(config.JoinServerGRPCAddress)
 	if host := getHost(device.NetworkServerAddress); host != "" && host != nsHost {
 		nsMismatch = true

--- a/cmd/ttn-lw-cli/commands/gateways.go
+++ b/cmd/ttn-lw-cli/commands/gateways.go
@@ -206,11 +206,18 @@ var (
 				}
 			}
 
-			setDefaults, _ := cmd.Flags().GetBool("defaults")
-			if setDefaults {
+			if setDefaults, _ := cmd.Flags().GetBool("defaults"); setDefaults {
 				gateway.GatewayServerAddress = getHost(config.GatewayServerGRPCAddress)
+				gateway.AutoUpdate = true
+				gateway.EnforceDutyCycle = true
+				gateway.StatusPublic = true
+				gateway.LocationPublic = true
 				paths = append(paths,
 					"gateway_server_address",
+					"auto_update",
+					"enforce_duty_cycle",
+					"status_public",
+					"location_public",
 				)
 			}
 
@@ -408,7 +415,7 @@ func init() {
 	gatewaysCreateCommand.Flags().AddFlagSet(setGatewayFlags)
 	gatewaysCreateCommand.Flags().AddFlagSet(setGatewayAntennaFlags)
 	gatewaysCreateCommand.Flags().AddFlagSet(attributesFlags())
-	gatewaysCreateCommand.Flags().Bool("defaults", true, "configure gateway with default gateway server address")
+	gatewaysCreateCommand.Flags().Bool("defaults", true, "configure gateway with defaults")
 	gatewaysCommand.AddCommand(gatewaysCreateCommand)
 	gatewaysUpdateCommand.Flags().AddFlagSet(gatewayIDFlags())
 	gatewaysUpdateCommand.Flags().AddFlagSet(setGatewayFlags)

--- a/cmd/ttn-lw-cli/commands/gateways.go
+++ b/cmd/ttn-lw-cli/commands/gateways.go
@@ -191,6 +191,8 @@ var (
 			if err != nil {
 				return err
 			}
+			paths := util.UpdateFieldMask(cmd.Flags(), setGatewayFlags, attributesFlags())
+
 			collaborator := getCollaborator(cmd.Flags())
 			if collaborator == nil {
 				return errNoCollaborator
@@ -217,6 +219,14 @@ var (
 
 			if gateway.GatewayID == "" {
 				return errNoGatewayID
+			}
+
+			setDefaults, _ := cmd.Flags().GetBool("defaults")
+			if setDefaults {
+				gateway.GatewayServerAddress = getHost(config.GatewayServerGRPCAddress)
+				paths = append(paths,
+					"gateway_server_address",
+				)
 			}
 
 			var antenna ttnpb.GatewayAntenna
@@ -377,6 +387,7 @@ func init() {
 	gatewaysCreateCommand.Flags().AddFlagSet(setGatewayFlags)
 	gatewaysCreateCommand.Flags().AddFlagSet(setGatewayAntennaFlags)
 	gatewaysCreateCommand.Flags().AddFlagSet(attributesFlags())
+	gatewaysCreateCommand.Flags().Bool("defaults", true, "configure gateway with default gateway server address")
 	gatewaysCommand.AddCommand(gatewaysCreateCommand)
 	gatewaysUpdateCommand.Flags().AddFlagSet(gatewayIDFlags())
 	gatewaysUpdateCommand.Flags().AddFlagSet(setGatewayFlags)

--- a/config/messages.json
+++ b/config/messages.json
@@ -1133,15 +1133,6 @@
       "file": "errors.go"
     }
   },
-  "error:cmd/ttn-lw-cli/commands:address_mismatch": {
-    "translations": {
-      "en": "server address mismatch"
-    },
-    "description": {
-      "package": "cmd/ttn-lw-cli/commands",
-      "file": "end_devices.go"
-    }
-  },
   "error:cmd/ttn-lw-cli/commands:antenna_index": {
     "translations": {
       "en": "index of antenna to update out of bounds"
@@ -1185,6 +1176,24 @@
     "description": {
       "package": "cmd/ttn-lw-cli/commands",
       "file": "end_devices.go"
+    }
+  },
+  "error:cmd/ttn-lw-cli/commands:end_device_server_address_mismatch": {
+    "translations": {
+      "en": "network/application/join server address mismatch"
+    },
+    "description": {
+      "package": "cmd/ttn-lw-cli/commands",
+      "file": "end_devices.go"
+    }
+  },
+  "error:cmd/ttn-lw-cli/commands:gateway_server_address_mismatch": {
+    "translations": {
+      "en": "gateway server address mismatch"
+    },
+    "description": {
+      "package": "cmd/ttn-lw-cli/commands",
+      "file": "gateways.go"
     }
   },
   "error:cmd/ttn-lw-cli/commands:inconsistent_end_device_eui": {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #637 

#### Changes
<!-- What are the changes made in this pull request? -->

- Added default (configured for CLI) gateway server address assignation to a gateway created with `gateways create` without specified `--gateway-server-adress`
- Added gateway server address mismatch check in `connection-stats` command

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

As requested by @htdvisser . The same procedures happen to end-devices' `ns`, `js`, `as`, so there is no reason gateways should not have it for `gs`.

Creating gateway without `--gateway-server-address`, `localhost` set as default:
```
go run ./cmd/ttn-lw-cli gateways create gtw5 \
  --user-id admin \
  --frequency-plan-id EU_863_870 \
  --gateway-eui 00800000A01009BA \
  --enforce-duty-cycle 
grpc_service=ttn.lorawan.v3.GatewayRegistry namespace=grpc
{
  "ids": {
    "gateway_id": "gtw5",
    "eui": "00800000A01009BA"
  },
  "created_at": "2019-05-15T21:59:07.302Z",
  "updated_at": "2019-05-15T21:59:07.302Z",
  "version_ids": {

  },
  "gateway_server_address": "localhost",
  "frequency_plan_id": "EU_863_870",
  "antennas": [
    {
      "location": {
        "source": "SOURCE_REGISTRY"
      }
    }
  ],
  "enforce_duty_cycle": true
```

Creating a gateway with specifying the `--gateway-server-address`:
```
go run ./cmd/ttn-lw-cli gateways create gtw6 \
  --user-id admin \
  --frequency-plan-id EU_863_870 \
  --gateway-eui 00800000A01009B0 \
  --enforce-duty-cycle \
--gateway-server-address 1234567
 DEBUG Using access token (valid until 12:39PM)
grpc_service=ttn.lorawan.v3.GatewayRegistry namespace=grpc
{
  "ids": {
    "gateway_id": "gtw6",
    "eui": "00800000A01009B0"
  },
  "created_at": "2019-05-16T09:40:22.381Z",
  "updated_at": "2019-05-16T09:40:22.381Z",
  "version_ids": {

  },
  "gateway_server_address": "1234567",
  "frequency_plan_id": "EU_863_870",
  "antennas": [
    {
      "location": {
        "source": "SOURCE_REGISTRY"
      }
    }
  ],
  "enforce_duty_cycle": true
}
```

Mismatch check, gtw6's g-s-a '1234567' differs from CLI's `localhost`, which leads to warning:

```
go run ./cmd/ttn-lw-cli gateways connection-stats "gtw6"
grpc_service=ttn.lorawan.v3.GatewayRegistry namespace=grpc
  WARN Registered Gateway Server address does not match CLI configuration configured=localhost registered=1234567
error:cmd/ttn-lw-cli/commands:gs_address_mismatch (gateway server address mismatch)
exit status 255
```