### PR TITLE
Extend js sdk to fetch single collaborator

### DIFF
--- a/sdk/js/src/service/applications.js
+++ b/sdk/js/src/service/applications.js
@@ -50,6 +50,7 @@ class Applications {
     this.Devices = new Devices(api, { proxy, stackConfig })
     this.Collaborators = new Collaborators(api.ApplicationAccess, {
       parentRoutes: {
+        get: 'application_ids.application_id',
         list: 'application_ids.application_id',
         set: 'application_ids.application_id',
       },

--- a/sdk/js/src/service/collaborators.js
+++ b/sdk/js/src/service/collaborators.js
@@ -20,6 +20,30 @@ class Collaborators {
     this._parentRoutes = parentRoutes
   }
 
+  async _getById (entityId, collaboratorId, isUser) {
+    const entityIdRoute = this._parentRoutes.get
+    const collaboratorIdRoute = isUser
+      ? 'collaborator.user_ids.user_id'
+      : 'collaborator.organization_ids.organization_id'
+
+    const result = await this._api.GetCollaborator({
+      routeParams: {
+        [entityIdRoute]: entityId,
+        [collaboratorIdRoute]: collaboratorId,
+      },
+    })
+
+    return Marshaler.payloadSingleResponse(result)
+  }
+
+  async getByUserId (entityId, userId) {
+    return this._getById(entityId, userId, true)
+  }
+
+  async getByOrganizationId (entityId, organizationId) {
+    return this._getById(entityId, organizationId, false)
+  }
+
   async getAll (entityId) {
     const entityIdRoute = this._parentRoutes.list
     const result = await this._api.ListCollaborators({


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #722

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `getByUserId` method to the collaborators service
- Add `getByOrganizationId` method to the collaborators service

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

You can use [this script](https://gist.github.com/bafonins/17ba2ba88d3cb50cd94af6fae3a51773) to check the new methods.

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Added `getByOrganizationId` and `getByUserId` methods to the JS SDK