### PR TITLE
cli: Check length of key-value pair for attributes

### DIFF
--- a/cmd/ttn-lw-cli/commands/flags.go
+++ b/cmd/ttn-lw-cli/commands/flags.go
@@ -71,6 +71,9 @@ func mergeAttributes(attributes map[string]string, flagSet *pflag.FlagSet) map[s
 	}
 	for _, kv := range kv {
 		kv := strings.SplitN(kv, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
 		if kv[1] == "" {
 			delete(out, kv[0])
 		} else {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #804 

#### Changes
<!-- What are the changes made in this pull request? -->

- Added an valid length check while parsing attributes.

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Fixed CLI panic for invalid attributes.
