### PR TITLE
Alias JS SDK imports in the console development builds

### DIFF
--- a/config/webpack.config.babel.js
+++ b/config/webpack.config.babel.js
@@ -97,9 +97,12 @@ export default {
     module: 'empty',
   },
   resolve: {
-    alias: {
-      'react-dom': '@hot-loader/react-dom',
-    },
+    alias: env({
+      development: {
+        'react-dom': '@hot-loader/react-dom',
+        'ttn-lw': path.resolve(context, 'sdk/js/src'),
+      },
+    }),
   },
   devServer: {
     port: 8080,

--- a/config/webpack.dll.babel.js
+++ b/config/webpack.dll.babel.js
@@ -23,7 +23,7 @@ const context = path.resolve(CONTEXT)
 const library = '[name]_[hash]'
 
 const pkg = require(path.resolve(context, 'package.json'))
-const excludeLibs = ['react-hot-loader']
+const excludeLibs = ['react-hot-loader', 'ttn-lw']
 const libs = Object.keys(pkg.dependencies || {}).filter(lib => !excludeLibs.includes(lib))
 
 export default {


### PR DESCRIPTION
#### Summary
Closes #1153
Basically, this will simplify and speed up cross-development between the console and the js SDK by referencing the SDK code directly inside the console build (in development only). So any changes in the SDK will be applied directly when using `mage js:serve` or `mage js:build`.

#### Changes
- Alias the `ttn-lw` package to reference the js sdk source code
- Exclude `ttn-lw` from the dll

