### PR TITLE
Application Server PubSub events

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -1601,6 +1601,15 @@
       "file": "format.go"
     }
   },
+  "error:pkg/applicationserver/io/pubsub:integration_failed": {
+    "translations": {
+      "en": "integration {pub_sub_id} failed"
+    },
+    "description": {
+      "package": "pkg/applicationserver/io/pubsub",
+      "file": "observability.go"
+    }
+  },
   "error:pkg/applicationserver/io/web/redis:invalid_fieldmask": {
     "translations": {
       "en": "invalid fieldmask"
@@ -5954,6 +5963,51 @@
     },
     "description": {
       "package": "pkg/applicationserver",
+      "file": "observability.go"
+    }
+  },
+  "event:as.pubsub.delete": {
+    "translations": {
+      "en": "delete pubsub"
+    },
+    "description": {
+      "package": "pkg/applicationserver/io/pubsub",
+      "file": "observability.go"
+    }
+  },
+  "event:as.pubsub.fail": {
+    "translations": {
+      "en": "fail pubsub"
+    },
+    "description": {
+      "package": "pkg/applicationserver/io/pubsub",
+      "file": "observability.go"
+    }
+  },
+  "event:as.pubsub.set": {
+    "translations": {
+      "en": "set pubsub"
+    },
+    "description": {
+      "package": "pkg/applicationserver/io/pubsub",
+      "file": "observability.go"
+    }
+  },
+  "event:as.pubsub.start": {
+    "translations": {
+      "en": "start pubsub"
+    },
+    "description": {
+      "package": "pkg/applicationserver/io/pubsub",
+      "file": "observability.go"
+    }
+  },
+  "event:as.pubsub.stop": {
+    "translations": {
+      "en": "stop pubsub"
+    },
+    "description": {
+      "package": "pkg/applicationserver/io/pubsub",
       "file": "observability.go"
     }
   },

--- a/pkg/applicationserver/applicationserver_util_test.go
+++ b/pkg/applicationserver/applicationserver_util_test.go
@@ -22,7 +22,8 @@ import (
 )
 
 var (
-	Timeout = (1 << 9) * test.Delay
+	Timeout          = (1 << 8) * test.Delay
+	EventsBufferSize = (1 << 6)
 )
 
 // MockDeviceRegistry is a mock DeviceRegistry used for testing.

--- a/pkg/applicationserver/applicationserver_util_test.go
+++ b/pkg/applicationserver/applicationserver_util_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	Timeout          = (1 << 8) * test.Delay
+	Timeout          = (1 << 6) * test.Delay
 	EventsBufferSize = (1 << 6)
 )
 

--- a/pkg/applicationserver/io/pubsub/grpc_pubsub.go
+++ b/pkg/applicationserver/io/pubsub/grpc_pubsub.go
@@ -20,6 +20,7 @@ import (
 	pbtypes "github.com/gogo/protobuf/types"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/pkg/errors"
+	"go.thethings.network/lorawan-stack/pkg/events"
 	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/unique"
@@ -98,7 +99,7 @@ func (ps *PubSub) Set(ctx context.Context, req *ttnpb.SetApplicationPubSubReques
 		)).WithError(err).Warn("Failed to cancel integration")
 	}
 	ps.startTask(ps.ctx, req.ApplicationPubSubIdentifiers)
-
+	events.Publish(evtSetPubSub(ctx, req.ApplicationPubSubIdentifiers, nil))
 	return pubsub, nil
 }
 
@@ -125,5 +126,6 @@ func (ps *PubSub) Delete(ctx context.Context, ids *ttnpb.ApplicationPubSubIdenti
 	if err != nil {
 		return nil, err
 	}
+	events.Publish(evtDeletePubSub(ctx, *ids, nil))
 	return ttnpb.Empty, nil
 }

--- a/pkg/applicationserver/io/pubsub/observability.go
+++ b/pkg/applicationserver/io/pubsub/observability.go
@@ -1,0 +1,132 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pubsub
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.thethings.network/lorawan-stack/pkg/errors"
+	"go.thethings.network/lorawan-stack/pkg/events"
+	"go.thethings.network/lorawan-stack/pkg/metrics"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/pkg/unique"
+)
+
+var (
+	evtSetPubSub = events.Define(
+		"as.pubsub.set", "set pubsub",
+		ttnpb.RIGHT_APPLICATION_SETTINGS_BASIC,
+	)
+	evtDeletePubSub = events.Define(
+		"as.pubsub.delete", "delete pubsub",
+		ttnpb.RIGHT_APPLICATION_SETTINGS_BASIC,
+	)
+	evtPubSubStart = events.Define(
+		"as.pubsub.start", "start pubsub",
+		ttnpb.RIGHT_APPLICATION_SETTINGS_BASIC,
+		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		ttnpb.RIGHT_APPLICATION_TRAFFIC_DOWN_WRITE,
+	)
+	evtPubSubStop = events.Define(
+		"as.pubsub.stop", "stop pubsub",
+		ttnpb.RIGHT_APPLICATION_SETTINGS_BASIC,
+		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		ttnpb.RIGHT_APPLICATION_TRAFFIC_DOWN_WRITE,
+	)
+	evtPubSubFail = events.Define(
+		"as.pubsub.fail", "fail pubsub",
+		ttnpb.RIGHT_APPLICATION_SETTINGS_BASIC,
+		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		ttnpb.RIGHT_APPLICATION_TRAFFIC_DOWN_WRITE,
+	)
+)
+
+const (
+	subsystem     = "as_pubsub"
+	unknown       = "unknown"
+	applicationID = "application_id"
+)
+
+var pubsubMetrics = &integrationsMetrics{
+	integrationsStarted: metrics.NewContextualCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "integrations_started_total",
+			Help:      "Number of integrations started",
+		},
+		[]string{applicationID},
+	),
+	integrationsStopped: metrics.NewContextualCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "integrations_stopped_total",
+			Help:      "Number of integrations stopped",
+		},
+		[]string{applicationID},
+	),
+	integrationsFailed: metrics.NewContextualCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "integrations_failed_total",
+			Help:      "Number of integrations failed",
+		},
+		[]string{applicationID},
+	),
+}
+
+func init() {
+	metrics.MustRegister(pubsubMetrics)
+}
+
+type integrationsMetrics struct {
+	integrationsStarted *metrics.ContextualCounterVec
+	integrationsStopped *metrics.ContextualCounterVec
+	integrationsFailed  *metrics.ContextualCounterVec
+}
+
+func (m integrationsMetrics) Describe(ch chan<- *prometheus.Desc) {
+	m.integrationsStarted.Describe(ch)
+	m.integrationsStopped.Describe(ch)
+	m.integrationsFailed.Describe(ch)
+}
+
+func (m integrationsMetrics) Collect(ch chan<- prometheus.Metric) {
+	m.integrationsStarted.Collect(ch)
+	m.integrationsStopped.Collect(ch)
+	m.integrationsFailed.Collect(ch)
+}
+
+func registerIntegrationStart(ctx context.Context, i *integration) {
+	events.Publish(evtPubSubStart(ctx, i.ApplicationIdentifiers, i.ApplicationPubSubIdentifiers))
+	pubsubMetrics.integrationsStarted.WithLabelValues(ctx, i.ApplicationID).Inc()
+}
+
+func registerIntegrationStop(ctx context.Context, i *integration) {
+	events.Publish(evtPubSubStop(ctx, i.ApplicationIdentifiers, i.ApplicationPubSubIdentifiers))
+	pubsubMetrics.integrationsStopped.WithLabelValues(ctx, i.ApplicationID).Inc()
+}
+
+var errIntegrationFailed = errors.DefineAborted("integration_failed", "integration {pub_sub_id} failed")
+
+func registerIntegrationFail(ctx context.Context, i *integration, err error) {
+	err = errIntegrationFailed.
+		WithAttributes(
+			"application_uid", unique.ID(ctx, i.ApplicationIdentifiers),
+			"pub_sub_id", i.PubSubID).
+		WithCause(err)
+	events.Publish(evtPubSubFail(ctx, i.ApplicationIdentifiers, err))
+	pubsubMetrics.integrationsFailed.WithLabelValues(ctx, i.ApplicationID).Inc()
+}

--- a/pkg/applicationserver/observability.go
+++ b/pkg/applicationserver/observability.go
@@ -253,6 +253,7 @@ func registerLinkStop(ctx context.Context, link *link) {
 
 func registerLinkFail(ctx context.Context, link *link, err error) {
 	events.Publish(evtLinkFail(ctx, link.ApplicationIdentifiers, err))
+	asMetrics.linksFailed.WithLabelValues(ctx, link.NetworkServerAddress).Inc()
 }
 
 func registerSubscribe(ctx context.Context, sub *io.Subscription) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #1286 
Closes #1017 
#### Changes
<!-- What are the changes made in this pull request? -->

- Add set, delete, start, stop and failed events to the PubSub integrations.
- Expand `pkg/util/test` with event redirection / waiting capabilities
- Cut the AS global test timeout in half.
- Wait for integrations to start before sending / receiving commands from them in tests.
- Ensure that integrations and links close properly.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

e4454060fef496fe5aaf4d2bb182e747be72cd39 and 1b80ac3c9b91a39a6e0c1c0d2eed30f4e237c170 are two important commits since they fix a race condition in the linking / integration process. Calling `stop` on an integration / link is expected to fully close the integration / link, such that a new `start` call can occur without an `already started` error. However, the behavior before these two commits was that `stop` will simply cancel the context. This is not correct, since the goroutine that clears the integration / link from the `sync.Map` that holds the integrations / links does not have to be scheduled before we start the linking / integration task. This is very important since it can result in `Set` calls that do not start the integration / link, if they were already started.

~Does moving `ApplicationPubSubIdentifiers` from one proto file to another count as breaking API ?~

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Added Application Server PubSub integrations events ! See `pkg/applicationserver/io/pubsub/observability.go` for more details.
