### PR TITLE
Fix error message for missing user/client flags

### DIFF
--- a/cmd/ttn-lw-cli/commands/users_oauth.go
+++ b/cmd/ttn-lw-cli/commands/users_oauth.go
@@ -40,10 +40,15 @@ func getUserAndClientID(flagSet *pflag.FlagSet, args []string) (*ttnpb.UserIdent
 		userID = args[0]
 		clientID = args[1]
 	}
-	if userID == "" || clientID == "" {
-		return nil, nil
+	switch {
+	case userID != "" && clientID != "":
+		return &ttnpb.UserIdentifiers{UserID: userID}, &ttnpb.ClientIdentifiers{ClientID: clientID}
+	case userID != "":
+		return &ttnpb.UserIdentifiers{UserID: userID}, nil
+	case clientID != "":
+		return nil, &ttnpb.ClientIdentifiers{ClientID: clientID}
 	}
-	return &ttnpb.UserIdentifiers{UserID: userID}, &ttnpb.ClientIdentifiers{ClientID: clientID}
+	return nil, nil
 }
 
 var errNoTokenID = errors.DefineInvalidArgument("no_token_id", "no token ID set")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quick fix for the error message of `ttn-lw-cli users oauth` commands that require both a user ID and client ID. If the client ID was missing, the error incorrectly used to say that the user ID was missing.

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Fixed incorrect error message in `ttn-lw-cli users oauth` commands
