### PR TITLE
Assume max data rate index is 5 for predefined channels

### DIFF
--- a/pkg/networkserver/utils.go
+++ b/pkg/networkserver/utils.go
@@ -253,12 +253,15 @@ func newMACState(dev *ttnpb.EndDevice, fps *frequencyplans.Store, defaults ttnpb
 		panic("uplink/downlink channel length is inconsistent")
 	}
 
+	// NOTE: FactoryPresetFrequencies does not indicate the data rate ranges allowed for channels.
+	// In the latest regional parameters spec(1.1b) the data rate ranges are DR0-DR5 for mandatory channels in all non-fixed channel plans,
+	// hence we assume the same range for predefined channels.
 	if len(dev.GetMACSettings().GetFactoryPresetFrequencies()) > 0 {
 		macState.CurrentParameters.Channels = make([]*ttnpb.MACParameters_Channel, 0, len(dev.MACSettings.FactoryPresetFrequencies))
 		for _, freq := range dev.MACSettings.FactoryPresetFrequencies {
 			macState.CurrentParameters.Channels = append(macState.CurrentParameters.Channels, &ttnpb.MACParameters_Channel{
 				MinDataRateIndex:  0,
-				MaxDataRateIndex:  ttnpb.DATA_RATE_15,
+				MaxDataRateIndex:  ttnpb.DATA_RATE_5,
 				UplinkFrequency:   freq,
 				DownlinkFrequency: freq,
 				EnableUplink:      true,
@@ -269,7 +272,7 @@ func newMACState(dev *ttnpb.EndDevice, fps *frequencyplans.Store, defaults ttnpb
 		for _, freq := range defaults.FactoryPresetFrequencies {
 			macState.CurrentParameters.Channels = append(macState.CurrentParameters.Channels, &ttnpb.MACParameters_Channel{
 				MinDataRateIndex:  0,
-				MaxDataRateIndex:  ttnpb.DATA_RATE_15,
+				MaxDataRateIndex:  ttnpb.DATA_RATE_5,
 				UplinkFrequency:   freq,
 				DownlinkFrequency: freq,
 				EnableUplink:      true,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Refs https://github.com/TheThingsNetwork/lorawan-stack/issues/1378

(see the comment in the code, copy-pasted here)
FactoryPresetFrequencies does not indicate the data rate ranges allowed for channels.
In the latest regional parameters spec(1.1b) the data rate ranges are DR0-DR5 for mandatory channels in all non-fixed channel plans, hence we assume the same range for predefined channels.

#### Changes
<!-- What are the changes made in this pull request? -->

- Assume max data rate index is 5 for predefined channels

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

With this change applied TTN Node works fine using:
```
--lorawan_phy_version 1.0.2-b
--lorawan-version 1.0.2
--frequency_plan_id EU_863_870
--mac-settings.factory-preset-frequencies 868100000,868300000,868500000,867100000,867300000,867500000,867700000,867900000
--mac-settings.resets-f-cnt=true
--mac-settings.rx2-data-rate-index DATA_RATE_3
```