### PR TITLE
Fix breadcrumbs mount order

### DIFF
--- a/pkg/webui/components/breadcrumbs/context.js
+++ b/pkg/webui/components/breadcrumbs/context.js
@@ -24,9 +24,21 @@ class BreadcrumbsProvider extends React.Component {
   }
 
   add(id, breadcrumb) {
-    this.setState(prev => ({
-      breadcrumbs: [...prev.breadcrumbs, { id, breadcrumb }],
-    }))
+    this.setState(prev => {
+      const index = prev.breadcrumbs.findIndex(({ id: breadcrumbId }) => breadcrumbId === id)
+      if (index === -1) {
+        return { breadcrumbs: [...prev.breadcrumbs, { id, breadcrumb }] }
+      }
+
+      // replace breadcrumb with existing id
+      return {
+        breadcrumbs: [
+          ...prev.breadcrumbs.slice(0, index),
+          { id, breadcrumb },
+          ...prev.breadcrumbs.slice(index + 1),
+        ],
+      }
+    })
   }
 
   remove(id) {
@@ -50,6 +62,12 @@ class BreadcrumbsProvider extends React.Component {
 const withBreadcrumb = (id, element) =>
   function(Component) {
     class BreadcrumbsConsumer extends React.Component {
+      constructor(props) {
+        super(props)
+
+        this.add()
+      }
+
       add() {
         const { add, breadcrumb } = this.props
 
@@ -60,10 +78,6 @@ const withBreadcrumb = (id, element) =>
         const { remove } = this.props
 
         remove(id)
-      }
-
-      componentDidMount() {
-        this.add()
       }
 
       componentWillUnmount() {

--- a/pkg/webui/components/breadcrumbs/context.js
+++ b/pkg/webui/components/breadcrumbs/context.js
@@ -15,10 +15,16 @@
 import React from 'react'
 import bind from 'autobind-decorator'
 
+import PropTypes from '../../lib/prop-types'
+
 const { Provider, Consumer } = React.createContext()
 
 @bind
 class BreadcrumbsProvider extends React.Component {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+  }
+
   state = {
     breadcrumbs: [],
   }
@@ -62,6 +68,12 @@ class BreadcrumbsProvider extends React.Component {
 const withBreadcrumb = (id, element) =>
   function(Component) {
     class BreadcrumbsConsumer extends React.Component {
+      static propTypes = {
+        add: PropTypes.func.isRequired,
+        breadcrumb: PropTypes.oneOfType([PropTypes.func, PropTypes.element]).isRequired,
+        remove: PropTypes.func.isRequired,
+      }
+
       constructor(props) {
         super(props)
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes the appearance of breadcrumbs when navigating directly to sub-views:
<img width="369" alt="Screenshot 2019-08-22 at 08 44 35" src="https://user-images.githubusercontent.com/16374166/63501618-3d294c80-c4cc-11e9-8597-f087944feed1.png">
The issue was introduced [here](https://github.com/TheThingsNetwork/lorawan-stack/pull/1176/commits/6975fb957ba50faa74bda45abe277016d8fce990#diff-2e38edf6135cade8310bd7149ced4171)

References https://github.com/TheThingsNetwork/lorawan-stack/issues/1086

#### Changes
<!-- What are the changes made in this pull request? -->

- Add breacrumbs in consumers contructor
- Replace breadcrumbs with the same id
- Add prop-types to breadcrumbs context

