### PR TITLE
Add support for organization api keys in console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Emails when the state of a user or OAuth client changes.
 - Option to generate claim authentication codes for devices automatically.
 - User invitations can now be sent and redeemed.
+- Support for creating organization API keys in the Console.
+- Support for deleting organization API keys in the Console.
+- Support for editing organization API keys in the Console.
+- Support for listing organization API keys in the Console.
+- Support for managing organization API keys and rights in the JS SDK.
 
 ### Changed
 

--- a/pkg/webui/console/api/index.js
+++ b/pkg/webui/console/api/index.js
@@ -215,5 +215,12 @@ export default {
     eventsSubscribe: ttnClient.Organizations.openStream.bind(ttnClient.Organizations),
     delete: ttnClient.Organizations.deleteById.bind(ttnClient.Organizations),
     update: ttnClient.Organizations.updateById.bind(ttnClient.Organizations),
+    apiKeys: {
+      get: ttnClient.Organizations.ApiKeys.getById.bind(ttnClient.Organizations.ApiKeys),
+      list: ttnClient.Organizations.ApiKeys.getAll.bind(ttnClient.Organizations.ApiKeys),
+      update: ttnClient.Organizations.ApiKeys.updateById.bind(ttnClient.Organizations.ApiKeys),
+      delete: ttnClient.Organizations.ApiKeys.deleteById.bind(ttnClient.Organizations.ApiKeys),
+      create: ttnClient.Organizations.ApiKeys.create.bind(ttnClient.Organizations.ApiKeys),
+    },
   },
 }

--- a/pkg/webui/console/api/index.js
+++ b/pkg/webui/console/api/index.js
@@ -189,6 +189,7 @@ export default {
   rights: {
     applications: ttnClient.Applications.getRightsById.bind(ttnClient.Applications),
     gateways: ttnClient.Gateways.getRightsById.bind(ttnClient.Gateways),
+    organizations: ttnClient.Organizations.getRightsById.bind(ttnClient.Organizations),
   },
   configuration: {
     listNsFrequencyPlans: ttnClient.Configuration.listNsFrequencyPlans.bind(

--- a/pkg/webui/console/components/api-key-form/edit.js
+++ b/pkg/webui/console/components/api-key-form/edit.js
@@ -127,6 +127,7 @@ class EditForm extends React.Component {
           component={RightsGroup}
           rights={rights}
           pseudoRight={pseudoRights[0]}
+          entityTypeMessage={sharedMessages.apiKey}
         />
         <SubmitBar>
           <FormSubmit component={SubmitButton} message={sharedMessages.saveChanges} />

--- a/pkg/webui/console/store/actions/organizations.js
+++ b/pkg/webui/console/store/actions/organizations.js
@@ -31,6 +31,7 @@ import {
   clearEvents,
   createClearEventsActionType,
 } from './events'
+import createApiKeysRequestActions, { createGetApiKeysListActionType } from './api-keys'
 
 export const SHARED_NAME = 'ORGANIZATION'
 
@@ -79,6 +80,20 @@ export const [
     failure: deleteORganizationFailure,
   },
 ] = createPaginationDeleteActions(SHARED_NAME, id => ({ id }))
+
+export const GET_ORG_API_KEYS_LIST_BASE = createGetApiKeysListActionType(SHARED_NAME)
+export const [
+  {
+    request: GET_ORG_API_KEYS_LIST,
+    success: GET_ORG_API_KEYS_LIST_SUCCESS,
+    failure: GET_ORG_API_KEYS_LIST_FAILURE,
+  },
+  {
+    request: getOrganizationApiKeysList,
+    success: getOrganizationApiKeysListSuccess,
+    failure: getOrganizationApiKeysListFailure,
+  },
+] = createApiKeysRequestActions(SHARED_NAME)
 
 export const START_ORG_EVENT_STREAM = createStartEventsStreamActionType(SHARED_NAME)
 export const START_ORG_EVENT_STREAM_SUCCESS = createStartEventsStreamSuccessActionType(SHARED_NAME)

--- a/pkg/webui/console/store/actions/organizations.js
+++ b/pkg/webui/console/store/actions/organizations.js
@@ -32,6 +32,7 @@ import {
   createClearEventsActionType,
 } from './events'
 import createApiKeysRequestActions, { createGetApiKeysListActionType } from './api-keys'
+import createApiKeyRequestActions, { createGetApiKeyActionType } from './api-key'
 import createGetRightsListRequestActions, { createGetRightsListActionType } from './rights'
 
 export const SHARED_NAME = 'ORGANIZATION'
@@ -81,6 +82,16 @@ export const [
     failure: deleteORganizationFailure,
   },
 ] = createPaginationDeleteActions(SHARED_NAME, id => ({ id }))
+
+export const GET_ORG_API_KEY_BASE = createGetApiKeyActionType(SHARED_NAME)
+export const [
+  { request: GET_ORG_API_KEY, success: GET_ORG_API_KEY_SUCCESS, failure: GET_ORG_API_KEY_FAILURE },
+  {
+    request: getOrganizationApiKey,
+    success: getOrganizationApiKeySuccess,
+    failure: getOrganizationApiKeyFailure,
+  },
+] = createApiKeyRequestActions(SHARED_NAME)
 
 export const GET_ORG_API_KEYS_LIST_BASE = createGetApiKeysListActionType(SHARED_NAME)
 export const [

--- a/pkg/webui/console/store/actions/organizations.js
+++ b/pkg/webui/console/store/actions/organizations.js
@@ -32,6 +32,7 @@ import {
   createClearEventsActionType,
 } from './events'
 import createApiKeysRequestActions, { createGetApiKeysListActionType } from './api-keys'
+import createGetRightsListRequestActions, { createGetRightsListActionType } from './rights'
 
 export const SHARED_NAME = 'ORGANIZATION'
 
@@ -94,6 +95,20 @@ export const [
     failure: getOrganizationApiKeysListFailure,
   },
 ] = createApiKeysRequestActions(SHARED_NAME)
+
+export const GET_ORGS_RIGHTS_LIST_BASE = createGetRightsListActionType(SHARED_NAME)
+export const [
+  {
+    request: GET_ORGS_RIGHTS_LIST,
+    success: GET_ORGS_RIGHTS_LIST_SUCCESS,
+    failure: GET_ORGS_RIGHTS_LIST_FAILURE,
+  },
+  {
+    request: getOrganizationsRightsList,
+    success: getOrganizationsRightsListSuccess,
+    failure: getOrganizationsRightsListFailure,
+  },
+] = createGetRightsListRequestActions(SHARED_NAME)
 
 export const START_ORG_EVENT_STREAM = createStartEventsStreamActionType(SHARED_NAME)
 export const START_ORG_EVENT_STREAM_SUCCESS = createStartEventsStreamSuccessActionType(SHARED_NAME)

--- a/pkg/webui/console/store/middleware/logics/organizations.js
+++ b/pkg/webui/console/store/middleware/logics/organizations.js
@@ -92,6 +92,14 @@ const getOrganizationApiKeysLogic = createRequestLogic({
   },
 })
 
+const getOrganizationApiKeyLogic = createRequestLogic({
+  type: organizations.GET_ORG_API_KEY,
+  async process({ action }) {
+    const { id: orgId, keyId } = action.payload
+    return api.organization.apiKeys.get(orgId, keyId)
+  },
+})
+
 const getOrganizationsRightsLogic = createRequestLogic({
   type: organizations.GET_ORGS_RIGHTS_LIST,
   async process({ action }) {
@@ -108,6 +116,7 @@ export default [
   updateOrganizationLogic,
   deleteOrganizationLogic,
   getOrganizationApiKeysLogic,
+  getOrganizationApiKeyLogic,
   getOrganizationsRightsLogic,
   ...createEventsConnectLogics(
     organizations.SHARED_NAME,

--- a/pkg/webui/console/store/middleware/logics/organizations.js
+++ b/pkg/webui/console/store/middleware/logics/organizations.js
@@ -80,12 +80,25 @@ const deleteOrganizationLogic = createRequestLogic({
   },
 })
 
+const getOrganizationApiKeysLogic = createRequestLogic({
+  type: organizations.GET_ORG_API_KEYS_LIST,
+  async process({ getState, action }) {
+    const {
+      id: orgId,
+      params: { page, limit },
+    } = action.payload
+    const res = await api.organization.apiKeys.list(orgId, { limit, page })
+    return { ...res, id: orgId }
+  },
+})
+
 export default [
   getOrganizationLogic,
   getOrganizationsLogic,
   createOrganizationLogic,
   updateOrganizationLogic,
   deleteOrganizationLogic,
+  getOrganizationApiKeysLogic,
   ...createEventsConnectLogics(
     organizations.SHARED_NAME,
     'organizations',

--- a/pkg/webui/console/store/middleware/logics/organizations.js
+++ b/pkg/webui/console/store/middleware/logics/organizations.js
@@ -92,6 +92,15 @@ const getOrganizationApiKeysLogic = createRequestLogic({
   },
 })
 
+const getOrganizationsRightsLogic = createRequestLogic({
+  type: organizations.GET_ORGS_RIGHTS_LIST,
+  async process({ action }) {
+    const { id } = action.payload
+    const result = await api.rights.organizations(id)
+    return result.rights.sort()
+  },
+})
+
 export default [
   getOrganizationLogic,
   getOrganizationsLogic,
@@ -99,6 +108,7 @@ export default [
   updateOrganizationLogic,
   deleteOrganizationLogic,
   getOrganizationApiKeysLogic,
+  getOrganizationsRightsLogic,
   ...createEventsConnectLogics(
     organizations.SHARED_NAME,
     'organizations',

--- a/pkg/webui/console/store/reducers/index.js
+++ b/pkg/webui/console/store/reducers/index.js
@@ -74,6 +74,7 @@ export default history =>
       applications: createNamedApiKeysReducer(APPLICATION_SHARED_NAME),
       gateway: createNamedApiKeyReducer(GATEWAY_SHARED_NAME),
       gateways: createNamedApiKeysReducer(GATEWAY_SHARED_NAME),
+      organization: createNamedApiKeyReducer(ORGANIZATION_SHARED_NAME),
       organizations: createNamedApiKeysReducer(ORGANIZATION_SHARED_NAME),
     }),
     rights: combineReducers({

--- a/pkg/webui/console/store/reducers/index.js
+++ b/pkg/webui/console/store/reducers/index.js
@@ -74,6 +74,7 @@ export default history =>
       applications: createNamedApiKeysReducer(APPLICATION_SHARED_NAME),
       gateway: createNamedApiKeyReducer(GATEWAY_SHARED_NAME),
       gateways: createNamedApiKeysReducer(GATEWAY_SHARED_NAME),
+      organizations: createNamedApiKeysReducer(ORGANIZATION_SHARED_NAME),
     }),
     rights: combineReducers({
       applications: createNamedRightsReducer(APPLICATIONS_SHARED_NAME),

--- a/pkg/webui/console/store/reducers/index.js
+++ b/pkg/webui/console/store/reducers/index.js
@@ -79,6 +79,7 @@ export default history =>
     rights: combineReducers({
       applications: createNamedRightsReducer(APPLICATIONS_SHARED_NAME),
       gateways: createNamedRightsReducer(GATEWAY_SHARED_NAME),
+      organizations: createNamedRightsReducer(ORGANIZATION_SHARED_NAME),
     }),
     collaborators: combineReducers({
       application: createNamedCollaboratorReducer(APPLICATION_SHARED_NAME),

--- a/pkg/webui/console/store/selectors/organizations.js
+++ b/pkg/webui/console/store/selectors/organizations.js
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { GET_ORGS_LIST_BASE, GET_ORG_BASE } from '../actions/organizations'
+import {
+  GET_ORGS_LIST_BASE,
+  GET_ORG_BASE,
+  GET_ORGS_RIGHTS_LIST_BASE,
+} from '../actions/organizations'
 import {
   createPaginationIdsSelectorByEntity,
   createPaginationTotalCountSelectorByEntity,
@@ -24,6 +28,7 @@ import {
 } from './events'
 import { createFetchingSelector } from './fetching'
 import { createErrorSelector } from './error'
+import { createRightsSelector, createPseudoRightsSelector } from './rights'
 
 const ENTITY = 'organizations'
 
@@ -49,6 +54,12 @@ export const selectOrganizations = state =>
 export const selectOrganizationsTotalCount = state => selectOrgsTotalCount(state)
 export const selectOrganizationsFetching = state => selectOrgsFetching(state)
 export const selectOrganizationsError = state => selectOrgsError(state)
+
+// Rights
+export const selectOrganizationRights = createRightsSelector(ENTITY)
+export const selectOrganizationPseudoRights = createPseudoRightsSelector(ENTITY)
+export const selectOrganizationRightsError = createErrorSelector(GET_ORGS_RIGHTS_LIST_BASE)
+export const selectOrganizationRightsFetching = createFetchingSelector(GET_ORGS_RIGHTS_LIST_BASE)
 
 // Events
 export const selectOrganizationEvents = createEventsSelector(ENTITY)

--- a/pkg/webui/console/store/selectors/organizations.js
+++ b/pkg/webui/console/store/selectors/organizations.js
@@ -16,6 +16,7 @@ import {
   GET_ORGS_LIST_BASE,
   GET_ORG_BASE,
   GET_ORGS_RIGHTS_LIST_BASE,
+  GET_ORG_API_KEY_BASE,
 } from '../actions/organizations'
 import {
   createPaginationIdsSelectorByEntity,
@@ -29,8 +30,10 @@ import {
 import { createFetchingSelector } from './fetching'
 import { createErrorSelector } from './error'
 import { createRightsSelector, createPseudoRightsSelector } from './rights'
+import { createApiKeySelector } from './api-key'
 
 const ENTITY = 'organizations'
+const ENTITY_SINGLE = 'organization'
 
 // Organization
 export const selectOrganizationStore = state => state.organizations
@@ -60,6 +63,11 @@ export const selectOrganizationRights = createRightsSelector(ENTITY)
 export const selectOrganizationPseudoRights = createPseudoRightsSelector(ENTITY)
 export const selectOrganizationRightsError = createErrorSelector(GET_ORGS_RIGHTS_LIST_BASE)
 export const selectOrganizationRightsFetching = createFetchingSelector(GET_ORGS_RIGHTS_LIST_BASE)
+
+// Api Keys
+export const selectOrganizationApiKey = createApiKeySelector(ENTITY_SINGLE)
+export const selectOrganizationApiKeyFetching = createFetchingSelector(GET_ORG_API_KEY_BASE)
+export const selectOrganizationApiKeyError = createErrorSelector(GET_ORG_API_KEY_BASE)
 
 // Events
 export const selectOrganizationEvents = createEventsSelector(ENTITY)

--- a/pkg/webui/console/views/organization-api-key-add/connect.js
+++ b/pkg/webui/console/views/organization-api-key-add/connect.js
@@ -1,0 +1,59 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { connect } from 'react-redux'
+import { replace } from 'connected-react-router'
+
+import withRequest from '../../../lib/components/with-request'
+
+import { getOrganizationsRightsList } from '../../store/actions/organizations'
+import {
+  selectSelectedOrganizationId,
+  selectOrganizationRights,
+  selectOrganizationPseudoRights,
+  selectOrganizationRightsError,
+  selectOrganizationRightsFetching,
+} from '../../store/selectors/organizations'
+
+import api from '../../api'
+
+export default OrganizationApiKeyAdd =>
+  connect(
+    state => ({
+      orgId: selectSelectedOrganizationId(state),
+      fetching: selectOrganizationRightsFetching(state),
+      error: selectOrganizationRightsError(state),
+      rights: selectOrganizationRights(state),
+      pseudoRights: selectOrganizationPseudoRights(state),
+    }),
+    dispatch => ({
+      getOrganizationsRightsList: orgId => dispatch(getOrganizationsRightsList(orgId)),
+      navigateToList: orgId => dispatch(replace(`/organizations/${orgId}/api-keys`)),
+      createOrganizationApiKey: api.organization.apiKeys.create,
+    }),
+    (stateProps, dispatchProps, ownProps) => ({
+      ...stateProps,
+      ...dispatchProps,
+      ...ownProps,
+      getOrganizationsRightsList: () => dispatchProps.getOrganizationsRightsList(stateProps.orgId),
+      navigateToList: () => dispatchProps.navigateToList(stateProps.orgId),
+      createOrganizationApiKey: key =>
+        dispatchProps.createOrganizationApiKey(stateProps.orgId, key),
+    }),
+  )(
+    withRequest(
+      ({ getOrganizationsRightsList }) => getOrganizationsRightsList(),
+      ({ fetching, rights }) => fetching || !Boolean(rights.length),
+    )(OrganizationApiKeyAdd),
+  )

--- a/pkg/webui/console/views/organization-api-key-add/index.js
+++ b/pkg/webui/console/views/organization-api-key-add/index.js
@@ -1,0 +1,20 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import connect from './connect'
+import OrganizationApiKeyAdd from './organization-api-key-add'
+
+const ConnectedOrganizationApiKey = connect(OrganizationApiKeyAdd)
+
+export { ConnectedOrganizationApiKey as default, OrganizationApiKeyAdd }

--- a/pkg/webui/console/views/organization-api-key-add/organization-api-key-add.js
+++ b/pkg/webui/console/views/organization-api-key-add/organization-api-key-add.js
@@ -1,0 +1,83 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import { Container, Col, Row } from 'react-grid-system'
+import bind from 'autobind-decorator'
+
+import { ApiKeyCreateForm } from '../../components/api-key-form'
+import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
+import { withBreadcrumb } from '../../../components/breadcrumbs/context'
+
+import sharedMessages from '../../../lib/shared-messages'
+import Message from '../../../lib/components/message'
+import IntlHelmet from '../../../lib/components/intl-helmet'
+import PropTypes from '../../../lib/prop-types'
+
+@withBreadcrumb('orgs.single.api-keys.add', function(props) {
+  const orgId = props.orgId
+  return (
+    <Breadcrumb
+      path={`/organizations/${orgId}/api-keys/add`}
+      icon="add"
+      content={sharedMessages.add}
+    />
+  )
+})
+class OrganizationApiKeyAdd extends React.Component {
+  static propTypes = {
+    createOrganizationApiKey: PropTypes.func.isRequired,
+    navigateToList: PropTypes.func.isRequired,
+    pseudoRights: PropTypes.rights,
+    rights: PropTypes.rights.isRequired,
+  }
+
+  static defaultProps = {
+    pseudoRights: [],
+  }
+
+  @bind
+  handleApprove() {
+    const { navigateToList } = this.props
+
+    navigateToList()
+  }
+
+  render() {
+    const { rights, pseudoRights, createOrganizationApiKey } = this.props
+
+    return (
+      <Container>
+        <Row>
+          <Col>
+            <IntlHelmet title={sharedMessages.addApiKey} />
+            <Message component="h2" content={sharedMessages.addApiKey} />
+          </Col>
+        </Row>
+        <Row>
+          <Col lg={8} md={12}>
+            <ApiKeyCreateForm
+              rights={rights}
+              pseudoRights={pseudoRights}
+              onCreate={createOrganizationApiKey}
+              onCreateSuccess={this.handleApprove}
+            />
+          </Col>
+        </Row>
+      </Container>
+    )
+  }
+}
+
+export default OrganizationApiKeyAdd

--- a/pkg/webui/console/views/organization-api-key-edit/connect.js
+++ b/pkg/webui/console/views/organization-api-key-edit/connect.js
@@ -1,0 +1,83 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { connect } from 'react-redux'
+import { replace } from 'connected-react-router'
+
+import withRequest from '../../../lib/components/with-request'
+
+import {
+  getOrganizationApiKey,
+  getOrganizationsRightsList,
+} from '../../store/actions/organizations'
+import {
+  selectSelectedOrganizationId,
+  selectOrganizationRights,
+  selectOrganizationPseudoRights,
+  selectOrganizationRightsError,
+  selectOrganizationRightsFetching,
+  selectOrganizationApiKey,
+  selectOrganizationApiKeyError,
+  selectOrganizationApiKeyFetching,
+} from '../../store/selectors/organizations'
+
+import api from '../../api'
+
+export default OrganizationApiKeyEdit =>
+  connect(
+    function(state, props) {
+      const { apiKeyId } = props.match.params
+
+      const keyFetching = selectOrganizationApiKeyFetching(state)
+      const rightsFetching = selectOrganizationRightsFetching(state)
+      const keyError = selectOrganizationApiKeyError(state)
+      const rightsError = selectOrganizationRightsError(state)
+
+      return {
+        keyId: apiKeyId,
+        orgId: selectSelectedOrganizationId(state),
+        apiKey: selectOrganizationApiKey(state),
+        rights: selectOrganizationRights(state),
+        pseudoRights: selectOrganizationPseudoRights(state),
+        fetching: keyFetching || rightsFetching,
+        error: keyError || rightsError,
+      }
+    },
+    dispatch => ({
+      loadData(orgId, apiKeyId) {
+        dispatch(getOrganizationsRightsList(orgId))
+        dispatch(getOrganizationApiKey(orgId, apiKeyId))
+      },
+      deleteOrganizationApiKeySuccess: orgId =>
+        dispatch(replace(`/organizations/${orgId}/api-keys`)),
+      deleteOrganizationApiKey: api.organization.apiKeys.delete,
+      updateOrganizationApiKey: api.organization.apiKeys.update,
+    }),
+    (stateProps, dispatchProps, ownProps) => ({
+      ...stateProps,
+      ...dispatchProps,
+      ...ownProps,
+      deleteOrganizationApiKeySuccess: keyId =>
+        dispatchProps.deleteOrganizationApiKey(stateProps.orgId, stateProps.keyId),
+      deleteOrganizationApiKey: () =>
+        dispatchProps.deleteOrganizationApiKeySuccess(stateProps.orgId),
+      updateOrganizationApiKey: key =>
+        dispatchProps.updateOrganizationApiKey(stateProps.orgId, stateProps.keyId, key),
+    }),
+  )(
+    withRequest(
+      ({ loadData, orgId, keyId }) => loadData(orgId, keyId),
+      ({ fetching, apiKey }) => fetching || !Boolean(apiKey),
+    )(OrganizationApiKeyEdit),
+  )

--- a/pkg/webui/console/views/organization-api-key-edit/index.js
+++ b/pkg/webui/console/views/organization-api-key-edit/index.js
@@ -1,0 +1,20 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import connect from './connect'
+import OrganizationApiKeyEdit from './organization-api-key-edit'
+
+const ConnectedOrganizationApiKeyEdit = connect(OrganizationApiKeyEdit)
+
+export { ConnectedOrganizationApiKeyEdit as default, OrganizationApiKeyEdit }

--- a/pkg/webui/console/views/organization-api-key-edit/organization-api-key-edit.js
+++ b/pkg/webui/console/views/organization-api-key-edit/organization-api-key-edit.js
@@ -1,0 +1,87 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import { Container, Col, Row } from 'react-grid-system'
+
+import { ApiKeyEditForm } from '../../components/api-key-form'
+import { withBreadcrumb } from '../../../components/breadcrumbs/context'
+import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
+
+import Message from '../../../lib/components/message'
+import sharedMessages from '../../../lib/shared-messages'
+import IntlHelmet from '../../../lib/components/intl-helmet'
+import PropTypes from '../../../lib/prop-types'
+
+@withBreadcrumb('orgs.single.api-keys.edit', function(props) {
+  const { orgId, keyId } = props
+
+  return (
+    <Breadcrumb
+      path={`/organizations/${orgId}/api-keys/${keyId}`}
+      icon="general_settings"
+      content={sharedMessages.edit}
+    />
+  )
+})
+class OrganizationApiKeyEdit extends React.Component {
+  static propTypes = {
+    apiKey: PropTypes.apiKey.isRequired,
+    deleteOrganizationApiKey: PropTypes.func.isRequired,
+    deleteOrganizationApiKeySuccess: PropTypes.func.isRequired,
+    pseudoRights: PropTypes.rights,
+    rights: PropTypes.rights.isRequired,
+    updateOrganizationApiKey: PropTypes.func.isRequired,
+  }
+
+  static defaultProps = {
+    pseudoRights: [],
+  }
+
+  render() {
+    const {
+      apiKey,
+      rights,
+      pseudoRights,
+      deleteOrganizationApiKey,
+      deleteOrganizationApiKeySuccess,
+      updateOrganizationApiKey,
+    } = this.props
+
+    return (
+      <Container>
+        <Row>
+          <Col>
+            <IntlHelmet title={sharedMessages.keyEdit} />
+            <Message component="h2" content={sharedMessages.keyEdit} />
+          </Col>
+        </Row>
+        <Row>
+          <Col lg={8} md={12}>
+            <ApiKeyEditForm
+              rights={rights}
+              pseudoRights={pseudoRights}
+              apiKey={apiKey}
+              onEdit={updateOrganizationApiKey}
+              onDelete={deleteOrganizationApiKey}
+              onDeleteSuccess={deleteOrganizationApiKeySuccess}
+            />
+          </Col>
+        </Row>
+      </Container>
+    )
+  }
+}
+
+export default OrganizationApiKeyEdit

--- a/pkg/webui/console/views/organization-api-keys-list/index.js
+++ b/pkg/webui/console/views/organization-api-keys-list/index.js
@@ -1,0 +1,63 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import { Container, Row, Col } from 'react-grid-system'
+import bind from 'autobind-decorator'
+
+import sharedMessages from '../../../lib/shared-messages'
+import IntlHelmet from '../../../lib/components/intl-helmet'
+import ApiKeysTable from '../../containers/api-keys-table'
+import { getOrganizationApiKeysList } from '../../store/actions/organizations'
+import PropTypes from '../../../lib/prop-types'
+
+import PAGE_SIZES from '../../constants/page-sizes'
+
+class OrganizationApiKeysList extends React.Component {
+  static propTypes = {
+    match: PropTypes.match.isRequired,
+  }
+
+  constructor(props) {
+    super(props)
+
+    const { orgId } = props.match.params
+    this.getOrganizationApiKeysList = filters => getOrganizationApiKeysList(orgId, filters)
+  }
+
+  @bind
+  baseDataSelector({ apiKeys }) {
+    const { orgId } = this.props.match.params
+    return apiKeys.organizations[orgId] || {}
+  }
+
+  render() {
+    return (
+      <Container>
+        <Row>
+          <IntlHelmet title={sharedMessages.apiKeys} />
+          <Col>
+            <ApiKeysTable
+              pageSize={PAGE_SIZES.REGULAR}
+              baseDataSelector={this.baseDataSelector}
+              getItemsAction={this.getOrganizationApiKeysList}
+            />
+          </Col>
+        </Row>
+      </Container>
+    )
+  }
+}
+
+export default OrganizationApiKeysList

--- a/pkg/webui/console/views/organization-api-keys/index.js
+++ b/pkg/webui/console/views/organization-api-keys/index.js
@@ -23,6 +23,7 @@ import PropTypes from '../../../lib/prop-types'
 
 import SubViewError from '../error/sub-view'
 import OrganizationApiKeysList from '../organization-api-keys-list'
+import OrganizationApiKeyAdd from '../organization-api-key-add'
 
 @withBreadcrumb('org.single.api-keys', function(props) {
   const { match } = props
@@ -47,6 +48,7 @@ class OrganizationApiKeys extends React.Component {
       <ErrorView ErrorComponent={SubViewError}>
         <Switch>
           <Route exact path={`${match.path}`} component={OrganizationApiKeysList} />
+          <Route exact path={`${match.path}/add`} component={OrganizationApiKeyAdd} />
         </Switch>
       </ErrorView>
     )

--- a/pkg/webui/console/views/organization-api-keys/index.js
+++ b/pkg/webui/console/views/organization-api-keys/index.js
@@ -24,6 +24,7 @@ import PropTypes from '../../../lib/prop-types'
 import SubViewError from '../error/sub-view'
 import OrganizationApiKeysList from '../organization-api-keys-list'
 import OrganizationApiKeyAdd from '../organization-api-key-add'
+import OrganizationApiKeyEdit from '../organization-api-key-edit'
 
 @withBreadcrumb('org.single.api-keys', function(props) {
   const { match } = props
@@ -49,6 +50,7 @@ class OrganizationApiKeys extends React.Component {
         <Switch>
           <Route exact path={`${match.path}`} component={OrganizationApiKeysList} />
           <Route exact path={`${match.path}/add`} component={OrganizationApiKeyAdd} />
+          <Route path={`${match.path}/:apiKeyId`} component={OrganizationApiKeyEdit} />
         </Switch>
       </ErrorView>
     )

--- a/pkg/webui/console/views/organization-api-keys/index.js
+++ b/pkg/webui/console/views/organization-api-keys/index.js
@@ -1,0 +1,56 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import { Switch, Route } from 'react-router'
+
+import sharedMessages from '../../../lib/shared-messages'
+import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
+import { withBreadcrumb } from '../../../components/breadcrumbs/context'
+import ErrorView from '../../../lib/components/error-view'
+import PropTypes from '../../../lib/prop-types'
+
+import SubViewError from '../error/sub-view'
+import OrganizationApiKeysList from '../organization-api-keys-list'
+
+@withBreadcrumb('org.single.api-keys', function(props) {
+  const { match } = props
+  const orgId = match.params.orgId
+
+  return (
+    <Breadcrumb
+      path={`/organizations/${orgId}/api-keys`}
+      icon="api_keys"
+      content={sharedMessages.apiKeys}
+    />
+  )
+})
+class OrganizationApiKeys extends React.Component {
+  static propTypes = {
+    match: PropTypes.match.isRequired,
+  }
+
+  render() {
+    const { match } = this.props
+    return (
+      <ErrorView ErrorComponent={SubViewError}>
+        <Switch>
+          <Route exact path={`${match.path}`} component={OrganizationApiKeysList} />
+        </Switch>
+      </ErrorView>
+    )
+  }
+}
+
+export default OrganizationApiKeys

--- a/pkg/webui/console/views/organization/organization.js
+++ b/pkg/webui/console/views/organization/organization.js
@@ -28,6 +28,7 @@ import NotFoundRoute from '../../../lib/components/not-found-route'
 import OrganizationOverview from '../organization-overview'
 import OrganizationData from '../organization-data'
 import OrganizationGeneralSettings from '../organization-general-settings'
+import OrganizationApiKeys from '../organization-api-keys'
 
 @withEnv
 @withSideNavigation(function(props) {
@@ -45,6 +46,12 @@ import OrganizationGeneralSettings from '../organization-general-settings'
         title: sharedMessages.data,
         path: `${matchedUrl}/data`,
         icon: 'data',
+      },
+      {
+        title: sharedMessages.apiKeys,
+        path: `${matchedUrl}/api-keys`,
+        icon: 'api_keys',
+        exact: false,
       },
       {
         title: sharedMessages.generalSettings,
@@ -83,6 +90,7 @@ class Organization extends React.Component {
           <Route exact path={`${match.path}`} component={OrganizationOverview} />
           <Route path={`${match.path}/data`} component={OrganizationData} />
           <Route path={`${match.path}/general-settings`} component={OrganizationGeneralSettings} />
+          <Route path={`${match.path}/api-keys`} component={OrganizationApiKeys} />
           <NotFoundRoute />
         </Switch>
       </BreadcrumbView>

--- a/pkg/webui/lib/prop-types.js
+++ b/pkg/webui/lib/prop-types.js
@@ -193,6 +193,11 @@ PropTypes.collaborator = PropTypes.shape({
   rights: PropTypes.rights,
 })
 
+PropTypes.apiKey = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  rights: PropTypes.rights,
+})
+
 PropTypes.rights = PropTypes.arrayOf(PropTypes.string)
 
 export default PropTypes

--- a/sdk/js/src/service/organizations.js
+++ b/sdk/js/src/service/organizations.js
@@ -93,6 +93,14 @@ class Organizations {
     return Marshaler.payloadSingleResponse(response)
   }
 
+  async getRightsById(organizationId) {
+    const result = await this._api.OrganizationAccess.ListRights({
+      routeParams: { organization_id: organizationId },
+    })
+
+    return Marshaler.unwrapRights(result)
+  }
+
   // Events Stream
 
   async openStream(identifiers, tail, after) {

--- a/sdk/js/src/service/organizations.js
+++ b/sdk/js/src/service/organizations.js
@@ -13,10 +13,20 @@
 // limitations under the License.
 
 import Marshaler from '../util/marshaler'
+import ApiKeys from './api-keys'
 
 class Organizations {
   constructor(api) {
     this._api = api
+
+    this.ApiKeys = new ApiKeys(api.OrganizationAccess, {
+      parentRoutes: {
+        get: 'organization_ids.organization_id',
+        list: 'organization_ids.organization_id',
+        create: 'organization_ids.organization_id',
+        update: 'organization_ids.organization_id',
+      },
+    })
   }
 
   // Retrieval


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/1205

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `OrganizationApiKeyList` page
- Add `OrganizationApiKeyAdd` page
- Add `OrganizationApiKeyEdit` page
- Add necessary redux primitives
- Fix prop-types warning in the api key edit form
- Extend the Organization service in the js sdk
- Extend console api definitions
- Update `CHANGELOG.md`
