### PR TITLE
Support absolute paths in fetch package

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -2744,9 +2744,45 @@
       "file": "errors.go"
     }
   },
+  "error:pkg/fetch:filename_not_specified": {
+    "translations": {
+      "en": "filename not specified"
+    },
+    "description": {
+      "package": "pkg/fetch",
+      "file": "errors.go"
+    }
+  },
   "error:pkg/fetch:read_file": {
     "translations": {
       "en": "could not read file `{filename}`"
+    },
+    "description": {
+      "package": "pkg/fetch",
+      "file": "errors.go"
+    }
+  },
+  "error:pkg/fetch:scheme_not_specified": {
+    "translations": {
+      "en": "URI scheme not specified"
+    },
+    "description": {
+      "package": "pkg/fetch",
+      "file": "errors.go"
+    }
+  },
+  "error:pkg/fetch:scheme_specified": {
+    "translations": {
+      "en": "URI scheme should not be specified"
+    },
+    "description": {
+      "package": "pkg/fetch",
+      "file": "errors.go"
+    }
+  },
+  "error:pkg/fetch:volume_specified": {
+    "translations": {
+      "en": "volume should not be specified"
     },
     "description": {
       "package": "pkg/fetch",

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -114,6 +114,11 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 		}
 	}
 
+	drCl, err := c.GetBaseConfig(c.Context()).DeviceRepository.Client()
+	if err != nil {
+		return nil, err
+	}
+
 	as = &ApplicationServer{
 		Component:      c,
 		ctx:            ctx,
@@ -121,7 +126,7 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 		linkRegistry:   conf.Links,
 		deviceRegistry: conf.Devices,
 		formatter: payloadFormatter{
-			repository: c.GetBaseConfig(c.Context()).DeviceRepository.Client(),
+			repository: drCl,
 			upFormatters: map[ttnpb.PayloadFormatter]messageprocessors.PayloadDecoder{
 				ttnpb.PayloadFormatter_FORMATTER_JAVASCRIPT: javascript.New(),
 				ttnpb.PayloadFormatter_FORMATTER_CAYENNELPP: cayennelpp.New(),

--- a/pkg/applicationserver/io/web/templates.go
+++ b/pkg/applicationserver/io/web/templates.go
@@ -61,7 +61,11 @@ func (c TemplatesConfig) NewTemplateStore() (*TemplateStore, error) {
 	case c.Directory != "":
 		fetcher = fetch.FromFilesystem(c.Directory)
 	case c.URL != "":
-		fetcher = fetch.FromHTTP(c.URL, true)
+		var err error
+		fetcher, err = fetch.FromHTTP(c.URL, true)
+		if err != nil {
+			return nil, err
+		}
 	default:
 		return nil, nil
 	}

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -119,6 +119,11 @@ func New(logger log.Stack, config *Config, opts ...Option) (*Component, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	ctx = log.NewContext(ctx, logger)
 
+	fps, err := config.FrequencyPlans.Store()
+	if err != nil {
+		return nil, err
+	}
+
 	c := &Component{
 		ctx:                ctx,
 		cancelCtx:          cancel,
@@ -131,7 +136,7 @@ func New(logger log.Stack, config *Config, opts ...Option) (*Component, error) {
 
 		tcpListeners: make(map[string]*listener),
 
-		FrequencyPlans: config.FrequencyPlans.Store(),
+		FrequencyPlans: fps,
 		KeyVault:       config.KeyVault.KeyVault(),
 	}
 

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -200,8 +200,8 @@ type FrequencyPlansConfig struct {
 
 // Store returns a frequencyplan.Store fwith a fetcher based on the configuration.
 // The order of precedence is Static, Directory and URL.
-// If neither Static, Directory nor a URL is set, this method returns nil.
-func (c FrequencyPlansConfig) Store() *frequencyplans.Store {
+// If neither Static, Directory nor a URL is set, this method returns nil, nil.
+func (c FrequencyPlansConfig) Store() (*frequencyplans.Store, error) {
 	var fetcher fetch.Interface
 	switch {
 	case c.Static != nil:
@@ -209,11 +209,15 @@ func (c FrequencyPlansConfig) Store() *frequencyplans.Store {
 	case c.Directory != "":
 		fetcher = fetch.FromFilesystem(c.Directory)
 	case c.URL != "":
-		fetcher = fetch.FromHTTP(c.URL, true)
+		var err error
+		fetcher, err = fetch.FromHTTP(c.URL, true)
+		if err != nil {
+			return nil, err
+		}
 	default:
-		return nil
+		return nil, nil
 	}
-	return frequencyplans.NewStore(fetcher)
+	return frequencyplans.NewStore(fetcher), nil
 }
 
 // DeviceRepositoryConfig defines the source of the device repository.
@@ -225,8 +229,8 @@ type DeviceRepositoryConfig struct {
 
 // Client instantiates a new devicerepository.Client with a fetcher based on the configuration.
 // The order of precedence is Static, Directory and URL.
-// If neither Static, Directory nor a URL is set, this method returns nil.
-func (c DeviceRepositoryConfig) Client() *devicerepository.Client {
+// If neither Static, Directory nor a URL is set, this method returns nil, nil.
+func (c DeviceRepositoryConfig) Client() (*devicerepository.Client, error) {
 	var fetcher fetch.Interface
 	switch {
 	case c.Static != nil:
@@ -234,13 +238,17 @@ func (c DeviceRepositoryConfig) Client() *devicerepository.Client {
 	case c.Directory != "":
 		fetcher = fetch.FromFilesystem(c.Directory)
 	case c.URL != "":
-		fetcher = fetch.FromHTTP(c.URL, true)
+		var err error
+		fetcher, err = fetch.FromHTTP(c.URL, true)
+		if err != nil {
+			return nil, err
+		}
 	default:
-		return nil
+		return nil, nil
 	}
 	return &devicerepository.Client{
 		Fetcher: fetcher,
-	}
+	}, nil
 }
 
 // InteropClient represents the client-side interoperability through LoRaWAN Backend Interfaces configuration.
@@ -251,19 +259,19 @@ type InteropClient struct {
 }
 
 // IsZero returns whether conf is empty.
-func (conf InteropClient) IsZero() bool {
-	return conf == (InteropClient{})
+func (c InteropClient) IsZero() bool {
+	return c == (InteropClient{})
 }
 
 // Fetcher returns fetch.Interface defined by conf.
-func (conf InteropClient) Fetcher() fetch.Interface {
+func (c InteropClient) Fetcher() (fetch.Interface, error) {
 	switch {
-	case conf.Directory != "":
-		return fetch.FromFilesystem(conf.Directory)
-	case conf.URL != "":
-		return fetch.FromHTTP(conf.URL, true)
+	case c.Directory != "":
+		return fetch.FromFilesystem(c.Directory), nil
+	case c.URL != "":
+		return fetch.FromHTTP(c.URL, true)
 	default:
-		return nil
+		return nil, nil
 	}
 }
 

--- a/pkg/fetch/basepath.go
+++ b/pkg/fetch/basepath.go
@@ -20,6 +20,9 @@ type basePathFetcher struct {
 }
 
 func (f basePathFetcher) File(pathElements ...string) ([]byte, error) {
+	if len(pathElements) == 0 {
+		return nil, errFilenameNotSpecified
+	}
 	return f.Interface.File(append(f.basePath, pathElements...)...)
 }
 

--- a/pkg/fetch/basepath.go
+++ b/pkg/fetch/basepath.go
@@ -14,6 +14,8 @@
 
 package fetch
 
+import "strings"
+
 type basePathFetcher struct {
 	Interface
 	basePath []string
@@ -22,6 +24,9 @@ type basePathFetcher struct {
 func (f basePathFetcher) File(pathElements ...string) ([]byte, error) {
 	if len(pathElements) == 0 {
 		return nil, errFilenameNotSpecified
+	}
+	if strings.HasPrefix(pathElements[0], "/") {
+		return f.Interface.File(pathElements...)
 	}
 	return f.Interface.File(append(f.basePath, pathElements...)...)
 }

--- a/pkg/fetch/basepath.go
+++ b/pkg/fetch/basepath.go
@@ -14,7 +14,9 @@
 
 package fetch
 
-import "strings"
+import (
+	"path/filepath"
+)
 
 type basePathFetcher struct {
 	Interface
@@ -25,12 +27,15 @@ func (f basePathFetcher) File(pathElements ...string) ([]byte, error) {
 	if len(pathElements) == 0 {
 		return nil, errFilenameNotSpecified
 	}
-	if strings.HasPrefix(pathElements[0], "/") {
+
+	// NOTE: filepath.IsAbs returns true for paths starting with '/' on all supported operating systems.
+	if filepath.IsAbs(pathElements[0]) {
 		return f.Interface.File(pathElements...)
 	}
 	return f.Interface.File(append(f.basePath, pathElements...)...)
 }
 
+// WithBasePath returns an Interface, which preprends basePath to non-absolute requested paths.
 func WithBasePath(f Interface, basePath ...string) Interface {
 	return basePathFetcher{
 		Interface: f,

--- a/pkg/fetch/basepath_test.go
+++ b/pkg/fetch/basepath_test.go
@@ -45,16 +45,15 @@ func TestWithBasePath(t *testing.T) {
 		AssertBytes    func(*testing.T, []byte) bool
 	}{
 		{
-			Name:  "empty base path/empty path",
-			Bytes: []byte{0x42, 0x41},
+			Name: "empty base path/empty path",
 			AssertPath: func(t *testing.T, pathElements ...string) bool {
 				return assertions.New(t).So(pathElements, should.BeEmpty)
 			},
 			AssertError: func(t *testing.T, err error) bool {
-				return assertions.New(t).So(err, should.BeNil)
+				return assertions.New(t).So(err, should.BeError)
 			},
 			AssertBytes: func(t *testing.T, b []byte) bool {
-				return assertions.New(t).So(b, should.Resemble, []byte{0x42, 0x41})
+				return assertions.New(t).So(b, should.BeNil)
 			},
 		},
 		{
@@ -72,11 +71,11 @@ func TestWithBasePath(t *testing.T) {
 			},
 		},
 		{
-			Name:     "base [foo bar baz]/empty path",
-			BasePath: []string{"foo", "bar", "baz"},
-			Bytes:    []byte{0x42, 0x41},
+			Name:  "empty base path/path [/foo bar baz]",
+			Path:  []string{"/foo", "bar", "baz"},
+			Bytes: []byte{0x42, 0x41},
 			AssertPath: func(t *testing.T, pathElements ...string) bool {
-				return assertions.New(t).So(pathElements, should.Resemble, []string{"foo", "bar", "baz"})
+				return assertions.New(t).So(pathElements, should.Resemble, []string{"/foo", "bar", "baz"})
 			},
 			AssertError: func(t *testing.T, err error) bool {
 				return assertions.New(t).So(err, should.BeNil)
@@ -86,12 +85,40 @@ func TestWithBasePath(t *testing.T) {
 			},
 		},
 		{
+			Name:     "base [foo bar baz]/empty path",
+			BasePath: []string{"foo", "bar", "baz"},
+			AssertPath: func(t *testing.T, pathElements ...string) bool {
+				return assertions.New(t).So(pathElements, should.Resemble, []string{"foo", "bar", "baz"})
+			},
+			AssertError: func(t *testing.T, err error) bool {
+				return assertions.New(t).So(err, should.BeError)
+			},
+			AssertBytes: func(t *testing.T, b []byte) bool {
+				return assertions.New(t).So(b, should.BeNil)
+			},
+		},
+		{
 			Name:     "base [foo bar baz]/path [42 baz bar foo]",
 			BasePath: []string{"foo", "bar", "baz"},
 			Path:     []string{"42", "baz", "bar", "foo"},
 			Bytes:    []byte{0x42, 0x41},
 			AssertPath: func(t *testing.T, pathElements ...string) bool {
 				return assertions.New(t).So(pathElements, should.Resemble, []string{"foo", "bar", "baz", "42", "baz", "bar", "foo"})
+			},
+			AssertError: func(t *testing.T, err error) bool {
+				return assertions.New(t).So(err, should.BeNil)
+			},
+			AssertBytes: func(t *testing.T, b []byte) bool {
+				return assertions.New(t).So(b, should.Resemble, []byte{0x42, 0x41})
+			},
+		},
+		{
+			Name:     "base [foo bar baz]/path [/42 baz bar foo]",
+			BasePath: []string{"foo", "bar", "baz"},
+			Path:     []string{"/42", "baz", "bar", "foo"},
+			Bytes:    []byte{0x42, 0x41},
+			AssertPath: func(t *testing.T, pathElements ...string) bool {
+				return assertions.New(t).So(pathElements, should.Resemble, []string{"/42", "baz", "bar", "foo"})
 			},
 			AssertError: func(t *testing.T, err error) bool {
 				return assertions.New(t).So(err, should.BeNil)

--- a/pkg/fetch/bucket.go
+++ b/pkg/fetch/bucket.go
@@ -40,6 +40,10 @@ func FromBucket(bucket *blob.Bucket, basePath string) Interface {
 }
 
 func (f *bucketFetcher) File(pathElements ...string) ([]byte, error) {
+	if len(pathElements) == 0 {
+		return nil, errFilenameNotSpecified
+	}
+
 	start := time.Now()
 	content, err := f.bucket.ReadAll(context.TODO(), filepath.Join(append([]string{f.base}, pathElements...)...))
 	if err == nil {

--- a/pkg/fetch/bucket.go
+++ b/pkg/fetch/bucket.go
@@ -29,18 +29,6 @@ type bucketFetcher struct {
 	root   string
 }
 
-// FromBucket returns an interface that fetches files from the given blob bucket.
-func FromBucket(bucket *blob.Bucket, root string) Interface {
-	root = path.Clean(root)
-	return &bucketFetcher{
-		baseFetcher: baseFetcher{
-			latency: fetchLatency.WithLabelValues("bucket", root),
-		},
-		bucket: bucket,
-		root:   root,
-	}
-}
-
 func (f *bucketFetcher) File(pathElements ...string) ([]byte, error) {
 	if len(pathElements) == 0 {
 		return nil, errFilenameNotSpecified
@@ -63,4 +51,16 @@ func (f *bucketFetcher) File(pathElements ...string) ([]byte, error) {
 		return nil, errFileNotFound.WithAttributes("filename", p)
 	}
 	return nil, errCouldNotReadFile.WithCause(err).WithAttributes("filename", p)
+}
+
+// FromBucket returns an interface that fetches files from the given blob bucket.
+func FromBucket(bucket *blob.Bucket, root string) Interface {
+	root = path.Clean(root)
+	return &bucketFetcher{
+		baseFetcher: baseFetcher{
+			latency: fetchLatency.WithLabelValues("bucket", root),
+		},
+		bucket: bucket,
+		root:   root,
+	}
 }

--- a/pkg/fetch/bucket.go
+++ b/pkg/fetch/bucket.go
@@ -16,7 +16,7 @@ package fetch
 
 import (
 	"context"
-	"path/filepath"
+	"path"
 	"time"
 
 	"gocloud.dev/blob"
@@ -26,16 +26,18 @@ import (
 type bucketFetcher struct {
 	baseFetcher
 	bucket *blob.Bucket
+	root   string
 }
 
 // FromBucket returns an interface that fetches files from the given blob bucket.
-func FromBucket(bucket *blob.Bucket, basePath string) Interface {
+func FromBucket(bucket *blob.Bucket, root string) Interface {
+	root = path.Clean(root)
 	return &bucketFetcher{
 		baseFetcher: baseFetcher{
-			base:    basePath,
-			latency: fetchLatency.WithLabelValues("bucket", basePath),
+			latency: fetchLatency.WithLabelValues("bucket", root),
 		},
 		bucket: bucket,
+		root:   root,
 	}
 }
 
@@ -45,14 +47,20 @@ func (f *bucketFetcher) File(pathElements ...string) ([]byte, error) {
 	}
 
 	start := time.Now()
-	content, err := f.bucket.ReadAll(context.TODO(), filepath.Join(append([]string{f.base}, pathElements...)...))
+
+	p := path.Join(pathElements...)
+	rp, err := realPath(f.root, p)
+	if err != nil {
+		return nil, err
+	}
+	content, err := f.bucket.ReadAll(context.TODO(), rp)
 	if err == nil {
 		f.observeLatency(time.Since(start))
 		return content, nil
 	}
 
 	if gcerrors.Code(err) == gcerrors.NotFound {
-		return nil, errFileNotFound.WithAttributes("filename", filepath.Join(pathElements...))
+		return nil, errFileNotFound.WithAttributes("filename", p)
 	}
-	return nil, errCouldNotReadFile.WithCause(err).WithAttributes("filename", filepath.Join(pathElements...))
+	return nil, errCouldNotReadFile.WithCause(err).WithAttributes("filename", p)
 }

--- a/pkg/fetch/bucket_test.go
+++ b/pkg/fetch/bucket_test.go
@@ -15,11 +15,9 @@
 package fetch_test
 
 import (
-	"fmt"
+	"io/ioutil"
 	"os"
-	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/blob"
@@ -29,10 +27,9 @@ import (
 )
 
 func TestBucket(t *testing.T) {
-	tmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("FetchTestBucket_%d", time.Now().UnixNano()/1000000))
-	err := os.Mkdir(tmpDir, 0755)
+	tmpDir, err := ioutil.TempDir("", "FetchTestBucket")
 	if err != nil {
-		panic(err)
+		t.Fatalf("Failed to create temporary directory: %v", err)
 	}
 	defer os.RemoveAll(tmpDir)
 

--- a/pkg/fetch/errors.go
+++ b/pkg/fetch/errors.go
@@ -19,6 +19,9 @@ import "go.thethings.network/lorawan-stack/pkg/errors"
 var (
 	errCouldNotFetchFile    = errors.Define("fetch_file", "could not fetch file `{filename}`")
 	errCouldNotReadFile     = errors.DefineCorruption("read_file", "could not read file `{filename}`")
-	errFilenameNotSpecified = errors.DefineInvalidArgument("no_filename", "filename not specified")
+	errFilenameNotSpecified = errors.DefineInvalidArgument("filename_not_specified", "filename not specified")
 	errFileNotFound         = errors.DefineNotFound("file_not_found", "file `{filename}` not found")
+	errSchemeNotSpecified   = errors.DefineInvalidArgument("scheme_not_specified", "URI scheme not specified")
+	errSchemeSpecified      = errors.DefineInvalidArgument("scheme_specified", "URI scheme should not be specified")
+	errVolumeSpecified      = errors.DefineInvalidArgument("volume_specified", "volume should not be specified")
 )

--- a/pkg/fetch/errors.go
+++ b/pkg/fetch/errors.go
@@ -17,7 +17,8 @@ package fetch
 import "go.thethings.network/lorawan-stack/pkg/errors"
 
 var (
-	errFileNotFound      = errors.DefineNotFound("file_not_found", "file `{filename}` not found")
-	errCouldNotFetchFile = errors.Define("fetch_file", "could not fetch file `{filename}`")
-	errCouldNotReadFile  = errors.DefineCorruption("read_file", "could not read file `{filename}`")
+	errCouldNotFetchFile    = errors.Define("fetch_file", "could not fetch file `{filename}`")
+	errCouldNotReadFile     = errors.DefineCorruption("read_file", "could not read file `{filename}`")
+	errFilenameNotSpecified = errors.DefineInvalidArgument("no_filename", "filename not specified")
+	errFileNotFound         = errors.DefineNotFound("file_not_found", "file `{filename}` not found")
 )

--- a/pkg/fetch/fetch_test.go
+++ b/pkg/fetch/fetch_test.go
@@ -21,7 +21,10 @@ import (
 )
 
 func Example() {
-	fetcher := fetch.FromHTTP("http://webserver.thethings.network/repository", true)
+	fetcher, err := fetch.FromHTTP("http://webserver.thethings.network/repository", true)
+	if err != nil {
+		panic(err)
+	}
 	content, err := fetcher.File("README.md")
 	if err != nil {
 		panic(err)

--- a/pkg/fetch/fs.go
+++ b/pkg/fetch/fs.go
@@ -39,7 +39,12 @@ func FromFilesystem(basePath string) Interface {
 }
 
 func (f fsFetcher) File(pathElements ...string) ([]byte, error) {
+	if len(pathElements) == 0 {
+		return nil, errFilenameNotSpecified
+	}
+
 	start := time.Now()
+
 	var path string
 	if f.base != "" {
 		path = filepath.Join(append([]string{f.base}, pathElements...)...)

--- a/pkg/fetch/fs.go
+++ b/pkg/fetch/fs.go
@@ -26,17 +26,6 @@ type fsFetcher struct {
 	root string
 }
 
-// FromFilesystem returns an interface that fetches files from the local filesystem.
-func FromFilesystem(rootElements ...string) Interface {
-	root := filepath.Join(rootElements...)
-	return fsFetcher{
-		baseFetcher: baseFetcher{
-			latency: fetchLatency.WithLabelValues("fs", root),
-		},
-		root: root,
-	}
-}
-
 func (f fsFetcher) File(pathElements ...string) ([]byte, error) {
 	if len(pathElements) == 0 {
 		return nil, errFilenameNotSpecified
@@ -59,4 +48,15 @@ func (f fsFetcher) File(pathElements ...string) ([]byte, error) {
 		return nil, errFileNotFound.WithAttributes("filename", p)
 	}
 	return nil, errCouldNotReadFile.WithCause(err).WithAttributes("filename", p)
+}
+
+// FromFilesystem returns an interface that fetches files from the local filesystem.
+func FromFilesystem(rootElements ...string) Interface {
+	root := filepath.Join(rootElements...)
+	return fsFetcher{
+		baseFetcher: baseFetcher{
+			latency: fetchLatency.WithLabelValues("fs", root),
+		},
+		root: root,
+	}
 }

--- a/pkg/fetch/http.go
+++ b/pkg/fetch/http.go
@@ -34,7 +34,12 @@ type httpFetcher struct {
 }
 
 func (f httpFetcher) File(pathElements ...string) ([]byte, error) {
+	if len(pathElements) == 0 {
+		return nil, errFilenameNotSpecified
+	}
+
 	start := time.Now()
+
 	filename := strings.TrimLeft(path.Join(pathElements...), "/")
 	url := fmt.Sprintf("%s/%s", f.base, filename)
 

--- a/pkg/fetch/http.go
+++ b/pkg/fetch/http.go
@@ -15,11 +15,10 @@
 package fetch
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"path"
-	"strings"
 	"time"
 
 	"github.com/gregjones/httpcache"
@@ -31,6 +30,7 @@ const timeout = 10 * time.Second
 type httpFetcher struct {
 	baseFetcher
 	httpClient *http.Client
+	root       *url.URL
 }
 
 func (f httpFetcher) File(pathElements ...string) ([]byte, error) {
@@ -40,45 +40,54 @@ func (f httpFetcher) File(pathElements ...string) ([]byte, error) {
 
 	start := time.Now()
 
-	filename := strings.TrimLeft(path.Join(pathElements...), "/")
-	url := fmt.Sprintf("%s/%s", f.base, filename)
+	p := path.Join(pathElements...)
+	url, err := realURLPath(f.root, p)
+	if err != nil {
+		return nil, err
+	}
 
 	resp, err := f.httpClient.Get(url)
 	if err != nil {
-		return nil, errCouldNotFetchFile.WithCause(err).WithAttributes("filename", filename)
+		return nil, errCouldNotFetchFile.WithCause(err).WithAttributes("filename", p)
 	}
-
 	if err = errors.FromHTTP(resp); err != nil {
-		return nil, errCouldNotFetchFile.WithCause(err).WithAttributes("filename", filename)
+		return nil, errCouldNotFetchFile.WithCause(err).WithAttributes("filename", p)
 	}
+	defer resp.Body.Close()
 
 	result, err := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
-
 	if err != nil {
-		return nil, errCouldNotReadFile.WithCause(err).WithAttributes("filename", filename)
+		return nil, errCouldNotReadFile.WithCause(err).WithAttributes("filename", p)
 	}
-
 	f.observeLatency(time.Since(start))
 	return result, nil
 }
 
 // FromHTTP returns an object to fetch files from a webserver.
-func FromHTTP(baseURL string, cache bool) Interface {
-	baseURL = strings.TrimRight(baseURL, "/")
+func FromHTTP(rootURL string, cache bool) (Interface, error) {
 	transport := http.DefaultTransport
 	if cache {
 		transport = httpcache.NewMemoryCacheTransport()
 	}
-	f := httpFetcher{
+	var root *url.URL
+	if rootURL != "" {
+		var err error
+		root, err = url.Parse(rootURL)
+		if err != nil {
+			return nil, err
+		}
+		if !root.IsAbs() {
+			return nil, errSchemeNotSpecified
+		}
+	}
+	return httpFetcher{
 		baseFetcher: baseFetcher{
-			base:    baseURL,
-			latency: fetchLatency.WithLabelValues("http", baseURL),
+			latency: fetchLatency.WithLabelValues("http", rootURL),
 		},
 		httpClient: &http.Client{
 			Transport: transport,
 			Timeout:   timeout,
 		},
-	}
-	return f
+		root: root,
+	}, nil
 }

--- a/pkg/fetch/mem.go
+++ b/pkg/fetch/mem.go
@@ -36,6 +36,10 @@ func NewMemFetcher(store map[string][]byte) Interface {
 
 // File gets content from memory.
 func (f *memFetcher) File(pathElements ...string) ([]byte, error) {
+	if len(pathElements) == 0 {
+		return nil, errFilenameNotSpecified
+	}
+
 	start := time.Now()
 
 	path := memFetcherPath(pathElements...)

--- a/pkg/fetch/mem.go
+++ b/pkg/fetch/mem.go
@@ -25,13 +25,6 @@ type memFetcher struct {
 	store map[string][]byte
 }
 
-// NewMemFetcher initializes a new memory fetcher.
-func NewMemFetcher(store map[string][]byte) Interface {
-	return &memFetcher{
-		store: store,
-	}
-}
-
 // File gets content from memory.
 func (f *memFetcher) File(pathElements ...string) ([]byte, error) {
 	if len(pathElements) == 0 {
@@ -48,4 +41,11 @@ func (f *memFetcher) File(pathElements ...string) ([]byte, error) {
 
 	f.observeLatency(time.Since(start))
 	return content, nil
+}
+
+// NewMemFetcher initializes a new memory fetcher.
+func NewMemFetcher(store map[string][]byte) Interface {
+	return &memFetcher{
+		store: store,
+	}
 }

--- a/pkg/fetch/mem.go
+++ b/pkg/fetch/mem.go
@@ -15,11 +15,9 @@
 package fetch
 
 import (
-	"strings"
+	"path"
 	"time"
 )
-
-const memFetcherSeparator = "/"
 
 // MemFetcher represents the memory fetcher.
 type memFetcher struct {
@@ -42,16 +40,12 @@ func (f *memFetcher) File(pathElements ...string) ([]byte, error) {
 
 	start := time.Now()
 
-	path := memFetcherPath(pathElements...)
-	content, ok := f.store[path]
+	p := path.Join(pathElements...)
+	content, ok := f.store[p]
 	if !ok {
-		return nil, errFileNotFound.WithAttributes("filename", path)
+		return nil, errFileNotFound.WithAttributes("filename", p)
 	}
 
 	f.observeLatency(time.Since(start))
 	return content, nil
-}
-
-func memFetcherPath(pathElements ...string) string {
-	return strings.Join(pathElements, memFetcherSeparator)
 }

--- a/pkg/frequencyplans/frequencyplans_test.go
+++ b/pkg/frequencyplans/frequencyplans_test.go
@@ -34,7 +34,11 @@ func boolPtr(v bool) *bool                       { return &v }
 func durationPtr(v time.Duration) *time.Duration { return &v }
 
 func Example() {
-	store := frequencyplans.NewStore(fetch.FromHTTP("https://raw.githubusercontent.com/TheThingsNetwork/lorawan-frequency-plans", true))
+	fetcher, err := fetch.FromHTTP("https://raw.githubusercontent.com/TheThingsNetwork/lorawan-frequency-plans", true)
+	if err != nil {
+		panic(err)
+	}
+	store := frequencyplans.NewStore(fetcher)
 
 	ids, err := store.GetAllIDs()
 	if err != nil {

--- a/pkg/identityserver/email_test.go
+++ b/pkg/identityserver/email_test.go
@@ -48,10 +48,11 @@ func TestGetEmailTemplates(t *testing.T) {
 	ctx := test.Context()
 
 	testWithIdentityServer(t, func(is *IdentityServer, cc *grpc.ClientConn) {
-		registry := is.getEmailTemplates(ctx)
-		if !a.So(registry, should.NotBeNil) {
-			t.FailNow()
+		registry, err := is.getEmailTemplates(ctx)
+		if !a.So(err, should.BeNil) {
+			t.Fatalf("Failed to construct email template registry: %v", err)
 		}
+		a.So(registry, should.NotBeNil)
 
 		for _, tc := range []struct {
 			name    string

--- a/pkg/interop/client.go
+++ b/pkg/interop/client.go
@@ -379,7 +379,10 @@ const InteropClientConfigurationName = "config.yaml"
 // NewClient return new interop client.
 // fallbackTLS is optional.
 func NewClient(ctx context.Context, conf config.InteropClient, fallbackTLS *tls.Config) (*Client, error) {
-	fetcher := conf.Fetcher()
+	fetcher, err := conf.Fetcher()
+	if err != nil {
+		return nil, errUnknownConfig.WithCause(err)
+	}
 	if fetcher == nil {
 		return nil, errUnknownConfig
 	}

--- a/pkg/pfconfig/semtechudp/semtechudp_test.go
+++ b/pkg/pfconfig/semtechudp/semtechudp_test.go
@@ -34,7 +34,11 @@ func TestBuild(t *testing.T) {
 	if _, err := os.Stat(localPath); err == nil {
 		fetcher = fetch.FromFilesystem(localPath)
 	} else {
-		fetcher = fetch.FromHTTP("https://raw.githubusercontent.com/TheThingsNetwork/lorawan-frequency-plans/master", true)
+		var err error
+		fetcher, err = fetch.FromHTTP("https://raw.githubusercontent.com/TheThingsNetwork/lorawan-frequency-plans/master", true)
+		if err != nil {
+			t.Fatalf("Failed to construct HTTP fetcher: %v", err)
+		}
 	}
 	store := frequencyplans.NewStore(fetcher)
 
@@ -43,7 +47,11 @@ func TestBuild(t *testing.T) {
 	if _, err := os.Stat(referenceLocalPath); err == nil {
 		referenceFetcher = fetch.FromFilesystem(referenceLocalPath)
 	} else {
-		referenceFetcher = fetch.FromHTTP("https://raw.githubusercontent.com/TheThingsNetwork/gateway-conf/master", true)
+		var err error
+		referenceFetcher, err = fetch.FromHTTP("https://raw.githubusercontent.com/TheThingsNetwork/gateway-conf/master", true)
+		if err != nil {
+			t.Fatalf("Failed to construct HTTP fetcher: %v", err)
+		}
 	}
 
 	var shouldResembleReference = func(actual interface{}, expected ...interface{}) string {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Refs https://github.com/TheThingsNetwork/lorawan-stack/issues/1340

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix (some of) inconsistencies in `fetch` package
- Fix non-Unix-like OS support in `fetch` package
- Validate the `root` URL passed to `fetch.FromHTTP`
- Support absolute paths in `fetch` package
- `fetch.basePathFetcher.File` now only prepends base path if requested path is not absolute
- Fetchers, which support a `root` path to be specified now correctly either prepend the `root` path to relative paths or replace the root in absolute paths

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Basically support for absolute OS paths is via `WithBasePath`
Existing deployments should not be affected, since the only "breaking" change is in the `WithBasePath` fetcher operation, which was only used by `interop` client config so far.

@bafonins @adriansmares no need for review