### PR TITLE
Fetch repo before checking out gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,6 +123,7 @@ script:
     set -e
     rm -rf doc/public
     mkdir doc/public
+    git fetch
     git --work-tree=doc/public checkout gh-pages .
     git reset .
     $MAGE docs:build


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quickfix for the failing `release` build. Travis only does a shallow clone, so we have to make sure to actually fetch the repo before checking out the gh-pages branch.

#### Changes
<!-- What are the changes made in this pull request? -->

- Fetch the repo before checking out a different branch

