### PR TITLE
Check if peers are available before using them

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -2177,6 +2177,15 @@
       "file": "errors.go"
     }
   },
+  "error:pkg/basicstation/cups:access_unavailable": {
+    "translations": {
+      "en": "Access unavailable for gateway_id `{gateway_id}`"
+    },
+    "description": {
+      "package": "pkg/basicstation/cups",
+      "file": "server.go"
+    }
+  },
   "error:pkg/basicstation/cups:cups_not_enabled": {
     "translations": {
       "en": "CUPS is not enabled for gateway `{gateway_uid}`"
@@ -2184,6 +2193,15 @@
     "description": {
       "package": "pkg/basicstation/cups",
       "file": "update_info.go"
+    }
+  },
+  "error:pkg/basicstation/cups:entity_registry_unavailable": {
+    "translations": {
+      "en": "Entity Registry unavailable for gateway_id `{gateway_id}`"
+    },
+    "description": {
+      "package": "pkg/basicstation/cups",
+      "file": "server.go"
     }
   },
   "error:pkg/basicstation/cups:field_length": {
@@ -2816,6 +2834,15 @@
       "file": "frequencyplans.go"
     }
   },
+  "error:pkg/gatewayconfigurationserver:entity_registry_unavailable": {
+    "translations": {
+      "en": "Entity Registry unavailable for gateway_id `{gateway_id}`"
+    },
+    "description": {
+      "package": "pkg/gatewayconfigurationserver",
+      "file": "gatewayconfigurationserver.go"
+    }
+  },
   "error:pkg/gatewayserver/io/basicstationlns/messages:data_rate": {
     "translations": {
       "en": "data rate not found"
@@ -3188,6 +3215,15 @@
   "error:pkg/gatewayserver:empty_identifiers": {
     "translations": {
       "en": "empty identifiers"
+    },
+    "description": {
+      "package": "pkg/gatewayserver",
+      "file": "gatewayserver.go"
+    }
+  },
+  "error:pkg/gatewayserver:entity_registry_unavailable": {
+    "translations": {
+      "en": "Entity Registry unavailable for gateway_id `{gateway_id}`"
     },
     "description": {
       "package": "pkg/gatewayserver",
@@ -5262,6 +5298,15 @@
     "description": {
       "package": "pkg/scripting/javascript",
       "file": "javascript.go"
+    }
+  },
+  "error:pkg/thethingsgateway/cups:entity_registry_unavailable": {
+    "translations": {
+      "en": "Entity Registry unavailable for gateway_id `{gateway_id}`"
+    },
+    "description": {
+      "package": "pkg/thethingsgateway/cups",
+      "file": "server.go"
     }
   },
   "error:pkg/thethingsgateway/cups:no_default_firmware_path": {

--- a/config/messages.json
+++ b/config/messages.json
@@ -2285,6 +2285,15 @@
       "file": "cluster.go"
     }
   },
+  "error:pkg/cluster:peer_unavailable": {
+    "translations": {
+      "en": "no peer with role {role} is available"
+    },
+    "description": {
+      "package": "pkg/cluster",
+      "file": "cluster.go"
+    }
+  },
   "error:pkg/component:listen_endpoint": {
     "translations": {
       "en": "could not listen on `{endpoint}` address"

--- a/config/messages.json
+++ b/config/messages.json
@@ -2177,15 +2177,6 @@
       "file": "errors.go"
     }
   },
-  "error:pkg/basicstation/cups:access_unavailable": {
-    "translations": {
-      "en": "Access unavailable"
-    },
-    "description": {
-      "package": "pkg/basicstation/cups",
-      "file": "server.go"
-    }
-  },
   "error:pkg/basicstation/cups:cups_not_enabled": {
     "translations": {
       "en": "CUPS is not enabled for gateway `{gateway_uid}`"
@@ -2193,15 +2184,6 @@
     "description": {
       "package": "pkg/basicstation/cups",
       "file": "update_info.go"
-    }
-  },
-  "error:pkg/basicstation/cups:entity_registry_unavailable": {
-    "translations": {
-      "en": "Entity Registry unavailable"
-    },
-    "description": {
-      "package": "pkg/basicstation/cups",
-      "file": "server.go"
     }
   },
   "error:pkg/basicstation/cups:field_length": {
@@ -2296,7 +2278,7 @@
   },
   "error:pkg/cluster:peer_unavailable": {
     "translations": {
-      "en": "no peer with role {role} is available"
+      "en": "{cluster_role} cluster peer unavailable"
     },
     "description": {
       "package": "pkg/cluster",
@@ -2852,15 +2834,6 @@
       "file": "frequencyplans.go"
     }
   },
-  "error:pkg/gatewayconfigurationserver:entity_registry_unavailable": {
-    "translations": {
-      "en": "Entity Registry unavailable"
-    },
-    "description": {
-      "package": "pkg/gatewayconfigurationserver",
-      "file": "gatewayconfigurationserver.go"
-    }
-  },
   "error:pkg/gatewayserver/io/basicstationlns/messages:data_rate": {
     "translations": {
       "en": "data rate not found"
@@ -3233,15 +3206,6 @@
   "error:pkg/gatewayserver:empty_identifiers": {
     "translations": {
       "en": "empty identifiers"
-    },
-    "description": {
-      "package": "pkg/gatewayserver",
-      "file": "gatewayserver.go"
-    }
-  },
-  "error:pkg/gatewayserver:entity_registry_unavailable": {
-    "translations": {
-      "en": "Entity Registry unavailable"
     },
     "description": {
       "package": "pkg/gatewayserver",
@@ -5316,15 +5280,6 @@
     "description": {
       "package": "pkg/scripting/javascript",
       "file": "javascript.go"
-    }
-  },
-  "error:pkg/thethingsgateway/cups:entity_registry_unavailable": {
-    "translations": {
-      "en": "Entity Registry unavailable"
-    },
-    "description": {
-      "package": "pkg/thethingsgateway/cups",
-      "file": "server.go"
     }
   },
   "error:pkg/thethingsgateway/cups:no_default_firmware_path": {

--- a/config/messages.json
+++ b/config/messages.json
@@ -2179,7 +2179,7 @@
   },
   "error:pkg/basicstation/cups:access_unavailable": {
     "translations": {
-      "en": "Access unavailable for gateway_id `{gateway_id}`"
+      "en": "Access unavailable for gateway `{gateway_uid}`"
     },
     "description": {
       "package": "pkg/basicstation/cups",
@@ -2197,7 +2197,7 @@
   },
   "error:pkg/basicstation/cups:entity_registry_unavailable": {
     "translations": {
-      "en": "Entity Registry unavailable for gateway_id `{gateway_id}`"
+      "en": "Entity Registry unavailable for gateway `{gateway_uid}`"
     },
     "description": {
       "package": "pkg/basicstation/cups",
@@ -2836,7 +2836,7 @@
   },
   "error:pkg/gatewayconfigurationserver:entity_registry_unavailable": {
     "translations": {
-      "en": "Entity Registry unavailable for gateway_id `{gateway_id}`"
+      "en": "Entity Registry unavailable for gateway `{gateway_uid}`"
     },
     "description": {
       "package": "pkg/gatewayconfigurationserver",
@@ -3223,7 +3223,7 @@
   },
   "error:pkg/gatewayserver:entity_registry_unavailable": {
     "translations": {
-      "en": "Entity Registry unavailable for gateway_id `{gateway_id}`"
+      "en": "Entity Registry unavailable for gateway `{gateway_uid}`"
     },
     "description": {
       "package": "pkg/gatewayserver",
@@ -5302,7 +5302,7 @@
   },
   "error:pkg/thethingsgateway/cups:entity_registry_unavailable": {
     "translations": {
-      "en": "Entity Registry unavailable for gateway_id `{gateway_id}`"
+      "en": "Entity Registry unavailable for gateway `{gateway_uid}`"
     },
     "description": {
       "package": "pkg/thethingsgateway/cups",

--- a/config/messages.json
+++ b/config/messages.json
@@ -2179,7 +2179,7 @@
   },
   "error:pkg/basicstation/cups:access_unavailable": {
     "translations": {
-      "en": "Access unavailable for gateway `{gateway_uid}`"
+      "en": "Access unavailable"
     },
     "description": {
       "package": "pkg/basicstation/cups",
@@ -2197,7 +2197,7 @@
   },
   "error:pkg/basicstation/cups:entity_registry_unavailable": {
     "translations": {
-      "en": "Entity Registry unavailable for gateway `{gateway_uid}`"
+      "en": "Entity Registry unavailable"
     },
     "description": {
       "package": "pkg/basicstation/cups",
@@ -2279,6 +2279,15 @@
   "error:pkg/cluster:peer_connection": {
     "translations": {
       "en": "connection to peer `{name}` on `{address}` failed"
+    },
+    "description": {
+      "package": "pkg/cluster",
+      "file": "cluster.go"
+    }
+  },
+  "error:pkg/cluster:peer_empty_target": {
+    "translations": {
+      "en": "peer target address is empty"
     },
     "description": {
       "package": "pkg/cluster",
@@ -2845,7 +2854,7 @@
   },
   "error:pkg/gatewayconfigurationserver:entity_registry_unavailable": {
     "translations": {
-      "en": "Entity Registry unavailable for gateway `{gateway_uid}`"
+      "en": "Entity Registry unavailable"
     },
     "description": {
       "package": "pkg/gatewayconfigurationserver",
@@ -3232,7 +3241,7 @@
   },
   "error:pkg/gatewayserver:entity_registry_unavailable": {
     "translations": {
-      "en": "Entity Registry unavailable for gateway `{gateway_uid}`"
+      "en": "Entity Registry unavailable"
     },
     "description": {
       "package": "pkg/gatewayserver",
@@ -5311,7 +5320,7 @@
   },
   "error:pkg/thethingsgateway/cups:entity_registry_unavailable": {
     "translations": {
-      "en": "Entity Registry unavailable for gateway `{gateway_uid}`"
+      "en": "Entity Registry unavailable"
     },
     "description": {
       "package": "pkg/thethingsgateway/cups",

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -432,7 +432,7 @@ func (as *ApplicationServer) fetchAppSKey(ctx context.Context, ids ttnpb.EndDevi
 		SessionKeyID: sessionKeyID,
 		DevEUI:       *ids.DevEUI,
 	}
-	if js, _ := as.GetPeer(ctx, ttnpb.ClusterRole_JOIN_SERVER, ids); js != nil {
+	if js, err := as.GetPeer(ctx, ttnpb.ClusterRole_JOIN_SERVER, ids); err == nil {
 		cc, err := js.Conn()
 		if err != nil {
 			return ttnpb.KeyEnvelope{}, err

--- a/pkg/applicationserver/io/grpc/grpc_util_test.go
+++ b/pkg/applicationserver/io/grpc/grpc_util_test.go
@@ -50,7 +50,7 @@ func (m *mockRegisterer) RegisterHandlers(s *runtime.ServeMux, conn *grpc.Client
 func mustHavePeer(ctx context.Context, c *component.Component, role ttnpb.ClusterRole) {
 	for i := 0; i < 20; i++ {
 		time.Sleep(20 * time.Millisecond)
-		if peer := c.GetPeer(ctx, role, nil); peer != nil {
+		if _, err := c.GetPeer(ctx, role, nil); err == nil {
 			return
 		}
 	}

--- a/pkg/applicationserver/io/mqtt/mqtt_util_test.go
+++ b/pkg/applicationserver/io/mqtt/mqtt_util_test.go
@@ -31,7 +31,7 @@ import (
 func mustHavePeer(ctx context.Context, c *component.Component, role ttnpb.ClusterRole) {
 	for i := 0; i < 20; i++ {
 		time.Sleep(20 * time.Millisecond)
-		if peer := c.GetPeer(ctx, role, nil); peer != nil {
+		if _, err := c.GetPeer(ctx, role, nil); err == nil {
 			return
 		}
 	}

--- a/pkg/applicationserver/io/pubsub/util_test.go
+++ b/pkg/applicationserver/io/pubsub/util_test.go
@@ -80,7 +80,7 @@ func (m *mockRegisterer) RegisterHandlers(s *runtime.ServeMux, conn *grpc.Client
 func mustHavePeer(ctx context.Context, c *component.Component, role ttnpb.ClusterRole) {
 	for i := 0; i < 20; i++ {
 		time.Sleep(20 * time.Millisecond)
-		if peer := c.GetPeer(ctx, role, nil); peer != nil {
+		if _, err := c.GetPeer(ctx, role, nil); err == nil {
 			return
 		}
 	}

--- a/pkg/applicationserver/io/web/util_test.go
+++ b/pkg/applicationserver/io/web/util_test.go
@@ -77,7 +77,7 @@ func (m *mockRegisterer) RegisterHandlers(s *runtime.ServeMux, conn *grpc.Client
 func mustHavePeer(ctx context.Context, c *component.Component, role ttnpb.ClusterRole) {
 	for i := 0; i < 20; i++ {
 		time.Sleep(20 * time.Millisecond)
-		if peer := c.GetPeer(ctx, role, nil); peer != nil {
+		if _, err := c.GetPeer(ctx, role, nil); err == nil {
 			return
 		}
 	}

--- a/pkg/applicationserver/linking.go
+++ b/pkg/applicationserver/linking.go
@@ -129,7 +129,11 @@ func (as *ApplicationServer) connectLink(ctx context.Context, link *link) error 
 		if err != nil {
 			return errNSPeerNotFound.WithCause(err).WithAttributes("application_uid", unique.ID(ctx, link.ApplicationIdentifiers))
 		}
-		link.conn = ns.Conn()
+		cc, err := ns.Conn()
+		if err != nil {
+			return errNSPeerNotFound.WithCause(err).WithAttributes("application_uid", unique.ID(ctx, link.ApplicationIdentifiers))
+		}
+		link.conn = cc
 		link.connName = ns.Name()
 	}
 	link.callOpts = []grpc.CallOption{

--- a/pkg/applicationserver/linking.go
+++ b/pkg/applicationserver/linking.go
@@ -102,8 +102,8 @@ type link struct {
 const linkBufferSize = 10
 
 var (
-	errAlreadyLinked = errors.DefineAlreadyExists("already_linked", "already linked to `{application_uid}`")
-	errNSNotFound    = errors.DefineNotFound("network_server_not_found", "Network Server not found for `{application_uid}`")
+	errAlreadyLinked  = errors.DefineAlreadyExists("already_linked", "already linked to `{application_uid}`")
+	errNSPeerNotFound = errors.DefineNotFound("network_server_not_found", "Network Server not found for `{application_uid}`")
 )
 
 func (as *ApplicationServer) connectLink(ctx context.Context, link *link) error {
@@ -125,9 +125,9 @@ func (as *ApplicationServer) connectLink(ctx context.Context, link *link) error 
 		}()
 	} else {
 		allowInsecure = !as.ClusterTLS()
-		ns := as.GetPeer(ctx, ttnpb.ClusterRole_NETWORK_SERVER, link.ApplicationIdentifiers)
-		if ns == nil {
-			return errNSNotFound.WithAttributes("application_uid", unique.ID(ctx, link.ApplicationIdentifiers))
+		ns, err := as.GetPeer(ctx, ttnpb.ClusterRole_NETWORK_SERVER, link.ApplicationIdentifiers)
+		if err != nil {
+			return errNSPeerNotFound.WithCause(err).WithAttributes("application_uid", unique.ID(ctx, link.ApplicationIdentifiers))
 		}
 		link.conn = ns.Conn()
 		link.connName = ns.Name()

--- a/pkg/applicationserver/util_test.go
+++ b/pkg/applicationserver/util_test.go
@@ -35,7 +35,7 @@ import (
 func mustHavePeer(ctx context.Context, c *component.Component, role ttnpb.ClusterRole) {
 	for i := 0; i < 20; i++ {
 		time.Sleep(20 * time.Millisecond)
-		if peer := c.GetPeer(ctx, role, nil); peer != nil {
+		if _, err := c.GetPeer(ctx, role, nil); err == nil {
 			return
 		}
 	}

--- a/pkg/basicstation/cups/server.go
+++ b/pkg/basicstation/cups/server.go
@@ -106,36 +106,24 @@ func (s *Server) getAuth(ctx context.Context, eui types.EUI64, auth string) grpc
 	return s.component.WithClusterAuth()
 }
 
-var errERPeerUnavailable = errors.DefineUnavailable("entity_registry_unavailable", "Entity Registry unavailable")
-
 func (s *Server) getRegistry(ctx context.Context, ids *ttnpb.GatewayIdentifiers) (ttnpb.GatewayRegistryClient, error) {
 	if s.registry != nil {
 		return s.registry, nil
 	}
-	peer, err := s.component.GetPeer(ctx, ttnpb.ClusterRole_ENTITY_REGISTRY, ids)
+	cc, err := s.component.GetPeerConn(ctx, ttnpb.ClusterRole_ENTITY_REGISTRY, ids)
 	if err != nil {
-		return nil, errERPeerUnavailable.WithCause(err)
-	}
-	cc, err := peer.Conn()
-	if err != nil {
-		return nil, errERPeerUnavailable.WithCause(err)
+		return nil, err
 	}
 	return ttnpb.NewGatewayRegistryClient(cc), nil
 }
-
-var errAccessPeerUnavailable = errors.DefineUnavailable("access_unavailable", "Access unavailable")
 
 func (s *Server) getAccess(ctx context.Context, ids *ttnpb.GatewayIdentifiers) (ttnpb.GatewayAccessClient, error) {
 	if s.access != nil {
 		return s.access, nil
 	}
-	peer, err := s.component.GetPeer(ctx, ttnpb.ClusterRole_ACCESS, ids)
+	cc, err := s.component.GetPeerConn(ctx, ttnpb.ClusterRole_ACCESS, ids)
 	if err != nil {
-		return nil, errAccessPeerUnavailable.WithCause(err)
-	}
-	cc, err := peer.Conn()
-	if err != nil {
-		return nil, errAccessPeerUnavailable.WithCause(err)
+		return nil, err
 	}
 	return ttnpb.NewGatewayAccessClient(cc), nil
 }

--- a/pkg/basicstation/cups/server.go
+++ b/pkg/basicstation/cups/server.go
@@ -113,13 +113,14 @@ func (s *Server) getRegistry(ctx context.Context, ids *ttnpb.GatewayIdentifiers)
 	if s.registry != nil {
 		return s.registry, nil
 	}
-	if peer := s.component.GetPeer(ctx, ttnpb.ClusterRole_ENTITY_REGISTRY, ids); peer != nil {
-		return ttnpb.NewGatewayRegistryClient(peer.Conn()), nil
+	peer, err := s.component.GetPeer(ctx, ttnpb.ClusterRole_ENTITY_REGISTRY, ids)
+	if err != nil {
+		if ids != nil {
+			return nil, errERPeerUnavailable.WithCause(err).WithAttributes("gateway_uid", unique.ID(ctx, ids))
+		}
+		return nil, errERPeerUnavailable.WithCause(err)
 	}
-	if ids != nil {
-		return nil, errERPeerUnavailable.WithAttributes("gateway_uid", unique.ID(ctx, ids))
-	}
-	return nil, errERPeerUnavailable
+	return ttnpb.NewGatewayRegistryClient(peer.Conn()), nil
 }
 
 var errAccessPeerUnavailable = errors.DefineUnavailable("access_unavailable", "Access unavailable for gateway `{gateway_uid}`")
@@ -128,13 +129,14 @@ func (s *Server) getAccess(ctx context.Context, ids *ttnpb.GatewayIdentifiers) (
 	if s.access != nil {
 		return s.access, nil
 	}
-	if peer := s.component.GetPeer(ctx, ttnpb.ClusterRole_ACCESS, ids); peer != nil {
-		return ttnpb.NewGatewayAccessClient(peer.Conn()), nil
+	peer, err := s.component.GetPeer(ctx, ttnpb.ClusterRole_ACCESS, ids)
+	if err != nil {
+		if ids != nil {
+			return nil, errAccessPeerUnavailable.WithCause(err).WithAttributes("gateway_uid", unique.ID(ctx, ids))
+		}
+		return nil, errAccessPeerUnavailable.WithCause(err)
 	}
-	if ids != nil {
-		return nil, errAccessPeerUnavailable.WithAttributes("gateway_uid", unique.ID(ctx, ids))
-	}
-	return nil, errAccessPeerUnavailable
+	return ttnpb.NewGatewayAccessClient(peer.Conn()), nil
 }
 
 // Option configures the CUPSServer.

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -105,10 +105,12 @@ func TestCluster(t *testing.T) {
 
 	a.So(c.Leave(), should.BeNil)
 
-	a.So(ac.Conn().GetState(), should.Equal, connectivity.Shutdown)
-	a.So(er.Conn().GetState(), should.Equal, connectivity.Shutdown)
-	a.So(gs.Conn().GetState(), should.Equal, connectivity.Shutdown)
-	a.So(ns.Conn().GetState(), should.Equal, connectivity.Shutdown)
-	a.So(as.Conn().GetState(), should.Equal, connectivity.Shutdown)
-	a.So(js.Conn().GetState(), should.Equal, connectivity.Shutdown)
+	for _, peer := range []Peer{
+		ac, er, gs, ns, as, js,
+	} {
+		cc, err := peer.Conn()
+		a.So(cc, should.NotBeNil)
+		a.So(err, should.BeNil)
+		a.So(cc.GetState(), should.Equal, connectivity.Shutdown)
+	}
 }

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -78,8 +78,8 @@ func TestCluster(t *testing.T) {
 	var ac Peer
 	for i := 0; i < 20; i++ {
 		time.Sleep(20 * time.Millisecond) // Wait for peers to join cluster.
-		ac = c.GetPeer(ctx, ttnpb.ClusterRole_ACCESS, nil)
-		if ac != nil {
+		ac, err = c.GetPeer(ctx, ttnpb.ClusterRole_ACCESS, nil)
+		if err == nil {
 			break
 		}
 	}
@@ -87,16 +87,21 @@ func TestCluster(t *testing.T) {
 		t.FailNow()
 	}
 
-	er := c.GetPeer(ctx, ttnpb.ClusterRole_ENTITY_REGISTRY, nil)
+	er, err := c.GetPeer(ctx, ttnpb.ClusterRole_ENTITY_REGISTRY, nil)
 	a.So(er, should.NotBeNil)
-	gs := c.GetPeer(ctx, ttnpb.ClusterRole_GATEWAY_SERVER, nil)
+	a.So(err, should.BeNil)
+	gs, err := c.GetPeer(ctx, ttnpb.ClusterRole_GATEWAY_SERVER, nil)
 	a.So(gs, should.NotBeNil)
-	ns := c.GetPeer(ctx, ttnpb.ClusterRole_NETWORK_SERVER, nil)
+	a.So(err, should.BeNil)
+	ns, err := c.GetPeer(ctx, ttnpb.ClusterRole_NETWORK_SERVER, nil)
 	a.So(ns, should.NotBeNil)
-	as := c.GetPeer(ctx, ttnpb.ClusterRole_APPLICATION_SERVER, nil)
+	a.So(err, should.BeNil)
+	as, err := c.GetPeer(ctx, ttnpb.ClusterRole_APPLICATION_SERVER, nil)
 	a.So(as, should.NotBeNil)
-	js := c.GetPeer(ctx, ttnpb.ClusterRole_JOIN_SERVER, nil)
+	a.So(err, should.BeNil)
+	js, err := c.GetPeer(ctx, ttnpb.ClusterRole_JOIN_SERVER, nil)
 	a.So(js, should.NotBeNil)
+	a.So(err, should.BeNil)
 
 	a.So(c.Leave(), should.BeNil)
 

--- a/pkg/cluster/peer.go
+++ b/pkg/cluster/peer.go
@@ -26,7 +26,7 @@ type Peer interface {
 	// Name of the peer
 	Name() string
 	// gRPC ClientConn to the peer (if available)
-	Conn() *grpc.ClientConn
+	Conn() (*grpc.ClientConn, error)
 	// Roles announced by the peer
 	Roles() []ttnpb.ClusterRole
 	// HasRole returns true iff the peer has the given role
@@ -42,15 +42,16 @@ type peer struct {
 
 	target string
 
-	ctx    context.Context
-	cancel context.CancelFunc
-	conn   *grpc.ClientConn
+	ctx     context.Context
+	cancel  context.CancelFunc
+	conn    *grpc.ClientConn
+	connErr error
 }
 
-func (p *peer) Name() string               { return p.name }
-func (p *peer) Conn() *grpc.ClientConn     { return p.conn }
-func (p *peer) Roles() []ttnpb.ClusterRole { return p.roles }
-func (p *peer) Tags() map[string]string    { return p.tags }
+func (p *peer) Name() string                    { return p.name }
+func (p *peer) Conn() (*grpc.ClientConn, error) { return p.conn, p.connErr }
+func (p *peer) Roles() []ttnpb.ClusterRole      { return p.roles }
+func (p *peer) Tags() map[string]string         { return p.tags }
 
 func (p *peer) HasRole(wanted ttnpb.ClusterRole) bool {
 	roles := p.Roles()

--- a/pkg/cluster/peer_internal_test.go
+++ b/pkg/cluster/peer_internal_test.go
@@ -38,5 +38,7 @@ func TestPeer(t *testing.T) {
 	a.So(p.HasRole(ttnpb.ClusterRole_APPLICATION_SERVER), should.BeFalse)
 	a.So(p.HasRole(ttnpb.ClusterRole_ACCESS), should.BeTrue)
 
-	a.So(p.Conn(), should.Equal, conn)
+	cc, err := p.Conn()
+	a.So(err, should.BeNil)
+	a.So(cc, should.Equal, conn)
 }

--- a/pkg/component/cluster.go
+++ b/pkg/component/cluster.go
@@ -43,13 +43,13 @@ func (c *Component) ClusterTLS() bool {
 
 // GetPeers returns cluster peers with the given role and the given tags.
 // See package ../cluster for more information.
-func (c *Component) GetPeers(ctx context.Context, role ttnpb.ClusterRole) []cluster.Peer {
+func (c *Component) GetPeers(ctx context.Context, role ttnpb.ClusterRole) ([]cluster.Peer, error) {
 	return c.cluster.GetPeers(ctx, role)
 }
 
 // GetPeer returns a cluster peer with the given role and the given tags.
 // See package ../cluster for more information.
-func (c *Component) GetPeer(ctx context.Context, role ttnpb.ClusterRole, ids ttnpb.Identifiers) cluster.Peer {
+func (c *Component) GetPeer(ctx context.Context, role ttnpb.ClusterRole, ids ttnpb.Identifiers) (cluster.Peer, error) {
 	return c.cluster.GetPeer(ctx, role, ids)
 }
 

--- a/pkg/component/cluster.go
+++ b/pkg/component/cluster.go
@@ -19,6 +19,7 @@ import (
 
 	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"google.golang.org/grpc"
 )
 
 func (c *Component) initCluster() (err error) {
@@ -51,6 +52,12 @@ func (c *Component) GetPeers(ctx context.Context, role ttnpb.ClusterRole) ([]clu
 // See package ../cluster for more information.
 func (c *Component) GetPeer(ctx context.Context, role ttnpb.ClusterRole, ids ttnpb.Identifiers) (cluster.Peer, error) {
 	return c.cluster.GetPeer(ctx, role, ids)
+}
+
+// GetPeerConn returns a gRPC client connection to the cluster peer.
+// See package ../cluster for more information.
+func (c *Component) GetPeerConn(ctx context.Context, role ttnpb.ClusterRole, ids ttnpb.Identifiers) (*grpc.ClientConn, error) {
+	return c.cluster.GetPeerConn(ctx, role, ids)
 }
 
 // ClaimIDs claims the identifiers in the cluster.

--- a/pkg/component/cluster_test.go
+++ b/pkg/component/cluster_test.go
@@ -72,8 +72,8 @@ func TestPeers(t *testing.T) {
 	var peer cluster.Peer
 	for i := 0; i < 20; i++ {
 		time.Sleep(20 * time.Millisecond) // Wait for peers to join cluster.
-		peer = c.GetPeer(context.Background(), ttnpb.ClusterRole_NETWORK_SERVER, nil)
-		if peer != nil {
+		peer, err = c.GetPeer(context.Background(), ttnpb.ClusterRole_NETWORK_SERVER, nil)
+		if err == nil {
 			break
 		}
 	}
@@ -86,15 +86,18 @@ func TestPeers(t *testing.T) {
 	a.So(conn, should.NotBeNil)
 
 	for _, role := range unusedRoles {
-		peer = c.GetPeer(context.Background(), role, nil)
+		peer, err := c.GetPeer(context.Background(), role, nil)
 		a.So(peer, should.BeNil)
+		a.So(err, should.NotBeNil)
 	}
 
-	peers := c.GetPeers(context.Background(), ttnpb.ClusterRole_NETWORK_SERVER)
+	peers, err := c.GetPeers(context.Background(), ttnpb.ClusterRole_NETWORK_SERVER)
 	a.So(peers, should.HaveLength, 1)
+	a.So(err, should.BeNil)
 
 	for _, role := range unusedRoles {
-		peers = c.GetPeers(context.Background(), role)
+		peers, err = c.GetPeers(context.Background(), role)
 		a.So(peers, should.HaveLength, 0)
+		a.So(err, should.BeNil)
 	}
 }

--- a/pkg/component/cluster_test.go
+++ b/pkg/component/cluster_test.go
@@ -82,7 +82,8 @@ func TestPeers(t *testing.T) {
 		t.FailNow()
 	}
 
-	conn := peer.Conn()
+	conn, err := peer.Conn()
+	a.So(err, should.BeNil)
 	a.So(conn, should.NotBeNil)
 
 	for _, role := range unusedRoles {

--- a/pkg/component/rights.go
+++ b/pkg/component/rights.go
@@ -24,8 +24,8 @@ import (
 
 func (c *Component) initRights() {
 	fetcher := rights.NewAccessFetcher(func(ctx context.Context) *grpc.ClientConn {
-		peer := c.GetPeer(ctx, ttnpb.ClusterRole_ACCESS, nil)
-		if peer == nil {
+		peer, err := c.GetPeer(ctx, ttnpb.ClusterRole_ACCESS, nil)
+		if err != nil {
 			return nil
 		}
 		return peer.Conn()

--- a/pkg/component/rights.go
+++ b/pkg/component/rights.go
@@ -24,11 +24,7 @@ import (
 
 func (c *Component) initRights() {
 	fetcher := rights.NewAccessFetcher(func(ctx context.Context) *grpc.ClientConn {
-		peer, err := c.GetPeer(ctx, ttnpb.ClusterRole_ACCESS, nil)
-		if err != nil {
-			return nil
-		}
-		conn, err := peer.Conn()
+		conn, err := c.GetPeerConn(ctx, ttnpb.ClusterRole_ACCESS, nil)
 		if err != nil {
 			return nil
 		}

--- a/pkg/component/rights.go
+++ b/pkg/component/rights.go
@@ -28,7 +28,11 @@ func (c *Component) initRights() {
 		if err != nil {
 			return nil
 		}
-		return peer.Conn()
+		conn, err := peer.Conn()
+		if err != nil {
+			return nil
+		}
+		return conn
 	}, c.config.GRPC.AllowInsecureForCredentials)
 
 	if c.config.Rights.TTL > 0 {

--- a/pkg/devicetemplateconverter/util_test.go
+++ b/pkg/devicetemplateconverter/util_test.go
@@ -26,7 +26,7 @@ import (
 func mustHavePeer(ctx context.Context, c *component.Component, role ttnpb.ClusterRole) {
 	for i := 0; i < 20; i++ {
 		time.Sleep(20 * time.Millisecond)
-		if peer := c.GetPeer(ctx, role, nil); peer != nil {
+		if _, err := c.GetPeer(ctx, role, nil); err == nil {
 			return
 		}
 	}

--- a/pkg/gatewayconfigurationserver/gatewayconfigurationserver.go
+++ b/pkg/gatewayconfigurationserver/gatewayconfigurationserver.go
@@ -84,9 +84,9 @@ var errERPeerUnavailable = errors.DefineUnavailable("entity_registry_unavailable
 func (gcs *GatewayConfigurationServer) handleGetGlobalConfig(c echo.Context) error {
 	ctx := gcs.getContext(c)
 	gtwID := c.Get(gatewayIDKey).(ttnpb.GatewayIdentifiers)
-	registry := gcs.GetPeer(ctx, ttnpb.ClusterRole_ENTITY_REGISTRY, nil)
-	if registry == nil {
-		return errERPeerUnavailable.WithAttributes("gateway_id", unique.ID(ctx, gtwID))
+	registry, err := gcs.GetPeer(ctx, ttnpb.ClusterRole_ENTITY_REGISTRY, nil)
+	if err != nil {
+		return errERPeerUnavailable.WithCause(err).WithAttributes("gateway_id", unique.ID(ctx, gtwID))
 	}
 	client := ttnpb.NewGatewayRegistryClient(registry.Conn())
 	gtw, err := client.Get(ctx, &ttnpb.GetGatewayRequest{

--- a/pkg/gatewayconfigurationserver/gatewayconfigurationserver.go
+++ b/pkg/gatewayconfigurationserver/gatewayconfigurationserver.go
@@ -22,7 +22,6 @@ import (
 	echo "github.com/labstack/echo/v4"
 	bscups "go.thethings.network/lorawan-stack/pkg/basicstation/cups"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/pfconfig/semtechudp"
 	ttgcups "go.thethings.network/lorawan-stack/pkg/thethingsgateway/cups"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
@@ -78,18 +77,12 @@ func New(c *component.Component, conf *Config) (*GatewayConfigurationServer, err
 	return gcs, nil
 }
 
-var errERPeerUnavailable = errors.DefineUnavailable("entity_registry_unavailable", "Entity Registry unavailable")
-
 func (gcs *GatewayConfigurationServer) handleGetGlobalConfig(c echo.Context) error {
 	ctx := gcs.getContext(c)
 	gtwID := c.Get(gatewayIDKey).(ttnpb.GatewayIdentifiers)
-	peer, err := gcs.GetPeer(ctx, ttnpb.ClusterRole_ENTITY_REGISTRY, nil)
+	cc, err := gcs.GetPeerConn(ctx, ttnpb.ClusterRole_ENTITY_REGISTRY, nil)
 	if err != nil {
-		return errERPeerUnavailable.WithCause(err)
-	}
-	cc, err := peer.Conn()
-	if err != nil {
-		return errERPeerUnavailable.WithCause(err)
+		return err
 	}
 	client := ttnpb.NewGatewayRegistryClient(cc)
 	gtw, err := client.Get(ctx, &ttnpb.GetGatewayRequest{

--- a/pkg/gatewayconfigurationserver/gatewayconfigurationserver_test.go
+++ b/pkg/gatewayconfigurationserver/gatewayconfigurationserver_test.go
@@ -156,7 +156,7 @@ func newContextWithRightsFetcher(ctx context.Context) context.Context {
 func mustHavePeer(ctx context.Context, c *component.Component, role ttnpb.ClusterRole) {
 	for i := 0; i < 20; i++ {
 		time.Sleep(20 * time.Millisecond)
-		if peer := c.GetPeer(ctx, role, nil); peer != nil {
+		if _, err := c.GetPeer(ctx, role, nil); err == nil {
 			return
 		}
 	}

--- a/pkg/gatewayserver/gatewayserver_util_test.go
+++ b/pkg/gatewayserver/gatewayserver_util_test.go
@@ -37,7 +37,7 @@ import (
 func mustHavePeer(ctx context.Context, c *component.Component, role ttnpb.ClusterRole) {
 	for i := 0; i < 20; i++ {
 		time.Sleep(20 * time.Millisecond)
-		if peer := c.GetPeer(ctx, role, nil); peer != nil {
+		if _, err := c.GetPeer(ctx, role, nil); err == nil {
 			return
 		}
 	}

--- a/pkg/gatewayserver/io/basicstationlns/basicstationlns_util_test.go
+++ b/pkg/gatewayserver/io/basicstationlns/basicstationlns_util_test.go
@@ -46,7 +46,7 @@ func newContextWithRightsFetcher(ctx context.Context) context.Context {
 func mustHavePeer(ctx context.Context, c *component.Component, role ttnpb.ClusterRole) {
 	for i := 0; i < 20; i++ {
 		time.Sleep(20 * time.Millisecond)
-		if peer := c.GetPeer(ctx, role, nil); peer != nil {
+		if _, err := c.GetPeer(ctx, role, nil); err == nil {
 			return
 		}
 	}

--- a/pkg/gatewayserver/io/grpc/grpc_util_test.go
+++ b/pkg/gatewayserver/io/grpc/grpc_util_test.go
@@ -43,7 +43,7 @@ func (m *mockRegisterer) RegisterHandlers(s *runtime.ServeMux, conn *grpc.Client
 func mustHavePeer(ctx context.Context, c *component.Component, role ttnpb.ClusterRole) {
 	for i := 0; i < 20; i++ {
 		time.Sleep(20 * time.Millisecond)
-		if peer := c.GetPeer(ctx, role, nil); peer != nil {
+		if _, err := c.GetPeer(ctx, role, nil); err == nil {
 			return
 		}
 	}

--- a/pkg/gatewayserver/io/mqtt/mqtt_util_test.go
+++ b/pkg/gatewayserver/io/mqtt/mqtt_util_test.go
@@ -25,7 +25,7 @@ import (
 func mustHavePeer(ctx context.Context, c *component.Component, role ttnpb.ClusterRole) {
 	for i := 0; i < 20; i++ {
 		time.Sleep(20 * time.Millisecond)
-		if peer := c.GetPeer(ctx, role, nil); peer != nil {
+		if _, err := c.GetPeer(ctx, role, nil); err == nil {
 			return
 		}
 	}

--- a/pkg/joinserver/grpc_deviceregistry.go
+++ b/pkg/joinserver/grpc_deviceregistry.go
@@ -72,7 +72,7 @@ func (srv jsEndDeviceRegistryServer) Get(ctx context.Context, req *ttnpb.GetEndD
 		dev.RootKeys = &ttnpb.RootKeys{
 			RootKeyID: rootKeysEnc.GetRootKeyID(),
 		}
-		cs := srv.JS.GetPeer(ctx, ttnpb.ClusterRole_CRYPTO_SERVER, dev.EndDeviceIdentifiers)
+		cs, _ := srv.JS.GetPeer(ctx, ttnpb.ClusterRole_CRYPTO_SERVER, dev.EndDeviceIdentifiers)
 		if ttnpb.HasAnyField(req.FieldMask.Paths, "root_keys.nwk_key") {
 			var networkCryptoService cryptoservices.Network
 			if rootKeysEnc.GetNwkKey() != nil {

--- a/pkg/joinserver/joinserver.go
+++ b/pkg/joinserver/joinserver.go
@@ -354,7 +354,7 @@ func (js *JoinServer) HandleJoin(ctx context.Context, req *ttnpb.JoinRequest) (r
 				return nil, nil, errGenerateSessionKeyID
 			}
 
-			cs := js.GetPeer(ctx, ttnpb.ClusterRole_CRYPTO_SERVER, dev.EndDeviceIdentifiers)
+			cs, _ := js.GetPeer(ctx, ttnpb.ClusterRole_CRYPTO_SERVER, dev.EndDeviceIdentifiers)
 
 			var networkCryptoService cryptoservices.Network
 			if req.SelectedMACVersion.Compare(ttnpb.MAC_V1_1) >= 0 && dev.RootKeys != nil && dev.RootKeys.NwkKey != nil {

--- a/pkg/joinserver/joinserver.go
+++ b/pkg/joinserver/joinserver.go
@@ -354,9 +354,12 @@ func (js *JoinServer) HandleJoin(ctx context.Context, req *ttnpb.JoinRequest) (r
 				return nil, nil, errGenerateSessionKeyID
 			}
 
-			var cc *grpc.ClientConn
-			if cs, _ := js.GetPeer(ctx, ttnpb.ClusterRole_CRYPTO_SERVER, dev.EndDeviceIdentifiers); cs != nil {
-				cc, _ = cs.Conn()
+			cc, err := js.GetPeerConn(ctx, ttnpb.ClusterRole_CRYPTO_SERVER, dev.EndDeviceIdentifiers)
+			if err != nil {
+				if !errors.IsNotFound(err) {
+					logger.WithError(err).Debug("Crypto Server connection is not available")
+				}
+				cc = nil
 			}
 
 			var networkCryptoService cryptoservices.Network

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -648,9 +648,9 @@ func (ns *NetworkServer) scheduleDownlinkByPaths(ctx context.Context, req *ttnpb
 			"gateway_uid", unique.ID(ctx, path.GatewayIdentifiers),
 		)
 
-		p := ns.GetPeer(ctx, ttnpb.ClusterRole_GATEWAY_SERVER, path.GatewayIdentifiers)
-		if p == nil {
-			logger.Debug("Could not get Gateway Server")
+		p, err := ns.GetPeer(ctx, ttnpb.ClusterRole_GATEWAY_SERVER, path.GatewayIdentifiers)
+		if err != nil {
+			logger.WithError(err).Debug("Could not get Gateway Server")
 			continue
 		}
 

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -679,7 +679,12 @@ func (ns *NetworkServer) scheduleDownlinkByPaths(ctx context.Context, req *ttnpb
 		}
 
 		logger.WithField("path_count", len(req.DownlinkPaths)).Debug("Schedule downlink")
-		res, err := ttnpb.NewNsGsClient(a.peer.Conn()).ScheduleDownlink(ctx, down, ns.WithClusterAuth())
+		cc, err := a.peer.Conn()
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		res, err := ttnpb.NewNsGsClient(cc).ScheduleDownlink(ctx, down, ns.WithClusterAuth())
 		if err != nil {
 			errs = append(errs, err)
 			continue

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -99,12 +99,12 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 		a := assertions.New(t)
 		return test.AssertClusterGetPeerRequestSequence(ctx, getPeerCh,
-			[]cluster.Peer{
-				nil,
-				peer124,
-				peer124,
-				peer3,
-				peer124,
+			[]test.ClusterGetPeerResponse{
+				{Peer: nil, Error: fmt.Errorf("peer not found")},
+				{Peer: peer124, Error: nil},
+				{Peer: peer124, Error: nil},
+				{Peer: peer3, Error: nil},
+				{Peer: peer124, Error: nil},
 			},
 			func(reqCtx context.Context, role ttnpb.ClusterRole, ids ttnpb.Identifiers) bool {
 				return a.So(reqCtx, should.HaveParentContextOrEqual, ctx) &&

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -100,11 +100,11 @@ func TestProcessDownlinkTask(t *testing.T) {
 		a := assertions.New(t)
 		return test.AssertClusterGetPeerRequestSequence(ctx, getPeerCh,
 			[]test.ClusterGetPeerResponse{
-				{Peer: nil, Error: fmt.Errorf("peer not found")},
-				{Peer: peer124, Error: nil},
-				{Peer: peer124, Error: nil},
-				{Peer: peer3, Error: nil},
-				{Peer: peer124, Error: nil},
+				{Error: errors.New("peer not found")},
+				{Peer: peer124},
+				{Peer: peer124},
+				{Peer: peer3},
+				{Peer: peer124},
 			},
 			func(reqCtx context.Context, role ttnpb.ClusterRole, ids ttnpb.Identifiers) bool {
 				return a.So(reqCtx, should.HaveParentContextOrEqual, ctx) &&

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -923,7 +923,8 @@ func (ns *NetworkServer) newDevAddr(context.Context, *ttnpb.EndDevice) types.Dev
 
 func (ns *NetworkServer) sendJoinRequest(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, req *ttnpb.JoinRequest) (*ttnpb.JoinResponse, error) {
 	logger := log.FromContext(ctx)
-	if js := ns.GetPeer(ctx, ttnpb.ClusterRole_JOIN_SERVER, ids); js != nil {
+	js, err := ns.GetPeer(ctx, ttnpb.ClusterRole_JOIN_SERVER, ids)
+	if err == nil {
 		resp, err := ttnpb.NewNsJsClient(js.Conn()).HandleJoin(ctx, req, ns.WithClusterAuth())
 		if err == nil {
 			logger.Debug("Join-request accepted by cluster-local Join Server")

--- a/pkg/networkserver/grpc_gsns_test.go
+++ b/pkg/networkserver/grpc_gsns_test.go
@@ -17,7 +17,6 @@ package networkserver_test
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"math/rand"
 	"sync"
 	"testing"
@@ -1019,10 +1018,7 @@ func TestHandleUplink(t *testing.T) {
 						a.So(role, should.Equal, ttnpb.ClusterRole_JOIN_SERVER) &&
 						a.So(ids, should.Resemble, getDevice.EndDeviceIdentifiers)
 				},
-					test.ClusterGetPeerResponse{
-						Peer:  nil,
-						Error: fmt.Errorf("peer not found"),
-					},
+					test.ClusterGetPeerResponse{Error: errors.New("peer not found")},
 				), should.BeTrue) {
 					return false
 				}
@@ -1132,10 +1128,7 @@ func TestHandleUplink(t *testing.T) {
 						a.So(role, should.Equal, ttnpb.ClusterRole_JOIN_SERVER) &&
 						a.So(ids, should.Resemble, getDevice.EndDeviceIdentifiers)
 				},
-					test.ClusterGetPeerResponse{
-						Peer:  nil,
-						Error: fmt.Errorf("peer not found"),
-					},
+					test.ClusterGetPeerResponse{Error: errors.New("peer not found")},
 				), should.BeTrue) {
 					return false
 				}
@@ -1251,10 +1244,7 @@ func TestHandleUplink(t *testing.T) {
 						a.So(role, should.Equal, ttnpb.ClusterRole_JOIN_SERVER) &&
 						a.So(ids, should.Resemble, getDevice.EndDeviceIdentifiers)
 				},
-					test.ClusterGetPeerResponse{
-						Peer:  nil,
-						Error: fmt.Errorf("peer not found"),
-					},
+					test.ClusterGetPeerResponse{Error: errors.New("peer not found")},
 				), should.BeTrue) {
 					return false
 				}

--- a/pkg/networkserver/grpc_gsns_test.go
+++ b/pkg/networkserver/grpc_gsns_test.go
@@ -17,6 +17,7 @@ package networkserver_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"math/rand"
 	"sync"
 	"testing"
@@ -1018,7 +1019,10 @@ func TestHandleUplink(t *testing.T) {
 						a.So(role, should.Equal, ttnpb.ClusterRole_JOIN_SERVER) &&
 						a.So(ids, should.Resemble, getDevice.EndDeviceIdentifiers)
 				},
-					nil,
+					test.ClusterGetPeerResponse{
+						Peer:  nil,
+						Error: fmt.Errorf("peer not found"),
+					},
 				), should.BeTrue) {
 					return false
 				}
@@ -1128,7 +1132,10 @@ func TestHandleUplink(t *testing.T) {
 						a.So(role, should.Equal, ttnpb.ClusterRole_JOIN_SERVER) &&
 						a.So(ids, should.Resemble, getDevice.EndDeviceIdentifiers)
 				},
-					nil,
+					test.ClusterGetPeerResponse{
+						Peer:  nil,
+						Error: fmt.Errorf("peer not found"),
+					},
 				), should.BeTrue) {
 					return false
 				}
@@ -1244,7 +1251,10 @@ func TestHandleUplink(t *testing.T) {
 						a.So(role, should.Equal, ttnpb.ClusterRole_JOIN_SERVER) &&
 						a.So(ids, should.Resemble, getDevice.EndDeviceIdentifiers)
 				},
-					nil,
+					test.ClusterGetPeerResponse{
+						Peer:  nil,
+						Error: fmt.Errorf("peer not found"),
+					},
 				), should.BeTrue) {
 					return false
 				}

--- a/pkg/networkserver/networkserver_flow_test.go
+++ b/pkg/networkserver/networkserver_flow_test.go
@@ -71,9 +71,12 @@ func AssertSetDevice(ctx context.Context, conn *grpc.ClientConn, getPeerCh <-cha
 		func(ctx context.Context, role ttnpb.ClusterRole, ids ttnpb.Identifiers) bool {
 			return a.So(role, should.Equal, ttnpb.ClusterRole_ACCESS) && a.So(ids, should.BeNil)
 		},
-		NewISPeer(ctx, &test.MockApplicationAccessServer{
-			ListRightsFunc: test.MakeApplicationAccessListRightsChFunc(listRightsCh),
-		}),
+		test.ClusterGetPeerResponse{
+			Peer: NewISPeer(ctx, &test.MockApplicationAccessServer{
+				ListRightsFunc: test.MakeApplicationAccessListRightsChFunc(listRightsCh),
+			}),
+			Error: nil,
+		},
 	), should.BeTrue) {
 		return nil, false
 	}
@@ -298,7 +301,10 @@ func handleOTAAClassA868FlowTest1_0_2(ctx context.Context, reg DeviceRegistry, t
 						DevEUI:                 &types.EUI64{0x42, 0x42, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 					})
 			},
-			jsPeer,
+			test.ClusterGetPeerResponse{
+				Peer:  jsPeer,
+				Error: nil,
+			},
 		), should.BeTrue) {
 			return
 		}
@@ -431,7 +437,10 @@ func handleOTAAClassA868FlowTest1_0_2(ctx context.Context, reg DeviceRegistry, t
 						GatewayID: "test-gtw-1",
 					})
 			},
-			gsPeer,
+			test.ClusterGetPeerResponse{
+				Peer:  gsPeer,
+				Error: nil,
+			},
 		), should.BeTrue) {
 			return
 		}
@@ -443,7 +452,10 @@ func handleOTAAClassA868FlowTest1_0_2(ctx context.Context, reg DeviceRegistry, t
 						GatewayID: "test-gtw-2",
 					})
 			},
-			gsPeer,
+			test.ClusterGetPeerResponse{
+				Peer:  gsPeer,
+				Error: nil,
+			},
 		), should.BeTrue) {
 			return
 		}
@@ -657,7 +669,10 @@ func handleOTAAClassA868FlowTest1_0_2(ctx context.Context, reg DeviceRegistry, t
 						GatewayID: "test-gtw-3",
 					})
 			},
-			gsPeer,
+			test.ClusterGetPeerResponse{
+				Peer:  gsPeer,
+				Error: nil,
+			},
 		), should.BeTrue)
 
 		a.So(test.AssertClusterGetPeerRequest(ctx, getPeerCh,
@@ -667,7 +682,10 @@ func handleOTAAClassA868FlowTest1_0_2(ctx context.Context, reg DeviceRegistry, t
 						GatewayID: "test-gtw-2",
 					})
 			},
-			gsPeer,
+			test.ClusterGetPeerResponse{
+				Peer:  gsPeer,
+				Error: nil,
+			},
 		), should.BeTrue)
 
 		a.So(AssertAuthNsGsScheduleDownlinkRequest(ctx, authCh, scheduleDownlinkCh,

--- a/pkg/networkserver/networkserver_flow_test.go
+++ b/pkg/networkserver/networkserver_flow_test.go
@@ -75,7 +75,6 @@ func AssertSetDevice(ctx context.Context, conn *grpc.ClientConn, getPeerCh <-cha
 			Peer: NewISPeer(ctx, &test.MockApplicationAccessServer{
 				ListRightsFunc: test.MakeApplicationAccessListRightsChFunc(listRightsCh),
 			}),
-			Error: nil,
 		},
 	), should.BeTrue) {
 		return nil, false
@@ -301,10 +300,7 @@ func handleOTAAClassA868FlowTest1_0_2(ctx context.Context, reg DeviceRegistry, t
 						DevEUI:                 &types.EUI64{0x42, 0x42, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 					})
 			},
-			test.ClusterGetPeerResponse{
-				Peer:  jsPeer,
-				Error: nil,
-			},
+			test.ClusterGetPeerResponse{Peer: jsPeer},
 		), should.BeTrue) {
 			return
 		}
@@ -437,10 +433,7 @@ func handleOTAAClassA868FlowTest1_0_2(ctx context.Context, reg DeviceRegistry, t
 						GatewayID: "test-gtw-1",
 					})
 			},
-			test.ClusterGetPeerResponse{
-				Peer:  gsPeer,
-				Error: nil,
-			},
+			test.ClusterGetPeerResponse{Peer: gsPeer},
 		), should.BeTrue) {
 			return
 		}
@@ -452,10 +445,7 @@ func handleOTAAClassA868FlowTest1_0_2(ctx context.Context, reg DeviceRegistry, t
 						GatewayID: "test-gtw-2",
 					})
 			},
-			test.ClusterGetPeerResponse{
-				Peer:  gsPeer,
-				Error: nil,
-			},
+			test.ClusterGetPeerResponse{Peer: gsPeer},
 		), should.BeTrue) {
 			return
 		}
@@ -669,10 +659,7 @@ func handleOTAAClassA868FlowTest1_0_2(ctx context.Context, reg DeviceRegistry, t
 						GatewayID: "test-gtw-3",
 					})
 			},
-			test.ClusterGetPeerResponse{
-				Peer:  gsPeer,
-				Error: nil,
-			},
+			test.ClusterGetPeerResponse{Peer: gsPeer},
 		), should.BeTrue)
 
 		a.So(test.AssertClusterGetPeerRequest(ctx, getPeerCh,
@@ -682,10 +669,7 @@ func handleOTAAClassA868FlowTest1_0_2(ctx context.Context, reg DeviceRegistry, t
 						GatewayID: "test-gtw-2",
 					})
 			},
-			test.ClusterGetPeerResponse{
-				Peer:  gsPeer,
-				Error: nil,
-			},
+			test.ClusterGetPeerResponse{Peer: gsPeer},
 		), should.BeTrue)
 
 		a.So(AssertAuthNsGsScheduleDownlinkRequest(ctx, authCh, scheduleDownlinkCh,

--- a/pkg/networkserver/networkserver_util_test.go
+++ b/pkg/networkserver/networkserver_util_test.go
@@ -869,9 +869,12 @@ func AssertNsJsPeerHandleAuthJoinRequest(ctx context.Context, peerReqCh <-chan t
 	if !test.AssertClusterGetPeerRequest(ctx, peerReqCh, func(ctx context.Context, role ttnpb.ClusterRole, ids ttnpb.Identifiers) bool {
 		return assertions.New(t).So(role, should.Equal, ttnpb.ClusterRole_JOIN_SERVER) && idsAssert(ctx, ids)
 	},
-		NewJSPeer(ctx, &MockNsJsServer{
-			HandleJoinFunc: MakeNsJsHandleJoinChFunc(joinReqCh),
-		}),
+		test.ClusterGetPeerResponse{
+			Peer: NewJSPeer(ctx, &MockNsJsServer{
+				HandleJoinFunc: MakeNsJsHandleJoinChFunc(joinReqCh),
+			}),
+			Error: nil,
+		},
 	) {
 		return false
 	}
@@ -941,9 +944,12 @@ func AssertLinkApplication(ctx context.Context, conn *grpc.ClientConn, getPeerCh
 		func(ctx context.Context, role ttnpb.ClusterRole, ids ttnpb.Identifiers) bool {
 			return a.So(role, should.Equal, ttnpb.ClusterRole_ACCESS) && a.So(ids, should.BeNil)
 		},
-		NewISPeer(ctx, &test.MockApplicationAccessServer{
-			ListRightsFunc: test.MakeApplicationAccessListRightsChFunc(listRightsCh),
-		}),
+		test.ClusterGetPeerResponse{
+			Peer: NewISPeer(ctx, &test.MockApplicationAccessServer{
+				ListRightsFunc: test.MakeApplicationAccessListRightsChFunc(listRightsCh),
+			}),
+			Error: nil,
+		},
 	), should.BeTrue) {
 		return nil, false
 	}

--- a/pkg/networkserver/networkserver_util_test.go
+++ b/pkg/networkserver/networkserver_util_test.go
@@ -873,7 +873,6 @@ func AssertNsJsPeerHandleAuthJoinRequest(ctx context.Context, peerReqCh <-chan t
 			Peer: NewJSPeer(ctx, &MockNsJsServer{
 				HandleJoinFunc: MakeNsJsHandleJoinChFunc(joinReqCh),
 			}),
-			Error: nil,
 		},
 	) {
 		return false
@@ -948,7 +947,6 @@ func AssertLinkApplication(ctx context.Context, conn *grpc.ClientConn, getPeerCh
 			Peer: NewISPeer(ctx, &test.MockApplicationAccessServer{
 				ListRightsFunc: test.MakeApplicationAccessListRightsChFunc(listRightsCh),
 			}),
-			Error: nil,
 		},
 	), should.BeTrue) {
 		return nil, false

--- a/pkg/thethingsgateway/cups/handlers.go
+++ b/pkg/thethingsgateway/cups/handlers.go
@@ -45,7 +45,11 @@ type gatewayInfoResponse struct {
 func (s *Server) handleGatewayInfo(c echo.Context) error {
 	ctx := s.getContext(c)
 	gatewayIDs := c.Get(gatewayIDKey).(ttnpb.GatewayIdentifiers)
-	if gateway, err := s.getRegistry(ctx, &gatewayIDs).Get(ctx, &ttnpb.GetGatewayRequest{
+	registry, err := s.getRegistry(ctx, &gatewayIDs)
+	if err != nil {
+		return err
+	}
+	if gateway, err := registry.Get(ctx, &ttnpb.GetGatewayRequest{
 		GatewayIdentifiers: gatewayIDs,
 		FieldMask: types.FieldMask{Paths: []string{
 			"frequency_plan_id",

--- a/pkg/thethingsgateway/cups/server.go
+++ b/pkg/thethingsgateway/cups/server.go
@@ -63,19 +63,13 @@ type Server struct {
 	config Config
 }
 
-var errERPeerUnavailable = errors.DefineUnavailable("entity_registry_unavailable", "Entity Registry unavailable")
-
 func (s *Server) getRegistry(ctx context.Context, ids *ttnpb.GatewayIdentifiers) (ttnpb.GatewayRegistryClient, error) {
 	if s.registry != nil {
 		return s.registry, nil
 	}
-	peer, err := s.component.GetPeer(ctx, ttnpb.ClusterRole_ENTITY_REGISTRY, ids)
+	cc, err := s.component.GetPeerConn(ctx, ttnpb.ClusterRole_ENTITY_REGISTRY, ids)
 	if err != nil {
-		return nil, errERPeerUnavailable.WithCause(err)
-	}
-	cc, err := peer.Conn()
-	if err != nil {
-		return nil, errERPeerUnavailable.WithCause(err)
+		return nil, err
 	}
 	return ttnpb.NewGatewayRegistryClient(cc), nil
 }

--- a/pkg/util/test/cluster.go
+++ b/pkg/util/test/cluster.go
@@ -27,7 +27,7 @@ import (
 // MockPeer is a mock cluster.Peer used for testing.
 type MockPeer struct {
 	NameFunc    func() string
-	ConnFunc    func() *grpc.ClientConn
+	ConnFunc    func() (*grpc.ClientConn, error)
 	HasRoleFunc func(ttnpb.ClusterRole) bool
 	RolesFunc   func() []ttnpb.ClusterRole
 	TagsFunc    func() map[string]string
@@ -42,7 +42,7 @@ func (m MockPeer) Name() string {
 }
 
 // Conn calls ConnFunc if set and panics otherwise.
-func (m MockPeer) Conn() *grpc.ClientConn {
+func (m MockPeer) Conn() (*grpc.ClientConn, error) {
 	if m.ConnFunc == nil {
 		panic("Conn called, but not set")
 	}
@@ -89,7 +89,7 @@ func NewGRPCServerPeer(ctx context.Context, srv interface{}, registrators ...int
 		return nil, err
 	}
 	return &MockPeer{
-		ConnFunc: func() *grpc.ClientConn { return conn },
+		ConnFunc: func() (*grpc.ClientConn, error) { return conn, nil },
 	}, nil
 }
 

--- a/pkg/util/test/cluster.go
+++ b/pkg/util/test/cluster.go
@@ -138,6 +138,15 @@ func (m MockCluster) GetPeer(ctx context.Context, role ttnpb.ClusterRole, ids tt
 	return m.GetPeerFunc(ctx, role, ids)
 }
 
+// GetPeerConn calls GetPeer and then Conn.
+func (m MockCluster) GetPeerConn(ctx context.Context, role ttnpb.ClusterRole, ids ttnpb.Identifiers) (*grpc.ClientConn, error) {
+	peer, err := m.GetPeer(ctx, role, ids)
+	if err != nil {
+		return nil, err
+	}
+	return peer.Conn()
+}
+
 // ClaimIDs calls ClaimIDsFunc if set and panics otherwise.
 func (m MockCluster) ClaimIDs(ctx context.Context, ids ttnpb.Identifiers) error {
 	if m.ClaimIDsFunc == nil {

--- a/pkg/util/test/cluster.go
+++ b/pkg/util/test/cluster.go
@@ -97,8 +97,8 @@ func NewGRPCServerPeer(ctx context.Context, srv interface{}, registrators ...int
 type MockCluster struct {
 	JoinFunc               func() error
 	LeaveFunc              func() error
-	GetPeersFunc           func(ctx context.Context, role ttnpb.ClusterRole) []cluster.Peer
-	GetPeerFunc            func(ctx context.Context, role ttnpb.ClusterRole, ids ttnpb.Identifiers) cluster.Peer
+	GetPeersFunc           func(ctx context.Context, role ttnpb.ClusterRole) ([]cluster.Peer, error)
+	GetPeerFunc            func(ctx context.Context, role ttnpb.ClusterRole, ids ttnpb.Identifiers) (cluster.Peer, error)
 	ClaimIDsFunc           func(ctx context.Context, ids ttnpb.Identifiers) error
 	UnclaimIDsFunc         func(ctx context.Context, ids ttnpb.Identifiers) error
 	TLSFunc                func() bool
@@ -123,7 +123,7 @@ func (m MockCluster) Leave() error {
 }
 
 // GetPeers calls GetPeersFunc if set and panics otherwise.
-func (m MockCluster) GetPeers(ctx context.Context, role ttnpb.ClusterRole) []cluster.Peer {
+func (m MockCluster) GetPeers(ctx context.Context, role ttnpb.ClusterRole) ([]cluster.Peer, error) {
 	if m.GetPeersFunc == nil {
 		panic("GetPeers called, but not set")
 	}
@@ -131,7 +131,7 @@ func (m MockCluster) GetPeers(ctx context.Context, role ttnpb.ClusterRole) []clu
 }
 
 // GetPeer calls GetPeerFunc if set and panics otherwise.
-func (m MockCluster) GetPeer(ctx context.Context, role ttnpb.ClusterRole, ids ttnpb.Identifiers) cluster.Peer {
+func (m MockCluster) GetPeer(ctx context.Context, role ttnpb.ClusterRole, ids ttnpb.Identifiers) (cluster.Peer, error) {
 	if m.GetPeerFunc == nil {
 		panic("GetPeer called, but not set")
 	}
@@ -192,23 +192,29 @@ func MakeClusterAuthChFunc(reqCh chan<- ClusterAuthRequest) func() grpc.CallOpti
 	}
 }
 
+type ClusterGetPeerResponse struct {
+	Peer  cluster.Peer
+	Error error
+}
+
 type ClusterGetPeerRequest struct {
 	Context     context.Context
 	Role        ttnpb.ClusterRole
 	Identifiers ttnpb.Identifiers
-	Response    chan<- cluster.Peer
+	Response    chan<- ClusterGetPeerResponse
 }
 
-func MakeClusterGetPeerChFunc(reqCh chan<- ClusterGetPeerRequest) func(context.Context, ttnpb.ClusterRole, ttnpb.Identifiers) cluster.Peer {
-	return func(ctx context.Context, role ttnpb.ClusterRole, ids ttnpb.Identifiers) cluster.Peer {
-		respCh := make(chan cluster.Peer)
+func MakeClusterGetPeerChFunc(reqCh chan<- ClusterGetPeerRequest) func(context.Context, ttnpb.ClusterRole, ttnpb.Identifiers) (cluster.Peer, error) {
+	return func(ctx context.Context, role ttnpb.ClusterRole, ids ttnpb.Identifiers) (cluster.Peer, error) {
+		respCh := make(chan ClusterGetPeerResponse)
 		reqCh <- ClusterGetPeerRequest{
 			Context:     ctx,
 			Role:        role,
 			Identifiers: ids,
 			Response:    respCh,
 		}
-		return <-respCh
+		resp := <-respCh
+		return resp.Peer, resp.Error
 	}
 }
 
@@ -249,7 +255,7 @@ func AssertClusterAuthRequest(ctx context.Context, reqCh <-chan ClusterAuthReque
 	}
 }
 
-func AssertClusterGetPeerRequest(ctx context.Context, reqCh <-chan ClusterGetPeerRequest, assert func(ctx context.Context, role ttnpb.ClusterRole, ids ttnpb.Identifiers) bool, resp cluster.Peer) bool {
+func AssertClusterGetPeerRequest(ctx context.Context, reqCh <-chan ClusterGetPeerRequest, assert func(ctx context.Context, role ttnpb.ClusterRole, ids ttnpb.Identifiers) bool, resp ClusterGetPeerResponse) bool {
 	t := MustTFromContext(ctx)
 	t.Helper()
 	select {
@@ -273,7 +279,7 @@ func AssertClusterGetPeerRequest(ctx context.Context, reqCh <-chan ClusterGetPee
 	}
 }
 
-func AssertClusterGetPeerRequestSequence(ctx context.Context, reqCh <-chan ClusterGetPeerRequest, peers []cluster.Peer, assertions ...func(context.Context, ttnpb.ClusterRole, ttnpb.Identifiers) bool) bool {
+func AssertClusterGetPeerRequestSequence(ctx context.Context, reqCh <-chan ClusterGetPeerRequest, peers []ClusterGetPeerResponse, assertions ...func(context.Context, ttnpb.ClusterRole, ttnpb.Identifiers) bool) bool {
 	t := MustTFromContext(ctx)
 	t.Helper()
 	if len(peers) != len(assertions) {

--- a/pkg/web/oauthclient/logout.go
+++ b/pkg/web/oauthclient/logout.go
@@ -39,7 +39,8 @@ func (oc *OAuthClient) HandleLogout(c echo.Context) error {
 	})
 
 	ctx := c.Request().Context()
-	if peer := oc.component.GetPeer(ctx, ttnpb.ClusterRole_ACCESS, nil); peer != nil {
+
+	if peer, err := oc.component.GetPeer(ctx, ttnpb.ClusterRole_ACCESS, nil); err == nil {
 		if cc := peer.Conn(); cc != nil {
 			if res, err := ttnpb.NewEntityAccessClient(cc).AuthInfo(ctx, ttnpb.Empty, creds); err == nil {
 				if tokenInfo := res.GetOAuthAccessToken(); tokenInfo != nil {

--- a/pkg/web/oauthclient/logout.go
+++ b/pkg/web/oauthclient/logout.go
@@ -41,7 +41,7 @@ func (oc *OAuthClient) HandleLogout(c echo.Context) error {
 	ctx := c.Request().Context()
 
 	if peer, err := oc.component.GetPeer(ctx, ttnpb.ClusterRole_ACCESS, nil); err == nil {
-		if cc := peer.Conn(); cc != nil {
+		if cc, err := peer.Conn(); err == nil {
 			if res, err := ttnpb.NewEntityAccessClient(cc).AuthInfo(ctx, ttnpb.Empty, creds); err == nil {
 				if tokenInfo := res.GetOAuthAccessToken(); tokenInfo != nil {
 					_, err := ttnpb.NewOAuthAuthorizationRegistryClient(cc).DeleteToken(ctx, &ttnpb.OAuthAccessTokenIdentifiers{

--- a/pkg/web/oauthclient/logout.go
+++ b/pkg/web/oauthclient/logout.go
@@ -40,18 +40,16 @@ func (oc *OAuthClient) HandleLogout(c echo.Context) error {
 
 	ctx := c.Request().Context()
 
-	if peer, err := oc.component.GetPeer(ctx, ttnpb.ClusterRole_ACCESS, nil); err == nil {
-		if cc, err := peer.Conn(); err == nil {
-			if res, err := ttnpb.NewEntityAccessClient(cc).AuthInfo(ctx, ttnpb.Empty, creds); err == nil {
-				if tokenInfo := res.GetOAuthAccessToken(); tokenInfo != nil {
-					_, err := ttnpb.NewOAuthAuthorizationRegistryClient(cc).DeleteToken(ctx, &ttnpb.OAuthAccessTokenIdentifiers{
-						UserIDs:   tokenInfo.UserIDs,
-						ClientIDs: tokenInfo.ClientIDs,
-						ID:        tokenInfo.ID,
-					}, creds)
-					if err != nil {
-						log.FromContext(ctx).WithError(err).Error("Could not invalidate access token")
-					}
+	if cc, err := oc.component.GetPeerConn(ctx, ttnpb.ClusterRole_ACCESS, nil); err == nil {
+		if res, err := ttnpb.NewEntityAccessClient(cc).AuthInfo(ctx, ttnpb.Empty, creds); err == nil {
+			if tokenInfo := res.GetOAuthAccessToken(); tokenInfo != nil {
+				_, err := ttnpb.NewOAuthAuthorizationRegistryClient(cc).DeleteToken(ctx, &ttnpb.OAuthAccessTokenIdentifiers{
+					UserIDs:   tokenInfo.UserIDs,
+					ClientIDs: tokenInfo.ClientIDs,
+					ID:        tokenInfo.ID,
+				}, creds)
+				if err != nil {
+					log.FromContext(ctx).WithError(err).Error("Could not invalidate access token")
 				}
 			}
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #1231

#### Changes
<!-- What are the changes made in this pull request? -->

- Check in `pkg/*/cups` if the peers are available.
- Check in GS if the peers are available.
- Refactor `Cluster.GetPeer`, `Cluster.GetPeers` and `Peer.Conn` to also return an error. Always take into account that if a peer is available, it doesn't necessary mean that the connection will be available as well.
- Add `Cluster.GetPeerConn` that combines `Cluster.GetPeer` and `Peer.Conn` due to popular usage.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

None.