### PR TITLE
Fix callback regression from #1307

### DIFF
--- a/pkg/oauth/server.go
+++ b/pkg/oauth/server.go
@@ -17,6 +17,7 @@ package oauth
 import (
 	"context"
 	"net/http"
+	"strings"
 	"time"
 
 	echo "github.com/labstack/echo/v4"
@@ -189,6 +190,10 @@ func (s *server) output(c echo.Context, resp *osin.Response) error {
 		location, err := resp.GetRedirectUrl()
 		if err != nil {
 			return err
+		}
+		uiMount := strings.TrimSuffix(s.config.UI.MountPath(), "/")
+		if strings.HasPrefix(location, "/code") || strings.HasPrefix(location, "/local-callback") {
+			location = uiMount + location
 		}
 		return c.Redirect(http.StatusFound, location)
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quickfix for a regression introduced by #1307 that caused `code` and `local-callback` redirects to lose the `/oauth` prefix.