### PR TITLE
Forward warning response header

### DIFF
--- a/pkg/component/grpc.go
+++ b/pkg/component/grpc.go
@@ -55,7 +55,16 @@ func (c *Component) setupGRPC() (err error) {
 	for _, sub := range c.grpcSubsystems {
 		sub.RegisterHandlers(c.grpc.ServeMux, c.loopback)
 	}
-	c.web.RootGroup(ttnpb.HTTPAPIPrefix).Any("/*", echo.WrapHandler(http.StripPrefix(ttnpb.HTTPAPIPrefix, c.grpc)), middleware.CORS())
+	c.web.RootGroup(ttnpb.HTTPAPIPrefix).Any(
+		"/*",
+		echo.WrapHandler(http.StripPrefix(ttnpb.HTTPAPIPrefix, c.grpc)),
+		middleware.CORSWithConfig(middleware.CORSConfig{
+			Skipper:      middleware.DefaultSkipper,
+			AllowOrigins: []string{"*"},
+			AllowMethods: []string{http.MethodGet, http.MethodHead, http.MethodPut, http.MethodPatch, http.MethodPost, http.MethodDelete},
+			AllowHeaders: []string{"Date", "Content-Length", "X-Total-Count", "X-Warning"},
+		}),
+	)
 	return nil
 }
 

--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/getsentry/raven-go"
-	"github.com/golang/protobuf/proto"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
 	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
@@ -188,10 +187,6 @@ func New(ctx context.Context, opts ...Option) *Server {
 	}
 	server.Server = grpc.NewServer(append(baseOptions, options.serverOptions...)...)
 	server.ServeMux = runtime.NewServeMux(
-		runtime.WithForwardResponseOption(func(ctx context.Context, w http.ResponseWriter, resp proto.Message) error {
-			w.Header().Set("Access-Control-Expose-Headers", "Date, Content-Length, X-Total-Count, X-Warning")
-			return nil
-		}),
 		runtime.WithMarshalerOption("*", jsonpb.TTN()),
 		runtime.WithMarshalerOption("text/event-stream", jsonpb.TTNEventStream()),
 		runtime.WithProtoErrorHandler(runtime.DefaultHTTPProtoErrorHandler),

--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -206,6 +206,7 @@ func New(ctx context.Context, opts ...Option) *Server {
 			return md.ToMetadata()
 		}),
 		runtime.WithOutgoingHeaderMatcher(func(s string) (string, bool) {
+			// NOTE: When adding headers, also add them to CORSConfig in ../component/grpc.go.
 			switch s {
 			case "x-total-count":
 				return "X-Total-Count", true

--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -189,7 +189,7 @@ func New(ctx context.Context, opts ...Option) *Server {
 	server.Server = grpc.NewServer(append(baseOptions, options.serverOptions...)...)
 	server.ServeMux = runtime.NewServeMux(
 		runtime.WithForwardResponseOption(func(ctx context.Context, w http.ResponseWriter, resp proto.Message) error {
-			w.Header().Set("Access-Control-Expose-Headers", "Link, Date, Content-Length, X-Total-Count")
+			w.Header().Set("Access-Control-Expose-Headers", "Date, Content-Length, X-Total-Count, X-Warning")
 			return nil
 		}),
 		runtime.WithMarshalerOption("*", jsonpb.TTN()),
@@ -214,8 +214,9 @@ func New(ctx context.Context, opts ...Option) *Server {
 			switch s {
 			case "x-total-count":
 				return "X-Total-Count", true
-			case "link":
-				return "Link", true
+			case "warning":
+				// NOTE: the "Warning" header in HTTP is specified differently than our "warning" gRPC metadata.
+				return "X-Warning", true
 			}
 			return s, false
 		}),


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quickfix that makes gRPC-Gateway forward the "warning" header.

It additionally fixes the CORS headers being set in the wrong place.

#### Changes
<!-- What are the changes made in this pull request? -->

- Replaced unused "link" header with "warning"

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

These warning still need to be handled in the UI (cc: @kschiffer). See the `X-Warning` header in the response below:

```
% curl -v -H "Authorization: Bearer $access_token" http://localhost:1885/api/v3/auth_info
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 1885 (#0)
> GET /api/v3/auth_info HTTP/1.1
> Host: localhost:1885
> User-Agent: curl/7.54.0
> Accept: */*
> Authorization: Bearer MFRWG.DMQ64K36A4OAT2OTK2QBAXVP3JAK3OD4TGJK62Q.UW2PLPVNK2X6JQNE6OWVF5BLGIURP3WDOKT3DXNSYU2DBJE2OEPQ
> 
< HTTP/1.1 200 OK
< Access-Control-Allow-Origin: *
< Access-Control-Expose-Headers: Link, Date, Content-Length, X-Total-Count
< Content-Type: application/json
< Vary: Accept-Encoding
< Vary: Origin
< X-Content-Type-Options: nosniff
< X-Frame-Options: SAMEORIGIN
< X-Request-Id: 01DJ5N03KGBCTNRQEEX031Q3JC
< X-Warning: Restricted rights while account pending
< X-Xss-Protection: 1; mode=block
< Date: Tue, 13 Aug 2019 14:09:35 GMT
< Content-Length: 294
< 
* Connection #0 to host localhost left intact
{"oauth_access_token":{"user_ids":{"user_id":"newuser"},"client_ids":{"client_id":"cli"},"id":"DMQ64K36A4OAT2OTK2QBAXVP3JAK3OD4TGJK62Q","rights":["RIGHT_USER_DELETE","RIGHT_USER_SETTINGS_BASIC","RIGHT_USER_INFO"],"created_at":"2019-08-13T13:58:07.866Z","expires_at":"2019-08-13T14:58:07.866Z"}}% 
```

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Fixed propagation of warning headers in API responses
