### PR TITLE
Fix Webpack calling wrong Mage

### DIFF
--- a/config/webpack.config.babel.js
+++ b/config/webpack.config.babel.js
@@ -36,6 +36,7 @@ const {
   CACHE_DIR = '.cache',
   PUBLIC_DIR = 'public',
   NODE_ENV = 'production',
+  MAGE = './mage',
   SUPPORT_LOCALES = 'en',
   DEFAULT_LOCALE = 'en',
 } = process.env
@@ -231,7 +232,7 @@ export default {
         filepath: path.resolve(context, PUBLIC_DIR, 'libs.bundle.js'),
       }),
       new ShellPlugin({
-        onBuildExit: ['mage js:translations'],
+        onBuildExit: [`${MAGE} js:translations`],
       }),
     ],
   }),


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quickfix for our development tooling. It fixes how Webpack calls Mage. Our tooling shouldn't rely on `mage` being available in `PATH`. Instead, it should use `MAGE` from the environment, or fall back to `./mage` in the root of the repo.
