### PR TITLE
[Quickfix] Remove help text in add application view

### DIFF
--- a/pkg/webui/console/views/application-add/application-add.styl
+++ b/pkg/webui/console/views/application-add/application-add.styl
@@ -21,13 +21,3 @@
   +media-query($bp.s)
     order: 2
     text-margin-bottom($ls.m)
-
-.description
-  aside
-    margin-bottom: $ls.m
-    +media-query-min($bp.s)
-      border-dark('left')
-      padding-left: $ls.s
-
-    p
-      eat-text-margins()

--- a/pkg/webui/console/views/application-add/index.js
+++ b/pkg/webui/console/views/application-add/index.js
@@ -148,17 +148,6 @@ export default class Add extends React.Component {
               </SubmitBar>
             </Form>
           </Col>
-          <Col className={style.description} sm={12} md={4} xl={3}>
-            <aside>
-              <p>
-                Here is a text that sort of explains the process of adding an application.
-                This is to help users making sense of what is actually happening.
-                <br />
-                We could also provide links and resources from our documentation.
-                Lorem Ipsum dolor sit amet.
-              </p>
-            </aside>
-          </Col>
         </Row>
       </Container>
     )


### PR DESCRIPTION
#### Summary
This PR removes the help text that is shown next to the add application form. While I think that using these spaces is good to aid users with helpful documentation resources, we don't hace such content yet. As such, I think it's best to remove it for the time being and to look into this option once we have proper documentation architecture ⟶ #395 

#### Changes
- Remove help text in add application view