### PR TITLE
Do not require abp flag for multicast

### DIFF
--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -312,7 +312,9 @@ var (
 				}
 			}
 
-			if abp, _ := cmd.Flags().GetBool("abp"); abp {
+			abp, _ := cmd.Flags().GetBool("abp")
+			multicast, _ := cmd.Flags().GetBool("multicast")
+			if abp || multicast {
 				device.SupportsJoin = false
 				if config.NetworkServerEnabled {
 					paths = append(paths, "supports_join")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Do not require `--abp` when creating multicast devices

#### Changes
<!-- What are the changes made in this pull request? -->

- Interpret `--multicast` as ABP implicitly