### PR TITLE
Increase connection waiting time in AS tests

### DIFF
--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -841,7 +841,7 @@ hardware_versions:
 				}
 			}()
 			// Wait for connection to establish.
-			time.Sleep(Timeout)
+			time.Sleep(2 * Timeout)
 
 			t.Run("Upstream", func(t *testing.T) {
 				ns.reset()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #1017 

#### Changes
<!-- What are the changes made in this pull request? -->

- Increase the waiting time for the connection to establish.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I think this should be one of the causes - some messages get lost since they are sent before the integration starts (since `Set` starts the task instead of blocking until it is done).