### PR TITLE
Use Mage command for testing binaries

### DIFF
--- a/.mage/go.go
+++ b/.mage/go.go
@@ -195,6 +195,22 @@ func (Go) Test() error {
 	return execGoTest("./...")
 }
 
+var goBinaries = []string{"./cmd/ttn-lw-cli", "./cmd/ttn-lw-stack"}
+
+// TestBinaries tests the Go binaries by executing them with the --help flag.
+func (Go) TestBinaries() error {
+	if mg.Verbose() {
+		fmt.Println("Testing Go binaries")
+	}
+	for _, binary := range goBinaries {
+		_, err := outputGo("run", binary, "--help")
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 const goCoverageFile = "coverage.out"
 
 // Cover tests all Go packages and writes test coverage into the coverage file.

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,8 +109,7 @@ script:
       GOARCH=$RUN_GOARCH $MAGE go:test
     fi
   fi
-- if [[ "$RUNTYPE" == "go.test" ]]; then GO111MODULE=on go run ./cmd/ttn-lw-stack version; fi
-- if [[ "$RUNTYPE" == "go.test" ]]; then GO111MODULE=on go run ./cmd/ttn-lw-cli version; fi
+- if [[ "$RUNTYPE" == "go.test" ]]; then $MAGE go:testBinaries; fi
 - if [[ "$RUNTYPE" == "release" ]]; then $MAGE version:files; fi
 - make git.diff
 after_success:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR is a quick one to move explicit `go run`s from our CI to Mage.

Refs https://github.com/TheThingsIndustries/lorawan-stack/pull/1658

#### Changes
<!-- What are the changes made in this pull request? -->

- Moved `go run` commands for binary testing from Travis to Mage
