### PR TITLE
Don't render button when action is not passed to notification

### DIFF
--- a/pkg/webui/components/notification/index.js
+++ b/pkg/webui/components/notification/index.js
@@ -86,7 +86,7 @@ Notification.propTypes = {
 }
 
 Notification.defaultProps = {
-  action: () => null,
+  action: undefined,
   actionMessage: undefined,
   buttonIcon: '',
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fixes bug where restart button is rendered even though the action is not passed to the `Notification` component

#### Changes
<!-- What are the changes made in this pull request? -->

- set `action` default prop to `undefined`
