### PR TITLE
Remove unnecessary props passed by breadcrumbs context

### DIFF
--- a/pkg/webui/components/breadcrumbs/context.js
+++ b/pkg/webui/components/breadcrumbs/context.js
@@ -79,7 +79,9 @@ const withBreadcrumb = (id, element) => function (Component) {
     }
 
     render () {
-      return <Component {...this.props} />
+      const { add, remove, breadcrumb, ...rest } = this.props
+
+      return <Component {...rest} />
     }
   }
 


### PR DESCRIPTION
dont pass breacrumbs context props to wrapper component

<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR removes props related to the breadcrumbs context from the original props of the component wrapped by the `withBreacrumb` hoc.

#### Changes
<!-- What are the changes made in this pull request? -->

- Destruct props in the context consumer and pass only `rest` to the wrapped component
