### PR TITLE
Document context filling and clarify use

### DIFF
--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -198,11 +198,6 @@ func (as *ApplicationServer) Roles() []ttnpb.PeerInfo_Role {
 	return []ttnpb.PeerInfo_Role{ttnpb.PeerInfo_APPLICATION_SERVER}
 }
 
-// FillApplicationContext fills the given context and identifiers.
-func (as *ApplicationServer) FillApplicationContext(ctx context.Context, ids ttnpb.ApplicationIdentifiers) (context.Context, ttnpb.ApplicationIdentifiers, error) {
-	return as.FillContext(ctx), ids, nil
-}
-
 // Subscribe subscribes an application or integration by its identifiers to the Application Server, and returns a
 // io.Subscription for traffic and control.
 func (as *ApplicationServer) Subscribe(ctx context.Context, protocol string, ids ttnpb.ApplicationIdentifiers) (*io.Subscription, error) {

--- a/pkg/applicationserver/io/grpc/grpc_test.go
+++ b/pkg/applicationserver/io/grpc/grpc_test.go
@@ -51,7 +51,6 @@ func TestAuthentication(t *testing.T) {
 	is, isAddr := startMockIS(ctx)
 	is.add(ctx, registeredApplicationID, registeredApplicationKey)
 
-	as := mock.NewServer()
 	c := component.MustNew(test.GetLogger(t), &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
@@ -63,6 +62,7 @@ func TestAuthentication(t *testing.T) {
 			},
 		},
 	})
+	as := mock.NewServer(c)
 	srv := New(as)
 	c.RegisterGRPC(&mockRegisterer{ctx, srv})
 	test.Must(nil, c.Start())
@@ -138,7 +138,6 @@ func TestTraffic(t *testing.T) {
 	is, isAddr := startMockIS(ctx)
 	is.add(ctx, registeredApplicationID, registeredApplicationKey)
 
-	as := mock.NewServer()
 	c := component.MustNew(test.GetLogger(t), &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
@@ -150,6 +149,7 @@ func TestTraffic(t *testing.T) {
 			},
 		},
 	})
+	as := mock.NewServer(c)
 	srv := New(as)
 	c.RegisterGRPC(&mockRegisterer{ctx, srv})
 	test.Must(nil, c.Start())

--- a/pkg/applicationserver/io/io.go
+++ b/pkg/applicationserver/io/io.go
@@ -27,9 +27,8 @@ const bufferSize = 32
 // Server represents the Application Server to gateway frontends.
 type Server interface {
 	// FillContext fills the given context.
+	// This method should only be used for request contexts.
 	FillContext(ctx context.Context) context.Context
-	// FillApplicationContext fills the given context and identifiers.
-	FillApplicationContext(ctx context.Context, ids ttnpb.ApplicationIdentifiers) (context.Context, ttnpb.ApplicationIdentifiers, error)
 	// Subscribe subscribes an application or integration by its identifiers to the Application Server, and returns a
 	// Subscription for traffic and control.
 	Subscribe(ctx context.Context, protocol string, ids ttnpb.ApplicationIdentifiers) (*Subscription, error)

--- a/pkg/applicationserver/io/mock/server.go
+++ b/pkg/applicationserver/io/mock/server.go
@@ -20,11 +20,13 @@ import (
 
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
+	"go.thethings.network/lorawan-stack/pkg/component"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/unique"
 )
 
 type server struct {
+	*component.Component
 	subscriptionsCh chan *io.Subscription
 	downlinkQueueMu sync.RWMutex
 	downlinkQueue   map[string][]*ttnpb.ApplicationDownlink
@@ -38,8 +40,9 @@ type Server interface {
 }
 
 // NewServer instantiates a new Server.
-func NewServer() Server {
+func NewServer(c *component.Component) Server {
 	return &server{
+		Component:       c,
 		subscriptionsCh: make(chan *io.Subscription, 10),
 		downlinkQueue:   make(map[string][]*ttnpb.ApplicationDownlink),
 	}
@@ -47,12 +50,7 @@ func NewServer() Server {
 
 // FillContext implements io.Server.
 func (s *server) FillContext(ctx context.Context) context.Context {
-	return ctx
-}
-
-// FillApplicationContext implements io.Server.
-func (s *server) FillApplicationContext(ctx context.Context, ids ttnpb.ApplicationIdentifiers) (context.Context, ttnpb.ApplicationIdentifiers, error) {
-	return ctx, ids, nil
+	return s.Component.FillContext(ctx)
 }
 
 // Subscribe implements io.Server.

--- a/pkg/applicationserver/io/mqtt/mqtt.go
+++ b/pkg/applicationserver/io/mqtt/mqtt.go
@@ -226,7 +226,7 @@ func (c *connection) Connect(ctx context.Context, info *auth.Info) (context.Cont
 	}
 	ctx = metadata.NewIncomingContext(ctx, md)
 
-	ctx, ids, err = c.server.FillApplicationContext(ctx, ids)
+	ctx = c.server.FillContext(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/applicationserver/io/mqtt/mqtt_test.go
+++ b/pkg/applicationserver/io/mqtt/mqtt_test.go
@@ -73,12 +73,12 @@ func TestAuthentication(t *testing.T) {
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.PeerInfo_ENTITY_REGISTRY)
 
-	as := mock.NewServer()
+	as := mock.NewServer(c)
 	lis, err := net.Listen("tcp", ":0")
 	if !a.So(err, should.BeNil) {
 		t.FailNow()
 	}
-	Start(c.FillContext(ctx), as, lis, JSON, "tcp")
+	Start(c.Context(), as, lis, JSON, "tcp")
 
 	for _, tc := range []struct {
 		UID string
@@ -147,12 +147,12 @@ func TestTraffic(t *testing.T) {
 
 	mustHavePeer(ctx, c, ttnpb.PeerInfo_ENTITY_REGISTRY)
 
-	as := mock.NewServer()
+	as := mock.NewServer(c)
 	lis, err := net.Listen("tcp", ":0")
 	if !a.So(err, should.BeNil) {
 		t.FailNow()
 	}
-	Start(c.FillContext(ctx), as, lis, JSON, "tcp")
+	Start(c.Context(), as, lis, JSON, "tcp")
 
 	clientOpts := mqtt.NewClientOptions()
 	clientOpts.AddBroker(fmt.Sprintf("tcp://%v", lis.Addr()))

--- a/pkg/applicationserver/io/pubsub/integrate_test.go
+++ b/pkg/applicationserver/io/pubsub/integrate_test.go
@@ -78,7 +78,6 @@ func TestIntegrate(t *testing.T) {
 	})
 	a.So(err, should.BeNil)
 
-	io := mock_server.NewServer()
 	c := component.MustNew(test.GetLogger(t), &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
@@ -90,6 +89,7 @@ func TestIntegrate(t *testing.T) {
 			},
 		},
 	})
+	io := mock_server.NewServer(c)
 	srv, err := pubsub.New(c, io, pubsubRegistry)
 	if !a.So(err, should.BeNil) {
 		t.FailNow()

--- a/pkg/applicationserver/io/pubsub/pubsub_test.go
+++ b/pkg/applicationserver/io/pubsub/pubsub_test.go
@@ -124,8 +124,8 @@ func TestPubSub(t *testing.T) {
 	a.So(err, should.BeNil)
 	mockImpl := mockProvider.(*mock_provider.Impl)
 
-	io := mock_server.NewServer()
 	c := component.MustNew(test.GetLogger(t), &component.Config{})
+	io := mock_server.NewServer(c)
 	_, err = pubsub.New(c, io, registry)
 	if !a.So(err, should.BeNil) {
 		t.FailNow()

--- a/pkg/applicationserver/io/web/webhooks_test.go
+++ b/pkg/applicationserver/io/web/webhooks_test.go
@@ -340,7 +340,7 @@ func TestWebhooks(t *testing.T) {
 			},
 		}
 		c := component.MustNew(test.GetLogger(t), conf)
-		io := mock.NewServer()
+		io := mock.NewServer(c)
 		testSink := &mockSink{
 			Component: c,
 			Server:    io,

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -204,6 +204,7 @@ func (c *Component) GetBaseConfig(ctx context.Context) config.ServiceBase {
 }
 
 // FillContext fills the context.
+// This method should only be used for request contexts.
 func (c *Component) FillContext(ctx context.Context) context.Context {
 	for _, filler := range c.fillers {
 		ctx = filler(ctx)

--- a/pkg/gatewayconfigurationserver/gatewayconfigurationserver.go
+++ b/pkg/gatewayconfigurationserver/gatewayconfigurationserver.go
@@ -101,8 +101,7 @@ func (gcs *GatewayConfigurationServer) handleGetGlobalConfig(c echo.Context) err
 }
 
 func (gcs *GatewayConfigurationServer) getContext(c echo.Context) context.Context {
-	ctx := c.Request().Context()
-	ctx = gcs.FillContext(ctx)
+	ctx := gcs.FillContext(c.Request().Context())
 	md := metadata.New(map[string]string{
 		"authorization": c.Request().Header.Get(echo.HeaderAuthorization),
 	})

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -204,6 +204,7 @@ var (
 )
 
 // FillGatewayContext fills the given context and identifiers.
+// This method should only be used for request contexts.
 func (gs *GatewayServer) FillGatewayContext(ctx context.Context, ids ttnpb.GatewayIdentifiers) (context.Context, ttnpb.GatewayIdentifiers, error) {
 	ctx = gs.FillContext(ctx)
 	if ids.IsZero() {

--- a/pkg/gatewayserver/io/grpc/grpc.go
+++ b/pkg/gatewayserver/io/grpc/grpc.go
@@ -47,14 +47,14 @@ func (s *impl) LinkGateway(link ttnpb.GtwGs_LinkGatewayServer) (err error) {
 	ids := ttnpb.GatewayIdentifiers{
 		GatewayID: rpcmetadata.FromIncomingContext(ctx).ID,
 	}
+	ctx, ids, err = s.server.FillGatewayContext(ctx, ids)
+	if err != nil {
+		return
+	}
 	if err = ids.ValidateContext(ctx); err != nil {
 		return
 	}
 	if err = rights.RequireGateway(ctx, ids, ttnpb.RIGHT_GATEWAY_LINK); err != nil {
-		return
-	}
-	ctx, ids, err = s.server.FillGatewayContext(ctx, ids)
-	if err != nil {
 		return
 	}
 

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -37,6 +37,7 @@ const (
 // Server represents the Gateway Server to gateway frontends.
 type Server interface {
 	// FillGatewayContext fills the given context and identifiers.
+	// This method should only be used for request contexts.
 	FillGatewayContext(ctx context.Context, ids ttnpb.GatewayIdentifiers) (context.Context, ttnpb.GatewayIdentifiers, error)
 	// Connect connects a gateway by its identifiers to the Gateway Server, and returns a Connection for traffic and
 	// control.

--- a/pkg/gatewayserver/io/io_test.go
+++ b/pkg/gatewayserver/io/io_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
+	"go.thethings.network/lorawan-stack/pkg/component"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/gatewayserver/io"
 	"go.thethings.network/lorawan-stack/pkg/gatewayserver/io/mock"
@@ -39,7 +40,8 @@ func Test(t *testing.T) {
 	a := assertions.New(t)
 	ctx := log.NewContext(test.Context(), test.GetLogger(t))
 
-	gs := mock.NewServer()
+	c := component.MustNew(test.GetLogger(t), &component.Config{})
+	gs := mock.NewServer(c)
 
 	ids := ttnpb.GatewayIdentifiers{GatewayID: "foo-gateway"}
 	antennaGain := float32(3)

--- a/pkg/gatewayserver/io/mock/server.go
+++ b/pkg/gatewayserver/io/mock/server.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
+	"go.thethings.network/lorawan-stack/pkg/component"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/frequencyplans"
 	"go.thethings.network/lorawan-stack/pkg/gatewayserver/io"
@@ -31,6 +32,7 @@ import (
 )
 
 type server struct {
+	*component.Component
 	store          *frequencyplans.Store
 	gateways       map[string]*ttnpb.Gateway
 	connections    map[string]*io.Connection
@@ -49,8 +51,9 @@ type Server interface {
 }
 
 // NewServer instantiates a new Server.
-func NewServer() Server {
+func NewServer(c *component.Component) Server {
 	return &server{
+		Component:     c,
 		store:         frequencyplans.NewStore(test.FrequencyPlansFetcher),
 		gateways:      make(map[string]*ttnpb.Gateway),
 		connections:   make(map[string]*io.Connection),
@@ -60,6 +63,7 @@ func NewServer() Server {
 
 // FillContext implements io.Server.
 func (s *server) FillGatewayContext(ctx context.Context, ids ttnpb.GatewayIdentifiers) (context.Context, ttnpb.GatewayIdentifiers, error) {
+	ctx = s.FillContext(ctx)
 	if ids.IsZero() {
 		return nil, ttnpb.GatewayIdentifiers{}, errors.New("the identifiers are zero")
 	}

--- a/pkg/gatewayserver/io/mqtt/mqtt_util_test.go
+++ b/pkg/gatewayserver/io/mqtt/mqtt_util_test.go
@@ -16,27 +16,92 @@ package mqtt_test
 
 import (
 	"context"
+	"fmt"
+	"net"
+	"time"
 
-	"go.thethings.network/lorawan-stack/pkg/auth/rights"
-	"go.thethings.network/lorawan-stack/pkg/rpcmetadata"
+	"go.thethings.network/lorawan-stack/pkg/component"
+	"go.thethings.network/lorawan-stack/pkg/errors"
+	"go.thethings.network/lorawan-stack/pkg/rpcserver"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/unique"
+	"google.golang.org/grpc/metadata"
 )
 
-func newContextWithRightsFetcher(ctx context.Context) context.Context {
-	return rights.NewContextWithFetcher(
-		ctx,
-		rights.FetcherFunc(func(ctx context.Context, ids ttnpb.Identifiers) (set *ttnpb.Rights, err error) {
-			uid := unique.ID(ctx, ids)
-			if uid != registeredGatewayUID {
-				return
-			}
-			md := rpcmetadata.FromIncomingContext(ctx)
-			if md.AuthType != "Bearer" || md.AuthValue != registeredGatewayKey {
-				return
-			}
-			set = ttnpb.RightsFrom(ttnpb.RIGHT_GATEWAY_LINK)
+func mustHavePeer(ctx context.Context, c *component.Component, role ttnpb.PeerInfo_Role) {
+	for i := 0; i < 20; i++ {
+		time.Sleep(20 * time.Millisecond)
+		if peer := c.GetPeer(ctx, role, nil); peer != nil {
 			return
-		}),
-	)
+		}
+	}
+	panic("could not connect to peer")
+}
+
+type mockIS struct {
+	ttnpb.GatewayRegistryServer
+	ttnpb.GatewayAccessServer
+	gateways     map[string]*ttnpb.Gateway
+	gatewayAuths map[string][]string
+}
+
+func startMockIS(ctx context.Context) (*mockIS, string) {
+	is := &mockIS{
+		gateways:     make(map[string]*ttnpb.Gateway),
+		gatewayAuths: make(map[string][]string),
+	}
+	srv := rpcserver.New(ctx)
+	ttnpb.RegisterGatewayRegistryServer(srv.Server, is)
+	ttnpb.RegisterGatewayAccessServer(srv.Server, is)
+	lis, err := net.Listen("tcp", ":0")
+	if err != nil {
+		panic(err)
+	}
+	go srv.Serve(lis)
+	return is, lis.Addr().String()
+}
+
+func (is *mockIS) add(ctx context.Context, ids ttnpb.GatewayIdentifiers, key string) {
+	uid := unique.ID(ctx, ids)
+	is.gateways[uid] = &ttnpb.Gateway{
+		GatewayIdentifiers: ids,
+	}
+	if key != "" {
+		is.gatewayAuths[uid] = []string{fmt.Sprintf("Bearer %v", key)}
+	}
+}
+
+var errNotFound = errors.DefineNotFound("not_found", "not found")
+
+func (is *mockIS) Get(ctx context.Context, req *ttnpb.GetGatewayRequest) (*ttnpb.Gateway, error) {
+	uid := unique.ID(ctx, req.GatewayIdentifiers)
+	app, ok := is.gateways[uid]
+	if !ok {
+		return nil, errNotFound
+	}
+	return app, nil
+}
+
+func (is *mockIS) ListRights(ctx context.Context, ids *ttnpb.GatewayIdentifiers) (res *ttnpb.Rights, err error) {
+	res = &ttnpb.Rights{}
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return
+	}
+	authorization, ok := md["authorization"]
+	if !ok || len(authorization) == 0 {
+		return
+	}
+	auths, ok := is.gatewayAuths[unique.ID(ctx, *ids)]
+	if !ok {
+		return
+	}
+	for _, auth := range auths {
+		if auth == authorization[0] {
+			res.Rights = append(res.Rights,
+				ttnpb.RIGHT_GATEWAY_LINK,
+			)
+		}
+	}
+	return
 }

--- a/pkg/gatewayserver/io/udp/udp_test.go
+++ b/pkg/gatewayserver/io/udp/udp_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/pkg/component"
 	"go.thethings.network/lorawan-stack/pkg/gatewayserver/io"
 	"go.thethings.network/lorawan-stack/pkg/gatewayserver/io/mock"
 	. "go.thethings.network/lorawan-stack/pkg/gatewayserver/io/udp"
@@ -57,8 +58,13 @@ func TestConnection(t *testing.T) {
 
 	ctx := log.NewContext(test.Context(), test.GetLogger(t))
 	ctx, cancelCtx := context.WithCancel(ctx)
+	defer cancelCtx()
 
-	gs := mock.NewServer()
+	c := component.MustNew(test.GetLogger(t), &component.Config{})
+	test.Must(nil, c.Start())
+	defer c.Close()
+
+	gs := mock.NewServer(c)
 	addr, _ := net.ResolveUDPAddr("udp", ":0")
 	lis, err := net.ListenUDP("udp", addr)
 	if !a.So(err, should.BeNil) {
@@ -191,8 +197,13 @@ func TestTraffic(t *testing.T) {
 
 	ctx := log.NewContext(test.Context(), test.GetLogger(t))
 	ctx, cancelCtx := context.WithCancel(ctx)
+	defer cancelCtx()
 
-	gs := mock.NewServer()
+	c := component.MustNew(test.GetLogger(t), &component.Config{})
+	test.Must(nil, c.Start())
+	defer c.Close()
+
+	gs := mock.NewServer(c)
 	addr, _ := net.ResolveUDPAddr("udp", ":0")
 	lis, err := net.ListenUDP("udp", addr)
 	if !a.So(err, should.BeNil) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Clean fix for #951 and ensure that it doesn't happen again

#### Changes
<!-- What are the changes made in this pull request? -->

- Document that `FillContext()` should only be used for request contexts
- Practice what we preach in GS and AS testing
- Harmonize GS MQTT testing with AS
- Minor cleanups of unused application context filling in AS