### PR TITLE
Move ttnpb/udp/datarate functions to pkg/util

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -5543,15 +5543,6 @@
       "file": "errors.go"
     }
   },
-  "error:pkg/ttnpb/udp:data_rate": {
-    "translations": {
-      "en": "invalid data rate"
-    },
-    "description": {
-      "package": "pkg/ttnpb/udp",
-      "file": "data_rate.go"
-    }
-  },
   "error:pkg/ttnpb/udp:eui": {
     "translations": {
       "en": "failed to parse EUI"
@@ -5784,6 +5775,15 @@
     "description": {
       "package": "pkg/unique",
       "file": "unique.go"
+    }
+  },
+  "error:pkg/util/datarate:data_rate": {
+    "translations": {
+      "en": "invalid data rate"
+    },
+    "description": {
+      "package": "pkg/util/datarate",
+      "file": "data_rate.go"
     }
   },
   "error:pkg/validate:email": {

--- a/pkg/gatewayserver/io/basicstationlns/messages/util.go
+++ b/pkg/gatewayserver/io/basicstationlns/messages/util.go
@@ -17,7 +17,6 @@ package messages
 import (
 	"bytes"
 	"encoding/binary"
-	"reflect"
 
 	"go.thethings.network/lorawan-stack/pkg/band"
 	"go.thethings.network/lorawan-stack/pkg/errors"
@@ -83,7 +82,7 @@ func getDataRateIndexFromDataRate(bandID string, DR ttnpb.DataRate) (int, error)
 		return 0, err
 	}
 	for i, dr := range band.DataRates {
-		if reflect.DeepEqual(dr.Rate, DR) {
+		if dr.Rate.Equal(DR) {
 			return i, nil
 		}
 	}

--- a/pkg/gatewayserver/io/mqtt/format_protobufv2.go
+++ b/pkg/gatewayserver/io/mqtt/format_protobufv2.go
@@ -24,7 +24,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/gatewayserver/io/mqtt/topics"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
-	"go.thethings.network/lorawan-stack/pkg/ttnpb/udp"
+	"go.thethings.network/lorawan-stack/pkg/util/datarate"
 )
 
 // eirpDelta is the delta between EIRP and ERP.
@@ -133,7 +133,7 @@ func (protobufv2) ToUplink(message []byte, ids ttnpb.GatewayIdentifiers) (*ttnpb
 		}
 		var drIndex ttnpb.DataRateIndex
 		var found bool
-		loraDr, err := udp.ParseLoRaDataRate(lorawanMetadata.DataRate)
+		loraDr, err := datarate.ParseLoRaDataRate(lorawanMetadata.DataRate)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/gatewayserver/io/mqtt/format_protobufv2.go
+++ b/pkg/gatewayserver/io/mqtt/format_protobufv2.go
@@ -133,7 +133,7 @@ func (protobufv2) ToUplink(message []byte, ids ttnpb.GatewayIdentifiers) (*ttnpb
 		}
 		var drIndex ttnpb.DataRateIndex
 		var found bool
-		loraDr, err := datarate.ParseLoRaDataRate(lorawanMetadata.DataRate)
+		loraDr, err := datarate.ParseLoRa(lorawanMetadata.DataRate)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/gatewayserver/io/udp/udp_util_test.go
+++ b/pkg/gatewayserver/io/udp/udp_util_test.go
@@ -67,7 +67,7 @@ func generatePushData(eui types.EUI64, status bool, timestamps ...time.Duration)
 			Chan: uint8(up.RxMetadata[0].ChannelIndex),
 			Modu: modulation,
 			CodR: codr,
-			DatR: datarate.DataRate{
+			DatR: datarate.DR{
 				DataRate: up.Settings.DataRate,
 			},
 			Size: uint16(len(up.RawPayload)),

--- a/pkg/gatewayserver/io/udp/udp_util_test.go
+++ b/pkg/gatewayserver/io/udp/udp_util_test.go
@@ -29,6 +29,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	encoding "go.thethings.network/lorawan-stack/pkg/ttnpb/udp"
 	"go.thethings.network/lorawan-stack/pkg/types"
+	"go.thethings.network/lorawan-stack/pkg/util/datarate"
 	"go.thethings.network/lorawan-stack/pkg/util/test"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 )
@@ -66,7 +67,7 @@ func generatePushData(eui types.EUI64, status bool, timestamps ...time.Duration)
 			Chan: uint8(up.RxMetadata[0].ChannelIndex),
 			Modu: modulation,
 			CodR: codr,
-			DatR: encoding.DataRate{
+			DatR: datarate.DataRate{
 				DataRate: up.Settings.DataRate,
 			},
 			Size: uint16(len(up.RawPayload)),

--- a/pkg/ttnpb/udp/packet_data.go
+++ b/pkg/ttnpb/udp/packet_data.go
@@ -14,7 +14,11 @@
 
 package udp
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"go.thethings.network/lorawan-stack/pkg/util/datarate"
+)
 
 // Data contains a LoRaWAN packet
 type Data struct {
@@ -26,23 +30,23 @@ type Data struct {
 
 // RxPacket contains a Rx message
 type RxPacket struct {
-	Time *CompactTime `json:"time,omitempty"` // UTC time of pkt Rx, us precision, ISO 8601 'compact' format
-	Tmms *uint64      `json:"tmms,omitempty"` // GPS time of pkt Rx, number of milliseconds since 06.Jan.1980
-	Tmst uint32       `json:"tmst"`           // Internal timestamp of "Rx finished" event (32b unsigned)
-	Freq float64      `json:"freq"`           // Rx central frequency in MHz (unsigned float, Hz precision)
-	Chan uint8        `json:"chan"`           // Concentrator "IF" channel used for Rx (unsigned integer)
-	RFCh uint8        `json:"rfch"`           // Concentrator "RF chain" used for Rx (unsigned integer)
-	Stat int8         `json:"stat"`           // CRC status: 1 = OK, -1 = fail, 0 = no CRC
-	Modu string       `json:"modu"`           // Modulation identifier "LORA" or "FSK"
-	DatR DataRate     `json:"datr"`           // LoRa datarate or FSK datarate
-	CodR string       `json:"codr"`           // LoRa ECC coding rate identifier
-	RSSI int16        `json:"rssi"`           // RSSI in dBm (signed integer, 1 dB precision)
-	LSNR float64      `json:"lsnr"`           // Lora SNR ratio in dB (signed float, 0.1 dB precision)
-	Size uint16       `json:"size"`           // RF packet payload size in bytes (unsigned integer)
-	Data string       `json:"data"`           // Base64 encoded RF packet payload, padded
-	RSig []RSig       `json:"rsig"`           // Received signal information, per antenna (Optional)
-	Brd  uint8        `json:"brd"`            // Concentrator board used for Rx (unsigned integer)
-	Aesk uint8        `json:"aesk"`           // AES key index used for encrypting fine timestamps
+	Time *CompactTime      `json:"time,omitempty"` // UTC time of pkt Rx, us precision, ISO 8601 'compact' format
+	Tmms *uint64           `json:"tmms,omitempty"` // GPS time of pkt Rx, number of milliseconds since 06.Jan.1980
+	Tmst uint32            `json:"tmst"`           // Internal timestamp of "Rx finished" event (32b unsigned)
+	Freq float64           `json:"freq"`           // Rx central frequency in MHz (unsigned float, Hz precision)
+	Chan uint8             `json:"chan"`           // Concentrator "IF" channel used for Rx (unsigned integer)
+	RFCh uint8             `json:"rfch"`           // Concentrator "RF chain" used for Rx (unsigned integer)
+	Stat int8              `json:"stat"`           // CRC status: 1 = OK, -1 = fail, 0 = no CRC
+	Modu string            `json:"modu"`           // Modulation identifier "LORA" or "FSK"
+	DatR datarate.DataRate `json:"datr"`           // LoRa datarate or FSK datarate
+	CodR string            `json:"codr"`           // LoRa ECC coding rate identifier
+	RSSI int16             `json:"rssi"`           // RSSI in dBm (signed integer, 1 dB precision)
+	LSNR float64           `json:"lsnr"`           // Lora SNR ratio in dB (signed float, 0.1 dB precision)
+	Size uint16            `json:"size"`           // RF packet payload size in bytes (unsigned integer)
+	Data string            `json:"data"`           // Base64 encoded RF packet payload, padded
+	RSig []RSig            `json:"rsig"`           // Received signal information, per antenna (Optional)
+	Brd  uint8             `json:"brd"`            // Concentrator board used for Rx (unsigned integer)
+	Aesk uint8             `json:"aesk"`           // AES key index used for encrypting fine timestamps
 }
 
 // RSig contains the metadata associated with the received signal
@@ -60,24 +64,24 @@ type RSig struct {
 
 // TxPacket contains a Tx message
 type TxPacket struct {
-	Imme bool         `json:"imme"`           // Send packet immediately (will ignore tmst & time)
-	Tmst uint32       `json:"tmst,omitempty"` // Send packet on a certain timestamp value (will ignore time)
-	Tmms *uint64      `json:"tmms,omitempty"` // Send packet at a certain GPS time (GPS synchronization required)
-	Time *CompactTime `json:"time,omitempty"` // Send packet at a certain time (GPS synchronization required)
-	Freq float64      `json:"freq"`           // Tx central frequency in MHz (unsigned float, Hz precision)
-	Brd  uint8        `json:"brd,omitempty"`  // Concentrator board used for Tx (unsigned integer)
-	Ant  uint8        `json:"ant,omitempty"`  // Concentrator antenna used for Tx (unsigned integer)
-	RFCh uint8        `json:"rfch"`           // Concentrator "RF chain" used for Tx (unsigned integer)
-	Powe uint8        `json:"powe"`           // Tx output power in dBm (unsigned integer, dBm precision)
-	Modu string       `json:"modu"`           // Modulation identifier "LORA" or "FSK"
-	DatR DataRate     `json:"datr"`           // LoRa datarate or FSK datarate
-	CodR string       `json:"codr,omitempty"` // LoRa ECC coding rate identifier
-	FDev uint16       `json:"fdev,omitempty"` // FSK frequency deviation (unsigned integer, in Hz)
-	IPol bool         `json:"ipol"`           // Lora modulation polarization inversion
-	Prea uint16       `json:"prea,omitempty"` // RF preamble size (unsigned integer)
-	Size uint16       `json:"size"`           // RF packet payload size in bytes (unsigned integer)
-	NCRC bool         `json:"ncrc,omitempty"` // If true, disable the CRC of the physical layer (optional)
-	Data string       `json:"data"`           // Base64 encoded RF packet payload, padding optional
+	Imme bool              `json:"imme"`           // Send packet immediately (will ignore tmst & time)
+	Tmst uint32            `json:"tmst,omitempty"` // Send packet on a certain timestamp value (will ignore time)
+	Tmms *uint64           `json:"tmms,omitempty"` // Send packet at a certain GPS time (GPS synchronization required)
+	Time *CompactTime      `json:"time,omitempty"` // Send packet at a certain time (GPS synchronization required)
+	Freq float64           `json:"freq"`           // Tx central frequency in MHz (unsigned float, Hz precision)
+	Brd  uint8             `json:"brd,omitempty"`  // Concentrator board used for Tx (unsigned integer)
+	Ant  uint8             `json:"ant,omitempty"`  // Concentrator antenna used for Tx (unsigned integer)
+	RFCh uint8             `json:"rfch"`           // Concentrator "RF chain" used for Tx (unsigned integer)
+	Powe uint8             `json:"powe"`           // Tx output power in dBm (unsigned integer, dBm precision)
+	Modu string            `json:"modu"`           // Modulation identifier "LORA" or "FSK"
+	DatR datarate.DataRate `json:"datr"`           // LoRa datarate or FSK datarate
+	CodR string            `json:"codr,omitempty"` // LoRa ECC coding rate identifier
+	FDev uint16            `json:"fdev,omitempty"` // FSK frequency deviation (unsigned integer, in Hz)
+	IPol bool              `json:"ipol"`           // Lora modulation polarization inversion
+	Prea uint16            `json:"prea,omitempty"` // RF preamble size (unsigned integer)
+	Size uint16            `json:"size"`           // RF packet payload size in bytes (unsigned integer)
+	NCRC bool              `json:"ncrc,omitempty"` // If true, disable the CRC of the physical layer (optional)
+	Data string            `json:"data"`           // Base64 encoded RF packet payload, padding optional
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/pkg/ttnpb/udp/packet_data.go
+++ b/pkg/ttnpb/udp/packet_data.go
@@ -30,23 +30,23 @@ type Data struct {
 
 // RxPacket contains a Rx message
 type RxPacket struct {
-	Time *CompactTime      `json:"time,omitempty"` // UTC time of pkt Rx, us precision, ISO 8601 'compact' format
-	Tmms *uint64           `json:"tmms,omitempty"` // GPS time of pkt Rx, number of milliseconds since 06.Jan.1980
-	Tmst uint32            `json:"tmst"`           // Internal timestamp of "Rx finished" event (32b unsigned)
-	Freq float64           `json:"freq"`           // Rx central frequency in MHz (unsigned float, Hz precision)
-	Chan uint8             `json:"chan"`           // Concentrator "IF" channel used for Rx (unsigned integer)
-	RFCh uint8             `json:"rfch"`           // Concentrator "RF chain" used for Rx (unsigned integer)
-	Stat int8              `json:"stat"`           // CRC status: 1 = OK, -1 = fail, 0 = no CRC
-	Modu string            `json:"modu"`           // Modulation identifier "LORA" or "FSK"
-	DatR datarate.DataRate `json:"datr"`           // LoRa datarate or FSK datarate
-	CodR string            `json:"codr"`           // LoRa ECC coding rate identifier
-	RSSI int16             `json:"rssi"`           // RSSI in dBm (signed integer, 1 dB precision)
-	LSNR float64           `json:"lsnr"`           // Lora SNR ratio in dB (signed float, 0.1 dB precision)
-	Size uint16            `json:"size"`           // RF packet payload size in bytes (unsigned integer)
-	Data string            `json:"data"`           // Base64 encoded RF packet payload, padded
-	RSig []RSig            `json:"rsig"`           // Received signal information, per antenna (Optional)
-	Brd  uint8             `json:"brd"`            // Concentrator board used for Rx (unsigned integer)
-	Aesk uint8             `json:"aesk"`           // AES key index used for encrypting fine timestamps
+	Time *CompactTime `json:"time,omitempty"` // UTC time of pkt Rx, us precision, ISO 8601 'compact' format
+	Tmms *uint64      `json:"tmms,omitempty"` // GPS time of pkt Rx, number of milliseconds since 06.Jan.1980
+	Tmst uint32       `json:"tmst"`           // Internal timestamp of "Rx finished" event (32b unsigned)
+	Freq float64      `json:"freq"`           // Rx central frequency in MHz (unsigned float, Hz precision)
+	Chan uint8        `json:"chan"`           // Concentrator "IF" channel used for Rx (unsigned integer)
+	RFCh uint8        `json:"rfch"`           // Concentrator "RF chain" used for Rx (unsigned integer)
+	Stat int8         `json:"stat"`           // CRC status: 1 = OK, -1 = fail, 0 = no CRC
+	Modu string       `json:"modu"`           // Modulation identifier "LORA" or "FSK"
+	DatR datarate.DR  `json:"datr"`           // LoRa datarate or FSK datarate
+	CodR string       `json:"codr"`           // LoRa ECC coding rate identifier
+	RSSI int16        `json:"rssi"`           // RSSI in dBm (signed integer, 1 dB precision)
+	LSNR float64      `json:"lsnr"`           // Lora SNR ratio in dB (signed float, 0.1 dB precision)
+	Size uint16       `json:"size"`           // RF packet payload size in bytes (unsigned integer)
+	Data string       `json:"data"`           // Base64 encoded RF packet payload, padded
+	RSig []RSig       `json:"rsig"`           // Received signal information, per antenna (Optional)
+	Brd  uint8        `json:"brd"`            // Concentrator board used for Rx (unsigned integer)
+	Aesk uint8        `json:"aesk"`           // AES key index used for encrypting fine timestamps
 }
 
 // RSig contains the metadata associated with the received signal
@@ -64,24 +64,24 @@ type RSig struct {
 
 // TxPacket contains a Tx message
 type TxPacket struct {
-	Imme bool              `json:"imme"`           // Send packet immediately (will ignore tmst & time)
-	Tmst uint32            `json:"tmst,omitempty"` // Send packet on a certain timestamp value (will ignore time)
-	Tmms *uint64           `json:"tmms,omitempty"` // Send packet at a certain GPS time (GPS synchronization required)
-	Time *CompactTime      `json:"time,omitempty"` // Send packet at a certain time (GPS synchronization required)
-	Freq float64           `json:"freq"`           // Tx central frequency in MHz (unsigned float, Hz precision)
-	Brd  uint8             `json:"brd,omitempty"`  // Concentrator board used for Tx (unsigned integer)
-	Ant  uint8             `json:"ant,omitempty"`  // Concentrator antenna used for Tx (unsigned integer)
-	RFCh uint8             `json:"rfch"`           // Concentrator "RF chain" used for Tx (unsigned integer)
-	Powe uint8             `json:"powe"`           // Tx output power in dBm (unsigned integer, dBm precision)
-	Modu string            `json:"modu"`           // Modulation identifier "LORA" or "FSK"
-	DatR datarate.DataRate `json:"datr"`           // LoRa datarate or FSK datarate
-	CodR string            `json:"codr,omitempty"` // LoRa ECC coding rate identifier
-	FDev uint16            `json:"fdev,omitempty"` // FSK frequency deviation (unsigned integer, in Hz)
-	IPol bool              `json:"ipol"`           // Lora modulation polarization inversion
-	Prea uint16            `json:"prea,omitempty"` // RF preamble size (unsigned integer)
-	Size uint16            `json:"size"`           // RF packet payload size in bytes (unsigned integer)
-	NCRC bool              `json:"ncrc,omitempty"` // If true, disable the CRC of the physical layer (optional)
-	Data string            `json:"data"`           // Base64 encoded RF packet payload, padding optional
+	Imme bool         `json:"imme"`           // Send packet immediately (will ignore tmst & time)
+	Tmst uint32       `json:"tmst,omitempty"` // Send packet on a certain timestamp value (will ignore time)
+	Tmms *uint64      `json:"tmms,omitempty"` // Send packet at a certain GPS time (GPS synchronization required)
+	Time *CompactTime `json:"time,omitempty"` // Send packet at a certain time (GPS synchronization required)
+	Freq float64      `json:"freq"`           // Tx central frequency in MHz (unsigned float, Hz precision)
+	Brd  uint8        `json:"brd,omitempty"`  // Concentrator board used for Tx (unsigned integer)
+	Ant  uint8        `json:"ant,omitempty"`  // Concentrator antenna used for Tx (unsigned integer)
+	RFCh uint8        `json:"rfch"`           // Concentrator "RF chain" used for Tx (unsigned integer)
+	Powe uint8        `json:"powe"`           // Tx output power in dBm (unsigned integer, dBm precision)
+	Modu string       `json:"modu"`           // Modulation identifier "LORA" or "FSK"
+	DatR datarate.DR  `json:"datr"`           // LoRa datarate or FSK datarate
+	CodR string       `json:"codr,omitempty"` // LoRa ECC coding rate identifier
+	FDev uint16       `json:"fdev,omitempty"` // FSK frequency deviation (unsigned integer, in Hz)
+	IPol bool         `json:"ipol"`           // Lora modulation polarization inversion
+	Prea uint16       `json:"prea,omitempty"` // RF preamble size (unsigned integer)
+	Size uint16       `json:"size"`           // RF packet payload size in bytes (unsigned integer)
+	NCRC bool         `json:"ncrc,omitempty"` // If true, disable the CRC of the physical layer (optional)
+	Data string       `json:"data"`           // Base64 encoded RF packet payload, padding optional
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/pkg/ttnpb/udp/packet_data_test.go
+++ b/pkg/ttnpb/udp/packet_data_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/pkg/util/datarate"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 )
 
@@ -55,6 +56,7 @@ func TestStatusPacket(t *testing.T) {
 	a.So(d.Stat.DWNb, should.Equal, 0)
 	a.So(d.Stat.TxNb, should.Equal, 0)
 }
+
 func TestUplinkPacket(t *testing.T) {
 	uplinkPacket := `{
 		"rxpk":[
@@ -92,7 +94,7 @@ func TestUplinkPacket(t *testing.T) {
 	a.So(uplink.RFCh, should.Equal, 0)
 	a.So(uplink.Stat, should.Equal, 1)
 	a.So(uplink.Modu, should.Equal, "LORA")
-	a.So(uplink.DatR, should.Resemble, DataRate{DataRate: ttnpb.DataRate{
+	a.So(uplink.DatR, should.Resemble, datarate.DataRate{DataRate: ttnpb.DataRate{
 		Modulation: &ttnpb.DataRate_LoRa{
 			LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 7,
@@ -135,7 +137,7 @@ func TestDownlinkPacket(t *testing.T) {
 	a.So(tx.RFCh, should.Equal, 0)
 	a.So(tx.Powe, should.Equal, 14)
 	a.So(tx.Modu, should.Equal, "LORA")
-	a.So(tx.DatR, should.Resemble, DataRate{DataRate: ttnpb.DataRate{
+	a.So(tx.DatR, should.Resemble, datarate.DataRate{DataRate: ttnpb.DataRate{
 		Modulation: &ttnpb.DataRate_LoRa{
 			LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 11,

--- a/pkg/ttnpb/udp/packet_data_test.go
+++ b/pkg/ttnpb/udp/packet_data_test.go
@@ -94,7 +94,7 @@ func TestUplinkPacket(t *testing.T) {
 	a.So(uplink.RFCh, should.Equal, 0)
 	a.So(uplink.Stat, should.Equal, 1)
 	a.So(uplink.Modu, should.Equal, "LORA")
-	a.So(uplink.DatR, should.Resemble, datarate.DataRate{DataRate: ttnpb.DataRate{
+	a.So(uplink.DatR, should.Resemble, datarate.DR{DataRate: ttnpb.DataRate{
 		Modulation: &ttnpb.DataRate_LoRa{
 			LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 7,
@@ -137,7 +137,7 @@ func TestDownlinkPacket(t *testing.T) {
 	a.So(tx.RFCh, should.Equal, 0)
 	a.So(tx.Powe, should.Equal, 14)
 	a.So(tx.Modu, should.Equal, "LORA")
-	a.So(tx.DatR, should.Resemble, datarate.DataRate{DataRate: ttnpb.DataRate{
+	a.So(tx.DatR, should.Resemble, datarate.DR{DataRate: ttnpb.DataRate{
 		Modulation: &ttnpb.DataRate_LoRa{
 			LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 11,

--- a/pkg/ttnpb/udp/translation.go
+++ b/pkg/ttnpb/udp/translation.go
@@ -287,7 +287,7 @@ func FromGatewayUp(up *ttnpb.GatewayUp) (rxs []*RxPacket, stat *Stat, ack *TxPac
 			Freq: float64(msg.Settings.Frequency) / 1000000,
 			Chan: uint8(msg.RxMetadata[0].ChannelIndex),
 			Modu: modulation,
-			DatR: datarate.DataRate{DataRate: msg.Settings.DataRate},
+			DatR: datarate.DR{DataRate: msg.Settings.DataRate},
 			CodR: codr,
 			Size: uint16(len(msg.RawPayload)),
 			Data: base64.StdEncoding.EncodeToString(msg.RawPayload),

--- a/pkg/ttnpb/udp/translation.go
+++ b/pkg/ttnpb/udp/translation.go
@@ -23,6 +23,7 @@ import (
 	pbtypes "github.com/gogo/protobuf/types"
 	"go.thethings.network/lorawan-stack/pkg/gpstime"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/pkg/util/datarate"
 	"go.thethings.network/lorawan-stack/pkg/version"
 )
 
@@ -286,7 +287,7 @@ func FromGatewayUp(up *ttnpb.GatewayUp) (rxs []*RxPacket, stat *Stat, ack *TxPac
 			Freq: float64(msg.Settings.Frequency) / 1000000,
 			Chan: uint8(msg.RxMetadata[0].ChannelIndex),
 			Modu: modulation,
-			DatR: DataRate{msg.Settings.DataRate},
+			DatR: datarate.DataRate{DataRate: msg.Settings.DataRate},
 			CodR: codr,
 			Size: uint16(len(msg.RawPayload)),
 			Data: base64.StdEncoding.EncodeToString(msg.RawPayload),

--- a/pkg/ttnpb/udp/translation_test.go
+++ b/pkg/ttnpb/udp/translation_test.go
@@ -99,7 +99,7 @@ func TestToGatewayUp(t *testing.T) {
 					Freq: 868.0,
 					Chan: 2,
 					Modu: "LORA",
-					DatR: datarate.DataRate{DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{SpreadingFactor: 10, Bandwidth: 125000}}}},
+					DatR: datarate.DR{DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{SpreadingFactor: 10, Bandwidth: 125000}}}},
 					CodR: "4/7",
 					Data: "QCkuASaAAAAByFaF53Iu+vzmwQ==",
 					Size: 19,
@@ -146,7 +146,7 @@ func TestToGatewayUpRoundtrip(t *testing.T) {
 						Freq: 868.0,
 						Chan: 2,
 						Modu: "LORA",
-						DatR: datarate.DataRate{DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{SpreadingFactor: 10, Bandwidth: 125000}}}},
+						DatR: datarate.DR{DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{SpreadingFactor: 10, Bandwidth: 125000}}}},
 						CodR: "4/7",
 						Data: "QCkuASaAAAAByFaF53Iu+vzmwQ==",
 						Size: 19,
@@ -348,7 +348,7 @@ func TestFromDownlinkMessage(t *testing.T) {
 	}
 	tx, err := udp.FromDownlinkMessage(msg)
 	a.So(err, should.BeNil)
-	a.So(tx.DatR, should.Resemble, datarate.DataRate{DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{Bandwidth: 500000, SpreadingFactor: 10}}}})
+	a.So(tx.DatR, should.Resemble, datarate.DR{DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{Bandwidth: 500000, SpreadingFactor: 10}}}})
 	a.So(tx.Tmst, should.Equal, 1886440700)
 	a.So(tx.NCRC, should.Equal, true)
 	a.So(tx.Data, should.Equal, "ffOO")

--- a/pkg/ttnpb/udp/translation_test.go
+++ b/pkg/ttnpb/udp/translation_test.go
@@ -26,6 +26,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb/udp"
 	"go.thethings.network/lorawan-stack/pkg/types"
+	"go.thethings.network/lorawan-stack/pkg/util/datarate"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 	"go.thethings.network/lorawan-stack/pkg/version"
 )
@@ -98,7 +99,7 @@ func TestToGatewayUp(t *testing.T) {
 					Freq: 868.0,
 					Chan: 2,
 					Modu: "LORA",
-					DatR: udp.DataRate{DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{SpreadingFactor: 10, Bandwidth: 125000}}}},
+					DatR: datarate.DataRate{DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{SpreadingFactor: 10, Bandwidth: 125000}}}},
 					CodR: "4/7",
 					Data: "QCkuASaAAAAByFaF53Iu+vzmwQ==",
 					Size: 19,
@@ -145,7 +146,7 @@ func TestToGatewayUpRoundtrip(t *testing.T) {
 						Freq: 868.0,
 						Chan: 2,
 						Modu: "LORA",
-						DatR: udp.DataRate{DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{SpreadingFactor: 10, Bandwidth: 125000}}}},
+						DatR: datarate.DataRate{DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{SpreadingFactor: 10, Bandwidth: 125000}}}},
 						CodR: "4/7",
 						Data: "QCkuASaAAAAByFaF53Iu+vzmwQ==",
 						Size: 19,
@@ -347,7 +348,7 @@ func TestFromDownlinkMessage(t *testing.T) {
 	}
 	tx, err := udp.FromDownlinkMessage(msg)
 	a.So(err, should.BeNil)
-	a.So(tx.DatR, should.Resemble, udp.DataRate{DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{Bandwidth: 500000, SpreadingFactor: 10}}}})
+	a.So(tx.DatR, should.Resemble, datarate.DataRate{DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{Bandwidth: 500000, SpreadingFactor: 10}}}})
 	a.So(tx.Tmst, should.Equal, 1886440700)
 	a.So(tx.NCRC, should.Equal, true)
 	a.So(tx.Data, should.Equal, "ffOO")

--- a/pkg/util/datarate/data_rate.go
+++ b/pkg/util/datarate/data_rate.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package udp
+package datarate
 
 import (
 	"fmt"

--- a/pkg/util/datarate/data_rate.go
+++ b/pkg/util/datarate/data_rate.go
@@ -23,37 +23,37 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 )
 
-// DataRate encodes a LoRa data rate or an FSK data rate, and implements marshalling and unmarshalling between JSON.
-type DataRate struct {
+// DR encodes a LoRa data rate or an FSK data rate, and implements marshalling and unmarshalling between JSON.
+type DR struct {
 	ttnpb.DataRate
 }
 
 // MarshalJSON implements the json.Marshaler interface.
-func (d DataRate) MarshalJSON() ([]byte, error) {
-	if d.GetLoRa() != nil {
-		return []byte(strconv.Quote(d.String())), nil
+func (dr DR) MarshalJSON() ([]byte, error) {
+	if dr.GetLoRa() != nil {
+		return []byte(strconv.Quote(dr.String())), nil
 	}
-	if d.GetFSK() != nil {
-		return []byte(d.String()), nil
+	if dr.GetFSK() != nil {
+		return []byte(dr.String()), nil
 	}
 	return nil, nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
-func (d *DataRate) UnmarshalJSON(data []byte) error {
+func (dr *DR) UnmarshalJSON(data []byte) error {
 	if len(data) >= 2 && data[0] == '"' && data[len(data)-1] == '"' {
-		dr, err := ParseLoRaDataRate(string(data[1 : len(data)-1]))
+		datarate, err := ParseLoRa(string(data[1 : len(data)-1]))
 		if err != nil {
 			return err
 		}
-		*d = dr
+		*dr = datarate
 		return nil
 	}
 	i, err := strconv.ParseUint(string(data), 10, 32)
 	if err != nil {
 		return err
 	}
-	*d = DataRate{
+	*dr = DR{
 		DataRate: ttnpb.DataRate{
 			Modulation: &ttnpb.DataRate_FSK{
 				FSK: &ttnpb.FSKDataRate{
@@ -72,35 +72,35 @@ var (
 )
 
 // String implements the Stringer interface.
-func (d DataRate) String() string {
-	if lora := d.GetLoRa(); lora != nil {
+func (dr DR) String() string {
+	if lora := dr.GetLoRa(); lora != nil {
 		return fmt.Sprintf("SF%dBW%v", lora.SpreadingFactor, float32(lora.Bandwidth)/1000)
 	}
-	if fsk := d.GetFSK(); fsk != nil {
+	if fsk := dr.GetFSK(); fsk != nil {
 		return fmt.Sprintf("%d", fsk.BitRate)
 	}
 	return ""
 }
 
-// ParseLoRaDataRate converts a string of format "SFxxBWxxx" to a LoRaDataRate.
-func ParseLoRaDataRate(dr string) (DataRate, error) {
+// ParseLoRa converts a string of format "SFxxBWxxx" to a LoRaDataRate.
+func ParseLoRa(dr string) (DR, error) {
 	matches := sfRegexp.FindStringSubmatch(dr)
 	if len(matches) != 2 {
-		return DataRate{}, errDataRate
+		return DR{}, errDataRate
 	}
 	sf, err := strconv.ParseUint(matches[1], 10, 64)
 	if err != nil {
-		return DataRate{}, errDataRate
+		return DR{}, errDataRate
 	}
 	matches = bwRegexp.FindStringSubmatch(dr)
 	if len(matches) != 2 {
-		return DataRate{}, errDataRate
+		return DR{}, errDataRate
 	}
 	bw, err := strconv.ParseFloat(matches[1], 64)
 	if err != nil {
-		return DataRate{}, errDataRate
+		return DR{}, errDataRate
 	}
-	return DataRate{
+	return DR{
 		DataRate: ttnpb.DataRate{
 			Modulation: &ttnpb.DataRate_LoRa{
 				LoRa: &ttnpb.LoRaDataRate{

--- a/pkg/util/datarate/data_rate_test.go
+++ b/pkg/util/datarate/data_rate_test.go
@@ -12,21 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package udp_test
+package datarate_test
 
 import (
 	"testing"
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
-	"go.thethings.network/lorawan-stack/pkg/ttnpb/udp"
+	"go.thethings.network/lorawan-stack/pkg/util/datarate"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 )
 
 func TestDataRate(t *testing.T) {
 	a := assertions.New(t)
 
-	table := map[string]udp.DataRate{
+	table := map[string]datarate.DataRate{
 		`"SF7BW125"`: {DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{SpreadingFactor: 7, Bandwidth: 125000}}}},
 		`50000`:      {DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_FSK{FSK: &ttnpb.FSKDataRate{BitRate: 50000}}}},
 	}
@@ -36,13 +36,13 @@ func TestDataRate(t *testing.T) {
 		a.So(err, should.BeNil)
 		a.So(string(enc), should.Equal, s)
 
-		var dec udp.DataRate
+		var dec datarate.DataRate
 		err = dec.UnmarshalJSON(enc)
 		a.So(err, should.BeNil)
 		a.So(dec, should.Resemble, dr)
 	}
 
-	var dr udp.DataRate
+	var dr datarate.DataRate
 	err := dr.UnmarshalJSON([]byte{})
 	a.So(err, should.NotBeNil)
 }
@@ -50,13 +50,13 @@ func TestDataRate(t *testing.T) {
 func TestValidLoRaDataRateParsing(t *testing.T) {
 	a := assertions.New(t)
 
-	table := map[string]udp.DataRate{
+	table := map[string]datarate.DataRate{
 		"SF6BW125":   {DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{SpreadingFactor: 6, Bandwidth: 125000}}}},
 		"SF9BW500":   {DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{SpreadingFactor: 9, Bandwidth: 500000}}}},
 		"SF5BW31.25": {DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{SpreadingFactor: 5, Bandwidth: 31250}}}},
 	}
 	for dr, expected := range table {
-		actual, err := udp.ParseLoRaDataRate(dr)
+		actual, err := datarate.ParseLoRaDataRate(dr)
 		a.So(err, should.BeNil)
 		a.So(actual, should.Resemble, expected)
 	}
@@ -70,7 +70,7 @@ func TestInvalidLoRaDataRateParsing(t *testing.T) {
 		"SF9B500",
 	}
 	for _, dr := range table {
-		_, err := udp.ParseLoRaDataRate(dr)
+		_, err := datarate.ParseLoRaDataRate(dr)
 		a.So(err, should.NotBeNil)
 	}
 }
@@ -78,7 +78,7 @@ func TestInvalidLoRaDataRateParsing(t *testing.T) {
 func TestStringer(t *testing.T) {
 	a := assertions.New(t)
 
-	table := map[udp.DataRate]string{
+	table := map[datarate.DataRate]string{
 		{DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{SpreadingFactor: 6, Bandwidth: 125000}}}}: "SF6BW125",
 		{DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{SpreadingFactor: 9, Bandwidth: 500000}}}}: "SF9BW500",
 		{DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{SpreadingFactor: 5, Bandwidth: 31250}}}}:  "SF5BW31.25",

--- a/pkg/util/datarate/data_rate_test.go
+++ b/pkg/util/datarate/data_rate_test.go
@@ -26,7 +26,7 @@ import (
 func TestDataRate(t *testing.T) {
 	a := assertions.New(t)
 
-	table := map[string]datarate.DataRate{
+	table := map[string]datarate.DR{
 		`"SF7BW125"`: {DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{SpreadingFactor: 7, Bandwidth: 125000}}}},
 		`50000`:      {DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_FSK{FSK: &ttnpb.FSKDataRate{BitRate: 50000}}}},
 	}
@@ -36,13 +36,13 @@ func TestDataRate(t *testing.T) {
 		a.So(err, should.BeNil)
 		a.So(string(enc), should.Equal, s)
 
-		var dec datarate.DataRate
+		var dec datarate.DR
 		err = dec.UnmarshalJSON(enc)
 		a.So(err, should.BeNil)
 		a.So(dec, should.Resemble, dr)
 	}
 
-	var dr datarate.DataRate
+	var dr datarate.DR
 	err := dr.UnmarshalJSON([]byte{})
 	a.So(err, should.NotBeNil)
 }
@@ -50,13 +50,13 @@ func TestDataRate(t *testing.T) {
 func TestValidLoRaDataRateParsing(t *testing.T) {
 	a := assertions.New(t)
 
-	table := map[string]datarate.DataRate{
+	table := map[string]datarate.DR{
 		"SF6BW125":   {DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{SpreadingFactor: 6, Bandwidth: 125000}}}},
 		"SF9BW500":   {DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{SpreadingFactor: 9, Bandwidth: 500000}}}},
 		"SF5BW31.25": {DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{SpreadingFactor: 5, Bandwidth: 31250}}}},
 	}
 	for dr, expected := range table {
-		actual, err := datarate.ParseLoRaDataRate(dr)
+		actual, err := datarate.ParseLoRa(dr)
 		a.So(err, should.BeNil)
 		a.So(actual, should.Resemble, expected)
 	}
@@ -70,7 +70,7 @@ func TestInvalidLoRaDataRateParsing(t *testing.T) {
 		"SF9B500",
 	}
 	for _, dr := range table {
-		_, err := datarate.ParseLoRaDataRate(dr)
+		_, err := datarate.ParseLoRa(dr)
 		a.So(err, should.NotBeNil)
 	}
 }
@@ -78,7 +78,7 @@ func TestInvalidLoRaDataRateParsing(t *testing.T) {
 func TestStringer(t *testing.T) {
 	a := assertions.New(t)
 
-	table := map[datarate.DataRate]string{
+	table := map[datarate.DR]string{
 		{DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{SpreadingFactor: 6, Bandwidth: 125000}}}}: "SF6BW125",
 		{DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{SpreadingFactor: 9, Bandwidth: 500000}}}}: "SF9BW500",
 		{DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{SpreadingFactor: 5, Bandwidth: 31250}}}}:  "SF5BW31.25",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/pull/1739#discussion_r328534388

#### Changes
<!-- What are the changes made in this pull request? -->

- Move `pkg/ttnpb/udp/datarate*` to `pkg/util/datarate`
- Remove reflection in basicstationlns util.