### PR TITLE
Use loopback connection in cluster package (#711)

### DIFF
--- a/pkg/cluster/auth_test.go
+++ b/pkg/cluster/auth_test.go
@@ -37,11 +37,9 @@ func TestVerifySource(t *testing.T) {
 
 	key := []byte{0x2A, 0x9C, 0x2C, 0x3C, 0x2A, 0x9C, 0x2A, 0x9C, 0x2A, 0x9C, 0x2A, 0x9C, 0x2A, 0x9C, 0x2A, 0x9C}
 
-	c, err := New(ctx, &config.ServiceBase{
-		Cluster: config.Cluster{
-			Keys: []string{
-				hex.EncodeToString(key),
-			},
+	c, err := New(ctx, &config.Cluster{
+		Keys: []string{
+			hex.EncodeToString(key),
 		},
 	})
 	a.So(err, should.BeNil)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -203,7 +203,6 @@ var errPeerConnection = errors.Define(
 
 func (c *cluster) Join() (err error) {
 	options := rpcclient.DefaultDialOptions(c.ctx)
-	// TODO: Use custom WithBalancer DialOption?
 	if c.tls {
 		options = append(options, grpc.WithTransportCredentials(credentials.NewTLS(c.tlsConfig)))
 	} else {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -17,6 +17,7 @@ package cluster
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/hex"
 	"fmt"
 	"os"
@@ -186,10 +187,11 @@ func New(ctx context.Context, config *config.Cluster, options ...Option) (Cluste
 }
 
 type cluster struct {
-	ctx   context.Context
-	tls   bool
-	peers map[string]*peer
-	self  *peer
+	ctx       context.Context
+	tls       bool
+	tlsConfig *tls.Config
+	peers     map[string]*peer
+	self      *peer
 
 	keys [][]byte
 }
@@ -203,7 +205,7 @@ func (c *cluster) Join() (err error) {
 	options := rpcclient.DefaultDialOptions(c.ctx)
 	// TODO: Use custom WithBalancer DialOption?
 	if c.tls {
-		options = append(options, grpc.WithTransportCredentials(credentials.NewTLS(nil))) // TODO: Get *tls.Config from context
+		options = append(options, grpc.WithTransportCredentials(credentials.NewTLS(c.tlsConfig)))
 	} else {
 		options = append(options, grpc.WithInsecure())
 	}

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -26,7 +26,6 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/rpcmiddleware/rpclog"
-	"go.thethings.network/lorawan-stack/pkg/rpcserver"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/util/test"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
@@ -56,7 +55,7 @@ func TestCluster(t *testing.T) {
 
 	go grpc.NewServer().Serve(lis)
 
-	config := &config.ServiceBase{Cluster: config.Cluster{
+	config := config.Cluster{
 		Address:           lis.Addr().String(),
 		IdentityServer:    lis.Addr().String(),
 		GatewayServer:     lis.Addr().String(),
@@ -64,11 +63,11 @@ func TestCluster(t *testing.T) {
 		ApplicationServer: lis.Addr().String(),
 		JoinServer:        lis.Addr().String(),
 		Join:              []string{lis.Addr().String()},
-	}}
+	}
 
 	ctx := test.Context()
 
-	c, err := New(ctx, config, []rpcserver.Registerer{}...)
+	c, err := New(ctx, &config)
 	a.So(err, should.BeNil)
 
 	a.So(c.Join(), should.BeNil)

--- a/pkg/component/cluster.go
+++ b/pkg/component/cluster.go
@@ -24,6 +24,7 @@ import (
 func (c *Component) initCluster() (err error) {
 	clusterOpts := []cluster.Option{
 		cluster.WithServices(c.grpcSubsystems...),
+		cluster.WithConn(c.LoopbackConn()),
 	}
 	c.cluster, err = c.clusterNew(c.ctx, &c.config.ServiceBase.Cluster, clusterOpts...)
 	if err != nil {

--- a/pkg/component/cluster.go
+++ b/pkg/component/cluster.go
@@ -26,6 +26,9 @@ func (c *Component) initCluster() (err error) {
 		cluster.WithServices(c.grpcSubsystems...),
 		cluster.WithConn(c.LoopbackConn()),
 	}
+	if tlsConfig, err := c.config.TLS.Config(c.Context()); err == nil {
+		clusterOpts = append(clusterOpts, cluster.WithTLSConfig(tlsConfig))
+	}
 	c.cluster, err = c.clusterNew(c.ctx, &c.config.ServiceBase.Cluster, clusterOpts...)
 	if err != nil {
 		return err

--- a/pkg/component/cluster.go
+++ b/pkg/component/cluster.go
@@ -22,7 +22,10 @@ import (
 )
 
 func (c *Component) initCluster() (err error) {
-	c.cluster, err = c.clusterNew(c.ctx, &c.config.ServiceBase, c.grpcSubsystems...)
+	clusterOpts := []cluster.Option{
+		cluster.WithServices(c.grpcSubsystems...),
+	}
+	c.cluster, err = c.clusterNew(c.ctx, &c.config.ServiceBase.Cluster, clusterOpts...)
 	if err != nil {
 		return err
 	}

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -63,7 +63,7 @@ type Component struct {
 	sentry *raven.Client
 
 	cluster    cluster.Cluster
-	clusterNew func(ctx context.Context, config *config.ServiceBase, services ...rpcserver.Registerer) (cluster.Cluster, error)
+	clusterNew func(ctx context.Context, config *config.Cluster, options ...cluster.Option) (cluster.Cluster, error)
 
 	grpc           *rpcserver.Server
 	grpcSubsystems []rpcserver.Registerer
@@ -97,7 +97,7 @@ type Option func(*Component)
 // setting up the cluster.
 // This allows extending the cluster configuration with custom logic based on
 // information in the context.
-func WithClusterNew(f func(ctx context.Context, config *config.ServiceBase, services ...rpcserver.Registerer) (cluster.Cluster, error)) Option {
+func WithClusterNew(f func(ctx context.Context, config *config.Cluster, options ...cluster.Option) (cluster.Cluster, error)) Option {
 	return func(c *Component) {
 		c.clusterNew = f
 	}

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -34,7 +34,6 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/encoding/lorawan"
 	"go.thethings.network/lorawan-stack/pkg/frequencyplans"
 	"go.thethings.network/lorawan-stack/pkg/log"
-	"go.thethings.network/lorawan-stack/pkg/rpcserver"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/types"
 	"go.thethings.network/lorawan-stack/pkg/util/test"
@@ -1531,7 +1530,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 			c := component.MustNew(
 				log.Noop,
 				&component.Config{},
-				component.WithClusterNew(func(context.Context, *config.ServiceBase, ...rpcserver.Registerer) (cluster.Cluster, error) {
+				component.WithClusterNew(func(context.Context, *config.Cluster, ...cluster.Option) (cluster.Cluster, error) {
 					return &test.MockCluster{
 						AuthFunc:    test.MakeClusterAuthChFunc(authCh),
 						GetPeerFunc: test.MakeClusterGetPeerChFunc(getPeerCh),
@@ -2564,7 +2563,7 @@ func TestGenerateDownlink(t *testing.T) {
 			c := component.MustNew(
 				log.Noop,
 				&component.Config{},
-				component.WithClusterNew(func(context.Context, *config.ServiceBase, ...rpcserver.Registerer) (cluster.Cluster, error) {
+				component.WithClusterNew(func(context.Context, *config.Cluster, ...cluster.Option) (cluster.Cluster, error) {
 					return &test.MockCluster{
 						JoinFunc: test.ClusterJoinNilFunc,
 					}, nil

--- a/pkg/networkserver/networkserver_flow_test.go
+++ b/pkg/networkserver/networkserver_flow_test.go
@@ -32,7 +32,6 @@ import (
 	. "go.thethings.network/lorawan-stack/pkg/networkserver"
 	"go.thethings.network/lorawan-stack/pkg/networkserver/redis"
 	"go.thethings.network/lorawan-stack/pkg/rpcmetadata"
-	"go.thethings.network/lorawan-stack/pkg/rpcserver"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/types"
 	"go.thethings.network/lorawan-stack/pkg/util/test"
@@ -171,13 +170,7 @@ func handleOTAAClassA868FlowTest1_0_2(ctx context.Context, reg DeviceRegistry, t
 		component.MustNew(
 			test.GetLogger(t),
 			&component.Config{},
-			component.WithClusterNew(func(_ context.Context, conf *config.ServiceBase, registerers ...rpcserver.Registerer) (cluster.Cluster, error) {
-				a.So(conf, should.Resemble, &config.ServiceBase{})
-				if a.So(registerers, should.HaveLength, 1) {
-					a.So(registerers[0].Roles(), should.Resemble, []ttnpb.PeerInfo_Role{
-						ttnpb.PeerInfo_NETWORK_SERVER,
-					})
-				}
+			component.WithClusterNew(func(_ context.Context, conf *config.Cluster, options ...cluster.Option) (cluster.Cluster, error) {
 				return &test.MockCluster{
 					AuthFunc:    test.MakeClusterAuthChFunc(authCh),
 					GetPeerFunc: test.MakeClusterGetPeerChFunc(getPeerCh),


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This Pull Request should resolve the second part of #711. It modifies the initialization of the cluster package so that it now takes (variadic) options. One of these options (the one that resolves the issue) is the loopback connection for the "self" peer. While at it, I also added an option to set the TLS config that the cluster package should use to connect to other peers.

#### Changes
<!-- What are the changes made in this pull request? -->

- Refactored initialization of cluster.
- Added option for setting loopback connection for cluster.
- Added option for setting TLS config for cluster.

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Resolved an issue where the stack complained about sending credentials on insecure connections.
