### PR TITLE
Fix page title on device views

### DIFF
--- a/pkg/webui/console/views/device/index.js
+++ b/pkg/webui/console/views/device/index.js
@@ -113,7 +113,7 @@ export default class Device extends React.Component {
       },
       devId,
       deviceName,
-      env,
+      env: { siteName },
     } = this.props
 
     const basePath = `/applications/${appId}/devices/${devId}`
@@ -142,7 +142,7 @@ export default class Device extends React.Component {
 
     return (
       <React.Fragment>
-        <IntlHelmet titleTemplate={`%s - ${deviceName || devId} - ${env.site_name}`} />
+        <IntlHelmet titleTemplate={`%s - ${deviceName || devId} - ${siteName}`} />
         <Container>
           <Row>
             <Col lg={12}>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes the page title on device views
<img width="426" alt="Screenshot 2019-08-15 at 10 00 12" src="https://user-images.githubusercontent.com/16374166/63081341-aac10000-bf43-11e9-8ab8-f8489412f7d4.png">
<img width="426" alt="Screenshot 2019-08-15 at 10 01 00" src="https://user-images.githubusercontent.com/16374166/63081342-aac10000-bf43-11e9-8a20-6cf7f87b35e4.png">


#### Changes
<!-- What are the changes made in this pull request? -->

- Use `siteName` instead of `site_name` from the `env` provider.
