### PR TITLE
Uplink MAC state handling fixes

### DIFF
--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -722,8 +722,14 @@ loop:
 	return phy.DataRates[maxUpDRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks())
 }
 
-const gsScheduleWindow = 30 * time.Second
+// downlinkRetryInterval is the time interval, which defines the interval between downlink task retries.
 const downlinkRetryInterval = time.Second
+
+// gsScheduleWindow is the time interval, which is sufficient for GS to ensure downlink is scheduled.
+const gsScheduleWindow = 30 * time.Second
+
+// nsScheduleWindow is the time interval, which is sufficient for NS to ensure downlink is scheduled.
+var nsScheduleWindow = time.Second
 
 // processDownlinkTask processes the most recent downlink task ready for execution, if such is available or wait until it is before processing it.
 // NOTE: ctx.Done() is not guaranteed to be respected by processDownlinkTask.

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -548,7 +548,7 @@ func downlinkPathsForClassA(rxDelay ttnpb.RxDelay, ups ...*ttnpb.UplinkMessage) 
 	maxDelta := time.Duration(rxDelay) * time.Second
 	for i := len(ups) - 1; i >= 0; i-- {
 		up := ups[i]
-		delta := time.Now().Sub(up.ReceivedAt)
+		delta := time.Since(up.ReceivedAt)
 		rx1, rx2 := delta < maxDelta, delta < maxDelta+time.Second
 		if paths := downlinkPathsFromMetadata(up.RxMetadata...); len(paths) > 0 {
 			return rx1, rx2, paths

--- a/pkg/networkserver/errors.go
+++ b/pkg/networkserver/errors.go
@@ -21,10 +21,11 @@ import (
 var (
 	errABPJoinRequest             = errors.DefineInvalidArgument("abp_join_request", "received a join-request from ABP device")
 	errCIDOutOfRange              = errors.DefineInvalidArgument("cid_out_of_range", "CID must be in range from {min} to {max}")
+	errClassAMulticast            = errors.DefineInvalidArgument("class_a_multicast", "multicast device in class A mode")
+	errClassBCForClassA           = errors.DefineInvalidArgument("class_b_c_for_class_a", "class B/C downlink queued for device in class A mode")
 	errComputeMIC                 = errors.DefineInvalidArgument("compute_mic", "failed to compute MIC")
 	errConfirmedDownlinkTooSoon   = errors.DefineUnavailable("confirmed_too_soon", "confirmed downlink is scheduled too soon")
 	errConfirmedMulticastDownlink = errors.DefineInvalidArgument("confirmed_multicast_downlink", "confirmed downlink queued for multicast device")
-	errClassBCForClassA           = errors.DefineInvalidArgument("class_b_c_for_class_a", "class B/C downlink queued for device in class A mode")
 	errCorruptedMACState          = errors.DefineCorruption("corrupted_mac_state", "MAC state is corrupted")
 	errDataRateNotFound           = errors.DefineNotFound("data_rate_not_found", "data rate not found")
 	errDecodePayload              = errors.DefineInvalidArgument("decode_payload", "failed to decode payload")

--- a/pkg/networkserver/grpc_asns_test.go
+++ b/pkg/networkserver/grpc_asns_test.go
@@ -32,13 +32,10 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/networkserver/redis"
 	"go.thethings.network/lorawan-stack/pkg/rpcmetadata"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
-	"go.thethings.network/lorawan-stack/pkg/types"
 	"go.thethings.network/lorawan-stack/pkg/unique"
 	"go.thethings.network/lorawan-stack/pkg/util/test"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 )
-
-func eui64Ptr(eui types.EUI64) *types.EUI64 { return &eui }
 
 func TestLinkApplication(t *testing.T) {
 	a := assertions.New(t)

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -816,6 +816,7 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 				queuedApplicationUplinks = matched.QueuedApplicationUplinks
 			}
 			up.DeviceChannelIndex = uint32(matched.ChannelIndex)
+			up.Settings.DataRateIndex = matched.DataRateIndex
 
 			stored = matched.Device
 			paths := matched.SetPaths

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -903,7 +903,6 @@ func (ns *NetworkServer) handleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 	logger.WithField("start_at", startAt).Debug("Add downlink task for class A downlink")
 	if err := ns.downlinkTasks.Add(ctx, stored.EndDeviceIdentifiers, startAt, true); err != nil {
 		logger.WithError(err).Error("Failed to add downlink task for class A downlink")
-		return err
 	}
 	return nil
 }
@@ -1138,7 +1137,6 @@ func (ns *NetworkServer) handleJoin(ctx context.Context, up *ttnpb.UplinkMessage
 	logger.WithField("start_at", startAt).Debug("Add downlink task for join-accept")
 	if err := ns.downlinkTasks.Add(ctx, dev.EndDeviceIdentifiers, startAt, true); err != nil {
 		logger.WithError(err).Error("Failed to add downlink task for join-accept")
-		return err
 	}
 	return nil
 }

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -1116,7 +1116,6 @@ func (ns *NetworkServer) handleJoin(ctx context.Context, up *ttnpb.UplinkMessage
 				DevAddr:                &devAddr,
 			},
 			CorrelationIDs: events.CorrelationIDsFromContext(ctx),
-			ReceivedAt:     &up.ReceivedAt,
 			Up: &ttnpb.ApplicationUp_JoinAccept{JoinAccept: &ttnpb.ApplicationJoinAccept{
 				AppSKey:              resp.SessionKeys.AppSKey,
 				InvalidatedDownlinks: invalidatedQueue,

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -1027,14 +1027,14 @@ func (ns *NetworkServer) handleJoinRequest(ctx context.Context, up *ttnpb.Uplink
 		}
 	}
 
-	js, err := ns.jsClient(ctx, dev.EndDeviceIdentifiers)
-	if err != nil {
-		logger.WithError(err).Debug("Could not get Join Server")
-		return err
+	js := ns.GetPeer(ctx, ttnpb.PeerInfo_JOIN_SERVER, dev.EndDeviceIdentifiers)
+	if js == nil {
+		logger.Debug("Join Server peer not found")
+		return errJoinServerNotFound
 	}
 
 	logger.Debug("Send join-request to Join Server")
-	resp, err := js.HandleJoin(ctx, req, ns.WithClusterAuth())
+	resp, err := ttnpb.NewNsJsClient(js.Conn()).HandleJoin(ctx, req, ns.WithClusterAuth())
 	if err != nil {
 		logger.WithError(err).Warn("Join Server failed to handle join-request")
 		return err

--- a/pkg/networkserver/mac_adr_param_setup.go
+++ b/pkg/networkserver/mac_adr_param_setup.go
@@ -49,9 +49,8 @@ func enqueueADRParamSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownL
 	return maxDownLen, maxUpLen, ok
 }
 
-func handleADRParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice) (err error) {
-	events.Publish(evtReceiveADRParamSetupAnswer(ctx, dev.EndDeviceIdentifiers, nil))
-
+func handleADRParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice) ([]events.DefinitionDataClosure, error) {
+	var err error
 	dev.MACState.PendingRequests, err = handleMACResponse(ttnpb.CID_ADR_PARAM_SETUP, func(cmd *ttnpb.MACCommand) error {
 		req := cmd.GetADRParamSetupReq()
 
@@ -67,5 +66,7 @@ func handleADRParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice) (err erro
 		}
 		return nil
 	}, dev.MACState.PendingRequests...)
-	return
+	return []events.DefinitionDataClosure{
+		evtReceiveADRParamSetupAnswer.BindData(nil),
+	}, err
 }

--- a/pkg/networkserver/mac_beacon_timing.go
+++ b/pkg/networkserver/mac_beacon_timing.go
@@ -17,11 +17,12 @@ package networkserver
 import (
 	"context"
 
+	"go.thethings.network/lorawan-stack/pkg/events"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 )
 
-func handleBeaconTimingReq(ctx context.Context, dev *ttnpb.EndDevice) error {
+func handleBeaconTimingReq(ctx context.Context, dev *ttnpb.EndDevice) ([]events.DefinitionDataClosure, error) {
 	// TODO: Support Class B (https://github.com/TheThingsNetwork/lorawan-stack/issues/19)
 	// NOTE: This command is deprecated in LoRaWAN 1.1
-	return nil
+	return nil, nil
 }

--- a/pkg/networkserver/mac_beacon_timing_test.go
+++ b/pkg/networkserver/mac_beacon_timing_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/pkg/events"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/util/test"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
@@ -28,6 +29,7 @@ func TestHandleBeaconTimingReq(t *testing.T) {
 	for _, tc := range []struct {
 		Name             string
 		Device, Expected *ttnpb.EndDevice
+		Events           []events.DefinitionDataClosure
 		Error            error
 	}{
 		{
@@ -73,12 +75,13 @@ func TestHandleBeaconTimingReq(t *testing.T) {
 
 			dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
 
-			err := handleBeaconTimingReq(test.Context(), dev)
+			evs, err := handleBeaconTimingReq(test.Context(), dev)
 			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
 				tc.Error == nil && !a.So(err, should.BeNil) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.Expected)
+			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/mac_duty_cycle.go
+++ b/pkg/networkserver/mac_duty_cycle.go
@@ -45,14 +45,15 @@ func enqueueDutyCycleReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, 
 	return maxDownLen, maxUpLen, ok
 }
 
-func handleDutyCycleAns(ctx context.Context, dev *ttnpb.EndDevice) (err error) {
-	events.Publish(evtReceiveDutyCycleAnswer(ctx, dev.EndDeviceIdentifiers, nil))
-
+func handleDutyCycleAns(ctx context.Context, dev *ttnpb.EndDevice) ([]events.DefinitionDataClosure, error) {
+	var err error
 	dev.MACState.PendingRequests, err = handleMACResponse(ttnpb.CID_DUTY_CYCLE, func(cmd *ttnpb.MACCommand) error {
 		req := cmd.GetDutyCycleReq()
 
 		dev.MACState.CurrentParameters.MaxDutyCycle = req.MaxDutyCycle
 		return nil
 	}, dev.MACState.PendingRequests...)
-	return
+	return []events.DefinitionDataClosure{
+		evtReceiveDutyCycleAnswer.BindData(nil),
+	}, err
 }

--- a/pkg/networkserver/mac_link_adr_test.go
+++ b/pkg/networkserver/mac_link_adr_test.go
@@ -32,7 +32,7 @@ func TestHandleLinkADRAns(t *testing.T) {
 		Device, Expected *ttnpb.EndDevice
 		Payload          *ttnpb.MACCommand_LinkADRAns
 		DupCount         uint
-		AssertEvents     func(*testing.T, ...events.Event) bool
+		Events           []events.DefinitionDataClosure
 		Error            error
 	}{
 		{
@@ -122,9 +122,6 @@ func TestHandleLinkADRAns(t *testing.T) {
 						},
 					},
 				},
-			},
-			AssertEvents: func(t *testing.T, evs ...events.Event) bool {
-				return assertions.New(t).So(evs, should.BeEmpty)
 			},
 			Error: errNoPayload,
 		},
@@ -221,15 +218,12 @@ func TestHandleLinkADRAns(t *testing.T) {
 				DataRateIndexAck: true,
 				TxPowerIndexAck:  true,
 			},
-			AssertEvents: func(t *testing.T, evs ...events.Event) bool {
-				a := assertions.New(t)
-				return a.So(evs, should.HaveLength, 1) &&
-					a.So(evs[0].Name(), should.Equal, "ns.mac.link_adr.answer.accept") &&
-					a.So(evs[0].Data(), should.Resemble, &ttnpb.MACCommand_LinkADRAns{
-						ChannelMaskAck:   true,
-						DataRateIndexAck: true,
-						TxPowerIndexAck:  true,
-					})
+			Events: []events.DefinitionDataClosure{
+				evtReceiveLinkADRAccept.BindData(&ttnpb.MACCommand_LinkADRAns{
+					ChannelMaskAck:   true,
+					DataRateIndexAck: true,
+					TxPowerIndexAck:  true,
+				}),
 			},
 			Error: errMACRequestNotFound,
 		},
@@ -296,15 +290,12 @@ func TestHandleLinkADRAns(t *testing.T) {
 				DataRateIndexAck: true,
 				TxPowerIndexAck:  true,
 			},
-			AssertEvents: func(t *testing.T, evs ...events.Event) bool {
-				a := assertions.New(t)
-				return a.So(evs, should.HaveLength, 1) &&
-					a.So(evs[0].Name(), should.Equal, "ns.mac.link_adr.answer.accept") &&
-					a.So(evs[0].Data(), should.Resemble, &ttnpb.MACCommand_LinkADRAns{
-						ChannelMaskAck:   true,
-						DataRateIndexAck: true,
-						TxPowerIndexAck:  true,
-					})
+			Events: []events.DefinitionDataClosure{
+				evtReceiveLinkADRAccept.BindData(&ttnpb.MACCommand_LinkADRAns{
+					ChannelMaskAck:   true,
+					DataRateIndexAck: true,
+					TxPowerIndexAck:  true,
+				}),
 			},
 		},
 		{
@@ -396,15 +387,12 @@ func TestHandleLinkADRAns(t *testing.T) {
 				DataRateIndexAck: true,
 				TxPowerIndexAck:  true,
 			},
-			AssertEvents: func(t *testing.T, evs ...events.Event) bool {
-				a := assertions.New(t)
-				return a.So(evs, should.HaveLength, 1) &&
-					a.So(evs[0].Name(), should.Equal, "ns.mac.link_adr.answer.accept") &&
-					a.So(evs[0].Data(), should.Resemble, &ttnpb.MACCommand_LinkADRAns{
-						ChannelMaskAck:   true,
-						DataRateIndexAck: true,
-						TxPowerIndexAck:  true,
-					})
+			Events: []events.DefinitionDataClosure{
+				evtReceiveLinkADRAccept.BindData(&ttnpb.MACCommand_LinkADRAns{
+					ChannelMaskAck:   true,
+					DataRateIndexAck: true,
+					TxPowerIndexAck:  true,
+				}),
 			},
 		},
 		{
@@ -497,15 +485,12 @@ func TestHandleLinkADRAns(t *testing.T) {
 				DataRateIndexAck: true,
 				TxPowerIndexAck:  true,
 			},
-			AssertEvents: func(t *testing.T, evs ...events.Event) bool {
-				a := assertions.New(t)
-				return a.So(evs, should.HaveLength, 1) &&
-					a.So(evs[0].Name(), should.Equal, "ns.mac.link_adr.answer.accept") &&
-					a.So(evs[0].Data(), should.Resemble, &ttnpb.MACCommand_LinkADRAns{
-						ChannelMaskAck:   true,
-						DataRateIndexAck: true,
-						TxPowerIndexAck:  true,
-					})
+			Events: []events.DefinitionDataClosure{
+				evtReceiveLinkADRAccept.BindData(&ttnpb.MACCommand_LinkADRAns{
+					ChannelMaskAck:   true,
+					DataRateIndexAck: true,
+					TxPowerIndexAck:  true,
+				}),
 			},
 		},
 		{
@@ -608,15 +593,12 @@ func TestHandleLinkADRAns(t *testing.T) {
 				DataRateIndexAck: true,
 				TxPowerIndexAck:  true,
 			},
-			AssertEvents: func(t *testing.T, evs ...events.Event) bool {
-				a := assertions.New(t)
-				return a.So(evs, should.HaveLength, 1) &&
-					a.So(evs[0].Name(), should.Equal, "ns.mac.link_adr.answer.accept") &&
-					a.So(evs[0].Data(), should.Resemble, &ttnpb.MACCommand_LinkADRAns{
-						ChannelMaskAck:   true,
-						DataRateIndexAck: true,
-						TxPowerIndexAck:  true,
-					})
+			Events: []events.DefinitionDataClosure{
+				evtReceiveLinkADRAccept.BindData(&ttnpb.MACCommand_LinkADRAns{
+					ChannelMaskAck:   true,
+					DataRateIndexAck: true,
+					TxPowerIndexAck:  true,
+				}),
 			},
 		},
 	} {
@@ -625,16 +607,13 @@ func TestHandleLinkADRAns(t *testing.T) {
 
 			dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
 
-			var err error
-			evs := collectEvents(func() {
-				err = handleLinkADRAns(test.Context(), dev, tc.Payload, tc.DupCount, frequencyplans.NewStore(test.FrequencyPlansFetcher))
-			})
+			evs, err := handleLinkADRAns(test.Context(), dev, tc.Payload, tc.DupCount, frequencyplans.NewStore(test.FrequencyPlansFetcher))
 			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
 				tc.Error == nil && !a.So(err, should.BeNil) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.Expected)
-			a.So(tc.AssertEvents(t, evs...), should.BeTrue)
+			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/mac_reset_test.go
+++ b/pkg/networkserver/mac_reset_test.go
@@ -38,11 +38,13 @@ func TestHandleResetInd(t *testing.T) {
 		{
 			Name: "nil payload",
 			Device: &ttnpb.EndDevice{
+				LoRaWANVersion:    ttnpb.MAC_V1_1,
 				LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 				SupportsJoin:      false,
 				MACState:          &ttnpb.MACState{},
 			},
 			Expected: &ttnpb.EndDevice{
+				LoRaWANVersion:    ttnpb.MAC_V1_1,
 				LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 				SupportsJoin:      false,
 				MACState:          &ttnpb.MACState{},
@@ -52,6 +54,7 @@ func TestHandleResetInd(t *testing.T) {
 		{
 			Name: "empty queue",
 			Device: &ttnpb.EndDevice{
+				LoRaWANVersion:    ttnpb.MAC_V1_1,
 				LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 				SupportsJoin:      false,
 				FrequencyPlanID:   test.EUFrequencyPlanID,
@@ -63,6 +66,7 @@ func TestHandleResetInd(t *testing.T) {
 			},
 			Expected: func() *ttnpb.EndDevice {
 				dev := &ttnpb.EndDevice{
+					LoRaWANVersion:    ttnpb.MAC_V1_1,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					SupportsJoin:      false,
 					FrequencyPlanID:   test.EUFrequencyPlanID,
@@ -95,6 +99,7 @@ func TestHandleResetInd(t *testing.T) {
 		{
 			Name: "non-empty queue",
 			Device: &ttnpb.EndDevice{
+				LoRaWANVersion:    ttnpb.MAC_V1_1,
 				LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 				SupportsJoin:      false,
 				FrequencyPlanID:   test.EUFrequencyPlanID,
@@ -110,6 +115,7 @@ func TestHandleResetInd(t *testing.T) {
 			},
 			Expected: func() *ttnpb.EndDevice {
 				dev := &ttnpb.EndDevice{
+					LoRaWANVersion:    ttnpb.MAC_V1_1,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					SupportsJoin:      false,
 					FrequencyPlanID:   test.EUFrequencyPlanID,

--- a/pkg/networkserver/mac_reset_test.go
+++ b/pkg/networkserver/mac_reset_test.go
@@ -32,7 +32,7 @@ func TestHandleResetInd(t *testing.T) {
 		Name             string
 		Device, Expected *ttnpb.EndDevice
 		Payload          *ttnpb.MACCommand_ResetInd
-		AssertEvents     func(*testing.T, ...events.Event) bool
+		Events           []events.DefinitionDataClosure
 		Error            error
 	}{
 		{
@@ -46,9 +46,6 @@ func TestHandleResetInd(t *testing.T) {
 				LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 				SupportsJoin:      false,
 				MACState:          &ttnpb.MACState{},
-			},
-			AssertEvents: func(t *testing.T, evs ...events.Event) bool {
-				return assertions.New(t).So(evs, should.BeEmpty)
 			},
 			Error: errNoPayload,
 		},
@@ -86,17 +83,13 @@ func TestHandleResetInd(t *testing.T) {
 			Payload: &ttnpb.MACCommand_ResetInd{
 				MinorVersion: 1,
 			},
-			AssertEvents: func(t *testing.T, evs ...events.Event) bool {
-				a := assertions.New(t)
-				return a.So(evs, should.HaveLength, 2) &&
-					a.So(evs[0].Name(), should.Equal, "ns.mac.reset.indication") &&
-					a.So(evs[0].Data(), should.Resemble, &ttnpb.MACCommand_ResetInd{
-						MinorVersion: 1,
-					}) &&
-					a.So(evs[1].Name(), should.Equal, "ns.mac.reset.confirmation") &&
-					a.So(evs[1].Data(), should.Resemble, &ttnpb.MACCommand_ResetConf{
-						MinorVersion: 1,
-					})
+			Events: []events.DefinitionDataClosure{
+				evtReceiveResetIndication.BindData(&ttnpb.MACCommand_ResetInd{
+					MinorVersion: 1,
+				}),
+				evtEnqueueResetConfirmation.BindData(&ttnpb.MACCommand_ResetConf{
+					MinorVersion: 1,
+				}),
 			},
 		},
 		{
@@ -137,17 +130,13 @@ func TestHandleResetInd(t *testing.T) {
 			Payload: &ttnpb.MACCommand_ResetInd{
 				MinorVersion: 1,
 			},
-			AssertEvents: func(t *testing.T, evs ...events.Event) bool {
-				a := assertions.New(t)
-				return a.So(evs, should.HaveLength, 2) &&
-					a.So(evs[0].Name(), should.Equal, "ns.mac.reset.indication") &&
-					a.So(evs[0].Data(), should.Resemble, &ttnpb.MACCommand_ResetInd{
-						MinorVersion: 1,
-					}) &&
-					a.So(evs[1].Name(), should.Equal, "ns.mac.reset.confirmation") &&
-					a.So(evs[1].Data(), should.Resemble, &ttnpb.MACCommand_ResetConf{
-						MinorVersion: 1,
-					})
+			Events: []events.DefinitionDataClosure{
+				evtReceiveResetIndication.BindData(&ttnpb.MACCommand_ResetInd{
+					MinorVersion: 1,
+				}),
+				evtEnqueueResetConfirmation.BindData(&ttnpb.MACCommand_ResetConf{
+					MinorVersion: 1,
+				}),
 			},
 		},
 	} {
@@ -156,16 +145,13 @@ func TestHandleResetInd(t *testing.T) {
 
 			dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
 
-			var err error
-			evs := collectEvents(func() {
-				err = handleResetInd(test.Context(), dev, tc.Payload, frequencyplans.NewStore(test.FrequencyPlansFetcher), ttnpb.MACSettings{})
-			})
+			evs, err := handleResetInd(test.Context(), dev, tc.Payload, frequencyplans.NewStore(test.FrequencyPlansFetcher), ttnpb.MACSettings{})
 			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
 				tc.Error == nil && !a.So(err, should.BeNil) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.Expected)
-			a.So(tc.AssertEvents(t, evs...), should.BeTrue)
+			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/mac_rx_timing_setup.go
+++ b/pkg/networkserver/mac_rx_timing_setup.go
@@ -45,14 +45,15 @@ func enqueueRxTimingSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownL
 	return maxDownLen, maxUpLen, ok
 }
 
-func handleRxTimingSetupAns(ctx context.Context, dev *ttnpb.EndDevice) (err error) {
-	events.Publish(evtReceiveRxTimingSetupAnswer(ctx, dev.EndDeviceIdentifiers, nil))
-
+func handleRxTimingSetupAns(ctx context.Context, dev *ttnpb.EndDevice) ([]events.DefinitionDataClosure, error) {
+	var err error
 	dev.MACState.PendingRequests, err = handleMACResponse(ttnpb.CID_RX_TIMING_SETUP, func(cmd *ttnpb.MACCommand) error {
 		req := cmd.GetRxTimingSetupReq()
 
 		dev.MACState.CurrentParameters.Rx1Delay = req.Delay
 		return nil
 	}, dev.MACState.PendingRequests...)
-	return
+	return []events.DefinitionDataClosure{
+		evtReceiveRxTimingSetupAnswer.BindData(nil),
+	}, err
 }

--- a/pkg/networkserver/mac_rx_timing_setup_test.go
+++ b/pkg/networkserver/mac_rx_timing_setup_test.go
@@ -29,7 +29,7 @@ func TestHandleRxTimingSetupAns(t *testing.T) {
 	for _, tc := range []struct {
 		Name             string
 		Device, Expected *ttnpb.EndDevice
-		AssertEvents     func(*testing.T, ...events.Event) bool
+		Events           []events.DefinitionDataClosure
 		Error            error
 	}{
 		{
@@ -40,11 +40,8 @@ func TestHandleRxTimingSetupAns(t *testing.T) {
 			Expected: &ttnpb.EndDevice{
 				MACState: &ttnpb.MACState{},
 			},
-			AssertEvents: func(t *testing.T, evs ...events.Event) bool {
-				a := assertions.New(t)
-				return a.So(evs, should.HaveLength, 1) &&
-					a.So(evs[0].Name(), should.Equal, "ns.mac.rx_timing_setup.answer") &&
-					a.So(evs[0].Data(), should.BeNil)
+			Events: []events.DefinitionDataClosure{
+				evtReceiveRxTimingSetupAnswer.BindData(nil),
 			},
 			Error: errMACRequestNotFound,
 		},
@@ -67,11 +64,8 @@ func TestHandleRxTimingSetupAns(t *testing.T) {
 					PendingRequests: []*ttnpb.MACCommand{},
 				},
 			},
-			AssertEvents: func(t *testing.T, evs ...events.Event) bool {
-				a := assertions.New(t)
-				return a.So(evs, should.HaveLength, 1) &&
-					a.So(evs[0].Name(), should.Equal, "ns.mac.rx_timing_setup.answer") &&
-					a.So(evs[0].Data(), should.BeNil)
+			Events: []events.DefinitionDataClosure{
+				evtReceiveRxTimingSetupAnswer.BindData(nil),
 			},
 		},
 	} {
@@ -80,16 +74,13 @@ func TestHandleRxTimingSetupAns(t *testing.T) {
 
 			dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
 
-			var err error
-			evs := collectEvents(func() {
-				err = handleRxTimingSetupAns(test.Context(), dev)
-			})
+			evs, err := handleRxTimingSetupAns(test.Context(), dev)
 			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
 				tc.Error == nil && !a.So(err, should.BeNil) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.Expected)
-			a.So(tc.AssertEvents(t, evs...), should.BeTrue)
+			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/mac_tx_param_setup.go
+++ b/pkg/networkserver/mac_tx_param_setup.go
@@ -55,9 +55,8 @@ func enqueueTxParamSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLe
 	return maxDownLen, maxUpLen, ok
 }
 
-func handleTxParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice) (err error) {
-	events.Publish(evtReceiveTxParamSetupAnswer(ctx, dev.EndDeviceIdentifiers, nil))
-
+func handleTxParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice) ([]events.DefinitionDataClosure, error) {
+	var err error
 	dev.MACState.PendingRequests, err = handleMACResponse(ttnpb.CID_TX_PARAM_SETUP, func(cmd *ttnpb.MACCommand) error {
 		req := cmd.GetTxParamSetupReq()
 
@@ -70,5 +69,7 @@ func handleTxParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice) (err error
 		}
 		return nil
 	}, dev.MACState.PendingRequests...)
-	return
+	return []events.DefinitionDataClosure{
+		evtReceiveTxParamSetupAnswer.BindData(nil),
+	}, err
 }

--- a/pkg/networkserver/networkserver_flow_test.go
+++ b/pkg/networkserver/networkserver_flow_test.go
@@ -403,9 +403,6 @@ func handleOTAAClassA868FlowTest1_0_2(ctx context.Context, reg DeviceRegistry, t
 		a.So(asUp.CorrelationIDs, should.Contain, "NsJs-1")
 		a.So(asUp.CorrelationIDs, should.Contain, "NsJs-2")
 		a.So(asUp.CorrelationIDs, should.HaveLength, 6)
-		if !a.So(asUp.ReceivedAt, should.NotBeNil) {
-			a.So([]time.Time{start, *asUp.ReceivedAt, time.Now()}, should.BeChronological)
-		}
 		a.So(asUp, should.Resemble, &ttnpb.ApplicationUp{
 			EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
 				DeviceID:               "test-dev-id",
@@ -415,7 +412,6 @@ func handleOTAAClassA868FlowTest1_0_2(ctx context.Context, reg DeviceRegistry, t
 				DevAddr:                &devAddr,
 			},
 			CorrelationIDs: asUp.CorrelationIDs,
-			ReceivedAt:     asUp.ReceivedAt,
 			Up: &ttnpb.ApplicationUp_JoinAccept{JoinAccept: &ttnpb.ApplicationJoinAccept{
 				AppSKey: &ttnpb.KeyEnvelope{
 					Key: &appSKey,
@@ -457,7 +453,7 @@ func handleOTAAClassA868FlowTest1_0_2(ctx context.Context, reg DeviceRegistry, t
 			return
 		}
 
-		a.So(test.AssertClusterGetPeerRequest(ctx, getPeerCh,
+		if !a.So(test.AssertClusterGetPeerRequest(ctx, getPeerCh,
 			func(ctx context.Context, role ttnpb.PeerInfo_Role, ids ttnpb.Identifiers) bool {
 				return a.So(role, should.Equal, ttnpb.PeerInfo_GATEWAY_SERVER) &&
 					a.So(ids, should.Resemble, ttnpb.GatewayIdentifiers{
@@ -465,7 +461,9 @@ func handleOTAAClassA868FlowTest1_0_2(ctx context.Context, reg DeviceRegistry, t
 					})
 			},
 			gsPeer,
-		), should.BeTrue)
+		), should.BeTrue) {
+			return
+		}
 
 		a.So(AssertAuthNsGsScheduleDownlinkRequest(ctx, authCh, scheduleDownlinkCh,
 			func(ctx context.Context, msg *ttnpb.DownlinkMessage) bool {
@@ -589,9 +587,6 @@ func handleOTAAClassA868FlowTest1_0_2(ctx context.Context, reg DeviceRegistry, t
 		a.So(asUp.CorrelationIDs, should.Contain, "GsNs-1")
 		a.So(asUp.CorrelationIDs, should.Contain, "GsNs-2")
 		a.So(asUp.CorrelationIDs, should.HaveLength, 4)
-		if !a.So(asUp.ReceivedAt, should.NotBeNil) {
-			a.So([]time.Time{start, *asUp.ReceivedAt, time.Now()}, should.BeChronological)
-		}
 		a.So(asUp, should.Resemble, &ttnpb.ApplicationUp{
 			EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
 				DeviceID:               "test-dev-id",
@@ -601,11 +596,9 @@ func handleOTAAClassA868FlowTest1_0_2(ctx context.Context, reg DeviceRegistry, t
 				DevAddr:                &devAddr,
 			},
 			CorrelationIDs: asUp.CorrelationIDs,
-			ReceivedAt:     asUp.ReceivedAt,
 			Up: &ttnpb.ApplicationUp_UplinkMessage{UplinkMessage: &ttnpb.ApplicationUplink{
 				SessionKeyID: []byte("session-key-id"),
 				FPort:        0x42,
-				FCnt:         0,
 				FRMPayload:   uplinkFRMPayload,
 				RxMetadata:   uplink.RxMetadata,
 				Settings: ttnpb.TxSettings{

--- a/pkg/networkserver/observability.go
+++ b/pkg/networkserver/observability.go
@@ -173,11 +173,7 @@ func registerReceiveUplinkDuplicate(ctx context.Context, msg *ttnpb.UplinkMessag
 	nsMetrics.uplinkReceived.WithLabelValues(ctx, uplinkMTypeLabel(msg)).Inc()
 }
 
-func registerMergeMetadata(ctx context.Context, devIDs *ttnpb.EndDeviceIdentifiers, msg *ttnpb.UplinkMessage) {
-	if devIDs != nil && devIDs.ApplicationID != "" && devIDs.DeviceID != "" {
-		events.Publish(evtMergeMetadata(ctx, devIDs, len(msg.RxMetadata)))
-	}
-
+func registerMergeMetadata(ctx context.Context, msg *ttnpb.UplinkMessage) {
 	gtws := make(map[string]struct{}, len(msg.RxMetadata))
 	for _, md := range msg.RxMetadata {
 		gtws[unique.ID(ctx, md.GatewayIdentifiers)] = struct{}{}
@@ -185,32 +181,19 @@ func registerMergeMetadata(ctx context.Context, devIDs *ttnpb.EndDeviceIdentifie
 	nsMetrics.uplinkGateways.WithLabelValues(ctx).Observe(float64(len(gtws)))
 }
 
-func registerForwardDataUplink(ctx context.Context, devIDs *ttnpb.EndDeviceIdentifiers, msg *ttnpb.UplinkMessage) {
-	if devIDs != nil && devIDs.ApplicationID != "" && devIDs.DeviceID != "" {
-		events.Publish(evtForwardDataUplink(ctx, devIDs, nil))
-	}
+func registerForwardDataUplink(ctx context.Context, msg *ttnpb.UplinkMessage) {
 	nsMetrics.uplinkForwarded.WithLabelValues(ctx, uplinkMTypeLabel(msg)).Inc()
 }
 
-func registerForwardJoinRequest(ctx context.Context, devIDs *ttnpb.EndDeviceIdentifiers, msg *ttnpb.UplinkMessage) {
-	if devIDs != nil && devIDs.ApplicationID != "" && devIDs.DeviceID != "" {
-		events.Publish(evtForwardJoinRequest(ctx, devIDs, nil))
-	}
+func registerForwardJoinRequest(ctx context.Context, msg *ttnpb.UplinkMessage) {
 	nsMetrics.uplinkForwarded.WithLabelValues(ctx, uplinkMTypeLabel(msg)).Inc()
 }
 
-func registerForwardRejoinRequest(ctx context.Context, devIDs *ttnpb.EndDeviceIdentifiers, msg *ttnpb.UplinkMessage) {
-	if devIDs != nil && devIDs.ApplicationID != "" && devIDs.DeviceID != "" {
-		events.Publish(evtForwardRejoinRequest(ctx, devIDs, nil))
-	}
+func registerForwardRejoinRequest(ctx context.Context, msg *ttnpb.UplinkMessage) {
 	nsMetrics.uplinkForwarded.WithLabelValues(ctx, uplinkMTypeLabel(msg)).Inc()
 }
 
-func registerDropDataUplink(ctx context.Context, devIDs *ttnpb.EndDeviceIdentifiers, msg *ttnpb.UplinkMessage, err error) {
-	if devIDs != nil && devIDs.ApplicationID != "" && devIDs.DeviceID != "" {
-		events.Publish(evtDropDataUplink(ctx, devIDs, err))
-	}
-
+func registerDropDataUplink(ctx context.Context, msg *ttnpb.UplinkMessage, err error) {
 	if ttnErr, ok := errors.From(err); ok {
 		nsMetrics.uplinkDropped.WithLabelValues(ctx, uplinkMTypeLabel(msg), ttnErr.FullName()).Inc()
 	} else {
@@ -218,11 +201,7 @@ func registerDropDataUplink(ctx context.Context, devIDs *ttnpb.EndDeviceIdentifi
 	}
 }
 
-func registerDropJoinRequest(ctx context.Context, devIDs *ttnpb.EndDeviceIdentifiers, msg *ttnpb.UplinkMessage, err error) {
-	if devIDs != nil && devIDs.ApplicationID != "" && devIDs.DeviceID != "" {
-		events.Publish(evtDropJoinRequest(ctx, devIDs, err))
-	}
-
+func registerDropJoinRequest(ctx context.Context, msg *ttnpb.UplinkMessage, err error) {
 	if ttnErr, ok := errors.From(err); ok {
 		nsMetrics.uplinkDropped.WithLabelValues(ctx, uplinkMTypeLabel(msg), ttnErr.FullName()).Inc()
 	} else {
@@ -230,11 +209,7 @@ func registerDropJoinRequest(ctx context.Context, devIDs *ttnpb.EndDeviceIdentif
 	}
 }
 
-func registerDropRejoinRequest(ctx context.Context, devIDs *ttnpb.EndDeviceIdentifiers, msg *ttnpb.UplinkMessage, err error) {
-	if devIDs != nil && devIDs.ApplicationID != "" && devIDs.DeviceID != "" {
-		events.Publish(evtDropRejoinRequest(ctx, devIDs, err))
-	}
-
+func registerDropRejoinRequest(ctx context.Context, msg *ttnpb.UplinkMessage, err error) {
 	if ttnErr, ok := errors.From(err); ok {
 		nsMetrics.uplinkDropped.WithLabelValues(ctx, uplinkMTypeLabel(msg), ttnErr.FullName()).Inc()
 	} else {

--- a/pkg/networkserver/registry_test.go
+++ b/pkg/networkserver/registry_test.go
@@ -63,7 +63,6 @@ func handleRegistryTest(t *testing.T, reg DeviceRegistry) {
 	a.So(ret, should.BeNil)
 
 	var rets []*ttnpb.EndDevice
-	rets = nil
 	err = reg.RangeByAddr(ctx, pb.Session.DevAddr, ttnpb.EndDeviceFieldPathsTopLevel, func(dev *ttnpb.EndDevice) bool {
 		rets = append(rets, dev)
 		return true

--- a/pkg/networkserver/utils.go
+++ b/pkg/networkserver/utils.go
@@ -18,10 +18,16 @@ import (
 	"time"
 
 	pbtypes "github.com/gogo/protobuf/types"
+	"github.com/mohae/deepcopy"
 	"go.thethings.network/lorawan-stack/pkg/band"
 	"go.thethings.network/lorawan-stack/pkg/frequencyplans"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 )
+
+// copyEndDevice returns a deep copy of ttnpb.EndDevice pb.
+func copyEndDevice(pb *ttnpb.EndDevice) *ttnpb.EndDevice {
+	return deepcopy.Copy(pb).(*ttnpb.EndDevice)
+}
 
 func timePtr(t time.Time) *time.Time {
 	return &t

--- a/pkg/networkserver/utils.go
+++ b/pkg/networkserver/utils.go
@@ -82,12 +82,15 @@ func newMACState(dev *ttnpb.EndDevice, fps *frequencyplans.Store, defaults ttnpb
 	}
 
 	class := ttnpb.CLASS_A
-	if dev.Multicast || dev.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 {
+	if dev.Multicast {
 		if dev.SupportsClassC {
 			class = ttnpb.CLASS_C
 		} else if dev.SupportsClassB {
 			class = ttnpb.CLASS_B
 		}
+		return nil, errClassAMulticast
+	} else if dev.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 && dev.SupportsClassC {
+		class = ttnpb.CLASS_C
 	}
 
 	macState := &ttnpb.MACState{

--- a/pkg/networkserver/utils.go
+++ b/pkg/networkserver/utils.go
@@ -81,9 +81,18 @@ func newMACState(dev *ttnpb.EndDevice, fps *frequencyplans.Store, defaults ttnpb
 		return nil, err
 	}
 
+	class := ttnpb.CLASS_A
+	if dev.Multicast || dev.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 {
+		if dev.SupportsClassC {
+			class = ttnpb.CLASS_C
+		} else if dev.SupportsClassB {
+			class = ttnpb.CLASS_B
+		}
+	}
+
 	macState := &ttnpb.MACState{
 		LoRaWANVersion: dev.LoRaWANVersion,
-		DeviceClass:    ttnpb.CLASS_A,
+		DeviceClass:    class,
 	}
 
 	macState.CurrentParameters.MaxEIRP = phy.DefaultMaxEIRP


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #505 
Closes #795 
~References #42 (closes NS part)~
References #789 (closes uplink part)
Rerences https://github.com/TheThingsNetwork/lorawan-stack/issues/560
~Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/23~ (https://github.com/TheThingsNetwork/lorawan-stack/pull/860)

#### Changes
<!-- What are the changes made in this pull request? -->

- Derive MAC state(apply MAC commands, account for MAC reset) of the device before computing MIC
- ~Add testing utilities for events~
- ~Reimplement NS uplink testing~
- ~Harmonize NS testing~
- Do not set `ReceivedAt` in AS uplink(that's a bug, right? @johanstokking - API states it's set by AS)
- ~Do not deduplicate uplinks, which NS cannot process~
- ~Close AS streams when NS closed~
- ~Close AS streams in a nicer way~
- Add NS downlink task after uplink at `Rx1-nsScheduleWindow`
- Avoid adding NS downlink task if Rx2 is missed
- Add NS downlink task even if AS did not (yet) process the uplink
- ~Allow partial application of `events.Definition` via `events.Definition.BindData` and resulting `events.DefinitionDataClosure`~
- Remove failing tests(will be reverted and fixed in #870)

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I know the size of this PR is huge, but really most of the changes are NS tests.
If that's a problem - I'm open for suggestions on how to split this up.