### PR TITLE
Remove fetched config caching

### DIFF
--- a/pkg/webui/console/store/middleware/logics/configuration.js
+++ b/pkg/webui/console/store/middleware/logics/configuration.js
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import * as configuration from '../../actions/configuration'
-import { get as cacheGet, set as cacheSet } from '../../../lib/cache'
 import api from '../../../api'
 
 import {
@@ -34,11 +33,8 @@ const getNsFrequencyPlansLogic = createRequestLogic({
     }
   },
   async process () {
-    let frequencyPlans = cacheGet('ns_frequency_plans')
-    if (!frequencyPlans) {
-      frequencyPlans = (await api.configuration.listNsFrequencyPlans()).frequency_plans
-      cacheSet('ns_frequency_plans', frequencyPlans)
-    }
+    const frequencyPlans = (await api.configuration.listNsFrequencyPlans()).frequency_plans
+
     return frequencyPlans
   },
 })
@@ -54,11 +50,7 @@ const getGsFrequencyPlansLogic = createRequestLogic({
     }
   },
   async process () {
-    let frequencyPlans = cacheGet('gs_frequency_plans')
-    if (!frequencyPlans) {
-      frequencyPlans = (await api.configuration.listGsFrequencyPlans()).frequency_plans
-      cacheSet('gs_frequency_plans', frequencyPlans)
-    }
+    const frequencyPlans = (await api.configuration.listGsFrequencyPlans()).frequency_plans
 
     return frequencyPlans
   },


### PR DESCRIPTION
#### Summary
This PR removes the caching of fetched config values in the console. We cannot properly do cache invalidation without expiration headers of the original request. This leads to config changes not being reflected in the console (unless clearing the cache/localStorage manually).

#### Changes
- Remove caching of GS/NS frequency plans

#### Notes for Reviewers
- Will follow up with an issue for expiration headers