### PR TITLE
CLI-only brew formula, small release fixes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,7 +56,12 @@ builds:
       - 7
 
 archives:
-  - files:
+  - id: stack
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    builds:
+      - cli
+      - stack
+    files:
       - LICENSE
       - README.md
       - doc/**/*
@@ -67,8 +72,24 @@ archives:
       - goos: windows
         format: zip
 
+  - id: cli
+    name_template: "{{ .ProjectName }}-cli_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    builds:
+      - cli
+    files:
+      - LICENSE
+      - README.md
+      - doc/**/*
+    wrap_in_directory: true
+    format_overrides:
+      - goos: windows
+        format: zip
+
 nfpms:
-  - vendor: The Things Network
+  - id: stack
+    builds:
+      - stack
+    vendor: The Things Network
     homepage: https://www.thethingsnetwork.org
     maintainer: The Things Network Foundation <stack@thethingsnetwork.org>
     description: The Things Stack for LoRaWAN
@@ -83,7 +104,10 @@ nfpms:
       "public/**/*": "/srv/ttn-lorawan/public"
 
 snapcrafts:
-  - name: ttn-lw-stack
+  - id: stack
+    builds:
+      - stack
+    name: ttn-lw-stack
     summary: The Things Stack for LoRaWAN
     description: The Things Stack for LoRaWAN
     grade: stable
@@ -96,8 +120,9 @@ snapcrafts:
         plugs: [ home, network, network-bind ]
 
 brews:
-  # TODO: Generate separate formulas for stack+CLI and CLI only.(https://github.com/TheThingsNetwork/lorawan-stack/issues/108)
   - name: ttn-lw-stack
+    ids:
+      - stack
     github:
       owner: TheThingsNetwork
       name: homebrew-lorawan-stack
@@ -106,6 +131,8 @@ brews:
       email: stack@thethingsnetwork.org
     homepage: https://www.thethingsnetwork.org
     description: The Things Stack for LoRaWAN
+    conflicts:
+      - ttn-lw-cli
     skip_upload: auto
     install: |
       bin.install "ttn-lw-cli"
@@ -114,6 +141,24 @@ brews:
           :TTN_LW_HTTP_STATIC_SEARCH_PATH => libexec/"public"
       }
       (bin/"ttn-lw-stack").write_env_script libexec/"ttn-lw-stack", env
+
+  - name: ttn-lw-cli
+    ids:
+      - cli
+    github:
+      owner: TheThingsNetwork
+      name: homebrew-lorawan-stack
+    commit_author:
+      name: ttn-ci
+      email: stack@thethingsnetwork.org
+    homepage: https://www.thethingsnetwork.org
+    description: CLI of The Things Stack for LoRaWAN
+    conflicts:
+      - ttn-lw-stack
+    skip_upload: auto
+    install: |
+      bin.install "ttn-lw-cli"
+      libexec.install doc
 
 dockers:
   - goos: linux

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -167,10 +167,10 @@ dockers:
       - ttn-lw-cli
       - ttn-lw-stack
     image_templates:
-      - '{{ or .Env.DOCKER_IMAGE "lorawan-stack" }}:latest'
-      - '{{ or .Env.DOCKER_IMAGE "lorawan-stack" }}:{{ .Major }}'
-      - '{{ or .Env.DOCKER_IMAGE "lorawan-stack" }}:{{ .Major }}.{{ .Minor }}'
-      - '{{ or .Env.DOCKER_IMAGE "lorawan-stack" }}:{{ .Version }}'
+      - '{{ or (index .Env "DOCKER_IMAGE") "lorawan-stack" }}:latest'
+      - '{{ or (index .Env "DOCKER_IMAGE") "lorawan-stack" }}:{{ .Major }}'
+      - '{{ or (index .Env "DOCKER_IMAGE") "lorawan-stack" }}:{{ .Major }}.{{ .Minor }}'
+      - '{{ or (index .Env "DOCKER_IMAGE") "lorawan-stack" }}:{{ .Version }}'
     skip_push: auto
     extra_files:
       - public

--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ after_success:
     docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
     snapcraft login --with snapcraft.login
     if [[ ! -z "$TRAVIS_TAG" ]]; then
-      GO111MODULE=on go run github.com/goreleaser/goreleaser --release-notes <(go run github.com/TheThingsIndustries/release-notes -owner TheThingsNetwork -repo lorawan-stack -id "release-notes" -head $(git rev-parse HEAD) | sort)
+      GO111MODULE=on go run github.com/goreleaser/goreleaser -p 1 --release-notes <(go run github.com/TheThingsIndustries/release-notes -owner TheThingsNetwork -repo lorawan-stack -id "release-notes" -head $(git rev-parse HEAD) | sort)
     else
       GO111MODULE=on go run github.com/goreleaser/goreleaser --snapshot
       if [[ ! -z "$DOCKER_IMAGE_DEV" ]]; then

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/gohugoio/hugo v0.56.3
 	github.com/golang/gddo v0.0.0-20190419222130-af0f2af80721
 	github.com/golang/protobuf v1.3.2
-	github.com/goreleaser/goreleaser v0.115.0
+	github.com/goreleaser/goreleaser v0.116.0
 	github.com/gorilla/securecookie v1.1.1
 	github.com/gorilla/websocket v1.4.0
 	github.com/gotnospirit/makeplural v0.0.0-20180622080156-a5f48d94d976 // indirect

--- a/go.sum
+++ b/go.sum
@@ -258,8 +258,8 @@ github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20190411002643-bd77b112433e/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
-github.com/goreleaser/goreleaser v0.115.0 h1:V69upi6k7ZkCfU7uHi8tBmqonD33P7hgbf7CDPcqj5Y=
-github.com/goreleaser/goreleaser v0.115.0/go.mod h1:FU8XnrQkPxsaRK+7szYV5m43U3r4iJO2KH8fqNgkglg=
+github.com/goreleaser/goreleaser v0.116.0 h1:Mou/X2V9jCZ7EXRHYyUAQf+stwzwMq2HZQyHBmbyhlk=
+github.com/goreleaser/goreleaser v0.116.0/go.mod h1:scw5I5zIehaYeTkGHpYapGjUxAMOyc4fpjO0XROuy0M=
 github.com/goreleaser/nfpm v0.12.0 h1:2eyO5y6SlnokPZIJN98ewVN45ch0j70WenFE9qWyJpg=
 github.com/goreleaser/nfpm v0.12.0/go.mod h1:F2yzin6cBAL9gb+mSiReuXdsfTrOQwDMsuSpULof+y4=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
@@ -587,8 +587,8 @@ github.com/valyala/fasttemplate v1.0.1 h1:tY9CJiPnMXf1ERmG2EyK7gNUd+c6RKGD0IfU8W
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/wellington/go-libsass v0.9.3-0.20181113175235-c63644206701 h1:9vG9vvVNVupO4Y7uwFkRgIMNe9rdaJMCINDe8vhAhLo=
 github.com/wellington/go-libsass v0.9.3-0.20181113175235-c63644206701/go.mod h1:mxgxgam0N0E+NAUMHLcu20Ccfc3mVpDkyrLDayqfiTs=
-github.com/xanzy/go-gitlab v0.18.0 h1:LybNSWSIw8BK+GnxuETAhUXEzzh5rHsHjopqVkGJXRE=
-github.com/xanzy/go-gitlab v0.18.0/go.mod h1:LSfUQ9OPDnwRqulJk2HcWaAiFfCzaknyeGvjQI67MbE=
+github.com/xanzy/go-gitlab v0.19.0 h1:WHw/JqUiQ82itbuB4IDS4AgTy8RQ0CBrbfljq65pJCo=
+github.com/xanzy/go-gitlab v0.19.0/go.mod h1:LSfUQ9OPDnwRqulJk2HcWaAiFfCzaknyeGvjQI67MbE=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #108 

#### Changes
<!-- What are the changes made in this pull request? -->

- Add CLI-only `brew` formula
- Fix `DOCKER_IMAGE` environment variable handling in Goreleaser

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

https://github.com/TheThingsNetwork/lorawan-stack/commit/d77b09b564bd50a0ffd8ff2cef48e4a8d062c0e8 is required due to https://github.com/goreleaser/goreleaser/issues/1120
We may want to revert the commit to speed up our builds once the mentioned issue is fixed.
The formulas of a (future) `3.1.1` release would look like this: https://github.com/rvolosatovs/homebrew-lorawan-stack/tree/af24ff7e39d7989063eb0656757882be093e432e

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- CLI-only brew tap formula is now available as `TheThingsNetwork/lorawan-stack/ttn-lw-cli`