### PR TITLE
Write newline between template-formatted output of CLI

### DIFF
--- a/cmd/ttn-lw-cli/internal/io/io.go
+++ b/cmd/ttn-lw-cli/internal/io/io.go
@@ -57,6 +57,7 @@ func Write(w io.Writer, format string, data interface{}) (err error) {
 		if err != nil {
 			return err
 		}
+		sep = []byte("\n")
 		writeItem = func(v interface{}) error {
 			return tmpl.Execute(w, v)
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quickfix for the CLI, which wouldn't write newlines between template-formatted items.

#### Changes
<!-- What are the changes made in this pull request? -->

- Set a `\n` separator in the template formatter of the CLI

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This does not influence JSON rendering from the CLI.

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Added a newline between list items returned from the CLI when using a custom `--output-format` template.
