### PR TITLE
Fix device location page breadcrumb id

### DIFF
--- a/pkg/webui/console/views/device-location/index.js
+++ b/pkg/webui/console/views/device-location/index.js
@@ -74,7 +74,7 @@ const getRegistryLocation = function(locations) {
   }),
   { updateDevice: attachPromise(updateDevice) },
 )
-@withBreadcrumb('device.single.data', function(props) {
+@withBreadcrumb('device.single.location', function(props) {
   const { devId, appId } = props
   return (
     <Breadcrumb


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes incorrect handling of breadcrumbs when navigating to the device data/location pages.
<img width="828" alt="Screenshot 2019-08-15 at 09 45 35" src="https://user-images.githubusercontent.com/16374166/63080544-a1cf2f00-bf41-11e9-9d88-3ee4b9ceac4d.png">
<img width="828" alt="Screenshot 2019-08-15 at 09 45 41" src="https://user-images.githubusercontent.com/16374166/63080545-a1cf2f00-bf41-11e9-8716-e47853a4a813.png">


#### Changes
<!-- What are the changes made in this pull request? -->

- Fix device location page breacrumb id