### PR TITLE
Implement setting webhook headers in CLI

### DIFF
--- a/cmd/ttn-lw-cli/commands/flags.go
+++ b/cmd/ttn-lw-cli/commands/flags.go
@@ -63,8 +63,7 @@ func attributesFlags() *pflag.FlagSet {
 	return flagSet
 }
 
-func mergeAttributes(attributes map[string]string, flagSet *pflag.FlagSet) map[string]string {
-	kv, _ := flagSet.GetStringSlice("attributes")
+func mergeKV(attributes map[string]string, kv []string) map[string]string {
 	out := make(map[string]string, len(attributes)+len(kv))
 	for k, v := range attributes {
 		out[k] = v
@@ -81,6 +80,11 @@ func mergeAttributes(attributes map[string]string, flagSet *pflag.FlagSet) map[s
 		}
 	}
 	return out
+}
+
+func mergeAttributes(attributes map[string]string, flagSet *pflag.FlagSet) map[string]string {
+	kv, _ := flagSet.GetStringSlice("attributes")
+	return mergeKV(attributes, kv)
 }
 
 func rightsFlags(filter func(string) bool) *pflag.FlagSet {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR allows users to set webhook headers from the CLI.

Resolves the CLI part of #938. 

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `--headers` flag to `applicationsWebhooksSetCommand`.

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Added `--headers` flag to `ttn-lw-cli applications webhooks set` allowing users to set HTTP headers to add to webhook requests.
