### PR TITLE
cli: Add error handling while not specifying usrID in organizations

### DIFF
--- a/cmd/ttn-lw-cli/commands/organizations.go
+++ b/cmd/ttn-lw-cli/commands/organizations.go
@@ -74,8 +74,12 @@ var (
 				return err
 			}
 			limit, page, opt, getTotal := withPagination(cmd.Flags())
+			usrID, err := getUserID(cmd.Flags(), nil)
+			if err != nil {
+				return err
+			}
 			res, err := ttnpb.NewOrganizationRegistryClient(is).List(ctx, &ttnpb.ListOrganizationsRequest{
-				Collaborator: getUserID(cmd.Flags(), nil).OrganizationOrUserIdentifiers(),
+				Collaborator: usrID.OrganizationOrUserIdentifiers(),
 				FieldMask:    types.FieldMask{Paths: paths},
 				Limit:        limit,
 				Page:         page,
@@ -141,7 +145,11 @@ var (
 		Short:   "Create an organization",
 		RunE: asBulk(func(cmd *cobra.Command, args []string) (err error) {
 			orgID := getOrganizationID(cmd.Flags(), args)
-			collaborator := getUserID(cmd.Flags(), nil).OrganizationOrUserIdentifiers()
+			usrID, err := getUserID(cmd.Flags(), nil)
+			if err != nil {
+				return err
+			}
+			collaborator := usrID.OrganizationOrUserIdentifiers()
 			if collaborator == nil {
 				return errNoCollaborator
 			}

--- a/cmd/ttn-lw-cli/commands/organizations_access.go
+++ b/cmd/ttn-lw-cli/commands/organizations_access.go
@@ -85,7 +85,11 @@ var (
 			if orgID == nil {
 				return errNoOrganizationID
 			}
-			collaborator := getUserID(cmd.Flags(), nil).OrganizationOrUserIdentifiers()
+			usrID, err := getUserID(cmd.Flags(), nil)
+			if err != nil {
+				return err
+			}
+			collaborator := usrID.OrganizationOrUserIdentifiers()
 			if collaborator == nil {
 				return errNoCollaborator
 			}
@@ -121,7 +125,11 @@ var (
 			if orgID == nil {
 				return errNoOrganizationID
 			}
-			collaborator := getUserID(cmd.Flags(), nil).OrganizationOrUserIdentifiers()
+			usrID, err := getUserID(cmd.Flags(), nil)
+			if err != nil {
+				return err
+			}
+			collaborator := usrID.OrganizationOrUserIdentifiers()
 			if collaborator == nil {
 				return errNoCollaborator
 			}

--- a/cmd/ttn-lw-cli/commands/users_access.go
+++ b/cmd/ttn-lw-cli/commands/users_access.go
@@ -29,9 +29,9 @@ var (
 		Use:   "rights [user-id]",
 		Short: "List the rights to a user",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			usrID := getUserID(cmd.Flags(), args)
-			if usrID == nil {
-				return errNoUserID
+			usrID, err := getUserID(cmd.Flags(), args)
+			if err != nil {
+				return err
 			}
 
 			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
@@ -56,9 +56,9 @@ var (
 		Aliases: []string{"ls"},
 		Short:   "List user API keys",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			usrID := getUserID(cmd.Flags(), args)
-			if usrID == nil {
-				return errNoUserID
+			usrID, err := getUserID(cmd.Flags(), args)
+			if err != nil {
+				return err
 			}
 
 			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
@@ -82,9 +82,9 @@ var (
 		Aliases: []string{"add", "generate"},
 		Short:   "Create a user API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			usrID := getUserID(cmd.Flags(), args)
-			if usrID == nil {
-				return errNoUserID
+			usrID, err := getUserID(cmd.Flags(), args)
+			if err != nil {
+				return err
 			}
 			name, _ := cmd.Flags().GetString("name")
 
@@ -119,9 +119,9 @@ var (
 		Aliases: []string{"set"},
 		Short:   "Update a user API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			usrID := getUserID(cmd.Flags(), firstArgs(1, args...))
-			if usrID == nil {
-				return errNoUserID
+			usrID, err := getUserID(cmd.Flags(), args)
+			if err != nil {
+				return err
 			}
 			id := getAPIKeyID(cmd.Flags(), args, 1)
 			if id == "" {
@@ -158,9 +158,9 @@ var (
 		Aliases: []string{"remove"},
 		Short:   "Delete a user API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			usrID := getUserID(cmd.Flags(), firstArgs(1, args...))
-			if usrID == nil {
-				return errNoUserID
+			usrID, err := getUserID(cmd.Flags(), args)
+			if err != nil {
+				return err
 			}
 			id := getAPIKeyID(cmd.Flags(), args, 1)
 			if id == "" {

--- a/cmd/ttn-lw-cli/commands/users_oauth.go
+++ b/cmd/ttn-lw-cli/commands/users_oauth.go
@@ -62,9 +62,9 @@ var (
 		Aliases: []string{"ls"},
 		Short:   "List OAuth authorizations",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			usrID := getUserID(cmd.Flags(), args)
-			if usrID == nil {
-				return errNoUserID
+			usrID, err := getUserID(cmd.Flags(), args)
+			if err != nil {
+				return err
 			}
 
 			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)

--- a/config/messages.json
+++ b/config/messages.json
@@ -1360,7 +1360,7 @@
   },
   "error:cmd/ttn-lw-cli/commands:no_user_id": {
     "translations": {
-      "en": "no user ID set"
+      "en": "no user ID set, please specify one"
     },
     "description": {
       "package": "cmd/ttn-lw-cli/commands",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #887 

#### Changes
<!-- What are the changes made in this pull request? -->

- Added error return to `getUserID` to get rid of null pointer dereference panic when no `usedID`s are specified
- Corrected all the usage of this function in according places

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This is the current response to `organizations ls` without usrID
```
➜ go run ./cmd/ttn-lw-cli organizations ls
error:cmd/ttn-lw-cli/commands:no_user_id (no user ID set, please specify one)
exit status 255
```
