### PR TITLE
Support fetching configuration from blobs

### DIFF
--- a/cmd/internal/shared/config.go
+++ b/cmd/internal/shared/config.go
@@ -86,7 +86,7 @@ var DefaultEventsConfig = config.Events{
 }
 
 // DefaultBlobConfig is the default config for the blob store.
-var DefaultBlobConfig = config.Blob{
+var DefaultBlobConfig = config.BlobConfig{
 	Provider: "local",
 	Local: config.BlobConfigLocal{
 		Directory: "./public/blob",

--- a/config/messages.json
+++ b/config/messages.json
@@ -2285,18 +2285,9 @@
       "file": "eui.go"
     }
   },
-  "error:pkg/blob:missing_config": {
+  "error:pkg/blob:invalid_config": {
     "translations": {
-      "en": "missing blob store configuration"
-    },
-    "description": {
-      "package": "pkg/blob",
-      "file": "bucket.go"
-    }
-  },
-  "error:pkg/blob:unknown_provider": {
-    "translations": {
-      "en": "unknown blob store provider `{provider}`"
+      "en": "invalid blob store configuration"
     },
     "description": {
       "package": "pkg/blob",
@@ -2400,6 +2391,24 @@
     "description": {
       "package": "pkg/config",
       "file": "hooks.go"
+    }
+  },
+  "error:pkg/config:missing_blob_config": {
+    "translations": {
+      "en": "missing blob store configuration"
+    },
+    "description": {
+      "package": "pkg/config",
+      "file": "shared.go"
+    }
+  },
+  "error:pkg/config:unknown_blob_provider": {
+    "translations": {
+      "en": "unknown blob store provider `{provider}`"
+    },
+    "description": {
+      "package": "pkg/config",
+      "file": "shared.go"
     }
   },
   "error:pkg/crypto/cryptoservices:no_app_key": {

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -38,6 +38,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/crypto"
 	"go.thethings.network/lorawan-stack/pkg/crypto/cryptoutil"
+	"go.thethings.network/lorawan-stack/pkg/devicerepository"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/events"
 	"go.thethings.network/lorawan-stack/pkg/interop"
@@ -117,7 +118,7 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 		}
 	}
 
-	drCl, err := baseConf.DeviceRepository.Client(ctx, baseConf.Blob)
+	drFetcher, err := baseConf.DeviceRepository.Fetcher(ctx, baseConf.Blob)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +131,9 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 		linkRegistry:   conf.Links,
 		deviceRegistry: conf.Devices,
 		formatter: payloadFormatter{
-			repository: drCl,
+			repository: &devicerepository.Client{
+				Fetcher: drFetcher,
+			},
 			upFormatters: map[ttnpb.PayloadFormatter]messageprocessors.PayloadDecoder{
 				ttnpb.PayloadFormatter_FORMATTER_JAVASCRIPT: javascript.New(),
 				ttnpb.PayloadFormatter_FORMATTER_CAYENNELPP: cayennelpp.New(),

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -101,6 +101,8 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 
 	ctx := log.NewContextWithField(c.Context(), "namespace", "applicationserver")
 
+	baseConf := c.GetBaseConfig(ctx)
+
 	var interopCl InteropClient
 	if !conf.Interop.IsZero() {
 		var fallbackTLS *tls.Config
@@ -111,13 +113,13 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 			fallbackTLS = cTLS
 		}
 
-		interopCl, err = interop.NewClient(ctx, conf.Interop.InteropClient, fallbackTLS)
+		interopCl, err = interop.NewClient(ctx, conf.Interop.InteropClient, baseConf.Blob, fallbackTLS)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	drCl, err := c.GetBaseConfig(c.Context()).DeviceRepository.Client()
+	drCl, err := baseConf.DeviceRepository.Client(ctx, baseConf.Blob)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -123,10 +123,6 @@ func New(logger log.Stack, config *Config, opts ...Option) (c *Component, err er
 
 	ctx = log.NewContext(ctx, logger)
 
-	fps, err := config.FrequencyPlans.Store()
-	if err != nil {
-		return nil, err
-	}
 	keyVault, err := config.KeyVault.KeyVault()
 	if err != nil {
 		return nil, err
@@ -144,8 +140,7 @@ func New(logger log.Stack, config *Config, opts ...Option) (c *Component, err er
 
 		tcpListeners: make(map[string]*listener),
 
-		FrequencyPlans: fps,
-		KeyVault:       keyVault,
+		KeyVault: keyVault,
 	}
 
 	if config.Sentry.DSN != "" {
@@ -158,6 +153,13 @@ func New(logger log.Stack, config *Config, opts ...Option) (c *Component, err er
 	for _, opt := range opts {
 		opt(c)
 	}
+
+	fps, err := config.FrequencyPlans.Store(c.ctx, c.GetBaseConfig(c.ctx).Blob)
+	if err != nil {
+		return nil, err
+	}
+	c.FrequencyPlans = fps
+
 	if c.clusterNew == nil {
 		c.clusterNew = cluster.New
 	}

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -154,11 +154,11 @@ func New(logger log.Stack, config *Config, opts ...Option) (c *Component, err er
 		opt(c)
 	}
 
-	fps, err := config.FrequencyPlans.Store(c.ctx, c.GetBaseConfig(c.ctx).Blob)
+	fpsFetcher, err := config.FrequencyPlans.Fetcher(ctx, c.GetBaseConfig(c.ctx).Blob)
 	if err != nil {
 		return nil, err
 	}
-	c.FrequencyPlans = fps
+	c.FrequencyPlans = frequencyplans.NewStore(fpsFetcher)
 
 	if c.clusterNew == nil {
 		c.clusterNew = cluster.New

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -334,15 +334,17 @@ func (c DeviceRepositoryConfig) Client(ctx context.Context, blobConf BlobConfig)
 
 // InteropClient represents the client-side interoperability through LoRaWAN Backend Interfaces configuration.
 type InteropClient struct {
-	Directory   string         `name:"directory" description:"Retrieve the interoperability client configuration from the filesystem"`
-	URL         string         `name:"url" description:"Retrieve the interoperability client configuration from a web server"`
-	Blob        BlobPathConfig `name:"blob" description:"Retrieve the interoperability client configuration from a blob"`
-	FallbackTLS *tls.Config    `name:"-"`
+	Directory string         `name:"directory" description:"Retrieve the interoperability client configuration from the filesystem"`
+	URL       string         `name:"url" description:"Retrieve the interoperability client configuration from a web server"`
+	Blob      BlobPathConfig `name:"blob" description:"Retrieve the interoperability client configuration from a blob"`
+
+	GetFallbackTLSConfig func(ctx context.Context) (*tls.Config, error) `name:"-"`
+	BlobConfig           BlobConfig                                     `name:"-"`
 }
 
 // IsZero returns whether conf is empty.
 func (c InteropClient) IsZero() bool {
-	return c == (InteropClient{})
+	return c.Directory == "" && c.URL == "" && c.Blob.IsZero() && c.GetFallbackTLSConfig == nil && c.BlobConfig == BlobConfig{}
 }
 
 // Fetcher returns fetch.Interface defined by conf.

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -17,14 +17,20 @@ package config
 import (
 	"context"
 	"crypto/tls"
+	"io/ioutil"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	ttnblob "go.thethings.network/lorawan-stack/pkg/blob"
 	"go.thethings.network/lorawan-stack/pkg/crypto"
 	"go.thethings.network/lorawan-stack/pkg/crypto/cryptoutil"
 	"go.thethings.network/lorawan-stack/pkg/devicerepository"
+	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/fetch"
 	"go.thethings.network/lorawan-stack/pkg/frequencyplans"
 	"go.thethings.network/lorawan-stack/pkg/log"
+	"gocloud.dev/blob"
 )
 
 // Base represents base component configuration.
@@ -165,6 +171,11 @@ func (v KeyVault) KeyVault() (crypto.KeyVault, error) {
 	}
 }
 
+var (
+	errUnknownBlobProvider = errors.DefineInvalidArgument("unknown_blob_provider", "unknown blob store provider `{provider}`")
+	errMissingBlobConfig   = errors.DefineInvalidArgument("missing_blob_config", "missing blob store configuration")
+)
+
 // BlobConfigLocal is the blob store configuration for the local filesystem provider.
 type BlobConfigLocal struct {
 	Directory string `name:"directory" description:"Local directory that holds the buckets"`
@@ -179,18 +190,72 @@ type BlobConfigAWS struct {
 	SessionToken    string `name:"session-token" description:"Session token"`
 }
 
+type blobConfigAWSCredentials BlobConfigAWS
+
+func (c blobConfigAWSCredentials) Retrieve() (credentials.Value, error) {
+	if c.AccessKeyID == "" || c.SecretAccessKey == "" {
+		return credentials.Value{}, errMissingBlobConfig
+	}
+	return credentials.Value{
+		ProviderName:    "TTNConfigProvider",
+		AccessKeyID:     c.AccessKeyID,
+		SecretAccessKey: c.SecretAccessKey,
+	}, nil
+}
+
+func (c blobConfigAWSCredentials) IsExpired() bool { return false }
+
 // BlobConfigGCP is the blob store configuration for the GCP provider.
 type BlobConfigGCP struct {
 	CredentialsFile string `name:"credentials-file" description:"Path to the GCP credentials JSON file"`
 	Credentials     string `name:"credentials" description:"JSON data of the GCP credentials, if not using JSON file"`
 }
 
-// Blob store configuration.
-type Blob struct {
+// BlobConfig is the blob store configuration.
+type BlobConfig struct {
 	Provider string          `name:"provider" description:"Blob store provider (local|aws|gcp)"`
 	Local    BlobConfigLocal `name:"local"`
 	AWS      BlobConfigAWS   `name:"aws"`
 	GCP      BlobConfigGCP   `name:"gcp"`
+}
+
+// Bucket returns the requested blob bucket using the config.
+func (c BlobConfig) Bucket(ctx context.Context, bucket string) (*blob.Bucket, error) {
+	switch c.Provider {
+	case "local":
+		return ttnblob.Local(ctx, bucket, c.Local.Directory)
+	case "aws":
+		return ttnblob.AWS(ctx, bucket, &aws.Config{
+			Endpoint:    &c.AWS.Endpoint,
+			Region:      &c.AWS.Region,
+			Credentials: credentials.NewCredentials(blobConfigAWSCredentials(c.AWS)),
+		})
+	case "gcp":
+		var jsonCreds []byte
+		if c.GCP.Credentials != "" {
+			jsonCreds = []byte(c.GCP.Credentials)
+		} else if c.GCP.CredentialsFile != "" {
+			var err error
+			jsonCreds, err = ioutil.ReadFile(c.GCP.CredentialsFile)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, errMissingBlobConfig
+		}
+		return ttnblob.GCP(ctx, bucket, jsonCreds)
+	default:
+		return nil, errUnknownBlobProvider.WithAttributes("provider", c.Provider)
+	}
+}
+
+type BlobPathConfig struct {
+	Bucket string `name:"bucket" description:"Bucket to use"`
+	Path   string `name:"path" description:"Path to use"`
+}
+
+func (c BlobPathConfig) IsZero() bool {
+	return c == BlobPathConfig{}
 }
 
 // FrequencyPlansConfig contains the source of the frequency plans.
@@ -198,12 +263,13 @@ type FrequencyPlansConfig struct {
 	Static    map[string][]byte `name:"-"`
 	Directory string            `name:"directory" description:"Retrieve the frequency plans from the filesystem"`
 	URL       string            `name:"url" description:"Retrieve the frequency plans from a web server"`
+	Blob      BlobPathConfig    `name:"blob" description:"Retrieve the frequency plans from a blob"`
 }
 
-// Store returns a frequencyplan.Store fwith a fetcher based on the configuration.
-// The order of precedence is Static, Directory and URL.
-// If neither Static, Directory nor a URL is set, this method returns nil, nil.
-func (c FrequencyPlansConfig) Store() (*frequencyplans.Store, error) {
+// Store returns a frequencyplan.Store with a fetcher based on the configuration.
+// The order of precedence is Static, Directory, URL and Blob.
+// If neither Static, Directory, URL nor a Blob is set, this method returns nil, nil.
+func (c FrequencyPlansConfig) Store(ctx context.Context, blobConf BlobConfig) (*frequencyplans.Store, error) {
 	var fetcher fetch.Interface
 	switch {
 	case c.Static != nil:
@@ -216,6 +282,12 @@ func (c FrequencyPlansConfig) Store() (*frequencyplans.Store, error) {
 		if err != nil {
 			return nil, err
 		}
+	case !c.Blob.IsZero():
+		b, err := blobConf.Bucket(ctx, c.Blob.Bucket)
+		if err != nil {
+			return nil, err
+		}
+		fetcher = fetch.FromBucket(ctx, b, c.Blob.Path)
 	default:
 		return nil, nil
 	}
@@ -227,12 +299,13 @@ type DeviceRepositoryConfig struct {
 	Static    map[string][]byte `name:"-"`
 	Directory string            `name:"directory" description:"Retrieve the device repository from the filesystem"`
 	URL       string            `name:"url" description:"Retrieve the device repository from a web server"`
+	Blob      BlobPathConfig    `name:"blob" description:"Retrieve the device repository from a blob"`
 }
 
 // Client instantiates a new devicerepository.Client with a fetcher based on the configuration.
-// The order of precedence is Static, Directory and URL.
-// If neither Static, Directory nor a URL is set, this method returns nil, nil.
-func (c DeviceRepositoryConfig) Client() (*devicerepository.Client, error) {
+// The order of precedence is Static, Directory, URL and Blob.
+// If neither Static, Directory, URL nor a Blob is set, this method returns nil, nil.
+func (c DeviceRepositoryConfig) Client(ctx context.Context, blobConf BlobConfig) (*devicerepository.Client, error) {
 	var fetcher fetch.Interface
 	switch {
 	case c.Static != nil:
@@ -245,6 +318,12 @@ func (c DeviceRepositoryConfig) Client() (*devicerepository.Client, error) {
 		if err != nil {
 			return nil, err
 		}
+	case !c.Blob.IsZero():
+		b, err := blobConf.Bucket(ctx, c.Blob.Bucket)
+		if err != nil {
+			return nil, err
+		}
+		fetcher = fetch.FromBucket(ctx, b, c.Blob.Path)
 	default:
 		return nil, nil
 	}
@@ -255,9 +334,10 @@ func (c DeviceRepositoryConfig) Client() (*devicerepository.Client, error) {
 
 // InteropClient represents the client-side interoperability through LoRaWAN Backend Interfaces configuration.
 type InteropClient struct {
-	Directory   string      `name:"directory" description:"Retrieve the interoperability client configuration from the filesystem"`
-	URL         string      `name:"url" description:"Retrieve the interoperability client configuration from a web server"`
-	FallbackTLS *tls.Config `name:"-"`
+	Directory   string         `name:"directory" description:"Retrieve the interoperability client configuration from the filesystem"`
+	URL         string         `name:"url" description:"Retrieve the interoperability client configuration from a web server"`
+	Blob        BlobPathConfig `name:"blob" description:"Retrieve the interoperability client configuration from a blob"`
+	FallbackTLS *tls.Config    `name:"-"`
 }
 
 // IsZero returns whether conf is empty.
@@ -266,12 +346,20 @@ func (c InteropClient) IsZero() bool {
 }
 
 // Fetcher returns fetch.Interface defined by conf.
-func (c InteropClient) Fetcher() (fetch.Interface, error) {
+// The order of precedence is Static, Directory, URL and Blob.
+// If neither Static, Directory, URL nor a Blob is set, this method returns nil, nil.
+func (c InteropClient) Fetcher(ctx context.Context, blobConf BlobConfig) (fetch.Interface, error) {
 	switch {
 	case c.Directory != "":
 		return fetch.FromFilesystem(c.Directory), nil
 	case c.URL != "":
 		return fetch.FromHTTP(c.URL, true)
+	case !c.Blob.IsZero():
+		b, err := blobConf.Bucket(ctx, c.Blob.Bucket)
+		if err != nil {
+			return nil, err
+		}
+		return fetch.FromBucket(ctx, b, c.Blob.Path), nil
 	default:
 		return nil, nil
 	}
@@ -288,7 +376,7 @@ type ServiceBase struct {
 	Interop          InteropServer          `name:"interop"`
 	TLS              TLS                    `name:"tls"`
 	Sentry           Sentry                 `name:"sentry"`
-	Blob             Blob                   `name:"blob"`
+	Blob             BlobConfig             `name:"blob"`
 	FrequencyPlans   FrequencyPlansConfig   `name:"frequency-plans" description:"Source of the frequency plans"`
 	DeviceRepository DeviceRepositoryConfig `name:"device-repository" description:"Source of the device repository"`
 	Rights           Rights                 `name:"rights"`

--- a/pkg/fetch/bucket_test.go
+++ b/pkg/fetch/bucket_test.go
@@ -20,34 +20,35 @@ import (
 	"testing"
 
 	"github.com/smartystreets/assertions"
-	"go.thethings.network/lorawan-stack/pkg/blob"
-	"go.thethings.network/lorawan-stack/pkg/fetch"
+	"go.thethings.network/lorawan-stack/pkg/config"
+	. "go.thethings.network/lorawan-stack/pkg/fetch"
 	"go.thethings.network/lorawan-stack/pkg/util/test"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 )
 
 func TestBucket(t *testing.T) {
+	a := assertions.New(t)
+	ctx := test.Context()
+
 	tmpDir, err := ioutil.TempDir("", "FetchTestBucket")
 	if err != nil {
 		t.Fatalf("Failed to create temporary directory: %v", err)
 	}
 	defer os.RemoveAll(tmpDir)
 
-	config := blob.Config{Provider: "local"}
-	config.Local.Directory = tmpDir
-
-	a := assertions.New(t)
+	conf := config.BlobConfig{Provider: "local"}
+	conf.Local.Directory = tmpDir
 
 	filename := "file"
 	content := []byte("Hello world")
 
-	bucket, err := config.GetBucket(test.Context(), "bucket")
+	bucket, err := conf.Bucket(ctx, "bucket")
 	a.So(err, should.BeNil)
 
-	err = bucket.WriteAll(test.Context(), filename, content, nil)
+	err = bucket.WriteAll(ctx, filename, content, nil)
 	a.So(err, should.BeNil)
 
-	fetcher := fetch.FromBucket(bucket, "")
+	fetcher := FromBucket(ctx, bucket, "")
 
 	// Reading working file
 	{

--- a/pkg/identityserver/picture/picture_test.go
+++ b/pkg/identityserver/picture/picture_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 
 	"github.com/smartystreets/assertions"
-	"go.thethings.network/lorawan-stack/pkg/blob"
+	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/identityserver/picture"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/util/test"
@@ -102,9 +102,9 @@ func TestStore(t *testing.T) {
 	a := assertions.New(t)
 
 	ctx := test.Context()
-	var blobConfig blob.Config
+	var blobConfig config.BlobConfig
 	blobConfig.Provider, blobConfig.Local.Directory = "local", "."
-	bucket, _ := blobConfig.GetBucket(ctx, "testdata")
+	bucket, _ := blobConfig.Bucket(ctx, "testdata")
 
 	pic, err := picture.Store(ctx, bucket, "picture", &ttnpb.Picture{
 		Sizes: map[uint32]string{

--- a/pkg/identityserver/profile_picture.go
+++ b/pkg/identityserver/profile_picture.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	ulid "github.com/oklog/ulid/v2"
-	ttnblob "go.thethings.network/lorawan-stack/pkg/blob"
 	"go.thethings.network/lorawan-stack/pkg/identityserver/picture"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/unique"
@@ -83,7 +82,7 @@ func (is *IdentityServer) processUserProfilePicture(ctx context.Context, usr *tt
 	}
 
 	// Store picture to bucket.
-	bucket, err := ttnblob.Config(is.Component.GetBaseConfig(ctx).Blob).GetBucket(ctx, is.configFromContext(ctx).ProfilePicture.Bucket)
+	bucket, err := is.Component.GetBaseConfig(ctx).Blob.Bucket(ctx, is.configFromContext(ctx).ProfilePicture.Bucket)
 	if err != nil {
 		return err
 	}

--- a/pkg/interop/client.go
+++ b/pkg/interop/client.go
@@ -378,10 +378,18 @@ const InteropClientConfigurationName = "config.yaml"
 
 // NewClient return new interop client.
 // fallbackTLS is optional.
-func NewClient(ctx context.Context, conf config.InteropClient, blobConf config.BlobConfig, fallbackTLS *tls.Config) (*Client, error) {
-	fetcher, err := conf.Fetcher(ctx, blobConf)
+func NewClient(ctx context.Context, conf config.InteropClient) (*Client, error) {
+	var fallbackTLS *tls.Config
+	tlsConf, err := conf.GetFallbackTLSConfig(ctx)
 	if err != nil {
-		return nil, errUnknownConfig.WithCause(err)
+		log.FromContext(ctx).WithError(err).Warn("Could not get fallback TLS config for interoperability")
+	} else {
+		fallbackTLS = tlsConf
+	}
+
+	fetcher, err := conf.Fetcher(ctx, conf.BlobConfig)
+	if err != nil {
+		return nil, err
 	}
 	if fetcher == nil {
 		return nil, errUnknownConfig

--- a/pkg/interop/client.go
+++ b/pkg/interop/client.go
@@ -378,8 +378,8 @@ const InteropClientConfigurationName = "config.yaml"
 
 // NewClient return new interop client.
 // fallbackTLS is optional.
-func NewClient(ctx context.Context, conf config.InteropClient, fallbackTLS *tls.Config) (*Client, error) {
-	fetcher, err := conf.Fetcher()
+func NewClient(ctx context.Context, conf config.InteropClient, blobConf config.BlobConfig, fallbackTLS *tls.Config) (*Client, error) {
+	fetcher, err := conf.Fetcher(ctx, blobConf)
 	if err != nil {
 		return nil, errUnknownConfig.WithCause(err)
 	}

--- a/pkg/interop/client_test.go
+++ b/pkg/interop/client_test.go
@@ -1189,7 +1189,7 @@ paths:
 			conf, flush := tc.NewClientConfig(host[0], uint32(test.Must(strconv.ParseUint(host[1], 10, 32)).(uint64)))
 			defer flush()
 
-			cl, err := NewClient(ctx, conf, tc.NewFallbackTLSConfig())
+			cl, err := NewClient(ctx, conf, config.BlobConfig{}, tc.NewFallbackTLSConfig())
 			if !a.So(err, should.BeNil) {
 				t.Fatalf("Failed to create new client: %s", err)
 			}

--- a/pkg/interop/client_test.go
+++ b/pkg/interop/client_test.go
@@ -15,6 +15,7 @@
 package interop_test
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io/ioutil"
@@ -63,14 +64,13 @@ func TestGetAppSKey(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		Name                 string
-		NewServer            func(*testing.T) *httptest.Server
-		NewFallbackTLSConfig func() *tls.Config
-		NewClientConfig      func(fqdn string, port uint32) (config.InteropClient, func() error)
-		AsID                 string
-		Request              *ttnpb.SessionKeyRequest
-		ResponseAssertion    func(*testing.T, *ttnpb.AppSKeyResponse) bool
-		ErrorAssertion       func(*testing.T, error) bool
+		Name              string
+		NewServer         func(*testing.T) *httptest.Server
+		NewClientConfig   func(fqdn string, port uint32) (config.InteropClient, func() error)
+		AsID              string
+		Request           *ttnpb.SessionKeyRequest
+		ResponseAssertion func(*testing.T, *ttnpb.AppSKeyResponse) bool
+		ErrorAssertion    func(*testing.T, error) bool
 	}{
 		{
 			Name: "Backend Interfaces 1.0/UnknownDevEUI",
@@ -93,7 +93,6 @@ func TestGetAppSKey(t *testing.T) {
 					a.So(err, should.BeNil)
 				}))
 			},
-			NewFallbackTLSConfig: func() *tls.Config { return nil },
 			NewClientConfig: func(fqdn string, port uint32) (config.InteropClient, func() error) {
 				confDir := test.Must(ioutil.TempDir("", "lorawan-stack-js-interop-test")).(string)
 				confPath := filepath.Join(confDir, InteropClientConfigurationName)
@@ -175,7 +174,8 @@ paths:
 				), 0644))
 
 				return config.InteropClient{
-						Directory: confDir,
+						Directory:            confDir,
+						GetFallbackTLSConfig: func(context.Context) (*tls.Config, error) { return nil, nil },
 					}, func() error {
 						return os.RemoveAll(confDir)
 					}
@@ -211,7 +211,6 @@ paths:
 					a.So(err, should.BeNil)
 				}))
 			},
-			NewFallbackTLSConfig: func() *tls.Config { return nil },
 			NewClientConfig: func(fqdn string, port uint32) (config.InteropClient, func() error) {
 				confDir := test.Must(ioutil.TempDir("", "lorawan-stack-js-interop-test")).(string)
 				confPath := filepath.Join(confDir, InteropClientConfigurationName)
@@ -293,7 +292,8 @@ paths:
 				), 0644))
 
 				return config.InteropClient{
-						Directory: confDir,
+						Directory:            confDir,
+						GetFallbackTLSConfig: func(context.Context) (*tls.Config, error) { return nil, nil },
 					}, func() error {
 						return os.RemoveAll(confDir)
 					}
@@ -341,7 +341,6 @@ paths:
 					a.So(err, should.BeNil)
 				}))
 			},
-			NewFallbackTLSConfig: func() *tls.Config { return nil },
 			NewClientConfig: func(fqdn string, port uint32) (config.InteropClient, func() error) {
 				confDir := test.Must(ioutil.TempDir("", "lorawan-stack-js-interop-test")).(string)
 				confPath := filepath.Join(confDir, InteropClientConfigurationName)
@@ -423,7 +422,8 @@ paths:
 				), 0644))
 
 				return config.InteropClient{
-						Directory: confDir,
+						Directory:            confDir,
+						GetFallbackTLSConfig: func(context.Context) (*tls.Config, error) { return nil, nil },
 					}, func() error {
 						return os.RemoveAll(confDir)
 					}
@@ -476,7 +476,6 @@ paths:
 					a.So(err, should.BeNil)
 				}))
 			},
-			NewFallbackTLSConfig: func() *tls.Config { return nil },
 			NewClientConfig: func(fqdn string, port uint32) (config.InteropClient, func() error) {
 				confDir := test.Must(ioutil.TempDir("", "lorawan-stack-js-interop-test")).(string)
 				confPath := filepath.Join(confDir, InteropClientConfigurationName)
@@ -558,7 +557,8 @@ paths:
 				), 0644))
 
 				return config.InteropClient{
-						Directory: confDir,
+						Directory:            confDir,
+						GetFallbackTLSConfig: func(context.Context) (*tls.Config, error) { return nil, nil },
 					}, func() error {
 						return os.RemoveAll(confDir)
 					}
@@ -595,7 +595,7 @@ paths:
 			conf, flush := tc.NewClientConfig(host[0], uint32(test.Must(strconv.ParseUint(host[1], 10, 32)).(uint64)))
 			defer flush()
 
-			cl, err := NewClient(ctx, conf, tc.NewFallbackTLSConfig())
+			cl, err := NewClient(ctx, conf)
 			if !a.So(err, should.BeNil) {
 				t.Fatalf("Failed to create new client: %s", err)
 			}
@@ -629,14 +629,13 @@ func TestHandleJoinRequest(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		Name                 string
-		NewServer            func(*testing.T) *httptest.Server
-		NewFallbackTLSConfig func() *tls.Config
-		NewClientConfig      func(fqdn string, port uint32) (config.InteropClient, func() error)
-		NetID                types.NetID
-		Request              *ttnpb.JoinRequest
-		ResponseAssertion    func(*testing.T, *ttnpb.JoinResponse) bool
-		ErrorAssertion       func(*testing.T, error) bool
+		Name              string
+		NewServer         func(*testing.T) *httptest.Server
+		NewClientConfig   func(fqdn string, port uint32) (config.InteropClient, func() error)
+		NetID             types.NetID
+		Request           *ttnpb.JoinRequest
+		ResponseAssertion func(*testing.T, *ttnpb.JoinResponse) bool
+		ErrorAssertion    func(*testing.T, error) bool
 	}{
 		{
 			Name: "Backend Interfaces 1.0/MICFailed",
@@ -659,7 +658,6 @@ func TestHandleJoinRequest(t *testing.T) {
 					a.So(err, should.BeNil)
 				}))
 			},
-			NewFallbackTLSConfig: func() *tls.Config { return nil },
 			NewClientConfig: func(fqdn string, port uint32) (config.InteropClient, func() error) {
 				confDir := test.Must(ioutil.TempDir("", "lorawan-stack-js-interop-test")).(string)
 				confPath := filepath.Join(confDir, InteropClientConfigurationName)
@@ -741,7 +739,8 @@ paths:
 				), 0644))
 
 				return config.InteropClient{
-						Directory: confDir,
+						Directory:            confDir,
+						GetFallbackTLSConfig: func(context.Context) (*tls.Config, error) { return nil, nil },
 					}, func() error {
 						return os.RemoveAll(confDir)
 					}
@@ -777,7 +776,6 @@ paths:
 					a.So(err, should.BeNil)
 				}))
 			},
-			NewFallbackTLSConfig: func() *tls.Config { return nil },
 			NewClientConfig: func(fqdn string, port uint32) (config.InteropClient, func() error) {
 				confDir := test.Must(ioutil.TempDir("", "lorawan-stack-js-interop-test")).(string)
 				confPath := filepath.Join(confDir, InteropClientConfigurationName)
@@ -859,7 +857,8 @@ paths:
 				), 0644))
 
 				return config.InteropClient{
-						Directory: confDir,
+						Directory:            confDir,
+						GetFallbackTLSConfig: func(context.Context) (*tls.Config, error) { return nil, nil },
 					}, func() error {
 						return os.RemoveAll(confDir)
 					}
@@ -913,7 +912,6 @@ paths:
 					a.So(err, should.BeNil)
 				}))
 			},
-			NewFallbackTLSConfig: func() *tls.Config { return nil },
 			NewClientConfig: func(fqdn string, port uint32) (config.InteropClient, func() error) {
 				confDir := test.Must(ioutil.TempDir("", "lorawan-stack-js-interop-test")).(string)
 				confPath := filepath.Join(confDir, InteropClientConfigurationName)
@@ -995,7 +993,8 @@ paths:
 				), 0644))
 
 				return config.InteropClient{
-						Directory: confDir,
+						Directory:            confDir,
+						GetFallbackTLSConfig: func(context.Context) (*tls.Config, error) { return nil, nil },
 					}, func() error {
 						return os.RemoveAll(confDir)
 					}
@@ -1062,7 +1061,6 @@ paths:
 					a.So(err, should.BeNil)
 				}))
 			},
-			NewFallbackTLSConfig: func() *tls.Config { return nil },
 			NewClientConfig: func(fqdn string, port uint32) (config.InteropClient, func() error) {
 				confDir := test.Must(ioutil.TempDir("", "lorawan-stack-js-interop-test")).(string)
 				confPath := filepath.Join(confDir, InteropClientConfigurationName)
@@ -1144,7 +1142,8 @@ paths:
 				), 0644))
 
 				return config.InteropClient{
-						Directory: confDir,
+						Directory:            confDir,
+						GetFallbackTLSConfig: func(context.Context) (*tls.Config, error) { return nil, nil },
 					}, func() error {
 						return os.RemoveAll(confDir)
 					}
@@ -1189,7 +1188,7 @@ paths:
 			conf, flush := tc.NewClientConfig(host[0], uint32(test.Must(strconv.ParseUint(host[1], 10, 32)).(uint64)))
 			defer flush()
 
-			cl, err := NewClient(ctx, conf, config.BlobConfig{}, tc.NewFallbackTLSConfig())
+			cl, err := NewClient(ctx, conf)
 			if !a.So(err, should.BeNil) {
 				t.Fatalf("Failed to create new client: %s", err)
 			}

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -171,15 +171,13 @@ func New(c *component.Component, conf *Config, opts ...Option) (*NetworkServer, 
 
 	var interopCl InteropClient
 	if !conf.Interop.IsZero() {
-		var fallbackTLS *tls.Config
-		cTLS, err := c.GetTLSClientConfig(ctx)
-		if err != nil {
-			log.FromContext(ctx).WithError(err).Warn("Could not get fallback TLS config for interoperability")
-		} else {
-			fallbackTLS = cTLS
+		interopConf := conf.Interop
+		interopConf.GetFallbackTLSConfig = func(ctx context.Context) (*tls.Config, error) {
+			return c.GetTLSClientConfig(ctx)
 		}
+		interopConf.BlobConfig = c.GetBaseConfig(ctx).Blob
 
-		interopCl, err = interop.NewClient(ctx, conf.Interop, c.GetBaseConfig(ctx).Blob, fallbackTLS)
+		interopCl, err = interop.NewClient(ctx, interopConf)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -179,7 +179,7 @@ func New(c *component.Component, conf *Config, opts ...Option) (*NetworkServer, 
 			fallbackTLS = cTLS
 		}
 
-		interopCl, err = interop.NewClient(ctx, conf.Interop, fallbackTLS)
+		interopCl, err = interop.NewClient(ctx, conf.Interop, c.GetBaseConfig(ctx).Blob, fallbackTLS)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #1272 

#### Changes
<!-- What are the changes made in this pull request? -->

- Support fetching configuration from blobs
- Remove `blob.Config` to avoid import cycles. Moving this logic to `config` is also more consistent with what we do for everything else

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Instead of explicitly passing `config.BlobConfig` it could be stored in the context, however we should keep in mind that `config.BlobConfig` may(and in most cases does) contain sensitive data, which may get exposed, hence I decided to err on the side of caution and simplicity and just pass it explicitly.

@adriansmares @bafonins no need for review

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Frequency plans, device repository and interoperability configuration can now be stored in AWS S3 buckets or GCP blobs.