### PR TITLE
Enum Handling in CLI

### DIFF
--- a/cmd/ttn-lw-cli/commands/clients.go
+++ b/cmd/ttn-lw-cli/commands/clients.go
@@ -146,6 +146,7 @@ var (
 				return errNoCollaborator
 			}
 			var client ttnpb.Client
+			client.State = ttnpb.STATE_APPROVED // This may not be honored by the server.
 			if inputDecoder != nil {
 				_, err := inputDecoder.Decode(&client)
 				if err != nil {
@@ -264,6 +265,7 @@ func init() {
 	clientsCreateCommand.Flags().AddFlagSet(collaboratorFlags())
 	clientsCreateCommand.Flags().AddFlagSet(setClientFlags)
 	clientsCreateCommand.Flags().AddFlagSet(attributesFlags())
+	clientsCreateCommand.Flags().Lookup("state").DefValue = ttnpb.STATE_APPROVED.String()
 	clientsCommand.AddCommand(clientsCreateCommand)
 	clientsUpdateCommand.Flags().AddFlagSet(clientIDFlags())
 	clientsUpdateCommand.Flags().AddFlagSet(setClientFlags)

--- a/cmd/ttn-lw-cli/commands/clients.go
+++ b/cmd/ttn-lw-cli/commands/clients.go
@@ -147,6 +147,9 @@ var (
 			}
 			var client ttnpb.Client
 			client.State = ttnpb.STATE_APPROVED // This may not be honored by the server.
+			client.Grants = []ttnpb.GrantType{
+				ttnpb.GRANT_AUTHORIZATION_CODE,
+			}
 			if inputDecoder != nil {
 				_, err := inputDecoder.Decode(&client)
 				if err != nil {
@@ -266,6 +269,7 @@ func init() {
 	clientsCreateCommand.Flags().AddFlagSet(setClientFlags)
 	clientsCreateCommand.Flags().AddFlagSet(attributesFlags())
 	clientsCreateCommand.Flags().Lookup("state").DefValue = ttnpb.STATE_APPROVED.String()
+	clientsCreateCommand.Flags().Lookup("grants").DefValue = ttnpb.GRANT_AUTHORIZATION_CODE.String()
 	clientsCommand.AddCommand(clientsCreateCommand)
 	clientsUpdateCommand.Flags().AddFlagSet(clientIDFlags())
 	clientsUpdateCommand.Flags().AddFlagSet(setClientFlags)

--- a/cmd/ttn-lw-cli/commands/users.go
+++ b/cmd/ttn-lw-cli/commands/users.go
@@ -121,6 +121,7 @@ var (
 		RunE: asBulk(func(cmd *cobra.Command, args []string) (err error) {
 			usrID := getUserID(cmd.Flags(), args)
 			var user ttnpb.User
+			user.State = ttnpb.STATE_APPROVED // This may not be honored by the server.
 			if inputDecoder != nil {
 				_, err := inputDecoder.Decode(&user)
 				if err != nil {
@@ -329,6 +330,7 @@ func init() {
 	usersCreateCommand.Flags().AddFlagSet(setUserFlags)
 	usersCreateCommand.Flags().AddFlagSet(attributesFlags())
 	usersCreateCommand.Flags().AddFlagSet(profilePictureFlags)
+	usersCreateCommand.Flags().Lookup("state").DefValue = ttnpb.STATE_APPROVED.String()
 	usersCommand.AddCommand(usersCreateCommand)
 	usersUpdateCommand.Flags().AddFlagSet(userIDFlags())
 	usersUpdateCommand.Flags().AddFlagSet(setUserFlags)

--- a/cmd/ttn-lw-cli/internal/util/flags.go
+++ b/cmd/ttn-lw-cli/internal/util/flags.go
@@ -189,11 +189,12 @@ func addField(fs *pflag.FlagSet, name string, t reflect.Type, maskOnly bool) {
 			case reflect.String:
 				fs.StringSlice(name, nil, "")
 			case reflect.Int32:
-				if valueMap := enumValues(t); valueMap != nil {
+				if valueMap := enumValues(t.Elem()); valueMap != nil {
 					values := make([]string, 0, len(valueMap))
 					for value := range valueMap {
 						values = append(values, value)
 					}
+					sort.Strings(values)
 					fs.StringSlice(name, nil, strings.Join(values, "|"))
 				} else {
 					fs.IntSlice(name, nil, "")

--- a/config/messages.json
+++ b/config/messages.json
@@ -5320,7 +5320,7 @@
   },
   "error:pkg/ttnpb:field_bound": {
     "translations": {
-      "en": "`{lorawan_field}` should be between `{min}` and `{max}`"
+      "en": "`{field}` should be between `{min}` and `{max}`"
     },
     "description": {
       "package": "pkg/ttnpb",
@@ -5329,7 +5329,7 @@
   },
   "error:pkg/ttnpb:field_with_max": {
     "translations": {
-      "en": "`{lorawan_field}` should be lower or equal to `{max}`"
+      "en": "`{field}` should be lower or equal to `{max}`"
     },
     "description": {
       "package": "pkg/ttnpb",
@@ -5365,7 +5365,7 @@
   },
   "error:pkg/ttnpb:parse": {
     "translations": {
-      "en": "could not parse `{lorawan_field}`"
+      "en": "could not parse `{value}` into `{field}`"
     },
     "description": {
       "package": "pkg/ttnpb",
@@ -5388,15 +5388,6 @@
     "description": {
       "package": "pkg/ttnpb",
       "file": "fieldmask_utils.go"
-    }
-  },
-  "error:pkg/ttnpb:unknown_field": {
-    "translations": {
-      "en": "unknown `{lorawan_field}`"
-    },
-    "description": {
-      "package": "pkg/ttnpb",
-      "file": "errors.go"
     }
   },
   "error:pkg/types:dev_addr_prefix": {

--- a/pkg/ttnpb/errors.go
+++ b/pkg/ttnpb/errors.go
@@ -140,25 +140,24 @@ func unexpectedValue(err interface {
 }
 
 var (
-	errFieldHasMax        = errors.DefineInvalidArgument("field_with_max", "`{lorawan_field}` should be lower or equal to `{max}`", valueKey)
-	errFieldBound         = errors.DefineInvalidArgument("field_bound", "`{lorawan_field}` should be between `{min}` and `{max}`", valueKey)
+	errFieldHasMax        = errors.DefineInvalidArgument("field_with_max", "`{field}` should be lower or equal to `{max}`", valueKey)
+	errFieldBound         = errors.DefineInvalidArgument("field_bound", "`{field}` should be between `{min}` and `{max}`", valueKey)
 	errMissingIdentifiers = errors.DefineInvalidArgument("missing_identifiers", "missing identifiers")
-	errParse              = errors.DefineInvalidArgument("parse", "could not parse `{lorawan_field}`", valueKey)
-	errUnknownField       = errors.DefineInvalidArgument("unknown_field", "unknown `{lorawan_field}`", valueKey)
+	errParse              = errors.DefineInvalidArgument("parse", "could not parse `{value}` into `{field}`", valueKey)
 )
 
 func errExpectedLowerOrEqual(lorawanField string, max interface{}) valueErr {
-	return unexpectedValue(errFieldHasMax.WithAttributes("lorawan_field", lorawanField, "max", max))
+	return unexpectedValue(errFieldHasMax.WithAttributes("field", lorawanField, "max", max))
 }
 
 func errExpectedBetween(lorawanField string, min, max interface{}) valueErr {
-	return unexpectedValue(errFieldBound.WithAttributes("lorawan_field", lorawanField, "min", min, "max", max))
+	return unexpectedValue(errFieldBound.WithAttributes("field", lorawanField, "min", min, "max", max))
 }
 
 func errCouldNotParse(lorawanField string) valueErr {
-	return unexpectedValue(errParse.WithAttributes("lorawan_field", lorawanField))
+	return unexpectedValue(errParse.WithAttributes("field", lorawanField))
 }
 
 func errMissing(lorawanField string) errors.Error {
-	return errUnknownField.WithAttributes("lorawan_field", lorawanField)
+	return errMissingField.WithAttributes("field", lorawanField)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This Pull Request addresses a number of issues with the CLI by refactoring how enums are handled.

Refs https://github.com/TheThingsNetwork/lorawan-stack/issues/1162#issuecomment-521193964

#### Changes
<!-- What are the changes made in this pull request? -->

- Added defaults to `ttn-lw-cli users create` and `ttn-lw-cli clients create`:
  - `State` = `APPROVED` for both users and clients
  - `Grants` = `AUTHORIZATION_CODE` for clients
- Refactored handling of enums and enum slices in the CLI
- Improved enum parse errors (and some cleanup)

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Fixed `grants` and `rights` flags of `ttn-lw-cli clients create`
- Added defaults to `ttn-lw-cli clients create` and `ttn-lw-cli users create`