### PR TITLE
Fix error reducer

### DIFF
--- a/pkg/webui/console/store/reducers/tests/error_test.js
+++ b/pkg/webui/console/store/reducers/tests/error_test.js
@@ -19,6 +19,7 @@ describe('error reducers', function () {
   const REQUEST = `${BASE}_REQUEST`
   const SUCCESS = `${BASE}_SUCCESS`
   const FAILURE = `${BASE}_FAILURE`
+  const defaultState = {}
 
   it('should return the initial state', function () {
     expect(reducer(undefined, {})).toEqual({})
@@ -26,21 +27,25 @@ describe('error reducers', function () {
 
   describe('dispatches invalid action type', function () {
     it('should ignore base type', function () {
-      expect(reducer({}, { type: BASE })).toEqual({})
+      expect(reducer(defaultState, { type: BASE })).toEqual(defaultState)
     })
   })
 
   describe('dispatches the `failure` action', function () {
+    const error = { status: 404 }
+    let newState
+
+    beforeAll(function () {
+      newState = reducer(defaultState, { type: FAILURE, payload: error, error: true })
+    })
+
     it('should set error', function () {
-      const error = { status: 404 }
-      expect(reducer({}, { type: FAILURE, payload: error, error: true })).toEqual({
-        [BASE]: error,
-      })
+      expect(newState).toEqual({ [BASE]: error })
     })
 
     describe('dispatches the `success` action', function () {
       it('should reset the error', function () {
-        expect(reducer({}, { type: SUCCESS })).toEqual({
+        expect(reducer(newState, { type: SUCCESS })).toEqual({
           [BASE]: undefined,
         })
       })
@@ -48,7 +53,7 @@ describe('error reducers', function () {
 
     describe('dispatches the `request` action', function () {
       it('should reset the error', function () {
-        expect(reducer({}, { type: REQUEST })).toEqual({
+        expect(reducer(newState, { type: REQUEST })).toEqual({
           [BASE]: undefined,
         })
       })

--- a/pkg/webui/console/store/reducers/ui/error.js
+++ b/pkg/webui/console/store/reducers/ui/error.js
@@ -16,14 +16,14 @@ const error = function (state = {}, action) {
   const { type, error, payload: errorValue } = action
 
   const matches = /(.*)_(REQUEST|SUCCESS|FAILURE)/.exec(type)
-  if (!matches || !error) {
+  if (!matches) {
     return state
   }
 
   const [ , key, status ] = matches
   return {
     ...state,
-    [key]: status === 'FAILURE' ? errorValue : undefined,
+    [key]: status === 'FAILURE' && error ? errorValue : undefined,
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes tests for the error reducer as well fixes an issue with removing the error value from the store on `request` and `success` actions

#### Changes
<!-- What are the changes made in this pull request? -->

- Adjust tests
- Dont require the `error` property to be `true` to clean up the error entry from the store
- Require the `error` property to be `true` when setting the error.