### PR TITLE
Remove leading space from safe inspector copy value

### DIFF
--- a/pkg/webui/components/safe-inspector/index.js
+++ b/pkg/webui/components/safe-inspector/index.js
@@ -55,6 +55,36 @@ const m = defineMessages({
 @injectIntl
 @bind
 export class SafeInspector extends Component {
+  static defaultProps = {
+    className: undefined,
+    disableResize: false,
+    hideable: true,
+    initiallyVisible: false,
+    isBytes: true,
+    small: false,
+  }
+
+  static propTypes = {
+    /** The classname to be applied **/
+    className: PropTypes.string,
+    /** The data to be displayed */
+    data: PropTypes.string.isRequired,
+    /** Whether the component should resize when its data is truncated */
+    disableResize: PropTypes.bool,
+    /** Whether the data can be hidden (like passwords) */
+    hideable: PropTypes.bool,
+    /** Whether the data is initially visible */
+    initiallyVisible: PropTypes.bool,
+    /** Utility functions passed via react-intl hoc **/
+    intl: PropTypes.shape({
+      formatMessage: PropTypes.func,
+    }).isRequired,
+    /** Whether the data is in byte format */
+    isBytes: PropTypes.bool,
+    /** Whether a smaller style should be rendered (useful for display in tables) */
+    small: PropTypes.bool,
+  }
+
   constructor(props) {
     super(props)
 
@@ -235,29 +265,6 @@ export class SafeInspector extends Component {
       </div>
     )
   }
-}
-
-SafeInspector.defaultProps = {
-  small: false,
-  isBytes: true,
-  initiallyVisible: false,
-  hideable: true,
-  disableResize: false,
-}
-
-SafeInspector.propTypes = {
-  /** The data to be displayed */
-  data: PropTypes.string.isRequired,
-  /** Whether the data is in byte format */
-  isBytes: PropTypes.bool,
-  /** Whether the data is initially visible */
-  initiallyVisible: PropTypes.bool,
-  /** Whether the data can be hidden (like passwords) */
-  hideable: PropTypes.bool,
-  /** Whether a smaller style should be rendered (useful for display in tables) */
-  small: PropTypes.bool,
-  /** Whether the component should resize when its data is truncated */
-  disableResize: PropTypes.bool,
 }
 
 export default SafeInspector

--- a/pkg/webui/components/safe-inspector/index.js
+++ b/pkg/webui/components/safe-inspector/index.js
@@ -150,7 +150,7 @@ export class SafeInspector extends Component {
       const chunks = chunkArray(data.toUpperCase().split(''), 2)
       if (!byteStyle) {
         const orderedChunks = msb ? chunks : chunks.reverse()
-        formattedData = display = `${orderedChunks.map(chunk => ` 0x${chunk.join('')}`)}`
+        formattedData = display = orderedChunks.map(chunk => `0x${chunk.join('')}`).join(', ')
       } else {
         display = chunks.map((chunk, index) => (
           <span key={`${data}_chunk_${index}`}>{hidden ? '••' : chunk}</span>


### PR DESCRIPTION
#### Summary
Closes #1235 
References #1086 

#### Changes
- Remove leading whitespace in the copied value of the safe inspector (when in c-style mode)
- Fix proptypes

#### Notes for Reviewers
Just putting this in-between as it was an easy fix…

cc @johanstokking 
