### PR TITLE
Add option to redirect all HTTP requests to a single host

### DIFF
--- a/pkg/component/web.go
+++ b/pkg/component/web.go
@@ -41,6 +41,9 @@ func (c *Component) initWeb() error {
 		web.WithCookieKeys(c.config.HTTP.Cookie.HashKey, c.config.HTTP.Cookie.BlockKey),
 		web.WithStatic(c.config.HTTP.Static.Mount, c.config.HTTP.Static.SearchPath...),
 	}
+	if c.config.HTTP.RedirectToHost != "" {
+		webOptions = append(webOptions, web.WithRedirectToHost(c.config.HTTP.RedirectToHost))
+	}
 	if c.config.HTTP.RedirectToHTTPS {
 		httpAddr, err := net.ResolveTCPAddr("tcp", c.config.HTTP.Listen)
 		if err != nil {

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -101,6 +101,7 @@ type HTTPStaticConfig struct {
 type HTTP struct {
 	Listen          string           `name:"listen" description:"Address for the HTTP server to listen on"`
 	ListenTLS       string           `name:"listen-tls" description:"Address for the HTTPS server to listen on"`
+	RedirectToHost  string           `name:"redirect-to-host" description:"Redirect all requests to one host"`
 	RedirectToHTTPS bool             `name:"redirect-to-tls" description:"Redirect HTTP requests to HTTPS"`
 	Static          HTTPStaticConfig `name:"static"`
 	Cookie          Cookie           `name:"cookie"`

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -55,6 +55,7 @@ type options struct {
 
 	contextFillers []fillcontext.Filler
 
+	redirectToHost  string
 	redirectToHTTPS map[int]int
 }
 
@@ -79,6 +80,13 @@ func WithCookieKeys(hashKey, blockKey []byte) Option {
 func WithStatic(mount string, searchPaths ...string) Option {
 	return func(o *options) {
 		o.staticMount, o.staticSearchPaths = mount, searchPaths
+	}
+}
+
+// WithRedirectToHost redirects all requests to this host.
+func WithRedirectToHost(target string) Option {
+	return func(o *options) {
+		o.redirectToHost = target
 	}
 }
 
@@ -135,6 +143,10 @@ func New(ctx context.Context, opts ...Option) (*Server, error) {
 		cookie.Cookies(blockKey, hashKey),
 		middleware.FillContext(options.contextFillers...),
 	)
+
+	if options.redirectToHost != "" {
+		server.Use(middleware.RedirectToHost(options.redirectToHost))
+	}
 
 	if options.redirectToHTTPS != nil {
 		server.Use(middleware.RedirectToHTTPS(options.redirectToHTTPS))


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR is similar to #1299, except that it redirects all HTTP(S) requests to a single configured host.


#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Addded `http.redirect-to-host` config to redirect all HTTP(S) requests to the same host
