### PR TITLE
Add ns service to js sdk

### DIFF
--- a/pkg/webui/console/api/index.js
+++ b/pkg/webui/console/api/index.js
@@ -164,4 +164,7 @@ export default {
       list: ttnClient.Js.listJoinEUIPrefixes.bind(ttnClient.Js),
     },
   },
+  ns: {
+    generateDevAddress: ttnClient.Ns.generateDevAddress.bind(ttnClient.Ns),
+  },
 }

--- a/sdk/js/src/index.js
+++ b/sdk/js/src/index.js
@@ -19,6 +19,7 @@ import Api from './api'
 import Token from './util/token'
 import Gateways from './service/gateways'
 import Js from './service/join-server'
+import Ns from './service/network-server'
 
 class TtnLw {
   constructor (token, {
@@ -37,6 +38,7 @@ class TtnLw {
     this.Configuration = new Configuration(this.api.Configuration)
     this.Gateways = new Gateways(this.api, { defaultUserId, proxy, stackConfig })
     this.Js = new Js(this.api.Js)
+    this.Ns = new Ns(this.api.Ns)
   }
 }
 

--- a/sdk/js/src/service/network-server.js
+++ b/sdk/js/src/service/network-server.js
@@ -1,0 +1,29 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Marshaler from '../util/marshaler'
+
+class Ns {
+  constructor (service) {
+    this._api = service
+  }
+
+  async generateDevAddress () {
+    const result = await this._api.GenerateDevAddr()
+
+    return Marshaler.payloadSingleResponse(result)
+  }
+}
+
+export default Ns


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #820 

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `Ns` service in the JS SDK
- Add `api.ns.generateDevAddress` entry in the console api defintions

You can use [this script](https://gist.github.com/bafonins/a3ac3afb601247314808baaf4d5a8015) for testing


#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Added the `Ns` service to the JS SDK
- Added the `generateDevAddress` method in the `Ns` service
