### PR TITLE
Remove sidebar from download page

### DIFF
--- a/doc/themes/the-things-stack/layouts/_default/baseof.html
+++ b/doc/themes/the-things-stack/layouts/_default/baseof.html
@@ -6,7 +6,7 @@
 
 {{- $hasSidebar := false -}}
 {{ if eq .Kind "section" "page" -}}
-  {{ $hasSidebar = and (not (eq .CurrentSection .FirstSection)) -}}
+  {{ $hasSidebar = and (not (eq .CurrentSection .FirstSection)) (not (eq . .FirstSection)) -}}
   {{ if not (eq .CurrentSection.Parent .FirstSection) -}}
     {{ .Scratch.Set "section" .CurrentSection.Parent -}}
   {{ end -}}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quickfix that disables the sidebar on the download page.