### PR TITLE
Identity Server email template fetching support

### DIFF
--- a/doc/content/concepts/email-templates.md
+++ b/doc/content/concepts/email-templates.md
@@ -1,0 +1,22 @@
+---
+title: "Email Templates"
+description: ""
+weight: 15
+---
+
+## What is it?
+
+Email templates define the contents of the emails that The Things Stack sends to its users. They allow network operators to override the default contents of the emails with their own custom contents.
+
+## Who is it for?
+
+Email templates are targeted at network operators that would like to customize the emails that The Things Stack sends to its users.
+
+### Typical use cases
+
+1. Adding additional styling to the default text-only emails that The Things Stack sends.
+2. Translating the emails The Things Stack sends to its users (applies deployment-wide).
+ 
+## How does it work?
+
+Email templates override the default emails that The Things Stack sends by providing custom template files written in Go's [html/template](https://golang.org/pkg/html/template/) format. The templates are retrieved when The Things Stack sends the first email of a certain type, and then are cached until it is restarted. See [Available Templates]({{< ref "/reference/email-templates/available.md" >}}) and [Overriding Default Templates]({{< ref "/reference/email-templates/overriding.md" >}}).

--- a/doc/content/reference/email-templates/_index.md
+++ b/doc/content/reference/email-templates/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Email Templates"
+description: ""
+weight: 2
+---

--- a/doc/content/reference/email-templates/available.md
+++ b/doc/content/reference/email-templates/available.md
@@ -1,0 +1,30 @@
+---
+title: "Available Templates"
+description: ""
+weight: 3
+---
+
+The following email templates are currently used by The Things Stack:
+
+Full Name | Identifier | Scope | Additional fields
+----------|------------|-------|------------------
+API Key changed | `api_key_changed` | Sent when the rights of an API Key have been changed. | `Identifiers` and `Rights`
+API Key created | `api_key_created` | Send when an API Key has been created. | `Identifiers` and `Rights`
+Collaborator changed | `collaborator_changed` | Sent when the rights of a collaborator have been changed. | `Collaborator`
+Password changed | `password_changed` | Sent when the the password of a user has been changed.
+Temporary password | `temporary_password` | Sent when a temporary password has been requested for an user. | `TemporaryPassword`
+Email validation | `validate` | Sent when a user is added as a collaborator of an entity, in order to validate their email. | `ID` and `Token`
+
+The following fields can be used inside all of the email templates:
+
+Field | Description | Notes
+------|-------------|------
+`User.ID` | The identifier of the user. | If the recipient is the contact of the target entity, the value will be empty.
+`User.Name` | The full name of the user. | If the recipient is the contact of the target entity, the value will be `user`.
+`User.Email` | The email of the user. | None.
+`Network.Name` | The full name of the network running on the stack. | None.
+`Network.IdentityServerURL` | The base URL of the Identity Server. | None.
+`Network.ConsoleURL` | The base URL of the Console. | None.
+`Entity.Type` | The type of the target entity, such as `application`, `client`, `gateway`, `organization` or `user`. | None.
+`Enitity.ID` | The identifier of the target entity. | None.
+`Contact.Type` | The contact type of the recipient, such as `technical`, `billing` or `abuse`. | Only used if the recipient is the contact of an entity.

--- a/doc/content/reference/email-templates/overriding.md
+++ b/doc/content/reference/email-templates/overriding.md
@@ -1,0 +1,67 @@
+---
+title: "Overriding Templates"
+description: ""
+weight: 6
+---
+
+> Note: We recommend getting familliar with the [html/template](https://golang.org/pkg/html/template/) template format first.
+
+## Template components
+
+An email template override has three components:
+
+1. The subject file, which contains the subject of the email and is named `<identifier>.subject.txt`. 
+2. The text contents file, which contains the contents of the email in text format and is named `<identifier>.txt`.
+3. The HTML contents file, which contains the contents of the email in HTML format and is named `<identifier>.html`.
+
+
+## Creating the overrides
+
+In order to override a template, one must provide all three files as part of the email templates repository and then provide them as part of the configuration.
+
+Let's consider that we want to override the email that a user receives once they register, the email validation email, which has the identifier `validate`. We need to create the following files:
+
+
+- `validate.subject.txt`
+```text
+Please confirm your email address for {{.Network.Name}}
+```
+- `validate.txt`
+```text
+Please confirm your email address for {{.Network.Name}}.
+Your email address will be used as contact for {{.Entity.Type}} "{{.Entity.ID}}". 
+
+Reference: {{.ID}}
+Confirmation Token: {{.Token}}
+```
+- `validate.html`
+```html
+Please confirm your email address for {{.Network.Name}}. <br> 
+Your email address will be used as contact for {{.Entity.Type}} "{{.Entity.ID}}". <br> <br> 
+
+Reference: {{.ID}} <br> 
+Confirmation Token: {{.Token}}
+```
+
+## Providing the overrides to the stack
+
+Once you have written your overrides, you can provide them to the stack either through an remote URL, or through the local file system.
+
+### Fetching from a remote URL
+
+In order to allow The Things Stack to access remote files, you must only provide the URL to the root folder that contains the files. Consider that you need to provide the The Things Stack access to a file called `validate.txt`, which you have uploaded on your host at `http://www.example.org/emails/validate.txt`. Then the URL that you provide to the email templates configuration is `http://www.example.org/emails/`.
+
+### Fetching from a local directory
+
+In order to allow the The Things Stack to access files which are hosted in your own file system, you must provide the path to the root folder that contains the files. Consider that you need to provide the The Things Stack access to a file called `validate.txt`, which is available on your file system in the `/srv/emails/validate.txt`. Then the path that you need to provide to the email templates configuration is `/srv/emails/`.
+
+### Example YAML configuration 
+
+```yaml
+is:
+  email:
+    templates:
+      # Specify only one source for the files.
+      directory: "/path/to/the/template/files"
+      url: "http://www.example.com/emails"
+```

--- a/pkg/identityserver/email.go
+++ b/pkg/identityserver/email.go
@@ -22,18 +22,27 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/email"
 	"go.thethings.network/lorawan-stack/pkg/email/sendgrid"
 	"go.thethings.network/lorawan-stack/pkg/email/smtp"
+	"go.thethings.network/lorawan-stack/pkg/fetch"
 	"go.thethings.network/lorawan-stack/pkg/identityserver/emails"
 	"go.thethings.network/lorawan-stack/pkg/identityserver/store"
 	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 )
 
-var globalEmailTemplateRegistry = email.NewTemplateRegistry(nil)
-
-func (is *IdentityServer) getEmailTemplates(_ context.Context) *email.TemplateRegistry {
-	// TODO: Get email template fetcher from config (https://github.com/TheThingsNetwork/lorawan-stack/issues/148).
-	// Re-use existing registry for same fetcher (to avoid re-compiling templates).
-	return globalEmailTemplateRegistry
+func (is *IdentityServer) getEmailTemplates(ctx context.Context) *email.TemplateRegistry {
+	c := is.configFromContext(ctx).Email.Templates
+	var fetcher fetch.Interface
+	switch {
+	case c.Static != nil:
+		fetcher = fetch.NewMemFetcher(c.Static)
+	case c.Directory != "":
+		fetcher = fetch.FromFilesystem(c.Directory)
+	case c.URL != "":
+		fetcher = fetch.FromHTTP(c.URL, true)
+	default:
+		fetcher = nil
+	}
+	return email.NewTemplateRegistry(fetcher, c.Includes...)
 }
 
 // SendEmail sends an email.

--- a/pkg/identityserver/email_test.go
+++ b/pkg/identityserver/email_test.go
@@ -1,0 +1,95 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package identityserver
+
+import (
+	"testing"
+
+	"github.com/smartystreets/assertions"
+	"github.com/smartystreets/assertions/should"
+	"go.thethings.network/lorawan-stack/pkg/email"
+	"go.thethings.network/lorawan-stack/pkg/util/test"
+	"google.golang.org/grpc"
+)
+
+type testEmail struct {
+	templateName string
+
+	User struct {
+		Name  string
+		Email string
+	}
+}
+
+func (e testEmail) Recipient() (name, address string) {
+	return e.User.Name, e.User.Email
+}
+
+func (e testEmail) TemplateName() string { return e.templateName }
+
+func (testEmail) DefaultTemplates() (subject, html, text string) {
+	return "Welcome {{.User.Name}}", "HTML {{.User.Name}} {{.User.Email}}", "Text {{.User.Name}} {{.User.Email}}"
+}
+
+func TestGetEmailTemplates(t *testing.T) {
+	a := assertions.New(t)
+	ctx := test.Context()
+
+	testWithIdentityServer(t, func(is *IdentityServer, cc *grpc.ClientConn) {
+		registry := is.getEmailTemplates(ctx)
+		a.So(registry, should.NotBeNil)
+
+		for _, tc := range []struct {
+			name    string
+			message *email.Message
+		}{
+			{
+				name: "Default",
+				message: &email.Message{
+					TemplateName:     "default",
+					RecipientName:    "foo",
+					RecipientAddress: "bar",
+					Subject:          "Welcome foo",
+					HTMLBody:         "HTML foo bar",
+					TextBody:         "Text foo bar",
+				},
+			},
+			{
+				name: "Overridden",
+				message: &email.Message{
+					TemplateName:     "overridden",
+					RecipientName:    "foo",
+					RecipientAddress: "bar",
+					Subject:          "Overridden subject foo",
+					HTMLBody:         "Overridden HTML foo bar",
+					TextBody:         "Overridden text foo bar",
+				},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				a := assertions.New(t)
+				email := testEmail{
+					templateName: tc.message.TemplateName,
+				}
+				email.User.Name = tc.message.RecipientName
+				email.User.Email = tc.message.RecipientAddress
+
+				message, err := registry.Render(email)
+				a.So(err, should.BeNil)
+				a.So(message, should.Resemble, tc.message)
+			})
+		}
+	})
+}

--- a/pkg/identityserver/emails/collaborator_changed.go
+++ b/pkg/identityserver/emails/collaborator_changed.go
@@ -23,14 +23,14 @@ type CollaboratorChanged struct {
 }
 
 // TemplateName returns the name of the template to use for this email.
-func (CollaboratorChanged) TemplateName() string { return "collaborator_added" }
+func (CollaboratorChanged) TemplateName() string { return "collaborator_changed" }
 
 const collaboratorChangedSubject = `A collaborator has been changed`
 
 const collaboratorChangedBody = `Dear {{.User.Name}},
 
 The collaborator "{{.Collaborator.EntityIdentifiers.IDString}}" of {{.Entity.Type}} "{{.Entity.ID}}" on {{.Network.Name}} now has the following rights:
-{{range $right := .Collaborator.Rights}} 
+{{range $right := .Collaborator.Rights}}
 {{$right}} {{end}}
 `
 

--- a/pkg/identityserver/emails/emails.go
+++ b/pkg/identityserver/emails/emails.go
@@ -17,6 +17,7 @@ package emails
 import "go.thethings.network/lorawan-stack/pkg/ttnpb"
 
 // Data for emails.
+// Update doc/content/reference/email-templates/available.md when changing fields or adding new emails.
 type Data struct {
 	// User we're sending this email to. We need at least an Email.
 	User struct {

--- a/pkg/identityserver/identityserver.go
+++ b/pkg/identityserver/identityserver.go
@@ -16,6 +16,7 @@ package identityserver
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
@@ -73,10 +74,12 @@ type Config struct {
 		SendGrid     sendgrid.Config `name:"sendgrid"`
 		SMTP         smtp.Config     `name:"smtp"`
 		Templates    struct {
-			Static    map[string][]byte `name:"-"`
-			Directory string            `name:"directory" description:"Retrieve the email templates from the filesystem"`
-			URL       string            `name:"url" description:"Retrieve the email templates from a web server"`
-			Includes  []string          `name:"includes" description:"The email templates that will be preloaded on startup"`
+			Static     map[string][]byte `name:"-"`
+			Directory  string            `name:"directory" description:"Retrieve the email templates from the filesystem"`
+			URL        string            `name:"url" description:"Retrieve the email templates from a web server"`
+			Includes   []string          `name:"includes" description:"The email templates that will be preloaded on startup"`
+			registry   *email.TemplateRegistry
+			registryMu sync.Mutex
 		} `name:"templates"`
 	} `name:"email"`
 }

--- a/pkg/identityserver/identityserver.go
+++ b/pkg/identityserver/identityserver.go
@@ -72,6 +72,12 @@ type Config struct {
 		email.Config `name:",squash"`
 		SendGrid     sendgrid.Config `name:"sendgrid"`
 		SMTP         smtp.Config     `name:"smtp"`
+		Templates    struct {
+			Static    map[string][]byte `name:"-"`
+			Directory string            `name:"directory" description:"Retrieve the email templates from the filesystem"`
+			URL       string            `name:"url" description:"Retrieve the email templates from a web server"`
+			Includes  []string          `name:"includes" description:"The email templates that will be preloaded on startup"`
+		} `name:"templates"`
 	} `name:"email"`
 }
 

--- a/pkg/identityserver/identityserver_test.go
+++ b/pkg/identityserver/identityserver_test.go
@@ -299,6 +299,11 @@ func getIdentityServer(t *testing.T) (*IdentityServer, *grpc.ClientConn) {
 	}
 	conf.UserRegistration.PasswordRequirements.MinLength = 10
 	conf.UserRegistration.PasswordRequirements.MaxLength = 1000
+	conf.Email.Templates.Static = map[string][]byte{
+		"overridden.subject.txt": []byte("Overridden subject {{.User.Name}}"),
+		"overridden.html":        []byte("Overridden HTML {{.User.Name}} {{.User.Email}}"),
+		"overridden.txt":         []byte("Overridden text {{.User.Name}} {{.User.Email}}"),
+	}
 	is, err := New(c, conf)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #148 
References https://github.com/TheThingsIndustries/lorawan-stack/issues/1648

#### Changes
<!-- What are the changes made in this pull request? -->

- Add configuration support for email template fetchers
- Add email template registry caching inside the configuration

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This implementation is compatible with https://github.com/TheThingsIndustries/lorawan-stack/issues/1648 . If holding the registry itself and the mutex inside the config is not fashionable, the cache can be moved to the IS itself, with the source as key, but won't support caching the in-memory templates. Suggestions are welcomed.

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Added support for external email templates in the Identity Server.
