### PR TITLE
Delete sucessfully extracted context data from events

### DIFF
--- a/pkg/events/context.go
+++ b/pkg/events/context.go
@@ -45,6 +45,7 @@ func unmarshalContext(ctx context.Context, data map[string][]byte) (context.Cont
 		if err != nil {
 			return nil, err
 		}
+		delete(data, name)
 	}
 	return ctx, nil
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quickfix for a small issue in the events package that I ran into while working on https://github.com/TheThingsIndustries/lorawan-stack/issues/431. The issue is fixed by making the `events.unmarshalContext` remove baggage from the `context` field of events after successful extraction to the `context.Context`.