### PR TITLE
Optimize downlink task timing and conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Rename "bulk device creation" to "import devices"
 - Move device import button to the end device tables (and adapt routing accordingly).
+- Improve downlink performance.
 
 ### Deprecated
 

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -115,6 +115,14 @@ func nextConfirmedClassCDownlinkAt(dev *ttnpb.EndDevice, defaults ttnpb.MACSetti
 	if dev.GetMACState().GetLastConfirmedDownlinkAt() == nil {
 		return time.Time{}
 	}
+	if dev.GetMACState().GetRxWindowsAvailable() {
+		return time.Time{}
+	}
+	if len(dev.RecentUplinks) > 0 {
+		if dev.RecentUplinks[len(dev.RecentUplinks)-1].ReceivedAt.After(*dev.MACState.LastConfirmedDownlinkAt) {
+			return time.Time{}
+		}
+	}
 	return dev.MACState.LastConfirmedDownlinkAt.Add(deviceClassCTimeout(dev, defaults))
 }
 

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -129,7 +129,7 @@ func nextConfirmedClassCDownlinkAt(dev *ttnpb.EndDevice, defaults ttnpb.MACSetti
 // For example, a sequence of 'NewChannel' MAC commands could be generated for a
 // device operating in a region where a fixed channel plan is defined in case
 // dev.MACState.CurrentParameters.Channels is not equal to dev.MACState.DesiredParameters.Channels.
-func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDevice, phy band.Band, class ttnpb.Class, maxDownLen, maxUpLen uint16) (*generatedDownlink, generateDownlinkState, error) {
+func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDevice, phy band.Band, class ttnpb.Class, scheduleAt time.Time, maxDownLen, maxUpLen uint16) (*generatedDownlink, generateDownlinkState, error) {
 	if dev.MACState == nil {
 		return nil, generateDownlinkState{}, errUnknownMACState
 	}
@@ -186,12 +186,12 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 				enqueueDutyCycleReq,
 				enqueueRxParamSetupReq,
 				func(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen uint16, maxUpLen uint16) macCommandEnqueueState {
-					return enqueueDevStatusReq(ctx, dev, maxDownLen, maxUpLen, ns.defaultMACSettings)
+					return enqueueDevStatusReq(ctx, dev, maxDownLen, maxUpLen, scheduleAt, ns.defaultMACSettings)
 				},
 				enqueueNewChannelReq,
 				func(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen uint16, maxUpLen uint16) macCommandEnqueueState {
 					// NOTE: LinkADRReq must be enqueued after NewChannelReq.
-					st, err := enqueueLinkADRReq(ctx, dev, maxDownLen, maxUpLen, ns.FrequencyPlans)
+					st, err := enqueueLinkADRReq(ctx, dev, maxDownLen, maxUpLen, phy)
 					if err != nil {
 						logger.WithError(err).Error("Failed to enqueue LinkADRReq")
 						return macCommandEnqueueState{
@@ -217,7 +217,9 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 		if dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_0_2) >= 0 {
 			if phy.TxParamSetupReqSupport {
 				enqueuers = append(enqueuers,
-					enqueueTxParamSetupReq,
+					func(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen uint16, maxUpLen uint16) macCommandEnqueueState {
+						return enqueueTxParamSetupReq(ctx, dev, maxDownLen, maxUpLen, phy)
+					},
 				)
 			}
 			enqueuers = append(enqueuers,
@@ -227,15 +229,7 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 		if dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) >= 0 {
 			enqueuers = append(enqueuers,
 				func(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen uint16, maxUpLen uint16) macCommandEnqueueState {
-					st, err := enqueueADRParamSetupReq(ctx, dev, maxDownLen, maxUpLen, ns.FrequencyPlans)
-					if err != nil {
-						logger.WithError(err).Error("Failed to enqueue ADRParamSetupReq")
-						return macCommandEnqueueState{
-							MaxDownLen: maxDownLen,
-							MaxUpLen:   maxUpLen,
-						}
-					}
-					return st
+					return enqueueADRParamSetupReq(ctx, dev, maxDownLen, maxUpLen, phy)
 				},
 				enqueueForceRejoinReq,
 				enqueueRejoinParamSetupReq,
@@ -265,7 +259,7 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 				spec[cmd.CID].ExpectAnswer &&
 				dev.MACState.DeviceClass == ttnpb.CLASS_C &&
 				dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 &&
-				nextConfirmedClassCDownlinkAt(dev, ns.defaultMACSettings).Before(time.Now()) {
+				nextConfirmedClassCDownlinkAt(dev, ns.defaultMACSettings).Before(timeNow()) {
 				logger.Debug("Use confirmed downlink to get immediate answer")
 				mType = ttnpb.MType_CONFIRMED_DOWN
 			}
@@ -363,7 +357,7 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 			skipAppDown = true
 
 		case down.ClassBC != nil:
-			if down.ClassBC.AbsoluteTime != nil && down.ClassBC.AbsoluteTime.Before(time.Now()) {
+			if down.ClassBC.AbsoluteTime != nil && down.ClassBC.AbsoluteTime.Before(timeNow()) {
 				logger.Debug("Drop expired downlink")
 				genState.baseApplicationUps = append(genState.baseApplicationUps, &ttnpb.ApplicationUp{
 					EndDeviceIdentifiers: dev.EndDeviceIdentifiers,
@@ -461,7 +455,7 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 	logger = logger.WithField("f_pending", pld.FHDR.FCtrl.FPending)
 
 	needsAck := mType == ttnpb.MType_CONFIRMED_DOWN || len(dev.MACState.PendingRequests) > 0
-	if class == ttnpb.CLASS_C && needsAck && nextConfirmedClassCDownlinkAt(dev, ns.defaultMACSettings).After(time.Now()) {
+	if class == ttnpb.CLASS_C && needsAck && nextConfirmedClassCDownlinkAt(dev, ns.defaultMACSettings).After(timeNow().Add(nsScheduleWindow)) {
 		return nil, genState, errConfirmedDownlinkTooSoon
 	}
 
@@ -583,7 +577,7 @@ func downlinkPathsForClassA(rxDelay ttnpb.RxDelay, ups ...*ttnpb.UplinkMessage) 
 	maxDelta := time.Duration(rxDelay) * time.Second
 	for i := len(ups) - 1; i >= 0; i-- {
 		up := ups[i]
-		delta := time.Since(up.ReceivedAt)
+		delta := timeSince(up.ReceivedAt)
 		rx1, rx2 := delta < maxDelta, delta < maxDelta+time.Second
 		if paths := downlinkPathsFromMetadata(up.RxMetadata...); len(paths) > 0 {
 			return rx1, rx2, paths
@@ -728,7 +722,7 @@ func (ns *NetworkServer) scheduleDownlinkByPaths(ctx context.Context, req *ttnpb
 		logger.WithField("delay", res.Delay).Debug("Scheduled downlink")
 		return &scheduledDownlink{
 			Message:    down,
-			TransmitAt: time.Now().Add(res.Delay),
+			TransmitAt: timeNow().Add(res.Delay),
 		}, nil
 	}
 	return nil, downlinkSchedulingError(errs)
@@ -839,7 +833,7 @@ const gsScheduleWindow = 30 * time.Second
 // nsScheduleWindow is the time interval, which is sufficient for NS to ensure downlink is scheduled.
 var nsScheduleWindow = time.Second
 
-func recordDownlink(dev *ttnpb.EndDevice, genDown *generatedDownlink, genState generateDownlinkState, down *scheduledDownlink, defaults ttnpb.MACSettings) (nextDownlinkAt time.Time) {
+func recordDataDownlink(dev *ttnpb.EndDevice, genDown *generatedDownlink, genState generateDownlinkState, down *scheduledDownlink, defaults ttnpb.MACSettings) {
 	if genState.ApplicationDownlink == nil || dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 && genDown.FCnt > dev.Session.LastNFCntDown {
 		dev.Session.LastNFCntDown = genDown.FCnt
 	}
@@ -850,30 +844,18 @@ func recordDownlink(dev *ttnpb.EndDevice, genDown *generatedDownlink, genState g
 		dev.MACState.PendingApplicationDownlink = genState.ApplicationDownlink
 		dev.Session.LastConfFCntDown = genDown.FCnt
 	}
-	if dev.MACState.DeviceClass == ttnpb.CLASS_C {
-		var nextConfirmedAt time.Time
-		if dev.MACState.LastConfirmedDownlinkAt != nil {
-			nextConfirmedAt = nextConfirmedClassCDownlinkAt(dev, defaults)
-		}
-		if nextConfirmedAt.After(down.TransmitAt) {
-			nextDownlinkAt = nextConfirmedAt
-		} else {
-			nextDownlinkAt = down.TransmitAt.Add(dev.MACState.CurrentParameters.Rx1Delay.Duration())
-		}
-	}
 	dev.MACState.QueuedResponses = nil
 	dev.MACState.RxWindowsAvailable = false
 	dev.RecentDownlinks = appendRecentDownlink(dev.RecentDownlinks, down.Message, recentDownlinkCount)
-	return nextDownlinkAt
 }
 
 type downlinkAttemptResult struct {
 	applicationUpAppender func([]*ttnpb.ApplicationUp, bool) []*ttnpb.ApplicationUp
 
-	SetPaths       []string
-	NextDownlinkAt time.Time
-	Scheduled      bool
-	QueuedEvents   []events.Event
+	SetPaths     []string
+	DownAt       time.Time
+	Scheduled    bool
+	QueuedEvents []events.Event
 }
 
 func (res downlinkAttemptResult) AppendApplicationUplinks(ups ...*ttnpb.ApplicationUp) []*ttnpb.ApplicationUp {
@@ -883,7 +865,7 @@ func (res downlinkAttemptResult) AppendApplicationUplinks(ups ...*ttnpb.Applicat
 	return res.applicationUpAppender(ups, res.Scheduled)
 }
 
-func (ns *NetworkServer) attemptClassADownlink(ctx context.Context, dev *ttnpb.EndDevice, phy band.Band, fp *frequencyplans.FrequencyPlan, maxUpLength uint16) downlinkAttemptResult {
+func (ns *NetworkServer) attemptClassADataDownlink(ctx context.Context, dev *ttnpb.EndDevice, phy band.Band, fp *frequencyplans.FrequencyPlan, maxUpLength uint16) downlinkAttemptResult {
 	var sets []string
 	logger := log.FromContext(ctx)
 	if len(dev.RecentUplinks) == 0 {
@@ -956,6 +938,8 @@ func (ns *NetworkServer) attemptClassADownlink(ctx context.Context, dev *ttnpb.E
 		}
 	}
 
+	// scheduleAt is the earliest time.Time when downlink will be transmitted to the device.
+	scheduleAt := up.ReceivedAt.Add(dev.MACState.CurrentParameters.Rx1Delay.Duration())
 	var maxDR ttnpb.DataRateIndex
 	switch {
 	case rx1 && rx2:
@@ -969,9 +953,11 @@ func (ns *NetworkServer) attemptClassADownlink(ctx context.Context, dev *ttnpb.E
 
 	case rx2:
 		maxDR = req.Rx2DataRateIndex
+		// scheduleAt corresponds to RX1 at this point, RX1 + time.Second = RX2.
+		scheduleAt = scheduleAt.Add(time.Second)
 	}
 
-	genDown, genState, err := ns.generateDownlink(ctx, dev, phy, ttnpb.CLASS_A,
+	genDown, genState, err := ns.generateDownlink(ctx, dev, phy, ttnpb.CLASS_A, scheduleAt,
 		phy.DataRates[maxDR].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 		maxUpLength,
 	)
@@ -1007,6 +993,8 @@ func (ns *NetworkServer) attemptClassADownlink(ctx context.Context, dev *ttnpb.E
 				applicationUpAppender: genState.appendApplicationUplinks,
 			}
 		}
+		// NOTE: It may be possible that RX1 is dropped at this point and DevStatusReq can be scheduled in RX2 due to the downlink being
+		// transmitted later, but that's micro-optimization, which we don't need to make.
 		req, err = txRequestFromUplink(phy, dev.MACState, rx1, rx2, rxDelay, up)
 		if err != nil {
 			logger.WithError(err).Warn("Failed to generate Tx request from uplink, skip class A downlink slot")
@@ -1049,6 +1037,7 @@ func (ns *NetworkServer) attemptClassADownlink(ctx context.Context, dev *ttnpb.E
 	if genState.ApplicationDownlink != nil {
 		sets = append(sets, "queued_application_downlinks")
 	}
+	recordDataDownlink(dev, genDown, genState, down, ns.defaultMACSettings)
 	return downlinkAttemptResult{
 		SetPaths: append(sets,
 			"mac_state",
@@ -1056,8 +1045,8 @@ func (ns *NetworkServer) attemptClassADownlink(ctx context.Context, dev *ttnpb.E
 			"session",
 		),
 		applicationUpAppender: genState.appendApplicationUplinks,
+		DownAt:                down.TransmitAt,
 		QueuedEvents:          genState.Events,
-		NextDownlinkAt:        recordDownlink(dev, genDown, genState, down, ns.defaultMACSettings),
 		Scheduled:             true,
 	}
 }
@@ -1070,7 +1059,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 	err := ns.downlinkTasks.Pop(ctx, func(ctx context.Context, devID ttnpb.EndDeviceIdentifiers, t time.Time) error {
 		logger := log.FromContext(ctx).WithFields(log.Fields(
 			"device_uid", unique.ID(ctx, devID),
-			"started_at", time.Now().UTC(),
+			"started_at", timeNow().UTC(),
 		))
 		ctx = log.NewContext(ctx, logger)
 		logger.WithField("start_at", t).Debug("Process downlink task")
@@ -1100,7 +1089,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 
 				fp, phy, err := getDeviceBandVersion(dev, ns.FrequencyPlans)
 				if err != nil {
-					nextDownlinkAt = time.Now().Add(downlinkRetryInterval).UTC()
+					nextDownlinkAt = timeNow().Add(downlinkRetryInterval).UTC()
 					logger.WithField("retry_at", nextDownlinkAt).WithError(err).Error("Failed to get frequency plan of the device, retry downlink slot")
 					return dev, nil, nil
 				}
@@ -1188,6 +1177,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 				}
 
 				logger = logger.WithField("device_class", dev.MACState.DeviceClass)
+				ctx = log.NewContext(ctx, logger)
 
 				if !dev.MACState.RxWindowsAvailable {
 					logger.Debug("Rx windows not available, skip class A downlink slot")
@@ -1203,19 +1193,23 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 
 				var sets []string
 				if dev.MACState.RxWindowsAvailable {
-					a := ns.attemptClassADownlink(ctx, dev, phy, fp, maxUpLength)
+					a := ns.attemptClassADataDownlink(ctx, dev, phy, fp, maxUpLength)
 					sets = append(sets, a.SetPaths...)
 					queuedEvents = append(queuedEvents, a.QueuedEvents...)
 					queuedApplicationUplinks = a.AppendApplicationUplinks(queuedApplicationUplinks...)
-					if !a.NextDownlinkAt.IsZero() {
-						nextDownlinkAt = a.NextDownlinkAt
-					}
 					if a.Scheduled {
+						t, hasNext := nextDataDownlinkAt(ctx, dev, phy, ns.defaultMACSettings)
+						if hasNext {
+							earliestAt := a.DownAt.Add(dev.MACState.CurrentParameters.Rx1Delay.Duration())
+							if t.Before(earliestAt) {
+								nextDownlinkAt = earliestAt
+							} else {
+								nextDownlinkAt = t
+							}
+						}
 						return dev, sets, nil
 					}
 				}
-
-				ctx = log.NewContext(ctx, logger)
 
 				switch dev.MACState.DeviceClass {
 				case ttnpb.CLASS_A:
@@ -1234,7 +1228,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 					Rx2Frequency:     dev.MACState.CurrentParameters.Rx2Frequency,
 				}
 
-				genDown, genState, err := ns.generateDownlink(ctx, dev, phy, dev.MACState.DeviceClass,
+				genDown, genState, err := ns.generateDownlink(ctx, dev, phy, dev.MACState.DeviceClass, timeNow().Add(nsScheduleWindow),
 					phy.DataRates[req.Rx2DataRateIndex].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
 					maxUpLength,
 				)
@@ -1293,7 +1287,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 					}
 				}
 				if absTime := genState.ApplicationDownlink.GetClassBC().GetAbsoluteTime(); absTime != nil {
-					if absTime.After(time.Now().Add(gsScheduleWindow)) {
+					if absTime.After(timeNow().Add(gsScheduleWindow + nsScheduleWindow)) {
 						nextDownlinkAt = absTime.Add(-gsScheduleWindow)
 						logger.WithField("retry_at", nextDownlinkAt).Info("Downlink scheduled too soon, retry attempt")
 						queuedApplicationUplinks = genState.appendApplicationUplinks(queuedApplicationUplinks, false)
@@ -1312,7 +1306,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 					paths...,
 				)
 				if err != nil {
-					nextDownlinkAt = time.Now().Add(downlinkRetryInterval).UTC()
+					nextDownlinkAt = timeNow().Add(downlinkRetryInterval).UTC()
 					schedErr, ok := err.(downlinkSchedulingError)
 					if ok {
 						logger = loggerWithDownlinkSchedulingErrorFields(logger, schedErr)
@@ -1369,14 +1363,20 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 					return dev, sets, nil
 				}
 
-				if t := recordDownlink(dev, genDown, genState, down, ns.defaultMACSettings); !t.IsZero() {
-					nextDownlinkAt = t
-				}
-				queuedApplicationUplinks = genState.appendApplicationUplinks(queuedApplicationUplinks, true)
+				recordDataDownlink(dev, genDown, genState, down, ns.defaultMACSettings)
 				queuedEvents = append(queuedEvents, genState.Events...)
-
+				queuedApplicationUplinks = genState.appendApplicationUplinks(queuedApplicationUplinks, true)
 				if genState.ApplicationDownlink != nil {
 					sets = append(sets, "queued_application_downlinks")
+				}
+				t, hasNext := nextDataDownlinkAt(ctx, dev, phy, ns.defaultMACSettings)
+				if hasNext {
+					earliestAt := down.TransmitAt.Add(dev.MACState.CurrentParameters.Rx1Delay.Duration())
+					if t.Before(earliestAt) {
+						nextDownlinkAt = earliestAt
+					} else {
+						nextDownlinkAt = t
+					}
 				}
 				return dev, append(sets,
 					"mac_state",
@@ -1412,7 +1412,8 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 			return err
 		}
 		if !nextDownlinkAt.IsZero() {
-			logger.WithField("start_at", nextDownlinkAt.UTC()).Debug("Add downlink task after downlink attempt")
+			nextDownlinkAt = nextDownlinkAt.Add(-nsScheduleWindow)
+			logger.WithField("start_at", nextDownlinkAt).Debug("Add downlink task after downlink attempt")
 			if err := ns.downlinkTasks.Add(ctx, devID, nextDownlinkAt, true); err != nil {
 				addErr = true
 				logger.WithError(err).Error("Failed to add downlink task after downlink attempt")

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -111,21 +111,6 @@ func (s generateDownlinkState) appendApplicationUplinks(ups []*ttnpb.Application
 	}
 }
 
-func nextConfirmedClassCDownlinkAt(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings) time.Time {
-	if dev.GetMACState().GetLastConfirmedDownlinkAt() == nil {
-		return time.Time{}
-	}
-	if dev.GetMACState().GetRxWindowsAvailable() {
-		return time.Time{}
-	}
-	if len(dev.RecentUplinks) > 0 {
-		if dev.RecentUplinks[len(dev.RecentUplinks)-1].ReceivedAt.After(*dev.MACState.LastConfirmedDownlinkAt) {
-			return time.Time{}
-		}
-	}
-	return dev.MACState.LastConfirmedDownlinkAt.Add(deviceClassCTimeout(dev, defaults))
-}
-
 // generateDownlink attempts to generate a downlink.
 // generateDownlink returns the generated downlink, application uplinks associated with the generation and error, if any.
 // generateDownlink may mutate the device in order to record the downlink generated.

--- a/pkg/networkserver/grpc_asns_test.go
+++ b/pkg/networkserver/grpc_asns_test.go
@@ -28,6 +28,7 @@ import (
 	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/events"
+	"go.thethings.network/lorawan-stack/pkg/frequencyplans"
 	. "go.thethings.network/lorawan-stack/pkg/networkserver"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/unique"
@@ -174,11 +175,16 @@ func TestDownlinkQueueReplace(t *testing.T) {
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
+					"frequency_plan_id",
+					"last_dev_status_received_at",
+					"lorawan_phy_version",
+					"mac_settings",
 					"mac_state",
 					"multicast",
 					"pending_mac_state",
 					"pending_session",
 					"queued_application_downlinks",
+					"recent_uplinks",
 					"session",
 				})
 				dev, sets, err := f(nil)
@@ -232,14 +238,21 @@ func TestDownlinkQueueReplace(t *testing.T) {
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
+					"frequency_plan_id",
+					"last_dev_status_received_at",
+					"lorawan_phy_version",
+					"mac_settings",
 					"mac_state",
 					"multicast",
 					"pending_mac_state",
 					"pending_session",
 					"queued_application_downlinks",
+					"recent_uplinks",
 					"session",
 				})
 				dev, sets, err := f(&ttnpb.EndDevice{
+					FrequencyPlanID:   test.EUFrequencyPlanID,
+					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
 						DeviceID:               "test-dev-id",
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
@@ -307,14 +320,21 @@ func TestDownlinkQueueReplace(t *testing.T) {
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
+					"frequency_plan_id",
+					"last_dev_status_received_at",
+					"lorawan_phy_version",
+					"mac_settings",
 					"mac_state",
 					"multicast",
 					"pending_mac_state",
 					"pending_session",
 					"queued_application_downlinks",
+					"recent_uplinks",
 					"session",
 				})
 				dev, sets, err := f(&ttnpb.EndDevice{
+					FrequencyPlanID:   test.EUFrequencyPlanID,
+					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
 						DeviceID:               "test-dev-id",
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
@@ -342,6 +362,8 @@ func TestDownlinkQueueReplace(t *testing.T) {
 					"queued_application_downlinks",
 				})
 				a.So(dev, should.Resemble, &ttnpb.EndDevice{
+					FrequencyPlanID:   test.EUFrequencyPlanID,
+					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
 						DeviceID:               "test-dev-id",
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
@@ -395,7 +417,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 					ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
 				})
 				a.So(replace, should.BeTrue)
-				a.So([]time.Time{start, at, time.Now()}, should.BeChronological)
+				a.So([]time.Time{start, at.Add(NSScheduleWindow()), time.Now()}, should.BeChronological)
 				return nil
 			},
 			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
@@ -403,14 +425,21 @@ func TestDownlinkQueueReplace(t *testing.T) {
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
+					"frequency_plan_id",
+					"last_dev_status_received_at",
+					"lorawan_phy_version",
+					"mac_settings",
 					"mac_state",
 					"multicast",
 					"pending_mac_state",
 					"pending_session",
 					"queued_application_downlinks",
+					"recent_uplinks",
 					"session",
 				})
 				dev, sets, err := f(&ttnpb.EndDevice{
+					FrequencyPlanID:   test.EUFrequencyPlanID,
+					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
 						DeviceID:               "test-dev-id",
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
@@ -438,6 +467,8 @@ func TestDownlinkQueueReplace(t *testing.T) {
 					"queued_application_downlinks",
 				})
 				a.So(dev, should.Resemble, &ttnpb.EndDevice{
+					FrequencyPlanID:   test.EUFrequencyPlanID,
+					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
 						DeviceID:               "test-dev-id",
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
@@ -503,6 +534,8 @@ func TestDownlinkQueueReplace(t *testing.T) {
 					"session",
 				})
 				dev, sets, err := f(&ttnpb.EndDevice{
+					FrequencyPlanID:   test.EUFrequencyPlanID,
+					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
 						DeviceID:               "test-dev-id",
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
@@ -574,6 +607,8 @@ func TestDownlinkQueueReplace(t *testing.T) {
 					"session",
 				})
 				dev, sets, err := f(&ttnpb.EndDevice{
+					FrequencyPlanID:   test.EUFrequencyPlanID,
+					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
 						DeviceID:               "test-dev-id",
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
@@ -601,6 +636,8 @@ func TestDownlinkQueueReplace(t *testing.T) {
 					"queued_application_downlinks",
 				})
 				a.So(dev, should.Resemble, &ttnpb.EndDevice{
+					FrequencyPlanID:   test.EUFrequencyPlanID,
+					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
 						DeviceID:               "test-dev-id",
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
@@ -657,6 +694,8 @@ func TestDownlinkQueueReplace(t *testing.T) {
 					"session",
 				})
 				dev, sets, err := f(&ttnpb.EndDevice{
+					FrequencyPlanID:   test.EUFrequencyPlanID,
+					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
 						DeviceID:               "test-dev-id",
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
@@ -684,6 +723,8 @@ func TestDownlinkQueueReplace(t *testing.T) {
 					"queued_application_downlinks",
 				})
 				a.So(dev, should.Resemble, &ttnpb.EndDevice{
+					FrequencyPlanID:   test.EUFrequencyPlanID,
+					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
 						DeviceID:               "test-dev-id",
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
@@ -733,6 +774,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 					DeduplicationWindow: 42,
 					CooldownWindow:      42,
 				})).(*NetworkServer)
+			ns.FrequencyPlans = frequencyplans.NewStore(test.FrequencyPlansFetcher)
 
 			ns.AddContextFiller(tc.ContextFunc)
 			ns.AddContextFiller(func(ctx context.Context) context.Context {
@@ -839,11 +881,16 @@ func TestDownlinkQueuePush(t *testing.T) {
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
+					"frequency_plan_id",
+					"last_dev_status_received_at",
+					"lorawan_phy_version",
+					"mac_settings",
 					"mac_state",
 					"multicast",
 					"pending_mac_state",
 					"pending_session",
 					"queued_application_downlinks",
+					"recent_uplinks",
 					"session",
 				})
 
@@ -898,14 +945,21 @@ func TestDownlinkQueuePush(t *testing.T) {
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
+					"frequency_plan_id",
+					"last_dev_status_received_at",
+					"lorawan_phy_version",
+					"mac_settings",
 					"mac_state",
 					"multicast",
 					"pending_mac_state",
 					"pending_session",
 					"queued_application_downlinks",
+					"recent_uplinks",
 					"session",
 				})
 				dev, sets, err := f(&ttnpb.EndDevice{
+					FrequencyPlanID:   test.EUFrequencyPlanID,
+					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
 						DeviceID:               "test-dev-id",
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
@@ -973,14 +1027,21 @@ func TestDownlinkQueuePush(t *testing.T) {
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
+					"frequency_plan_id",
+					"last_dev_status_received_at",
+					"lorawan_phy_version",
+					"mac_settings",
 					"mac_state",
 					"multicast",
 					"pending_mac_state",
 					"pending_session",
 					"queued_application_downlinks",
+					"recent_uplinks",
 					"session",
 				})
 				dev, sets, err := f(&ttnpb.EndDevice{
+					FrequencyPlanID:   test.EUFrequencyPlanID,
+					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
 						DeviceID:               "test-dev-id",
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
@@ -1008,6 +1069,8 @@ func TestDownlinkQueuePush(t *testing.T) {
 					"queued_application_downlinks",
 				})
 				a.So(dev, should.Resemble, &ttnpb.EndDevice{
+					FrequencyPlanID:   test.EUFrequencyPlanID,
+					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
 						DeviceID:               "test-dev-id",
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
@@ -1068,14 +1131,21 @@ func TestDownlinkQueuePush(t *testing.T) {
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
+					"frequency_plan_id",
+					"last_dev_status_received_at",
+					"lorawan_phy_version",
+					"mac_settings",
 					"mac_state",
 					"multicast",
 					"pending_mac_state",
 					"pending_session",
 					"queued_application_downlinks",
+					"recent_uplinks",
 					"session",
 				})
 				dev, sets, err := f(&ttnpb.EndDevice{
+					FrequencyPlanID:   test.EUFrequencyPlanID,
+					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
 						DeviceID:               "test-dev-id",
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
@@ -1108,6 +1178,8 @@ func TestDownlinkQueuePush(t *testing.T) {
 					"queued_application_downlinks",
 				})
 				a.So(dev, should.Resemble, &ttnpb.EndDevice{
+					FrequencyPlanID:   test.EUFrequencyPlanID,
+					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
 						DeviceID:               "test-dev-id",
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
@@ -1178,14 +1250,21 @@ func TestDownlinkQueuePush(t *testing.T) {
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
+					"frequency_plan_id",
+					"last_dev_status_received_at",
+					"lorawan_phy_version",
+					"mac_settings",
 					"mac_state",
 					"multicast",
 					"pending_mac_state",
 					"pending_session",
 					"queued_application_downlinks",
+					"recent_uplinks",
 					"session",
 				})
 				dev, sets, err := f(&ttnpb.EndDevice{
+					FrequencyPlanID:   test.EUFrequencyPlanID,
+					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
 						DeviceID:               "test-dev-id",
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
@@ -1262,14 +1341,21 @@ func TestDownlinkQueuePush(t *testing.T) {
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
+					"frequency_plan_id",
+					"last_dev_status_received_at",
+					"lorawan_phy_version",
+					"mac_settings",
 					"mac_state",
 					"multicast",
 					"pending_mac_state",
 					"pending_session",
 					"queued_application_downlinks",
+					"recent_uplinks",
 					"session",
 				})
 				dev, sets, err := f(&ttnpb.EndDevice{
+					FrequencyPlanID:   test.EUFrequencyPlanID,
+					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
 						DeviceID:               "test-dev-id",
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
@@ -1342,14 +1428,21 @@ func TestDownlinkQueuePush(t *testing.T) {
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
+					"frequency_plan_id",
+					"last_dev_status_received_at",
+					"lorawan_phy_version",
+					"mac_settings",
 					"mac_state",
 					"multicast",
 					"pending_mac_state",
 					"pending_session",
 					"queued_application_downlinks",
+					"recent_uplinks",
 					"session",
 				})
 				dev, sets, err := f(&ttnpb.EndDevice{
+					FrequencyPlanID:   test.EUFrequencyPlanID,
+					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
 						DeviceID:               "test-dev-id",
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
@@ -1412,6 +1505,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 					DeduplicationWindow: 42,
 					CooldownWindow:      42,
 				})).(*NetworkServer)
+			ns.FrequencyPlans = frequencyplans.NewStore(test.FrequencyPlansFetcher)
 
 			ns.AddContextFiller(tc.ContextFunc)
 			ns.AddContextFiller(func(ctx context.Context) context.Context {
@@ -1423,6 +1517,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 				return test.ContextWithT(ctx, t)
 			})
 			componenttest.StartComponent(t, ns.Component)
+			defer ns.Close()
 
 			req := deepcopy.Copy(tc.Request).(*ttnpb.DownlinkQueueRequest)
 

--- a/pkg/networkserver/grpc_deviceregistry_test.go
+++ b/pkg/networkserver/grpc_deviceregistry_test.go
@@ -212,10 +212,12 @@ func TestDeviceRegistrySet(t *testing.T) {
 	for _, tc := range []struct {
 		Name           string
 		ContextFunc    func(context.Context) context.Context
+		AddFunc        func(context.Context, ttnpb.EndDeviceIdentifiers, time.Time, bool) error
 		SetByIDFunc    func(context.Context, ttnpb.ApplicationIdentifiers, string, []string, func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error)
 		Request        *ttnpb.SetEndDeviceRequest
 		Device         *ttnpb.EndDevice
 		ErrorAssertion func(*testing.T, error) bool
+		AddCalls       uint64
 		SetByIDCalls   uint64
 	}{
 		{
@@ -230,6 +232,11 @@ func TestDeviceRegistrySet(t *testing.T) {
 						},
 					},
 				})
+			},
+			AddFunc: func(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, at time.Time, replace bool) error {
+				err := errors.New("AddFunc must not be called")
+				test.MustTFromContext(ctx).Error(err)
+				return err
 			},
 			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
 				err := errors.New("SetByIDFunc must not be called")
@@ -279,6 +286,11 @@ func TestDeviceRegistrySet(t *testing.T) {
 						},
 					},
 				})
+			},
+			AddFunc: func(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, at time.Time, replace bool) error {
+				err := errors.New("AddFunc must not be called")
+				test.MustTFromContext(ctx).Error(err)
+				return err
 			},
 			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
@@ -346,15 +358,29 @@ func TestDeviceRegistrySet(t *testing.T) {
 					},
 				})
 			},
+			AddFunc: func(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, at time.Time, replace bool) error {
+				err := errors.New("AddFunc must not be called")
+				test.MustTFromContext(ctx).Error(err)
+				return err
+			},
 			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"frequency_plan_id",
+					"frequency_plan_id",
+					"last_dev_status_received_at",
+					"lorawan_phy_version",
 					"lorawan_phy_version",
 					"lorawan_version",
+					"mac_settings",
 					"mac_settings.adr_margin",
+					"mac_state",
+					"multicast",
+					"queued_application_downlinks",
+					"recent_uplinks",
+					"session",
 					"supports_class_b",
 					"supports_class_c",
 					"supports_join",
@@ -454,16 +480,30 @@ func TestDeviceRegistrySet(t *testing.T) {
 					},
 				})
 			},
+			AddFunc: func(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, at time.Time, replace bool) error {
+				err := errors.New("AddFunc must not be called")
+				test.MustTFromContext(ctx).Error(err)
+				return err
+			},
 			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"frequency_plan_id",
+					"frequency_plan_id",
+					"last_dev_status_received_at",
+					"lorawan_phy_version",
 					"lorawan_phy_version",
 					"lorawan_version",
+					"mac_settings",
 					"mac_settings.supports_32_bit_f_cnt",
 					"mac_settings.use_adr",
+					"mac_state",
+					"multicast",
+					"queued_application_downlinks",
+					"recent_uplinks",
+					"session",
 					"session.dev_addr",
 					"session.keys.f_nwk_s_int_key.key",
 					"session.last_f_cnt_up",
@@ -643,6 +683,11 @@ func TestDeviceRegistrySet(t *testing.T) {
 					},
 				})
 			},
+			AddFunc: func(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, at time.Time, replace bool) error {
+				err := errors.New("AddFunc must not be called")
+				test.MustTFromContext(ctx).Error(err)
+				return err
+			},
 			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
@@ -659,6 +704,15 @@ func TestDeviceRegistrySet(t *testing.T) {
 					"session.last_n_f_cnt_down",
 					"session.started_at",
 					"supports_join",
+					"frequency_plan_id",
+					"last_dev_status_received_at",
+					"lorawan_phy_version",
+					"mac_settings",
+					"mac_state",
+					"multicast",
+					"queued_application_downlinks",
+					"recent_uplinks",
+					"session",
 				})
 
 				dev, sets, err := f(nil)
@@ -822,16 +876,30 @@ func TestDeviceRegistrySet(t *testing.T) {
 					},
 				})
 			},
+			AddFunc: func(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, at time.Time, replace bool) error {
+				err := errors.New("AddFunc must not be called")
+				test.MustTFromContext(ctx).Error(err)
+				return err
+			},
 			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"frequency_plan_id",
+					"frequency_plan_id",
+					"last_dev_status_received_at",
+					"lorawan_phy_version",
 					"lorawan_phy_version",
 					"lorawan_version",
+					"mac_settings",
 					"mac_settings.supports_32_bit_f_cnt",
 					"mac_settings.use_adr",
+					"mac_state",
+					"multicast",
+					"queued_application_downlinks",
+					"recent_uplinks",
+					"session",
 					"session.dev_addr",
 					"session.keys.f_nwk_s_int_key.key",
 					"session.last_f_cnt_up",
@@ -1008,14 +1076,26 @@ func TestDeviceRegistrySet(t *testing.T) {
 					},
 				})
 			},
+			AddFunc: func(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, at time.Time, replace bool) error {
+				err := errors.New("AddFunc must not be called")
+				test.MustTFromContext(ctx).Error(err)
+				return err
+			},
 			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.HaveSameElementsDeep, []string{
+					"frequency_plan_id",
+					"last_dev_status_received_at",
+					"lorawan_phy_version",
+					"mac_settings",
 					"mac_state",
 					"mac_state.desired_parameters.rx2_frequency",
+					"multicast",
 					"queued_application_downlinks",
+					"recent_uplinks",
+					"session",
 				})
 
 				dev, sets, err := f(&ttnpb.EndDevice{
@@ -1023,7 +1103,13 @@ func TestDeviceRegistrySet(t *testing.T) {
 						DeviceID:               "test-dev-id",
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
 					},
+					FrequencyPlanID:   test.EUFrequencyPlanID,
+					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					MACState: &ttnpb.MACState{
+						LoRaWANVersion: ttnpb.MAC_V1_1,
+						CurrentParameters: ttnpb.MACParameters{
+							Rx2Frequency: 868000000,
+						},
 						DesiredParameters: ttnpb.MACParameters{
 							Rx2Frequency: 868000000,
 						},
@@ -1046,7 +1132,23 @@ func TestDeviceRegistrySet(t *testing.T) {
 						},
 					},
 				})
-				return dev, nil
+				return &ttnpb.EndDevice{
+					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
+						DeviceID:               "test-dev-id",
+						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
+					},
+					FrequencyPlanID:   test.EUFrequencyPlanID,
+					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
+					MACState: &ttnpb.MACState{
+						LoRaWANVersion: ttnpb.MAC_V1_1,
+						CurrentParameters: ttnpb.MACParameters{
+							Rx2Frequency: 868000000,
+						},
+						DesiredParameters: ttnpb.MACParameters{
+							Rx2Frequency: 123456789,
+						},
+					},
+				}, nil
 			},
 			Request: &ttnpb.SetEndDeviceRequest{
 				EndDevice: ttnpb.EndDevice{
@@ -1071,7 +1173,13 @@ func TestDeviceRegistrySet(t *testing.T) {
 					DeviceID:               "test-dev-id",
 					ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
 				},
+				FrequencyPlanID:   test.EUFrequencyPlanID,
+				LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 				MACState: &ttnpb.MACState{
+					LoRaWANVersion: ttnpb.MAC_V1_1,
+					CurrentParameters: ttnpb.MACParameters{
+						Rx2Frequency: 868000000,
+					},
 					DesiredParameters: ttnpb.MACParameters{
 						Rx2Frequency: 123456789,
 					},
@@ -1083,7 +1191,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			a := assertions.New(t)
 
-			var setByIDCalls uint64
+			var addCalls, setByIDCalls uint64
 
 			ns := test.Must(New(
 				componenttest.NewComponent(t, &component.Config{}),
@@ -1095,6 +1203,10 @@ func TestDeviceRegistrySet(t *testing.T) {
 						},
 					},
 					DownlinkTasks: &MockDownlinkTaskQueue{
+						AddFunc: func(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, at time.Time, replace bool) error {
+							atomic.AddUint64(&addCalls, 1)
+							return tc.AddFunc(ctx, ids, at, replace)
+						},
 						PopFunc: DownlinkTaskPopBlockFunc,
 					},
 					DeduplicationWindow: 42,
@@ -1118,13 +1230,14 @@ func TestDeviceRegistrySet(t *testing.T) {
 			req := deepcopy.Copy(tc.Request).(*ttnpb.SetEndDeviceRequest)
 
 			dev, err := ttnpb.NewNsEndDeviceRegistryClient(ns.LoopbackConn()).Set(ctx, req)
-			a.So(setByIDCalls, should.Equal, tc.SetByIDCalls)
 			if tc.ErrorAssertion != nil && a.So(tc.ErrorAssertion(t, err), should.BeTrue) {
 				a.So(dev, should.BeNil)
 			} else if a.So(err, should.BeNil) {
 				a.So(dev, should.Resemble, tc.Device)
 			}
 			a.So(req, should.Resemble, tc.Request)
+			a.So(setByIDCalls, should.Equal, tc.SetByIDCalls)
+			a.So(addCalls, should.Equal, tc.AddCalls)
 		})
 	}
 }

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -723,7 +723,7 @@ func appendRecentUplink(recent []*ttnpb.UplinkMessage, up *ttnpb.UplinkMessage, 
 	return recent
 }
 
-var handleUplinkGetPaths = [...]string{
+var handleDataUplinkGetPaths = [...]string{
 	"frequency_plan_id",
 	"last_dev_status_received_at",
 	"lorawan_phy_version",
@@ -761,7 +761,7 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 	logger.Debug("Match device")
 
 	var addrMatches []*ttnpb.EndDevice
-	if err := ns.devices.RangeByAddr(ctx, pld.DevAddr, handleUplinkGetPaths[:],
+	if err := ns.devices.RangeByAddr(ctx, pld.DevAddr, handleDataUplinkGetPaths[:],
 		func(dev *ttnpb.EndDevice) bool {
 			addrMatches = append(addrMatches, dev)
 			return true
@@ -808,7 +808,7 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 	}
 
 	var handleErr bool
-	stored, err := ns.devices.SetByID(ctx, matched.Device.ApplicationIdentifiers, matched.Device.DeviceID, handleUplinkGetPaths[:],
+	stored, err := ns.devices.SetByID(ctx, matched.Device.ApplicationIdentifiers, matched.Device.DeviceID, handleDataUplinkGetPaths[:],
 		func(stored *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
 			if stored == nil {
 				logger.Warn("Device deleted during uplink handling, drop")

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -149,6 +149,7 @@ func makeDeferredMACHandler(dev *ttnpb.EndDevice, f macHandler) macHandler {
 
 type matchedDevice struct {
 	logger log.Interface
+	phy    band.Band
 
 	ChannelIndex             uint8
 	DataRateIndex            ttnpb.DataRateIndex
@@ -234,6 +235,7 @@ func (ns *NetworkServer) matchAndHandleDataUplink(ctx context.Context, up *ttnpb
 			matches = append(matches, device{
 				matchedDevice: matchedDevice{
 					logger:        logger,
+					phy:           phy,
 					DataRateIndex: drIdx,
 					Device:        pendingDev,
 					FCnt:          pld.FCnt,
@@ -313,6 +315,7 @@ func (ns *NetworkServer) matchAndHandleDataUplink(ctx context.Context, up *ttnpb
 			matches = append(matches, device{
 				matchedDevice: matchedDevice{
 					logger:        logger,
+					phy:           phy,
 					DataRateIndex: drIdx,
 					Device:        dev,
 					FCnt:          dev.Session.LastFCntUp,
@@ -349,6 +352,7 @@ func (ns *NetworkServer) matchAndHandleDataUplink(ctx context.Context, up *ttnpb
 						"full_f_cnt_up", pld.FCnt,
 						"transmission", 1,
 					)),
+					phy:           phy,
 					DataRateIndex: drIdx,
 					Device:        dev,
 					FCnt:          pld.FCnt,
@@ -382,6 +386,7 @@ func (ns *NetworkServer) matchAndHandleDataUplink(ctx context.Context, up *ttnpb
 							"f_cnt_reset", true,
 							"full_f_cnt_up", pld.FCnt,
 						)),
+						phy:           phy,
 						DataRateIndex: drIdx,
 						Device:        dev,
 						FCnt:          pld.FCnt,
@@ -413,6 +418,7 @@ func (ns *NetworkServer) matchAndHandleDataUplink(ctx context.Context, up *ttnpb
 		matches = append(matches, device{
 			matchedDevice: matchedDevice{
 				logger:        logger,
+				phy:           phy,
 				DataRateIndex: drIdx,
 				Device:        dev,
 				FCnt:          fCnt,
@@ -727,6 +733,7 @@ var handleUplinkGetPaths = [...]string{
 	"multicast",
 	"pending_mac_state",
 	"pending_session",
+	"queued_application_downlinks",
 	"recent_downlinks",
 	"recent_uplinks",
 	"session",
@@ -855,6 +862,17 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 		return err
 	}
 
+	downAt, ok := nextDataDownlinkAt(ctx, stored, matched.phy, ns.defaultMACSettings)
+	if !ok {
+		logger.Debug("No downlink to send or windows expired, avoid adding downlink task after data uplink")
+	} else {
+		downAt = downAt.Add(-nsScheduleWindow)
+		logger.WithField("start_at", downAt).Debug("Add downlink task after data uplink")
+		if err := ns.downlinkTasks.Add(ctx, stored.EndDeviceIdentifiers, downAt, true); err != nil {
+			logger.WithError(err).Error("Failed to add downlink task after data uplink")
+		}
+	}
+
 	if matched.NbTrans == 1 {
 		queuedApplicationUplinks = append(queuedApplicationUplinks, &ttnpb.ApplicationUp{
 			EndDeviceIdentifiers: stored.EndDeviceIdentifiers,
@@ -872,15 +890,7 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 		registerForwardDataUplink(ctx, up)
 	}
 
-	if len(queuedEvents) > 0 {
-		for _, ev := range queuedEvents {
-			events.Publish(ev(ctx, stored.EndDeviceIdentifiers))
-		}
-	}
-
-	startAt := up.ReceivedAt.Add(stored.MACState.CurrentParameters.Rx1Delay.Duration() - nsScheduleWindow)
 	if len(queuedApplicationUplinks) > 0 {
-		doneCh := make(chan struct{})
 		go func() {
 			for _, asUp := range queuedApplicationUplinks {
 				logger.Debug("Send application uplink to Application Server")
@@ -891,22 +901,12 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 					logger.Warn("Application Server not found, drop application uplink")
 				}
 			}
-			close(doneCh)
 		}()
-		select {
-		case <-doneCh:
-		case <-time.After(time.Until(startAt)):
+	}
+	if len(queuedEvents) > 0 {
+		for _, ev := range queuedEvents {
+			events.Publish(ev(ctx, stored.EndDeviceIdentifiers))
 		}
-	}
-
-	if up.ReceivedAt.Add(stored.MACState.CurrentParameters.Rx1Delay.Duration() + time.Second).Before(time.Now()) {
-		logger.Warn("Rx2 of uplink is expired, avoid adding downlink task for class A downlink")
-		return nil
-	}
-
-	logger.WithField("start_at", startAt).Debug("Add downlink task for class A downlink")
-	if err := ns.downlinkTasks.Add(ctx, stored.EndDeviceIdentifiers, startAt, true); err != nil {
-		logger.WithError(err).Error("Failed to add downlink task for class A downlink")
 	}
 	return nil
 }
@@ -1143,6 +1143,12 @@ func (ns *NetworkServer) handleJoinRequest(ctx context.Context, up *ttnpb.Uplink
 		return err
 	}
 
+	startAt := up.ReceivedAt.Add(phy.JoinAcceptDelay1 - nsScheduleWindow)
+	logger.WithField("start_at", startAt).Debug("Add downlink task for join-accept")
+	if err := ns.downlinkTasks.Add(ctx, dev.EndDeviceIdentifiers, startAt, true); err != nil {
+		logger.WithError(err).Error("Failed to add downlink task for join-accept")
+	}
+
 	go func() {
 		logger := logger.WithField(
 			"application_uid", unique.ID(ctx, dev.EndDeviceIdentifiers.ApplicationIdentifiers),
@@ -1170,16 +1176,6 @@ func (ns *NetworkServer) handleJoinRequest(ctx context.Context, up *ttnpb.Uplink
 		}
 	}()
 
-	if up.ReceivedAt.Add(phy.JoinAcceptDelay2).Before(time.Now()) {
-		logger.Warn("Rx2 of join-request is expired, avoid adding downlink task for join-accept")
-		return nil
-	}
-
-	startAt := up.ReceivedAt.Add(phy.JoinAcceptDelay1 - nsScheduleWindow)
-	logger.WithField("start_at", startAt).Debug("Add downlink task for join-accept")
-	if err := ns.downlinkTasks.Add(ctx, dev.EndDeviceIdentifiers, startAt, true); err != nil {
-		logger.WithError(err).Error("Failed to add downlink task for join-accept")
-	}
 	return nil
 }
 
@@ -1204,7 +1200,7 @@ func (ns *NetworkServer) HandleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 		fmt.Sprintf("ns:uplink:%s", events.NewCorrelationID()),
 	)...)
 	up.CorrelationIDs = events.CorrelationIDsFromContext(ctx)
-	up.ReceivedAt = time.Now().UTC()
+	up.ReceivedAt = timeNow().UTC()
 	up.Payload = &ttnpb.Message{}
 	if err := lorawan.UnmarshalMessage(up.RawPayload, up.Payload); err != nil {
 		return nil, errDecodePayload.WithCause(err)

--- a/pkg/networkserver/grpc_gsns_internal_test.go
+++ b/pkg/networkserver/grpc_gsns_internal_test.go
@@ -21,6 +21,7 @@ import (
 
 	pbtypes "github.com/gogo/protobuf/types"
 	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/pkg/band"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/encoding/lorawan"
@@ -292,6 +293,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 				macState.RxWindowsAvailable = true
 				expectedDev := &matchedDevice{
 					logger:              dev.logger,
+					phy:                 test.Must(band.All[band.EU_863_870].Version(ttnpb.PHY_V1_1_REV_B)).(band.Band),
 					ChannelIndex:        1,
 					DataRateIndex:       ttnpb.DATA_RATE_2,
 					DeferredMACHandlers: dev.DeferredMACHandlers,
@@ -317,9 +319,10 @@ func TestMatchAndHandleUplink(t *testing.T) {
 						"session",
 					},
 				}
+
 				if !a.So([]time.Time{start, dev.Device.Session.StartedAt, time.Now()}, should.BeChronological) ||
 					!a.So(dev.DeferredMACHandlers, should.HaveLength, 1) ||
-					!a.So(dev, should.Resemble, expectedDev) {
+					!a.So(dev, should.HaveEmptyDiff, expectedDev) {
 					return false
 				}
 
@@ -336,7 +339,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 				expectedDev.Device.MACState.QueuedResponses = []*ttnpb.MACCommand{
 					linkCheckAns,
 				}
-				return a.So(dev, should.Resemble, expectedDev)
+				return a.So(dev, should.HaveEmptyDiff, expectedDev)
 			},
 			ErrorAssertion: func(ctx context.Context, err error) bool {
 				return assertions.New(test.MustTFromContext(ctx)).So(err, should.BeNil)
@@ -403,6 +406,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 				macState.RxWindowsAvailable = true
 				expectedDev := &matchedDevice{
 					logger:              dev.logger,
+					phy:                 test.Must(band.All[band.EU_863_870].Version(ttnpb.PHY_V1_1_REV_B)).(band.Band),
 					ChannelIndex:        1,
 					DataRateIndex:       ttnpb.DATA_RATE_2,
 					DeferredMACHandlers: dev.DeferredMACHandlers,
@@ -433,7 +437,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 				}
 				if !a.So([]time.Time{start, dev.Device.Session.StartedAt, time.Now()}, should.BeChronological) ||
 					!a.So(dev.DeferredMACHandlers, should.HaveLength, 1) ||
-					!a.So(dev, should.Resemble, expectedDev) {
+					!a.So(dev, should.HaveEmptyDiff, expectedDev) {
 					return false
 				}
 
@@ -450,7 +454,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 				expectedDev.Device.MACState.QueuedResponses = []*ttnpb.MACCommand{
 					linkCheckAns,
 				}
-				return a.So(dev, should.Resemble, expectedDev)
+				return a.So(dev, should.HaveEmptyDiff, expectedDev)
 			},
 			ErrorAssertion: func(ctx context.Context, err error) bool {
 				return assertions.New(test.MustTFromContext(ctx)).So(err, should.BeNil)
@@ -512,6 +516,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 				macState.RxWindowsAvailable = true
 				expectedDev := &matchedDevice{
 					logger:              dev.logger,
+					phy:                 test.Must(band.All[band.EU_863_870].Version(ttnpb.PHY_V1_1_REV_B)).(band.Band),
 					ChannelIndex:        1,
 					DataRateIndex:       ttnpb.DATA_RATE_2,
 					DeferredMACHandlers: dev.DeferredMACHandlers,
@@ -538,7 +543,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 				}
 				if !a.So([]time.Time{start, dev.Device.Session.StartedAt, time.Now()}, should.BeChronological) ||
 					!a.So(dev.DeferredMACHandlers, should.HaveLength, 1) ||
-					!a.So(dev, should.Resemble, expectedDev) {
+					!a.So(dev, should.HaveEmptyDiff, expectedDev) {
 					return false
 				}
 
@@ -555,7 +560,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 				expectedDev.Device.MACState.QueuedResponses = []*ttnpb.MACCommand{
 					linkCheckAns,
 				}
-				return a.So(dev, should.Resemble, expectedDev)
+				return a.So(dev, should.HaveEmptyDiff, expectedDev)
 			},
 			ErrorAssertion: func(ctx context.Context, err error) bool {
 				return assertions.New(test.MustTFromContext(ctx)).So(err, should.BeNil)
@@ -622,6 +627,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 				macState.RxWindowsAvailable = true
 				expectedDev := &matchedDevice{
 					logger:              dev.logger,
+					phy:                 test.Must(band.All[band.EU_863_870].Version(ttnpb.PHY_V1_1_REV_B)).(band.Band),
 					ChannelIndex:        1,
 					DataRateIndex:       ttnpb.DATA_RATE_2,
 					DeferredMACHandlers: dev.DeferredMACHandlers,
@@ -649,7 +655,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 					},
 				}
 				if !a.So(dev.DeferredMACHandlers, should.HaveLength, 1) ||
-					!a.So(dev, should.Resemble, expectedDev) {
+					!a.So(dev, should.HaveEmptyDiff, expectedDev) {
 					return false
 				}
 
@@ -666,7 +672,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 				expectedDev.Device.MACState.QueuedResponses = []*ttnpb.MACCommand{
 					linkCheckAns,
 				}
-				return a.So(dev, should.Resemble, expectedDev)
+				return a.So(dev, should.HaveEmptyDiff, expectedDev)
 			},
 			ErrorAssertion: func(ctx context.Context, err error) bool {
 				return assertions.New(test.MustTFromContext(ctx)).So(err, should.BeNil)

--- a/pkg/networkserver/mac_beacon_freq.go
+++ b/pkg/networkserver/mac_beacon_freq.go
@@ -28,8 +28,14 @@ var (
 	evtReceiveBeaconFreqAccept  = defineReceiveMACAcceptEvent("beacon_freq", "beacon frequency change")()
 )
 
+func needsBeaconFreqReq(dev *ttnpb.EndDevice) bool {
+	return dev.MACState != nil &&
+		dev.MACState.DeviceClass == ttnpb.CLASS_B &&
+		dev.MACState.DesiredParameters.BeaconFrequency != dev.MACState.CurrentParameters.BeaconFrequency
+}
+
 func enqueueBeaconFreqReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16) macCommandEnqueueState {
-	if dev.MACState.DesiredParameters.BeaconFrequency == dev.MACState.CurrentParameters.BeaconFrequency {
+	if !needsBeaconFreqReq(dev) {
 		return macCommandEnqueueState{
 			MaxDownLen: maxDownLen,
 			MaxUpLen:   maxUpLen,

--- a/pkg/networkserver/mac_beacon_timing.go
+++ b/pkg/networkserver/mac_beacon_timing.go
@@ -21,7 +21,14 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 )
 
+func needsBeaconTimingReq(dev *ttnpb.EndDevice) bool {
+	return dev.MACState != nil &&
+		dev.MACState.DeviceClass == ttnpb.CLASS_B &&
+		false // TODO: Support Class B (https://github.com/TheThingsNetwork/lorawan-stack/issues/19)
+}
+
 func handleBeaconTimingReq(ctx context.Context, dev *ttnpb.EndDevice) ([]events.DefinitionDataClosure, error) {
+	_ = needsBeaconTimingReq(dev)
 	// TODO: Support Class B (https://github.com/TheThingsNetwork/lorawan-stack/issues/19)
 	// NOTE: This command is deprecated in LoRaWAN 1.1
 	return nil, nil

--- a/pkg/networkserver/mac_duty_cycle.go
+++ b/pkg/networkserver/mac_duty_cycle.go
@@ -27,8 +27,13 @@ var (
 	evtReceiveDutyCycleAnswer  = defineReceiveMACAnswerEvent("duty_cycle", "maximum aggregated transmit duty-cycle change")()
 )
 
+func needsDutyCycleReq(dev *ttnpb.EndDevice) bool {
+	return dev.MACState != nil &&
+		dev.MACState.DesiredParameters.MaxDutyCycle != dev.MACState.CurrentParameters.MaxDutyCycle
+}
+
 func enqueueDutyCycleReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16) macCommandEnqueueState {
-	if dev.MACState.DesiredParameters.MaxDutyCycle == dev.MACState.CurrentParameters.MaxDutyCycle {
+	if !needsDutyCycleReq(dev) {
 		return macCommandEnqueueState{
 			MaxDownLen: maxDownLen,
 			MaxUpLen:   maxUpLen,

--- a/pkg/networkserver/mac_new_channel_test.go
+++ b/pkg/networkserver/mac_new_channel_test.go
@@ -25,6 +25,210 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 )
 
+func TestNeedsNewChannelReq(t *testing.T) {
+	for _, tc := range []struct {
+		Name        string
+		InputDevice *ttnpb.EndDevice
+		Needs       bool
+	}{
+		{
+			Name:        "no MAC state",
+			InputDevice: &ttnpb.EndDevice{},
+		},
+		{
+			Name: "current(channels:[(123,1-5),(124,1-3),(128,2-4)]),desired(channels:[(123,1-5),(124,1-3),(128,2-4)])",
+			InputDevice: &ttnpb.EndDevice{
+				MACState: &ttnpb.MACState{
+					CurrentParameters: ttnpb.MACParameters{
+						Channels: []*ttnpb.MACParameters_Channel{
+							{
+								UplinkFrequency:  123,
+								MinDataRateIndex: ttnpb.DATA_RATE_1,
+								MaxDataRateIndex: ttnpb.DATA_RATE_5,
+							},
+							{
+								UplinkFrequency:  124,
+								MinDataRateIndex: ttnpb.DATA_RATE_1,
+								MaxDataRateIndex: ttnpb.DATA_RATE_3,
+							},
+							{
+								UplinkFrequency:  128,
+								MinDataRateIndex: ttnpb.DATA_RATE_2,
+								MaxDataRateIndex: ttnpb.DATA_RATE_4,
+							},
+						},
+					},
+					DesiredParameters: ttnpb.MACParameters{
+						Channels: []*ttnpb.MACParameters_Channel{
+							{
+								UplinkFrequency:  123,
+								MinDataRateIndex: ttnpb.DATA_RATE_1,
+								MaxDataRateIndex: ttnpb.DATA_RATE_5,
+							},
+							{
+								UplinkFrequency:  124,
+								MinDataRateIndex: ttnpb.DATA_RATE_1,
+								MaxDataRateIndex: ttnpb.DATA_RATE_3,
+							},
+							{
+								UplinkFrequency:  128,
+								MinDataRateIndex: ttnpb.DATA_RATE_2,
+								MaxDataRateIndex: ttnpb.DATA_RATE_4,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			// TODO: Disable channels using NewChannelReq. (https://github.com/TheThingsNetwork/lorawan-stack/issues/1499)
+			Name: "current(channels:[(123,1-5),(124,1-3),(128,2-4)]),desired(channels:[(123,1-5),(124,1-3)])",
+			InputDevice: &ttnpb.EndDevice{
+				MACState: &ttnpb.MACState{
+					CurrentParameters: ttnpb.MACParameters{
+						Channels: []*ttnpb.MACParameters_Channel{
+							{
+								UplinkFrequency:  123,
+								MinDataRateIndex: ttnpb.DATA_RATE_1,
+								MaxDataRateIndex: ttnpb.DATA_RATE_5,
+							},
+							{
+								UplinkFrequency:  124,
+								MinDataRateIndex: ttnpb.DATA_RATE_1,
+								MaxDataRateIndex: ttnpb.DATA_RATE_3,
+							},
+							{
+								UplinkFrequency:  128,
+								MinDataRateIndex: ttnpb.DATA_RATE_2,
+								MaxDataRateIndex: ttnpb.DATA_RATE_4,
+							},
+						},
+					},
+					DesiredParameters: ttnpb.MACParameters{
+						Channels: []*ttnpb.MACParameters_Channel{
+							{
+								UplinkFrequency:  123,
+								MinDataRateIndex: ttnpb.DATA_RATE_1,
+								MaxDataRateIndex: ttnpb.DATA_RATE_5,
+							},
+							{
+								UplinkFrequency:  124,
+								MinDataRateIndex: ttnpb.DATA_RATE_1,
+								MaxDataRateIndex: ttnpb.DATA_RATE_3,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "current(channels:[(123,1-5),(124,1-3),(128,2-4)]),desired(channels:[(123,1-5),(124,1-3),(128,2-3)])",
+			InputDevice: &ttnpb.EndDevice{
+				MACState: &ttnpb.MACState{
+					CurrentParameters: ttnpb.MACParameters{
+						Channels: []*ttnpb.MACParameters_Channel{
+							{
+								UplinkFrequency:  123,
+								MinDataRateIndex: ttnpb.DATA_RATE_1,
+								MaxDataRateIndex: ttnpb.DATA_RATE_5,
+							},
+							{
+								UplinkFrequency:  124,
+								MinDataRateIndex: ttnpb.DATA_RATE_1,
+								MaxDataRateIndex: ttnpb.DATA_RATE_3,
+							},
+							{
+								UplinkFrequency:  128,
+								MinDataRateIndex: ttnpb.DATA_RATE_2,
+								MaxDataRateIndex: ttnpb.DATA_RATE_4,
+							},
+						},
+					},
+					DesiredParameters: ttnpb.MACParameters{
+						Channels: []*ttnpb.MACParameters_Channel{
+							{
+								UplinkFrequency:  123,
+								MinDataRateIndex: ttnpb.DATA_RATE_1,
+								MaxDataRateIndex: ttnpb.DATA_RATE_5,
+							},
+							{
+								UplinkFrequency:  124,
+								MinDataRateIndex: ttnpb.DATA_RATE_1,
+								MaxDataRateIndex: ttnpb.DATA_RATE_3,
+							},
+							{
+								UplinkFrequency:  128,
+								MinDataRateIndex: ttnpb.DATA_RATE_2,
+								MaxDataRateIndex: ttnpb.DATA_RATE_3,
+							},
+						},
+					},
+				},
+			},
+			Needs: true,
+		},
+		{
+			Name: "current(channels:[(123,1-5),(124,1-3),(128,2-4)]),desired(channels:[(123,1-5),(124,1-3),(127,2-4)])",
+			InputDevice: &ttnpb.EndDevice{
+				MACState: &ttnpb.MACState{
+					CurrentParameters: ttnpb.MACParameters{
+						Channels: []*ttnpb.MACParameters_Channel{
+							{
+								UplinkFrequency:  123,
+								MinDataRateIndex: ttnpb.DATA_RATE_1,
+								MaxDataRateIndex: ttnpb.DATA_RATE_5,
+							},
+							{
+								UplinkFrequency:  124,
+								MinDataRateIndex: ttnpb.DATA_RATE_1,
+								MaxDataRateIndex: ttnpb.DATA_RATE_3,
+							},
+							{
+								UplinkFrequency:  128,
+								MinDataRateIndex: ttnpb.DATA_RATE_2,
+								MaxDataRateIndex: ttnpb.DATA_RATE_4,
+							},
+						},
+					},
+					DesiredParameters: ttnpb.MACParameters{
+						Channels: []*ttnpb.MACParameters_Channel{
+							{
+								UplinkFrequency:  123,
+								MinDataRateIndex: ttnpb.DATA_RATE_1,
+								MaxDataRateIndex: ttnpb.DATA_RATE_5,
+							},
+							{
+								UplinkFrequency:  124,
+								MinDataRateIndex: ttnpb.DATA_RATE_1,
+								MaxDataRateIndex: ttnpb.DATA_RATE_3,
+							},
+							{
+								UplinkFrequency:  127,
+								MinDataRateIndex: ttnpb.DATA_RATE_2,
+								MaxDataRateIndex: ttnpb.DATA_RATE_4,
+							},
+						},
+					},
+				},
+			},
+			Needs: true,
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			a := assertions.New(t)
+
+			dev := CopyEndDevice(tc.InputDevice)
+			res := needsNewChannelReq(dev)
+			if tc.Needs {
+				a.So(res, should.BeTrue)
+			} else {
+				a.So(res, should.BeFalse)
+			}
+			a.So(dev, should.Resemble, tc.InputDevice)
+		})
+	}
+}
+
 func TestHandleNewChannelAns(t *testing.T) {
 	for _, tc := range []struct {
 		Name             string

--- a/pkg/networkserver/mac_ping_slot_channel.go
+++ b/pkg/networkserver/mac_ping_slot_channel.go
@@ -27,9 +27,14 @@ var (
 	evtReceivePingSlotChannelAnswer  = defineReceiveMACAcceptEvent("ping_slot_channel", "ping slot channel")()
 )
 
+func needsPingSlotChannelReq(dev *ttnpb.EndDevice) bool {
+	return dev.MACState != nil &&
+		(dev.MACState.DesiredParameters.PingSlotDataRateIndex != dev.MACState.CurrentParameters.PingSlotDataRateIndex ||
+			dev.MACState.DesiredParameters.PingSlotFrequency != dev.MACState.CurrentParameters.PingSlotFrequency)
+}
+
 func enqueuePingSlotChannelReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16) macCommandEnqueueState {
-	if dev.MACState.DesiredParameters.PingSlotDataRateIndex == dev.MACState.CurrentParameters.PingSlotDataRateIndex &&
-		dev.MACState.DesiredParameters.PingSlotFrequency == dev.MACState.CurrentParameters.PingSlotFrequency {
+	if !needsPingSlotChannelReq(dev) {
 		return macCommandEnqueueState{
 			MaxDownLen: maxDownLen,
 			MaxUpLen:   maxUpLen,

--- a/pkg/networkserver/mac_rejoin_param_setup.go
+++ b/pkg/networkserver/mac_rejoin_param_setup.go
@@ -27,8 +27,15 @@ var (
 	evtReceiveRejoinParamSetupAnswer  = defineReceiveMACAnswerEvent("rejoin_param_setup", "rejoin parameter setup")()
 )
 
+func needsRejoinParamSetupReq(dev *ttnpb.EndDevice) bool {
+	return dev.MACState != nil &&
+		dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) >= 0 &&
+		(dev.MACState.DesiredParameters.RejoinTimePeriodicity != dev.MACState.CurrentParameters.RejoinTimePeriodicity ||
+			dev.MACState.DesiredParameters.RejoinCountPeriodicity != dev.MACState.CurrentParameters.RejoinCountPeriodicity)
+}
+
 func enqueueRejoinParamSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16) macCommandEnqueueState {
-	if dev.MACState.DesiredParameters.RejoinTimePeriodicity == dev.MACState.CurrentParameters.RejoinTimePeriodicity {
+	if !needsRejoinParamSetupReq(dev) {
 		return macCommandEnqueueState{
 			MaxDownLen: maxDownLen,
 			MaxUpLen:   maxUpLen,

--- a/pkg/networkserver/mac_rx_timing_setup.go
+++ b/pkg/networkserver/mac_rx_timing_setup.go
@@ -27,8 +27,13 @@ var (
 	evtReceiveRxTimingSetupAnswer  = defineReceiveMACAnswerEvent("rx_timing_setup", "Rx timing setup")()
 )
 
+func needsRxTimingSetupReq(dev *ttnpb.EndDevice) bool {
+	return dev.MACState != nil &&
+		dev.MACState.DesiredParameters.Rx1Delay != dev.MACState.CurrentParameters.Rx1Delay
+}
+
 func enqueueRxTimingSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16) macCommandEnqueueState {
-	if dev.MACState.DesiredParameters.Rx1Delay == dev.MACState.CurrentParameters.Rx1Delay {
+	if !needsRxTimingSetupReq(dev) {
 		return macCommandEnqueueState{
 			MaxDownLen: maxDownLen,
 			MaxUpLen:   maxUpLen,

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -54,18 +54,19 @@ func NewWindowEndAfterFunc(d time.Duration) WindowEndFunc {
 	return func(ctx context.Context, up *ttnpb.UplinkMessage) <-chan time.Time {
 		ch := make(chan time.Time, 1)
 
+		now := timeNow()
 		if up.ReceivedAt.IsZero() {
-			up.ReceivedAt = time.Now()
+			up.ReceivedAt = now
 		}
 
 		end := up.ReceivedAt.Add(d)
-		if end.Before(time.Now()) {
+		if end.Before(now) {
 			ch <- end
 			return ch
 		}
 
 		go func() {
-			time.Sleep(time.Until(up.ReceivedAt.Add(d)))
+			time.Sleep(timeUntil(up.ReceivedAt.Add(d)))
 			ch <- end
 		}()
 		return ch

--- a/pkg/networkserver/utils.go
+++ b/pkg/networkserver/utils.go
@@ -15,6 +15,8 @@
 package networkserver
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	pbtypes "github.com/gogo/protobuf/types"
@@ -23,6 +25,16 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/frequencyplans"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 )
+
+var timeNow func() time.Time = time.Now
+
+func timeUntil(t time.Time) time.Duration {
+	return t.Sub(timeNow())
+}
+
+func timeSince(t time.Time) time.Duration {
+	return timeNow().Sub(t)
+}
 
 // copyEndDevice returns a deep copy of ttnpb.EndDevice pb.
 func copyEndDevice(pb *ttnpb.EndDevice) *ttnpb.EndDevice {
@@ -79,6 +91,114 @@ func searchUplinkChannel(freq uint64, macState *ttnpb.MACState) (uint8, error) {
 		}
 	}
 	return 0, errUplinkChannelNotFound.WithAttributes("frequency", freq)
+}
+
+func needsMACRequestsAt(ctx context.Context, dev *ttnpb.EndDevice, t time.Time, phy band.Band, defaults ttnpb.MACSettings) bool {
+	switch {
+	case needsADRParamSetupReq(dev, phy),
+		needsBeaconFreqReq(dev),
+		needsBeaconTimingReq(dev),
+		needsDLChannelReq(dev),
+		needsDutyCycleReq(dev),
+		needsLinkADRReq(dev),
+		needsNewChannelReq(dev),
+		needsPingSlotChannelReq(dev),
+		needsRejoinParamSetupReq(dev),
+		needsRxParamSetupReq(dev),
+		needsRxTimingSetupReq(dev),
+		needsTxParamSetupReq(dev, phy):
+		return true
+	}
+	statusAt, ok := needsDevStatusReqAt(dev, defaults)
+	return ok && t.After(statusAt)
+}
+
+func needsClassADataDownlinkAt(ctx context.Context, dev *ttnpb.EndDevice, t time.Time, phy band.Band, defaults ttnpb.MACSettings) bool {
+	if dev.MACState == nil || !dev.MACState.RxWindowsAvailable || len(dev.RecentUplinks) == 0 {
+		return false
+	}
+	if len(dev.MACState.QueuedResponses) > 0 {
+		return true
+	}
+	up := dev.RecentUplinks[len(dev.RecentUplinks)-1]
+	switch up.Payload.MHDR.MType {
+	case ttnpb.MType_UNCONFIRMED_UP:
+		if up.Payload.GetMACPayload().FCtrl.ADRAckReq {
+			return true
+		}
+	case ttnpb.MType_CONFIRMED_UP:
+		return true
+	}
+	if len(dev.QueuedApplicationDownlinks) > 0 && dev.QueuedApplicationDownlinks[0].GetClassBC() == nil {
+		return true
+	}
+	return needsMACRequestsAt(ctx, dev, t, phy, defaults)
+}
+
+func nextClassADataDownlinkSlot(dev *ttnpb.EndDevice) (time.Time, bool) {
+	if dev.MACState == nil || !dev.MACState.RxWindowsAvailable || len(dev.RecentUplinks) == 0 {
+		return time.Time{}, false
+	}
+	rx1 := dev.RecentUplinks[len(dev.RecentUplinks)-1].ReceivedAt.Add(dev.MACState.CurrentParameters.Rx1Delay.Duration())
+	rx2 := rx1.Add(time.Second)
+	switch {
+	case rx2.Before(timeNow()):
+		return time.Time{}, false
+	case rx1.After(timeNow()):
+		return rx1, true
+	default:
+		return rx2, true
+	}
+}
+
+// nextDataDownlinkAt returns the time.Time when the downlink should be scheduled on the Gateway Server
+// and whether or not there is a data downlink to schedule.
+func nextDataDownlinkAt(ctx context.Context, dev *ttnpb.EndDevice, phy band.Band, defaults ttnpb.MACSettings) (time.Time, bool) {
+	if dev.MACState == nil {
+		return time.Time{}, false
+	}
+	if !dev.Multicast {
+		downAt, ok := nextClassADataDownlinkSlot(dev)
+		if ok && needsClassADataDownlinkAt(ctx, dev, downAt, phy, defaults) {
+			return downAt.Add(-gsScheduleWindow), true
+		}
+	}
+	switch dev.MACState.DeviceClass {
+	case ttnpb.CLASS_A, ttnpb.CLASS_B:
+		return time.Time{}, false
+	case ttnpb.CLASS_C:
+		now := timeNow().UTC()
+		confirmedAt := nextConfirmedClassCDownlinkAt(dev, defaults)
+		if confirmedAt.Before(now) {
+			confirmedAt = now
+		}
+		if needsMACRequestsAt(ctx, dev, confirmedAt, phy, defaults) {
+			return confirmedAt, true
+		}
+		var absTime time.Time
+		if len(dev.QueuedApplicationDownlinks) > 0 {
+			classBC := dev.QueuedApplicationDownlinks[0].ClassBC
+			if classBC == nil || classBC.AbsoluteTime == nil || classBC.AbsoluteTime.IsZero() {
+				return now, true
+			}
+			absTime = classBC.AbsoluteTime.UTC()
+		}
+
+		statusAt, ok := needsDevStatusReqAt(dev, defaults)
+		if !ok {
+			if absTime.IsZero() {
+				return time.Time{}, false
+			}
+			return absTime.Add(-gsScheduleWindow), true
+		}
+		// NOTE: statusAt is after confirmedAt, otherwise needsMACRequestsAt call above would evaluate to true.
+		if statusAt.After(absTime) {
+			return absTime.Add(-gsScheduleWindow), true
+		}
+		return statusAt, true
+	default:
+		panic(fmt.Sprintf("Unmatched device class: %v", dev.MACState.DeviceClass))
+	}
 }
 
 func newMACState(dev *ttnpb.EndDevice, fps *frequencyplans.Store, defaults ttnpb.MACSettings) (*ttnpb.MACState, error) {

--- a/pkg/networkserver/utils.go
+++ b/pkg/networkserver/utils.go
@@ -151,6 +151,21 @@ func nextClassADataDownlinkSlot(dev *ttnpb.EndDevice) (time.Time, bool) {
 	}
 }
 
+func nextConfirmedClassCDownlinkAt(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings) time.Time {
+	if dev.GetMACState().GetLastConfirmedDownlinkAt() == nil {
+		return time.Time{}
+	}
+	if dev.GetMACState().GetRxWindowsAvailable() {
+		return time.Time{}
+	}
+	if len(dev.RecentUplinks) > 0 {
+		if dev.RecentUplinks[len(dev.RecentUplinks)-1].ReceivedAt.After(*dev.MACState.LastConfirmedDownlinkAt) {
+			return time.Time{}
+		}
+	}
+	return dev.MACState.LastConfirmedDownlinkAt.Add(deviceClassCTimeout(dev, defaults))
+}
+
 // nextDataDownlinkAt returns the time.Time when the downlink should be scheduled on the Gateway Server
 // and whether or not there is a data downlink to schedule.
 func nextDataDownlinkAt(ctx context.Context, dev *ttnpb.EndDevice, phy band.Band, defaults ttnpb.MACSettings) (time.Time, bool) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #936 

#### Changes
<!-- What are the changes made in this pull request? -->

- Instead of just blindly adding downlink tasks whenever something *may* trigger a downlink, calculate if and when a downlink is required and schedule accordingly
- Ensure confirmed class C downlinks are allowed before timeout expires if an uplink is received
- Time downlink task relative to RX2 instead of RX1 if the latter is expired
- Use (approximate) transmission time for determining whether or not `DevStatusReq` should be scheduled instead of using generation time(e.g. if a class A downlink is generated 30 sec before RX1 starts and `DevStatusReq` is not ready to be sent yet,  NS can send it regardless, if `DevStatusReq` will be ready at RX1.)
- Downlink queue pushes/replaces and device registry *may* trigger a class A downlink task if there exists an unanswered uplink, for which either RX1 or RX2 is not expired.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Note that for class A devices a downlink task will not be added after an uplink if there's no MAC and no application downlink to send.

Tested on metal in EU868 OTAA flow using ff1705 in classes A and C

>NOTE: This PR contains many changed LoC, big part of this is `TestNeeds*` tests(I was trying to decrease the coverage drop).
Please keep in mind that main goals of this PR are:
> 1. Limit unnecessary registry transactions(e.g. processing a downlink task when no downlink available)
> 2. Make sure downlinks are scheduled efficiently