### PR TITLE
Strictly Enforce HTTP methods in API specification

### DIFF
--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -216,6 +216,7 @@ func New(ctx context.Context, opts ...Option) *Server {
 			}
 			return s, false
 		}),
+		runtime.WithDisablePathLengthFallback(),
 	)
 	return server
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This Pull Request is a quickfix for grpc-gateway allowing HTTP POST requests to endpoints that are not specified as POST. By strictly enforcing HTTP clients to use the HTTP methods in our API specification we'll hopefully reduce improper use of the API.

#### Changes
<!-- What are the changes made in this pull request? -->

- Added grpc-gateway option to disable HTTP method fallback

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Fixed API endpoints that allowed HTTP methods that are not part of our API specification.