### PR TITLE
Use test.Delay instead of millisecond in events test

### DIFF
--- a/pkg/events/handler_test.go
+++ b/pkg/events/handler_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/events"
@@ -72,12 +71,12 @@ func TestChannelReceive(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(test.Context())
 
-	a.So(eventChan.ReceiveTimeout(time.Millisecond), should.NotBeNil)
+	a.So(eventChan.ReceiveTimeout(test.Delay), should.NotBeNil)
 	a.So(eventChan.ReceiveContext(ctx), should.NotBeNil)
 
 	cancel()
 
-	a.So(eventChan.ReceiveTimeout(time.Millisecond), should.BeNil)
+	a.So(eventChan.ReceiveTimeout(test.Delay), should.BeNil)
 	a.So(eventChan.ReceiveContext(ctx), should.BeNil)
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR should fix #1349.

#### Changes
<!-- What are the changes made in this pull request? -->

- Use `test.Delay` in test, which is equal to the existing Millisecond, except on Travis, where it's something else.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

We may want to look into using [`runtime.Gosched()`](https://golang.org/pkg/runtime/#Gosched) to force executing other goroutines in these kind of tests before doing our assertions.
