### PR TITLE
console: Fix misaligned spinner

### DIFF
--- a/pkg/webui/components/spinner/index.js
+++ b/pkg/webui/components/spinner/index.js
@@ -85,13 +85,15 @@ export default class Spinner extends React.PureComponent {
               <stop offset="100%" className={style.stop} stopColor="white" stopOpacity="0" />
             </linearGradient>
           </defs>
-          <circle
-            cx="50"
-            cy="50"
-            r="40"
-            className={style.bar}
-            stroke={`url(#${this.id})`}
-          />
+          <g transform="translate(50, 50)">
+            <circle
+              cx="0"
+              cy="0"
+              r="40"
+              className={style.bar}
+              stroke={`url(#${this.id})`}
+            />
+          </g>
           <circle
             cx="50"
             cy="50"

--- a/pkg/webui/components/spinner/spinner.styl
+++ b/pkg/webui/components/spinner/spinner.styl
@@ -44,7 +44,6 @@ $s = $cs.l
   stroke-linecap: round
 
   animation: rotate .6s infinite linear
-  transform-origin: center center
 
 .stop
   stop-color: $c-active-blue


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #941 

#### Changes
<!-- What are the changes made in this pull request? -->

- Wrapped spinning part of spinner in a svg container of which I used to center the circle, which means the center point for the circle to spin is not different between browsers and different view percentages.



