### PR TITLE
Schedule MAC answers in Class A

### DIFF
--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -972,7 +972,10 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 					}
 				}
 
-				maxUpLength := maximumUplinkLength(fp, phy, dev.RecentUplinks...)
+				var maxUpLength uint16 = math.MaxUint16
+				if dev.MACState.LoRaWANVersion == ttnpb.MAC_V1_1 {
+					maxUpLength = maximumUplinkLength(fp, phy, dev.RecentUplinks...)
+				}
 
 				var sets []string
 			outer:

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -153,6 +153,7 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 			continue
 		}
 		if desc.DownlinkLength > maxDownLen {
+			maxDownLen = 0
 			continue
 		}
 		cmds = append(cmds, cmd)

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -603,7 +603,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class A/windows open/no uplink",
+			Name: "Class A/windows open/1.1/no uplink",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -683,7 +683,10 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case resp := <-setFuncRespCh:
 					a.So(resp.Error, should.BeNil)
-					a.So(resp.Paths, should.BeNil)
+					a.So(resp.Paths, should.HaveSameElementsDeep, []string{
+						"mac_state.queued_responses",
+						"mac_state.rx_windows_available",
+					})
 					a.So(resp.Device, should.NotBeNil)
 				}
 				close(setFuncRespCh)
@@ -718,7 +721,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class A/windows open/no session",
+			Name: "Class A/windows open/1.1/no session",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -827,7 +830,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class A/windows open/Rx1,2 expired",
+			Name: "Class A/windows open/1.1/RX1,RX2 expired",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -932,6 +935,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				case resp := <-setFuncRespCh:
 					a.So(resp.Error, should.BeNil)
 					a.So(resp.Paths, should.HaveSameElementsDeep, []string{
+						"mac_state.queued_responses",
 						"mac_state.rx_windows_available",
 					})
 					if a.So(resp.Device, should.NotBeNil) && a.So(resp.Device.MACState, should.NotBeNil) {
@@ -970,7 +974,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class A/windows open/Rx1,2/no downlink",
+			Name: "Class A/windows open/1.1/RX1,RX2/no downlink",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -1109,7 +1113,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class A/windows open/Rx1,2/1.0.3/FCnt too low",
+			Name: "Class A/windows open/1.0.3/RX1,RX2/FCnt too low",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -1273,7 +1277,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class A/windows open/Rx1,2/payload too long",
+			Name: "Class A/windows open/1.0.3/RX1,RX2/payload too long",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -1429,7 +1433,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class A/windows open/Rx1,2/application downlink/FOpts present/EU868/1.1/scheduling fail",
+			Name: "Class A/windows open/1.1/RX1,RX2/application downlink/FOpts present/EU868/scheduling fail",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -1681,7 +1685,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class A/windows open/Rx1,2/application downlink/FOpts present/EU868/1.1",
+			Name: "Class A/windows open/1.1/RX1,RX2/application downlink/FOpts present/EU868",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -1982,7 +1986,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 		// Adapted from https://github.com/TheThingsNetwork/lorawan-stack/issues/866#issue-461484955.
 		{
-			Name: "Class A/windows open/Rx1, Rx2 does not fit/application downlink/FOpts present/EU868/1.0.2",
+			Name: "Class A/windows open/1.0.2/RX1, RX2 does not fit/application downlink/FOpts present/EU868",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -2414,7 +2418,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class C/windows open/Rx1/application downlink/FOpts present/EU868/1.1",
+			Name: "Class C/windows open/1.1/RX1,RX2/application downlink/FOpts present/EU868",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -2604,6 +2608,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 							Rx1Delay:         ttnpb.RX_DELAY_3,
 							Rx1DataRateIndex: ttnpb.DATA_RATE_0,
 							Rx1Frequency:     431000000,
+							Rx2DataRateIndex: ttnpb.DATA_RATE_1,
+							Rx2Frequency:     420000000,
 						}
 					},
 					NsGsScheduleDownlinkResponse{
@@ -2733,7 +2739,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class C/windows open/Rx2/application downlink/no absolute time/no forced gateways/windows open/FOpts present/EU868/1.1",
+			Name: "Class C/windows closed/1.1/RX1,RX2,RXC/application downlink/no absolute time/no forced gateways/FOpts present/EU868",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -2923,6 +2929,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 							Rx1Delay:         ttnpb.RX_DELAY_3,
 							Rx1DataRateIndex: ttnpb.DATA_RATE_0,
 							Rx1Frequency:     431000000,
+							Rx2DataRateIndex: ttnpb.DATA_RATE_1,
+							Rx2Frequency:     420000000,
 						}
 					},
 					NsGsScheduleDownlinkResponse{
@@ -2958,7 +2966,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 							/*** DevAddr ***/
 							devAddr[3], devAddr[2], devAddr[1], devAddr[0],
 							/*** FCtrl ***/
-							0x86,
+							0x81,
 							/*** FCnt ***/
 							0x42, 0x00,
 						}
@@ -2969,10 +2977,6 @@ func TestProcessDownlinkTask(t *testing.T) {
 							devAddr,
 							0x24,
 							[]byte{
-								/* ResetConf */
-								0x01, 0x01,
-								/* LinkCheckAns */
-								0x02, 0x02, 0x05,
 								/* DevStatusReq */
 								0x06,
 							},
@@ -3124,7 +3128,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class C/windows open/Rx2/application downlink/absolute time within window/no forced gateways/windows open/FOpts present/EU868/1.1",
+			Name: "Class C/windows open/1.1/RXC/application downlink/absolute time within window/no forced gateways/FOpts present/EU868",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -3185,19 +3189,10 @@ func TestProcessDownlinkTask(t *testing.T) {
 						ClassCTimeout: DurationPtr(42 * time.Second),
 					},
 					MACState: &ttnpb.MACState{
-						CurrentParameters: *CopyMACParameters(eu868macParameters),
-						DesiredParameters: *CopyMACParameters(eu868macParameters),
-						DeviceClass:       ttnpb.CLASS_C,
-						LoRaWANVersion:    ttnpb.MAC_V1_1,
-						QueuedResponses: []*ttnpb.MACCommand{
-							(&ttnpb.MACCommand_ResetConf{
-								MinorVersion: 1,
-							}).MACCommand(),
-							(&ttnpb.MACCommand_LinkCheckAns{
-								Margin:       2,
-								GatewayCount: 5,
-							}).MACCommand(),
-						},
+						CurrentParameters:  *CopyMACParameters(eu868macParameters),
+						DesiredParameters:  *CopyMACParameters(eu868macParameters),
+						DeviceClass:        ttnpb.CLASS_C,
+						LoRaWANVersion:     ttnpb.MAC_V1_1,
 						RxWindowsAvailable: true,
 					},
 					QueuedApplicationDownlinks: []*ttnpb.ApplicationDownlink{
@@ -3275,7 +3270,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 							/*** DevAddr ***/
 							devAddr[3], devAddr[2], devAddr[1], devAddr[0],
 							/*** FCtrl ***/
-							0x86,
+							0x81,
 							/*** FCnt ***/
 							0x42, 0x00,
 						}
@@ -3286,10 +3281,6 @@ func TestProcessDownlinkTask(t *testing.T) {
 							devAddr,
 							0x24,
 							[]byte{
-								/* ResetConf */
-								0x01, 0x01,
-								/* LinkCheckAns */
-								0x02, 0x02, 0x05,
 								/* DevStatusReq */
 								0x06,
 							},
@@ -3448,7 +3439,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class C/windows open/Rx2/application downlink/absolute time within window/no forced gateways/windows open/FOpts present/EU868/1.1/non-retryable errors",
+			Name: "Class C/windows open/1.1/RXC/application downlink/absolute time within window/no forced gateways/FOpts present/EU868/non-retryable errors",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -3509,19 +3500,10 @@ func TestProcessDownlinkTask(t *testing.T) {
 						ClassCTimeout: DurationPtr(42 * time.Second),
 					},
 					MACState: &ttnpb.MACState{
-						CurrentParameters: *CopyMACParameters(eu868macParameters),
-						DesiredParameters: *CopyMACParameters(eu868macParameters),
-						DeviceClass:       ttnpb.CLASS_C,
-						LoRaWANVersion:    ttnpb.MAC_V1_1,
-						QueuedResponses: []*ttnpb.MACCommand{
-							(&ttnpb.MACCommand_ResetConf{
-								MinorVersion: 1,
-							}).MACCommand(),
-							(&ttnpb.MACCommand_LinkCheckAns{
-								Margin:       2,
-								GatewayCount: 5,
-							}).MACCommand(),
-						},
+						CurrentParameters:  *CopyMACParameters(eu868macParameters),
+						DesiredParameters:  *CopyMACParameters(eu868macParameters),
+						DeviceClass:        ttnpb.CLASS_C,
+						LoRaWANVersion:     ttnpb.MAC_V1_1,
 						RxWindowsAvailable: true,
 					},
 					QueuedApplicationDownlinks: []*ttnpb.ApplicationDownlink{
@@ -3599,7 +3581,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 							/*** DevAddr ***/
 							devAddr[3], devAddr[2], devAddr[1], devAddr[0],
 							/*** FCtrl ***/
-							0x86,
+							0x81,
 							/*** FCnt ***/
 							0x42, 0x00,
 						}
@@ -3610,10 +3592,6 @@ func TestProcessDownlinkTask(t *testing.T) {
 							devAddr,
 							0x24,
 							[]byte{
-								/* ResetConf */
-								0x01, 0x01,
-								/* LinkCheckAns */
-								0x02, 0x02, 0x05,
 								/* DevStatusReq */
 								0x06,
 							},
@@ -3743,7 +3721,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class C/windows open/Rx2/application downlink/absolute time within window/no forced gateways/windows open/FOpts present/EU868/1.1/retryable error",
+			Name: "Class C/windows open/RXC/application downlink/absolute time within window/no forced gateways/windows open/FOpts present/EU868/1.1/retryable error",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -3804,19 +3782,10 @@ func TestProcessDownlinkTask(t *testing.T) {
 						ClassCTimeout: DurationPtr(42 * time.Second),
 					},
 					MACState: &ttnpb.MACState{
-						CurrentParameters: *CopyMACParameters(eu868macParameters),
-						DesiredParameters: *CopyMACParameters(eu868macParameters),
-						DeviceClass:       ttnpb.CLASS_C,
-						LoRaWANVersion:    ttnpb.MAC_V1_1,
-						QueuedResponses: []*ttnpb.MACCommand{
-							(&ttnpb.MACCommand_ResetConf{
-								MinorVersion: 1,
-							}).MACCommand(),
-							(&ttnpb.MACCommand_LinkCheckAns{
-								Margin:       2,
-								GatewayCount: 5,
-							}).MACCommand(),
-						},
+						CurrentParameters:  *CopyMACParameters(eu868macParameters),
+						DesiredParameters:  *CopyMACParameters(eu868macParameters),
+						DeviceClass:        ttnpb.CLASS_C,
+						LoRaWANVersion:     ttnpb.MAC_V1_1,
 						RxWindowsAvailable: true,
 					},
 					QueuedApplicationDownlinks: []*ttnpb.ApplicationDownlink{
@@ -3894,7 +3863,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 							/*** DevAddr ***/
 							devAddr[3], devAddr[2], devAddr[1], devAddr[0],
 							/*** FCtrl ***/
-							0x86,
+							0x81,
 							/*** FCnt ***/
 							0x42, 0x00,
 						}
@@ -3905,10 +3874,6 @@ func TestProcessDownlinkTask(t *testing.T) {
 							devAddr,
 							0x24,
 							[]byte{
-								/* ResetConf */
-								0x01, 0x01,
-								/* LinkCheckAns */
-								0x02, 0x02, 0x05,
 								/* DevStatusReq */
 								0x06,
 							},
@@ -4031,7 +3996,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class C/windows open/Rx2/application downlink/absolute time outside window",
+			Name: "Class C/windows open/RXC/application downlink/absolute time outside window",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -4090,19 +4055,10 @@ func TestProcessDownlinkTask(t *testing.T) {
 						ClassCTimeout: DurationPtr(42 * time.Second),
 					},
 					MACState: &ttnpb.MACState{
-						CurrentParameters: *CopyMACParameters(eu868macParameters),
-						DesiredParameters: *CopyMACParameters(eu868macParameters),
-						DeviceClass:       ttnpb.CLASS_C,
-						LoRaWANVersion:    ttnpb.MAC_V1_1,
-						QueuedResponses: []*ttnpb.MACCommand{
-							(&ttnpb.MACCommand_ResetConf{
-								MinorVersion: 1,
-							}).MACCommand(),
-							(&ttnpb.MACCommand_LinkCheckAns{
-								Margin:       2,
-								GatewayCount: 5,
-							}).MACCommand(),
-						},
+						CurrentParameters:  *CopyMACParameters(eu868macParameters),
+						DesiredParameters:  *CopyMACParameters(eu868macParameters),
+						DeviceClass:        ttnpb.CLASS_C,
+						LoRaWANVersion:     ttnpb.MAC_V1_1,
 						RxWindowsAvailable: true,
 					},
 					QueuedApplicationDownlinks: []*ttnpb.ApplicationDownlink{
@@ -4206,7 +4162,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class C/windows open/Rx2/expired application downlinks",
+			Name: "Class C/windows open/RX2/expired application downlinks",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -4374,7 +4330,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "join-accept/windows open/Rx2/no active MAC state/window open/EU868/1.1",
+			Name: "join-accept/windows open/RX2/no active MAC state/window open/EU868/1.1",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -4631,8 +4587,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			a := assertions.New(t)
 
-			ns, ctx, env, stop := StartTest(t, Config{}, (1<<10)*test.Delay)
-			defer stop()
+			ns, ctx, env, stopTest := StartTest(t, Config{}, (1<<10)*test.Delay)
 
 			ns.downlinkPriorities = tc.DownlinkPriorities
 
@@ -4676,6 +4631,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 				}
 			}
 			close(processDownlinkTaskErrCh)
+
+			stopTest()
 		})
 	}
 }
@@ -4910,7 +4867,7 @@ func TestGenerateDownlink(t *testing.T) {
 					},
 					Session: &ttnpb.Session{
 						DevAddr:       devAddr,
-						LastNFCntDown: 42,
+						LastNFCntDown: 41,
 						SessionKeys: ttnpb.SessionKeys{
 							NwkSEncKey: &ttnpb.KeyEnvelope{
 								Key: &nwkSEncKey,
@@ -5245,16 +5202,9 @@ func TestGenerateDownlink(t *testing.T) {
 					},
 					MACState: &ttnpb.MACState{
 						LoRaWANVersion: ttnpb.MAC_V1_1,
-						PendingApplicationDownlink: &ttnpb.ApplicationDownlink{
-							Confirmed:  true,
-							FCnt:       42,
-							FPort:      1,
-							FRMPayload: []byte("test"),
-						},
 					},
 					Session: &ttnpb.Session{
-						DevAddr:          devAddr,
-						LastConfFCntDown: 42,
+						DevAddr: devAddr,
 						SessionKeys: ttnpb.SessionKeys{
 							NwkSEncKey: &ttnpb.KeyEnvelope{
 								Key: &nwkSEncKey,
@@ -5368,16 +5318,9 @@ func TestGenerateDownlink(t *testing.T) {
 					MACState: &ttnpb.MACState{
 						LoRaWANVersion:     ttnpb.MAC_V1_1,
 						RxWindowsAvailable: true,
-						PendingApplicationDownlink: &ttnpb.ApplicationDownlink{
-							Confirmed:  true,
-							FCnt:       42,
-							FPort:      1,
-							FRMPayload: []byte("test"),
-						},
 					},
 					Session: &ttnpb.Session{
-						DevAddr:          devAddr,
-						LastConfFCntDown: 42,
+						DevAddr: devAddr,
 						SessionKeys: ttnpb.SessionKeys{
 							NwkSEncKey: &ttnpb.KeyEnvelope{
 								Key: &nwkSEncKey,
@@ -5493,7 +5436,7 @@ func TestGenerateDownlink(t *testing.T) {
 					Session: &ttnpb.Session{
 						DevAddr:       devAddr,
 						LastFCntUp:    99,
-						LastNFCntDown: 42,
+						LastNFCntDown: 41,
 						SessionKeys: ttnpb.SessionKeys{
 							NwkSEncKey: &ttnpb.KeyEnvelope{
 								Key: &nwkSEncKey,
@@ -5598,7 +5541,7 @@ func TestGenerateDownlink(t *testing.T) {
 					},
 					Session: &ttnpb.Session{
 						DevAddr:       devAddr,
-						LastNFCntDown: 42,
+						LastNFCntDown: 41,
 						SessionKeys: ttnpb.SessionKeys{
 							NwkSEncKey: &ttnpb.KeyEnvelope{
 								Key: &nwkSEncKey,
@@ -5661,7 +5604,7 @@ func TestGenerateDownlink(t *testing.T) {
 				return
 			}
 
-			genDown, genState, err := ns.generateDownlink(ctx, dev, phy, math.MaxUint16, math.MaxUint16)
+			genDown, genState, err := ns.generateDownlink(ctx, dev, phy, dev.MACState.DeviceClass, math.MaxUint16, math.MaxUint16)
 			if tc.Error != nil {
 				a.So(err, should.EqualErrorOrDefinition, tc.Error)
 				a.So(genDown, should.BeNil)

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -3018,9 +3018,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					return false
 				}
 
-				if a.So(lastDown.CorrelationIDs, should.HaveLength, 5) {
-					a.So(lastDown.CorrelationIDs, should.Contain, "correlation-up-1")
-					a.So(lastDown.CorrelationIDs, should.Contain, "correlation-up-2")
+				if a.So(lastDown.CorrelationIDs, should.HaveLength, 3) {
 					a.So(lastDown.CorrelationIDs, should.Contain, "correlation-app-down-1")
 					a.So(lastDown.CorrelationIDs, should.Contain, "correlation-app-down-2")
 				}
@@ -3329,9 +3327,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					return false
 				}
 
-				if a.So(lastDown.CorrelationIDs, should.HaveLength, 5) {
-					a.So(lastDown.CorrelationIDs, should.Contain, "correlation-up-1")
-					a.So(lastDown.CorrelationIDs, should.Contain, "correlation-up-2")
+				if a.So(lastDown.CorrelationIDs, should.HaveLength, 3) {
 					a.So(lastDown.CorrelationIDs, should.Contain, "correlation-app-down-1")
 					a.So(lastDown.CorrelationIDs, should.Contain, "correlation-app-down-2")
 				}
@@ -3651,9 +3647,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					return false
 				}
 
-				if a.So(lastDown.CorrelationIDs, should.HaveLength, 5) {
-					a.So(lastDown.CorrelationIDs, should.Contain, "correlation-up-1")
-					a.So(lastDown.CorrelationIDs, should.Contain, "correlation-up-2")
+				if a.So(lastDown.CorrelationIDs, should.HaveLength, 3) {
 					a.So(lastDown.CorrelationIDs, should.Contain, "correlation-app-down-1")
 					a.So(lastDown.CorrelationIDs, should.Contain, "correlation-app-down-2")
 				}
@@ -3933,9 +3927,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					return false
 				}
 
-				if a.So(lastDown.CorrelationIDs, should.HaveLength, 5) {
-					a.So(lastDown.CorrelationIDs, should.Contain, "correlation-up-1")
-					a.So(lastDown.CorrelationIDs, should.Contain, "correlation-up-2")
+				if a.So(lastDown.CorrelationIDs, should.HaveLength, 3) {
 					a.So(lastDown.CorrelationIDs, should.Contain, "correlation-app-down-1")
 					a.So(lastDown.CorrelationIDs, should.Contain, "correlation-app-down-2")
 				}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/1109
Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/1110 (only account for this in 1.1)

#### Changes
<!-- What are the changes made in this pull request? -->

- Only schedule MAC answers in Class A for all devices
- Only schedule `PingSlotReq` in Class A downlink slots
- Only skip Class A downlink slots for Class B/C devices if no MAC answers are to schedule and RX1 is already expired
- Removed necessity for `deepcopy` by moving the mutation of device to record the downlink out of `generateDownlink` 

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The diff is quite unfortunate, but since class A downlink scheduling logic is now shared between devices of all classes, there's not much I can do to improve it.
`generateDownlink` goes through application downlink before MAC processing, such that we can access `dev.QueuedResponses` directly before it may get mutated. That also means we don't need to do redundant work of adding MAC commands to class A downlink buffer if we're going to abort it later to do B/C and that we actually may have more opportunities to send class A downlink(e.g. if absolute time downlink is expired and next one in queue is not Class B/C bound, we can immediately schedule the *next* downlink in Class A)

Tested with Tektelic + ff1705:
```
Initialized Arm Mbed LoRaWAN stack
[DBG ][LSTK]: Initiating OTAA
[DBG ][LSTK]: Sending Join Request ...
[DBG ][LMAC]: Frame prepared to send at port 0
[DBG ][LMAC]: TX: Channel=2, TX DR=5, RX1 DR=5
Joining network...
[DBG ][LSTK]: Transmission completed
[DBG ][LMAC]: RX1 slot open, Freq = 868500000
[DBG ][LSTK]: OTAA Connection OK!
Joined network
[DBG ][LMAC]: Changing device class to -> CLASS_C
[DBG ][LMAC]: RX2 slot open, Freq = 869525000
Switched to class C
[INFO][LMAC]: RTS = 0 bytes, PEND = 0, Port: 1
[DBG ][LMAC]: Frame prepared to send at port 1
[DBG ][LMAC]: TX: Channel=7, TX DR=5, RX1 DR=5
Sending 0 bytes
[DBG ][LSTK]: Transmission completed
[DBG ][LMAC]: RX2 slot open, Freq = 869525000
Message sent
[DBG ][LMAC]: RX1 slot open, Freq = 867900000
[DBG ][LMAC]: RX2 slot open, Freq = 869525000
Message sent
Message sent
[DBG ][LSTK]: Packet Received 2 bytes, Port=15
Message sent
Received message on port 15 (2 bytes, flags = 1): ab ba 
Message sent
[DBG ][LSTK]: Packet Received 4 bytes, Port=2
Message sent
Received message on port 2 (4 bytes, flags = 1): 2d 5a 6d 5d 
Synchronized clock to Mon Sep  2 18:06:37 2019
Message sent
```

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Improved compatibility with various Class C devices
