### PR TITLE
Fix form generic error display

### DIFF
--- a/pkg/webui/lib/components/error-message/index.js
+++ b/pkg/webui/lib/components/error-message/index.js
@@ -18,7 +18,7 @@ import classnames from 'classnames'
 import Message from '../message'
 
 import PropTypes from '../../prop-types'
-import sharedMessages from '../../shared-messages'
+import errorMessages from '../../errors/error-messages'
 
 import {
   isBackend,
@@ -48,7 +48,7 @@ const ErrorMessage = function ({ content, ...rest }) {
     props.content = content
   } else {
     // Fall back to generic error message
-    props.content = sharedMessages.genericError
+    props.content = errorMessages.genericError
   }
 
   return <Message {...props} />

--- a/pkg/webui/lib/prop-types.js
+++ b/pkg/webui/lib/prop-types.js
@@ -41,6 +41,10 @@ PropTypes.error = PropTypes.oneOfType([
   ]),
   PropTypes.message,
   PropTypes.string,
+  PropTypes.shape({
+    message: PropTypes.string,
+    stack: PropTypes.object,
+  }),
 ])
 
 PropTypes.link = PropTypes.shape({


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #1083 

#### Changes
<!-- What are the changes made in this pull request? -->

- Show generic error message on unknown error in `<ErrorMessage />`
- Extend the error prop type to accept instances of the `Error` class
