### PR TITLE
Test 'resets_join_nonces' behavior in JS

### DIFF
--- a/pkg/joinserver/joinserver.go
+++ b/pkg/joinserver/joinserver.go
@@ -226,11 +226,11 @@ func (js *JoinServer) HandleJoin(ctx context.Context, req *ttnpb.JoinRequest) (r
 			"last_join_nonce",
 			"net_id",
 			"network_server_address",
+			"provisioner_id",
+			"provisioning_data",
 			"resets_join_nonces",
 			"root_keys",
 			"used_dev_nonces",
-			"provisioner_id",
-			"provisioning_data",
 		},
 		func(dev *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
 			if dn, ok := auth.X509DNFromContext(ctx); ok {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Test 'resets_join_nonces' behavior in JS. References #42

#### Changes
<!-- What are the changes made in this pull request? -->

- Add a testcase for `resets_join_nonces` behavior
- Remove unnecessary assignments in (test case) struct constructors.
- Improve consistency in JS testcases

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->
No actual functional changes in this PR.
Tested `resets_join_nonces` behavior with(on clean, running stack):
```
cli device create test-app test-dev --join-eui 4200000000000000 --dev-eui 4200000000000000 --root-keys.app-key.key 42000000000000000000000000000000 --lorawan_phy_version 1.0.3-a --lorawan-version 1.0.3 --frequency_plan_id EU_863_870 --supports-class-c --resets_join_nonces=true
cli gateway create test-gtw --frequency-plan-id EU_863_80 --user_id admin
cli simulate join-request --join-eui 4200000000000000 --dev-eui 4200000000000000 --lorawan_phy_version 1.0.3-a --lorawan-version 1.0.3 --gateway-id test-gtw --app-key 42000000000000000000000000000000 --dev-nonce 0x0000
cli simulate join-request --join-eui 4200000000000000 --dev-eui 4200000000000000 --lorawan_phy_version 1.0.3-a --lorawan-version 1.0.3 --gateway-id test-gtw --app-key 42000000000000000000000000000000 --dev-nonce 0x0042
cli simulate join-request --join-eui 4200000000000000 --dev-eui 4200000000000000 --lorawan_phy_version 1.0.3-a --lorawan-version 1.0.3 --gateway-id test-gtw --app-key 42000000000000000000000000000000 --dev-nonce 0x0000
cli simulate join-request --join-eui 4200000000000000 --dev-eui 4200000000000000 --lorawan_phy_version 1.0.3-a --lorawan-version 1.0.3 --gateway-id test-gtw --app-key 42000000000000000000000000000000 --dev-nonce 0x0001
cli simulate join-request --join-eui 4200000000000000 --dev-eui 4200000000000000 --lorawan_phy_version 1.0.3-a --lorawan-version 1.0.3 --gateway-id test-gtw --app-key 42000000000000000000000000000000 --dev-nonce 0x0000
```