### PR TITLE
Do not clear device form on errors

### DIFF
--- a/pkg/webui/console/components/device-data-form/index.js
+++ b/pkg/webui/console/components/device-data-form/index.js
@@ -75,8 +75,8 @@ class DeviceDataForm extends Component {
 
     try {
       const device = await onSubmit(values)
-      resetForm(values)
       if (update) {
+        resetForm(values)
         toast({
           title: deviceId,
           message: m.updateSuccess,
@@ -85,7 +85,7 @@ class DeviceDataForm extends Component {
       }
       await onSubmitSuccess(device)
     } catch (error) {
-      resetForm()
+      setSubmitting(false)
       const err = error instanceof Error ? errorMessages.genericError : error
       await this.setState({ error: err })
     }


### PR DESCRIPTION
#### Summary
This PR fixes the clearing of fields in the device data form, when an error occurred during submit. There is no reason to clear the form fields and it results in other weird issues upon resubmitting.

#### Changes
- Replace `resetForm()` with `setSubmitting(false)`
- Only `resetForm()` when updating, otherwise we have the redirect
