### PR TITLE
Publish master builds to alternative Docker image

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -122,10 +122,10 @@ dockers:
       - ttn-lw-cli
       - ttn-lw-stack
     image_templates:
-      - "{{ .Env.DOCKER_IMAGE }}:latest"
-      - "{{ .Env.DOCKER_IMAGE }}:{{ .Major }}"
-      - "{{ .Env.DOCKER_IMAGE }}:{{ .Major }}.{{ .Minor }}"
-      - "{{ .Env.DOCKER_IMAGE }}:{{ .Version }}"
+      - "{{ or .Env.DOCKER_IMAGE "lorawan-stack" }}:latest"
+      - "{{ or .Env.DOCKER_IMAGE "lorawan-stack" }}:{{ .Major }}"
+      - "{{ or .Env.DOCKER_IMAGE "lorawan-stack" }}:{{ .Major }}.{{ .Minor }}"
+      - "{{ or .Env.DOCKER_IMAGE "lorawan-stack" }}:{{ .Version }}"
     skip_push: auto
     extra_files:
       - public

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -122,10 +122,10 @@ dockers:
       - ttn-lw-cli
       - ttn-lw-stack
     image_templates:
-      - "thethingsnetwork/lorawan-stack:latest"
-      - "thethingsnetwork/lorawan-stack:{{ .Major }}"
-      - "thethingsnetwork/lorawan-stack:{{ .Major }}.{{ .Minor }}"
-      - "thethingsnetwork/lorawan-stack:{{ .Version }}"
+      - "{{ .Env.DOCKER_IMAGE }}:latest"
+      - "{{ .Env.DOCKER_IMAGE }}:{{ .Major }}"
+      - "{{ .Env.DOCKER_IMAGE }}:{{ .Major }}.{{ .Minor }}"
+      - "{{ .Env.DOCKER_IMAGE }}:{{ .Version }}"
     skip_push: auto
     extra_files:
       - public

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
   - TEST_REDIS=1
   - PATH=/snap/bin:$PATH
   - HUGO_BASE_URL=https://thethingsnetwork.github.io/lorawan-stack/
+  - DOCKER_IMAGE=thethingsnetwork/lorawan-stack
 matrix:
   include:
   - env: RUNTYPE=js

--- a/.travis.yml
+++ b/.travis.yml
@@ -123,9 +123,9 @@ after_success:
     docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
     snapcraft login --with snapcraft.login
     if [[ ! -z "$TRAVIS_TAG" ]]; then
-      GO111MODULE=on go run github.com/goreleaser/goreleaser --release-notes <(go run github.com/TheThingsIndustries/release-notes -owner TheThingsNetwork -repo lorawan-stack -id "release-notes" -head $(git rev-parse HEAD))
+      GO111MODULE=on go run github.com/goreleaser/goreleaser --release-notes <(go run github.com/TheThingsIndustries/release-notes -owner TheThingsNetwork -repo lorawan-stack -id "release-notes" -head $(git rev-parse HEAD) | sort)
     else
-      GO111MODULE=on go run github.com/goreleaser/goreleaser --snapshot --release-notes <(go run github.com/TheThingsIndustries/release-notes -owner TheThingsNetwork -repo lorawan-stack -id "release-notes" -head $(git rev-parse HEAD))
+      GO111MODULE=on go run github.com/goreleaser/goreleaser --snapshot --release-notes <(go run github.com/TheThingsIndustries/release-notes -owner TheThingsNetwork -repo lorawan-stack -id "release-notes" -head $(git rev-parse HEAD) | sort)
     fi
   fi
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -127,7 +127,7 @@ after_success:
     if [[ ! -z "$TRAVIS_TAG" ]]; then
       GO111MODULE=on go run github.com/goreleaser/goreleaser --release-notes <(go run github.com/TheThingsIndustries/release-notes -owner TheThingsNetwork -repo lorawan-stack -id "release-notes" -head $(git rev-parse HEAD) | sort)
     else
-      GO111MODULE=on go run github.com/goreleaser/goreleaser --snapshot --release-notes <(go run github.com/TheThingsIndustries/release-notes -owner TheThingsNetwork -repo lorawan-stack -id "release-notes" -head $(git rev-parse HEAD) | sort)
+      GO111MODULE=on go run github.com/goreleaser/goreleaser --snapshot
       if [[ ! -z "$DOCKER_IMAGE_DEV" ]]; then
         docker tag $DOCKER_IMAGE:latest $DOCKER_IMAGE_DEV:$TRAVIS_COMMIT
         docker push $DOCKER_IMAGE_DEV:$TRAVIS_COMMIT

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   - PATH=/snap/bin:$PATH
   - HUGO_BASE_URL=https://thethingsnetwork.github.io/lorawan-stack/
   - DOCKER_IMAGE=thethingsnetwork/lorawan-stack
+  - DOCKER_IMAGE_DEV=thethingsnetwork/lorawan-stack-dev
 matrix:
   include:
   - env: RUNTYPE=js
@@ -127,6 +128,10 @@ after_success:
       GO111MODULE=on go run github.com/goreleaser/goreleaser --release-notes <(go run github.com/TheThingsIndustries/release-notes -owner TheThingsNetwork -repo lorawan-stack -id "release-notes" -head $(git rev-parse HEAD) | sort)
     else
       GO111MODULE=on go run github.com/goreleaser/goreleaser --snapshot --release-notes <(go run github.com/TheThingsIndustries/release-notes -owner TheThingsNetwork -repo lorawan-stack -id "release-notes" -head $(git rev-parse HEAD) | sort)
+      if [[ ! -z "$DOCKER_IMAGE_DEV" ]]; then
+        docker tag $DOCKER_IMAGE:latest $DOCKER_IMAGE_DEV:$TRAVIS_COMMIT
+        docker push $DOCKER_IMAGE_DEV:$TRAVIS_COMMIT
+      fi
     fi
   fi
 deploy:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR closes #1137 by pushing docker images built from master to an alternative image. 

#### Changes
<!-- What are the changes made in this pull request? -->

- Sort release notes (not part of the issue, but previously discussed).
- Use environment variables for Docker image names.
- Push non-tag docker images to `$DOCKER_IMAGE_DEV:$TRAVIS_COMMIT`.
