### PR TITLE
Fix rights modification of collaborators with more rights than…

### DIFF
--- a/api/api.md
+++ b/api/api.md
@@ -630,7 +630,7 @@ where the user or organization is collaborator on.
 | `GetAPIKey` | [`GetApplicationAPIKeyRequest`](#ttn.lorawan.v3.GetApplicationAPIKeyRequest) | [`APIKey`](#ttn.lorawan.v3.APIKey) |  |
 | `UpdateAPIKey` | [`UpdateApplicationAPIKeyRequest`](#ttn.lorawan.v3.UpdateApplicationAPIKeyRequest) | [`APIKey`](#ttn.lorawan.v3.APIKey) | Update the rights of an existing application API key. To generate an API key, the CreateAPIKey should be used. To delete an API key, update it with zero rights. |
 | `GetCollaborator` | [`GetApplicationCollaboratorRequest`](#ttn.lorawan.v3.GetApplicationCollaboratorRequest) | [`GetCollaboratorResponse`](#ttn.lorawan.v3.GetCollaboratorResponse) | Get the rights of a collaborator (member) of the application. Pseudo-rights in the response (such as the "_ALL" right) are not expanded. |
-| `SetCollaborator` | [`SetApplicationCollaboratorRequest`](#ttn.lorawan.v3.SetApplicationCollaboratorRequest) | [`.google.protobuf.Empty`](#google.protobuf.Empty) | Set the rights of a collaborator (member) on the application. Setting a collaborator without rights, removes them. |
+| `SetCollaborator` | [`SetApplicationCollaboratorRequest`](#ttn.lorawan.v3.SetApplicationCollaboratorRequest) | [`.google.protobuf.Empty`](#google.protobuf.Empty) | Set the rights of a collaborator (member) on the application. It is required for the caller to have all assigned or/and removed rights. Setting a collaborator without rights, removes them. |
 | `ListCollaborators` | [`ListApplicationCollaboratorsRequest`](#ttn.lorawan.v3.ListApplicationCollaboratorsRequest) | [`Collaborators`](#ttn.lorawan.v3.Collaborators) |  |
 
 #### HTTP bindings
@@ -1404,7 +1404,7 @@ The OAuth2 flows an OAuth client can use to get an access token.
 | ----------- | ------------ | ------------- | ------------|
 | `ListRights` | [`ClientIdentifiers`](#ttn.lorawan.v3.ClientIdentifiers) | [`Rights`](#ttn.lorawan.v3.Rights) |  |
 | `GetCollaborator` | [`GetClientCollaboratorRequest`](#ttn.lorawan.v3.GetClientCollaboratorRequest) | [`GetCollaboratorResponse`](#ttn.lorawan.v3.GetCollaboratorResponse) | Get the rights of a collaborator (member) of the client. Pseudo-rights in the response (such as the "_ALL" right) are not expanded. |
-| `SetCollaborator` | [`SetClientCollaboratorRequest`](#ttn.lorawan.v3.SetClientCollaboratorRequest) | [`.google.protobuf.Empty`](#google.protobuf.Empty) | Set the rights of a collaborator (member) on the client. Setting a collaborator without rights, removes them. |
+| `SetCollaborator` | [`SetClientCollaboratorRequest`](#ttn.lorawan.v3.SetClientCollaboratorRequest) | [`.google.protobuf.Empty`](#google.protobuf.Empty) | Set the rights of a collaborator (member) on the client. It is required for the caller to have all assigned or/and removed rights. Setting a collaborator without rights, removes them. |
 | `ListCollaborators` | [`ListClientCollaboratorsRequest`](#ttn.lorawan.v3.ListClientCollaboratorsRequest) | [`Collaborators`](#ttn.lorawan.v3.Collaborators) |  |
 
 #### HTTP bindings
@@ -2729,7 +2729,7 @@ where the user or organization is collaborator on.
 | `GetAPIKey` | [`GetGatewayAPIKeyRequest`](#ttn.lorawan.v3.GetGatewayAPIKeyRequest) | [`APIKey`](#ttn.lorawan.v3.APIKey) |  |
 | `UpdateAPIKey` | [`UpdateGatewayAPIKeyRequest`](#ttn.lorawan.v3.UpdateGatewayAPIKeyRequest) | [`APIKey`](#ttn.lorawan.v3.APIKey) | Update the rights of an existing gateway API key. To generate an API key, the CreateAPIKey should be used. To delete an API key, update it with zero rights. |
 | `GetCollaborator` | [`GetGatewayCollaboratorRequest`](#ttn.lorawan.v3.GetGatewayCollaboratorRequest) | [`GetCollaboratorResponse`](#ttn.lorawan.v3.GetCollaboratorResponse) | Get the rights of a collaborator (member) of the gateway. Pseudo-rights in the response (such as the "_ALL" right) are not expanded. |
-| `SetCollaborator` | [`SetGatewayCollaboratorRequest`](#ttn.lorawan.v3.SetGatewayCollaboratorRequest) | [`.google.protobuf.Empty`](#google.protobuf.Empty) | Set the rights of a collaborator (member) on the gateway. Setting a collaborator without rights, removes them. |
+| `SetCollaborator` | [`SetGatewayCollaboratorRequest`](#ttn.lorawan.v3.SetGatewayCollaboratorRequest) | [`.google.protobuf.Empty`](#google.protobuf.Empty) | Set the rights of a collaborator (member) on the gateway. It is required for the caller to have all assigned or/and removed rights. Setting a collaborator without rights, removes them. |
 | `ListCollaborators` | [`ListGatewayCollaboratorsRequest`](#ttn.lorawan.v3.ListGatewayCollaboratorsRequest) | [`Collaborators`](#ttn.lorawan.v3.Collaborators) |  |
 
 #### HTTP bindings
@@ -5115,7 +5115,7 @@ where the user or organization is collaborator on.
 | `GetAPIKey` | [`GetOrganizationAPIKeyRequest`](#ttn.lorawan.v3.GetOrganizationAPIKeyRequest) | [`APIKey`](#ttn.lorawan.v3.APIKey) |  |
 | `UpdateAPIKey` | [`UpdateOrganizationAPIKeyRequest`](#ttn.lorawan.v3.UpdateOrganizationAPIKeyRequest) | [`APIKey`](#ttn.lorawan.v3.APIKey) | Update the rights of an existing organization API key. To generate an API key, the CreateAPIKey should be used. To delete an API key, update it with zero rights. |
 | `GetCollaborator` | [`GetOrganizationCollaboratorRequest`](#ttn.lorawan.v3.GetOrganizationCollaboratorRequest) | [`GetCollaboratorResponse`](#ttn.lorawan.v3.GetCollaboratorResponse) | Get the rights of a collaborator (member) of the organization. Pseudo-rights in the response (such as the "_ALL" right) are not expanded. |
-| `SetCollaborator` | [`SetOrganizationCollaboratorRequest`](#ttn.lorawan.v3.SetOrganizationCollaboratorRequest) | [`.google.protobuf.Empty`](#google.protobuf.Empty) | Set the rights of a collaborator (member) on the organization. Setting a collaborator without rights, removes them. Note that only users can collaborate (be member of) an organization. |
+| `SetCollaborator` | [`SetOrganizationCollaboratorRequest`](#ttn.lorawan.v3.SetOrganizationCollaboratorRequest) | [`.google.protobuf.Empty`](#google.protobuf.Empty) | Set the rights of a collaborator (member) on the organization. It is required for the caller to have all assigned or/and removed rights. Setting a collaborator without rights, removes them. Note that only users can collaborate (be member of) an organization. |
 | `ListCollaborators` | [`ListOrganizationCollaboratorsRequest`](#ttn.lorawan.v3.ListOrganizationCollaboratorsRequest) | [`Collaborators`](#ttn.lorawan.v3.Collaborators) |  |
 
 #### HTTP bindings

--- a/api/api.swagger.json
+++ b/api/api.swagger.json
@@ -477,7 +477,7 @@
         ]
       },
       "put": {
-        "summary": "Set the rights of a collaborator (member) on the application.\nSetting a collaborator without rights, removes them.",
+        "summary": "Set the rights of a collaborator (member) on the application. It is required for the caller to\nhave all assigned or/and removed rights.\nSetting a collaborator without rights, removes them.",
         "operationId": "SetCollaborator",
         "responses": {
           "200": {
@@ -2837,7 +2837,7 @@
         ]
       },
       "put": {
-        "summary": "Set the rights of a collaborator (member) on the gateway.\nSetting a collaborator without rights, removes them.",
+        "summary": "Set the rights of a collaborator (member) on the gateway. It is required for the caller to\nhave all assigned or/and removed rights.\nSetting a collaborator without rights, removes them.",
         "operationId": "SetCollaborator",
         "responses": {
           "200": {
@@ -4219,7 +4219,7 @@
         ]
       },
       "put": {
-        "summary": "Set the rights of a collaborator (member) on the organization.\nSetting a collaborator without rights, removes them.\nNote that only users can collaborate (be member of) an organization.",
+        "summary": "Set the rights of a collaborator (member) on the organization. It is required for the caller to\nhave all assigned or/and removed rights.\nSetting a collaborator without rights, removes them.\nNote that only users can collaborate (be member of) an organization.",
         "operationId": "SetCollaborator",
         "responses": {
           "200": {

--- a/api/application_services.proto
+++ b/api/application_services.proto
@@ -125,7 +125,8 @@ service ApplicationAccess {
     };
   }
 
-  // Set the rights of a collaborator (member) on the application.
+  // Set the rights of a collaborator (member) on the application. It is required for the caller to
+  // have all assigned or/and removed rights.
   // Setting a collaborator without rights, removes them.
   rpc SetCollaborator(SetApplicationCollaboratorRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {

--- a/api/client_services.proto
+++ b/api/client_services.proto
@@ -96,7 +96,8 @@ service ClientAccess {
     };
   }
 
-  // Set the rights of a collaborator (member) on the client.
+  // Set the rights of a collaborator (member) on the client. It is required for the caller to
+  // have all assigned or/and removed rights.
   // Setting a collaborator without rights, removes them.
   rpc SetCollaborator(SetClientCollaboratorRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {

--- a/api/gateway_services.proto
+++ b/api/gateway_services.proto
@@ -128,7 +128,8 @@ service GatewayAccess {
     };
   }
 
-  // Set the rights of a collaborator (member) on the gateway.
+  // Set the rights of a collaborator (member) on the gateway. It is required for the caller to
+  // have all assigned or/and removed rights.
   // Setting a collaborator without rights, removes them.
   rpc SetCollaborator(SetGatewayCollaboratorRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {

--- a/api/organization_services.proto
+++ b/api/organization_services.proto
@@ -115,7 +115,8 @@ service OrganizationAccess {
     };
   }
 
-  // Set the rights of a collaborator (member) on the organization.
+  // Set the rights of a collaborator (member) on the organization. It is required for the caller to
+  // have all assigned or/and removed rights.
   // Setting a collaborator without rights, removes them.
   // Note that only users can collaborate (be member of) an organization.
   rpc SetCollaborator(SetOrganizationCollaboratorRequest) returns (google.protobuf.Empty) {

--- a/pkg/identityserver/client_access.go
+++ b/pkg/identityserver/client_access.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jinzhu/gorm"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/pkg/email"
+	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/events"
 	"go.thethings.network/lorawan-stack/pkg/identityserver/emails"
 	"go.thethings.network/lorawan-stack/pkg/identityserver/store"
@@ -79,12 +80,32 @@ func (is *IdentityServer) setClientCollaborator(ctx context.Context, req *ttnpb.
 	if err := rights.RequireClient(ctx, req.ClientIdentifiers, ttnpb.RIGHT_CLIENT_ALL); err != nil {
 		return nil, err
 	}
-	// Require that caller has at least the rights we're giving to the collaborator.
-	if err := rights.RequireClient(ctx, req.ClientIdentifiers, req.Collaborator.Rights...); err != nil {
-		return nil, err
-	}
+
 	err := is.withDatabase(ctx, func(db *gorm.DB) error {
-		return is.getMembershipStore(ctx, db).SetMember(
+		store := is.getMembershipStore(ctx, db)
+
+		if len(req.Collaborator.Rights) > 0 {
+			newRights := ttnpb.RightsFrom(req.Collaborator.Rights...)
+			existingRights, err := store.GetMember(
+				ctx,
+				&req.Collaborator.OrganizationOrUserIdentifiers,
+				req.ClientIdentifiers,
+			)
+
+			if err != nil && !errors.IsNotFound(err) {
+				return err
+			}
+			// Require the caller to have all added rights.
+			if err := rights.RequireClient(ctx, req.ClientIdentifiers, newRights.Sub(existingRights).GetRights()...); err != nil {
+				return err
+			}
+			// Require the caller to have all removed rights.
+			if err := rights.RequireClient(ctx, req.ClientIdentifiers, existingRights.Sub(newRights).GetRights()...); err != nil {
+				return err
+			}
+		}
+
+		return store.SetMember(
 			ctx,
 			&req.Collaborator.OrganizationOrUserIdentifiers,
 			req.ClientIdentifiers,

--- a/pkg/identityserver/gateway_access_test.go
+++ b/pkg/identityserver/gateway_access_test.go
@@ -34,6 +34,13 @@ func init() {
 			ttnpb.RIGHT_GATEWAY_SETTINGS_COLLABORATORS,
 		}
 	}
+	gtwAccessCollaboratorUser.Admin = false
+	gtwAccessCollaboratorUser.State = ttnpb.STATE_APPROVED
+	for _, apiKey := range userAPIKeys(&gtwAccessCollaboratorUser.UserIdentifiers).APIKeys {
+		apiKey.Rights = []ttnpb.Right{
+			ttnpb.RIGHT_GATEWAY_ALL,
+		}
+	}
 }
 
 func TestGatewayAccessNotFound(t *testing.T) {
@@ -310,5 +317,127 @@ func TestGatewayAccessCRUD(t *testing.T) {
 
 		a.So(err, should.BeNil)
 		a.So(res.Rights, should.Resemble, []ttnpb.Right{ttnpb.RIGHT_GATEWAY_ALL})
+	})
+}
+
+func TestGatewayAccessCollaboratorRights(t *testing.T) {
+	a := assertions.New(t)
+	ctx := test.Context()
+
+	testWithIdentityServer(t, func(is *IdentityServer, cc *grpc.ClientConn) {
+		userID, usrCreds := defaultUser.UserIdentifiers, userCreds(defaultUserIdx)
+		gatewayID := userGateways(&userID).Gateways[0].GatewayIdentifiers
+		collaboratorID := gatewayAccessUser.UserIdentifiers.OrganizationOrUserIdentifiers()
+		collaboratorCreds := userCreds(gatewayAccessUserIdx)
+		removedCollaboratorID := gtwAccessCollaboratorUser.UserIdentifiers.OrganizationOrUserIdentifiers()
+
+		reg := ttnpb.NewGatewayAccessClient(cc)
+
+		_, err := reg.SetCollaborator(ctx, &ttnpb.SetGatewayCollaboratorRequest{
+			GatewayIdentifiers: gatewayID,
+			Collaborator: ttnpb.Collaborator{
+				OrganizationOrUserIdentifiers: *collaboratorID,
+				Rights: []ttnpb.Right{
+					ttnpb.RIGHT_GATEWAY_SETTINGS_API_KEYS,
+					ttnpb.RIGHT_GATEWAY_SETTINGS_COLLABORATORS,
+				},
+			},
+		}, usrCreds)
+
+		a.So(err, should.BeNil)
+
+		_, err = reg.SetCollaborator(ctx, &ttnpb.SetGatewayCollaboratorRequest{
+			GatewayIdentifiers: gatewayID,
+			Collaborator: ttnpb.Collaborator{
+				OrganizationOrUserIdentifiers: *removedCollaboratorID,
+				Rights: []ttnpb.Right{
+					ttnpb.RIGHT_GATEWAY_ALL,
+				},
+			},
+		}, usrCreds)
+
+		a.So(err, should.BeNil)
+
+		// Try revoking rights for the collaborator with RIGHT_GATEWAY_ALL without having it
+		_, err = reg.SetCollaborator(ctx, &ttnpb.SetGatewayCollaboratorRequest{
+			GatewayIdentifiers: gatewayID,
+			Collaborator: ttnpb.Collaborator{
+				OrganizationOrUserIdentifiers: *removedCollaboratorID,
+				Rights: []ttnpb.Right{
+					ttnpb.RIGHT_GATEWAY_SETTINGS_API_KEYS,
+					ttnpb.RIGHT_GATEWAY_SETTINGS_COLLABORATORS,
+				},
+			},
+		}, collaboratorCreds)
+
+		if a.So(err, should.NotBeNil) {
+			a.So(errors.IsPermissionDenied(err), should.BeTrue)
+		}
+
+		// Remove RIGHT_GATEWAY_ALL from collaborator to be removed
+		newRights := ttnpb.AllGatewayRights.Sub(ttnpb.RightsFrom(ttnpb.RIGHT_GATEWAY_ALL))
+		_, err = reg.SetCollaborator(ctx, &ttnpb.SetGatewayCollaboratorRequest{
+			GatewayIdentifiers: gatewayID,
+			Collaborator: ttnpb.Collaborator{
+				OrganizationOrUserIdentifiers: *removedCollaboratorID,
+				Rights:                        newRights.Rights,
+			},
+		}, usrCreds)
+
+		a.So(err, should.BeNil)
+
+		newRights = newRights.Sub(ttnpb.RightsFrom(ttnpb.RIGHT_GATEWAY_SETTINGS_API_KEYS))
+		_, err = reg.SetCollaborator(ctx, &ttnpb.SetGatewayCollaboratorRequest{
+			GatewayIdentifiers: gatewayID,
+			Collaborator: ttnpb.Collaborator{
+				OrganizationOrUserIdentifiers: *removedCollaboratorID,
+				Rights:                        newRights.Rights,
+			},
+		}, collaboratorCreds)
+
+		a.So(err, should.BeNil)
+
+		// Try revoking RIGHT_GATEWAY_INFO without having it
+		_, err = reg.SetCollaborator(ctx, &ttnpb.SetGatewayCollaboratorRequest{
+			GatewayIdentifiers: gatewayID,
+			Collaborator: ttnpb.Collaborator{
+				OrganizationOrUserIdentifiers: *removedCollaboratorID,
+				Rights:                        newRights.Sub(ttnpb.RightsFrom(ttnpb.RIGHT_GATEWAY_INFO)).Rights,
+			},
+		}, collaboratorCreds)
+
+		if a.So(err, should.NotBeNil) {
+			a.So(errors.IsPermissionDenied(err), should.BeTrue)
+		}
+
+		res, err := reg.GetCollaborator(ctx, &ttnpb.GetGatewayCollaboratorRequest{
+			GatewayIdentifiers:            gatewayID,
+			OrganizationOrUserIdentifiers: *removedCollaboratorID,
+		}, collaboratorCreds)
+
+		if a.So(err, should.BeNil) {
+			a.So(res.Rights, should.Resemble, newRights.Rights)
+
+		}
+
+		// Delete collaborator with more rights
+		_, err = reg.SetCollaborator(ctx, &ttnpb.SetGatewayCollaboratorRequest{
+			GatewayIdentifiers: gatewayID,
+			Collaborator: ttnpb.Collaborator{
+				OrganizationOrUserIdentifiers: *removedCollaboratorID,
+				Rights:                        []ttnpb.Right{},
+			},
+		}, collaboratorCreds)
+
+		a.So(err, should.BeNil)
+
+		_, err = reg.GetCollaborator(ctx, &ttnpb.GetGatewayCollaboratorRequest{
+			GatewayIdentifiers:            gatewayID,
+			OrganizationOrUserIdentifiers: *removedCollaboratorID,
+		}, collaboratorCreds)
+
+		if a.So(err, should.NotBeNil) {
+			a.So(errors.IsNotFound(err), should.BeTrue)
+		}
 	})
 }

--- a/pkg/identityserver/identityserver_test.go
+++ b/pkg/identityserver/identityserver_test.go
@@ -34,7 +34,7 @@ import (
 var (
 	setup        sync.Once
 	dbConnString string
-	population   = store.NewPopulator(13, 42)
+	population   = store.NewPopulator(14, 42)
 )
 
 var (
@@ -49,6 +49,7 @@ var (
 	appAccessCollaboratorUser, appAccessCollaboratorUserIdx = getTestUser()
 	clientAccessUser, clientAccessUserIdx                   = getTestUser()
 	gatewayAccessUser, gatewayAccessUserIdx                 = getTestUser()
+	gtwAccessCollaboratorUser, gtwAccessCollaboratorUserIdx = getTestUser()
 	organizationAccessUser, organizationAccessUserIdx       = getTestUser()
 	userAccessUser, userAccessUserIdx                       = getTestUser()
 	paginationUser, paginationUserIdx                       = getTestUser()

--- a/pkg/identityserver/identityserver_test.go
+++ b/pkg/identityserver/identityserver_test.go
@@ -34,7 +34,7 @@ import (
 var (
 	setup        sync.Once
 	dbConnString string
-	population   = store.NewPopulator(14, 42)
+	population   = store.NewPopulator(15, 42)
 )
 
 var (
@@ -51,6 +51,7 @@ var (
 	gatewayAccessUser, gatewayAccessUserIdx                 = getTestUser()
 	gtwAccessCollaboratorUser, gtwAccessCollaboratorUserIdx = getTestUser()
 	organizationAccessUser, organizationAccessUserIdx       = getTestUser()
+	orgAccessCollaboratorUser, orgAccessCollaboratorUserIdx = getTestUser()
 	userAccessUser, userAccessUserIdx                       = getTestUser()
 	paginationUser, paginationUserIdx                       = getTestUser()
 )

--- a/pkg/identityserver/identityserver_test.go
+++ b/pkg/identityserver/identityserver_test.go
@@ -34,23 +34,24 @@ import (
 var (
 	setup        sync.Once
 	dbConnString string
-	population   = store.NewPopulator(12, 42)
+	population   = store.NewPopulator(13, 42)
 )
 
 var (
-	userIndex                                         int
-	newUser, newUserIdx                               = getTestUser()
-	rejectedUser, rejectedUserIdx                     = getTestUser()
-	defaultUser, defaultUserIdx                       = getTestUser()
-	suspendedUser, suspendedUserIdx                   = getTestUser()
-	adminUser, adminUserIdx                           = getTestUser()
-	collaboratorUser, collaboratorUserIdx             = getTestUser()
-	applicationAccessUser, applicationAccessUserIdx   = getTestUser()
-	clientAccessUser, clientAccessUserIdx             = getTestUser()
-	gatewayAccessUser, gatewayAccessUserIdx           = getTestUser()
-	organizationAccessUser, organizationAccessUserIdx = getTestUser()
-	userAccessUser, userAccessUserIdx                 = getTestUser()
-	paginationUser, paginationUserIdx                 = getTestUser()
+	userIndex                                               int
+	newUser, newUserIdx                                     = getTestUser()
+	rejectedUser, rejectedUserIdx                           = getTestUser()
+	defaultUser, defaultUserIdx                             = getTestUser()
+	suspendedUser, suspendedUserIdx                         = getTestUser()
+	adminUser, adminUserIdx                                 = getTestUser()
+	collaboratorUser, collaboratorUserIdx                   = getTestUser()
+	applicationAccessUser, applicationAccessUserIdx         = getTestUser()
+	appAccessCollaboratorUser, appAccessCollaboratorUserIdx = getTestUser()
+	clientAccessUser, clientAccessUserIdx                   = getTestUser()
+	gatewayAccessUser, gatewayAccessUserIdx                 = getTestUser()
+	organizationAccessUser, organizationAccessUserIdx       = getTestUser()
+	userAccessUser, userAccessUserIdx                       = getTestUser()
+	paginationUser, paginationUserIdx                       = getTestUser()
 )
 
 var now = time.Now()

--- a/pkg/identityserver/organization_access.go
+++ b/pkg/identityserver/organization_access.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jinzhu/gorm"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/pkg/email"
+	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/events"
 	"go.thethings.network/lorawan-stack/pkg/identityserver/emails"
 	"go.thethings.network/lorawan-stack/pkg/identityserver/store"
@@ -202,12 +203,32 @@ func (is *IdentityServer) setOrganizationCollaborator(ctx context.Context, req *
 	if err := rights.RequireOrganization(ctx, req.OrganizationIdentifiers, ttnpb.RIGHT_ORGANIZATION_SETTINGS_MEMBERS); err != nil {
 		return nil, err
 	}
-	// Require that caller has at least the rights we're giving to the collaborator.
-	if err := rights.RequireOrganization(ctx, req.OrganizationIdentifiers, req.Collaborator.Rights...); err != nil {
-		return nil, err
-	}
+
 	err := is.withDatabase(ctx, func(db *gorm.DB) error {
-		return is.getMembershipStore(ctx, db).SetMember(
+		store := is.getMembershipStore(ctx, db)
+
+		if len(req.Collaborator.Rights) > 0 {
+			newRights := ttnpb.RightsFrom(req.Collaborator.Rights...)
+			existingRights, err := store.GetMember(
+				ctx,
+				&req.Collaborator.OrganizationOrUserIdentifiers,
+				req.OrganizationIdentifiers,
+			)
+
+			if err != nil && !errors.IsNotFound(err) {
+				return err
+			}
+			// Require the caller to have all added rights.
+			if err := rights.RequireOrganization(ctx, req.OrganizationIdentifiers, newRights.Sub(existingRights).GetRights()...); err != nil {
+				return err
+			}
+			// Require the caller to have all removed rights.
+			if err := rights.RequireOrganization(ctx, req.OrganizationIdentifiers, existingRights.Sub(newRights).GetRights()...); err != nil {
+				return err
+			}
+		}
+
+		return store.SetMember(
 			ctx,
 			&req.Collaborator.OrganizationOrUserIdentifiers,
 			req.OrganizationIdentifiers,

--- a/pkg/ttnpb/application_services.pb.go
+++ b/pkg/ttnpb/application_services.pb.go
@@ -348,7 +348,8 @@ type ApplicationAccessClient interface {
 	// Get the rights of a collaborator (member) of the application.
 	// Pseudo-rights in the response (such as the "_ALL" right) are not expanded.
 	GetCollaborator(ctx context.Context, in *GetApplicationCollaboratorRequest, opts ...grpc.CallOption) (*GetCollaboratorResponse, error)
-	// Set the rights of a collaborator (member) on the application.
+	// Set the rights of a collaborator (member) on the application. It is required for the caller to
+	// have all assigned or/and removed rights.
 	// Setting a collaborator without rights, removes them.
 	SetCollaborator(ctx context.Context, in *SetApplicationCollaboratorRequest, opts ...grpc.CallOption) (*types.Empty, error)
 	ListCollaborators(ctx context.Context, in *ListApplicationCollaboratorsRequest, opts ...grpc.CallOption) (*Collaborators, error)
@@ -447,7 +448,8 @@ type ApplicationAccessServer interface {
 	// Get the rights of a collaborator (member) of the application.
 	// Pseudo-rights in the response (such as the "_ALL" right) are not expanded.
 	GetCollaborator(context.Context, *GetApplicationCollaboratorRequest) (*GetCollaboratorResponse, error)
-	// Set the rights of a collaborator (member) on the application.
+	// Set the rights of a collaborator (member) on the application. It is required for the caller to
+	// have all assigned or/and removed rights.
 	// Setting a collaborator without rights, removes them.
 	SetCollaborator(context.Context, *SetApplicationCollaboratorRequest) (*types.Empty, error)
 	ListCollaborators(context.Context, *ListApplicationCollaboratorsRequest) (*Collaborators, error)

--- a/pkg/ttnpb/client_services.pb.go
+++ b/pkg/ttnpb/client_services.pb.go
@@ -331,7 +331,8 @@ type ClientAccessClient interface {
 	// Get the rights of a collaborator (member) of the client.
 	// Pseudo-rights in the response (such as the "_ALL" right) are not expanded.
 	GetCollaborator(ctx context.Context, in *GetClientCollaboratorRequest, opts ...grpc.CallOption) (*GetCollaboratorResponse, error)
-	// Set the rights of a collaborator (member) on the client.
+	// Set the rights of a collaborator (member) on the client. It is required for the caller to
+	// have all assigned or/and removed rights.
 	// Setting a collaborator without rights, removes them.
 	SetCollaborator(ctx context.Context, in *SetClientCollaboratorRequest, opts ...grpc.CallOption) (*types.Empty, error)
 	ListCollaborators(ctx context.Context, in *ListClientCollaboratorsRequest, opts ...grpc.CallOption) (*Collaborators, error)
@@ -387,7 +388,8 @@ type ClientAccessServer interface {
 	// Get the rights of a collaborator (member) of the client.
 	// Pseudo-rights in the response (such as the "_ALL" right) are not expanded.
 	GetCollaborator(context.Context, *GetClientCollaboratorRequest) (*GetCollaboratorResponse, error)
-	// Set the rights of a collaborator (member) on the client.
+	// Set the rights of a collaborator (member) on the client. It is required for the caller to
+	// have all assigned or/and removed rights.
 	// Setting a collaborator without rights, removes them.
 	SetCollaborator(context.Context, *SetClientCollaboratorRequest) (*types.Empty, error)
 	ListCollaborators(context.Context, *ListClientCollaboratorsRequest) (*Collaborators, error)

--- a/pkg/ttnpb/gateway_services.pb.go
+++ b/pkg/ttnpb/gateway_services.pb.go
@@ -475,7 +475,8 @@ type GatewayAccessClient interface {
 	// Get the rights of a collaborator (member) of the gateway.
 	// Pseudo-rights in the response (such as the "_ALL" right) are not expanded.
 	GetCollaborator(ctx context.Context, in *GetGatewayCollaboratorRequest, opts ...grpc.CallOption) (*GetCollaboratorResponse, error)
-	// Set the rights of a collaborator (member) on the gateway.
+	// Set the rights of a collaborator (member) on the gateway. It is required for the caller to
+	// have all assigned or/and removed rights.
 	// Setting a collaborator without rights, removes them.
 	SetCollaborator(ctx context.Context, in *SetGatewayCollaboratorRequest, opts ...grpc.CallOption) (*types.Empty, error)
 	ListCollaborators(ctx context.Context, in *ListGatewayCollaboratorsRequest, opts ...grpc.CallOption) (*Collaborators, error)
@@ -574,7 +575,8 @@ type GatewayAccessServer interface {
 	// Get the rights of a collaborator (member) of the gateway.
 	// Pseudo-rights in the response (such as the "_ALL" right) are not expanded.
 	GetCollaborator(context.Context, *GetGatewayCollaboratorRequest) (*GetCollaboratorResponse, error)
-	// Set the rights of a collaborator (member) on the gateway.
+	// Set the rights of a collaborator (member) on the gateway. It is required for the caller to
+	// have all assigned or/and removed rights.
 	// Setting a collaborator without rights, removes them.
 	SetCollaborator(context.Context, *SetGatewayCollaboratorRequest) (*types.Empty, error)
 	ListCollaborators(context.Context, *ListGatewayCollaboratorsRequest) (*Collaborators, error)

--- a/pkg/ttnpb/organization_services.pb.go
+++ b/pkg/ttnpb/organization_services.pb.go
@@ -345,7 +345,8 @@ type OrganizationAccessClient interface {
 	// Get the rights of a collaborator (member) of the organization.
 	// Pseudo-rights in the response (such as the "_ALL" right) are not expanded.
 	GetCollaborator(ctx context.Context, in *GetOrganizationCollaboratorRequest, opts ...grpc.CallOption) (*GetCollaboratorResponse, error)
-	// Set the rights of a collaborator (member) on the organization.
+	// Set the rights of a collaborator (member) on the organization. It is required for the caller to
+	// have all assigned or/and removed rights.
 	// Setting a collaborator without rights, removes them.
 	// Note that only users can collaborate (be member of) an organization.
 	SetCollaborator(ctx context.Context, in *SetOrganizationCollaboratorRequest, opts ...grpc.CallOption) (*types.Empty, error)
@@ -445,7 +446,8 @@ type OrganizationAccessServer interface {
 	// Get the rights of a collaborator (member) of the organization.
 	// Pseudo-rights in the response (such as the "_ALL" right) are not expanded.
 	GetCollaborator(context.Context, *GetOrganizationCollaboratorRequest) (*GetCollaboratorResponse, error)
-	// Set the rights of a collaborator (member) on the organization.
+	// Set the rights of a collaborator (member) on the organization. It is required for the caller to
+	// have all assigned or/and removed rights.
 	// Setting a collaborator without rights, removes them.
 	// Note that only users can collaborate (be member of) an organization.
 	SetCollaborator(context.Context, *SetOrganizationCollaboratorRequest) (*types.Empty, error)

--- a/sdk/js/generated/api.json
+++ b/sdk/js/generated/api.json
@@ -911,7 +911,7 @@
             },
             {
               "name": "SetCollaborator",
-              "description": "Set the rights of a collaborator (member) on the application.\nSetting a collaborator without rights, removes them.",
+              "description": "Set the rights of a collaborator (member) on the application. It is required for the caller to\nhave all assigned or/and removed rights.\nSetting a collaborator without rights, removes them.",
               "requestType": "SetApplicationCollaboratorRequest",
               "requestLongType": "SetApplicationCollaboratorRequest",
               "requestFullType": "ttn.lorawan.v3.SetApplicationCollaboratorRequest",
@@ -4363,7 +4363,7 @@
             },
             {
               "name": "SetCollaborator",
-              "description": "Set the rights of a collaborator (member) on the client.\nSetting a collaborator without rights, removes them.",
+              "description": "Set the rights of a collaborator (member) on the client. It is required for the caller to\nhave all assigned or/and removed rights.\nSetting a collaborator without rights, removes them.",
               "requestType": "SetClientCollaboratorRequest",
               "requestLongType": "SetClientCollaboratorRequest",
               "requestFullType": "ttn.lorawan.v3.SetClientCollaboratorRequest",
@@ -10780,7 +10780,7 @@
             },
             {
               "name": "SetCollaborator",
-              "description": "Set the rights of a collaborator (member) on the gateway.\nSetting a collaborator without rights, removes them.",
+              "description": "Set the rights of a collaborator (member) on the gateway. It is required for the caller to\nhave all assigned or/and removed rights.\nSetting a collaborator without rights, removes them.",
               "requestType": "SetGatewayCollaboratorRequest",
               "requestLongType": "SetGatewayCollaboratorRequest",
               "requestFullType": "ttn.lorawan.v3.SetGatewayCollaboratorRequest",
@@ -20736,7 +20736,7 @@
             },
             {
               "name": "SetCollaborator",
-              "description": "Set the rights of a collaborator (member) on the organization.\nSetting a collaborator without rights, removes them.\nNote that only users can collaborate (be member of) an organization.",
+              "description": "Set the rights of a collaborator (member) on the organization. It is required for the caller to\nhave all assigned or/and removed rights.\nSetting a collaborator without rights, removes them.\nNote that only users can collaborate (be member of) an organization.",
               "requestType": "SetOrganizationCollaboratorRequest",
               "requestLongType": "SetOrganizationCollaboratorRequest",
               "requestFullType": "ttn.lorawan.v3.SetOrganizationCollaboratorRequest",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #1204 

#### Changes
<!-- What are the changes made in this pull request? -->

- Change implementation of `SetApplicationCollaboratorRequest`
- Change implementation of `SetCollaboratorCollaboratorRequest`
- Change implementation of `SetGatewayCollaboratorRequest`
- Add tests for each entity to test new handling of collaborator rights

#### Notes for Reviewers 
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

~~@htdvisser I left the clients access rpc without changes, since it seems to be inherently different from applications, gateways and collaborators.~~

@johanstokking @rvolosatovs no need for review
@kschiffer please verify that this PR solves the issue

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Changed the way collaborator rights are handled in the `SetCollaborator` rpc for Applications, Gateways and Organizations. Collaborators can revoke or add rights to other collaborators as long as they have these rights.
