### PR TITLE
Give OrganizationOrUserIdentifiers() pointer receiver

### DIFF
--- a/cmd/ttn-lw-cli/commands/organizations.go
+++ b/cmd/ttn-lw-cli/commands/organizations.go
@@ -75,7 +75,7 @@ var (
 			}
 			limit, page, opt, getTotal := withPagination(cmd.Flags())
 			res, err := ttnpb.NewOrganizationRegistryClient(is).List(ctx, &ttnpb.ListOrganizationsRequest{
-				Collaborator: getUserID(cmd.Flags(), nil).OrganizationOrUserIdentifiers(),
+				Collaborator: getUserID(cmd.Flags(), nil).GetOrganizationOrUserIdentifiers(),
 				FieldMask:    types.FieldMask{Paths: paths},
 				Limit:        limit,
 				Page:         page,
@@ -141,7 +141,7 @@ var (
 		Short:   "Create an organization",
 		RunE: asBulk(func(cmd *cobra.Command, args []string) (err error) {
 			orgID := getOrganizationID(cmd.Flags(), args)
-			collaborator := getUserID(cmd.Flags(), nil).OrganizationOrUserIdentifiers()
+			collaborator := getUserID(cmd.Flags(), nil).GetOrganizationOrUserIdentifiers()
 			if collaborator == nil {
 				return errNoCollaborator
 			}

--- a/cmd/ttn-lw-cli/commands/organizations_access.go
+++ b/cmd/ttn-lw-cli/commands/organizations_access.go
@@ -85,7 +85,7 @@ var (
 			if orgID == nil {
 				return errNoOrganizationID
 			}
-			collaborator := getUserID(cmd.Flags(), nil).OrganizationOrUserIdentifiers()
+			collaborator := getUserID(cmd.Flags(), nil).GetOrganizationOrUserIdentifiers()
 			if collaborator == nil {
 				return errNoCollaborator
 			}
@@ -121,7 +121,7 @@ var (
 			if orgID == nil {
 				return errNoOrganizationID
 			}
-			collaborator := getUserID(cmd.Flags(), nil).OrganizationOrUserIdentifiers()
+			collaborator := getUserID(cmd.Flags(), nil).GetOrganizationOrUserIdentifiers()
 			if collaborator == nil {
 				return errNoCollaborator
 			}

--- a/pkg/ttnpb/identifiers.go
+++ b/pkg/ttnpb/identifiers.go
@@ -55,11 +55,27 @@ func (ids UserIdentifiers) IsZero() bool {
 	return ids.UserID == "" && ids.Email == ""
 }
 
+// GetOrganizationOrUserIdentifiers returns the OrganizationIdentifiers as *OrganizationOrUserIdentifiers.
+func (ids *OrganizationIdentifiers) GetOrganizationOrUserIdentifiers() *OrganizationOrUserIdentifiers {
+	if ids == nil {
+		return nil
+	}
+	return ids.OrganizationOrUserIdentifiers()
+}
+
 // OrganizationOrUserIdentifiers returns the OrganizationIdentifiers as *OrganizationOrUserIdentifiers.
 func (ids OrganizationIdentifiers) OrganizationOrUserIdentifiers() *OrganizationOrUserIdentifiers {
 	return &OrganizationOrUserIdentifiers{Ids: &OrganizationOrUserIdentifiers_OrganizationIDs{
 		OrganizationIDs: &ids,
 	}}
+}
+
+// GetOrganizationOrUserIdentifiers returns the UserIdentifiers as *OrganizationOrUserIdentifiers.
+func (ids *UserIdentifiers) GetOrganizationOrUserIdentifiers() *OrganizationOrUserIdentifiers {
+	if ids == nil {
+		return nil
+	}
+	return ids.OrganizationOrUserIdentifiers()
 }
 
 // OrganizationOrUserIdentifiers returns the UserIdentifiers as *OrganizationOrUserIdentifiers.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This Pull Request closes #887 with the changes I proposed in https://github.com/TheThingsNetwork/lorawan-stack/pull/993#pullrequestreview-261725926.

#### Changes
<!-- What are the changes made in this pull request? -->

- Gave `OrganizationOrUserIdentifiers()` a pointer receiver
- Made them return `nil` if receiver `nil`
- Updated usage

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Fixed crash when running some `ttn-lw-cli organizations` commands without `--user-id` flag.
