### PR TITLE
Starting point for Component Testing Utilities 

### DIFF
--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -38,6 +38,7 @@ import (
 	iowebredis "go.thethings.network/lorawan-stack/pkg/applicationserver/io/web/redis"
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/redis"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/events"
@@ -240,7 +241,7 @@ hardware_versions:
 	}()
 	time.Sleep(Timeout)
 
-	c := component.MustNew(test.GetLogger(t), &component.Config{
+	c := NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":9184",
@@ -290,7 +291,7 @@ hardware_versions:
 	a.So(len(roles), should.Equal, 1)
 	a.So(roles[0], should.Equal, ttnpb.ClusterRole_APPLICATION_SERVER)
 
-	test.Must(nil, c.Start())
+	StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_NETWORK_SERVER)
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_JOIN_SERVER)

--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -38,7 +38,7 @@ import (
 	iowebredis "go.thethings.network/lorawan-stack/pkg/applicationserver/io/web/redis"
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/redis"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/events"
@@ -241,7 +241,7 @@ hardware_versions:
 	}()
 	time.Sleep(Timeout)
 
-	c := NewComponent(t, &component.Config{
+	c := componenttest.NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":9184",
@@ -291,7 +291,7 @@ hardware_versions:
 	a.So(len(roles), should.Equal, 1)
 	a.So(roles[0], should.Equal, ttnpb.ClusterRole_APPLICATION_SERVER)
 
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_NETWORK_SERVER)
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_JOIN_SERVER)

--- a/pkg/applicationserver/grpc_deviceregistry_test.go
+++ b/pkg/applicationserver/grpc_deviceregistry_test.go
@@ -239,7 +239,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			as.AddContextFiller(func(ctx context.Context) context.Context {
 				return test.ContextWithT(ctx, t)
 			})
-			test.Must(nil, as.Start())
+			StartComponent(t, as.Component)
 			defer as.Close()
 
 			ctx := as.FillContext(test.Context())
@@ -457,7 +457,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			as.AddContextFiller(func(ctx context.Context) context.Context {
 				return test.ContextWithT(ctx, t)
 			})
-			test.Must(nil, as.Start())
+			StartComponent(t, as.Component)
 			defer as.Close()
 
 			ctx := as.FillContext(test.Context())
@@ -615,7 +615,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			as.AddContextFiller(func(ctx context.Context) context.Context {
 				return test.ContextWithT(ctx, t)
 			})
-			test.Must(nil, as.Start())
+			StartComponent(t, as.Component)
 			defer as.Close()
 
 			ctx := as.FillContext(test.Context())

--- a/pkg/applicationserver/grpc_deviceregistry_test.go
+++ b/pkg/applicationserver/grpc_deviceregistry_test.go
@@ -26,7 +26,7 @@ import (
 	. "go.thethings.network/lorawan-stack/pkg/applicationserver"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
@@ -213,7 +213,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			var getCalls uint64
 
 			as := test.Must(New(
-				NewComponent(t, &component.Config{
+				componenttest.NewComponent(t, &component.Config{
 					ServiceBase: config.ServiceBase{
 						KeyVault: config.KeyVault{
 							Static: registeredKEKs,
@@ -239,7 +239,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			as.AddContextFiller(func(ctx context.Context) context.Context {
 				return test.ContextWithT(ctx, t)
 			})
-			StartComponent(t, as.Component)
+			componenttest.StartComponent(t, as.Component)
 			defer as.Close()
 
 			ctx := as.FillContext(test.Context())
@@ -437,7 +437,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 
 			var setCalls uint64
 
-			as := test.Must(New(NewComponent(t, &component.Config{}),
+			as := test.Must(New(componenttest.NewComponent(t, &component.Config{}),
 				&Config{
 					LinkMode: "explicit",
 					Devices: &MockDeviceRegistry{
@@ -457,7 +457,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			as.AddContextFiller(func(ctx context.Context) context.Context {
 				return test.ContextWithT(ctx, t)
 			})
-			StartComponent(t, as.Component)
+			componenttest.StartComponent(t, as.Component)
 			defer as.Close()
 
 			ctx := as.FillContext(test.Context())
@@ -595,7 +595,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 
 			var setCalls uint64
 
-			as := test.Must(New(NewComponent(t, &component.Config{}),
+			as := test.Must(New(componenttest.NewComponent(t, &component.Config{}),
 				&Config{
 					LinkMode: "explicit",
 					Devices: &MockDeviceRegistry{
@@ -615,7 +615,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			as.AddContextFiller(func(ctx context.Context) context.Context {
 				return test.ContextWithT(ctx, t)
 			})
-			StartComponent(t, as.Component)
+			componenttest.StartComponent(t, as.Component)
 			defer as.Close()
 
 			ctx := as.FillContext(test.Context())

--- a/pkg/applicationserver/grpc_deviceregistry_test.go
+++ b/pkg/applicationserver/grpc_deviceregistry_test.go
@@ -26,6 +26,7 @@ import (
 	. "go.thethings.network/lorawan-stack/pkg/applicationserver"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
@@ -212,7 +213,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			var getCalls uint64
 
 			as := test.Must(New(
-				component.MustNew(test.GetLogger(t), &component.Config{
+				NewComponent(t, &component.Config{
 					ServiceBase: config.ServiceBase{
 						KeyVault: config.KeyVault{
 							Static: registeredKEKs,
@@ -436,7 +437,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 
 			var setCalls uint64
 
-			as := test.Must(New(component.MustNew(test.GetLogger(t), &component.Config{}),
+			as := test.Must(New(NewComponent(t, &component.Config{}),
 				&Config{
 					LinkMode: "explicit",
 					Devices: &MockDeviceRegistry{
@@ -594,7 +595,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 
 			var setCalls uint64
 
-			as := test.Must(New(component.MustNew(test.GetLogger(t), &component.Config{}),
+			as := test.Must(New(NewComponent(t, &component.Config{}),
 				&Config{
 					LinkMode: "explicit",
 					Devices: &MockDeviceRegistry{

--- a/pkg/applicationserver/io/grpc/grpc_test.go
+++ b/pkg/applicationserver/io/grpc/grpc_test.go
@@ -26,6 +26,7 @@ import (
 	. "go.thethings.network/lorawan-stack/pkg/applicationserver/io/grpc"
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/mock"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/log"
@@ -51,7 +52,7 @@ func TestAuthentication(t *testing.T) {
 	is, isAddr := startMockIS(ctx)
 	is.add(ctx, registeredApplicationID, registeredApplicationKey)
 
-	c := component.MustNew(test.GetLogger(t), &component.Config{
+	c := NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -65,7 +66,7 @@ func TestAuthentication(t *testing.T) {
 	as := mock.NewServer(c)
 	srv := New(as)
 	c.RegisterGRPC(&mockRegisterer{ctx, srv})
-	test.Must(nil, c.Start())
+	StartComponent(t, c)
 	defer c.Close()
 
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
@@ -136,7 +137,7 @@ func TestTraffic(t *testing.T) {
 	is, isAddr := startMockIS(ctx)
 	is.add(ctx, registeredApplicationID, registeredApplicationKey)
 
-	c := component.MustNew(test.GetLogger(t), &component.Config{
+	c := NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -150,7 +151,7 @@ func TestTraffic(t *testing.T) {
 	as := mock.NewServer(c)
 	srv := New(as)
 	c.RegisterGRPC(&mockRegisterer{ctx, srv})
-	test.Must(nil, c.Start())
+	StartComponent(t, c)
 	defer c.Close()
 
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)

--- a/pkg/applicationserver/io/grpc/grpc_test.go
+++ b/pkg/applicationserver/io/grpc/grpc_test.go
@@ -26,7 +26,7 @@ import (
 	. "go.thethings.network/lorawan-stack/pkg/applicationserver/io/grpc"
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/mock"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/log"
@@ -52,7 +52,7 @@ func TestAuthentication(t *testing.T) {
 	is, isAddr := startMockIS(ctx)
 	is.add(ctx, registeredApplicationID, registeredApplicationKey)
 
-	c := NewComponent(t, &component.Config{
+	c := componenttest.NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -66,7 +66,7 @@ func TestAuthentication(t *testing.T) {
 	as := mock.NewServer(c)
 	srv := New(as)
 	c.RegisterGRPC(&mockRegisterer{ctx, srv})
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
@@ -137,7 +137,7 @@ func TestTraffic(t *testing.T) {
 	is, isAddr := startMockIS(ctx)
 	is.add(ctx, registeredApplicationID, registeredApplicationKey)
 
-	c := NewComponent(t, &component.Config{
+	c := componenttest.NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -151,7 +151,7 @@ func TestTraffic(t *testing.T) {
 	as := mock.NewServer(c)
 	srv := New(as)
 	c.RegisterGRPC(&mockRegisterer{ctx, srv})
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)

--- a/pkg/applicationserver/io/mqtt/mqtt_test.go
+++ b/pkg/applicationserver/io/mqtt/mqtt_test.go
@@ -27,7 +27,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/mock"
 	. "go.thethings.network/lorawan-stack/pkg/applicationserver/io/mqtt"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/jsonpb"
 	"go.thethings.network/lorawan-stack/pkg/log"
@@ -59,7 +59,7 @@ func TestAuthentication(t *testing.T) {
 	is, isAddr := startMockIS(ctx)
 	is.add(ctx, registeredApplicationID, registeredApplicationKey)
 
-	c := NewComponent(t, &component.Config{
+	c := componenttest.NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -70,7 +70,7 @@ func TestAuthentication(t *testing.T) {
 			},
 		},
 	})
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 
@@ -132,7 +132,7 @@ func TestTraffic(t *testing.T) {
 	is, isAddr := startMockIS(ctx)
 	is.add(ctx, registeredApplicationID, registeredApplicationKey)
 
-	c := NewComponent(t, &component.Config{
+	c := componenttest.NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -143,7 +143,7 @@ func TestTraffic(t *testing.T) {
 			},
 		},
 	})
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)

--- a/pkg/applicationserver/io/mqtt/mqtt_test.go
+++ b/pkg/applicationserver/io/mqtt/mqtt_test.go
@@ -27,6 +27,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/mock"
 	. "go.thethings.network/lorawan-stack/pkg/applicationserver/io/mqtt"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/jsonpb"
 	"go.thethings.network/lorawan-stack/pkg/log"
@@ -58,7 +59,7 @@ func TestAuthentication(t *testing.T) {
 	is, isAddr := startMockIS(ctx)
 	is.add(ctx, registeredApplicationID, registeredApplicationKey)
 
-	c := component.MustNew(test.GetLogger(t), &component.Config{
+	c := NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -69,7 +70,7 @@ func TestAuthentication(t *testing.T) {
 			},
 		},
 	})
-	test.Must(nil, c.Start())
+	StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 
@@ -131,7 +132,7 @@ func TestTraffic(t *testing.T) {
 	is, isAddr := startMockIS(ctx)
 	is.add(ctx, registeredApplicationID, registeredApplicationKey)
 
-	c := component.MustNew(test.GetLogger(t), &component.Config{
+	c := NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -142,7 +143,7 @@ func TestTraffic(t *testing.T) {
 			},
 		},
 	})
-	test.Must(nil, c.Start())
+	StartComponent(t, c)
 	defer c.Close()
 
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)

--- a/pkg/applicationserver/io/pubsub/integrate_test.go
+++ b/pkg/applicationserver/io/pubsub/integrate_test.go
@@ -26,7 +26,7 @@ import (
 	mock_provider "go.thethings.network/lorawan-stack/pkg/applicationserver/io/pubsub/provider/mock"
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/pubsub/redis"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/rpcmetadata"
@@ -81,7 +81,7 @@ func TestIntegrate(t *testing.T) {
 	})
 	a.So(err, should.BeNil)
 
-	c := NewComponent(t, &component.Config{
+	c := componenttest.NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":9185",
@@ -98,7 +98,7 @@ func TestIntegrate(t *testing.T) {
 		t.FailNow()
 	}
 	c.RegisterGRPC(&mockRegisterer{srv})
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)

--- a/pkg/applicationserver/io/pubsub/integrate_test.go
+++ b/pkg/applicationserver/io/pubsub/integrate_test.go
@@ -26,6 +26,7 @@ import (
 	mock_provider "go.thethings.network/lorawan-stack/pkg/applicationserver/io/pubsub/provider/mock"
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/pubsub/redis"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/rpcmetadata"
@@ -80,7 +81,7 @@ func TestIntegrate(t *testing.T) {
 	})
 	a.So(err, should.BeNil)
 
-	c := component.MustNew(test.GetLogger(t), &component.Config{
+	c := NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":9185",
@@ -97,7 +98,7 @@ func TestIntegrate(t *testing.T) {
 		t.FailNow()
 	}
 	c.RegisterGRPC(&mockRegisterer{srv})
-	test.Must(nil, c.Start())
+	StartComponent(t, c)
 	defer c.Close()
 
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)

--- a/pkg/applicationserver/io/pubsub/pubsub_test.go
+++ b/pkg/applicationserver/io/pubsub/pubsub_test.go
@@ -27,6 +27,7 @@ import (
 	mock_provider "go.thethings.network/lorawan-stack/pkg/applicationserver/io/pubsub/provider/mock"
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/pubsub/redis"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/jsonpb"
 	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
@@ -126,13 +127,13 @@ func TestPubSub(t *testing.T) {
 	a.So(err, should.BeNil)
 	mockImpl := mockProvider.(*mock_provider.Impl)
 
-	c := component.MustNew(test.GetLogger(t), &component.Config{})
+	c := NewComponent(t, &component.Config{})
 	io := mock_server.NewServer(c)
 	_, err = pubsub.New(c, io, registry)
 	if !a.So(err, should.BeNil) {
 		t.FailNow()
 	}
-	test.Must(nil, c.Start())
+	StartComponent(t, c)
 	defer c.Close()
 
 	sub := <-io.Subscriptions()

--- a/pkg/applicationserver/io/pubsub/pubsub_test.go
+++ b/pkg/applicationserver/io/pubsub/pubsub_test.go
@@ -27,7 +27,7 @@ import (
 	mock_provider "go.thethings.network/lorawan-stack/pkg/applicationserver/io/pubsub/provider/mock"
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/pubsub/redis"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/jsonpb"
 	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
@@ -127,13 +127,13 @@ func TestPubSub(t *testing.T) {
 	a.So(err, should.BeNil)
 	mockImpl := mockProvider.(*mock_provider.Impl)
 
-	c := NewComponent(t, &component.Config{})
+	c := componenttest.NewComponent(t, &component.Config{})
 	io := mock_server.NewServer(c)
 	_, err = pubsub.New(c, io, registry)
 	if !a.So(err, should.BeNil) {
 		t.FailNow()
 	}
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 
 	sub := <-io.Subscriptions()

--- a/pkg/applicationserver/io/web/grpc_webhooks_test.go
+++ b/pkg/applicationserver/io/web/grpc_webhooks_test.go
@@ -24,7 +24,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/web"
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/web/redis"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/rpcmetadata"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
@@ -40,7 +40,7 @@ func TestWebhookRegistryRPC(t *testing.T) {
 	is, isAddr := startMockIS(ctx)
 	is.add(ctx, registeredApplicationID, registeredApplicationKey)
 
-	c := NewComponent(t, &component.Config{
+	c := componenttest.NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -57,7 +57,7 @@ func TestWebhookRegistryRPC(t *testing.T) {
 	webhookReg := &redis.WebhookRegistry{Redis: redisClient}
 	srv := web.NewWebhookRegistryRPC(webhookReg, nil)
 	c.RegisterGRPC(&mockRegisterer{ctx, srv})
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
@@ -233,9 +233,9 @@ description: Bar`),
 			store, err := config.NewTemplateStore()
 			a.So(err, should.BeNil)
 
-			c := NewComponent(t, &component.Config{})
+			c := componenttest.NewComponent(t, &component.Config{})
 			c.RegisterGRPC(&mockRegisterer{ctx, web.NewWebhookRegistryRPC(nil, store)})
-			StartComponent(t, c)
+			componenttest.StartComponent(t, c)
 			defer c.Close()
 
 			client := ttnpb.NewApplicationWebhookRegistryClient(c.LoopbackConn())

--- a/pkg/applicationserver/io/web/grpc_webhooks_test.go
+++ b/pkg/applicationserver/io/web/grpc_webhooks_test.go
@@ -24,6 +24,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/web"
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/web/redis"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/rpcmetadata"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
@@ -39,7 +40,7 @@ func TestWebhookRegistryRPC(t *testing.T) {
 	is, isAddr := startMockIS(ctx)
 	is.add(ctx, registeredApplicationID, registeredApplicationKey)
 
-	c := component.MustNew(test.GetLogger(t), &component.Config{
+	c := NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -56,7 +57,7 @@ func TestWebhookRegistryRPC(t *testing.T) {
 	webhookReg := &redis.WebhookRegistry{Redis: redisClient}
 	srv := web.NewWebhookRegistryRPC(webhookReg, nil)
 	c.RegisterGRPC(&mockRegisterer{ctx, srv})
-	test.Must(nil, c.Start())
+	StartComponent(t, c)
 	defer c.Close()
 
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
@@ -232,9 +233,9 @@ description: Bar`),
 			store, err := config.NewTemplateStore()
 			a.So(err, should.BeNil)
 
-			c := component.MustNew(test.GetLogger(t), &component.Config{})
+			c := NewComponent(t, &component.Config{})
 			c.RegisterGRPC(&mockRegisterer{ctx, web.NewWebhookRegistryRPC(nil, store)})
-			test.Must(nil, c.Start())
+			StartComponent(t, c)
 			defer c.Close()
 
 			client := ttnpb.NewApplicationWebhookRegistryClient(c.LoopbackConn())

--- a/pkg/applicationserver/io/web/webhooks_test.go
+++ b/pkg/applicationserver/io/web/webhooks_test.go
@@ -30,6 +30,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/web"
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/web/redis"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
@@ -340,7 +341,7 @@ func TestWebhooks(t *testing.T) {
 				},
 			},
 		}
-		c := component.MustNew(test.GetLogger(t), conf)
+		c := NewComponent(t, conf)
 		io := mock.NewServer(c)
 		testSink := &mockSink{
 			Component: c,
@@ -348,7 +349,7 @@ func TestWebhooks(t *testing.T) {
 		}
 		w := web.NewWebhooks(ctx, testSink.Server, registry, testSink)
 		c.RegisterWeb(w)
-		test.Must(nil, c.Start())
+		StartComponent(t, c)
 		defer c.Close()
 
 		mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)

--- a/pkg/applicationserver/io/web/webhooks_test.go
+++ b/pkg/applicationserver/io/web/webhooks_test.go
@@ -30,7 +30,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/web"
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/web/redis"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
@@ -341,7 +341,7 @@ func TestWebhooks(t *testing.T) {
 				},
 			},
 		}
-		c := NewComponent(t, conf)
+		c := componenttest.NewComponent(t, conf)
 		io := mock.NewServer(c)
 		testSink := &mockSink{
 			Component: c,
@@ -349,7 +349,7 @@ func TestWebhooks(t *testing.T) {
 		}
 		w := web.NewWebhooks(ctx, testSink.Server, registry, testSink)
 		c.RegisterWeb(w)
-		StartComponent(t, c)
+		componenttest.StartComponent(t, c)
 		defer c.Close()
 
 		mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)

--- a/pkg/applicationserver/linking_test.go
+++ b/pkg/applicationserver/linking_test.go
@@ -25,6 +25,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/redis"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/rpcmetadata"
@@ -64,7 +65,7 @@ func TestLink(t *testing.T) {
 		}, paths, nil
 	})
 
-	c := component.MustNew(test.GetLogger(t), &component.Config{
+	c := NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			Cluster: config.Cluster{
 				NetworkServer: nsAddr,
@@ -81,7 +82,7 @@ func TestLink(t *testing.T) {
 	if !a.So(err, should.BeNil) {
 		t.FailNow()
 	}
-	test.Must(nil, c.Start())
+	StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_NETWORK_SERVER)
 

--- a/pkg/applicationserver/linking_test.go
+++ b/pkg/applicationserver/linking_test.go
@@ -25,7 +25,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/redis"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/rpcmetadata"
@@ -65,7 +65,7 @@ func TestLink(t *testing.T) {
 		}, paths, nil
 	})
 
-	c := NewComponent(t, &component.Config{
+	c := componenttest.NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			Cluster: config.Cluster{
 				NetworkServer: nsAddr,
@@ -82,7 +82,7 @@ func TestLink(t *testing.T) {
 	if !a.So(err, should.BeNil) {
 		t.FailNow()
 	}
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_NETWORK_SERVER)
 

--- a/pkg/basicstation/cups/server_test.go
+++ b/pkg/basicstation/cups/server_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/smartystreets/assertions/should"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/rpcmetadata"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
@@ -347,7 +347,7 @@ func TestServer(t *testing.T) {
 				tt.StoreSetup(store)
 			}
 
-			s := NewServer(NewComponent(t, &component.Config{}), append([]Option{
+			s := NewServer(componenttest.NewComponent(t, &component.Config{}), append([]Option{
 				WithTLSConfig(&tls.Config{
 					InsecureSkipVerify: true,
 				}),

--- a/pkg/basicstation/cups/server_test.go
+++ b/pkg/basicstation/cups/server_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/smartystreets/assertions/should"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/rpcmetadata"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
@@ -346,7 +347,7 @@ func TestServer(t *testing.T) {
 				tt.StoreSetup(store)
 			}
 
-			s := NewServer(component.MustNew(test.GetLogger(t), &component.Config{}), append([]Option{
+			s := NewServer(NewComponent(t, &component.Config{}), append([]Option{
 				WithTLSConfig(&tls.Config{
 					InsecureSkipVerify: true,
 				}),

--- a/pkg/component/test/component.go
+++ b/pkg/component/test/component.go
@@ -12,28 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package devicetemplateconverter_test
+package test
 
 import (
 	"testing"
 
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
-	. "go.thethings.network/lorawan-stack/pkg/devicetemplateconverter"
-	"go.thethings.network/lorawan-stack/pkg/log"
-	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/util/test"
 )
 
-func TestDeviceTemplateConverter(t *testing.T) {
-	ctx := log.NewContext(test.Context(), test.GetLogger(t))
+// NewComponent returns a new Component that can be used for testing.
+func NewComponent(t *testing.T, config *component.Config, opts ...component.Option) *component.Component {
+	c, err := component.New(test.GetLogger(t), config, opts...)
+	if err != nil {
+		t.Fatalf("Failed to create component: %v", err)
+	}
+	return c
+}
 
-	conf := &component.Config{}
-	c := NewComponent(t, conf)
-
-	test.Must(New(c, &Config{}))
-	test.Must(c.Start(), nil)
-	defer c.Close()
-
-	mustHavePeer(ctx, c, ttnpb.ClusterRole_DEVICE_TEMPLATE_CONVERTER)
+// StartComponent starts the component for testing.
+func StartComponent(t *testing.T, c *component.Component) {
+	if err := c.Start(); err != nil {
+		t.Fatalf("Failed to start component: %v", err)
+	}
 }

--- a/pkg/devicetemplateconverter/devicetemplateconverter_test.go
+++ b/pkg/devicetemplateconverter/devicetemplateconverter_test.go
@@ -32,7 +32,7 @@ func TestDeviceTemplateConverter(t *testing.T) {
 	c := NewComponent(t, conf)
 
 	test.Must(New(c, &Config{}))
-	test.Must(c.Start(), nil)
+	StartComponent(t, c)
 	defer c.Close()
 
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_DEVICE_TEMPLATE_CONVERTER)

--- a/pkg/devicetemplateconverter/devicetemplateconverter_test.go
+++ b/pkg/devicetemplateconverter/devicetemplateconverter_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	. "go.thethings.network/lorawan-stack/pkg/devicetemplateconverter"
 	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
@@ -29,10 +29,10 @@ func TestDeviceTemplateConverter(t *testing.T) {
 	ctx := log.NewContext(test.Context(), test.GetLogger(t))
 
 	conf := &component.Config{}
-	c := NewComponent(t, conf)
+	c := componenttest.NewComponent(t, conf)
 
 	test.Must(New(c, &Config{}))
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_DEVICE_TEMPLATE_CONVERTER)

--- a/pkg/devicetemplateconverter/grpc_test.go
+++ b/pkg/devicetemplateconverter/grpc_test.go
@@ -24,6 +24,7 @@ import (
 	pbtypes "github.com/gogo/protobuf/types"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	. "go.thethings.network/lorawan-stack/pkg/devicetemplateconverter"
 	"go.thethings.network/lorawan-stack/pkg/devicetemplates"
 	"go.thethings.network/lorawan-stack/pkg/log"
@@ -66,7 +67,7 @@ func TestConvertEndDeviceTemplate(t *testing.T) {
 		},
 	})
 
-	c := component.MustNew(test.GetLogger(t), &component.Config{})
+	c := NewComponent(t, &component.Config{})
 	test.Must(New(c, &Config{
 		Enabled: []string{"test"},
 	}))

--- a/pkg/devicetemplateconverter/grpc_test.go
+++ b/pkg/devicetemplateconverter/grpc_test.go
@@ -71,7 +71,7 @@ func TestConvertEndDeviceTemplate(t *testing.T) {
 	test.Must(New(c, &Config{
 		Enabled: []string{"test"},
 	}))
-	test.Must(c.Start(), nil)
+	StartComponent(t, c)
 	defer c.Close()
 
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_DEVICE_TEMPLATE_CONVERTER)

--- a/pkg/devicetemplateconverter/grpc_test.go
+++ b/pkg/devicetemplateconverter/grpc_test.go
@@ -24,7 +24,7 @@ import (
 	pbtypes "github.com/gogo/protobuf/types"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	. "go.thethings.network/lorawan-stack/pkg/devicetemplateconverter"
 	"go.thethings.network/lorawan-stack/pkg/devicetemplates"
 	"go.thethings.network/lorawan-stack/pkg/log"
@@ -67,11 +67,11 @@ func TestConvertEndDeviceTemplate(t *testing.T) {
 		},
 	})
 
-	c := NewComponent(t, &component.Config{})
+	c := componenttest.NewComponent(t, &component.Config{})
 	test.Must(New(c, &Config{
 		Enabled: []string{"test"},
 	}))
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_DEVICE_TEMPLATE_CONVERTER)

--- a/pkg/gatewayconfigurationserver/gatewayconfigurationserver_test.go
+++ b/pkg/gatewayconfigurationserver/gatewayconfigurationserver_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	. "go.thethings.network/lorawan-stack/pkg/gatewayconfigurationserver"
 	"go.thethings.network/lorawan-stack/pkg/log"
@@ -51,10 +51,10 @@ func TestGatewayConfigurationServer(t *testing.T) {
 	ctx := log.NewContext(test.Context(), test.GetLogger(t))
 
 	conf := &component.Config{}
-	c := NewComponent(t, conf)
+	c := componenttest.NewComponent(t, conf)
 
 	test.Must(New(c, testConfig))
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_GATEWAY_CONFIGURATION_SERVER)
@@ -85,7 +85,7 @@ func TestWeb(t *testing.T) {
 			},
 		},
 	}
-	c := NewComponent(t, conf)
+	c := componenttest.NewComponent(t, conf)
 	c.AddContextFiller(func(ctx context.Context) context.Context {
 		ctx = newContextWithRightsFetcher(ctx)
 		return ctx
@@ -95,7 +95,7 @@ func TestWeb(t *testing.T) {
 	a.So(err, should.BeNil)
 	a.So(gcs, should.NotBeNil)
 
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)

--- a/pkg/gatewayconfigurationserver/gatewayconfigurationserver_test.go
+++ b/pkg/gatewayconfigurationserver/gatewayconfigurationserver_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	. "go.thethings.network/lorawan-stack/pkg/gatewayconfigurationserver"
 	"go.thethings.network/lorawan-stack/pkg/log"
@@ -50,7 +51,7 @@ func TestGatewayConfigurationServer(t *testing.T) {
 	ctx := log.NewContext(test.Context(), test.GetLogger(t))
 
 	conf := &component.Config{}
-	c := component.MustNew(test.GetLogger(t), conf)
+	c := NewComponent(t, conf)
 
 	test.Must(New(c, testConfig))
 	test.Must(c.Start(), nil)
@@ -84,7 +85,7 @@ func TestWeb(t *testing.T) {
 			},
 		},
 	}
-	c := component.MustNew(test.GetLogger(t), conf)
+	c := NewComponent(t, conf)
 	c.AddContextFiller(func(ctx context.Context) context.Context {
 		ctx = newContextWithRightsFetcher(ctx)
 		return ctx

--- a/pkg/gatewayconfigurationserver/gatewayconfigurationserver_test.go
+++ b/pkg/gatewayconfigurationserver/gatewayconfigurationserver_test.go
@@ -54,7 +54,7 @@ func TestGatewayConfigurationServer(t *testing.T) {
 	c := NewComponent(t, conf)
 
 	test.Must(New(c, testConfig))
-	test.Must(c.Start(), nil)
+	StartComponent(t, c)
 	defer c.Close()
 
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_GATEWAY_CONFIGURATION_SERVER)
@@ -95,8 +95,7 @@ func TestWeb(t *testing.T) {
 	a.So(err, should.BeNil)
 	a.So(gcs, should.NotBeNil)
 
-	err = c.Start()
-	a.So(err, should.BeNil)
+	StartComponent(t, c)
 	defer c.Close()
 
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)

--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/auth/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/encoding/lorawan"
 	"go.thethings.network/lorawan-stack/pkg/errors"
@@ -68,7 +69,7 @@ func TestGatewayServer(t *testing.T) {
 	is, isAddr := startMockIS(ctx)
 	ns, nsAddr := mock.StartNS(ctx)
 
-	c := component.MustNew(test.GetLogger(t), &component.Config{
+	c := NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":9187",
@@ -112,7 +113,7 @@ func TestGatewayServer(t *testing.T) {
 	a.So(len(roles), should.Equal, 1)
 	a.So(roles[0], should.Equal, ttnpb.ClusterRole_GATEWAY_SERVER)
 
-	test.Must(nil, c.Start())
+	StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_NETWORK_SERVER)
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)

--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/auth/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/encoding/lorawan"
 	"go.thethings.network/lorawan-stack/pkg/errors"
@@ -69,7 +69,7 @@ func TestGatewayServer(t *testing.T) {
 	is, isAddr := startMockIS(ctx)
 	ns, nsAddr := mock.StartNS(ctx)
 
-	c := NewComponent(t, &component.Config{
+	c := componenttest.NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":9187",
@@ -113,7 +113,7 @@ func TestGatewayServer(t *testing.T) {
 	a.So(len(roles), should.Equal, 1)
 	a.So(roles[0], should.Equal, ttnpb.ClusterRole_GATEWAY_SERVER)
 
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_NETWORK_SERVER)
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)

--- a/pkg/gatewayserver/io/basicstationlns/basicstationlns_test.go
+++ b/pkg/gatewayserver/io/basicstationlns/basicstationlns_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/basicstation"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/encoding/lorawan"
 	"go.thethings.network/lorawan-stack/pkg/gatewayserver/io"
@@ -68,7 +69,7 @@ func TestClientTokenAuth(t *testing.T) {
 
 	is, isAddr := mock.NewIS(ctx)
 	is.Add(ctx, registeredGatewayID, registeredGatewayToken)
-	c := component.MustNew(test.GetLogger(t), &component.Config{
+	c := NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -79,7 +80,7 @@ func TestClientTokenAuth(t *testing.T) {
 			},
 		},
 	})
-	test.Must(nil, c.Start())
+	StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 	gs := mock.NewServer(c)
@@ -171,7 +172,7 @@ func TestDiscover(t *testing.T) {
 
 	is, isAddr := mock.NewIS(ctx)
 	is.Add(ctx, registeredGatewayID, registeredGatewayToken)
-	c := component.MustNew(test.GetLogger(t), &component.Config{
+	c := NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -182,7 +183,7 @@ func TestDiscover(t *testing.T) {
 			},
 		},
 	})
-	test.Must(nil, c.Start())
+	StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 	gs := mock.NewServer(c)
@@ -409,7 +410,7 @@ func TestVersion(t *testing.T) {
 
 	is, isAddr := mock.NewIS(ctx)
 	is.Add(ctx, registeredGatewayID, registeredGatewayToken)
-	c := component.MustNew(test.GetLogger(t), &component.Config{
+	c := NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -420,7 +421,7 @@ func TestVersion(t *testing.T) {
 			},
 		},
 	})
-	test.Must(nil, c.Start())
+	StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 	gs := mock.NewServer(c)
@@ -705,7 +706,7 @@ func TestTraffic(t *testing.T) {
 
 	is, isAddr := mock.NewIS(ctx)
 	is.Add(ctx, registeredGatewayID, registeredGatewayToken)
-	c := component.MustNew(test.GetLogger(t), &component.Config{
+	c := NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -716,7 +717,7 @@ func TestTraffic(t *testing.T) {
 			},
 		},
 	})
-	test.Must(nil, c.Start())
+	StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 	gs := mock.NewServer(c)
@@ -1035,7 +1036,7 @@ func TestRTT(t *testing.T) {
 
 	is, isAddr := mock.NewIS(ctx)
 	is.Add(ctx, registeredGatewayID, registeredGatewayToken)
-	c := component.MustNew(test.GetLogger(t), &component.Config{
+	c := NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -1046,7 +1047,7 @@ func TestRTT(t *testing.T) {
 			},
 		},
 	})
-	test.Must(nil, c.Start())
+	StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 	gs := mock.NewServer(c)

--- a/pkg/gatewayserver/io/basicstationlns/basicstationlns_test.go
+++ b/pkg/gatewayserver/io/basicstationlns/basicstationlns_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/basicstation"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/encoding/lorawan"
 	"go.thethings.network/lorawan-stack/pkg/gatewayserver/io"
@@ -69,7 +69,7 @@ func TestClientTokenAuth(t *testing.T) {
 
 	is, isAddr := mock.NewIS(ctx)
 	is.Add(ctx, registeredGatewayID, registeredGatewayToken)
-	c := NewComponent(t, &component.Config{
+	c := componenttest.NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -80,7 +80,7 @@ func TestClientTokenAuth(t *testing.T) {
 			},
 		},
 	})
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 	gs := mock.NewServer(c)
@@ -172,7 +172,7 @@ func TestDiscover(t *testing.T) {
 
 	is, isAddr := mock.NewIS(ctx)
 	is.Add(ctx, registeredGatewayID, registeredGatewayToken)
-	c := NewComponent(t, &component.Config{
+	c := componenttest.NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -183,7 +183,7 @@ func TestDiscover(t *testing.T) {
 			},
 		},
 	})
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 	gs := mock.NewServer(c)
@@ -410,7 +410,7 @@ func TestVersion(t *testing.T) {
 
 	is, isAddr := mock.NewIS(ctx)
 	is.Add(ctx, registeredGatewayID, registeredGatewayToken)
-	c := NewComponent(t, &component.Config{
+	c := componenttest.NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -421,7 +421,7 @@ func TestVersion(t *testing.T) {
 			},
 		},
 	})
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 	gs := mock.NewServer(c)
@@ -706,7 +706,7 @@ func TestTraffic(t *testing.T) {
 
 	is, isAddr := mock.NewIS(ctx)
 	is.Add(ctx, registeredGatewayID, registeredGatewayToken)
-	c := NewComponent(t, &component.Config{
+	c := componenttest.NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -717,7 +717,7 @@ func TestTraffic(t *testing.T) {
 			},
 		},
 	})
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 	gs := mock.NewServer(c)
@@ -1036,7 +1036,7 @@ func TestRTT(t *testing.T) {
 
 	is, isAddr := mock.NewIS(ctx)
 	is.Add(ctx, registeredGatewayID, registeredGatewayToken)
-	c := NewComponent(t, &component.Config{
+	c := componenttest.NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -1047,7 +1047,7 @@ func TestRTT(t *testing.T) {
 			},
 		},
 	})
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 	gs := mock.NewServer(c)

--- a/pkg/gatewayserver/io/grpc/grpc_test.go
+++ b/pkg/gatewayserver/io/grpc/grpc_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/gatewayserver/io"
@@ -55,7 +56,7 @@ func TestAuthentication(t *testing.T) {
 	is, isAddr := mock.NewIS(ctx)
 	is.Add(ctx, registeredGatewayID, registeredGatewayKey)
 
-	c := component.MustNew(test.GetLogger(t), &component.Config{
+	c := NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -69,7 +70,7 @@ func TestAuthentication(t *testing.T) {
 	gs := mock.NewServer(c)
 	srv := New(gs)
 	c.RegisterGRPC(&mockRegisterer{ctx, srv})
-	test.Must(nil, c.Start())
+	StartComponent(t, c)
 	defer c.Close()
 
 	eui := types.EUI64{0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01}
@@ -150,7 +151,7 @@ func TestTraffic(t *testing.T) {
 	is, isAddr := mock.NewIS(ctx)
 	is.Add(ctx, registeredGatewayID, registeredGatewayKey)
 
-	c := component.MustNew(test.GetLogger(t), &component.Config{
+	c := NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -164,7 +165,7 @@ func TestTraffic(t *testing.T) {
 	gs := mock.NewServer(c)
 	srv := New(gs)
 	c.RegisterGRPC(&mockRegisterer{ctx, srv})
-	test.Must(nil, c.Start())
+	StartComponent(t, c)
 	defer c.Close()
 
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
@@ -412,7 +413,7 @@ func TestConcentratorConfig(t *testing.T) {
 	is, isAddr := mock.NewIS(ctx)
 	is.Add(ctx, registeredGatewayID, registeredGatewayKey)
 
-	c := component.MustNew(test.GetLogger(t), &component.Config{
+	c := NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -426,7 +427,7 @@ func TestConcentratorConfig(t *testing.T) {
 	gs := mock.NewServer(c)
 	srv := New(gs)
 	c.RegisterGRPC(&mockRegisterer{ctx, srv})
-	test.Must(nil, c.Start())
+	StartComponent(t, c)
 	defer c.Close()
 
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)

--- a/pkg/gatewayserver/io/grpc/grpc_test.go
+++ b/pkg/gatewayserver/io/grpc/grpc_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/gatewayserver/io"
@@ -56,7 +56,7 @@ func TestAuthentication(t *testing.T) {
 	is, isAddr := mock.NewIS(ctx)
 	is.Add(ctx, registeredGatewayID, registeredGatewayKey)
 
-	c := NewComponent(t, &component.Config{
+	c := componenttest.NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -70,7 +70,7 @@ func TestAuthentication(t *testing.T) {
 	gs := mock.NewServer(c)
 	srv := New(gs)
 	c.RegisterGRPC(&mockRegisterer{ctx, srv})
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 
 	eui := types.EUI64{0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01}
@@ -151,7 +151,7 @@ func TestTraffic(t *testing.T) {
 	is, isAddr := mock.NewIS(ctx)
 	is.Add(ctx, registeredGatewayID, registeredGatewayKey)
 
-	c := NewComponent(t, &component.Config{
+	c := componenttest.NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -165,7 +165,7 @@ func TestTraffic(t *testing.T) {
 	gs := mock.NewServer(c)
 	srv := New(gs)
 	c.RegisterGRPC(&mockRegisterer{ctx, srv})
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
@@ -413,7 +413,7 @@ func TestConcentratorConfig(t *testing.T) {
 	is, isAddr := mock.NewIS(ctx)
 	is.Add(ctx, registeredGatewayID, registeredGatewayKey)
 
-	c := NewComponent(t, &component.Config{
+	c := componenttest.NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -427,7 +427,7 @@ func TestConcentratorConfig(t *testing.T) {
 	gs := mock.NewServer(c)
 	srv := New(gs)
 	c.RegisterGRPC(&mockRegisterer{ctx, srv})
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)

--- a/pkg/gatewayserver/io/io_test.go
+++ b/pkg/gatewayserver/io/io_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/gatewayserver/io"
 	"go.thethings.network/lorawan-stack/pkg/gatewayserver/io/mock"
@@ -41,7 +41,7 @@ func Test(t *testing.T) {
 	a := assertions.New(t)
 	ctx := log.NewContext(test.Context(), test.GetLogger(t))
 
-	c := NewComponent(t, &component.Config{})
+	c := componenttest.NewComponent(t, &component.Config{})
 	gs := mock.NewServer(c)
 
 	ids := ttnpb.GatewayIdentifiers{GatewayID: "foo-gateway"}

--- a/pkg/gatewayserver/io/io_test.go
+++ b/pkg/gatewayserver/io/io_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/gatewayserver/io"
 	"go.thethings.network/lorawan-stack/pkg/gatewayserver/io/mock"
@@ -40,7 +41,7 @@ func Test(t *testing.T) {
 	a := assertions.New(t)
 	ctx := log.NewContext(test.Context(), test.GetLogger(t))
 
-	c := component.MustNew(test.GetLogger(t), &component.Config{})
+	c := NewComponent(t, &component.Config{})
 	gs := mock.NewServer(c)
 
 	ids := ttnpb.GatewayIdentifiers{GatewayID: "foo-gateway"}

--- a/pkg/gatewayserver/io/mqtt/mqtt_test.go
+++ b/pkg/gatewayserver/io/mqtt/mqtt_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/gatewayserver/io"
@@ -56,7 +56,7 @@ func TestAuthentication(t *testing.T) {
 	is, isAddr := mock.NewIS(ctx)
 	is.Add(ctx, registeredGatewayID, registeredGatewayKey)
 
-	c := NewComponent(t, &component.Config{
+	c := componenttest.NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -67,7 +67,7 @@ func TestAuthentication(t *testing.T) {
 			},
 		},
 	})
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 
@@ -129,7 +129,7 @@ func TestTraffic(t *testing.T) {
 	is, isAddr := mock.NewIS(ctx)
 	is.Add(ctx, registeredGatewayID, registeredGatewayKey)
 
-	c := NewComponent(t, &component.Config{
+	c := componenttest.NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -140,7 +140,7 @@ func TestTraffic(t *testing.T) {
 			},
 		},
 	})
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 

--- a/pkg/gatewayserver/io/mqtt/mqtt_test.go
+++ b/pkg/gatewayserver/io/mqtt/mqtt_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/gatewayserver/io"
@@ -55,7 +56,7 @@ func TestAuthentication(t *testing.T) {
 	is, isAddr := mock.NewIS(ctx)
 	is.Add(ctx, registeredGatewayID, registeredGatewayKey)
 
-	c := component.MustNew(test.GetLogger(t), &component.Config{
+	c := NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -66,7 +67,7 @@ func TestAuthentication(t *testing.T) {
 			},
 		},
 	})
-	test.Must(nil, c.Start())
+	StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 
@@ -128,7 +129,7 @@ func TestTraffic(t *testing.T) {
 	is, isAddr := mock.NewIS(ctx)
 	is.Add(ctx, registeredGatewayID, registeredGatewayKey)
 
-	c := component.MustNew(test.GetLogger(t), &component.Config{
+	c := NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -139,7 +140,7 @@ func TestTraffic(t *testing.T) {
 			},
 		},
 	})
-	test.Must(nil, c.Start())
+	StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 

--- a/pkg/gatewayserver/io/udp/udp_test.go
+++ b/pkg/gatewayserver/io/udp/udp_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/gatewayserver/io"
 	"go.thethings.network/lorawan-stack/pkg/gatewayserver/io/mock"
 	. "go.thethings.network/lorawan-stack/pkg/gatewayserver/io/udp"
@@ -58,8 +58,8 @@ func TestConnection(t *testing.T) {
 	ctx, cancelCtx := context.WithCancel(ctx)
 	defer cancelCtx()
 
-	c := NewComponent(t, &component.Config{})
-	StartComponent(t, c)
+	c := componenttest.NewComponent(t, &component.Config{})
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 
 	gs := mock.NewServer(c)
@@ -197,8 +197,8 @@ func TestTraffic(t *testing.T) {
 	ctx, cancelCtx := context.WithCancel(ctx)
 	defer cancelCtx()
 
-	c := NewComponent(t, &component.Config{})
-	StartComponent(t, c)
+	c := componenttest.NewComponent(t, &component.Config{})
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 
 	gs := mock.NewServer(c)

--- a/pkg/gatewayserver/io/udp/udp_test.go
+++ b/pkg/gatewayserver/io/udp/udp_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/gatewayserver/io"
 	"go.thethings.network/lorawan-stack/pkg/gatewayserver/io/mock"
 	. "go.thethings.network/lorawan-stack/pkg/gatewayserver/io/udp"
@@ -57,8 +58,8 @@ func TestConnection(t *testing.T) {
 	ctx, cancelCtx := context.WithCancel(ctx)
 	defer cancelCtx()
 
-	c := component.MustNew(test.GetLogger(t), &component.Config{})
-	test.Must(nil, c.Start())
+	c := NewComponent(t, &component.Config{})
+	StartComponent(t, c)
 	defer c.Close()
 
 	gs := mock.NewServer(c)
@@ -196,8 +197,8 @@ func TestTraffic(t *testing.T) {
 	ctx, cancelCtx := context.WithCancel(ctx)
 	defer cancelCtx()
 
-	c := component.MustNew(test.GetLogger(t), &component.Config{})
-	test.Must(nil, c.Start())
+	c := NewComponent(t, &component.Config{})
+	StartComponent(t, c)
 	defer c.Close()
 
 	gs := mock.NewServer(c)

--- a/pkg/gatewayserver/upstream/ns/ns_test.go
+++ b/pkg/gatewayserver/upstream/ns/ns_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/gatewayserver/upstream/mock"
 	"go.thethings.network/lorawan-stack/pkg/log"
@@ -38,7 +39,7 @@ func TestNSHandler(t *testing.T) {
 	defer cancel()
 	gtwIds := ttnpb.GatewayIdentifiers{GatewayID: "test-gateway"}
 	ns, nsAddr := mock.StartNS(ctx)
-	c := component.MustNew(test.GetLogger(t), &component.Config{
+	c := NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -49,7 +50,7 @@ func TestNSHandler(t *testing.T) {
 			},
 		},
 	})
-	test.Must(nil, c.Start())
+	StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_NETWORK_SERVER)
 	h := NewHandler(ctx, "cluster", c, nil)

--- a/pkg/gatewayserver/upstream/ns/ns_test.go
+++ b/pkg/gatewayserver/upstream/ns/ns_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/gatewayserver/upstream/mock"
 	"go.thethings.network/lorawan-stack/pkg/log"
@@ -39,7 +39,7 @@ func TestNSHandler(t *testing.T) {
 	defer cancel()
 	gtwIds := ttnpb.GatewayIdentifiers{GatewayID: "test-gateway"}
 	ns, nsAddr := mock.StartNS(ctx)
-	c := NewComponent(t, &component.Config{
+	c := componenttest.NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
@@ -50,7 +50,7 @@ func TestNSHandler(t *testing.T) {
 			},
 		},
 	})
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_NETWORK_SERVER)
 	h := NewHandler(ctx, "cluster", c, nil)

--- a/pkg/identityserver/identityserver_test.go
+++ b/pkg/identityserver/identityserver_test.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/identityserver/store"
 	"go.thethings.network/lorawan-stack/pkg/log"
@@ -291,7 +291,7 @@ func getIdentityServer(t *testing.T) (*IdentityServer, *grpc.ClientConn) {
 			panic(err)
 		}
 	})
-	c := NewComponent(t, &component.Config{ServiceBase: config.ServiceBase{
+	c := componenttest.NewComponent(t, &component.Config{ServiceBase: config.ServiceBase{
 		Base: config.Base{
 			Log: config.Log{
 				Level: log.DebugLevel,
@@ -312,7 +312,7 @@ func getIdentityServer(t *testing.T) (*IdentityServer, *grpc.ClientConn) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 	return is, is.LoopbackConn()
 }
 

--- a/pkg/identityserver/identityserver_test.go
+++ b/pkg/identityserver/identityserver_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/identityserver/store"
 	"go.thethings.network/lorawan-stack/pkg/log"
@@ -290,7 +291,7 @@ func getIdentityServer(t *testing.T) (*IdentityServer, *grpc.ClientConn) {
 			panic(err)
 		}
 	})
-	c := component.MustNew(test.GetLogger(t), &component.Config{ServiceBase: config.ServiceBase{
+	c := NewComponent(t, &component.Config{ServiceBase: config.ServiceBase{
 		Base: config.Base{
 			Log: config.Log{
 				Level: log.DebugLevel,

--- a/pkg/identityserver/identityserver_test.go
+++ b/pkg/identityserver/identityserver_test.go
@@ -310,11 +310,9 @@ func getIdentityServer(t *testing.T) (*IdentityServer, *grpc.ClientConn) {
 	}
 	is, err := New(c, conf)
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
-	if err = is.Start(); err != nil {
-		panic(err)
-	}
+	StartComponent(t, c)
 	return is, is.LoopbackConn()
 }
 

--- a/pkg/joinserver/grpc_deviceregistry_test.go
+++ b/pkg/joinserver/grpc_deviceregistry_test.go
@@ -318,7 +318,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			js.AddContextFiller(func(ctx context.Context) context.Context {
 				return test.ContextWithT(ctx, t)
 			})
-			test.Must(nil, js.Start())
+			StartComponent(t, js.Component)
 			defer js.Close()
 
 			ctx := js.FillContext(test.Context())
@@ -650,7 +650,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			js.AddContextFiller(func(ctx context.Context) context.Context {
 				return test.ContextWithT(ctx, t)
 			})
-			test.Must(nil, js.Start())
+			StartComponent(t, js.Component)
 			defer js.Close()
 
 			ctx := js.FillContext(test.Context())
@@ -859,7 +859,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			js.AddContextFiller(func(ctx context.Context) context.Context {
 				return test.ContextWithT(ctx, t)
 			})
-			test.Must(nil, js.Start())
+			StartComponent(t, js.Component)
 			defer js.Close()
 
 			ctx := js.FillContext(test.Context())

--- a/pkg/joinserver/grpc_deviceregistry_test.go
+++ b/pkg/joinserver/grpc_deviceregistry_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/crypto/cryptoutil"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	. "go.thethings.network/lorawan-stack/pkg/joinserver"
@@ -297,7 +297,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			var getByIDCalls uint64
 
 			js := test.Must(New(
-				NewComponent(t, &component.Config{}),
+				componenttest.NewComponent(t, &component.Config{}),
 				&Config{
 					Devices: &MockDeviceRegistry{
 						GetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, paths []string) (*ttnpb.EndDevice, error) {
@@ -318,7 +318,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			js.AddContextFiller(func(ctx context.Context) context.Context {
 				return test.ContextWithT(ctx, t)
 			})
-			StartComponent(t, js.Component)
+			componenttest.StartComponent(t, js.Component)
 			defer js.Close()
 
 			ctx := js.FillContext(test.Context())
@@ -629,7 +629,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			var setByIDCalls uint64
 
 			js := test.Must(New(
-				NewComponent(t, &component.Config{}),
+				componenttest.NewComponent(t, &component.Config{}),
 				&Config{
 					Devices: &MockDeviceRegistry{
 						SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, paths []string, cb func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
@@ -650,7 +650,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			js.AddContextFiller(func(ctx context.Context) context.Context {
 				return test.ContextWithT(ctx, t)
 			})
-			StartComponent(t, js.Component)
+			componenttest.StartComponent(t, js.Component)
 			defer js.Close()
 
 			ctx := js.FillContext(test.Context())
@@ -838,7 +838,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			var setByIDCalls uint64
 
 			js := test.Must(New(
-				NewComponent(t, &component.Config{}),
+				componenttest.NewComponent(t, &component.Config{}),
 				&Config{
 					Devices: &MockDeviceRegistry{
 						SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, paths []string, cb func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
@@ -859,7 +859,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			js.AddContextFiller(func(ctx context.Context) context.Context {
 				return test.ContextWithT(ctx, t)
 			})
-			StartComponent(t, js.Component)
+			componenttest.StartComponent(t, js.Component)
 			defer js.Close()
 
 			ctx := js.FillContext(test.Context())

--- a/pkg/joinserver/grpc_deviceregistry_test.go
+++ b/pkg/joinserver/grpc_deviceregistry_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/crypto/cryptoutil"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	. "go.thethings.network/lorawan-stack/pkg/joinserver"
@@ -296,7 +297,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			var getByIDCalls uint64
 
 			js := test.Must(New(
-				component.MustNew(test.GetLogger(t), &component.Config{}),
+				NewComponent(t, &component.Config{}),
 				&Config{
 					Devices: &MockDeviceRegistry{
 						GetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, paths []string) (*ttnpb.EndDevice, error) {
@@ -628,7 +629,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			var setByIDCalls uint64
 
 			js := test.Must(New(
-				component.MustNew(test.GetLogger(t), &component.Config{}),
+				NewComponent(t, &component.Config{}),
 				&Config{
 					Devices: &MockDeviceRegistry{
 						SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, paths []string, cb func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
@@ -837,7 +838,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			var setByIDCalls uint64
 
 			js := test.Must(New(
-				component.MustNew(test.GetLogger(t), &component.Config{}),
+				NewComponent(t, &component.Config{}),
 				&Config{
 					Devices: &MockDeviceRegistry{
 						SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, paths []string, cb func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {

--- a/pkg/joinserver/grpc_test.go
+++ b/pkg/joinserver/grpc_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	. "go.thethings.network/lorawan-stack/pkg/joinserver"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/types"
@@ -83,11 +83,11 @@ func TestGetJoinEUIPrefixes(t *testing.T) {
 			a := assertions.New(t)
 
 			js := test.Must(New(
-				NewComponent(t, &component.Config{}),
+				componenttest.NewComponent(t, &component.Config{}),
 				&Config{
 					JoinEUIPrefixes: tc.JoinEUIPrefixes,
 				})).(*JoinServer)
-			StartComponent(t, js.Component)
+			componenttest.StartComponent(t, js.Component)
 			defer js.Close()
 
 			resp, err := ttnpb.NewJsClient(js.LoopbackConn()).GetJoinEUIPrefixes(test.Context(), ttnpb.Empty)

--- a/pkg/joinserver/grpc_test.go
+++ b/pkg/joinserver/grpc_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	. "go.thethings.network/lorawan-stack/pkg/joinserver"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/types"
@@ -82,7 +83,7 @@ func TestGetJoinEUIPrefixes(t *testing.T) {
 			a := assertions.New(t)
 
 			js := test.Must(New(
-				component.MustNew(test.GetLogger(t), &component.Config{}),
+				NewComponent(t, &component.Config{}),
 				&Config{
 					JoinEUIPrefixes: tc.JoinEUIPrefixes,
 				})).(*JoinServer)

--- a/pkg/joinserver/grpc_test.go
+++ b/pkg/joinserver/grpc_test.go
@@ -87,7 +87,7 @@ func TestGetJoinEUIPrefixes(t *testing.T) {
 				&Config{
 					JoinEUIPrefixes: tc.JoinEUIPrefixes,
 				})).(*JoinServer)
-			test.Must(nil, js.Start())
+			StartComponent(t, js.Component)
 			defer js.Close()
 
 			resp, err := ttnpb.NewJsClient(js.LoopbackConn()).GetJoinEUIPrefixes(test.Context(), ttnpb.Empty)

--- a/pkg/joinserver/joinserver_test.go
+++ b/pkg/joinserver/joinserver_test.go
@@ -26,7 +26,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/auth"
 	clusterauth "go.thethings.network/lorawan-stack/pkg/auth/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/crypto"
 	"go.thethings.network/lorawan-stack/pkg/errors"
@@ -71,7 +71,7 @@ func TestHandleJoin(t *testing.T) {
 	devReg := &redis.DeviceRegistry{Redis: redisClient}
 	keyReg := &redis.KeyRegistry{Redis: redisClient}
 
-	c := NewComponent(t, &component.Config{})
+	c := componenttest.NewComponent(t, &component.Config{})
 	js := test.Must(New(
 		c,
 		&Config{
@@ -80,7 +80,7 @@ func TestHandleJoin(t *testing.T) {
 			JoinEUIPrefixes: joinEUIPrefixes,
 		},
 	)).(*JoinServer)
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 
 	{
 		ctx := clusterauth.NewContext(ctx, nil)
@@ -1629,7 +1629,7 @@ func TestHandleJoin(t *testing.T) {
 			devReg := &redis.DeviceRegistry{Redis: redisClient}
 			keyReg := &redis.KeyRegistry{Redis: redisClient}
 
-			c := NewComponent(t, &component.Config{
+			c := componenttest.NewComponent(t, &component.Config{
 				ServiceBase: config.ServiceBase{
 					KeyVault: config.KeyVault{
 						Static: tc.KeyVault,
@@ -1644,7 +1644,7 @@ func TestHandleJoin(t *testing.T) {
 					JoinEUIPrefixes: joinEUIPrefixes,
 				},
 			)).(*JoinServer)
-			StartComponent(t, c)
+			componenttest.StartComponent(t, c)
 
 			pb := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
 
@@ -1929,7 +1929,7 @@ func TestGetNwkSKeys(t *testing.T) {
 			a := assertions.New(t)
 			ctx := test.ContextWithT(tc.ContextFunc(ctx), t)
 
-			c := NewComponent(t, &component.Config{})
+			c := componenttest.NewComponent(t, &component.Config{})
 			js := test.Must(New(
 				c,
 				&Config{
@@ -1937,7 +1937,7 @@ func TestGetNwkSKeys(t *testing.T) {
 					Devices: &MockDeviceRegistry{},
 				},
 			)).(*JoinServer)
-			StartComponent(t, c)
+			componenttest.StartComponent(t, c)
 			res, err := js.GetNwkSKeys(ctx, tc.KeyRequest)
 
 			if tc.ErrorAssertion != nil {
@@ -2193,7 +2193,7 @@ func TestGetAppSKey(t *testing.T) {
 			ctx := test.ContextWithT(tc.ContextFunc(ctx), t)
 
 			js := test.Must(New(
-				NewComponent(t, &component.Config{}),
+				componenttest.NewComponent(t, &component.Config{}),
 				&Config{
 					Keys:    &MockKeyRegistry{GetByIDFunc: tc.GetKeyByID},
 					Devices: &MockDeviceRegistry{GetByEUIFunc: tc.GetDeviceByEUI},
@@ -2280,7 +2280,7 @@ func TestGetHomeNetID(t *testing.T) {
 			ctx := test.ContextWithT(tc.ContextFunc(ctx), t)
 
 			js := test.Must(New(
-				NewComponent(t, &component.Config{}),
+				componenttest.NewComponent(t, &component.Config{}),
 				&Config{
 					Devices: &MockDeviceRegistry{
 						GetByEUIFunc: tc.GetByEUI,

--- a/pkg/joinserver/joinserver_test.go
+++ b/pkg/joinserver/joinserver_test.go
@@ -26,6 +26,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/auth"
 	clusterauth "go.thethings.network/lorawan-stack/pkg/auth/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/crypto"
 	"go.thethings.network/lorawan-stack/pkg/errors"
@@ -70,7 +71,7 @@ func TestHandleJoin(t *testing.T) {
 	devReg := &redis.DeviceRegistry{Redis: redisClient}
 	keyReg := &redis.KeyRegistry{Redis: redisClient}
 
-	c := component.MustNew(test.GetLogger(t), &component.Config{})
+	c := NewComponent(t, &component.Config{})
 	js := test.Must(New(
 		c,
 		&Config{
@@ -79,7 +80,7 @@ func TestHandleJoin(t *testing.T) {
 			JoinEUIPrefixes: joinEUIPrefixes,
 		},
 	)).(*JoinServer)
-	test.Must(nil, c.Start())
+	StartComponent(t, c)
 
 	{
 		ctx := clusterauth.NewContext(ctx, nil)
@@ -1628,7 +1629,7 @@ func TestHandleJoin(t *testing.T) {
 			devReg := &redis.DeviceRegistry{Redis: redisClient}
 			keyReg := &redis.KeyRegistry{Redis: redisClient}
 
-			c := component.MustNew(test.GetLogger(t), &component.Config{
+			c := NewComponent(t, &component.Config{
 				ServiceBase: config.ServiceBase{
 					KeyVault: config.KeyVault{
 						Static: tc.KeyVault,
@@ -1643,7 +1644,7 @@ func TestHandleJoin(t *testing.T) {
 					JoinEUIPrefixes: joinEUIPrefixes,
 				},
 			)).(*JoinServer)
-			test.Must(nil, c.Start())
+			StartComponent(t, c)
 
 			pb := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
 
@@ -1928,7 +1929,7 @@ func TestGetNwkSKeys(t *testing.T) {
 			a := assertions.New(t)
 			ctx := test.ContextWithT(tc.ContextFunc(ctx), t)
 
-			c := component.MustNew(test.GetLogger(t), &component.Config{})
+			c := NewComponent(t, &component.Config{})
 			js := test.Must(New(
 				c,
 				&Config{
@@ -1936,7 +1937,7 @@ func TestGetNwkSKeys(t *testing.T) {
 					Devices: &MockDeviceRegistry{},
 				},
 			)).(*JoinServer)
-			test.Must(nil, c.Start())
+			StartComponent(t, c)
 			res, err := js.GetNwkSKeys(ctx, tc.KeyRequest)
 
 			if tc.ErrorAssertion != nil {
@@ -2192,7 +2193,7 @@ func TestGetAppSKey(t *testing.T) {
 			ctx := test.ContextWithT(tc.ContextFunc(ctx), t)
 
 			js := test.Must(New(
-				component.MustNew(test.GetLogger(t), &component.Config{}),
+				NewComponent(t, &component.Config{}),
 				&Config{
 					Keys:    &MockKeyRegistry{GetByIDFunc: tc.GetKeyByID},
 					Devices: &MockDeviceRegistry{GetByEUIFunc: tc.GetDeviceByEUI},
@@ -2279,7 +2280,7 @@ func TestGetHomeNetID(t *testing.T) {
 			ctx := test.ContextWithT(tc.ContextFunc(ctx), t)
 
 			js := test.Must(New(
-				component.MustNew(test.GetLogger(t), &component.Config{}),
+				NewComponent(t, &component.Config{}),
 				&Config{
 					Devices: &MockDeviceRegistry{
 						GetByEUIFunc: tc.GetByEUI,

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -29,7 +29,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/band"
 	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/crypto"
 	"go.thethings.network/lorawan-stack/pkg/encoding/lorawan"
@@ -5885,7 +5885,7 @@ func TestGenerateDownlink(t *testing.T) {
 			)
 			c.FrequencyPlans = frequencyplans.NewStore(test.FrequencyPlansFetcher)
 
-			StartComponent(t, c)
+			componenttest.StartComponent(t, c)
 
 			ns := &NetworkServer{
 				Component: c,

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -29,6 +29,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/band"
 	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/crypto"
 	"go.thethings.network/lorawan-stack/pkg/encoding/lorawan"
@@ -5883,8 +5884,8 @@ func TestGenerateDownlink(t *testing.T) {
 				}),
 			)
 			c.FrequencyPlans = frequencyplans.NewStore(test.FrequencyPlansFetcher)
-			err := c.Start()
-			a.So(err, should.BeNil)
+
+			StartComponent(t, c)
 
 			ns := &NetworkServer{
 				Component: c,

--- a/pkg/networkserver/grpc_asns_test.go
+++ b/pkg/networkserver/grpc_asns_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/events"
 	. "go.thethings.network/lorawan-stack/pkg/networkserver"
@@ -714,7 +715,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 			var addCalls, setByIDCalls uint64
 
 			ns := test.Must(New(
-				component.MustNew(test.GetLogger(t), &component.Config{}),
+				NewComponent(t, &component.Config{}),
 				&Config{
 					Devices: &MockDeviceRegistry{
 						SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
@@ -1393,7 +1394,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 			var addCalls, setByIDCalls uint64
 
 			ns := test.Must(New(
-				component.MustNew(test.GetLogger(t), &component.Config{}),
+				NewComponent(t, &component.Config{}),
 				&Config{
 					Devices: &MockDeviceRegistry{
 						SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
@@ -1572,7 +1573,7 @@ func TestDownlinkQueueList(t *testing.T) {
 			var getByIDCalls uint64
 
 			ns := test.Must(New(
-				component.MustNew(test.GetLogger(t), &component.Config{}),
+				NewComponent(t, &component.Config{}),
 				&Config{
 					Devices: &MockDeviceRegistry{
 						GetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, error) {

--- a/pkg/networkserver/grpc_asns_test.go
+++ b/pkg/networkserver/grpc_asns_test.go
@@ -743,7 +743,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 			ns.AddContextFiller(func(ctx context.Context) context.Context {
 				return test.ContextWithT(ctx, t)
 			})
-			test.Must(nil, ns.Start())
+			StartComponent(t, ns.Component)
 			defer ns.Close()
 
 			req := deepcopy.Copy(tc.Request).(*ttnpb.DownlinkQueueRequest)
@@ -1422,8 +1422,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 			ns.AddContextFiller(func(ctx context.Context) context.Context {
 				return test.ContextWithT(ctx, t)
 			})
-			test.Must(nil, ns.Start())
-			defer ns.Close()
+			StartComponent(t, ns.Component)
 
 			req := deepcopy.Copy(tc.Request).(*ttnpb.DownlinkQueueRequest)
 
@@ -1597,7 +1596,7 @@ func TestDownlinkQueueList(t *testing.T) {
 			ns.AddContextFiller(func(ctx context.Context) context.Context {
 				return test.ContextWithT(ctx, t)
 			})
-			test.Must(nil, ns.Start())
+			StartComponent(t, ns.Component)
 			defer ns.Close()
 
 			req := deepcopy.Copy(tc.Request).(*ttnpb.EndDeviceIdentifiers)

--- a/pkg/networkserver/grpc_asns_test.go
+++ b/pkg/networkserver/grpc_asns_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/events"
 	. "go.thethings.network/lorawan-stack/pkg/networkserver"
@@ -715,7 +715,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 			var addCalls, setByIDCalls uint64
 
 			ns := test.Must(New(
-				NewComponent(t, &component.Config{}),
+				componenttest.NewComponent(t, &component.Config{}),
 				&Config{
 					Devices: &MockDeviceRegistry{
 						SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
@@ -743,7 +743,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 			ns.AddContextFiller(func(ctx context.Context) context.Context {
 				return test.ContextWithT(ctx, t)
 			})
-			StartComponent(t, ns.Component)
+			componenttest.StartComponent(t, ns.Component)
 			defer ns.Close()
 
 			req := deepcopy.Copy(tc.Request).(*ttnpb.DownlinkQueueRequest)
@@ -1394,7 +1394,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 			var addCalls, setByIDCalls uint64
 
 			ns := test.Must(New(
-				NewComponent(t, &component.Config{}),
+				componenttest.NewComponent(t, &component.Config{}),
 				&Config{
 					Devices: &MockDeviceRegistry{
 						SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
@@ -1422,7 +1422,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 			ns.AddContextFiller(func(ctx context.Context) context.Context {
 				return test.ContextWithT(ctx, t)
 			})
-			StartComponent(t, ns.Component)
+			componenttest.StartComponent(t, ns.Component)
 
 			req := deepcopy.Copy(tc.Request).(*ttnpb.DownlinkQueueRequest)
 
@@ -1572,7 +1572,7 @@ func TestDownlinkQueueList(t *testing.T) {
 			var getByIDCalls uint64
 
 			ns := test.Must(New(
-				NewComponent(t, &component.Config{}),
+				componenttest.NewComponent(t, &component.Config{}),
 				&Config{
 					Devices: &MockDeviceRegistry{
 						GetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, error) {
@@ -1596,7 +1596,7 @@ func TestDownlinkQueueList(t *testing.T) {
 			ns.AddContextFiller(func(ctx context.Context) context.Context {
 				return test.ContextWithT(ctx, t)
 			})
-			StartComponent(t, ns.Component)
+			componenttest.StartComponent(t, ns.Component)
 			defer ns.Close()
 
 			req := deepcopy.Copy(tc.Request).(*ttnpb.EndDeviceIdentifiers)

--- a/pkg/networkserver/grpc_deviceregistry_test.go
+++ b/pkg/networkserver/grpc_deviceregistry_test.go
@@ -190,7 +190,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			ns.AddContextFiller(func(ctx context.Context) context.Context {
 				return test.ContextWithT(ctx, t)
 			})
-			test.Must(nil, ns.Start())
+			StartComponent(t, ns.Component)
 			defer ns.Close()
 
 			req := deepcopy.Copy(tc.Request).(*ttnpb.GetEndDeviceRequest)
@@ -1111,7 +1111,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			ns.AddContextFiller(func(ctx context.Context) context.Context {
 				return test.ContextWithT(ctx, t)
 			})
-			test.Must(nil, ns.Start())
+			StartComponent(t, ns.Component)
 			defer ns.Close()
 
 			ctx := ns.FillContext(test.Context())
@@ -1273,7 +1273,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			ns.AddContextFiller(func(ctx context.Context) context.Context {
 				return test.ContextWithT(ctx, t)
 			})
-			test.Must(nil, ns.Start())
+			StartComponent(t, ns.Component)
 			defer ns.Close()
 
 			req := deepcopy.Copy(tc.Request).(*ttnpb.EndDeviceIdentifiers)

--- a/pkg/networkserver/grpc_deviceregistry_test.go
+++ b/pkg/networkserver/grpc_deviceregistry_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/frequencyplans"
@@ -159,7 +160,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			var getByIDCalls uint64
 
 			ns := test.Must(New(
-				component.MustNew(test.GetLogger(t), &component.Config{
+				NewComponent(t, &component.Config{
 					ServiceBase: config.ServiceBase{
 						KeyVault: config.KeyVault{
 							Static: tc.KeyVault,
@@ -1085,7 +1086,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			var setByIDCalls uint64
 
 			ns := test.Must(New(
-				component.MustNew(test.GetLogger(t), &component.Config{}),
+				NewComponent(t, &component.Config{}),
 				&Config{
 					Devices: &MockDeviceRegistry{
 						SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
@@ -1248,7 +1249,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			var setByIDCalls uint64
 
 			ns := test.Must(New(
-				component.MustNew(test.GetLogger(t), &component.Config{}),
+				NewComponent(t, &component.Config{}),
 				&Config{
 					Devices: &MockDeviceRegistry{
 						SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {

--- a/pkg/networkserver/grpc_deviceregistry_test.go
+++ b/pkg/networkserver/grpc_deviceregistry_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/frequencyplans"
@@ -160,7 +160,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			var getByIDCalls uint64
 
 			ns := test.Must(New(
-				NewComponent(t, &component.Config{
+				componenttest.NewComponent(t, &component.Config{
 					ServiceBase: config.ServiceBase{
 						KeyVault: config.KeyVault{
 							Static: tc.KeyVault,
@@ -190,7 +190,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			ns.AddContextFiller(func(ctx context.Context) context.Context {
 				return test.ContextWithT(ctx, t)
 			})
-			StartComponent(t, ns.Component)
+			componenttest.StartComponent(t, ns.Component)
 			defer ns.Close()
 
 			req := deepcopy.Copy(tc.Request).(*ttnpb.GetEndDeviceRequest)
@@ -1086,7 +1086,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			var setByIDCalls uint64
 
 			ns := test.Must(New(
-				NewComponent(t, &component.Config{}),
+				componenttest.NewComponent(t, &component.Config{}),
 				&Config{
 					Devices: &MockDeviceRegistry{
 						SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
@@ -1111,7 +1111,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			ns.AddContextFiller(func(ctx context.Context) context.Context {
 				return test.ContextWithT(ctx, t)
 			})
-			StartComponent(t, ns.Component)
+			componenttest.StartComponent(t, ns.Component)
 			defer ns.Close()
 
 			ctx := ns.FillContext(test.Context())
@@ -1249,7 +1249,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			var setByIDCalls uint64
 
 			ns := test.Must(New(
-				NewComponent(t, &component.Config{}),
+				componenttest.NewComponent(t, &component.Config{}),
 				&Config{
 					Devices: &MockDeviceRegistry{
 						SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
@@ -1273,7 +1273,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			ns.AddContextFiller(func(ctx context.Context) context.Context {
 				return test.ContextWithT(ctx, t)
 			})
-			StartComponent(t, ns.Component)
+			componenttest.StartComponent(t, ns.Component)
 			defer ns.Close()
 
 			req := deepcopy.Copy(tc.Request).(*ttnpb.EndDeviceIdentifiers)

--- a/pkg/networkserver/grpc_gsns_internal_test.go
+++ b/pkg/networkserver/grpc_gsns_internal_test.go
@@ -22,6 +22,7 @@ import (
 	pbtypes "github.com/gogo/protobuf/types"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/encoding/lorawan"
 	"go.thethings.network/lorawan-stack/pkg/events"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
@@ -36,7 +37,7 @@ func TestNewDevAddr(t *testing.T) {
 	// Use DevAddr prefix from NetID.
 	{
 		ns := test.Must(New(
-			component.MustNew(test.GetLogger(t), &component.Config{}),
+			NewComponent(t, &component.Config{}),
 			&Config{
 				NetID:               types.NetID{0x00, 0x00, 0x13},
 				DeduplicationWindow: 42,
@@ -61,7 +62,7 @@ func TestNewDevAddr(t *testing.T) {
 	// Configured DevAddr prefixes.
 	{
 		ns := test.Must(New(
-			component.MustNew(test.GetLogger(t), &component.Config{}),
+			NewComponent(t, &component.Config{}),
 			&Config{
 				NetID: types.NetID{0x00, 0x00, 0x13},
 				DevAddrPrefixes: []types.DevAddrPrefix{

--- a/pkg/networkserver/grpc_gsns_internal_test.go
+++ b/pkg/networkserver/grpc_gsns_internal_test.go
@@ -22,7 +22,7 @@ import (
 	pbtypes "github.com/gogo/protobuf/types"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/encoding/lorawan"
 	"go.thethings.network/lorawan-stack/pkg/events"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
@@ -37,7 +37,7 @@ func TestNewDevAddr(t *testing.T) {
 	// Use DevAddr prefix from NetID.
 	{
 		ns := test.Must(New(
-			NewComponent(t, &component.Config{}),
+			componenttest.NewComponent(t, &component.Config{}),
 			&Config{
 				NetID:               types.NetID{0x00, 0x00, 0x13},
 				DeduplicationWindow: 42,
@@ -62,7 +62,7 @@ func TestNewDevAddr(t *testing.T) {
 	// Configured DevAddr prefixes.
 	{
 		ns := test.Must(New(
-			NewComponent(t, &component.Config{}),
+			componenttest.NewComponent(t, &component.Config{}),
 			&Config{
 				NetID: types.NetID{0x00, 0x00, 0x13},
 				DevAddrPrefixes: []types.DevAddrPrefix{

--- a/pkg/networkserver/grpc_test.go
+++ b/pkg/networkserver/grpc_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	. "go.thethings.network/lorawan-stack/pkg/networkserver"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/types"
@@ -61,7 +62,7 @@ func TestGenerateDevAddr(t *testing.T) {
 			a := assertions.New(t)
 
 			ns := test.Must(New(
-				component.MustNew(test.GetLogger(t), &component.Config{}),
+				NewComponent(t, &component.Config{}),
 				&Config{
 					NetID:               tc.NetID,
 					DeduplicationWindow: 42,
@@ -139,7 +140,7 @@ func TestGenerateDevAddr(t *testing.T) {
 			a := assertions.New(t)
 
 			ns := test.Must(New(
-				component.MustNew(test.GetLogger(t), &component.Config{}),
+				NewComponent(t, &component.Config{}),
 				&Config{
 					NetID:               types.NetID{0x00, 0x00, 0x13},
 					DevAddrPrefixes:     tc.DevAddrPrefixes,

--- a/pkg/networkserver/grpc_test.go
+++ b/pkg/networkserver/grpc_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	. "go.thethings.network/lorawan-stack/pkg/networkserver"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/types"
@@ -62,7 +62,7 @@ func TestGenerateDevAddr(t *testing.T) {
 			a := assertions.New(t)
 
 			ns := test.Must(New(
-				NewComponent(t, &component.Config{}),
+				componenttest.NewComponent(t, &component.Config{}),
 				&Config{
 					NetID:               tc.NetID,
 					DeduplicationWindow: 42,
@@ -72,7 +72,7 @@ func TestGenerateDevAddr(t *testing.T) {
 					},
 				})).(*NetworkServer)
 
-			StartComponent(t, ns.Component)
+			componenttest.StartComponent(t, ns.Component)
 			defer ns.Close()
 
 			devAddr, err := ttnpb.NewNsClient(ns.LoopbackConn()).GenerateDevAddr(test.Context(), ttnpb.Empty)
@@ -140,7 +140,7 @@ func TestGenerateDevAddr(t *testing.T) {
 			a := assertions.New(t)
 
 			ns := test.Must(New(
-				NewComponent(t, &component.Config{}),
+				componenttest.NewComponent(t, &component.Config{}),
 				&Config{
 					NetID:               types.NetID{0x00, 0x00, 0x13},
 					DevAddrPrefixes:     tc.DevAddrPrefixes,
@@ -151,7 +151,7 @@ func TestGenerateDevAddr(t *testing.T) {
 					},
 				})).(*NetworkServer)
 
-			StartComponent(t, ns.Component)
+			componenttest.StartComponent(t, ns.Component)
 			defer ns.Close()
 
 			hasOneOfPrefixes := func(devAddr *types.DevAddr, seen map[types.DevAddrPrefix]int, prefixes ...types.DevAddrPrefix) bool {

--- a/pkg/networkserver/grpc_test.go
+++ b/pkg/networkserver/grpc_test.go
@@ -72,7 +72,7 @@ func TestGenerateDevAddr(t *testing.T) {
 					},
 				})).(*NetworkServer)
 
-			test.Must(nil, ns.Start())
+			StartComponent(t, ns.Component)
 			defer ns.Close()
 
 			devAddr, err := ttnpb.NewNsClient(ns.LoopbackConn()).GenerateDevAddr(test.Context(), ttnpb.Empty)
@@ -151,7 +151,7 @@ func TestGenerateDevAddr(t *testing.T) {
 					},
 				})).(*NetworkServer)
 
-			test.Must(nil, ns.Start())
+			StartComponent(t, ns.Component)
 			defer ns.Close()
 
 			hasOneOfPrefixes := func(devAddr *types.DevAddr, seen map[types.DevAddrPrefix]int, prefixes ...types.DevAddrPrefix) bool {

--- a/pkg/networkserver/networkserver_util_test.go
+++ b/pkg/networkserver/networkserver_util_test.go
@@ -26,6 +26,7 @@ import (
 	clusterauth "go.thethings.network/lorawan-stack/pkg/auth/cluster"
 	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/crypto"
 	"go.thethings.network/lorawan-stack/pkg/events"
@@ -1203,9 +1204,8 @@ func StartTest(t *testing.T, conf Config, timeout time.Duration, stubDeduplicati
 		closeFuncs = append(closeFuncs, closeM)
 	}
 
-	if err := ns.Start(); err != nil {
-		t.Fatalf("Failed to start Network Server: %s", err)
-	}
+	StartComponent(t, ns.Component)
+
 	return ns, ctx, env, func() {
 		cancel()
 		for _, f := range closeFuncs {

--- a/pkg/networkserver/networkserver_util_test.go
+++ b/pkg/networkserver/networkserver_util_test.go
@@ -26,7 +26,7 @@ import (
 	clusterauth "go.thethings.network/lorawan-stack/pkg/auth/cluster"
 	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/crypto"
 	"go.thethings.network/lorawan-stack/pkg/events"
@@ -1204,7 +1204,7 @@ func StartTest(t *testing.T, conf Config, timeout time.Duration, stubDeduplicati
 		closeFuncs = append(closeFuncs, closeM)
 	}
 
-	StartComponent(t, ns.Component)
+	componenttest.StartComponent(t, ns.Component)
 
 	return ns, ctx, env, func() {
 		cancel()

--- a/pkg/oauth/server_test.go
+++ b/pkg/oauth/server_test.go
@@ -32,6 +32,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/auth"
 	"go.thethings.network/lorawan-stack/pkg/auth/pbkdf2"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/oauth"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
@@ -96,7 +97,7 @@ func TestOAuthFlow(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	c := component.MustNew(test.GetLogger(t), &component.Config{
+	c := NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			HTTP: config.HTTP{
 				Cookie: config.Cookie{
@@ -502,7 +503,7 @@ func TestOAuthFlow(t *testing.T) {
 func TestTokenExchange(t *testing.T) {
 	ctx := test.Context()
 	store := &mockStore{}
-	c := component.MustNew(test.GetLogger(t), &component.Config{
+	c := NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			HTTP: config.HTTP{
 				Cookie: config.Cookie{

--- a/pkg/oauth/server_test.go
+++ b/pkg/oauth/server_test.go
@@ -118,9 +118,7 @@ func TestOAuthFlow(t *testing.T) {
 		},
 	})
 	c.RegisterWeb(s)
-	if err = c.Start(); err != nil {
-		panic(err)
-	}
+	StartComponent(t, c)
 
 	for _, tt := range []struct {
 		Name             string
@@ -523,9 +521,7 @@ func TestTokenExchange(t *testing.T) {
 		},
 	})
 	c.RegisterWeb(s)
-	if err := c.Start(); err != nil {
-		panic(err)
-	}
+	StartComponent(t, c)
 
 	for _, tt := range []struct {
 		Name         string

--- a/pkg/oauth/server_test.go
+++ b/pkg/oauth/server_test.go
@@ -32,7 +32,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/auth"
 	"go.thethings.network/lorawan-stack/pkg/auth/pbkdf2"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/oauth"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
@@ -97,7 +97,7 @@ func TestOAuthFlow(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	c := NewComponent(t, &component.Config{
+	c := componenttest.NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			HTTP: config.HTTP{
 				Cookie: config.Cookie{
@@ -118,7 +118,7 @@ func TestOAuthFlow(t *testing.T) {
 		},
 	})
 	c.RegisterWeb(s)
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 
 	for _, tt := range []struct {
 		Name             string
@@ -501,7 +501,7 @@ func TestOAuthFlow(t *testing.T) {
 func TestTokenExchange(t *testing.T) {
 	ctx := test.Context()
 	store := &mockStore{}
-	c := NewComponent(t, &component.Config{
+	c := componenttest.NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			HTTP: config.HTTP{
 				Cookie: config.Cookie{
@@ -521,7 +521,7 @@ func TestTokenExchange(t *testing.T) {
 		},
 	})
 	c.RegisterWeb(s)
-	StartComponent(t, c)
+	componenttest.StartComponent(t, c)
 
 	for _, tt := range []struct {
 		Name         string

--- a/pkg/thethingsgateway/cups/handlers_test.go
+++ b/pkg/thethingsgateway/cups/handlers_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 )
 
 const (
@@ -32,7 +32,7 @@ func TestAdaptUpdateChannel(t *testing.T) {
 	var conf Config
 	conf.Default.UpdateChannel = testUpdateChannel
 	conf.Default.FirmwareURL = testFirmwarePath
-	s, err := conf.NewServer(NewComponent(t, &component.Config{}))
+	s, err := conf.NewServer(componenttest.NewComponent(t, &component.Config{}))
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/thethingsgateway/cups/handlers_test.go
+++ b/pkg/thethingsgateway/cups/handlers_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	"go.thethings.network/lorawan-stack/pkg/util/test"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 )
 
 const (
@@ -32,7 +32,7 @@ func TestAdaptUpdateChannel(t *testing.T) {
 	var conf Config
 	conf.Default.UpdateChannel = testUpdateChannel
 	conf.Default.FirmwareURL = testFirmwarePath
-	s, err := conf.NewServer(component.MustNew(test.GetLogger(t), &component.Config{}))
+	s, err := conf.NewServer(NewComponent(t, &component.Config{}))
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/thethingsgateway/cups/server_test.go
+++ b/pkg/thethingsgateway/cups/server_test.go
@@ -24,8 +24,8 @@ import (
 	echo "github.com/labstack/echo/v4"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/component"
+	. "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
-	"go.thethings.network/lorawan-stack/pkg/util/test"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -149,7 +149,7 @@ func TestServer(t *testing.T) {
 				tt.StoreSetup(store)
 			}
 
-			s := NewServer(component.MustNew(test.GetLogger(t), &component.Config{}), append([]Option{
+			s := NewServer(NewComponent(t, &component.Config{}), append([]Option{
 				WithRegistry(store),
 				WithDefaultFirmwareURL(testFirmwarePath),
 				WithDefaultUpdateChannel(testUpdateChannel),

--- a/pkg/thethingsgateway/cups/server_test.go
+++ b/pkg/thethingsgateway/cups/server_test.go
@@ -24,7 +24,7 @@ import (
 	echo "github.com/labstack/echo/v4"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/component"
-	. "go.thethings.network/lorawan-stack/pkg/component/test"
+	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 	"google.golang.org/grpc"
@@ -149,7 +149,7 @@ func TestServer(t *testing.T) {
 				tt.StoreSetup(store)
 			}
 
-			s := NewServer(NewComponent(t, &component.Config{}), append([]Option{
+			s := NewServer(componenttest.NewComponent(t, &component.Config{}), append([]Option{
 				WithRegistry(store),
 				WithDefaultFirmwareURL(testFirmwarePath),
 				WithDefaultUpdateChannel(testUpdateChannel),


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is the starting point for the component testing utilities we discussed.

Needed for https://github.com/TheThingsIndustries/lorawan-stack/pull/1744

#### Changes
<!-- What are the changes made in this pull request? -->

- Added `pkg/component/test` utils (`pkg/util/test` would create import cycles)

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- Main reviewer is @johanstokking; see `pkg/component/test`.
- All other changes are just search/replace.
- There is still alternative logic in the NS, because tests in the NS didn't follow the common pattern of setting up the component.
- This is just a starting point. As next steps we'll move other common use cases to the test utilities: setting `AllowInsecureForCredentials`, hooking up the cluster, ...