### PR TITLE
KEK labeler escaping

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -2453,7 +2453,7 @@
     },
     "description": {
       "package": "pkg/crypto/cryptoutil",
-      "file": "keyvault_mem.go"
+      "file": "cryptoutil.go"
     }
   },
   "error:pkg/crypto/cryptoutil:invalid_length": {
@@ -2471,7 +2471,7 @@
     },
     "description": {
       "package": "pkg/crypto/cryptoutil",
-      "file": "keyvault_mem.go"
+      "file": "cryptoutil.go"
     }
   },
   "error:pkg/crypto:corrupt_key": {

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -168,7 +168,7 @@ func (v KeyVault) KeyVault() (crypto.KeyVault, error) {
 		kv.ReplaceOldNew = []string{":", "_"}
 		return kv, nil
 	default:
-		return cryptoutil.NewMemKeyVault(map[string][]byte{}), nil
+		return cryptoutil.EmptyKeyVault, nil
 	}
 }
 

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -163,7 +163,10 @@ type KeyVault struct {
 func (v KeyVault) KeyVault() (crypto.KeyVault, error) {
 	switch {
 	case v.Static != nil:
-		return cryptoutil.NewMemKeyVault(v.Static), nil
+		kv := cryptoutil.NewMemKeyVault(v.Static)
+		kv.Separator = ":"
+		kv.ReplaceOldNew = []string{":", "_"}
+		return kv, nil
 	default:
 		return cryptoutil.NewMemKeyVault(map[string][]byte{}), nil
 	}

--- a/pkg/crypto/cryptoutil/cryptoutil.go
+++ b/pkg/crypto/cryptoutil/cryptoutil.go
@@ -23,6 +23,11 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/types"
 )
 
+var (
+	errKEKNotFound         = errors.DefineNotFound("kek_not_found", "KEK with label `{label}` not found")
+	errCertificateNotFound = errors.DefineNotFound("certificate_not_found", "certificate with ID `{id}` not found")
+)
+
 // WrapAES128Key performs the RFC 3394 Wrap algorithm on the given key using the given key vault and KEK label.
 // If the KEK label is empty, the key will be returned in the clear.
 func WrapAES128Key(ctx context.Context, key types.AES128Key, kekLabel string, v crypto.KeyVault) (ttnpb.KeyEnvelope, error) {

--- a/pkg/crypto/cryptoutil/kek_labelers.go
+++ b/pkg/crypto/cryptoutil/kek_labelers.go
@@ -23,9 +23,12 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/types"
 )
 
-// ComponentPrefixKEKLabeler is a ComponentKEKLabeler that joins the component prefix, separator and host.
+// ComponentPrefixKEKLabeler is a ComponentKEKLabeler that joins the component prefix, separators and host.
 type ComponentPrefixKEKLabeler struct {
+	// Separator is the string to join parts.
 	Separator string
+	// ReplaceOldNew is a set of old and new string pairs to replace in parts.
+	ReplaceOldNew []string
 }
 
 func hostFromAddr(addr string) string {
@@ -42,7 +45,14 @@ func hostFromAddr(addr string) string {
 func (c ComponentPrefixKEKLabeler) join(parts ...string) string {
 	sep := c.Separator
 	if sep == "" {
-		sep = ":"
+		sep = "/"
+	}
+	if len(c.ReplaceOldNew) > 0 {
+		replacer := strings.NewReplacer(c.ReplaceOldNew...)
+		parts = append(parts[:0:0], parts...)
+		for i := range parts {
+			parts[i] = replacer.Replace(parts[i])
+		}
 	}
 	return strings.Join(parts, sep)
 }

--- a/pkg/crypto/cryptoutil/keyvault_empty.go
+++ b/pkg/crypto/cryptoutil/keyvault_empty.go
@@ -1,0 +1,41 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cryptoutil
+
+import (
+	"context"
+	"crypto/tls"
+
+	"go.thethings.network/lorawan-stack/pkg/crypto"
+)
+
+type emptyKeyVault struct {
+	ComponentPrefixKEKLabeler
+}
+
+// EmptyKeyVault is an empty key vault.
+var EmptyKeyVault crypto.KeyVault = emptyKeyVault{}
+
+func (emptyKeyVault) Wrap(ctx context.Context, plaintext []byte, kekLabel string) ([]byte, error) {
+	return nil, errKEKNotFound
+}
+
+func (emptyKeyVault) Unwrap(ctx context.Context, ciphertext []byte, kekLabel string) ([]byte, error) {
+	return nil, errKEKNotFound
+}
+
+func (emptyKeyVault) LoadCertificate(ctx context.Context, id string) (*tls.Certificate, error) {
+	return nil, errCertificateNotFound
+}

--- a/pkg/crypto/cryptoutil/keyvault_empty_test.go
+++ b/pkg/crypto/cryptoutil/keyvault_empty_test.go
@@ -1,0 +1,39 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cryptoutil_test
+
+import (
+	"testing"
+
+	"github.com/smartystreets/assertions"
+
+	"go.thethings.network/lorawan-stack/pkg/crypto/cryptoutil"
+	"go.thethings.network/lorawan-stack/pkg/errors"
+	"go.thethings.network/lorawan-stack/pkg/util/test"
+	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
+)
+
+func TestEmptyKeyVault(t *testing.T) {
+	a := assertions.New(t)
+
+	_, err := cryptoutil.EmptyKeyVault.Wrap(test.Context(), []byte{0x1, 0x2}, "test")
+	a.So(errors.IsNotFound(err), should.BeTrue)
+
+	_, err = cryptoutil.EmptyKeyVault.Unwrap(test.Context(), []byte{0x1, 0x2}, "test")
+	a.So(errors.IsNotFound(err), should.BeTrue)
+
+	_, err = cryptoutil.EmptyKeyVault.LoadCertificate(test.Context(), "test")
+	a.So(errors.IsNotFound(err), should.BeTrue)
+}

--- a/pkg/crypto/cryptoutil/keyvault_mem.go
+++ b/pkg/crypto/cryptoutil/keyvault_mem.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"go.thethings.network/lorawan-stack/pkg/crypto"
-	"go.thethings.network/lorawan-stack/pkg/errors"
 )
 
 // MemKeyVault is a KeyVault that uses secrets from memory.
@@ -39,8 +38,6 @@ func NewMemKeyVault(m map[string][]byte) *MemKeyVault {
 		m: m,
 	}
 }
-
-var errKEKNotFound = errors.DefineNotFound("kek_not_found", "KEK with label `{label}` not found")
 
 // Wrap implements KeyVault.
 func (v MemKeyVault) Wrap(ctx context.Context, plaintext []byte, kekLabel string) ([]byte, error) {
@@ -59,8 +56,6 @@ func (v MemKeyVault) Unwrap(ctx context.Context, ciphertext []byte, kekLabel str
 	}
 	return crypto.UnwrapKey(ciphertext, kek)
 }
-
-var errCertificateNotFound = errors.DefineNotFound("certificate_not_found", "certificate with ID `{id}` not found")
 
 // LoadCertificate implements KeyVault.
 func (v MemKeyVault) LoadCertificate(ctx context.Context, id string) (*tls.Certificate, error) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

KEK labeler escaping

#### Changes
<!-- What are the changes made in this pull request? -->

- Add support to escape in automatically generated KEK labels
- Minor housekeeping