### PR TITLE
[Quickfix] Fix device payload formatters title

### DIFF
--- a/pkg/webui/console/views/device/index.js
+++ b/pkg/webui/console/views/device/index.js
@@ -124,7 +124,7 @@ export default class Device extends React.Component {
       { title: sharedMessages.overview, name: 'overview', link: basePath },
       { title: sharedMessages.data, name: 'data', link: `${basePath}/data` },
       { title: sharedMessages.location, name: 'location', link: `${basePath}/location` },
-      { title: sharedMessages.payloadFormats, name: 'develop' },
+      { title: sharedMessages.payloadFormatters, name: 'develop' },
       { title: sharedMessages.generalSettings, name: 'general-settings', link: `${basePath}/general-settings` },
     ]
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fixes one of the tabs on the Device Overview Page.
![Screenshot 2019-05-28 at 18 44 40](https://user-images.githubusercontent.com/16374166/58495804-b25cde00-8178-11e9-908a-ad68626db878.png)


#### Changes
<!-- What are the changes made in this pull request? -->

- `sharedMessages.payloadFormats` -> `sharedMessages.payloadFormatters`

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

While working on https://github.com/TheThingsNetwork/lorawan-stack/pull/742 I changed `Payload Formats` to `Payload Formatters` according to [this comment](https://github.com/TheThingsNetwork/lorawan-stack/issues/71#issuecomment-470935614)
