### PR TITLE
Fix flaky AS test in CI

### DIFF
--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -499,8 +499,11 @@ hardware_versions:
 							chs.downErr <- err
 							continue
 						}
-						err = nc.Publish(subject, buf)
-						chs.downErr <- err
+						chs.downErr <- nc.Publish(subject, buf)
+						err = nc.FlushTimeout(Timeout)
+						if err != nil {
+							chs.downErr <- err
+						}
 					}
 				}()
 				errCh := make(chan error, 1)

--- a/pkg/applicationserver/applicationserver_util_test.go
+++ b/pkg/applicationserver/applicationserver_util_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	Timeout = (1 << 8) * test.Delay
+	Timeout = (1 << 9) * test.Delay
 )
 
 // MockDeviceRegistry is a mock DeviceRegistry used for testing.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #1017

#### Changes
<!-- What are the changes made in this pull request? -->

- Increase timeout only for upstream messages inside tests

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I'm not closing #1017 directly after merging this, since I do believe this heisenbug needs more time testing than just CI passing 10 times.