### PR TITLE
[Quickfix] Fix Application Collaborators breadcrumb id

### DIFF
--- a/pkg/webui/console/views/application-collaborators/index.js
+++ b/pkg/webui/console/views/application-collaborators/index.js
@@ -25,7 +25,7 @@ import ApplicationCollaboratorsList from '../application-collaborators-list'
 import ApplicationCollaboratorAdd from '../application-collaborator-add'
 import ApplicationCollaboratorEdit from '../application-collaborator-edit'
 
-@withBreadcrumb('apps.single.api-keys', function (props) {
+@withBreadcrumb('apps.single.collaborators', function (props) {
   const { match } = props
   const appId = match.params.appId
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes breadcrumb issue on the Application Collaborators page. Having duplicate ids in the breacrumbs context results in unexpected behavior of the breadcrumbs.

<img width="834" alt="Screenshot 2019-06-17 at 11 29 44" src="https://user-images.githubusercontent.com/16374166/59594003-432d3680-90f3-11e9-87e4-68ae84cb8ec1.png">

#### Changes
<!-- What are the changes made in this pull request? -->

- Rename `apps.single.api-keys` to `apps.single.collaborators`
