### PR TITLE
Change app/network key types in Device Overview

### DIFF
--- a/pkg/webui/console/views/device-overview/index.js
+++ b/pkg/webui/console/views/device-overview/index.js
@@ -105,7 +105,7 @@ class DeviceOverview extends React.Component {
         sensitive: false,
         subItems: [
           { key: sharedMessages.appKey, value: root_keys.app_key.key, type: 'byte', sensitive: true },
-          { key: sharedMessages.networkKey, value: root_keys.nwk_key.key, type: 'byte', sensitive: true },
+          { key: sharedMessages.nwkKey, value: root_keys.nwk_key.key, type: 'byte', sensitive: true },
         ],
       })
     }

--- a/pkg/webui/console/views/device-overview/index.js
+++ b/pkg/webui/console/views/device-overview/index.js
@@ -104,8 +104,8 @@ class DeviceOverview extends React.Component {
         type: 'code',
         sensitive: false,
         subItems: [
-          { key: sharedMessages.appKey, value: root_keys.app_key.key, type: 'code', sensitive: true },
-          { key: sharedMessages.networkKey, value: root_keys.nwk_key.key, type: 'code', sensitive: true },
+          { key: sharedMessages.appKey, value: root_keys.app_key.key, type: 'byte', sensitive: true },
+          { key: sharedMessages.networkKey, value: root_keys.nwk_key.key, type: 'byte', sensitive: true },
         ],
       })
     }

--- a/pkg/webui/lib/shared-messages.js
+++ b/pkg/webui/lib/shared-messages.js
@@ -94,7 +94,6 @@ export default defineMessages({
   macVersion: 'MAC Version',
   model: 'Model',
   name: 'Name',
-  networkKey: 'Network Key',
   noDesc: 'This device has no description',
   noEvents: '{entityId} has not sent any events recently',
   noMatch: 'No items matched your criteria',

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -211,7 +211,6 @@
   "lib.shared-messages.macVersion": "MAC Version",
   "lib.shared-messages.model": "Model",
   "lib.shared-messages.name": "Name",
-  "lib.shared-messages.networkKey": "Network Key",
   "lib.shared-messages.noDesc": "This device has no description",
   "lib.shared-messages.noEvents": "{entityId} has not sent any events recently",
   "lib.shared-messages.noMatch": "No items matched your criteria",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -211,7 +211,6 @@
   "lib.shared-messages.macVersion": "XXX Xxxxxxx",
   "lib.shared-messages.model": "Xxxxx",
   "lib.shared-messages.name": "Xxxx",
-  "lib.shared-messages.networkKey": "Xxxxxxx Xxx",
   "lib.shared-messages.noDesc": "Xxxx xxxxxx xxx xx xxxxxxxxxxx",
   "lib.shared-messages.noEvents": "{entityId} xxx xxx xxxx xxx xxxxxx xxxxxxxx",
   "lib.shared-messages.noMatch": "Xx xxxxx xxxxxxx xxxx xxxxxxxx",


### PR DESCRIPTION

<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #753 
This PR adds changed the type of `AppKey` and `NwkKey` inspectors to `byte` as well as makes the `NwkKey` label consistent with the Device Add Page (`Network Key` was used before)

<img width="616" alt="Screenshot 2019-05-24 at 13 52 56" src="https://user-images.githubusercontent.com/16374166/58325830-4ce0b880-7e2b-11e9-92ee-679425234d8b.png">
