### PR TITLE
Rename goreleaser s3 config to blob

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -162,12 +162,12 @@ brews:
       bin.install "ttn-lw-cli"
       libexec.install doc
 
-s3:
-  - bucket: '{{ or (index .Env "AWS_BUCKET") "the-things-stack-releases" }}'
+blobs:
+  - provider: s3
+    bucket: '{{ or (index .Env "AWS_BUCKET") "the-things-stack-releases" }}'
     ids:
     - stack
     - cli
-    region: '{{ or (index .Env "AWS_REGION") "eu-west-1" }}'
     folder: "{{ .Version }}"
 
 dockers:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quickfix that renames s3 to blob in the goreleaser config. Although s3 works, it is actually deprecated, so let's get it out before they remove it.