### PR TITLE
Always replace the downlink task start time

### DIFF
--- a/pkg/networkserver/grpc_asns.go
+++ b/pkg/networkserver/grpc_asns.go
@@ -199,7 +199,7 @@ func (ns *NetworkServer) DownlinkQueueReplace(ctx context.Context, req *ttnpb.Do
 	if dev.MACState != nil && dev.MACState.DeviceClass != ttnpb.CLASS_A && len(dev.QueuedApplicationDownlinks) > 0 {
 		startAt := time.Now().UTC()
 		logger.WithField("start_at", startAt).Debug("Add downlink task with application downlink pending")
-		return ttnpb.Empty, ns.downlinkTasks.Add(ctx, req.EndDeviceIdentifiers, startAt, false)
+		return ttnpb.Empty, ns.downlinkTasks.Add(ctx, req.EndDeviceIdentifiers, startAt, true)
 	}
 	return ttnpb.Empty, nil
 }
@@ -245,7 +245,7 @@ func (ns *NetworkServer) DownlinkQueuePush(ctx context.Context, req *ttnpb.Downl
 	if dev.MACState != nil && dev.MACState.DeviceClass != ttnpb.CLASS_A {
 		startAt := time.Now().UTC()
 		logger.WithField("start_at", startAt).Debug("Add downlink task with application downlink pending")
-		return ttnpb.Empty, ns.downlinkTasks.Add(ctx, req.EndDeviceIdentifiers, startAt, false)
+		return ttnpb.Empty, ns.downlinkTasks.Add(ctx, req.EndDeviceIdentifiers, startAt, true)
 	}
 	return ttnpb.Empty, nil
 }

--- a/pkg/networkserver/grpc_asns_test.go
+++ b/pkg/networkserver/grpc_asns_test.go
@@ -427,7 +427,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 					DeviceID:               "test-dev-id",
 					ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
 				})
-				a.So(replace, should.BeFalse)
+				a.So(replace, should.BeTrue)
 				a.So([]time.Time{start, at, time.Now()}, should.BeChronological)
 				return nil
 			},
@@ -1202,7 +1202,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 					DeviceID:               "test-dev-id",
 					ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
 				})
-				a.So(replace, should.BeFalse)
+				a.So(replace, should.BeTrue)
 				a.So([]time.Time{start, at, time.Now()}, should.BeChronological)
 				return nil
 			},
@@ -1286,7 +1286,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 					DeviceID:               "test-dev-id",
 					ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
 				})
-				a.So(replace, should.BeFalse)
+				a.So(replace, should.BeTrue)
 				a.So([]time.Time{start, at, time.Now()}, should.BeChronological)
 				return nil
 			},
@@ -1366,7 +1366,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 					DeviceID:               "test-dev-id",
 					ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
 				})
-				a.So(replace, should.BeFalse)
+				a.So(replace, should.BeTrue)
 				a.So([]time.Time{start, at, time.Now()}, should.BeChronological)
 				return nil
 			},

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -348,7 +348,7 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 	if addDownlinkTask {
 		startAt := time.Now().UTC()
 		log.FromContext(ctx).WithField("start_at", startAt).Debug("Add downlink task")
-		if err = ns.downlinkTasks.Add(ctx, dev.EndDeviceIdentifiers, startAt, false); err != nil {
+		if err = ns.downlinkTasks.Add(ctx, dev.EndDeviceIdentifiers, startAt, true); err != nil {
 			log.FromContext(ctx).WithError(err).Warn("Failed to add downlink task for device after set")
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Refs #936 
Proper downlink task start times will be done as part of #936. For now it's nice to get this in, such that if e.g. an absolute time downlink is queued, but later replaced NS doesn't wait until the timestamp of that old downlink before scheduling downlink.