### PR TITLE
Return events to be published from MAC handlers

### DIFF
--- a/pkg/networkserver/mac_adr_param_setup.go
+++ b/pkg/networkserver/mac_adr_param_setup.go
@@ -49,9 +49,8 @@ func enqueueADRParamSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownL
 	return maxDownLen, maxUpLen, ok
 }
 
-func handleADRParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice) (err error) {
-	events.Publish(evtReceiveADRParamSetupAnswer(ctx, dev.EndDeviceIdentifiers, nil))
-
+func handleADRParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice) ([]events.DefinitionDataClosure, error) {
+	var err error
 	dev.MACState.PendingRequests, err = handleMACResponse(ttnpb.CID_ADR_PARAM_SETUP, func(cmd *ttnpb.MACCommand) error {
 		req := cmd.GetADRParamSetupReq()
 
@@ -67,5 +66,7 @@ func handleADRParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice) (err erro
 		}
 		return nil
 	}, dev.MACState.PendingRequests...)
-	return
+	return []events.DefinitionDataClosure{
+		evtReceiveADRParamSetupAnswer.BindData(nil),
+	}, err
 }

--- a/pkg/networkserver/mac_beacon_timing.go
+++ b/pkg/networkserver/mac_beacon_timing.go
@@ -17,11 +17,12 @@ package networkserver
 import (
 	"context"
 
+	"go.thethings.network/lorawan-stack/pkg/events"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 )
 
-func handleBeaconTimingReq(ctx context.Context, dev *ttnpb.EndDevice) error {
+func handleBeaconTimingReq(ctx context.Context, dev *ttnpb.EndDevice) ([]events.DefinitionDataClosure, error) {
 	// TODO: Support Class B (https://github.com/TheThingsNetwork/lorawan-stack/issues/19)
 	// NOTE: This command is deprecated in LoRaWAN 1.1
-	return nil
+	return nil, nil
 }

--- a/pkg/networkserver/mac_beacon_timing_test.go
+++ b/pkg/networkserver/mac_beacon_timing_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/pkg/events"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/util/test"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
@@ -28,6 +29,7 @@ func TestHandleBeaconTimingReq(t *testing.T) {
 	for _, tc := range []struct {
 		Name             string
 		Device, Expected *ttnpb.EndDevice
+		Events           []events.DefinitionDataClosure
 		Error            error
 	}{
 		{
@@ -73,12 +75,13 @@ func TestHandleBeaconTimingReq(t *testing.T) {
 
 			dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
 
-			err := handleBeaconTimingReq(test.Context(), dev)
+			evs, err := handleBeaconTimingReq(test.Context(), dev)
 			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
 				tc.Error == nil && !a.So(err, should.BeNil) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.Expected)
+			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/mac_duty_cycle.go
+++ b/pkg/networkserver/mac_duty_cycle.go
@@ -45,14 +45,15 @@ func enqueueDutyCycleReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, 
 	return maxDownLen, maxUpLen, ok
 }
 
-func handleDutyCycleAns(ctx context.Context, dev *ttnpb.EndDevice) (err error) {
-	events.Publish(evtReceiveDutyCycleAnswer(ctx, dev.EndDeviceIdentifiers, nil))
-
+func handleDutyCycleAns(ctx context.Context, dev *ttnpb.EndDevice) ([]events.DefinitionDataClosure, error) {
+	var err error
 	dev.MACState.PendingRequests, err = handleMACResponse(ttnpb.CID_DUTY_CYCLE, func(cmd *ttnpb.MACCommand) error {
 		req := cmd.GetDutyCycleReq()
 
 		dev.MACState.CurrentParameters.MaxDutyCycle = req.MaxDutyCycle
 		return nil
 	}, dev.MACState.PendingRequests...)
-	return
+	return []events.DefinitionDataClosure{
+		evtReceiveDutyCycleAnswer.BindData(nil),
+	}, err
 }

--- a/pkg/networkserver/mac_link_adr_test.go
+++ b/pkg/networkserver/mac_link_adr_test.go
@@ -32,7 +32,7 @@ func TestHandleLinkADRAns(t *testing.T) {
 		Device, Expected *ttnpb.EndDevice
 		Payload          *ttnpb.MACCommand_LinkADRAns
 		DupCount         uint
-		AssertEvents     func(*testing.T, ...events.Event) bool
+		Events           []events.DefinitionDataClosure
 		Error            error
 	}{
 		{
@@ -122,9 +122,6 @@ func TestHandleLinkADRAns(t *testing.T) {
 						},
 					},
 				},
-			},
-			AssertEvents: func(t *testing.T, evs ...events.Event) bool {
-				return assertions.New(t).So(evs, should.BeEmpty)
 			},
 			Error: errNoPayload,
 		},
@@ -221,15 +218,12 @@ func TestHandleLinkADRAns(t *testing.T) {
 				DataRateIndexAck: true,
 				TxPowerIndexAck:  true,
 			},
-			AssertEvents: func(t *testing.T, evs ...events.Event) bool {
-				a := assertions.New(t)
-				return a.So(evs, should.HaveLength, 1) &&
-					a.So(evs[0].Name(), should.Equal, "ns.mac.link_adr.answer.accept") &&
-					a.So(evs[0].Data(), should.Resemble, &ttnpb.MACCommand_LinkADRAns{
-						ChannelMaskAck:   true,
-						DataRateIndexAck: true,
-						TxPowerIndexAck:  true,
-					})
+			Events: []events.DefinitionDataClosure{
+				evtReceiveLinkADRAccept.BindData(&ttnpb.MACCommand_LinkADRAns{
+					ChannelMaskAck:   true,
+					DataRateIndexAck: true,
+					TxPowerIndexAck:  true,
+				}),
 			},
 			Error: errMACRequestNotFound,
 		},
@@ -296,15 +290,12 @@ func TestHandleLinkADRAns(t *testing.T) {
 				DataRateIndexAck: true,
 				TxPowerIndexAck:  true,
 			},
-			AssertEvents: func(t *testing.T, evs ...events.Event) bool {
-				a := assertions.New(t)
-				return a.So(evs, should.HaveLength, 1) &&
-					a.So(evs[0].Name(), should.Equal, "ns.mac.link_adr.answer.accept") &&
-					a.So(evs[0].Data(), should.Resemble, &ttnpb.MACCommand_LinkADRAns{
-						ChannelMaskAck:   true,
-						DataRateIndexAck: true,
-						TxPowerIndexAck:  true,
-					})
+			Events: []events.DefinitionDataClosure{
+				evtReceiveLinkADRAccept.BindData(&ttnpb.MACCommand_LinkADRAns{
+					ChannelMaskAck:   true,
+					DataRateIndexAck: true,
+					TxPowerIndexAck:  true,
+				}),
 			},
 		},
 		{
@@ -396,15 +387,12 @@ func TestHandleLinkADRAns(t *testing.T) {
 				DataRateIndexAck: true,
 				TxPowerIndexAck:  true,
 			},
-			AssertEvents: func(t *testing.T, evs ...events.Event) bool {
-				a := assertions.New(t)
-				return a.So(evs, should.HaveLength, 1) &&
-					a.So(evs[0].Name(), should.Equal, "ns.mac.link_adr.answer.accept") &&
-					a.So(evs[0].Data(), should.Resemble, &ttnpb.MACCommand_LinkADRAns{
-						ChannelMaskAck:   true,
-						DataRateIndexAck: true,
-						TxPowerIndexAck:  true,
-					})
+			Events: []events.DefinitionDataClosure{
+				evtReceiveLinkADRAccept.BindData(&ttnpb.MACCommand_LinkADRAns{
+					ChannelMaskAck:   true,
+					DataRateIndexAck: true,
+					TxPowerIndexAck:  true,
+				}),
 			},
 		},
 		{
@@ -497,15 +485,12 @@ func TestHandleLinkADRAns(t *testing.T) {
 				DataRateIndexAck: true,
 				TxPowerIndexAck:  true,
 			},
-			AssertEvents: func(t *testing.T, evs ...events.Event) bool {
-				a := assertions.New(t)
-				return a.So(evs, should.HaveLength, 1) &&
-					a.So(evs[0].Name(), should.Equal, "ns.mac.link_adr.answer.accept") &&
-					a.So(evs[0].Data(), should.Resemble, &ttnpb.MACCommand_LinkADRAns{
-						ChannelMaskAck:   true,
-						DataRateIndexAck: true,
-						TxPowerIndexAck:  true,
-					})
+			Events: []events.DefinitionDataClosure{
+				evtReceiveLinkADRAccept.BindData(&ttnpb.MACCommand_LinkADRAns{
+					ChannelMaskAck:   true,
+					DataRateIndexAck: true,
+					TxPowerIndexAck:  true,
+				}),
 			},
 		},
 		{
@@ -608,15 +593,12 @@ func TestHandleLinkADRAns(t *testing.T) {
 				DataRateIndexAck: true,
 				TxPowerIndexAck:  true,
 			},
-			AssertEvents: func(t *testing.T, evs ...events.Event) bool {
-				a := assertions.New(t)
-				return a.So(evs, should.HaveLength, 1) &&
-					a.So(evs[0].Name(), should.Equal, "ns.mac.link_adr.answer.accept") &&
-					a.So(evs[0].Data(), should.Resemble, &ttnpb.MACCommand_LinkADRAns{
-						ChannelMaskAck:   true,
-						DataRateIndexAck: true,
-						TxPowerIndexAck:  true,
-					})
+			Events: []events.DefinitionDataClosure{
+				evtReceiveLinkADRAccept.BindData(&ttnpb.MACCommand_LinkADRAns{
+					ChannelMaskAck:   true,
+					DataRateIndexAck: true,
+					TxPowerIndexAck:  true,
+				}),
 			},
 		},
 	} {
@@ -625,16 +607,13 @@ func TestHandleLinkADRAns(t *testing.T) {
 
 			dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
 
-			var err error
-			evs := collectEvents(func() {
-				err = handleLinkADRAns(test.Context(), dev, tc.Payload, tc.DupCount, frequencyplans.NewStore(test.FrequencyPlansFetcher))
-			})
+			evs, err := handleLinkADRAns(test.Context(), dev, tc.Payload, tc.DupCount, frequencyplans.NewStore(test.FrequencyPlansFetcher))
 			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
 				tc.Error == nil && !a.So(err, should.BeNil) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.Expected)
-			a.So(tc.AssertEvents(t, evs...), should.BeTrue)
+			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/mac_reset_test.go
+++ b/pkg/networkserver/mac_reset_test.go
@@ -32,7 +32,7 @@ func TestHandleResetInd(t *testing.T) {
 		Name             string
 		Device, Expected *ttnpb.EndDevice
 		Payload          *ttnpb.MACCommand_ResetInd
-		AssertEvents     func(*testing.T, ...events.Event) bool
+		Events           []events.DefinitionDataClosure
 		Error            error
 	}{
 		{
@@ -46,9 +46,6 @@ func TestHandleResetInd(t *testing.T) {
 				LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 				SupportsJoin:      false,
 				MACState:          &ttnpb.MACState{},
-			},
-			AssertEvents: func(t *testing.T, evs ...events.Event) bool {
-				return assertions.New(t).So(evs, should.BeEmpty)
 			},
 			Error: errNoPayload,
 		},
@@ -86,17 +83,13 @@ func TestHandleResetInd(t *testing.T) {
 			Payload: &ttnpb.MACCommand_ResetInd{
 				MinorVersion: 1,
 			},
-			AssertEvents: func(t *testing.T, evs ...events.Event) bool {
-				a := assertions.New(t)
-				return a.So(evs, should.HaveLength, 2) &&
-					a.So(evs[0].Name(), should.Equal, "ns.mac.reset.indication") &&
-					a.So(evs[0].Data(), should.Resemble, &ttnpb.MACCommand_ResetInd{
-						MinorVersion: 1,
-					}) &&
-					a.So(evs[1].Name(), should.Equal, "ns.mac.reset.confirmation") &&
-					a.So(evs[1].Data(), should.Resemble, &ttnpb.MACCommand_ResetConf{
-						MinorVersion: 1,
-					})
+			Events: []events.DefinitionDataClosure{
+				evtReceiveResetIndication.BindData(&ttnpb.MACCommand_ResetInd{
+					MinorVersion: 1,
+				}),
+				evtEnqueueResetConfirmation.BindData(&ttnpb.MACCommand_ResetConf{
+					MinorVersion: 1,
+				}),
 			},
 		},
 		{
@@ -137,17 +130,13 @@ func TestHandleResetInd(t *testing.T) {
 			Payload: &ttnpb.MACCommand_ResetInd{
 				MinorVersion: 1,
 			},
-			AssertEvents: func(t *testing.T, evs ...events.Event) bool {
-				a := assertions.New(t)
-				return a.So(evs, should.HaveLength, 2) &&
-					a.So(evs[0].Name(), should.Equal, "ns.mac.reset.indication") &&
-					a.So(evs[0].Data(), should.Resemble, &ttnpb.MACCommand_ResetInd{
-						MinorVersion: 1,
-					}) &&
-					a.So(evs[1].Name(), should.Equal, "ns.mac.reset.confirmation") &&
-					a.So(evs[1].Data(), should.Resemble, &ttnpb.MACCommand_ResetConf{
-						MinorVersion: 1,
-					})
+			Events: []events.DefinitionDataClosure{
+				evtReceiveResetIndication.BindData(&ttnpb.MACCommand_ResetInd{
+					MinorVersion: 1,
+				}),
+				evtEnqueueResetConfirmation.BindData(&ttnpb.MACCommand_ResetConf{
+					MinorVersion: 1,
+				}),
 			},
 		},
 	} {
@@ -156,16 +145,13 @@ func TestHandleResetInd(t *testing.T) {
 
 			dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
 
-			var err error
-			evs := collectEvents(func() {
-				err = handleResetInd(test.Context(), dev, tc.Payload, frequencyplans.NewStore(test.FrequencyPlansFetcher), ttnpb.MACSettings{})
-			})
+			evs, err := handleResetInd(test.Context(), dev, tc.Payload, frequencyplans.NewStore(test.FrequencyPlansFetcher), ttnpb.MACSettings{})
 			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
 				tc.Error == nil && !a.So(err, should.BeNil) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.Expected)
-			a.So(tc.AssertEvents(t, evs...), should.BeTrue)
+			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/mac_rx_timing_setup.go
+++ b/pkg/networkserver/mac_rx_timing_setup.go
@@ -45,14 +45,15 @@ func enqueueRxTimingSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownL
 	return maxDownLen, maxUpLen, ok
 }
 
-func handleRxTimingSetupAns(ctx context.Context, dev *ttnpb.EndDevice) (err error) {
-	events.Publish(evtReceiveRxTimingSetupAnswer(ctx, dev.EndDeviceIdentifiers, nil))
-
+func handleRxTimingSetupAns(ctx context.Context, dev *ttnpb.EndDevice) ([]events.DefinitionDataClosure, error) {
+	var err error
 	dev.MACState.PendingRequests, err = handleMACResponse(ttnpb.CID_RX_TIMING_SETUP, func(cmd *ttnpb.MACCommand) error {
 		req := cmd.GetRxTimingSetupReq()
 
 		dev.MACState.CurrentParameters.Rx1Delay = req.Delay
 		return nil
 	}, dev.MACState.PendingRequests...)
-	return
+	return []events.DefinitionDataClosure{
+		evtReceiveRxTimingSetupAnswer.BindData(nil),
+	}, err
 }

--- a/pkg/networkserver/mac_rx_timing_setup_test.go
+++ b/pkg/networkserver/mac_rx_timing_setup_test.go
@@ -29,7 +29,7 @@ func TestHandleRxTimingSetupAns(t *testing.T) {
 	for _, tc := range []struct {
 		Name             string
 		Device, Expected *ttnpb.EndDevice
-		AssertEvents     func(*testing.T, ...events.Event) bool
+		Events           []events.DefinitionDataClosure
 		Error            error
 	}{
 		{
@@ -40,11 +40,8 @@ func TestHandleRxTimingSetupAns(t *testing.T) {
 			Expected: &ttnpb.EndDevice{
 				MACState: &ttnpb.MACState{},
 			},
-			AssertEvents: func(t *testing.T, evs ...events.Event) bool {
-				a := assertions.New(t)
-				return a.So(evs, should.HaveLength, 1) &&
-					a.So(evs[0].Name(), should.Equal, "ns.mac.rx_timing_setup.answer") &&
-					a.So(evs[0].Data(), should.BeNil)
+			Events: []events.DefinitionDataClosure{
+				evtReceiveRxTimingSetupAnswer.BindData(nil),
 			},
 			Error: errMACRequestNotFound,
 		},
@@ -67,11 +64,8 @@ func TestHandleRxTimingSetupAns(t *testing.T) {
 					PendingRequests: []*ttnpb.MACCommand{},
 				},
 			},
-			AssertEvents: func(t *testing.T, evs ...events.Event) bool {
-				a := assertions.New(t)
-				return a.So(evs, should.HaveLength, 1) &&
-					a.So(evs[0].Name(), should.Equal, "ns.mac.rx_timing_setup.answer") &&
-					a.So(evs[0].Data(), should.BeNil)
+			Events: []events.DefinitionDataClosure{
+				evtReceiveRxTimingSetupAnswer.BindData(nil),
 			},
 		},
 	} {
@@ -80,16 +74,13 @@ func TestHandleRxTimingSetupAns(t *testing.T) {
 
 			dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
 
-			var err error
-			evs := collectEvents(func() {
-				err = handleRxTimingSetupAns(test.Context(), dev)
-			})
+			evs, err := handleRxTimingSetupAns(test.Context(), dev)
 			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
 				tc.Error == nil && !a.So(err, should.BeNil) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.Expected)
-			a.So(tc.AssertEvents(t, evs...), should.BeTrue)
+			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/mac_tx_param_setup.go
+++ b/pkg/networkserver/mac_tx_param_setup.go
@@ -55,9 +55,8 @@ func enqueueTxParamSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLe
 	return maxDownLen, maxUpLen, ok
 }
 
-func handleTxParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice) (err error) {
-	events.Publish(evtReceiveTxParamSetupAnswer(ctx, dev.EndDeviceIdentifiers, nil))
-
+func handleTxParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice) ([]events.DefinitionDataClosure, error) {
+	var err error
 	dev.MACState.PendingRequests, err = handleMACResponse(ttnpb.CID_TX_PARAM_SETUP, func(cmd *ttnpb.MACCommand) error {
 		req := cmd.GetTxParamSetupReq()
 
@@ -70,5 +69,7 @@ func handleTxParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice) (err error
 		}
 		return nil
 	}, dev.MACState.PendingRequests...)
-	return
+	return []events.DefinitionDataClosure{
+		evtReceiveTxParamSetupAnswer.BindData(nil),
+	}, err
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #789 

#### Changes
<!-- What are the changes made in this pull request? -->

- Avoid publishing events directly from MAC handlers - let the caller decice when to do that instead
- Remove custom MAC handlers

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Requires #860 