### PR TITLE
Fix device template formats marshaling

### DIFF
--- a/sdk/js/src/service/devices/index.js
+++ b/sdk/js/src/service/devices/index.js
@@ -288,8 +288,9 @@ class Devices {
 
   async listTemplateFormats() {
     const result = await this._api.EndDeviceTemplateConverter.ListFormats()
+    const payload = Marshaler.payloadSingleResponse(result)
 
-    return Marshaler.payloadListResponse('formats', result)
+    return payload.formats
   }
 
   convertTemplate(formatId, data) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fix prop-types validation in `<DeviceDataForm />`

```
Warning: Failed prop type: Invalid prop `deviceTemplateFormats` of type `array` supplied to `DevicesTable`, expected `object`.
...
```

#### Changes
<!-- What are the changes made in this pull request? -->

- `Use payloadSingleResponse`
