### PR TITLE
Fix scroll-bar flickers

### DIFF
--- a/pkg/webui/console/views/landing/landing.styl
+++ b/pkg/webui/console/views/landing/landing.styl
@@ -25,5 +25,5 @@
 .content-container
   flex-grow: 1
   position: relative
-  overflow: auto
+  overflow-y: scroll
   padding-bottom: $ls.xxs


### PR DESCRIPTION
#### Summary
This quickfix PR resolves scroll-bar flickers happening in the device and gateway overview pages.

#### Changes
- Change overflow setting from auto to fixed

#### Notes for Reviewers
The issue occurs inconsistently on smaller screen-sizes on the device/gateway overview page and has to do with the scroll bar switching from visible to invisible:
![Screen Recording](https://user-images.githubusercontent.com/5710611/62950667-c95eb400-bde8-11e9-85c5-092b4b940a2f.gif)

#### Release Notes
- Resolved flickering display issue in the overview pages of entities in the console.
