### PR TITLE
Use config from request context in oauthclient

### DIFF
--- a/pkg/web/oauthclient/callback.go
+++ b/pkg/web/oauthclient/callback.go
@@ -69,5 +69,6 @@ func (oc *OAuthClient) HandleCallback(c echo.Context) error {
 		return err
 	}
 
-	return c.Redirect(http.StatusFound, oc.config.RootURL+stateCookie.Next)
+	config := oc.configFromContext(c.Request().Context())
+	return c.Redirect(http.StatusFound, config.RootURL+stateCookie.Next)
 }

--- a/pkg/web/oauthclient/oauthclient.go
+++ b/pkg/web/oauthclient/oauthclient.go
@@ -93,8 +93,8 @@ func (oc *OAuthClient) oauth(c echo.Context) *oauth2.Config {
 	config := oc.configFromContext(c.Request().Context())
 
 	authorizeURL := config.AuthorizeURL
-	redirectURL := fmt.Sprintf("%s/oauth/callback", strings.TrimSuffix(oc.config.RootURL, "/"))
-	if oauthRootURL, err := url.Parse(oc.config.RootURL); err == nil {
+	redirectURL := fmt.Sprintf("%s/oauth/callback", strings.TrimSuffix(config.RootURL, "/"))
+	if oauthRootURL, err := url.Parse(config.RootURL); err == nil {
 		rootURL := (&url.URL{Scheme: oauthRootURL.Scheme, Host: oauthRootURL.Host}).String()
 		if strings.HasPrefix(authorizeURL, rootURL) {
 			authorizeURL = strings.TrimPrefix(authorizeURL, rootURL)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quickfix that makes the oauthclient package use config from the request context if available.
