### PR TITLE
Use DefaultHost from ACME config for non-SNI fallback

### DIFF
--- a/pkg/component/tls.go
+++ b/pkg/component/tls.go
@@ -55,7 +55,12 @@ func (c *Component) GetTLSConfig(ctx context.Context, opts ...TLSConfigOption) (
 	var conf *tls.Config
 	if c.acme != nil {
 		conf = &tls.Config{
-			GetCertificate: c.acme.GetCertificate,
+			GetCertificate: func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+				if hello.ServerName == "" {
+					hello.ServerName = c.config.TLS.ACME.DefaultHost
+				}
+				return c.acme.GetCertificate(hello)
+			},
 		}
 		opts = append(opts, WithNextProtos(acme.ALPNProto))
 	} else {

--- a/pkg/config/tls.go
+++ b/pkg/config/tls.go
@@ -38,11 +38,12 @@ type TLS struct {
 
 // ACME represents ACME configuration.
 type ACME struct {
-	Enable   bool     `name:"enable" description:"Enable automated certificate management (ACME)"`
-	Endpoint string   `name:"endpoint" description:"ACME endpoint"`
-	Dir      string   `name:"dir" description:"Location of ACME storage directory"`
-	Email    string   `name:"email" description:"Email address to register with the ACME account"`
-	Hosts    []string `name:"hosts" description:"Hosts to enable automatic certificates for"`
+	Enable      bool     `name:"enable" description:"Enable automated certificate management (ACME)"`
+	Endpoint    string   `name:"endpoint" description:"ACME endpoint"`
+	Dir         string   `name:"dir" description:"Location of ACME storage directory"`
+	Email       string   `name:"email" description:"Email address to register with the ACME account"`
+	Hosts       []string `name:"hosts" description:"Hosts to enable automatic certificates for"`
+	DefaultHost string   `name:"default-host" description:"Default host to assume for clients without SNI"`
 }
 
 var errNoKeyPair = errors.DefineFailedPrecondition("no_key_pair", "no TLS key pair")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This Pull Request closes #1070 by adding a configuration flag that sets the fallback host when TLS clients do not use SNI when connecting to a Stack that uses autocert.

#### Changes
<!-- What are the changes made in this pull request? -->

- Added `--tls.acme.default-host` config
- Added fallback to that value with clients that don't use TLS-SNI

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@KrishnaIyer does this solve the issue?

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Added `--tls.acme.default-host` flag to set a default (fallback) host for connecting clients that do not use TLS-SNI.
