### PR TITLE
Fix Basic Station CUPS Update-Info Request

### DIFF
--- a/cmd/internal/shared/config.go
+++ b/cmd/internal/shared/config.go
@@ -126,8 +126,11 @@ var DefaultServiceBase = config.ServiceBase{
 	KeyVault:         DefaultKeyVaultConfig,
 }
 
+// DefaultPublicHost is the default public host where The Things Stack is served.
+var DefaultPublicHost = "localhost"
+
 // DefaultPublicURL is the default public URL where The Things Stack is served.
-var DefaultPublicURL = "http://localhost:1885"
+var DefaultPublicURL = "http://" + DefaultPublicHost + ":1885"
 
 // DefaultAssetsBaseURL is the default public URL where the assets are served.
 var DefaultAssetsBaseURL = DefaultHTTPConfig.Static.Mount

--- a/cmd/internal/shared/gatewayconfigurationserver/config.go
+++ b/cmd/internal/shared/gatewayconfigurationserver/config.go
@@ -15,6 +15,8 @@
 package shared
 
 import (
+	"go.thethings.network/lorawan-stack/cmd/internal/shared"
+	gs "go.thethings.network/lorawan-stack/cmd/internal/shared/gatewayserver"
 	"go.thethings.network/lorawan-stack/pkg/gatewayconfigurationserver"
 )
 
@@ -25,5 +27,7 @@ var DefaultGatewayConfigurationServerConfig = gatewayconfigurationserver.Config{
 
 func init() {
 	DefaultGatewayConfigurationServerConfig.TheThingsGateway.Default.UpdateChannel = "stable"
+	DefaultGatewayConfigurationServerConfig.TheThingsGateway.Default.MQTTServer = "mqtts://" + shared.DefaultPublicHost + gs.DefaultGatewayServerConfig.MQTT.ListenTLS
 	DefaultGatewayConfigurationServerConfig.TheThingsGateway.Default.FirmwareURL = "https://thethingsproducts.blob.core.windows.net/the-things-gateway/v1"
+	DefaultGatewayConfigurationServerConfig.BasicStation.Default.LNSURI = "wss://" + shared.DefaultPublicHost + gs.DefaultGatewayServerConfig.BasicStation.ListenTLS
 }

--- a/config/messages.json
+++ b/config/messages.json
@@ -2215,7 +2215,7 @@
   },
   "error:pkg/basicstation/cups:no_trust": {
     "translations": {
-      "en": "no trusted certificate configured"
+      "en": "no trusted certificate found"
     },
     "description": {
       "package": "pkg/basicstation/cups",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,10 @@ services:
       # - TTN_LW_IS_EMAIL_SMTP_USERNAME=enter username
       # - TTN_LW_IS_EMAIL_SMTP_PASSWORD=enter password
 
+      # If Gateway Configuration Server enabled, defaults for "thethings.example.com":
+      # - TTN_LW_GCS_BASIC_STATION_DEFAULT_LNS_URI=wss://thethings.example.com:8887
+      # - TTN_LW_GCS_THE_THINGS_GATEWAY_DEFAULT_MQTT_SERVER=mqtts://thethings.example.com:8882
+
       # Web UI configuration for "thethings.example.com":
       # - TTN_LW_IS_OAUTH_UI_CANONICAL_URL=https://thethings.example.com/oauth
       # - TTN_LW_IS_OAUTH_UI_IS_BASE_URL=https://thethings.example.com/api/v3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
 
       # If using (self) signed certificates:
       - TTN_LW_TLS_CERTIFICATE=/run/secrets/cert.pem
-      - TTN_LW_CA=/run/secrets/cert.pem
+      - TTN_LW_TLS_ROOT_CA=/run/secrets/cert.pem
       - TTN_LW_TLS_KEY=/run/secrets/key.pem
 
       # HTTP Server configuration:

--- a/go.mod
+++ b/go.mod
@@ -145,6 +145,7 @@ require (
 	golang.org/x/image v0.0.0-20190910094157-69e4b8554b2a // indirect
 	golang.org/x/net v0.0.0-20190909003024-a7b16738d86b
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20190910064555-bbd175535a8b // indirect
 	golang.org/x/tools v0.0.0-20190911022129-16c5e0f7d110
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7

--- a/go.sum
+++ b/go.sum
@@ -826,6 +826,8 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190910064555-bbd175535a8b h1:3S2h5FadpNr0zUUCVZjlKIEYF+KaX/OBplTGo89CYHI=
 golang.org/x/sys v0.0.0-20190910064555-bbd175535a8b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=

--- a/pkg/basicstation/cups/server.go
+++ b/pkg/basicstation/cups/server.go
@@ -28,7 +28,6 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/rpcmetadata"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
-	"go.thethings.network/lorawan-stack/pkg/types"
 	"go.thethings.network/lorawan-stack/pkg/web"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -42,11 +41,19 @@ type ServerConfig struct {
 		ID     string `name:"id" description:"ID of the account to register unknown gateways to"`
 		APIKey string `name:"api-key" description:"API Key to use for unknown gateway registration"`
 	} `name:"owner-for-unknown"`
+	Default struct {
+		LNSURI string `name:"lns-uri" description:"The default LNS URI that the gateways should use"`
+	} `name:"default" description:"Default gateway settings"`
 	AllowCUPSURIUpdate bool `name:"allow-cups-uri-update" description:"Allow CUPS URI updates"`
 }
 
 // NewServer returns a new CUPS server from this config on top of the component.
 func (conf ServerConfig) NewServer(c *component.Component, customOpts ...Option) *Server {
+	opts := []Option{
+		WithExplicitEnable(conf.ExplicitEnable),
+		WithAllowCUPSURIUpdate(conf.AllowCUPSURIUpdate),
+		WithDefaultLNSURI(conf.Default.LNSURI),
+	}
 	var registerUnknownTo *ttnpb.OrganizationOrUserIdentifiers
 	switch conf.RegisterUnknown.Type {
 	case "user":
@@ -54,22 +61,19 @@ func (conf ServerConfig) NewServer(c *component.Component, customOpts ...Option)
 	case "organization":
 		registerUnknownTo = ttnpb.OrganizationIdentifiers{OrganizationID: conf.RegisterUnknown.ID}.OrganizationOrUserIdentifiers()
 	}
-	opts := []Option{
-		WithExplicitEnable(conf.ExplicitEnable),
-		WithRegisterUnknown(registerUnknownTo),
-		WithAllowCUPSURIUpdate(conf.AllowCUPSURIUpdate),
-	}
-	if conf.RegisterUnknown.APIKey != "" {
-		opts = append(opts, WithAuth(func(ctx context.Context, gatewayEUI types.EUI64, auth string) grpc.CallOption {
-			return grpc.PerRPCCredentials(rpcmetadata.MD{
-				AuthType:      "bearer",
-				AuthValue:     conf.RegisterUnknown.APIKey,
-				AllowInsecure: c.AllowInsecureForCredentials(),
-			})
-		}))
+	if registerUnknownTo != nil && conf.RegisterUnknown.APIKey != "" {
+		opts = append(opts,
+			WithRegisterUnknown(registerUnknownTo, func(ctx context.Context) grpc.CallOption {
+				return grpc.PerRPCCredentials(rpcmetadata.MD{
+					AuthType:      "bearer",
+					AuthValue:     conf.RegisterUnknown.APIKey,
+					AllowInsecure: c.AllowInsecureForCredentials(),
+				})
+			}),
+		)
 	}
 	if tlsConfig, err := c.GetTLSConfig(c.Context()); err == nil {
-		opts = append(opts, WithRootCAs(tlsConfig.RootCAs))
+		opts = append(opts, WithTLSConfig(tlsConfig))
 	}
 	s := NewServer(c, append(opts, customOpts...)...)
 	c.RegisterWeb(s)
@@ -84,24 +88,25 @@ type Server struct {
 	// clients from the appropriate cluster peer.
 	registry ttnpb.GatewayRegistryClient
 	access   ttnpb.GatewayAccessClient
-
-	auth func(context.Context, types.EUI64, string) grpc.CallOption
+	auth     func(context.Context) grpc.CallOption
 
 	requireExplicitEnable bool
 	registerUnknown       bool
 	defaultOwner          ttnpb.OrganizationOrUserIdentifiers
+	defaultOwnerAuth      func(context.Context) grpc.CallOption
+	defaultLNSURI         string
 
 	allowCUPSURIUpdate bool
 
-	rootCAs *x509.CertPool
-	trust   *x509.Certificate
+	tlsConfig *tls.Config
+	trust     *x509.Certificate
 
 	signers map[uint32]crypto.Signer
 }
 
-func (s *Server) getAuth(ctx context.Context, eui types.EUI64, auth string) grpc.CallOption {
+func (s *Server) getServerAuth(ctx context.Context) grpc.CallOption {
 	if s.auth != nil {
-		return s.auth(ctx, eui, auth)
+		return s.auth(ctx)
 	}
 	return s.component.WithClusterAuth()
 }
@@ -131,15 +136,6 @@ func (s *Server) getAccess(ctx context.Context, ids *ttnpb.GatewayIdentifiers) (
 // Option configures the CUPSServer.
 type Option func(s *Server)
 
-// WithAuth sets the auth function for gateways that don't provide TTN auth.
-// When this auth method is used, the CUPS server will look up the cups-credentials
-// attribute in the gateway registry.
-func WithAuth(auth func(ctx context.Context, gatewayEUI types.EUI64, auth string) grpc.CallOption) Option {
-	return func(s *Server) {
-		s.auth = auth
-	}
-}
-
 // WithExplicitEnable requires CUPS to be explicitly enabled with a cups attribute
 // in the gateway registry.
 func WithExplicitEnable(enable bool) Option {
@@ -151,12 +147,12 @@ func WithExplicitEnable(enable bool) Option {
 // WithRegisterUnknown configures the CUPS server to register gateways if they
 // do not already exist in the registry. The gateways will be registered under the
 // given owner.
-func WithRegisterUnknown(owner *ttnpb.OrganizationOrUserIdentifiers) Option {
+func WithRegisterUnknown(owner *ttnpb.OrganizationOrUserIdentifiers, auth func(context.Context) grpc.CallOption) Option {
 	return func(s *Server) {
 		if owner != nil {
-			s.registerUnknown, s.defaultOwner = true, *owner
+			s.registerUnknown, s.defaultOwner, s.defaultOwnerAuth = true, *owner, auth
 		} else {
-			s.registerUnknown, s.defaultOwner = false, ttnpb.OrganizationOrUserIdentifiers{}
+			s.registerUnknown, s.defaultOwner, s.defaultOwnerAuth = false, ttnpb.OrganizationOrUserIdentifiers{}, nil
 		}
 	}
 }
@@ -169,6 +165,14 @@ func WithAllowCUPSURIUpdate(allow bool) Option {
 	}
 }
 
+// WithDefaultLNSURI configures the CUPS server with a default LNS URI to use when
+// no Gateway Server address is registered for a gateway.
+func WithDefaultLNSURI(uri string) Option {
+	return func(s *Server) {
+		s.defaultLNSURI = uri
+	}
+}
+
 // WithTrust configures the CUPS server to return the given certificate to gateways
 // as trusted certificate for the CUPS server. This should typically be the certificate
 // of the Root CA in the chain of the CUPS server's TLS certificate.
@@ -178,11 +182,11 @@ func WithTrust(cert *x509.Certificate) Option {
 	}
 }
 
-// WithRootCAs configures the CUPS server with the given Root CAs that will be used
-// to lookup CUPS/LNS Root CAs.
-func WithRootCAs(pool *x509.CertPool) Option {
+// WithTLSConfig configures the CUPS server with the given TLS config that will
+// be used to lookup CUPS/LNS Root CAs.
+func WithTLSConfig(tlsConfig *tls.Config) Option {
 	return func(s *Server) {
-		s.rootCAs = pool
+		s.tlsConfig = tlsConfig
 	}
 }
 
@@ -197,6 +201,13 @@ func WithSigner(keyCRC uint32, signer crypto.Signer) Option {
 func WithRegistries(registry ttnpb.GatewayRegistryClient, access ttnpb.GatewayAccessClient) Option {
 	return func(s *Server) {
 		s.registry, s.access = registry, access
+	}
+}
+
+// WithAuth overrides the CUPS server's server auth func.
+func WithAuth(auth func(ctx context.Context) grpc.CallOption) Option {
+	return func(s *Server) {
+		s.auth = auth
 	}
 }
 
@@ -229,7 +240,7 @@ func getContext(c echo.Context) context.Context {
 	return metadata.NewIncomingContext(ctx, md)
 }
 
-var errNoTrust = errors.DefineInternal("no_trust", "no trusted certificate configured")
+var errNoTrust = errors.DefineInternal("no_trust", "no trusted certificate found")
 
 // parseAddress parses a CUPS or LNS address.
 //
@@ -269,10 +280,10 @@ func parseAddress(address string) (scheme, host, port string, err error) {
 
 func (s *Server) getTrust(address string) (*x509.Certificate, error) {
 	if address == "" {
-		if s.trust == nil {
-			return nil, errNoTrust
+		if s.trust != nil {
+			return s.trust, nil
 		}
-		return s.trust, nil
+		return nil, errNoTrust
 	}
 	_, host, port, err := parseAddress(address)
 	if err != nil {
@@ -281,11 +292,18 @@ func (s *Server) getTrust(address string) (*x509.Certificate, error) {
 	if port == "" {
 		port = "443"
 	}
-	conn, err := tls.Dial("tcp", net.JoinHostPort(host, port), &tls.Config{RootCAs: s.rootCAs})
+	conn, err := tls.Dial("tcp", net.JoinHostPort(host, port), s.tlsConfig)
 	if err != nil {
 		return nil, err
 	}
 	defer conn.Close()
-	certChain := conn.ConnectionState().VerifiedChains[0]
-	return certChain[len(certChain)-1], nil
+	if verifiedChains := conn.ConnectionState().VerifiedChains; len(verifiedChains) > 0 {
+		chain := verifiedChains[0]
+		return chain[len(chain)-1], nil
+	}
+	if s.tlsConfig != nil && s.tlsConfig.InsecureSkipVerify {
+		chain := conn.ConnectionState().PeerCertificates
+		return chain[len(chain)-1], nil
+	}
+	return nil, errNoTrust
 }

--- a/pkg/basicstation/cups/server.go
+++ b/pkg/basicstation/cups/server.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"time"
 
 	echo "github.com/labstack/echo/v4"
 	"go.thethings.network/lorawan-stack/pkg/component"
@@ -309,7 +310,9 @@ func (s *Server) getTrust(address string) (*x509.Certificate, error) {
 			return trust, nil
 		}
 
-		conn, err := tls.Dial("tcp", net.JoinHostPort(host, port), s.tlsConfig)
+		conn, err := tls.DialWithDialer(&net.Dialer{
+			Timeout: 5 * time.Second,
+		}, "tcp", address, s.tlsConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/basicstation/cups/server_test.go
+++ b/pkg/basicstation/cups/server_test.go
@@ -36,7 +36,7 @@ import (
 func TestGetTrust(t *testing.T) {
 	a := assertions.New(t)
 
-	s := new(Server)
+	s := NewServer(nil)
 
 	for _, addr := range []string{
 		"thethingsnetwork.org:443",

--- a/pkg/basicstation/cups/server_test.go
+++ b/pkg/basicstation/cups/server_test.go
@@ -153,7 +153,7 @@ func mockGateway() *ttnpb.Gateway {
 			EUI:       &mockGatewayEUI,
 		},
 		Attributes: map[string]string{
-			cupsURIAttribute:           "https://mh.sm.tc:7007",
+			cupsURIAttribute:           "https://example.com:443",
 			cupsCredentialsIDAttribute: "KEYID",
 			cupsCredentialsAttribute:   "Bearer KEYCONTENTS",
 			cupsStationAttribute:       "2.0.0(minihub/debug) 2018-12-06 09:30:35",
@@ -162,7 +162,7 @@ func mockGateway() *ttnpb.Gateway {
 			lnsCredentialsIDAttribute:  "KEYID",
 			lnsCredentialsAttribute:    "Bearer KEYCONTENTS",
 		},
-		GatewayServerAddress: "wss://mh.sm.tc:7000",
+		GatewayServerAddress: "wss://example.com:443",
 	}
 }
 
@@ -221,7 +221,7 @@ func TestServer(t *testing.T) {
 			},
 			Options: []Option{
 				WithRegisterUnknown(&ttnpb.OrganizationOrUserIdentifiers{}, mockAuthFunc),
-				WithDefaultLNSURI("wss://mh.sm.tc:7000"),
+				WithDefaultLNSURI("wss://example.com:443"),
 			},
 			AssertError: should.BeNil,
 			AssertResponse: func(a *assertions.Assertion, rec *httptest.ResponseRecorder) {
@@ -229,7 +229,7 @@ func TestServer(t *testing.T) {
 				err := res.UnmarshalBinary(rec.Body.Bytes())
 				a.So(err, should.BeNil)
 				a.So(res.CUPSURI, should.BeEmpty) // No update.
-				a.So(res.LNSURI, should.Equal, "wss://mh.sm.tc:7000")
+				a.So(res.LNSURI, should.Equal, "wss://example.com:443")
 				a.So(res.CUPSCredentials, should.NotBeEmpty)
 				a.So(res.LNSCredentials, should.NotBeEmpty)
 				a.So(res.SignatureKeyCRC, should.BeZeroValue)
@@ -287,8 +287,8 @@ func TestServer(t *testing.T) {
 				var res UpdateInfoResponse
 				err := res.UnmarshalBinary(rec.Body.Bytes())
 				a.So(err, should.BeNil)
-				a.So(res.CUPSURI, should.Equal, "https://mh.sm.tc:7007")
-				a.So(res.LNSURI, should.Equal, "wss://mh.sm.tc:7000")
+				a.So(res.CUPSURI, should.Equal, "https://example.com:443")
+				a.So(res.LNSURI, should.Equal, "wss://example.com:443")
 				a.So(res.CUPSCredentials, should.NotBeEmpty)
 				a.So(res.LNSCredentials, should.NotBeEmpty)
 				a.So(res.SignatureKeyCRC, should.BeZeroValue)

--- a/pkg/basicstation/cups/update_info.go
+++ b/pkg/basicstation/cups/update_info.go
@@ -194,6 +194,7 @@ func (s *Server) UpdateInfo(c echo.Context) error {
 	}
 
 	if credentials := gtw.Attributes[cupsCredentialsAttribute]; credentials != "" {
+		logger.WithField("cups_uri", gtw.Attributes[cupsURIAttribute]).Debug("Getting trusted certificate for CUPS...")
 		cupsTrust, err := s.getTrust(gtw.Attributes[cupsURIAttribute])
 		if err != nil {
 			return err
@@ -230,6 +231,7 @@ func (s *Server) UpdateInfo(c echo.Context) error {
 	}
 
 	if credentials := gtw.Attributes[lnsCredentialsAttribute]; credentials != "" {
+		logger.WithField("lns_uri", gtw.GatewayServerAddress).Debug("Getting trusted certificate for LNS...")
 		lnsTrust, err := s.getTrust(gtw.GatewayServerAddress)
 		if err != nil {
 			return err

--- a/pkg/basicstation/cups/update_info.go
+++ b/pkg/basicstation/cups/update_info.go
@@ -175,15 +175,13 @@ func (s *Server) UpdateInfo(c echo.Context) error {
 		}, serverAuth)
 	} else if errors.IsNotFound(err) && s.registerUnknown {
 		gtw, err = s.registerGateway(ctx, req)
-		if err != nil {
-			return err
-		}
 	}
 	if err != nil {
 		return err
 	}
 
-	logger = logger.WithField("gateway_uid", unique.ID(ctx, gtw.GatewayIdentifiers))
+	uid := unique.ID(ctx, gtw.GatewayIdentifiers)
+	logger = logger.WithField("gateway_uid", uid)
 
 	var gatewayAuth grpc.CallOption
 	if rights.RequireGateway(ctx, gtw.GatewayIdentifiers,
@@ -214,7 +212,7 @@ func (s *Server) UpdateInfo(c echo.Context) error {
 
 	if s.requireExplicitEnable || gtw.Attributes[cupsAttribute] != "" {
 		if cups, _ := strconv.ParseBool(gtw.Attributes[cupsAttribute]); !cups {
-			return errCUPSNotEnabled.WithAttributes("gateway_uid", unique.ID(ctx, gtw.GatewayIdentifiers))
+			return errCUPSNotEnabled.WithAttributes("gateway_uid", uid)
 		}
 	}
 

--- a/pkg/basicstation/cups/update_info.go
+++ b/pkg/basicstation/cups/update_info.go
@@ -27,29 +27,26 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gogo/protobuf/types"
+	pbtypes "github.com/gogo/protobuf/types"
 	echo "github.com/labstack/echo/v4"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/rpcmetadata"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/unique"
-	"google.golang.org/grpc"
 )
 
 const (
-	cupsAttribute               = "cups"
-	cupsURIAttribute            = "cups-uri"
-	cupsLastSeenAttribute       = "cups-last-seen"
-	cupsCredentialsIDAttribute  = "cups-credentials-id"
-	cupsCredentialsAttribute    = "cups-credentials"
-	cupsCredentialsCRCAttribute = "cups-credentials-crc"
-	cupsStationAttribute        = "cups-station"
-	cupsModelAttribute          = "cups-model"
-	cupsPackageAttribute        = "cups-package"
-	lnsCredentialsIDAttribute   = "lns-credentials-id"
-	lnsCredentialsAttribute     = "lns-credentials"
-	lnsCredentialsCRCAttribute  = "lns-credentials-crc"
+	cupsAttribute              = "cups"
+	cupsURIAttribute           = "cups-uri"
+	cupsLastSeenAttribute      = "cups-last-seen"
+	cupsCredentialsIDAttribute = "cups-credentials-id"
+	cupsCredentialsAttribute   = "cups-credentials"
+	cupsStationAttribute       = "cups-station"
+	cupsModelAttribute         = "cups-model"
+	cupsPackageAttribute       = "cups-package"
+	lnsCredentialsIDAttribute  = "lns-credentials-id"
+	lnsCredentialsAttribute    = "lns-credentials"
 )
 
 var (
@@ -58,7 +55,70 @@ var (
 	errInvalidToken    = errors.DefinePermissionDenied("invalid_token", "invalid provisioning token")
 )
 
-var getGatewayMask = types.FieldMask{Paths: []string{
+func (s *Server) registerGateway(ctx context.Context, req UpdateInfoRequest) (*ttnpb.Gateway, error) {
+	logger := log.FromContext(ctx)
+	ids := ttnpb.GatewayIdentifiers{
+		GatewayID: fmt.Sprintf("eui-%s", strings.ToLower(req.Router.EUI64.String())),
+		EUI:       &req.Router.EUI64,
+	}
+	logger = logger.WithField("gateway_uid", unique.ID(ctx, ids))
+	registry, err := s.getRegistry(ctx, &ids)
+	if err != nil {
+		return nil, err
+	}
+	auth := s.defaultOwnerAuth(ctx)
+	gtw, err := registry.Create(ctx, &ttnpb.CreateGatewayRequest{
+		Gateway: ttnpb.Gateway{
+			GatewayIdentifiers:   ids,
+			GatewayServerAddress: s.defaultLNSURI,
+		},
+		Collaborator: s.defaultOwner,
+	}, auth)
+	if err != nil {
+		return nil, err
+	}
+	logger.Info("Created new gateway")
+	accessRegistry, err := s.getAccess(ctx, &gtw.GatewayIdentifiers)
+	if err != nil {
+		return nil, err
+	}
+	cupsKey, err := accessRegistry.CreateAPIKey(ctx, &ttnpb.CreateGatewayAPIKeyRequest{
+		GatewayIdentifiers: gtw.GatewayIdentifiers,
+		Name:               fmt.Sprintf("CUPS Key, generated %s", time.Now().UTC().Format(time.RFC3339)),
+		Rights: []ttnpb.Right{
+			ttnpb.RIGHT_GATEWAY_INFO,
+			ttnpb.RIGHT_GATEWAY_SETTINGS_BASIC,    // We need to write attributes.
+			ttnpb.RIGHT_GATEWAY_SETTINGS_API_KEYS, // We need to create API keys.
+			ttnpb.RIGHT_GATEWAY_LINK,              // We need to create the LNS API key with this right.
+		},
+	}, auth)
+	if err != nil {
+		return nil, err
+	}
+	logger.WithField("api_key_id", cupsKey.ID).Info("Created gateway API key for CUPS")
+	lnsKey, err := accessRegistry.CreateAPIKey(ctx, &ttnpb.CreateGatewayAPIKeyRequest{
+		GatewayIdentifiers: gtw.GatewayIdentifiers,
+		Name:               fmt.Sprintf("LNS Key, generated %s", time.Now().UTC().Format(time.RFC3339)),
+		Rights: []ttnpb.Right{
+			ttnpb.RIGHT_GATEWAY_INFO,
+			ttnpb.RIGHT_GATEWAY_LINK,
+		},
+	}, auth)
+	if err != nil {
+		return nil, err
+	}
+	logger.WithField("api_key_id", lnsKey.ID).Info("Created gateway API key for LNS")
+	gtw.Attributes = map[string]string{
+		cupsAttribute:              "true",
+		cupsCredentialsIDAttribute: cupsKey.ID,
+		cupsCredentialsAttribute:   fmt.Sprintf("Bearer %s", cupsKey.Key),
+		lnsCredentialsIDAttribute:  lnsKey.ID,
+		lnsCredentialsAttribute:    fmt.Sprintf("Bearer %s", lnsKey.Key),
+	}
+	return gtw, nil
+}
+
+var getGatewayMask = pbtypes.FieldMask{Paths: []string{
 	"attributes",
 	"version_ids",
 	"gateway_server_address",
@@ -66,81 +126,6 @@ var getGatewayMask = types.FieldMask{Paths: []string{
 	"update_channel",
 	"frequency_plan_id",
 }}
-
-func (s *Server) getOrRegisterGateway(ctx context.Context, req UpdateInfoRequest, authHeader string) (gtw *ttnpb.Gateway, err error) {
-	logger := log.FromContext(ctx)
-	serverAuth := s.getAuth(ctx, req.Router.EUI64, authHeader)
-
-	logger.Info("Finding gateway...")
-	registry, err := s.getRegistry(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	ids, err := registry.GetIdentifiersForEUI(ctx, &ttnpb.GetGatewayIdentifiersForEUIRequest{
-		EUI: req.Router.EUI64,
-	}, serverAuth)
-
-	if errors.IsNotFound(err) && s.registerUnknown {
-		gatewayID := fmt.Sprintf("eui-%s", strings.ToLower(req.Router.EUI64.String()))
-		logger.WithField("gateway_id", gatewayID).Info("Registering new gateway")
-		ids := ttnpb.GatewayIdentifiers{
-			GatewayID: gatewayID,
-			EUI:       &req.Router.EUI64,
-		}
-		registry, err = s.getRegistry(ctx, &ids)
-		if err != nil {
-			return nil, err
-		}
-		return registry.Create(ctx, &ttnpb.CreateGatewayRequest{
-			Gateway: ttnpb.Gateway{
-				GatewayIdentifiers: ids,
-				Attributes: map[string]string{
-					cupsAttribute:               "true",
-					cupsCredentialsAttribute:    authHeader,
-					cupsCredentialsCRCAttribute: strconv.FormatUint(uint64(req.CUPSCredentialsCRC), 10),
-					lnsCredentialsCRCAttribute:  strconv.FormatUint(uint64(req.LNSCredentialsCRC), 10),
-				},
-				GatewayServerAddress: req.LNSURI,
-			},
-			Collaborator: s.defaultOwner,
-		}, serverAuth)
-	} else if err != nil {
-		return nil, err
-	}
-
-	registry, err = s.getRegistry(ctx, ids)
-	if err != nil {
-		return nil, err
-	}
-	logger = logger.WithField("gateway_id", ids.GetGatewayID())
-
-	if md := rpcmetadata.FromIncomingContext(ctx); strings.ToLower(md.AuthType) == "bearer" && md.AuthValue != "" {
-		logger.Debug("Getting gateway with request credentials")
-		md.AllowInsecure = s.component.AllowInsecureForCredentials()
-		if gtw, err = registry.Get(ctx, &ttnpb.GetGatewayRequest{
-			GatewayIdentifiers: *ids,
-			FieldMask:          getGatewayMask,
-		}, grpc.PerRPCCredentials(md)); err == nil {
-			return gtw, nil
-		} else if !errors.IsUnauthenticated(err) && !errors.IsPermissionDenied(err) {
-			return nil, err
-		}
-	}
-
-	logger.Debug("Getting gateway with server credentials")
-	gtw, err = registry.Get(ctx, &ttnpb.GetGatewayRequest{
-		GatewayIdentifiers: *ids,
-		FieldMask:          getGatewayMask,
-	}, serverAuth)
-	if err != nil {
-		return nil, err
-	}
-	if gtw.Attributes[cupsCredentialsAttribute] != "" && authHeader != gtw.Attributes[cupsCredentialsAttribute] {
-		return nil, errInvalidToken
-	}
-
-	return gtw, nil
-}
 
 // UpdateInfo implements the CUPS update-info handler.
 func (s *Server) UpdateInfo(c echo.Context) error {
@@ -159,14 +144,37 @@ func (s *Server) UpdateInfo(c echo.Context) error {
 	))
 	ctx = log.NewContext(ctx, logger)
 
-	authHeader := c.Request().Header.Get(echo.HeaderAuthorization)
-	if authHeader == "" {
-		return errUnauthenticated
-	}
-	gtw, err := s.getOrRegisterGateway(ctx, req, authHeader)
+	registry, err := s.getRegistry(ctx, nil)
 	if err != nil {
 		return err
 	}
+	serverAuth := s.getServerAuth(ctx)
+	gatewayAuth, err := rpcmetadata.WithForwardedAuth(ctx, s.component.AllowInsecureForCredentials())
+	if err != nil {
+		return err
+	}
+
+	var gtw *ttnpb.Gateway
+	ids, err := registry.GetIdentifiersForEUI(ctx, &ttnpb.GetGatewayIdentifiersForEUIRequest{
+		EUI: req.Router.EUI64,
+	}, serverAuth)
+	if err == nil {
+		logger.WithField("gateway_uid", unique.ID(ctx, ids)).Debug("Found gateway for EUI")
+		gtw, err = registry.Get(ctx, &ttnpb.GetGatewayRequest{
+			GatewayIdentifiers: *ids,
+			FieldMask:          getGatewayMask,
+		}, gatewayAuth)
+	} else if errors.IsNotFound(err) && s.registerUnknown {
+		gtw, err = s.registerGateway(ctx, req)
+		if err != nil {
+			return err
+		}
+	}
+	if err != nil {
+		return err
+	}
+
+	logger = logger.WithField("gateway_uid", unique.ID(ctx, gtw.GatewayIdentifiers))
 
 	if gtw.Attributes == nil {
 		gtw.Attributes = make(map[string]string)
@@ -179,17 +187,36 @@ func (s *Server) UpdateInfo(c echo.Context) error {
 	}
 
 	res := UpdateInfoResponse{}
-	authorization := s.getAuth(ctx, req.Router.EUI64, authHeader)
 
 	if gtw.Attributes[cupsURIAttribute] == "" {
 		gtw.Attributes[cupsURIAttribute] = req.CUPSURI
-	} else if s.allowCUPSURIUpdate && gtw.Attributes[cupsURIAttribute] != req.CUPSURI {
+	}
+	if s.allowCUPSURIUpdate && gtw.Attributes[cupsURIAttribute] != req.CUPSURI {
 		res.CUPSURI = gtw.Attributes[cupsURIAttribute]
 	}
 
+	if credentials := gtw.Attributes[cupsCredentialsAttribute]; credentials != "" {
+		cupsTrust, err := s.getTrust(gtw.Attributes[cupsURIAttribute])
+		if err != nil {
+			return err
+		}
+		cupsCredentials, err := TokenCredentials(cupsTrust, credentials)
+		if err != nil {
+			return err
+		}
+		if crc32.ChecksumIEEE(cupsCredentials) != req.CUPSCredentialsCRC {
+			res.CUPSCredentials = cupsCredentials
+		}
+	}
+
 	if gtw.GatewayServerAddress == "" {
-		gtw.GatewayServerAddress = req.LNSURI
-	} else if gtw.GatewayServerAddress != req.LNSURI {
+		if req.LNSURI != "" {
+			gtw.GatewayServerAddress = req.LNSURI
+		} else {
+			gtw.GatewayServerAddress = s.defaultLNSURI
+		}
+	}
+	if gtw.GatewayServerAddress != req.LNSURI {
 		scheme, host, port, err := parseAddress(gtw.GatewayServerAddress)
 		if err != nil {
 			return err
@@ -204,102 +231,20 @@ func (s *Server) UpdateInfo(c echo.Context) error {
 		res.LNSURI = fmt.Sprintf("%s://%s", scheme, address)
 	}
 
-	if gtw.Attributes[cupsCredentialsCRCAttribute] != strconv.FormatUint(uint64(req.CUPSCredentialsCRC), 10) {
-		if gtw.Attributes[cupsCredentialsAttribute] == "" {
-			registry, err := s.getAccess(ctx, &gtw.GatewayIdentifiers)
-			if err != nil {
-				return err
-			}
-			apiKey, err := registry.CreateAPIKey(ctx, &ttnpb.CreateGatewayAPIKeyRequest{
-				GatewayIdentifiers: gtw.GatewayIdentifiers,
-				Name:               fmt.Sprintf("CUPS Key, generated %s", time.Now().UTC().Format(time.RFC3339)),
-				Rights: []ttnpb.Right{
-					ttnpb.RIGHT_GATEWAY_INFO,              // We need to read private attributes.
-					ttnpb.RIGHT_GATEWAY_SETTINGS_BASIC,    // We need to write attributes.
-					ttnpb.RIGHT_GATEWAY_SETTINGS_API_KEYS, // We need to create API keys.
-					ttnpb.RIGHT_GATEWAY_LINK,              // We need to create the LNS API key with this right.
-				},
-			}, authorization)
-			if err != nil {
-				return err
-			}
-			if gtw.Attributes[cupsCredentialsIDAttribute] != "" {
-				_, err = registry.UpdateAPIKey(ctx, &ttnpb.UpdateGatewayAPIKeyRequest{
-					GatewayIdentifiers: gtw.GatewayIdentifiers,
-					APIKey: ttnpb.APIKey{
-						ID:     gtw.Attributes[cupsCredentialsIDAttribute],
-						Rights: nil,
-					},
-				}, authorization)
-				if err != nil {
-					return err
-				}
-			}
-			gtw.Attributes[cupsCredentialsIDAttribute] = apiKey.ID
-			gtw.Attributes[cupsCredentialsAttribute] = apiKey.Key
-		}
-		trust, err := s.getTrust(gtw.Attributes[cupsURIAttribute])
+	if credentials := gtw.Attributes[lnsCredentialsAttribute]; credentials != "" {
+		lnsTrust, err := s.getTrust(gtw.GatewayServerAddress)
 		if err != nil {
 			return err
 		}
-		if trust != nil {
-			creds, err := TokenCredentials(trust, gtw.Attributes[cupsCredentialsAttribute])
-			if err != nil {
-				return err
-			}
-			res.CUPSCredentials = creds
-			gtw.Attributes[cupsCredentialsCRCAttribute] = strconv.FormatUint(uint64(crc32.ChecksumIEEE(res.CUPSCredentials)), 10)
-		} else {
-			delete(gtw.Attributes, cupsCredentialsCRCAttribute)
-		}
-	}
-	if gtw.Attributes[lnsCredentialsCRCAttribute] != strconv.FormatUint(uint64(req.LNSCredentialsCRC), 10) {
-		if gtw.Attributes[lnsCredentialsAttribute] == "" {
-			registry, err := s.getAccess(ctx, &gtw.GatewayIdentifiers)
-			if err != nil {
-				return err
-			}
-			apiKey, err := registry.CreateAPIKey(ctx, &ttnpb.CreateGatewayAPIKeyRequest{
-				GatewayIdentifiers: gtw.GatewayIdentifiers,
-				Name:               fmt.Sprintf("LNS Key, generated %s", time.Now().UTC().Format(time.RFC3339)),
-				Rights: []ttnpb.Right{
-					ttnpb.RIGHT_GATEWAY_INFO,
-					ttnpb.RIGHT_GATEWAY_LINK,
-				},
-			}, authorization)
-			if err != nil {
-				return err
-			}
-			if gtw.Attributes[lnsCredentialsIDAttribute] != "" {
-				_, err = registry.UpdateAPIKey(ctx, &ttnpb.UpdateGatewayAPIKeyRequest{
-					GatewayIdentifiers: gtw.GatewayIdentifiers,
-					APIKey: ttnpb.APIKey{
-						ID:     gtw.Attributes[lnsCredentialsIDAttribute],
-						Rights: nil,
-					},
-				}, authorization)
-				if err != nil {
-					return err
-				}
-			}
-			gtw.Attributes[lnsCredentialsIDAttribute] = apiKey.ID
-			gtw.Attributes[lnsCredentialsAttribute] = apiKey.Key
-		}
-		trust, err := s.getTrust(gtw.GatewayServerAddress)
+		lnsCredentials, err := TokenCredentials(lnsTrust, credentials)
 		if err != nil {
 			return err
 		}
-		if trust != nil {
-			creds, err := TokenCredentials(trust, gtw.Attributes[lnsCredentialsAttribute])
-			if err != nil {
-				return err
-			}
-			res.LNSCredentials = creds
-			gtw.Attributes[lnsCredentialsCRCAttribute] = strconv.FormatUint(uint64(crc32.ChecksumIEEE(res.LNSCredentials)), 10)
-		} else {
-			delete(gtw.Attributes, lnsCredentialsCRCAttribute)
+		if crc32.ChecksumIEEE(lnsCredentials) != req.LNSCredentialsCRC {
+			res.LNSCredentials = lnsCredentials
 		}
 	}
+
 	if gtw.AutoUpdate {
 		// TODO: Compare the Station, Model, Package, version_ids and update_channel in order to check if any updates are required
 		// (https://github.com/TheThingsNetwork/lorawan-stack/issues/365)
@@ -333,16 +278,16 @@ func (s *Server) UpdateInfo(c echo.Context) error {
 	gtw.Attributes[cupsModelAttribute] = req.Model
 	gtw.Attributes[cupsPackageAttribute] = req.Package
 
-	registry, err := s.getRegistry(ctx, &gtw.GatewayIdentifiers)
+	registry, err = s.getRegistry(ctx, &gtw.GatewayIdentifiers)
 	if err != nil {
 		return err
 	}
 	gtw, err = registry.Update(ctx, &ttnpb.UpdateGatewayRequest{
 		Gateway: *gtw,
-		FieldMask: types.FieldMask{Paths: []string{
+		FieldMask: pbtypes.FieldMask{Paths: []string{
 			"attributes",
 		}},
-	}, authorization)
+	}, gatewayAuth)
 	if err != nil {
 		return err
 	}

--- a/pkg/basicstation/cups/update_info.go
+++ b/pkg/basicstation/cups/update_info.go
@@ -87,9 +87,7 @@ func (s *Server) registerGateway(ctx context.Context, req UpdateInfoRequest) (*t
 		Name:               fmt.Sprintf("CUPS Key, generated %s", time.Now().UTC().Format(time.RFC3339)),
 		Rights: []ttnpb.Right{
 			ttnpb.RIGHT_GATEWAY_INFO,
-			ttnpb.RIGHT_GATEWAY_SETTINGS_BASIC,    // We need to write attributes.
-			ttnpb.RIGHT_GATEWAY_SETTINGS_API_KEYS, // We need to create API keys.
-			ttnpb.RIGHT_GATEWAY_LINK,              // We need to create the LNS API key with this right.
+			ttnpb.RIGHT_GATEWAY_SETTINGS_BASIC,
 		},
 	}, auth)
 	if err != nil {

--- a/pkg/config/tls.go
+++ b/pkg/config/tls.go
@@ -49,10 +49,11 @@ func (a ACME) IsZero() bool {
 
 // TLS represents TLS configuration.
 type TLS struct {
-	RootCA      string `name:"root-ca" description:"Location of TLS root CA certificate (optional)"`
-	Certificate string `name:"certificate" description:"Location of TLS certificate"`
-	Key         string `name:"key" description:"Location of TLS private key"`
-	ACME        ACME   `name:"acme"`
+	RootCA             string `name:"root-ca" description:"Location of TLS root CA certificate (optional)"`
+	InsecureSkipVerify bool   `name:"insecure-skip-verify" description:"Skip verification of certificate chains (insecure)"`
+	Certificate        string `name:"certificate" description:"Location of TLS certificate"`
+	Key                string `name:"key" description:"Location of TLS private key"`
+	ACME               ACME   `name:"acme"`
 }
 
 // IsZero returns whether the TLS configuration is empty.
@@ -116,7 +117,8 @@ func (t TLS) Config(ctx context.Context) (*tls.Config, error) {
 	}))
 
 	return &tls.Config{
-		RootCAs: rootCAs,
+		RootCAs:            rootCAs,
+		InsecureSkipVerify: t.InsecureSkipVerify,
 		GetCertificate: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
 			return cv.Load().(*tls.Certificate), nil
 		},


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This Pull Request refactors the `update-info` handler of Basic Station CUPS and improves its usability (at least a little bit).

Closes #1313

#### Changes
<!-- What are the changes made in this pull request? -->

- Basically rewrote the entire flow. 
- Added defaults to GCS config.
- Updated docker-compose accordingly.
- Made it easier to test locally with `--tls.insecure-skip-verify`

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Tested this with https://github.com/lorabasics/basicstation/commit/c29b8502f8c715daecec6666835da6e981dc820a

For testing, use the following commands to register the gateway, create the API keys and basicstation config files:

```sh
ttn-lw-cli login

gateway_eui=XXX
gateway_id=yyy
server_host=zzz

export TTN_LW_OAUTH_SERVER_ADDRESS=https://$server_host:8885/oauth
export TTN_LW_IDENTITY_SERVER_GRPC_ADDRESS=$server_host:8884
export TTN_LW_GATEWAY_SERVER_GRPC_ADDRESS=$server_host:8884

ttn-lw-cli gateways create $gateway_id --user-id admin --gateway-eui $gateway_eui --gateway-server-address wss://$server_host:8887

cups_api_key=$(ttn-lw-cli gateways api-keys create $gateway_id --name "CUPS Key" --right-gateway-info --right-gateway-settings-basic)
cups_credentials=$(echo $cups_api_key | jq -r '.key')

lns_api_key=$(ttn-lw-cli gateways api-keys create $gateway_id --name "LNS Key" --right-gateway-info --right-gateway-link)
lns_credentials=$(echo $lns_api_key | jq -r '.key')

ttn-lw-cli gateways update $gateway_id \
  --attributes="lns-credentials=$lns_credentials"

echo -n "https://$server_host:8885" > cups-boot.uri
cat cert.pem > cups-boot.trust
echo -n "" > cups-boot.crt
echo -ne "Authorization: Bearer $cups_credentials\r\n" > cups-boot.key
```

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Fixed implementation of CUPS update-info endpoint
- Added `--tls.insecure-skip-verify` to skip certificate chain verification (insecure; for development only).