### PR TITLE
[Quickfix] Use correct node version in release builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ before_install:
 - |
   if [[ "$RUNTYPE" == "release" ]]; then
     openssl aes-256-cbc -K $encrypted_82ec1379e985_key -iv $encrypted_82ec1379e985_iv -in snapcraft.login.enc -out snapcraft.login -d
+    nvm install 10.16.0
   fi
 - |
   if [[ "$RUNTYPE" == "js" ]]; then


### PR DESCRIPTION
#### Summary
#793 broke travis release builds due to using an old node js version. This PR makes sure the correct version is used.

#### Changes
- Change travis configuration to use proper node js version in release builds

#### Notes for Reviewers
One line fix.
