### PR TITLE
Fix select blur handling

### DIFF
--- a/pkg/webui/components/select/index.js
+++ b/pkg/webui/components/select/index.js
@@ -90,8 +90,10 @@ class Select extends React.PureComponent {
     const { value } = this.state
     const { onBlur } = this.props
 
-    // https://github.com/JedWatson/react-select/issues/3175
-    event.target.value = value
+    if (typeof value !== 'undefined') {
+      // https://github.com/JedWatson/react-select/issues/3175
+      event.target.value = value
+    }
 
     onBlur(event)
   }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes the `onBlur` event handler of the `<Select />` component.

#### Changes
<!-- What are the changes made in this pull request? -->

- Do not reassign targets value if it is `undefined`

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

`event.target.value` treats any value as `string` and always returns `string` on value assignment. this caused errors being shown in empty select fields.

<img width="423" alt="Screenshot 2019-08-05 at 16 00 14" src="https://user-images.githubusercontent.com/16374166/62466518-25e32300-b79a-11e9-861c-b32950f2349c.png">
