### PR TITLE
Use explicit config sources and providers with fallback

### DIFF
--- a/cmd/internal/shared/config.go
+++ b/cmd/internal/shared/config.go
@@ -107,7 +107,9 @@ var DefaultRightsConfig = config.Rights{
 }
 
 // DefaultKeyVaultConfig is the default config for key vaults.
-var DefaultKeyVaultConfig = config.KeyVault{}
+var DefaultKeyVaultConfig = config.KeyVault{
+	Provider: "static",
+}
 
 // DefaultServiceBase is the default base config for a service.
 var DefaultServiceBase = config.ServiceBase{

--- a/config/messages.json
+++ b/config/messages.json
@@ -2357,15 +2357,6 @@
       "file": "acme.go"
     }
   },
-  "error:pkg/component:tls_config_ambiguous": {
-    "translations": {
-      "en": "ambiguous TLS configuration"
-    },
-    "description": {
-      "package": "pkg/component",
-      "file": "tls.go"
-    }
-  },
   "error:pkg/component:tls_config_empty": {
     "translations": {
       "en": "empty TLS configuration"

--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -256,9 +256,11 @@ hardware_versions:
 				NetworkServer:  nsAddr,
 			},
 			DeviceRepository: config.DeviceRepositoryConfig{
-				Static: deviceRepositoryData,
+				ConfigSource: "static",
+				Static:       deviceRepositoryData,
 			},
 			KeyVault: config.KeyVault{
+				Provider: "static",
 				Static: map[string][]byte{
 					"test": {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F},
 				},

--- a/pkg/applicationserver/grpc_deviceregistry_test.go
+++ b/pkg/applicationserver/grpc_deviceregistry_test.go
@@ -216,7 +216,8 @@ func TestDeviceRegistryGet(t *testing.T) {
 				componenttest.NewComponent(t, &component.Config{
 					ServiceBase: config.ServiceBase{
 						KeyVault: config.KeyVault{
-							Static: registeredKEKs,
+							Provider: "static",
+							Static:   registeredKEKs,
 						},
 					},
 				}),

--- a/pkg/component/tls.go
+++ b/pkg/component/tls.go
@@ -65,6 +65,8 @@ var (
 // GetTLSServerConfig gets the component's server TLS config and applies the given options.
 func (c *Component) GetTLSServerConfig(ctx context.Context, opts ...TLSConfigOption) (*tls.Config, error) {
 	conf := c.GetBaseConfig(ctx).TLS
+
+	// TODO: Remove detection mechanism (https://github.com/TheThingsNetwork/lorawan-stack/issues/1450)
 	if conf.Source == "" {
 		switch {
 		case conf.Certificate != "" && conf.Key != "":

--- a/pkg/component/tls.go
+++ b/pkg/component/tls.go
@@ -58,104 +58,98 @@ func WithNextProtos(protos ...string) TLSConfigOption {
 }
 
 var (
-	errAmbiguousTLSConfig = errors.DefineFailedPrecondition("tls_config_ambiguous", "ambiguous TLS configuration")
-	errEmptyTLSConfig     = errors.DefineFailedPrecondition("tls_config_empty", "empty TLS configuration")
-	errTLSKeyVaultID      = errors.DefineFailedPrecondition("tls_key_vault_id", "invalid TLS key vault ID")
+	errEmptyTLSConfig = errors.DefineFailedPrecondition("tls_config_empty", "empty TLS configuration")
+	errTLSKeyVaultID  = errors.DefineFailedPrecondition("tls_key_vault_id", "invalid TLS key vault ID")
 )
 
 // GetTLSServerConfig gets the component's server TLS config and applies the given options.
 func (c *Component) GetTLSServerConfig(ctx context.Context, opts ...TLSConfigOption) (*tls.Config, error) {
-	var (
-		logger = log.FromContext(ctx)
-		conf   = c.GetBaseConfig(ctx).TLS
-		res    *tls.Config
-	)
-	for _, src := range []struct {
-		Enable            bool
-		CertificateGetter func() (func(*tls.ClientHelloInfo) (*tls.Certificate, error), error)
-	}{
-		{
-			Enable: conf.Certificate != "" && conf.Key != "",
-			CertificateGetter: func() (func(*tls.ClientHelloInfo) (*tls.Certificate, error), error) {
-				var cv atomic.Value
-				loadCertificate := func() error {
-					cert, err := tls.LoadX509KeyPair(conf.Certificate, conf.Key)
-					if err != nil {
-						return err
-					}
-					cv.Store(&cert)
-					logger.Debug("Loaded TLS certificate")
-					return nil
-				}
-				if err := loadCertificate(); err != nil {
-					return nil, err
-				}
-				debounce := make(chan struct{}, 1)
-				fs.Watch(conf.Certificate, events.HandlerFunc(func(evt events.Event) {
-					if evt.Name() != "fs.write" {
-						return
-					}
-					// We have to debounce this; OpenSSL typically causes a lot of write events.
-					select {
-					case debounce <- struct{}{}:
-						time.AfterFunc(5*time.Second, func() {
-							if err := loadCertificate(); err != nil {
-								logger.WithError(err).Error("Could not reload TLS certificate")
-								return
-							}
-							<-debounce
-						})
-					default:
-					}
-				}))
-				return func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
-					return cv.Load().(*tls.Certificate), nil
-				}, nil
-			},
-		},
-		{
-			Enable: conf.ACME.Enable,
-			CertificateGetter: func() (func(*tls.ClientHelloInfo) (*tls.Certificate, error), error) {
-				opts = append(opts, WithNextProtos(acme.ALPNProto))
-				return func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
-					if hello.ServerName == "" {
-						hello.ServerName = conf.ACME.DefaultHost
-					}
-					return c.acme.GetCertificate(hello)
-				}, nil
-			},
-		},
-		{
-			Enable: conf.KeyVault.Enable,
-			CertificateGetter: func() (func(*tls.ClientHelloInfo) (*tls.Certificate, error), error) {
-				if conf.KeyVault.ID == "" {
-					return nil, errTLSKeyVaultID
-				}
-				return func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
-					return c.KeyVault.ExportCertificate(ctx, conf.KeyVault.ID)
-				}, nil
-			},
-		},
-	} {
-		if !src.Enable {
-			continue
-		}
-		if res != nil {
-			return nil, errAmbiguousTLSConfig
-		}
-		fn, err := src.CertificateGetter()
-		if err != nil {
-			return nil, err
-		}
-		res = &tls.Config{
-			GetCertificate: fn,
+	conf := c.GetBaseConfig(ctx).TLS
+	if conf.Source == "" {
+		switch {
+		case conf.Certificate != "" && conf.Key != "":
+			conf.Source = "file"
+		case conf.ACME.Enable:
+			conf.Source = "acme"
+		case !conf.KeyVault.IsZero():
+			conf.Source = "key-vault"
 		}
 	}
-	if res == nil {
+
+	var (
+		logger            = log.FromContext(ctx)
+		certificateGetter func() (func(*tls.ClientHelloInfo) (*tls.Certificate, error), error)
+	)
+	switch conf.Source {
+	case "file":
+		certificateGetter = func() (func(*tls.ClientHelloInfo) (*tls.Certificate, error), error) {
+			var cv atomic.Value
+			loadCertificate := func() error {
+				cert, err := tls.LoadX509KeyPair(conf.Certificate, conf.Key)
+				if err != nil {
+					return err
+				}
+				cv.Store(&cert)
+				logger.Debug("Loaded TLS certificate")
+				return nil
+			}
+			if err := loadCertificate(); err != nil {
+				return nil, err
+			}
+			debounce := make(chan struct{}, 1)
+			fs.Watch(conf.Certificate, events.HandlerFunc(func(evt events.Event) {
+				if evt.Name() != "fs.write" {
+					return
+				}
+				// We have to debounce this; OpenSSL typically causes a lot of write events.
+				select {
+				case debounce <- struct{}{}:
+					time.AfterFunc(5*time.Second, func() {
+						if err := loadCertificate(); err != nil {
+							logger.WithError(err).Error("Could not reload TLS certificate")
+							return
+						}
+						<-debounce
+					})
+				default:
+				}
+			}))
+			return func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
+				return cv.Load().(*tls.Certificate), nil
+			}, nil
+		}
+	case "acme":
+		certificateGetter = func() (func(*tls.ClientHelloInfo) (*tls.Certificate, error), error) {
+			opts = append(opts, WithNextProtos(acme.ALPNProto))
+			return func(hello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+				if hello.ServerName == "" {
+					hello.ServerName = conf.ACME.DefaultHost
+				}
+				return c.acme.GetCertificate(hello)
+			}, nil
+		}
+	case "key-vault":
+		certificateGetter = func() (func(*tls.ClientHelloInfo) (*tls.Certificate, error), error) {
+			if conf.KeyVault.ID == "" {
+				return nil, errTLSKeyVaultID
+			}
+			return func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+				return c.KeyVault.ExportCertificate(ctx, conf.KeyVault.ID)
+			}, nil
+		}
+	}
+	if certificateGetter == nil {
 		return nil, errEmptyTLSConfig
 	}
-	res.MinVersion = tls.VersionTLS12
-	res.PreferServerCipherSuites = true
+	fn, err := certificateGetter()
+	if err != nil {
+		return nil, err
+	}
+	res := &tls.Config{
+		GetCertificate:           fn,
+		MinVersion:               tls.VersionTLS12,
+		PreferServerCipherSuites: true,
+	}
 	for _, opt := range opts {
 		opt.apply(res)
 	}

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -271,6 +271,7 @@ type FrequencyPlansConfig struct {
 // Fetcher returns a fetch.Interface based on the configuration.
 // If no configuration source is set, this method returns nil, nil.
 func (c FrequencyPlansConfig) Fetcher(ctx context.Context, blobConf BlobConfig) (fetch.Interface, error) {
+	// TODO: Remove detection mechanism (https://github.com/TheThingsNetwork/lorawan-stack/issues/1450)
 	if c.ConfigSource == "" {
 		switch {
 		case c.Static != nil:
@@ -313,6 +314,7 @@ type DeviceRepositoryConfig struct {
 // Fetcher returns a fetch.Interface based on the configuration.
 // If no configuration source is set, this method returns nil, nil.
 func (c DeviceRepositoryConfig) Fetcher(ctx context.Context, blobConf BlobConfig) (fetch.Interface, error) {
+	// TODO: Remove detection mechanism (https://github.com/TheThingsNetwork/lorawan-stack/issues/1450)
 	if c.ConfigSource == "" {
 		switch {
 		case c.Static != nil:
@@ -367,6 +369,7 @@ func (c InteropClient) IsZero() bool {
 // Fetcher returns fetch.Interface defined by conf.
 // If no configuration source is set, this method returns nil, nil.
 func (c InteropClient) Fetcher(ctx context.Context, blobConf BlobConfig) (fetch.Interface, error) {
+	// TODO: Remove detection mechanism (https://github.com/TheThingsNetwork/lorawan-stack/issues/1450)
 	if c.ConfigSource == "" {
 		switch {
 		case c.Directory != "":

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -155,14 +155,14 @@ type Rights struct {
 
 // KeyVault represents configuration for key vaults.
 type KeyVault struct {
-	Static map[string][]byte `name:"static" description:"Static labeled key encryption keys"`
+	Provider string            `name:"provider" description:"Provider (static)"`
+	Static   map[string][]byte `name:"static"`
 }
 
 // KeyVault returns an initialized crypto.KeyVault based on the configuration.
-// The order of precedence is Static.
 func (v KeyVault) KeyVault() (crypto.KeyVault, error) {
-	switch {
-	case v.Static != nil:
+	switch v.Provider {
+	case "static":
 		kv := cryptoutil.NewMemKeyVault(v.Static)
 		kv.Separator = ":"
 		kv.ReplaceOldNew = []string{":", "_"}
@@ -214,7 +214,7 @@ type BlobConfigGCP struct {
 
 // BlobConfig is the blob store configuration.
 type BlobConfig struct {
-	Provider string          `name:"provider" description:"Blob store provider (local|aws|gcp)"`
+	Provider string          `name:"provider" description:"Blob store provider (local, aws, gcp)"`
 	Local    BlobConfigLocal `name:"local"`
 	AWS      BlobConfigAWS   `name:"aws"`
 	GCP      BlobConfigGCP   `name:"gcp"`
@@ -261,24 +261,36 @@ func (c BlobPathConfig) IsZero() bool {
 
 // FrequencyPlansConfig contains the source of the frequency plans.
 type FrequencyPlansConfig struct {
-	Static    map[string][]byte `name:"-"`
-	Directory string            `name:"directory" description:"Retrieve the frequency plans from the filesystem"`
-	URL       string            `name:"url" description:"Retrieve the frequency plans from a web server"`
-	Blob      BlobPathConfig    `name:"blob" description:"Retrieve the frequency plans from a blob"`
+	ConfigSource string            `name:"config-source" description:"Source of the frequency plans (static, directory, url, blob)"`
+	Static       map[string][]byte `name:"-"`
+	Directory    string            `name:"directory"`
+	URL          string            `name:"url"`
+	Blob         BlobPathConfig    `name:"blob"`
 }
 
 // Fetcher returns a fetch.Interface based on the configuration.
-// The order of precedence is Static, Directory, URL and Blob.
-// If neither Static, Directory, URL nor a Blob is set, this method returns nil, nil.
+// If no configuration source is set, this method returns nil, nil.
 func (c FrequencyPlansConfig) Fetcher(ctx context.Context, blobConf BlobConfig) (fetch.Interface, error) {
-	switch {
-	case c.Static != nil:
+	if c.ConfigSource == "" {
+		switch {
+		case c.Static != nil:
+			c.ConfigSource = "static"
+		case c.Directory != "":
+			c.ConfigSource = "directory"
+		case c.URL != "":
+			c.ConfigSource = "url"
+		case !c.Blob.IsZero():
+			c.ConfigSource = "blob"
+		}
+	}
+	switch c.ConfigSource {
+	case "static":
 		return fetch.NewMemFetcher(c.Static), nil
-	case c.Directory != "":
+	case "directory":
 		return fetch.FromFilesystem(c.Directory), nil
-	case c.URL != "":
+	case "url":
 		return fetch.FromHTTP(c.URL, true)
-	case !c.Blob.IsZero():
+	case "blob":
 		b, err := blobConf.Bucket(ctx, c.Blob.Bucket)
 		if err != nil {
 			return nil, err
@@ -291,24 +303,36 @@ func (c FrequencyPlansConfig) Fetcher(ctx context.Context, blobConf BlobConfig) 
 
 // DeviceRepositoryConfig defines the source of the device repository.
 type DeviceRepositoryConfig struct {
-	Static    map[string][]byte `name:"-"`
-	Directory string            `name:"directory" description:"Retrieve the device repository from the filesystem"`
-	URL       string            `name:"url" description:"Retrieve the device repository from a web server"`
-	Blob      BlobPathConfig    `name:"blob" description:"Retrieve the device repository from a blob"`
+	ConfigSource string            `name:"config-source" description:"Source of the device repository (static, directory, url, blob)"`
+	Static       map[string][]byte `name:"-"`
+	Directory    string            `name:"directory"`
+	URL          string            `name:"url"`
+	Blob         BlobPathConfig    `name:"blob"`
 }
 
 // Fetcher returns a fetch.Interface based on the configuration.
-// The order of precedence is Static, Directory, URL and Blob.
-// If neither Static, Directory, URL nor a Blob is set, this method returns nil, nil.
+// If no configuration source is set, this method returns nil, nil.
 func (c DeviceRepositoryConfig) Fetcher(ctx context.Context, blobConf BlobConfig) (fetch.Interface, error) {
-	switch {
-	case c.Static != nil:
+	if c.ConfigSource == "" {
+		switch {
+		case c.Static != nil:
+			c.ConfigSource = "static"
+		case c.Directory != "":
+			c.ConfigSource = "directory"
+		case c.URL != "":
+			c.ConfigSource = "url"
+		case !c.Blob.IsZero():
+			c.ConfigSource = "blob"
+		}
+	}
+	switch c.ConfigSource {
+	case "static":
 		return fetch.NewMemFetcher(c.Static), nil
-	case c.Directory != "":
+	case "directory":
 		return fetch.FromFilesystem(c.Directory), nil
-	case c.URL != "":
+	case "url":
 		return fetch.FromHTTP(c.URL, true)
-	case !c.Blob.IsZero():
+	case "blob":
 		b, err := blobConf.Bucket(ctx, c.Blob.Bucket)
 		if err != nil {
 			return nil, err
@@ -321,9 +345,10 @@ func (c DeviceRepositoryConfig) Fetcher(ctx context.Context, blobConf BlobConfig
 
 // InteropClient represents the client-side interoperability through LoRaWAN Backend Interfaces configuration.
 type InteropClient struct {
-	Directory string         `name:"directory" description:"Retrieve the interoperability client configuration from the filesystem"`
-	URL       string         `name:"url" description:"Retrieve the interoperability client configuration from a web server"`
-	Blob      BlobPathConfig `name:"blob" description:"Retrieve the interoperability client configuration from a blob"`
+	ConfigSource string         `name:"config-source" description:"Source of the interoperability client configuration (directory, url, blob)"`
+	Directory    string         `name:"directory"`
+	URL          string         `name:"url"`
+	Blob         BlobPathConfig `name:"blob"`
 
 	GetFallbackTLSConfig func(ctx context.Context) (*tls.Config, error) `name:"-"`
 	BlobConfig           BlobConfig                                     `name:"-"`
@@ -331,19 +356,33 @@ type InteropClient struct {
 
 // IsZero returns whether conf is empty.
 func (c InteropClient) IsZero() bool {
-	return c.Directory == "" && c.URL == "" && c.Blob.IsZero() && c.GetFallbackTLSConfig == nil && c.BlobConfig == BlobConfig{}
+	return c.ConfigSource == "" &&
+		c.Directory == "" &&
+		c.URL == "" &&
+		c.Blob.IsZero() &&
+		c.GetFallbackTLSConfig == nil &&
+		c.BlobConfig == BlobConfig{}
 }
 
 // Fetcher returns fetch.Interface defined by conf.
-// The order of precedence is Static, Directory, URL and Blob.
-// If neither Static, Directory, URL nor a Blob is set, this method returns nil, nil.
+// If no configuration source is set, this method returns nil, nil.
 func (c InteropClient) Fetcher(ctx context.Context, blobConf BlobConfig) (fetch.Interface, error) {
-	switch {
-	case c.Directory != "":
+	if c.ConfigSource == "" {
+		switch {
+		case c.Directory != "":
+			c.ConfigSource = "directory"
+		case c.URL != "":
+			c.ConfigSource = "url"
+		case !c.Blob.IsZero():
+			c.ConfigSource = "blob"
+		}
+	}
+	switch c.ConfigSource {
+	case "directory":
 		return fetch.FromFilesystem(c.Directory), nil
-	case c.URL != "":
+	case "url":
 		return fetch.FromHTTP(c.URL, true)
-	case !c.Blob.IsZero():
+	case "blob":
 		b, err := blobConf.Bucket(ctx, c.Blob.Bucket)
 		if err != nil {
 			return nil, err

--- a/pkg/config/tls.go
+++ b/pkg/config/tls.go
@@ -35,14 +35,20 @@ func (a ACME) IsZero() bool {
 
 // TLSKeyVault defines configuration for loading a certificate from the key vault.
 type TLSKeyVault struct {
-	Enable bool   `name:"enable" description:"Enable loading the certificate from the key vault"`
-	ID     string `name:"id" description:"ID of the certificate"`
+	ID string `name:"id" description:"ID of the certificate"`
+}
+
+// IsZero returns whether the TLSKeyVault is empty.
+func (t TLSKeyVault) IsZero() bool {
+	return t.ID == ""
 }
 
 // TLS represents TLS configuration.
 type TLS struct {
 	RootCA             string `name:"root-ca" description:"Location of TLS root CA certificate (optional)"`
 	InsecureSkipVerify bool   `name:"insecure-skip-verify" description:"Skip verification of certificate chains (insecure)"`
+
+	Source string `name:"source" description:"Source of the TLS certificate (file, acme, key-vault)"`
 
 	Certificate string `name:"certificate" description:"Location of TLS certificate"`
 	Key         string `name:"key" description:"Location of TLS private key"`
@@ -54,8 +60,10 @@ type TLS struct {
 
 // IsZero returns whether the TLS configuration is empty.
 func (t TLS) IsZero() bool {
-	return t.RootCA == "" &&
+	return t.Source == "" &&
+		t.RootCA == "" &&
 		t.Certificate == "" &&
 		t.Key == "" &&
-		t.ACME.IsZero()
+		t.ACME.IsZero() &&
+		t.KeyVault.IsZero()
 }

--- a/pkg/config/tls.go
+++ b/pkg/config/tls.go
@@ -16,6 +16,7 @@ package config
 
 // ACME represents ACME configuration.
 type ACME struct {
+	// TODO: Remove Enable (https://github.com/TheThingsNetwork/lorawan-stack/issues/1450)
 	Enable      bool     `name:"enable" description:"Enable automated certificate management (ACME)"`
 	Endpoint    string   `name:"endpoint" description:"ACME endpoint"`
 	Dir         string   `name:"dir" description:"Location of ACME storage directory"`

--- a/pkg/crypto/cryptoutil/keyvault_empty.go
+++ b/pkg/crypto/cryptoutil/keyvault_empty.go
@@ -30,17 +30,17 @@ type emptyKeyVault struct {
 var EmptyKeyVault crypto.KeyVault = emptyKeyVault{}
 
 func (emptyKeyVault) Wrap(ctx context.Context, plaintext []byte, kekLabel string) ([]byte, error) {
-	return nil, errKEKNotFound
+	return nil, errKEKNotFound.WithAttributes("label", kekLabel)
 }
 
 func (emptyKeyVault) Unwrap(ctx context.Context, ciphertext []byte, kekLabel string) ([]byte, error) {
-	return nil, errKEKNotFound
+	return nil, errKEKNotFound.WithAttributes("label", kekLabel)
 }
 
 func (emptyKeyVault) GetCertificate(ctx context.Context, id string) (*x509.Certificate, error) {
-	return nil, errCertificateNotFound
+	return nil, errCertificateNotFound.WithAttributes("id", id)
 }
 
 func (emptyKeyVault) ExportCertificate(ctx context.Context, id string) (*tls.Certificate, error) {
-	return nil, errCertificateNotFound
+	return nil, errCertificateNotFound.WithAttributes("id", id)
 }

--- a/pkg/joinserver/joinserver_test.go
+++ b/pkg/joinserver/joinserver_test.go
@@ -1632,7 +1632,8 @@ func TestHandleJoin(t *testing.T) {
 			c := componenttest.NewComponent(t, &component.Config{
 				ServiceBase: config.ServiceBase{
 					KeyVault: config.KeyVault{
-						Static: tc.KeyVault,
+						Provider: "static",
+						Static:   tc.KeyVault,
 					},
 				},
 			})

--- a/pkg/networkserver/grpc_deviceregistry_test.go
+++ b/pkg/networkserver/grpc_deviceregistry_test.go
@@ -163,7 +163,8 @@ func TestDeviceRegistryGet(t *testing.T) {
 				componenttest.NewComponent(t, &component.Config{
 					ServiceBase: config.ServiceBase{
 						KeyVault: config.KeyVault{
-							Static: tc.KeyVault,
+							Provider: "static",
+							Static:   tc.KeyVault,
 						},
 					},
 				}),


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Use explicit config sources and providers. There's fallback to not break existing configuration.

References https://github.com/TheThingsNetwork/lorawan-stack/issues/1450

#### Changes
<!-- What are the changes made in this pull request? -->

- Add configuration sources and providers setting
- Fallback to what we've been doing so far

#### Release Notes
<!--
NOTE: This section is optional.

Any notes that we need to include in the Release Notes for the next release.
These notes are formatted as bullet points, written in past tense, and will be
combined with the labels of this Pull Request.
- Always mention changes in API, database models, configuration options or defaults.
- Are there any database migrations required?
- What are the functional or behavioral changes?
-->

- Supported specifying configuration sources for TLS, frequency plans, device repository, key vault and interop configuration explicitly