### PR TITLE
Fix occasional scrolling to invalid field issue

### DIFF
--- a/pkg/webui/components/form/index.js
+++ b/pkg/webui/components/form/index.js
@@ -40,7 +40,7 @@ class InnerForm extends React.PureComponent {
     }
 
     // Scroll invalid fields into view if needed and focus them
-    if (!prevIsSubmitting && isSubmitting && !isValid) {
+    if (prevIsSubmitting && !isSubmitting && !isValid) {
       const firstErrorNode = document.querySelectorAll('[data-needs-focus="true"]')[0]
       if (firstErrorNode) {
         scrollIntoView(firstErrorNode, { behavior: 'smooth' })


### PR DESCRIPTION
#### Summary
This PR fixes an issue where occasionally an invalid field is not scrolled into view in forms. This happens when the `isValid` value is not initially `false` as soon as the submit happens, which can be the case for more some validation logics.

#### Changes
- Check for the `isValid` value when the submit process ended (as in: `isSubmitting` turning from `true` to `false`), instead of when it begins

#### Notes for Reviewers
- This issue occurred to me for invalid key-value-map values in the new webhook form
