### PR TITLE
TLS configuration sources and key vault support

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -2366,6 +2366,33 @@
       "file": "acme.go"
     }
   },
+  "error:pkg/component:tls_config_ambiguous": {
+    "translations": {
+      "en": "ambiguous TLS configuration"
+    },
+    "description": {
+      "package": "pkg/component",
+      "file": "tls.go"
+    }
+  },
+  "error:pkg/component:tls_config_empty": {
+    "translations": {
+      "en": "empty TLS configuration"
+    },
+    "description": {
+      "package": "pkg/component",
+      "file": "tls.go"
+    }
+  },
+  "error:pkg/component:tls_key_vault_id": {
+    "translations": {
+      "en": "invalid TLS key vault ID"
+    },
+    "description": {
+      "package": "pkg/component",
+      "file": "tls.go"
+    }
+  },
   "error:pkg/config:format": {
     "translations": {
       "en": "invalid format `{input}`"
@@ -2373,15 +2400,6 @@
     "description": {
       "package": "pkg/config",
       "file": "hooks.go"
-    }
-  },
-  "error:pkg/config:no_key_pair": {
-    "translations": {
-      "en": "no TLS key pair"
-    },
-    "description": {
-      "package": "pkg/config",
-      "file": "tls.go"
     }
   },
   "error:pkg/crypto/cryptoservices:no_app_key": {
@@ -2418,6 +2436,15 @@
     "description": {
       "package": "pkg/crypto/cryptoservices",
       "file": "mem.go"
+    }
+  },
+  "error:pkg/crypto/cryptoutil:certificate_not_found": {
+    "translations": {
+      "en": "certificate with ID `{id}` not found"
+    },
+    "description": {
+      "package": "pkg/crypto/cryptoutil",
+      "file": "keyvault_mem.go"
     }
   },
   "error:pkg/crypto/cryptoutil:invalid_length": {

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -104,7 +104,7 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 	var interopCl InteropClient
 	if !conf.Interop.IsZero() {
 		var fallbackTLS *tls.Config
-		cTLS, err := c.GetTLSConfig(ctx)
+		cTLS, err := c.GetTLSClientConfig(ctx)
 		if err != nil {
 			log.FromContext(ctx).WithError(err).Warn("Could not get fallback TLS config for interoperability")
 		} else {

--- a/pkg/basicstation/cups/server.go
+++ b/pkg/basicstation/cups/server.go
@@ -75,7 +75,7 @@ func (conf ServerConfig) NewServer(c *component.Component, customOpts ...Option)
 			}),
 		)
 	}
-	if tlsConfig, err := c.GetTLSConfig(c.Context()); err == nil {
+	if tlsConfig, err := c.GetTLSServerConfig(c.Context()); err == nil {
 		opts = append(opts, WithTLSConfig(tlsConfig))
 	}
 	s := NewServer(c, append(opts, customOpts...)...)

--- a/pkg/component/cluster.go
+++ b/pkg/component/cluster.go
@@ -27,7 +27,7 @@ func (c *Component) initCluster() (err error) {
 		cluster.WithServices(c.grpcSubsystems...),
 		cluster.WithConn(c.LoopbackConn()),
 	}
-	if tlsConfig, err := c.GetTLSConfig(c.Context()); err == nil {
+	if tlsConfig, err := c.GetTLSClientConfig(c.Context()); err == nil {
 		clusterOpts = append(clusterOpts, cluster.WithTLSConfig(tlsConfig))
 	}
 	c.cluster, err = c.clusterNew(c.ctx, &c.config.ServiceBase.Cluster, clusterOpts...)

--- a/pkg/component/cluster.go
+++ b/pkg/component/cluster.go
@@ -27,7 +27,7 @@ func (c *Component) initCluster() (err error) {
 		cluster.WithServices(c.grpcSubsystems...),
 		cluster.WithConn(c.LoopbackConn()),
 	}
-	if tlsConfig, err := c.config.TLS.Config(c.Context()); err == nil {
+	if tlsConfig, err := c.GetTLSConfig(c.Context()); err == nil {
 		clusterOpts = append(clusterOpts, cluster.WithTLSConfig(tlsConfig))
 	}
 	c.cluster, err = c.clusterNew(c.ctx, &c.config.ServiceBase.Cluster, clusterOpts...)

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -113,10 +113,14 @@ func WithBaseConfigGetter(f func(ctx context.Context) config.ServiceBase) Option
 }
 
 // New returns a new component.
-func New(logger log.Stack, config *Config, opts ...Option) (*Component, error) {
-	var err error
-
+func New(logger log.Stack, config *Config, opts ...Option) (c *Component, err error) {
 	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		if err != nil {
+			cancel()
+		}
+	}()
+
 	ctx = log.NewContext(ctx, logger)
 
 	fps, err := config.FrequencyPlans.Store()
@@ -124,7 +128,7 @@ func New(logger log.Stack, config *Config, opts ...Option) (*Component, error) {
 		return nil, err
 	}
 
-	c := &Component{
+	c = &Component{
 		ctx:                ctx,
 		cancelCtx:          cancel,
 		terminationSignals: make(chan os.Signal),

--- a/pkg/component/grpc.go
+++ b/pkg/component/grpc.go
@@ -81,7 +81,7 @@ func (c *Component) serveGRPC(lis net.Listener) error {
 func (c *Component) grpcEndpoints() []Endpoint {
 	return []Endpoint{
 		NewTCPEndpoint(c.config.GRPC.Listen, "gRPC"),
-		NewTLSEndpoint(c.config.GRPC.ListenTLS, "gRPC"),
+		NewTLSEndpoint(c.config.GRPC.ListenTLS, "gRPC", WithNextProtos("h2", "http/1.1")),
 	}
 }
 

--- a/pkg/component/interop.go
+++ b/pkg/component/interop.go
@@ -43,7 +43,10 @@ func (c *Component) interopEndpoints() []Endpoint {
 	}
 	return []Endpoint{
 		// TODO: Enable TCP endpoint (https://github.com/TheThingsNetwork/lorawan-stack/issues/717)
-		NewTLSEndpoint(c.config.Interop.ListenTLS, "Interop", WithTLSClientAuth(tls.RequireAndVerifyClientCert, certPool, nil)),
+		NewTLSEndpoint(c.config.Interop.ListenTLS, "Interop",
+			WithTLSClientAuth(tls.RequireAndVerifyClientCert, certPool, nil),
+			WithNextProtos("h2", "http/1.1"),
+		),
 	}
 }
 

--- a/pkg/component/listeners.go
+++ b/pkg/component/listeners.go
@@ -49,7 +49,7 @@ func (l *listener) TLS(opts ...TLSConfigOption) (net.Listener, error) {
 	if l.tlsUsed {
 		return nil, errors.New("TLS listener already in use")
 	}
-	config, err := l.c.GetTLSConfig(l.c.Context(), opts...)
+	config, err := l.c.GetTLSServerConfig(l.c.Context(), opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/component/tls.go
+++ b/pkg/component/tls.go
@@ -155,7 +155,6 @@ func (c *Component) GetTLSServerConfig(ctx context.Context, opts ...TLSConfigOpt
 		return nil, errEmptyTLSConfig
 	}
 	res.MinVersion = tls.VersionTLS12
-	res.NextProtos = []string{"h2", "http/1.1"}
 	res.PreferServerCipherSuites = true
 	for _, opt := range opts {
 		opt.apply(res)

--- a/pkg/component/tls.go
+++ b/pkg/component/tls.go
@@ -167,6 +167,7 @@ func (c *Component) GetTLSClientConfig(ctx context.Context, opts ...TLSConfigOpt
 	conf := c.GetBaseConfig(ctx).TLS
 	res := &tls.Config{}
 	if conf.RootCA != "" {
+		// TODO: Cache file (https://github.com/TheThingsNetwork/lorawan-stack/issues/1432)
 		pem, err := ioutil.ReadFile(conf.RootCA)
 		if err != nil {
 			return nil, err

--- a/pkg/component/web.go
+++ b/pkg/component/web.go
@@ -88,7 +88,7 @@ func (c *Component) serveWeb(lis net.Listener) error {
 func (c *Component) webEndpoints() []Endpoint {
 	return []Endpoint{
 		NewTCPEndpoint(c.config.HTTP.Listen, "Web"),
-		NewTLSEndpoint(c.config.HTTP.ListenTLS, "Web"),
+		NewTLSEndpoint(c.config.HTTP.ListenTLS, "Web", WithNextProtos("h2", "http/1.1")),
 	}
 }
 

--- a/pkg/config/tls.go
+++ b/pkg/config/tls.go
@@ -14,20 +14,6 @@
 
 package config
 
-import (
-	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"io/ioutil"
-	"sync/atomic"
-	"time"
-
-	"go.thethings.network/lorawan-stack/pkg/errors"
-	"go.thethings.network/lorawan-stack/pkg/events"
-	"go.thethings.network/lorawan-stack/pkg/events/fs"
-	"go.thethings.network/lorawan-stack/pkg/log"
-)
-
 // ACME represents ACME configuration.
 type ACME struct {
 	Enable      bool     `name:"enable" description:"Enable automated certificate management (ACME)"`
@@ -51,9 +37,11 @@ func (a ACME) IsZero() bool {
 type TLS struct {
 	RootCA             string `name:"root-ca" description:"Location of TLS root CA certificate (optional)"`
 	InsecureSkipVerify bool   `name:"insecure-skip-verify" description:"Skip verification of certificate chains (insecure)"`
-	Certificate        string `name:"certificate" description:"Location of TLS certificate"`
-	Key                string `name:"key" description:"Location of TLS private key"`
-	ACME               ACME   `name:"acme"`
+
+	Certificate string `name:"certificate" description:"Location of TLS certificate"`
+	Key         string `name:"key" description:"Location of TLS private key"`
+
+	ACME ACME `name:"acme"`
 }
 
 // IsZero returns whether the TLS configuration is empty.
@@ -62,65 +50,4 @@ func (t TLS) IsZero() bool {
 		t.Certificate == "" &&
 		t.Key == "" &&
 		t.ACME.IsZero()
-}
-
-var errNoKeyPair = errors.DefineFailedPrecondition("no_key_pair", "no TLS key pair")
-
-// Config loads the key pair and returns the server TLS configuration.
-// Config watches the certificate file and reloads the key pair on changes.
-// NOTE: The configuration returned by Config cannot be used for client connections.
-func (t TLS) Config(ctx context.Context) (*tls.Config, error) {
-	logger := log.FromContext(ctx)
-	if t.Certificate == "" || t.Key == "" {
-		return nil, errNoKeyPair
-	}
-	var cv atomic.Value
-	loadCertificate := func() error {
-		cert, err := tls.LoadX509KeyPair(t.Certificate, t.Key)
-		if err != nil {
-			return err
-		}
-		cv.Store(&cert)
-		logger.Debug("Loaded TLS certificate")
-		return nil
-	}
-	if err := loadCertificate(); err != nil {
-		return nil, err
-	}
-	var rootCAs *x509.CertPool
-	if t.RootCA != "" {
-		pem, err := ioutil.ReadFile(t.RootCA)
-		if err != nil {
-			return nil, err
-		}
-		rootCAs = x509.NewCertPool()
-		rootCAs.AppendCertsFromPEM(pem)
-	}
-
-	debounce := make(chan struct{}, 1)
-	fs.Watch(t.Certificate, events.HandlerFunc(func(evt events.Event) {
-		if evt.Name() != "fs.write" {
-			return
-		}
-		// We have to debounce this; OpenSSL typically causes a lot of write events.
-		select {
-		case debounce <- struct{}{}:
-			time.AfterFunc(5*time.Second, func() {
-				if err := loadCertificate(); err != nil {
-					logger.WithError(err).Error("Could not reload TLS certificate")
-					return
-				}
-				<-debounce
-			})
-		default:
-		}
-	}))
-
-	return &tls.Config{
-		RootCAs:            rootCAs,
-		InsecureSkipVerify: t.InsecureSkipVerify,
-		GetCertificate: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
-			return cv.Load().(*tls.Certificate), nil
-		},
-	}, nil
 }

--- a/pkg/config/tls.go
+++ b/pkg/config/tls.go
@@ -33,6 +33,12 @@ func (a ACME) IsZero() bool {
 		len(a.Hosts) == 0
 }
 
+// TLSKeyVault defines configuration for loading a certificate from the key vault.
+type TLSKeyVault struct {
+	Enable bool   `name:"enable" description:"Enable loading the certificate from the key vault"`
+	ID     string `name:"id" description:"ID of the certificate"`
+}
+
 // TLS represents TLS configuration.
 type TLS struct {
 	RootCA             string `name:"root-ca" description:"Location of TLS root CA certificate (optional)"`
@@ -42,6 +48,8 @@ type TLS struct {
 	Key         string `name:"key" description:"Location of TLS private key"`
 
 	ACME ACME `name:"acme"`
+
+	KeyVault TLSKeyVault `name:"key-vault"`
 }
 
 // IsZero returns whether the TLS configuration is empty.

--- a/pkg/crypto/cryptoutil/keyvault_mem.go
+++ b/pkg/crypto/cryptoutil/keyvault_mem.go
@@ -15,18 +15,24 @@
 package cryptoutil
 
 import (
+	"bytes"
+	"crypto/tls"
+	"encoding/pem"
+	"strings"
+
 	"go.thethings.network/lorawan-stack/pkg/crypto"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 )
 
-// MemKeyVault is a KeyVault that uses KEKs from memory.
-// This implementation does not provide any security as KEKs are stored in the clear.
+// MemKeyVault is a KeyVault that uses secrets from memory.
+// This implementation does not provide any security as secrets are stored in the clear.
 type MemKeyVault struct {
 	ComponentPrefixKEKLabeler
 	m map[string][]byte
 }
 
 // NewMemKeyVault returns a MemKeyVault.
+// For certificates,
 func NewMemKeyVault(m map[string][]byte) *MemKeyVault {
 	return &MemKeyVault{
 		m: m,
@@ -36,7 +42,7 @@ func NewMemKeyVault(m map[string][]byte) *MemKeyVault {
 var errKEKNotFound = errors.DefineNotFound("kek_not_found", "KEK with label `{label}` not found")
 
 // Wrap implements KeyVault.
-func (v *MemKeyVault) Wrap(plaintext []byte, kekLabel string) ([]byte, error) {
+func (v MemKeyVault) Wrap(plaintext []byte, kekLabel string) ([]byte, error) {
 	kek, ok := v.m[kekLabel]
 	if !ok {
 		return nil, errKEKNotFound.WithAttributes("label", kekLabel)
@@ -45,10 +51,42 @@ func (v *MemKeyVault) Wrap(plaintext []byte, kekLabel string) ([]byte, error) {
 }
 
 // Unwrap implements KeyVault.
-func (v *MemKeyVault) Unwrap(ciphertext []byte, kekLabel string) ([]byte, error) {
+func (v MemKeyVault) Unwrap(ciphertext []byte, kekLabel string) ([]byte, error) {
 	kek, ok := v.m[kekLabel]
 	if !ok {
 		return nil, errKEKNotFound.WithAttributes("label", kekLabel)
 	}
 	return crypto.UnwrapKey(ciphertext, kek)
+}
+
+var errCertificateNotFound = errors.DefineNotFound("certificate_not_found", "certificate with ID `{id}` not found")
+
+// LoadCertificate implements KeyVault.
+func (v MemKeyVault) LoadCertificate(id string) (*tls.Certificate, error) {
+	raw, ok := v.m[id]
+	if !ok {
+		return nil, errCertificateNotFound.WithAttributes("id", id)
+	}
+	certPEMBlock, keyPEMBlock := &bytes.Buffer{}, &bytes.Buffer{}
+	for {
+		block, rest := pem.Decode(raw)
+		if block == nil {
+			break
+		}
+		if block.Type == "CERTIFICATE" {
+			if err := pem.Encode(certPEMBlock, block); err != nil {
+				return nil, err
+			}
+		} else if block.Type == "PRIVATE KEY" || strings.HasSuffix(block.Type, " PRIVATE KEY") {
+			if err := pem.Encode(keyPEMBlock, block); err != nil {
+				return nil, err
+			}
+		}
+		raw = rest
+	}
+	res, err := tls.X509KeyPair(certPEMBlock.Bytes(), keyPEMBlock.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	return &res, nil
 }

--- a/pkg/crypto/keyvault.go
+++ b/pkg/crypto/keyvault.go
@@ -14,9 +14,14 @@
 
 package crypto
 
+import "crypto/tls"
+
 // KeyVault provides wrapping and unwrapping keys using KEK labels.
 type KeyVault interface {
+	ComponentKEKLabeler
+
 	Wrap(plaintext []byte, kekLabel string) ([]byte, error)
 	Unwrap(ciphertext []byte, kekLabel string) ([]byte, error)
-	ComponentKEKLabeler
+
+	LoadCertificate(id string) (*tls.Certificate, error)
 }

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -197,7 +197,7 @@ func New(c *component.Component, conf *Config, opts ...Option) (gs *GatewayServe
 	bsWebServer := basicstationlns.New(bsCtx, gs)
 	for _, endpoint := range []component.Endpoint{
 		component.NewTCPEndpoint(conf.BasicStation.Listen, "Basic Station"),
-		component.NewTLSEndpoint(conf.BasicStation.ListenTLS, "Basic Station"),
+		component.NewTLSEndpoint(conf.BasicStation.ListenTLS, "Basic Station", component.WithNextProtos("h2", "http/1.1")),
 	} {
 		if endpoint.Address() == "" {
 			continue

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -172,7 +172,7 @@ func New(c *component.Component, conf *Config, opts ...Option) (*NetworkServer, 
 	var interopCl InteropClient
 	if !conf.Interop.IsZero() {
 		var fallbackTLS *tls.Config
-		cTLS, err := c.GetTLSConfig(ctx)
+		cTLS, err := c.GetTLSClientConfig(ctx)
 		if err != nil {
 			log.FromContext(ctx).WithError(err).Warn("Could not get fallback TLS config for interoperability")
 		} else {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

TLS configuration sources

#### Changes
<!-- What are the changes made in this pull request? -->

- Move reading certificate from file, watching it etc from `pkg/config` to `pkg/component` where it's solely used and to move logic away from `pkg/config`
- Put TLS certificate sources in one place and check that there's no ambiguity. So for example if both a local file and ACME are configured, an error is returned because we don't know what the user wanted
- Support loading certificates from the key vault
- `RootCA` and `InsecureSkipVerify` are now applied regardless of the certificate source. Before, if ACME was configured, these settings were not used, and I think that was wrong. ACME is for inbound; these two settings are for outbound TLS. Typically, when using ACME, people are using commercial certs and system root chain, but we cannot assume that is always the case
- Fix lint warning on component cancelation

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Fixed not respecting `RootCA` and `InsecureSkipVerify` TLS settings when ACME was configured for requesting TLS certificates