### PR TITLE
Add component chooser to device import

### DIFF
--- a/pkg/webui/components/checkbox/group/group.styl
+++ b/pkg/webui/components/checkbox/group/group.styl
@@ -15,6 +15,7 @@
 .group
   display: flex
   flex-direction: row
+  flex-wrap: wrap
 
   .group-checkbox:not(:last-child)
     margin-right: $cs.m

--- a/pkg/webui/console/components/device-import-form/index.js
+++ b/pkg/webui/console/components/device-import-form/index.js
@@ -26,6 +26,7 @@ import SubmitButton from '../../../components/submit-button'
 import sharedMessages from '../../../lib/shared-messages'
 import Message from '../../../lib/components/message'
 import PropTypes from '../../../lib/prop-types'
+import { dict as componentDict } from '../../../constants/components'
 
 import style from './device-import-form.styl'
 
@@ -37,15 +38,24 @@ const m = defineMessages({
   selectAFile: 'Please select a template file',
   fileInfoPlaceholder: 'Please select a template format',
   claimAuthCode: 'Set claim authentication code',
+  targetedComponents: 'Targeted Components',
 })
 
 const validationSchema = Yup.object({
   format_id: Yup.string().required(sharedMessages.validateRequired),
   data: Yup.string().required(m.selectAFile),
+  set_claim_auth_code: Yup.boolean(),
+  components: Yup.object({
+    is: Yup.boolean().required(),
+    as: Yup.boolean(),
+    js: Yup.boolean(),
+    ns: Yup.boolean(),
+  }).required(sharedMessages.validateRequired),
 })
 
 export default class DeviceBulkCreateForm extends Component {
   static propTypes = {
+    components: PropTypes.components.isRequired,
     initialValues: PropTypes.shape({
       format_id: PropTypes.string,
       data: PropTypes.string,
@@ -73,7 +83,7 @@ export default class DeviceBulkCreateForm extends Component {
   }
 
   render() {
-    const { initialValues, onSubmit } = this.props
+    const { initialValues, onSubmit, components } = this.props
     const { allowedFileExtensions, formatSelected, formatDescription } = this.state
     return (
       <Form
@@ -96,6 +106,23 @@ export default class DeviceBulkCreateForm extends Component {
           name="data"
           required
         />
+        <Form.Field
+          component={Checkbox.Group}
+          name="components"
+          title={m.targetedComponents}
+          required
+          horizontal={false}
+          disabled={!formatSelected}
+        >
+          {components.map(component => (
+            <Checkbox
+              disabled={component === 'is'}
+              key={component}
+              name={component}
+              label={componentDict[component]}
+            />
+          ))}
+        </Form.Field>
         <Form.Field
           disabled={!formatSelected}
           title={m.claimAuthCode}

--- a/pkg/webui/constants/components.js
+++ b/pkg/webui/constants/components.js
@@ -1,0 +1,23 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export const components = ['is', 'as', 'ns', 'gs', 'js', 'edtc']
+export const dict = {
+  is: 'Identity Server',
+  as: 'Application Server',
+  ns: 'Network Server',
+  gs: 'Gateway Server',
+  js: 'Join Server',
+  edtc: 'End Device Template Converter',
+}

--- a/pkg/webui/lib/prop-types.js
+++ b/pkg/webui/lib/prop-types.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import originalPropTypes from 'prop-types'
+import { components } from '../constants/components'
 
 const PropTypes = { ...originalPropTypes }
 
@@ -194,5 +195,8 @@ PropTypes.collaborator = PropTypes.shape({
 })
 
 PropTypes.rights = PropTypes.arrayOf(PropTypes.string)
+
+PropTypes.component = PropTypes.oneOf(components)
+PropTypes.components = PropTypes.arrayOf(PropTypes.component)
 
 export default PropTypes

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -76,6 +76,7 @@
   "console.components.device-import-form.index.selectAFile": "Please select a template file",
   "console.components.device-import-form.index.fileInfoPlaceholder": "Please select a template format",
   "console.components.device-import-form.index.claimAuthCode": "Set claim authentication code",
+  "console.components.device-import-form.index.targetedComponents": "Targeted Components",
   "console.components.gateway-data-form.index.enforced": "Enforced",
   "console.components.gateway-data-form.index.dutyCycle": "Duty Cycle",
   "console.components.gateway-data-form.index.gatewayIdPlaceholder": "my-new-gateway",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -76,6 +76,7 @@
   "console.components.device-import-form.index.selectAFile": "Xxxxxx xxxxxx x xxxxxxxx xxxx",
   "console.components.device-import-form.index.fileInfoPlaceholder": "Xxxxxx xxxxxx x xxxxxxxx xxxxxx",
   "console.components.device-import-form.index.claimAuthCode": "Xxx xxxxx xxxxxxxxxxxxxx xxxx",
+  "console.components.device-import-form.index.targetedComponents": "Xxxxxxxx Xxxxxxxxxx",
   "console.components.gateway-data-form.index.enforced": "Xxxxxxxx",
   "console.components.gateway-data-form.index.dutyCycle": "Xxxx Xxxxx",
   "console.components.gateway-data-form.index.gatewayIdPlaceholder": "xx-xxx-xxxxxxx",


### PR DESCRIPTION
#### Summary
This quickfix PR will make it possible to select which stack components will be targeted when importing devices, which was a request from @johanstokking.
![image](https://user-images.githubusercontent.com/5710611/66919644-00885600-f022-11e9-9e96-6147e7899255.png)

#### Changes
- Add component constants module and prop-types
- Add checkbox group to enable selection of targeted stack components