### PR TITLE
Use code prop in key-value-map input

### DIFF
--- a/pkg/webui/components/key-value-map/entry.js
+++ b/pkg/webui/components/key-value-map/entry.js
@@ -63,6 +63,7 @@ class Entry extends React.Component {
           type="text"
           onChange={this.handleKeyChanged}
           value={value.key}
+          code
         />
         <Input
           className={style.input}
@@ -72,6 +73,7 @@ class Entry extends React.Component {
           onChange={this.handleValueChanged}
           onBlur={onBlur}
           value={value.value}
+          code
         />
         <Button
           type="button"

--- a/pkg/webui/components/key-value-map/key-value-map.styl
+++ b/pkg/webui/components/key-value-map/key-value-map.styl
@@ -21,6 +21,4 @@
     flex-shrink: 2
     min-width: 10rem
 
-  font-family: $font-family-mono
-  font-size: $fs.s
   margin-right: $cs.s


### PR DESCRIPTION
#### Summary
This PR removes unnecessary styling and adds the `code` prop to the inputs of the key value map component instead.

#### Changes
- Replace manual styling by the inputs `code` prop
