### PR TITLE
Extend webui stack config with EDTC (Console / JS SDK)

### DIFF
--- a/cmd/internal/shared/console/config.go
+++ b/cmd/internal/shared/console/config.go
@@ -43,11 +43,12 @@ var DefaultConsoleConfig = console.Config{
 		},
 		FrontendConfig: console.FrontendConfig{
 			StackConfig: console.StackConfig{
-				IS: webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
-				GS: webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
-				NS: webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
-				AS: webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
-				JS: webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
+				IS:   webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
+				GS:   webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
+				NS:   webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
+				AS:   webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
+				JS:   webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
+				EDTC: webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
 			},
 		},
 	},

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -35,11 +35,12 @@ type UIConfig struct {
 
 // StackConfig is the configuration of the stack components.
 type StackConfig struct {
-	IS webui.APIConfig `json:"is" name:"is"`
-	GS webui.APIConfig `json:"gs" name:"gs"`
-	NS webui.APIConfig `json:"ns" name:"ns"`
-	AS webui.APIConfig `json:"as" name:"as"`
-	JS webui.APIConfig `json:"js" name:"js"`
+	IS   webui.APIConfig `json:"is" name:"is"`
+	GS   webui.APIConfig `json:"gs" name:"gs"`
+	NS   webui.APIConfig `json:"ns" name:"ns"`
+	AS   webui.APIConfig `json:"as" name:"as"`
+	JS   webui.APIConfig `json:"js" name:"js"`
+	EDTC webui.APIConfig `json:"edtc" name:"edtc"`
 }
 
 // FrontendConfig is the configuration for the Console frontend.

--- a/pkg/webui/console/api/index.js
+++ b/pkg/webui/console/api/index.js
@@ -28,6 +28,7 @@ const stack = {
   ns: stackConfig.ns.enabled ? stackConfig.ns.base_url : undefined,
   as: stackConfig.as.enabled ? stackConfig.as.base_url : undefined,
   js: stackConfig.js.enabled ? stackConfig.js.base_url : undefined,
+  edtc: stackConfig.edtc.enabled ? stackConfig.edtc.base_url : undefined,
 }
 
 const isBaseUrl = stackConfig.is.base_url

--- a/sdk/js/src/util/constants.js
+++ b/sdk/js/src/util/constants.js
@@ -14,6 +14,6 @@
 
 /* eslint-disable import/prefer-default-export */
 
-const STACK_COMPONENTS = ['as', 'is', 'ns', 'js', 'gs']
+const STACK_COMPONENTS = ['as', 'is', 'ns', 'js', 'gs', 'edtc']
 
 export { STACK_COMPONENTS }


### PR DESCRIPTION
#### Summary
#1471

#### Changes
- Add edtc stack config to the console config
- Pass edtc to the stack config passed to the SDK
- Extend the stack component constants of the SDK