### PR TITLE
IS maximum password length restriction

### DIFF
--- a/cmd/internal/shared/identityserver/config.go
+++ b/cmd/internal/shared/identityserver/config.go
@@ -46,6 +46,7 @@ func init() {
 	DefaultIdentityServerConfig.AuthCache.MembershipTTL = 10 * time.Minute
 	DefaultIdentityServerConfig.UserRegistration.Invitation.TokenTTL = 7 * 24 * time.Hour
 	DefaultIdentityServerConfig.UserRegistration.PasswordRequirements.MinLength = 8
+	DefaultIdentityServerConfig.UserRegistration.PasswordRequirements.MaxLength = 1000
 	DefaultIdentityServerConfig.UserRegistration.PasswordRequirements.MinUppercase = 1
 	DefaultIdentityServerConfig.UserRegistration.PasswordRequirements.MinDigits = 1
 	DefaultIdentityServerConfig.Email.Network.Name = DefaultIdentityServerConfig.OAuth.UI.SiteName

--- a/config/messages.json
+++ b/config/messages.json
@@ -3374,7 +3374,16 @@
       "file": "user_registry.go"
     }
   },
-  "error:pkg/identityserver:password_strength_length": {
+  "error:pkg/identityserver:password_strength_max_length": {
+    "translations": {
+      "en": "need at most `{n}` characters"
+    },
+    "description": {
+      "package": "pkg/identityserver",
+      "file": "user_registry.go"
+    }
+  },
+  "error:pkg/identityserver:password_strength_min_length": {
     "translations": {
       "en": "need at least `{n}` characters"
     },

--- a/pkg/identityserver/identityserver.go
+++ b/pkg/identityserver/identityserver.go
@@ -53,6 +53,7 @@ type Config struct {
 		} `name:"admin-approval"`
 		PasswordRequirements struct {
 			MinLength    int `name:"min-length" description:"Minimum password length"`
+			MaxLength    int `name:"max-length" description:"Maximum password length"`
 			MinUppercase int `name:"min-uppercase" description:"Minimum number of uppercase letters"`
 			MinDigits    int `name:"min-digits" description:"Minimum number of digits"`
 			MinSpecial   int `name:"min-special" description:"Minimum number of special characters"`

--- a/pkg/identityserver/identityserver_test.go
+++ b/pkg/identityserver/identityserver_test.go
@@ -298,6 +298,7 @@ func getIdentityServer(t *testing.T) (*IdentityServer, *grpc.ClientConn) {
 		DatabaseURI: dbConnString,
 	}
 	conf.UserRegistration.PasswordRequirements.MinLength = 10
+	conf.UserRegistration.PasswordRequirements.MaxLength = 1000
 	is, err := New(c, conf)
 	if err != nil {
 		panic(err)

--- a/pkg/identityserver/user_registry.go
+++ b/pkg/identityserver/user_registry.go
@@ -48,7 +48,8 @@ var (
 var (
 	errInvitationTokenRequired   = errors.DefineUnauthenticated("invitation_token_required", "invitation token required")
 	errInvitationTokenExpired    = errors.DefineUnauthenticated("invitation_token_expired", "invitation token expired")
-	errPasswordStrengthLength    = errors.DefineInvalidArgument("password_strength_length", "need at least `{n}` characters")
+	errPasswordStrengthMinLength = errors.DefineInvalidArgument("password_strength_min_length", "need at least `{n}` characters")
+	errPasswordStrengthMaxLength = errors.DefineInvalidArgument("password_strength_max_length", "need at most `{n}` characters")
 	errPasswordStrengthUppercase = errors.DefineInvalidArgument("password_strength_uppercase", "need at least `{n}` uppercase letter(s)")
 	errPasswordStrengthDigits    = errors.DefineInvalidArgument("password_strength_digits", "need at least `{n}` digit(s)")
 	errPasswordStrengthSpecial   = errors.DefineInvalidArgument("password_strength_special", "need at least `{n}` special character(s)")
@@ -57,7 +58,10 @@ var (
 func (is *IdentityServer) validatePasswordStrength(ctx context.Context, password string) error {
 	requirements := is.configFromContext(ctx).UserRegistration.PasswordRequirements
 	if len(password) < requirements.MinLength {
-		return errPasswordStrengthLength.WithAttributes("n", requirements.MinLength)
+		return errPasswordStrengthMinLength.WithAttributes("n", requirements.MinLength)
+	}
+	if len(password) > requirements.MaxLength {
+		return errPasswordStrengthMaxLength.WithAttributes("n", requirements.MaxLength)
 	}
 	var uppercase, digits, special int
 	for _, r := range password {

--- a/pkg/identityserver/user_registry_test.go
+++ b/pkg/identityserver/user_registry_test.go
@@ -16,6 +16,7 @@ package identityserver
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,13 +35,15 @@ func TestValidatePasswordStrength(t *testing.T) {
 	testWithIdentityServer(t, func(is *IdentityServer, _ *grpc.ClientConn) {
 		conf := *is.config
 		conf.UserRegistration.PasswordRequirements.MinLength = 8
+		conf.UserRegistration.PasswordRequirements.MaxLength = 1000
 		conf.UserRegistration.PasswordRequirements.MinUppercase = 1
 		conf.UserRegistration.PasswordRequirements.MinDigits = 1
 		conf.UserRegistration.PasswordRequirements.MinSpecial = 1
 		ctx := context.WithValue(is.Context(), ctxKey, &conf)
 
 		for p, ok := range map[string]bool{
-			"aA0$":         false, // Fails length check.
+			"aA0$": false, // Fails minimum length check.
+			strings.Repeat("aaaAAA123!@#aaaAAA12aaaAAA123!@#aaaAAA12aaaAAA123!@#aaaAAA12aaaAAA123!@#aaaAAA12aaaAAA123!@#aaaAAA12aaa", 10): false, // Fails maximum length check.
 			"aaa123!@#":    false, // Fails uppercase check.
 			"aaaAAA!@#":    false, // Fails digits check.
 			"aaaAAA123":    false, // Fails special check.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #781 

#### Changes
<!-- What are the changes made in this pull request? -->

- Added MaxLen attribute to password requirements
- Added default max length configuration of 100 symbols in cmd/.../identityserver/config.go
- Added error messages for min/max length violation
- Added tests
