### PR TITLE
Add option to hide one page pagination

### DIFF
--- a/pkg/webui/components/pagination/__snapshots__/index_test.js.snap
+++ b/pkg/webui/components/pagination/__snapshots__/index_test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Pagination has only a single page should match snapshot 1`] = `
+exports[`Pagination has only a single page with hiding option disabled should match snapshot 1`] = `
 <ul
   className="pagination"
 >

--- a/pkg/webui/components/pagination/index.js
+++ b/pkg/webui/components/pagination/index.js
@@ -36,9 +36,16 @@ class Pagination extends React.PureComponent {
       initialPage = 1,
       pageRangeDisplayed,
       marginPagesDisplayed,
+      hideIfOnlyOnePage,
       onPageChange,
+      pageCount,
       ...rest
     } = this.props
+
+    // Don't show pagination if there is only one page
+    if (hideIfOnlyOnePage && pageCount === 1) {
+      return null
+    }
 
     const containerClassNames = classnames(style.pagination, className)
     const breakClassNames = classnames(style.item, style.itemBreak)
@@ -74,6 +81,7 @@ class Pagination extends React.PureComponent {
         pageRangeDisplayed={pageRangeDisplayed}
         marginPagesDisplayed={marginPagesDisplayed}
         onPageChange={this.onPageChange}
+        pageCount={pageCount}
         {...rest}
       />
     )
@@ -100,10 +108,14 @@ Pagination.propTypes = {
   marginPagesDisplayed: PropTypes.number,
   /** The initial page number to be selected when the component
    * gets rendered for the first time. Is 1-based.
-   * */
+   */
   initialPage: PropTypes.number,
   /** An onClick handler that gets called with the new page number */
   onPageChange: PropTypes.func.isRequired,
+  /** A flag indicating whether the pagination should be hidden when there is
+   * only one page.
+   */
+  hideIfOnlyOnePage: PropTypes.bool,
 }
 
 Pagination.defaultProps = {
@@ -111,6 +123,7 @@ Pagination.defaultProps = {
   pageRangeDisplayed: 1,
   marginPagesDisplayed: 1,
   initialPage: 1,
+  hideIfOnlyOnePage: true,
 }
 
 export default Pagination

--- a/pkg/webui/components/pagination/index_driver.js
+++ b/pkg/webui/components/pagination/index_driver.js
@@ -21,11 +21,16 @@ export default function () {
     component: undefined,
     when: {
       created (props) {
-        driver.component = shallow(
+        const wrapper = shallow(
           <Pagination {...props} />
-        ).dive()
+        )
 
-        return driver
+        if (wrapper.type() !== null) {
+          driver.component = wrapper.dive()
+          return driver
+        }
+
+        return undefined
       },
       navigatedNextPage () {
         driver.get.nextNavigationButton().simulate('click', {

--- a/pkg/webui/components/pagination/index_test.js
+++ b/pkg/webui/components/pagination/index_test.js
@@ -22,19 +22,29 @@ describe('Pagination', function () {
   })
 
   describe('has only a single page', function () {
-    beforeEach(function () {
-      driver.when.created({ pageCount: 1 })
-    })
-    it('should match snapshot', function () {
-      expect(driver.component).toMatchSnapshot()
-    })
+    describe('with hiding option disabled', function () {
+      beforeEach(function () {
+        driver.when.created({ pageCount: 1, hideIfOnlyOnePage: false })
+      })
+      it('should match snapshot', function () {
+        expect(driver.component).toMatchSnapshot()
+      })
 
-    it('should disable the previous page navigation', function () {
-      expect(driver.is.prevNavigationDisabled()).toBeTruthy()
-    })
+      it('should disable the previous page navigation', function () {
+        expect(driver.is.prevNavigationDisabled()).toBeTruthy()
+      })
 
-    it('should disable the next page navigation', function () {
-      expect(driver.is.nextNavigationDisabled()).toBeTruthy()
+      it('should disable the next page navigation', function () {
+        expect(driver.is.nextNavigationDisabled()).toBeTruthy()
+      })
+    })
+    describe('with hiding option enabled', function () {
+      beforeEach(function () {
+        driver.when.created({ pageCount: 1 })
+      })
+      it('should not render', function () {
+        expect(driver.component).toBe(undefined)
+      })
     })
   })
 

--- a/pkg/webui/components/table/__snapshots__/index_test.js.snap
+++ b/pkg/webui/components/table/__snapshots__/index_test.js.snap
@@ -201,6 +201,7 @@ exports[`Table is paginated should match snapshot 1`] = `
             <Pagination
               className="pagination"
               disableInitialCallback={true}
+              hideIfOnlyOnePage={true}
               initialPage={0}
               marginPagesDisplayed={1}
               onPageChange={[Function]}


### PR DESCRIPTION
#### Summary
Closes #728 

#### Changes
- Add an option to the pagination component to hide the widget when there is only one page displayed (will be enabled by default)
