### PR TITLE
Resolve stylint warnings

### DIFF
--- a/pkg/webui/components/breadcrumbs/breadcrumb/breadcrumb.styl
+++ b/pkg/webui/components/breadcrumbs/breadcrumb/breadcrumb.styl
@@ -33,12 +33,12 @@
     color: $tc-deep-gray
 
   +media-query($bp.s)
-   &:not(:last-child):not(:first-child):not(:nth-child(2))
-     display: none
+    &:not(:last-child):not(:first-child):not(:nth-child(2))
+      display: none
 
-   &:nth-child(2):after
-     nudge('down')
-     content: 'more_horiz'
+    &:nth-child(2):after
+      nudge('down')
+      content: 'more_horiz'
 
 .last
   one-liner()

--- a/pkg/webui/components/checkbox/checkbox.styl
+++ b/pkg/webui/components/checkbox/checkbox.styl
@@ -14,7 +14,7 @@
 
 .wrapper
   cursor: pointer
-  display flex
+  display: flex
   flex-wrap: nowrap
   justify-content: flex-start
   align-items: center
@@ -35,7 +35,7 @@
   display: inline-block
   white-space: nowrap
   vertical-align: middle
-  outline: none
+  outline: 0
 
   input
     position: absolute

--- a/pkg/webui/components/input/input.styl
+++ b/pkg/webui/components/input/input.styl
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 .container
-  display flex
+  display: flex
 
 .input-box
   border-input()
@@ -49,7 +49,7 @@
 
   &.disabled
     background-color: $c-backdrop
-    opacity .6
+    opacity: .6
 
     .input
       cursor: not-allowed

--- a/pkg/webui/components/navigation/side/list/list.styl
+++ b/pkg/webui/components/navigation/side/list/list.styl
@@ -29,7 +29,7 @@
     max-height: 10rem
 
   &-expanded, &-nested
-    li a
+    & li a
       padding-left: $cs.l + $cs.l
 
 .icon

--- a/pkg/webui/components/navigation/side/side.styl
+++ b/pkg/webui/components/navigation/side/side.styl
@@ -24,7 +24,6 @@
   &-minimized
     min-width: auto
     display: inline-flex
-    min-width: auto
 
   &-button
     align-self: center

--- a/pkg/webui/components/radio-button/radio-button.styl
+++ b/pkg/webui/components/radio-button/radio-button.styl
@@ -14,7 +14,7 @@
 
 .wrapper
   cursor: pointer
-  display flex
+  display: flex
   flex-wrap: nowrap
   justify-content: flex-start
   align-items: center
@@ -35,7 +35,7 @@
   display: inline-block
   white-space: nowrap
   vertical-align: middle
-  outline: none
+  outline: 0
 
   input
     position: absolute

--- a/pkg/webui/console/views/error/error.styl
+++ b/pkg/webui/console/views/error/error.styl
@@ -28,7 +28,7 @@
     background-position: 60vw 20%
   +media-query($bp.s)
     background-size: 160vh
-    background-position: 0vw 20vh
+    background-position: 0 20vh
 
   &-header
     h2()

--- a/pkg/webui/console/views/login/login.styl
+++ b/pkg/webui/console/views/login/login.styl
@@ -22,7 +22,7 @@
     background-position: 37vw 20%
   +media-query($bp.s)
     background-size: 160vh
-    background-position: 0vw 20vh
+    background-position: 0 20vh
 
   &-header
     h2()

--- a/pkg/webui/console/views/overview/overview.styl
+++ b/pkg/webui/console/views/overview/overview.styl
@@ -26,8 +26,6 @@
 
 .get-started
   font-size: $fs.l
-
-.get-started
   font-weight: normal
 
 .chooser
@@ -40,10 +38,10 @@
   height: 28rem
   width: 28rem
   background: white
-  margin: 0 auto $ls.l auto
-  box-shadow: 0 4px 35px 0 rgba(0,0,0,0.04), inset 0 -1px 0 0 rgba(0,0,0,0.11)
+  margin: 0 auto $ls.l
+  box-shadow: 0 4px 35px 0 rgba(0, 0, 0, .04), inset 0 -1px 0 0 rgba(0, 0, 0, .11)
   border-radius: 25px
-  transition: box-shadow .4s cubic-bezier(0.250, 0.010, 0.070, 1.000), transform .4s cubic-bezier(0.250, 0.010, 0.070, 1.000)
+  transition: box-shadow .4s cubic-bezier(.250, .010, .070, 1), transform .4s cubic-bezier(.250, .010, .070, 1)
 
   & > div
     margin-top: -2.9rem
@@ -57,7 +55,7 @@
 
   &:hover
     transform: scale(1.05)
-    box-shadow: 0 4px 55px 0 rgba(0,0,0,0.04), inset 0 -1px 0 0 rgba(0,0,0,0.11)
+    box-shadow: 0 4px 55px 0 rgba(0, 0, 0, .04), inset 0 -1px 0 0 rgba(0, 0, 0, .11)
 
 
 .chooser-nav

--- a/pkg/webui/oauth/views/error/full-view.styl
+++ b/pkg/webui/oauth/views/error/full-view.styl
@@ -23,7 +23,7 @@
     background-position: 60vw 20%
   +media-query($bp.s)
     background-size: 160vh
-    background-position: 0vw 20vh
+    background-position: 0 20vh
 
   &-header
     h2()

--- a/pkg/webui/styles/main.styl
+++ b/pkg/webui/styles/main.styl
@@ -56,12 +56,13 @@ h2
 h3
   h3()
 
-ul li:not(:last-child)
-  margin-bottom: $cs.s
+ul li
+  &:not(:last-child)
+    margin-bottom: $cs.s
 
-ul li a
-  text-decoration: none
-  color: $tc-deep-gray
+  a
+    text-decoration: none
+    color: $tc-deep-gray
 
 a
   color: $tc-active


### PR DESCRIPTION
#### Summary
This quickfix PR resolves the linter warnings of stylint, which have amassed a little since they're not part of the commit hooks any more.

#### Changes
- Modify stylus files to resolve stylint warnings

#### Notes for Reviewers
`mage styl:lint`