### PR TITLE
Add support button to console

### DIFF
--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -35,12 +35,13 @@ type UIConfig struct {
 
 // FrontendConfig is the configuration for the Console frontend.
 type FrontendConfig struct {
-	Language string          `json:"language" name:"-"`
-	IS       webui.APIConfig `json:"is" name:"is"`
-	GS       webui.APIConfig `json:"gs" name:"gs"`
-	NS       webui.APIConfig `json:"ns" name:"ns"`
-	AS       webui.APIConfig `json:"as" name:"as"`
-	JS       webui.APIConfig `json:"js" name:"js"`
+	Language    string          `json:"language" name:"-"`
+	SupportLink string          `json:"support_link" name:"support-link" description:"The URI that the support button will point to"`
+	IS          webui.APIConfig `json:"is" name:"is"`
+	GS          webui.APIConfig `json:"gs" name:"gs"`
+	NS          webui.APIConfig `json:"ns" name:"ns"`
+	AS          webui.APIConfig `json:"as" name:"as"`
+	JS          webui.APIConfig `json:"js" name:"js"`
 }
 
 // Config is the configuration for the Console.

--- a/pkg/webui/components/footer/footer.styl
+++ b/pkg/webui/components/footer/footer.styl
@@ -16,7 +16,8 @@
   border-normal('top')
   display: flex
   justify-content: space-between
-  padding: $cs.s
+  align-items: center
+  padding: $cs.xs
   color: $tc-subtle-gray
   flex: none
   +media-query($bp.s)
@@ -34,4 +35,6 @@
     color: $tc-deep-gray
 
 .version
-  margin-left: $ls.xxs
+  margin-left: $cs.xs
+  &:not(:last-child)
+    margin-right: $cs.xs

--- a/pkg/webui/components/footer/index.js
+++ b/pkg/webui/components/footer/index.js
@@ -19,14 +19,16 @@ import { Link } from 'react-router-dom'
 import PropTypes from '../../lib/prop-types'
 
 import Message from '../../lib/components/message'
+import Button from '../../components/button'
 
 import style from './footer.styl'
 
 const m = defineMessages({
   footer: "You are the network. Let's build this thing together.",
+  getSupport: 'Get Support',
 })
 
-const Footer = function({ className, links = [] }) {
+const Footer = function({ className, links, supportLink }) {
   return (
     <footer className={classnames(className, style.footer)}>
       <div>
@@ -44,12 +46,22 @@ const Footer = function({ className, links = [] }) {
           </Link>
         ))}
         <span className={style.version}>v{process.env.VERSION}</span>
+        {supportLink && (
+          <Button.AnchorLink
+            message={m.getSupport}
+            icon="contact_support"
+            href={supportLink}
+            target="_blank"
+          />
+        )}
       </div>
     </footer>
   )
 }
 
 Footer.propTypes = {
+  /** The classname to be applied to the footer */
+  className: PropTypes.string,
   /**
    * A list of links to be displayed in the footer component
    * @param {(string|Object)} title - The title of the link
@@ -61,6 +73,14 @@ Footer.propTypes = {
       link: PropTypes.string.isRequired,
     }),
   ),
+  /** Optional link for a support button */
+  supportLink: PropTypes.string,
+}
+
+Footer.defaultProps = {
+  className: undefined,
+  links: [],
+  supportLink: undefined,
 }
 
 export default Footer

--- a/pkg/webui/console/views/app/index.js
+++ b/pkg/webui/console/views/app/index.js
@@ -22,6 +22,7 @@ import IntlHelmet from '../../../lib/components/intl-helmet'
 import { withEnv } from '../../../lib/components/env'
 import ErrorView from '../../../lib/components/error-view'
 import dev from '../../../lib/dev'
+import PropTypes from '../../../lib/prop-types'
 
 import SideNavigation from '../../../components/navigation/side'
 import Header from '../../containers/header'
@@ -33,7 +34,16 @@ import FullViewError from '../error'
 import style from './app.styl'
 
 @withEnv
+@(Component => (dev ? hot(Component) : Component))
 class ConsoleApp extends React.Component {
+  static propTypes = {
+    env: PropTypes.env.isRequired,
+    history: PropTypes.shape({
+      push: PropTypes.func,
+      replace: PropTypes.func,
+    }).isRequired,
+  }
+
   render() {
     const {
       env: {
@@ -83,6 +93,4 @@ class ConsoleApp extends React.Component {
   }
 }
 
-const ExportedApp = dev ? hot(ConsoleApp) : ConsoleApp
-
-export default ExportedApp
+export default ConsoleApp

--- a/pkg/webui/console/views/app/index.js
+++ b/pkg/webui/console/views/app/index.js
@@ -36,7 +36,12 @@ import style from './app.styl'
 class ConsoleApp extends React.Component {
   render() {
     const {
-      env: { siteTitle, pageData, siteName },
+      env: {
+        siteTitle,
+        pageData,
+        siteName,
+        config: { supportLink },
+      },
       history,
     } = this.props
 
@@ -70,7 +75,7 @@ class ConsoleApp extends React.Component {
                 </Switch>
               </div>
             </main>
-            <Footer className={style.footer} />
+            <Footer className={style.footer} supportLink={supportLink} />
           </div>
         </ErrorView>
       </ConnectedRouter>

--- a/pkg/webui/lib/env.js
+++ b/pkg/webui/lib/env.js
@@ -17,7 +17,15 @@ import * as envSelector from './selectors/env'
 const env = {
   appRoot: envSelector.selectApplicationRootPath(),
   assetsRoot: envSelector.selectAssetsRootPath(),
-  config: envSelector.selectApplicationConfig(),
+  config: {
+    as: envSelector.selectAsConfig(),
+    gs: envSelector.selectGsConfig(),
+    is: envSelector.selectIsConfig(),
+    js: envSelector.selectJsConfig(),
+    ns: envSelector.selectNsConfig(),
+    language: envSelector.selectLanguageConfig(),
+    supportLink: envSelector.selectSupportLinkConfig(),
+  },
   pageData: envSelector.selectPageData(),
   siteName: envSelector.selectApplicationSiteName(),
   siteTitle: envSelector.selectApplicationSiteTitle(),

--- a/pkg/webui/lib/prop-types.js
+++ b/pkg/webui/lib/prop-types.js
@@ -143,6 +143,7 @@ PropTypes.env = PropTypes.shape({
   pageData: PropTypes.shape({}),
   config: PropTypes.shape({
     language: PropTypes.string,
+    support_link: PropTypes.string,
     is: PropTypes.stackComponent,
     as: PropTypes.stackComponent,
     ns: PropTypes.stackComponent,

--- a/pkg/webui/lib/selectors/env.js
+++ b/pkg/webui/lib/selectors/env.js
@@ -38,4 +38,6 @@ export const selectAsConfig = () => selectApplicationConfig().as
 
 export const selectLanguageConfig = () => selectApplicationConfig().language
 
+export const selectSupportLinkConfig = () => selectApplicationConfig().support_link
+
 export const selectPageData = () => configSelector().PAGE_DATA

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -13,6 +13,7 @@
   "components.file-input.index.tooBig": "The selected file is too large.",
   "components.file-input.index.remove": "Remove",
   "components.footer.index.footer": "You are the network. Let's build this thing together.",
+  "components.footer.index.getSupport": "Get Support",
   "components.key-value-map.entry.deleteEntry": "Delete Entry",
   "components.key-value-map.index.addEntry": "Add entry",
   "components.location-form.index.deleteWarning": "Are you sure you want to delete this location entry?",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -13,6 +13,7 @@
   "components.file-input.index.tooBig": "Xxx xxxxxxxx xxxx xx xxx xxxxx.",
   "components.file-input.index.remove": "Xxxxxx",
   "components.footer.index.footer": "Xxx xxx xxx xxxxxxx. Xxx'x xxxxx xxxx xxxxx xxxxxxxx.",
+  "components.footer.index.getSupport": "Xxx Xxxxxxx",
   "components.key-value-map.entry.deleteEntry": "Xxxxxx Xxxxx",
   "components.key-value-map.index.addEntry": "Xxx xxxxx",
   "components.location-form.index.deleteWarning": "Xxx xxx xxxx xxx xxxx xx xxxxxx xxxx xxxxxxxx xxxxx?",


### PR DESCRIPTION
#### Summary
Closes https://github.com/TheThingsIndustries/lorawan-stack/issues/1734
References #1086 

![image](https://user-images.githubusercontent.com/5710611/65950640-bbb7c900-e43e-11e9-9eb1-6fbe624af7d9.png)

#### Changes
- Add optional `support-link` config to console
- Display a support button in the footer, when the config is set
- Update env selectors, prop-types, lib

#### Release Notes

- Added `support-link` URI config to the Console to show a "Get Support" button