### PR TITLE
[Quickfix] Fix device settings submit button message

### DIFF
--- a/pkg/webui/console/containers/device-data-form/index.js
+++ b/pkg/webui/console/containers/device-data-form/index.js
@@ -320,7 +320,10 @@ class DeviceDataForm extends Component {
         </FieldGroup>
         {otaa ? this.OTAASection : this.ABPSection}
         <SubmitBar>
-          <Button type="submit" message={m.createDevice} />
+          <Button
+            type="submit"
+            message={update ? sharedMessages.saveChanges : m.createDevice}
+          />
         </SubmitBar>
       </Form>
     )


### PR DESCRIPTION
#### Summary
This PR fixes the submit button in the general settings form for end devices wrongfully reading "Create Device".

#### Changes
- Set button message based on whether the form is for updating or creating devices

#### Notes for Reviewers
Small fix.