### PR TITLE
Prevent browser auto-prefill of linking form

### DIFF
--- a/pkg/webui/components/input/index.js
+++ b/pkg/webui/components/input/index.js
@@ -48,6 +48,7 @@ class Input extends React.Component {
     label: PropTypes.string,
     loading: PropTypes.bool,
     title: PropTypes.message,
+    code: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -102,6 +103,7 @@ class Input extends React.Component {
       title,
       intl,
       horizontal,
+      code,
       ...rest
     } = this.props
 
@@ -134,6 +136,7 @@ class Input extends React.Component {
       [style.readOnly]: readOnly,
       [style.warn]: !error && warning,
       [style.disabled]: disabled,
+      [style.code]: code,
     })
 
     return (

--- a/pkg/webui/components/input/input.styl
+++ b/pkg/webui/components/input/input.styl
@@ -101,13 +101,17 @@
   path
     fill: $c-active-blue
 
-.byte
+.byte, .code, .placeholder
   font-family: 'IBM Plex Mono', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace
+
+.byte
   font-weight: 600
   letter-spacing: .05rem
 
+.code
+  font-size: $fs.s
+
 .placeholder
-  font-family: 'IBM Plex Mono', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace
   position: absolute
   left: .7rem
   white-space: pre

--- a/pkg/webui/console/views/application-link/index.js
+++ b/pkg/webui/console/views/application-link/index.js
@@ -266,11 +266,11 @@ class ApplicationLink extends React.Component {
                 autoFocus
               />
               <Form.Field
-                type="password"
                 component={Input}
                 required
                 name="api_key"
                 title={sharedMessages.apiKey}
+                code
               />
               <SubmitBar>
                 <Form.Submit


### PR DESCRIPTION
#### Summary
This PR fixes an issue where the login credentials will be auto-prefilled by (at least) chrome:
![image](https://user-images.githubusercontent.com/5710611/62375465-a7d71000-b53e-11e9-9e63-741e011cef93.png)

Chrome appears to assume any form consisting of a text input followed by a password input to be a login form. Circumventing this behavior via workaround appears to be [very dirty and instable](https://gist.github.com/runspired/b9fdf1fa74fc9fb4554418dea35718fe). I hence decided to change the type of the Api Key field from `password` to `text`, which is also more correct semantically. 
Later, we should add a toggle to show/hide the value.

#### Changes
- Add a `code` prop to the `<Input />` component that will adjust the styling of the input to have monospace font
- Change the input type of the `api_key` field from `password` to `text`
