### PR TITLE
Fix unhandled promise rejections of action dispatches

### DIFF
--- a/pkg/webui/console/containers/device-payload-formatters/downlink.js
+++ b/pkg/webui/console/containers/device-payload-formatters/downlink.js
@@ -26,6 +26,7 @@ import PAYLOAD_FORMATTER_TYPES from '../../constants/formatter-types'
 import toast from '../../../components/toast'
 
 import { updateDevice } from '../../store/actions/device'
+import { attachPromise } from '../../store/actions/lib'
 import { selectSelectedApplicationId } from '../../store/selectors/applications'
 import {
   selectSelectedDeviceId,
@@ -41,7 +42,7 @@ import {
     formatters,
   }
 },
-{ updateDevice })
+{ updateDevice: attachPromise(updateDevice) })
 @withBreadcrumb('device.single.payload-formatters.downlink', function (props) {
   const { appId, devId } = props
 

--- a/pkg/webui/console/containers/device-payload-formatters/uplink.js
+++ b/pkg/webui/console/containers/device-payload-formatters/uplink.js
@@ -26,6 +26,7 @@ import PAYLOAD_FORMATTER_TYPES from '../../constants/formatter-types'
 import toast from '../../../components/toast'
 
 import { updateDevice } from '../../store/actions/device'
+import { attachPromise } from '../../store/actions/lib'
 import { selectSelectedApplicationId } from '../../store/selectors/applications'
 import {
   selectSelectedDeviceId,
@@ -43,7 +44,7 @@ import {
     formatters,
   }
 },
-{ updateDevice })
+{ updateDevice: attachPromise(updateDevice) })
 @withBreadcrumb('device.single.payload-formatters.uplink', function (props) {
   const { appId, devId } = props
 

--- a/pkg/webui/console/store/actions/lib.js
+++ b/pkg/webui/console/store/actions/lib.js
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/* eslint-disable import/prefer-default-export */
-
 import { createAction } from 'redux-actions'
 
-const createRequestActions = function (
+export const createRequestActions = function (
   baseType,
   requestPayloadCreator,
   requestMetaCreator,
@@ -36,4 +34,20 @@ const createRequestActions = function (
   }]
 }
 
-export { createRequestActions }
+/**
+* attachPromise is a function which extends an action creator to include a flag
+* which results in a promise being attached to the action by the promise
+* middleware.
+* @param {Function} actionCreator - The original action creator
+* @returns {Function} - The modified action creator
+*/
+export const attachPromise = actionCreator => function (...args) {
+  const action = actionCreator(...args)
+  return {
+    ...action,
+    meta: {
+      ...action.meta,
+      _attachPromise: true,
+    },
+  }
+}

--- a/pkg/webui/console/store/middleware/request-promise-middleware.js
+++ b/pkg/webui/console/store/middleware/request-promise-middleware.js
@@ -19,7 +19,7 @@
  * @returns {Object} The middleware
  */
 const requestPromiseMiddleware = store => next => function (action) {
-  if (action.type.endsWith('_REQUEST')) {
+  if (action.meta && action.meta._attachPromise) {
     return new Promise(function (resolve, reject) {
       action.meta = {
         ...action.meta,

--- a/pkg/webui/console/views/application-general-settings/index.js
+++ b/pkg/webui/console/views/application-general-settings/index.js
@@ -34,6 +34,7 @@ import SubmitBar from '../../../components/submit-bar'
 
 import { selectSelectedApplication } from '../../store/selectors/applications'
 import { updateApplication, deleteApplication } from '../../store/actions/applications'
+import { attachPromise } from '../../store/actions/lib'
 
 const m = defineMessages({
   basics: 'Basics',
@@ -54,8 +55,8 @@ const validationSchema = Yup.object().shape({
   application: selectSelectedApplication(state),
 }),
 {
-  updateApplication,
-  deleteApplication,
+  updateApplication: attachPromise(updateApplication),
+  deleteApplication: attachPromise(deleteApplication),
 })
 @withBreadcrumb('apps.single.general-settings', function (props) {
   const { appId } = props

--- a/pkg/webui/console/views/device-general-settings/index.js
+++ b/pkg/webui/console/views/device-general-settings/index.js
@@ -14,6 +14,7 @@
 
 import React from 'react'
 import { replace } from 'connected-react-router'
+import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
 import { Col, Row, Container } from 'react-grid-system'
 import bind from 'autobind-decorator'
@@ -27,6 +28,7 @@ import IntlHelmet from '../../../lib/components/intl-helmet'
 import api from '../../api'
 
 import { updateDevice } from '../../store/actions/device'
+import { attachPromise } from '../../store/actions/lib'
 import { selectSelectedApplicationId } from '../../store/selectors/applications'
 import { selectSelectedDevice, selectSelectedDeviceId } from '../../store/selectors/device'
 
@@ -37,8 +39,8 @@ import { selectSelectedDevice, selectSelectedDeviceId } from '../../store/select
     appId: selectSelectedApplicationId(state),
   }
 }, dispatch => ({
+  ...bindActionCreators({ updateDevice: attachPromise(updateDevice) }, dispatch),
   onDeleteSuccess: appId => dispatch(replace(`/applications/${appId}/devices`)),
-  updateDevice: (appId, deviceId, patch) => dispatch(updateDevice(appId, deviceId, patch)),
 }),
 (stateProps, dispatchProps, ownProps) => ({
   ...stateProps, ...dispatchProps, ...ownProps,

--- a/pkg/webui/console/views/device-location/index.js
+++ b/pkg/webui/console/views/device-location/index.js
@@ -28,6 +28,7 @@ import { withBreadcrumb } from '../../../components/breadcrumbs/context'
 import IntlHelmet from '../../../lib/components/intl-helmet'
 
 import { updateDevice } from '../../store/actions/device'
+import { attachPromise } from '../../store/actions/lib'
 import { selectSelectedApplicationId } from '../../store/selectors/applications'
 
 import {
@@ -67,7 +68,7 @@ const getRegistryLocation = function (locations) {
     appId: selectSelectedApplicationId(state),
     devId: getDeviceId(state.device.device),
   }),
-  { updateDevice }
+  { updateDevice: attachPromise(updateDevice) }
 )
 @withBreadcrumb('device.single.data', function (props) {
   const { devId, appId } = props

--- a/pkg/webui/console/views/gateway-general-settings/index.js
+++ b/pkg/webui/console/views/gateway-general-settings/index.js
@@ -32,6 +32,7 @@ import IntlHelmet from '../../../lib/components/intl-helmet'
 import diff from '../../../lib/diff'
 
 import { updateGateway, deleteGateway } from '../../store/actions/gateways'
+import { attachPromise } from '../../store/actions/lib'
 import { getGatewayId } from '../../../lib/selectors/id'
 import { selectSelectedGateway } from '../../store/selectors/gateways'
 
@@ -49,7 +50,10 @@ const m = defineMessages({
     gateway,
   }
 },
-{ updateGateway, deleteGateway })
+{
+  updateGateway: attachPromise(updateGateway),
+  deleteGateway: attachPromise(deleteGateway),
+})
 @withBreadcrumb('gateways.single.general-settings', function (props) {
   const { gtwId } = props
 

--- a/pkg/webui/console/views/gateway-location/index.js
+++ b/pkg/webui/console/views/gateway-location/index.js
@@ -28,6 +28,7 @@ import { withBreadcrumb } from '../../../components/breadcrumbs/context'
 import IntlHelmet from '../../../lib/components/intl-helmet'
 
 import { updateGateway } from '../../store/actions/gateways'
+import { attachPromise } from '../../store/actions/lib'
 import { selectSelectedGateway } from '../../store/selectors/gateways'
 
 import {
@@ -71,7 +72,7 @@ const getRegistryLocation = function (antennas) {
     gtwId: getGatewayId(gateway),
   }
 },
-{ updateGateway })
+{ updateGateway: attachPromise(updateGateway) })
 @withBreadcrumb('gateway.single.data', function (props) {
   const { gtwId } = props
   return (


### PR DESCRIPTION
#### Summary
Closes #975.

#### Changes
- Change promise attacher middleware to check for an `_attachPromise` flag to be true
- Change `createRequestLogic` to resolve/reject only when a promise is attached
- Add a wrapping function for action creators that will attach the `_attachPromise` flag to the `meta`-object of the action
- Refactor awaited dispatches to use the new action creator wrapper

#### Notes for Reviewers
This is the solution according to our discussion in #975

#### Release Notes
- Fixed an issue resulting in errors being unnecessarily logged in the console