### PR TITLE
Introduce update action for applications

### DIFF
--- a/pkg/webui/console/store/actions/applications.js
+++ b/pkg/webui/console/store/actions/applications.js
@@ -49,6 +49,19 @@ export const [{
   (id, selector) => ({ selector })
 )
 
+export const UPDATE_APP_BASE = 'UPDATE_APPLICATION'
+export const [{
+  request: UPDATE_APP,
+  success: UPDATE_APP_SUCCESS,
+  failure: UPDATE_APP_FAILURE,
+}, {
+  request: updateApplication,
+  success: updateApplicationSuccess,
+  failure: updateApplicationFailure,
+}] = createRequestActions(UPDATE_APP_BASE,
+  (id, patch) => ({ id, patch }),
+)
+
 export const GET_APPS_LIST_BASE = createPaginationBaseActionType(SHARED_NAME)
 export const [{
   request: GET_APPS_LIST,

--- a/pkg/webui/console/store/actions/applications.js
+++ b/pkg/webui/console/store/actions/applications.js
@@ -13,7 +13,12 @@
 // limitations under the License.
 
 import createGetRightsListRequestActions, { createGetRightsListActionType } from './rights'
-import { createPaginationRequestActions, createPaginationBaseActionType } from './pagination'
+import {
+  createPaginationRequestActions,
+  createPaginationBaseActionType,
+  createPaginationDeleteBaseActionType,
+  createPaginationDeleteActions,
+} from './pagination'
 import createApiKeysRequestActions, { createGetApiKeysListActionType } from './api-keys'
 import createApiKeyRequestActions, { createGetApiKeyActionType } from './api-key'
 import { createGetCollaboratorsListRequestActions, createGetCollaboratorsListActionType } from './collaborators'
@@ -62,7 +67,20 @@ export const [{
   (id, patch) => ({ id, patch }),
 )
 
-export const GET_APPS_LIST_BASE = createPaginationBaseActionType(SHARED_NAME)
+export const DELETE_APP_BASE = createPaginationDeleteBaseActionType(SHARED_NAME_SINGLE)
+export const [{
+  request: DELETE_APP,
+  success: DELETE_APP_SUCCESS,
+  failure: DELETE_APP_FAILURE,
+}, {
+  request: deleteApplication,
+  success: deleteApplicationSuccess,
+  failure: deleteApplicationFailure,
+}] = createPaginationDeleteActions(SHARED_NAME_SINGLE,
+  id => ({ id }),
+)
+
+export const GET_APPS_LIST_BASE = createPaginationBaseActionType(SHARED_NAME_SINGLE)
 export const [{
   request: GET_APPS_LIST,
   success: GET_APPS_LIST_SUCCESS,
@@ -71,7 +89,7 @@ export const [{
   request: getApplicationsList,
   success: getApplicationsSuccess,
   failure: getApplicationsFailure,
-}] = createPaginationRequestActions(SHARED_NAME)
+}] = createPaginationRequestActions(SHARED_NAME_SINGLE)
 
 export const GET_APPS_RIGHTS_LIST_BASE = createGetRightsListActionType(SHARED_NAME)
 export const [{

--- a/pkg/webui/console/store/actions/pagination.js
+++ b/pkg/webui/console/store/actions/pagination.js
@@ -18,6 +18,10 @@ export const createPaginationBaseActionType = name => (
   `GET_${name}_LIST`
 )
 
+export const createPaginationDeleteBaseActionType = name => (
+  `DELETE_${name}`
+)
+
 export const createPaginationByIdRequestActions = name => createRequestActions(
   createPaginationBaseActionType(name),
   (id, { page, limit, query } = {}) => ({ id, params: { page, limit, query }}),
@@ -28,4 +32,14 @@ export const createPaginationRequestActions = name => createRequestActions(
   createPaginationBaseActionType(name),
   ({ page, limit, query } = {}) => ({ params: { page, limit, query }}),
   (params, selectors) => ({ selectors })
+)
+
+export const createPaginationDeleteActions = name => createRequestActions(
+  createPaginationDeleteBaseActionType(name),
+  id => ({ id })
+)
+
+export const createPaginationByIdDeleteActions = name => createRequestActions(
+  createPaginationDeleteBaseActionType(name),
+  (id, targetId) => ({ id, targetId }),
 )

--- a/pkg/webui/console/store/middleware/logics/applications.js
+++ b/pkg/webui/console/store/middleware/logics/applications.js
@@ -31,6 +31,17 @@ const getApplicationLogic = createRequestLogic({
   },
 })
 
+const updateApplicationLogic = createRequestLogic({
+  type: applications.UPDATE_APP,
+  async process ({ action }) {
+    const { id, patch } = action.payload
+
+    const result = await api.application.update(id, patch)
+
+    return { ...patch, ...result }
+  },
+})
+
 const getApplicationsLogic = createRequestLogic({
   type: applications.GET_APPS_LIST,
   latest: true,
@@ -149,6 +160,7 @@ const getWebhookFormatsLogic = createRequestLogic({
 
 export default [
   getApplicationLogic,
+  updateApplicationLogic,
   getApplicationsLogic,
   getApplicationsRightsLogic,
   getApplicationApiKeysLogic,

--- a/pkg/webui/console/store/middleware/logics/applications.js
+++ b/pkg/webui/console/store/middleware/logics/applications.js
@@ -42,6 +42,17 @@ const updateApplicationLogic = createRequestLogic({
   },
 })
 
+const deleteApplicationLogic = createRequestLogic({
+  type: applications.DELETE_APP,
+  async process ({ action }) {
+    const { id } = action.payload
+
+    await api.application.delete(id)
+
+    return { id }
+  },
+})
+
 const getApplicationsLogic = createRequestLogic({
   type: applications.GET_APPS_LIST,
   latest: true,
@@ -161,6 +172,7 @@ const getWebhookFormatsLogic = createRequestLogic({
 export default [
   getApplicationLogic,
   updateApplicationLogic,
+  deleteApplicationLogic,
   getApplicationsLogic,
   getApplicationsRightsLogic,
   getApplicationApiKeysLogic,

--- a/pkg/webui/console/store/reducers/applications.js
+++ b/pkg/webui/console/store/reducers/applications.js
@@ -59,7 +59,7 @@ const applications = function (state = defaultState, { type, payload }) {
       ...state,
       entities: {
         ...state.entities,
-        [id]: application(state[id], payload),
+        [id]: application(state.entities[id], payload),
       },
     }
   default:

--- a/pkg/webui/console/store/reducers/applications.js
+++ b/pkg/webui/console/store/reducers/applications.js
@@ -18,6 +18,7 @@ import {
   GET_APP_SUCCESS,
   GET_APPS_LIST_SUCCESS,
   UPDATE_APP_SUCCESS,
+  DELETE_APP_SUCCESS,
 } from '../actions/applications'
 
 const application = function (state = {}, application) {
@@ -61,6 +62,13 @@ const applications = function (state = defaultState, { type, payload }) {
         ...state.entities,
         [id]: application(state.entities[id], payload),
       },
+    }
+  case DELETE_APP_SUCCESS:
+    const { [payload.id]: deleted, ...rest } = state.entities
+
+    return {
+      selectedApplication: null,
+      entities: rest,
     }
   default:
     return state

--- a/pkg/webui/console/store/reducers/applications.js
+++ b/pkg/webui/console/store/reducers/applications.js
@@ -17,6 +17,7 @@ import {
   GET_APP,
   GET_APP_SUCCESS,
   GET_APPS_LIST_SUCCESS,
+  UPDATE_APP_SUCCESS,
 } from '../actions/applications'
 
 const application = function (state = {}, application) {
@@ -51,6 +52,7 @@ const applications = function (state = defaultState, { type, payload }) {
       entities,
     }
   case GET_APP_SUCCESS:
+  case UPDATE_APP_SUCCESS:
     const id = getApplicationId(payload)
 
     return {

--- a/pkg/webui/console/store/reducers/index.js
+++ b/pkg/webui/console/store/reducers/index.js
@@ -80,7 +80,7 @@ export default combineReducers({
   }),
   pagination: combineReducers({
     applications: createNamedPaginationReducer(
-      APPLICATIONS_SHARED_NAME,
+      APPLICATION_SHARED_NAME,
       getApplicationId
     ),
   }),

--- a/pkg/webui/console/store/reducers/tests/applications_test.js
+++ b/pkg/webui/console/store/reducers/tests/applications_test.js
@@ -1,0 +1,208 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import reducer from '../applications'
+
+import {
+  getApplication,
+  getApplicationSuccess,
+  getApplicationFailure,
+  getApplicationsList,
+  getApplicationsSuccess,
+  getApplicationsFailure,
+  updateApplication,
+  updateApplicationSuccess,
+  updateApplicationFailure,
+  deleteApplication,
+  deleteApplicationSuccess,
+  deleteApplicationFailure,
+} from '../../actions/applications'
+
+describe('applications reducer', function () {
+  const defaultState = {
+    entities: {},
+    selectedApplication: null,
+  }
+
+  it('should return the initial state', function () {
+    expect(reducer(undefined, { type: '@@TEST_INIT', payload: {}})).toEqual(defaultState)
+  })
+
+  it('should ignore `getApplicationFailure` action', function () {
+    expect(reducer(defaultState, getApplicationFailure({ status: 404 }))).toEqual(defaultState)
+  })
+
+  it('should ignore `updateApplicationFailure` action', function () {
+    expect(reducer(defaultState, updateApplicationFailure({ status: 404 }))).toEqual(defaultState)
+  })
+
+  it('should ignore `getApplicationsFailure` action', function () {
+    expect(reducer(defaultState, getApplicationsFailure({ status: 404 }))).toEqual(defaultState)
+  })
+
+  it('should ignore `updateApplication` action', function () {
+    expect(reducer(defaultState, updateApplication('test-id', {}))).toEqual(defaultState)
+  })
+
+  it('should ignore `deleteApplicationFailure` action', function () {
+    expect(reducer(defaultState, deleteApplicationFailure({ status: 404 }))).toEqual(defaultState)
+  })
+
+  it('should ignore `deleteApplication` action', function () {
+    expect(reducer(defaultState, deleteApplication('test-id'))).toEqual(defaultState)
+  })
+
+  describe('requests single application', function () {
+    const testApplicationId = 'test-app-id'
+    const testApplication = { ids: { application_id: testApplicationId }, name: 'test-app' }
+    let newState
+
+    beforeAll(function () {
+      newState = reducer(defaultState, getApplication(testApplicationId))
+    })
+
+    it('should set `selectedApplication` on `getApplication` action', function () {
+      expect(newState.selectedApplication).toEqual(testApplicationId)
+    })
+
+    it('should not update `entities` on `getApplication` action', function () {
+      expect(newState.entities).toEqual(defaultState.entities)
+    })
+
+    describe('receives application', function () {
+      beforeAll(function () {
+        newState = reducer(newState, getApplicationSuccess(testApplication))
+      })
+
+      it('should not change `selectedApplication` on `getApplicationSuccess`', function () {
+        expect(newState.selectedApplication).toEqual(testApplicationId)
+      })
+
+      it('should add new application to `entities` on `getApplicationSuccess`', function () {
+        expect(Object.keys(newState.entities)).toHaveLength(1)
+        expect(newState.entities[testApplicationId]).toEqual(testApplication)
+      })
+
+      describe('updates application', function () {
+        const updatedTestApplication = { ids: { application_id: testApplicationId }, name: 'updated-test-app' }
+        let updatedState
+
+        beforeAll(function () {
+          updatedState = reducer(newState, updateApplicationSuccess(updatedTestApplication))
+        })
+
+        it('should not change `selectedApplication` on `updateApplicationSuccess`', function () {
+          expect(updatedState.selectedApplication).toEqual(testApplicationId)
+        })
+
+        it('should update application in `entities` on `updateApplicationSuccess` action', function () {
+          expect(updatedState.entities[testApplicationId].name).toEqual(updatedTestApplication.name)
+        })
+      })
+
+      describe('deletes application', function () {
+        let updatedState
+
+        beforeAll(function () {
+          updatedState = reducer(newState, deleteApplicationSuccess({ id: testApplicationId }))
+        })
+
+        it('should remove `selectedApplication` on `deleteApplicationSuccess`', function () {
+          expect(updatedState.selectedApplication).toBeNull()
+        })
+
+        it('should remove application in `entities` on `deleteApplicationSuccess` action', function () {
+          expect(updatedState.entities[testApplicationId]).toBeUndefined()
+        })
+      })
+
+      describe('requests another application', function () {
+        const otherTestApplicationId = 'another-test-app-id'
+        const otherTestApplication = { ids: { application_id: otherTestApplicationId }, name: 'test-app' }
+        let updatedState
+
+        beforeAll(function () {
+          updatedState = reducer(newState, getApplication(otherTestApplicationId))
+        })
+
+        it('should set `selectedApplication` on `getApplication` action', function () {
+          expect(updatedState.selectedApplication).toEqual(otherTestApplicationId)
+        })
+
+        it('should not update `entities` on `getApplication` action', function () {
+          expect(Object.keys(updatedState.entities)).toHaveLength(1)
+          expect(updatedState.entities[testApplicationId]).toEqual(testApplication)
+        })
+
+        describe('receives application', function () {
+          beforeAll(function () {
+            updatedState = reducer(updatedState, getApplicationSuccess(otherTestApplication))
+          })
+
+          it('should not change `selectedApplication` on `getApplicationSuccess`', function () {
+            expect(updatedState.selectedApplication).toEqual(otherTestApplicationId)
+          })
+
+          it('should keep previously received application in `entities`', function () {
+            expect(updatedState.entities[testApplicationId]).toEqual(testApplication)
+          })
+
+          it('should add new application to `entities` on `getApplicationSuccess`', function () {
+            expect(Object.keys(updatedState.entities)).toHaveLength(2)
+            expect(updatedState.entities[otherTestApplicationId]).toEqual(otherTestApplication)
+          })
+        })
+      })
+
+      describe('requests a list of applications', function () {
+        beforeAll(function () {
+          newState = reducer(newState, getApplicationsList({}))
+        })
+
+        it('should not change `selectedApplication` on `getApplicationList` action', function () {
+          expect(newState.selectedApplication).toEqual(testApplicationId)
+        })
+
+        it('should not change `entities` on `getApplicationList` action', function () {
+          expect(Object.keys(newState.entities)).toHaveLength(1)
+          expect(newState.entities[testApplicationId]).toEqual(testApplication)
+        })
+
+        describe('receives a list of applications', function () {
+          const entities = [
+            { ids: { application_id: 'test-app-1' }, name: 'test-app-1' },
+            { ids: { application_id: 'test-app-2' }, name: 'test-app-2' },
+            { ids: { application_id: 'test-app-3' }, name: 'test-app-3' },
+          ]
+          const totalCount = entities.length
+
+          beforeAll(function () {
+            newState = reducer(newState, getApplicationsSuccess({ entities, totalCount }))
+          })
+
+          it('should not remove previously received application on `getApplicationsSuccess` action', function () {
+            expect(newState.entities[testApplicationId]).toEqual(testApplication)
+          })
+
+          it('should add new applications to `entities` on `getApplicationSuccess`', function () {
+            expect(Object.keys(newState.entities)).toHaveLength(4)
+            for (const app of entities) {
+              expect(newState.entities[app.ids.application_id]).toEqual(app)
+            }
+          })
+        })
+      })
+    })
+  })
+})

--- a/pkg/webui/console/store/reducers/tests/pagination_test.js
+++ b/pkg/webui/console/store/reducers/tests/pagination_test.js
@@ -19,6 +19,8 @@ import {
 import {
   createPaginationRequestActions,
   createPaginationByIdRequestActions,
+  createPaginationDeleteActions,
+  createPaginationByIdDeleteActions,
 } from '../../actions/pagination'
 
 describe('pagination reducers', function () {
@@ -34,17 +36,30 @@ describe('pagination reducers', function () {
       success,
       failure,
     } = createPaginationRequestActions(NAME)[1]
+    const {
+      request: requestDelete,
+      success: successDelete,
+      failure: failureDelete,
+    } = createPaginationDeleteActions(NAME)[1]
 
     it('should return the initial state', function () {
       expect(reducer(undefined, { payload: {}})).toEqual(defaultState)
     })
 
-    it('should ignore the `request` action', function () {
+    it('should ignore the get `request` action', function () {
       expect(reducer(defaultState, request())).toEqual(defaultState)
     })
 
-    it('should ignore the `failure` action', function () {
+    it('should ignore the get `failure` action', function () {
       expect(reducer(defaultState, failure())).toEqual(defaultState)
+    })
+
+    it('should ignore the delete `request` action', function () {
+      expect(reducer(defaultState, requestDelete('test-id'))).toEqual(defaultState)
+    })
+
+    it('should ignore the delete `failure` action', function () {
+      expect(reducer(defaultState, failureDelete())).toEqual(defaultState)
     })
 
     describe('receives the `success` action', function () {
@@ -76,6 +91,23 @@ describe('pagination reducers', function () {
 
         expect(newTotalCount).toEqual(totalCount)
       })
+
+      describe('deletes an entity', function () {
+        beforeAll(function () {
+          newState = reducer(newState, successDelete({ id: entities[0].id }))
+        })
+
+        it('should decrease `totalCount`', function () {
+          expect(newState.totalCount).toEqual(entities.length - 1)
+        })
+
+        it('should remove deleted id from `ids`', function () {
+          expect(newState.ids).toHaveLength(entities.length - 1)
+          expect(newState.ids).toEqual(
+            expect.not.arrayContaining(entities)
+          )
+        })
+      })
     })
   })
 
@@ -89,6 +121,11 @@ describe('pagination reducers', function () {
       success,
       failure,
     } = createPaginationByIdRequestActions(NAME)[1]
+    const {
+      request: requestDelete,
+      success: successDelete,
+      failure: failureDelete,
+    } = createPaginationByIdDeleteActions(NAME)[1]
 
     it('should return the initial state', function () {
       expect(reducer(undefined, { payload: {}})).toEqual(defaultState)
@@ -99,8 +136,15 @@ describe('pagination reducers', function () {
     })
 
     it('should ignore the `failure` action', function () {
-      const res = reducer(defaultState, failure({}))
-      expect(res).toEqual(defaultState)
+      expect(reducer(defaultState, failure({}))).toEqual(defaultState)
+    })
+
+    it('should ignore the delete `request` action', function () {
+      expect(reducer(defaultState, requestDelete('test-id', 'target-test-id'))).toEqual(defaultState)
+    })
+
+    it('should ignore the delete `failure` action', function () {
+      expect(reducer(defaultState, failureDelete('test-id'))).toEqual(defaultState)
     })
 
     describe('receives the `success` action', function () {
@@ -143,6 +187,27 @@ describe('pagination reducers', function () {
         const { [entityId]: results } = newState
 
         expect(results.totalCount).toEqual(totalCount)
+      })
+
+      describe('deletes entity', function () {
+        let updatedState
+
+        beforeAll(function () {
+          updatedState = reducer(newState, successDelete({ id: entityId, targetId: entities[0].id }))
+        })
+
+        it('should decrease `totalCount`', function () {
+          const { [entityId]: results } = updatedState
+          expect(results.totalCount).toEqual(entities.length - 1)
+        })
+
+        it('should remove deleted id from `ids`', function () {
+          const { [entityId]: results } = updatedState
+          expect(results.ids).toHaveLength(entities.length - 1)
+          expect(results.ids).toEqual(
+            expect.not.arrayContaining(entities)
+          )
+        })
       })
 
       describe('receives the `success` action for another entity', function () {
@@ -193,6 +258,27 @@ describe('pagination reducers', function () {
           const { [otherEntityId]: results } = otherNewState
 
           expect(results.totalCount).toEqual(otherTotalCount)
+        })
+
+        describe('deletes entity', function () {
+          let updatedState
+
+          beforeAll(function () {
+            updatedState = reducer(otherNewState, successDelete({ id: otherEntityId, targetId: otherEntities[0].id }))
+          })
+
+          it('should decrease `totalCount`', function () {
+            const { [entityId]: results } = updatedState
+            expect(results.totalCount).toEqual(otherEntities.length - 1)
+          })
+
+          it('should remove deleted id from `ids`', function () {
+            const { [entityId]: results } = updatedState
+            expect(results.ids).toHaveLength(otherEntities.length - 1)
+            expect(results.ids).toEqual(
+              expect.not.arrayContaining(otherEntities)
+            )
+          })
         })
       })
     })

--- a/pkg/webui/console/views/application-general-settings/index.js
+++ b/pkg/webui/console/views/application-general-settings/index.js
@@ -18,7 +18,6 @@ import { Col, Row, Container } from 'react-grid-system'
 import { defineMessages } from 'react-intl'
 import { connect } from 'react-redux'
 import * as Yup from 'yup'
-import { replace } from 'connected-react-router'
 
 import IntlHelmet from '../../../lib/components/intl-helmet'
 import { withBreadcrumb } from '../../../components/breadcrumbs/context'
@@ -34,9 +33,7 @@ import toast from '../../../components/toast'
 import SubmitBar from '../../../components/submit-bar'
 
 import { selectSelectedApplication } from '../../store/selectors/applications'
-import { updateApplication } from '../../store/actions/applications'
-
-import api from '../../api'
+import { updateApplication, deleteApplication } from '../../store/actions/applications'
 
 const m = defineMessages({
   basics: 'Basics',
@@ -56,10 +53,10 @@ const validationSchema = Yup.object().shape({
 @connect(state => ({
   application: selectSelectedApplication(state),
 }),
-dispatch => ({
-  updateApplication: (id, patch) => dispatch(updateApplication(id, patch)),
-  redirectToList: () => dispatch(replace('/console/applications')),
-}))
+{
+  updateApplication,
+  deleteApplication,
+})
 @withBreadcrumb('apps.single.general-settings', function (props) {
   const { appId } = props
 
@@ -101,14 +98,13 @@ export default class ApplicationGeneralSettings extends React.Component {
   }
 
   async handleDelete () {
-    const { redirectToList } = this.props
+    const { deleteApplication } = this.props
     const { appId } = this.props.match.params
 
     await this.setState({ error: '' })
 
     try {
-      await api.application.delete(appId)
-      redirectToList()
+      await deleteApplication(appId)
     } catch (error) {
       await this.setState({ error })
     }

--- a/pkg/webui/console/views/application/index.js
+++ b/pkg/webui/console/views/application/index.js
@@ -15,6 +15,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { Switch, Route } from 'react-router'
+import { replace } from 'connected-react-router'
 
 import sharedMessages from '../../../lib/shared-messages'
 import Message from '../../../lib/components/message'
@@ -59,6 +60,7 @@ dispatch => ({
   startStream: id => dispatch(startApplicationEventsStream(id)),
   stopStream: id => dispatch(stopApplicationEventsStream(id)),
   getApplication: id => dispatch(getApplication(id, 'name,description')),
+  redirectToList: () => dispatch(replace('/console/applications')),
 }))
 @withSideNavigation(function (props) {
   const matchedUrl = props.match.url
@@ -140,7 +142,6 @@ dispatch => ({
     />
   )
 })
-
 @withEnv
 export default class Application extends React.Component {
 
@@ -149,6 +150,14 @@ export default class Application extends React.Component {
 
     getApplication(appId)
     startStream(appId)
+  }
+
+  componentDidUpdate (prevProps) {
+    const { application, redirectToList } = this.props
+
+    if (Boolean(prevProps.application) && !Boolean(application)) {
+      redirectToList()
+    }
   }
 
   componentWillUnmount () {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/723

#### Changes
<!-- What are the changes made in this pull request? -->

- Add tests for the applications reducer
- Simplify the Application General Settings page
- Fix issue when updating application in the store
- Add application update actions
- Add application delete actions
- Add functionality to the application root view to redirect to the applications list when `selectedApplication` is unset. In the future we can introduce a separate component that could wrap the `<Route />` and redirect automatically.
- Add delete functionality to the pagination reducer
- Add delete action creators to the pagination action creators

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Please check the submit method in the general settings form. are you fine with such implementation?

I also changed the type of list request actions, from `GET_APPLICATIONS_LIST` to `GET_APPLICATION_LIST`. First, it doesnt really align with the api of the pagination higher order reducer. Second, the whole `SHARED_NAME`, `SHARED_NAME_SINGLE` introduces quite some mess and i think we should get rid of this. `GET_APPLICATION` and `GET_APPLICATION_LIST` gives enough context to distinguish which action fetches a single entity and which fetches the list.