### PR TITLE
Stop doing shallow git clones in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: required
 conditions: v1
 if: type = pull_request OR branch = master OR tag IS present
 os: linux
+git:
+  depth: false
 language: go
 go: 1.12.x
 go_import_path: go.thethings.network/lorawan-stack


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This Pull Request fixes the problem that git tags aren't present in Travis builds.

Replaces #861.

#### Changes
<!-- What are the changes made in this pull request? -->

- Tell Travis to not do a shallow clone of the repository
