### PR TITLE
Don't try to parse EUI from ID in Basic Station frontend

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -2852,15 +2852,6 @@
       "file": "messages.go"
     }
   },
-  "error:pkg/gatewayserver/io/basicstationlns/messages:gateway_id": {
-    "translations": {
-      "en": "invalid gateway ID `{id}`"
-    },
-    "description": {
-      "package": "pkg/gatewayserver/io/basicstationlns/messages",
-      "file": "upstream.go"
-    }
-  },
   "error:pkg/gatewayserver/io/basicstationlns/messages:join_request_message": {
     "translations": {
       "en": "invalid join-request message received"

--- a/pkg/gatewayserver/io/basicstationlns/messages/upstream.go
+++ b/pkg/gatewayserver/io/basicstationlns/messages/upstream.go
@@ -33,7 +33,6 @@ var (
 	errJoinRequestMessage = errors.Define("join_request_message", "invalid join-request message received")
 	errUplinkDataFrame    = errors.Define("uplink_data_Frame", "invalid uplink data frame received")
 	errUplinkMessage      = errors.Define("uplink_message", "invalid uplink message received")
-	errGatewayID          = errors.Define("gateway_id", "invalid gateway ID `{id}`")
 )
 
 // UpInfo provides additional metadata on each upstream message.

--- a/pkg/gatewayserver/io/basicstationlns/messages/upstream.go
+++ b/pkg/gatewayserver/io/basicstationlns/messages/upstream.go
@@ -175,11 +175,6 @@ func (req *JoinRequest) ToUplinkMessage(ids ttnpb.GatewayIdentifiers, bandID str
 		rxTime = &val
 	}
 
-	ids.EUI, err = GetEUIfromUID(ids.GatewayID)
-	if err != nil {
-		return nil, errGatewayID.WithAttributes("id", ids.GatewayID).WithCause(err)
-	}
-
 	rxMetadata := &ttnpb.RxMetadata{
 		GatewayIdentifiers: ids,
 		Time:               rxTime,
@@ -332,11 +327,6 @@ func (updf *UplinkDataFrame) ToUplinkMessage(ids ttnpb.GatewayIdentifiers, bandI
 	}
 
 	timestamp := uint32(updf.RadioMetaData.UpInfo.XTime & 0xFFFFFFFF)
-
-	ids.EUI, err = GetEUIfromUID(ids.GatewayID)
-	if err != nil {
-		return nil, errGatewayID.WithAttributes("id", ids.GatewayID).WithCause(err)
-	}
 
 	ulToken := ttnpb.UplinkToken{
 		GatewayAntennaIdentifiers: ttnpb.GatewayAntennaIdentifiers{

--- a/pkg/gatewayserver/io/basicstationlns/messages/upstream_test.go
+++ b/pkg/gatewayserver/io/basicstationlns/messages/upstream_test.go
@@ -108,6 +108,11 @@ func TestMarshalJSON(t *testing.T) {
 }
 
 func TestJoinRequest(t *testing.T) {
+	gtwID := ttnpb.GatewayIdentifiers{
+		GatewayID: "eui-1122334455667788",
+		EUI:       &types.EUI64{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88},
+	}
+
 	for _, tc := range []struct {
 		Name                  string
 		JoinRequest           JoinRequest
@@ -135,7 +140,7 @@ func TestJoinRequest(t *testing.T) {
 					},
 				},
 			},
-			GatewayIDs:     ttnpb.GatewayIdentifiers{GatewayID: "eui-1122334455667788"},
+			GatewayIDs:     gtwID,
 			BandID:         "EU_86_870",
 			ErrorAssertion: errors.IsInvalidArgument,
 		},
@@ -158,14 +163,14 @@ func TestJoinRequest(t *testing.T) {
 					},
 				},
 			},
-			GatewayIDs:     ttnpb.GatewayIdentifiers{GatewayID: "eui-1122334455667788"},
+			GatewayIDs:     gtwID,
 			BandID:         "EU_868_870",
 			ErrorAssertion: errors.IsInvalidArgument,
 		},
 		{
 			Name:        "EmptyJoinRequest",
 			JoinRequest: JoinRequest{},
-			GatewayIDs:  ttnpb.GatewayIdentifiers{GatewayID: "eui-1122334455667788"},
+			GatewayIDs:  gtwID,
 			BandID:      "EU_863_870",
 			ExpectedUplinkMessage: ttnpb.UplinkMessage{
 				Payload: &ttnpb.Message{
@@ -178,11 +183,8 @@ func TestJoinRequest(t *testing.T) {
 					}},
 				},
 				RxMetadata: []*ttnpb.RxMetadata{{
-					GatewayIdentifiers: ttnpb.GatewayIdentifiers{
-						GatewayID: "eui-1122334455667788",
-						EUI:       &types.EUI64{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88},
-					},
-					UplinkToken: []byte{10, 24, 10, 22, 10, 20, 101, 117, 105, 45, 49, 49, 50, 50, 51, 51, 52, 52, 53, 53, 54, 54, 55, 55, 56, 56},
+					GatewayIdentifiers: gtwID,
+					UplinkToken:        []byte{10, 34, 10, 32, 10, 20, 101, 117, 105, 45, 49, 49, 50, 50, 51, 51, 52, 52, 53, 53, 54, 54, 55, 55, 56, 56, 18, 8, 17, 34, 51, 68, 85, 102, 119, 136},
 				}},
 				Settings: ttnpb.TxSettings{
 					CodingRate: "4/5",
@@ -212,7 +214,7 @@ func TestJoinRequest(t *testing.T) {
 					},
 				},
 			},
-			GatewayIDs: ttnpb.GatewayIdentifiers{GatewayID: "eui-1122334455667788"},
+			GatewayIDs: gtwID,
 			BandID:     "EU_863_870",
 			ExpectedUplinkMessage: ttnpb.UplinkMessage{
 				Payload: &ttnpb.Message{
@@ -226,16 +228,13 @@ func TestJoinRequest(t *testing.T) {
 				},
 				RxMetadata: []*ttnpb.RxMetadata{
 					{
-						GatewayIdentifiers: ttnpb.GatewayIdentifiers{
-							GatewayID: "eui-1122334455667788",
-							EUI:       &types.EUI64{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88},
-						},
-						Time:        &[]time.Time{time.Unix(1548059982, 0)}[0],
-						Timestamp:   (uint32)(12666373963464220 & 0xFFFFFFFF),
-						RSSI:        89,
-						ChannelRSSI: 89,
-						SNR:         9.25,
-						UplinkToken: []byte{10, 24, 10, 22, 10, 20, 101, 117, 105, 45, 49, 49, 50, 50, 51, 51, 52, 52, 53, 53, 54, 54, 55, 55, 56, 56, 16, 156, 252, 188, 5},
+						GatewayIdentifiers: gtwID,
+						Time:               &[]time.Time{time.Unix(1548059982, 0)}[0],
+						Timestamp:          (uint32)(12666373963464220 & 0xFFFFFFFF),
+						RSSI:               89,
+						ChannelRSSI:        89,
+						SNR:                9.25,
+						UplinkToken:        []byte{10, 34, 10, 32, 10, 20, 101, 117, 105, 45, 49, 49, 50, 50, 51, 51, 52, 52, 53, 53, 54, 54, 55, 55, 56, 56, 18, 8, 17, 34, 51, 68, 85, 102, 119, 136, 16, 156, 252, 188, 5},
 					},
 				},
 				Settings: ttnpb.TxSettings{
@@ -276,6 +275,11 @@ func TestJoinRequest(t *testing.T) {
 }
 
 func TestUplinkDataFrame(t *testing.T) {
+	gtwID := ttnpb.GatewayIdentifiers{
+		GatewayID: "eui-1122334455667788",
+		EUI:       &types.EUI64{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88},
+	}
+
 	for _, tc := range []struct {
 		Name                  string
 		UplinkDataFrame       UplinkDataFrame
@@ -287,7 +291,7 @@ func TestUplinkDataFrame(t *testing.T) {
 		{
 			Name:                  "Empty",
 			UplinkDataFrame:       UplinkDataFrame{},
-			GatewayIDs:            ttnpb.GatewayIdentifiers{GatewayID: "eui-1122334455667788"},
+			GatewayIDs:            gtwID,
 			FrequencyPlanID:       "EU_863_870",
 			ExpectedUplinkMessage: ttnpb.UplinkMessage{},
 			ErrorAssertion: func(err error) bool {
@@ -316,7 +320,7 @@ func TestUplinkDataFrame(t *testing.T) {
 					},
 				},
 			},
-			GatewayIDs:      ttnpb.GatewayIdentifiers{GatewayID: "eui-1122334455667788"},
+			GatewayIDs:      gtwID,
 			FrequencyPlanID: "EU_863_870",
 			ExpectedUplinkMessage: ttnpb.UplinkMessage{
 				Payload: &ttnpb.Message{
@@ -338,16 +342,13 @@ func TestUplinkDataFrame(t *testing.T) {
 				},
 				RxMetadata: []*ttnpb.RxMetadata{
 					{
-						GatewayIdentifiers: ttnpb.GatewayIdentifiers{
-							GatewayID: "eui-1122334455667788",
-							EUI:       &types.EUI64{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88},
-						},
-						Time:        &[]time.Time{time.Unix(1548059982, 0)}[0],
-						Timestamp:   (uint32)(12666373963464220 & 0xFFFFFFFF),
-						RSSI:        89,
-						ChannelRSSI: 89,
-						SNR:         9.25,
-						UplinkToken: []byte{10, 34, 10, 32, 10, 20, 101, 117, 105, 45, 49, 49, 50, 50, 51, 51, 52, 52, 53, 53, 54, 54, 55, 55, 56, 56, 18, 8, 17, 34, 51, 68, 85, 102, 119, 136, 16, 156, 252, 188, 5},
+						GatewayIdentifiers: gtwID,
+						Time:               &[]time.Time{time.Unix(1548059982, 0)}[0],
+						Timestamp:          (uint32)(12666373963464220 & 0xFFFFFFFF),
+						RSSI:               89,
+						ChannelRSSI:        89,
+						SNR:                9.25,
+						UplinkToken:        []byte{10, 34, 10, 32, 10, 20, 101, 117, 105, 45, 49, 49, 50, 50, 51, 51, 52, 52, 53, 53, 54, 54, 55, 55, 56, 56, 18, 8, 17, 34, 51, 68, 85, 102, 119, 136, 16, 156, 252, 188, 5},
 					},
 				},
 				Settings: ttnpb.TxSettings{
@@ -384,7 +385,7 @@ func TestUplinkDataFrame(t *testing.T) {
 					},
 				},
 			},
-			GatewayIDs:      ttnpb.GatewayIdentifiers{GatewayID: "eui-1122334455667788"},
+			GatewayIDs:      gtwID,
 			FrequencyPlanID: "EU_863_870",
 			ExpectedUplinkMessage: ttnpb.UplinkMessage{
 				Payload: &ttnpb.Message{
@@ -406,16 +407,13 @@ func TestUplinkDataFrame(t *testing.T) {
 				},
 				RxMetadata: []*ttnpb.RxMetadata{
 					{
-						GatewayIdentifiers: ttnpb.GatewayIdentifiers{
-							GatewayID: "eui-1122334455667788",
-							EUI:       &types.EUI64{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88},
-						},
-						Time:        &[]time.Time{time.Unix(1548059982, 0)}[0],
-						Timestamp:   (uint32)(12666373963464220 & 0xFFFFFFFF),
-						RSSI:        89,
-						ChannelRSSI: 89,
-						SNR:         9.25,
-						UplinkToken: []byte{10, 34, 10, 32, 10, 20, 101, 117, 105, 45, 49, 49, 50, 50, 51, 51, 52, 52, 53, 53, 54, 54, 55, 55, 56, 56, 18, 8, 17, 34, 51, 68, 85, 102, 119, 136, 16, 156, 252, 188, 5},
+						GatewayIdentifiers: gtwID,
+						Time:               &[]time.Time{time.Unix(1548059982, 0)}[0],
+						Timestamp:          (uint32)(12666373963464220 & 0xFFFFFFFF),
+						RSSI:               89,
+						ChannelRSSI:        89,
+						SNR:                9.25,
+						UplinkToken:        []byte{10, 34, 10, 32, 10, 20, 101, 117, 105, 45, 49, 49, 50, 50, 51, 51, 52, 52, 53, 53, 54, 54, 55, 55, 56, 56, 18, 8, 17, 34, 51, 68, 85, 102, 119, 136, 16, 156, 252, 188, 5},
 					},
 				},
 				Settings: ttnpb.TxSettings{
@@ -451,6 +449,11 @@ func TestUplinkDataFrame(t *testing.T) {
 }
 
 func TestFromUplinkDataFrame(t *testing.T) {
+	gtwID := ttnpb.GatewayIdentifiers{
+		GatewayID: "eui-1122334455667788",
+		EUI:       &types.EUI64{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88},
+	}
+
 	for _, tc := range []struct {
 		Name                    string
 		UplinkMessage           ttnpb.UplinkMessage
@@ -494,12 +497,12 @@ func TestFromUplinkDataFrame(t *testing.T) {
 				},
 				RxMetadata: []*ttnpb.RxMetadata{
 					{
-						GatewayIdentifiers: ttnpb.GatewayIdentifiers{GatewayID: "eui-1122334455667788"},
+						GatewayIdentifiers: gtwID,
 						Time:               &[]time.Time{time.Unix(1548059982, 0)}[0],
 						Timestamp:          (uint32)(12666373963464220 & 0xFFFFFFFF),
 						RSSI:               89,
 						SNR:                9.25,
-						UplinkToken:        []byte{10, 16, 10, 14, 10, 12, 116, 101, 115, 116, 45, 103, 97, 116, 101, 119, 97, 121, 16, 156, 252, 188, 5},
+						UplinkToken:        []byte{10, 34, 10, 32, 10, 20, 101, 117, 105, 45, 49, 49, 50, 50, 51, 51, 52, 52, 53, 53, 54, 54, 55, 55, 56, 56, 18, 8, 17, 34, 51, 68, 85, 102, 119, 136, 16, 156, 252, 188, 5},
 					},
 				},
 				Settings: ttnpb.TxSettings{
@@ -553,6 +556,11 @@ func TestFromUplinkDataFrame(t *testing.T) {
 }
 
 func TestJreqFromUplinkDataFrame(t *testing.T) {
+	gtwID := ttnpb.GatewayIdentifiers{
+		GatewayID: "eui-1122334455667788",
+		EUI:       &types.EUI64{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88},
+	}
+
 	for _, tc := range []struct {
 		Name                string
 		UplinkMessage       ttnpb.UplinkMessage
@@ -584,7 +592,7 @@ func TestJreqFromUplinkDataFrame(t *testing.T) {
 				},
 				RxMetadata: []*ttnpb.RxMetadata{
 					{
-						GatewayIdentifiers: ttnpb.GatewayIdentifiers{GatewayID: "eui-1122334455667788"},
+						GatewayIdentifiers: gtwID,
 						Time:               &[]time.Time{time.Unix(1548059982, 0)}[0],
 						Timestamp:          (uint32)(12666373963464220 & 0xFFFFFFFF),
 						RSSI:               89,

--- a/pkg/gatewayserver/io/basicstationlns/messages/util.go
+++ b/pkg/gatewayserver/io/basicstationlns/messages/util.go
@@ -17,14 +17,11 @@ package messages
 import (
 	"bytes"
 	"encoding/binary"
-	"encoding/hex"
 	"reflect"
-	"strings"
 
 	"go.thethings.network/lorawan-stack/pkg/band"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
-	"go.thethings.network/lorawan-stack/pkg/types"
 )
 
 var (
@@ -118,22 +115,4 @@ func getDataRatesFromBandID(id string) (DataRates, error) {
 		}
 	}
 	return drs, nil
-}
-
-// GetEUIfromUID extracts the Gateway EUI from the UID.
-func GetEUIfromUID(uid string) (*types.EUI64, error) {
-	s := strings.Split(uid, "-")
-	if len(s) != 2 || s[0] != "eui" {
-		return nil, errUID.WithAttributes("uid", uid)
-	}
-	euiBytes, err := hex.DecodeString(s[1])
-	if err != nil {
-		return nil, errUID.WithAttributes("uid", uid)
-	}
-	var eui types.EUI64
-	err = eui.Unmarshal(euiBytes)
-	if err != nil {
-		return nil, errUID.WithAttributes("uid", uid)
-	}
-	return &eui, nil
 }

--- a/pkg/gatewayserver/io/basicstationlns/messages/util_test.go
+++ b/pkg/gatewayserver/io/basicstationlns/messages/util_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
-	"go.thethings.network/lorawan-stack/pkg/types"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 )
 
@@ -99,72 +98,6 @@ func TestGetUint32IntegerAsByteSlice(t *testing.T) {
 	b, err = getInt32AsByteSlice(0x7FFFFFFF)
 	a.So(err, should.BeNil)
 	a.So(b, should.Resemble, []byte{0xFF, 0xFF, 0xFF, 0x7F})
-}
-
-func TestGetEUIfromUID(t *testing.T) {
-	for i, tc := range []struct {
-		UID            string
-		ErrorAssertion func(error) bool
-		ExpectedEUI    types.EUI64
-	}{
-		{
-			UID: "",
-			ErrorAssertion: func(err error) bool {
-				return errors.Resemble(err, errUID)
-			},
-		},
-		{
-			UID: "eui",
-			ErrorAssertion: func(err error) bool {
-				return errors.Resemble(err, errUID)
-			},
-		},
-		{
-			UID: "eui",
-			ErrorAssertion: func(err error) bool {
-				return errors.Resemble(err, errUID)
-			},
-		},
-		{
-			UID: "uid-0101010101010101",
-			ErrorAssertion: func(err error) bool {
-				return errors.Resemble(err, errUID)
-			},
-		},
-		{
-			UID: "eui-11223344556677",
-			ErrorAssertion: func(err error) bool {
-				return errors.Resemble(err, errUID)
-			},
-		},
-		{
-			UID: "eui-112233445566778899",
-			ErrorAssertion: func(err error) bool {
-				return errors.Resemble(err, errUID)
-			},
-		},
-		{
-			UID:            "eui-1122334455667788",
-			ErrorAssertion: nil,
-			ExpectedEUI:    types.EUI64{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88},
-		},
-	} {
-		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			a := assertions.New(t)
-			eui, err := GetEUIfromUID(tc.UID)
-			if err != nil {
-				if tc.ErrorAssertion == nil || !a.So(tc.ErrorAssertion(err), should.BeTrue) {
-					t.Fatalf("Unexpected error: %v", err)
-				}
-			} else if tc.ErrorAssertion != nil {
-				t.Fatalf("Expected error")
-			} else {
-				if !a.So(*eui, should.Resemble, tc.ExpectedEUI) {
-					t.Fatalf("Invalid EUI: %v", eui)
-				}
-			}
-		})
-	}
 }
 
 func TestGetDataRateFromDataRateIndex(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This Pull Request deletes some unnecessary code that attempted to parse a GatewayID into an EUI. `FillGatewayContext` already ensures that there is an EUI for gateways that have one.

This also fixes a bug where Basic Station gateways with a GatewayID that doesn't follow the v2 `eui-xxx` pattern couldn't send uplinks.

#### Changes
<!-- What are the changes made in this pull request? -->

- Removed calls to `GetEUIfromUID`
- Removed `GetEUIfromUID` and tests

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Fixed a bug where uplinks from some Basic Station gateways resulted in the connection to break.