### PR TITLE
Remove hardcoded app root paths

### DIFF
--- a/pkg/webui/components/event/types/crud/index.js
+++ b/pkg/webui/components/event/types/crud/index.js
@@ -20,9 +20,9 @@ import Icon from '../../../icon'
 import PropTypes from '../../../../lib/prop-types'
 import { getEntityId } from '../../../../lib/selectors/id'
 import { warn } from '../../../../lib/log'
-import { getEventActionByName } from '..'
-
 import style from './crud.styl'
+
+import { getEventActionByName } from '..'
 
 class CRUDEvent extends React.PureComponent {
 

--- a/pkg/webui/components/header/index.js
+++ b/pkg/webui/components/header/index.js
@@ -20,42 +20,14 @@ import NavigationBar from '../navigation/bar'
 import ProfileDropdown from '../profile-dropdown'
 import Input from '../input'
 import PropTypes from '../../lib/prop-types'
-import sharedMessages from '../../lib/shared-messages'
 
 import styles from './header.styl'
-
-const defaultNavigationEntries = [
-  {
-    title: sharedMessages.overview,
-    icon: 'overview',
-    path: '/console',
-    exact: true,
-  },
-  {
-    title: sharedMessages.applications,
-    icon: 'application',
-    path: '/console/applications',
-  },
-  {
-    title: sharedMessages.gateways,
-    icon: 'gateway',
-    path: '/console/gateways',
-  },
-]
-
-const defaultDropdownItems = handleLogout => [
-  {
-    title: sharedMessages.logout,
-    icon: 'power_settings_new',
-    action: handleLogout,
-  },
-]
 
 const Header = function ({
   className,
   handleLogout = () => null,
-  dropdownItems = defaultDropdownItems(handleLogout),
-  navigationEntries = defaultNavigationEntries,
+  dropdownItems,
+  navigationEntries,
   user,
   searchable,
   handleSearchRequest = () => null,
@@ -84,7 +56,7 @@ const Header = function ({
             <div className={styles.right}>
               { searchable && <Input icon="search" onEnter={handleSearchRequest} /> }
               <ProfileDropdown
-                dropdownItems={dropdownItems || defaultDropdownItems}
+                dropdownItems={dropdownItems}
                 userId={user.ids.user_id}
                 anchored={anchored}
               />
@@ -112,9 +84,9 @@ Header.propTypes = {
   dropdownItems: PropTypes.arrayOf(PropTypes.shape({
     title: PropTypes.message.isRequired,
     icon: PropTypes.string,
-    path: PropTypes.string.isRequired,
+    path: PropTypes.string,
     action: PropTypes.func,
-  })),
+  })).isRequired,
   /**
    * A list of navigation bar entries.
    * @param {(string|Object)} title - The title to be displayed
@@ -122,11 +94,11 @@ Header.propTypes = {
    * @param {string} path -  The path for a navigation tab
    * @param {boolean} exact - Flag identifying whether the path should be matched exactly
    */
-  navigationEntries: PropTypes.arrayOf(PropTypes.shape({
+  entries: PropTypes.arrayOf(PropTypes.shape({
     path: PropTypes.string.isRequired,
     title: PropTypes.message.isRequired,
-    action: PropTypes.func,
     icon: PropTypes.string,
+    exact: PropTypes.bool,
   })),
   /** Flag identifying whether links should be rendered as plain anchor link */
   anchored: PropTypes.bool,

--- a/pkg/webui/components/link/index.js
+++ b/pkg/webui/components/link/index.js
@@ -18,6 +18,8 @@ import classnames from 'classnames'
 import { injectIntl } from 'react-intl'
 
 import PropTypes from '../../lib/prop-types'
+import { withEnv } from '../../lib/components/env'
+import { url as urlPattern } from '../../lib/regexp'
 
 import style from './link.styl'
 
@@ -126,5 +128,19 @@ AnchorLink.defaultProps = {
 }
 
 Link.Anchor = injectIntl(AnchorLink)
+
+const BaseAnchorLink = function ({ env, href, ...rest }) {
+  const { appRoot } = env
+
+  // Prevent prefixing proper URLs
+  const path = href.match(urlPattern) ? href : appRoot + href
+
+  return <Link.Anchor href={path} {...rest} />
+}
+
+BaseAnchorLink.propTypes = AnchorLink.propTypes
+BaseAnchorLink.defaultProps = AnchorLink.defaultProps
+
+Link.BaseAnchor = withEnv(BaseAnchorLink)
 
 export default injectIntl(Link)

--- a/pkg/webui/components/navigation/link/index.js
+++ b/pkg/webui/components/navigation/link/index.js
@@ -52,7 +52,7 @@ const NavigationAnchorLink = function ({
   ...rest
 }) {
   return (
-    <Link.Anchor
+    <Link.BaseAnchor
       href={path}
       className={classnames(className, style.link)}
       children={children}

--- a/pkg/webui/components/profile-dropdown/index.js
+++ b/pkg/webui/components/profile-dropdown/index.js
@@ -116,7 +116,7 @@ const Dropdown = ({ items, anchored }) => (
             <Message content={item.title} />
           </button>)
         : anchored
-          ? <Link.Anchor href={item.path}>{icon}<Message content={item.title} /></Link.Anchor>
+          ? <Link.BaseAnchor href={item.path}>{icon}<Message content={item.title} /></Link.BaseAnchor>
           : <Link to={item.path}>{icon}<Message content={item.title} /></Link>
       return (
         <li className={styles.dropdownItem} key={item.title.id || item.title}>

--- a/pkg/webui/console.js
+++ b/pkg/webui/console.js
@@ -24,11 +24,13 @@ import { SideNavigationProvider } from './components/navigation/side/context'
 import Init from './lib/components/init'
 import WithLocale from './lib/components/with-locale'
 import env from './lib/env'
+import { selectApplicationRootPath } from './lib/selectors/env'
 
 import createStore from './console/store'
 import App from './console/views/app'
 
-const history = createBrowserHistory()
+const appRoot = selectApplicationRootPath()
+const history = createBrowserHistory({ basename: `${appRoot}/` })
 const store = createStore(history)
 
 const Console = () => (

--- a/pkg/webui/console.js
+++ b/pkg/webui/console.js
@@ -23,20 +23,13 @@ import { BreadcrumbsProvider } from './components/breadcrumbs/context'
 import { SideNavigationProvider } from './components/navigation/side/context'
 import Init from './lib/components/init'
 import WithLocale from './lib/components/with-locale'
+import env from './lib/env'
 
 import createStore from './console/store'
 import App from './console/views/app'
 
 const history = createBrowserHistory()
 const store = createStore(history)
-const env = {
-  app_root: window.APP_ROOT,
-  assets_root: window.ASSETS_ROOT,
-  config: window.APP_CONFIG,
-  page_data: window.PAGE_DATA,
-  site_name: window.SITE_NAME,
-  site_title: window.SITE_TITLE,
-}
 
 const Console = () => (
   <EnvProvider env={env}>

--- a/pkg/webui/console/api/index.js
+++ b/pkg/webui/console/api/index.js
@@ -17,8 +17,14 @@ import TTN from 'ttn-lw'
 
 import token from '../lib/access-token'
 import getCookieValue from '../../lib/cookie'
+import {
+  selectApplicationConfig,
+  selectApplicationRootPath,
+} from '../../lib/selectors/env'
 
-const config = window.APP_CONFIG
+const config = selectApplicationConfig()
+const appRoot = selectApplicationRootPath()
+
 const stack = {
   is: config.is.enabled ? config.is.base_url : undefined,
   gs: config.gs.enabled ? config.gs.base_url : undefined,
@@ -41,10 +47,10 @@ const instance = axios.create({
 export default {
   console: {
     token () {
-      return instance.get('/console/api/auth/token')
+      return instance.get(`${appRoot}/api/auth/token`)
     },
     logout () {
-      return instance.post('/console/api/auth/logout')
+      return instance.post(`${appRoot}/api/auth/logout`)
     },
   },
   clients: {

--- a/pkg/webui/console/containers/application-events/index.js
+++ b/pkg/webui/console/containers/application-events/index.js
@@ -62,7 +62,7 @@ export default class ApplicationEvents extends React.Component {
         statusSelector={selectApplicationEventsStatus}
         errorSelector={selectApplicationEventsError}
         onClear={onClear}
-        toAllUrl={`/console/applications/${appId}/data`}
+        toAllUrl={`/applications/${appId}/data`}
       />
     )
   }

--- a/pkg/webui/console/containers/application-payload-formatters/downlink.js
+++ b/pkg/webui/console/containers/application-payload-formatters/downlink.js
@@ -49,7 +49,7 @@ import api from '../../api'
 
   return (
     <Breadcrumb
-      path={`/console/applications/${appId}/payload-formatters/downlink`}
+      path={`/applications/${appId}/payload-formatters/downlink`}
       icon="downlink"
       content={sharedMessages.downlink}
     />

--- a/pkg/webui/console/containers/application-payload-formatters/uplink.js
+++ b/pkg/webui/console/containers/application-payload-formatters/uplink.js
@@ -49,7 +49,7 @@ import api from '../../api'
 
   return (
     <Breadcrumb
-      path={`/console/applications/${appId}/payload-formatters/uplink`}
+      path={`/applications/${appId}/payload-formatters/uplink`}
       icon="uplink"
       content={sharedMessages.uplink}
     />

--- a/pkg/webui/console/containers/device-events/index.js
+++ b/pkg/webui/console/containers/device-events/index.js
@@ -53,7 +53,7 @@ class DeviceEvents extends React.Component {
         eventsSelector={selectDeviceEvents}
         statusSelector={selectDeviceEventsStatus}
         onClear={onClear}
-        toAllUrl={`/console/applications/${appId}/devices/${devId}/data`}
+        toAllUrl={`/applications/${appId}/devices/${devId}/data`}
       />
     )
   }

--- a/pkg/webui/console/containers/device-payload-formatters/downlink.js
+++ b/pkg/webui/console/containers/device-payload-formatters/downlink.js
@@ -47,7 +47,7 @@ import {
 
   return (
     <Breadcrumb
-      path={`/console/applications/${appId}/devices/${devId}/payload-formatters/downlink`}
+      path={`/applications/${appId}/devices/${devId}/payload-formatters/downlink`}
       icon="downlink"
       content={sharedMessages.downlink}
     />

--- a/pkg/webui/console/containers/device-payload-formatters/uplink.js
+++ b/pkg/webui/console/containers/device-payload-formatters/uplink.js
@@ -49,7 +49,7 @@ import {
 
   return (
     <Breadcrumb
-      path={`/console/applications/${appId}/devices/${devId}/payload-formatters/uplink`}
+      path={`/applications/${appId}/devices/${devId}/payload-formatters/uplink`}
       icon="uplink"
       content={sharedMessages.uplink}
     />

--- a/pkg/webui/console/containers/fetch-table/index.js
+++ b/pkg/webui/console/containers/fetch-table/index.js
@@ -67,7 +67,7 @@ const filterValidator = function (filters) {
     totalCount: base.totalCount || 0,
     fetching: base.fetching,
     fetchingSearch: base.fetchingSearch,
-    pathname: location.pathname,
+    pathname: state.router.location.pathname,
   }
 })
 @bind
@@ -160,12 +160,6 @@ class FetchTable extends Component {
     this.fetchItems()
   }
 
-  onItemAdd () {
-    const { dispatch, pathname, itemPathPrefix } = this.props
-
-    dispatch(push(`${pathname}${itemPathPrefix}/add`))
-  }
-
   onItemClick (index) {
     const {
       dispatch,
@@ -210,6 +204,8 @@ class FetchTable extends Component {
       tabs,
       searchable,
       handlesPagination,
+      itemPathPrefix,
+      pathname,
     } = this.props
     const { page, query, tab } = this.state
 
@@ -242,11 +238,11 @@ class FetchTable extends Component {
                 onChange={this.onQueryChange}
               />
             )}
-            <Button
-              onClick={this.onItemAdd}
+            <Button.Link
               className={style.addButton}
               message={addMessage}
               icon="add"
+              to={`${pathname}${itemPathPrefix}/add`}
             />
           </div>
         </div>

--- a/pkg/webui/console/containers/gateway-events/index.js
+++ b/pkg/webui/console/containers/gateway-events/index.js
@@ -62,7 +62,7 @@ export default class GatewayEvents extends React.Component {
         statusSelector={selectGatewayEventsStatus}
         errorSelector={selectGatewayEventsError}
         onClear={onClear}
-        toAllUrl={`/console/gateways/${gtwId}/data`}
+        toAllUrl={`/gateways/${gtwId}/data`}
       />
     )
   }

--- a/pkg/webui/console/containers/header/index.js
+++ b/pkg/webui/console/containers/header/index.js
@@ -17,7 +17,6 @@ import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 import bind from 'autobind-decorator'
 
-import { withEnv } from '../../../lib/components/env'
 import { logout } from '../../store/actions/user'
 import PropTypes from '../../../lib/prop-types'
 import sharedMessages from '../../../lib/shared-messages'
@@ -28,7 +27,6 @@ import HeaderComponent from '../../../components/header'
 @connect(state => ({
   user: state.user.user,
 }))
-@withEnv
 @bind
 class Header extends Component {
 
@@ -43,25 +41,24 @@ class Header extends Component {
       anchored,
       handleSearchRequest,
       searchable,
-      env: { appRoot },
     } = this.props
 
     const navigationEntries = [
       {
         title: sharedMessages.overview,
         icon: 'overview',
-        path: appRoot,
+        path: '/',
         exact: true,
       },
       {
         title: sharedMessages.applications,
         icon: 'application',
-        path: `${appRoot}/applications`,
+        path: '/applications',
       },
       {
         title: sharedMessages.gateways,
         icon: 'gateway',
-        path: `${appRoot}/gateways`,
+        path: '/gateways',
       },
     ]
 

--- a/pkg/webui/console/containers/header/index.js
+++ b/pkg/webui/console/containers/header/index.js
@@ -17,8 +17,10 @@ import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 import bind from 'autobind-decorator'
 
+import { withEnv } from '../../../lib/components/env'
 import { logout } from '../../store/actions/user'
 import PropTypes from '../../../lib/prop-types'
+import sharedMessages from '../../../lib/shared-messages'
 
 import HeaderComponent from '../../../components/header'
 
@@ -26,6 +28,7 @@ import HeaderComponent from '../../../components/header'
 @connect(state => ({
   user: state.user.user,
 }))
+@withEnv
 @bind
 class Header extends Component {
 
@@ -37,12 +40,38 @@ class Header extends Component {
   render () {
     const {
       user,
-      dropdownItems,
-      navigationEntries,
       anchored,
       handleSearchRequest,
       searchable,
+      env: { appRoot },
     } = this.props
+
+    const navigationEntries = [
+      {
+        title: sharedMessages.overview,
+        icon: 'overview',
+        path: appRoot,
+        exact: true,
+      },
+      {
+        title: sharedMessages.applications,
+        icon: 'application',
+        path: `${appRoot}/applications`,
+      },
+      {
+        title: sharedMessages.gateways,
+        icon: 'gateway',
+        path: `${appRoot}/gateways`,
+      },
+    ]
+
+    const dropdownItems = [
+      {
+        title: sharedMessages.logout,
+        icon: 'power_settings_new',
+        action: this.handleLogout,
+      },
+    ]
 
     return (
       <HeaderComponent
@@ -59,32 +88,6 @@ class Header extends Component {
 }
 
 Header.propTypes = {
-  /**
-  * A list of items for the dropdown
-  * @param {(string|Object)} title - The title to be displayed
-  * @param {string} icon - The icon name to be displayed next to the title
-  * @param {string} path - The path for a navigation tab
-  * @param {function} action - Alternatively, the function to be called on click
-  */
-  dropdownItems: PropTypes.arrayOf(PropTypes.shape({
-    title: PropTypes.message.isRequired,
-    icon: PropTypes.string,
-    path: PropTypes.string.isRequired,
-    action: PropTypes.func,
-  })),
-  /**
-   * A list of navigation bar entries.
-   * @param {(string|Object)} title - The title to be displayed
-   * @param {string} icon - The icon name to be displayed next to the title
-   * @param {string} path -  The path for a navigation tab
-   * @param {boolean} exact - Flag identifying whether the path should be matched exactly
-   */
-  navigationEntries: PropTypes.arrayOf(PropTypes.shape({
-    path: PropTypes.string.isRequired,
-    title: PropTypes.message.isRequired,
-    action: PropTypes.func,
-    icon: PropTypes.string,
-  })),
   /** Flag identifying whether links should be rendered as plain anchor link */
   anchored: PropTypes.bool,
   /**

--- a/pkg/webui/console/store/middleware/logics/gateways.js
+++ b/pkg/webui/console/store/middleware/logics/gateways.js
@@ -17,7 +17,7 @@ import { createLogic } from 'redux-logic'
 import sharedMessages from '../../../../lib/shared-messages'
 import api from '../../../api'
 import * as gateways from '../../actions/gateways'
-import { gsConfigSelector } from '../../../../lib/selectors/env'
+import { selectGsConfig } from '../../../../lib/selectors/env'
 import { selectGatewayById } from '../../selectors/gateways'
 import createEventsConnectLogics from './events'
 import createRequestLogic from './lib'
@@ -142,7 +142,7 @@ const startGatewayStatisticsLogic = createLogic({
     const { id } = action.payload
     const { timeout = 5000 } = action.meta
 
-    const gsConfig = gsConfigSelector()
+    const gsConfig = selectGsConfig()
     const gtw = selectGatewayById(getState(), id)
 
     if (!gsConfig.enabled) {

--- a/pkg/webui/console/views/app/index.js
+++ b/pkg/webui/console/views/app/index.js
@@ -39,7 +39,6 @@ export default class ConsoleApp extends React.Component {
         siteTitle,
         pageData,
         siteName,
-        appRoot,
       },
     } = this.props
 
@@ -63,8 +62,8 @@ export default class ConsoleApp extends React.Component {
             <div className={style.content}>
               <Switch>
                 {/* routes for registration, privacy policy, other public pages */}
-                <Route path={`${appRoot}/login`} component={Login} />
-                <Route path={appRoot} component={Landing} />
+                <Route path="/login" component={Login} />
+                <Route path="/" component={Landing} />
               </Switch>
             </div>
           </main>

--- a/pkg/webui/console/views/app/index.js
+++ b/pkg/webui/console/views/app/index.js
@@ -18,9 +18,9 @@ import { Route, Switch } from 'react-router-dom'
 import bind from 'autobind-decorator'
 
 import IntlHelmet from '../../../lib/components/intl-helmet'
-import { withEnv, EnvProvider } from '../../../lib/components/env'
+import { withEnv } from '../../../lib/components/env'
 import ErrorView from '../../../lib/components/error-view'
-import { pageDataSelector } from '../../../lib/selectors/env'
+
 import SideNavigation from '../../../components/navigation/side'
 import Header from '../../containers/header'
 import Footer from '../../../components/footer'
@@ -35,41 +35,42 @@ import style from './app.styl'
 export default class ConsoleApp extends React.Component {
   render () {
     const {
-      env,
+      env: {
+        siteTitle,
+        pageData,
+        siteName,
+        appRoot,
+      },
     } = this.props
-
-    const pageData = pageDataSelector(env)
 
     if (pageData && pageData.error) {
       return <FullViewError error={pageData.error} />
     }
 
     return (
-      <EnvProvider env={env}>
-        <ErrorView ErrorComponent={FullViewError}>
-          <div className={style.app}>
-            <IntlHelmet
-              titleTemplate={`%s - ${env.site_title ? `${env.site_title} - ` : ''}${env.site_name}`}
-              defaultTitle={env.site_name}
-            />
-            <div id="modal-container" />
-            <Header className={style.header} />
-            <main className={style.main}>
-              <div>
-                <SideNavigation />
-              </div>
-              <div className={style.content}>
-                <Switch>
-                  {/* routes for registration, privacy policy, other public pages */}
-                  <Route path={`${env.app_root}/login`} component={Login} />
-                  <Route path={env.app_root} component={Landing} />
-                </Switch>
-              </div>
-            </main>
-            <Footer className={style.footer} />
-          </div>
-        </ErrorView>
-      </EnvProvider>
+      <ErrorView ErrorComponent={FullViewError}>
+        <div className={style.app}>
+          <IntlHelmet
+            titleTemplate={`%s - ${siteTitle ? `${siteName} - ` : ''}${siteName}`}
+            defaultTitle={siteName}
+          />
+          <div id="modal-container" />
+          <Header className={style.header} />
+          <main className={style.main}>
+            <div>
+              <SideNavigation />
+            </div>
+            <div className={style.content}>
+              <Switch>
+                {/* routes for registration, privacy policy, other public pages */}
+                <Route path={`${appRoot}/login`} component={Login} />
+                <Route path={appRoot} component={Landing} />
+              </Switch>
+            </div>
+          </main>
+          <Footer className={style.footer} />
+        </div>
+      </ErrorView>
     )
   }
 }

--- a/pkg/webui/console/views/application-add/index.js
+++ b/pkg/webui/console/views/application-add/index.js
@@ -64,7 +64,7 @@ const validationSchema = Yup.object().shape({
 @withBreadcrumb('apps.add', function (props) {
   return (
     <Breadcrumb
-      path="/console/applications/add"
+      path="/applications/add"
       icon="add"
       content={sharedMessages.add}
     />
@@ -72,6 +72,8 @@ const validationSchema = Yup.object().shape({
 })
 @connect(({ user }) => ({
   userId: user.user.ids.user_id,
+}), dispatch => ({
+  navigateToApplication: appId => dispatch(push(`/applications/${appId}`)),
 }))
 @bind
 export default class Add extends React.Component {
@@ -81,7 +83,7 @@ export default class Add extends React.Component {
   }
 
   async handleSubmit (values, { resetForm }) {
-    const { userId, dispatch } = this.props
+    const { userId, navigateToApplication } = this.props
 
     await this.setState({ error: '' })
 
@@ -93,8 +95,8 @@ export default class Add extends React.Component {
           description: values.description,
         })
 
-      const { ids: { application_id }} = result
-      dispatch(push(`/console/applications/${application_id}`))
+      const { ids: { application_id: appId }} = result
+      navigateToApplication(appId)
     } catch (error) {
       const { application_id, name, description } = values
       resetForm({ application_id, name, description })

--- a/pkg/webui/console/views/application-api-key-add/index.js
+++ b/pkg/webui/console/views/application-api-key-add/index.js
@@ -46,7 +46,7 @@ import api from '../../api'
 }),
 dispatch => ({
   getApplicationsRightsList: appId => dispatch(getApplicationsRightsList(appId)),
-  navigateToList: appId => dispatch(replace(`/console/applications/${appId}/api-keys`)),
+  navigateToList: appId => dispatch(replace(`/applications/${appId}/api-keys`)),
 }))
 @withRequest(
   ({ appId, getApplicationsRightsList }) => getApplicationsRightsList(appId),
@@ -56,7 +56,7 @@ dispatch => ({
   const appId = props.appId
   return (
     <Breadcrumb
-      path={`/console/applications/${appId}/api-keys/add`}
+      path={`/applications/${appId}/api-keys/add`}
       icon="add"
       content={sharedMessages.add}
     />

--- a/pkg/webui/console/views/application-api-key-edit/index.js
+++ b/pkg/webui/console/views/application-api-key-edit/index.js
@@ -77,7 +77,7 @@ dispatch => ({
 
   return (
     <Breadcrumb
-      path={`/applications/${appId}/api-keys/${keyId}/edit`}
+      path={`/applications/${appId}/api-keys/${keyId}`}
       icon="general_settings"
       content={sharedMessages.edit}
     />

--- a/pkg/webui/console/views/application-api-key-edit/index.js
+++ b/pkg/webui/console/views/application-api-key-edit/index.js
@@ -66,7 +66,7 @@ dispatch => ({
     dispatch(getApplicationsRightsList(appId))
     dispatch(getApplicationApiKey(appId, apiKeyId))
   },
-  deleteSuccess: appId => dispatch(replace(`/console/applications/${appId}/api-keys`)),
+  deleteSuccess: appId => dispatch(replace(`/applications/${appId}/api-keys`)),
 }))
 @withRequest(
   ({ loadData, appId, keyId }) => loadData(appId, keyId),
@@ -77,7 +77,7 @@ dispatch => ({
 
   return (
     <Breadcrumb
-      path={`/console/applications/${appId}/api-keys/${keyId}/edit`}
+      path={`/applications/${appId}/api-keys/${keyId}/edit`}
       icon="general_settings"
       content={sharedMessages.edit}
     />

--- a/pkg/webui/console/views/application-api-keys/index.js
+++ b/pkg/webui/console/views/application-api-keys/index.js
@@ -31,7 +31,7 @@ import ApplicationApiKeyAdd from '../application-api-key-add'
 
   return (
     <Breadcrumb
-      path={`/console/applications/${appId}/api-keys`}
+      path={`/applications/${appId}/api-keys`}
       icon="api_keys"
       content={sharedMessages.apiKeys}
     />

--- a/pkg/webui/console/views/application-collaborator-add/index.js
+++ b/pkg/webui/console/views/application-collaborator-add/index.js
@@ -47,7 +47,7 @@ import api from '../../api'
     error: selectApplicationRightsError(state),
   }
 }, (dispatch, ownProps) => ({
-  redirectToList: appId => dispatch(push(`/console/applications/${appId}/collaborators`)),
+  redirectToList: appId => dispatch(push(`/applications/${appId}/collaborators`)),
   getApplicationsRightsList: appId => dispatch(getApplicationsRightsList(appId)),
 }), (stateProps, dispatchProps, ownProps) => ({
   ...stateProps, ...dispatchProps, ...ownProps,
@@ -62,7 +62,7 @@ import api from '../../api'
   const appId = props.appId
   return (
     <Breadcrumb
-      path={`/console/applications/${appId}/collaborators/add`}
+      path={`/applications/${appId}/collaborators/add`}
       icon="add"
       content={sharedMessages.add}
     />

--- a/pkg/webui/console/views/application-collaborator-edit/index.js
+++ b/pkg/webui/console/views/application-collaborator-edit/index.js
@@ -72,7 +72,7 @@ import api from '../../api'
     dispatch(getApplicationCollaborator(appId, collaboratorId, isUser))
   },
   redirectToList (appId) {
-    dispatch(replace(`/console/applications/${appId}/collaborators`))
+    dispatch(replace(`/applications/${appId}/collaborators`))
   },
 }), (stateProps, dispatchProps, ownProps) => ({
   ...stateProps, ...dispatchProps, ...ownProps,
@@ -93,7 +93,7 @@ import api from '../../api'
 
   return (
     <Breadcrumb
-      path={`/console/applications/${appId}/collaborators/${collaboratorType}/${collaboratorId}`}
+      path={`/applications/${appId}/collaborators/${collaboratorType}/${collaboratorId}`}
       icon="general_settings"
       content={sharedMessages.edit}
     />

--- a/pkg/webui/console/views/application-collaborators/index.js
+++ b/pkg/webui/console/views/application-collaborators/index.js
@@ -31,7 +31,7 @@ import ApplicationCollaboratorEdit from '../application-collaborator-edit'
 
   return (
     <Breadcrumb
-      path={`/console/applications/${appId}/collaborators`}
+      path={`/applications/${appId}/collaborators`}
       icon="organization"
       content={sharedMessages.collaborators}
     />

--- a/pkg/webui/console/views/application-data/index.js
+++ b/pkg/webui/console/views/application-data/index.js
@@ -36,7 +36,7 @@ const m = defineMessages({
 @withBreadcrumb('apps.single.data', function (props) {
   return (
     <Breadcrumb
-      path={`/console/applications/${props.appId}/data`}
+      path={`/applications/${props.appId}/data`}
       icon="data"
       content={sharedMessages.data}
     />

--- a/pkg/webui/console/views/application-general-settings/index.js
+++ b/pkg/webui/console/views/application-general-settings/index.js
@@ -62,7 +62,7 @@ const validationSchema = Yup.object().shape({
 
   return (
     <Breadcrumb
-      path={`/console/applications/${appId}/general-settings`}
+      path={`/applications/${appId}/general-settings`}
       icon="general_settings"
       content={sharedMessages.generalSettings}
     />

--- a/pkg/webui/console/views/application-integration-add/index.js
+++ b/pkg/webui/console/views/application-integration-add/index.js
@@ -32,12 +32,15 @@ import api from '../../api'
 
 @connect(state => ({
   appId: selectSelectedApplicationId(state),
+}),
+dispatch => ({
+  navigateToList: appId => dispatch(push(`/applications/${appId}/integrations`)),
 }))
 @withBreadcrumb('apps.single.integrations.add', function (props) {
   const { appId } = props
   return (
     <Breadcrumb
-      path={`/console/applications/${appId}/integrations/add`}
+      path={`/applications/${appId}/integrations/add`}
       icon="add"
       content={sharedMessages.add}
     />
@@ -52,9 +55,9 @@ export default class ApplicationIntegrationAdd extends Component {
   }
 
   handleSubmitSuccess () {
-    const { dispatch, appId } = this.props
+    const { navigateToList, appId } = this.props
 
-    dispatch(push(`/console/applications/${appId}/integrations`))
+    navigateToList(appId)
   }
 
   render () {

--- a/pkg/webui/console/views/application-integration-edit/index.js
+++ b/pkg/webui/console/views/application-integration-edit/index.js
@@ -67,7 +67,7 @@ const webhookEntitySelector = [
   const { appId, webhookId } = match.params
   return {
     getWebhook: () => dispatch(getWebhook(appId, webhookId, webhookEntitySelector)),
-    navigateToList: () => dispatch(replace(`/console/applications/${appId}/integrations`)),
+    navigateToList: () => dispatch(replace(`/applications/${appId}/integrations`)),
   }
 })
 @withRequest(
@@ -78,7 +78,7 @@ const webhookEntitySelector = [
   const { appId, match: { params: { webhookId }}} = props
   return (
     <Breadcrumb
-      path={`/console/applications/${appId}/integrations/${webhookId}`}
+      path={`/applications/${appId}/integrations/${webhookId}`}
       icon="general_settings"
       content={sharedMessages.edit}
     />

--- a/pkg/webui/console/views/application-integrations/index.js
+++ b/pkg/webui/console/views/application-integrations/index.js
@@ -31,7 +31,7 @@ import ApplicationIntegrationEdit from '../application-integration-edit'
 
   return (
     <Breadcrumb
-      path={`/console/applications/${appId}/integrations`}
+      path={`/applications/${appId}/integrations`}
       icon="integration"
       content={sharedMessages.integrations}
     />

--- a/pkg/webui/console/views/application-link/index.js
+++ b/pkg/webui/console/views/application-link/index.js
@@ -102,7 +102,7 @@ dispatch => ({
 @withBreadcrumb('apps.single.link', function (props) {
   return (
     <Breadcrumb
-      path={`/console/applications/${props.appId}/link`}
+      path={`/applications/${props.appId}/link`}
       icon="link"
       content={sharedMessages.link}
     />

--- a/pkg/webui/console/views/application-overview/index.js
+++ b/pkg/webui/console/views/application-overview/index.js
@@ -23,8 +23,8 @@ import DateTime from '../../../lib/components/date-time'
 import DevicesTable from '../../containers/devices-table'
 import DataSheet from '../../../components/data-sheet'
 import ApplicationEvents from '../../containers/application-events'
-import PAGE_SIZES from '../../constants/page-sizes'
 
+import PAGE_SIZES from '../../constants/page-sizes'
 import { getApplicationId } from '../../../lib/selectors/id'
 import { selectSelectedApplication } from '../../store/selectors/applications'
 

--- a/pkg/webui/console/views/application-payload-formatters/index.js
+++ b/pkg/webui/console/views/application-payload-formatters/index.js
@@ -62,7 +62,7 @@ dispatch => ({
 
   return (
     <Breadcrumb
-      path={`/console/applications/${appId}/payload-formatters`}
+      path={`/applications/${appId}/payload-formatters`}
       icon="link"
       content={sharedMessages.payloadFormatters}
     />
@@ -105,7 +105,7 @@ export default class ApplicationPayloadFormatters extends React.Component {
         warning={m.warningText}
         messageValues={{
           link: (
-            <Link key="warnining-link" to={`/console/applications/${appId}/link`}>
+            <Link key="warnining-link" to={`/applications/${appId}/link`}>
               <Message content={m.linkApplication} />
             </Link>
           ),

--- a/pkg/webui/console/views/application/index.js
+++ b/pkg/webui/console/views/application/index.js
@@ -23,6 +23,7 @@ import { withSideNavigation } from '../../../components/navigation/side/context'
 import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
 import IntlHelmet from '../../../lib/components/intl-helmet'
 import withRequest from '../../../lib/components/with-request'
+import { withEnv } from '../../../lib/components/env'
 
 import ApplicationOverview from '../application-overview'
 import ApplicationGeneralSettings from '../application-general-settings'
@@ -45,7 +46,6 @@ import {
 } from '../../store/selectors/applications'
 
 import Devices from '../devices'
-import withEnv from '../../../lib/components/env'
 
 @connect(function (state, props) {
   return {

--- a/pkg/webui/console/views/application/index.js
+++ b/pkg/webui/console/views/application/index.js
@@ -58,7 +58,7 @@ import withEnv from '../../../lib/components/env'
 dispatch => ({
   stopStream: id => dispatch(stopApplicationEventsStream(id)),
   getApplication: id => dispatch(getApplication(id, 'name,description')),
-  redirectToList: () => dispatch(replace('/console/applications')),
+  redirectToList: () => dispatch(replace('/applications')),
 }))
 @withRequest(
   ({ appId, getApplication }) => getApplication(appId),
@@ -138,7 +138,7 @@ dispatch => ({
   const { appId } = props
   return (
     <Breadcrumb
-      path={`/console/applications/${appId}`}
+      path={`/applications/${appId}`}
       icon="application"
       content={appId}
     />

--- a/pkg/webui/console/views/application/index.js
+++ b/pkg/webui/console/views/application/index.js
@@ -170,7 +170,7 @@ export default class Application extends React.Component {
     return (
       <React.Fragment>
         <IntlHelmet
-          titleTemplate={`%s - ${application.name || appId} - ${env.site_name}`}
+          titleTemplate={`%s - ${application.name || appId} - ${env.siteName}`}
         />
         <Switch>
           <Route exact path={`${match.path}`} component={ApplicationOverview} />

--- a/pkg/webui/console/views/application/index.js
+++ b/pkg/webui/console/views/application/index.js
@@ -45,7 +45,7 @@ import {
 } from '../../store/selectors/applications'
 
 import Devices from '../devices'
-import withEnv, { EnvProvider } from '../../../lib/components/env'
+import withEnv from '../../../lib/components/env'
 
 @connect(function (state, props) {
   return {
@@ -168,7 +168,7 @@ export default class Application extends React.Component {
     const { match, application, appId, env } = this.props
 
     return (
-      <EnvProvider env={env}>
+      <React.Fragment>
         <IntlHelmet
           titleTemplate={`%s - ${application.name || appId} - ${env.site_name}`}
         />
@@ -183,7 +183,7 @@ export default class Application extends React.Component {
           <Route path={`${match.path}/payload-formatters`} component={ApplicationPayloadFormatters} />
           <Route path={`${match.path}/integrations`} component={ApplicationIntegrations} />
         </Switch>
-      </EnvProvider>
+      </React.Fragment>
     )
   }
 }

--- a/pkg/webui/console/views/applications/index.js
+++ b/pkg/webui/console/views/applications/index.js
@@ -26,7 +26,7 @@ import { withBreadcrumb } from '../../../components/breadcrumbs/context'
 @withBreadcrumb('apps', function (props) {
   return (
     <Breadcrumb
-      path="/console/applications"
+      path="/applications"
       content={sharedMessages.applications}
     />
   )

--- a/pkg/webui/console/views/device-add/index.js
+++ b/pkg/webui/console/views/device-add/index.js
@@ -36,7 +36,7 @@ import style from './device-add.styl'
   const { appId } = props.match.params
   return (
     <Breadcrumb
-      path={`/console/applications/${appId}/devices/add`}
+      path={`/applications/${appId}/devices/add`}
       icon="add"
       content={sharedMessages.add}
     />
@@ -48,7 +48,7 @@ import style from './device-add.styl'
     appId: selectSelectedApplicationId(state),
   }
 }, dispatch => ({
-  redirectToList: (appId, deviceId) => dispatch(push(`/console/applications/${appId}/devices/${deviceId}`)),
+  redirectToList: (appId, deviceId) => dispatch(push(`/applications/${appId}/devices/${deviceId}`)),
 }),
 )
 @bind

--- a/pkg/webui/console/views/device-data/index.js
+++ b/pkg/webui/console/views/device-data/index.js
@@ -37,7 +37,7 @@ import { getDeviceId } from '../../../lib/selectors/id'
   const { appId } = props.match.params
   return (
     <Breadcrumb
-      path={`/console/applications/${appId}/devices/${devId}/data`}
+      path={`/applications/${appId}/devices/${devId}/data`}
       icon="data"
       content={sharedMessages.data}
     />

--- a/pkg/webui/console/views/device-general-settings/index.js
+++ b/pkg/webui/console/views/device-general-settings/index.js
@@ -33,7 +33,7 @@ import { selectSelectedApplicationId } from '../../store/selectors/applications'
     appId: selectSelectedApplicationId(state),
   }
 }, dispatch => ({
-  onDeleteSuccess: appId => dispatch(replace(`/console/applications/${appId}/devices`)),
+  onDeleteSuccess: appId => dispatch(replace(`/applications/${appId}/devices`)),
   updateDevice: (appId, deviceId, patch) => dispatch(updateDevice(appId, deviceId, patch)),
 }),
 (stateProps, dispatchProps, ownProps) => ({

--- a/pkg/webui/console/views/device-location/index.js
+++ b/pkg/webui/console/views/device-location/index.js
@@ -73,7 +73,7 @@ const getRegistryLocation = function (locations) {
   const { devId, appId } = props
   return (
     <Breadcrumb
-      path={`/console/applications/${appId}/devices/${devId}/location`}
+      path={`/applications/${appId}/devices/${devId}/location`}
       icon="location"
       content={sharedMessages.location}
     />

--- a/pkg/webui/console/views/device-payload-formatters/index.js
+++ b/pkg/webui/console/views/device-payload-formatters/index.js
@@ -49,7 +49,7 @@ import style from './device-payload-formatters.styl'
   const { appId, devId } = props
   return (
     <Breadcrumb
-      path={`/console/applications/${appId}/devices/${devId}/payload-formatters`}
+      path={`/applications/${appId}/devices/${devId}/payload-formatters`}
       icon="link"
       content={sharedMessages.payloadFormatters}
     />

--- a/pkg/webui/console/views/device/index.js
+++ b/pkg/webui/console/views/device/index.js
@@ -23,7 +23,7 @@ import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
 import Tabs from '../../../components/tabs'
 import IntlHelmet from '../../../lib/components/intl-helmet'
 import withRequest from '../../../lib/components/with-request'
-import withEnv, { EnvProvider } from '../../../lib/components/env'
+import withEnv from '../../../lib/components/env'
 
 import DeviceOverview from '../device-overview'
 import DeviceData from '../device-data'
@@ -35,6 +35,7 @@ import {
   getDevice,
   stopDeviceEventsStream,
 } from '../../store/actions/device'
+
 import { selectSelectedApplicationId } from '../../store/selectors/applications'
 import { selectSelectedDevice, selectDeviceFetching, selectGetDeviceError } from '../../store/selectors/device'
 
@@ -131,7 +132,7 @@ export default class Device extends React.Component {
     ]
 
     return (
-      <EnvProvider env={env}>
+      <React.Fragment>
         <IntlHelmet
           titleTemplate={`%s - ${deviceName || devId} - ${env.site_name}`}
         />
@@ -155,7 +156,7 @@ export default class Device extends React.Component {
           <Route exact path={`${basePath}/general-settings`} component={DeviceGeneralSettings} />
           <Route path={`${basePath}/payload-formatters`} component={DevicePayloadFormatters} />
         </Switch>
-      </EnvProvider>
+      </React.Fragment>
     )
   }
 }

--- a/pkg/webui/console/views/device/index.js
+++ b/pkg/webui/console/views/device/index.js
@@ -35,7 +35,6 @@ import {
   getDevice,
   stopDeviceEventsStream,
 } from '../../store/actions/device'
-
 import { selectSelectedApplicationId } from '../../store/selectors/applications'
 import { selectSelectedDevice, selectDeviceFetching, selectGetDeviceError } from '../../store/selectors/device'
 
@@ -91,7 +90,7 @@ import style from './device.styl'
   const { devId, appId } = props
   return (
     <Breadcrumb
-      path={`/console/applications/${appId}/devices/${devId}`}
+      path={`/applications/${appId}/devices/${devId}`}
       icon="device"
       content={devId}
     />
@@ -116,7 +115,7 @@ export default class Device extends React.Component {
       env,
     } = this.props
 
-    const basePath = `/console/applications/${appId}/devices/${devId}`
+    const basePath = `/applications/${appId}/devices/${devId}`
 
     // Prevent default redirect to uplink when tab is already open
     const payloadFormattersLink =
@@ -134,7 +133,7 @@ export default class Device extends React.Component {
     return (
       <React.Fragment>
         <IntlHelmet
-          titleTemplate={`%s - ${deviceName || devId} - ${env.siteName}`}
+          titleTemplate={`%s - ${deviceName || devId} - ${env.site_name}`}
         />
         <Container>
           <Row>

--- a/pkg/webui/console/views/device/index.js
+++ b/pkg/webui/console/views/device/index.js
@@ -134,7 +134,7 @@ export default class Device extends React.Component {
     return (
       <React.Fragment>
         <IntlHelmet
-          titleTemplate={`%s - ${deviceName || devId} - ${env.site_name}`}
+          titleTemplate={`%s - ${deviceName || devId} - ${env.siteName}`}
         />
         <Container>
           <Row>

--- a/pkg/webui/console/views/devices/index.js
+++ b/pkg/webui/console/views/devices/index.js
@@ -27,7 +27,7 @@ import { withBreadcrumb } from '../../../components/breadcrumbs/context'
   const { appId } = props.match.params
   return (
     <Breadcrumb
-      path={`/console/applications/${appId}/devices`}
+      path={`/applications/${appId}/devices`}
       content={sharedMessages.devices}
     />
   )

--- a/pkg/webui/console/views/error/index.js
+++ b/pkg/webui/console/views/error/index.js
@@ -71,7 +71,7 @@ const FullViewErrorInner = function ({ error, env }) {
                 <Button.AnchorLink
                   icon="keyboard_arrow_left"
                   message={sharedMessages.takeMeBack}
-                  href={env.app_root}
+                  href={env.appRoot}
                 />
               )
               : (

--- a/pkg/webui/console/views/gateway-add/index.js
+++ b/pkg/webui/console/views/gateway-add/index.js
@@ -44,7 +44,7 @@ const m = defineMessages({
 @withBreadcrumb('gateways.add', function () {
   return (
     <Breadcrumb
-      path="/console/gateways/add"
+      path="/gateways/add"
       icon="add"
       content={sharedMessages.add}
     />
@@ -56,7 +56,7 @@ const m = defineMessages({
   return { userId }
 },
 dispatch => ({
-  createSuccess: gtwId => dispatch(push(`/console/gateways/${gtwId}`)),
+  createSuccess: gtwId => dispatch(push(`/gateways/${gtwId}`)),
 }))
 @bind
 export default class GatewayAdd extends React.Component {

--- a/pkg/webui/console/views/gateway-api-key-add/index.js
+++ b/pkg/webui/console/views/gateway-api-key-add/index.js
@@ -46,7 +46,7 @@ import api from '../../api'
 }),
 dispatch => ({
   getGatewaysRightsList: gtwId => dispatch(getGatewaysRightsList(gtwId)),
-  navigateToList: gtwId => dispatch(replace(`/console/gateways/${gtwId}/api-keys`)),
+  navigateToList: gtwId => dispatch(replace(`/gateways/${gtwId}/api-keys`)),
 }))
 @withRequest(
   ({ gtwId, getGatewaysRightsList }) => getGatewaysRightsList(gtwId),
@@ -57,7 +57,7 @@ dispatch => ({
 
   return (
     <Breadcrumb
-      path={`/console/gateways/${gtwId}/api-keys/add`}
+      path={`/gateways/${gtwId}/api-keys/add`}
       icon="add"
       content={sharedMessages.add}
     />

--- a/pkg/webui/console/views/gateway-api-key-edit/index.js
+++ b/pkg/webui/console/views/gateway-api-key-edit/index.js
@@ -76,7 +76,7 @@ dispatch => ({
 
   return (
     <Breadcrumb
-      path={`/gateways/${gtwId}/api-keys/${keyId}/edit`}
+      path={`/gateways/${gtwId}/api-keys/${keyId}`}
       icon="general_settings"
       content={sharedMessages.edit}
     />

--- a/pkg/webui/console/views/gateway-api-key-edit/index.js
+++ b/pkg/webui/console/views/gateway-api-key-edit/index.js
@@ -65,7 +65,7 @@ dispatch => ({
     dispatch(getGatewaysRightsList(gtwId))
     dispatch(getGatewayApiKey(gtwId, apiKeyId))
   },
-  deleteSuccess: gtwId => dispatch(replace(`/console/gateways/${gtwId}/api-keys`)),
+  deleteSuccess: gtwId => dispatch(replace(`/gateways/${gtwId}/api-keys`)),
 }))
 @withRequest(
   ({ gtwId, keyId, loadData }) => loadData(gtwId, keyId),
@@ -76,7 +76,7 @@ dispatch => ({
 
   return (
     <Breadcrumb
-      path={`/console/gateways/${gtwId}/api-keys/${keyId}/edit`}
+      path={`/gateways/${gtwId}/api-keys/${keyId}/edit`}
       icon="general_settings"
       content={sharedMessages.edit}
     />

--- a/pkg/webui/console/views/gateway-api-keys/index.js
+++ b/pkg/webui/console/views/gateway-api-keys/index.js
@@ -30,7 +30,7 @@ import GatewayApiKeyEdit from '../gateway-api-key-edit'
 
   return (
     <Breadcrumb
-      path={`/console/gateways/${gtwId}/api-keys`}
+      path={`/gateways/${gtwId}/api-keys`}
       icon="api_keys"
       content={sharedMessages.apiKeys}
     />

--- a/pkg/webui/console/views/gateway-collaborator-add/index.js
+++ b/pkg/webui/console/views/gateway-collaborator-add/index.js
@@ -50,7 +50,7 @@ import api from '../../api'
   }
 }, (dispatch, ownProps) => ({
   getGatewaysRightsList: gtwId => dispatch(getGatewaysRightsList(gtwId)),
-  redirectToList: gtwId => dispatch(push(`/console/gateways/${gtwId}/collaborators`)),
+  redirectToList: gtwId => dispatch(push(`/gateways/${gtwId}/collaborators`)),
 }), (stateProps, dispatchProps, ownProps) => ({
   ...stateProps, ...dispatchProps, ...ownProps,
   getGatewaysRightsList: () => dispatchProps.getGatewaysRightsList(stateProps.gtwId),
@@ -64,7 +64,7 @@ import api from '../../api'
   const gtwId = props.gtwId
   return (
     <Breadcrumb
-      path={`/console/gateways/${gtwId}/collaborators/add`}
+      path={`/gateways/${gtwId}/collaborators/add`}
       icon="add"
       content={sharedMessages.add}
     />

--- a/pkg/webui/console/views/gateway-collaborator-edit/index.js
+++ b/pkg/webui/console/views/gateway-collaborator-edit/index.js
@@ -74,7 +74,7 @@ import api from '../../api'
     dispatch(getGatewayCollaborator(gtwId, collaboratorId, isUser))
   },
   redirectToList (gtwId) {
-    dispatch(replace(`/console/gateways/${gtwId}/collaborators`))
+    dispatch(replace(`/gateways/${gtwId}/collaborators`))
   },
 }), (stateProps, dispatchProps, ownProps) => ({
   ...stateProps, ...dispatchProps, ...ownProps,
@@ -94,7 +94,7 @@ import api from '../../api'
 
   return (
     <Breadcrumb
-      path={`/console/gateways/${gtwId}/collaborators/${collaboratorId}/edit`}
+      path={`/gateways/${gtwId}/collaborators/${collaboratorId}/edit`}
       icon="general_settings"
       content={sharedMessages.edit}
     />

--- a/pkg/webui/console/views/gateway-collaborator-edit/index.js
+++ b/pkg/webui/console/views/gateway-collaborator-edit/index.js
@@ -90,11 +90,11 @@ import api from '../../api'
   ({ fetching, collaborator }) => fetching || !Boolean(collaborator)
 )
 @withBreadcrumb('gtws.single.collaborators.edit', function (props) {
-  const { gtwId, collaboratorId } = props
+  const { gtwId, collaboratorId, collaboratorType } = props
 
   return (
     <Breadcrumb
-      path={`/gateways/${gtwId}/collaborators/${collaboratorId}/edit`}
+      path={`/gateways/${gtwId}/collaborators/${collaboratorType}/${collaboratorId}`}
       icon="general_settings"
       content={sharedMessages.edit}
     />

--- a/pkg/webui/console/views/gateway-collaborators/index.js
+++ b/pkg/webui/console/views/gateway-collaborators/index.js
@@ -31,7 +31,7 @@ import GatewayCollaboratorEdit from '../gateway-collaborator-edit'
 
   return (
     <Breadcrumb
-      path={`/console/gateways/${gtwId}/collaborators`}
+      path={`/gateways/${gtwId}/collaborators`}
       icon="organization"
       content={sharedMessages.collaborators}
     />

--- a/pkg/webui/console/views/gateway-data/index.js
+++ b/pkg/webui/console/views/gateway-data/index.js
@@ -38,7 +38,7 @@ const m = defineMessages({
 @withBreadcrumb('gateways.single.data', function (props) {
   return (
     <Breadcrumb
-      path={`/console/gateways/${props.gtwId}/data`}
+      path={`/gateways/${props.gtwId}/data`}
       icon="data"
       content={sharedMessages.data}
     />

--- a/pkg/webui/console/views/gateway-general-settings/index.js
+++ b/pkg/webui/console/views/gateway-general-settings/index.js
@@ -55,7 +55,7 @@ const m = defineMessages({
 
   return (
     <Breadcrumb
-      path={`/console/gateways/${gtwId}/general-settings`}
+      path={`/gateways/${gtwId}/general-settings`}
       icon="general_settings"
       content={sharedMessages.generalSettings}
     />

--- a/pkg/webui/console/views/gateway-location/index.js
+++ b/pkg/webui/console/views/gateway-location/index.js
@@ -76,7 +76,7 @@ const getRegistryLocation = function (antennas) {
   const { gtwId } = props
   return (
     <Breadcrumb
-      path={`/console/gateways/${gtwId}/location`}
+      path={`/gateways/${gtwId}/location`}
       icon="location"
       content={sharedMessages.location}
     />

--- a/pkg/webui/console/views/gateway/index.js
+++ b/pkg/webui/console/views/gateway/index.js
@@ -22,8 +22,8 @@ import sharedMessages from '../../../lib/shared-messages'
 import { withSideNavigation } from '../../../components/navigation/side/context'
 import { withBreadcrumb } from '../../../components/breadcrumbs/context'
 import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
-import withEnv, { EnvProvider } from '../../../lib/components/env'
 import withRequest from '../../../lib/components/with-request'
+import withEnv from '../../../lib/components/env'
 
 import GatewayOverview from '../gateway-overview'
 import GatewayApiKeys from '../gateway-api-keys'
@@ -152,7 +152,7 @@ export default class Gateway extends React.Component {
     const { match, gateway, gtwId, env } = this.props
 
     return (
-      <EnvProvider env={env}>
+      <React.Fragment>
         <IntlHelmet
           titleTemplate={`%s - ${gateway.name || gtwId} - ${env.site_name}`}
         />
@@ -164,7 +164,7 @@ export default class Gateway extends React.Component {
           <Route path={`${match.path}/data`} component={GatewayData} />
           <Route path={`${match.path}/general-settings`} component={GatewayGeneralSettings} />
         </Switch>
-      </EnvProvider>
+      </React.Fragment>
     )
   }
 }

--- a/pkg/webui/console/views/gateway/index.js
+++ b/pkg/webui/console/views/gateway/index.js
@@ -61,7 +61,7 @@ import {
 dispatch => ({
   getGateway: (id, meta) => dispatch(getGateway(id, meta)),
   stopStream: id => dispatch(stopGatewayEventsStream(id)),
-  redirectToList: () => dispatch(replace('/console/gateways')),
+  redirectToList: () => dispatch(replace('/gateways')),
 }))
 @withRequest(
   ({ gtwId, getGateway }) => getGateway(gtwId, [
@@ -122,7 +122,7 @@ dispatch => ({
 
   return (
     <Breadcrumb
-      path={`/console/gateways/${gtwId}`}
+      path={`/gateways/${gtwId}`}
       icon="gateway"
       content={gtwId}
     />

--- a/pkg/webui/console/views/gateway/index.js
+++ b/pkg/webui/console/views/gateway/index.js
@@ -76,8 +76,7 @@ dispatch => ({
   ({ fetching, gateway }) => fetching || !Boolean(gateway)
 )
 @withSideNavigation(function (props) {
-  const { match, gtwId } = props
-  const matchedUrl = match.url
+  const { match: { url: matchedUrl }, gtwId } = props
 
   return {
     header: { title: gtwId, icon: 'gateway' },

--- a/pkg/webui/console/views/gateway/index.js
+++ b/pkg/webui/console/views/gateway/index.js
@@ -154,7 +154,7 @@ export default class Gateway extends React.Component {
     return (
       <React.Fragment>
         <IntlHelmet
-          titleTemplate={`%s - ${gateway.name || gtwId} - ${env.site_name}`}
+          titleTemplate={`%s - ${gateway.name || gtwId} - ${env.siteName}`}
         />
         <Switch>
           <Route exact path={`${match.path}`} component={GatewayOverview} />

--- a/pkg/webui/console/views/gateways/index.js
+++ b/pkg/webui/console/views/gateways/index.js
@@ -26,7 +26,7 @@ import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
 @withBreadcrumb('gateways', function (props) {
   return (
     <Breadcrumb
-      path="/console/gateways"
+      path="/gateways"
       content={sharedMessages.gateways}
     />
   )

--- a/pkg/webui/console/views/landing/index.js
+++ b/pkg/webui/console/views/landing/index.js
@@ -37,15 +37,15 @@ export default class Landing extends React.PureComponent {
         <ToastContainer />
         <div className={style.breadcrumbsContainer}>
           <Container>
-            <Breadcrumbs />
+            <Breadcrumbs pathPrefix={path} />
           </Container>
         </div>
         <div className={style.contentContainer}>
           <WithAuth>
             <Switch>
-              <Route exact path={`${path}`} component={Overview} />
-              <Route path={`${path}/applications`} component={Applications} />
-              <Route path={`${path}/gateways`} component={Gateways} />
+              <Route exact path="/" component={Overview} />
+              <Route path="/applications" component={Applications} />
+              <Route path="/gateways" component={Gateways} />
               <Route component={GenericNotFound} />
             </Switch>
           </WithAuth>

--- a/pkg/webui/console/views/login/index.js
+++ b/pkg/webui/console/views/login/index.js
@@ -41,13 +41,13 @@ const m = defineMessages({
 @bind
 export default class Login extends React.PureComponent {
   render () {
-    const { user, env } = this.props
+    const { user, env: { appRoot }} = this.props
     const { next } = Query.parse(location.search)
     const redirectAppend = next ? `?next=${next}` : ''
 
     // dont show the login page if the user is already logged in
     if (Boolean(user)) {
-      return <Redirect to={env.app_root} />
+      return <Redirect to={appRoot} />
     }
 
     return (
@@ -65,7 +65,7 @@ export default class Login extends React.PureComponent {
               <Message className={style.loginSub} content={m.login} />
               <Button.AnchorLink
                 message={m.loginWithStackAccount}
-                href={`${env.app_root}/login/ttn-stack${redirectAppend}`}
+                href={`${appRoot}/login/ttn-stack${redirectAppend}`}
               />
             </Col>
           </Row>

--- a/pkg/webui/console/views/login/index.js
+++ b/pkg/webui/console/views/login/index.js
@@ -47,7 +47,7 @@ export default class Login extends React.PureComponent {
 
     // dont show the login page if the user is already logged in
     if (Boolean(user)) {
-      return <Redirect to={appRoot} />
+      return <Redirect to="/" />
     }
 
     return (

--- a/pkg/webui/console/views/overview/index.js
+++ b/pkg/webui/console/views/overview/index.js
@@ -76,7 +76,7 @@ const componentMap = {
 @withBreadcrumb('overview', function (props) {
   return (
     <Breadcrumb
-      path="/console"
+      path="/"
       content={sharedMessages.overview}
     />
   )
@@ -118,7 +118,6 @@ export default class Overview extends React.Component {
   render () {
     const { config } = this.props.env
     const { fetching, applicationCount, gatewayCount, userId } = this.props
-    const { path } = this.props.match
 
     if (fetching || applicationCount === undefined || gatewayCount === undefined) {
       return (
@@ -129,8 +128,8 @@ export default class Overview extends React.Component {
     }
 
     const hasEntities = applicationCount + gatewayCount !== 0
-    const appPath = path + (hasEntities ? '/applications' : '/applications/add')
-    const gatewayPath = path + (hasEntities ? '/gateways' : '/gateways/add')
+    const appPath = hasEntities ? '/applications' : '/applications/add'
+    const gatewayPath = hasEntities ? '/gateways' : '/gateways/add'
 
     return (
       <Container>

--- a/pkg/webui/lib/components/with-auth.js
+++ b/pkg/webui/lib/components/with-auth.js
@@ -51,7 +51,7 @@ class Auth extends React.PureComponent {
       return (
         <Redirect
           to={{
-            pathname: `${appRoot}/login`,
+            pathname: `/login`,
             search: redirectPath && `?next=${redirectPath}`,
             state: { from: this.props.location.pathname },
           }}

--- a/pkg/webui/lib/components/with-auth.js
+++ b/pkg/webui/lib/components/with-auth.js
@@ -39,7 +39,7 @@ class Auth extends React.PureComponent {
       user,
       fetching,
       children,
-      env,
+      env: { appRoot },
     } = this.props
 
     if (fetching) {
@@ -47,11 +47,11 @@ class Auth extends React.PureComponent {
     }
 
     if (!Boolean(user)) {
-      const redirectPath = window.location.pathname.substring(env.app_root.length)
+      const redirectPath = window.location.pathname.substring(appRoot.length)
       return (
         <Redirect
           to={{
-            pathname: `${env.app_root}/login`,
+            pathname: `${appRoot}/login`,
             search: redirectPath && `?next=${redirectPath}`,
             state: { from: this.props.location.pathname },
           }}

--- a/pkg/webui/lib/components/with-locale.js
+++ b/pkg/webui/lib/components/with-locale.js
@@ -63,10 +63,8 @@ export default class UserLocale extends React.PureComponent {
 
     if (dev) {
       window.addEventListener('keydown', this.onKeydown)
-      log('Press alt + X to toggle the xx locale')
+      log('Press alt + L to toggle the xx locale')
     }
-
-
   }
 
   check (prev, props) {
@@ -90,7 +88,7 @@ export default class UserLocale extends React.PureComponent {
   }
 
   onKeydown (evt) {
-    if (evt.altKey && evt.code === 'KeyX') {
+    if (evt.altKey && evt.code === 'KeyL') {
       this.toggle()
     }
   }

--- a/pkg/webui/lib/components/with-locale.js
+++ b/pkg/webui/lib/components/with-locale.js
@@ -59,7 +59,7 @@ export default class UserLocale extends React.PureComponent {
   }
 
   componentDidMount () {
-    this.check({ env: {}}, this.props)
+    this.check({ env: { config: {}}}, this.props)
 
     if (dev) {
       window.addEventListener('keydown', this.onKeydown)
@@ -70,8 +70,8 @@ export default class UserLocale extends React.PureComponent {
   }
 
   check (prev, props) {
-    const current = prev.user && prev.user.language || prev.env.default_language || defaultLanguage
-    const next = props.user && props.user.language || props.env.default_language || defaultLanguage
+    const current = prev.user && prev.user.language || prev.env.config.language || defaultLanguage
+    const next = props.user && props.user.language || props.env.config.language || defaultLanguage
 
     if (current !== next && next !== 'en') {
       this.promise = this.load(next)
@@ -135,14 +135,14 @@ export default class UserLocale extends React.PureComponent {
     const {
       user,
       children,
-      env,
+      env: { config },
     } = this.props
 
     const { xx } = this.state
 
     let { messages } = this.state
 
-    const lang = user && user.language || env.default_language || defaultLanguage
+    const lang = user && user.language || config.language || defaultLanguage
 
     if (dev && xx) {
       messages = {

--- a/pkg/webui/lib/env.js
+++ b/pkg/webui/lib/env.js
@@ -1,0 +1,27 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as envSelector from './selectors/env'
+
+const env = {
+  appRoot: envSelector.selectApplicationRootPath(),
+  assetsRoot: envSelector.selectAssetsRootPath(),
+  config: envSelector.selectApplicationConfig(),
+  pageData: envSelector.selectPageData(),
+  siteName: envSelector.selectApplicationSiteName(),
+  siteTitle: envSelector.selectApplicationSiteTitle(),
+  siteSubTitle: envSelector.selectApplicationSiteSubTitle(),
+}
+
+export default env

--- a/pkg/webui/lib/regexp.js
+++ b/pkg/webui/lib/regexp.js
@@ -1,0 +1,17 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable import/prefer-default-export */
+
+export const url = /[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)?/gi

--- a/pkg/webui/lib/selectors/env.js
+++ b/pkg/webui/lib/selectors/env.js
@@ -14,34 +14,46 @@
 
 export const configSelector = () => window
 
-export const applicationRootSelector = () => (
+export const selectApplicationRootPath = () => (
   configSelector().APP_ROOT
 )
 
-export const applicationConfigSelector = () => (
+export const selectApplicationConfig = () => (
   configSelector().APP_CONFIG
 )
 
-export const gsConfigSelector = () => (
-  applicationConfigSelector().gs
+export const selectApplicationSiteName = () => (
+  configSelector().SITE_NAME
 )
 
-export const isConfigSelector = () => (
-  applicationConfigSelector().is
+export const selectApplicationSiteTitle = () => (
+  configSelector().SITE_TITLE
 )
 
-export const nsConfigSelector = () => (
-  applicationConfigSelector().ns
+export const selectApplicationSiteSubtitle = () => (
+  configSelector().SITE_SUB_TITLE
 )
 
-export const jsConfigSelector = () => (
-  applicationConfigSelector().js
+export const selectGsConfig = () => (
+  selectApplicationConfig().gs
 )
 
-export const asConfigSelector = () => (
-  applicationConfigSelector().as
+export const selectIsConfig = () => (
+  selectApplicationConfig().is
 )
 
-export const pageDataSelector = () => (
+export const selectNsConfig = () => (
+  selectApplicationConfig().ns
+)
+
+export const selectJsConfig = () => (
+  selectApplicationConfig().js
+)
+
+export const selectAsConfig = () => (
+  selectApplicationConfig().as
+)
+
+export const selectPageData = () => (
   configSelector().PAGE_DATA
 )

--- a/pkg/webui/lib/selectors/env.js
+++ b/pkg/webui/lib/selectors/env.js
@@ -18,6 +18,10 @@ export const selectApplicationRootPath = () => (
   configSelector().APP_ROOT
 )
 
+export const selectAssetsRootPath = () => (
+  configSelector().ASSETS_ROOT
+)
+
 export const selectApplicationConfig = () => (
   configSelector().APP_CONFIG
 )
@@ -30,7 +34,7 @@ export const selectApplicationSiteTitle = () => (
   configSelector().SITE_TITLE
 )
 
-export const selectApplicationSiteSubtitle = () => (
+export const selectApplicationSiteSubTitle = () => (
   configSelector().SITE_SUB_TITLE
 )
 
@@ -52,6 +56,10 @@ export const selectJsConfig = () => (
 
 export const selectAsConfig = () => (
   selectApplicationConfig().as
+)
+
+export const selectLanguageConfig = () => (
+  selectApplicationConfig().language
 )
 
 export const selectPageData = () => (

--- a/pkg/webui/oauth/api/index.js
+++ b/pkg/webui/oauth/api/index.js
@@ -15,6 +15,9 @@
 import axios from 'axios'
 
 import getCookieValue from '../../lib/cookie'
+import { selectApplicationRootPath } from '../../lib/selectors/env'
+
+const appRoot = selectApplicationRootPath()
 
 const csrf = getCookieValue('_csrf')
 const instance = axios.create({
@@ -29,13 +32,13 @@ export default {
   },
   oauth: {
     login (credentials) {
-      return instance.post('/oauth/api/auth/login', credentials)
+      return instance.post(`${appRoot}/api/auth/login`, credentials)
     },
     logout () {
-      return instance.post('/oauth/api/auth/logout')
+      return instance.post(`${appRoot}/api/auth/logout`)
     },
     me () {
-      return instance.get('/oauth/api/me')
+      return instance.get(`${appRoot}/api/me`)
     },
   },
 }

--- a/pkg/webui/oauth/views/app/index.js
+++ b/pkg/webui/oauth/views/app/index.js
@@ -22,6 +22,7 @@ import { Helmet } from 'react-helmet'
 import WithLocale from '../../../lib/components/with-locale'
 import withEnv, { EnvProvider } from '../../../lib/components/env'
 import ErrorView from '../../../lib/components/error-view'
+import { selectApplicationRootPath } from '../../../lib/selectors/env'
 import env from '../../../lib/env'
 
 import Landing from '../landing'
@@ -33,7 +34,8 @@ import createStore from '../../store'
 import Init from '../../../lib/components/init'
 import Code from '../code'
 
-const history = createBrowserHistory()
+const appRoot = selectApplicationRootPath()
+const history = createBrowserHistory({ basename: appRoot })
 const store = createStore(history)
 
 const GenericNotFound = () => <FullViewError error={{ statusCode: 404 }} />

--- a/pkg/webui/oauth/views/app/index.js
+++ b/pkg/webui/oauth/views/app/index.js
@@ -21,8 +21,8 @@ import { Helmet } from 'react-helmet'
 
 import WithLocale from '../../../lib/components/with-locale'
 import withEnv, { EnvProvider } from '../../../lib/components/env'
-import { pageDataSelector } from '../../../lib/selectors/env'
 import ErrorView from '../../../lib/components/error-view'
+import env from '../../../lib/env'
 
 import Landing from '../landing'
 import Login from '../login'
@@ -35,20 +35,13 @@ import Code from '../code'
 
 const history = createBrowserHistory()
 const store = createStore(history)
-const env = {
-  app_root: window.APP_ROOT,
-  assets_root: window.ASSETS_ROOT,
-  config: window.APP_CONFIG,
-  page_data: window.PAGE_DATA,
-  site_name: window.SITE_NAME,
-  site_title: window.SITE_TITLE,
-}
 
 const GenericNotFound = () => <FullViewError error={{ statusCode: 404 }} />
 @withEnv
 export default class OAuthApp extends React.PureComponent {
   render () {
-    const pageData = pageDataSelector(env)
+
+    const { pageData } = env
 
     if (pageData && pageData.error) {
       return (

--- a/pkg/webui/oauth/views/app/index.js
+++ b/pkg/webui/oauth/views/app/index.js
@@ -69,11 +69,11 @@ export default class OAuthApp extends React.PureComponent {
               <ErrorView ErrorComponent={FullViewError}>
                 <ConnectedRouter history={history}>
                   <Switch>
-                    <Route path="/oauth" exact component={Landing} />
-                    <Route path="/oauth/login" component={Login} />
-                    <Route path="/oauth/authorize" component={Authorize} />
-                    <Route path="/oauth/register" component={CreateAccount} />
-                    <Route path="/oauth/code" component={Code} />
+                    <Route path="/" exact component={Landing} />
+                    <Route path="/login" component={Login} />
+                    <Route path="/authorize" component={Authorize} />
+                    <Route path="/register" component={CreateAccount} />
+                    <Route path="/code" component={Code} />
                     <Route component={GenericNotFound} />
                   </Switch>
                 </ConnectedRouter>

--- a/pkg/webui/oauth/views/app/index.js
+++ b/pkg/webui/oauth/views/app/index.js
@@ -62,8 +62,8 @@ export default class OAuthApp extends React.PureComponent {
         <Provider store={store}>
           <Init>
             <Helmet
-              titleTemplate={`%s - ${env.site_title ? `${env.site_title} - ` : ''}${env.site_name}`}
-              defaultTitle={`${env.site_title ? `${env.site_title} - ` : ''}${env.site_name}`}
+              titleTemplate={`%s - ${env.siteTitle ? `${env.siteTitle} - ` : ''}${env.siteName}`}
+              defaultTitle={`${env.siteTitle ? `${env.siteTitle} - ` : ''}${env.siteName}`}
             />
             <WithLocale>
               <ErrorView ErrorComponent={FullViewError}>

--- a/pkg/webui/oauth/views/authorize/index.js
+++ b/pkg/webui/oauth/views/authorize/index.js
@@ -15,6 +15,9 @@
 import React, { PureComponent, Fragment } from 'react'
 import Query from 'query-string'
 import { defineMessages } from 'react-intl'
+import { connect } from 'react-redux'
+import { replace } from 'connected-react-router'
+import bind from 'autobind-decorator'
 
 import api from '../../api'
 import sharedMessages from '../../../lib/shared-messages'
@@ -37,12 +40,17 @@ const m = defineMessages({
   authorize: 'Authorize',
 })
 
+@connect(undefined, dispatch => ({
+  redirectToLogin: () => dispatch(replace('/login')),
+}))
 @withEnv
+@bind
 export default class Authorize extends PureComponent {
 
   async handleLogout () {
+    const { redirectToLogin } = this.props
     await api.oauth.logout()
-    window.location = '/oauth/login'
+    redirectToLogin()
   }
 
   render () {

--- a/pkg/webui/oauth/views/code/index.js
+++ b/pkg/webui/oauth/views/code/index.js
@@ -33,7 +33,7 @@ export default class Code extends React.Component {
 
     if (!query.code) {
       return (
-        <Redirect to="/oauth/login" />
+        <Redirect to="/login" />
       )
     }
 

--- a/pkg/webui/oauth/views/create-account/index.js
+++ b/pkg/webui/oauth/views/create-account/index.js
@@ -114,7 +114,7 @@ export default class CreateAccount extends React.PureComponent {
         user: { ids: { user_id }, ...rest },
       })
 
-      push('/oauth/login', {
+      push('/login', {
         info: getSuccessMessage(result.data.state),
       })
 
@@ -131,7 +131,7 @@ export default class CreateAccount extends React.PureComponent {
     const { replace, location } = this.props
     const state = location.state || {}
 
-    const back = state.back || '/oauth/login'
+    const back = state.back || '/login'
 
     replace(back)
   }

--- a/pkg/webui/oauth/views/error/index.js
+++ b/pkg/webui/oauth/views/error/index.js
@@ -68,7 +68,7 @@ const FullViewError = function ({ error, env }) {
                 <Button.AnchorLink
                   icon="keyboard_arrow_left"
                   message={sharedMessages.takeMeBack}
-                  href={env.app_root}
+                  href={env.appRoot}
                 />
               )
               : (

--- a/pkg/webui/oauth/views/login/index.js
+++ b/pkg/webui/oauth/views/login/index.js
@@ -23,6 +23,7 @@ import * as Yup from 'yup'
 
 import api from '../../api'
 import sharedMessages from '../../../lib/shared-messages'
+import { selectApplicationRootPath } from '../../../lib/selectors/env'
 
 import Button from '../../../components/button'
 import Form from '../../../components/form'
@@ -46,6 +47,8 @@ const validationSchema = Yup.object().shape({
   password: Yup.string()
     .required(sharedMessages.validateRequired),
 })
+
+const appRoot = selectApplicationRootPath()
 
 @withRouter
 @connect()
@@ -74,7 +77,7 @@ export default class OAuth extends React.PureComponent {
 
   navigateToRegister () {
     const { dispatch, location } = this.props
-    dispatch(replace('/oauth/register', {
+    dispatch(replace('/register', {
       back: `${location.pathname}${location.search}`,
     }))
   }
@@ -138,7 +141,7 @@ export default class OAuth extends React.PureComponent {
 function url (location, omitQuery = false) {
   const query = Query.parse(location.search)
 
-  const next = query.n || '/oauth'
+  const next = query.n || appRoot
 
   if (omitQuery) {
     return next.split('?')[0]


### PR DESCRIPTION
#### Summary
Closes #727.

#### Changes
- Move environment mapper to own module and use snakeCase
- Refactor env prop references accordingly
- Change routing to use  the `app_root` as `basename`
- Refactor all routes accordingly
- Both for oauth and console app
- Various related minor fixes and improvements
- Remove unnecessary env context provider, introduced by cc @pgalic96 (see [here](https://github.com/TheThingsNetwork/lorawan-stack/commit/59d6efde5b1b494504c7d32b8d41a8702c60f099))

#### Notes for Reviewers
Obviously a lot of refactoring here, so maybe better to go commit by commit. The new approach using `basename` saves us a lot of referencing `env.appRoot`. Please check this also by changing the mount path of the console.

#### Release Notes
- Fixed console handling of configured mount paths other than `/console`