### PR TITLE
console: Include page-size constants for tables

### DIFF
--- a/pkg/webui/console/constants/page-sizes.js
+++ b/pkg/webui/console/constants/page-sizes.js
@@ -1,0 +1,18 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export default Object.freeze({
+  SMALL: 5,
+  REGULAR: 20,
+})

--- a/pkg/webui/console/containers/fetch-table/index.js
+++ b/pkg/webui/console/containers/fetch-table/index.js
@@ -270,7 +270,7 @@ class FetchTable extends Component {
 
 
 FetchTable.defaultProps = {
-  pageSize: 15,
+  pageSize: 20,
   filterValidator,
   itemPathPrefix: '',
 }

--- a/pkg/webui/console/views/application-api-keys-list/index.js
+++ b/pkg/webui/console/views/application-api-keys-list/index.js
@@ -21,7 +21,7 @@ import ApiKeysTable from '../../containers/api-keys-table'
 import { getApplicationApiKeysList } from '../../store/actions/applications'
 import sharedMessages from '../../../lib/shared-messages'
 
-const API_KEYS_TABLE_SIZE = 10
+import PAGE_SIZES from '../../constants/page-sizes'
 
 @bind
 export default class ApplicationApiKeys extends React.Component {
@@ -45,7 +45,7 @@ export default class ApplicationApiKeys extends React.Component {
           <IntlHelmet title={sharedMessages.apiKeys} />
           <Col sm={12}>
             <ApiKeysTable
-              pageSize={API_KEYS_TABLE_SIZE}
+              pageSize={PAGE_SIZES.REGULAR}
               baseDataSelector={this.baseDataSelector}
               getItemsAction={this.getApplicationsApiKeysList}
             />

--- a/pkg/webui/console/views/application-collaborators-list/index.js
+++ b/pkg/webui/console/views/application-collaborators-list/index.js
@@ -21,7 +21,7 @@ import CollaboratorsTable from '../../containers/collaborators-table'
 import { getApplicationCollaboratorsList } from '../../store/actions/applications'
 import sharedMessages from '../../../lib/shared-messages'
 
-const COLLABORATORS_TABLE_SIZE = 10
+import PAGE_SIZES from '../../constants/page-sizes'
 
 @bind
 export default class ApplicationCollaborators extends React.Component {
@@ -45,7 +45,7 @@ export default class ApplicationCollaborators extends React.Component {
           <IntlHelmet title={sharedMessages.collaborators} />
           <Col sm={12}>
             <CollaboratorsTable
-              pageSize={COLLABORATORS_TABLE_SIZE}
+              pageSize={PAGE_SIZES.REGULAR}
               baseDataSelector={this.baseDataSelector}
               getItemsAction={this.getApplicationCollaboratorsList}
             />

--- a/pkg/webui/console/views/application-integrations-list/index.js
+++ b/pkg/webui/console/views/application-integrations-list/index.js
@@ -20,6 +20,8 @@ import WebhooksTable from '../../containers/webhooks-table'
 import IntlHelmet from '../../../lib/components/intl-helmet'
 import sharedMessages from '../../../lib/shared-messages'
 
+import PAGE_SIZES from '../../constants/page-sizes'
+
 export default class ApplicationIntegrationsList extends Component {
   render () {
     const { appId } = this.props.match.params
@@ -29,7 +31,10 @@ export default class ApplicationIntegrationsList extends Component {
         <Row>
           <IntlHelmet title={sharedMessages.integrations} />
           <Col sm={12}>
-            <WebhooksTable appId={appId} />
+            <WebhooksTable
+              pageSize={PAGE_SIZES.REGULAR}
+              appId={appId}
+            />
           </Col>
         </Row>
       </Container>

--- a/pkg/webui/console/views/application-overview/index.js
+++ b/pkg/webui/console/views/application-overview/index.js
@@ -29,7 +29,7 @@ import { selectSelectedApplication } from '../../store/selectors/applications'
 
 import style from './application-overview.styl'
 
-const DEVICES_TABLE_SIZE = 5
+import PAGE_SIZES from '../../constants/page-sizes'
 
 @connect(function (state) {
   return {
@@ -92,7 +92,7 @@ class ApplicationOverview extends React.Component {
         </Row>
         <Row>
           <Col sm={12} className={style.table}>
-            <DevicesTable pageSize={DEVICES_TABLE_SIZE} devicePathPrefix="/devices" />
+            <DevicesTable pageSize={PAGE_SIZES.SMALL} devicePathPrefix="/devices" />
           </Col>
         </Row>
       </Container>

--- a/pkg/webui/console/views/applications-list/index.js
+++ b/pkg/webui/console/views/applications-list/index.js
@@ -20,7 +20,7 @@ import IntlHelmet from '../../../lib/components/intl-helmet'
 
 import ApplicationsTable from '../../containers/applications-table'
 
-const APPLICATIONS_TABLE_SIZE = 5
+import PAGE_SIZES from '../../constants/page-sizes'
 
 export default class List extends React.Component {
   render () {
@@ -29,7 +29,7 @@ export default class List extends React.Component {
         <Row>
           <IntlHelmet title={sharedMessages.applications} />
           <Col sm={12}>
-            <ApplicationsTable pageSize={APPLICATIONS_TABLE_SIZE} />
+            <ApplicationsTable pageSize={PAGE_SIZES.REGULAR} />
           </Col>
         </Row>
       </Container>

--- a/pkg/webui/console/views/device-list/index.js
+++ b/pkg/webui/console/views/device-list/index.js
@@ -22,7 +22,7 @@ import DevicesTable from '../../containers/devices-table'
 
 import { selectSelectedApplication } from '../../store/selectors/applications'
 
-const DEVICES_TABLE_SIZE = 25
+import PAGE_SIZES from '../../constants/page-sizes'
 
 @connect(function (state, props) {
   return {
@@ -36,7 +36,7 @@ class ApplicationDeviceList extends React.Component {
         <Row>
           <IntlHelmet title={sharedMessages.devices} />
           <Col sm={12}>
-            <DevicesTable pageSize={DEVICES_TABLE_SIZE} />
+            <DevicesTable pageSize={PAGE_SIZES.REGULAR} />
           </Col>
         </Row>
       </Container>

--- a/pkg/webui/console/views/gateway-api-keys-list/index.js
+++ b/pkg/webui/console/views/gateway-api-keys-list/index.js
@@ -23,7 +23,7 @@ import sharedMessages from '../../../lib/shared-messages'
 import { getGatewayApiKeysList } from '../../store/actions/gateways'
 import { selectGatewayApiKeysStore } from '../../store/selectors/gateways'
 
-const API_KEYS_TABLE_SIZE = 10
+import PAGE_SIZES from '../../constants/page-sizes'
 
 @bind
 export default class GatewayApiKeys extends React.Component {
@@ -45,7 +45,7 @@ export default class GatewayApiKeys extends React.Component {
           <Col sm={12}>
             <ApiKeysTable
               entityId={gtwId}
-              pageSize={API_KEYS_TABLE_SIZE}
+              pageSize={PAGE_SIZES.REGULAR}
               baseDataSelector={selectGatewayApiKeysStore}
               getItemsAction={this.getGatewayApiKeysList}
             />

--- a/pkg/webui/console/views/gateway-collaborators-list/index.js
+++ b/pkg/webui/console/views/gateway-collaborators-list/index.js
@@ -24,7 +24,7 @@ import sharedMessages from '../../../lib/shared-messages'
 import { getGatewayCollaboratorsList } from '../../store/actions/gateways'
 import { selectSelectedGatewayId } from '../../store/selectors/gateways'
 
-const COLLABORATORS_TABLE_SIZE = 10
+import PAGE_SIZES from '../../constants/page-sizes'
 
 @connect(state => ({
   gtwId: selectSelectedGatewayId(state),
@@ -50,7 +50,7 @@ export default class GatewayCollaborators extends React.Component {
           <IntlHelmet title={sharedMessages.collaborators} />
           <Col sm={12}>
             <CollaboratorsTable
-              pageSize={COLLABORATORS_TABLE_SIZE}
+              pageSize={PAGE_SIZES.REGULAR}
               baseDataSelector={this.baseDataSelector}
               getItemsAction={this.getGatewayCollaboratorsList}
             />

--- a/pkg/webui/console/views/gateways-list/index.js
+++ b/pkg/webui/console/views/gateways-list/index.js
@@ -19,7 +19,7 @@ import GatewaysTable from '../../containers/gateways-table'
 import sharedMessages from '../../../lib/shared-messages'
 import IntlHelmet from '../../../lib/components/intl-helmet'
 
-const GATEWAYS_TABLE_SIZE = 5
+import PAGE_SIZES from '../../constants/page-sizes'
 
 export default class GatewaysList extends React.Component {
   render () {
@@ -28,7 +28,7 @@ export default class GatewaysList extends React.Component {
         <Row>
           <IntlHelmet title={sharedMessages.gateways} />
           <Col sm={12}>
-            <GatewaysTable pageSize={GATEWAYS_TABLE_SIZE} />
+            <GatewaysTable pageSize={PAGE_SIZES.REGULAR} />
           </Col>
         </Row>
       </Container>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Close #907 

#### Changes
<!-- What are the changes made in this pull request? -->

- Include constants file `pkg/webui/console/constants/page-sizes.js` containing two constants `TABLE_SIZE_SMALL` = 5 and `TABLE_SIZE_LARGE` = 20
- Include and Applied constants to tables in the following files 
  - pkg/webui/console/views/application-api-keys-list/index.js
  - pkg/webui/console/views/application-collaborators-list/index.js
  - pkg/webui/console/views/application-overview/index.js
  - pkg/webui/console/views/applications-list/index.js
  - pkg/webui/console/views/device-list/index.js
  - pkg/webui/console/views/gateway-api-keys-list/index.js
  - pkg/webui/console/views/gateway-collaborators-list/index.js
  - pkg/webui/console/views/gateways-list/index.js
