### PR TITLE
Redirect user when accessToken not found

### DIFF
--- a/pkg/webui/console/store/middleware/logics/events.js
+++ b/pkg/webui/console/store/middleware/logics/events.js
@@ -27,6 +27,8 @@ import {
   stopEventsStream,
 } from '../../actions/events'
 import { createEventsStatusSelector } from '../../selectors/events'
+import { isUnauthenticatedError } from '../../../../lib/errors/utils'
+import user from './user'
 
 /**
  * Creates `redux-logic` logic from processing entity events.
@@ -91,7 +93,11 @@ const createEventsConnectLogics = function (
           channel.on('error', error => dispatch(getEventFailure(id, error)))
           channel.on('close', () => dispatch(stopEvents(id)))
         } catch (error) {
-          dispatch(startEventsFailure(id, error))
+          if (isUnauthenticatedError(error)) {
+            dispatch(user.logoutSuccess())
+          } else {
+            dispatch(startEventsFailure(id, error))
+          }
         }
       },
     }),

--- a/pkg/webui/console/store/middleware/logics/lib.js
+++ b/pkg/webui/console/store/middleware/logics/lib.js
@@ -14,6 +14,8 @@
 
 
 import { createLogic } from 'redux-logic'
+import * as user from '../../actions/user'
+import { isUnauthenticatedError } from '../../../../lib/errors/utils'
 
 const getResultActionFromType = function (typeString, status) {
   if (typeString instanceof Array) {
@@ -63,7 +65,11 @@ const createRequestLogic = function (
         dispatch(successAction(res))
         _resolve(res)
       } catch (e) {
-        dispatch(failAction(e))
+        if (isUnauthenticatedError(e)) {
+          dispatch(user.logoutSuccess())
+        } else {
+          dispatch(failAction(e))
+        }
         _reject(e)
       }
 

--- a/pkg/webui/lib/errors/utils.js
+++ b/pkg/webui/lib/errors/utils.js
@@ -118,6 +118,7 @@ export const isPermissionDeniedError = error => (
  */
 export const isUnauthenticatedError = error => (
   grpcStatusCode(error) === 16
+  || (isBackend(error) && error.details[0].attributes.message === 'code=401, message=You are not logged in') // TODO: Remove this once #1014 is resolved
 )
 
 /**


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->
Closes #426 

#### Changes
<!-- What are the changes made in this pull request? -->

- ~~Add check in `requestLogic` that makes an api request to the token and in case of an error dispatches a `logoutSuccess` action that clears the user store~~
- Add unauthenticated error handling in `createRequestLogic` wrapper
- Updated `isUnauthenticated` error such that it recognizes `401` error (@kschiffer )
- Add additional check in `events.js`where `createRequestLogic` is not used
