### PR TITLE
Fix validation rules for gateway form

### DIFF
--- a/pkg/webui/console.js
+++ b/pkg/webui/console.js
@@ -25,6 +25,7 @@ import Init from './lib/components/init'
 import WithLocale from './lib/components/with-locale'
 import env from './lib/env'
 import { selectApplicationRootPath } from './lib/selectors/env'
+import './lib/yup-extensions'
 
 import createStore from './console/store'
 import App from './console/views/app'

--- a/pkg/webui/console/components/gateway-data-form/index.js
+++ b/pkg/webui/console/components/gateway-data-form/index.js
@@ -41,7 +41,7 @@ const validationSchema = Yup.object().shape({
       .min(2, sharedMessages.validateTooShort)
       .max(36, sharedMessages.validateTooLong)
       .required(sharedMessages.validateRequired),
-    eui: Yup.string()
+    eui: Yup.nullableString()
       .length(8 * 2, sharedMessages.validateTooShort),
   }),
   name: Yup.string()
@@ -57,9 +57,16 @@ const validationSchema = Yup.object().shape({
 
 @bind
 class GatewayDataForm extends React.Component {
+
+  onSubmit (values, helpers) {
+    const { onSubmit } = this.props
+    const castedValues = validationSchema.cast(values)
+
+    onSubmit(castedValues, helpers)
+  }
+
   render () {
     const {
-      onSubmit,
       update,
       error,
       initialValues,
@@ -70,7 +77,7 @@ class GatewayDataForm extends React.Component {
     return (
       <Form
         error={error}
-        onSubmit={onSubmit}
+        onSubmit={this.onSubmit}
         initialValues={initialValues}
         validationSchema={validationSchema}
         formikRef={formRef}

--- a/pkg/webui/lib/yup-extensions.js
+++ b/pkg/webui/lib/yup-extensions.js
@@ -1,0 +1,43 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as Yup from 'yup'
+
+const StringSchema = Yup.string
+
+/**
+ * `NullableStringSchemaType` is an extension for the default `yup.string` schema type.
+ * It transforms the value to `null` if it is empty and skips validation.
+ */
+class NullableStringSchemaType extends StringSchema {
+  constructor () {
+    super()
+
+    const self = this
+
+    self.withMutation(function () {
+      self.transform(function (value) {
+        if (self.isType(value) && Boolean(value)) {
+          return value
+        }
+
+        return null
+      }).nullable(true)
+    })
+  }
+}
+
+Yup.nullableString = () => new NullableStringSchemaType()
+
+export default Yup


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #905

#### Changes
<!-- What are the changes made in this pull request? -->

- Change validation rules for the gateway eui field


#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Approach in this pr is different than in https://github.com/TheThingsNetwork/lorawan-stack/pull/1075 because:
1. `null` is valid value for the gateway eui. We cant do that for device keys, because the js would return an error.
2. api allows users to change/remove eui, we have to reflect this in the form. 
