### PR TITLE
Use -failfast in go test commands by default

### DIFF
--- a/.mage/go.go
+++ b/.mage/go.go
@@ -183,12 +183,16 @@ func init() {
 	preCommitChecks = append(preCommitChecks, Go.Quality)
 }
 
+func execGoTest(args ...string) error {
+	return execGo("test", append([]string{"-timeout=5m", "-failfast"}, args...)...)
+}
+
 // Test tests all Go packages.
 func (Go) Test() error {
 	if mg.Verbose() {
 		fmt.Println("Testing all Go packages")
 	}
-	return execGo("test", "./...")
+	return execGoTest("./...")
 }
 
 const goCoverageFile = "coverage.out"
@@ -198,7 +202,7 @@ func (Go) Cover() error {
 	if mg.Verbose() {
 		fmt.Println("Testing all Go packages with coverage")
 	}
-	return execGo("test", "-cover", "-covermode=atomic", "-coverprofile="+goCoverageFile, "-timeout=5m", "./...")
+	return execGoTest("-cover", "-covermode=atomic", "-coverprofile="+goCoverageFile, "./...")
 }
 
 var coverallsIgnored = []string{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->
From `go help testflag`:
```
        -failfast
            Do not start new tests after the first test failure.
```

This means that CI can fail faster if one of the tests fail instead of wasting resources. :earth_africa:

YMMV, but I've been running `go test -failfast` exclusively for testing for several months and it has really improved my developer experience.
So overall, IMO it makes our CI faster and our development experience better with no drawbacks, hence this PR.

#### Changes
<!-- What are the changes made in this pull request? -->

- Ensure all `go` test `mage` targets specify `-timeout`
- Ensure all `go` test `mage` targets specify `-failfast`