### PR TITLE
Add proper handling of disabled components to JS SDK

### DIFF
--- a/sdk/js/generated/api-definition.json
+++ b/sdk/js/generated/api-definition.json
@@ -698,7 +698,8 @@
           "method": "post",
           "pattern": "/events",
           "body": "*",
-          "parameters": []
+          "parameters": [],
+          "stream": true
         }
       ]
     }
@@ -1003,7 +1004,8 @@
           "body": "*",
           "parameters": [
             "application_ids.application_id"
-          ]
+          ],
+          "stream": true
         }
       ]
     },

--- a/sdk/js/src/api/http.js
+++ b/sdk/js/src/api/http.js
@@ -64,6 +64,12 @@ class Http {
 
   async handleRequest (method, endpoint, component, payload = {}, config) {
     const parsedComponent = component || this._parseStackComponent(endpoint)
+    if (!this._stackConfig[parsedComponent]) {
+      // If the component has not been defined in the stack config, make no
+      // request and throw an error instead
+      throw new Error(`Cannot run "${method.toUpperCase()} ${endpoint}" API call on disabled component: "${parsedComponent}"`)
+    }
+
     try {
       return await this[parsedComponent]({
         method,

--- a/sdk/js/src/api/http.js
+++ b/sdk/js/src/api/http.js
@@ -29,14 +29,17 @@ class Http {
 
     const stackComponents = Object.keys(stackConfig)
     const instances = stackComponents.reduce(function (acc, curr) {
-      acc[curr] = axios.create({
-        baseURL: stackConfig[curr],
-        headers: {
-          Authorization,
-          ...headers,
-        },
-        ...axiosConfig,
-      })
+      const componentUrl = stackConfig[curr]
+      if (componentUrl) {
+        acc[curr] = axios.create({
+          baseURL: componentUrl,
+          headers: {
+            Authorization,
+            ...headers,
+          },
+          ...axiosConfig,
+        })
+      }
 
       return acc
     }, {})

--- a/sdk/js/src/api/http.js
+++ b/sdk/js/src/api/http.js
@@ -13,13 +13,16 @@
 // limitations under the License.
 
 import axios from 'axios'
+
 import { STACK_COMPONENTS } from '../util/constants'
+import stream from './stream/stream-node'
 
 /**
  * Http Class is a connector for the API that uses the HTTP bridge to connect.
  */
 class Http {
   constructor (token, stackConfig, axiosConfig = {}) {
+    this._stackConfig = stackConfig
     const headers = axiosConfig.headers || {}
 
     let Authorization = null
@@ -62,7 +65,7 @@ class Http {
     }
   }
 
-  async handleRequest (method, endpoint, component, payload = {}, config) {
+  async handleRequest (method, endpoint, component, payload = {}, isStream) {
     const parsedComponent = component || this._parseStackComponent(endpoint)
     if (!this._stackConfig[parsedComponent]) {
       // If the component has not been defined in the stack config, make no
@@ -71,12 +74,26 @@ class Http {
     }
 
     try {
-      return await this[parsedComponent]({
+      if (isStream) {
+        const url = this._stackConfig[parsedComponent] + endpoint
+        return stream(payload, url)
+      }
+
+      const config = {
         method,
         url: endpoint,
-        data: payload,
-        ...config,
-      })
+      }
+
+      if (method === 'get' || method === 'delete') {
+        // For GETs and DELETEs, convert payload to query params (should usually
+        // be field_mask only)
+        config.params = this._payloadToQueryParams(payload)
+      } else {
+        // Otherwise pass data as request body
+        config.data = payload
+      }
+
+      return await this[parsedComponent](config)
     } catch (err) {
       if ('response' in err && err.response && 'data' in err.response) {
         throw err.response.data
@@ -86,38 +103,25 @@ class Http {
     }
   }
 
-  async get (endpoint, component, params) {
-    // Convert payload to query params (should usually be field_mask only)
-    const config = {}
-    if (params && Object.keys(params).length > 0) {
-      if ('field_mask' in params) {
+  /**
+   * Converts a payload object to a query parameter object, making sure that the
+   * field mask parameter is converted correctly.
+   * @param {Object} payload - The payload object.
+   * @returns {Object} The params object, to be passed to axios config.
+   */
+  _payloadToQueryParams (payload) {
+    const res = { ...payload }
+    if (payload && Object.keys(payload).length > 0) {
+      if ('field_mask' in payload) {
         // Convert field mask prop to a query param friendly format
-        params.field_mask = params.field_mask.paths.join(',')
+        res.field_mask = payload.field_mask.paths.join(',')
       }
-      config.params = params
+      return res
     }
-
-    return this.handleRequest('get', endpoint, component, undefined, config)
-  }
-
-  async post (endpoint, component, payload) {
-    return this.handleRequest('post', endpoint, component, payload)
-  }
-
-  async patch (endpoint, component, payload) {
-    return this.handleRequest('patch', endpoint, component, payload)
-  }
-
-  async put (endpoint, component, payload) {
-    return this.handleRequest('put', endpoint, component, payload)
-  }
-
-  async delete (endpoint, component) {
-    return this.handleRequest('delete', endpoint, component)
   }
 
   /**
-   *  Extracts the stack component abbreviation from the endpoint.
+   * Extracts the stack component abbreviation from the endpoint.
    * @param {string} endpoint - The endpoint got for a request method.
    * @returns {string} One of {is|as|gs|js|ns}.
    */

--- a/sdk/js/src/api/index.js
+++ b/sdk/js/src/api/index.js
@@ -62,12 +62,13 @@ Signature tried: ${paramSignature}`)
           }
 
           let route = endpoint.pattern
+          const isStream = Boolean(endpoint.stream)
 
           for (const parameter of endpoint.parameters) {
             route = route.replace(`{${parameter}}`, routeParams[parameter])
           }
 
-          return connector[endpoint.method](route, component, payload)
+          return connector.handleRequest(endpoint.method, route, component, payload, isStream)
         }
       }
     }

--- a/sdk/js/src/api/index.test.js
+++ b/sdk/js/src/api/index.test.js
@@ -48,6 +48,17 @@ jest.mock('../../generated/api-definition.json', () => (
           },
         ],
       },
+      Events: {
+        file: 'lorawan-stack/api/application_services.proto',
+        http: [
+          {
+            method: 'get',
+            pattern: '/events',
+            parameters: [],
+            stream: true,
+          },
+        ],
+      },
     },
   }
 ))
@@ -56,8 +67,7 @@ describe('API', function () {
   let api
   beforeEach(function () {
     api = new Api('http', { baseURL: 'http://localhost:1885' })
-    api._connector.post = jest.fn()
-    api._connector.get = jest.fn()
+    api._connector.handleRequest = jest.fn()
   })
 
   test('it applies api definitions correctly', function () {
@@ -68,8 +78,8 @@ describe('API', function () {
   test('it applies parameters correctly', function () {
     api.ApplicationRegistry.Create({ routeParams: { 'collaborator.user_ids.user_id': 'test' }}, { name: 'test-name' })
 
-    expect(api._connector.post).toHaveBeenCalledTimes(1)
-    expect(api._connector.post).toHaveBeenCalledWith('/users/test/applications', undefined, { name: 'test-name' })
+    expect(api._connector.handleRequest).toHaveBeenCalledTimes(1)
+    expect(api._connector.handleRequest).toHaveBeenCalledWith('post', '/users/test/applications', undefined, { name: 'test-name' }, false)
   })
 
   test('it throws when parameters mismatch', function () {
@@ -81,7 +91,14 @@ describe('API', function () {
   test('it respects the search query', function () {
     api.ApplicationRegistry.List(undefined, { limit: 2, page: 1 })
 
-    expect(api._connector.get).toHaveBeenCalledTimes(1)
-    expect(api._connector.get).toHaveBeenCalledWith('/applications', undefined, { limit: 2, page: 1 })
+    expect(api._connector.handleRequest).toHaveBeenCalledTimes(1)
+    expect(api._connector.handleRequest).toHaveBeenCalledWith('get', '/applications', undefined, { limit: 2, page: 1 }, false)
+  })
+
+  test('it sets stream value to true for streaming endpoints', function () {
+    api.ApplicationRegistry.Events()
+
+    expect(api._connector.handleRequest).toHaveBeenCalledTimes(1)
+    expect(api._connector.handleRequest).toHaveBeenCalledWith('get', '/events', undefined, undefined, true)
   })
 })

--- a/sdk/js/src/api/stream/stream.js
+++ b/sdk/js/src/api/stream/stream.js
@@ -44,7 +44,7 @@ import 'web-streams-polyfill/dist/polyfill.js'
  * @returns {Object} The stream subscription object with the `on` function for
  * attaching listeners and the `close` function to close the stream.
  */
-export default async function (payload, url = '/api/v3/events') {
+export default async function (payload, url) {
   let listeners = Object.values(EVENTS)
     .reduce((acc, curr) => ({ ...acc, [curr]: null }), {})
   const token = new Token().get()

--- a/sdk/js/src/entity/application.js
+++ b/sdk/js/src/entity/application.js
@@ -31,7 +31,7 @@ class Application extends Entity {
 
     this._parent = parent
     this._id = data.ids.application_id
-    this.Devices = new Devices(parent._api, this._id)
+    this.Devices = new Devices(parent._api, { stackConfig: parent._stackConfig })
   }
 
   // API Keys

--- a/sdk/js/src/service/applications.js
+++ b/sdk/js/src/service/applications.js
@@ -15,7 +15,6 @@
 import Marshaler from '../util/marshaler'
 import Devices from '../service/devices'
 import Application from '../entity/application'
-import stream from '../api/stream/stream-node'
 import ApiKeys from './api-keys'
 import Link from './link'
 import Collaborators from './collaborators'
@@ -160,7 +159,6 @@ class Applications {
   // Events Stream
 
   async openStream (identifiers, tail, after) {
-    const eventsUrl = `${this._stackConfig.as}/events`
     const payload = {
       identifiers: identifiers.map(id => ({
         application_ids: { application_id: id },
@@ -169,7 +167,7 @@ class Applications {
       after,
     }
 
-    return stream(payload, eventsUrl)
+    return this._api.Events.Stream(undefined, payload)
   }
 }
 

--- a/sdk/js/src/service/devices/index.js
+++ b/sdk/js/src/service/devices/index.js
@@ -18,7 +18,6 @@ import { URL } from 'url'
 import traverse from 'traverse'
 import Marshaler from '../../util/marshaler'
 import Device from '../../entity/device'
-import stream from '../../api/stream/stream-node'
 import randomByteString from '../../util/random-bytes'
 import deviceEntityMap from '../../../generated/device-entity-map.json'
 import { splitSetPaths, splitGetPaths, makeRequests } from './split'
@@ -317,7 +316,6 @@ class Devices {
   // Events Stream
 
   async openStream (identifiers, tail, after) {
-    const eventsUrl = `${this._stackConfig.as}/events`
     const payload = {
       identifiers: identifiers.map(ids => ({
         device_ids: ids,
@@ -326,7 +324,7 @@ class Devices {
       after,
     }
 
-    return stream(payload, eventsUrl)
+    return this._api.Events.Stream(undefined, payload)
   }
 }
 

--- a/sdk/js/src/service/gateways.js
+++ b/sdk/js/src/service/gateways.js
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import Marshaler from '../util/marshaler'
-import stream from '../api/stream/stream-node'
 import ApiKeys from './api-keys'
 import Collaborators from './collaborators'
 
@@ -112,7 +111,6 @@ class Gateways {
   // Events Stream
 
   async openStream (identifiers, tail, after) {
-    const eventsUrl = `${this._stackConfig.as}/events`
     const payload = {
       identifiers: identifiers.map(id => ({
         gateway_ids: { gateway_id: id },
@@ -121,7 +119,7 @@ class Gateways {
       after,
     }
 
-    return stream(payload, eventsUrl)
+    return this._api.Events.Stream(undefined, payload)
   }
 }
 

--- a/sdk/js/util/http-mapper.js
+++ b/sdk/js/util/http-mapper.js
@@ -40,6 +40,9 @@ function map (files) {
             }
 
             rule.method = rule.method.toLowerCase()
+            if (method.responseStreaming) {
+              rule.stream = method.responseStreaming
+            }
             result[service.name][method.name].http.push(rule)
           }
         }


### PR DESCRIPTION
#### Summary
Closes #881.
This PR is the first step towards proper support of different stack component setups. It introduces a couple of fixes and enhancements to ensure the SDK can handle arbitrary setups in terms of what components (AS, IS, JS, NS, etc) are enabled or disabled. As a result, the console will be able to receive proper errors for queries to disabled components.

#### Changes
- Fix an issue where passed `stackConfig` keys set as `undefined` would still be mapped to axios instances without a `baseUrl` (leading to requests without `/api/v3` being made, as described in #881)
- Throw a proper error when requests to disabled components are made
- Add support for stream RPCs via the `Api() / Http()` classes
- Replace hard-coded stream logics in services with implementation via the `Api()` instance
- Change api mapper utility function to pass a `stream` prop to `api-definition.json`, if the given RPC uses a streaming response
- Change end device service logic to handle requests to disabled components
- Update and enhance api tests
- Minor related fixes

#### Notes for Reviewers
Note that with this PR alone, there will still be errors logged whenever a request is made to a disabled component. However, the SDK will now throw proper errors instead of making requests to faulty URLs. The next step would be to disable certain components/logics in the console, based on what components are available.

Important for this PR is that it will fix issues where the console would error out altogether because of faulty requests being made to disabled components. (cc @johanstokking)

#### Release Notes
Fixed issues in the console that resulted in errors on setups with some stack components being disabled.