### PR TITLE
Return ErrNotFound on deleting not found membership

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -3266,6 +3266,15 @@
       "file": "invitation_store.go"
     }
   },
+  "error:pkg/identityserver/store:membership_not_found": {
+    "translations": {
+      "en": "account `{account_id}` is not a member of `{entity_type}` `{entity_id}`"
+    },
+    "description": {
+      "package": "pkg/identityserver/store",
+      "file": "membership_store.go"
+    }
+  },
   "error:pkg/identityserver/store:multiple_application_ids": {
     "translations": {
       "en": "can not list devices for multiple application IDs"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR closes #942 by returning an ErrNotFound when a caller tries to delete a membership that isn't found in the database.

#### Changes
<!-- What are the changes made in this pull request? -->

- Defined `errMembershipNotFound` that is returned when deleting a membership that isn't actually there.

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Fixed the error that is returned when deleting a collaborator fails.
