### PR TITLE
Take frequency plan's max EIRP as override when set

### DIFF
--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -295,7 +295,8 @@ func (c *Connection) SendDown(path *ttnpb.DownlinkPath, msg *ttnpb.DownlinkMessa
 		if sb, ok := phy.FindSubBand(rx.frequency); ok {
 			eirp = sb.MaxEIRP
 		}
-		if c.fp.MaxEIRP != nil && *c.fp.MaxEIRP < eirp {
+		// TODO: Take frequency plan's sub-band MaxEIRP (https://github.com/TheThingsNetwork/lorawan-stack/issues/300)
+		if c.fp.MaxEIRP != nil {
 			eirp = *c.fp.MaxEIRP
 		}
 		settings := ttnpb.TxSettings{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #1033 
References #300 

#### Changes
<!-- What are the changes made in this pull request? -->

- Take the frequency plan's max EIRP as override when set. This changes behavior and is documented in https://github.com/TheThingsNetwork/lorawan-frequency-plans already

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Changed interpretation of frequency plan's maximum EIRP from a ceiling to a overriding value of any band (PHY) settings