### PR TITLE
Fix / improve frontend mage targets

### DIFF
--- a/.mage/js.go
+++ b/.mage/js.go
@@ -187,8 +187,9 @@ func (js Js) BuildMain() error {
 
 // BuildDll runs the webpack to build the DLL bundle
 func (js Js) BuildDll() error {
+	mg.Deps(js.Deps)
 	changed, err := target.Path("./public/libs.bundle.js", "./yarn.lock")
-	if os.IsNotExist(err) || (err == nil && changed) {
+	if changed || os.IsNotExist(err) {
 		if mg.Verbose() {
 			fmt.Println("Running Webpack for DLL…")
 		}

--- a/.mage/js.go
+++ b/.mage/js.go
@@ -185,7 +185,7 @@ func (js Js) BuildMain() error {
 	return webpack("--config", "config/webpack.config.babel.js")
 }
 
-// BuildDll runs the webpack to build the DLL bundle
+// BuildDll runs the webpack command to build the DLL bundle
 func (js Js) BuildDll() error {
 	mg.Deps(js.Deps)
 	changed, err := target.Path("./public/libs.bundle.js", "./yarn.lock")

--- a/.mage/js.go
+++ b/.mage/js.go
@@ -188,16 +188,22 @@ func (js Js) BuildMain() error {
 // BuildDll runs the webpack command to build the DLL bundle
 func (js Js) BuildDll() error {
 	mg.Deps(js.Deps)
-	changed, err := target.Path("./public/libs.bundle.js", "./yarn.lock")
-	if changed || os.IsNotExist(err) {
-		if mg.Verbose() {
-			fmt.Println("Running Webpack for DLL…")
+	if nodeEnv := os.Getenv("NODE_ENV"); nodeEnv == "development" {
+		changed, err := target.Path("./public/libs.bundle.js", "./yarn.lock")
+		if changed || os.IsNotExist(err) {
+			if mg.Verbose() {
+				fmt.Println("Running Webpack for DLL…")
+			}
+			webpack, err := js.webpack()
+			if err != nil {
+				return err
+			}
+			return webpack("--config", "config/webpack.dll.babel.js")
 		}
-		webpack, err := js.webpack()
-		if err != nil {
-			return err
-		}
-		return webpack("--config", "config/webpack.dll.babel.js")
+		return nil
+	}
+	if mg.Verbose() {
+		fmt.Println("Skipping DLL module bundling (production mode)")
 	}
 	return nil
 }

--- a/.mage/js.go
+++ b/.mage/js.go
@@ -192,7 +192,7 @@ func (js Js) BuildDll() error {
 		changed, err := target.Path("./public/libs.bundle.js", "./yarn.lock")
 		if changed || os.IsNotExist(err) {
 			if mg.Verbose() {
-				fmt.Println("Running Webpack for DLL…")
+				fmt.Println("Running Webpack for DLL...")
 			}
 			webpack, err := js.webpack()
 			if err != nil {
@@ -217,7 +217,7 @@ func (js Js) Serve() {
 func (js Js) ServeMain() error {
 	mg.Deps(js.Translations, js.BackendTranslations, js.BuildDll)
 	if mg.Verbose() {
-		fmt.Println("Running Webpack for Main Bundle in watch mode…")
+		fmt.Println("Running Webpack for Main Bundle in watch mode...")
 	}
 	webpackServe, err := js.webpackServe()
 	if err != nil {
@@ -232,7 +232,7 @@ func (js Js) Messages() error {
 	changed, err := target.Dir("./.cache/messages", "./pkg/webui/console")
 	if os.IsNotExist(err) || (err == nil && changed) {
 		if mg.Verbose() {
-			fmt.Println("Extracting frontend messages…")
+			fmt.Println("Extracting frontend messages...")
 		}
 		babel, err := js.babel()
 		if err != nil {
@@ -255,7 +255,7 @@ func (js Js) Translations() error {
 	if os.IsNotExist(err) || (err == nil && changed) {
 		mg.Deps(js.Messages)
 		if mg.Verbose() {
-			fmt.Println("Building frontend locale files…")
+			fmt.Println("Building frontend locale files...")
 		}
 		node, err := js.node()
 		if err != nil {
@@ -272,7 +272,7 @@ func (js Js) BackendTranslations() error {
 	if os.IsNotExist(err) || (err == nil && changed) {
 
 		if mg.Verbose() {
-			fmt.Println("Building backend locale files…")
+			fmt.Println("Building backend locale files...")
 		}
 		node, err := js.node()
 		if err != nil {
@@ -354,7 +354,7 @@ func (js Js) LintAll() {
 // Storybook runs a local server with storybook.
 func (js Js) Storybook() error {
 	if mg.Verbose() {
-		fmt.Println("Serving storybook…")
+		fmt.Println("Serving storybook...")
 	}
 	storybook, err := js.storybook()
 	if err != nil {

--- a/.mage/js.go
+++ b/.mage/js.go
@@ -146,7 +146,7 @@ func (js Js) DevDeps() error {
 // Deps installs the javascript dependencies.
 func (js Js) Deps() error {
 	files, readErr := ioutil.ReadDir("node_modules")
-	changed, targetErr := target.Dir("node_modules", "./package.json", "./yarn.lock")
+	changed, targetErr := target.Path("node_modules", "./package.json", "./yarn.lock")
 	// Check whether package.json/yarn.lock are newer than node_modules
 	// and whether it is not only yarn that is installed via DevDeps()
 	if readErr != nil || os.IsNotExist(targetErr) || (targetErr == nil && changed) || len(files) <= 4 {

--- a/.mage/js_sdk.go
+++ b/.mage/js_sdk.go
@@ -42,7 +42,7 @@ func (k JsSDK) yarn() (func(args ...string) error, error) {
 
 // Deps installs the javascript SDK dependencies.
 func (k JsSDK) Deps() error {
-	changed, err := target.Dir("./sdk/js/node_modules", "./sdk/js/package.json", "./sdk/js/yarn.lock")
+	changed, err := target.Path("./sdk/js/node_modules", "./sdk/js/package.json", "./sdk/js/yarn.lock")
 	if os.IsNotExist(err) || (err == nil && changed) {
 		if mg.Verbose() {
 			fmt.Println("Installing JS SDK dependencies")

--- a/.mage/styl.go
+++ b/.mage/styl.go
@@ -36,7 +36,7 @@ func (styl Styl) stylint() (func(args ...string) (string, error), error) {
 	}, nil
 }
 
-// Lint runs eslint over frontend js files.
+// Lint runs stylint over frontend styl files.
 func (styl Styl) Lint() error {
 	if mg.Verbose() {
 		fmt.Println("Running stylint")

--- a/config/webpack.config.babel.js
+++ b/config/webpack.config.babel.js
@@ -217,7 +217,7 @@ export default {
       new webpack.HotModuleReplacementPlugin(),
       new webpack.DllReferencePlugin({
         context,
-        manifest: require(path.resolve(context, CACHE_DIR, 'dll.json')),
+        manifest: path.resolve(context, CACHE_DIR, 'dll.json'),
       }),
       new webpack.WatchIgnorePlugin([
         /node_modules/,


### PR DESCRIPTION
#### Summary
This quickfix PR will fix a couple of issues with our frontend mage targets:
- `mage js:deps` sometimes not running due to faulty mod-time checks
- `mage jsSdk:deps` sometimes not running due to faulty mod-time checks
- dependency updates not applied when running the `js:serve` command
- DLL bundle creation unnecessarily running in production environments

#### Changes
- Replace `target.Dir` with `target.Path`, as that seems to resolve issues with faulty modification time checks
- Add `js.Deps` as dependency of `js:BuildDll`
- Add env check to `js:BuildDll` to avoid unnecessary dll builds in production
- Fix some target descriptions

#### Notes for reviewers
@bafonins please confirm this causes no issues for you