### PR TITLE
Fix warnings in js tests

### DIFF
--- a/config/jest/setup.js
+++ b/config/jest/setup.js
@@ -23,3 +23,15 @@ global.shallow = shallow
 global.mount = mount
 global.render = render
 global.snapshotDiff = snapshotDiff
+
+/* eslint-disable no-console */
+const originalConsoleError = console.error
+console.error = function (message, ...args) {
+  console.log(message)
+  if (/(Invalid prop|Failed prop type|Failed context type)/gi.test(message)) {
+    throw new Error(message)
+  }
+
+  originalConsoleError.apply(console, [ message, ...args ])
+}
+/* eslint-enable no-console */

--- a/pkg/webui/components/navigation/side/index_driver.js
+++ b/pkg/webui/components/navigation/side/index_driver.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import React from 'react'
+import { IntlProvider } from 'react-intl'
 
 import SideNavigation from './side'
 
@@ -22,9 +23,10 @@ export default function () {
     when: {
       created (props) {
         driver.component = shallow(
-          <SideNavigation {...props} />,
-          { context: { intl: {}}}
-        )
+          <IntlProvider>
+            <SideNavigation {...props} />
+          </IntlProvider>
+        ).dive()
 
         return driver
       },
@@ -75,7 +77,6 @@ export default function () {
       hideButton () {
         return driver.component
           .find('[data-hook="side-nav-hide-button"]')
-          .dive()
       },
       items () {
         return driver.get.list().children()

--- a/pkg/webui/components/navigation/side/item/index_driver.js
+++ b/pkg/webui/components/navigation/side/item/index_driver.js
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import React from 'react'
-import { IntlProvider } from 'react-intl'
 
 import SideNavigationItem from '.'
 
@@ -23,10 +22,8 @@ export default function () {
     when: {
       created (props) {
         driver.component = shallow(
-          <IntlProvider>
-            <SideNavigationItem {...props} />
-          </IntlProvider>
-        ).dive()
+          <SideNavigationItem {...props} />
+        )
 
         return driver
       },

--- a/pkg/webui/components/navigation/side/item/index_driver.js
+++ b/pkg/webui/components/navigation/side/item/index_driver.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import React from 'react'
+import { IntlProvider } from 'react-intl'
 
 import SideNavigationItem from '.'
 
@@ -22,8 +23,10 @@ export default function () {
     when: {
       created (props) {
         driver.component = shallow(
-          <SideNavigationItem {...props} />
-        )
+          <IntlProvider>
+            <SideNavigationItem {...props} />
+          </IntlProvider>
+        ).dive()
 
         return driver
       },

--- a/pkg/webui/components/profile-dropdown/__snapshots__/index_test.js.snap
+++ b/pkg/webui/components/profile-dropdown/__snapshots__/index_test.js.snap
@@ -21,7 +21,7 @@ exports[`Profile Dropdown is in initial state has dropdown open should match sna
       Array [
         Object {
           "icon": "settings",
-          "link": "/profile-settings",
+          "path": "/profile-settings",
           "title": "Profile Settings",
         },
         Object {

--- a/pkg/webui/components/profile-dropdown/index_driver.js
+++ b/pkg/webui/components/profile-dropdown/index_driver.js
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import React from 'react'
-import { IntlProvider } from 'react-intl'
 
 import ProfileDropdown from '.'
 
@@ -23,10 +22,8 @@ export default function () {
     when: {
       created (props) {
         driver.component = shallow(
-          <IntlProvider>
-            <ProfileDropdown {...props} />
-          </IntlProvider>
-        ).dive()
+          <ProfileDropdown {...props} />
+        )
 
         return driver
       },

--- a/pkg/webui/components/profile-dropdown/index_driver.js
+++ b/pkg/webui/components/profile-dropdown/index_driver.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import React from 'react'
+import { IntlProvider } from 'react-intl'
 
 import ProfileDropdown from '.'
 
@@ -22,9 +23,10 @@ export default function () {
     when: {
       created (props) {
         driver.component = shallow(
-          <ProfileDropdown {...props} />,
-          { context: { intl: {}}}
-        )
+          <IntlProvider>
+            <ProfileDropdown {...props} />
+          </IntlProvider>
+        ).dive()
 
         return driver
       },

--- a/pkg/webui/components/profile-dropdown/index_test.js
+++ b/pkg/webui/components/profile-dropdown/index_test.js
@@ -19,7 +19,7 @@ const dropdownItems = [
   {
     title: 'Profile Settings',
     icon: 'settings',
-    link: '/profile-settings',
+    path: '/profile-settings',
   },
   {
     title: 'Logout',

--- a/pkg/webui/components/table/sort-button/index_driver.js
+++ b/pkg/webui/components/table/sort-button/index_driver.js
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 import React from 'react'
+import { IntlProvider } from 'react-intl'
+
 import SortButton from '.'
 
 export default function () {
@@ -21,8 +23,10 @@ export default function () {
     when: {
       created (props) {
         driver.component = shallow(
-          <SortButton {...props} />
-        )
+          <IntlProvider>
+            <SortButton {...props} />
+          </IntlProvider>
+        ).dive()
       },
       buttonPressed () {
         driver.component.simulate('click')


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes several tests under `/pkg/webui/components` and adds `jest` setup to fail on `console.error` with messages related to prop-types/context handling.

```
  console.error node_modules/prop-types/checkPropTypes.js:20    Warning: Failed prop type: Invalid prop `dropdownItems[0]` supplied to `ProfileDropdown`.
        in ProfileDropdown  console.error node_modules/prop-types/checkPropTypes.js:20
    Warning: Failed prop type: Invalid prop `items[0]` supplied to `Dropdown`.        in Dropdown

  console.error node_modules/prop-types/checkPropTypes.js:20    Warning: Failed context type: The context `intl.formatDate` is marked as required in `InjectIntl(Button)`, but its value is `undefined`.
        in InjectIntl(Button)
```

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix tests
- Mock `console.error` for `jest` tests

#### Notes for Reviewers
<!--
NOTE: This section is optional.
