### PR TITLE
Fix collaborators handling in console

### DIFF
--- a/pkg/webui/console/api/index.js
+++ b/pkg/webui/console/api/index.js
@@ -92,6 +92,8 @@ export default {
       stats: ttnClient.Applications.Link.getStats.bind(ttnClient.Applications.Link),
     },
     collaborators: {
+      getOrganization: ttnClient.Applications.Collaborators.getByOrganizationId.bind(ttnClient.Applications.Collaborators),
+      getUser: ttnClient.Applications.Collaborators.getByUserId.bind(ttnClient.Applications.Collaborators),
       list: ttnClient.Applications.Collaborators.getAll.bind(ttnClient.Applications.Collaborators),
       add: ttnClient.Applications.Collaborators.add.bind(ttnClient.Applications.Collaborators),
       update: ttnClient.Applications.Collaborators.update.bind(ttnClient.Applications.Collaborators),

--- a/pkg/webui/console/api/index.js
+++ b/pkg/webui/console/api/index.js
@@ -130,6 +130,8 @@ export default {
     stats: ttnClient.Gateways.getStatisticsById.bind(ttnClient.Gateways),
     eventsSubscribe: ttnClient.Gateways.openStream.bind(ttnClient.Gateways),
     collaborators: {
+      getOrganization: ttnClient.Gateways.Collaborators.getByOrganizationId.bind(ttnClient.Gateways.Collaborators),
+      getUser: ttnClient.Gateways.Collaborators.getByUserId.bind(ttnClient.Gateways.Collaborators),
       list: ttnClient.Gateways.Collaborators.getAll.bind(ttnClient.Gateways.Collaborators),
       add: ttnClient.Gateways.Collaborators.add.bind(ttnClient.Gateways.Collaborators),
       update: ttnClient.Gateways.Collaborators.update.bind(ttnClient.Gateways.Collaborators),

--- a/pkg/webui/console/containers/collaborators-table/index.js
+++ b/pkg/webui/console/containers/collaborators-table/index.js
@@ -63,11 +63,17 @@ const headers = [
 ]
 
 export default class CollaboratorsTable extends Component {
+
+  getCollaboratorPathPrefix (collaborator) {
+    return `/${collaborator.isUser ? 'user' : 'organization'}/${collaborator.id}`
+  }
+
   render () {
     return (
       <FetchTable
         entity="collaborators"
         headers={headers}
+        getItemPathPrefix={this.getCollaboratorPathPrefix}
         addMessage={sharedMessages.collaboratorAdd}
         tableTitle={<Message content={sharedMessages.collaborators} />}
         {...this.props}

--- a/pkg/webui/console/containers/fetch-table/index.js
+++ b/pkg/webui/console/containers/fetch-table/index.js
@@ -173,6 +173,7 @@ class FetchTable extends Component {
       items,
       entity,
       itemPathPrefix,
+      getItemPathPrefix,
       handlesPagination,
       pageSize,
     } = this.props
@@ -185,9 +186,15 @@ class FetchTable extends Component {
     }
 
     const entitySingle = entity.substr(0, entity.length - 1)
-    const item_id = items[itemIndex].id || items[itemIndex].ids[`${entitySingle}_id`]
+    let entityPath
+    if (Boolean(getItemPathPrefix)) {
+      entityPath = getItemPathPrefix(items[itemIndex])
+    } else {
+      const item_id = items[itemIndex].id || items[itemIndex].ids[`${entitySingle}_id`]
+      entityPath = `${itemPathPrefix}/${item_id}`
+    }
 
-    dispatch(push(`${pathname}${itemPathPrefix}/${item_id}`))
+    dispatch(push(`${pathname}${entityPath}`))
   }
 
   render () {

--- a/pkg/webui/console/store/actions/applications.js
+++ b/pkg/webui/console/store/actions/applications.js
@@ -21,7 +21,12 @@ import {
 } from './pagination'
 import createApiKeysRequestActions, { createGetApiKeysListActionType } from './api-keys'
 import createApiKeyRequestActions, { createGetApiKeyActionType } from './api-key'
-import { createGetCollaboratorsListRequestActions, createGetCollaboratorsListActionType } from './collaborators'
+import {
+  createGetCollaboratorsListRequestActions,
+  createGetCollaboratorsListActionType,
+  createGetCollaboratorRequestActions,
+  createGetCollaboratorActionType,
+} from './collaborators'
 import { createRequestActions } from './lib'
 
 import {
@@ -123,6 +128,17 @@ export const [{
   success: getApplicationApiKeysListSuccess,
   failure: getApplicationApiKeysListFailure,
 }] = createApiKeysRequestActions(SHARED_NAME_SINGLE)
+
+export const GET_APP_COLLABORATOR_BASE = createGetCollaboratorActionType(SHARED_NAME_SINGLE)
+export const [{
+  request: GET_APP_COLLABORATOR,
+  success: GET_APP_COLLABORATOR_SUCCESS,
+  failure: GET_APP_COLLABORATOR_FAILURE,
+}, {
+  request: getApplicationCollaborator,
+  success: getApplicationCollaboratorSuccess,
+  failure: getApplicationCollaboratorFailure,
+}] = createGetCollaboratorRequestActions(SHARED_NAME_SINGLE)
 
 export const GET_APP_COLLABORATORS_LIST_BASE = createGetCollaboratorsListActionType(SHARED_NAME_SINGLE)
 export const [{

--- a/pkg/webui/console/store/actions/collaborators.js
+++ b/pkg/webui/console/store/actions/collaborators.js
@@ -26,7 +26,8 @@ export const createGetCollaboratorsListRequestActions = name =>
 export const createGetCollaboratorActionType = name => (
   `GET_${name}_COLLABORATOR`
 )
-
-export const getCollaborator = name => id => (
-  { type: createGetCollaboratorActionType(name), id }
-)
+export const createGetCollaboratorRequestActions = name =>
+  createRequestActions(
+    createGetCollaboratorActionType(name),
+    (parentId, collaboratorId, isUser) => ({ id: parentId, collaboratorId, isUser })
+  )

--- a/pkg/webui/console/store/actions/gateways.js
+++ b/pkg/webui/console/store/actions/gateways.js
@@ -15,7 +15,12 @@
 import createGetRightsListRequestActions, { createGetRightsListActionType } from './rights'
 import createApiKeysRequestActions, { createGetApiKeysListActionType } from './api-keys'
 import createApiKeyRequestActions, { createGetApiKeyActionType } from './api-key'
-import { createGetCollaboratorsListActionType } from './collaborators'
+import {
+  createGetCollaboratorsListRequestActions,
+  createGetCollaboratorsListActionType,
+  createGetCollaboratorRequestActions,
+  createGetCollaboratorActionType,
+} from './collaborators'
 import { createRequestActions } from './lib'
 import {
   startEventsStream,
@@ -134,6 +139,17 @@ export const [{
   failure: getGatewayApiKeysListFailure,
 }] = createApiKeysRequestActions(SHARED_NAME)
 
+export const GET_GTW_COLLABORATOR_BASE = createGetCollaboratorActionType(SHARED_NAME)
+export const [{
+  request: GET_GTW_COLLABORATOR,
+  success: GET_GTW_COLLABORATOR_SUCCESS,
+  failure: GET_GTW_COLLABORATOR_FAILURE,
+}, {
+  request: getGatewayCollaborator,
+  success: getGatewayCollaboratorSuccess,
+  failure: getGatewayCollaboratorFailure,
+}] = createGetCollaboratorRequestActions(SHARED_NAME)
+
 export const GET_GTW_COLLABORATORS_LIST_BASE = createGetCollaboratorsListActionType(SHARED_NAME)
 export const [{
   request: GET_GTW_COLLABORATORS_LIST,
@@ -143,8 +159,7 @@ export const [{
   request: getGatewayCollaboratorsList,
   success: getGatewayCollaboratorsListSuccess,
   failure: getGatewayCollaboratorsListFailure,
-}] = createRequestActions(GET_GTW_COLLABORATORS_LIST_BASE,
-  (gtwId, { page, limit } = {}) => ({ gtwId, params: { page, limit }}))
+}] = createGetCollaboratorsListRequestActions(SHARED_NAME)
 
 export const START_GTW_STATS_BASE = 'START_GATEWAY_STATISTICS'
 export const [{

--- a/pkg/webui/console/store/middleware/logics/applications.js
+++ b/pkg/webui/console/store/middleware/logics/applications.js
@@ -99,6 +99,25 @@ const getApplicationApiKeyLogic = createRequestLogic({
   },
 })
 
+const getApplicationCollaboratorLogic = createRequestLogic({
+  type: applications.GET_APP_COLLABORATOR,
+  async process ({ action }) {
+    const { id: appId, collaboratorId, isUser } = action.payload
+
+    const collaborator = isUser
+      ? await api.application.collaborators.getUser(appId, collaboratorId)
+      : await api.application.collaborators.getOrganization(appId, collaboratorId)
+
+    const { ids, ...rest } = collaborator
+
+    return {
+      id: collaboratorId,
+      isUser,
+      ...rest,
+    }
+  },
+})
+
 const getApplicationCollaboratorsLogic = createRequestLogic({
   type: applications.GET_APP_COLLABORATORS_LIST,
   async process ({ action }) {
@@ -178,6 +197,7 @@ export default [
   getApplicationsRightsLogic,
   getApplicationApiKeysLogic,
   getApplicationApiKeyLogic,
+  getApplicationCollaboratorLogic,
   getApplicationCollaboratorsLogic,
   getWebhooksLogic,
   getWebhookLogic,

--- a/pkg/webui/console/store/middleware/logics/applications.js
+++ b/pkg/webui/console/store/middleware/logics/applications.js
@@ -121,8 +121,8 @@ const getApplicationCollaboratorLogic = createRequestLogic({
 const getApplicationCollaboratorsLogic = createRequestLogic({
   type: applications.GET_APP_COLLABORATORS_LIST,
   async process ({ action }) {
-    const { id: appId } = action.payload
-    const res = await api.application.collaborators.list(appId)
+    const { id: appId, params } = action.payload
+    const res = await api.application.collaborators.list(appId, params)
     const collaborators = res.collaborators.map(function (collaborator) {
       const { ids, ...rest } = collaborator
       const isUser = !!ids.user_ids

--- a/pkg/webui/console/store/middleware/logics/gateways.js
+++ b/pkg/webui/console/store/middleware/logics/gateways.js
@@ -85,11 +85,30 @@ const getGatewaysRightsLogic = createRequestLogic({
   },
 })
 
+const getGatewayCollaboratorLogic = createRequestLogic({
+  type: gateways.GET_GTW_COLLABORATOR,
+  async process ({ action }) {
+    const { id: gtwId, collaboratorId, isUser } = action.payload
+
+    const collaborator = isUser
+      ? await api.gateway.collaborators.getUser(gtwId, collaboratorId)
+      : await api.gateway.collaborators.getOrganization(gtwId, collaboratorId)
+
+    const { ids, ...rest } = collaborator
+
+    return {
+      id: collaboratorId,
+      isUser,
+      ...rest,
+    }
+  },
+})
+
 const getGatewayCollaboratorsLogic = createRequestLogic({
   type: gateways.GET_GTW_COLLABORATORS_LIST,
   async process ({ action }) {
-    const { gtwId } = action.payload
-    const res = await api.gateway.collaborators.list(gtwId)
+    const { id } = action.payload
+    const res = await api.gateway.collaborators.list(id)
     const collaborators = res.collaborators.map(function (collaborator) {
       const { ids, ...rest } = collaborator
       const isUser = !!ids.user_ids
@@ -103,7 +122,7 @@ const getGatewayCollaboratorsLogic = createRequestLogic({
         ...rest,
       }
     })
-    return { id: gtwId, collaborators, totalCount: res.totalCount }
+    return { id, collaborators, totalCount: res.totalCount }
   },
 })
 
@@ -202,6 +221,7 @@ export default [
   deleteGatewayLogic,
   getGatewaysLogic,
   getGatewaysRightsLogic,
+  getGatewayCollaboratorLogic,
   getGatewayCollaboratorsLogic,
   startGatewayStatisticsLogic,
   updateGatewayStatisticsLogic,

--- a/pkg/webui/console/store/middleware/logics/gateways.js
+++ b/pkg/webui/console/store/middleware/logics/gateways.js
@@ -107,8 +107,8 @@ const getGatewayCollaboratorLogic = createRequestLogic({
 const getGatewayCollaboratorsLogic = createRequestLogic({
   type: gateways.GET_GTW_COLLABORATORS_LIST,
   async process ({ action }) {
-    const { id } = action.payload
-    const res = await api.gateway.collaborators.list(id)
+    const { id, params } = action.payload
+    const res = await api.gateway.collaborators.list(id, params)
     const collaborators = res.collaborators.map(function (collaborator) {
       const { ids, ...rest } = collaborator
       const isUser = !!ids.user_ids

--- a/pkg/webui/console/store/reducers/collaborator.js
+++ b/pkg/webui/console/store/reducers/collaborator.js
@@ -1,0 +1,42 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {
+  createGetCollaboratorActionType,
+} from '../actions/collaborators'
+
+import { createRequestActions } from '../actions/lib'
+
+const defaultState = {
+  collaborator: undefined,
+}
+
+const createNamedCollaboratorReducer = function (reducerName = '') {
+  const GET_COLLABORATOR_BASE = createGetCollaboratorActionType(reducerName)
+  const [{ success: GET_COLLABORATOR_SUCCESS }] = createRequestActions(GET_COLLABORATOR_BASE)
+
+  return function (state = defaultState, { type, payload }) {
+    switch (type) {
+    case GET_COLLABORATOR_SUCCESS:
+      return {
+        ...state,
+        collaborator: payload,
+      }
+    default:
+      return state
+    }
+  }
+}
+
+export default createNamedCollaboratorReducer

--- a/pkg/webui/console/store/reducers/index.js
+++ b/pkg/webui/console/store/reducers/index.js
@@ -31,6 +31,7 @@ import configuration from './configuration'
 import createNamedApiKeysReducer from './api-keys'
 import createNamedRightsReducer from './rights'
 import createNamedCollaboratorsReducer from './collaborators'
+import createNamedCollaboratorReducer from './collaborator'
 import createNamedEventsReducer from './events'
 import createNamedApiKeyReducer from './api-key'
 import link from './link'
@@ -64,6 +65,7 @@ export default combineReducers({
     gateways: createNamedRightsReducer(GATEWAY_SHARED_NAME),
   }),
   collaborators: combineReducers({
+    application: createNamedCollaboratorReducer(APPLICATION_SHARED_NAME),
     applications: createNamedCollaboratorsReducer(APPLICATION_SHARED_NAME),
     gateways: createNamedCollaboratorsReducer(GATEWAY_SHARED_NAME),
   }),

--- a/pkg/webui/console/store/reducers/index.js
+++ b/pkg/webui/console/store/reducers/index.js
@@ -67,6 +67,7 @@ export default combineReducers({
   collaborators: combineReducers({
     application: createNamedCollaboratorReducer(APPLICATION_SHARED_NAME),
     applications: createNamedCollaboratorsReducer(APPLICATION_SHARED_NAME),
+    gateway: createNamedCollaboratorReducer(GATEWAY_SHARED_NAME),
     gateways: createNamedCollaboratorsReducer(GATEWAY_SHARED_NAME),
   }),
   events: combineReducers({

--- a/pkg/webui/console/store/selectors/applications.js
+++ b/pkg/webui/console/store/selectors/applications.js
@@ -18,6 +18,7 @@ import {
   GET_APP_BASE,
   GET_APP_API_KEY_BASE,
   GET_APP_API_KEYS_LIST_BASE,
+  GET_APP_COLLABORATOR_BASE,
 } from '../actions/applications'
 import { GET_APP_LINK_BASE } from '../actions/link'
 
@@ -34,6 +35,10 @@ import {
   createRightsSelector,
   createUniversalRightsSelector,
 } from './rights'
+import {
+  createUserCollaboratorSelector,
+  createOrganizationCollaboratorSelector,
+} from './collaborators'
 import { createApiKeysSelector } from './api-keys'
 import { createApiKeySelector } from './api-key'
 import { createFetchingSelector } from './fetching'
@@ -105,3 +110,9 @@ export const selectApplicationIsLinked = function (state) {
 
   return hasBase && !hasError && isLinked && hasStats
 }
+
+// Collaborators
+export const selectApplicationUserCollaborator = createUserCollaboratorSelector(ENTITY_SINGLE)
+export const selectApplicationOrganizationCollaborator = createOrganizationCollaboratorSelector(ENTITY_SINGLE)
+export const selectApplicationCollaboratorFetching = createFetchingSelector(GET_APP_COLLABORATOR_BASE)
+export const selectApplicationCollaboratorError = createErrorSelector(GET_APP_COLLABORATOR_BASE)

--- a/pkg/webui/console/store/selectors/collaborators.js
+++ b/pkg/webui/console/store/selectors/collaborators.js
@@ -1,0 +1,39 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const selectCollaboratorsStore = (state, entity) => state.collaborators[entity]
+
+export const createCollaboratorSelector = entity => function (state) {
+  const store = selectCollaboratorsStore(state, entity)
+
+  return store.collaborator
+}
+
+export const createUserCollaboratorSelector = entity => function (state) {
+  const store = selectCollaboratorsStore(state, entity)
+  const collaborator = store.collaborator
+
+  if (Boolean(collaborator) && collaborator.isUser) {
+    return collaborator
+  }
+}
+
+export const createOrganizationCollaboratorSelector = entity => function (state) {
+  const store = selectCollaboratorsStore(state, entity)
+  const collaborator = store.collaborator
+
+  if (Boolean(collaborator) && !collaborator.isUser) {
+    return collaborator
+  }
+}

--- a/pkg/webui/console/store/selectors/gateways.js
+++ b/pkg/webui/console/store/selectors/gateways.js
@@ -20,6 +20,7 @@ import {
   UPDATE_GTW_STATS_BASE,
   GET_GTWS_RIGHTS_LIST_BASE,
   START_GTW_STATS_BASE,
+  GET_GTW_COLLABORATOR_BASE,
 } from '../actions/gateways'
 
 import {
@@ -39,13 +40,16 @@ import {
   createPaginationIdsSelectorByEntity,
   createPaginationTotalCountSelectorByEntity,
 } from './pagination'
+import {
+  createUserCollaboratorSelector,
+  createOrganizationCollaboratorSelector,
+} from './collaborators'
 import { createApiKeySelector } from './api-key'
 import { createFetchingSelector } from './fetching'
 import { createErrorSelector } from './error'
 
 const ENTITY = 'gateways'
 const ENTITY_SINGLE = 'gateway'
-
 
 // Gateway Entity
 export const selectGatewayStore = state => state.gateways
@@ -104,3 +108,9 @@ export const selectGatewayStatistics = function (state) {
 
   return statistics.stats
 }
+
+// Collaborators
+export const selectGatewayUserCollaborator = createUserCollaboratorSelector(ENTITY_SINGLE)
+export const selectGatewayOrganizationCollaborator = createOrganizationCollaboratorSelector(ENTITY_SINGLE)
+export const selectGatewayCollaboratorFetching = createFetchingSelector(GET_GTW_COLLABORATOR_BASE)
+export const selectGatewayCollaboratorError = createErrorSelector(GET_GTW_COLLABORATOR_BASE)

--- a/pkg/webui/console/views/application-collaborator-add/index.js
+++ b/pkg/webui/console/views/application-collaborator-add/index.js
@@ -77,6 +77,14 @@ export default class ApplicationCollaboratorAdd extends React.Component {
     getApplicationsRightsList()
   }
 
+  componentDidUpdate (prevProps) {
+    const { error } = this.props
+
+    if (Boolean(error) && prevProps.error !== error) {
+      throw error
+    }
+  }
+
   async handleSubmit (collaborator) {
     const { appId } = this.props
 
@@ -85,11 +93,12 @@ export default class ApplicationCollaboratorAdd extends React.Component {
   }
 
   render () {
-    const { rights, fetching, error, universalRights, redirectToList } = this.props
-
-    if (error) {
-      throw error
-    }
+    const {
+      rights,
+      fetching,
+      universalRights,
+      redirectToList,
+    } = this.props
 
     if (fetching && !rights.length) {
       return <Spinner center />

--- a/pkg/webui/console/views/application-collaborator-edit/index.js
+++ b/pkg/webui/console/views/application-collaborator-edit/index.js
@@ -103,9 +103,17 @@ export default class ApplicationCollaboratorEdit extends React.Component {
   }
 
   componentDidMount () {
-    const { loadData, appId } = this.props
+    const { loadData } = this.props
 
-    loadData(appId)
+    loadData()
+  }
+
+  componentDidUpdate (prevProps) {
+    const { error } = this.props
+
+    if (Boolean(error) && prevProps.error !== error) {
+      throw error
+    }
   }
 
   async handleSubmit (updatedCollaborator) {
@@ -151,14 +159,9 @@ export default class ApplicationCollaboratorEdit extends React.Component {
       collaborator,
       rights,
       fetching,
-      error,
       universalRights,
       redirectToList,
     } = this.props
-
-    if (error) {
-      throw error
-    }
 
     if (fetching || !collaborator) {
       return <Spinner center />

--- a/pkg/webui/console/views/application-collaborators/index.js
+++ b/pkg/webui/console/views/application-collaborators/index.js
@@ -47,7 +47,10 @@ export default class ApplicationCollaborators extends React.Component {
         <Switch>
           <Route exact path={`${match.path}`} component={ApplicationCollaboratorsList} />
           <Route path={`${match.path}/add`} component={ApplicationCollaboratorAdd} />
-          <Route path={`${match.path}/:collaboratorId`} component={ApplicationCollaboratorEdit} />
+          <Route
+            path={`${match.path}/:collaboratorType(user|organization)/:collaboratorId`}
+            component={ApplicationCollaboratorEdit}
+          />
         </Switch>
       </ErrorView>
     )

--- a/pkg/webui/console/views/gateway-collaborator-add/index.js
+++ b/pkg/webui/console/views/gateway-collaborator-add/index.js
@@ -79,6 +79,14 @@ export default class GatewayCollaboratorAdd extends React.Component {
     getGatewaysRightsList()
   }
 
+  componentDidUpdate (prevProps) {
+    const { error } = this.props
+
+    if (Boolean(error) && prevProps.error !== error) {
+      throw error
+    }
+  }
+
   handleSubmit (collaborator) {
     const { gtwId } = this.props
 
@@ -86,11 +94,12 @@ export default class GatewayCollaboratorAdd extends React.Component {
   }
 
   render () {
-    const { rights, fetching, error, redirectToList, universalRights } = this.props
-
-    if (error) {
-      throw error
-    }
+    const {
+      rights,
+      fetching,
+      redirectToList,
+      universalRights,
+    } = this.props
 
     if (fetching && !rights.length) {
       return <Spinner center />

--- a/pkg/webui/console/views/gateway-collaborator-edit/index.js
+++ b/pkg/webui/console/views/gateway-collaborator-edit/index.js
@@ -28,7 +28,7 @@ import IntlHelmet from '../../../lib/components/intl-helmet'
 import toast from '../../../components/toast'
 
 import {
-  getGatewayCollaboratorsList,
+  getGatewayCollaborator,
   getGatewaysRightsList,
 } from '../../store/actions/gateways'
 import {
@@ -37,25 +37,29 @@ import {
   selectGatewayUniversalRights,
   selectGatewayRightsFetching,
   selectGatewayRightsError,
+  selectGatewayUserCollaborator,
+  selectGatewayOrganizationCollaborator,
+  selectGatewayCollaboratorFetching,
+  selectGatewayCollaboratorError,
 } from '../../store/selectors/gateways'
 
 import api from '../../api'
 
 @connect(function (state, props) {
   const gtwId = selectSelectedGatewayId(state, props)
-  const { collaboratorId } = props.match.params
-  const collaboratorsFetching = state.collaborators.gateways.fetching
-  const collaboratorsError = state.collaborators.gateways.error
 
-  const gtwCollaborators = state.collaborators.gateways[gtwId]
-  const collaborator = gtwCollaborators ? gtwCollaborators.collaborators
-    .find(c => c.id === collaboratorId) : undefined
+  const { collaboratorId, collaboratorType } = props.match.params
 
-  const fetching = selectGatewayRightsFetching(state) || collaboratorsFetching
-  const error = selectGatewayRightsError(state) || collaboratorsError
+  const collaborator = collaboratorType === 'user'
+    ? selectGatewayUserCollaborator(state)
+    : selectGatewayOrganizationCollaborator(state)
+
+  const fetching = selectGatewayRightsFetching(state) || selectGatewayCollaboratorFetching(state)
+  const error = selectGatewayRightsError(state) || selectGatewayCollaboratorError(state)
 
   return {
     collaboratorId,
+    collaboratorType,
     collaborator,
     gtwId,
     rights: selectGatewayRights(state),
@@ -65,16 +69,20 @@ import api from '../../api'
   }
 
 }, (dispatch, ownProps) => ({
-  async loadData (gtwId) {
+  loadData (gtwId, collaboratorId, isUser) {
     dispatch(getGatewaysRightsList(gtwId))
-    dispatch(getGatewayCollaboratorsList(gtwId))
+    dispatch(getGatewayCollaborator(gtwId, collaboratorId, isUser))
   },
   redirectToList (gtwId) {
     dispatch(replace(`/console/gateways/${gtwId}/collaborators`))
   },
 }), (stateProps, dispatchProps, ownProps) => ({
   ...stateProps, ...dispatchProps, ...ownProps,
-  loadData: () => dispatchProps.loadData(stateProps.gtwId),
+  loadData: () => dispatchProps.loadData(
+    stateProps.gtwId,
+    stateProps.collaboratorId,
+    stateProps.collaboratorType === 'user'
+  ),
   redirectToList: () => dispatchProps.redirectToList(stateProps.gtwId),
 }))
 @withBreadcrumb('gtws.single.collaborators.edit', function (props) {

--- a/pkg/webui/console/views/gateway-collaborator-edit/index.js
+++ b/pkg/webui/console/views/gateway-collaborator-edit/index.js
@@ -109,6 +109,14 @@ export default class GatewayCollaboratorEdit extends React.Component {
     loadData()
   }
 
+  componentDidUpdate (prevProps) {
+    const { error } = this.props
+
+    if (Boolean(error) && prevProps.error !== error) {
+      throw error
+    }
+  }
+
   handleSubmit (updatedCollaborator) {
     const { gtwId } = this.props
 
@@ -129,11 +137,13 @@ export default class GatewayCollaboratorEdit extends React.Component {
   }
 
   render () {
-    const { collaborator, rights, fetching, error, redirectToList, universalRights } = this.props
-
-    if (error) {
-      throw error
-    }
+    const {
+      collaborator,
+      rights,
+      fetching,
+      redirectToList,
+      universalRights,
+    } = this.props
 
     if (fetching || !collaborator) {
       return <Spinner center />

--- a/pkg/webui/console/views/gateway-collaborators/index.js
+++ b/pkg/webui/console/views/gateway-collaborators/index.js
@@ -47,7 +47,10 @@ export default class GatewayCollaborators extends React.Component {
         <Switch>
           <Route exact path={`${match.path}`} component={GatewayCollaboratorsList} />
           <Route path={`${match.path}/add`} component={GatewayCollaboratorAdd} />
-          <Route path={`${match.path}/:collaboratorId`} component={GatewayCollaboratorEdit} />
+          <Route
+            path={`${match.path}/:collaboratorType(user|organization)/:collaboratorId`}
+            component={GatewayCollaboratorEdit}
+          />
         </Switch>
       </ErrorView>
     )

--- a/sdk/js/src/service/collaborators.js
+++ b/sdk/js/src/service/collaborators.js
@@ -44,11 +44,11 @@ class Collaborators {
     return this._getById(entityId, organizationId, false)
   }
 
-  async getAll (entityId) {
+  async getAll (entityId, params) {
     const entityIdRoute = this._parentRoutes.list
     const result = await this._api.ListCollaborators({
       routeParams: { [entityIdRoute]: entityId },
-    })
+    }, params)
 
     return Marshaler.payloadListResponse('collaborators', result)
   }

--- a/sdk/js/src/service/gateways.js
+++ b/sdk/js/src/service/gateways.js
@@ -31,6 +31,7 @@ class Gateways {
     })
     this.Collaborators = new Collaborators(api.GatewayAccess, {
       parentRoutes: {
+        get: 'gateway_ids.gateway_id',
         list: 'gateway_ids.gateway_id',
         set: 'gateway_ids.gateway_id',
       },


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/722

#### Changes
<!-- What are the changes made in this pull request? -->

- Add the `params` argument to the `getAll` method of the collaborators service
- Refactor app/gtw collaborators store similar to app/gtw api-keys store
- Change routes for editing collaborators `/console/{entity}/{id}/collaborators/{collaboratorId}` to `/console/{entity}/{id}/collaborators/user/{collaboratorId}` and `/console/{entity}/{id}/collaborators/organization/{collaboratorId}`

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

1. New routes to the edit view are necessary to distinguish between user and organization collaborators. If the user navigated directly to `/console/{entity}/{id}/collaborators/{collaboratorId}` there is no way to know the type of the collaborator and hence no clear way to decide which endpoint to call (after https://github.com/TheThingsNetwork/lorawan-stack/pull/1001 we cannot fetch organization collaborators via the `user` endpoint)
2. Error handling:
```
  componentDidUpdate (prevProps) {
    const { error } = this.props

    if (Boolean(error) && prevProps.error !== error) {
      throw error
    }
  }
```
See https://github.com/TheThingsNetwork/lorawan-stack/issues/1021
3. You can use [this scrpt](https://gist.github.com/bafonins/8dc9d62866132d136cd2489643520fc0) to populate the stack with test entities.