### PR TITLE
console: Fix modal position

### DIFF
--- a/pkg/webui/components/modal/modal.styl
+++ b/pkg/webui/components/modal/modal.styl
@@ -19,7 +19,10 @@
   flex-direction: column
 
   &-absolute
-    center-absolute()
+    top: 50%
+    left: 50%
+    position: fixed
+    transform: translate(-50%, -50%)
     z-index: $zi.modal
     width: 60%
     max-height: 80vh


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #682 

#### Changes
<!-- What are the changes made in this pull request? -->

- Changed position of modal div from `absolute` to `fixed` such that it stays in the middle of screen always

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- Haven't disabled scrolling when the modal is on screen, since according to @bafonins we will replace custom modals with new ones which will have this behaviour from the start
