### PR TITLE
Use configured component addresses as default on device update

### DIFF
--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -492,12 +492,21 @@ var (
 			isPaths, nsPaths, asPaths, jsPaths := splitEndDeviceSetPaths(device.SupportsJoin, paths...)
 
 			if len(nsPaths) > 0 && config.NetworkServerEnabled {
+				if device.NetworkServerAddress == "" {
+					device.NetworkServerAddress = getHost(config.NetworkServerGRPCAddress)
+				}
 				isPaths = append(isPaths, "network_server_address")
 			}
 			if len(asPaths) > 0 && config.ApplicationServerEnabled {
+				if device.ApplicationServerAddress == "" {
+					device.ApplicationServerAddress = getHost(config.ApplicationServerGRPCAddress)
+				}
 				isPaths = append(isPaths, "application_server_address")
 			}
 			if len(jsPaths) > 0 && config.JoinServerEnabled {
+				if device.JoinServerAddress == "" {
+					device.JoinServerAddress = getHost(config.JoinServerGRPCAddress)
+				}
 				isPaths = append(isPaths, "join_server_address")
 			}
 

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -300,19 +300,6 @@ var (
 				paths = append(paths, ttnpb.FlattenPaths(decodedPaths, endDeviceFlattenPaths)...)
 			}
 
-			var macVersion ttnpb.MACVersion
-			s, err := setEndDeviceFlags.GetString("lorawan_version")
-			if err != nil {
-				return err
-			}
-
-			if err := macVersion.UnmarshalText([]byte(s)); err != nil {
-				return err
-			}
-			if err := macVersion.Validate(); err != nil {
-				return errInvalidMACVerson
-			}
-
 			setDefaults, _ := cmd.Flags().GetBool("defaults")
 			if setDefaults {
 				if config.NetworkServerEnabled {
@@ -354,6 +341,17 @@ var (
 						"session.keys.app_s_key.key",
 						"session.dev_addr",
 					)
+					var macVersion ttnpb.MACVersion
+					s, err := setEndDeviceFlags.GetString("lorawan_version")
+					if err != nil {
+						return err
+					}
+					if err := macVersion.UnmarshalText([]byte(s)); err != nil {
+						return err
+					}
+					if err := macVersion.Validate(); err != nil {
+						return errInvalidMACVerson
+					}
 					if macVersion.Compare(ttnpb.MAC_V1_1) >= 0 {
 						device.Session.SessionKeys.SNwkSIntKey = &ttnpb.KeyEnvelope{Key: generateKey()}
 						device.Session.SessionKeys.NwkSEncKey = &ttnpb.KeyEnvelope{Key: generateKey()}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #899

#### Changes
<!-- What are the changes made in this pull request? -->

- Use configured component address as default on device update
- Pretty unrelated; do not require MAC version when it's not necessary in CLI. When bulk create in JS, there's no need for MAC version, for example

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Fixed clearing component addresses on updating end devices through CLI