### PR TITLE
Only publish MAC downlink events on success

### DIFF
--- a/pkg/networkserver/mac_force_rejoin.go
+++ b/pkg/networkserver/mac_force_rejoin.go
@@ -17,16 +17,17 @@ package networkserver
 import (
 	"context"
 
-	"go.thethings.network/lorawan-stack/pkg/events"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 )
 
 var evtEnqueueForceRejoinRequest = defineEnqueueMACRequestEvent("force_rejoin", "force rejoin")()
 
-func enqueueForceRejoinReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16) (uint16, uint16, bool) {
-	var pld *ttnpb.MACCommand_ForceRejoinReq
-	if pld != nil {
-		events.Publish(evtEnqueueForceRejoinRequest(ctx, dev.EndDeviceIdentifiers, pld))
+func enqueueForceRejoinReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16) macCommandEnqueueState {
+	// TODO: Support rejoins. (https://github.com/TheThingsNetwork/lorawan-stack/issues/8)
+	_ = evtEnqueueForceRejoinRequest
+	return macCommandEnqueueState{
+		MaxDownLen: maxDownLen,
+		MaxUpLen:   maxUpLen,
+		Ok:         true,
 	}
-	return maxDownLen, maxUpLen, true
 }

--- a/pkg/networkserver/mac_ping_slot_channel.go
+++ b/pkg/networkserver/mac_ping_slot_channel.go
@@ -38,7 +38,7 @@ func enqueuePingSlotChannelReq(ctx context.Context, dev *ttnpb.EndDevice, maxDow
 	}
 
 	var st macCommandEnqueueState
-	dev.MACState.PendingRequests, st = enqueueMACCommand(ttnpb.CID_DUTY_CYCLE, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, []events.DefinitionDataClosure, bool) {
+	dev.MACState.PendingRequests, st = enqueueMACCommand(ttnpb.CID_PING_SLOT_CHANNEL, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, []events.DefinitionDataClosure, bool) {
 		if nDown < 1 || nUp < 1 {
 			return nil, 0, nil, false
 		}

--- a/pkg/networkserver/mac_rejoin_param_setup.go
+++ b/pkg/networkserver/mac_rejoin_param_setup.go
@@ -37,7 +37,7 @@ func enqueueRejoinParamSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDo
 	}
 
 	var st macCommandEnqueueState
-	dev.MACState.PendingRequests, st = enqueueMACCommand(ttnpb.CID_DUTY_CYCLE, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, []events.DefinitionDataClosure, bool) {
+	dev.MACState.PendingRequests, st = enqueueMACCommand(ttnpb.CID_REJOIN_PARAM_SETUP, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, []events.DefinitionDataClosure, bool) {
 		if nDown < 1 || nUp < 1 {
 			return nil, 0, nil, false
 		}

--- a/pkg/networkserver/mac_rejoin_param_setup.go
+++ b/pkg/networkserver/mac_rejoin_param_setup.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"go.thethings.network/lorawan-stack/pkg/events"
+	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 )
 
@@ -26,25 +27,39 @@ var (
 	evtReceiveRejoinParamSetupAnswer  = defineReceiveMACAnswerEvent("rejoin_param_setup", "rejoin parameter setup")()
 )
 
-func enqueueRejoinParamSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16) (uint16, uint16, bool) {
+func enqueueRejoinParamSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16) macCommandEnqueueState {
 	if dev.MACState.DesiredParameters.RejoinTimePeriodicity == dev.MACState.CurrentParameters.RejoinTimePeriodicity {
-		return maxDownLen, maxUpLen, true
+		return macCommandEnqueueState{
+			MaxDownLen: maxDownLen,
+			MaxUpLen:   maxUpLen,
+			Ok:         true,
+		}
 	}
 
-	var ok bool
-	dev.MACState.PendingRequests, maxDownLen, maxUpLen, ok = enqueueMACCommand(ttnpb.CID_DUTY_CYCLE, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, bool) {
+	var st macCommandEnqueueState
+	dev.MACState.PendingRequests, st = enqueueMACCommand(ttnpb.CID_DUTY_CYCLE, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, []events.DefinitionDataClosure, bool) {
 		if nDown < 1 || nUp < 1 {
-			return nil, 0, false
+			return nil, 0, nil, false
 		}
 
-		pld := &ttnpb.MACCommand_RejoinParamSetupReq{
+		req := &ttnpb.MACCommand_RejoinParamSetupReq{
 			MaxTimeExponent:  dev.MACState.DesiredParameters.RejoinTimePeriodicity,
 			MaxCountExponent: dev.MACState.DesiredParameters.RejoinCountPeriodicity,
 		}
-		events.Publish(evtEnqueueRejoinParamSetupRequest(ctx, dev.EndDeviceIdentifiers, pld))
-		return []*ttnpb.MACCommand{pld.MACCommand()}, 1, true
+		log.FromContext(ctx).WithFields(log.Fields(
+			"max_time_exponent", req.MaxTimeExponent,
+			"max_count_exponent", req.MaxCountExponent,
+		)).Debug("Enqueued RejoinParamSetupReq")
+		return []*ttnpb.MACCommand{
+				req.MACCommand(),
+			},
+			1,
+			[]events.DefinitionDataClosure{
+				evtEnqueueRejoinParamSetupRequest.BindData(req),
+			},
+			true
 	}, dev.MACState.PendingRequests...)
-	return maxDownLen, maxUpLen, ok
+	return st
 }
 
 func handleRejoinParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_RejoinParamSetupAns) ([]events.DefinitionDataClosure, error) {

--- a/pkg/networkserver/mac_rx_param_setup.go
+++ b/pkg/networkserver/mac_rx_param_setup.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"go.thethings.network/lorawan-stack/pkg/events"
+	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 )
 
@@ -27,27 +28,42 @@ var (
 	evtReceiveRxParamSetupReject  = defineReceiveMACRejectEvent("rx_param_setup", "Rx parameter setup")()
 )
 
-func enqueueRxParamSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16) (uint16, uint16, bool) {
+func enqueueRxParamSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16) macCommandEnqueueState {
 	if dev.MACState.DesiredParameters.Rx2Frequency == dev.MACState.CurrentParameters.Rx2Frequency &&
 		dev.MACState.DesiredParameters.Rx2DataRateIndex == dev.MACState.CurrentParameters.Rx2DataRateIndex &&
 		dev.MACState.DesiredParameters.Rx1DataRateOffset == dev.MACState.CurrentParameters.Rx1DataRateOffset {
-		return maxDownLen, maxUpLen, true
+		return macCommandEnqueueState{
+			MaxDownLen: maxDownLen,
+			MaxUpLen:   maxUpLen,
+			Ok:         true,
+		}
 	}
 
-	var ok bool
-	dev.MACState.PendingRequests, maxDownLen, maxUpLen, ok = enqueueMACCommand(ttnpb.CID_RX_PARAM_SETUP, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, bool) {
+	var st macCommandEnqueueState
+	dev.MACState.PendingRequests, st = enqueueMACCommand(ttnpb.CID_RX_PARAM_SETUP, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, []events.DefinitionDataClosure, bool) {
 		if nDown < 1 || nUp < 1 {
-			return nil, 0, false
+			return nil, 0, nil, false
 		}
-		pld := &ttnpb.MACCommand_RxParamSetupReq{
+		req := &ttnpb.MACCommand_RxParamSetupReq{
 			Rx2Frequency:      dev.MACState.DesiredParameters.Rx2Frequency,
 			Rx2DataRateIndex:  dev.MACState.DesiredParameters.Rx2DataRateIndex,
 			Rx1DataRateOffset: dev.MACState.DesiredParameters.Rx1DataRateOffset,
 		}
-		events.Publish(evtEnqueueRxParamSetupRequest(ctx, dev.EndDeviceIdentifiers, pld))
-		return []*ttnpb.MACCommand{pld.MACCommand()}, 1, true
+		log.FromContext(ctx).WithFields(log.Fields(
+			"rx2_frequency", req.Rx2Frequency,
+			"rx2_data_rate_index", req.Rx2DataRateIndex,
+			"rx1_data_rate_offset", req.Rx1DataRateOffset,
+		)).Debug("Enqueued RxParamSetupReq")
+		return []*ttnpb.MACCommand{
+				req.MACCommand(),
+			},
+			1,
+			[]events.DefinitionDataClosure{
+				evtEnqueueRxParamSetupRequest.BindData(req),
+			},
+			true
 	}, dev.MACState.PendingRequests...)
-	return maxDownLen, maxUpLen, ok
+	return st
 }
 
 func handleRxParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_RxParamSetupAns) ([]events.DefinitionDataClosure, error) {

--- a/pkg/networkserver/mac_rx_timing_setup.go
+++ b/pkg/networkserver/mac_rx_timing_setup.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"go.thethings.network/lorawan-stack/pkg/events"
+	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 )
 
@@ -26,23 +27,36 @@ var (
 	evtReceiveRxTimingSetupAnswer  = defineReceiveMACAnswerEvent("rx_timing_setup", "Rx timing setup")()
 )
 
-func enqueueRxTimingSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16) (uint16, uint16, bool) {
+func enqueueRxTimingSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16) macCommandEnqueueState {
 	if dev.MACState.DesiredParameters.Rx1Delay == dev.MACState.CurrentParameters.Rx1Delay {
-		return maxDownLen, maxUpLen, true
+		return macCommandEnqueueState{
+			MaxDownLen: maxDownLen,
+			MaxUpLen:   maxUpLen,
+			Ok:         true,
+		}
 	}
 
-	var ok bool
-	dev.MACState.PendingRequests, maxDownLen, maxUpLen, ok = enqueueMACCommand(ttnpb.CID_RX_TIMING_SETUP, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, bool) {
+	var st macCommandEnqueueState
+	dev.MACState.PendingRequests, st = enqueueMACCommand(ttnpb.CID_RX_TIMING_SETUP, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, []events.DefinitionDataClosure, bool) {
 		if nDown < 1 || nUp < 1 {
-			return nil, 0, false
+			return nil, 0, nil, false
 		}
-		pld := &ttnpb.MACCommand_RxTimingSetupReq{
+		req := &ttnpb.MACCommand_RxTimingSetupReq{
 			Delay: dev.MACState.DesiredParameters.Rx1Delay,
 		}
-		events.Publish(evtEnqueueRxTimingSetupRequest(ctx, dev.EndDeviceIdentifiers, pld))
-		return []*ttnpb.MACCommand{pld.MACCommand()}, 1, true
+		log.FromContext(ctx).WithFields(log.Fields(
+			"delay", req.Delay,
+		)).Debug("Enqueued RxTimingSetupReq")
+		return []*ttnpb.MACCommand{
+				req.MACCommand(),
+			},
+			1,
+			[]events.DefinitionDataClosure{
+				evtEnqueueRxTimingSetupRequest.BindData(req),
+			},
+			true
 	}, dev.MACState.PendingRequests...)
-	return maxDownLen, maxUpLen, ok
+	return st
 }
 
 func handleRxTimingSetupAns(ctx context.Context, dev *ttnpb.EndDevice) ([]events.DefinitionDataClosure, error) {

--- a/pkg/networkserver/networkserver_flow_test.go
+++ b/pkg/networkserver/networkserver_flow_test.go
@@ -765,20 +765,6 @@ func handleClassAOTAAEU868FlowTest1_0_2(ctx context.Context, conn *grpc.ClientCo
 			return
 		}
 
-		if !a.So(test.AssertEventPubSubPublishRequest(ctx, env.Events, func(ev events.Event) bool {
-			return a.So(ev, should.ResembleEvent, EvtEnqueueDevStatusRequest(events.ContextWithCorrelationID(test.Context(), reqCIDs...),
-				ttnpb.EndDeviceIdentifiers{
-					DeviceID:               devID,
-					ApplicationIdentifiers: appID,
-					JoinEUI:                &types.EUI64{0x42, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
-					DevEUI:                 &types.EUI64{0x42, 0x42, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
-					DevAddr:                &devAddr,
-				}, nil))
-		}), should.BeTrue) {
-			t.Error("DevStatus enqueue event assertion failed")
-			return
-		}
-
 		a.So(test.AssertClusterGetPeerRequest(ctx, env.Cluster.GetPeer,
 			func(ctx context.Context, role ttnpb.ClusterRole, ids ttnpb.Identifiers) bool {
 				return a.So(role, should.Equal, ttnpb.ClusterRole_GATEWAY_SERVER) &&
@@ -860,6 +846,17 @@ func handleClassAOTAAEU868FlowTest1_0_2(ctx context.Context, conn *grpc.ClientCo
 				Response: &ttnpb.ScheduleDownlinkResponse{},
 			},
 		), should.BeTrue)
+
+		a.So(test.AssertEventPubSubPublishRequest(ctx, env.Events, func(ev events.Event) bool {
+			return a.So(ev, should.ResembleEvent, EvtEnqueueDevStatusRequest(events.ContextWithCorrelationID(test.Context(), reqCIDs...),
+				ttnpb.EndDeviceIdentifiers{
+					DeviceID:               devID,
+					ApplicationIdentifiers: appID,
+					JoinEUI:                &types.EUI64{0x42, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+					DevEUI:                 &types.EUI64{0x42, 0x42, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+					DevAddr:                &devAddr,
+				}, nil))
+		}), should.BeTrue)
 	})
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #789 

#### Changes
<!-- What are the changes made in this pull request? -->

- Only publish MAC downlink events on successful scheduling
- Fix invalid CIDs used for `RejoinParamSetupReq` and `PingSlotReq` MAC commands
- Wrap multiple return values of MAC enqueuers into a struct

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Tested on metal