### PR TITLE
Scroll form errors into view

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "redux": "^4.0.1",
     "redux-actions": "^2.6.5",
     "redux-logic": "^2.1.1",
+    "scroll-into-view-if-needed": "^2.2.20",
     "ttn-lw": "file:sdk/js",
     "url-polyfill": "^1.1.5",
     "yup": "^0.26.6"

--- a/pkg/webui/components/form/field/index.js
+++ b/pkg/webui/components/form/field/index.js
@@ -182,7 +182,7 @@ class FormField extends React.Component {
     }))
 
     return (
-      <div className={cls}>
+      <div className={cls} data-needs-focus={showError}>
         <label className={style.label}>
           <Message content={title} className={style.title} />
           <span className={style.reqicon}>&middot;</span>

--- a/pkg/webui/components/form/index.js
+++ b/pkg/webui/components/form/index.js
@@ -24,9 +24,20 @@ import FormField from './field'
 import FormSubmit from './submit'
 
 class InnerForm extends React.PureComponent {
+  constructor (props) {
+    super(props)
+    this.notificationRef = React.createRef()
+  }
+
   componentDidUpdate (prevProps) {
     const { formError, isSubmitting, isValid } = this.props
-    const { isSubmitting: prevIsSubmitting } = prevProps
+    const { isSubmitting: prevIsSubmitting, formError: prevFormError } = prevProps
+
+    // Scroll form notification into view if needed
+    if (formError && !prevFormError) {
+      scrollIntoView(this.notificationRef.current, { behavior: 'smooth' })
+      this.notificationRef.current.focus({ preventScroll: true })
+    }
 
     // Scroll invalid fields into view if needed and focus them
     if (!prevIsSubmitting && isSubmitting && !isValid) {
@@ -51,8 +62,12 @@ class InnerForm extends React.PureComponent {
 
     return (
       <form className={className} onSubmit={handleSubmit}>
-        {formError && <Notification error={formError} small />}
-        {formInfo && <Notification info={formInfo} small /> }
+        {(formError || formInfo) && (
+          <div style={{ outline: 'none' }} ref={this.notificationRef} tabIndex="-1">
+            {formError && <Notification error={formError} small />}
+            {formInfo && <Notification info={formInfo} small /> }
+          </div>
+        )}
         <FormContext.Provider value={{
           ...rest,
           horizontal,

--- a/pkg/webui/components/form/index.js
+++ b/pkg/webui/components/form/index.js
@@ -15,6 +15,7 @@
 import React from 'react'
 import { Formik } from 'formik'
 import bind from 'autobind-decorator'
+import scrollIntoView from 'scroll-into-view-if-needed'
 
 import Notification from '../notification'
 import PropTypes from '../../lib/prop-types'
@@ -23,6 +24,20 @@ import FormField from './field'
 import FormSubmit from './submit'
 
 class InnerForm extends React.PureComponent {
+  componentDidUpdate (prevProps) {
+    const { formError, isSubmitting, isValid } = this.props
+    const { isSubmitting: prevIsSubmitting } = prevProps
+
+    // Scroll invalid fields into view if needed and focus them
+    if (!prevIsSubmitting && isSubmitting && !isValid) {
+      const firstErrorNode = document.querySelectorAll('[data-needs-focus="true"]')[0]
+      if (firstErrorNode) {
+        scrollIntoView(firstErrorNode, { behavior: 'smooth' })
+        firstErrorNode.querySelector('input,textarea').focus({ preventScroll: true })
+      }
+    }
+  }
+
   render () {
     const {
       className,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3749,6 +3749,11 @@ compression@^1.7.4:
     safe-buffer "5.1.2"
     vary "~1.1.2"
 
+compute-scroll-into-view@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.11.tgz#7ff0a57f9aeda6314132d8994cce7aeca794fecf"
+  integrity sha512-uUnglJowSe0IPmWOdDtrlHXof5CTIJitfJEyITHBW6zDVOGu9Pjk5puaLM73SLcwak0L4hEjO7Td88/a6P5i7A==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -10531,6 +10536,13 @@ schema-utils@^1.0.0:
     ajv "^6.1.0"
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
+
+scroll-into-view-if-needed@^2.2.20:
+  version "2.2.20"
+  resolved "https://registry.yarnpkg.com/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.20.tgz#3a46847a72233a3af9770e55df450f2a7f2e2a0e"
+  integrity sha512-P9kYMrhi9f6dvWwTGpO5I3HgjSU/8Mts7xL3lkoH5xlewK7O9Obdc5WmMCzppln7bCVGNmf3qfoZXrpCeyNJXw==
+  dependencies:
+    compute-scroll-into-view "1.0.11"
 
 seamless-immutable@^7.1.2, seamless-immutable@^7.1.3:
   version "7.1.4"


### PR DESCRIPTION
#### Summary
This draft PR is a suggestion for a simple solution to scroll form errors into view.

#### Changes
- Add `scroll-into-view-if needed` package (somehow smooth scrolling works for me with this now)
- Add a data attribute to fields, holding whether they are valid or not
- Use this info to scroll the first item that has the error data attribute into view on form submits
- Additionally focus the input
- Scroll form notifications into view if necessary

#### Notes for Reviewers
It's a suggestion for implementation. It sort of leaves the react scope at times to achieve the effect, but I think it is fair here because it enables us having this essential functionality without a lot of logic necessary.


