### PR TITLE
Fix device overview with no root keys

### DIFF
--- a/pkg/webui/console/views/device-overview/index.js
+++ b/pkg/webui/console/views/device-overview/index.js
@@ -35,6 +35,7 @@ const m = defineMessages({
   sessionInfo: 'Session Information',
   latestData: 'Latest Data',
   rootKeys: 'Root Keys',
+  keysNotExposed: 'Keys are not exposed',
 })
 
 @connect(function({ device }, props) {
@@ -105,12 +106,21 @@ class DeviceOverview extends React.Component {
 
       // Add root keys, if available
       if (Object.keys(root_keys).length > 0) {
-        activationInfoData.items.push({
+        const infoEntry = {
           key: m.rootKeyId,
           value: root_keys.root_key_id,
           type: 'code',
           sensitive: false,
-          subItems: [
+        }
+        if (!Boolean(root_keys.app_key) && !Boolean(root_keys.nwk_key)) {
+          infoEntry.subItems = [
+            {
+              key: m.rootKeys,
+              value: <Message content={m.keysNotExposed} />,
+            },
+          ]
+        } else {
+          infoEntry.subItems = [
             {
               key: sharedMessages.appKey,
               value: root_keys.app_key.key,
@@ -125,8 +135,9 @@ class DeviceOverview extends React.Component {
                   sensitive: true,
                 }
               : { key: sharedMessages.nwkKey, value: undefined }),
-          ],
-        })
+          ]
+        }
+        activationInfoData.items.push(infoEntry)
       } else {
         activationInfoData.items.push({
           key: m.rootKeys,

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -194,6 +194,7 @@
   "console.views.device-overview.index.sessionInfo": "Session Information",
   "console.views.device-overview.index.latestData": "Latest Data",
   "console.views.device-overview.index.rootKeys": "Root Keys",
+  "console.views.device-overview.index.keysNotExposed": "Keys are not exposed",
   "console.views.gateway-add.index.createGateway": "Create Gateway",
   "console.views.gateway-data.index.gtwData": "Gateway Data",
   "console.views.gateway-general-settings.index.updateSuccess": "Successfully updated gateway",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -194,6 +194,7 @@
   "console.views.device-overview.index.sessionInfo": "Xxxxxxx Xxxxxxxxxxx",
   "console.views.device-overview.index.latestData": "Xxxxxx Xxxx",
   "console.views.device-overview.index.rootKeys": "Xxxx Xxxx",
+  "console.views.device-overview.index.keysNotExposed": "Xxxx xxx xxx xxxxxxx",
   "console.views.gateway-add.index.createGateway": "Xxxxxx Xxxxxxx",
   "console.views.gateway-data.index.gtwData": "Xxxxxxx Xxxx",
   "console.views.gateway-general-settings.index.updateSuccess": "Xxxxxxxxxxxx xxxxxxx xxxxxxx",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/1473

#### Changes
<!-- What are the changes made in this pull request? -->

1. With root keys:
<img width="707" alt="regular" src="https://user-images.githubusercontent.com/16374166/66820171-dadb4e00-ef48-11e9-992d-3a4895c03007.png">


2. Not exposed:
<img width="708" alt="not-exposed" src="https://user-images.githubusercontent.com/16374166/66820130-c5feba80-ef48-11e9-9f5f-eb89b852dec1.png">

3. External JS:
<img width="707" alt="external-js" src="https://user-images.githubusercontent.com/16374166/66820190-e3cc1f80-ef48-11e9-82ea-32cc002b30e8.png">

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Create device without root keys:
```
go run ./cmd/ttn-lw-cli devices create --supports-join --with-root-keys=false --root-keys.root-key-id=test --application-id test-app --dev-eui ADADADADADADA123 --device-id dev-keys-not-exposed --join-eui ADADDDDDDDDDD123 --lorawan-version "1.0.0" --lorawan-phy-version "1.0.0" --frequency-plan-id "Europe 863-870 MHz"
```
