### PR TITLE
Fix PubSub events identifiers

### DIFF
--- a/pkg/applicationserver/io/pubsub/grpc_pubsub.go
+++ b/pkg/applicationserver/io/pubsub/grpc_pubsub.go
@@ -99,7 +99,7 @@ func (ps *PubSub) Set(ctx context.Context, req *ttnpb.SetApplicationPubSubReques
 		)).WithError(err).Warn("Failed to cancel integration")
 	}
 	ps.startTask(ps.ctx, req.ApplicationPubSubIdentifiers)
-	events.Publish(evtSetPubSub(ctx, req.ApplicationPubSubIdentifiers, nil))
+	events.Publish(evtSetPubSub(ctx, req.ApplicationIdentifiers, req.ApplicationPubSubIdentifiers))
 	return pubsub, nil
 }
 
@@ -126,6 +126,6 @@ func (ps *PubSub) Delete(ctx context.Context, ids *ttnpb.ApplicationPubSubIdenti
 	if err != nil {
 		return nil, err
 	}
-	events.Publish(evtDeletePubSub(ctx, *ids, nil))
+	events.Publish(evtDeletePubSub(ctx, ids.ApplicationIdentifiers, *ids))
 	return ttnpb.Empty, nil
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #1331 

#### Changes
<!-- What are the changes made in this pull request? -->

- Add the missing PubSub identifiers to the events.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

After the refactor back to using application identifiers in the last PR I forgot to add the PubSub identifiers in two places. This fixes this issue.