### PR TITLE
Make last breadcrumb unclickable

### DIFF
--- a/pkg/webui/components/breadcrumbs/breadcrumb/breadcrumb.styl
+++ b/pkg/webui/components/breadcrumbs/breadcrumb/breadcrumb.styl
@@ -16,6 +16,7 @@
   one-liner()
   text-decoration: none
   color: $tc-subtle-gray
+  min-height: 18px
 
   &:not(:last-child):after
     material-icon()
@@ -30,6 +31,11 @@
   +focus-visible()
     text-decoration: underline
     color: $tc-deep-gray
+
+.last
+  one-liner()
+  color: $tc-deep-gray
+  min-height: 18px
 
 .icon
   nudge('up')

--- a/pkg/webui/components/breadcrumbs/breadcrumb/index.js
+++ b/pkg/webui/components/breadcrumbs/breadcrumb/index.js
@@ -27,17 +27,24 @@ const Breadcrumb = function ({
   path,
   content,
   icon = null,
+  isLast = false,
 }) {
   const isRawText = typeof content === 'string' || typeof content === 'number'
+  let Component
+  let componentProps
+  if (!isLast) {
+    Component = Link
+    componentProps = { className: classnames(className, style.link), to: path }
+  } else {
+    Component = 'span'
+    componentProps = { className: classnames(className, style.last) }
+  }
 
   return (
-    <Link
-      to={path}
-      className={classnames(className, style.link)}
-    >
+    <Component {...componentProps}>
       {icon && <Icon className={style.icon} icon={icon} />}
-      {isRawText ? <span>{content}</span> : <Message content={content} /> }
-    </Link>
+      {isRawText ? <span>{content}</span> : <Message content={content} />}
+    </Component>
   )
 }
 
@@ -48,6 +55,8 @@ Breadcrumb.propTypes = {
   icon: PropTypes.string,
   /** The content of the breadcrumb */
   content: PropTypes.message.isRequired,
+  /** The flag for rendering last breadcrumb as plain text */
+  isLast: PropTypes.bool,
 }
 
 export default Breadcrumb

--- a/pkg/webui/components/breadcrumbs/breadcrumbs.js
+++ b/pkg/webui/components/breadcrumbs/breadcrumbs.js
@@ -24,9 +24,13 @@ const Breadcrumbs = ({ className, breadcrumbs }) => (
   <nav className={classnames(className, style.breadcrumbs)}>
     {breadcrumbs.map(function (component, index) {
       return (
-        React.cloneElement(component, { key: index })
+        React.cloneElement(component, {
+          key: index,
+          isLast: index === breadcrumbs.length - 1,
+        })
       )
-    })}
+    })
+    }
   </nav>
 )
 

--- a/pkg/webui/components/breadcrumbs/story.js
+++ b/pkg/webui/components/breadcrumbs/story.js
@@ -19,7 +19,7 @@ import { withInfo } from '@storybook/addon-info'
 import Breadcrumb from './breadcrumb'
 import Breadcrumbs from './breadcrumbs'
 
-storiesOf('Breacrumbs', module)
+storiesOf('Breadcrumbs', module)
   .addDecorator((story, context) => withInfo({
     inline: true,
     header: false,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->
Closes #735 

#### Changes
<!-- What are the changes made in this pull request? -->

- Add new `lastBreadcrumb` prop to breadcrumb component
- If `lastBreadcrumb = true` render span instead of `Link` component
- Add custom styling class for the new span
- Fix typo in storybook