### PR TITLE
Fix HTTP Error code conversion

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -2285,6 +2285,33 @@
       "file": "tls.go"
     }
   },
+  "error:pkg/console:invalid_state": {
+    "translations": {
+      "en": "invalid state parameter in request"
+    },
+    "description": {
+      "package": "pkg/console",
+      "file": "callback.go"
+    }
+  },
+  "error:pkg/console:missing_code": {
+    "translations": {
+      "en": "missing code parameter in request"
+    },
+    "description": {
+      "package": "pkg/console",
+      "file": "callback.go"
+    }
+  },
+  "error:pkg/console:missing_state": {
+    "translations": {
+      "en": "missing state parameter in request"
+    },
+    "description": {
+      "package": "pkg/console",
+      "file": "callback.go"
+    }
+  },
   "error:pkg/console:no_oauth_config": {
     "translations": {
       "en": "no OAuth configuration found for the Console"
@@ -2292,6 +2319,15 @@
     "description": {
       "package": "pkg/console",
       "file": "console.go"
+    }
+  },
+  "error:pkg/console:oauth_authorization": {
+    "translations": {
+      "en": "OAuth authorization failed with `{error}`"
+    },
+    "description": {
+      "package": "pkg/console",
+      "file": "callback.go"
     }
   },
   "error:pkg/crypto/cryptoservices:no_app_key": {

--- a/config/messages.json
+++ b/config/messages.json
@@ -2654,15 +2654,6 @@
       "file": "mac.go"
     }
   },
-  "error:pkg/errors/web:http": {
-    "translations": {
-      "en": "HTTP error: {message}"
-    },
-    "description": {
-      "package": "pkg/errors/web",
-      "file": "middleware.go"
-    }
-  },
   "error:pkg/errors:odd_kv": {
     "translations": {
       "en": "Odd number of key-value elements"

--- a/pkg/console/cookie_auth.go
+++ b/pkg/console/cookie_auth.go
@@ -45,27 +45,22 @@ type authCookie struct {
 	Expiry       time.Time
 }
 
-// setCookie sets the authCookie on the request.
-func (console *Console) setAuthCookie(c echo.Context, value authCookie) error {
-	return console.AuthCookie().Set(c, value)
-}
-
-// getCookie returns the authCookie from the echo context.
 func (console *Console) getAuthCookie(c echo.Context) (authCookie, error) {
 	value := authCookie{}
 	ok, err := console.AuthCookie().Get(c, &value)
 	if err != nil {
 		return authCookie{}, err
 	}
-
 	if !ok {
-		return authCookie{}, echo.NewHTTPError(http.StatusUnauthorized, "You are not logged in")
+		return authCookie{}, echo.NewHTTPError(http.StatusUnauthorized, "No auth cookie")
 	}
-
 	return value, nil
 }
 
-// removeCookie removes the authCookie.
+func (console *Console) setAuthCookie(c echo.Context, value authCookie) error {
+	return console.AuthCookie().Set(c, value)
+}
+
 func (console *Console) removeAuthCookie(c echo.Context) {
 	console.AuthCookie().Remove(c)
 }

--- a/pkg/console/cookie_state.go
+++ b/pkg/console/cookie_state.go
@@ -34,19 +34,16 @@ const stateCookieName = "_console_state"
 func (console *Console) StateCookie() *cookie.Cookie {
 	return &cookie.Cookie{
 		Name:     stateCookieName,
+		HTTPOnly: true,
 		Path:     console.config.UI.MountPath(),
 		MaxAge:   10 * time.Minute,
-		HTTPOnly: true,
 	}
 }
 
 // state is the shape of the state for the OAuth flow.
 type state struct {
-	// Secret is the secret in the state.
 	Secret string
-
-	// Next is the path the user was trying to visit.
-	Next string
+	Next   string
 }
 
 func newState(next string) state {
@@ -60,13 +57,11 @@ func (console *Console) getStateCookie(c echo.Context) (state, error) {
 	s := state{}
 	ok, err := console.StateCookie().Get(c, &s)
 	if err != nil {
-		return s, echo.NewHTTPError(http.StatusBadRequest, "Invalid state cookie")
+		return s, err
 	}
-
 	if !ok {
 		return s, echo.NewHTTPError(http.StatusBadRequest, "No state cookie")
 	}
-
 	return s, nil
 }
 

--- a/pkg/errors/http.go
+++ b/pkg/errors/http.go
@@ -75,15 +75,16 @@ func ToHTTPStatusCode(err error) int {
 }
 
 // FromHTTPStatusCode maps an HTTP response code to an error.
-func FromHTTPStatusCode(status int) error {
+func FromHTTPStatusCode(status int, publicAttributes ...string) Error {
 	code := uint32(codes.Unknown)
 	if c, ok := httpErrorCodes[status]; ok {
 		code = c
 	}
 	return build(Definition{
-		namespace:     namespace(2),
-		messageFormat: http.StatusText(status),
-		code:          code,
+		namespace:        namespace(2),
+		messageFormat:    http.StatusText(status),
+		publicAttributes: publicAttributes,
+		code:             code,
 	}, 4)
 }
 

--- a/pkg/errors/web/middleware_test.go
+++ b/pkg/errors/web/middleware_test.go
@@ -43,7 +43,7 @@ func TestErrorHandling(t *testing.T) {
 			Assert: func(a *assertions.Assertion, res *http.Response) {
 				a.So(res.StatusCode, should.Equal, http.StatusNotFound)
 				b, _ := ioutil.ReadAll(res.Body)
-				a.So(string(b), should.ContainSubstring, `"namespace":"pkg/errors/web","name":"http"`)
+				a.So(string(b), should.ContainSubstring, `"namespace":"pkg/errors/web"`)
 			},
 		},
 		{

--- a/pkg/web/error_handler.go
+++ b/pkg/web/error_handler.go
@@ -22,5 +22,5 @@ import (
 // ErrorHandler is an echo.HTTPErrorHandler.
 func ErrorHandler(err error, c echo.Context) {
 	status, err := web.ProcessError(err)
-	c.JSON(status, err.Error())
+	c.JSONPretty(status, err, "  ")
 }

--- a/pkg/webui/lib/errors/utils.js
+++ b/pkg/webui/lib/errors/utils.js
@@ -87,7 +87,7 @@ export const isNotFoundError = error => (
  * `false` otherwise.
  */
 export const isInternalError = error => (
-  grpcStatusCode(error) === 13
+  grpcStatusCode(error) === 13 // NOTE: HTTP 500 can also be UnknownError.
 )
 
 /**
@@ -97,7 +97,7 @@ export const isInternalError = error => (
  * `false` otherwise.
  */
 export const isAlreadyExistsError = error => (
-  grpcStatusCode(error) === 6
+  grpcStatusCode(error) === 6 // NOTE: HTTP 409 can also be AbortedError.
 )
 
 /**
@@ -107,7 +107,7 @@ export const isAlreadyExistsError = error => (
  * `false` otherwise.
  */
 export const isPermissionDeniedError = error => (
-  grpcStatusCode(error) === 7
+  grpcStatusCode(error) === 7 || httpStatusCode(error) === 403
 )
 
 /**
@@ -117,7 +117,7 @@ export const isPermissionDeniedError = error => (
  * `false` otherwise.
  */
 export const isUnauthenticatedError = error => (
-  grpcStatusCode(error) === 16
+  grpcStatusCode(error) === 16 || httpStatusCode(error) === 401
 )
 
 /**

--- a/pkg/webui/lib/errors/utils.js
+++ b/pkg/webui/lib/errors/utils.js
@@ -118,9 +118,6 @@ export const isPermissionDeniedError = error => (
  */
 export const isUnauthenticatedError = error => (
   grpcStatusCode(error) === 16
-  || (isBackend(error)
-    && error.details[0].attributes
-    && error.details[0].attributes.message === 'code=401, message=You are not logged in') // TODO: Remove this once #1014 is resolved
 )
 
 /**


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This Pull Request fixes the conversion from Echo errors to TTN errors.

Additionally it turns the particular errors mentioned in #1014 into TTN errors.

Resolves #1014 	

#### Changes
<!-- What are the changes made in this pull request? -->

- Fixed conversion from Echo errors to TTN errors
- Changed errors used in Console OAuth flow

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Fixed an issue where incorrect error codes were returned from the console's OAuth flow.
