### PR TITLE
Fix saving device settings via upsert

### DIFF
--- a/pkg/webui/console/components/device-data-form/index.js
+++ b/pkg/webui/console/components/device-data-form/index.js
@@ -30,6 +30,7 @@ import DevAddrInput from '../../containers/dev-addr-input'
 import JoinEUIPrefixesInput from '../../containers/join-eui-prefixes-input'
 
 import sharedMessages from '../../../lib/shared-messages'
+import { selectNsConfig, selectJsConfig, selectAsConfig } from '../../../lib/selectors/env'
 import errorMessages from '../../../lib/errors/error-messages'
 import { getDeviceId } from '../../../lib/selectors/id'
 import PropTypes from '../../../lib/prop-types'
@@ -87,7 +88,8 @@ class DeviceDataForm extends Component {
       resets_join_nonces: external_js ? false : resets_join_nonces,
     }))
 
-    const { initialValues, jsConfig } = this.props
+    const { initialValues } = this.props
+    const jsConfig = selectJsConfig()
     const { setValues, state } = this.formRef.current
 
     // Reset Join Server related entries if the device is provisined by
@@ -343,12 +345,19 @@ class DeviceDataForm extends Component {
       },
     }
 
+    const nsConfig = selectNsConfig()
+    const asConfig = selectAsConfig()
+    const jsConfig = selectJsConfig()
+    const joinServerAddress = jsConfig.enabled ? new URL(jsConfig.base_url).hostname : ''
+
     const formValues = {
+      network_server_address: nsConfig.enabled ? new URL(nsConfig.base_url).hostname : '',
+      application_server_address: asConfig.enabled ? new URL(asConfig.base_url).hostname : '',
+      join_server_address: external_js ? undefined : joinServerAddress,
       ...emptyValues,
       ...initialValues,
       activation_mode: otaa ? 'otaa' : 'abp',
       external_js,
-      join_server_address: external_js ? undefined : initialValues.join_server_address,
     }
 
     return (
@@ -500,7 +509,6 @@ const initialValuesPropType = PropTypes.shape({
 
 DeviceDataForm.propTypes = {
   initialValues: initialValuesPropType,
-  jsConfig: PropTypes.stackComponent.isRequired,
   onDelete: PropTypes.func,
   onDeleteSuccess: PropTypes.func,
   onSubmit: PropTypes.func.isRequired,

--- a/pkg/webui/console/views/device-add/index.js
+++ b/pkg/webui/console/views/device-add/index.js
@@ -26,7 +26,6 @@ import DeviceDataForm from '../../components/device-data-form'
 import sharedMessages from '../../../lib/shared-messages'
 import { selectSelectedApplicationId } from '../../store/selectors/applications'
 import { getDeviceId } from '../../../lib/selectors/id'
-import { selectNsConfig, selectJsConfig, selectAsConfig } from '../../../lib/selectors/env'
 import PropTypes from '../../../lib/prop-types'
 import api from '../../api'
 import style from './device-add-single.styl'
@@ -34,9 +33,6 @@ import style from './device-add-single.styl'
 @connect(
   state => ({
     appId: selectSelectedApplicationId(state),
-    asConfig: selectAsConfig(),
-    nsConfig: selectNsConfig(),
-    jsConfig: selectJsConfig(),
   }),
   dispatch => ({
     redirectToList: (appId, deviceId) =>
@@ -56,9 +52,6 @@ import style from './device-add-single.styl'
 export default class DeviceAdd extends Component {
   static propTypes = {
     appId: PropTypes.string.isRequired,
-    asConfig: PropTypes.stackComponent.isRequired,
-    jsConfig: PropTypes.stackComponent.isRequired,
-    nsConfig: PropTypes.stackComponent.isRequired,
     redirectToList: PropTypes.func.isRequired,
   }
 
@@ -81,14 +74,6 @@ export default class DeviceAdd extends Component {
   }
 
   render() {
-    const { asConfig, nsConfig, jsConfig } = this.props
-
-    const initialValues = {
-      network_server_address: nsConfig.enabled ? new URL(nsConfig.base_url).hostname : '',
-      application_server_address: asConfig.enabled ? new URL(asConfig.base_url).hostname : '',
-      join_server_address: jsConfig.enabled ? new URL(jsConfig.base_url).hostname : '',
-    }
-
     return (
       <Container>
         <Row>
@@ -102,8 +87,6 @@ export default class DeviceAdd extends Component {
             <DeviceDataForm
               onSubmit={this.handleSubmit}
               onSubmitSuccess={this.handleSubmitSuccess}
-              initialValues={initialValues}
-              jsConfig={jsConfig}
             />
           </Col>
         </Row>

--- a/sdk/js/src/service/devices/index.js
+++ b/sdk/js/src/service/devices/index.js
@@ -62,10 +62,18 @@ class Devices {
       throw new Error('Missing application_id for device.')
     }
 
+    // Ensure proper id object
+    if (!('ids' in device)) {
+      device.ids = { device_id: deviceId, application_ids: { application_id: applicationId } }
+    } else if (!device.ids.device_id) {
+      device.ids.device_id = deviceId
+    } else if (!device.ids.application_ids || !device.ids.application_ids.application_id) {
+      device.ids.application_ids = { application_id: applicationId }
+    }
+
     const params = {
       routeParams: {
         'end_device.ids.application_ids.application_id': appId,
-        ...(create ? {} : { 'end_device.ids.device_id': devId }),
       },
     }
 
@@ -152,6 +160,8 @@ class Devices {
         }
       }
     }
+
+    const devicePayload = Marshaler.payload(device, 'end_device')
 
     try {
       const setParts = await makeRequests(

--- a/sdk/js/src/service/devices/index.js
+++ b/sdk/js/src/service/devices/index.js
@@ -146,17 +146,21 @@ class Devices {
     // Retrieve necessary EUIs in case of a join server query being necessary
     if ('js' in requestTree) {
       if (!create && (!ids || !ids.join_eui || !ids.dev_eui)) {
-        try {
-          const res = await this._getDevice(appId, devId, [['ids', 'join_eui'], ['ids', 'dev_eui']])
-          device.ids = {
-            ...device.ids,
-            join_eui: res.ids.join_eui,
-            dev_eui: res.ids.dev_eui,
-          }
-        } catch (err) {
+        const res = await this._getDevice(
+          appId,
+          devId,
+          [['ids', 'join_eui'], ['ids', 'dev_eui']],
+          true,
+        )
+        if (!res.ids || !res.ids.join_eui || !res.ids.dev_eui) {
           throw new Error(
             'Could not update Join Server data on a device without Join EUI or Dev EUI',
           )
+        }
+        device.ids = {
+          ...device.ids,
+          join_eui: res.ids.join_eui,
+          dev_eui: res.ids.dev_eui,
         }
       }
     }


### PR DESCRIPTION
#### Summary
Closes #1509 

#### Changes
- Stop erroring when trying to retrieve `supports_join` information
  - Determine join server availability via 1) trying to get `supports_join` or 2) checking whether `join_server_address` is set
- Move building of route params to the `makeRequests` helper for set/create requests
- Ensure using the `PUT` binding of the `Set` RPCs to ensure proper *upserting*
- Ignore not found stack components when trying to retrieve `join_eui` and `device_eui` when querying the JS
- Ensure prefilled component addresses in the device update form