### PR TITLE
Add issue template for questions and doc requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation_request.md
+++ b/.github/ISSUE_TEMPLATE/documentation_request.md
@@ -1,0 +1,40 @@
+---
+name: Documentation request
+about: Missing documentation or suggest an improvement
+
+---
+
+<!--
+Thanks for submitting this documentation request. Please fill the template below,
+otherwise we will not be able to process this request.
+
+Open an issue with this template if you think documentation regarding a certain aspect of the stack is lacking or
+missing, or if you have an idea on how to improve the documentaion via new tools, theme, etc.
+-->
+
+#### Summary
+<!-- Summarize the suggesstion in a few sentences: -->
+
+
+#### Why do we need this ?
+<!-- Please explain the motivation, for whom, etc. -->
+
+
+#### What is already there? What do you see now?
+<!--
+Please paste terminal output, upload logs (as .txt) or upload screenshots.
+Describe or link to related APIs, screen designs, packages, etc.
+Nothing related is a valid answer.
+-->
+
+#### What is missing? What do you want to see?
+<!-- Please add documentation source (forum/slakc links, outside sources), mock-ups if applicable -->
+
+...
+
+#### (Optional for content only) How do you propose to implement this?
+<!-- Please think about how this could be fixed. -->
+
+
+#### Can you do this yourself and submit a Pull Request?
+<!-- You can also @mention experts if you need help with this. -->

--- a/.github/ISSUE_TEMPLATE/documentation_request.md
+++ b/.github/ISSUE_TEMPLATE/documentation_request.md
@@ -5,36 +5,38 @@ about: Missing documentation or suggest an improvement
 ---
 
 <!--
-Thanks for submitting this documentation request. Please fill the template below,
-otherwise we will not be able to process this request.
-
-Open an issue with this template if you think documentation regarding a certain aspect of the stack is lacking or
-missing, or if you have an idea on how to improve the documentaion via new tools, theme, etc.
+Thanks for submitting this documentation request. Please fill the template
+below, otherwise we will not be able to process this request.
 -->
 
 #### Summary
-<!-- Summarize the suggesstion in a few sentences: -->
+<!-- Summarize the request in a few sentences: -->
 
+...
 
 #### Why do we need this ?
 <!-- Please explain the motivation, for whom, etc. -->
 
+...
 
 #### What is already there? What do you see now?
 <!--
-Please paste terminal output, upload logs (as .txt) or upload screenshots.
-Describe or link to related APIs, screen designs, packages, etc.
-Nothing related is a valid answer.
+Please add any relevant documentation articles and resources. Screenshots if necessary.
 -->
-
-#### What is missing? What do you want to see?
-<!-- Please add documentation source (forum/slakc links, outside sources), mock-ups if applicable -->
 
 ...
 
-#### (Optional for content only) How do you propose to implement this?
+#### What is missing? What do you want to see?
+<!-- Please add documentation sources (forum links, outside sources...), mock-ups if applicable -->
+
+...
+
+#### How do you propose to document this?
 <!-- Please think about how this could be fixed. -->
 
+...
 
 #### Can you do this yourself and submit a Pull Request?
 <!-- You can also @mention experts if you need help with this. -->
+
+...

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,14 @@
+---
+name: Question
+about: Please raise your question on our community platforms:
+       - The forum: https://www.thethingsnetwork.org/forum/
+       - Slack: https://thethingsnetwork.slack.com (you can self join via https://account.thethingsnetwork.org) 
+---
+
+:rotating_light: :stop_sign: This issue tracker is not for questions :stop_sign: :rotating_light:
+
+Please raise your question on our community platforms:
+- The forum: https://www.thethingsnetwork.org/forum/
+- Slack: https://thethingsnetwork.slack.com (you can self join via https://account.thethingsnetwork.org)
+
+

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,14 +1,11 @@
 ---
 name: Question
-about: Please raise your question on our community platforms:
-       - The forum: https://www.thethingsnetwork.org/forum/
-       - Slack: https://thethingsnetwork.slack.com (you can self join via https://account.thethingsnetwork.org) 
+about: Please raise your question on our community platforms. https://www.thethingsnetwork.org/forum/ or https://thethingsnetwork.slack.com
+
 ---
 
 :rotating_light: :stop_sign: This issue tracker is not for questions :stop_sign: :rotating_light:
 
 Please raise your question on our community platforms:
-- The forum: https://www.thethingsnetwork.org/forum/
+- Forum: https://www.thethingsnetwork.org/forum/
 - Slack: https://thethingsnetwork.slack.com (you can self join via https://account.thethingsnetwork.org)
-
-


### PR DESCRIPTION
#### Summary

Close #890 by introducing two issue templates.
...

#### Changes
Added to issue template. One to raise documentation and one redirecting questions to the forum and slack.
