### PR TITLE
gs: Add timeout to wait for gateway disconnection

### DIFF
--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -571,6 +571,9 @@ func TestGatewayServer(t *testing.T) {
 			}
 		})
 
+		// Wait for gateway disconnection to be processed.
+		time.Sleep(timeout)
+
 		t.Run(fmt.Sprintf("Traffic/%v", ptc.Protocol), func(t *testing.T) {
 			a := assertions.New(t)
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This draft PR hopes to fix #1052 

#### Changes
<!-- What are the changes made in this pull request? -->

- Wait for gateway disconnection before starting traffic tests.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This is a draft PR to test on travis. I'll add an actual PR once this passes.