### PR TITLE
Enable GS MQTT V2 listener by default and assign port

### DIFF
--- a/cmd/internal/shared/gatewayconfigurationserver/config.go
+++ b/cmd/internal/shared/gatewayconfigurationserver/config.go
@@ -27,7 +27,7 @@ var DefaultGatewayConfigurationServerConfig = gatewayconfigurationserver.Config{
 
 func init() {
 	DefaultGatewayConfigurationServerConfig.TheThingsGateway.Default.UpdateChannel = "stable"
-	DefaultGatewayConfigurationServerConfig.TheThingsGateway.Default.MQTTServer = "mqtts://" + shared.DefaultPublicHost + gs.DefaultGatewayServerConfig.MQTT.ListenTLS
+	DefaultGatewayConfigurationServerConfig.TheThingsGateway.Default.MQTTServer = "mqtts://" + gs.DefaultGatewayServerConfig.MQTTV2.PublicTLSAddress
 	DefaultGatewayConfigurationServerConfig.TheThingsGateway.Default.FirmwareURL = "https://thethingsproducts.blob.core.windows.net/the-things-gateway/v1"
 	DefaultGatewayConfigurationServerConfig.BasicStation.Default.LNSURI = "wss://" + shared.DefaultPublicHost + gs.DefaultGatewayServerConfig.BasicStation.ListenTLS
 }

--- a/cmd/internal/shared/gatewayserver/config.go
+++ b/cmd/internal/shared/gatewayserver/config.go
@@ -35,6 +35,12 @@ var DefaultGatewayServerConfig = gatewayserver.Config{
 			":1700": "",
 		},
 	},
+	MQTTV2: config.MQTT{
+		Listen:           ":1881",
+		ListenTLS:        ":8881",
+		PublicAddress:    fmt.Sprintf("%s:1881", shared.DefaultPublicHost),
+		PublicTLSAddress: fmt.Sprintf("%s:8881", shared.DefaultPublicHost),
+	},
 	MQTT: config.MQTT{
 		Listen:           ":1882",
 		ListenTLS:        ":8882",

--- a/doc/networking.md
+++ b/doc/networking.md
@@ -7,6 +7,7 @@ The Things Stack uses a port per protocol, with a TLS counterpart when applicabl
 | Purpose | Protocol | Authentication | Port | Port (TLS) |
 | --- | --- | --- | --- | --- | 
 | Gateway data | [Semtech Packet Forwarder](https://github.com/Lora-net/packet_forwarder/blob/master/PROTOCOL.TXT) | None | 1700 (UDP) | N/A |
+| Gateway data | MQTT (V2) | API key, token | 1881 | 8881 |
 | Gateway data | MQTT | API key, token | 1882 | 8882 |
 | Application data, events | MQTT | API key, token | 1883 | 8883 |
 | Management, data, events | gRPC | API key, token | 1884 | 8884 |


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Enable GS MQTT V2 listener by default and assign port

#### Changes
<!-- What are the changes made in this pull request? -->

- Assign port 1881/8881 to for V2 MQTT gateways
- Enable the listener by default

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Enabled the V2 MQTT gateway listener by default on ports 1881/8881