### PR TITLE
Fix issues with passing errors to device data form

### DIFF
--- a/pkg/webui/console/views/device-add/index.js
+++ b/pkg/webui/console/views/device-add/index.js
@@ -27,6 +27,7 @@ import DeviceDataForm from '../../containers/device-data-form'
 import api from '../../api'
 
 import sharedMessages from '../../../lib/shared-messages'
+import errorMessages from '../../../lib/errors/error-messages'
 
 import style from './device-add.styl'
 
@@ -79,7 +80,7 @@ export default class DeviceAdd extends Component {
       dispatch(push(`/console/applications/${appId}/devices/${device_id}`))
     } catch (error) {
       resetForm(values)
-      const err = error instanceof Error ? sharedMessages.genericError : error
+      const err = error instanceof Error ? errorMessages.genericError : error
 
       await this.setState({ error: err })
     }

--- a/pkg/webui/console/views/device-general-settings/index.js
+++ b/pkg/webui/console/views/device-general-settings/index.js
@@ -19,6 +19,7 @@ import bind from 'autobind-decorator'
 import { defineMessages } from 'react-intl'
 
 import sharedMessages from '../../../lib/shared-messages'
+import errorMessages from '../../../lib/errors/error-messages'
 import diff from '../../../lib/diff'
 
 import DeviceDataForm from '../../containers/device-data-form'
@@ -78,7 +79,7 @@ export default class DeviceGeneralSettings extends React.Component {
       })
     } catch (error) {
       resetForm()
-      const err = error instanceof Error ? sharedMessages.genericError : error
+      const err = error instanceof Error ? errorMessages.genericError : error
       await this.setState({ error: err })
     }
   }


### PR DESCRIPTION
#### Summary
Fixes a faulty message reference, which resulted in generic error messages not showing when creating/updating devices.

#### Changes
- Fix references of the generic error messages
