### PR TITLE
Broaden the IS password character limits, allow Unicode

### DIFF
--- a/pkg/identityserver/user_registry.go
+++ b/pkg/identityserver/user_registry.go
@@ -20,6 +20,7 @@ import (
 	"runtime/trace"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/gogo/protobuf/types"
 	"github.com/jinzhu/gorm"
@@ -77,11 +78,11 @@ func (is *IdentityServer) validatePasswordStrength(ctx context.Context, password
 	var uppercase, digits, special int
 	for _, r := range password {
 		switch {
-		case r >= 'A' && r <= 'Z':
+		case unicode.IsUpper(r):
 			uppercase++
-		case r >= '0' && r <= '9':
+		case unicode.IsDigit(r):
 			digits++
-		case r == '!' || r == '%' || r == '@' || r == '#' || r == '$' || r == '&' || r == '*':
+		case !unicode.IsLetter(r) && !unicode.IsNumber(r):
 			special++
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #1223 

#### Changes
<!-- What are the changes made in this pull request? -->

- Broaden IS password character limits
- Support Unicode

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

It's a very small change, but I assigned both @johanstokking and @htdvisser to take look, since it's quite important that we agree on this.
Using unicode characters should not be a problem - it's 2019 already. This also gives a lot of freedom to our users, which I'm sure (at least) some will be happy about.