### PR TITLE
Adjust anchor location for navbar

### DIFF
--- a/doc/themes/the-things-stack/assets/css/theme.scss
+++ b/doc/themes/the-things-stack/assets/css/theme.scss
@@ -179,6 +179,12 @@ html.has-navbar-fixed-top {
   body {
     min-height: calc(100vh - #{$navbar-height});
   }
+  :target::before {
+    content: "";
+    display: block;
+    height: $navbar-height;
+    margin-top: -$navbar-height;
+  }
 }
 
 @import "highlight.scss";


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quickfix for the documentation site. It adjusts the position of anchors so that they compensate for the navbar in the top of our pages.

Refs https://stackoverflow.com/questions/4086107/fixed-page-header-overlaps-in-page-anchors
