### PR TITLE
Add support for organization collaborators in console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for editing organization API keys in the Console.
 - Support for listing organization API keys in the Console.
 - Support for managing organization API keys and rights in the JS SDK.
+- Support for removing organization collaborators in the Console.
+- Support for editing organization collaborators in the Console.
+- Support for listing organization collaborators in the Console.
+- Support for managing organization collaborators and rights in the JS SDK.
 
 ### Changed
 

--- a/pkg/webui/console/api/index.js
+++ b/pkg/webui/console/api/index.js
@@ -223,5 +223,23 @@ export default {
       delete: ttnClient.Organizations.ApiKeys.deleteById.bind(ttnClient.Organizations.ApiKeys),
       create: ttnClient.Organizations.ApiKeys.create.bind(ttnClient.Organizations.ApiKeys),
     },
+    collaborators: {
+      getOrganization: ttnClient.Organizations.Collaborators.getByOrganizationId.bind(
+        ttnClient.Organizations.Collaborators,
+      ),
+      getUser: ttnClient.Organizations.Collaborators.getByUserId.bind(
+        ttnClient.Organizations.Collaborators,
+      ),
+      list: ttnClient.Organizations.Collaborators.getAll.bind(
+        ttnClient.Organizations.Collaborators,
+      ),
+      add: ttnClient.Organizations.Collaborators.add.bind(ttnClient.Organizations.Collaborators),
+      update: ttnClient.Organizations.Collaborators.update.bind(
+        ttnClient.Organizations.Collaborators,
+      ),
+      remove: ttnClient.Organizations.Collaborators.remove.bind(
+        ttnClient.Organizations.Collaborators,
+      ),
+    },
   },
 }

--- a/pkg/webui/console/components/rights-group/index.js
+++ b/pkg/webui/console/components/rights-group/index.js
@@ -42,7 +42,7 @@ const computeProps = function(props) {
   const { value, pseudoRight: grantablePseudoRight, rights: grantableRights } = props
 
   // Extract the pseudo right from own rights or granted rights
-  let derivedPseudoRight
+  let derivedPseudoRight = []
   if (grantablePseudoRight && !Array.isArray(grantablePseudoRight)) {
     derivedPseudoRight = [grantablePseudoRight]
   } else if (Boolean(grantablePseudoRight) && Array.isArray(grantablePseudoRight)) {

--- a/pkg/webui/console/store/actions/organizations.js
+++ b/pkg/webui/console/store/actions/organizations.js
@@ -37,6 +37,8 @@ import createGetRightsListRequestActions, { createGetRightsListActionType } from
 import {
   createGetCollaboratorsListRequestActions,
   createGetCollaboratorsListActionType,
+  createGetCollaboratorRequestActions,
+  createGetCollaboratorActionType,
 } from './collaborators'
 
 export const SHARED_NAME = 'ORGANIZATION'
@@ -124,6 +126,20 @@ export const [
     failure: deleteORganizationFailure,
   },
 ] = createPaginationDeleteActions(SHARED_NAME, id => ({ id }))
+
+export const GET_ORG_COLLABORATOR_BASE = createGetCollaboratorActionType(SHARED_NAME)
+export const [
+  {
+    request: GET_ORG_COLLABORATOR,
+    success: GET_ORG_COLLABORATOR_SUCCESS,
+    failure: GET_ORG_COLLABORATOR_FAILURE,
+  },
+  {
+    request: getOrganizationCollaborator,
+    success: getOrganizationCollaboratorSuccess,
+    failure: getOrganizationCollaboratorFailure,
+  },
+] = createGetCollaboratorRequestActions(SHARED_NAME)
 
 export const GET_ORG_COLLABORATORS_LIST_BASE = createGetCollaboratorsListActionType(SHARED_NAME)
 export const [

--- a/pkg/webui/console/store/actions/organizations.js
+++ b/pkg/webui/console/store/actions/organizations.js
@@ -34,6 +34,10 @@ import {
 import createApiKeysRequestActions, { createGetApiKeysListActionType } from './api-keys'
 import createApiKeyRequestActions, { createGetApiKeyActionType } from './api-key'
 import createGetRightsListRequestActions, { createGetRightsListActionType } from './rights'
+import {
+  createGetCollaboratorsListRequestActions,
+  createGetCollaboratorsListActionType,
+} from './collaborators'
 
 export const SHARED_NAME = 'ORGANIZATION'
 
@@ -73,16 +77,6 @@ export const [
   },
 ] = createRequestActions(UPDATE_ORG_BASE, (id, patch) => ({ id, patch }))
 
-export const DELETE_ORG_BASE = createPaginationDeleteBaseActionType(SHARED_NAME)
-export const [
-  { request: DELETE_ORG, success: DELETE_ORG_SUCCESS, failure: DELETE_ORG_FAILURE },
-  {
-    request: deleteOrganization,
-    success: deleteOrganizationSuccess,
-    failure: deleteORganizationFailure,
-  },
-] = createPaginationDeleteActions(SHARED_NAME, id => ({ id }))
-
 export const GET_ORG_API_KEY_BASE = createGetApiKeyActionType(SHARED_NAME)
 export const [
   { request: GET_ORG_API_KEY, success: GET_ORG_API_KEY_SUCCESS, failure: GET_ORG_API_KEY_FAILURE },
@@ -120,6 +114,30 @@ export const [
     failure: getOrganizationsRightsListFailure,
   },
 ] = createGetRightsListRequestActions(SHARED_NAME)
+
+export const DELETE_ORG_BASE = createPaginationDeleteBaseActionType(SHARED_NAME)
+export const [
+  { request: DELETE_ORG, success: DELETE_ORG_SUCCESS, failure: DELETE_ORG_FAILURE },
+  {
+    request: deleteOrganization,
+    success: deleteOrganizationSuccess,
+    failure: deleteORganizationFailure,
+  },
+] = createPaginationDeleteActions(SHARED_NAME, id => ({ id }))
+
+export const GET_ORG_COLLABORATORS_LIST_BASE = createGetCollaboratorsListActionType(SHARED_NAME)
+export const [
+  {
+    request: GET_ORG_COLLABORATORS_LIST,
+    success: GET_ORG_COLLABORATORS_LIST_SUCCESS,
+    failure: GET_ORG_COLLABORATORS_LIST_FAILURE,
+  },
+  {
+    request: getOrganizationCollaboratorsList,
+    success: getOrganizationCollaboratorsListSuccess,
+    failure: getOrganizationCollaboratorsListFailure,
+  },
+] = createGetCollaboratorsListRequestActions(SHARED_NAME)
 
 export const START_ORG_EVENT_STREAM = createStartEventsStreamActionType(SHARED_NAME)
 export const START_ORG_EVENT_STREAM_SUCCESS = createStartEventsStreamSuccessActionType(SHARED_NAME)

--- a/pkg/webui/console/store/middleware/logics/organizations.js
+++ b/pkg/webui/console/store/middleware/logics/organizations.js
@@ -109,6 +109,26 @@ const getOrganizationsRightsLogic = createRequestLogic({
   },
 })
 
+const getOrganizationCollaboratorsLogic = createRequestLogic({
+  type: organizations.GET_ORG_COLLABORATORS_LIST,
+  async process({ action }) {
+    const { id, params } = action.payload
+    const res = await api.organization.collaborators.list(id, params)
+    const collaborators = res.collaborators.map(function(collaborator) {
+      const { ids, ...rest } = collaborator
+      const isUser = !!ids.user_ids
+      const collaboratorId = isUser ? ids.user_ids.user_id : ids.organization_ids.organization_id
+
+      return {
+        id: collaboratorId,
+        isUser,
+        ...rest,
+      }
+    })
+    return { id, collaborators, totalCount: res.totalCount }
+  },
+})
+
 export default [
   getOrganizationLogic,
   getOrganizationsLogic,
@@ -118,6 +138,7 @@ export default [
   getOrganizationApiKeysLogic,
   getOrganizationApiKeyLogic,
   getOrganizationsRightsLogic,
+  getOrganizationCollaboratorsLogic,
   ...createEventsConnectLogics(
     organizations.SHARED_NAME,
     'organizations',

--- a/pkg/webui/console/store/middleware/logics/organizations.js
+++ b/pkg/webui/console/store/middleware/logics/organizations.js
@@ -109,6 +109,25 @@ const getOrganizationsRightsLogic = createRequestLogic({
   },
 })
 
+const getOrganizationCollaboratorLogic = createRequestLogic({
+  type: organizations.GET_ORG_COLLABORATOR,
+  async process({ action }) {
+    const { id: orgId, collaboratorId, isUser } = action.payload
+
+    const collaborator = isUser
+      ? await api.organization.collaborators.getUser(orgId, collaboratorId)
+      : await api.organization.collaborators.getOrganization(orgId, collaboratorId)
+
+    const { ids, ...rest } = collaborator
+
+    return {
+      id: collaboratorId,
+      isUser,
+      ...rest,
+    }
+  },
+})
+
 const getOrganizationCollaboratorsLogic = createRequestLogic({
   type: organizations.GET_ORG_COLLABORATORS_LIST,
   async process({ action }) {
@@ -129,15 +148,6 @@ const getOrganizationCollaboratorsLogic = createRequestLogic({
   },
 })
 
-const getOrganizationsRightsLogic = createRequestLogic({
-  type: organizations.GET_ORGS_RIGHTS_LIST,
-  async process({ action }) {
-    const { id } = action.payload
-    const result = await api.rights.organizations(id)
-    return result.rights.sort()
-  },
-})
-
 export default [
   getOrganizationLogic,
   getOrganizationsLogic,
@@ -147,8 +157,8 @@ export default [
   getOrganizationApiKeysLogic,
   getOrganizationApiKeyLogic,
   getOrganizationsRightsLogic,
+  getOrganizationCollaboratorLogic,
   getOrganizationCollaboratorsLogic,
-  getOrganizationsRightsLogic,
   ...createEventsConnectLogics(
     organizations.SHARED_NAME,
     'organizations',

--- a/pkg/webui/console/store/middleware/logics/organizations.js
+++ b/pkg/webui/console/store/middleware/logics/organizations.js
@@ -129,6 +129,15 @@ const getOrganizationCollaboratorsLogic = createRequestLogic({
   },
 })
 
+const getOrganizationsRightsLogic = createRequestLogic({
+  type: organizations.GET_ORGS_RIGHTS_LIST,
+  async process({ action }) {
+    const { id } = action.payload
+    const result = await api.rights.organizations(id)
+    return result.rights.sort()
+  },
+})
+
 export default [
   getOrganizationLogic,
   getOrganizationsLogic,
@@ -139,6 +148,7 @@ export default [
   getOrganizationApiKeyLogic,
   getOrganizationsRightsLogic,
   getOrganizationCollaboratorsLogic,
+  getOrganizationsRightsLogic,
   ...createEventsConnectLogics(
     organizations.SHARED_NAME,
     'organizations',

--- a/pkg/webui/console/store/reducers/index.js
+++ b/pkg/webui/console/store/reducers/index.js
@@ -87,6 +87,7 @@ export default history =>
       applications: createNamedCollaboratorsReducer(APPLICATION_SHARED_NAME),
       gateway: createNamedCollaboratorReducer(GATEWAY_SHARED_NAME),
       gateways: createNamedCollaboratorsReducer(GATEWAY_SHARED_NAME),
+      organization: createNamedCollaboratorReducer(ORGANIZATION_SHARED_NAME),
       organizations: createNamedCollaboratorsReducer(ORGANIZATION_SHARED_NAME),
     }),
     events: combineReducers({

--- a/pkg/webui/console/store/reducers/index.js
+++ b/pkg/webui/console/store/reducers/index.js
@@ -87,6 +87,7 @@ export default history =>
       applications: createNamedCollaboratorsReducer(APPLICATION_SHARED_NAME),
       gateway: createNamedCollaboratorReducer(GATEWAY_SHARED_NAME),
       gateways: createNamedCollaboratorsReducer(GATEWAY_SHARED_NAME),
+      organizations: createNamedCollaboratorsReducer(ORGANIZATION_SHARED_NAME),
     }),
     events: combineReducers({
       applications: createNamedEventsReducer(APPLICATION_SHARED_NAME),

--- a/pkg/webui/console/store/selectors/organizations.js
+++ b/pkg/webui/console/store/selectors/organizations.js
@@ -17,6 +17,7 @@ import {
   GET_ORG_BASE,
   GET_ORGS_RIGHTS_LIST_BASE,
   GET_ORG_API_KEY_BASE,
+  GET_ORG_COLLABORATOR_BASE,
 } from '../actions/organizations'
 import {
   createPaginationIdsSelectorByEntity,
@@ -31,6 +32,10 @@ import { createFetchingSelector } from './fetching'
 import { createErrorSelector } from './error'
 import { createRightsSelector, createPseudoRightsSelector } from './rights'
 import { createApiKeySelector } from './api-key'
+import {
+  createUserCollaboratorSelector,
+  createOrganizationCollaboratorSelector,
+} from './collaborators'
 
 const ENTITY = 'organizations'
 const ENTITY_SINGLE = 'organization'
@@ -73,3 +78,13 @@ export const selectOrganizationApiKeyError = createErrorSelector(GET_ORG_API_KEY
 export const selectOrganizationEvents = createEventsSelector(ENTITY)
 export const selectOrganizationEventsError = createEventsErrorSelector(ENTITY)
 export const selectOrganizationEventsStatus = createEventsStatusSelector(ENTITY)
+
+// Collaborators
+export const selectOrganizationUserCollaborator = createUserCollaboratorSelector(ENTITY_SINGLE)
+export const selectOrganizationOrganizationCollaborator = createOrganizationCollaboratorSelector(
+  ENTITY_SINGLE,
+)
+export const selectOrganizationCollaboratorFetching = createFetchingSelector(
+  GET_ORG_COLLABORATOR_BASE,
+)
+export const selectOrganizationCollaboratorError = createErrorSelector(GET_ORG_COLLABORATOR_BASE)

--- a/pkg/webui/console/views/organization-collaborator-add/connect.js
+++ b/pkg/webui/console/views/organization-collaborator-add/connect.js
@@ -1,0 +1,59 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { connect } from 'react-redux'
+import { push } from 'connected-react-router'
+
+import withRequest from '../../../lib/components/with-request'
+
+import {
+  selectSelectedOrganizationId,
+  selectOrganizationRights,
+  selectOrganizationPseudoRights,
+  selectOrganizationRightsFetching,
+  selectOrganizationRightsError,
+} from '../../store/selectors/organizations'
+import { getOrganizationsRightsList } from '../../store/actions/organizations'
+
+import api from '../../api'
+
+export default OrganizationCollaboratorAdd =>
+  connect(
+    state => ({
+      orgId: selectSelectedOrganizationId(state),
+      fetching: selectOrganizationRightsFetching(state),
+      error: selectOrganizationRightsError(state),
+      rights: selectOrganizationRights(state),
+      pseudoRights: selectOrganizationPseudoRights(state),
+    }),
+    dispatch => ({
+      getOrganizationsRightsList: orgId => dispatch(getOrganizationsRightsList(orgId)),
+      redirectToList: orgId => dispatch(push(`/organizations/${orgId}/collaborators`)),
+      addOrganizationCollaborator: api.organization.collaborators.add,
+    }),
+    (stateProps, dispatchProps, ownProps) => ({
+      ...stateProps,
+      ...dispatchProps,
+      ...ownProps,
+      getOrganizationsRightsList: () => dispatchProps.getOrganizationsRightsList(stateProps.orgId),
+      redirectToList: () => dispatchProps.redirectToList(stateProps.orgId),
+      addOrganizationCollaborator: collaborator =>
+        dispatchProps.addOrganizationCollaborator(stateProps.orgId, collaborator),
+    }),
+  )(
+    withRequest(
+      ({ getOrganizationsRightsList }) => getOrganizationsRightsList(),
+      ({ fetching, rights }) => fetching || !Boolean(rights.length),
+    )(OrganizationCollaboratorAdd),
+  )

--- a/pkg/webui/console/views/organization-collaborator-add/index.js
+++ b/pkg/webui/console/views/organization-collaborator-add/index.js
@@ -1,0 +1,20 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import connect from './connect'
+import OrganizationCollaboratorAdd from './organization-collaborator-add'
+
+const ConnectedOrganizationCollaboratorAdd = connect(OrganizationCollaboratorAdd)
+
+export { ConnectedOrganizationCollaboratorAdd as default, OrganizationCollaboratorAdd }

--- a/pkg/webui/console/views/organization-collaborator-add/organization-collaborator-add.js
+++ b/pkg/webui/console/views/organization-collaborator-add/organization-collaborator-add.js
@@ -1,0 +1,76 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import { Container, Col, Row } from 'react-grid-system'
+
+import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
+import { withBreadcrumb } from '../../../components/breadcrumbs/context'
+import CollaboratorForm from '../../components/collaborator-form'
+
+import sharedMessages from '../../../lib/shared-messages'
+import Message from '../../../lib/components/message'
+import IntlHelmet from '../../../lib/components/intl-helmet'
+import PropTypes from '../../../lib/prop-types'
+
+@withBreadcrumb('orgs.single.collaborators.add', props => {
+  const { orgId } = props
+
+  return (
+    <Breadcrumb
+      path={`/organizations/${orgId}/collaborators/add`}
+      icon="add"
+      content={sharedMessages.add}
+    />
+  )
+})
+class OrganizationCollaboratorAdd extends React.Component {
+  static propTypes = {
+    addOrganizationCollaborator: PropTypes.func.isRequired,
+    pseudoRights: PropTypes.rights,
+    redirectToList: PropTypes.func.isRequired,
+    rights: PropTypes.rights.isRequired,
+  }
+
+  static defaultProps = {
+    pseudoRights: [],
+  }
+
+  render() {
+    const { rights, redirectToList, pseudoRights, addOrganizationCollaborator } = this.props
+
+    return (
+      <Container>
+        <Row>
+          <Col>
+            <IntlHelmet title={sharedMessages.addCollaborator} />
+            <Message component="h2" content={sharedMessages.addCollaborator} />
+          </Col>
+        </Row>
+        <Row>
+          <Col lg={8} md={12}>
+            <CollaboratorForm
+              onSubmit={addOrganizationCollaborator}
+              onSubmitSuccess={redirectToList}
+              pseudoRights={pseudoRights}
+              rights={rights}
+            />
+          </Col>
+        </Row>
+      </Container>
+    )
+  }
+}
+
+export default OrganizationCollaboratorAdd

--- a/pkg/webui/console/views/organization-collaborator-edit/connect.js
+++ b/pkg/webui/console/views/organization-collaborator-edit/connect.js
@@ -1,0 +1,100 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { connect } from 'react-redux'
+import { replace } from 'connected-react-router'
+
+import withRequest from '../../../lib/components/with-request'
+
+import {
+  getOrganizationCollaborator,
+  getOrganizationsRightsList,
+} from '../../store/actions/organizations'
+import {
+  selectSelectedOrganizationId,
+  selectOrganizationRights,
+  selectOrganizationPseudoRights,
+  selectOrganizationRightsFetching,
+  selectOrganizationRightsError,
+  selectOrganizationUserCollaborator,
+  selectOrganizationOrganizationCollaborator,
+  selectOrganizationCollaboratorFetching,
+  selectOrganizationCollaboratorError,
+} from '../../store/selectors/organizations'
+
+import api from '../../api'
+
+export default OrganizationCollaboratorEdit =>
+  connect(
+    (state, props) => {
+      const orgId = selectSelectedOrganizationId(state, props)
+
+      const { collaboratorId, collaboratorType } = props.match.params
+
+      const collaborator =
+        collaboratorType === 'user'
+          ? selectOrganizationUserCollaborator(state)
+          : selectOrganizationOrganizationCollaborator(state)
+
+      const fetching =
+        selectOrganizationRightsFetching(state) || selectOrganizationCollaboratorFetching(state)
+      const error =
+        selectOrganizationRightsError(state) || selectOrganizationCollaboratorError(state)
+
+      return {
+        collaboratorId,
+        collaboratorType,
+        collaborator,
+        orgId,
+        rights: selectOrganizationRights(state),
+        pseudoRights: selectOrganizationPseudoRights(state),
+        fetching,
+        error,
+      }
+    },
+    dispatch => ({
+      loadData(orgId, collaboratorId, isUser) {
+        dispatch(getOrganizationsRightsList(orgId))
+        dispatch(getOrganizationCollaborator(orgId, collaboratorId, isUser))
+      },
+      redirectToList(orgId) {
+        dispatch(replace(`/organizations/${orgId}/collaborators`))
+      },
+      updateOrganizationCollaborator: (orgId, collaborator) =>
+        api.organization.collaborators.update(orgId, collaborator),
+      removeOrganizationCollaborator: (orgId, collaborator) =>
+        api.organization.collaborators.remove(orgId, collaborator),
+    }),
+    (stateProps, dispatchProps, ownProps) => ({
+      ...stateProps,
+      ...dispatchProps,
+      ...ownProps,
+      loadData: () =>
+        dispatchProps.loadData(
+          stateProps.orgId,
+          stateProps.collaboratorId,
+          stateProps.collaboratorType === 'user',
+        ),
+      redirectToList: () => dispatchProps.redirectToList(stateProps.orgId),
+      updateOrganizationCollaborator: collaborator =>
+        dispatchProps.updateOrganizationCollaborator(stateProps.orgId, collaborator),
+      removeOrganizationCollaborator: collaborator =>
+        dispatchProps.removeOrganizationCollaborator(stateProps.orgId, collaborator),
+    }),
+  )(
+    withRequest(
+      ({ loadData }) => loadData(),
+      ({ fetching, collaborator }) => fetching || !Boolean(collaborator),
+    )(OrganizationCollaboratorEdit),
+  )

--- a/pkg/webui/console/views/organization-collaborator-edit/index.js
+++ b/pkg/webui/console/views/organization-collaborator-edit/index.js
@@ -1,0 +1,20 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import connect from './connect'
+import OrganizationCollaboratorEdit from './organization-collaborator-edit'
+
+const ConnectedOrganizationCollaboratorEdit = connect(OrganizationCollaboratorEdit)
+
+export { ConnectedOrganizationCollaboratorEdit as default, OrganizationCollaboratorEdit }

--- a/pkg/webui/console/views/organization-collaborator-edit/organization-collaborator-edit.js
+++ b/pkg/webui/console/views/organization-collaborator-edit/organization-collaborator-edit.js
@@ -1,0 +1,104 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import { Container, Col, Row } from 'react-grid-system'
+
+import { withBreadcrumb } from '../../../components/breadcrumbs/context'
+import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
+import CollaboratorForm from '../../components/collaborator-form'
+import toast from '../../../components/toast'
+
+import sharedMessages from '../../../lib/shared-messages'
+import Message from '../../../lib/components/message'
+import IntlHelmet from '../../../lib/components/intl-helmet'
+import PropTypes from '../../../lib/prop-types'
+
+@withBreadcrumb('orgs.single.collaborators.edit', function(props) {
+  const { orgId, collaboratorId, collaboratorType } = props
+
+  return (
+    <Breadcrumb
+      path={`/organizations/${orgId}/collaborators/${collaboratorType}/${collaboratorId}`}
+      icon="general_settings"
+      content={sharedMessages.edit}
+    />
+  )
+})
+class OrganizationCollaboratorEdit extends React.Component {
+  static propTypes = {
+    collaborator: PropTypes.collaborator.isRequired,
+    pseudoRights: PropTypes.rights,
+    redirectToList: PropTypes.func.isRequired,
+    removeOrganizationCollaborator: PropTypes.func.isRequired,
+    rights: PropTypes.rights.isRequired,
+    updateOrganizationCollaborator: PropTypes.func.isRequired,
+  }
+
+  static defaultProps = {
+    pseudoRights: [],
+  }
+
+  handleSubmitSuccess() {
+    toast({
+      message: sharedMessages.collaboratorUpdateSuccess,
+      type: toast.types.SUCCESS,
+    })
+  }
+
+  render() {
+    const {
+      collaborator,
+      rights,
+      redirectToList,
+      pseudoRights,
+      updateOrganizationCollaborator,
+      removeOrganizationCollaborator,
+    } = this.props
+
+    return (
+      <Container>
+        <Row>
+          <Col>
+            <IntlHelmet
+              title={sharedMessages.collaboratorEdit}
+              values={{ collaboratorId: collaborator.id }}
+            />
+            <Message
+              component="h2"
+              content={sharedMessages.collaboratorEditRights}
+              values={{ collaboratorId: collaborator.id }}
+            />
+          </Col>
+        </Row>
+        <Row>
+          <Col lg={8} md={12}>
+            <CollaboratorForm
+              onSubmit={updateOrganizationCollaborator}
+              onSubmitSuccess={this.handleSubmitSuccess}
+              onDelete={removeOrganizationCollaborator}
+              onDeleteSuccess={redirectToList}
+              collaborator={collaborator}
+              pseudoRights={pseudoRights}
+              rights={rights}
+              update
+            />
+          </Col>
+        </Row>
+      </Container>
+    )
+  }
+}
+
+export default OrganizationCollaboratorEdit

--- a/pkg/webui/console/views/organization-collaborators-list/connect.js
+++ b/pkg/webui/console/views/organization-collaborators-list/connect.js
@@ -1,0 +1,36 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { connect } from 'react-redux'
+
+import { getOrganizationCollaboratorsList } from '../../store/actions/organizations'
+import { selectSelectedOrganizationId } from '../../store/selectors/organizations'
+
+export default OrganizationCollaboratorsList =>
+  connect(
+    state => ({
+      orgId: selectSelectedOrganizationId(state),
+    }),
+    dispatch => ({
+      getOrganizationCollaboratorsList: (id, filters) =>
+        dispatch(getOrganizationCollaboratorsList(id, filters)),
+    }),
+    (stateProps, dispatchProps, ownProps) => ({
+      ...stateProps,
+      ...dispatchProps,
+      ...ownProps,
+      getOrganizationCollaboratorsList: filters =>
+        dispatchProps.getOrganizationCollaboratorsList(stateProps.orgId, filters),
+    }),
+  )(OrganizationCollaboratorsList)

--- a/pkg/webui/console/views/organization-collaborators-list/index.js
+++ b/pkg/webui/console/views/organization-collaborators-list/index.js
@@ -1,0 +1,20 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import connect from './connect'
+import OrganizationCollaboratorsList from './organization-collaborators-list'
+
+const ConnectedOrganizationCollaboratorsList = connect(OrganizationCollaboratorsList)
+
+export { ConnectedOrganizationCollaboratorsList as default, OrganizationCollaboratorsList }

--- a/pkg/webui/console/views/organization-collaborators-list/organization-collaborators-list.js
+++ b/pkg/webui/console/views/organization-collaborators-list/organization-collaborators-list.js
@@ -1,0 +1,59 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import { Container, Row, Col } from 'react-grid-system'
+import bind from 'autobind-decorator'
+
+import CollaboratorsTable from '../../containers/collaborators-table'
+
+import IntlHelmet from '../../../lib/components/intl-helmet'
+import sharedMessages from '../../../lib/shared-messages'
+import PropTypes from '../../../lib/prop-types'
+
+import PAGE_SIZES from '../../constants/page-sizes'
+
+class OrganizationCollaboratorsList extends React.Component {
+  static propTypes = {
+    getOrganizationCollaboratorsList: PropTypes.func.isRequired,
+    orgId: PropTypes.string.isRequired,
+  }
+
+  @bind
+  baseDataSelector({ collaborators }) {
+    const { orgId } = this.props
+    return collaborators.organizations[orgId] || {}
+  }
+
+  render() {
+    const { getOrganizationCollaboratorsList } = this.props
+
+    return (
+      <Container>
+        <Row>
+          <IntlHelmet title={sharedMessages.collaborators} />
+          <Col>
+            <CollaboratorsTable
+              pageSize={PAGE_SIZES.REGULAR}
+              baseDataSelector={this.baseDataSelector}
+              getItemsAction={getOrganizationCollaboratorsList}
+            />
+          </Col>
+        </Row>
+      </Container>
+    )
+  }
+}
+
+export default OrganizationCollaboratorsList

--- a/pkg/webui/console/views/organization-collaborators/index.js
+++ b/pkg/webui/console/views/organization-collaborators/index.js
@@ -25,6 +25,7 @@ import PropTypes from '../../../lib/prop-types'
 
 import SubViewError from '../error/sub-view'
 import OrganizationCollaboratorsList from '../organization-collaborators-list'
+import OrganizationCollaboratorAdd from '../organization-collaborator-add'
 
 @withBreadcrumb('orgs.single.collaborators', function(props) {
   const { match } = props
@@ -50,6 +51,7 @@ class OrganizationCollaborators extends React.Component {
       <ErrorView ErrorComponent={SubViewError}>
         <Switch>
           <Route exact path={`${match.path}`} component={OrganizationCollaboratorsList} />
+          <Route exact path={`${match.path}/add`} component={OrganizationCollaboratorAdd} />
           <NotFoundRoute />
         </Switch>
       </ErrorView>

--- a/pkg/webui/console/views/organization-collaborators/index.js
+++ b/pkg/webui/console/views/organization-collaborators/index.js
@@ -1,0 +1,60 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import { Switch, Route } from 'react-router'
+
+import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
+import { withBreadcrumb } from '../../../components/breadcrumbs/context'
+
+import sharedMessages from '../../../lib/shared-messages'
+import ErrorView from '../../../lib/components/error-view'
+import NotFoundRoute from '../../../lib/components/not-found-route'
+import PropTypes from '../../../lib/prop-types'
+
+import SubViewError from '../error/sub-view'
+import OrganizationCollaboratorsList from '../organization-collaborators-list'
+
+@withBreadcrumb('orgs.single.collaborators', function(props) {
+  const { match } = props
+  const { orgId } = match.params
+
+  return (
+    <Breadcrumb
+      path={`/organizations/${orgId}/collaborators`}
+      icon="organization"
+      content={sharedMessages.collaborators}
+    />
+  )
+})
+class OrganizationCollaborators extends React.Component {
+  static propTypes = {
+    match: PropTypes.match.isRequired,
+  }
+
+  render() {
+    const { match } = this.props
+
+    return (
+      <ErrorView ErrorComponent={SubViewError}>
+        <Switch>
+          <Route exact path={`${match.path}`} component={OrganizationCollaboratorsList} />
+          <NotFoundRoute />
+        </Switch>
+      </ErrorView>
+    )
+  }
+}
+
+export default OrganizationCollaborators

--- a/pkg/webui/console/views/organization-collaborators/index.js
+++ b/pkg/webui/console/views/organization-collaborators/index.js
@@ -26,6 +26,7 @@ import PropTypes from '../../../lib/prop-types'
 import SubViewError from '../error/sub-view'
 import OrganizationCollaboratorsList from '../organization-collaborators-list'
 import OrganizationCollaboratorAdd from '../organization-collaborator-add'
+import OrganizationCollaboratorEdit from '../organization-collaborator-edit'
 
 @withBreadcrumb('orgs.single.collaborators', function(props) {
   const { match } = props
@@ -52,6 +53,10 @@ class OrganizationCollaborators extends React.Component {
         <Switch>
           <Route exact path={`${match.path}`} component={OrganizationCollaboratorsList} />
           <Route exact path={`${match.path}/add`} component={OrganizationCollaboratorAdd} />
+          <Route
+            path={`${match.path}/:collaboratorType(user|organization)/:collaboratorId`}
+            component={OrganizationCollaboratorEdit}
+          />
           <NotFoundRoute />
         </Switch>
       </ErrorView>

--- a/pkg/webui/console/views/organization/organization.js
+++ b/pkg/webui/console/views/organization/organization.js
@@ -29,6 +29,7 @@ import OrganizationOverview from '../organization-overview'
 import OrganizationData from '../organization-data'
 import OrganizationGeneralSettings from '../organization-general-settings'
 import OrganizationApiKeys from '../organization-api-keys'
+import OrganizationCollaborators from '../organization-collaborators'
 
 @withEnv
 @withSideNavigation(function(props) {
@@ -51,6 +52,12 @@ import OrganizationApiKeys from '../organization-api-keys'
         title: sharedMessages.apiKeys,
         path: `${matchedUrl}/api-keys`,
         icon: 'api_keys',
+        exact: false,
+      },
+      {
+        title: sharedMessages.collaborators,
+        path: `${matchedUrl}/collaborators`,
+        icon: 'organization',
         exact: false,
       },
       {
@@ -91,6 +98,7 @@ class Organization extends React.Component {
           <Route path={`${match.path}/data`} component={OrganizationData} />
           <Route path={`${match.path}/general-settings`} component={OrganizationGeneralSettings} />
           <Route path={`${match.path}/api-keys`} component={OrganizationApiKeys} />
+          <Route path={`${match.path}/collaborators`} component={OrganizationCollaborators} />
           <NotFoundRoute />
         </Switch>
       </BreadcrumbView>

--- a/sdk/js/src/service/organizations.js
+++ b/sdk/js/src/service/organizations.js
@@ -14,6 +14,7 @@
 
 import Marshaler from '../util/marshaler'
 import ApiKeys from './api-keys'
+import Collaborators from './collaborators'
 
 class Organizations {
   constructor(api) {
@@ -25,6 +26,13 @@ class Organizations {
         list: 'organization_ids.organization_id',
         create: 'organization_ids.organization_id',
         update: 'organization_ids.organization_id',
+      },
+    })
+    this.Collaborators = new Collaborators(api.OrganizationAccess, {
+      parentRoutes: {
+        get: 'organization_ids.organization_id',
+        list: 'organization_ids.organization_id',
+        set: 'organization_ids.organization_id',
       },
     })
   }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References Add support for organization api keys in console

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `OrganizationCollaboratorList` page
- Add `OrganizationCollaboratorAdd` page
- Add `OrganizationCollaboratorEdit` page
- Add necessary redux primitives
- Extend the Organization service in the js sdk
- Extend console api definitions
- Update `CHANGELOG.md`
