### PR TITLE
[Quickfix] Prevent writing of empty version values in CI

### DIFF
--- a/.mage/version.go
+++ b/.mage/version.go
@@ -70,6 +70,10 @@ func (Version) Files() error {
 		return err
 	}
 	version := strings.TrimPrefix(currentVersion, "v")
+	if version == "" {
+		fmt.Println("No version rewrite necessary")
+		return nil
+	}
 	for _, packageJSONFile := range packageJSONFilePaths {
 		err = sh.Run(
 			nodeBin("json"),


### PR DESCRIPTION
#### Summary
The release builds for our master branches currently fail because of empty version strings being written to the `package.json`'s, which appears to happen when the commit has not been tagged. In these cases, we can simply abort the mage targets for writing the version values, because they didn't change.

#### Changes
- Add a check to see if the version value is empty and exit the target if so

#### Notes for Reviewers
I'm not really familiar with the release workflow in the CI, so this is my best bet of solving the issue. Please have a look if you can make more sense of it.

