### PR TITLE
Implement LoRa Alliance TR005 QR code parsing

### DIFF
--- a/pkg/qrcode/lora_alliance_tr005.go
+++ b/pkg/qrcode/lora_alliance_tr005.go
@@ -1,0 +1,134 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package qrcode
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"go.thethings.network/lorawan-stack/pkg/types"
+)
+
+// LoRaAllianceTR005Draft2 is the LoRa Alliance defined format in Technical Recommendation TR005 Draft 2.
+type LoRaAllianceTR005Draft2 struct {
+	JoinEUI,
+	DevEUI types.EUI64
+	VendorID             [2]byte
+	ModelID              [2]byte
+	DeviceValidationCode []byte
+	SerialNumber,
+	Proprietary string
+}
+
+// validTR005ExtensionChars defines the QR code alphanumeric character set except :, % and space.
+const validTR005ExtensionChars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ$*+-./"
+
+func (m LoRaAllianceTR005Draft2) validateExtensionChars(s string) error {
+	for _, r := range s {
+		if strings.IndexRune(validTR005ExtensionChars, r) == -1 {
+			return errCharacter.WithAttributes("r", r)
+		}
+	}
+	return nil
+}
+
+// Validate implements the Data interface.
+func (m LoRaAllianceTR005Draft2) Validate() error {
+	for _, err := range []error{
+		m.validateExtensionChars(m.SerialNumber),
+		m.validateExtensionChars(m.Proprietary),
+	} {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MarshalText implements the TextMarshaler interface.
+func (m LoRaAllianceTR005Draft2) MarshalText() ([]byte, error) {
+	if err := m.Validate(); err != nil {
+		return nil, err
+	}
+	var ext string
+	if len(m.DeviceValidationCode) > 0 {
+		ext += fmt.Sprintf("%%V%X", m.DeviceValidationCode[:])
+	}
+	if m.SerialNumber != "" {
+		ext += fmt.Sprintf("%%S%s", m.SerialNumber)
+	}
+	if m.Proprietary != "" {
+		ext += fmt.Sprintf("%%P%s", m.Proprietary)
+	}
+	if ext != "" {
+		ext = ":" + ext
+	}
+	return []byte(fmt.Sprintf("URN:LW:DP:%X:%X:%X%X%s", m.JoinEUI[:], m.DevEUI[:], m.VendorID[:], m.ModelID[:], ext)), nil
+}
+
+// UnmarshalText implements the TextUnmarshaler interface.
+func (m *LoRaAllianceTR005Draft2) UnmarshalText(text []byte) error {
+	parts := bytes.SplitN(text, []byte(":"), 7)
+	if len(parts) < 6 ||
+		!bytes.Equal(parts[0], []byte("URN")) ||
+		!bytes.Equal(parts[1], []byte("LW")) ||
+		!bytes.Equal(parts[2], []byte("DP")) {
+		return errFormat
+	}
+	*m = LoRaAllianceTR005Draft2{}
+	if err := m.JoinEUI.UnmarshalText(parts[3]); err != nil {
+		return err
+	}
+	if err := m.DevEUI.UnmarshalText(parts[4]); err != nil {
+		return err
+	}
+	prodID := make([]byte, hex.DecodedLen(len(parts[5])))
+	if n, err := hex.Decode(prodID, parts[5]); err == nil && n == 4 {
+		copy(m.VendorID[:], prodID[:2])
+		copy(m.ModelID[:], prodID[2:])
+	} else if n != 4 {
+		return errFormat
+	} else {
+		return err
+	}
+	if len(parts) == 7 {
+		for _, ext := range strings.Split(string(parts[6]), "%") {
+			if len(ext) < 1 {
+				continue
+			}
+			val := ext[1:]
+			switch ext[0] {
+			case 'V':
+				if buf, err := hex.DecodeString(val); err == nil {
+					m.DeviceValidationCode = buf
+				} else {
+					return errFormat.WithCause(err)
+				}
+			case 'S':
+				m.SerialNumber = val
+			case 'P':
+				m.Proprietary = val
+			}
+		}
+	}
+	return m.Validate()
+}
+
+// AuthenticatedEndDeviceIdentifiers implements the AuthenticatedEndDeviceIdentifiers interface.
+func (m *LoRaAllianceTR005Draft2) AuthenticatedEndDeviceIdentifiers() (joinEUI, devEUI types.EUI64, authenticationCode []byte) {
+	return m.JoinEUI, m.DevEUI, m.DeviceValidationCode
+}

--- a/pkg/qrcode/lora_alliance_tr005_test.go
+++ b/pkg/qrcode/lora_alliance_tr005_test.go
@@ -1,0 +1,128 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package qrcode_test
+
+import (
+	"testing"
+
+	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/pkg/errors"
+	. "go.thethings.network/lorawan-stack/pkg/qrcode"
+	"go.thethings.network/lorawan-stack/pkg/types"
+	"go.thethings.network/lorawan-stack/pkg/util/test"
+	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
+)
+
+func TestLoRaAllianceTR005Draft2(t *testing.T) {
+	for _, tc := range []struct {
+		Name           string
+		Data           []byte
+		CanonicalData  []byte
+		Expected       LoRaAllianceTR005Draft2
+		ErrorAssertion func(t *testing.T, err error) bool
+	}{
+		{
+			Name: "Simple",
+			Data: []byte("URN:LW:DP:42FFFFFFFFFFFFFF:4242FFFFFFFFFFFF:42FFFF42"),
+			Expected: LoRaAllianceTR005Draft2{
+				JoinEUI:  types.EUI64{0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+				DevEUI:   types.EUI64{0x42, 0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+				VendorID: [2]byte{0x42, 0xff},
+				ModelID:  [2]byte{0xff, 0x42},
+			},
+		},
+		{
+			Name: "Extensions",
+			Data: []byte("URN:LW:DP:42FFFFFFFFFFFFFF:4242FFFFFFFFFFFF:42FFFF42:%V0102%SSERIAL%PPROPRIETARY"),
+			Expected: LoRaAllianceTR005Draft2{
+				JoinEUI:              types.EUI64{0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+				DevEUI:               types.EUI64{0x42, 0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+				VendorID:             [2]byte{0x42, 0xff},
+				ModelID:              [2]byte{0xff, 0x42},
+				DeviceValidationCode: []byte{0x01, 0x02},
+				SerialNumber:         "SERIAL",
+				Proprietary:          "PROPRIETARY",
+			},
+		},
+		{
+			Name:          "EmptyExtensions",
+			Data:          []byte("URN:LW:DP:42FFFFFFFFFFFFFF:4242FFFFFFFFFFFF:42FFFF42:%V%S%P"),
+			CanonicalData: []byte("URN:LW:DP:42FFFFFFFFFFFFFF:4242FFFFFFFFFFFF:42FFFF42"),
+			Expected: LoRaAllianceTR005Draft2{
+				JoinEUI:              types.EUI64{0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+				DevEUI:               types.EUI64{0x42, 0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+				VendorID:             [2]byte{0x42, 0xff},
+				ModelID:              [2]byte{0xff, 0x42},
+				DeviceValidationCode: []byte{},
+			},
+		},
+		{
+			Name: "Invalid/Type",
+			Data: []byte{0x42, 0xff, 0x42, 0x42},
+			ErrorAssertion: func(t *testing.T, err error) bool {
+				return assertions.New(t).So(errors.IsInvalidArgument(err), should.BeTrue)
+			},
+		},
+		{
+			Name: "Invalid/EUI",
+			Data: []byte("URN:LW:DP:42FFFFFFFF:4242FFFFFFFFFFFF:42FFFF42"),
+			ErrorAssertion: func(t *testing.T, err error) bool {
+				return assertions.New(t).So(errors.IsInvalidArgument(err), should.BeTrue)
+			},
+		},
+		{
+			Name: "Invalid/ProdID",
+			Data: []byte("URN:LW:DP:42FFFFFFFFFFFFFF:4242FFFFFFFFFFFF:42FFFF42AABB"),
+			ErrorAssertion: func(t *testing.T, err error) bool {
+				return assertions.New(t).So(errors.IsInvalidArgument(err), should.BeTrue)
+			},
+		},
+		{
+			Name: "Invalid/DevVCode",
+			Data: []byte("URN:LW:DP:42FFFFFFFFFFFFFF:4242FFFFFFFFFFFF:42FFFF42:%VGHIJKLMN"),
+			ErrorAssertion: func(t *testing.T, err error) bool {
+				return assertions.New(t).So(errors.IsInvalidArgument(err), should.BeTrue)
+			},
+		},
+		{
+			Name: "Invalid/ExtensionChars",
+			Data: []byte("URN:LW:DP:42FFFFFFFFFFFFFF:4242FFFFFFFFFFFF:42FFFF42:%P#_"),
+			ErrorAssertion: func(t *testing.T, err error) bool {
+				return assertions.New(t).So(errors.IsInvalidArgument(err), should.BeTrue)
+			},
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			a := assertions.New(t)
+
+			var data LoRaAllianceTR005Draft2
+			err := data.UnmarshalText(tc.Data)
+			if tc.ErrorAssertion != nil && a.So(tc.ErrorAssertion(t, err), should.BeTrue) {
+				return
+			}
+			if !a.So(err, should.BeNil) || !a.So(data, should.Resemble, tc.Expected) {
+				t.FailNow()
+			}
+
+			canonical := tc.CanonicalData
+			if canonical == nil {
+				canonical = tc.Data
+			}
+
+			text := test.Must(data.MarshalText()).([]byte)
+			a.So(string(text), should.Equal, string(canonical))
+		})
+	}
+}

--- a/pkg/qrcode/qrcode.go
+++ b/pkg/qrcode/qrcode.go
@@ -1,0 +1,52 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package qrcode implements working with QR codes.
+package qrcode
+
+import (
+	"encoding"
+
+	"go.thethings.network/lorawan-stack/pkg/errors"
+	"go.thethings.network/lorawan-stack/pkg/types"
+)
+
+// Data represents QR code data.
+type Data interface {
+	Validate() error
+	encoding.TextMarshaler
+	encoding.TextUnmarshaler
+}
+
+// AuthenticatedEndDeviceIdentifiers defines end device identifiers with authentication code.
+type AuthenticatedEndDeviceIdentifiers interface {
+	AuthenticatedEndDeviceIdentifiers() (joinEUI, devEUI types.EUI64, authenticationCode []byte)
+}
+
+var (
+	errFormat    = errors.DefineInvalidArgument("format", "invalid format")
+	errCharacter = errors.DefineInvalidArgument("character", "invalid character `{r}`")
+)
+
+// Parse attempts to parse the given QR code data.
+func Parse(data []byte) (Data, error) {
+	for _, model := range [...]Data{
+		&LoRaAllianceTR005Draft2{},
+	} {
+		if err := model.UnmarshalText(data); err == nil {
+			return model, nil
+		}
+	}
+	return nil, errFormat
+}

--- a/pkg/qrcode/qrcode_test.go
+++ b/pkg/qrcode/qrcode_test.go
@@ -1,0 +1,57 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package qrcode_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/smartystreets/assertions"
+	. "go.thethings.network/lorawan-stack/pkg/qrcode"
+	"go.thethings.network/lorawan-stack/pkg/types"
+	"go.thethings.network/lorawan-stack/pkg/util/test"
+	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
+)
+
+func TestParseEndDeviceAuthenticationCodes(t *testing.T) {
+	for i, tc := range []struct {
+		Data []byte
+		ExpectedJoinEUI,
+		ExpectedDevEUI types.EUI64
+		ExpectedAuthenticationCode []byte
+	}{
+		{
+			Data:                       []byte("URN:LW:DP:42FFFFFFFFFFFFFF:4242FFFFFFFFFFFF:42FFFF42:%V0102"),
+			ExpectedJoinEUI:            types.EUI64{0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+			ExpectedDevEUI:             types.EUI64{0x42, 0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+			ExpectedAuthenticationCode: []byte{0x01, 0x02},
+		},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			a := assertions.New(t)
+
+			data := test.Must(Parse(tc.Data)).(Data)
+			intf, ok := data.(AuthenticatedEndDeviceIdentifiers)
+			if !ok {
+				t.Fatalf("Expected %T to implement AuthenticatedEndDeviceIdentifiers", data)
+			}
+
+			joinEUI, devEUI, authCode := intf.AuthenticatedEndDeviceIdentifiers()
+			a.So(joinEUI, should.Resemble, tc.ExpectedJoinEUI)
+			a.So(devEUI, should.Resemble, tc.ExpectedDevEUI)
+			a.So(authCode, should.Resemble, tc.ExpectedAuthenticationCode)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Needed for https://github.com/TheThingsIndustries/lorawan-stack/issues/1673

#### Changes
<!-- What are the changes made in this pull request? -->

- Implement basic QR code plumbing and interfaces
- Implement TR005 Draft 2

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

TR005 is expected to come out of draft during India AMM. We don't have a compatibility commitment on exposed struct names and `Parse()` returns QR-code-independent interfaces, but we could keep this implementation with a type alias if it doesn't change. Still using `Draft2` gives enough human friendly warnings in the future if the TR becomes stale.

TR005 Draft 2 is LoRa Alliance confidential so please search document in workspace.