### PR TITLE
Fix downlink length computation in Network Server

### DIFF
--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -137,11 +137,11 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 	))
 	logger := log.FromContext(ctx)
 
-	// NOTE: len(MHDR) + len(MIC) = 1 + 4 = 5
-	if maxDownLen < 5 || maxUpLen < 5 {
+	// NOTE: len(MHDR) + len(FHDR) + len(MIC) = 1 + 7 + 4 = 12
+	if maxDownLen < 12 || maxUpLen < 12 {
 		panic("payload length limits too short to generate downlink")
 	}
-	maxDownLen, maxUpLen = maxDownLen-5, maxUpLen-5
+	maxDownLen, maxUpLen = maxDownLen-12, maxUpLen-12
 
 	var fPending bool
 	spec := lorawan.DefaultMACCommands

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -1024,10 +1024,12 @@ func (ns *NetworkServer) attemptClassADownlink(ctx context.Context, dev *ttnpb.E
 			applicationUpAppender: genState.appendApplicationUplinks,
 		}
 	}
+	if genState.ApplicationDownlink != nil {
+		sets = append(sets, "queued_application_downlinks")
+	}
 	return downlinkAttemptResult{
 		SetPaths: append(sets,
 			"mac_state",
-			"queued_application_downlinks",
 			"recent_downlinks",
 			"session",
 		),
@@ -1350,12 +1352,15 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 				}
 				queuedApplicationUplinks = genState.appendApplicationUplinks(queuedApplicationUplinks, true)
 				queuedEvents = append(queuedEvents, genState.Events...)
-				return dev, []string{
+
+				if genState.ApplicationDownlink != nil {
+					sets = append(sets, "queued_application_downlinks")
+				}
+				return dev, append(sets,
 					"mac_state",
-					"queued_application_downlinks",
 					"recent_downlinks",
 					"session",
-				}, nil
+				), nil
 			},
 		)
 		if len(queuedApplicationUplinks) > 0 {

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -1568,13 +1568,13 @@ func TestProcessDownlinkTask(t *testing.T) {
 					func() []byte {
 						b := []byte{
 							/* MHDR */
-							0x60,
+							0b011_000_00,
 							/* MACPayload */
 							/** FHDR **/
 							/*** DevAddr ***/
 							devAddr[3], devAddr[2], devAddr[1], devAddr[0],
 							/*** FCtrl ***/
-							0x86,
+							0b1_0_0_0_0110,
 							/*** FCnt ***/
 							0x42, 0x00,
 						}
@@ -1586,7 +1586,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 							0x24,
 							[]byte{
 								/* ResetConf */
-								0x01, 0x01,
+								0x01, 0b0000_0001,
 								/* LinkCheckAns */
 								0x02, 0x02, 0x05,
 								/* DevStatusReq */
@@ -1822,13 +1822,13 @@ func TestProcessDownlinkTask(t *testing.T) {
 					func() []byte {
 						b := []byte{
 							/* MHDR */
-							0x60,
+							0b011_000_00,
 							/* MACPayload */
 							/** FHDR **/
 							/*** DevAddr ***/
 							devAddr[3], devAddr[2], devAddr[1], devAddr[0],
 							/*** FCtrl ***/
-							0x86,
+							0b1_0_0_0_0110,
 							/*** FCnt ***/
 							0x42, 0x00,
 						}
@@ -1840,7 +1840,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 							0x24,
 							[]byte{
 								/* ResetConf */
-								0x01, 0x01,
+								0x01, 0b0000_0001,
 								/* LinkCheckAns */
 								0x02, 0x02, 0x05,
 								/* DevStatusReq */
@@ -2123,13 +2123,13 @@ func TestProcessDownlinkTask(t *testing.T) {
 					func() []byte {
 						b := []byte{
 							/* MHDR */
-							0x60,
+							0b011_000_00,
 							/* MACPayload */
 							/** FHDR **/
 							/*** DevAddr ***/
 							devAddr[3], devAddr[2], devAddr[1], devAddr[0],
 							/*** FCtrl ***/
-							0x86,
+							0b1_0_0_0_0110,
 							/*** FCnt ***/
 							0x42, 0x00,
 						}
@@ -2141,7 +2141,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 							0x24,
 							[]byte{
 								/* ResetConf */
-								0x01, 0x01,
+								0x01, 0b0000_0001,
 								/* LinkCheckAns */
 								0x02, 0x02, 0x05,
 								/* DevStatusReq */
@@ -2558,13 +2558,13 @@ func TestProcessDownlinkTask(t *testing.T) {
 					func() []byte {
 						b := []byte{
 							/* MHDR */
-							0x60,
+							0b011_000_00,
 							/* MACPayload */
 							/** FHDR **/
 							/*** DevAddr ***/
 							devAddr[3], devAddr[2], devAddr[1], devAddr[0],
 							/*** FCtrl ***/
-							0x86,
+							0b1_0_0_0_0110,
 							/*** FCnt ***/
 							0x42, 0x00,
 						}
@@ -2576,7 +2576,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 							0x24,
 							[]byte{
 								/* ResetConf */
-								0x01, 0x01,
+								0x01, 0b0000_0001,
 								/* LinkCheckAns */
 								0x02, 0x02, 0x05,
 								/* DevStatusReq */
@@ -2879,13 +2879,13 @@ func TestProcessDownlinkTask(t *testing.T) {
 					func() []byte {
 						b := []byte{
 							/* MHDR */
-							0x60,
+							0b011_000_00,
 							/* MACPayload */
 							/** FHDR **/
 							/*** DevAddr ***/
 							devAddr[3], devAddr[2], devAddr[1], devAddr[0],
 							/*** FCtrl ***/
-							0x86,
+							0b1_0_0_0_0110,
 							/*** FCnt ***/
 							0x42, 0x00,
 						}
@@ -2897,7 +2897,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 							0x24,
 							[]byte{
 								/* ResetConf */
-								0x01, 0x01,
+								0x01, 0b0000_0001,
 								/* LinkCheckAns */
 								0x02, 0x02, 0x05,
 								/* DevStatusReq */
@@ -2960,13 +2960,13 @@ func TestProcessDownlinkTask(t *testing.T) {
 					func() []byte {
 						b := []byte{
 							/* MHDR */
-							0x60,
+							0b011_000_00,
 							/* MACPayload */
 							/** FHDR **/
 							/*** DevAddr ***/
 							devAddr[3], devAddr[2], devAddr[1], devAddr[0],
 							/*** FCtrl ***/
-							0x81,
+							0b1_0_0_0_0001,
 							/*** FCnt ***/
 							0x42, 0x00,
 						}
@@ -3262,13 +3262,13 @@ func TestProcessDownlinkTask(t *testing.T) {
 					func() []byte {
 						b := []byte{
 							/* MHDR */
-							0x60,
+							0b011_000_00,
 							/* MACPayload */
 							/** FHDR **/
 							/*** DevAddr ***/
 							devAddr[3], devAddr[2], devAddr[1], devAddr[0],
 							/*** FCtrl ***/
-							0x81,
+							0b1_0_0_0_0001,
 							/*** FCnt ***/
 							0x42, 0x00,
 						}
@@ -3571,13 +3571,13 @@ func TestProcessDownlinkTask(t *testing.T) {
 					func() []byte {
 						b := []byte{
 							/* MHDR */
-							0x60,
+							0b011_000_00,
 							/* MACPayload */
 							/** FHDR **/
 							/*** DevAddr ***/
 							devAddr[3], devAddr[2], devAddr[1], devAddr[0],
 							/*** FCtrl ***/
-							0x81,
+							0b1_0_0_0_0001,
 							/*** FCnt ***/
 							0x42, 0x00,
 						}
@@ -3851,13 +3851,13 @@ func TestProcessDownlinkTask(t *testing.T) {
 					func() []byte {
 						b := []byte{
 							/* MHDR */
-							0x60,
+							0b011_000_00,
 							/* MACPayload */
 							/** FHDR **/
 							/*** DevAddr ***/
 							devAddr[3], devAddr[2], devAddr[1], devAddr[0],
 							/*** FCtrl ***/
-							0x81,
+							0b1_0_0_0_0001,
 							/*** FCnt ***/
 							0x42, 0x00,
 						}

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -1277,7 +1277,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class A/windows open/1.0.3/RX1,RX2 available/no MAC/generic application downlink/payload too long",
+			Name: "Class A/windows open/1.0.3/RX1,RX2 available/no MAC/generic application downlink/application downlink exceeds length limit",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -1984,9 +1984,313 @@ func TestProcessDownlinkTask(t *testing.T) {
 			},
 		},
 
+		{
+			Name: "Class A/windows open/1.1/RX1,RX2 available/MAC answers/MAC requests/generic application downlink/application downlink does not fit due to FOpts/MAC/RX1,RX2/EU868",
+			DownlinkPriorities: DownlinkPriorities{
+				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
+				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
+				MaxApplicationDownlink: ttnpb.TxSchedulePriority_NORMAL,
+			},
+			Handler: func(ctx context.Context, env TestEnvironment) bool {
+				t := test.MustTFromContext(ctx)
+				a := assertions.New(t)
+
+				start := time.Now()
+
+				var popRespCh chan<- error
+				popFuncRespCh := make(chan error)
+				select {
+				case <-ctx.Done():
+					t.Error("Timed out while waiting for DownlinkTasks.Pop to be called")
+					return false
+
+				case req := <-env.DownlinkTasks.Pop:
+					popRespCh = req.Response
+					a.So(req.Context, should.HaveParentContextOrEqual, ctx)
+					go func() {
+						popFuncRespCh <- req.Func(req.Context, ttnpb.EndDeviceIdentifiers{
+							ApplicationIdentifiers: appID,
+							DeviceID:               devID,
+						}, time.Now())
+					}()
+				}
+
+				lastUp := &ttnpb.UplinkMessage{
+					CorrelationIDs:     []string{"correlation-up-1", "correlation-up-2"},
+					DeviceChannelIndex: 3,
+					Payload: &ttnpb.Message{
+						MHDR: ttnpb.MHDR{
+							MType: ttnpb.MType_UNCONFIRMED_UP,
+						},
+						Payload: &ttnpb.Message_MACPayload{MACPayload: &ttnpb.MACPayload{}},
+					},
+					ReceivedAt: time.Now().Add(-time.Second),
+					RxMetadata: deepcopy.Copy(rxMetadata).([]*ttnpb.RxMetadata),
+					Settings: ttnpb.TxSettings{
+						DataRateIndex: ttnpb.DATA_RATE_0,
+						Frequency:     430000000,
+					},
+				}
+
+				// NOTE: Maximum FRMPayload length in both Rx1(DR0) and RX2(DR1) is 51. There are 6 bytes of FOpts, hence maximum fitting application downlink length is 45.
+				getDevice := &ttnpb.EndDevice{
+					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
+						ApplicationIdentifiers: appID,
+						DeviceID:               devID,
+						DevAddr:                &devAddr,
+					},
+					FrequencyPlanID:   test.EUFrequencyPlanID,
+					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
+					MACState: &ttnpb.MACState{
+						CurrentParameters: *CopyMACParameters(eu868macParameters),
+						DesiredParameters: *CopyMACParameters(eu868macParameters),
+						DeviceClass:       ttnpb.CLASS_A,
+						LoRaWANVersion:    ttnpb.MAC_V1_1,
+						QueuedResponses: []*ttnpb.MACCommand{
+							(&ttnpb.MACCommand_ResetConf{
+								MinorVersion: 1,
+							}).MACCommand(),
+							(&ttnpb.MACCommand_LinkCheckAns{
+								Margin:       2,
+								GatewayCount: 5,
+							}).MACCommand(),
+						},
+						RxWindowsAvailable: true,
+					},
+					QueuedApplicationDownlinks: []*ttnpb.ApplicationDownlink{
+						{
+							CorrelationIDs: []string{"correlation-app-down-1", "correlation-app-down-2"},
+							FCnt:           0x42,
+							FPort:          0x15,
+							FRMPayload:     bytes.Repeat([]byte{0x42}, 46),
+							Priority:       ttnpb.TxSchedulePriority_HIGHEST,
+							SessionKeyID:   []byte{0x11, 0x22, 0x33, 0x44},
+						},
+					},
+					RecentUplinks: []*ttnpb.UplinkMessage{
+						CopyUplinkMessage(lastUp),
+					},
+					Session: &ttnpb.Session{
+						DevAddr:       devAddr,
+						LastNFCntDown: 0x24,
+						SessionKeys:   *CopySessionKeys(sessionKeys),
+					},
+				}
+
+				var setRespCh chan<- DeviceRegistrySetByIDResponse
+				setFuncRespCh := make(chan DeviceRegistrySetByIDRequestFuncResponse)
+				select {
+				case <-ctx.Done():
+					t.Error("Timed out while waiting for DeviceRegistry.SetByID to be called")
+					return false
+
+				case req := <-env.DeviceRegistry.SetByID:
+					setRespCh = req.Response
+					a.So(req.Context, should.HaveParentContextOrEqual, ctx)
+					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
+					a.So(req.DeviceID, should.Resemble, devID)
+					a.So(req.Paths, should.Resemble, getPaths)
+
+					go func() {
+						dev, sets, err := req.Func(CopyEndDevice(getDevice))
+						setFuncRespCh <- DeviceRegistrySetByIDRequestFuncResponse{
+							Device: dev,
+							Paths:  sets,
+							Error:  err,
+						}
+					}()
+				}
+
+				scheduleDownlink124Ch := make(chan NsGsScheduleDownlinkRequest)
+				peer124 := NewGSPeer(ctx, &MockNsGsServer{
+					ScheduleDownlinkFunc: MakeNsGsScheduleDownlinkChFunc(scheduleDownlink124Ch),
+				})
+
+				scheduleDownlink3Ch := make(chan NsGsScheduleDownlinkRequest)
+				peer3 := NewGSPeer(ctx, &MockNsGsServer{
+					ScheduleDownlinkFunc: MakeNsGsScheduleDownlinkChFunc(scheduleDownlink3Ch),
+				})
+
+				if !a.So(assertGetRxMetadataGatewayPeers(ctx, env.Cluster.GetPeer, peer124, peer3), should.BeTrue) {
+					return false
+				}
+
+				lastDown, ok := assertScheduleRxMetadataGateways(
+					ctx,
+					env.Cluster.Auth,
+					scheduleDownlink124Ch,
+					scheduleDownlink3Ch,
+					func() []byte {
+						b := []byte{
+							/* MHDR */
+							0b011_000_00,
+							/* MACPayload */
+							/** FHDR **/
+							/*** DevAddr ***/
+							devAddr[3], devAddr[2], devAddr[1], devAddr[0],
+							/*** FCtrl ***/
+							0b1_0_0_1_0000,
+							/*** FCnt ***/
+							0x25, 0x00,
+						}
+
+						/** FPort **/
+						b = append(b, 0x0)
+
+						/** FRMPayload **/
+						b = append(b, test.Must(crypto.EncryptDownlink(
+							nwkSEncKey,
+							devAddr,
+							0x25,
+							[]byte{
+								/* ResetConf */
+								0x01, 0b0000_0001,
+								/* LinkCheckAns */
+								0x02, 0x02, 0x05,
+								/* DevStatusReq */
+								0x06,
+							},
+						)).([]byte)...)
+
+						/* MIC */
+						mic := test.Must(crypto.ComputeDownlinkMIC(
+							sNwkSIntKey,
+							devAddr,
+							0,
+							0x25,
+							b,
+						)).([4]byte)
+						return append(b, mic[:]...)
+					}(),
+					func(paths ...*ttnpb.DownlinkPath) *ttnpb.TxRequest {
+						return &ttnpb.TxRequest{
+							Class:            ttnpb.CLASS_A,
+							DownlinkPaths:    paths,
+							Priority:         ttnpb.TxSchedulePriority_HIGH,
+							Rx1DataRateIndex: ttnpb.DATA_RATE_0,
+							Rx1Delay:         ttnpb.RX_DELAY_3,
+							Rx1Frequency:     431000000,
+							Rx2DataRateIndex: ttnpb.DATA_RATE_1,
+							Rx2Frequency:     420000000,
+						}
+					},
+					NsGsScheduleDownlinkResponse{
+						Error: errors.New("test"),
+					},
+					NsGsScheduleDownlinkResponse{
+						Error: errors.New("test"),
+					},
+					NsGsScheduleDownlinkResponse{
+						Response: &ttnpb.ScheduleDownlinkResponse{
+							Delay: time.Second,
+						},
+					},
+				)
+				if !a.So(ok, should.BeTrue) {
+					t.Error("Scheduling assertion failed")
+					return false
+				}
+
+				if a.So(lastDown.CorrelationIDs, should.HaveLength, 3) {
+					a.So(lastDown.CorrelationIDs, should.Contain, "correlation-up-1")
+					a.So(lastDown.CorrelationIDs, should.Contain, "correlation-up-2")
+				}
+
+				setDevice := &ttnpb.EndDevice{
+					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
+						ApplicationIdentifiers: appID,
+						DeviceID:               devID,
+						DevAddr:                &devAddr,
+					},
+					FrequencyPlanID:   test.EUFrequencyPlanID,
+					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
+					MACState: &ttnpb.MACState{
+						CurrentParameters: *CopyMACParameters(eu868macParameters),
+						DesiredParameters: *CopyMACParameters(eu868macParameters),
+						DeviceClass:       ttnpb.CLASS_A,
+						LoRaWANVersion:    ttnpb.MAC_V1_1,
+						PendingRequests: []*ttnpb.MACCommand{
+							{
+								CID: ttnpb.CID_DEV_STATUS,
+							},
+						},
+					},
+					QueuedApplicationDownlinks: []*ttnpb.ApplicationDownlink{
+						{
+							CorrelationIDs: []string{"correlation-app-down-1", "correlation-app-down-2"},
+							FCnt:           0x42,
+							FPort:          0x15,
+							FRMPayload:     bytes.Repeat([]byte{0x42}, 46),
+							Priority:       ttnpb.TxSchedulePriority_HIGHEST,
+							SessionKeyID:   []byte{0x11, 0x22, 0x33, 0x44},
+						},
+					},
+					RecentUplinks: []*ttnpb.UplinkMessage{
+						CopyUplinkMessage(lastUp),
+					},
+					RecentDownlinks: []*ttnpb.DownlinkMessage{
+						lastDown,
+					},
+					Session: &ttnpb.Session{
+						DevAddr:       devAddr,
+						LastNFCntDown: 0x25,
+						SessionKeys:   *CopySessionKeys(sessionKeys),
+					},
+				}
+
+				select {
+				case <-ctx.Done():
+					t.Error("Timed out while waiting for DeviceRegistry.SetByID callback to return")
+
+				case resp := <-setFuncRespCh:
+					a.So(resp.Error, should.BeNil)
+					a.So(resp.Paths, should.Resemble, []string{
+						"mac_state",
+						"recent_downlinks",
+						"session",
+					})
+					if a.So(resp.Device, should.NotBeNil) &&
+						a.So(resp.Device.MACState, should.NotBeNil) &&
+						a.So(resp.Device.MACState.LastConfirmedDownlinkAt, should.NotBeNil) {
+						a.So([]time.Time{start, *resp.Device.MACState.LastConfirmedDownlinkAt, time.Now().Add(time.Second)}, should.BeChronological)
+						setDevice.MACState.LastConfirmedDownlinkAt = resp.Device.MACState.LastConfirmedDownlinkAt
+					}
+					a.So(resp.Device, should.Resemble, setDevice)
+				}
+				close(setFuncRespCh)
+
+				select {
+				case <-ctx.Done():
+					t.Error("Timed out while waiting for DeviceRegistry.SetByID response to be processed")
+
+				case setRespCh <- DeviceRegistrySetByIDResponse{
+					Device: setDevice,
+				}:
+				}
+
+				select {
+				case <-ctx.Done():
+					t.Error("Timed out while waiting for DownlinkTasks.Pop callback to return")
+
+				case resp := <-popFuncRespCh:
+					a.So(resp, should.BeNil)
+				}
+				close(popFuncRespCh)
+
+				select {
+				case <-ctx.Done():
+					t.Error("Timed out while waiting for DownlinkTasks.Pop response to be processed")
+
+				case popRespCh <- nil:
+				}
+
+				return true
+			},
+		},
+
 		// Adapted from https://github.com/TheThingsNetwork/lorawan-stack/issues/866#issue-461484955.
 		{
-			Name: "Class A/windows open/1.0.2/RX1,RX2 available/MAC answers/MAC requests/generic application downlink/RX2 does not fit/data+MAC/RX1,RX2/EU868",
+			Name: "Class A/windows open/1.0.2/RX1,RX2 available/MAC answers/MAC requests/generic application downlink/data+MAC/RX2 does not fit/RX1/EU868",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -1939,7 +1939,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case resp := <-setFuncRespCh:
 					a.So(resp.Error, should.BeNil)
-					a.So(resp.Paths, should.Resemble, []string{
+					a.So(resp.Paths, should.HaveSameElementsDeep, []string{
 						"mac_state",
 						"queued_application_downlinks",
 						"recent_downlinks",
@@ -2542,7 +2542,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case resp := <-setFuncRespCh:
 					a.So(resp.Error, should.BeNil)
-					a.So(resp.Paths, should.Resemble, []string{
+					a.So(resp.Paths, should.HaveSameElementsDeep, []string{
 						"mac_state",
 						"queued_application_downlinks",
 						"recent_downlinks",
@@ -2982,7 +2982,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case resp := <-setFuncRespCh:
 					a.So(resp.Error, should.BeNil)
-					a.So(resp.Paths, should.Resemble, []string{
+					a.So(resp.Paths, should.HaveSameElementsDeep, []string{
 						"mac_state",
 						"queued_application_downlinks",
 						"recent_downlinks",
@@ -3369,7 +3369,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case resp := <-setFuncRespCh:
 					a.So(resp.Error, should.BeNil)
-					a.So(resp.Paths, should.Resemble, []string{
+					a.So(resp.Paths, should.HaveSameElementsDeep, []string{
 						"mac_state",
 						"queued_application_downlinks",
 						"recent_downlinks",
@@ -3678,7 +3678,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case resp := <-setFuncRespCh:
 					a.So(resp.Error, should.BeNil)
-					a.So(resp.Paths, should.Resemble, []string{
+					a.So(resp.Paths, should.HaveSameElementsDeep, []string{
 						"mac_state",
 						"queued_application_downlinks",
 						"recent_downlinks",

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -974,7 +974,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class A/windows open/1.1/RX1,RX2/no downlink",
+			Name: "Class A/windows open/1.1/RX1,RX2 available/no MAC/no application downlink",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -1035,8 +1035,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 						RxWindowsAvailable: true,
 					},
 					MACSettings: &ttnpb.MACSettings{
-						StatusTimePeriodicity:  DurationPtr(0),
 						StatusCountPeriodicity: &pbtypes.UInt32Value{Value: 0},
+						StatusTimePeriodicity:  DurationPtr(0),
 					},
 					RecentUplinks: []*ttnpb.UplinkMessage{
 						CopyUplinkMessage(lastUp),
@@ -1113,7 +1113,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class A/windows open/1.0.3/RX1,RX2/FCnt too low",
+			Name: "Class A/windows open/1.0.3/RX1,RX2 available/no MAC/generic application downlink/FCnt too low",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -1174,8 +1174,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 						RxWindowsAvailable: true,
 					},
 					MACSettings: &ttnpb.MACSettings{
-						StatusTimePeriodicity:  DurationPtr(0),
 						StatusCountPeriodicity: &pbtypes.UInt32Value{Value: 0},
+						StatusTimePeriodicity:  DurationPtr(0),
 					},
 					QueuedApplicationDownlinks: []*ttnpb.ApplicationDownlink{
 						{
@@ -1277,7 +1277,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class A/windows open/1.0.3/RX1,RX2/payload too long",
+			Name: "Class A/windows open/1.0.3/RX1,RX2 available/no MAC/generic application downlink/payload too long",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -1338,8 +1338,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 						RxWindowsAvailable: true,
 					},
 					MACSettings: &ttnpb.MACSettings{
-						StatusTimePeriodicity:  DurationPtr(0),
 						StatusCountPeriodicity: &pbtypes.UInt32Value{Value: 0},
+						StatusTimePeriodicity:  DurationPtr(0),
 					},
 					QueuedApplicationDownlinks: []*ttnpb.ApplicationDownlink{
 						{
@@ -1433,7 +1433,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class A/windows open/1.1/RX1,RX2/application downlink/FOpts present/EU868/scheduling fail",
+			Name: "Class A/windows open/1.1/RX1,RX2 available/MAC answers/MAC requests/generic application downlink/data+MAC/RX1,RX2/EU868/scheduling fail",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -1685,7 +1685,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class A/windows open/1.1/RX1,RX2/application downlink/FOpts present/EU868",
+			Name: "Class A/windows open/1.1/RX1,RX2 available/MAC answers/MAC requests/generic application downlink/data+MAC/RX1,RX2/EU868",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -1986,7 +1986,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 		// Adapted from https://github.com/TheThingsNetwork/lorawan-stack/issues/866#issue-461484955.
 		{
-			Name: "Class A/windows open/1.0.2/RX1, RX2 does not fit/application downlink/FOpts present/EU868",
+			Name: "Class A/windows open/1.0.2/RX1,RX2 available/MAC answers/MAC requests/generic application downlink/RX2 does not fit/data+MAC/RX1,RX2/EU868",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -2418,7 +2418,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class C/windows open/1.1/RX1,RX2/application downlink/FOpts present/EU868",
+			Name: "Class C/windows open/1.1/RX1,RX2 available/MAC answers/MAC requests/generic application downlink/data+MAC/RX1,RX2/EU868",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -2739,7 +2739,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class C/windows closed/1.1/RX1,RX2,RXC/application downlink/no absolute time/no forced gateways/FOpts present/EU868",
+			Name: "Class C/windows open/1.1/RX1,RX2 available/MAC answers/MAC requests/generic application downlink/data+MAC/RX1,RX2,RXC/EU868",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -3126,7 +3126,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class C/windows open/1.1/RXC/application downlink/absolute time within window/no forced gateways/FOpts present/EU868",
+			Name: "Class C/windows open/1.1/RX1,RX2 available/no MAC answers/MAC requests/classBC application downlink/absolute time within window/no forced gateways/data+MAC/RXC/EU868",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -3435,7 +3435,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class C/windows open/1.1/RXC/application downlink/absolute time within window/no forced gateways/FOpts present/EU868/non-retryable errors",
+			Name: "Class C/windows open/1.1/RX1,RX2 available/no MAC answers/MAC requests/classBC application downlink/absolute time within window/no forced gateways/data+MAC/RXC/EU868/non-retryable errors",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -3715,7 +3715,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class C/windows open/RXC/application downlink/absolute time within window/no forced gateways/windows open/FOpts present/EU868/1.1/retryable error",
+			Name: "Class C/windows open/1.1/RX1,RX2 available/no MAC answers/MAC requests/classBC application downlink/absolute time within window/no forced gateways/data+MAC/RXC/EU868/retryable error",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -3988,7 +3988,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class C/windows open/RXC/application downlink/absolute time outside window",
+			Name: "Class C/windows open/1.1/RX1,RX2 available/no MAC/classBC application downlink/absolute time outside window",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -4044,7 +4044,9 @@ func TestProcessDownlinkTask(t *testing.T) {
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					MACSettings: &ttnpb.MACSettings{
-						ClassCTimeout: DurationPtr(42 * time.Second),
+						ClassCTimeout:          DurationPtr(42 * time.Second),
+						StatusCountPeriodicity: &pbtypes.UInt32Value{Value: 0},
+						StatusTimePeriodicity:  DurationPtr(0),
 					},
 					MACState: &ttnpb.MACState{
 						CurrentParameters:  *CopyMACParameters(eu868macParameters),
@@ -4154,7 +4156,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "Class C/windows open/RX2/expired application downlinks",
+			Name: "Class C/windows open/1.1/RX1,RX2 available/no MAC/expired application downlinks",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,
@@ -4322,7 +4324,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "join-accept/windows open/RX2/no active MAC state/window open/EU868/1.1",
+			Name: "join-accept/windows open/RX1,RX2 available/no active MAC state/EU868",
 			DownlinkPriorities: DownlinkPriorities{
 				JoinAccept:             ttnpb.TxSchedulePriority_HIGHEST,
 				MACCommands:            ttnpb.TxSchedulePriority_HIGH,

--- a/pkg/networkserver/grpc_gsns_test.go
+++ b/pkg/networkserver/grpc_gsns_test.go
@@ -234,7 +234,7 @@ func TestHandleUplink(t *testing.T) {
 			CorrelationIDs: correlationIDs[:],
 			RawPayload: []byte{
 				/* MHDR */
-				0x00,
+				0b000_000_00,
 				/* Join-request */
 				/** JoinEUI **/
 				joinEUI[7], joinEUI[6], joinEUI[5], joinEUI[4], joinEUI[3], joinEUI[2], joinEUI[1], joinEUI[0],
@@ -282,7 +282,7 @@ func TestHandleUplink(t *testing.T) {
 			CorrelationIDs: correlationIDs[:],
 			RawPayload: []byte{
 				/* MHDR */
-				0xc0,
+				0b110_000_00,
 				/* Rejoin-request */
 				/** Rejoin Type **/
 				0x00,
@@ -376,7 +376,7 @@ func TestHandleUplink(t *testing.T) {
 				uint32(fCnt),
 				append([]byte{
 					/* MHDR */
-					0x40,
+					0b010_000_00,
 					/* MACPayload */
 					/** FHDR **/
 					/*** DevAddr ***/
@@ -428,7 +428,7 @@ func TestHandleUplink(t *testing.T) {
 					append(
 						append([]byte{
 							/* MHDR */
-							0x40,
+							0b010_000_00,
 							/* MACPayload */
 							/** FHDR **/
 							/*** DevAddr ***/
@@ -538,7 +538,7 @@ func TestHandleUplink(t *testing.T) {
 					return &ttnpb.UplinkMessage{
 						RawPayload: []byte{
 							/* MHDR */
-							0x01,
+							0b000_000_01,
 							/* Join-request */
 							/** JoinEUI **/
 							joinEUI[7], joinEUI[6], joinEUI[5], joinEUI[4], joinEUI[3], joinEUI[2], joinEUI[1], joinEUI[0],
@@ -592,7 +592,7 @@ func TestHandleUplink(t *testing.T) {
 					return &ttnpb.UplinkMessage{
 						RawPayload: []byte{
 							/* MHDR */
-							0xe0,
+							0b111_000_00,
 						},
 						RxMetadata: MakeRxMetadataSlice(),
 					}

--- a/pkg/networkserver/networkserver_flow_test.go
+++ b/pkg/networkserver/networkserver_flow_test.go
@@ -225,7 +225,7 @@ func handleOTAAClassA868FlowTest1_0_2(ctx context.Context, reg DeviceRegistry, t
 
 		payload := []byte{
 			/* MHDR */
-			0x00,
+			0b000_000_00,
 			/* Join-request */
 			/** JoinEUI **/
 			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x42,
@@ -513,13 +513,13 @@ func handleOTAAClassA868FlowTest1_0_2(ctx context.Context, reg DeviceRegistry, t
 					0,
 					append([]byte{
 						/* MHDR */
-						0x40,
+						0b010_000_00,
 						/* MACPayload */
 						/** FHDR **/
 						/*** DevAddr ***/
 						devAddr[3], devAddr[2], devAddr[1], devAddr[0],
 						/*** FCtrl ***/
-						0x80,
+						0b1_0_0_0_0000,
 						/*** FCnt ***/
 						0x00, 0x00,
 						/** FPort **/
@@ -724,13 +724,13 @@ func handleOTAAClassA868FlowTest1_0_2(ctx context.Context, reg DeviceRegistry, t
 							1,
 							append([]byte{
 								/* MHDR */
-								0x60,
+								0b011_000_00,
 								/* MACPayload */
 								/** FHDR **/
 								/*** DevAddr ***/
 								devAddr[3], devAddr[2], devAddr[1], devAddr[0],
 								/*** FCtrl ***/
-								0x80,
+								0b1_0_0_0_0000,
 								/*** FCnt ***/
 								0x01, 0x00,
 								/** FPort **/


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

In https://github.com/TheThingsNetwork/lorawan-stack/pull/1287 application downlink validation was moved before MAC buffer adding to downlink, which is incorrect, since NS shall first compute the MAC buffer in order to determine if application downlink fits or not.

Refs #1310 

#### Changes
<!-- What are the changes made in this pull request? -->

- Compute MAC buffer before validating application downlink
- Do not fail downlink, which does not fit due to MAC commands.
- Only update `queued_application_downlinks` if actually changed
- Use binary number syntax in NS where applicable
- Account for FHDR length when computing `FRMPayload` length limit (can't believe this went unnoticed for so long)

#### Notes for reviewers

https://github.com/TheThingsNetwork/lorawan-stack/pull/1360/commits/f2569005ba1b6274732b29cf9d21d08067ddeb27 is just moving stuff around