### PR TITLE
Decouple provider connection from ApplicationPubSub

### DIFF
--- a/pkg/applicationserver/io/pubsub/integrate_test.go
+++ b/pkg/applicationserver/io/pubsub/integrate_test.go
@@ -42,7 +42,9 @@ func TestIntegrate(t *testing.T) {
 	is, isAddr := startMockIS(ctx)
 	is.add(ctx, registeredApplicationID, registeredApplicationKey)
 
-	mockProvider, err := provider.GetProvider(&ttnpb.ApplicationPubSub_NATS{})
+	mockProvider, err := provider.GetProvider(&ttnpb.ApplicationPubSub{
+		Provider: &ttnpb.ApplicationPubSub_NATS{},
+	})
 	a.So(mockProvider, should.NotBeNil)
 	a.So(err, should.BeNil)
 	mockImpl := mockProvider.(*mock_provider.Impl)
@@ -111,7 +113,7 @@ func TestIntegrate(t *testing.T) {
 	t.Run("AlreadyExisting", func(t *testing.T) {
 		select {
 		case conn := <-mockImpl.OpenConnectionCh:
-			a.So(conn.ApplicationPubSubIdentifiers, should.Resemble, ps1)
+			a.So(conn.ApplicationPubSubIdentifiers(), should.Resemble, &ps1)
 		case <-time.After(timeout):
 			t.Fatal("Expect integration timeout")
 		}
@@ -158,7 +160,7 @@ func TestIntegrate(t *testing.T) {
 		}
 		select {
 		case conn := <-mockImpl.OpenConnectionCh:
-			a.So(conn.ApplicationPubSubIdentifiers, should.Resemble, ps2)
+			a.So(conn.ApplicationPubSubIdentifiers(), should.Resemble, &ps2)
 		case <-time.After(timeout):
 			t.Fatal("Expect integration timeout")
 		}
@@ -182,7 +184,7 @@ func TestIntegrate(t *testing.T) {
 		}
 		select {
 		case conn := <-mockImpl.ShutdownCh:
-			a.So(conn.ApplicationPubSubIdentifiers, should.Resemble, ps2)
+			a.So(conn.ApplicationPubSubIdentifiers(), should.Resemble, &ps2)
 		case <-time.After(timeout):
 			t.Fatal("Expect integration timeout")
 		}

--- a/pkg/applicationserver/io/pubsub/provider/mock/provider.go
+++ b/pkg/applicationserver/io/pubsub/provider/mock/provider.go
@@ -41,7 +41,7 @@ type Impl struct {
 // Connection is a set of mempubsub topics.
 type Connection struct {
 	impl *Impl
-	*ttnpb.ApplicationPubSub
+	provider.Target
 
 	Push    *pubsub.Topic
 	Replace *pubsub.Topic
@@ -54,6 +54,13 @@ type Connection struct {
 	DownlinkFailed *pubsub.Subscription
 	DownlinkQueued *pubsub.Subscription
 	LocationSolved *pubsub.Subscription
+}
+
+func (c *Connection) ApplicationPubSubIdentifiers() *ttnpb.ApplicationPubSubIdentifiers {
+	if pb, ok := c.Target.(*ttnpb.ApplicationPubSub); ok {
+		return &pb.ApplicationPubSubIdentifiers
+	}
+	return nil
 }
 
 // Shutdown implements provider.Shutdowner.
@@ -87,10 +94,10 @@ func (c *Connection) Shutdown(ctx context.Context) (err error) {
 }
 
 // OpenConnection implements provider.Provider using the mempubsub package.
-func (i *Impl) OpenConnection(ctx context.Context, pb *ttnpb.ApplicationPubSub) (pc *provider.Connection, err error) {
+func (i *Impl) OpenConnection(ctx context.Context, target provider.Target) (pc *provider.Connection, err error) {
 	conn := &Connection{
-		impl:              i,
-		ApplicationPubSub: pb,
+		impl:   i,
+		Target: target,
 	}
 	pc = &provider.Connection{
 		ProviderConnection: conn,

--- a/pkg/applicationserver/io/pubsub/provider/mqtt/provider_test.go
+++ b/pkg/applicationserver/io/pubsub/provider/mqtt/provider_test.go
@@ -65,7 +65,7 @@ func TestOpenConnection(t *testing.T) {
 			PubSubID: "ps1",
 		},
 		Provider: &ttnpb.ApplicationPubSub_MQTT{
-			MQTT: nil,
+			MQTT: &ttnpb.ApplicationPubSub_MQTTProvider{},
 		},
 		BaseTopic: "app1/ps1",
 		DownlinkPush: &ttnpb.ApplicationPubSub_Message{
@@ -100,7 +100,9 @@ func TestOpenConnection(t *testing.T) {
 		},
 	}
 
-	impl, err := provider.GetProvider(&ttnpb.ApplicationPubSub_MQTT{})
+	impl, err := provider.GetProvider(&ttnpb.ApplicationPubSub{
+		Provider: &ttnpb.ApplicationPubSub_MQTT{},
+	})
 	a.So(impl, should.NotBeNil)
 	a.So(err, should.BeNil)
 

--- a/pkg/applicationserver/io/pubsub/provider/nats/provider_test.go
+++ b/pkg/applicationserver/io/pubsub/provider/nats/provider_test.go
@@ -54,7 +54,7 @@ func TestOpenConnection(t *testing.T) {
 			PubSubID: "ps1",
 		},
 		Provider: &ttnpb.ApplicationPubSub_NATS{
-			NATS: nil,
+			NATS: &ttnpb.ApplicationPubSub_NATSProvider{},
 		},
 		BaseTopic: "app1.ps1",
 		DownlinkPush: &ttnpb.ApplicationPubSub_Message{
@@ -89,7 +89,9 @@ func TestOpenConnection(t *testing.T) {
 		},
 	}
 
-	impl, err := provider.GetProvider(&ttnpb.ApplicationPubSub_NATS{})
+	impl, err := provider.GetProvider(&ttnpb.ApplicationPubSub{
+		Provider: &ttnpb.ApplicationPubSub_NATS{},
+	})
 	a.So(impl, should.NotBeNil)
 	a.So(err, should.BeNil)
 

--- a/pkg/applicationserver/io/pubsub/pubsub.go
+++ b/pkg/applicationserver/io/pubsub/pubsub.go
@@ -246,7 +246,7 @@ func (ps *PubSub) start(ctx context.Context, pb *ttnpb.ApplicationPubSub) (err e
 		ps.integrationErrors.Store(psUID, ctx.Err())
 		ps.integrations.Delete(psUID)
 	}()
-	provider, err := provider.GetProvider(pb.Provider)
+	provider, err := provider.GetProvider(pb)
 	if err != nil {
 		return err
 	}

--- a/pkg/applicationserver/io/pubsub/pubsub_test.go
+++ b/pkg/applicationserver/io/pubsub/pubsub_test.go
@@ -119,7 +119,9 @@ func TestPubSub(t *testing.T) {
 		t.Fatalf("Failed to set pubsub in registry: %s", err)
 	}
 
-	mockProvider, err := provider.GetProvider(&ttnpb.ApplicationPubSub_NATS{})
+	mockProvider, err := provider.GetProvider(&ttnpb.ApplicationPubSub{
+		Provider: &ttnpb.ApplicationPubSub_NATS{},
+	})
 	a.So(mockProvider, should.NotBeNil)
 	a.So(err, should.BeNil)
 	mockImpl := mockProvider.(*mock_provider.Impl)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Needed for https://github.com/TheThingsIndustries/lorawan-stack/issues/1705

#### Changes
<!-- What are the changes made in this pull request? -->

- Decouple `*ttnpb.ApplicationPubSub` from connecting by introducing the `Target` interface