### PR TITLE
Add enforced validation to fields after change

### DIFF
--- a/pkg/webui/components/file-input/index.js
+++ b/pkg/webui/components/file-input/index.js
@@ -77,7 +77,7 @@ export default class FileInput extends Component {
     const { result: content } = event.target
 
     const data = dataTransform(content)
-    onChange(data)
+    onChange(data, true)
   }
 
   @bind
@@ -103,7 +103,7 @@ export default class FileInput extends Component {
     const { onChange } = this.props
 
     this.setState({ filename: '', error: undefined })
-    onChange(undefined)
+    onChange(undefined, true)
   }
 
   get statusMessage() {

--- a/pkg/webui/components/form/field/index.js
+++ b/pkg/webui/components/form/field/index.js
@@ -104,14 +104,19 @@ class FormField extends React.Component {
     return newValue
   }
 
-  handleChange(value) {
+  handleChange(value, enforceValidation = false) {
     const { name, onChange } = this.props
-    const { setFieldValue } = this.context
+    const { setFieldValue, setFieldTouched } = this.context
 
     // check if the value is react's synthetic event
     const newValue = this.extractValue(value)
 
     setFieldValue(name, newValue)
+
+    if (enforceValidation) {
+      setFieldTouched(name)
+    }
+
     onChange(value)
   }
 

--- a/pkg/webui/components/key-value-map/index.js
+++ b/pkg/webui/components/key-value-map/index.js
@@ -35,11 +35,8 @@ class KeyValueMap extends React.PureComponent {
   }
 
   removeEntry(index) {
-    const { onChange, onBlur, value } = this.props
-    onChange(value.filter((_, i) => i !== index) || [])
-
-    // Trigger also the onBlur event to enforce revalidation
-    onBlur()
+    const { onChange, value } = this.props
+    onChange(value.filter((_, i) => i !== index) || [], true)
   }
 
   addEmptyEntry() {


### PR DESCRIPTION
#### Summary
This PR adds a way to enforce validation of a field after it was changed.

#### Changes
- Add `enforceValidation` argument to `handleChange` handler of fields
- Add enforced validation to file input
- Add enforced validation to key-value-map (remove handler)

#### Notes for Reviewers
Added this as for some fields validation on blur is not really applicable (file input, key value map), meaning that sometimes fields are not validated when they are changed, although one would expect this to happen.
I think adding the option to the change handler is a nice and easy way to solve this. Let me know if you think otherwise.
