### PR TITLE
Add device bulk creation services to JS SDK

### DIFF
--- a/pkg/webui/console/api/index.js
+++ b/pkg/webui/console/api/index.js
@@ -147,9 +147,16 @@ export default {
   device: {
     get: ttnClient.Applications.Devices.getById.bind(ttnClient.Applications.Devices),
     create: ttnClient.Applications.Devices.create.bind(ttnClient.Applications.Devices),
+    bulkCreate: ttnClient.Applications.Devices.bulkCreate.bind(ttnClient.Applications.Devices),
     update: ttnClient.Applications.Devices.updateById.bind(ttnClient.Applications.Devices),
     eventsSubscribe: ttnClient.Applications.Devices.openStream.bind(ttnClient.Applications.Devices),
     delete: ttnClient.Applications.Devices.deleteById.bind(ttnClient.Applications.Devices),
+  },
+  deviceTemplates: {
+    listFormats: ttnClient.Applications.Devices.listTemplateFormats.bind(
+      ttnClient.Applications.Devices,
+    ),
+    convert: ttnClient.Applications.Devices.convertTemplate.bind(ttnClient.Applications.Devices),
   },
   gateways: {
     list: ttnClient.Gateways.getAll.bind(ttnClient.Gateways),

--- a/pkg/webui/console/containers/device-template-format-select/index.js
+++ b/pkg/webui/console/containers/device-template-format-select/index.js
@@ -1,0 +1,45 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { defineMessages } from 'react-intl'
+
+import CreateFetchSelect from '../fetch-select'
+import {
+  selectDeviceTemplateFormats,
+  selectDeviceTemplateFormatsError,
+  selectDeviceTemplateFormatsFetching,
+} from '../../store/selectors/device-template-formats'
+import { getDeviceTemplateFormats } from '../../store/actions/device-template-formats'
+
+const m = defineMessages({
+  title: 'File Format',
+  warning: 'Could not retrieve the list of available device template formats',
+})
+
+const formatOptions = formats =>
+  Object.keys(formats).map(key => ({
+    value: key,
+    label: `${formats[key].name} (${formats[key].description})`,
+    fileExtensions: formats[key].file_extensions,
+  }))
+
+export default CreateFetchSelect({
+  fetchOptions: getDeviceTemplateFormats,
+  optionsSelector: selectDeviceTemplateFormats,
+  errorSelector: selectDeviceTemplateFormatsError,
+  fetchingSelector: selectDeviceTemplateFormatsFetching,
+  defaultWarning: m.warning,
+  defaultTitle: m.title,
+  optionsFormatter: formatOptions,
+})

--- a/pkg/webui/console/store/actions/device-template-formats.js
+++ b/pkg/webui/console/store/actions/device-template-formats.js
@@ -1,0 +1,29 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { createRequestActions } from './lib'
+
+export const GET_DEVICE_TEMPLATE_FORMATS_BASE = 'GET_DEVICE_TEMPLATE_FORMATS'
+export const [
+  {
+    request: GET_DEVICE_TEMPLATE_FORMATS,
+    success: GET_DEVICE_TEMPLATE_FORMATS_SUCCESS,
+    failure: GET_DEVICE_TEMPLATE_FORMATS_FAILURE,
+  },
+  {
+    request: getDeviceTemplateFormats,
+    success: getDeviceTemplateFormatsSuccess,
+    failure: geteviceTemplateFormatsFailure,
+  },
+] = createRequestActions(GET_DEVICE_TEMPLATE_FORMATS_BASE)

--- a/pkg/webui/console/store/middleware/logics/devices.js
+++ b/pkg/webui/console/store/middleware/logics/devices.js
@@ -14,6 +14,7 @@
 
 import api from '../../../api'
 import * as devices from '../../actions/devices'
+import * as deviceTemplateFormats from '../../actions/device-template-formats'
 import createRequestLogic from './lib'
 
 const getDevicesListLogic = createRequestLogic({
@@ -30,4 +31,12 @@ const getDevicesListLogic = createRequestLogic({
   },
 })
 
-export default [getDevicesListLogic]
+const getDeviceTemplateFormatsLogic = createRequestLogic({
+  type: deviceTemplateFormats.GET_DEVICE_TEMPLATE_FORMATS,
+  async process() {
+    const { formats } = await api.deviceTemplates.listFormats()
+    return formats
+  },
+})
+
+export default [getDevicesListLogic, getDeviceTemplateFormatsLogic]

--- a/pkg/webui/console/store/middleware/logics/events.js
+++ b/pkg/webui/console/store/middleware/logics/events.js
@@ -85,7 +85,7 @@ const createEventsConnectLogics = function(reducerName, entityName, onEventsStar
           channel = await onEventsStart([id])
 
           channel.on('start', () => dispatch(startEventsSuccess(id)))
-          channel.on('event', message => dispatch(getEventSuccess(id, message)))
+          channel.on('chunk', message => dispatch(getEventSuccess(id, message)))
           channel.on('error', error => dispatch(getEventFailure(id, error)))
           channel.on('close', () => dispatch(stopEvents(id)))
         } catch (error) {

--- a/pkg/webui/console/store/reducers/device-template-formats.js
+++ b/pkg/webui/console/store/reducers/device-template-formats.js
@@ -1,0 +1,33 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { GET_DEVICE_TEMPLATE_FORMATS_SUCCESS } from '../actions/device-template-formats'
+
+const defaultState = {
+  formats: undefined,
+}
+
+const pubsubs = function(state = defaultState, { type, payload }) {
+  switch (type) {
+    case GET_DEVICE_TEMPLATE_FORMATS_SUCCESS:
+      return {
+        ...state,
+        formats: payload,
+      }
+    default:
+      return state
+  }
+}
+
+export default pubsubs

--- a/pkg/webui/console/store/reducers/device-template-formats.js
+++ b/pkg/webui/console/store/reducers/device-template-formats.js
@@ -18,7 +18,7 @@ const defaultState = {
   formats: undefined,
 }
 
-const pubsubs = function(state = defaultState, { type, payload }) {
+const deviceTemplateFormats = function(state = defaultState, { type, payload }) {
   switch (type) {
     case GET_DEVICE_TEMPLATE_FORMATS_SUCCESS:
       return {
@@ -30,4 +30,4 @@ const pubsubs = function(state = defaultState, { type, payload }) {
   }
 }
 
-export default pubsubs
+export default deviceTemplateFormats

--- a/pkg/webui/console/store/reducers/index.js
+++ b/pkg/webui/console/store/reducers/index.js
@@ -45,6 +45,7 @@ import webhookFormats from './webhook-formats'
 import pubsub from './pubsub'
 import pubsubs from './pubsubs'
 import pubsubFormats from './pubsub-formats'
+import deviceTemplateFormats from './device-template-formats'
 import organizations from './organizations'
 import { createNamedPaginationReducer } from './pagination'
 import js from './join-server'
@@ -62,6 +63,7 @@ export default history =>
     webhook,
     webhooks,
     webhookFormats,
+    deviceTemplateFormats,
     pubsub,
     pubsubs,
     pubsubFormats,

--- a/pkg/webui/console/store/selectors/device-template-formats.js
+++ b/pkg/webui/console/store/selectors/device-template-formats.js
@@ -1,0 +1,32 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { GET_DEVICE_TEMPLATE_FORMATS_BASE } from '../actions/device-template-formats'
+import { createFetchingSelector } from './fetching'
+import { createErrorSelector } from './error'
+
+const selectDeviceTemplateFormatsStore = state => state.deviceTemplateFormats
+
+export const selectDeviceTemplateFormats = function(state) {
+  const store = selectDeviceTemplateFormatsStore(state)
+
+  return store.formats || {}
+}
+
+export const selectDeviceTemplateFormatsError = createErrorSelector(
+  GET_DEVICE_TEMPLATE_FORMATS_BASE,
+)
+export const selectDeviceTemplateFormatsFetching = createFetchingSelector(
+  GET_DEVICE_TEMPLATE_FORMATS_BASE,
+)

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -127,6 +127,8 @@
   "console.containers.collaborators-table.index.id": "User / Organization ID",
   "console.containers.dev-addr-input.dev-addr-input.generate": "Generate Device Address",
   "console.containers.dev-addr-input.index.devAddrFetchingFailure": "Could not generate device address",
+  "console.containers.device-template-format-select.index.title": "File Format",
+  "console.containers.device-template-format-select.index.warning": "Could not retrieve the list of available device template formats",
   "console.containers.freq-plans-select.index.title": "Frequency Plan",
   "console.containers.freq-plans-select.index.warning": "Could not retrieve the list of available frequency plans",
   "console.containers.join-eui-prefixes-input.index.prefixesFetchingFailure": "Could not retrieve the list of available prefixes",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -127,6 +127,8 @@
   "console.containers.collaborators-table.index.id": "Xxxx / Xxxxxxxxxxxx XX",
   "console.containers.dev-addr-input.dev-addr-input.generate": "Xxxxxxxx Xxxxxx Xxxxxxx",
   "console.containers.dev-addr-input.index.devAddrFetchingFailure": "Xxxxx xxx xxxxxxxx xxxxxx xxxxxxx",
+  "console.containers.device-template-format-select.index.title": "Xxxx Xxxxxx",
+  "console.containers.device-template-format-select.index.warning": "Xxxxx xxx xxxxxxxx xxx xxxx xx xxxxxxxxx xxxxxx xxxxxxxx xxxxxxx",
   "console.containers.freq-plans-select.index.title": "Xxxxxxxxx Xxxx",
   "console.containers.freq-plans-select.index.warning": "Xxxxx xxx xxxxxxxx xxx xxxx xx xxxxxxxxx xxxxxxxxx xxxxx",
   "console.containers.join-eui-prefixes-input.index.prefixesFetchingFailure": "Xxxxx xxx xxxxxxxx xxx xxxx xx xxxxxxxxx xxxxxxxx",

--- a/sdk/js/src/api/stream/shared.js
+++ b/sdk/js/src/api/stream/shared.js
@@ -20,7 +20,7 @@ export const notify = function(listener, ...args) {
 
 export const EVENTS = Object.freeze({
   START: 'start',
-  EVENT: 'event',
+  CHUNK: 'chunk',
   ERROR: 'error',
   CLOSE: 'close',
 })

--- a/sdk/js/src/api/stream/stream-node.js
+++ b/sdk/js/src/api/stream/stream-node.js
@@ -33,7 +33,7 @@ import { notify, EVENTS } from './shared'
  *    // add listeners to the stream
  *    stream
  *      .on('start', () => console.log('conn opened'));
- *      .on('event', message => console.log('received event message', message));
+ *      .on('chunk', chunk => console.log('received chunk', chunk));
  *      .on('error', error => console.log(error));
  *      .on('close', () => console.log('conn closed'))
  *
@@ -75,7 +75,7 @@ export default async function(payload, url) {
 
         for (const line of parsed.trim().split('\n')) {
           const result = JSON.parse(line).result
-          notify(listeners[EVENTS.EVENT], result)
+          notify(listeners[EVENTS.CHUNK], result)
         }
       })
       stream.on('end', function() {
@@ -92,7 +92,7 @@ export default async function(payload, url) {
     on(eventName, callback) {
       if (listeners[eventName] === undefined) {
         throw new Error(
-          `${eventName} event is not supported. Should be one of: start, error, event or close`,
+          `${eventName} event is not supported. Should be one of: start, error, chunk or close`,
         )
       }
 

--- a/sdk/js/src/api/stream/stream.js
+++ b/sdk/js/src/api/stream/stream.js
@@ -22,7 +22,7 @@ import 'web-streams-polyfill/dist/polyfill.js'
  *
  * @async
  * @param {Object} payload  - The body of the initial request.
- * @param {string} url - The stream endpoint, defaults to `/api/v3/events`.
+ * @param {string} url - The stream endpoint.
  *
  * @example
  * (async () => {
@@ -34,7 +34,7 @@ import 'web-streams-polyfill/dist/polyfill.js'
  *    // add listeners to the stream
  *    stream
  *      .on('start', () => console.log('conn opened'));
- *      .on('event', message => console.log('received event message', message));
+ *      .on('chunk', chunk => console.log('received chunk', chunk));
  *      .on('error', error => console.log(error));
  *      .on('close', () => console.log('conn closed'))
  *
@@ -90,7 +90,7 @@ export default async function(payload, url) {
 
       for (const line of parsed.trim().split('\n')) {
         const result = JSON.parse(line).result
-        notify(listeners[EVENTS.EVENT], result)
+        notify(listeners[EVENTS.CHUNK], result)
       }
 
       return reader.read().then(onChunk)
@@ -104,7 +104,7 @@ export default async function(payload, url) {
     on(eventName, callback) {
       if (listeners[eventName] === undefined) {
         throw new Error(
-          `${eventName} event is not supported. Should be one of: start, error, event or close`,
+          `${eventName} event is not supported. Should be one of: start, error, chunk or close`,
         )
       }
 

--- a/sdk/js/src/service/devices/index.js
+++ b/sdk/js/src/service/devices/index.js
@@ -283,6 +283,14 @@ class Devices {
     return result
   }
 
+  // End Device Template Converter
+
+  async listTemplateFormats() {
+    const result = await this._api.EndDeviceTemplateConverter.ListFormats()
+
+    return Marshaler.payloadListResponse('formats', result)
+  }
+
   // Events Stream
 
   async openStream(identifiers, tail, after) {

--- a/sdk/js/src/service/devices/index.js
+++ b/sdk/js/src/service/devices/index.js
@@ -291,6 +291,14 @@ class Devices {
     return Marshaler.payloadListResponse('formats', result)
   }
 
+  convertTemplate(formatId, data) {
+    // This is a stream endpoint
+    return this._api.EndDeviceTemplateConverter.Convert(undefined, {
+      format_id: formatId,
+      data,
+    })
+  }
+
   // Events Stream
 
   async openStream(identifiers, tail, after) {


### PR DESCRIPTION
#### Summary
This PR adds necessary services for bulk device creation to the JS SDK. It also adds minor related changes to the console.

References #1404 

#### Changes
- Rename the `event`-event in streams to `chunk` (more generic, we don't only receive events in streams)
- Add a component whitelist to the path splitter of the device service
- Improve `_setDevice` helper function versatility
- Add possibility to pass precalculated request tree to `makeRequests()` helper function (to avoid unnecessary calculations)
- Move create/update request distinction into `makeRequests()`
- Add `EndDeviceTemplateConverter.ListFormats` rpc to device service
- Add `EndDeviceTemplateConverter.Convert` rpc to device service
- Add `bulkCreate` function to device service
- Update the api tree of the console accordingly
- Add device template format selector component to console (including redux primitives)

#### Notes for Reviewers
You can use [this script](https://gist.github.com/kschiffer/864473d0f65a9cb04c3b3ffabfc43d30) for testing.
The `bulkCreate` will create the passed devices (via `_setDevice()`) and provide a subscribable stream as output to facilitate progress-tracking of this potentially lengthy operation.
I've included also the `DeviceTemplateFormatSelector` to this PR, as I think it will be easier/faster to review this in conjunction with the SDK changes. Let me know if you prefer to exclude this.

#### Release Notes
- Added end device template conversion RPCs to the JS SDK
- Added end device bulk creation capabilities to the JS SDK
