### PR TITLE
Add default values to gateway message count

### DIFF
--- a/pkg/webui/console/containers/gateway-statistics/index.js
+++ b/pkg/webui/console/containers/gateway-statistics/index.js
@@ -119,8 +119,8 @@ class GatewayStatistic extends React.PureComponent {
       return null
     }
 
-    const uplinkCount = statistics.uplink_count
-    const downlinkCount = statistics.downlink_count
+    const uplinkCount = statistics.uplink_count || 0
+    const downlinkCount = statistics.downlink_count || 0
 
     return (
       <React.Fragment>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #766 
Apparently default values are not returned from the api


@johanstokking please check that its fixed
