### PR TITLE
Add option to disable HMR via environment variable

### DIFF
--- a/config/webpack.config.babel.js
+++ b/config/webpack.config.babel.js
@@ -41,7 +41,12 @@ const {
   DEFAULT_LOCALE = 'en',
 } = process.env
 
-const DEV_SERVER_BUILD = process.env.DEV_SERVER_BUILD && process.env.DEV_SERVER_BUILD === 'true'
+const DEV_SERVER_BUILD = Boolean(
+  process.env.DEV_SERVER_BUILD && process.env.DEV_SERVER_BUILD === 'true',
+)
+const WEBPACK_DISABLE_HMR = Boolean(
+  process.env.WEBPACK_DISABLE_HMR && process.env.WEBPACK_DISABLE_HMR === 'true',
+)
 const ASSETS_ROOT = '/assets'
 
 const context = path.resolve(CONTEXT)
@@ -108,7 +113,7 @@ export default {
   devServer: {
     port: 8080,
     inline: true,
-    hot: true,
+    hot: !WEBPACK_DISABLE_HMR,
     stats: 'minimal',
     publicPath: `${ASSETS_ROOT}/`,
     proxy: [


### PR DESCRIPTION
#### Summary
This PR will make the HMR setting of webpack configurable through the `WEBPACK_HMR_DISABLED` env (defaults to false). 

#### Changes
- Modify webpack config to check for the env variable

#### Notes for Reviewers
I would like to be able to disable HMR as a personal preference.