### PR TITLE
Add progress bar component

### DIFF
--- a/pkg/webui/components/progress-bar/index.js
+++ b/pkg/webui/components/progress-bar/index.js
@@ -1,0 +1,132 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React, { PureComponent } from 'react'
+import classnames from 'classnames'
+
+import PropTypes from '../../lib/prop-types'
+import RelativeDateTime from '../../lib/components/date-time/relative'
+
+import style from './progress-bar.styl'
+
+export default class ProgressBar extends PureComponent {
+  static propTypes = {
+    /* The class to be attached to the outer container */
+    className: PropTypes.string,
+    /* The current progress value, used in conjunction with the `target` value */
+    current: PropTypes.number,
+    /* Current percentage */
+    percentage: PropTypes.number,
+    /* Decimals to be shown for the percentage value */
+    percentageDecimals: PropTypes.number,
+    /* Flag indicating whether an ETA estimation is shown */
+    showEstimation: PropTypes.bool,
+    /* Flag indicating whether a status text is shown (percentage value) */
+    showStatus: PropTypes.bool,
+    /* The target value, used in conjunction with the `current` value */
+    target: PropTypes.number,
+  }
+
+  static defaultProps = {
+    className: undefined,
+    current: 0,
+    percentage: undefined,
+    percentageDecimals: 2,
+    showEstimation: true,
+    showStatus: false,
+    target: 1,
+  }
+
+  state = {
+    estimatedDuration: Infinity,
+    startTime: undefined,
+    elapsedTime: undefined,
+    estimations: 0,
+  }
+
+  static getDerivedStateFromProps(props, state) {
+    const { current, target, showEstimation } = props
+    const { percentage = (current / target) * 100 } = props
+    let { estimatedDuration, startTime, elapsedTime, estimations } = state
+
+    if (!showEstimation) {
+      return { estimatedDuration, startTime, elapsedTime, estimations }
+    }
+
+    if (percentage === 0) {
+      startTime = Date.now()
+      return { estimatedDuration: Infinity, startTime, elapsedTime, estimations: 0 }
+    }
+
+    elapsedTime = Date.now() - startTime
+    estimatedDuration = Math.max(0, elapsedTime * (100 / percentage))
+    estimations++
+
+    return { estimatedDuration, startTime, elapsedTime, estimations }
+  }
+
+  render() {
+    const {
+      current,
+      target,
+      showStatus,
+      percentageDecimals,
+      showEstimation,
+      className,
+    } = this.props
+    const { percentage = (current / target) * 100 } = this.props
+    const { estimatedDuration, startTime, estimations } = this.state
+    const displayPercentage = Math.max(0, Math.min(100, percentage)).toFixed(percentageDecimals)
+    let displayEstimation = null
+
+    if (showEstimation) {
+      const now = new Date(Date.now() + 1000)
+      let eta = new Date(startTime + estimatedDuration)
+      if (eta < now) {
+        // Avoid estimations in the past
+        eta = new Date(now + 1000)
+      }
+      displayEstimation =
+        !showEstimation ||
+        estimations < 3 || // Avoid inaccurate early estimations
+        estimatedDuration === Infinity ||
+        !startTime ? null : (
+          <div>
+            <span>
+              Estimated completion <RelativeDateTime value={eta} />
+            </span>
+          </div>
+        )
+    }
+
+    return (
+      <div className={classnames(className, style.container)}>
+        <div className={style.bar}>
+          <div style={{ width: `${displayPercentage}%` }} className={style.filler} />
+        </div>
+        {showStatus && (
+          <div className={style.status}>
+            {this.props.percentage === undefined && (
+              <div>
+                {current} of {target} ({displayPercentage}% finished)
+              </div>
+            )}
+            {this.props.percentage !== undefined && <div>{displayPercentage}% finished</div>}
+            {displayEstimation}
+          </div>
+        )}
+      </div>
+    )
+  }
+}

--- a/pkg/webui/components/progress-bar/progress-bar.styl
+++ b/pkg/webui/components/progress-bar/progress-bar.styl
@@ -1,0 +1,34 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.container
+  width: 100%
+
+.bar
+  width: 100%
+  height: 1rem
+  border: $c-input-border
+  border-radius: $br.s
+
+.filler
+  background-color: $c-active-blue
+  border: 1px solid white
+  height: 100%
+  box-sizing: border-box
+  transition: width $ad.s
+
+.status
+  horizontalize()
+  div
+    display:flex

--- a/pkg/webui/components/progress-bar/story.js
+++ b/pkg/webui/components/progress-bar/story.js
@@ -1,0 +1,46 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import ProgressBar from '.'
+
+export default class Helper extends React.Component {
+  state = {
+    percentage: 0,
+  }
+
+  increment() {
+    const { percentage } = this.state
+    const newVal = percentage > 100 ? 0 : percentage + Math.random() * 15
+
+    this.setState({ percentage: newVal })
+  }
+
+  componentDidMount() {
+    setInterval(this.increment.bind(this), 1000)
+  }
+
+  render() {
+    const { percentage } = this.state
+
+    return <ProgressBar percentage={percentage} showStatus />
+  }
+}
+
+storiesOf('ProgressBar', module)
+  .add('Default', () => <ProgressBar percentage={50} />)
+  .add('With Status', () => <ProgressBar current={24} target={190} showStatus />)
+  .add('With ETA Estimation', () => <Helper />)


### PR DESCRIPTION
#### Summary
This PR adds a simple progress bar component to the webui.
References #1404 

![image](https://user-images.githubusercontent.com/5710611/66321981-b3b9c680-e921-11e9-9cf3-a48e243d75ce.png)

#### Changes
- Add progress bar component
- Add progress bar story

#### Notes for Reviewers
The component is needed for #1404, to indicate the progress of bulk device creation. I sourced this out into a separate PR, to reduce diff size and to maintain proper scope.
