### PR TITLE
Fix error handling of event streams

### DIFF
--- a/pkg/webui/components/events/index.js
+++ b/pkg/webui/components/events/index.js
@@ -18,6 +18,7 @@ import classnames from 'classnames'
 import { defineMessages } from 'react-intl'
 
 import Button from '../button'
+import Notification from '../notification'
 import Message from '../../lib/components/message'
 import List from '../list'
 import Icon from '../icon'
@@ -110,8 +111,13 @@ class Events extends React.Component {
       onClear,
       emitterId,
       limit,
+      error,
     } = this.props
     const { paused } = this.state
+
+    if (error) {
+      return <Notification title={sharedMessages.eventsCannotShow} error={error} />
+    }
 
     let limitedEvents = events
     const truncated = events.length > limit

--- a/pkg/webui/components/events/widget/index.js
+++ b/pkg/webui/components/events/widget/index.js
@@ -20,6 +20,7 @@ import Link from '../../link'
 import Message from '../../../lib/components/message'
 import Status from '../../status'
 import List from '../../list'
+import Notification from '../../notification'
 import PropTypes from '../../../lib/prop-types'
 import getEventComponentByName from '../../event/types'
 
@@ -58,6 +59,7 @@ class EventsWidget extends React.PureComponent {
       emitterId,
       connectionStatus,
       limit,
+      error,
     } = this.props
 
     let latestActivityTime = null
@@ -90,23 +92,30 @@ class EventsWidget extends React.PureComponent {
             label={statusMessage}
             status={connectionStatus}
           />
-          <Link to={toAllUrl}>
-            <Message
-              className={style.seeAllMessage}
-              content={m.seeAllActivity}
-            />
-            →
-          </Link>
+          {!error && (
+            <Link to={toAllUrl}>
+              <Message
+                className={style.seeAllMessage}
+                content={m.seeAllActivity}
+              />
+              →
+            </Link>
+          )}
         </div>
-        <List
-          bordered
-          listClassName={style.list}
-          size="small"
-          items={truncatedEvents}
-          renderItem={this.renderEvent}
-          emptyMessage={sharedMessages.noEvents}
-          emptyMessageValues={{ entityId: emitterId }}
-        />
+        {error
+          ? <Notification small title={sharedMessages.eventsCannotShow} error={error} />
+          : (
+            <List
+              bordered
+              listClassName={style.list}
+              size="small"
+              items={truncatedEvents}
+              renderItem={this.renderEvent}
+              emptyMessage={sharedMessages.noEvents}
+              emptyMessageValues={{ entityId: emitterId }}
+            />
+          )
+        }
       </aside>
     )
   }

--- a/pkg/webui/console/constants/connection-status.js
+++ b/pkg/webui/console/constants/connection-status.js
@@ -17,4 +17,5 @@ export default Object.freeze({
   DISCONNECTED: 'disconnected',
   CONNECTING: 'connecting',
   UNKNOWN: 'unknown',
+  ERROR: 'error',
 })

--- a/pkg/webui/console/containers/application-events/index.js
+++ b/pkg/webui/console/containers/application-events/index.js
@@ -26,6 +26,7 @@ import {
 import {
   selectApplicationEvents,
   selectApplicationEventsStatus,
+  selectApplicationEventsError,
 } from '../../store/selectors/applications'
 
 @connect(
@@ -34,7 +35,18 @@ import {
     onClear: () => dispatch(clearApplicationEventsStream(ownProps.appId)),
   }))
 @bind
-class ApplicationEvents extends React.Component {
+export default class ApplicationEvents extends React.Component {
+
+  static propTypes = {
+    appId: PropTypes.string.isRequired,
+    onClear: PropTypes.func.isRequired,
+    widget: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    widget: false,
+  }
+
   render () {
     const {
       appId,
@@ -48,20 +60,10 @@ class ApplicationEvents extends React.Component {
         widget={widget}
         eventsSelector={selectApplicationEvents}
         statusSelector={selectApplicationEventsStatus}
+        errorSelector={selectApplicationEventsError}
         onClear={onClear}
         toAllUrl={`/console/applications/${appId}/data`}
       />
     )
   }
 }
-
-ApplicationEvents.propTypes = {
-  appId: PropTypes.string.isRequired,
-  widget: PropTypes.bool,
-}
-
-ApplicationEvents.defaultProps = {
-  widget: false,
-}
-
-export default ApplicationEvents

--- a/pkg/webui/console/containers/events-subscription/index.js
+++ b/pkg/webui/console/containers/events-subscription/index.js
@@ -28,6 +28,7 @@ const mapConnectionStatusToWidget = function (status) {
   case CONNECTION_STATUS.CONNECTING:
     return Widget.CONNECTION_STATUS.MEDIOCRE
   case CONNECTION_STATUS.DISCONNECTED:
+  case CONNECTION_STATUS.ERROR:
     return Widget.CONNECTION_STATUS.BAD
   case CONNECTION_STATUS.UNKNOWN:
   default:

--- a/pkg/webui/console/containers/events-subscription/index.js
+++ b/pkg/webui/console/containers/events-subscription/index.js
@@ -40,11 +40,13 @@ const mapConnectionStatusToWidget = function (status) {
     id,
     eventsSelector,
     statusSelector,
+    errorSelector,
   } = props
 
   return {
     events: eventsSelector(state, id),
     connectionStatus: statusSelector(state, id),
+    error: errorSelector(state, id),
   }
 })
 class EventsSubscription extends React.Component {
@@ -56,6 +58,7 @@ class EventsSubscription extends React.Component {
       connectionStatus,
       onClear,
       toAllUrl,
+      error,
     } = this.props
 
     if (widget) {
@@ -65,6 +68,7 @@ class EventsSubscription extends React.Component {
           events={events}
           connectionStatus={mapConnectionStatusToWidget(connectionStatus)}
           toAllUrl={toAllUrl}
+          error={error}
         />
       )
     }
@@ -74,6 +78,7 @@ class EventsSubscription extends React.Component {
         emitterId={id}
         events={events}
         onClear={onClear}
+        error={error}
       />
     )
   }
@@ -83,6 +88,7 @@ EventsSubscription.propTypes = {
   id: PropTypes.string.isRequired,
   eventsSelector: PropTypes.func.isRequired,
   statusSelector: PropTypes.func,
+  errorSelector: PropTypes.func,
   onClear: PropTypes.func,
   widget: PropTypes.bool,
   toAllUrl: PropTypes.string,
@@ -92,6 +98,7 @@ EventsSubscription.defaultProps = {
   widget: false,
   onClear: () => null,
   statusSelector: () => 'unknown',
+  errorSelector: () => undefined,
   toAllUrl: null,
 }
 

--- a/pkg/webui/console/containers/gateway-events/index.js
+++ b/pkg/webui/console/containers/gateway-events/index.js
@@ -29,8 +29,24 @@ import {
   selectGatewayEventsError,
 } from '../../store/selectors/gateways'
 
+@connect(
+  null,
+  (dispatch, ownProps) => ({
+    onClear: () => dispatch(clearGatewayEventsStream(ownProps.gtwId)),
+  }))
 @bind
-class GatewayEvents extends React.Component {
+export default class GatewayEvents extends React.Component {
+
+  static propTypes = {
+    gtwId: PropTypes.string.isRequired,
+    onClear: PropTypes.func.isRequired,
+    widget: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    widget: false,
+  }
+
   render () {
     const {
       gtwId,
@@ -51,19 +67,3 @@ class GatewayEvents extends React.Component {
     )
   }
 }
-
-GatewayEvents.propTypes = {
-  gtwId: PropTypes.string.isRequired,
-  onClear: PropTypes.func.isRequired,
-  widget: PropTypes.bool,
-}
-
-GatewayEvents.defaultProps = {
-  widget: false,
-}
-
-export default connect(
-  null,
-  (dispatch, ownProps) => ({
-    onClear: () => dispatch(clearGatewayEventsStream(ownProps.gtwId)),
-  }))(GatewayEvents)

--- a/pkg/webui/console/containers/gateway-events/index.js
+++ b/pkg/webui/console/containers/gateway-events/index.js
@@ -26,6 +26,7 @@ import {
 import {
   selectGatewayEvents,
   selectGatewayEventsStatus,
+  selectGatewayEventsError,
 } from '../../store/selectors/gateways'
 
 @bind
@@ -43,6 +44,7 @@ class GatewayEvents extends React.Component {
         widget={widget}
         eventsSelector={selectGatewayEvents}
         statusSelector={selectGatewayEventsStatus}
+        errorSelector={selectGatewayEventsError}
         onClear={onClear}
         toAllUrl={`/console/gateways/${gtwId}/data`}
       />

--- a/pkg/webui/console/store/middleware/logics/events.js
+++ b/pkg/webui/console/store/middleware/logics/events.js
@@ -19,6 +19,7 @@ import {
   createStartEventsStreamActionType,
   createStopEventsStreamActionType,
   createStartEventsStreamFailureActionType,
+  createGetEventMessageFailureActionType,
   getEventMessageSuccess,
   getEventMessageFailure,
   startEventsStreamFailure,
@@ -43,6 +44,7 @@ const createEventsConnectLogics = function (
   const START_EVENTS = createStartEventsStreamActionType(reducerName)
   const START_EVENTS_FAILURE = createStartEventsStreamFailureActionType(reducerName)
   const STOP_EVENTS = createStopEventsStreamActionType(reducerName)
+  const GET_EVENT_MESSAGE_FAILURE = createGetEventMessageFailureActionType(reducerName)
   const startEventsSuccess = startEventsStreamSuccess(reducerName)
   const startEventsFailure = startEventsStreamFailure(reducerName)
   const stopEvents = stopEventsStream(reducerName)
@@ -55,7 +57,11 @@ const createEventsConnectLogics = function (
   return [
     createLogic({
       type: START_EVENTS,
+      cancelType: [ STOP_EVENTS, START_EVENTS_FAILURE, GET_EVENT_MESSAGE_FAILURE ],
       warnTimeout: 0,
+      processOptions: {
+        dispatchMultiple: true,
+      },
       validate ({ getState, action }, allow, reject) {
         const { id } = action
         if (!id) {
@@ -72,26 +78,26 @@ const createEventsConnectLogics = function (
 
         allow(action)
       },
-      async process ({ action }, dispatch, done) {
+      async process ({ getState, action }, dispatch) {
         const { id } = action
 
         try {
           channel = await onEventsStart([ id ])
+
           channel.on('start', () => dispatch(startEventsSuccess(id)))
           channel.on('event', message => dispatch(getEventSuccess(id, message)))
           channel.on('error', error => dispatch(getEventFailure(id, error)))
           channel.on('close', () => dispatch(stopEvents(id)))
         } catch (error) {
-          dispatch(startEventsFailure(error))
-          done()
+          dispatch(startEventsFailure(id, error))
         }
       },
     }),
     createLogic({
-      type: [ STOP_EVENTS, START_EVENTS_FAILURE ],
+      type: [ STOP_EVENTS, START_EVENTS_FAILURE, GET_EVENT_MESSAGE_FAILURE ],
       validate ({ getState, action }, allow, reject) {
         const { id } = action
-        if (!id || !channel) {
+        if (!id) {
           reject()
         }
 
@@ -106,7 +112,9 @@ const createEventsConnectLogics = function (
         allow(action)
       },
       process (_, __, done) {
-        channel.close()
+        if (channel) {
+          channel.close()
+        }
         done()
       },
     }),

--- a/pkg/webui/console/store/middleware/logics/events.js
+++ b/pkg/webui/console/store/middleware/logics/events.js
@@ -106,9 +106,9 @@ const createEventsConnectLogics = function (
 
         // only proceed if connected
         const status = selectEntityEventsStatus(getState(), id)
-        const disconnected = status === CONNECTION_STATUS.DISCONNECTED
-        const unknown = status === CONNECTION_STATUS.UNKNOWN
-        if (disconnected || unknown) {
+        const connected = status === CONNECTION_STATUS.CONNECTED
+        const connecting = status === CONNECTION_STATUS.CONNECTING
+        if (!connected && !connecting) {
           reject()
           return
         }

--- a/pkg/webui/console/store/middleware/logics/events.js
+++ b/pkg/webui/console/store/middleware/logics/events.js
@@ -66,6 +66,7 @@ const createEventsConnectLogics = function (
         const { id } = action
         if (!id) {
           reject()
+          return
         }
 
         // only proceed if not already connected
@@ -74,6 +75,7 @@ const createEventsConnectLogics = function (
         const connecting = status === CONNECTION_STATUS.CONNECTING
         if (connected || connecting) {
           reject()
+          return
         }
 
         allow(action)
@@ -99,6 +101,7 @@ const createEventsConnectLogics = function (
         const { id } = action
         if (!id) {
           reject()
+          return
         }
 
         // only proceed if connected
@@ -107,6 +110,7 @@ const createEventsConnectLogics = function (
         const unknown = status === CONNECTION_STATUS.UNKNOWN
         if (disconnected || unknown) {
           reject()
+          return
         }
 
         allow(action)

--- a/pkg/webui/console/store/reducers/events.js
+++ b/pkg/webui/console/store/reducers/events.js
@@ -62,7 +62,7 @@ const createNamedEventReducer = function (reducerName = '') {
       return {
         ...state,
         error: action.error,
-        state: CONNECTION_STATUS.UNKNOWN,
+        status: CONNECTION_STATUS.UNKNOWN,
       }
     case STOP_EVENTS:
       return {

--- a/pkg/webui/console/store/reducers/events.js
+++ b/pkg/webui/console/store/reducers/events.js
@@ -62,7 +62,7 @@ const createNamedEventReducer = function (reducerName = '') {
       return {
         ...state,
         error: action.error,
-        status: CONNECTION_STATUS.UNKNOWN,
+        status: CONNECTION_STATUS.ERROR,
       }
     case STOP_EVENTS:
       return {

--- a/pkg/webui/lib/components/error-message/error-message.styl
+++ b/pkg/webui/lib/components/error-message/error-message.styl
@@ -13,5 +13,6 @@
 // limitations under the License.
 
 .message
+  display: block
   &::first-letter
     text-transform: uppercase

--- a/pkg/webui/lib/prop-types.js
+++ b/pkg/webui/lib/prop-types.js
@@ -27,11 +27,18 @@ PropTypes.message = PropTypes.oneOfType([
 ])
 
 PropTypes.error = PropTypes.oneOfType([
-  PropTypes.shape({
-    details: PropTypes.array.isRequired,
-    message: PropTypes.string.isRequired,
-    code: PropTypes.number.isRequired,
-  }),
+  PropTypes.oneOfType([
+    PropTypes.shape({
+      details: PropTypes.array.isRequired,
+      message: PropTypes.string.isRequired,
+      code: PropTypes.number.isRequired,
+    }),
+    PropTypes.shape({
+      details: PropTypes.array.isRequired,
+      message: PropTypes.string.isRequired,
+      grpc_code: PropTypes.number.isRequired,
+    }),
+  ]),
   PropTypes.message,
   PropTypes.string,
 ])

--- a/pkg/webui/lib/shared-messages.js
+++ b/pkg/webui/lib/shared-messages.js
@@ -68,6 +68,7 @@ export default defineMessages({
   email: 'Email',
   enabled: 'Enabled',
   entityId: 'Entity ID',
+  eventsCannotShow: 'Cannot show events',
   firmwareVersion: 'Firmware Version',
   frequencyPlan: 'Frequency Plan',
   fwdNtwkKey: 'FNwkSIntKey',

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -209,6 +209,7 @@
   "lib.shared-messages.email": "Email",
   "lib.shared-messages.enabled": "Enabled",
   "lib.shared-messages.entityId": "Entity ID",
+  "lib.shared-messages.eventsCannotShow": "Cannot show events",
   "lib.shared-messages.firmwareVersion": "Firmware Version",
   "lib.shared-messages.frequencyPlan": "Frequency Plan",
   "lib.shared-messages.fwdNtwkKey": "FNwkSIntKey",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -209,6 +209,7 @@
   "lib.shared-messages.email": "Xxxxx",
   "lib.shared-messages.enabled": "Xxxxxxx",
   "lib.shared-messages.entityId": "Xxxxxx XX",
+  "lib.shared-messages.eventsCannotShow": "Xxxxxx xxxx xxxxxx",
   "lib.shared-messages.firmwareVersion": "Xxxxxxxx Xxxxxxx",
   "lib.shared-messages.frequencyPlan": "Xxxxxxxxx Xxxx",
   "lib.shared-messages.fwdNtwkKey": "XXxxXXxxXxx",

--- a/sdk/js/src/api/stream/stream-node.js
+++ b/sdk/js/src/api/stream/stream-node.js
@@ -19,6 +19,7 @@ import { notify, EVENTS } from './shared'
 /**
  * Opens a new stream.
  *
+ * @async
  * @param {Object} payload  - The body of the initial request.
  * @param {string} url - The stream endpoint.
  *


### PR DESCRIPTION
#### Summary
Closes #932 and a general issue on event streams that caused errors for opening streams to be swallowed.

#### Changes
- Modify stream logic in JS SDK to await the initial request result of the stream endpoint enabling proper catching of errors
- Fix request logic middleware to call `done()` when the stream closes
- Pass stream errors to the `<EventSubscription />` via the error selector
- Add display logic for event stream errors
- Extend error proptype to accept `code` and `grpc_code` property
- Some related refactoring of `propTypes` and `defaultProps` into class statics

#### Notes for Reviewers
I think it's better to use async/await to the extent possible in `sdk/js/src/api/stream.js`, so we can await the initial request and react on errors, before returning the channel. The old implementation failed to catch/handle the error that was thrown in these cases. 

#### Release Notes
- Fixed an issue that resulted in some event errors not being shown in the console