### PR TITLE
gs: Add new listener for Basic Station frontend

### DIFF
--- a/cmd/internal/shared/gatewayserver/config.go
+++ b/cmd/internal/shared/gatewayserver/config.go
@@ -35,4 +35,8 @@ var DefaultGatewayServerConfig = gatewayserver.Config{
 		Listen:    ":1882",
 		ListenTLS: ":8882",
 	},
+	BasicStation: gatewayserver.BasicStationConfig{
+		Listen:    ":1887",
+		ListenTLS: ":8887",
+	},
 }

--- a/config/messages.json
+++ b/config/messages.json
@@ -2807,6 +2807,15 @@
       "file": "basicstationlns.go"
     }
   },
+  "error:pkg/gatewayserver/io/basicstationlns:listener": {
+    "translations": {
+      "en": "failed to serve Basic Station frontend listener"
+    },
+    "description": {
+      "package": "pkg/gatewayserver/io/basicstationlns",
+      "file": "basicstationlns.go"
+    }
+  },
   "error:pkg/gatewayserver/io/grpc:connect": {
     "translations": {
       "en": "failed to connect gateway `{gateway_uid}`"

--- a/doc/networking.md
+++ b/doc/networking.md
@@ -12,3 +12,4 @@ The Things Network Stack uses a port per protocol, with a TLS counterpart when a
 | Management, data, events | gRPC | API key, token | 1884 | 8884 |
 | Management | HTTP | API key, token | 1885 | 8885 |
 | Backend Interfaces | HTTP | Custom | N/A | 8886 |
+| Basic Station LNS | HTTP | Auth Token, Custom | 1887 | 8887 |

--- a/pkg/gatewayserver/config.go
+++ b/pkg/gatewayserver/config.go
@@ -34,6 +34,8 @@ type UDPConfig struct {
 // BasicStationConfig defines the Basic Station configuration of the Gateway Server.
 type BasicStationConfig struct {
 	FallbackFrequencyPlanID string `name:"fallback-frequency-plan-id" description:"Fallback frequency plan ID for non-registered gateways"`
+	Listen                  string `name:"listen" description:"Address for the Basic Station frontend to listen on"`
+	ListenTLS               string `name:"listen-tls" description:"Address for the Basic Station frontend to listen on (with TLS)"`
 }
 
 // Config represents the Gateway Server configuration.

--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -73,9 +73,6 @@ func TestGatewayServer(t *testing.T) {
 				Listen:                      ":9187",
 				AllowInsecureForCredentials: true,
 			},
-			HTTP: config.HTTP{
-				Listen: ":1885",
-			},
 			Cluster: config.Cluster{
 				IdentityServer: isAddr,
 				NetworkServer:  nsAddr,
@@ -100,6 +97,9 @@ func TestGatewayServer(t *testing.T) {
 			Listeners: map[string]string{
 				":1700": test.EUFrequencyPlanID,
 			},
+		},
+		BasicStation: gatewayserver.BasicStationConfig{
+			Listen: ":1887",
 		},
 	}
 	gs, err := gatewayserver.New(c, config)
@@ -415,7 +415,7 @@ func TestGatewayServer(t *testing.T) {
 				if ids.EUI == nil {
 					t.SkipNow()
 				}
-				wsConn, _, err := websocket.DefaultDialer.Dial("ws://0.0.0.0:1885/api/v3/gs/io/basicstation/traffic/"+registeredGatewayID, nil)
+				wsConn, _, err := websocket.DefaultDialer.Dial("ws://0.0.0.0:1887/traffic/"+registeredGatewayID, nil)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes the last item on #74

#### Changes
<!-- What are the changes made in this pull request? -->

- Attach a new listener to the Basic Station frontend.
- Add related config.
- Update tests.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- The Web Server configuration (logger, middleware) has been directly adapted from Interop. If there needs to be any custom stuff added, please let me know.
- Many return statements are modified to return nil since echo nastily logs the following if we actually return an error:
```
echo: http: response.WriteHeader on hijacked connection from github.com/labstack/echo/v4.(*Response).WriteHeader (response.go:63)
echo: http: response.Write on hijacked connection from github.com/labstack/echo/v4.(*Response).Write (response.go:75)
```

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Added new WebSocket listeners on 1887 and 8887.
