### PR TITLE
Remove trailing quote from Web UI configuration variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,8 +114,8 @@ services:
       # - TTN_LW_IS_EMAIL_SMTP_PASSWORD=enter password
 
       # Web UI configuration for "thethings.example.com":
-      # - TTN_LW_IS_OAUTH_UI_CANONICAL_URL=https://thethings.example.com/oauth"
-      # - TTN_LW_IS_OAUTH_UI_IS_BASE_URL=https://thethings.example.com/api/v3"
+      # - TTN_LW_IS_OAUTH_UI_CANONICAL_URL=https://thethings.example.com/oauth
+      # - TTN_LW_IS_OAUTH_UI_IS_BASE_URL=https://thethings.example.com/api/v3
       # - TTN_LW_CONSOLE_OAUTH_AUTHORIZE_URL=https://thethings.example.com/oauth/authorize
       # - TTN_LW_CONSOLE_OAUTH_TOKEN_URL=https://thethings.example.com/oauth/token
       # - TTN_LW_CONSOLE_UI_CANONICAL_URL=https://thethings.example.com/console


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Tidy up `docker-compose.yml`. I encountered this issue when I tried to use these variables when trying to self host this system, the trailing quotes where not obvious enough for me to catch initially, so it took me a while to find this issue when getting setup.

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove unnecessary quote from commented out variables.