### PR TITLE
[Quickfix] Enable webpack source maps in dev mode

### DIFF
--- a/config/webpack.config.babel.js
+++ b/config/webpack.config.babel.js
@@ -54,6 +54,7 @@ export default {
   externals: [ filterLocales ],
   stats: 'minimal',
   target: 'web',
+  devtool: production ? false : 'eval-source-map',
   node: {
     fs: 'empty',
     module: 'empty',


### PR DESCRIPTION
#### Summary
This PR adds a source map option to the webpack config, resulting in source maps being properly generated in `development` builds. I believe the source maps went missing in our builds after the webpack upgrade a while back.

#### Changes
- Update webpack config

#### Notes for Reviewers
One line fix.
