### PR TITLE
Replace remaining hardcoded `/api/v3` api prefixes

### DIFF
--- a/cmd/internal/shared/console/config.go
+++ b/cmd/internal/shared/console/config.go
@@ -41,11 +41,11 @@ var DefaultConsoleConfig = console.Config{
 			JSFiles:       []string{"console.js"},
 		},
 		FrontendConfig: console.FrontendConfig{
-			IS: console.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
-			GS: console.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
-			NS: console.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
-			AS: console.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
-			JS: console.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
+			IS: webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
+			GS: webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
+			NS: webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
+			AS: webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
+			JS: webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
 		},
 	},
 }

--- a/cmd/internal/shared/identityserver/config.go
+++ b/cmd/internal/shared/identityserver/config.go
@@ -38,6 +38,9 @@ var DefaultIdentityServerConfig = identityserver.Config{
 				CSSFiles:      []string{"oauth.css"},
 				JSFiles:       []string{"oauth.js"},
 			},
+			FrontendConfig: oauth.FrontendConfig{
+				IS: webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
+			},
 		},
 	},
 }

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -30,12 +30,6 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// APIConfig for upstream APIs.
-type APIConfig struct {
-	Enabled bool   `json:"enabled" name:"enabled" description:"Enable this API"`
-	BaseURL string `json:"base_url" name:"base-url" description:"Base URL to the HTTP API"`
-}
-
 // UIConfig is the combined configuration for the Console UI.
 type UIConfig struct {
 	webui.TemplateData `name:",squash"`
@@ -44,12 +38,12 @@ type UIConfig struct {
 
 // FrontendConfig is the configuration for the Console frontend.
 type FrontendConfig struct {
-	Language string    `json:"language" name:"-"`
-	IS       APIConfig `json:"is" name:"is"`
-	GS       APIConfig `json:"gs" name:"gs"`
-	NS       APIConfig `json:"ns" name:"ns"`
-	AS       APIConfig `json:"as" name:"as"`
-	JS       APIConfig `json:"js" name:"js"`
+	Language string          `json:"language" name:"-"`
+	IS       webui.APIConfig `json:"is" name:"is"`
+	GS       webui.APIConfig `json:"gs" name:"gs"`
+	NS       webui.APIConfig `json:"ns" name:"ns"`
+	AS       webui.APIConfig `json:"as" name:"as"`
+	JS       webui.APIConfig `json:"js" name:"js"`
 }
 
 // Config is the configuration for the Console.

--- a/pkg/oauth/server.go
+++ b/pkg/oauth/server.go
@@ -67,7 +67,8 @@ type UIConfig struct {
 
 // FrontendConfig is the configuration for the OAuth frontend.
 type FrontendConfig struct {
-	Language string `json:"language" name:"-"`
+	Language string          `json:"language" name:"-"`
+	IS       webui.APIConfig `json:"is" name:"is"`
 }
 
 // Config is the configuration for the OAuth server.

--- a/pkg/webui/console/api/index.js
+++ b/pkg/webui/console/api/index.js
@@ -30,6 +30,8 @@ const stack = {
   js: config.js.enabled ? config.js.base_url : undefined,
 }
 
+const isBaseUrl = config.is.base_url
+
 const ttnClient = new TTN(token, {
   stackConfig: stack,
   connectionType: 'http',
@@ -52,19 +54,19 @@ export default {
   },
   clients: {
     get(client_id) {
-      return instance.get(`/api/v3/is/clients/${client_id}`)
+      return instance.get(`${isBaseUrl}/is/clients/${client_id}`)
     },
   },
   users: {
     async get(userId) {
-      return instance.get(`/api/v3/users/${userId}`, {
+      return instance.get(`${isBaseUrl}/users/${userId}`, {
         headers: {
           Authorization: `Bearer ${(await token()).access_token}`,
         },
       })
     },
     async authInfo() {
-      return instance.get('/api/v3/auth_info', {
+      return instance.get(`${isBaseUrl}/auth_info`, {
         headers: {
           Authorization: `Bearer ${(await token()).access_token}`,
         },

--- a/pkg/webui/oauth/api/index.js
+++ b/pkg/webui/oauth/api/index.js
@@ -15,9 +15,11 @@
 import axios from 'axios'
 
 import getCookieValue from '../../lib/cookie'
-import { selectApplicationRootPath } from '../../lib/selectors/env'
+import { selectApplicationRootPath, selectApplicationConfig } from '../../lib/selectors/env'
 
 const appRoot = selectApplicationRootPath()
+const config = selectApplicationConfig()
+const isBaseUrl = config.is.base_url
 
 const csrf = getCookieValue('_csrf')
 const instance = axios.create({
@@ -27,13 +29,13 @@ const instance = axios.create({
 export default {
   users: {
     async register(userData) {
-      return axios.post(`/api/v3/users`, userData)
+      return axios.post(`${isBaseUrl}/users`, userData)
     },
     async resetPassword(user_id) {
-      return axios.post(`/api/v3/users/${user_id}/temporary_password`)
+      return axios.post(`${isBaseUrl}/users/${user_id}/temporary_password`)
     },
     async updatePassword(user_id, passwordData) {
-      return axios.put(`/api/v3/users/${user_id}/password`, passwordData)
+      return axios.put(`${isBaseUrl}/users/${user_id}/password`, passwordData)
     },
   },
   oauth: {

--- a/pkg/webui/types.go
+++ b/pkg/webui/types.go
@@ -1,0 +1,21 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webui
+
+// APIConfig for upstream APIs.
+type APIConfig struct {
+	Enabled bool   `json:"enabled" name:"enabled" description:"Enable this API"`
+	BaseURL string `json:"base_url" name:"base-url" description:"Base URL to the HTTP API"`
+}


### PR DESCRIPTION
#### Summary
This quickfix PR will remove a couple of hardcoded `/api/v3` prefixes for API URLs in the console and oauth app. These were not called through the JS SDK, which already handles API URLs correctly. 
Without this fix, the console and oauth apps would not work in environments where other api url prefixes are configured, or when the IS is served from another host.

#### Changes
- Add configurable IS API base route value to the oauth app of the IS
- Replace hardcoded bits with config passed via page data (in console and oauth app)

#### Notes for Reviewers
@htdvisser / @johanstokking, (and also @bafonins I guess) please review the IS/oauth backend part
@bafonins please review the console/oauth WebUI part

The oauth app currently queries the IS to register new users, which is why the base URL of the IS needs to be passed there. In the future, the responsibilities of the oauth app might change (with a new `account` app e.g., yet to be figured out), so then we might need to (re)move this config again.
