### PR TITLE
Set empty preRun on forgot and update password cmds

### DIFF
--- a/cmd/ttn-lw-cli/commands/users.go
+++ b/cmd/ttn-lw-cli/commands/users.go
@@ -219,8 +219,9 @@ var (
 		},
 	}
 	usersForgotPasswordCommand = &cobra.Command{
-		Use:   "forgot-password [user-id]",
-		Short: "Request a temporary user password",
+		Use:               "forgot-password [user-id]",
+		Short:             "Request a temporary user password",
+		PersistentPreRunE: preRun(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			usrID := getUserID(cmd.Flags(), args)
 			if usrID == nil {
@@ -241,10 +242,14 @@ var (
 		},
 	}
 	usersUpdatePasswordCommand = &cobra.Command{
-		Use:     "update-password [user-id]",
-		Aliases: []string{"change-password"},
-		Short:   "Update a user password",
+		Use:               "update-password [user-id]",
+		Aliases:           []string{"change-password"},
+		Short:             "Update a user password",
+		PersistentPreRunE: preRun(),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			refreshToken() // NOTE: ignore errors.
+			optionalAuth()
+
 			usrID := getUserID(cmd.Flags(), args)
 			if usrID == nil {
 				return errNoUserID


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request sets an empty `preRun` on password commands in the CLI. This completely removes auth from the forgot-password command and makes auth optional on the change-password command.

Refs #1042

#### Changes
<!-- What are the changes made in this pull request? -->

- Set empty `preRun` on `forgot-password` and `update-password` commands
- Use optional auth on `update-password`

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Removed auth from CLI's `forgot-password` command and made it optional on `update-password` command.
