### PR TITLE
Various interop-related fixes and improvements

### DIFF
--- a/pkg/fetch/basepath.go
+++ b/pkg/fetch/basepath.go
@@ -1,0 +1,31 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fetch
+
+type basePathFetcher struct {
+	Interface
+	basePath []string
+}
+
+func (f basePathFetcher) File(pathElements ...string) ([]byte, error) {
+	return f.Interface.File(append(f.basePath, pathElements...)...)
+}
+
+func WithBasePath(f Interface, basePath ...string) Interface {
+	return basePathFetcher{
+		Interface: f,
+		basePath:  append(basePath[:0:0], basePath...),
+	}
+}

--- a/pkg/fetch/basepath_test.go
+++ b/pkg/fetch/basepath_test.go
@@ -1,0 +1,124 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fetch_test
+
+import (
+	"testing"
+
+	"github.com/mohae/deepcopy"
+	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/pkg/fetch"
+	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
+)
+
+type MockInterface struct {
+	FileFunc func(...string) ([]byte, error)
+}
+
+func (m MockInterface) File(pathElements ...string) ([]byte, error) {
+	if m.FileFunc == nil {
+		panic("File called, but not set")
+	}
+	return m.FileFunc(pathElements...)
+}
+
+func TestWithBasePath(t *testing.T) {
+	for _, tc := range []struct {
+		Name           string
+		BasePath, Path []string
+		Error          error
+		Bytes          []byte
+		AssertPath     func(*testing.T, ...string) bool
+		AssertError    func(*testing.T, error) bool
+		AssertBytes    func(*testing.T, []byte) bool
+	}{
+		{
+			Name:  "empty base path/empty path",
+			Bytes: []byte{0x42, 0x41},
+			AssertPath: func(t *testing.T, pathElements ...string) bool {
+				return assertions.New(t).So(pathElements, should.BeEmpty)
+			},
+			AssertError: func(t *testing.T, err error) bool {
+				return assertions.New(t).So(err, should.BeNil)
+			},
+			AssertBytes: func(t *testing.T, b []byte) bool {
+				return assertions.New(t).So(b, should.Resemble, []byte{0x42, 0x41})
+			},
+		},
+		{
+			Name:  "empty base path/path [foo bar baz]",
+			Path:  []string{"foo", "bar", "baz"},
+			Bytes: []byte{0x42, 0x41},
+			AssertPath: func(t *testing.T, pathElements ...string) bool {
+				return assertions.New(t).So(pathElements, should.Resemble, []string{"foo", "bar", "baz"})
+			},
+			AssertError: func(t *testing.T, err error) bool {
+				return assertions.New(t).So(err, should.BeNil)
+			},
+			AssertBytes: func(t *testing.T, b []byte) bool {
+				return assertions.New(t).So(b, should.Resemble, []byte{0x42, 0x41})
+			},
+		},
+		{
+			Name:     "base [foo bar baz]/empty path",
+			BasePath: []string{"foo", "bar", "baz"},
+			Bytes:    []byte{0x42, 0x41},
+			AssertPath: func(t *testing.T, pathElements ...string) bool {
+				return assertions.New(t).So(pathElements, should.Resemble, []string{"foo", "bar", "baz"})
+			},
+			AssertError: func(t *testing.T, err error) bool {
+				return assertions.New(t).So(err, should.BeNil)
+			},
+			AssertBytes: func(t *testing.T, b []byte) bool {
+				return assertions.New(t).So(b, should.Resemble, []byte{0x42, 0x41})
+			},
+		},
+		{
+			Name:     "base [foo bar baz]/path [42 baz bar foo]",
+			BasePath: []string{"foo", "bar", "baz"},
+			Path:     []string{"42", "baz", "bar", "foo"},
+			Bytes:    []byte{0x42, 0x41},
+			AssertPath: func(t *testing.T, pathElements ...string) bool {
+				return assertions.New(t).So(pathElements, should.Resemble, []string{"foo", "bar", "baz", "42", "baz", "bar", "foo"})
+			},
+			AssertError: func(t *testing.T, err error) bool {
+				return assertions.New(t).So(err, should.BeNil)
+			},
+			AssertBytes: func(t *testing.T, b []byte) bool {
+				return assertions.New(t).So(b, should.Resemble, []byte{0x42, 0x41})
+			},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			a := assertions.New(t)
+
+			m := MockInterface{
+				FileFunc: func(pathElements ...string) ([]byte, error) {
+					a.So(tc.AssertPath(t, pathElements...), should.BeTrue)
+					return tc.Bytes, tc.Error
+				},
+			}
+
+			basePath := deepcopy.Copy(tc.BasePath).([]string)
+			path := deepcopy.Copy(tc.Path).([]string)
+			b, err := fetch.WithBasePath(m, basePath...).File(path...)
+			if a.So(tc.AssertError(t, err), should.BeTrue) {
+				a.So(tc.AssertBytes(t, b), should.BeTrue)
+			}
+			a.So(basePath, should.Resemble, tc.BasePath)
+			a.So(path, should.Resemble, tc.Path)
+		})
+	}
+}

--- a/pkg/fetch/fetch_test.go
+++ b/pkg/fetch/fetch_test.go
@@ -12,12 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fetch
+package fetch_test
 
-import "fmt"
+import (
+	"fmt"
+
+	"go.thethings.network/lorawan-stack/pkg/fetch"
+)
 
 func Example() {
-	fetcher := FromHTTP("http://webserver.thethings.network/repository", true)
+	fetcher := fetch.FromHTTP("http://webserver.thethings.network/repository", true)
 	content, err := fetcher.File("README.md")
 	if err != nil {
 		panic(err)

--- a/pkg/interop/client.go
+++ b/pkg/interop/client.go
@@ -262,9 +262,6 @@ func makeJoinServerHTTPRequestFunc(scheme string, dns, fqdn, path string, port u
 	if port == 0 {
 		port = defaultHTTPSPort
 	}
-	if path != "" {
-		path = fmt.Sprintf("/%s", path)
-	}
 	return func(joinEUI types.EUI64, pld interface{}) (*http.Request, error) {
 		if fqdn == "" {
 			fqdn = JoinServerFQDN(joinEUI, dns)

--- a/pkg/interop/client.go
+++ b/pkg/interop/client.go
@@ -21,6 +21,8 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"path/filepath"
 	"sort"
@@ -31,6 +33,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/encoding/lorawan"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/fetch"
+	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/types"
 	yaml "gopkg.in/yaml.v2"
@@ -146,18 +149,40 @@ type joinServerHTTPClient struct {
 	Protocol       JoinServerProtocol
 }
 
-func (cl joinServerHTTPClient) exchange(joinEUI types.EUI64, req, res interface{}) error {
+func (cl joinServerHTTPClient) exchange(ctx context.Context, joinEUI types.EUI64, req, res interface{}) error {
+	logger := log.FromContext(ctx)
+
 	httpReq, err := cl.NewRequestFunc(joinEUI, req)
 	if err != nil {
 		return err
 	}
+	httpReq = httpReq.WithContext(ctx)
+	logger = logger.WithField("url", httpReq.URL)
 
+	logger.Debug("Send interop HTTP request")
 	httpRes, err := cl.Client.Do(httpReq)
 	if err != nil {
 		return err
 	}
 	defer httpRes.Body.Close()
-	return json.NewDecoder(httpRes.Body).Decode(res)
+
+	logger = logger.WithField("http_code", httpRes.StatusCode)
+	logger.Debug("Receive interop HTTP response")
+
+	b, err := ioutil.ReadAll(httpRes.Body)
+	if err != nil {
+		if err == io.EOF && res == nil {
+			return nil
+		}
+		logger.WithError(err).Warn("Failed to read HTTP response body")
+		return errors.FromHTTPStatusCode(httpRes.StatusCode)
+	}
+
+	if err := json.Unmarshal(b, res); err != nil {
+		logger.WithError(err).Warn("Failed to decode HTTP response body")
+		return errors.FromHTTPStatusCode(httpRes.StatusCode)
+	}
+	return nil
 }
 
 func parseResult(r Result) error {
@@ -175,7 +200,7 @@ func parseResult(r Result) error {
 // GetAppSKey performs AppSKey request according to LoRaWAN Backend Interfaces specification.
 func (cl joinServerHTTPClient) GetAppSKey(ctx context.Context, asID string, req *ttnpb.SessionKeyRequest) (*ttnpb.AppSKeyResponse, error) {
 	interopAns := &AppSKeyAns{}
-	if err := cl.exchange(req.JoinEUI, &AppSKeyReq{
+	if err := cl.exchange(ctx, req.JoinEUI, &AppSKeyReq{
 		AsJsMessageHeader: AsJsMessageHeader{
 			MessageHeader: MessageHeader{
 				ProtocolVersion: cl.Protocol.BackendInterfacesVersion(),
@@ -219,7 +244,7 @@ func (cl joinServerHTTPClient) HandleJoinRequest(ctx context.Context, netID type
 	}
 
 	interopAns := &JoinAns{}
-	if err := cl.exchange(pld.JoinEUI, &JoinReq{
+	if err := cl.exchange(ctx, pld.JoinEUI, &JoinReq{
 		NsJsMessageHeader: NsJsMessageHeader{
 			MessageHeader: MessageHeader{
 				ProtocolVersion: cl.Protocol.BackendInterfacesVersion(),

--- a/pkg/interop/client.go
+++ b/pkg/interop/client.go
@@ -22,7 +22,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"go.thethings.network/lorawan-stack/pkg/config"
@@ -360,7 +362,10 @@ func NewClient(ctx context.Context, conf config.InteropClient, fallbackTLS *tls.
 
 	jss := make([]prefixJoinServerClient, 0, len(yamlConf.JoinServers))
 	for _, jsConf := range yamlConf.JoinServers {
-		jsFileBytes, err := fetcher.File(jsConf.File)
+		jsConfEls := strings.Split(filepath.ToSlash(jsConf.File), "/")
+
+		fetcher := fetch.WithBasePath(fetcher, jsConfEls[:len(jsConfEls)-1]...)
+		jsFileBytes, err := fetcher.File(jsConfEls[len(jsConfEls)-1])
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/interop/client_test.go
+++ b/pkg/interop/client_test.go
@@ -159,9 +159,9 @@ headers:
    TestHeader: baz`,
 					fqdn,
 					port,
-					RootCAPath,
-					ClientCertPath,
-					ClientKeyPath,
+					filepath.Join("..", RootCAPath),
+					filepath.Join("..", ClientCertPath),
+					filepath.Join("..", ClientKeyPath),
 				)), 0644))
 
 				test.MustMultiple(ioutil.WriteFile(js3Path, []byte(`dns: invalid.dns
@@ -271,9 +271,9 @@ headers:
    TestHeader: baz`,
 					fqdn,
 					port,
-					RootCAPath,
-					ClientCertPath,
-					ClientKeyPath,
+					filepath.Join("..", RootCAPath),
+					filepath.Join("..", ClientCertPath),
+					filepath.Join("..", ClientKeyPath),
 				)), 0644))
 
 				test.MustMultiple(ioutil.WriteFile(js3Path, []byte(`dns: invalid.dns
@@ -395,9 +395,9 @@ headers:
    TestHeader: baz`,
 					fqdn,
 					port,
-					RootCAPath,
-					ClientCertPath,
-					ClientKeyPath,
+					filepath.Join("..", RootCAPath),
+					filepath.Join("..", ClientCertPath),
+					filepath.Join("..", ClientKeyPath),
 				)), 0644))
 
 				test.MustMultiple(ioutil.WriteFile(js3Path, []byte(`dns: invalid.dns
@@ -524,9 +524,9 @@ headers:
    TestHeader: baz`,
 					fqdn,
 					port,
-					RootCAPath,
-					ClientCertPath,
-					ClientKeyPath,
+					filepath.Join("..", RootCAPath),
+					filepath.Join("..", ClientCertPath),
+					filepath.Join("..", ClientKeyPath),
 				)), 0644))
 
 				test.MustMultiple(ioutil.WriteFile(js3Path, []byte(`dns: invalid.dns
@@ -719,9 +719,9 @@ headers:
    TestHeader: baz`,
 					fqdn,
 					port,
-					RootCAPath,
-					ClientCertPath,
-					ClientKeyPath,
+					filepath.Join("..", RootCAPath),
+					filepath.Join("..", ClientCertPath),
+					filepath.Join("..", ClientKeyPath),
 				)), 0644))
 
 				test.MustMultiple(ioutil.WriteFile(js3Path, []byte(`dns: invalid.dns
@@ -862,9 +862,9 @@ headers:
    TestHeader: baz`,
 					fqdn,
 					port,
-					RootCAPath,
-					ClientCertPath,
-					ClientKeyPath,
+					filepath.Join("..", RootCAPath),
+					filepath.Join("..", ClientCertPath),
+					filepath.Join("..", ClientKeyPath),
 				)), 0644))
 
 				test.MustMultiple(ioutil.WriteFile(js3Path, []byte(`dns: invalid.dns

--- a/pkg/networkserver/adr_test.go
+++ b/pkg/networkserver/adr_test.go
@@ -278,7 +278,8 @@ func TestAdaptDataRate(t *testing.T) {
 					{FCnt: 28, MaxSNR: -10, GtwDiversity: 2},
 					{FCnt: 29, MaxSNR: -10, GtwDiversity: 3},
 					{FCnt: 30, MaxSNR: -9, GtwDiversity: 3},
-					{FCnt: 31, MaxSNR: -7, GtwDiversity: 2,
+					{
+						FCnt: 31, MaxSNR: -7, GtwDiversity: 2,
 						TxSettings: ttnpb.TxSettings{
 							DataRate: ttnpb.DataRate{
 								Modulation: &ttnpb.DataRate_LoRa{

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -1010,6 +1010,7 @@ func (ns *NetworkServer) handleJoinRequest(ctx context.Context, up *ttnpb.Uplink
 	}
 
 	req := &ttnpb.JoinRequest{
+		Payload:            up.Payload,
 		CFList:             frequencyplans.CFList(*fp, dev.LoRaWANPHYVersion),
 		CorrelationIDs:     events.CorrelationIDsFromContext(ctx),
 		DevAddr:            devAddr,

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -929,8 +929,8 @@ func (ns *NetworkServer) sendJoinRequest(ctx context.Context, ids ttnpb.EndDevic
 			logger.Debug("Join-request accepted by cluster-local Join Server")
 			return resp, nil
 		}
+		logger.WithError(err).Info("Cluster-local Join Server did not accept join-request")
 		if !errors.IsNotFound(err) {
-			logger.WithError(err).Warn("Cluster-local Join Server did not accept join-request")
 			return nil, err
 		}
 	}
@@ -940,8 +940,8 @@ func (ns *NetworkServer) sendJoinRequest(ctx context.Context, ids ttnpb.EndDevic
 			logger.Debug("Join-request accepted by interop Join Server")
 			return resp, nil
 		}
+		logger.WithError(err).Warn("Interop Join Server did not accept join-request")
 		if !errors.IsNotFound(err) {
-			logger.WithError(err).Warn("Interop Join Server did not accept join-request")
 			return nil, err
 		}
 	}

--- a/pkg/networkserver/grpc_gsns_test.go
+++ b/pkg/networkserver/grpc_gsns_test.go
@@ -502,7 +502,7 @@ func TestHandleUplink(t *testing.T) {
 		Response chan<- *pbtypes.Empty
 	}
 
-	var errTest = errors.New("testError")
+	errTest := errors.New("testError")
 
 	for _, tc := range []struct {
 		Name    string
@@ -826,6 +826,7 @@ func TestHandleUplink(t *testing.T) {
 								DevAddr:            req.DevAddr,
 								NetID:              netID,
 								RawPayload:         msg.RawPayload,
+								Payload:            makeJoinRequest(true).Payload,
 								RxDelay:            ttnpb.RX_DELAY_3,
 								SelectedMACVersion: ttnpb.MAC_V1_0_2,
 							})
@@ -929,6 +930,7 @@ func TestHandleUplink(t *testing.T) {
 								},
 								NetID:              netID,
 								RawPayload:         msg.RawPayload,
+								Payload:            makeJoinRequest(true).Payload,
 								RxDelay:            ttnpb.RX_DELAY_3,
 								SelectedMACVersion: ttnpb.MAC_V1_1,
 							})
@@ -1039,6 +1041,7 @@ func TestHandleUplink(t *testing.T) {
 								DevAddr:            req.DevAddr,
 								NetID:              netID,
 								RawPayload:         msg.RawPayload,
+								Payload:            makeJoinRequest(true).Payload,
 								RxDelay:            ttnpb.RX_DELAY_3,
 								SelectedMACVersion: ttnpb.MAC_V1_0_3,
 							})
@@ -1151,6 +1154,7 @@ func TestHandleUplink(t *testing.T) {
 								},
 								NetID:              netID,
 								RawPayload:         msg.RawPayload,
+								Payload:            makeJoinRequest(true).Payload,
 								RxDelay:            ttnpb.RX_DELAY_3,
 								SelectedMACVersion: ttnpb.MAC_V1_1,
 							})
@@ -1270,6 +1274,7 @@ func TestHandleUplink(t *testing.T) {
 								},
 								NetID:              netID,
 								RawPayload:         msg.RawPayload,
+								Payload:            makeJoinRequest(true).Payload,
 								RxDelay:            ttnpb.RX_DELAY_3,
 								SelectedMACVersion: ttnpb.MAC_V1_1,
 							})
@@ -1485,6 +1490,7 @@ func TestHandleUplink(t *testing.T) {
 								DevAddr:            req.DevAddr,
 								NetID:              netID,
 								RawPayload:         msg.RawPayload,
+								Payload:            makeJoinRequest(true).Payload,
 								RxDelay:            ttnpb.RX_DELAY_3,
 								SelectedMACVersion: ttnpb.MAC_V1_0_2,
 							})
@@ -1668,6 +1674,7 @@ func TestHandleUplink(t *testing.T) {
 								},
 								NetID:              netID,
 								RawPayload:         msg.RawPayload,
+								Payload:            makeJoinRequest(true).Payload,
 								RxDelay:            ttnpb.RX_DELAY_3,
 								SelectedMACVersion: ttnpb.MAC_V1_1,
 							})
@@ -1884,6 +1891,7 @@ func TestHandleUplink(t *testing.T) {
 								DevAddr:            req.DevAddr,
 								NetID:              netID,
 								RawPayload:         msg.RawPayload,
+								Payload:            makeJoinRequest(true).Payload,
 								RxDelay:            ttnpb.RX_DELAY_3,
 								SelectedMACVersion: ttnpb.MAC_V1_0_2,
 							})
@@ -2103,6 +2111,7 @@ func TestHandleUplink(t *testing.T) {
 								},
 								NetID:              netID,
 								RawPayload:         msg.RawPayload,
+								Payload:            makeJoinRequest(true).Payload,
 								RxDelay:            ttnpb.RX_DELAY_3,
 								SelectedMACVersion: ttnpb.MAC_V1_1,
 							})

--- a/pkg/networkserver/mac_force_rejoin.go
+++ b/pkg/networkserver/mac_force_rejoin.go
@@ -21,9 +21,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 )
 
-var (
-	evtEnqueueForceRejoinRequest = defineEnqueueMACRequestEvent("force_rejoin", "force rejoin")()
-)
+var evtEnqueueForceRejoinRequest = defineEnqueueMACRequestEvent("force_rejoin", "force rejoin")()
 
 func enqueueForceRejoinReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16) (uint16, uint16, bool) {
 	var pld *ttnpb.MACCommand_ForceRejoinReq

--- a/pkg/networkserver/networkserver_flow_test.go
+++ b/pkg/networkserver/networkserver_flow_test.go
@@ -312,6 +312,16 @@ func handleOTAAClassA868FlowTest1_0_2(ctx context.Context, reg DeviceRegistry, t
 				a.So(req.DevAddr.NwkID(), should.Resemble, netID.ID()) &&
 				a.So(req.DevAddr.NetIDType(), should.Equal, netID.Type()) &&
 				a.So(req, should.Resemble, &ttnpb.JoinRequest{
+					Payload: &ttnpb.Message{
+						Payload: &ttnpb.Message_JoinRequestPayload{
+							JoinRequestPayload: &ttnpb.JoinRequestPayload{
+								JoinEUI:  types.EUI64{0x42, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+								DevEUI:   types.EUI64{0x42, 0x42, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+								DevNonce: [2]byte{0x00, 0x01},
+							},
+						},
+						MIC: []byte{3, 2, 1, 0},
+					},
 					RawPayload:         payload,
 					DevAddr:            req.DevAddr,
 					SelectedMACVersion: ttnpb.MAC_V1_0_2,

--- a/pkg/networkserver/networkserver_util_test.go
+++ b/pkg/networkserver/networkserver_util_test.go
@@ -660,6 +660,7 @@ type NsJsHandleJoinResponse struct {
 	Response *ttnpb.JoinResponse
 	Error    error
 }
+
 type NsJsHandleJoinRequest struct {
 	Context  context.Context
 	Message  *ttnpb.JoinRequest
@@ -721,6 +722,7 @@ type NsGsScheduleDownlinkResponse struct {
 	Response *ttnpb.ScheduleDownlinkResponse
 	Error    error
 }
+
 type NsGsScheduleDownlinkRequest struct {
 	Context  context.Context
 	Message  *ttnpb.DownlinkMessage


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Various small fixes

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `fetch.WithBasePath` and use in `interop`
- Improve interop-related logging
- Fix `/` being added twice to configured path
- Set context in interop HTTP requests
- Set decoded payload in join-request(it's not used by cluster-local JS, but is used by the `interop` client)