### PR TITLE
Make OAuth errors explicit

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -4958,6 +4958,15 @@
       "file": "errors.go"
     }
   },
+  "error:pkg/oauth:access_denied": {
+    "translations": {
+      "en": "access denied"
+    },
+    "description": {
+      "package": "pkg/oauth",
+      "file": "server.go"
+    }
+  },
   "error:pkg/oauth:auth_cookie": {
     "translations": {
       "en": "could not get auth cookie"
@@ -4965,6 +4974,96 @@
     "description": {
       "package": "pkg/oauth",
       "file": "user.go"
+    }
+  },
+  "error:pkg/oauth:client_missing_grant": {
+    "translations": {
+      "en": "OAuth client does not have {grant} grant"
+    },
+    "description": {
+      "package": "pkg/oauth",
+      "file": "oauth.go"
+    }
+  },
+  "error:pkg/oauth:client_not_approved": {
+    "translations": {
+      "en": "OAuth client was not approved"
+    },
+    "description": {
+      "package": "pkg/oauth",
+      "file": "oauth.go"
+    }
+  },
+  "error:pkg/oauth:client_rejected": {
+    "translations": {
+      "en": "OAuth client was rejected"
+    },
+    "description": {
+      "package": "pkg/oauth",
+      "file": "oauth.go"
+    }
+  },
+  "error:pkg/oauth:client_suspended": {
+    "translations": {
+      "en": "OAuth client was suspended"
+    },
+    "description": {
+      "package": "pkg/oauth",
+      "file": "oauth.go"
+    }
+  },
+  "error:pkg/oauth:internal": {
+    "translations": {
+      "en": "internal error {id}"
+    },
+    "description": {
+      "package": "pkg/oauth",
+      "file": "server.go"
+    }
+  },
+  "error:pkg/oauth:invalid client": {
+    "translations": {
+      "en": "invalid or unauthenticated client"
+    },
+    "description": {
+      "package": "pkg/oauth",
+      "file": "server.go"
+    }
+  },
+  "error:pkg/oauth:invalid_grant": {
+    "translations": {
+      "en": "invalid, expired or revoked authorization code"
+    },
+    "description": {
+      "package": "pkg/oauth",
+      "file": "server.go"
+    }
+  },
+  "error:pkg/oauth:invalid_redirect_uri": {
+    "translations": {
+      "en": "invalid redirect URI"
+    },
+    "description": {
+      "package": "pkg/oauth",
+      "file": "server.go"
+    }
+  },
+  "error:pkg/oauth:invalid_request": {
+    "translations": {
+      "en": "invalid or missing request parameter"
+    },
+    "description": {
+      "package": "pkg/oauth",
+      "file": "server.go"
+    }
+  },
+  "error:pkg/oauth:invalid_scope": {
+    "translations": {
+      "en": "invalid scope"
+    },
+    "description": {
+      "package": "pkg/oauth",
+      "file": "server.go"
     }
   },
   "error:pkg/oauth:no_access_token": {
@@ -5028,6 +5127,33 @@
     "description": {
       "package": "pkg/oauth",
       "file": "storage.go"
+    }
+  },
+  "error:pkg/oauth:unauthorized_client": {
+    "translations": {
+      "en": "client is not authorized to request a token using this method"
+    },
+    "description": {
+      "package": "pkg/oauth",
+      "file": "server.go"
+    }
+  },
+  "error:pkg/oauth:unsupported_grant_type": {
+    "translations": {
+      "en": "unsupported grant type"
+    },
+    "description": {
+      "package": "pkg/oauth",
+      "file": "server.go"
+    }
+  },
+  "error:pkg/oauth:unsupported_response_type": {
+    "translations": {
+      "en": "unsupported response type"
+    },
+    "description": {
+      "package": "pkg/oauth",
+      "file": "server.go"
     }
   },
   "error:pkg/pfconfig/shared:unmarshal_not_implemented": {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request makes OAuth errors explicit by turning error IDs returned by the OAuth library into defined errors.

Closes #1232 and perhaps also #1226.

#### Changes
<!-- What are the changes made in this pull request? -->

- Return defined errors from `/oauth/authorize` if possible
- Inspect errors from OAuth library and convert to defined errors

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Improved error handling in OAuth flow
