### PR TITLE
Check additional admin-only fields in updateClient

### DIFF
--- a/pkg/identityserver/client_registry.go
+++ b/pkg/identityserver/client_registry.go
@@ -237,8 +237,13 @@ func (is *IdentityServer) updateClient(ctx context.Context, req *ttnpb.UpdateCli
 	}
 	updatedByAdmin := is.IsAdmin(ctx)
 
-	if ttnpb.HasAnyField(req.FieldMask.Paths, "grants") && !updatedByAdmin {
-		return nil, errUpdateClientAdminField.WithAttributes("field", "grants")
+	if !updatedByAdmin {
+		for _, path := range req.FieldMask.Paths {
+			switch path {
+			case "state", "skip_authorization", "endorsed", "grants":
+				return nil, errUpdateUserAdminField.WithAttributes("field", path)
+			}
+		}
 	}
 
 	err = is.withDatabase(ctx, func(db *gorm.DB) (err error) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This Pull Request fixes a security issue in the updateClient RPC implementation.

#### Changes
<!-- What are the changes made in this pull request? -->

- Added check for more admin-only fields in `updateClient`

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Fixed a security issue where non-admin users could edit admin-only fields of OAuth clients.