### PR TITLE
Fix dev_addr handling in device update/create

### DIFF
--- a/pkg/webui/console/views/device-add/index.js
+++ b/pkg/webui/console/views/device-add/index.js
@@ -62,9 +62,6 @@ export default class DeviceAdd extends Component {
       delete device.ids.dev_eui
       delete device.root_keys
       delete device.resets_join_nonces
-      if (device.session.dev_addr) {
-        device.ids.dev_addr = device.session.dev_addr
-      }
     }
     delete device.activation_mode
 

--- a/pkg/webui/console/views/device-general-settings/index.js
+++ b/pkg/webui/console/views/device-general-settings/index.js
@@ -59,9 +59,6 @@ export default class DeviceGeneralSettings extends React.Component {
       delete updatedDevice.ids.dev_eui
       delete updatedDevice.root_keys
       delete updatedDevice.resets_join_nonces
-      if (updatedDevice.session.dev_addr) {
-        updatedDevice.ids.dev_addr = updatedDevice.session.dev_addr
-      }
     }
 
     await this.setState({ error: '' })


### PR DESCRIPTION
#### Summary
This PR fixes errors in device create/update form, when setting a `dev_addr` — originating from the console setting this value both in `session.dev_addr` and `ids.dev_addr`, while only `session.dev_addr` is necessary. Setting the value in `ids.dev_addr` results in a backend error.

#### Changes
- Remove propagation of the `dev_addr` value into `ids.dev_addr`
