### PR TITLE
Add pubsub service to JS SDK

### DIFF
--- a/pkg/webui/console/api/index.js
+++ b/pkg/webui/console/api/index.js
@@ -120,6 +120,14 @@ export default {
       delete: ttnClient.Applications.Webhooks.deleteById.bind(ttnClient.Applications.Webhooks),
       getFormats: ttnClient.Applications.Webhooks.getFormats.bind(ttnClient.Applications.Webhooks),
     },
+    pubsubs: {
+      list: ttnClient.Applications.PubSubs.getAll.bind(ttnClient.Applications.PubSubs),
+      get: ttnClient.Applications.PubSubs.getById.bind(ttnClient.Applications.PubSubs),
+      create: ttnClient.Applications.PubSubs.create.bind(ttnClient.Applications.PubSubs),
+      update: ttnClient.Applications.PubSubs.updateById.bind(ttnClient.Applications.PubSubs),
+      delete: ttnClient.Applications.PubSubs.deleteById.bind(ttnClient.Applications.PubSubs),
+      getFormats: ttnClient.Applications.PubSubs.getFormats.bind(ttnClient.Applications.PubSubs),
+    },
   },
   devices: {
     list: ttnClient.Applications.Devices.getAll.bind(ttnClient.Applications.Devices),

--- a/sdk/js/src/service/applications.js
+++ b/sdk/js/src/service/applications.js
@@ -19,6 +19,7 @@ import ApiKeys from './api-keys'
 import Link from './link'
 import Collaborators from './collaborators'
 import Webhooks from './webhooks'
+import PubSubs from './pubsubs'
 
 /**
  * Applications Class provides an abstraction on all applications and manages
@@ -56,6 +57,7 @@ class Applications {
       },
     })
     this.Webhooks = new Webhooks(api.ApplicationWebhookRegistry)
+    this.PubSubs = new PubSubs(api.ApplicationPubSubRegistry)
   }
 
   _responseTransform(response, single = true) {

--- a/sdk/js/src/service/pubsubs.js
+++ b/sdk/js/src/service/pubsubs.js
@@ -1,0 +1,143 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Marshaler from '../util/marshaler'
+
+const remaps = [['nats', 'provider.nats'], ['mqtt', 'provider.mqtt']]
+
+class PubSub {
+  constructor(registry) {
+    this._api = registry
+  }
+
+  _fillZeroValues(pubsub, paths) {
+    // Add zero values that would otherwise be swallowed by the http bridge
+    if (
+      (paths.includes('provider.mqtt') || paths.includes('provider.mqtt.publish_qos')) &&
+      'mqtt' in pubsub &&
+      !('publish_qos' in pubsub.mqtt)
+    ) {
+      pubsub.mqtt.publish_qos = 'AT_MOST_ONCE'
+    }
+
+    if (
+      (paths.includes('provider.mqtt') || paths.includes('provider.mqtt.subscribe_qos')) &&
+      'mqtt' in pubsub &&
+      !('subscribe_qos' in pubsub.mqtt)
+    ) {
+      pubsub.mqtt.subscribe_qos = 'AT_MOST_ONCE'
+    }
+
+    if (
+      (paths.includes('provider.mqtt') || paths.includes('provider.mqtt.use_tls')) &&
+      'mqtt' in pubsub &&
+      !('use_tls' in pubsub.mqtt)
+    ) {
+      pubsub.mqtt.use_tls = false
+    }
+  }
+
+  async getAll(appId, selector) {
+    const result = await this._api.List(
+      {
+        routeParams: { 'application_ids.application_id': appId },
+      },
+      {
+        ...Marshaler.selectorToFieldMask(selector),
+      },
+    )
+
+    return Marshaler.payloadListResponse('pubsubs', result)
+  }
+
+  async create(
+    appId,
+    pubsub,
+    mask = Marshaler.fieldMaskFromPatch(pubsub, this._api.SetAllowedFieldMaskPaths, remaps),
+  ) {
+    const result = await this._api.Set(
+      {
+        routeParams: {
+          'pubsub.ids.application_ids.application_id': appId,
+        },
+      },
+      {
+        pubsub,
+        field_mask: Marshaler.fieldMask(mask),
+      },
+    )
+
+    return Marshaler.payloadSingleResponse(result)
+  }
+
+  async getById(appId, pubsubId, selector) {
+    const fieldMask = Marshaler.selectorToFieldMask(selector)
+    const paths = fieldMask.field_mask.paths
+    const result = await this._api.Get(
+      {
+        routeParams: {
+          'ids.application_ids.application_id': appId,
+          'ids.pub_sub_id': pubsubId,
+        },
+      },
+      fieldMask,
+    )
+
+    const pubsub = Marshaler.payloadSingleResponse(result)
+    this._fillZeroValues(pubsub, paths)
+
+    return pubsub
+  }
+
+  async updateById(
+    appId,
+    pubsubId,
+    patch,
+    mask = Marshaler.fieldMaskFromPatch(patch, this._api.SetAllowedFieldMaskPaths, remaps),
+  ) {
+    const result = await this._api.Set(
+      {
+        routeParams: {
+          'pubsub.ids.application_ids.application_id': appId,
+          'pubsub.ids.pub_sub_id': pubsubId,
+        },
+      },
+      {
+        pubsub: patch,
+        field_mask: Marshaler.fieldMask(mask),
+      },
+    )
+
+    return Marshaler.payloadSingleResponse(result)
+  }
+
+  async deleteById(appId, pubsubId) {
+    const result = await this._api.Delete({
+      routeParams: {
+        'application_ids.application_id': appId,
+        pub_sub_id: pubsubId,
+      },
+    })
+
+    return Marshaler.payloadSingleResponse(result)
+  }
+
+  async getFormats() {
+    const result = await this._api.GetFormats()
+
+    return Marshaler.payloadSingleResponse(result)
+  }
+}
+
+export default PubSub

--- a/sdk/js/src/util/marshaler.js
+++ b/sdk/js/src/util/marshaler.js
@@ -115,7 +115,7 @@ class Marshaler {
         // Do not consider array elements and do not recurse into them
         this.update(undefined, true)
       }
-      if (!this.isRoot && this.isLeaf) {
+      if (this.isLeaf) {
         paths.push(this.path.join('.'))
       }
     })


### PR DESCRIPTION
#### Summary
Add the PubSub service to JavaScript SDK.

References #1281 

#### Changes
- Add functionality to remap field masks from patches to SDK
- Add pubsub service to the SDK
- Add pubsub to the console api tree

#### Notes for Reviewers
PubSubs use a [oneof structure](https://github.com/TheThingsNetwork/lorawan-stack/blob/master/api/applicationserver_pubsub.proto#L71-L77) to store the provider information. This results in the field masks not being directly mappable to the patch. E.g.`provider.nats` is expected for the nats property, which is actually in the root of the entity.  This is why I added functionality to the Marshaler to set field mask paths that should be remapped.

You can use [this script](https://gist.github.com/kschiffer/c97fd138d45a00dfb1a4307543a0e60e) to test.

#### Release Notes
- Add PubSub service to JavaScript SDK