### PR TITLE
Fix parsing of stream chunks in JS SDK

### DIFF
--- a/sdk/js/src/api/stream/stream-node.js
+++ b/sdk/js/src/api/stream/stream-node.js
@@ -73,8 +73,11 @@ export default async function (payload, url) {
 
       stream.on('data', function (data) {
         const parsed = data.toString('utf8')
-        const result = JSON.parse(parsed).result
-        notify(listeners[EVENTS.EVENT], result)
+
+        for (const line of parsed.trim().split('\n')) {
+          const result = JSON.parse(line).result
+          notify(listeners[EVENTS.EVENT], result)
+        }
       })
       stream.on('end', function () {
         notify(listeners[EVENTS.CLOSE])

--- a/sdk/js/src/api/stream/stream.js
+++ b/sdk/js/src/api/stream/stream.js
@@ -87,8 +87,11 @@ export default async function (payload, url) {
       }
 
       const parsed = ArrayBufferToString(value)
-      const result = JSON.parse(parsed).result
-      notify(listeners[EVENTS.EVENT], result)
+
+      for (const line of parsed.trim().split('\n')) {
+        const result = JSON.parse(line).result
+        notify(listeners[EVENTS.EVENT], result)
+      }
 
       return reader.read().then(onChunk)
     })


### PR DESCRIPTION
#### Summary
Closes #1125

#### Changes
- Account for multi line stream chunks, with multiple separate json strings

#### Notes for Reviewers
Very likely the cause of #1125. I was able to reproduce and fix it with this diff.

#### Release Notes
- Fixed a bug that resulted in events streams crashing in the console.
