### PR TITLE
Fix unhandled promise rejections of request actions

### DIFF
--- a/pkg/webui/components/location-form/index.js
+++ b/pkg/webui/components/location-form/index.js
@@ -60,16 +60,16 @@ class LocationForm extends Component {
 
     this.setState({ error: '' })
 
-    try {
-      await onSubmit(values)
+    const res = await onSubmit(values)
+    if (!res.error) {
       resetForm()
       toast({
         title: entityId,
         message: m.updateSuccess,
         type: toast.types.SUCCESS,
       })
-    } catch (error) {
-      await this.setState({ error })
+    } else {
+      await this.setState({ error: res.payload })
       setSubmitting(false)
     }
   }
@@ -77,16 +77,16 @@ class LocationForm extends Component {
   async onDelete () {
     const { onDelete, entityId } = this.props
 
-    try {
-      await onDelete()
+    const res = await onDelete()
+    if (!res.error) {
       this.form.current.resetForm()
       toast({
         title: entityId,
         message: m.deleteSuccess,
         type: toast.types.SUCCESS,
       })
-    } catch (error) {
-      await this.setState({ error })
+    } else {
+      await this.setState({ error: res.payload })
     }
   }
 

--- a/pkg/webui/console/views/device-location/index.js
+++ b/pkg/webui/console/views/device-location/index.js
@@ -81,7 +81,7 @@ const getRegistryLocation = function (locations) {
 })
 @bind
 export default class DeviceGeneralSettings extends React.Component {
-  async handleSubmit (values) {
+  handleSubmit (values) {
     const { device, appId, devId, updateDevice } = this.props
 
     const patch = {
@@ -106,10 +106,10 @@ export default class DeviceGeneralSettings extends React.Component {
       }
     }
 
-    await updateDevice(appId, devId, patch)
+    return updateDevice(appId, devId, patch)
   }
 
-  async handleDelete () {
+  handleDelete () {
     const { device, devId, appId, updateDevice } = this.props
     const registryLocation = getRegistryLocation(device.locations)
 
@@ -118,7 +118,7 @@ export default class DeviceGeneralSettings extends React.Component {
     }
     delete patch.locations[registryLocation.key]
 
-    await updateDevice(appId, devId, patch)
+    return updateDevice(appId, devId, patch)
   }
 
   render () {

--- a/pkg/webui/console/views/gateway-location/index.js
+++ b/pkg/webui/console/views/gateway-location/index.js
@@ -20,7 +20,10 @@ import { defineMessages } from 'react-intl'
 import * as Yup from 'yup'
 
 import sharedMessages from '../../../lib/shared-messages'
-import { getGatewayId } from '../../../lib/selectors/id'
+import {
+  selectSelectedGatewayId,
+  selectSelectedGateway,
+} from '../../store/selectors/gateways'
 
 import LocationForm from '../../../components/location-form'
 import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
@@ -63,9 +66,9 @@ const getRegistryLocation = function (antennas) {
 }
 
 @connect(
-  ({ gateway }, props) => ({
-    gateway: gateway.gateway,
-    gtwId: getGatewayId(gateway.gateway),
+  (state, props) => ({
+    gateway: selectSelectedGateway(state),
+    gtwId: selectSelectedGatewayId(state),
   }),
   { updateGateway }
 )

--- a/pkg/webui/console/views/gateway-location/index.js
+++ b/pkg/webui/console/views/gateway-location/index.js
@@ -84,7 +84,7 @@ const getRegistryLocation = function (antennas) {
 })
 @bind
 export default class GatewayLocation extends React.Component {
-  async handleSubmit (values) {
+  handleSubmit (values) {
     const { gateway, gtwId, updateGateway } = this.props
 
     const patch = {}
@@ -108,10 +108,10 @@ export default class GatewayLocation extends React.Component {
       }]
     }
 
-    await updateGateway(gtwId, patch)
+    return updateGateway(gtwId, patch)
   }
 
-  async handleDelete () {
+  handleDelete () {
     const { gateway, gtwId, updateGateway } = this.props
     const registryLocation = getRegistryLocation(gateway.antennas)
 
@@ -120,7 +120,7 @@ export default class GatewayLocation extends React.Component {
     }
     patch.antennas.splice(registryLocation.key, 1)
 
-    await updateGateway(gtwId, patch)
+    return updateGateway(gtwId, patch)
   }
 
   render () {


### PR DESCRIPTION
#### Summary
This is a draft for a possible resolution of #975 as basis for discussion.

#### Changes
- Change redux request logic wrapper to resolve promises also on request failures
- Resolve the request dispatch promise with the result action
- Replace try/catches in submit logics with if statements, checking for the error property of the returned action (Note: I only did some of these, to keep the diff small for now)

#### Notes for Reviewers
This issue turned out to be more complex than I had initially thought. In essence, we cannot reject the promise of our request dispatches, as that would lead to unhandled promise rejections whenever we have a dispatch that isn't wrapped in a try/catch. We definitely don't want to wrap all of our request action dispatches into try/catches, so we need to avoid rejecting the promise altogether.

However, if we do not reject the promise, we cannot work with try/catches anymore when e.g. dispatching an update action on a form submit. Instead, we need to check the resolved value of the promise. My solution works with resolving the promise with the result action of the request. Since we have a clear contract of how these look via FSA. We can safely assume the `error` prop to be present in the result action, whenever a request failed.