### PR TITLE
Add default date to gateway statistics

### DIFF
--- a/pkg/webui/console/containers/gateway-statistics/index.js
+++ b/pkg/webui/console/containers/gateway-statistics/index.js
@@ -88,7 +88,7 @@ class GatewayStatistic extends React.PureComponent {
         />
         { statusIndicator === 'good' && (
           <DateTime.Relative
-            value={statistics.last_status_received_at}
+            value={statistics.last_status_received_at || new Date()}
           />
         )}
       </Status>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR adds fallback for `last_status_received_at` since this field is optional in the `GatewayConnectionStats` message.

#### Changes
<!-- What are the changes made in this pull request? -->

- Provide current time if `last_status_received_at` is not present in the response payload
