### PR TITLE
Fix metrics prefix and gRPC labels

### DIFF
--- a/pkg/metrics/grpc.go
+++ b/pkg/metrics/grpc.go
@@ -19,7 +19,7 @@ import (
 	"net"
 	"runtime/pprof"
 
-	"github.com/grpc-ecosystem/go-grpc-prometheus"
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/stats"
@@ -61,7 +61,7 @@ var gRPCStats = statsHandler{
 			Name:      "client_conns_opened_total",
 			Help:      "Opened client connections",
 		},
-		[]string{"server_address"},
+		[]string{"remote_address"},
 	),
 	closedClientConns: NewContextualCounterVec(
 		prometheus.CounterOpts{
@@ -69,7 +69,7 @@ var gRPCStats = statsHandler{
 			Name:      "client_conns_closed_total",
 			Help:      "Closed client connections",
 		},
-		[]string{"server_address"},
+		[]string{"remote_address"},
 	),
 	openedServerConns: NewContextualCounterVec(
 		prometheus.CounterOpts{
@@ -77,7 +77,7 @@ var gRPCStats = statsHandler{
 			Name:      "server_conns_opened_total",
 			Help:      "Opened server connections",
 		},
-		[]string{"server_address"},
+		[]string{"remote_address"},
 	),
 	closedServerConns: NewContextualCounterVec(
 		prometheus.CounterOpts{
@@ -85,7 +85,7 @@ var gRPCStats = statsHandler{
 			Name:      "server_conns_closed_total",
 			Help:      "Closed server connections",
 		},
-		[]string{"server_address"},
+		[]string{"remote_address"},
 	),
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -23,7 +23,7 @@ import (
 )
 
 // Namespace for metrics.
-const Namespace = "ttn"
+const Namespace = "ttn_lw"
 
 // ContextLabelNames are the label names that can be retrieved from a context for XXXVec metrics.
 var ContextLabelNames []string


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quickfix for incorrect metrics prefix and gRPC labels (it used `server_addresss` for client addresses.

#### Changes
<!-- What are the changes made in this pull request? -->

- Use `ttn_lw` metrics prefix instead of `ttn`
- Use `remote_address` for gRPC connection metrics labels

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

~We may want to get rid of the `remote_address` label for `server_conns_{opened,closed}_total` to reduce the number of series that we'll export.~

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Changed the prefix of Prometheus metrics from `ttn_` to `ttn_lw_`
- Removed the address label from Prometheus metric `grpc_server_conns_{opened,closed}_total`
- Renamed the label `server_address` of Prometheus metrics `grpc_client_conns_{opened,closed}_total` to `remote_address`
