### PR TITLE
Send Basic Station version info upstream

### DIFF
--- a/pkg/gatewayserver/io/basicstationlns/basicstationlns.go
+++ b/pkg/gatewayserver/io/basicstationlns/basicstationlns.go
@@ -305,7 +305,7 @@ func (s *srv) handleTraffic(c echo.Context) (err error) {
 					logger.WithError(err).Debug("Failed to unmarshal version message")
 					return err
 				}
-				logger = logger.WithFields(log.Fields(
+				logger := logger.WithFields(log.Fields(
 					"station", version.Station,
 					"firmware", version.Firmware,
 					"model", version.Model,
@@ -323,6 +323,15 @@ func (s *srv) handleTraffic(c echo.Context) (err error) {
 				if err := ws.WriteMessage(websocket.TextMessage, data); err != nil {
 					logger.WithError(err).Warn("Failed to send router configuration")
 					return err
+				}
+				stat := &ttnpb.GatewayStatus{
+					Time: receivedAt,
+					Versions: map[string]string{
+						"platform": fmt.Sprintf("%s:%s", version.Model, version.Station),
+					},
+				}
+				if err := conn.HandleStatus(stat); err != nil {
+					logger.WithError(err).Warn("Failed to send status message")
 				}
 
 			case messages.TypeUpstreamJoinRequest:

--- a/pkg/gatewayserver/io/basicstationlns/basicstationlns_test.go
+++ b/pkg/gatewayserver/io/basicstationlns/basicstationlns_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	pbtypes "github.com/gogo/protobuf/types"
 	"github.com/gorilla/websocket"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/basicstation"
@@ -537,7 +538,19 @@ func TestVersion(t *testing.T) {
 			},
 			ExpectedStatusMessage: ttnpb.GatewayStatus{
 				Versions: map[string]string{
-					"platform": fmt.Sprintf("test-model:test-station"),
+					"station":  "test-station",
+					"firmware": "1.0.0",
+					"package":  "test-package",
+				},
+				Advanced: &pbtypes.Struct{
+					Fields: map[string]*pbtypes.Value{
+						"model": {
+							Kind: &pbtypes.Value_StringValue{StringValue: "test-model"},
+						},
+						"features": {
+							Kind: &pbtypes.Value_StringValue{StringValue: "prod gps"},
+						},
+					},
 				},
 			},
 		},
@@ -625,7 +638,19 @@ func TestVersion(t *testing.T) {
 			},
 			ExpectedStatusMessage: ttnpb.GatewayStatus{
 				Versions: map[string]string{
-					"platform": fmt.Sprintf("test-model:test-station-rc1"),
+					"station":  "test-station-rc1",
+					"firmware": "1.0.0",
+					"package":  "test-package",
+				},
+				Advanced: &pbtypes.Struct{
+					Fields: map[string]*pbtypes.Value{
+						"model": {
+							Kind: &pbtypes.Value_StringValue{StringValue: "test-model"},
+						},
+						"features": {
+							Kind: &pbtypes.Value_StringValue{StringValue: "rmtsh gps"},
+						},
+					},
 				},
 			},
 		},

--- a/pkg/gatewayserver/io/grpc/grpc.go
+++ b/pkg/gatewayserver/io/grpc/grpc.go
@@ -39,7 +39,6 @@ func New(server io.Server) ttnpb.GtwGsServer {
 }
 
 func (*impl) Protocol() string            { return "grpc" }
-func (*impl) SupportsStatusMessage() bool { return true }
 func (*impl) SupportsDownlinkClaim() bool { return false }
 
 var errConnect = errors.Define("connect", "failed to connect gateway `{gateway_uid}`")

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -39,8 +39,6 @@ const (
 type Frontend interface {
 	// Protocol returns the protocol used in the frontend.
 	Protocol() string
-	// SupportsStatusMessage returns true if the protocol supports status messages.
-	SupportsStatusMessage() bool
 	// SupportsDownlinkClaim returns true if the frontend can itself claim downlinks.
 	SupportsDownlinkClaim() bool
 }

--- a/pkg/gatewayserver/io/mock/frontend.go
+++ b/pkg/gatewayserver/io/mock/frontend.go
@@ -31,7 +31,6 @@ type Frontend struct {
 }
 
 func (*Frontend) Protocol() string            { return "mock" }
-func (*Frontend) SupportsStatusMessage() bool { return true }
 func (*Frontend) SupportsDownlinkClaim() bool { return true }
 
 // ConnectFrontend connects a new mock front-end to the given server.

--- a/pkg/gatewayserver/io/mqtt/mqtt.go
+++ b/pkg/gatewayserver/io/mqtt/mqtt.go
@@ -87,7 +87,6 @@ type connection struct {
 }
 
 func (*connection) Protocol() string            { return "mqtt" }
-func (*connection) SupportsStatusMessage() bool { return true }
 func (*connection) SupportsDownlinkClaim() bool { return false }
 
 func (c *connection) setup(ctx context.Context) error {

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -75,7 +75,6 @@ type srv struct {
 }
 
 func (*srv) Protocol() string            { return "udp" }
-func (*srv) SupportsStatusMessage() bool { return true }
 func (*srv) SupportsDownlinkClaim() bool { return true }
 
 // Start starts the UDP frontend.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #1370 

#### Changes
<!-- What are the changes made in this pull request? -->

- Send a status message with version info on every connect.
- Remove `SupportsStatusMessage` since this PR makes it obsolete.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- Targeted the PR to `feature/gs-upstreams` (#1198)

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Added  Basic Station version information to status message.
