### PR TITLE
Improve proptypes

### DIFF
--- a/pkg/webui/components/header/index.js
+++ b/pkg/webui/components/header/index.js
@@ -70,45 +70,27 @@ const Header = function ({
 
 Header.propTypes = {
   /**
-  * The User object, retrieved from the API. If it is
-  * `undefined`, then the guest header is rendered.
+  * The User object, retrieved from the API. If it is `undefined`, then the
+  * guest header is rendered
   */
   user: PropTypes.object,
   /**
   * A list of items for the dropdown
-  * @param {(string|Object)} title - The title to be displayed
-  * @param {string} icon - The icon name to be displayed next to the title
-  * @param {string} path - The path for a navigation tab
-  * @param {function} action - Alternatively, the function to be called on click
+  * See `<ProfileDropdown/>`'s `items` proptypes for details
   */
-  dropdownItems: PropTypes.arrayOf(PropTypes.shape({
-    title: PropTypes.message.isRequired,
-    icon: PropTypes.string,
-    path: PropTypes.string,
-    action: PropTypes.func,
-  })).isRequired,
+  dropdownItems: ProfileDropdown.propTypes.dropdownItems,
   /**
-   * A list of navigation bar entries.
-   * @param {(string|Object)} title - The title to be displayed
-   * @param {string} icon - The icon name to be displayed next to the title
-   * @param {string} path -  The path for a navigation tab
-   * @param {boolean} exact - Flag identifying whether the path should be matched exactly
+   * A list of navigation bar entries
+   * See `<NavigationBar/>`'s `entries` proptypes for details
    */
-  entries: PropTypes.arrayOf(PropTypes.shape({
-    path: PropTypes.string.isRequired,
-    title: PropTypes.message.isRequired,
-    icon: PropTypes.string,
-    exact: PropTypes.bool,
-  })),
+  entries: NavigationBar.propTypes.entries,
   /** Flag identifying whether links should be rendered as plain anchor link */
   anchored: PropTypes.bool,
   /**
   * A handler for when the user clicks the logout button
   */
   handleLogout: PropTypes.func,
-  /**
-  * A handler for when the user used the search input
-  */
+  /** A handler for when the user used the search input */
   handleSearchRequest: PropTypes.func,
   /** A flag identifying whether the header should display the search input */
   searchable: PropTypes.bool,

--- a/pkg/webui/components/navigation/bar/index.js
+++ b/pkg/webui/components/navigation/bar/index.js
@@ -64,12 +64,7 @@ NavigationBar.propTypes = {
    * @param {string} path -  The path for a navigation tab
    * @param {boolean} exact - Flag identifying whether the path should be matched exactly
    */
-  entries: PropTypes.arrayOf(PropTypes.shape({
-    path: PropTypes.string.isRequired,
-    title: PropTypes.message.isRequired,
-    icon: PropTypes.string,
-    exact: PropTypes.bool,
-  })),
+  entries: PropTypes.arrayOf(PropTypes.link),
   /** Flag identifying whether links should be rendered as plain anchor link */
   anchored: PropTypes.bool,
 }

--- a/pkg/webui/components/navigation/side/side.js
+++ b/pkg/webui/components/navigation/side/side.js
@@ -140,18 +140,11 @@ class SideNavigation extends Component {
 }
 
 SideNavigation.propTypes = {
-  /** A list of entry objects for the side navigation */
-  entries: PropTypes.arrayOf(
-    PropTypes.oneOfType([
-      PropTypes.link,
-      PropTypes.shape({
-        title: PropTypes.message.isRequired,
-        icon: PropTypes.string,
-        nested: PropTypes.bool.isRequired,
-        items: PropTypes.array.isRequired,
-      }),
-    ])
-  ).isRequired,
+  /**
+   * A list of entry objects for the side navigation
+   * See `<SideNavigationList/>`'s `items` proptypes for details
+   */
+  entries: SideNavigationList.propTypes.items,
   /** The header for the side navigation */
   header: PropTypes.shape({
     title: PropTypes.string,

--- a/pkg/webui/components/profile-dropdown/index.js
+++ b/pkg/webui/components/profile-dropdown/index.js
@@ -22,27 +22,34 @@ import PropTypes from '../../lib/prop-types'
 
 import styles from './profile-dropdown.styl'
 
+const dropdownItemsPropTypes = PropTypes.arrayOf(
+  PropTypes.oneOfType([
+    PropTypes.shape({
+      title: PropTypes.message.isRequired,
+      icon: PropTypes.string,
+      path: PropTypes.string,
+      action: PropTypes.func.isRequired,
+    }),
+    PropTypes.shape({
+      title: PropTypes.message.isRequired,
+      icon: PropTypes.string,
+      path: PropTypes.string.isRequired,
+      action: PropTypes.func,
+    }),
+  ])
+).isRequired
+
 @bind
 export default class ProfileDropdown extends React.PureComponent {
 
   static propTypes = {
+    /** The id of the current user */
+    userId: PropTypes.string,
     /**
-    * The id of the current user
+    * A list of items for the dropdown component
+    * See `<Dropdown />`'s `items` proptypes for details
     */
-    userId: PropTypes.string.isRequired,
-    /**
-    * A list of items for the dropdown
-    * @param {(string|Object)} title - The title to be displayed
-    * @param {string} icon - The icon name to be displayed next to the title
-    * @param {string} path - The path for a navigation tab
-    * @param {function} action - Alternatively, the function to be called on click
-    */
-    dropdownItems: PropTypes.arrayOf(PropTypes.shape({
-      title: PropTypes.message.isRequired,
-      icon: PropTypes.string,
-      path: PropTypes.string,
-      action: PropTypes.func,
-    })),
+    dropdownItems: dropdownItemsPropTypes,
   }
 
   state = {
@@ -136,12 +143,7 @@ Dropdown.propTypes = {
   * @param {string} path - The path for a navigation tab
   * @param {function} action - Alternatively, the function to be called on click
   */
-  items: PropTypes.arrayOf(PropTypes.shape({
-    title: PropTypes.message.isRequired,
-    icon: PropTypes.string,
-    path: PropTypes.string,
-    action: PropTypes.func,
-  })),
+  items: dropdownItemsPropTypes,
   /** Flag identifying whether link should be rendered as plain anchor link */
   anchored: PropTypes.bool,
 }

--- a/pkg/webui/console/containers/freq-plans-select/index.js
+++ b/pkg/webui/console/containers/freq-plans-select/index.js
@@ -112,14 +112,12 @@ FrequencyPlansSelect.propTypes = {
   required: PropTypes.bool,
   title: PropTypes.message,
   autoFocus: PropTypes.bool,
-  horizontal: PropTypes.bool,
   menuPlacement: PropTypes.oneOf([ 'top', 'bottom', 'auto' ]),
 }
 
 FrequencyPlansSelect.defaultProps = {
   title: sharedMessages.frequencyPlan,
   autoFocus: false,
-  horizontal: false,
   menuPlacement: 'auto',
   required: false,
 }

--- a/pkg/webui/console/containers/webhook-formats-select/index.js
+++ b/pkg/webui/console/containers/webhook-formats-select/index.js
@@ -65,7 +65,6 @@ class WebhookFormatsSelector extends React.PureComponent {
       required,
       title,
       autoFocus,
-      horizontal,
       error,
       fetching,
       menuPlacement,
@@ -76,7 +75,6 @@ class WebhookFormatsSelector extends React.PureComponent {
     return (
       <Field
         component={Select}
-        horizontal={horizontal}
         type="select"
         options={fieldOptions}
         name={name}
@@ -96,14 +94,12 @@ WebhookFormatsSelector.propTypes = {
   required: PropTypes.bool.isRequired,
   title: PropTypes.message,
   autoFocus: PropTypes.bool,
-  horizontal: PropTypes.bool,
   menuPlacement: PropTypes.oneOf([ 'top', 'bottom', 'auto' ]),
 }
 
 WebhookFormatsSelector.defaultProps = {
   title: sharedMessages.webhookFormat,
   autoFocus: false,
-  horizontal: false,
   menuPlacement: 'auto',
 }
 


### PR DESCRIPTION
#### Summary
This PR is a follow up from [this comment](https://github.com/TheThingsNetwork/lorawan-stack/pull/1060#discussion_r308819815). It will improve reused proptypes through referencing them rather than redefining. Additionally, it fixes some minor proptype related issues that I found while going through them.

#### Changes
- Replace redundant proptype definitions with references
- Increase proptype precision of `<ProfileDropdown />` items
- Remove unused `horizontal` proptype from selector container components

#### Notes for Reviewers
Let me know if you have any other proptype related issues worth taking care of in this PR.

