### PR TITLE
Fix validation rules for device form

### DIFF
--- a/pkg/webui/console/components/device-data-form/index.js
+++ b/pkg/webui/console/components/device-data-form/index.js
@@ -32,7 +32,7 @@ import errorMessages from '../../../lib/errors/error-messages'
 import { getDeviceId } from '../../../lib/selectors/id'
 import PropTypes from '../../../lib/prop-types'
 import m from './messages'
-import validationSchema from './validation-schema'
+import { createFormValidationSchema, updateFormValidationSchema } from './validation-schema'
 
 @bind
 class DeviceDataForm extends Component {
@@ -70,11 +70,13 @@ class DeviceDataForm extends Component {
 
   async handleSubmit (values, { setSubmitting, resetForm }) {
     const { onSubmit, onSubmitSuccess, initialValues, update } = this.props
+    const validationSchema = update ? updateFormValidationSchema : createFormValidationSchema
     const deviceId = getDeviceId(initialValues)
+    const castedValues = validationSchema.cast(values)
     await this.setState({ error: '' })
 
     try {
-      const device = await onSubmit(values)
+      const device = await onSubmit(castedValues)
       if (update) {
         resetForm(values)
         toast({
@@ -279,7 +281,7 @@ class DeviceDataForm extends Component {
       <Form
         error={error}
         onSubmit={this.handleSubmit}
-        validationSchema={validationSchema}
+        validationSchema={update ? updateFormValidationSchema : createFormValidationSchema}
         submitEnabledWhenInvalid
         initialValues={formValues}
       >


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #905, see my comment https://github.com/TheThingsNetwork/lorawan-stack/issues/905#issuecomment-512876391

#### Changes
<!-- What are the changes made in this pull request? -->

- Split update/create validation schemas
- Cast final form values before submitting

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The main idea is to strip key values in the create form and skip their validation.
For the edit form we keep validation logic as it was before (the user has to specify the keys to pass validation)