### PR TITLE
Add fallback https redirection port

### DIFF
--- a/pkg/component/web.go
+++ b/pkg/component/web.go
@@ -53,6 +53,9 @@ func (c *Component) initWeb() error {
 		if err != nil {
 			return err
 		}
+		if httpsAddr.Port == 0 {
+			httpsAddr.Port = 443
+		}
 		webOptions = append(webOptions, web.WithRedirectToHTTPS(httpAddr.Port, httpsAddr.Port))
 		if httpAddr.Port != 80 && httpsAddr.Port != 443 {
 			webOptions = append(webOptions, web.WithRedirectToHTTPS(80, 443))


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This `quickfix` adds a fallback https redirection port. This is needed when there's no tls listener configured.

#### Changes
<!-- What are the changes made in this pull request? -->

- Check for zero value https port and set default.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

References: https://github.com/TheThingsIndustries/lorawan-stack-aws/issues/14