### PR TITLE
Wrap keys from JS

### DIFF
--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -227,7 +227,7 @@ var (
 			if err != nil {
 				return err
 			}
-			logger.WithField("paths", isPaths).Debug("Get EndDevice from Identity Server")
+			logger.WithField("paths", isPaths).Debug("Get end device from Identity Server")
 			device, err := ttnpb.NewEndDeviceRegistryClient(is).Get(ctx, &ttnpb.GetEndDeviceRequest{
 				EndDeviceIdentifiers: *devID,
 				FieldMask:            pbtypes.FieldMask{Paths: isPaths},
@@ -492,7 +492,7 @@ var (
 			if err != nil {
 				return err
 			}
-			logger.WithField("paths", isPaths).Debug("Get EndDevice from Identity Server")
+			logger.WithField("paths", isPaths).Debug("Get end device from Identity Server")
 			existingDevice, err := ttnpb.NewEndDeviceRegistryClient(is).Get(ctx, &ttnpb.GetEndDeviceRequest{
 				EndDeviceIdentifiers: *devID,
 				FieldMask:            pbtypes.FieldMask{Paths: isPaths},

--- a/config/messages.json
+++ b/config/messages.json
@@ -4166,6 +4166,15 @@
       "file": "errors.go"
     }
   },
+  "error:pkg/joinserver:wrap_key": {
+    "translations": {
+      "en": "failed to wrap key"
+    },
+    "description": {
+      "package": "pkg/joinserver",
+      "file": "errors.go"
+    }
+  },
   "error:pkg/messageprocessors/cayennelpp:channel": {
     "translations": {
       "en": "invalid channel `{channel}`"

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -107,9 +107,7 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 		},
 	}
 
-	as.grpc.asDevices = asEndDeviceRegistryServer{
-		registry: as.deviceRegistry,
-	}
+	as.grpc.asDevices = asEndDeviceRegistryServer{AS: as}
 	as.grpc.appAs = iogrpc.New(as)
 
 	ctx, cancel := context.WithCancel(as.Context())

--- a/pkg/applicationserver/util_test.go
+++ b/pkg/applicationserver/util_test.go
@@ -52,6 +52,9 @@ func withDevAddr(ids ttnpb.EndDeviceIdentifiers, devAddr types.DevAddr) ttnpb.En
 	ids.DevAddr = &devAddr
 	return ids
 }
+func aes128KeyPtr(key types.AES128Key) *types.AES128Key {
+	return &key
+}
 
 type mockNS struct {
 	linkCh          chan ttnpb.ApplicationIdentifiers

--- a/pkg/crypto/cryptoutil/kek_labelers.go
+++ b/pkg/crypto/cryptoutil/kek_labelers.go
@@ -1,0 +1,71 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cryptoutil
+
+import (
+	"context"
+	"net"
+	"net/url"
+	"strings"
+
+	"go.thethings.network/lorawan-stack/pkg/types"
+)
+
+// ComponentPrefixKEKLabeler is a ComponentKEKLabeler that joins the component prefix, separator and host.
+type ComponentPrefixKEKLabeler struct {
+	Separator string
+}
+
+func hostFromAddr(addr string) string {
+	host := addr
+	if url, err := url.Parse(addr); err == nil && url.Host != "" {
+		host = url.Host
+	}
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		return h
+	}
+	return host
+}
+
+// NsKEKLabel returns a KEK label in the form `ns:netID:host` from the given NetID and address, where `:` is the default separator. Empty parts are omitted.
+func (c ComponentPrefixKEKLabeler) NsKEKLabel(ctx context.Context, netID *types.NetID, addr string) string {
+	sep := c.Separator
+	if sep == "" {
+		sep = ":"
+	}
+	parts := make([]string, 0, 3)
+	parts = append(parts, "ns")
+	if netID != nil {
+		parts = append(parts, netID.String())
+	}
+	if addr != "" {
+		parts = append(parts, hostFromAddr(addr))
+	}
+	return strings.Join(parts, sep)
+}
+
+// AsKEKLabel returns a KEK label in the form `as:host` from the given address, where `:` is the default separator. Empty parts are omitted.
+func (c ComponentPrefixKEKLabeler) AsKEKLabel(ctx context.Context, addr string) string {
+	sep := c.Separator
+	if sep == "" {
+		sep = ":"
+	}
+	parts := make([]string, 0, 2)
+	parts = append(parts, "as")
+	if addr != "" {
+		parts = append(parts, hostFromAddr(addr))
+	}
+	return strings.Join(parts, sep)
+}

--- a/pkg/crypto/cryptoutil/kek_labelers_test.go
+++ b/pkg/crypto/cryptoutil/kek_labelers_test.go
@@ -1,0 +1,120 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cryptoutil_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/smartystreets/assertions"
+	. "go.thethings.network/lorawan-stack/pkg/crypto/cryptoutil"
+	"go.thethings.network/lorawan-stack/pkg/types"
+	"go.thethings.network/lorawan-stack/pkg/util/test"
+	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
+)
+
+func netIDPtr(netID types.NetID) *types.NetID { return &netID }
+
+func TestComponentPrefixKEKLabeler(t *testing.T) {
+	for i, tc := range []struct {
+		Separator,
+		Addr string
+		Func     func(context.Context, ComponentPrefixKEKLabeler, string) string
+		Expected string
+	}{
+		{
+			Separator: "",
+			Addr:      "localhost",
+			Func: func(ctx context.Context, labeler ComponentPrefixKEKLabeler, addr string) string {
+				return labeler.NsKEKLabel(ctx, nil, "")
+			},
+			Expected: "ns",
+		},
+		{
+			Separator: "",
+			Addr:      "",
+			Func: func(ctx context.Context, labeler ComponentPrefixKEKLabeler, addr string) string {
+				return labeler.NsKEKLabel(ctx, netIDPtr(types.NetID{0x00, 0x00, 0x42}), addr)
+			},
+			Expected: "ns:000042",
+		},
+		{
+			Separator: "",
+			Addr:      "localhost",
+			Func: func(ctx context.Context, labeler ComponentPrefixKEKLabeler, addr string) string {
+				return labeler.NsKEKLabel(ctx, nil, addr)
+			},
+			Expected: "ns:localhost",
+		},
+		{
+			Separator: "",
+			Addr:      "localhost",
+			Func: func(ctx context.Context, labeler ComponentPrefixKEKLabeler, addr string) string {
+				return labeler.NsKEKLabel(ctx, netIDPtr(types.NetID{0x00, 0x00, 0x42}), addr)
+			},
+			Expected: "ns:000042:localhost",
+		},
+		{
+			Separator: "",
+			Addr:      "localhost",
+			Func: func(ctx context.Context, labeler ComponentPrefixKEKLabeler, addr string) string {
+				return labeler.AsKEKLabel(ctx, addr)
+			},
+			Expected: "as:localhost",
+		},
+		{
+			Separator: "",
+			Addr:      "localhost:1234",
+			Func: func(ctx context.Context, labeler ComponentPrefixKEKLabeler, addr string) string {
+				return labeler.NsKEKLabel(ctx, netIDPtr(types.NetID{0x00, 0x00, 0x42}), addr)
+			},
+			Expected: "ns:000042:localhost",
+		},
+		{
+			Separator: "",
+			Addr:      "http://localhost",
+			Func: func(ctx context.Context, labeler ComponentPrefixKEKLabeler, addr string) string {
+				return labeler.NsKEKLabel(ctx, netIDPtr(types.NetID{0x00, 0x00, 0x42}), addr)
+			},
+			Expected: "ns:000042:localhost",
+		},
+		{
+			Separator: "",
+			Addr:      "http://localhost:1234",
+			Func: func(ctx context.Context, labeler ComponentPrefixKEKLabeler, addr string) string {
+				return labeler.NsKEKLabel(ctx, netIDPtr(types.NetID{0x00, 0x00, 0x42}), addr)
+			},
+			Expected: "ns:000042:localhost",
+		},
+		{
+			Separator: "_",
+			Addr:      "http://localhost:1234",
+			Func: func(ctx context.Context, labeler ComponentPrefixKEKLabeler, addr string) string {
+				return labeler.NsKEKLabel(ctx, netIDPtr(types.NetID{0x00, 0x00, 0x42}), addr)
+			},
+			Expected: "ns_000042_localhost",
+		},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			a := assertions.New(t)
+			labeler := ComponentPrefixKEKLabeler{
+				Separator: tc.Separator,
+			}
+			label := tc.Func(test.Context(), labeler, tc.Addr)
+			a.So(label, should.Equal, tc.Expected)
+		})
+	}
+}

--- a/pkg/crypto/cryptoutil/keyvault_mem.go
+++ b/pkg/crypto/cryptoutil/keyvault_mem.go
@@ -22,12 +22,15 @@ import (
 // MemKeyVault is a KeyVault that uses KEKs from memory.
 // This implementation does not provide any security as KEKs are stored in the clear.
 type MemKeyVault struct {
+	ComponentPrefixKEKLabeler
 	m map[string][]byte
 }
 
 // NewMemKeyVault returns a MemKeyVault.
 func NewMemKeyVault(m map[string][]byte) *MemKeyVault {
-	return &MemKeyVault{m}
+	return &MemKeyVault{
+		m: m,
+	}
 }
 
 var errKEKNotFound = errors.DefineNotFound("kek_not_found", "KEK with label `{label}` not found")

--- a/pkg/crypto/kek_labeler.go
+++ b/pkg/crypto/kek_labeler.go
@@ -14,9 +14,14 @@
 
 package crypto
 
-// KeyVault provides wrapping and unwrapping keys using KEK labels.
-type KeyVault interface {
-	Wrap(plaintext []byte, kekLabel string) ([]byte, error)
-	Unwrap(ciphertext []byte, kekLabel string) ([]byte, error)
-	ComponentKEKLabeler
+import (
+	"context"
+
+	"go.thethings.network/lorawan-stack/pkg/types"
+)
+
+// ComponentKEKLabeler provides KEK labels for components.
+type ComponentKEKLabeler interface {
+	NsKEKLabel(ctx context.Context, netID *types.NetID, addr string) string
+	AsKEKLabel(ctx context.Context, addr string) string
 }

--- a/pkg/interop/messages_test.go
+++ b/pkg/interop/messages_test.go
@@ -207,11 +207,11 @@ func TestParseMessage(t *testing.T) {
 				"Result": "Success",
 				"Lifetime": 3600,
 				"NwkSKey": {
-					"KEKLabel": "",
+					"KEKLabel": "test",
 					"AESKey": "000102030405060708090A0B0C0D0E0F"
 				},
 				"AppSKey": {
-					"KEKLabel": "",
+					"KEKLabel": "test",
 					"AESKey": "000102030405060708090A0B0C0D0E0F"
 				},
 				"SessionKeyID": "01020304"
@@ -238,9 +238,11 @@ func TestParseMessage(t *testing.T) {
 					Result:     ResultSuccess,
 					Lifetime:   3600,
 					NwkSKey: (*KeyEnvelope)(&ttnpb.KeyEnvelope{
+						KEKLabel:     "test",
 						EncryptedKey: []byte{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf},
 					}),
 					AppSKey: (*KeyEnvelope)(&ttnpb.KeyEnvelope{
+						KEKLabel:     "test",
 						EncryptedKey: []byte{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf},
 					}),
 					SessionKeyID: []byte{0x1, 0x2, 0x3, 0x4},
@@ -299,7 +301,7 @@ func TestParseMessage(t *testing.T) {
 				"Result": "Success",
 				"DevEUI": "0102030405060708",
 				"AppSKey": {
-					"KEKLabel": "",
+					"KEKLabel": "test",
 					"AESKey": "000102030405060708090A0B0C0D0E0F"
 				},
 				"SessionKeyID": "01020304"
@@ -324,6 +326,7 @@ func TestParseMessage(t *testing.T) {
 					Result: ResultSuccess,
 					DevEUI: EUI64{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8},
 					AppSKey: KeyEnvelope{
+						KEKLabel:     "test",
 						EncryptedKey: []byte{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf},
 					},
 					SessionKeyID: []byte{0x1, 0x2, 0x3, 0x4},

--- a/pkg/interop/types.go
+++ b/pkg/interop/types.go
@@ -151,12 +151,18 @@ type KeyEnvelope ttnpb.KeyEnvelope
 
 // MarshalJSON marshals the key envelope to JSON.
 func (k KeyEnvelope) MarshalJSON() ([]byte, error) {
+	var key []byte
+	if k.KEKLabel != "" {
+		key = k.EncryptedKey
+	} else if k.Key != nil {
+		key = k.Key[:]
+	}
 	return json.Marshal(struct {
 		KEKLabel string
 		AESKey   Buffer
 	}{
 		KEKLabel: k.KEKLabel,
-		AESKey:   Buffer(k.EncryptedKey),
+		AESKey:   Buffer(key),
 	})
 }
 
@@ -169,9 +175,18 @@ func (k *KeyEnvelope) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
 	}
+	var key *types.AES128Key
+	var encryptedKey []byte
+	if aux.KEKLabel != "" {
+		encryptedKey = aux.AESKey
+	} else {
+		key = new(types.AES128Key)
+		copy(key[:], aux.AESKey)
+	}
 	*k = KeyEnvelope{
 		KEKLabel:     aux.KEKLabel,
-		EncryptedKey: aux.AESKey,
+		Key:          key,
+		EncryptedKey: encryptedKey,
 	}
 	return nil
 }

--- a/pkg/interop/types.go
+++ b/pkg/interop/types.go
@@ -130,7 +130,7 @@ type Buffer []byte
 
 // MarshalJSON marshals the binary data to a hexadecimal string.
 func (b Buffer) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf(`"%s"`, hex.EncodeToString(b))), nil
+	return []byte(fmt.Sprintf(`"%s"`, strings.ToUpper(hex.EncodeToString(b)))), nil
 }
 
 // UnmarshalJSON unmarshals a hexadecimal string to binary data.

--- a/pkg/joinserver/errors.go
+++ b/pkg/joinserver/errors.go
@@ -60,5 +60,6 @@ var (
 	errUnknownAppEUI                  = errors.Define("unknown_app_eui", "AppEUI specified is not known")
 	errUnsupportedLoRaWANMajorVersion = errors.DefineInvalidArgument("lorawan_major_version", "unsupported LoRaWAN major version: `{major}`")
 	errUnsupportedMACVersion          = errors.DefineInvalidArgument("mac_version", "unsupported MAC version: `{version}`")
+	errWrapKey                        = errors.Define("wrap_key", "failed to wrap key")
 	errWrongPayloadType               = errors.DefineInvalidArgument("payload_type", "wrong payload type: {type}")
 )

--- a/pkg/joinserver/joinserver.go
+++ b/pkg/joinserver/joinserver.go
@@ -37,6 +37,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/crypto/cryptoservices"
 	"go.thethings.network/lorawan-stack/pkg/crypto/cryptoutil"
 	"go.thethings.network/lorawan-stack/pkg/encoding/lorawan"
+	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/interop"
 	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/rpcmiddleware/hooks"
@@ -155,6 +156,21 @@ func validateCaller(dn pkix.Name, addr string) error {
 	return nil
 }
 
+// wrapKeyIfKEKExists wraps the given key with the KEK label.
+// If the configured key vault cannot find the KEK, the key is returned in the clear.
+func (js *JoinServer) wrapKeyIfKEKExists(key types.AES128Key, kekLabel string) (*ttnpb.KeyEnvelope, error) {
+	env, err := cryptoutil.WrapAES128Key(key, kekLabel, js.KeyVault)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return &ttnpb.KeyEnvelope{
+				Key: &key,
+			}, nil
+		}
+		return nil, err
+	}
+	return &env, nil
+}
+
 // HandleJoin handles the given join-request.
 func (js *JoinServer) HandleJoin(ctx context.Context, req *ttnpb.JoinRequest) (res *ttnpb.JoinResponse, err error) {
 	if _, ok := auth.X509DNFromContext(ctx); !ok {
@@ -222,6 +238,7 @@ func (js *JoinServer) HandleJoin(ctx context.Context, req *ttnpb.JoinRequest) (r
 
 	dev, err := js.devices.SetByEUI(ctx, pld.JoinEUI, pld.DevEUI,
 		[]string{
+			"application_server_address",
 			"last_dev_nonce",
 			"last_join_nonce",
 			"net_id",
@@ -379,23 +396,23 @@ func (js *JoinServer) HandleJoin(ctx context.Context, req *ttnpb.JoinRequest) (r
 
 			sessionKeys := ttnpb.SessionKeys{
 				SessionKeyID: skID[:],
-				FNwkSIntKey: &ttnpb.KeyEnvelope{
-					// TODO: Encrypt key with NS KEK https://github.com/TheThingsNetwork/lorawan-stack/issues/5
-					Key: &nwkSKeys.FNwkSIntKey,
-				},
-				AppSKey: &ttnpb.KeyEnvelope{
-					// TODO: Encrypt key with AS KEK https://github.com/TheThingsNetwork/lorawan-stack/issues/5
-					Key: &appSKey,
-				},
+			}
+			sessionKeys.FNwkSIntKey, err = js.wrapKeyIfKEKExists(nwkSKeys.FNwkSIntKey, js.KeyVault.NsKEKLabel(ctx, dev.NetID, dev.NetworkServerAddress))
+			if err != nil {
+				return nil, nil, errWrapKey.WithCause(err)
+			}
+			sessionKeys.AppSKey, err = js.wrapKeyIfKEKExists(appSKey, js.KeyVault.AsKEKLabel(ctx, dev.ApplicationServerAddress))
+			if err != nil {
+				return nil, nil, errWrapKey.WithCause(err)
 			}
 			if req.SelectedMACVersion >= ttnpb.MAC_V1_1 {
-				sessionKeys.SNwkSIntKey = &ttnpb.KeyEnvelope{
-					// TODO: Encrypt key with NS KEK https://github.com/TheThingsNetwork/lorawan-stack/issues/5
-					Key: &nwkSKeys.SNwkSIntKey,
+				sessionKeys.SNwkSIntKey, err = js.wrapKeyIfKEKExists(nwkSKeys.SNwkSIntKey, js.KeyVault.NsKEKLabel(ctx, dev.NetID, dev.NetworkServerAddress))
+				if err != nil {
+					return nil, nil, errWrapKey.WithCause(err)
 				}
-				sessionKeys.NwkSEncKey = &ttnpb.KeyEnvelope{
-					// TODO: Encrypt key with NS KEK https://github.com/TheThingsNetwork/lorawan-stack/issues/5
-					Key: &nwkSKeys.NwkSEncKey,
+				sessionKeys.NwkSEncKey, err = js.wrapKeyIfKEKExists(nwkSKeys.NwkSEncKey, js.KeyVault.NsKEKLabel(ctx, dev.NetID, dev.NetworkServerAddress))
+				if err != nil {
+					return nil, nil, errWrapKey.WithCause(err)
 				}
 			}
 

--- a/pkg/joinserver/joinserver.go
+++ b/pkg/joinserver/joinserver.go
@@ -388,7 +388,7 @@ func (js *JoinServer) HandleJoin(ctx context.Context, req *ttnpb.JoinRequest) (r
 					Key: &appSKey,
 				},
 			}
-			if req.SelectedMACVersion == ttnpb.MAC_V1_1 {
+			if req.SelectedMACVersion >= ttnpb.MAC_V1_1 {
 				sessionKeys.SNwkSIntKey = &ttnpb.KeyEnvelope{
 					// TODO: Encrypt key with NS KEK https://github.com/TheThingsNetwork/lorawan-stack/issues/5
 					Key: &nwkSKeys.SNwkSIntKey,

--- a/pkg/joinserver/joinserver_internal_test.go
+++ b/pkg/joinserver/joinserver_internal_test.go
@@ -17,8 +17,10 @@ package joinserver
 import (
 	"context"
 
+	"go.thethings.network/lorawan-stack/pkg/crypto"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/types"
+	"go.thethings.network/lorawan-stack/pkg/util/test"
 )
 
 var (
@@ -35,6 +37,10 @@ var (
 func KeyToBytes(key types.AES128Key) []byte { return key[:] }
 
 func KeyPtr(key types.AES128Key) *types.AES128Key { return &key }
+
+func MustWrapAES128Key(key types.AES128Key, kek []byte) []byte {
+	return test.Must(crypto.WrapKey(key[:], kek)).([]byte)
+}
 
 type AsJsServer = asJsServer
 type NsJsServer = nsJsServer

--- a/pkg/networkserver/networkserver_util_test.go
+++ b/pkg/networkserver/networkserver_util_test.go
@@ -77,6 +77,10 @@ func DurationPtr(v time.Duration) *time.Duration {
 	return &v
 }
 
+func AES128KeyPtr(key types.AES128Key) *types.AES128Key {
+	return &key
+}
+
 func MakeEU868Channels(chs ...*ttnpb.MACParameters_Channel) []*ttnpb.MACParameters_Channel {
 	return append([]*ttnpb.MACParameters_Channel{
 		{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #5 
Closes #58 

#### Changes
<!-- What are the changes made in this pull request? -->

- Added KEK labeler to key vault. The in-memory implementation is quite simple but that's based on static config anyway
- Added wrapping keys in JS
- Some minor fixes

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

JS now uses the `network_server_address` and `application_server_address` for authentication (client certificate CN) as well as picking the KEK. If we want a different approach, please make a proposal. I think this is a good way forward.

- We cannot only use NetID for authentication and KEKs as there may be many clusters within the same NetID
- "AS ID" is basically `application_server_address`. It supports addresses and URL-like host names