### PR TITLE
Secure in-process loopback gRPC connection (#711)

### DIFF
--- a/pkg/networkserver/networkserver_flow_test.go
+++ b/pkg/networkserver/networkserver_flow_test.go
@@ -170,19 +170,9 @@ func handleOTAAClassA868FlowTest1_0_2(ctx context.Context, reg DeviceRegistry, t
 	ns := test.Must(New(
 		component.MustNew(
 			test.GetLogger(t),
-			&component.Config{
-				ServiceBase: config.ServiceBase{
-					GRPC: config.GRPC{
-						AllowInsecureForCredentials: true,
-					},
-				},
-			},
+			&component.Config{},
 			component.WithClusterNew(func(_ context.Context, conf *config.ServiceBase, registerers ...rpcserver.Registerer) (cluster.Cluster, error) {
-				a.So(conf, should.Resemble, &config.ServiceBase{
-					GRPC: config.GRPC{
-						AllowInsecureForCredentials: true,
-					},
-				})
+				a.So(conf, should.Resemble, &config.ServiceBase{})
 				if a.So(registerers, should.HaveLength, 1) {
 					a.So(registerers[0].Roles(), should.Resemble, []ttnpb.PeerInfo_Role{
 						ttnpb.PeerInfo_NETWORK_SERVER,

--- a/pkg/rpcserver/loopback.go
+++ b/pkg/rpcserver/loopback.go
@@ -17,17 +17,103 @@ package rpcserver
 import (
 	"context"
 	"net"
+	"time"
 
+	"go.thethings.network/lorawan-stack/pkg/version"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
+
+const inProcess = "in-process"
+
+type inProcessAuthInfo struct{}
+
+func (inProcessAuthInfo) AuthType() string { return inProcess }
+
+type inProcessCredentials struct {
+	ServerName string
+}
+
+func (inProcessCredentials) ClientHandshake(_ context.Context, _ string, conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	return conn, inProcessAuthInfo{}, nil
+}
+
+func (inProcessCredentials) ServerHandshake(conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	return conn, inProcessAuthInfo{}, nil
+}
+
+func (c inProcessCredentials) Info() credentials.ProtocolInfo {
+	return credentials.ProtocolInfo{
+		SecurityProtocol: inProcess,
+		SecurityVersion:  version.TTN,
+		ServerName:       c.ServerName,
+	}
+}
+
+func (c *inProcessCredentials) Clone() credentials.TransportCredentials { return c }
+
+func (c *inProcessCredentials) OverrideServerName(serverName string) error {
+	c.ServerName = serverName
+	return nil
+}
+
+func newInProcessListener(parent context.Context) *inProcessListener {
+	ctx, cancel := context.WithCancel(parent)
+	return &inProcessListener{
+		ctx:    ctx,
+		cancel: cancel,
+		ch:     make(chan net.Conn),
+	}
+}
+
+type inProcessListener struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	ch     chan net.Conn
+}
+
+func (l inProcessListener) Accept() (net.Conn, error) {
+	select {
+	case <-l.ctx.Done():
+		return nil, l.ctx.Err()
+	case conn := <-l.ch:
+		return conn, nil
+	}
+}
+
+func (l inProcessListener) Close() error {
+	l.cancel()
+	return nil
+}
+
+type inProcessAddr string
+
+func (inProcessAddr) Network() string  { return "in-process" }
+func (a inProcessAddr) String() string { return string(a) }
+
+func (l inProcessListener) Addr() net.Addr { return inProcessAddr("in-process") }
+
+func inProcessDialer(lis *inProcessListener) func(string, time.Duration) (net.Conn, error) {
+	return func(addr string, timeout time.Duration) (net.Conn, error) {
+		server, client := net.Pipe()
+		select {
+		case <-time.After(timeout):
+			return nil, context.DeadlineExceeded
+		case lis.ch <- server:
+			return client, nil
+		}
+	}
+}
 
 // StartLoopback starts the server on a local address and returns a connection to that address.
 // This function does not add the default DialOptions.
 func StartLoopback(ctx context.Context, s *grpc.Server, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		return nil, err
-	}
+	lis := newInProcessListener(ctx)
 	go s.Serve(lis)
-	return grpc.Dial(lis.Addr().String(), append(append([]grpc.DialOption{}, grpc.WithInsecure()), opts...)...)
+	return grpc.Dial(
+		lis.Addr().String(),
+		append([]grpc.DialOption{
+			grpc.WithDialer(inProcessDialer(lis)),
+			grpc.WithTransportCredentials(&inProcessCredentials{}),
+		}, opts...)...)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This Pull Requests implements an in-process loopback connection (which is obviously as secure as it gets) and faking transport security on top of it.

Refs #711

#### Changes
<!-- What are the changes made in this pull request? -->

- Use an in-process listener and dialer for the gRPC loopback conn
- Adapt tests so that they no longer require us to allow credentials on insecure connections.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I'll create an issue for unit-testing this entire package.
