### PR TITLE
Update protoc image

### DIFF
--- a/.mage/proto.go
+++ b/.mage/proto.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	protocName    = "thethingsindustries/protoc"
-	protocVersion = "3.1.14-ttn"
+	protocVersion = "3.1.15-ttn"
 
 	protocOut = "/out"
 )

--- a/pkg/gatewayserver/io/grpc/grpc_test.go
+++ b/pkg/gatewayserver/io/grpc/grpc_test.go
@@ -226,6 +226,17 @@ func TestTraffic(t *testing.T) {
 								GatewayIdentifiers: registeredGatewayID,
 							},
 						},
+						Settings: ttnpb.TxSettings{
+							DataRate: ttnpb.DataRate{
+								Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
+									Bandwidth:       125000,
+									SpreadingFactor: 11,
+								}},
+							},
+							EnableCRC: true,
+							Frequency: 868500000,
+							Timestamp: 42,
+						},
 					},
 				},
 			},
@@ -237,6 +248,17 @@ func TestTraffic(t *testing.T) {
 							{
 								GatewayIdentifiers: registeredGatewayID,
 							},
+						},
+						Settings: ttnpb.TxSettings{
+							DataRate: ttnpb.DataRate{
+								Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
+									Bandwidth:       125000,
+									SpreadingFactor: 11,
+								}},
+							},
+							EnableCRC: true,
+							Frequency: 868500000,
+							Timestamp: 42,
 						},
 					},
 				},
@@ -253,6 +275,17 @@ func TestTraffic(t *testing.T) {
 								GatewayIdentifiers: registeredGatewayID,
 							},
 						},
+						Settings: ttnpb.TxSettings{
+							DataRate: ttnpb.DataRate{
+								Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
+									Bandwidth:       125000,
+									SpreadingFactor: 11,
+								}},
+							},
+							EnableCRC: true,
+							Frequency: 868500000,
+							Timestamp: 42,
+						},
 					},
 					{
 						RawPayload: []byte{0x04},
@@ -261,6 +294,17 @@ func TestTraffic(t *testing.T) {
 								GatewayIdentifiers: registeredGatewayID,
 							},
 						},
+						Settings: ttnpb.TxSettings{
+							DataRate: ttnpb.DataRate{
+								Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
+									Bandwidth:       125000,
+									SpreadingFactor: 11,
+								}},
+							},
+							EnableCRC: true,
+							Frequency: 868500000,
+							Timestamp: 42,
+						},
 					},
 					{
 						RawPayload: []byte{0x05},
@@ -268,6 +312,17 @@ func TestTraffic(t *testing.T) {
 							{
 								GatewayIdentifiers: registeredGatewayID,
 							},
+						},
+						Settings: ttnpb.TxSettings{
+							DataRate: ttnpb.DataRate{
+								Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
+									Bandwidth:       125000,
+									SpreadingFactor: 11,
+								}},
+							},
+							EnableCRC: true,
+							Frequency: 868500000,
+							Timestamp: 42,
 						},
 					},
 				},

--- a/pkg/networkserver/grpc_gsns_test.go
+++ b/pkg/networkserver/grpc_gsns_test.go
@@ -518,6 +518,7 @@ func TestHandleUplink(t *testing.T) {
 				makeMsg := func(_ bool) *ttnpb.UplinkMessage {
 					return &ttnpb.UplinkMessage{
 						RxMetadata: MakeRxMetadataSlice(),
+						Settings:   makeDataUplinkSettings(),
 					}
 				}
 
@@ -551,6 +552,7 @@ func TestHandleUplink(t *testing.T) {
 							0x03, 0x02, 0x01, 0x00,
 						},
 						RxMetadata: MakeRxMetadataSlice(),
+						Settings:   makeDataUplinkSettings(),
 					}
 				}
 
@@ -572,6 +574,7 @@ func TestHandleUplink(t *testing.T) {
 					return &ttnpb.UplinkMessage{
 						RawPayload: bytes.Repeat([]byte{0x20}, 33),
 						RxMetadata: MakeRxMetadataSlice(),
+						Settings:   makeDataUplinkSettings(),
 					}
 				}
 
@@ -596,6 +599,7 @@ func TestHandleUplink(t *testing.T) {
 							0b111_000_00,
 						},
 						RxMetadata: MakeRxMetadataSlice(),
+						Settings:   makeDataUplinkSettings(),
 					}
 				}
 

--- a/pkg/ttnpb/application.pb.go
+++ b/pkg/ttnpb/application.pb.go
@@ -4466,6 +4466,7 @@ func (m *SetApplicationCollaboratorRequest) Unmarshal(dAtA []byte) error {
 func skipApplication(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -4497,10 +4498,8 @@ func skipApplication(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -4521,55 +4520,30 @@ func skipApplication(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthApplication
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthApplication
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowApplication
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipApplication(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthApplication
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupApplication
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthApplication
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthApplication = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowApplication   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthApplication        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowApplication          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupApplication = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/applicationserver.pb.go
+++ b/pkg/ttnpb/applicationserver.pb.go
@@ -2334,6 +2334,7 @@ func (m *ApplicationLinkStats) Unmarshal(dAtA []byte) error {
 func skipApplicationserver(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -2365,10 +2366,8 @@ func skipApplicationserver(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -2389,55 +2388,30 @@ func skipApplicationserver(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthApplicationserver
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthApplicationserver
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowApplicationserver
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipApplicationserver(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthApplicationserver
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupApplicationserver
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthApplicationserver
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthApplicationserver = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowApplicationserver   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthApplicationserver        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowApplicationserver          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupApplicationserver = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/applicationserver_packages.pb.go
+++ b/pkg/ttnpb/applicationserver_packages.pb.go
@@ -2811,6 +2811,7 @@ func (m *SetApplicationPackageAssociationRequest) Unmarshal(dAtA []byte) error {
 func skipApplicationserverPackages(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -2842,10 +2843,8 @@ func skipApplicationserverPackages(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -2866,55 +2865,30 @@ func skipApplicationserverPackages(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthApplicationserverPackages
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthApplicationserverPackages
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowApplicationserverPackages
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipApplicationserverPackages(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthApplicationserverPackages
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupApplicationserverPackages
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthApplicationserverPackages
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthApplicationserverPackages = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowApplicationserverPackages   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthApplicationserverPackages        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowApplicationserverPackages          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupApplicationserverPackages = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/applicationserver_pubsub.pb.go
+++ b/pkg/ttnpb/applicationserver_pubsub.pb.go
@@ -182,10 +182,10 @@ type isApplicationPubSub_Provider interface {
 }
 
 type ApplicationPubSub_NATS struct {
-	NATS *ApplicationPubSub_NATSProvider `protobuf:"bytes,17,opt,name=nats,proto3,oneof"`
+	NATS *ApplicationPubSub_NATSProvider `protobuf:"bytes,17,opt,name=nats,proto3,oneof" json:"nats,omitempty"`
 }
 type ApplicationPubSub_MQTT struct {
-	MQTT *ApplicationPubSub_MQTTProvider `protobuf:"bytes,25,opt,name=mqtt,proto3,oneof"`
+	MQTT *ApplicationPubSub_MQTTProvider `protobuf:"bytes,25,opt,name=mqtt,proto3,oneof" json:"mqtt,omitempty"`
 }
 
 func (*ApplicationPubSub_NATS) isApplicationPubSub_Provider() {}
@@ -1756,7 +1756,8 @@ func (m *ApplicationPubSub) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *ApplicationPubSub_NATS) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ApplicationPubSub_NATS) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -1778,7 +1779,8 @@ func (m *ApplicationPubSub_NATS) MarshalToSizedBuffer(dAtA []byte) (int, error) 
 	return len(dAtA) - i, nil
 }
 func (m *ApplicationPubSub_MQTT) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ApplicationPubSub_MQTT) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -4747,6 +4749,7 @@ func (m *SetApplicationPubSubRequest) Unmarshal(dAtA []byte) error {
 func skipApplicationserverPubsub(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -4778,10 +4781,8 @@ func skipApplicationserverPubsub(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -4802,55 +4803,30 @@ func skipApplicationserverPubsub(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthApplicationserverPubsub
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthApplicationserverPubsub
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowApplicationserverPubsub
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipApplicationserverPubsub(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthApplicationserverPubsub
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupApplicationserverPubsub
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthApplicationserverPubsub
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthApplicationserverPubsub = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowApplicationserverPubsub   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthApplicationserverPubsub        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowApplicationserverPubsub          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupApplicationserverPubsub = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/applicationserver_pubsub.pb.validate.go
+++ b/pkg/ttnpb/applicationserver_pubsub.pb.validate.go
@@ -344,6 +344,12 @@ func (m *ApplicationPubSub) ValidateFields(paths ...string) error {
 			}
 
 		case "provider":
+			if m.Provider == nil {
+				return ApplicationPubSubValidationError{
+					field:  "provider",
+					reason: "value is required",
+				}
+			}
 			if len(subs) == 0 {
 				subs = []string{
 					"nats", "mqtt",
@@ -353,6 +359,10 @@ func (m *ApplicationPubSub) ValidateFields(paths ...string) error {
 				_ = subs
 				switch name {
 				case "nats":
+					w, ok := m.Provider.(*ApplicationPubSub_NATS)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetNATS()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -365,6 +375,10 @@ func (m *ApplicationPubSub) ValidateFields(paths ...string) error {
 					}
 
 				case "mqtt":
+					w, ok := m.Provider.(*ApplicationPubSub_MQTT)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetMQTT()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -376,11 +390,6 @@ func (m *ApplicationPubSub) ValidateFields(paths ...string) error {
 						}
 					}
 
-				default:
-					return ApplicationPubSubValidationError{
-						field:  "provider",
-						reason: "value is required",
-					}
 				}
 			}
 		default:

--- a/pkg/ttnpb/applicationserver_web.pb.go
+++ b/pkg/ttnpb/applicationserver_web.pb.go
@@ -6911,6 +6911,7 @@ func (m *ListApplicationWebhookTemplatesRequest) Unmarshal(dAtA []byte) error {
 func skipApplicationserverWeb(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -6942,10 +6943,8 @@ func skipApplicationserverWeb(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -6966,55 +6965,30 @@ func skipApplicationserverWeb(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthApplicationserverWeb
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthApplicationserverWeb
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowApplicationserverWeb
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipApplicationserverWeb(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthApplicationserverWeb
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupApplicationserverWeb
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthApplicationserverWeb
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthApplicationserverWeb = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowApplicationserverWeb   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthApplicationserverWeb        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowApplicationserverWeb          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupApplicationserverWeb = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/client.pb.go
+++ b/pkg/ttnpb/client.pb.go
@@ -3796,6 +3796,7 @@ func (m *SetClientCollaboratorRequest) Unmarshal(dAtA []byte) error {
 func skipClient(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -3827,10 +3828,8 @@ func skipClient(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -3851,55 +3850,30 @@ func skipClient(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthClient
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthClient
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowClient
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipClient(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthClient
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupClient
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthClient
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthClient = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowClient   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthClient        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowClient          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupClient = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/cluster.pb.go
+++ b/pkg/ttnpb/cluster.pb.go
@@ -729,6 +729,7 @@ func (m *PeerInfo) Unmarshal(dAtA []byte) error {
 func skipCluster(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -760,10 +761,8 @@ func skipCluster(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -784,55 +783,30 @@ func skipCluster(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthCluster
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthCluster
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowCluster
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipCluster(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthCluster
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupCluster
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthCluster
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthCluster = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowCluster   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthCluster        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowCluster          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupCluster = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/configuration_services.pb.go
+++ b/pkg/ttnpb/configuration_services.pb.go
@@ -1079,6 +1079,7 @@ func (m *ListFrequencyPlansResponse) Unmarshal(dAtA []byte) error {
 func skipConfigurationServices(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -1110,10 +1111,8 @@ func skipConfigurationServices(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -1134,55 +1133,30 @@ func skipConfigurationServices(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthConfigurationServices
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthConfigurationServices
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowConfigurationServices
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipConfigurationServices(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthConfigurationServices
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupConfigurationServices
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthConfigurationServices
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthConfigurationServices = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowConfigurationServices   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthConfigurationServices        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowConfigurationServices          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupConfigurationServices = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/contact_info.pb.go
+++ b/pkg/ttnpb/contact_info.pb.go
@@ -1363,6 +1363,7 @@ func (m *ContactInfoValidation) Unmarshal(dAtA []byte) error {
 func skipContactInfo(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -1394,10 +1395,8 @@ func skipContactInfo(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -1418,55 +1417,30 @@ func skipContactInfo(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthContactInfo
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthContactInfo
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowContactInfo
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipContactInfo(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthContactInfo
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupContactInfo
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthContactInfo
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthContactInfo = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowContactInfo   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthContactInfo        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowContactInfo          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupContactInfo = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/deviceclaimingserver.pb.go
+++ b/pkg/ttnpb/deviceclaimingserver.pb.go
@@ -108,10 +108,10 @@ type isClaimEndDeviceRequest_SourceDevice interface {
 }
 
 type ClaimEndDeviceRequest_AuthenticatedIdentifiers_ struct {
-	AuthenticatedIdentifiers *ClaimEndDeviceRequest_AuthenticatedIdentifiers `protobuf:"bytes,1,opt,name=authenticated_identifiers,json=authenticatedIdentifiers,proto3,oneof"`
+	AuthenticatedIdentifiers *ClaimEndDeviceRequest_AuthenticatedIdentifiers `protobuf:"bytes,1,opt,name=authenticated_identifiers,json=authenticatedIdentifiers,proto3,oneof" json:"authenticated_identifiers,omitempty"`
 }
 type ClaimEndDeviceRequest_QRCode struct {
-	QRCode []byte `protobuf:"bytes,2,opt,name=qr_code,json=qrCode,proto3,oneof"`
+	QRCode []byte `protobuf:"bytes,2,opt,name=qr_code,json=qrCode,proto3,oneof" json:"qr_code,omitempty"`
 }
 
 func (*ClaimEndDeviceRequest_AuthenticatedIdentifiers_) isClaimEndDeviceRequest_SourceDevice() {}
@@ -823,7 +823,8 @@ func (m *ClaimEndDeviceRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *ClaimEndDeviceRequest_AuthenticatedIdentifiers_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ClaimEndDeviceRequest_AuthenticatedIdentifiers_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -843,7 +844,8 @@ func (m *ClaimEndDeviceRequest_AuthenticatedIdentifiers_) MarshalToSizedBuffer(d
 	return len(dAtA) - i, nil
 }
 func (m *ClaimEndDeviceRequest_QRCode) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ClaimEndDeviceRequest_QRCode) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -1940,6 +1942,7 @@ func (m *AuthorizeApplicationRequest) Unmarshal(dAtA []byte) error {
 func skipDeviceclaimingserver(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -1971,10 +1974,8 @@ func skipDeviceclaimingserver(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -1995,55 +1996,30 @@ func skipDeviceclaimingserver(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthDeviceclaimingserver
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthDeviceclaimingserver
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowDeviceclaimingserver
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipDeviceclaimingserver(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthDeviceclaimingserver
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupDeviceclaimingserver
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthDeviceclaimingserver
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthDeviceclaimingserver = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowDeviceclaimingserver   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthDeviceclaimingserver        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowDeviceclaimingserver          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupDeviceclaimingserver = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/deviceclaimingserver.pb.validate.go
+++ b/pkg/ttnpb/deviceclaimingserver.pb.validate.go
@@ -128,6 +128,12 @@ func (m *ClaimEndDeviceRequest) ValidateFields(paths ...string) error {
 		case "invalidate_authentication_code":
 			// no validation rules for InvalidateAuthenticationCode
 		case "source_device":
+			if m.SourceDevice == nil {
+				return ClaimEndDeviceRequestValidationError{
+					field:  "source_device",
+					reason: "value is required",
+				}
+			}
 			if len(subs) == 0 {
 				subs = []string{
 					"authenticated_identifiers", "qr_code",
@@ -137,6 +143,10 @@ func (m *ClaimEndDeviceRequest) ValidateFields(paths ...string) error {
 				_ = subs
 				switch name {
 				case "authenticated_identifiers":
+					w, ok := m.SourceDevice.(*ClaimEndDeviceRequest_AuthenticatedIdentifiers_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetAuthenticatedIdentifiers()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -149,6 +159,10 @@ func (m *ClaimEndDeviceRequest) ValidateFields(paths ...string) error {
 					}
 
 				case "qr_code":
+					w, ok := m.SourceDevice.(*ClaimEndDeviceRequest_QRCode)
+					if !ok || w == nil {
+						continue
+					}
 
 					if l := len(m.GetQRCode()); l < 0 || l > 1024 {
 						return ClaimEndDeviceRequestValidationError{
@@ -157,11 +171,6 @@ func (m *ClaimEndDeviceRequest) ValidateFields(paths ...string) error {
 						}
 					}
 
-				default:
-					return ClaimEndDeviceRequestValidationError{
-						field:  "source_device",
-						reason: "value is required",
-					}
 				}
 			}
 		default:

--- a/pkg/ttnpb/end_device.pb.go
+++ b/pkg/ttnpb/end_device.pb.go
@@ -14484,6 +14484,7 @@ func (m *ConvertEndDeviceTemplateRequest) Unmarshal(dAtA []byte) error {
 func skipEndDevice(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -14515,10 +14516,8 @@ func skipEndDevice(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -14539,55 +14538,30 @@ func skipEndDevice(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthEndDevice
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthEndDevice
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowEndDevice
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipEndDevice(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthEndDevice
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupEndDevice
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthEndDevice
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthEndDevice = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowEndDevice   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthEndDevice        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowEndDevice          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupEndDevice = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/error.pb.go
+++ b/pkg/ttnpb/error.pb.go
@@ -826,6 +826,7 @@ func (m *ErrorDetails) Unmarshal(dAtA []byte) error {
 func skipError(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -857,10 +858,8 @@ func skipError(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -881,55 +880,30 @@ func skipError(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthError
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthError
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowError
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipError(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthError
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupError
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthError
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthError = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowError   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthError        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowError          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupError = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/events.pb.go
+++ b/pkg/ttnpb/events.pb.go
@@ -1486,6 +1486,7 @@ func (m *StreamEventsRequest) Unmarshal(dAtA []byte) error {
 func skipEvents(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -1517,10 +1518,8 @@ func skipEvents(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -1541,55 +1540,30 @@ func skipEvents(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthEvents
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthEvents
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowEvents
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipEvents(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthEvents
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupEvents
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthEvents
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthEvents = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowEvents   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthEvents        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowEvents          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupEvents = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/gateway.pb.go
+++ b/pkg/ttnpb/gateway.pb.go
@@ -9951,6 +9951,7 @@ func (m *GatewayConnectionStats_RoundTripTimes) Unmarshal(dAtA []byte) error {
 func skipGateway(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -9982,10 +9983,8 @@ func skipGateway(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -10006,55 +10005,30 @@ func skipGateway(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthGateway
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthGateway
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowGateway
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipGateway(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthGateway
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupGateway
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthGateway
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthGateway = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowGateway   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthGateway        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowGateway          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupGateway = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/gateway_services.pb.go
+++ b/pkg/ttnpb/gateway_services.pb.go
@@ -1196,6 +1196,7 @@ func (m *PullGatewayConfigurationRequest) Unmarshal(dAtA []byte) error {
 func skipGatewayServices(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -1227,10 +1228,8 @@ func skipGatewayServices(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -1251,55 +1250,30 @@ func skipGatewayServices(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthGatewayServices
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthGatewayServices
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowGatewayServices
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipGatewayServices(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthGatewayServices
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupGatewayServices
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthGatewayServices
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthGatewayServices = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowGatewayServices   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthGatewayServices        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowGatewayServices          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupGatewayServices = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/gatewayserver.pb.go
+++ b/pkg/ttnpb/gatewayserver.pb.go
@@ -1662,6 +1662,7 @@ func (m *ScheduleDownlinkErrorDetails) Unmarshal(dAtA []byte) error {
 func skipGatewayserver(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -1693,10 +1694,8 @@ func skipGatewayserver(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -1717,55 +1716,30 @@ func skipGatewayserver(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthGatewayserver
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthGatewayserver
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowGatewayserver
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipGatewayserver(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthGatewayserver
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupGatewayserver
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthGatewayserver
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthGatewayserver = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowGatewayserver   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthGatewayserver        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowGatewayserver          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupGatewayserver = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/identifiers.pb.go
+++ b/pkg/ttnpb/identifiers.pb.go
@@ -370,10 +370,10 @@ type isOrganizationOrUserIdentifiers_Ids interface {
 }
 
 type OrganizationOrUserIdentifiers_OrganizationIDs struct {
-	OrganizationIDs *OrganizationIdentifiers `protobuf:"bytes,1,opt,name=organization_ids,json=organizationIds,proto3,oneof"`
+	OrganizationIDs *OrganizationIdentifiers `protobuf:"bytes,1,opt,name=organization_ids,json=organizationIds,proto3,oneof" json:"organization_ids,omitempty"`
 }
 type OrganizationOrUserIdentifiers_UserIDs struct {
-	UserIDs *UserIdentifiers `protobuf:"bytes,2,opt,name=user_ids,json=userIds,proto3,oneof"`
+	UserIDs *UserIdentifiers `protobuf:"bytes,2,opt,name=user_ids,json=userIds,proto3,oneof" json:"user_ids,omitempty"`
 }
 
 func (*OrganizationOrUserIdentifiers_OrganizationIDs) isOrganizationOrUserIdentifiers_Ids() {}
@@ -462,22 +462,22 @@ type isEntityIdentifiers_Ids interface {
 }
 
 type EntityIdentifiers_ApplicationIDs struct {
-	ApplicationIDs *ApplicationIdentifiers `protobuf:"bytes,1,opt,name=application_ids,json=applicationIds,proto3,oneof"`
+	ApplicationIDs *ApplicationIdentifiers `protobuf:"bytes,1,opt,name=application_ids,json=applicationIds,proto3,oneof" json:"application_ids,omitempty"`
 }
 type EntityIdentifiers_ClientIDs struct {
-	ClientIDs *ClientIdentifiers `protobuf:"bytes,2,opt,name=client_ids,json=clientIds,proto3,oneof"`
+	ClientIDs *ClientIdentifiers `protobuf:"bytes,2,opt,name=client_ids,json=clientIds,proto3,oneof" json:"client_ids,omitempty"`
 }
 type EntityIdentifiers_DeviceIDs struct {
-	DeviceIDs *EndDeviceIdentifiers `protobuf:"bytes,3,opt,name=device_ids,json=deviceIds,proto3,oneof"`
+	DeviceIDs *EndDeviceIdentifiers `protobuf:"bytes,3,opt,name=device_ids,json=deviceIds,proto3,oneof" json:"device_ids,omitempty"`
 }
 type EntityIdentifiers_GatewayIDs struct {
-	GatewayIDs *GatewayIdentifiers `protobuf:"bytes,4,opt,name=gateway_ids,json=gatewayIds,proto3,oneof"`
+	GatewayIDs *GatewayIdentifiers `protobuf:"bytes,4,opt,name=gateway_ids,json=gatewayIds,proto3,oneof" json:"gateway_ids,omitempty"`
 }
 type EntityIdentifiers_OrganizationIDs struct {
-	OrganizationIDs *OrganizationIdentifiers `protobuf:"bytes,5,opt,name=organization_ids,json=organizationIds,proto3,oneof"`
+	OrganizationIDs *OrganizationIdentifiers `protobuf:"bytes,5,opt,name=organization_ids,json=organizationIds,proto3,oneof" json:"organization_ids,omitempty"`
 }
 type EntityIdentifiers_UserIDs struct {
-	UserIDs *UserIdentifiers `protobuf:"bytes,6,opt,name=user_ids,json=userIds,proto3,oneof"`
+	UserIDs *UserIdentifiers `protobuf:"bytes,6,opt,name=user_ids,json=userIds,proto3,oneof" json:"user_ids,omitempty"`
 }
 
 func (*EntityIdentifiers_ApplicationIDs) isEntityIdentifiers_Ids()  {}
@@ -1424,7 +1424,8 @@ func (m *OrganizationOrUserIdentifiers) MarshalToSizedBuffer(dAtA []byte) (int, 
 }
 
 func (m *OrganizationOrUserIdentifiers_OrganizationIDs) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *OrganizationOrUserIdentifiers_OrganizationIDs) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -1444,7 +1445,8 @@ func (m *OrganizationOrUserIdentifiers_OrganizationIDs) MarshalToSizedBuffer(dAt
 	return len(dAtA) - i, nil
 }
 func (m *OrganizationOrUserIdentifiers_UserIDs) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *OrganizationOrUserIdentifiers_UserIDs) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -1496,7 +1498,8 @@ func (m *EntityIdentifiers) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *EntityIdentifiers_ApplicationIDs) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *EntityIdentifiers_ApplicationIDs) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -1516,7 +1519,8 @@ func (m *EntityIdentifiers_ApplicationIDs) MarshalToSizedBuffer(dAtA []byte) (in
 	return len(dAtA) - i, nil
 }
 func (m *EntityIdentifiers_ClientIDs) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *EntityIdentifiers_ClientIDs) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -1536,7 +1540,8 @@ func (m *EntityIdentifiers_ClientIDs) MarshalToSizedBuffer(dAtA []byte) (int, er
 	return len(dAtA) - i, nil
 }
 func (m *EntityIdentifiers_DeviceIDs) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *EntityIdentifiers_DeviceIDs) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -1556,7 +1561,8 @@ func (m *EntityIdentifiers_DeviceIDs) MarshalToSizedBuffer(dAtA []byte) (int, er
 	return len(dAtA) - i, nil
 }
 func (m *EntityIdentifiers_GatewayIDs) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *EntityIdentifiers_GatewayIDs) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -1576,7 +1582,8 @@ func (m *EntityIdentifiers_GatewayIDs) MarshalToSizedBuffer(dAtA []byte) (int, e
 	return len(dAtA) - i, nil
 }
 func (m *EntityIdentifiers_OrganizationIDs) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *EntityIdentifiers_OrganizationIDs) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -1596,7 +1603,8 @@ func (m *EntityIdentifiers_OrganizationIDs) MarshalToSizedBuffer(dAtA []byte) (i
 	return len(dAtA) - i, nil
 }
 func (m *EntityIdentifiers_UserIDs) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *EntityIdentifiers_UserIDs) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -3446,6 +3454,7 @@ func (m *CombinedIdentifiers) Unmarshal(dAtA []byte) error {
 func skipIdentifiers(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -3477,10 +3486,8 @@ func skipIdentifiers(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -3501,55 +3508,30 @@ func skipIdentifiers(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthIdentifiers
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthIdentifiers
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowIdentifiers
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipIdentifiers(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthIdentifiers
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupIdentifiers
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthIdentifiers
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthIdentifiers = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowIdentifiers   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthIdentifiers        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowIdentifiers          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupIdentifiers = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/identifiers.pb.validate.go
+++ b/pkg/ttnpb/identifiers.pb.validate.go
@@ -674,6 +674,10 @@ func (m *OrganizationOrUserIdentifiers) ValidateFields(paths ...string) error {
 				_ = subs
 				switch name {
 				case "organization_ids":
+					w, ok := m.Ids.(*OrganizationOrUserIdentifiers_OrganizationIDs)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetOrganizationIDs()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -686,6 +690,10 @@ func (m *OrganizationOrUserIdentifiers) ValidateFields(paths ...string) error {
 					}
 
 				case "user_ids":
+					w, ok := m.Ids.(*OrganizationOrUserIdentifiers_UserIDs)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetUserIDs()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -791,6 +799,10 @@ func (m *EntityIdentifiers) ValidateFields(paths ...string) error {
 				_ = subs
 				switch name {
 				case "application_ids":
+					w, ok := m.Ids.(*EntityIdentifiers_ApplicationIDs)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetApplicationIDs()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -803,6 +815,10 @@ func (m *EntityIdentifiers) ValidateFields(paths ...string) error {
 					}
 
 				case "client_ids":
+					w, ok := m.Ids.(*EntityIdentifiers_ClientIDs)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetClientIDs()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -815,6 +831,10 @@ func (m *EntityIdentifiers) ValidateFields(paths ...string) error {
 					}
 
 				case "device_ids":
+					w, ok := m.Ids.(*EntityIdentifiers_DeviceIDs)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetDeviceIDs()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -827,6 +847,10 @@ func (m *EntityIdentifiers) ValidateFields(paths ...string) error {
 					}
 
 				case "gateway_ids":
+					w, ok := m.Ids.(*EntityIdentifiers_GatewayIDs)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetGatewayIDs()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -839,6 +863,10 @@ func (m *EntityIdentifiers) ValidateFields(paths ...string) error {
 					}
 
 				case "organization_ids":
+					w, ok := m.Ids.(*EntityIdentifiers_OrganizationIDs)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetOrganizationIDs()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -851,6 +879,10 @@ func (m *EntityIdentifiers) ValidateFields(paths ...string) error {
 					}
 
 				case "user_ids":
+					w, ok := m.Ids.(*EntityIdentifiers_UserIDs)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetUserIDs()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {

--- a/pkg/ttnpb/identityserver.pb.go
+++ b/pkg/ttnpb/identityserver.pb.go
@@ -86,10 +86,10 @@ type isAuthInfoResponse_AccessMethod interface {
 }
 
 type AuthInfoResponse_APIKey struct {
-	APIKey *AuthInfoResponse_APIKeyAccess `protobuf:"bytes,1,opt,name=api_key,json=apiKey,proto3,oneof"`
+	APIKey *AuthInfoResponse_APIKeyAccess `protobuf:"bytes,1,opt,name=api_key,json=apiKey,proto3,oneof" json:"api_key,omitempty"`
 }
 type AuthInfoResponse_OAuthAccessToken struct {
-	OAuthAccessToken *OAuthAccessToken `protobuf:"bytes,2,opt,name=oauth_access_token,json=oauthAccessToken,proto3,oneof"`
+	OAuthAccessToken *OAuthAccessToken `protobuf:"bytes,2,opt,name=oauth_access_token,json=oauthAccessToken,proto3,oneof" json:"oauth_access_token,omitempty"`
 }
 
 func (*AuthInfoResponse_APIKey) isAuthInfoResponse_AccessMethod()           {}
@@ -492,7 +492,8 @@ func (m *AuthInfoResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *AuthInfoResponse_APIKey) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *AuthInfoResponse_APIKey) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -512,7 +513,8 @@ func (m *AuthInfoResponse_APIKey) MarshalToSizedBuffer(dAtA []byte) (int, error)
 	return len(dAtA) - i, nil
 }
 func (m *AuthInfoResponse_OAuthAccessToken) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *AuthInfoResponse_OAuthAccessToken) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -1110,6 +1112,7 @@ func (m *AuthInfoResponse_APIKeyAccess) Unmarshal(dAtA []byte) error {
 func skipIdentityserver(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -1141,10 +1144,8 @@ func skipIdentityserver(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -1165,55 +1166,30 @@ func skipIdentityserver(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthIdentityserver
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthIdentityserver
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowIdentityserver
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipIdentityserver(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthIdentityserver
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupIdentityserver
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthIdentityserver
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthIdentityserver = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowIdentityserver   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthIdentityserver        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowIdentityserver          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupIdentityserver = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/identityserver.pb.validate.go
+++ b/pkg/ttnpb/identityserver.pb.validate.go
@@ -74,6 +74,10 @@ func (m *AuthInfoResponse) ValidateFields(paths ...string) error {
 				_ = subs
 				switch name {
 				case "api_key":
+					w, ok := m.AccessMethod.(*AuthInfoResponse_APIKey)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetAPIKey()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -86,6 +90,10 @@ func (m *AuthInfoResponse) ValidateFields(paths ...string) error {
 					}
 
 				case "oauth_access_token":
+					w, ok := m.AccessMethod.(*AuthInfoResponse_OAuthAccessToken)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetOAuthAccessToken()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {

--- a/pkg/ttnpb/join.pb.go
+++ b/pkg/ttnpb/join.pb.go
@@ -1237,6 +1237,7 @@ func (m *JoinResponse) Unmarshal(dAtA []byte) error {
 func skipJoin(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -1268,10 +1269,8 @@ func skipJoin(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -1292,55 +1291,30 @@ func skipJoin(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthJoin
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthJoin
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowJoin
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipJoin(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthJoin
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupJoin
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthJoin
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthJoin = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowJoin   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthJoin        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowJoin          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupJoin = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/joinserver.pb.go
+++ b/pkg/ttnpb/joinserver.pb.go
@@ -534,13 +534,13 @@ type isProvisionEndDevicesRequest_EndDevices interface {
 }
 
 type ProvisionEndDevicesRequest_List struct {
-	List *ProvisionEndDevicesRequest_IdentifiersList `protobuf:"bytes,4,opt,name=list,proto3,oneof"`
+	List *ProvisionEndDevicesRequest_IdentifiersList `protobuf:"bytes,4,opt,name=list,proto3,oneof" json:"list,omitempty"`
 }
 type ProvisionEndDevicesRequest_Range struct {
-	Range *ProvisionEndDevicesRequest_IdentifiersRange `protobuf:"bytes,5,opt,name=range,proto3,oneof"`
+	Range *ProvisionEndDevicesRequest_IdentifiersRange `protobuf:"bytes,5,opt,name=range,proto3,oneof" json:"range,omitempty"`
 }
 type ProvisionEndDevicesRequest_FromData struct {
-	FromData *ProvisionEndDevicesRequest_IdentifiersFromData `protobuf:"bytes,6,opt,name=from_data,json=fromData,proto3,oneof"`
+	FromData *ProvisionEndDevicesRequest_IdentifiersFromData `protobuf:"bytes,6,opt,name=from_data,json=fromData,proto3,oneof" json:"from_data,omitempty"`
 }
 
 func (*ProvisionEndDevicesRequest_List) isProvisionEndDevicesRequest_EndDevices()     {}
@@ -2804,7 +2804,8 @@ func (m *ProvisionEndDevicesRequest) MarshalToSizedBuffer(dAtA []byte) (int, err
 }
 
 func (m *ProvisionEndDevicesRequest_List) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ProvisionEndDevicesRequest_List) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -2824,7 +2825,8 @@ func (m *ProvisionEndDevicesRequest_List) MarshalToSizedBuffer(dAtA []byte) (int
 	return len(dAtA) - i, nil
 }
 func (m *ProvisionEndDevicesRequest_Range) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ProvisionEndDevicesRequest_Range) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -2844,7 +2846,8 @@ func (m *ProvisionEndDevicesRequest_Range) MarshalToSizedBuffer(dAtA []byte) (in
 	return len(dAtA) - i, nil
 }
 func (m *ProvisionEndDevicesRequest_FromData) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ProvisionEndDevicesRequest_FromData) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -5891,6 +5894,7 @@ func (m *JoinEUIPrefixes) Unmarshal(dAtA []byte) error {
 func skipJoinserver(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -5922,10 +5926,8 @@ func skipJoinserver(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -5946,55 +5948,30 @@ func skipJoinserver(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthJoinserver
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthJoinserver
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowJoinserver
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipJoinserver(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthJoinserver
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupJoinserver
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthJoinserver
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthJoinserver = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowJoinserver   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthJoinserver        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowJoinserver          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupJoinserver = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/joinserver.pb.validate.go
+++ b/pkg/ttnpb/joinserver.pb.validate.go
@@ -975,6 +975,10 @@ func (m *ProvisionEndDevicesRequest) ValidateFields(paths ...string) error {
 				_ = subs
 				switch name {
 				case "list":
+					w, ok := m.EndDevices.(*ProvisionEndDevicesRequest_List)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetList()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -987,6 +991,10 @@ func (m *ProvisionEndDevicesRequest) ValidateFields(paths ...string) error {
 					}
 
 				case "range":
+					w, ok := m.EndDevices.(*ProvisionEndDevicesRequest_Range)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetRange()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -999,6 +1007,10 @@ func (m *ProvisionEndDevicesRequest) ValidateFields(paths ...string) error {
 					}
 
 				case "from_data":
+					w, ok := m.EndDevices.(*ProvisionEndDevicesRequest_FromData)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetFromData()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {

--- a/pkg/ttnpb/keys.pb.go
+++ b/pkg/ttnpb/keys.pb.go
@@ -1358,6 +1358,7 @@ func (m *SessionKeys) Unmarshal(dAtA []byte) error {
 func skipKeys(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -1389,10 +1390,8 @@ func skipKeys(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -1413,55 +1412,30 @@ func skipKeys(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthKeys
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthKeys
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowKeys
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipKeys(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthKeys
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupKeys
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthKeys
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthKeys = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowKeys   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthKeys        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowKeys          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupKeys = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/lorawan.pb.go
+++ b/pkg/ttnpb/lorawan.pb.go
@@ -1053,16 +1053,16 @@ type isMessage_Payload interface {
 }
 
 type Message_MACPayload struct {
-	MACPayload *MACPayload `protobuf:"bytes,3,opt,name=mac_payload,json=macPayload,proto3,oneof"`
+	MACPayload *MACPayload `protobuf:"bytes,3,opt,name=mac_payload,json=macPayload,proto3,oneof" json:"mac_payload,omitempty"`
 }
 type Message_JoinRequestPayload struct {
-	JoinRequestPayload *JoinRequestPayload `protobuf:"bytes,4,opt,name=join_request_payload,json=joinRequestPayload,proto3,oneof"`
+	JoinRequestPayload *JoinRequestPayload `protobuf:"bytes,4,opt,name=join_request_payload,json=joinRequestPayload,proto3,oneof" json:"join_request_payload,omitempty"`
 }
 type Message_JoinAcceptPayload struct {
-	JoinAcceptPayload *JoinAcceptPayload `protobuf:"bytes,5,opt,name=join_accept_payload,json=joinAcceptPayload,proto3,oneof"`
+	JoinAcceptPayload *JoinAcceptPayload `protobuf:"bytes,5,opt,name=join_accept_payload,json=joinAcceptPayload,proto3,oneof" json:"join_accept_payload,omitempty"`
 }
 type Message_RejoinRequestPayload struct {
-	RejoinRequestPayload *RejoinRequestPayload `protobuf:"bytes,6,opt,name=rejoin_request_payload,json=rejoinRequestPayload,proto3,oneof"`
+	RejoinRequestPayload *RejoinRequestPayload `protobuf:"bytes,6,opt,name=rejoin_request_payload,json=rejoinRequestPayload,proto3,oneof" json:"rejoin_request_payload,omitempty"`
 }
 
 func (*Message_MACPayload) isMessage_Payload()           {}
@@ -1808,10 +1808,10 @@ type isDataRate_Modulation interface {
 }
 
 type DataRate_LoRa struct {
-	LoRa *LoRaDataRate `protobuf:"bytes,1,opt,name=lora,proto3,oneof"`
+	LoRa *LoRaDataRate `protobuf:"bytes,1,opt,name=lora,proto3,oneof" json:"lora,omitempty"`
 }
 type DataRate_FSK struct {
-	FSK *FSKDataRate `protobuf:"bytes,2,opt,name=fsk,proto3,oneof"`
+	FSK *FSKDataRate `protobuf:"bytes,2,opt,name=fsk,proto3,oneof" json:"fsk,omitempty"`
 }
 
 func (*DataRate_LoRa) isDataRate_Modulation() {}
@@ -2169,10 +2169,10 @@ type isDownlinkPath_Path interface {
 }
 
 type DownlinkPath_UplinkToken struct {
-	UplinkToken []byte `protobuf:"bytes,1,opt,name=uplink_token,json=uplinkToken,proto3,oneof"`
+	UplinkToken []byte `protobuf:"bytes,1,opt,name=uplink_token,json=uplinkToken,proto3,oneof" json:"uplink_token,omitempty"`
 }
 type DownlinkPath_Fixed struct {
-	Fixed *GatewayAntennaIdentifiers `protobuf:"bytes,2,opt,name=fixed,proto3,oneof"`
+	Fixed *GatewayAntennaIdentifiers `protobuf:"bytes,2,opt,name=fixed,proto3,oneof" json:"fixed,omitempty"`
 }
 
 func (*DownlinkPath_UplinkToken) isDownlinkPath_Path() {}
@@ -2425,97 +2425,97 @@ type isMACCommand_Payload interface {
 }
 
 type MACCommand_RawPayload struct {
-	RawPayload []byte `protobuf:"bytes,2,opt,name=raw_payload,json=rawPayload,proto3,oneof"`
+	RawPayload []byte `protobuf:"bytes,2,opt,name=raw_payload,json=rawPayload,proto3,oneof" json:"raw_payload,omitempty"`
 }
 type MACCommand_ResetInd_ struct {
-	ResetInd *MACCommand_ResetInd `protobuf:"bytes,3,opt,name=reset_ind,json=resetInd,proto3,oneof"`
+	ResetInd *MACCommand_ResetInd `protobuf:"bytes,3,opt,name=reset_ind,json=resetInd,proto3,oneof" json:"reset_ind,omitempty"`
 }
 type MACCommand_ResetConf_ struct {
-	ResetConf *MACCommand_ResetConf `protobuf:"bytes,4,opt,name=reset_conf,json=resetConf,proto3,oneof"`
+	ResetConf *MACCommand_ResetConf `protobuf:"bytes,4,opt,name=reset_conf,json=resetConf,proto3,oneof" json:"reset_conf,omitempty"`
 }
 type MACCommand_LinkCheckAns_ struct {
-	LinkCheckAns *MACCommand_LinkCheckAns `protobuf:"bytes,5,opt,name=link_check_ans,json=linkCheckAns,proto3,oneof"`
+	LinkCheckAns *MACCommand_LinkCheckAns `protobuf:"bytes,5,opt,name=link_check_ans,json=linkCheckAns,proto3,oneof" json:"link_check_ans,omitempty"`
 }
 type MACCommand_LinkADRReq_ struct {
-	LinkADRReq *MACCommand_LinkADRReq `protobuf:"bytes,6,opt,name=link_adr_req,json=linkAdrReq,proto3,oneof"`
+	LinkADRReq *MACCommand_LinkADRReq `protobuf:"bytes,6,opt,name=link_adr_req,json=linkAdrReq,proto3,oneof" json:"link_adr_req,omitempty"`
 }
 type MACCommand_LinkADRAns_ struct {
-	LinkADRAns *MACCommand_LinkADRAns `protobuf:"bytes,7,opt,name=link_adr_ans,json=linkAdrAns,proto3,oneof"`
+	LinkADRAns *MACCommand_LinkADRAns `protobuf:"bytes,7,opt,name=link_adr_ans,json=linkAdrAns,proto3,oneof" json:"link_adr_ans,omitempty"`
 }
 type MACCommand_DutyCycleReq_ struct {
-	DutyCycleReq *MACCommand_DutyCycleReq `protobuf:"bytes,8,opt,name=duty_cycle_req,json=dutyCycleReq,proto3,oneof"`
+	DutyCycleReq *MACCommand_DutyCycleReq `protobuf:"bytes,8,opt,name=duty_cycle_req,json=dutyCycleReq,proto3,oneof" json:"duty_cycle_req,omitempty"`
 }
 type MACCommand_RxParamSetupReq_ struct {
-	RxParamSetupReq *MACCommand_RxParamSetupReq `protobuf:"bytes,9,opt,name=rx_param_setup_req,json=rxParamSetupReq,proto3,oneof"`
+	RxParamSetupReq *MACCommand_RxParamSetupReq `protobuf:"bytes,9,opt,name=rx_param_setup_req,json=rxParamSetupReq,proto3,oneof" json:"rx_param_setup_req,omitempty"`
 }
 type MACCommand_RxParamSetupAns_ struct {
-	RxParamSetupAns *MACCommand_RxParamSetupAns `protobuf:"bytes,10,opt,name=rx_param_setup_ans,json=rxParamSetupAns,proto3,oneof"`
+	RxParamSetupAns *MACCommand_RxParamSetupAns `protobuf:"bytes,10,opt,name=rx_param_setup_ans,json=rxParamSetupAns,proto3,oneof" json:"rx_param_setup_ans,omitempty"`
 }
 type MACCommand_DevStatusAns_ struct {
-	DevStatusAns *MACCommand_DevStatusAns `protobuf:"bytes,11,opt,name=dev_status_ans,json=devStatusAns,proto3,oneof"`
+	DevStatusAns *MACCommand_DevStatusAns `protobuf:"bytes,11,opt,name=dev_status_ans,json=devStatusAns,proto3,oneof" json:"dev_status_ans,omitempty"`
 }
 type MACCommand_NewChannelReq_ struct {
-	NewChannelReq *MACCommand_NewChannelReq `protobuf:"bytes,12,opt,name=new_channel_req,json=newChannelReq,proto3,oneof"`
+	NewChannelReq *MACCommand_NewChannelReq `protobuf:"bytes,12,opt,name=new_channel_req,json=newChannelReq,proto3,oneof" json:"new_channel_req,omitempty"`
 }
 type MACCommand_NewChannelAns_ struct {
-	NewChannelAns *MACCommand_NewChannelAns `protobuf:"bytes,13,opt,name=new_channel_ans,json=newChannelAns,proto3,oneof"`
+	NewChannelAns *MACCommand_NewChannelAns `protobuf:"bytes,13,opt,name=new_channel_ans,json=newChannelAns,proto3,oneof" json:"new_channel_ans,omitempty"`
 }
 type MACCommand_DLChannelReq_ struct {
-	DLChannelReq *MACCommand_DLChannelReq `protobuf:"bytes,14,opt,name=dl_channel_req,json=dlChannelReq,proto3,oneof"`
+	DLChannelReq *MACCommand_DLChannelReq `protobuf:"bytes,14,opt,name=dl_channel_req,json=dlChannelReq,proto3,oneof" json:"dl_channel_req,omitempty"`
 }
 type MACCommand_DLChannelAns_ struct {
-	DLChannelAns *MACCommand_DLChannelAns `protobuf:"bytes,15,opt,name=dl_channel_ans,json=dlChannelAns,proto3,oneof"`
+	DLChannelAns *MACCommand_DLChannelAns `protobuf:"bytes,15,opt,name=dl_channel_ans,json=dlChannelAns,proto3,oneof" json:"dl_channel_ans,omitempty"`
 }
 type MACCommand_RxTimingSetupReq_ struct {
-	RxTimingSetupReq *MACCommand_RxTimingSetupReq `protobuf:"bytes,16,opt,name=rx_timing_setup_req,json=rxTimingSetupReq,proto3,oneof"`
+	RxTimingSetupReq *MACCommand_RxTimingSetupReq `protobuf:"bytes,16,opt,name=rx_timing_setup_req,json=rxTimingSetupReq,proto3,oneof" json:"rx_timing_setup_req,omitempty"`
 }
 type MACCommand_TxParamSetupReq_ struct {
-	TxParamSetupReq *MACCommand_TxParamSetupReq `protobuf:"bytes,17,opt,name=tx_param_setup_req,json=txParamSetupReq,proto3,oneof"`
+	TxParamSetupReq *MACCommand_TxParamSetupReq `protobuf:"bytes,17,opt,name=tx_param_setup_req,json=txParamSetupReq,proto3,oneof" json:"tx_param_setup_req,omitempty"`
 }
 type MACCommand_RekeyInd_ struct {
-	RekeyInd *MACCommand_RekeyInd `protobuf:"bytes,18,opt,name=rekey_ind,json=rekeyInd,proto3,oneof"`
+	RekeyInd *MACCommand_RekeyInd `protobuf:"bytes,18,opt,name=rekey_ind,json=rekeyInd,proto3,oneof" json:"rekey_ind,omitempty"`
 }
 type MACCommand_RekeyConf_ struct {
-	RekeyConf *MACCommand_RekeyConf `protobuf:"bytes,19,opt,name=rekey_conf,json=rekeyConf,proto3,oneof"`
+	RekeyConf *MACCommand_RekeyConf `protobuf:"bytes,19,opt,name=rekey_conf,json=rekeyConf,proto3,oneof" json:"rekey_conf,omitempty"`
 }
 type MACCommand_ADRParamSetupReq_ struct {
-	ADRParamSetupReq *MACCommand_ADRParamSetupReq `protobuf:"bytes,20,opt,name=adr_param_setup_req,json=adrParamSetupReq,proto3,oneof"`
+	ADRParamSetupReq *MACCommand_ADRParamSetupReq `protobuf:"bytes,20,opt,name=adr_param_setup_req,json=adrParamSetupReq,proto3,oneof" json:"adr_param_setup_req,omitempty"`
 }
 type MACCommand_DeviceTimeAns_ struct {
-	DeviceTimeAns *MACCommand_DeviceTimeAns `protobuf:"bytes,21,opt,name=device_time_ans,json=deviceTimeAns,proto3,oneof"`
+	DeviceTimeAns *MACCommand_DeviceTimeAns `protobuf:"bytes,21,opt,name=device_time_ans,json=deviceTimeAns,proto3,oneof" json:"device_time_ans,omitempty"`
 }
 type MACCommand_ForceRejoinReq_ struct {
-	ForceRejoinReq *MACCommand_ForceRejoinReq `protobuf:"bytes,22,opt,name=force_rejoin_req,json=forceRejoinReq,proto3,oneof"`
+	ForceRejoinReq *MACCommand_ForceRejoinReq `protobuf:"bytes,22,opt,name=force_rejoin_req,json=forceRejoinReq,proto3,oneof" json:"force_rejoin_req,omitempty"`
 }
 type MACCommand_RejoinParamSetupReq_ struct {
-	RejoinParamSetupReq *MACCommand_RejoinParamSetupReq `protobuf:"bytes,23,opt,name=rejoin_param_setup_req,json=rejoinParamSetupReq,proto3,oneof"`
+	RejoinParamSetupReq *MACCommand_RejoinParamSetupReq `protobuf:"bytes,23,opt,name=rejoin_param_setup_req,json=rejoinParamSetupReq,proto3,oneof" json:"rejoin_param_setup_req,omitempty"`
 }
 type MACCommand_RejoinParamSetupAns_ struct {
-	RejoinParamSetupAns *MACCommand_RejoinParamSetupAns `protobuf:"bytes,24,opt,name=rejoin_param_setup_ans,json=rejoinParamSetupAns,proto3,oneof"`
+	RejoinParamSetupAns *MACCommand_RejoinParamSetupAns `protobuf:"bytes,24,opt,name=rejoin_param_setup_ans,json=rejoinParamSetupAns,proto3,oneof" json:"rejoin_param_setup_ans,omitempty"`
 }
 type MACCommand_PingSlotInfoReq_ struct {
-	PingSlotInfoReq *MACCommand_PingSlotInfoReq `protobuf:"bytes,25,opt,name=ping_slot_info_req,json=pingSlotInfoReq,proto3,oneof"`
+	PingSlotInfoReq *MACCommand_PingSlotInfoReq `protobuf:"bytes,25,opt,name=ping_slot_info_req,json=pingSlotInfoReq,proto3,oneof" json:"ping_slot_info_req,omitempty"`
 }
 type MACCommand_PingSlotChannelReq_ struct {
-	PingSlotChannelReq *MACCommand_PingSlotChannelReq `protobuf:"bytes,26,opt,name=ping_slot_channel_req,json=pingSlotChannelReq,proto3,oneof"`
+	PingSlotChannelReq *MACCommand_PingSlotChannelReq `protobuf:"bytes,26,opt,name=ping_slot_channel_req,json=pingSlotChannelReq,proto3,oneof" json:"ping_slot_channel_req,omitempty"`
 }
 type MACCommand_PingSlotChannelAns_ struct {
-	PingSlotChannelAns *MACCommand_PingSlotChannelAns `protobuf:"bytes,27,opt,name=ping_slot_channel_ans,json=pingSlotChannelAns,proto3,oneof"`
+	PingSlotChannelAns *MACCommand_PingSlotChannelAns `protobuf:"bytes,27,opt,name=ping_slot_channel_ans,json=pingSlotChannelAns,proto3,oneof" json:"ping_slot_channel_ans,omitempty"`
 }
 type MACCommand_BeaconTimingAns_ struct {
-	BeaconTimingAns *MACCommand_BeaconTimingAns `protobuf:"bytes,28,opt,name=beacon_timing_ans,json=beaconTimingAns,proto3,oneof"`
+	BeaconTimingAns *MACCommand_BeaconTimingAns `protobuf:"bytes,28,opt,name=beacon_timing_ans,json=beaconTimingAns,proto3,oneof" json:"beacon_timing_ans,omitempty"`
 }
 type MACCommand_BeaconFreqReq_ struct {
-	BeaconFreqReq *MACCommand_BeaconFreqReq `protobuf:"bytes,29,opt,name=beacon_freq_req,json=beaconFreqReq,proto3,oneof"`
+	BeaconFreqReq *MACCommand_BeaconFreqReq `protobuf:"bytes,29,opt,name=beacon_freq_req,json=beaconFreqReq,proto3,oneof" json:"beacon_freq_req,omitempty"`
 }
 type MACCommand_BeaconFreqAns_ struct {
-	BeaconFreqAns *MACCommand_BeaconFreqAns `protobuf:"bytes,30,opt,name=beacon_freq_ans,json=beaconFreqAns,proto3,oneof"`
+	BeaconFreqAns *MACCommand_BeaconFreqAns `protobuf:"bytes,30,opt,name=beacon_freq_ans,json=beaconFreqAns,proto3,oneof" json:"beacon_freq_ans,omitempty"`
 }
 type MACCommand_DeviceModeInd_ struct {
-	DeviceModeInd *MACCommand_DeviceModeInd `protobuf:"bytes,31,opt,name=device_mode_ind,json=deviceModeInd,proto3,oneof"`
+	DeviceModeInd *MACCommand_DeviceModeInd `protobuf:"bytes,31,opt,name=device_mode_ind,json=deviceModeInd,proto3,oneof" json:"device_mode_ind,omitempty"`
 }
 type MACCommand_DeviceModeConf_ struct {
-	DeviceModeConf *MACCommand_DeviceModeConf `protobuf:"bytes,32,opt,name=device_mode_conf,json=deviceModeConf,proto3,oneof"`
+	DeviceModeConf *MACCommand_DeviceModeConf `protobuf:"bytes,32,opt,name=device_mode_conf,json=deviceModeConf,proto3,oneof" json:"device_mode_conf,omitempty"`
 }
 
 func (*MACCommand_RawPayload) isMACCommand_Payload()           {}
@@ -7913,7 +7913,8 @@ func (m *Message) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *Message_MACPayload) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Message_MACPayload) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -7933,7 +7934,8 @@ func (m *Message_MACPayload) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 func (m *Message_JoinRequestPayload) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Message_JoinRequestPayload) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -7953,7 +7955,8 @@ func (m *Message_JoinRequestPayload) MarshalToSizedBuffer(dAtA []byte) (int, err
 	return len(dAtA) - i, nil
 }
 func (m *Message_JoinAcceptPayload) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Message_JoinAcceptPayload) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -7973,7 +7976,8 @@ func (m *Message_JoinAcceptPayload) MarshalToSizedBuffer(dAtA []byte) (int, erro
 	return len(dAtA) - i, nil
 }
 func (m *Message_RejoinRequestPayload) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *Message_RejoinRequestPayload) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -8609,7 +8613,8 @@ func (m *DataRate) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *DataRate_LoRa) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *DataRate_LoRa) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -8629,7 +8634,8 @@ func (m *DataRate_LoRa) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 func (m *DataRate_FSK) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *DataRate_FSK) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -8888,7 +8894,8 @@ func (m *DownlinkPath) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *DownlinkPath_UplinkToken) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *DownlinkPath_UplinkToken) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -8903,7 +8910,8 @@ func (m *DownlinkPath_UplinkToken) MarshalToSizedBuffer(dAtA []byte) (int, error
 	return len(dAtA) - i, nil
 }
 func (m *DownlinkPath_Fixed) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *DownlinkPath_Fixed) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9056,7 +9064,8 @@ func (m *MACCommand) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *MACCommand_RawPayload) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_RawPayload) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9071,7 +9080,8 @@ func (m *MACCommand_RawPayload) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_ResetInd_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_ResetInd_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9091,7 +9101,8 @@ func (m *MACCommand_ResetInd_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_ResetConf_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_ResetConf_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9111,7 +9122,8 @@ func (m *MACCommand_ResetConf_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_LinkCheckAns_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_LinkCheckAns_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9131,7 +9143,8 @@ func (m *MACCommand_LinkCheckAns_) MarshalToSizedBuffer(dAtA []byte) (int, error
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_LinkADRReq_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_LinkADRReq_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9151,7 +9164,8 @@ func (m *MACCommand_LinkADRReq_) MarshalToSizedBuffer(dAtA []byte) (int, error) 
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_LinkADRAns_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_LinkADRAns_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9171,7 +9185,8 @@ func (m *MACCommand_LinkADRAns_) MarshalToSizedBuffer(dAtA []byte) (int, error) 
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_DutyCycleReq_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_DutyCycleReq_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9191,7 +9206,8 @@ func (m *MACCommand_DutyCycleReq_) MarshalToSizedBuffer(dAtA []byte) (int, error
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_RxParamSetupReq_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_RxParamSetupReq_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9211,7 +9227,8 @@ func (m *MACCommand_RxParamSetupReq_) MarshalToSizedBuffer(dAtA []byte) (int, er
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_RxParamSetupAns_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_RxParamSetupAns_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9231,7 +9248,8 @@ func (m *MACCommand_RxParamSetupAns_) MarshalToSizedBuffer(dAtA []byte) (int, er
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_DevStatusAns_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_DevStatusAns_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9251,7 +9269,8 @@ func (m *MACCommand_DevStatusAns_) MarshalToSizedBuffer(dAtA []byte) (int, error
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_NewChannelReq_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_NewChannelReq_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9271,7 +9290,8 @@ func (m *MACCommand_NewChannelReq_) MarshalToSizedBuffer(dAtA []byte) (int, erro
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_NewChannelAns_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_NewChannelAns_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9291,7 +9311,8 @@ func (m *MACCommand_NewChannelAns_) MarshalToSizedBuffer(dAtA []byte) (int, erro
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_DLChannelReq_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_DLChannelReq_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9311,7 +9332,8 @@ func (m *MACCommand_DLChannelReq_) MarshalToSizedBuffer(dAtA []byte) (int, error
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_DLChannelAns_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_DLChannelAns_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9331,7 +9353,8 @@ func (m *MACCommand_DLChannelAns_) MarshalToSizedBuffer(dAtA []byte) (int, error
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_RxTimingSetupReq_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_RxTimingSetupReq_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9353,7 +9376,8 @@ func (m *MACCommand_RxTimingSetupReq_) MarshalToSizedBuffer(dAtA []byte) (int, e
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_TxParamSetupReq_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_TxParamSetupReq_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9375,7 +9399,8 @@ func (m *MACCommand_TxParamSetupReq_) MarshalToSizedBuffer(dAtA []byte) (int, er
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_RekeyInd_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_RekeyInd_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9397,7 +9422,8 @@ func (m *MACCommand_RekeyInd_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_RekeyConf_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_RekeyConf_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9419,7 +9445,8 @@ func (m *MACCommand_RekeyConf_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_ADRParamSetupReq_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_ADRParamSetupReq_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9441,7 +9468,8 @@ func (m *MACCommand_ADRParamSetupReq_) MarshalToSizedBuffer(dAtA []byte) (int, e
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_DeviceTimeAns_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_DeviceTimeAns_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9463,7 +9491,8 @@ func (m *MACCommand_DeviceTimeAns_) MarshalToSizedBuffer(dAtA []byte) (int, erro
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_ForceRejoinReq_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_ForceRejoinReq_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9485,7 +9514,8 @@ func (m *MACCommand_ForceRejoinReq_) MarshalToSizedBuffer(dAtA []byte) (int, err
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_RejoinParamSetupReq_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_RejoinParamSetupReq_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9507,7 +9537,8 @@ func (m *MACCommand_RejoinParamSetupReq_) MarshalToSizedBuffer(dAtA []byte) (int
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_RejoinParamSetupAns_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_RejoinParamSetupAns_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9529,7 +9560,8 @@ func (m *MACCommand_RejoinParamSetupAns_) MarshalToSizedBuffer(dAtA []byte) (int
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_PingSlotInfoReq_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_PingSlotInfoReq_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9551,7 +9583,8 @@ func (m *MACCommand_PingSlotInfoReq_) MarshalToSizedBuffer(dAtA []byte) (int, er
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_PingSlotChannelReq_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_PingSlotChannelReq_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9573,7 +9606,8 @@ func (m *MACCommand_PingSlotChannelReq_) MarshalToSizedBuffer(dAtA []byte) (int,
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_PingSlotChannelAns_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_PingSlotChannelAns_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9595,7 +9629,8 @@ func (m *MACCommand_PingSlotChannelAns_) MarshalToSizedBuffer(dAtA []byte) (int,
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_BeaconTimingAns_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_BeaconTimingAns_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9617,7 +9652,8 @@ func (m *MACCommand_BeaconTimingAns_) MarshalToSizedBuffer(dAtA []byte) (int, er
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_BeaconFreqReq_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_BeaconFreqReq_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9639,7 +9675,8 @@ func (m *MACCommand_BeaconFreqReq_) MarshalToSizedBuffer(dAtA []byte) (int, erro
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_BeaconFreqAns_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_BeaconFreqAns_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9661,7 +9698,8 @@ func (m *MACCommand_BeaconFreqAns_) MarshalToSizedBuffer(dAtA []byte) (int, erro
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_DeviceModeInd_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_DeviceModeInd_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -9683,7 +9721,8 @@ func (m *MACCommand_DeviceModeInd_) MarshalToSizedBuffer(dAtA []byte) (int, erro
 	return len(dAtA) - i, nil
 }
 func (m *MACCommand_DeviceModeConf_) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *MACCommand_DeviceModeConf_) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -21216,6 +21255,7 @@ func (m *ADRAckDelayExponentValue) Unmarshal(dAtA []byte) error {
 func skipLorawan(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -21247,10 +21287,8 @@ func skipLorawan(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -21271,55 +21309,30 @@ func skipLorawan(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthLorawan
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthLorawan
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowLorawan
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipLorawan(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthLorawan
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupLorawan
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthLorawan
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthLorawan = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowLorawan   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthLorawan        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowLorawan          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupLorawan = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/lorawan.pb.validate.go
+++ b/pkg/ttnpb/lorawan.pb.validate.go
@@ -72,6 +72,12 @@ func (m *Message) ValidateFields(paths ...string) error {
 			}
 
 		case "Payload":
+			if m.Payload == nil {
+				return MessageValidationError{
+					field:  "Payload",
+					reason: "value is required",
+				}
+			}
 			if len(subs) == 0 {
 				subs = []string{
 					"mac_payload", "join_request_payload", "join_accept_payload", "rejoin_request_payload",
@@ -81,6 +87,10 @@ func (m *Message) ValidateFields(paths ...string) error {
 				_ = subs
 				switch name {
 				case "mac_payload":
+					w, ok := m.Payload.(*Message_MACPayload)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetMACPayload()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -93,6 +103,10 @@ func (m *Message) ValidateFields(paths ...string) error {
 					}
 
 				case "join_request_payload":
+					w, ok := m.Payload.(*Message_JoinRequestPayload)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetJoinRequestPayload()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -105,6 +119,10 @@ func (m *Message) ValidateFields(paths ...string) error {
 					}
 
 				case "join_accept_payload":
+					w, ok := m.Payload.(*Message_JoinAcceptPayload)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetJoinAcceptPayload()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -117,6 +135,10 @@ func (m *Message) ValidateFields(paths ...string) error {
 					}
 
 				case "rejoin_request_payload":
+					w, ok := m.Payload.(*Message_RejoinRequestPayload)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetRejoinRequestPayload()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -128,11 +150,6 @@ func (m *Message) ValidateFields(paths ...string) error {
 						}
 					}
 
-				default:
-					return MessageValidationError{
-						field:  "Payload",
-						reason: "value is required",
-					}
 				}
 			}
 		default:
@@ -1286,6 +1303,12 @@ func (m *DataRate) ValidateFields(paths ...string) error {
 		_ = subs
 		switch name {
 		case "modulation":
+			if m.Modulation == nil {
+				return DataRateValidationError{
+					field:  "modulation",
+					reason: "value is required",
+				}
+			}
 			if len(subs) == 0 {
 				subs = []string{
 					"lora", "fsk",
@@ -1295,6 +1318,10 @@ func (m *DataRate) ValidateFields(paths ...string) error {
 				_ = subs
 				switch name {
 				case "lora":
+					w, ok := m.Modulation.(*DataRate_LoRa)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetLoRa()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -1307,6 +1334,10 @@ func (m *DataRate) ValidateFields(paths ...string) error {
 					}
 
 				case "fsk":
+					w, ok := m.Modulation.(*DataRate_FSK)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetFSK()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -1318,11 +1349,6 @@ func (m *DataRate) ValidateFields(paths ...string) error {
 						}
 					}
 
-				default:
-					return DataRateValidationError{
-						field:  "modulation",
-						reason: "value is required",
-					}
 				}
 			}
 		default:
@@ -1726,6 +1752,12 @@ func (m *DownlinkPath) ValidateFields(paths ...string) error {
 		_ = subs
 		switch name {
 		case "path":
+			if m.Path == nil {
+				return DownlinkPathValidationError{
+					field:  "path",
+					reason: "value is required",
+				}
+			}
 			if len(subs) == 0 {
 				subs = []string{
 					"uplink_token", "fixed",
@@ -1735,8 +1767,16 @@ func (m *DownlinkPath) ValidateFields(paths ...string) error {
 				_ = subs
 				switch name {
 				case "uplink_token":
+					w, ok := m.Path.(*DownlinkPath_UplinkToken)
+					if !ok || w == nil {
+						continue
+					}
 					// no validation rules for UplinkToken
 				case "fixed":
+					w, ok := m.Path.(*DownlinkPath_Fixed)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetFixed()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -1748,11 +1788,6 @@ func (m *DownlinkPath) ValidateFields(paths ...string) error {
 						}
 					}
 
-				default:
-					return DownlinkPathValidationError{
-						field:  "path",
-						reason: "value is required",
-					}
 				}
 			}
 		default:
@@ -2022,8 +2057,16 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 				_ = subs
 				switch name {
 				case "raw_payload":
+					w, ok := m.Payload.(*MACCommand_RawPayload)
+					if !ok || w == nil {
+						continue
+					}
 					// no validation rules for RawPayload
 				case "reset_ind":
+					w, ok := m.Payload.(*MACCommand_ResetInd_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetResetInd()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2036,6 +2079,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "reset_conf":
+					w, ok := m.Payload.(*MACCommand_ResetConf_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetResetConf()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2048,6 +2095,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "link_check_ans":
+					w, ok := m.Payload.(*MACCommand_LinkCheckAns_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetLinkCheckAns()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2060,6 +2111,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "link_adr_req":
+					w, ok := m.Payload.(*MACCommand_LinkADRReq_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetLinkADRReq()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2072,6 +2127,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "link_adr_ans":
+					w, ok := m.Payload.(*MACCommand_LinkADRAns_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetLinkADRAns()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2084,6 +2143,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "duty_cycle_req":
+					w, ok := m.Payload.(*MACCommand_DutyCycleReq_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetDutyCycleReq()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2096,6 +2159,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "rx_param_setup_req":
+					w, ok := m.Payload.(*MACCommand_RxParamSetupReq_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetRxParamSetupReq()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2108,6 +2175,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "rx_param_setup_ans":
+					w, ok := m.Payload.(*MACCommand_RxParamSetupAns_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetRxParamSetupAns()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2120,6 +2191,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "dev_status_ans":
+					w, ok := m.Payload.(*MACCommand_DevStatusAns_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetDevStatusAns()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2132,6 +2207,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "new_channel_req":
+					w, ok := m.Payload.(*MACCommand_NewChannelReq_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetNewChannelReq()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2144,6 +2223,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "new_channel_ans":
+					w, ok := m.Payload.(*MACCommand_NewChannelAns_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetNewChannelAns()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2156,6 +2239,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "dl_channel_req":
+					w, ok := m.Payload.(*MACCommand_DLChannelReq_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetDLChannelReq()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2168,6 +2255,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "dl_channel_ans":
+					w, ok := m.Payload.(*MACCommand_DLChannelAns_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetDLChannelAns()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2180,6 +2271,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "rx_timing_setup_req":
+					w, ok := m.Payload.(*MACCommand_RxTimingSetupReq_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetRxTimingSetupReq()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2192,6 +2287,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "tx_param_setup_req":
+					w, ok := m.Payload.(*MACCommand_TxParamSetupReq_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetTxParamSetupReq()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2204,6 +2303,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "rekey_ind":
+					w, ok := m.Payload.(*MACCommand_RekeyInd_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetRekeyInd()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2216,6 +2319,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "rekey_conf":
+					w, ok := m.Payload.(*MACCommand_RekeyConf_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetRekeyConf()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2228,6 +2335,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "adr_param_setup_req":
+					w, ok := m.Payload.(*MACCommand_ADRParamSetupReq_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetADRParamSetupReq()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2240,6 +2351,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "device_time_ans":
+					w, ok := m.Payload.(*MACCommand_DeviceTimeAns_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetDeviceTimeAns()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2252,6 +2367,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "force_rejoin_req":
+					w, ok := m.Payload.(*MACCommand_ForceRejoinReq_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetForceRejoinReq()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2264,6 +2383,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "rejoin_param_setup_req":
+					w, ok := m.Payload.(*MACCommand_RejoinParamSetupReq_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetRejoinParamSetupReq()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2276,6 +2399,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "rejoin_param_setup_ans":
+					w, ok := m.Payload.(*MACCommand_RejoinParamSetupAns_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetRejoinParamSetupAns()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2288,6 +2415,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "ping_slot_info_req":
+					w, ok := m.Payload.(*MACCommand_PingSlotInfoReq_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetPingSlotInfoReq()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2300,6 +2431,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "ping_slot_channel_req":
+					w, ok := m.Payload.(*MACCommand_PingSlotChannelReq_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetPingSlotChannelReq()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2312,6 +2447,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "ping_slot_channel_ans":
+					w, ok := m.Payload.(*MACCommand_PingSlotChannelAns_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetPingSlotChannelAns()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2324,6 +2463,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "beacon_timing_ans":
+					w, ok := m.Payload.(*MACCommand_BeaconTimingAns_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetBeaconTimingAns()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2336,6 +2479,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "beacon_freq_req":
+					w, ok := m.Payload.(*MACCommand_BeaconFreqReq_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetBeaconFreqReq()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2348,6 +2495,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "beacon_freq_ans":
+					w, ok := m.Payload.(*MACCommand_BeaconFreqAns_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetBeaconFreqAns()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2360,6 +2511,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "device_mode_ind":
+					w, ok := m.Payload.(*MACCommand_DeviceModeInd_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetDeviceModeInd()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -2372,6 +2527,10 @@ func (m *MACCommand) ValidateFields(paths ...string) error {
 					}
 
 				case "device_mode_conf":
+					w, ok := m.Payload.(*MACCommand_DeviceModeConf_)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetDeviceModeConf()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {

--- a/pkg/ttnpb/message_services.pb.go
+++ b/pkg/ttnpb/message_services.pb.go
@@ -1110,6 +1110,7 @@ func (m *ProcessDownlinkMessageRequest) Unmarshal(dAtA []byte) error {
 func skipMessageServices(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -1141,10 +1142,8 @@ func skipMessageServices(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -1165,55 +1164,30 @@ func skipMessageServices(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthMessageServices
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthMessageServices
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowMessageServices
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipMessageServices(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthMessageServices
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupMessageServices
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthMessageServices
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthMessageServices = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowMessageServices   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthMessageServices        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowMessageServices          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupMessageServices = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/messages.pb.go
+++ b/pkg/ttnpb/messages.pb.go
@@ -265,10 +265,10 @@ type isDownlinkMessage_Settings interface {
 }
 
 type DownlinkMessage_Request struct {
-	Request *TxRequest `protobuf:"bytes,4,opt,name=request,proto3,oneof"`
+	Request *TxRequest `protobuf:"bytes,4,opt,name=request,proto3,oneof" json:"request,omitempty"`
 }
 type DownlinkMessage_Scheduled struct {
-	Scheduled *TxSettings `protobuf:"bytes,5,opt,name=scheduled,proto3,oneof"`
+	Scheduled *TxSettings `protobuf:"bytes,5,opt,name=scheduled,proto3,oneof" json:"scheduled,omitempty"`
 }
 
 func (*DownlinkMessage_Request) isDownlinkMessage_Settings()   {}
@@ -984,31 +984,31 @@ type isApplicationUp_Up interface {
 }
 
 type ApplicationUp_UplinkMessage struct {
-	UplinkMessage *ApplicationUplink `protobuf:"bytes,3,opt,name=uplink_message,json=uplinkMessage,proto3,oneof"`
+	UplinkMessage *ApplicationUplink `protobuf:"bytes,3,opt,name=uplink_message,json=uplinkMessage,proto3,oneof" json:"uplink_message,omitempty"`
 }
 type ApplicationUp_JoinAccept struct {
-	JoinAccept *ApplicationJoinAccept `protobuf:"bytes,4,opt,name=join_accept,json=joinAccept,proto3,oneof"`
+	JoinAccept *ApplicationJoinAccept `protobuf:"bytes,4,opt,name=join_accept,json=joinAccept,proto3,oneof" json:"join_accept,omitempty"`
 }
 type ApplicationUp_DownlinkAck struct {
-	DownlinkAck *ApplicationDownlink `protobuf:"bytes,5,opt,name=downlink_ack,json=downlinkAck,proto3,oneof"`
+	DownlinkAck *ApplicationDownlink `protobuf:"bytes,5,opt,name=downlink_ack,json=downlinkAck,proto3,oneof" json:"downlink_ack,omitempty"`
 }
 type ApplicationUp_DownlinkNack struct {
-	DownlinkNack *ApplicationDownlink `protobuf:"bytes,6,opt,name=downlink_nack,json=downlinkNack,proto3,oneof"`
+	DownlinkNack *ApplicationDownlink `protobuf:"bytes,6,opt,name=downlink_nack,json=downlinkNack,proto3,oneof" json:"downlink_nack,omitempty"`
 }
 type ApplicationUp_DownlinkSent struct {
-	DownlinkSent *ApplicationDownlink `protobuf:"bytes,7,opt,name=downlink_sent,json=downlinkSent,proto3,oneof"`
+	DownlinkSent *ApplicationDownlink `protobuf:"bytes,7,opt,name=downlink_sent,json=downlinkSent,proto3,oneof" json:"downlink_sent,omitempty"`
 }
 type ApplicationUp_DownlinkFailed struct {
-	DownlinkFailed *ApplicationDownlinkFailed `protobuf:"bytes,8,opt,name=downlink_failed,json=downlinkFailed,proto3,oneof"`
+	DownlinkFailed *ApplicationDownlinkFailed `protobuf:"bytes,8,opt,name=downlink_failed,json=downlinkFailed,proto3,oneof" json:"downlink_failed,omitempty"`
 }
 type ApplicationUp_DownlinkQueued struct {
-	DownlinkQueued *ApplicationDownlink `protobuf:"bytes,9,opt,name=downlink_queued,json=downlinkQueued,proto3,oneof"`
+	DownlinkQueued *ApplicationDownlink `protobuf:"bytes,9,opt,name=downlink_queued,json=downlinkQueued,proto3,oneof" json:"downlink_queued,omitempty"`
 }
 type ApplicationUp_DownlinkQueueInvalidated struct {
-	DownlinkQueueInvalidated *ApplicationInvalidatedDownlinks `protobuf:"bytes,10,opt,name=downlink_queue_invalidated,json=downlinkQueueInvalidated,proto3,oneof"`
+	DownlinkQueueInvalidated *ApplicationInvalidatedDownlinks `protobuf:"bytes,10,opt,name=downlink_queue_invalidated,json=downlinkQueueInvalidated,proto3,oneof" json:"downlink_queue_invalidated,omitempty"`
 }
 type ApplicationUp_LocationSolved struct {
-	LocationSolved *ApplicationLocation `protobuf:"bytes,11,opt,name=location_solved,json=locationSolved,proto3,oneof"`
+	LocationSolved *ApplicationLocation `protobuf:"bytes,11,opt,name=location_solved,json=locationSolved,proto3,oneof" json:"location_solved,omitempty"`
 }
 
 func (*ApplicationUp_UplinkMessage) isApplicationUp_Up()            {}
@@ -2393,7 +2393,8 @@ func (m *DownlinkMessage) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *DownlinkMessage_Request) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *DownlinkMessage_Request) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -2413,7 +2414,8 @@ func (m *DownlinkMessage_Request) MarshalToSizedBuffer(dAtA []byte) (int, error)
 	return len(dAtA) - i, nil
 }
 func (m *DownlinkMessage_Scheduled) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *DownlinkMessage_Scheduled) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -3003,7 +3005,8 @@ func (m *ApplicationUp) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 }
 
 func (m *ApplicationUp_UplinkMessage) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ApplicationUp_UplinkMessage) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -3023,7 +3026,8 @@ func (m *ApplicationUp_UplinkMessage) MarshalToSizedBuffer(dAtA []byte) (int, er
 	return len(dAtA) - i, nil
 }
 func (m *ApplicationUp_JoinAccept) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ApplicationUp_JoinAccept) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -3043,7 +3047,8 @@ func (m *ApplicationUp_JoinAccept) MarshalToSizedBuffer(dAtA []byte) (int, error
 	return len(dAtA) - i, nil
 }
 func (m *ApplicationUp_DownlinkAck) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ApplicationUp_DownlinkAck) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -3063,7 +3068,8 @@ func (m *ApplicationUp_DownlinkAck) MarshalToSizedBuffer(dAtA []byte) (int, erro
 	return len(dAtA) - i, nil
 }
 func (m *ApplicationUp_DownlinkNack) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ApplicationUp_DownlinkNack) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -3083,7 +3089,8 @@ func (m *ApplicationUp_DownlinkNack) MarshalToSizedBuffer(dAtA []byte) (int, err
 	return len(dAtA) - i, nil
 }
 func (m *ApplicationUp_DownlinkSent) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ApplicationUp_DownlinkSent) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -3103,7 +3110,8 @@ func (m *ApplicationUp_DownlinkSent) MarshalToSizedBuffer(dAtA []byte) (int, err
 	return len(dAtA) - i, nil
 }
 func (m *ApplicationUp_DownlinkFailed) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ApplicationUp_DownlinkFailed) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -3123,7 +3131,8 @@ func (m *ApplicationUp_DownlinkFailed) MarshalToSizedBuffer(dAtA []byte) (int, e
 	return len(dAtA) - i, nil
 }
 func (m *ApplicationUp_DownlinkQueued) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ApplicationUp_DownlinkQueued) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -3143,7 +3152,8 @@ func (m *ApplicationUp_DownlinkQueued) MarshalToSizedBuffer(dAtA []byte) (int, e
 	return len(dAtA) - i, nil
 }
 func (m *ApplicationUp_DownlinkQueueInvalidated) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ApplicationUp_DownlinkQueueInvalidated) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -3163,7 +3173,8 @@ func (m *ApplicationUp_DownlinkQueueInvalidated) MarshalToSizedBuffer(dAtA []byt
 	return len(dAtA) - i, nil
 }
 func (m *ApplicationUp_LocationSolved) MarshalTo(dAtA []byte) (int, error) {
-	return m.MarshalToSizedBuffer(dAtA[:m.Size()])
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
 func (m *ApplicationUp_LocationSolved) MarshalToSizedBuffer(dAtA []byte) (int, error) {
@@ -7238,6 +7249,7 @@ func (m *DownlinkQueueRequest) Unmarshal(dAtA []byte) error {
 func skipMessages(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -7269,10 +7281,8 @@ func skipMessages(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -7293,55 +7303,30 @@ func skipMessages(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthMessages
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthMessages
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowMessages
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipMessages(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthMessages
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupMessages
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthMessages
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthMessages = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowMessages   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthMessages        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowMessages          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupMessages = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/messages.pb.validate.go
+++ b/pkg/ttnpb/messages.pb.validate.go
@@ -255,6 +255,12 @@ func (m *DownlinkMessage) ValidateFields(paths ...string) error {
 			}
 
 		case "settings":
+			if m.Settings == nil {
+				return DownlinkMessageValidationError{
+					field:  "settings",
+					reason: "value is required",
+				}
+			}
 			if len(subs) == 0 {
 				subs = []string{
 					"request", "scheduled",
@@ -264,6 +270,10 @@ func (m *DownlinkMessage) ValidateFields(paths ...string) error {
 				_ = subs
 				switch name {
 				case "request":
+					w, ok := m.Settings.(*DownlinkMessage_Request)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetRequest()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -276,6 +286,10 @@ func (m *DownlinkMessage) ValidateFields(paths ...string) error {
 					}
 
 				case "scheduled":
+					w, ok := m.Settings.(*DownlinkMessage_Scheduled)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetScheduled()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -287,11 +301,6 @@ func (m *DownlinkMessage) ValidateFields(paths ...string) error {
 						}
 					}
 
-				default:
-					return DownlinkMessageValidationError{
-						field:  "settings",
-						reason: "value is required",
-					}
 				}
 			}
 		default:
@@ -1391,6 +1400,12 @@ func (m *ApplicationUp) ValidateFields(paths ...string) error {
 			}
 
 		case "up":
+			if m.Up == nil {
+				return ApplicationUpValidationError{
+					field:  "up",
+					reason: "value is required",
+				}
+			}
 			if len(subs) == 0 {
 				subs = []string{
 					"uplink_message", "join_accept", "downlink_ack", "downlink_nack", "downlink_sent", "downlink_failed", "downlink_queued", "downlink_queue_invalidated", "location_solved",
@@ -1400,6 +1415,10 @@ func (m *ApplicationUp) ValidateFields(paths ...string) error {
 				_ = subs
 				switch name {
 				case "uplink_message":
+					w, ok := m.Up.(*ApplicationUp_UplinkMessage)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetUplinkMessage()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -1412,6 +1431,10 @@ func (m *ApplicationUp) ValidateFields(paths ...string) error {
 					}
 
 				case "join_accept":
+					w, ok := m.Up.(*ApplicationUp_JoinAccept)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetJoinAccept()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -1424,6 +1447,10 @@ func (m *ApplicationUp) ValidateFields(paths ...string) error {
 					}
 
 				case "downlink_ack":
+					w, ok := m.Up.(*ApplicationUp_DownlinkAck)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetDownlinkAck()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -1436,6 +1463,10 @@ func (m *ApplicationUp) ValidateFields(paths ...string) error {
 					}
 
 				case "downlink_nack":
+					w, ok := m.Up.(*ApplicationUp_DownlinkNack)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetDownlinkNack()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -1448,6 +1479,10 @@ func (m *ApplicationUp) ValidateFields(paths ...string) error {
 					}
 
 				case "downlink_sent":
+					w, ok := m.Up.(*ApplicationUp_DownlinkSent)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetDownlinkSent()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -1460,6 +1495,10 @@ func (m *ApplicationUp) ValidateFields(paths ...string) error {
 					}
 
 				case "downlink_failed":
+					w, ok := m.Up.(*ApplicationUp_DownlinkFailed)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetDownlinkFailed()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -1472,6 +1511,10 @@ func (m *ApplicationUp) ValidateFields(paths ...string) error {
 					}
 
 				case "downlink_queued":
+					w, ok := m.Up.(*ApplicationUp_DownlinkQueued)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetDownlinkQueued()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -1484,6 +1527,10 @@ func (m *ApplicationUp) ValidateFields(paths ...string) error {
 					}
 
 				case "downlink_queue_invalidated":
+					w, ok := m.Up.(*ApplicationUp_DownlinkQueueInvalidated)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetDownlinkQueueInvalidated()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -1496,6 +1543,10 @@ func (m *ApplicationUp) ValidateFields(paths ...string) error {
 					}
 
 				case "location_solved":
+					w, ok := m.Up.(*ApplicationUp_LocationSolved)
+					if !ok || w == nil {
+						continue
+					}
 
 					if v, ok := interface{}(m.GetLocationSolved()).(interface{ ValidateFields(...string) error }); ok {
 						if err := v.ValidateFields(subs...); err != nil {
@@ -1507,11 +1558,6 @@ func (m *ApplicationUp) ValidateFields(paths ...string) error {
 						}
 					}
 
-				default:
-					return ApplicationUpValidationError{
-						field:  "up",
-						reason: "value is required",
-					}
 				}
 			}
 		default:

--- a/pkg/ttnpb/metadata.pb.go
+++ b/pkg/ttnpb/metadata.pb.go
@@ -1660,6 +1660,7 @@ func (m *Location) Unmarshal(dAtA []byte) error {
 func skipMetadata(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -1691,10 +1692,8 @@ func skipMetadata(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -1715,55 +1714,30 @@ func skipMetadata(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthMetadata
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthMetadata
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowMetadata
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipMetadata(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthMetadata
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupMetadata
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthMetadata
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthMetadata = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowMetadata   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthMetadata        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowMetadata          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupMetadata = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/mqtt.pb.go
+++ b/pkg/ttnpb/mqtt.pb.go
@@ -507,6 +507,7 @@ func (m *MQTTConnectionInfo) Unmarshal(dAtA []byte) error {
 func skipMqtt(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -538,10 +539,8 @@ func skipMqtt(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -562,55 +561,30 @@ func skipMqtt(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthMqtt
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthMqtt
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowMqtt
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipMqtt(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthMqtt
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupMqtt
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthMqtt
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthMqtt = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowMqtt   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthMqtt        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowMqtt          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupMqtt = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/networkserver.pb.go
+++ b/pkg/ttnpb/networkserver.pb.go
@@ -938,6 +938,7 @@ func (m *GenerateDevAddrResponse) Unmarshal(dAtA []byte) error {
 func skipNetworkserver(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -969,10 +970,8 @@ func skipNetworkserver(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -993,55 +992,30 @@ func skipNetworkserver(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthNetworkserver
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthNetworkserver
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowNetworkserver
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipNetworkserver(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthNetworkserver
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupNetworkserver
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthNetworkserver
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthNetworkserver = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowNetworkserver   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthNetworkserver        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowNetworkserver          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupNetworkserver = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/oauth.pb.go
+++ b/pkg/ttnpb/oauth.pb.go
@@ -3937,6 +3937,7 @@ func (m *ListOAuthAccessTokensRequest) Unmarshal(dAtA []byte) error {
 func skipOauth(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -3968,10 +3969,8 @@ func skipOauth(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -3992,55 +3991,30 @@ func skipOauth(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthOauth
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthOauth
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowOauth
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipOauth(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthOauth
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupOauth
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthOauth
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthOauth = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowOauth   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthOauth        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowOauth          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupOauth = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/organization.pb.go
+++ b/pkg/ttnpb/organization.pb.go
@@ -4468,6 +4468,7 @@ func (m *SetOrganizationCollaboratorRequest) Unmarshal(dAtA []byte) error {
 func skipOrganization(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -4499,10 +4500,8 @@ func skipOrganization(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -4523,55 +4522,30 @@ func skipOrganization(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthOrganization
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthOrganization
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowOrganization
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipOrganization(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthOrganization
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupOrganization
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthOrganization
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthOrganization = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowOrganization   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthOrganization        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowOrganization          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupOrganization = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/picture.pb.go
+++ b/pkg/ttnpb/picture.pb.go
@@ -856,6 +856,7 @@ func (m *Picture_Embedded) Unmarshal(dAtA []byte) error {
 func skipPicture(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -887,10 +888,8 @@ func skipPicture(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -911,55 +910,30 @@ func skipPicture(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthPicture
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthPicture
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowPicture
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipPicture(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthPicture
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupPicture
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthPicture
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthPicture = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowPicture   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthPicture        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowPicture          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupPicture = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/qrcodegenerator.pb.go
+++ b/pkg/ttnpb/qrcodegenerator.pb.go
@@ -2053,6 +2053,7 @@ func (m *GenerateQRCodeResponse) Unmarshal(dAtA []byte) error {
 func skipQrcodegenerator(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -2084,10 +2085,8 @@ func skipQrcodegenerator(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -2108,55 +2107,30 @@ func skipQrcodegenerator(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthQrcodegenerator
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthQrcodegenerator
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowQrcodegenerator
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipQrcodegenerator(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthQrcodegenerator
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupQrcodegenerator
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthQrcodegenerator
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthQrcodegenerator = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowQrcodegenerator   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthQrcodegenerator        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowQrcodegenerator          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupQrcodegenerator = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/regional.pb.go
+++ b/pkg/ttnpb/regional.pb.go
@@ -1928,6 +1928,7 @@ func (m *ConcentratorConfig_LBTConfiguration) Unmarshal(dAtA []byte) error {
 func skipRegional(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -1959,10 +1960,8 @@ func skipRegional(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -1983,55 +1982,30 @@ func skipRegional(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthRegional
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthRegional
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowRegional
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipRegional(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthRegional
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupRegional
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthRegional
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthRegional = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowRegional   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthRegional        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowRegional          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupRegional = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/rights.pb.go
+++ b/pkg/ttnpb/rights.pb.go
@@ -2352,6 +2352,7 @@ func (m *Collaborators) Unmarshal(dAtA []byte) error {
 func skipRights(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -2383,10 +2384,8 @@ func skipRights(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -2407,55 +2406,30 @@ func skipRights(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthRights
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthRights
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowRights
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipRights(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthRights
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupRights
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthRights
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthRights = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowRights   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthRights        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowRights          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupRights = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/search_services.pb.go
+++ b/pkg/ttnpb/search_services.pb.go
@@ -1901,6 +1901,7 @@ func (m *SearchEndDevicesRequest) Unmarshal(dAtA []byte) error {
 func skipSearchServices(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -1932,10 +1933,8 @@ func skipSearchServices(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -1956,55 +1955,30 @@ func skipSearchServices(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthSearchServices
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthSearchServices
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowSearchServices
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipSearchServices(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthSearchServices
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupSearchServices
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthSearchServices
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthSearchServices = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowSearchServices   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthSearchServices        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowSearchServices          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupSearchServices = fmt.Errorf("proto: unexpected end of group")
 )

--- a/pkg/ttnpb/user.pb.go
+++ b/pkg/ttnpb/user.pb.go
@@ -7290,6 +7290,7 @@ func (m *ListUserSessionsRequest) Unmarshal(dAtA []byte) error {
 func skipUser(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -7321,10 +7322,8 @@ func skipUser(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -7345,55 +7344,30 @@ func skipUser(dAtA []byte) (n int, err error) {
 				return 0, ErrInvalidLengthUser
 			}
 			iNdEx += length
-			if iNdEx < 0 {
-				return 0, ErrInvalidLengthUser
-			}
-			return iNdEx, nil
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowUser
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipUser(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-				if iNdEx < 0 {
-					return 0, ErrInvalidLengthUser
-				}
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupUser
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthUser
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthUser = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowUser   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthUser        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowUser          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupUser = fmt.Errorf("proto: unexpected end of group")
 )


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Regular dependency update.
Refs https://github.com/TheThingsIndustries/docker-protobuf/pull/34 https://github.com/TheThingsIndustries/docker-protobuf/pull/36

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix oneof validation(https://github.com/TheThingsIndustries/protoc-gen-fieldmask/issues/32)

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

~@johanstokking please fix the GS test failure(s).~
<details>

```
  WARN No cookie hash key configured, generated a random one hash_key=6D64C5176CF19901AE1DBBF3ECDE34D13A68E98796457D051C1444079CFC52E5825BC3497E977CCCE04264718BB946C692277A7193078544B14D6FA1EA741A47 namespace=web test_name=TestAuthentication
  WARN No cookie block key configured, generated a random one block_key=C0F8B5AA32CEFD5FE0DDB0AF0CF00E24B109DE4EC679E75D5808011A8AD9C646 namespace=web test_name=TestAuthentication
  WARN No static assets found in any search path namespace=web search_paths=[] test_name=TestAuthentication
  WARN No rights TTL configured                 test_name=TestAuthentication
  WARN No cluster key configured, generated a random one key=d6170c0654f0c0f1f89c4a5f969fa60aa9721925143f516ea092dde3c32665d0 test_name=TestAuthentication
  INFO Listening for connections                address=:0 namespace=grpc protocol=gRPC test_name=TestAuthentication
  WARN No cookie hash key configured, generated a random one hash_key=AD47E08412C643C62861B3290CE5D60B5ABBC00740C7B3DC4A6686939C87FA9940F7ECFA8270247920F54E6D3974DDE58732D34706CFEE26093AD8FA8550C3E8 namespace=web test_name=TestTraffic
  WARN No cookie block key configured, generated a random one block_key=72A3A12ABB22AC48E315DF90153ADD6B09B745C292C0D2A500D8E6CC40AFF2CD namespace=web test_name=TestTraffic
  WARN No static assets found in any search path namespace=web search_paths=[] test_name=TestTraffic
  WARN No rights TTL configured                 test_name=TestTraffic
  WARN No cluster key configured, generated a random one key=f83f6b28984e37994ccad51ae126048b24250af4442774ca6b23e3d17932e04e test_name=TestTraffic
  INFO Listening for connections                address=:0 namespace=grpc protocol=gRPC test_name=TestTraffic
  INFO Finished unary call                      duration=104.838µs grpc_method=ListRights grpc_service=ttn.lorawan.v3.GatewayAccess namespace=grpc request_id=01DR1GV1948FS03GDD1KP34W0K test_name=TestTraffic
  INFO Finished unary call                      duration=59.021µs grpc_method=ListRights grpc_service=ttn.lorawan.v3.GatewayAccess namespace=grpc request_id=01DR1GV195H5KNASKWEVJEVPZ5 test_name=TestTraffic
  WARN Link failed                              error=error:pkg/errors:validation (invalid `uplink_messages[0]`: embedded message failed validation) error_cause=error:pkg/errors:validation (invalid `settings`: embedded message failed validation) error_cause_cause=error:pkg/errors:validation (invalid `data_rate`: embedded message failed validation) error_cause_cause_cause=error:pkg/errors:validation (invalid `modulation`: value is required) gateway_uid=test-gateway grpc_method=LinkGateway grpc_service=ttn.lorawan.v3.GtwGs namespace=gatewayserver/io/grpc remote_addr=pipe request_id=01DR1GV193EVEF0EZYK68AN2RH test_name=TestTraffic
  INFO Finished streaming call                  duration=4.146841ms error=error:pkg/errors:validation (invalid `uplink_messages[0]`: embedded message failed validation) error_cause=error:pkg/errors:validation (invalid `settings`: embedded message failed validation) error_cause_cause=error:pkg/errors:validation (invalid `data_rate`: embedded message failed validation) error_cause_cause_cause=error:pkg/errors:validation (invalid `modulation`: value is required) error_correlation_id=85644eb62082411ea8f040a0f54a15eb error_name=validation error_namespace=pkg/errors grpc_code=InvalidArgument grpc_method=LinkGateway grpc_service=ttn.lorawan.v3.GtwGs namespace=grpc request_id=01DR1GV193EVEF0EZYK68AN2RH test_name=TestTraffic
--- FAIL: TestTraffic (0.04s)
    --- FAIL: TestTraffic/Upstream (0.02s)
        --- FAIL: TestTraffic/Upstream/1/false (0.02s)
            grpc_test.go:309: Receive expected upstream timeout; ups = 0, needStatus = false, needAck = false
FAIL
FAIL    go.thethings.network/lorawan-stack/pkg/gatewayserver/io/grpc    0.195s
```

</details>
Please use the provided protos in this PR and don't attempt to regenerate.