### PR TITLE
Fix goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,8 @@ release:
   prerelease: auto
 
 builds:
-  - main: ./cmd/ttn-lw-stack
+  - id: stack
+    main: ./cmd/ttn-lw-stack
     binary: ttn-lw-stack
     ldflags:
     - -s
@@ -30,7 +31,8 @@ builds:
       - 6
       - 7
 
-  - main: ./cmd/ttn-lw-cli
+  - id: cli
+    main: ./cmd/ttn-lw-cli
     binary: ttn-lw-cli
     ldflags:
     - -s

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,11 @@
 project_name: lorawan-stack
 
+changelog:
+  skip: true
+
+release:
+  prerelease: auto
+
 builds:
   - main: ./cmd/ttn-lw-stack
     binary: ttn-lw-stack
@@ -47,71 +53,65 @@ builds:
       - 6
       - 7
 
-archive:
-  files:
-    - LICENSE
-    - README.md
-    - doc/**/*
-    - docker-compose.yml
-    - public/**/*
-  wrap_in_directory: true
-  format_overrides:
-    - goos: windows
-      format: zip
+archives:
+  - files:
+      - LICENSE
+      - README.md
+      - doc/**/*
+      - docker-compose.yml
+      - public/**/*
+    wrap_in_directory: true
+    format_overrides:
+      - goos: windows
+        format: zip
 
-changelog:
-  skip: true
+nfpms:
+  - vendor: The Things Network
+    homepage: https://www.thethingsnetwork.org
+    maintainer: The Things Network Foundation <stack@thethingsnetwork.org>
+    description: The Things Network Stack for LoRaWAN
+    license: Apache 2.0
+    formats:
+      - deb
+      - rpm
+    recommends:
+      - redis
+      - cockroach
+    files:
+      "public/**/*": "/srv/ttn-lorawan/public"
 
-release:
-  prerelease: auto
+snapcrafts:
+  - name: ttn-lw-stack
+    summary: The Things Network Stack for LoRaWAN
+    description: The Things Network Stack for LoRaWAN
+    grade: stable
+    confinement: strict
+    publish: true
+    apps:
+      ttn-lw-stack:
+        plugs: [ home, network, network-bind ]
+      ttn-lw-cli:
+        plugs: [ home, network, network-bind ]
 
-nfpm:
-  vendor: The Things Network
-  homepage: https://www.thethingsnetwork.org
-  maintainer: The Things Network Foundation <stack@thethingsnetwork.org>
-  description: The Things Network Stack for LoRaWAN
-  license: Apache 2.0
-  formats:
-    - deb
-    - rpm
-  recommends:
-    - redis
-    - cockroach
-  files:
-    "public/**/*": "/srv/ttn-lorawan/public"
-
-snapcraft:
-  name: ttn-lw-stack
-  summary: The Things Network Stack for LoRaWAN
-  description: The Things Network Stack for LoRaWAN
-  grade: stable
-  confinement: strict
-  publish: true
-  apps:
-    ttn-lw-stack:
-      plugs: [ home, network, network-bind ]
-    ttn-lw-cli:
-      plugs: [ home, network, network-bind ]
-
-# TODO: Generate separate formulas for stack+CLI and CLI only.(https://github.com/TheThingsNetwork/lorawan-stack/issues/108)
-brew:
-  name: ttn-lw-stack
-  github:
-    owner: TheThingsNetwork
-    name: homebrew-lorawan-stack
-  commit_author:
-    name: ttn-ci
-    email: stack@thethingsnetwork.org
-  homepage: https://www.thethingsnetwork.org
-  description: The Things Network Stack for LoRaWAN
-  skip_upload: auto
-  install: |
-    bin.install "ttn-lw-cli"
-    libexec.install %w[ttn-lw-stack public doc]
-    env = {
-        :TTN_LW_HTTP_STATIC_SEARCH_PATH => libexec/"public"
-    }
-    (bin/"ttn-lw-stack").write_env_script libexec/"ttn-lw-stack", env
+brews:
+  # TODO: Generate separate formulas for stack+CLI and CLI only.(https://github.com/TheThingsNetwork/lorawan-stack/issues/108)
+  - name: ttn-lw-stack
+    github:
+      owner: TheThingsNetwork
+      name: homebrew-lorawan-stack
+    commit_author:
+      name: ttn-ci
+      email: stack@thethingsnetwork.org
+    homepage: https://www.thethingsnetwork.org
+    description: The Things Network Stack for LoRaWAN
+    skip_upload: auto
+    install: |
+      bin.install "ttn-lw-cli"
+      libexec.install %w[ttn-lw-stack public doc]
+      env = {
+          :TTN_LW_HTTP_STATIC_SEARCH_PATH => libexec/"public"
+      }
+      (bin/"ttn-lw-stack").write_env_script libexec/"ttn-lw-stack", env
 
 dockers:
   - goos: linux


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #966 
I suppose the issue was caused by https://github.com/goreleaser/goreleaser/pull/1008, even though the binary names were different.

#### Changes
<!-- What are the changes made in this pull request? -->

- Stop using legacy config options(https://goreleaser.com/deprecations/)
- Add IDs to binary builds(https://github.com/goreleaser/goreleaser/pull/1008)