### PR TITLE
Network Server testing

### DIFF
--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -1380,11 +1380,9 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 			}()
 		}
 		if len(queuedEvents) > 0 {
-			go func() {
-				for _, ev := range queuedEvents {
-					events.Publish(ev)
-				}
-			}()
+			for _, ev := range queuedEvents {
+				events.Publish(ev)
+			}
 		}
 		if err != nil {
 			setErr = true

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -4885,7 +4885,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			a := assertions.New(t)
 
-			ns, ctx, env, stopTest := StartTest(t, Config{}, (1<<10)*test.Delay)
+			ns, ctx, env, stopTest := StartTest(t, Config{}, (1<<10)*test.Delay, true)
 
 			ns.downlinkPriorities = tc.DownlinkPriorities
 

--- a/pkg/networkserver/grpc_asns.go
+++ b/pkg/networkserver/grpc_asns.go
@@ -82,15 +82,17 @@ func (ns *NetworkServer) LinkApplication(link ttnpb.AsNs_LinkApplicationServer) 
 	logger.Debug("Linked application")
 
 	events.Publish(evtBeginApplicationLink(ctx, ids, nil))
-	defer events.Publish(evtEndApplicationLink(ctx, ids, err))
 
 	select {
 	case <-ctx.Done():
 		err = ctx.Err()
 		logger.WithError(err).Debug("Context done - close stream")
+		events.Publish(evtEndApplicationLink(ctx, ids, err))
 		return err
+
 	case ws.closeCh <- struct{}{}:
 		logger.Debug("Link closed - close stream")
+		events.Publish(evtEndApplicationLink(ctx, ids, nil))
 		return nil
 	}
 }

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -873,11 +873,9 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 	}
 
 	if len(queuedEvents) > 0 {
-		go func() {
-			for _, ev := range queuedEvents {
-				events.Publish(ev(ctx, stored.EndDeviceIdentifiers))
-			}
-		}()
+		for _, ev := range queuedEvents {
+			events.Publish(ev(ctx, stored.EndDeviceIdentifiers))
+		}
 	}
 
 	startAt := up.ReceivedAt.Add(stored.MACState.CurrentParameters.Rx1Delay.Duration() - nsScheduleWindow)

--- a/pkg/networkserver/grpc_gsns_internal_test.go
+++ b/pkg/networkserver/grpc_gsns_internal_test.go
@@ -675,7 +675,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			a := assertions.New(t)
 
-			ns, ctx, env, stop := StartTest(t, Config{NetID: netID}, (1<<10)*test.Delay)
+			ns, ctx, env, stop := StartTest(t, Config{NetID: netID}, (1<<10)*test.Delay, true)
 			defer stop()
 
 			<-env.DownlinkTasks.Pop

--- a/pkg/networkserver/grpc_gsns_test.go
+++ b/pkg/networkserver/grpc_gsns_test.go
@@ -2397,17 +2397,6 @@ func TestHandleUplink(t *testing.T) {
 					}
 				}
 
-				if !a.So(AssertDownlinkTaskAddRequest(ctx, env.DownlinkTasks.Add, func(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, startAt time.Time, replace bool) bool {
-					return a.So(ctx, should.HaveParentContextOrEqual, upCtx) &&
-						a.So(ids, should.Resemble, *makeOTAAIdentifiers(&devAddr)) &&
-						a.So(startAt, should.Resemble, recentUp.ReceivedAt.Add(time.Second-NSScheduleWindow())) &&
-						a.So(replace, should.BeTrue)
-				},
-					nil,
-				), should.BeTrue) {
-					return false
-				}
-
 				if !a.So(test.AssertEventPubSubPublishRequest(ctx, env.Events, func(ev events.Event) bool {
 					return a.So(ev, should.ResembleEvent, EvtMergeMetadata(upCtx, rangeDevice.EndDeviceIdentifiers, len(mds)))
 				}), should.BeTrue) {
@@ -2429,6 +2418,17 @@ func TestHandleUplink(t *testing.T) {
 				if !a.So(test.AssertEventPubSubPublishRequest(ctx, env.Events, func(ev events.Event) bool {
 					return a.So(ev, should.ResembleEvent, EvtForwardDataUplink(upCtx, rangeDevice.EndDeviceIdentifiers, nil))
 				}), should.BeTrue) {
+					return false
+				}
+
+				if !a.So(AssertDownlinkTaskAddRequest(ctx, env.DownlinkTasks.Add, func(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, startAt time.Time, replace bool) bool {
+					return a.So(ctx, should.HaveParentContextOrEqual, upCtx) &&
+						a.So(ids, should.Resemble, *makeOTAAIdentifiers(&devAddr)) &&
+						a.So(startAt, should.Resemble, recentUp.ReceivedAt.Add(time.Second-NSScheduleWindow())) &&
+						a.So(replace, should.BeTrue)
+				},
+					nil,
+				), should.BeTrue) {
 					return false
 				}
 
@@ -2609,17 +2609,6 @@ func TestHandleUplink(t *testing.T) {
 					}
 				}
 
-				if !a.So(AssertDownlinkTaskAddRequest(ctx, env.DownlinkTasks.Add, func(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, startAt time.Time, replace bool) bool {
-					return a.So(ctx, should.HaveParentContextOrEqual, upCtx) &&
-						a.So(ids, should.Resemble, *makeOTAAIdentifiers(&devAddr)) &&
-						a.So(startAt, should.Resemble, recentUp.ReceivedAt.Add(time.Second-NSScheduleWindow())) &&
-						a.So(replace, should.BeTrue)
-				},
-					nil,
-				), should.BeTrue) {
-					return false
-				}
-
 				if !a.So(test.AssertEventPubSubPublishRequest(ctx, env.Events, func(ev events.Event) bool {
 					return a.So(ev, should.ResembleEvent, EvtMergeMetadata(upCtx, rangeDevice.EndDeviceIdentifiers, len(mds)))
 				}), should.BeTrue) {
@@ -2641,6 +2630,17 @@ func TestHandleUplink(t *testing.T) {
 				if !a.So(test.AssertEventPubSubPublishRequest(ctx, env.Events, func(ev events.Event) bool {
 					return a.So(ev, should.ResembleEvent, EvtForwardDataUplink(upCtx, rangeDevice.EndDeviceIdentifiers, nil))
 				}), should.BeTrue) {
+					return false
+				}
+
+				if !a.So(AssertDownlinkTaskAddRequest(ctx, env.DownlinkTasks.Add, func(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, startAt time.Time, replace bool) bool {
+					return a.So(ctx, should.HaveParentContextOrEqual, upCtx) &&
+						a.So(ids, should.Resemble, *makeOTAAIdentifiers(&devAddr)) &&
+						a.So(startAt, should.Resemble, recentUp.ReceivedAt.Add(time.Second-NSScheduleWindow())) &&
+						a.So(replace, should.BeTrue)
+				},
+					nil,
+				), should.BeTrue) {
 					return false
 				}
 
@@ -2823,17 +2823,6 @@ func TestHandleUplink(t *testing.T) {
 					}
 				}
 
-				if !a.So(AssertDownlinkTaskAddRequest(ctx, env.DownlinkTasks.Add, func(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, startAt time.Time, replace bool) bool {
-					return a.So(ctx, should.HaveParentContextOrEqual, upCtx) &&
-						a.So(ids, should.Resemble, *makeOTAAIdentifiers(&devAddr)) &&
-						a.So(startAt, should.Resemble, recentUp.ReceivedAt.Add(time.Second-NSScheduleWindow())) &&
-						a.So(replace, should.BeTrue)
-				},
-					nil,
-				), should.BeTrue) {
-					return false
-				}
-
 				if !a.So(test.AssertEventPubSubPublishRequest(ctx, env.Events, func(ev events.Event) bool {
 					return a.So(ev, should.ResembleEvent, EvtMergeMetadata(upCtx, rangeDevice.EndDeviceIdentifiers, len(mds)))
 				}), should.BeTrue) {
@@ -2855,6 +2844,17 @@ func TestHandleUplink(t *testing.T) {
 				if !a.So(test.AssertEventPubSubPublishRequest(ctx, env.Events, func(ev events.Event) bool {
 					return a.So(ev, should.ResembleEvent, EvtForwardDataUplink(upCtx, rangeDevice.EndDeviceIdentifiers, nil))
 				}), should.BeTrue) {
+					return false
+				}
+
+				if !a.So(AssertDownlinkTaskAddRequest(ctx, env.DownlinkTasks.Add, func(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, startAt time.Time, replace bool) bool {
+					return a.So(ctx, should.HaveParentContextOrEqual, upCtx) &&
+						a.So(ids, should.Resemble, *makeOTAAIdentifiers(&devAddr)) &&
+						a.So(startAt, should.Resemble, recentUp.ReceivedAt.Add(time.Second-NSScheduleWindow())) &&
+						a.So(replace, should.BeTrue)
+				},
+					nil,
+				), should.BeTrue) {
 					return false
 				}
 
@@ -3041,6 +3041,12 @@ func TestHandleUplink(t *testing.T) {
 					}
 				}
 
+				if !a.So(test.AssertEventPubSubPublishRequest(ctx, env.Events, func(ev events.Event) bool {
+					return a.So(ev, should.ResembleEvent, EvtMergeMetadata(upCtx, rangeDevice.EndDeviceIdentifiers, len(mds)))
+				}), should.BeTrue) {
+					return false
+				}
+
 				if !a.So(AssertDownlinkTaskAddRequest(ctx, env.DownlinkTasks.Add, func(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, startAt time.Time, replace bool) bool {
 					return a.So(ctx, should.HaveParentContextOrEqual, upCtx) &&
 						a.So(ids, should.Resemble, *makeOTAAIdentifiers(&devAddr)) &&
@@ -3049,12 +3055,6 @@ func TestHandleUplink(t *testing.T) {
 				},
 					nil,
 				), should.BeTrue) {
-					return false
-				}
-
-				if !a.So(test.AssertEventPubSubPublishRequest(ctx, env.Events, func(ev events.Event) bool {
-					return a.So(ev, should.ResembleEvent, EvtMergeMetadata(upCtx, rangeDevice.EndDeviceIdentifiers, len(mds)))
-				}), should.BeTrue) {
 					return false
 				}
 

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"crypto/tls"
 	"hash/fnv"
-	"io"
 	"sync"
 	"time"
 
@@ -314,19 +313,4 @@ func (ns *NetworkServer) RegisterHandlers(s *runtime.ServeMux, conn *grpc.Client
 // Roles returns the roles that the Network Server fulfills.
 func (ns *NetworkServer) Roles() []ttnpb.ClusterRole {
 	return []ttnpb.ClusterRole{ttnpb.ClusterRole_NETWORK_SERVER}
-}
-
-func (ns *NetworkServer) Close() {
-	ns.Component.Close()
-
-	logger := ns.Logger()
-	ns.applicationServers.Range(func(k interface{}, v interface{}) bool {
-		logger := logger.WithField("application_uid", k.(string))
-		logger.Debug("Close Application Server link")
-		if err := v.(io.Closer).Close(); err != nil {
-			logger.WithError(err).Warn("Failed to close AS link")
-		}
-		logger.Debug("Application Server link closed")
-		return true
-	})
 }

--- a/pkg/networkserver/networkserver_util_test.go
+++ b/pkg/networkserver/networkserver_util_test.go
@@ -987,7 +987,9 @@ type DeviceRegistryEnvironment struct {
 	SetByID     <-chan DeviceRegistrySetByIDRequest
 }
 
-func newMockDeviceRegistry() (DeviceRegistry, DeviceRegistryEnvironment, func()) {
+func newMockDeviceRegistry(t *testing.T) (DeviceRegistry, DeviceRegistryEnvironment, func()) {
+	t.Helper()
+
 	getByEUICh := make(chan DeviceRegistryGetByEUIRequest)
 	getByIDCh := make(chan DeviceRegistryGetByIDRequest)
 	rangeByAddrCh := make(chan DeviceRegistryRangeByAddrRequest)
@@ -1003,10 +1005,30 @@ func newMockDeviceRegistry() (DeviceRegistry, DeviceRegistryEnvironment, func())
 			SetByID:     setByIDCh,
 		},
 		func() {
-			close(getByEUICh)
-			close(getByIDCh)
-			close(rangeByAddrCh)
-			close(setByIDCh)
+			select {
+			case <-getByEUICh:
+				t.Error("DeviceRegistry.GetByEUI call missed")
+			default:
+				close(getByEUICh)
+			}
+			select {
+			case <-getByIDCh:
+				t.Error("DeviceRegistry.GetByID call missed")
+			default:
+				close(getByIDCh)
+			}
+			select {
+			case <-rangeByAddrCh:
+				t.Error("DeviceRegistry.RangeByAddr call missed")
+			default:
+				close(rangeByAddrCh)
+			}
+			select {
+			case <-setByIDCh:
+				t.Error("DeviceRegistry.SetByID call missed")
+			default:
+				close(setByIDCh)
+			}
 		}
 }
 
@@ -1015,7 +1037,9 @@ type DownlinkTaskQueueEnvironment struct {
 	Pop <-chan DownlinkTaskPopRequest
 }
 
-func newMockDownlinkTaskQueue() (DownlinkTaskQueue, DownlinkTaskQueueEnvironment, func()) {
+func newMockDownlinkTaskQueue(t *testing.T) (DownlinkTaskQueue, DownlinkTaskQueueEnvironment, func()) {
+	t.Helper()
+
 	addCh := make(chan DownlinkTaskAddRequest)
 	popCh := make(chan DownlinkTaskPopRequest)
 	return &MockDownlinkTaskQueue{
@@ -1026,8 +1050,18 @@ func newMockDownlinkTaskQueue() (DownlinkTaskQueue, DownlinkTaskQueueEnvironment
 			Pop: popCh,
 		},
 		func() {
-			close(addCh)
-			close(popCh)
+			select {
+			case <-addCh:
+				t.Error("DownlinkTaskQueue.Add call missed")
+			default:
+				close(addCh)
+			}
+			select {
+			case <-popCh:
+				t.Error("DownlinkTaskQueue.Pop call missed")
+			default:
+				close(popCh)
+			}
 		}
 }
 
@@ -1035,7 +1069,9 @@ type InteropClientEnvironment struct {
 	HandleJoinRequest <-chan InteropClientHandleJoinRequestRequest
 }
 
-func newMockInteropClient() (InteropClient, InteropClientEnvironment, func()) {
+func newMockInteropClient(t *testing.T) (InteropClient, InteropClientEnvironment, func()) {
+	t.Helper()
+
 	handleJoinCh := make(chan InteropClientHandleJoinRequestRequest)
 	return &MockInteropClient{
 			HandleJoinRequestFunc: MakeInteropClientHandleJoinRequestChFunc(handleJoinCh),
@@ -1043,7 +1079,12 @@ func newMockInteropClient() (InteropClient, InteropClientEnvironment, func()) {
 			HandleJoinRequest: handleJoinCh,
 		},
 		func() {
-			close(handleJoinCh)
+			select {
+			case <-handleJoinCh:
+				t.Error("InteropClient.HandleJoin call missed")
+			default:
+				close(handleJoinCh)
+			}
 		}
 }
 
@@ -1060,7 +1101,7 @@ type TestEnvironment struct {
 	InteropClient     *InteropClientEnvironment
 }
 
-func StartTest(t *testing.T, conf Config, timeout time.Duration, opts ...Option) (*NetworkServer, context.Context, TestEnvironment, func()) {
+func StartTest(t *testing.T, conf Config, timeout time.Duration, stubDeduplication bool, opts ...Option) (*NetworkServer, context.Context, TestEnvironment, func()) {
 	t.Helper()
 
 	logger := test.GetLogger(t)
@@ -1071,7 +1112,7 @@ func StartTest(t *testing.T, conf Config, timeout time.Duration, opts ...Option)
 
 	authCh := make(chan test.ClusterAuthRequest)
 	getPeerCh := make(chan test.ClusterGetPeerRequest)
-	eventsCh := make(chan test.EventPubSubPublishRequest)
+	eventsPublishCh := make(chan test.EventPubSubPublishRequest)
 
 	c := component.MustNew(
 		logger,
@@ -1089,8 +1130,16 @@ func StartTest(t *testing.T, conf Config, timeout time.Duration, opts ...Option)
 	)
 	c.FrequencyPlans = frequencyplans.NewStore(test.FrequencyPlansFetcher)
 
-	collectionDoneCh := make(chan WindowEndRequest)
-	deduplicationDoneCh := make(chan WindowEndRequest)
+	var collectionDoneCh, deduplicationDoneCh chan WindowEndRequest
+	if stubDeduplication {
+		collectionDoneCh = make(chan WindowEndRequest)
+		deduplicationDoneCh = make(chan WindowEndRequest)
+
+		opts = append([]Option{
+			WithCollectionDoneFunc(MakeWindowEndChFunc(collectionDoneCh)),
+			WithDeduplicationDoneFunc(MakeWindowEndChFunc(deduplicationDoneCh)),
+		}, opts...)
+	}
 
 	env := TestEnvironment{
 		CollectionDone:    collectionDoneCh,
@@ -1098,20 +1147,20 @@ func StartTest(t *testing.T, conf Config, timeout time.Duration, opts ...Option)
 	}
 	env.Cluster.Auth = authCh
 	env.Cluster.GetPeer = getPeerCh
-	env.Events = eventsCh
+	env.Events = eventsPublishCh
 
 	var closeFuncs []func()
 	closeFuncs = append(closeFuncs, test.SetDefaultEventsPubSub(&test.MockEventPubSub{
-		PublishFunc: test.MakeEventPubSubPublishChFunc(eventsCh),
+		PublishFunc: test.MakeEventPubSubPublishChFunc(eventsPublishCh),
 	}))
 	if conf.Devices == nil {
-		m, mEnv, closeM := newMockDeviceRegistry()
+		m, mEnv, closeM := newMockDeviceRegistry(t)
 		conf.Devices = m
 		env.DeviceRegistry = &mEnv
 		closeFuncs = append(closeFuncs, closeM)
 	}
 	if conf.DownlinkTasks == nil {
-		m, mEnv, closeM := newMockDownlinkTaskQueue()
+		m, mEnv, closeM := newMockDownlinkTaskQueue(t)
 		conf.DownlinkTasks = m
 		env.DownlinkTasks = &mEnv
 		closeFuncs = append(closeFuncs, closeM)
@@ -1120,12 +1169,11 @@ func StartTest(t *testing.T, conf Config, timeout time.Duration, opts ...Option)
 	ns := test.Must(New(
 		c,
 		&conf,
-		WithCollectionDoneFunc(MakeWindowEndChFunc(collectionDoneCh)),
-		WithDeduplicationDoneFunc(MakeWindowEndChFunc(deduplicationDoneCh)),
+		opts...,
 	)).(*NetworkServer)
 
 	if ns.interopClient == nil {
-		m, mEnv, closeM := newMockInteropClient()
+		m, mEnv, closeM := newMockInteropClient(t)
 		ns.interopClient = m
 		env.InteropClient = &mEnv
 		closeFuncs = append(closeFuncs, closeM)
@@ -1139,8 +1187,23 @@ func StartTest(t *testing.T, conf Config, timeout time.Duration, opts ...Option)
 		for _, f := range closeFuncs {
 			f()
 		}
-		close(authCh)
-		close(getPeerCh)
-		close(eventsCh)
+		select {
+		case <-authCh:
+			t.Error("Cluster.Auth call missed")
+		default:
+			close(authCh)
+		}
+		select {
+		case <-getPeerCh:
+			t.Error("Cluster.GetPeer call missed")
+		default:
+			close(getPeerCh)
+		}
+		select {
+		case <-eventsPublishCh:
+			t.Error("events.Publish call missed")
+		default:
+			close(eventsPublishCh)
+		}
 	}
 }

--- a/pkg/util/test/events.go
+++ b/pkg/util/test/events.go
@@ -93,6 +93,22 @@ func AssertEventPubSubPublishRequest(ctx context.Context, reqCh <-chan EventPubS
 	}
 }
 
+func AssertEventPubSubPublishRequests(ctx context.Context, reqCh <-chan EventPubSubPublishRequest, n int, assert func(evs ...events.Event) bool) bool {
+	t := MustTFromContext(ctx)
+	t.Helper()
+
+	var evs []events.Event
+	for i := 0; i < n; i++ {
+		if !AssertEventPubSubPublishRequest(ctx, reqCh, func(ev events.Event) bool {
+			evs = append(evs, ev)
+			return true
+		}) {
+			return false
+		}
+	}
+	return assert(evs...)
+}
+
 func EventEqual(a, b events.Event) bool {
 	if a == nil {
 		return b == nil


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #960 
The US915 flow test will be added later and it will be largely based on this one, so decided to first bring the existing flow test in order.

#### Changes
<!-- What are the changes made in this pull request? -->

- Do ~all~ *not do any* observability/metrics stuff in goroutines ~(no reason to block execution of critical functionality)~
- Use `networkserver.StartTest` in flow tests
- Add more event testing utilities
- Ensure NS tests does not panic on missed function calls
- Remove custom `ns.Close()` logic and rely exclusively on context