### PR TITLE
console: Fix Device tab display

### DIFF
--- a/pkg/webui/components/tabs/tab/tab.styl
+++ b/pkg/webui/components/tabs/tab/tab.styl
@@ -16,6 +16,9 @@
   display: flex
   flex-direction: column
 
+  &:not(:last-child)
+    margin-bottom: 0
+
 .tab-item
   display: flex
   white-space: nowrap
@@ -29,9 +32,6 @@
 
   &:not(.tab-item-active):hover
     color: $tc-deep-gray
-
-  &:not(:last-child)
-    margin-bottom: 0
 
   &-narrow
     padding: $cs.l $cs.m

--- a/pkg/webui/components/tabs/tabs.styl
+++ b/pkg/webui/components/tabs/tabs.styl
@@ -16,8 +16,8 @@
   box-sizing: border-box
   list-style-type: none
   padding: 0
-  height: 3rem
   display: flex
+  margin: 0
 
   .icon
     margin-right: $cs.xs

--- a/pkg/webui/console/views/device/device.styl
+++ b/pkg/webui/console/views/device/device.styl
@@ -36,5 +36,5 @@
   border-left: 0
   border-right: 0
   border-top: 0
-  margin-top: "calc(%s + 2px)" % ($cs.m * -1)
+  margin-top: 0
   margin-bottom: $ls.s


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #1035 

#### Changes
<!-- What are the changes made in this pull request? -->

- Removes css "calc" for margin as results where inconsistent across browsers.
- Removed fixed height of tab containers so tab item content and padding controls height.
- Moved tab ul margin override to correct classname. 

