### PR TITLE
Make web initialization consistent with gRPC

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -149,8 +149,7 @@ func New(logger log.Stack, config *Config, opts ...Option) (*Component, error) {
 		c.clusterNew = cluster.New
 	}
 
-	c.web, err = web.New(c.ctx, config.HTTP)
-	if err != nil {
+	if err = c.initWeb(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/component/web.go
+++ b/pkg/component/web.go
@@ -35,6 +35,20 @@ const (
 	healthUsername  = "health"
 )
 
+func (c *Component) initWeb() error {
+	web, err := web.New(
+		c.ctx,
+		web.WithContextFiller(c.FillContext),
+		web.WithCookieKeys(c.config.HTTP.Cookie.HashKey, c.config.HTTP.Cookie.BlockKey),
+		web.WithStatic(c.config.HTTP.Static.Mount, c.config.HTTP.Static.SearchPath...),
+	)
+	if err != nil {
+		return err
+	}
+	c.web = web
+	return nil
+}
+
 // RegisterWeb registers a web subsystem to the component.
 func (c *Component) RegisterWeb(s web.Registerer) {
 	c.webSubsystems = append(c.webSubsystems, s)

--- a/pkg/web/middleware/fillcontext.go
+++ b/pkg/web/middleware/fillcontext.go
@@ -1,0 +1,37 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	echo "github.com/labstack/echo/v4"
+	"go.thethings.network/lorawan-stack/pkg/fillcontext"
+)
+
+// FillContext fills the request context by executing the given fillers.
+func FillContext(fillers ...fillcontext.Filler) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		if fillers == nil {
+			return next
+		}
+		return func(c echo.Context) error {
+			ctx := c.Request().Context()
+			for _, fill := range fillers {
+				ctx = fill(ctx)
+			}
+			c.SetRequest(c.Request().WithContext(ctx))
+			return next(c)
+		}
+	}
+}

--- a/pkg/web/middleware/fillcontext_test.go
+++ b/pkg/web/middleware/fillcontext_test.go
@@ -1,0 +1,48 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	echo "github.com/labstack/echo/v4"
+	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
+)
+
+func TestFillContext(t *testing.T) {
+	a := assertions.New(t)
+
+	type ctxKeyType struct{}
+	var ctxKey ctxKeyType
+
+	middleware := FillContext(func(ctx context.Context) context.Context {
+		return context.WithValue(ctx, ctxKey, "value")
+	})
+
+	req := httptest.NewRequest("GET", "/", nil)
+	rec := httptest.NewRecorder()
+	c := echo.New().NewContext(req, rec)
+
+	err := middleware(func(c echo.Context) error {
+		a.So(c.Request().Context().Value(ctxKey), should.Equal, "value")
+		return nil
+	})(c)
+	a.So(err, should.BeNil)
+	a.So(rec.Code, should.Equal, http.StatusOK)
+}

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -23,7 +23,6 @@ import (
 
 	echo "github.com/labstack/echo/v4"
 	echomiddleware "github.com/labstack/echo/v4/middleware"
-	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/random"
@@ -39,7 +38,6 @@ type Registerer interface {
 // Server is the server.
 type Server struct {
 	*rootGroup
-	config config.HTTP
 	server *echo.Echo
 }
 
@@ -47,11 +45,41 @@ type rootGroup struct {
 	*echo.Group
 }
 
+type options struct {
+	cookieHashKey  []byte
+	cookieBlockKey []byte
+
+	staticMount       string
+	staticSearchPaths []string
+}
+
+// Option for the web server
+type Option func(*options)
+
+// WithCookieKeys sets the cookie hash key and block key.
+func WithCookieKeys(hashKey, blockKey []byte) Option {
+	return func(o *options) {
+		o.cookieHashKey, o.cookieBlockKey = hashKey, blockKey
+	}
+}
+
+// WithStatic sets the mount and search paths for static assets.
+func WithStatic(mount string, searchPaths ...string) Option {
+	return func(o *options) {
+		o.staticMount, o.staticSearchPaths = mount, searchPaths
+	}
+}
+
 // New builds a new server.
-func New(ctx context.Context, config config.HTTP) (*Server, error) {
+func New(ctx context.Context, opts ...Option) (*Server, error) {
 	logger := log.FromContext(ctx).WithField("namespace", "web")
 
-	hashKey, blockKey := config.Cookie.HashKey, config.Cookie.BlockKey
+	options := new(options)
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	hashKey, blockKey := options.cookieHashKey, options.cookieBlockKey
 
 	if len(hashKey) == 0 || isZeros(hashKey) {
 		hashKey = random.Bytes(64)
@@ -93,22 +121,21 @@ func New(ctx context.Context, config config.HTTP) (*Server, error) {
 				middleware.Normalize(middleware.RedirectPermanent),
 			),
 		},
-		config: config,
 		server: server,
 	}
 
 	var staticDir http.Dir
-	for _, path := range config.Static.SearchPath {
+	for _, path := range options.staticSearchPaths {
 		if s, err := os.Stat(path); err == nil && s.IsDir() {
 			staticDir = http.Dir(path)
 			break
 		}
 	}
 	if staticDir != "" {
-		logger.WithFields(log.Fields("path", staticDir, "mount", config.Static.Mount)).Debug("Serving static assets")
-		s.Static(config.Static.Mount, staticDir, middleware.Immutable)
+		logger.WithFields(log.Fields("path", staticDir, "mount", options.staticMount)).Debug("Serving static assets")
+		s.Static(options.staticMount, staticDir, middleware.Immutable)
 	} else {
-		logger.WithField("search_path", config.Static.SearchPath).Warn("No static assets found in any search path")
+		logger.WithField("search_paths", options.staticSearchPaths).Warn("No static assets found in any search path")
 	}
 
 	return s, nil

--- a/pkg/web/web_test.go
+++ b/pkg/web/web_test.go
@@ -24,7 +24,6 @@ import (
 
 	echo "github.com/labstack/echo/v4"
 	"github.com/smartystreets/assertions"
-	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/random"
 	"go.thethings.network/lorawan-stack/pkg/util/test"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
@@ -37,7 +36,7 @@ func handler(c echo.Context) error {
 
 func TestGroup(t *testing.T) {
 	a := assertions.New(t)
-	s, err := New(test.Context(), config.HTTP{})
+	s, err := New(test.Context())
 	if !a.So(err, should.BeNil) {
 		t.Fatal("Could not create a web instance")
 	}
@@ -82,7 +81,7 @@ func TestIsZeros(t *testing.T) {
 
 func TestServeHTTP(t *testing.T) {
 	a := assertions.New(t)
-	s, err := New(test.Context(), config.HTTP{})
+	s, err := New(test.Context())
 	if !a.So(err, should.BeNil) {
 		t.Fatal("Could not create a web instance")
 	}
@@ -103,7 +102,7 @@ func TestServeHTTP(t *testing.T) {
 
 func TestRootGroup(t *testing.T) {
 	a := assertions.New(t)
-	s, err := New(test.Context(), config.HTTP{})
+	s, err := New(test.Context())
 	if !a.So(err, should.BeNil) {
 		t.Fatal("Could not create a web instance")
 	}
@@ -117,7 +116,7 @@ func TestRootGroup(t *testing.T) {
 
 func TestStatic(t *testing.T) {
 	a := assertions.New(t)
-	s, err := New(test.Context(), config.HTTP{})
+	s, err := New(test.Context())
 	if !a.So(err, should.BeNil) {
 		t.Fatal("Could not create a web instance")
 	}
@@ -162,20 +161,12 @@ func TestCookies(t *testing.T) {
 	a := assertions.New(t)
 	// Errors on illegal hash key byte size
 	{
-		c := config.HTTP{}
-		c.Cookie.HashKey = random.Bytes(2)
-
-		_, err := New(test.Context(), c)
-
+		_, err := New(test.Context(), WithCookieKeys(random.Bytes(2), nil))
 		a.So(err, should.NotBeNil)
 	}
 	// Errors on non 32bit block key
 	{
-		c := config.HTTP{}
-		c.Cookie.BlockKey = random.Bytes(31)
-
-		_, err := New(test.Context(), c)
-
+		_, err := New(test.Context(), WithCookieKeys(nil, random.Bytes(31)))
 		a.So(err, should.NotBeNil)
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR makes the initialization of the component's web server consistent with the initiation of its gRPC server.

Refs https://github.com/TheThingsIndustries/lorawan-stack/pull/1658

#### Changes
<!-- What are the changes made in this pull request? -->

- Use options instead of relying on config struct
- Add context filler middleware