### PR TITLE
Use Crypto Server only when provisioner ID is set

### DIFF
--- a/pkg/joinserver/grpc_deviceregistry.go
+++ b/pkg/joinserver/grpc_deviceregistry.go
@@ -68,7 +68,7 @@ func (srv jsEndDeviceRegistryServer) Get(ctx context.Context, req *ttnpb.GetEndD
 					return nil, err
 				}
 				networkCryptoService = cryptoservices.NewMemory(&nwkKey, nil)
-			} else if cs != nil {
+			} else if cs != nil && dev.ProvisionerID != "" {
 				networkCryptoService = cryptoservices.NewNetworkRPCClient(cs.Conn(), srv.JS.KeyVault, srv.JS.WithClusterAuth())
 			}
 			if networkCryptoService != nil {
@@ -89,7 +89,7 @@ func (srv jsEndDeviceRegistryServer) Get(ctx context.Context, req *ttnpb.GetEndD
 					return nil, err
 				}
 				applicationCryptoService = cryptoservices.NewMemory(nil, &appKey)
-			} else if cs != nil {
+			} else if cs != nil && dev.ProvisionerID != "" {
 				applicationCryptoService = cryptoservices.NewApplicationRPCClient(cs.Conn(), srv.JS.KeyVault, srv.JS.WithClusterAuth())
 			}
 			if applicationCryptoService != nil {

--- a/pkg/joinserver/joinserver.go
+++ b/pkg/joinserver/joinserver.go
@@ -341,7 +341,7 @@ func (js *JoinServer) HandleJoin(ctx context.Context, req *ttnpb.JoinRequest) (r
 					return nil, nil, err
 				}
 				networkCryptoService = cryptoservices.NewMemory(&nwkKey, nil)
-			} else if cs != nil {
+			} else if cs != nil && dev.ProvisionerID != "" {
 				networkCryptoService = cryptoservices.NewNetworkRPCClient(cs.Conn(), js.KeyVault, js.WithClusterAuth())
 			}
 
@@ -356,7 +356,7 @@ func (js *JoinServer) HandleJoin(ctx context.Context, req *ttnpb.JoinRequest) (r
 					// LoRaWAN 1.0.x use the AppKey for network security operations.
 					networkCryptoService = cryptoservices.NewMemory(nil, &appKey)
 				}
-			} else if cs != nil {
+			} else if cs != nil && dev.ProvisionerID != "" {
 				applicationCryptoService = cryptoservices.NewApplicationRPCClient(cs.Conn(), js.KeyVault, js.WithClusterAuth())
 			}
 			if networkCryptoService == nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/issues/1668

#### Changes
<!-- What are the changes made in this pull request? -->

- Check if provisioner ID is set before contacting CS. This implies that a Crypto Server can return a `NwkKey` if there's a provisioner ID set, also in case of LoRaWAN 1.0.x. Since JS doesn't know about MAC version at this point, a CS will probably return `AppKey` in that case