### PR TITLE
Allow users to configure the CLI with an API Key

### DIFF
--- a/cmd/ttn-lw-cli/commands/login.go
+++ b/cmd/ttn-lw-cli/commands/login.go
@@ -81,6 +81,11 @@ var (
 
 			cache.Set("hosts", config.getHosts())
 
+			if apiKey, _ := cmd.Flags().GetString("api-key"); apiKey != "" {
+				cache.Set("api_key", apiKey)
+				return nil
+			}
+
 			ctx, done := context.WithCancel(ctx)
 			defer done()
 
@@ -183,6 +188,7 @@ var (
 
 func init() {
 	loginCommand.Flags().Bool("callback", true, "use local OAuth callback endpoint")
+	loginCommand.Flags().String("api-key", "", "API key to login with (instead of using OAuth)")
 	Root.AddCommand(loginCommand)
 	Root.AddCommand(logoutCommand)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This Pull Request adds the `--api-key` flag to `ttn-lw-cli login`, allowing users to more easily configure the CLI with an API key instead of an OAuth access token (previously they had to edit the auth file by hand to do this).

Refs https://github.com/TheThingsIndustries/lorawan-stack/pull/1680

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `--api-key` flag
- Set API key to auth cache when `--api-key` flag used to login

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Added an `--api-key` flag to `ttn-lw-cli login` that allows users to configure the CLI with a more restricted (Application, Gateway, ...) API key instead of the usual "all rights" OAuth access token.
