### PR TITLE
Merge correlation IDs from event context and event data

### DIFF
--- a/pkg/events/correlation_context.go
+++ b/pkg/events/correlation_context.go
@@ -33,8 +33,7 @@ func ContextWithCorrelationID(ctx context.Context, cids ...string) context.Conte
 	if !ok {
 		return context.WithValue(ctx, correlationKey{}, cids)
 	}
-	merged := mergeCorrelationIDs(existing, cids)
-	return context.WithValue(ctx, correlationKey{}, merged)
+	return context.WithValue(ctx, correlationKey{}, mergeStrings(existing, cids))
 }
 
 // CorrelationIDsFromContext returns the correlation IDs that are attached to the context.
@@ -51,12 +50,10 @@ func NewCorrelationID() string {
 	return ulid.MustNew(ulid.Now(), rand.Reader).String()
 }
 
-// mergeCorrelationIDs returns sorted array of correlation ids from context and payload
-// Since existing and cids are sorted, merging them will result in a sorted slice.
+// mergeStrings merges 2 sorted string slices and returns the resulting slice
 // See https://en.wikipedia.org/wiki/Merge_sort
-func mergeCorrelationIDs(existing, cids []string) []string {
-	merged := make([]string, 0, len(existing)+len(cids))
-	a, b := existing, cids
+func mergeStrings(a, b []string) []string {
+	merged := make([]string, 0, len(a)+len(b))
 	var i, j int
 	for i < len(a) && j < len(b) {
 		if a[i] < b[j] {

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -149,7 +149,7 @@ func New(ctx context.Context, name string, identifiers CombinedIdentifiers, data
 		if cids := data.GetCorrelationIDs(); len(cids) > 0 {
 			cids = append(cids[:0:0], cids...)
 			sort.Strings(cids)
-			evt.innerEvent.CorrelationIDs = mergeCorrelationIDs(evt.innerEvent.CorrelationIDs, cids)
+			evt.innerEvent.CorrelationIDs = mergeStrings(evt.innerEvent.CorrelationIDs, cids)
 		}
 	}
 	if identifiers != nil {

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"sort"
 	"strings"
 	"time"
 
@@ -145,7 +146,11 @@ func New(ctx context.Context, name string, identifiers CombinedIdentifiers, data
 		data: data,
 	}
 	if data, ok := data.(interface{ GetCorrelationIDs() []string }); ok {
-		evt.innerEvent.CorrelationIDs = append(evt.innerEvent.CorrelationIDs, data.GetCorrelationIDs()...)
+		if cids := data.GetCorrelationIDs(); len(cids) > 0 {
+			cids = append(cids[:0:0], cids...)
+			sort.Strings(cids)
+			evt.innerEvent.CorrelationIDs = mergeCorrelationIDs(evt.innerEvent.CorrelationIDs, cids)
+		}
 	}
 	if identifiers != nil {
 		evt.innerEvent.Identifiers = identifiers.CombinedIdentifiers().GetEntityIdentifiers()

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -32,6 +32,20 @@ type wrappedEvent struct {
 	events.Event
 }
 
+type testData struct{}
+
+func (testData) GetCorrelationIDs() []string {
+	return []string{"TestNew"}
+}
+
+func TestNew(t *testing.T) {
+	a := assertions.New(t)
+	events.IncludeCaller = true
+	ctx := events.ContextWithCorrelationID(test.Context(), t.Name())
+	evt := events.New(ctx, "as.up.receive", nil, testData{})
+	a.So(evt.CorrelationIDs(), should.Resemble, []string{"TestNew"})
+}
+
 func TestEvents(t *testing.T) {
 	a := assertions.New(t)
 

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -40,7 +40,6 @@ func (testData) GetCorrelationIDs() []string {
 
 func TestNew(t *testing.T) {
 	a := assertions.New(t)
-	events.IncludeCaller = true
 	ctx := events.ContextWithCorrelationID(test.Context(), t.Name())
 	evt := events.New(ctx, "as.up.receive", nil, testData{})
 	a.So(evt.CorrelationIDs(), should.Resemble, []string{"TestNew"})


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->
Closes #668 

#### Changes
<!-- What are the changes made in this pull request? -->

- Use MergeSort to merge correlation ids from context and from the payload
- Add test for duplicate correlation ids

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->
Implemented suggestion by @htdvisser to use the MergeSort algorithm already present in `correlation_context.go`.