### PR TITLE
Add onKeyDown listener for table rows

### DIFF
--- a/pkg/webui/components/table/row/index.js
+++ b/pkg/webui/components/table/row/index.js
@@ -27,6 +27,13 @@ class Row extends React.Component {
     onClick(id)
   }
 
+  onKeyDown(evt) {
+    const { id, onClick } = this.props
+    if (evt.key === 'Enter') {
+      onClick(id)
+    }
+  }
+
   get clickListener() {
     const { body, clickable } = this.props
 
@@ -52,7 +59,12 @@ class Row extends React.Component {
     })
 
     return (
-      <tr className={rowClassNames} onClick={this.clickListener} tabIndex={this.tabIndex}>
+      <tr
+        className={rowClassNames}
+        onKeyDown={this.onKeyDown}
+        onClick={this.clickListener}
+        tabIndex={this.tabIndex}
+      >
         {children}
       </tr>
     )


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #1464 

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `onKeyListener` such that the clickable rows can be clicked with `Enter` key after selecting it with `Tab`
