### PR TITLE
Fix stack config issue in console

### DIFF
--- a/cmd/internal/shared/console/config.go
+++ b/cmd/internal/shared/console/config.go
@@ -42,11 +42,13 @@ var DefaultConsoleConfig = console.Config{
 			JSFiles:       []string{"console.js"},
 		},
 		FrontendConfig: console.FrontendConfig{
-			IS: webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
-			GS: webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
-			NS: webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
-			AS: webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
-			JS: webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
+			StackConfig: console.StackConfig{
+				IS: webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
+				GS: webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
+				NS: webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
+				AS: webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
+				JS: webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
+			},
 		},
 	},
 }

--- a/cmd/internal/shared/identityserver/config.go
+++ b/cmd/internal/shared/identityserver/config.go
@@ -39,7 +39,9 @@ var DefaultIdentityServerConfig = identityserver.Config{
 				JSFiles:       []string{"oauth.js"},
 			},
 			FrontendConfig: oauth.FrontendConfig{
-				IS: webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
+				StackConfig: oauth.StackConfig{
+					IS: webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
+				},
 			},
 		},
 	},

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -33,15 +33,20 @@ type UIConfig struct {
 	FrontendConfig     `name:",squash"`
 }
 
+// StackConfig is the configuration of the stack components.
+type StackConfig struct {
+	IS webui.APIConfig `json:"is" name:"is"`
+	GS webui.APIConfig `json:"gs" name:"gs"`
+	NS webui.APIConfig `json:"ns" name:"ns"`
+	AS webui.APIConfig `json:"as" name:"as"`
+	JS webui.APIConfig `json:"js" name:"js"`
+}
+
 // FrontendConfig is the configuration for the Console frontend.
 type FrontendConfig struct {
-	Language    string          `json:"language" name:"-"`
-	SupportLink string          `json:"support_link" name:"support-link" description:"The URI that the support button will point to"`
-	IS          webui.APIConfig `json:"is" name:"is"`
-	GS          webui.APIConfig `json:"gs" name:"gs"`
-	NS          webui.APIConfig `json:"ns" name:"ns"`
-	AS          webui.APIConfig `json:"as" name:"as"`
-	JS          webui.APIConfig `json:"js" name:"js"`
+	Language    string `json:"language" name:"-"`
+	SupportLink string `json:"support_link" name:"support-link" description:"The URI that the support button will point to"`
+	StackConfig `json:"stack_config" name:",squash"`
 }
 
 // Config is the configuration for the Console.

--- a/pkg/oauth/server.go
+++ b/pkg/oauth/server.go
@@ -66,10 +66,15 @@ type UIConfig struct {
 	FrontendConfig     `name:",squash"`
 }
 
+// StackConfig is the configuration of the stack components.
+type StackConfig struct {
+	IS webui.APIConfig `json:"is" name:"is"`
+}
+
 // FrontendConfig is the configuration for the OAuth frontend.
 type FrontendConfig struct {
-	Language string          `json:"language" name:"-"`
-	IS       webui.APIConfig `json:"is" name:"is"`
+	Language    string `json:"language" name:"-"`
+	StackConfig `json:"stack_config" name:",squash"`
 }
 
 // Config is the configuration for the OAuth server.

--- a/pkg/webui/console/api/index.js
+++ b/pkg/webui/console/api/index.js
@@ -17,20 +17,20 @@ import TTN from 'ttn-lw'
 
 import token from '../lib/access-token'
 import getCookieValue from '../../lib/cookie'
-import { selectApplicationConfig, selectApplicationRootPath } from '../../lib/selectors/env'
+import { selectStackConfig, selectApplicationRootPath } from '../../lib/selectors/env'
 
-const config = selectApplicationConfig()
+const stackConfig = selectStackConfig()
 const appRoot = selectApplicationRootPath()
 
 const stack = {
-  is: config.is.enabled ? config.is.base_url : undefined,
-  gs: config.gs.enabled ? config.gs.base_url : undefined,
-  ns: config.ns.enabled ? config.ns.base_url : undefined,
-  as: config.as.enabled ? config.as.base_url : undefined,
-  js: config.js.enabled ? config.js.base_url : undefined,
+  is: stackConfig.is.enabled ? stackConfig.is.base_url : undefined,
+  gs: stackConfig.gs.enabled ? stackConfig.gs.base_url : undefined,
+  ns: stackConfig.ns.enabled ? stackConfig.ns.base_url : undefined,
+  as: stackConfig.as.enabled ? stackConfig.as.base_url : undefined,
+  js: stackConfig.js.enabled ? stackConfig.js.base_url : undefined,
 }
 
-const isBaseUrl = config.is.base_url
+const isBaseUrl = stackConfig.is.base_url
 
 const ttnClient = new TTN(token, {
   stackConfig: stack,

--- a/pkg/webui/console/views/gateway-add/index.js
+++ b/pkg/webui/console/views/gateway-add/index.js
@@ -82,7 +82,9 @@ export default class GatewayAdd extends React.Component {
   render() {
     const { error } = this.state
     const {
-      env: { config },
+      env: {
+        config: { stack },
+      },
     } = this.props
 
     const initialValues = {
@@ -90,7 +92,7 @@ export default class GatewayAdd extends React.Component {
         gateway_id: undefined,
       },
       enforce_duty_cycle: true,
-      gateway_server_address: config.gs.enabled ? new URL(config.gs.base_url).hostname : '',
+      gateway_server_address: stack.gs.enabled ? new URL(stack.gs.base_url).hostname : '',
       frequency_plan_id: undefined,
     }
 

--- a/pkg/webui/console/views/overview/index.js
+++ b/pkg/webui/console/views/overview/index.js
@@ -113,7 +113,9 @@ export default class Overview extends React.Component {
   }
 
   render() {
-    const { config } = this.props.env
+    const {
+      config: { stack: stackConfig },
+    } = this.props.env
     const { fetching, applicationCount, gatewayCount, userId } = this.props
 
     if (fetching || applicationCount === undefined || gatewayCount === undefined) {
@@ -179,11 +181,11 @@ export default class Overview extends React.Component {
           <Col sm={8}>
             <Message className={style.componentStatus} content={m.componentStatus} component="h3" />
             <div className={style.componentCards}>
-              {Object.keys(config).map(function(componentKey) {
+              {Object.keys(stackConfig).map(function(componentKey) {
                 if (componentKey === 'language') {
                   return null
                 }
-                const component = config[componentKey]
+                const component = stackConfig[componentKey]
                 const name = componentMap[componentKey]
                 const host = new URL(component.base_url).host
                 return (

--- a/pkg/webui/lib/env.js
+++ b/pkg/webui/lib/env.js
@@ -18,11 +18,13 @@ const env = {
   appRoot: envSelector.selectApplicationRootPath(),
   assetsRoot: envSelector.selectAssetsRootPath(),
   config: {
-    as: envSelector.selectAsConfig(),
-    gs: envSelector.selectGsConfig(),
-    is: envSelector.selectIsConfig(),
-    js: envSelector.selectJsConfig(),
-    ns: envSelector.selectNsConfig(),
+    stack: {
+      as: envSelector.selectAsConfig(),
+      gs: envSelector.selectGsConfig(),
+      is: envSelector.selectIsConfig(),
+      js: envSelector.selectJsConfig(),
+      ns: envSelector.selectNsConfig(),
+    },
     language: envSelector.selectLanguageConfig(),
     supportLink: envSelector.selectSupportLinkConfig(),
   },

--- a/pkg/webui/lib/prop-types.js
+++ b/pkg/webui/lib/prop-types.js
@@ -145,12 +145,14 @@ PropTypes.env = PropTypes.shape({
   pageData: PropTypes.shape({}),
   config: PropTypes.shape({
     language: PropTypes.string,
-    support_link: PropTypes.string,
-    is: PropTypes.stackComponent,
-    as: PropTypes.stackComponent,
-    ns: PropTypes.stackComponent,
-    js: PropTypes.stackComponent,
-    gs: PropTypes.stackComponent,
+    supportLink: PropTypes.string,
+    stack: PropTypes.shape({
+      is: PropTypes.stackComponent,
+      as: PropTypes.stackComponent,
+      ns: PropTypes.stackComponent,
+      js: PropTypes.stackComponent,
+      gs: PropTypes.stackComponent,
+    }),
   }).isRequired,
 })
 

--- a/pkg/webui/lib/selectors/env.js
+++ b/pkg/webui/lib/selectors/env.js
@@ -26,15 +26,17 @@ export const selectApplicationSiteTitle = () => configSelector().SITE_TITLE
 
 export const selectApplicationSiteSubTitle = () => configSelector().SITE_SUB_TITLE
 
-export const selectGsConfig = () => selectApplicationConfig().gs
+export const selectStackConfig = () => selectApplicationConfig().stack_config
 
-export const selectIsConfig = () => selectApplicationConfig().is
+export const selectGsConfig = () => selectStackConfig().gs
 
-export const selectNsConfig = () => selectApplicationConfig().ns
+export const selectIsConfig = () => selectStackConfig().is
 
-export const selectJsConfig = () => selectApplicationConfig().js
+export const selectNsConfig = () => selectStackConfig().ns
 
-export const selectAsConfig = () => selectApplicationConfig().as
+export const selectJsConfig = () => selectStackConfig().js
+
+export const selectAsConfig = () => selectStackConfig().as
 
 export const selectLanguageConfig = () => selectApplicationConfig().language
 

--- a/pkg/webui/oauth/api/index.js
+++ b/pkg/webui/oauth/api/index.js
@@ -15,11 +15,11 @@
 import axios from 'axios'
 
 import getCookieValue from '../../lib/cookie'
-import { selectApplicationRootPath, selectApplicationConfig } from '../../lib/selectors/env'
+import { selectApplicationRootPath, selectStackConfig } from '../../lib/selectors/env'
 
 const appRoot = selectApplicationRootPath()
-const config = selectApplicationConfig()
-const isBaseUrl = config.is.base_url
+const stackConfig = selectStackConfig()
+const isBaseUrl = stackConfig.is.base_url
 
 const csrf = getCookieValue('_csrf')
 const instance = axios.create({


### PR DESCRIPTION
#### Summary
This quickfix PR will change the json structure of the frontend config that is passed to the console frontend. This resolves a bug that caused the overview page to crash since #1402.

#### Changes
- Change the config structure of the console config setup (config flags remain the same)
  - Move the stack config from the root into `stack_config` prop (json)
- Update env selectors, lib and references accordingly
