### PR TITLE
Fix flaky field masks impacting test coverage

### DIFF
--- a/pkg/identityserver/store/application.go
+++ b/pkg/identityserver/store/application.go
@@ -59,8 +59,10 @@ var defaultApplicationFieldMask = &types.FieldMask{}
 
 func init() {
 	paths := make([]string, 0, len(applicationPBSetters))
-	for path := range applicationPBSetters {
-		paths = append(paths, path)
+	for _, path := range ttnpb.ApplicationFieldPathsNested {
+		if _, ok := applicationPBSetters[path]; ok {
+			paths = append(paths, path)
+		}
 	}
 	defaultApplicationFieldMask.Paths = paths
 }

--- a/pkg/identityserver/store/client.go
+++ b/pkg/identityserver/store/client.go
@@ -84,8 +84,10 @@ var defaultClientFieldMask = &types.FieldMask{}
 
 func init() {
 	paths := make([]string, 0, len(clientPBSetters))
-	for path := range clientPBSetters {
-		paths = append(paths, path)
+	for _, path := range ttnpb.ClientFieldPathsNested {
+		if _, ok := clientPBSetters[path]; ok {
+			paths = append(paths, path)
+		}
 	}
 	defaultClientFieldMask.Paths = paths
 }

--- a/pkg/identityserver/store/end_device.go
+++ b/pkg/identityserver/store/end_device.go
@@ -132,8 +132,10 @@ var defaultEndDeviceFieldMask = &types.FieldMask{}
 
 func init() {
 	paths := make([]string, 0, len(devicePBSetters))
-	for path := range devicePBSetters {
-		paths = append(paths, path)
+	for _, path := range ttnpb.EndDeviceFieldPathsNested {
+		if _, ok := devicePBSetters[path]; ok {
+			paths = append(paths, path)
+		}
 	}
 	defaultEndDeviceFieldMask.Paths = paths
 }

--- a/pkg/identityserver/store/gateway.go
+++ b/pkg/identityserver/store/gateway.go
@@ -147,8 +147,10 @@ var defaultGatewayFieldMask = &pbtypes.FieldMask{}
 
 func init() {
 	paths := make([]string, 0, len(gatewayPBSetters))
-	for path := range gatewayPBSetters {
-		paths = append(paths, path)
+	for _, path := range ttnpb.GatewayFieldPathsNested {
+		if _, ok := gatewayPBSetters[path]; ok {
+			paths = append(paths, path)
+		}
 	}
 	defaultGatewayFieldMask.Paths = paths
 }

--- a/pkg/identityserver/store/organization.go
+++ b/pkg/identityserver/store/organization.go
@@ -60,8 +60,10 @@ var defaultOrganizationFieldMask = &types.FieldMask{}
 
 func init() {
 	paths := make([]string, 0, len(organizationPBSetters))
-	for path := range organizationPBSetters {
-		paths = append(paths, path)
+	for _, path := range ttnpb.OrganizationFieldPathsNested {
+		if _, ok := organizationPBSetters[path]; ok {
+			paths = append(paths, path)
+		}
 	}
 	defaultOrganizationFieldMask.Paths = paths
 }

--- a/pkg/identityserver/store/user.go
+++ b/pkg/identityserver/store/user.go
@@ -140,8 +140,10 @@ var defaultUserFieldMask = &types.FieldMask{}
 
 func init() {
 	paths := make([]string, 0, len(userPBSetters))
-	for path := range userPBSetters {
-		paths = append(paths, path)
+	for _, path := range ttnpb.UserFieldPathsNested {
+		if _, ok := userPBSetters[path]; ok {
+			paths = append(paths, path)
+		}
 	}
 	defaultUserFieldMask.Paths = paths
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quickfix that changes the way the default field masks for IS entities are built to be fully deterministic (instead of relying on map range ordering)
