### PR TITLE
Fix GS address comparison in console

### DIFF
--- a/pkg/webui/console/store/middleware/logics/gateway.js
+++ b/pkg/webui/console/store/middleware/logics/gateway.js
@@ -81,10 +81,18 @@ const startGatewayStatisticsLogic = createLogic({
       return
     }
 
-    const gtwGsAddress = gtw.gateway_server_address
-    const consoleGsAddress = new URL(gsConfig.base_url).host
+    let gtwGsAddress
+    let consoleGsAddress
+    try {
+      const gtwAddress = gtw.gateway_server_address
 
-    if (!Boolean(gtwGsAddress)) {
+      if (!Boolean(gtwAddress)) {
+        throw new Error()
+      }
+
+      gtwGsAddress = gtwAddress.split(':')[0]
+      consoleGsAddress = new URL(gsConfig.base_url).hostname
+    } catch (error) {
       reject(gateway.updateGatewayStatisticsFailure({
         message: sharedMessages.unknown,
       }))


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #877 

#### Changes
<!-- What are the changes made in this pull request? -->

- Compare only hostnames of the gateway gs server and the gs in the cluster.
