### PR TITLE
Queue application uplinks

### DIFF
--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -124,6 +124,7 @@ var startCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		redisConsumerID := redis.Key(host, strconv.Itoa(os.Getpid()))
 
 		if start.IdentityServer || startDefault {
 			logger.Info("Setting up Identity Server")
@@ -152,7 +153,13 @@ var startCommand = &cobra.Command{
 		}
 
 		if start.NetworkServer || startDefault {
+			redisConsumerGroup := "ns"
+
 			logger.Info("Setting up Network Server")
+			config.NS.ApplicationUplinks = nsredis.NewApplicationUplinkQueue(redis.New(&redis.Config{
+				Redis:     config.Redis,
+				Namespace: []string{"ns", "application-uplinks"},
+			}), 100, redisConsumerGroup, redisConsumerID)
 			config.NS.Devices = &nsredis.DeviceRegistry{Redis: redis.New(&redis.Config{
 				Redis:     config.Redis,
 				Namespace: []string{"ns", "devices"},
@@ -160,7 +167,7 @@ var startCommand = &cobra.Command{
 			nsDownlinkTasks := nsredis.NewDownlinkTaskQueue(redis.New(&redis.Config{
 				Redis:     config.Redis,
 				Namespace: []string{"ns", "tasks"},
-			}), 100000, "ns", redis.Key(host, strconv.Itoa(os.Getpid())))
+			}), 100000, redisConsumerGroup, redisConsumerID)
 			if err := nsDownlinkTasks.Init(); err != nil {
 				return shared.ErrInitializeNetworkServer.WithCause(err)
 			}

--- a/config/messages.json
+++ b/config/messages.json
@@ -4850,6 +4850,24 @@
       "file": "registry.go"
     }
   },
+  "error:pkg/networkserver/redis:invalid_payload": {
+    "translations": {
+      "en": "invalid payload"
+    },
+    "description": {
+      "package": "pkg/networkserver/redis",
+      "file": "application_uplink_queue.go"
+    }
+  },
+  "error:pkg/networkserver/redis:missing_payload": {
+    "translations": {
+      "en": "missing payload"
+    },
+    "description": {
+      "package": "pkg/networkserver/redis",
+      "file": "application_uplink_queue.go"
+    }
+  },
   "error:pkg/networkserver/redis:read_only_field": {
     "translations": {
       "en": "read-only field `{field}`"

--- a/pkg/networkserver/config.go
+++ b/pkg/networkserver/config.go
@@ -25,6 +25,7 @@ import (
 
 // Config represents the NetworkServer configuration.
 type Config struct {
+	ApplicationUplinks  ApplicationUplinkQueue `name:"-"`
 	Devices             DeviceRegistry         `name:"-"`
 	DownlinkTasks       DownlinkTaskQueue      `name:"-"`
 	NetID               types.NetID            `name:"net-id" description:"NetID of this Network Server"`

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -327,7 +327,7 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 				Up: &ttnpb.ApplicationUp_DownlinkQueueInvalidated{
 					DownlinkQueueInvalidated: &ttnpb.ApplicationInvalidatedDownlinks{
 						Downlinks:    dev.QueuedApplicationDownlinks,
-						LastFCntDown: dev.Session.LastNFCntDown + 1,
+						LastFCntDown: dev.Session.LastNFCntDown,
 					},
 				},
 			})

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -1386,20 +1386,9 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 			},
 		)
 		if len(queuedApplicationUplinks) > 0 {
-			go func() {
-				// TODO: Enqueue the uplinks and let a task processor take care of them.
-				// (https://github.com/TheThingsNetwork/lorawan-stack/issues/560)
-				for _, up := range queuedApplicationUplinks {
-					ok, err := ns.handleASUplink(ctx, devID.ApplicationIdentifiers, up)
-					if !ok {
-						logger.Warn("Application Server not found, drop uplinks associated with downlink task processing")
-						return
-					}
-					if err != nil {
-						logger.WithError(err).Warn("Failed to send uplink to Application Server")
-					}
-				}
-			}()
+			if err := ns.applicationUplinks.Add(ctx, queuedApplicationUplinks...); err != nil {
+				logger.WithError(err).Warn("Failed to queue application uplinks for sending to Application Server")
+			}
 		}
 		if len(queuedEvents) > 0 {
 			for _, ev := range queuedEvents {

--- a/pkg/networkserver/grpc_gsns_test.go
+++ b/pkg/networkserver/grpc_gsns_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	pbtypes "github.com/gogo/protobuf/types"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/events"
@@ -498,20 +497,15 @@ func TestHandleUplink(t *testing.T) {
 		}
 	}
 
-	type AsNsLinkRecvRequest struct {
-		Uplink   *ttnpb.ApplicationUp
-		Response chan<- *pbtypes.Empty
-	}
-
 	errTest := errors.New("testError")
 
 	for _, tc := range []struct {
 		Name    string
-		Handler func(context.Context, TestEnvironment, <-chan AsNsLinkRecvRequest, func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool
+		Handler func(context.Context, TestEnvironment, func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool
 	}{
 		{
 			Name: "Invalid payload",
-			Handler: func(ctx context.Context, env TestEnvironment, asRecvCh <-chan AsNsLinkRecvRequest, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
+			Handler: func(ctx context.Context, env TestEnvironment, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
 
@@ -532,7 +526,7 @@ func TestHandleUplink(t *testing.T) {
 
 		{
 			Name: "Unknown Major",
-			Handler: func(ctx context.Context, env TestEnvironment, asRecvCh <-chan AsNsLinkRecvRequest, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
+			Handler: func(ctx context.Context, env TestEnvironment, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
 
@@ -566,7 +560,7 @@ func TestHandleUplink(t *testing.T) {
 
 		{
 			Name: "Invalid MType",
-			Handler: func(ctx context.Context, env TestEnvironment, asRecvCh <-chan AsNsLinkRecvRequest, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
+			Handler: func(ctx context.Context, env TestEnvironment, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
 
@@ -588,7 +582,7 @@ func TestHandleUplink(t *testing.T) {
 
 		{
 			Name: "Proprietary MType",
-			Handler: func(ctx context.Context, env TestEnvironment, asRecvCh <-chan AsNsLinkRecvRequest, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
+			Handler: func(ctx context.Context, env TestEnvironment, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
 
@@ -613,7 +607,7 @@ func TestHandleUplink(t *testing.T) {
 
 		{
 			Name: "Join-request/Get fail",
-			Handler: func(ctx context.Context, env TestEnvironment, asRecvCh <-chan AsNsLinkRecvRequest, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
+			Handler: func(ctx context.Context, env TestEnvironment, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
 
@@ -652,7 +646,7 @@ func TestHandleUplink(t *testing.T) {
 
 		{
 			Name: "Join-request/Get ABP device",
-			Handler: func(ctx context.Context, env TestEnvironment, asRecvCh <-chan AsNsLinkRecvRequest, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
+			Handler: func(ctx context.Context, env TestEnvironment, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
 
@@ -708,7 +702,7 @@ func TestHandleUplink(t *testing.T) {
 
 		{
 			Name: "Join-request/Get multicast device",
-			Handler: func(ctx context.Context, env TestEnvironment, asRecvCh <-chan AsNsLinkRecvRequest, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
+			Handler: func(ctx context.Context, env TestEnvironment, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
 
@@ -765,7 +759,7 @@ func TestHandleUplink(t *testing.T) {
 
 		{
 			Name: "Join-request/Get OTAA device/1.0.2/JS fail",
-			Handler: func(ctx context.Context, env TestEnvironment, asRecvCh <-chan AsNsLinkRecvRequest, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
+			Handler: func(ctx context.Context, env TestEnvironment, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
 
@@ -867,7 +861,7 @@ func TestHandleUplink(t *testing.T) {
 
 		{
 			Name: "Join-request/Get OTAA device/1.1/JS fail",
-			Handler: func(ctx context.Context, env TestEnvironment, asRecvCh <-chan AsNsLinkRecvRequest, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
+			Handler: func(ctx context.Context, env TestEnvironment, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
 
@@ -971,7 +965,7 @@ func TestHandleUplink(t *testing.T) {
 
 		{
 			Name: "Join-request/Get OTAA device/1.0.3/Cluster-local JS not found/Interop JS fail",
-			Handler: func(ctx context.Context, env TestEnvironment, asRecvCh <-chan AsNsLinkRecvRequest, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
+			Handler: func(ctx context.Context, env TestEnvironment, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
 
@@ -1081,7 +1075,7 @@ func TestHandleUplink(t *testing.T) {
 
 		{
 			Name: "Join-request/Get OTAA device/1.1/Cluster-local JS not found/Interop JS fail",
-			Handler: func(ctx context.Context, env TestEnvironment, asRecvCh <-chan AsNsLinkRecvRequest, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
+			Handler: func(ctx context.Context, env TestEnvironment, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
 
@@ -1194,7 +1188,7 @@ func TestHandleUplink(t *testing.T) {
 
 		{
 			Name: "Join-request/Get OTAA device/1.1/Cluster-local JS not found/Interop JS accept/Set success/Downlink add success",
-			Handler: func(ctx context.Context, env TestEnvironment, asRecvCh <-chan AsNsLinkRecvRequest, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
+			Handler: func(ctx context.Context, env TestEnvironment, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
 
@@ -1379,6 +1373,27 @@ func TestHandleUplink(t *testing.T) {
 					return false
 				}
 
+				if !a.So(AssertApplicationUplinkQueueAddRequest(ctx, env.ApplicationUplinks.Add, func(ctx context.Context, ups ...*ttnpb.ApplicationUp) bool {
+					return a.So(ctx, should.HaveParentContextOrEqual, reqCtx) &&
+						a.So(ups, should.Resemble, []*ttnpb.ApplicationUp{
+							{
+								CorrelationIDs:       reqCorrelationIDs,
+								EndDeviceIdentifiers: *makeOTAAIdentifiers(&joinReq.DevAddr),
+								Up: &ttnpb.ApplicationUp_JoinAccept{JoinAccept: &ttnpb.ApplicationJoinAccept{
+									AppSKey: makeSessionKeys(ttnpb.MAC_V1_1).AppSKey,
+									InvalidatedDownlinks: []*ttnpb.ApplicationDownlink{
+										makeApplicationDownlink(),
+									},
+									SessionKeyID: makeSessionKeys(ttnpb.MAC_V1_1).SessionKeyID,
+								}},
+							},
+						})
+				},
+					nil,
+				), should.BeTrue) {
+					return false
+				}
+
 				_ = sendUplinkDuplicates(ctx, handle, env.CollectionDone, func(decoded bool) *ttnpb.UplinkMessage {
 					msg := makeJoinRequest(decoded)
 					if !decoded {
@@ -1394,35 +1409,13 @@ func TestHandleUplink(t *testing.T) {
 				}) {
 					return false
 				}
-
-				if asRecvCh != nil {
-					select {
-					case <-ctx.Done():
-						t.Error("Timed out while waiting for NetworkServer.handleASUplink to be called")
-						return false
-
-					case req := <-asRecvCh:
-						a.So(req.Uplink, should.Resemble, &ttnpb.ApplicationUp{
-							CorrelationIDs:       reqCorrelationIDs,
-							EndDeviceIdentifiers: *makeOTAAIdentifiers(&joinReq.DevAddr),
-							Up: &ttnpb.ApplicationUp_JoinAccept{JoinAccept: &ttnpb.ApplicationJoinAccept{
-								AppSKey: makeSessionKeys(ttnpb.MAC_V1_1).AppSKey,
-								InvalidatedDownlinks: []*ttnpb.ApplicationDownlink{
-									makeApplicationDownlink(),
-								},
-								SessionKeyID: makeSessionKeys(ttnpb.MAC_V1_1).SessionKeyID,
-							}},
-						})
-						req.Response <- ttnpb.Empty
-					}
-				}
 				return true
 			},
 		},
 
 		{
 			Name: "Join-request/Get OTAA device/1.0.2/JS accept/Set fail",
-			Handler: func(ctx context.Context, env TestEnvironment, asRecvCh <-chan AsNsLinkRecvRequest, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
+			Handler: func(ctx context.Context, env TestEnvironment, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
 
@@ -1603,7 +1596,7 @@ func TestHandleUplink(t *testing.T) {
 
 		{
 			Name: "Join-request/Get OTAA device/1.1/JS accept/Set success/Downlink add fail",
-			Handler: func(ctx context.Context, env TestEnvironment, asRecvCh <-chan AsNsLinkRecvRequest, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
+			Handler: func(ctx context.Context, env TestEnvironment, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
 
@@ -1780,6 +1773,27 @@ func TestHandleUplink(t *testing.T) {
 					return false
 				}
 
+				if !a.So(AssertApplicationUplinkQueueAddRequest(ctx, env.ApplicationUplinks.Add, func(ctx context.Context, ups ...*ttnpb.ApplicationUp) bool {
+					return a.So(ctx, should.HaveParentContextOrEqual, reqCtx) &&
+						a.So(ups, should.Resemble, []*ttnpb.ApplicationUp{
+							{
+								CorrelationIDs:       reqCorrelationIDs,
+								EndDeviceIdentifiers: *makeOTAAIdentifiers(&joinReq.DevAddr),
+								Up: &ttnpb.ApplicationUp_JoinAccept{JoinAccept: &ttnpb.ApplicationJoinAccept{
+									AppSKey: makeSessionKeys(ttnpb.MAC_V1_1).AppSKey,
+									InvalidatedDownlinks: []*ttnpb.ApplicationDownlink{
+										makeApplicationDownlink(),
+									},
+									SessionKeyID: makeSessionKeys(ttnpb.MAC_V1_1).SessionKeyID,
+								}},
+							},
+						})
+				},
+					nil,
+				), should.BeTrue) {
+					return false
+				}
+
 				_ = sendUplinkDuplicates(ctx, handle, env.CollectionDone, func(decoded bool) *ttnpb.UplinkMessage {
 					msg := makeJoinRequest(decoded)
 					if !decoded {
@@ -1795,35 +1809,13 @@ func TestHandleUplink(t *testing.T) {
 				}) {
 					return false
 				}
-
-				if asRecvCh != nil {
-					select {
-					case <-ctx.Done():
-						t.Error("Timed out while waiting for NetworkServer.handleASUplink to be called")
-						return false
-
-					case req := <-asRecvCh:
-						a.So(req.Uplink, should.Resemble, &ttnpb.ApplicationUp{
-							CorrelationIDs:       reqCorrelationIDs,
-							EndDeviceIdentifiers: *makeOTAAIdentifiers(&joinReq.DevAddr),
-							Up: &ttnpb.ApplicationUp_JoinAccept{JoinAccept: &ttnpb.ApplicationJoinAccept{
-								AppSKey: makeSessionKeys(ttnpb.MAC_V1_1).AppSKey,
-								InvalidatedDownlinks: []*ttnpb.ApplicationDownlink{
-									makeApplicationDownlink(),
-								},
-								SessionKeyID: makeSessionKeys(ttnpb.MAC_V1_1).SessionKeyID,
-							}},
-						})
-						req.Response <- ttnpb.Empty
-					}
-				}
 				return true
 			},
 		},
 
 		{
 			Name: "Join-request/Get OTAA device/1.0.2/JS accept/Set success/Downlink add success",
-			Handler: func(ctx context.Context, env TestEnvironment, asRecvCh <-chan AsNsLinkRecvRequest, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
+			Handler: func(ctx context.Context, env TestEnvironment, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
 
@@ -1997,6 +1989,27 @@ func TestHandleUplink(t *testing.T) {
 					return false
 				}
 
+				if !a.So(AssertApplicationUplinkQueueAddRequest(ctx, env.ApplicationUplinks.Add, func(ctx context.Context, ups ...*ttnpb.ApplicationUp) bool {
+					return a.So(ctx, should.HaveParentContextOrEqual, reqCtx) &&
+						a.So(ups, should.Resemble, []*ttnpb.ApplicationUp{
+							{
+								CorrelationIDs:       reqCorrelationIDs,
+								EndDeviceIdentifiers: *makeOTAAIdentifiers(&joinReq.DevAddr),
+								Up: &ttnpb.ApplicationUp_JoinAccept{JoinAccept: &ttnpb.ApplicationJoinAccept{
+									AppSKey: makeSessionKeys(ttnpb.MAC_V1_0_2).AppSKey,
+									InvalidatedDownlinks: []*ttnpb.ApplicationDownlink{
+										makeApplicationDownlink(),
+									},
+									SessionKeyID: makeSessionKeys(ttnpb.MAC_V1_0_2).SessionKeyID,
+								}},
+							},
+						})
+				},
+					nil,
+				), should.BeTrue) {
+					return false
+				}
+
 				_ = sendUplinkDuplicates(ctx, handle, env.CollectionDone, func(decoded bool) *ttnpb.UplinkMessage {
 					msg := makeJoinRequest(decoded)
 					if !decoded {
@@ -2012,35 +2025,13 @@ func TestHandleUplink(t *testing.T) {
 				}) {
 					return false
 				}
-
-				if asRecvCh != nil {
-					select {
-					case <-ctx.Done():
-						t.Error("Timed out while waiting for NetworkServer.handleASUplink to be called")
-						return false
-
-					case req := <-asRecvCh:
-						a.So(req.Uplink, should.Resemble, &ttnpb.ApplicationUp{
-							CorrelationIDs:       reqCorrelationIDs,
-							EndDeviceIdentifiers: *makeOTAAIdentifiers(&joinReq.DevAddr),
-							Up: &ttnpb.ApplicationUp_JoinAccept{JoinAccept: &ttnpb.ApplicationJoinAccept{
-								AppSKey: makeSessionKeys(ttnpb.MAC_V1_0_2).AppSKey,
-								InvalidatedDownlinks: []*ttnpb.ApplicationDownlink{
-									makeApplicationDownlink(),
-								},
-								SessionKeyID: makeSessionKeys(ttnpb.MAC_V1_0_2).SessionKeyID,
-							}},
-						})
-						req.Response <- ttnpb.Empty
-					}
-				}
 				return true
 			},
 		},
 
 		{
 			Name: "Join-request/Get OTAA device/1.1/JS accept/Set success/Downlink add success",
-			Handler: func(ctx context.Context, env TestEnvironment, asRecvCh <-chan AsNsLinkRecvRequest, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
+			Handler: func(ctx context.Context, env TestEnvironment, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
 
@@ -2217,6 +2208,27 @@ func TestHandleUplink(t *testing.T) {
 					return false
 				}
 
+				if !a.So(AssertApplicationUplinkQueueAddRequest(ctx, env.ApplicationUplinks.Add, func(ctx context.Context, ups ...*ttnpb.ApplicationUp) bool {
+					return a.So(ctx, should.HaveParentContextOrEqual, reqCtx) &&
+						a.So(ups, should.Resemble, []*ttnpb.ApplicationUp{
+							{
+								CorrelationIDs:       reqCorrelationIDs,
+								EndDeviceIdentifiers: *makeOTAAIdentifiers(&joinReq.DevAddr),
+								Up: &ttnpb.ApplicationUp_JoinAccept{JoinAccept: &ttnpb.ApplicationJoinAccept{
+									AppSKey: makeSessionKeys(ttnpb.MAC_V1_1).AppSKey,
+									InvalidatedDownlinks: []*ttnpb.ApplicationDownlink{
+										makeApplicationDownlink(),
+									},
+									SessionKeyID: makeSessionKeys(ttnpb.MAC_V1_1).SessionKeyID,
+								}},
+							},
+						})
+				},
+					nil,
+				), should.BeTrue) {
+					return false
+				}
+
 				_ = sendUplinkDuplicates(ctx, handle, env.CollectionDone, func(decoded bool) *ttnpb.UplinkMessage {
 					msg := makeJoinRequest(decoded)
 					if !decoded {
@@ -2232,35 +2244,13 @@ func TestHandleUplink(t *testing.T) {
 				}) {
 					return false
 				}
-
-				if asRecvCh != nil {
-					select {
-					case <-ctx.Done():
-						t.Error("Timed out while waiting for NetworkServer.handleASUplink to be called")
-						return false
-
-					case req := <-asRecvCh:
-						a.So(req.Uplink, should.Resemble, &ttnpb.ApplicationUp{
-							CorrelationIDs:       reqCorrelationIDs,
-							EndDeviceIdentifiers: *makeOTAAIdentifiers(&joinReq.DevAddr),
-							Up: &ttnpb.ApplicationUp_JoinAccept{JoinAccept: &ttnpb.ApplicationJoinAccept{
-								AppSKey: makeSessionKeys(ttnpb.MAC_V1_1).AppSKey,
-								InvalidatedDownlinks: []*ttnpb.ApplicationDownlink{
-									makeApplicationDownlink(),
-								},
-								SessionKeyID: makeSessionKeys(ttnpb.MAC_V1_1).SessionKeyID,
-							}},
-						})
-						req.Response <- ttnpb.Empty
-					}
-				}
 				return true
 			},
 		},
 
 		{
 			Name: "Rejoin-request",
-			Handler: func(ctx context.Context, env TestEnvironment, asRecvCh <-chan AsNsLinkRecvRequest, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
+			Handler: func(ctx context.Context, env TestEnvironment, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
 
@@ -2280,7 +2270,7 @@ func TestHandleUplink(t *testing.T) {
 
 		{
 			Name: "Data uplink/Matching device/No concurrent update/1.0.2/First transmission/No ADR/Set success/Downlink add success",
-			Handler: func(ctx context.Context, env TestEnvironment, asRecvCh <-chan AsNsLinkRecvRequest, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
+			Handler: func(ctx context.Context, env TestEnvironment, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
 
@@ -2415,6 +2405,39 @@ func TestHandleUplink(t *testing.T) {
 					return false
 				}
 
+				if !a.So(AssertApplicationUplinkQueueAddRequest(ctx, env.ApplicationUplinks.Add, func(ctx context.Context, ups ...*ttnpb.ApplicationUp) bool {
+					return a.So(ctx, should.HaveParentContextOrEqual, upCtx) &&
+						a.So(ups, should.Resemble, []*ttnpb.ApplicationUp{
+							{
+								CorrelationIDs:       upCorrelationIDs,
+								EndDeviceIdentifiers: *makeOTAAIdentifiers(&devAddr),
+								Up: &ttnpb.ApplicationUp_UplinkMessage{UplinkMessage: &ttnpb.ApplicationUplink{
+									SessionKeyID: makeSessionKeys(ttnpb.MAC_V1_1).SessionKeyID,
+									FPort:        fPort,
+									FCnt:         34,
+									FRMPayload:   makeDataUplinkFRMPayload(34),
+									RxMetadata:   mds,
+									Settings: ttnpb.TxSettings{
+										DataRateIndex: ttnpb.DATA_RATE_2,
+										DataRate: ttnpb.DataRate{
+											Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
+												Bandwidth:       125000,
+												SpreadingFactor: 10,
+											}},
+										},
+										EnableCRC: true,
+										Frequency: 868300000,
+										Timestamp: 42,
+									},
+								}},
+							},
+						})
+				},
+					nil,
+				), should.BeTrue) {
+					return false
+				}
+
 				if !a.So(test.AssertEventPubSubPublishRequest(ctx, env.Events, func(ev events.Event) bool {
 					return a.So(ev, should.ResembleEvent, EvtMergeMetadata(upCtx, rangeDevice.EndDeviceIdentifiers, len(mds)))
 				}), should.BeTrue) {
@@ -2454,47 +2477,13 @@ func TestHandleUplink(t *testing.T) {
 				}) {
 					return false
 				}
-
-				if asRecvCh != nil {
-					select {
-					case <-ctx.Done():
-						t.Error("Timed out while waiting for NetworkServer.handleASUplink to be called")
-						return false
-
-					case req := <-asRecvCh:
-						a.So(req.Uplink, should.Resemble, &ttnpb.ApplicationUp{
-							CorrelationIDs:       upCorrelationIDs,
-							EndDeviceIdentifiers: *makeOTAAIdentifiers(&devAddr),
-							Up: &ttnpb.ApplicationUp_UplinkMessage{UplinkMessage: &ttnpb.ApplicationUplink{
-								SessionKeyID: makeSessionKeys(ttnpb.MAC_V1_1).SessionKeyID,
-								FPort:        fPort,
-								FCnt:         34,
-								FRMPayload:   makeDataUplinkFRMPayload(34),
-								RxMetadata:   mds,
-								Settings: ttnpb.TxSettings{
-									DataRateIndex: ttnpb.DATA_RATE_2,
-									DataRate: ttnpb.DataRate{
-										Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-											Bandwidth:       125000,
-											SpreadingFactor: 10,
-										}},
-									},
-									EnableCRC: true,
-									Frequency: 868300000,
-									Timestamp: 42,
-								},
-							}},
-						})
-						req.Response <- ttnpb.Empty
-					}
-				}
 				return true
 			},
 		},
 
 		{
 			Name: "Data uplink/Matching device/No concurrent update/1.1/First transmission/No ADR/Set success/Downlink add success",
-			Handler: func(ctx context.Context, env TestEnvironment, asRecvCh <-chan AsNsLinkRecvRequest, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
+			Handler: func(ctx context.Context, env TestEnvironment, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
 
@@ -2629,6 +2618,39 @@ func TestHandleUplink(t *testing.T) {
 					return false
 				}
 
+				if !a.So(AssertApplicationUplinkQueueAddRequest(ctx, env.ApplicationUplinks.Add, func(ctx context.Context, ups ...*ttnpb.ApplicationUp) bool {
+					return a.So(ctx, should.HaveParentContextOrEqual, upCtx) &&
+						a.So(ups, should.Resemble, []*ttnpb.ApplicationUp{
+							{
+								CorrelationIDs:       upCorrelationIDs,
+								EndDeviceIdentifiers: *makeOTAAIdentifiers(&devAddr),
+								Up: &ttnpb.ApplicationUp_UplinkMessage{UplinkMessage: &ttnpb.ApplicationUplink{
+									SessionKeyID: makeSessionKeys(ttnpb.MAC_V1_1).SessionKeyID,
+									FPort:        fPort,
+									FCnt:         34,
+									FRMPayload:   makeDataUplinkFRMPayload(34),
+									RxMetadata:   mds,
+									Settings: ttnpb.TxSettings{
+										DataRateIndex: ttnpb.DATA_RATE_2,
+										DataRate: ttnpb.DataRate{
+											Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
+												Bandwidth:       125000,
+												SpreadingFactor: 10,
+											}},
+										},
+										EnableCRC: true,
+										Frequency: 868300000,
+										Timestamp: 42,
+									},
+								}},
+							},
+						})
+				},
+					nil,
+				), should.BeTrue) {
+					return false
+				}
+
 				if !a.So(test.AssertEventPubSubPublishRequest(ctx, env.Events, func(ev events.Event) bool {
 					return a.So(ev, should.ResembleEvent, EvtMergeMetadata(upCtx, rangeDevice.EndDeviceIdentifiers, len(mds)))
 				}), should.BeTrue) {
@@ -2668,47 +2690,13 @@ func TestHandleUplink(t *testing.T) {
 				}) {
 					return false
 				}
-
-				if asRecvCh != nil {
-					select {
-					case <-ctx.Done():
-						t.Error("Timed out while waiting for NetworkServer.handleASUplink to be called")
-						return false
-
-					case req := <-asRecvCh:
-						a.So(req.Uplink, should.Resemble, &ttnpb.ApplicationUp{
-							CorrelationIDs:       upCorrelationIDs,
-							EndDeviceIdentifiers: *makeOTAAIdentifiers(&devAddr),
-							Up: &ttnpb.ApplicationUp_UplinkMessage{UplinkMessage: &ttnpb.ApplicationUplink{
-								SessionKeyID: makeSessionKeys(ttnpb.MAC_V1_1).SessionKeyID,
-								FPort:        fPort,
-								FCnt:         34,
-								FRMPayload:   makeDataUplinkFRMPayload(34),
-								RxMetadata:   mds,
-								Settings: ttnpb.TxSettings{
-									DataRateIndex: ttnpb.DATA_RATE_2,
-									DataRate: ttnpb.DataRate{
-										Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-											Bandwidth:       125000,
-											SpreadingFactor: 10,
-										}},
-									},
-									EnableCRC: true,
-									Frequency: 868300000,
-									Timestamp: 42,
-								},
-							}},
-						})
-						req.Response <- ttnpb.Empty
-					}
-				}
 				return true
 			},
 		},
 
 		{
 			Name: "Data uplink/Matching device/Concurrent update/1.0.2/First transmission/No ADR/Set success/Downlink add success",
-			Handler: func(ctx context.Context, env TestEnvironment, asRecvCh <-chan AsNsLinkRecvRequest, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
+			Handler: func(ctx context.Context, env TestEnvironment, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
 
@@ -2845,6 +2833,39 @@ func TestHandleUplink(t *testing.T) {
 					return false
 				}
 
+				if !a.So(AssertApplicationUplinkQueueAddRequest(ctx, env.ApplicationUplinks.Add, func(ctx context.Context, ups ...*ttnpb.ApplicationUp) bool {
+					return a.So(ctx, should.HaveParentContextOrEqual, upCtx) &&
+						a.So(ups, should.Resemble, []*ttnpb.ApplicationUp{
+							{
+								CorrelationIDs:       upCorrelationIDs,
+								EndDeviceIdentifiers: *makeOTAAIdentifiers(&devAddr),
+								Up: &ttnpb.ApplicationUp_UplinkMessage{UplinkMessage: &ttnpb.ApplicationUplink{
+									SessionKeyID: makeSessionKeys(ttnpb.MAC_V1_1).SessionKeyID,
+									FPort:        fPort,
+									FCnt:         34,
+									FRMPayload:   makeDataUplinkFRMPayload(34),
+									RxMetadata:   mds,
+									Settings: ttnpb.TxSettings{
+										DataRateIndex: ttnpb.DATA_RATE_2,
+										DataRate: ttnpb.DataRate{
+											Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
+												Bandwidth:       125000,
+												SpreadingFactor: 10,
+											}},
+										},
+										EnableCRC: true,
+										Frequency: 868300000,
+										Timestamp: 42,
+									},
+								}},
+							},
+						})
+				},
+					nil,
+				), should.BeTrue) {
+					return false
+				}
+
 				if !a.So(test.AssertEventPubSubPublishRequest(ctx, env.Events, func(ev events.Event) bool {
 					return a.So(ev, should.ResembleEvent, EvtMergeMetadata(upCtx, rangeDevice.EndDeviceIdentifiers, len(mds)))
 				}), should.BeTrue) {
@@ -2884,47 +2905,13 @@ func TestHandleUplink(t *testing.T) {
 				}) {
 					return false
 				}
-
-				if asRecvCh != nil {
-					select {
-					case <-ctx.Done():
-						t.Error("Timed out while waiting for NetworkServer.handleASUplink to be called")
-						return false
-
-					case req := <-asRecvCh:
-						a.So(req.Uplink, should.Resemble, &ttnpb.ApplicationUp{
-							CorrelationIDs:       upCorrelationIDs,
-							EndDeviceIdentifiers: *makeOTAAIdentifiers(&devAddr),
-							Up: &ttnpb.ApplicationUp_UplinkMessage{UplinkMessage: &ttnpb.ApplicationUplink{
-								SessionKeyID: makeSessionKeys(ttnpb.MAC_V1_1).SessionKeyID,
-								FPort:        fPort,
-								FCnt:         34,
-								FRMPayload:   makeDataUplinkFRMPayload(34),
-								RxMetadata:   mds,
-								Settings: ttnpb.TxSettings{
-									DataRateIndex: ttnpb.DATA_RATE_2,
-									DataRate: ttnpb.DataRate{
-										Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-											Bandwidth:       125000,
-											SpreadingFactor: 10,
-										}},
-									},
-									EnableCRC: true,
-									Frequency: 868300000,
-									Timestamp: 42,
-								},
-							}},
-						})
-						req.Response <- ttnpb.Empty
-					}
-				}
 				return true
 			},
 		},
 
 		{
 			Name: "Data uplink/Matching device/No concurrent update/1.0.2/Second transmission/No ADR/Set success/Downlink add success",
-			Handler: func(ctx context.Context, env TestEnvironment, asRecvCh <-chan AsNsLinkRecvRequest, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
+			Handler: func(ctx context.Context, env TestEnvironment, handle func(context.Context, *ttnpb.UplinkMessage) <-chan error) bool {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
 
@@ -3087,102 +3074,31 @@ func TestHandleUplink(t *testing.T) {
 		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
-			handleTest := func(ctx context.Context, ns *NetworkServer, env TestEnvironment, asRecvCh <-chan AsNsLinkRecvRequest, stop func()) {
-				defer stop()
+			ns, ctx, env, stop := StartTest(t, Config{
+				NetID:              *netID.Copy(&types.NetID{}),
+				DefaultMACSettings: MACSettingConfig{},
+			}, (1<<12)*test.Delay, true)
+			defer stop()
 
-				<-env.DownlinkTasks.Pop
+			<-env.DownlinkTasks.Pop
 
-				if !tc.Handler(ctx, env, asRecvCh, func(ctx context.Context, msg *ttnpb.UplinkMessage) <-chan error {
-					ch := make(chan error)
-					go func() {
-						_, err := ttnpb.NewGsNsClient(ns.LoopbackConn()).HandleUplink(ctx, CopyUplinkMessage(msg))
-						ttnErr, ok := errors.From(err)
-						if ok {
-							ch <- ttnErr
-						} else {
-							ch <- err
-						}
-						close(ch)
-					}()
-					return ch
-				}) {
-					t.Error("Test handler failed")
-				}
-			}
-
-			makeConfig := func() Config {
-				return Config{
-					NetID:              *netID.Copy(&types.NetID{}),
-					DefaultMACSettings: MACSettingConfig{},
-				}
-			}
-
-			timeout := (1 << 12) * test.Delay
-
-			t.Run("no link", func(t *testing.T) {
-				ns, ctx, env, stop := StartTest(t, makeConfig(), timeout, true)
-				handleTest(ctx, ns, env, nil, func() {
-					defer stop()
-					assertions.New(t).So(AssertNetworkServerClose(ctx, ns), should.BeTrue)
-				})
-			})
-
-			t.Run("active link", func(t *testing.T) {
-				ns, ctx, env, stop := StartTest(t, makeConfig(), timeout, true)
-
-				link, linkEndEvent, ok := AssertLinkApplication(ctx, ns.LoopbackConn(), env.Cluster.GetPeer, env.Events, appID)
-				if !ok {
-					t.Fatal("Failed to link application")
-				}
-
-				a := assertions.New(t)
-
-				asRecvCh := make(chan AsNsLinkRecvRequest)
-				wg := &sync.WaitGroup{}
-				wg.Add(1)
+			if !tc.Handler(ctx, env, func(ctx context.Context, msg *ttnpb.UplinkMessage) <-chan error {
+				ch := make(chan error)
 				go func() {
-					defer wg.Done()
-					for {
-						up, err := link.Recv()
-						if err != nil {
-							t.Logf("Receive on AS link returned error: %v", err)
-							close(asRecvCh)
-							return
-						}
-
-						respCh := make(chan *pbtypes.Empty)
-						select {
-						case <-ctx.Done():
-							t.Error("Timed out while waiting for AS uplink to be processed")
-							return
-						case asRecvCh <- AsNsLinkRecvRequest{
-							Uplink:   up,
-							Response: respCh,
-						}:
-						}
-
-						select {
-						case <-ctx.Done():
-							t.Error("Timed out while waiting for AS uplink response to be processed")
-							return
-						case resp := <-respCh:
-							if err := link.Send(resp); err != nil {
-								t.Logf("Send on the link returned error: %v", err)
-							}
-						}
+					_, err := ttnpb.NewGsNsClient(ns.LoopbackConn()).HandleUplink(ctx, CopyUplinkMessage(msg))
+					ttnErr, ok := errors.From(err)
+					if ok {
+						ch <- ttnErr
+					} else {
+						ch <- err
 					}
+					close(ch)
 				}()
-				handleTest(ctx, ns, env, asRecvCh, func() {
-					defer stop()
-
-					a.So(AssertNetworkServerClose(ctx, ns), should.BeTrue)
-					if !a.So(test.AssertEventPubSubPublishRequest(ctx, env.Events, func(ev events.Event) bool {
-						return a.So(ev, should.ResembleEvent, linkEndEvent(context.Canceled))
-					}), should.BeTrue) {
-						return
-					}
-				})
-			})
+				return ch
+			}) {
+				t.Error("Test handler failed")
+			}
+			assertions.New(t).So(AssertNetworkServerClose(ctx, ns), should.BeTrue)
 		})
 	}
 }

--- a/pkg/networkserver/redis/application_uplink_queue.go
+++ b/pkg/networkserver/redis/application_uplink_queue.go
@@ -1,0 +1,184 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redis
+
+import (
+	"context"
+	"crypto/rand"
+	"time"
+
+	"github.com/go-redis/redis"
+	ulid "github.com/oklog/ulid/v2"
+	"go.thethings.network/lorawan-stack/pkg/errors"
+	"go.thethings.network/lorawan-stack/pkg/log"
+	ttnredis "go.thethings.network/lorawan-stack/pkg/redis"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/pkg/unique"
+)
+
+type ApplicationUplinkQueue struct {
+	Redis  *ttnredis.Client
+	MaxLen int64
+	Group  string
+	ID     string
+}
+
+// NewApplicationUplinkQueue returns new application uplink queue.
+func NewApplicationUplinkQueue(cl *ttnredis.Client, maxLen int64, group, id string) *ApplicationUplinkQueue {
+	return &ApplicationUplinkQueue{
+		Redis:  cl,
+		MaxLen: maxLen,
+		Group:  group,
+		ID:     id,
+	}
+}
+
+func (q *ApplicationUplinkQueue) uidUplinkKey(uid string) string {
+	return q.Redis.Key("uid", uid, "uplinks")
+}
+
+func (q *ApplicationUplinkQueue) uidCloseKey(uid, streamID string) string {
+	return q.Redis.Key("uid", uid, "close", streamID)
+}
+
+const payloadKey = "payload"
+
+func (q *ApplicationUplinkQueue) Add(ctx context.Context, ups ...*ttnpb.ApplicationUp) error {
+	for _, up := range ups {
+		s, err := ttnredis.MarshalProto(up)
+		if err != nil {
+			return err
+		}
+		if err := q.Redis.XAdd(&redis.XAddArgs{
+			Stream:       q.uidUplinkKey(unique.ID(ctx, up.ApplicationIdentifiers)),
+			MaxLenApprox: q.MaxLen,
+			Values: map[string]interface{}{
+				payloadKey: s,
+			},
+		}).Err(); err != nil {
+			return ttnredis.ConvertError(err)
+		}
+	}
+	return nil
+}
+
+var (
+	errInvalidPayload = errors.DefineCorruption("invalid_payload", "invalid payload")
+	errMissingPayload = errors.DefineDataLoss("missing_payload", "missing payload")
+)
+
+// Subscribe ranges over q.upStream(unique.ID(ctx, appID)) using f until ctx is done.
+// Subscribe assumes that there's at most 1 active consumer in q.Group per stream at all times.
+func (q *ApplicationUplinkQueue) Subscribe(ctx context.Context, appID ttnpb.ApplicationIdentifiers, f func(context.Context, *ttnpb.ApplicationUp) error) error {
+	streamULID, err := ulid.New(ulid.Now(), rand.Reader)
+	if err != nil {
+		return err
+	}
+	uid := unique.ID(ctx, appID)
+	upStream := q.uidUplinkKey(uid)
+	closeStream := q.uidCloseKey(uid, streamULID.String())
+
+	_, err = q.Redis.XGroupCreateMkStream(closeStream, q.Group, "0").Result()
+	if err != nil {
+		return ttnredis.ConvertError(err)
+	}
+
+	dl, hasDL := ctx.Deadline()
+	if hasDL {
+		_, err = q.Redis.ExpireAt(closeStream, dl).Result()
+		if err != nil {
+			return ttnredis.ConvertError(err)
+		}
+	}
+
+	doneCh := make(chan struct{})
+	defer func() {
+		close(doneCh)
+	}()
+	go func() {
+		logger := log.FromContext(ctx).WithField("key", closeStream)
+		select {
+		case <-ctx.Done():
+			_, err := q.Redis.XAdd(&redis.XAddArgs{
+				Stream: closeStream,
+				Values: map[string]interface{}{"": ""},
+			}).Result()
+			if err != nil {
+				logger.WithError(err).Error("Failed to add message to Redis stream")
+				return
+			}
+			<-doneCh
+
+		case <-doneCh:
+		}
+
+		_, err := q.Redis.Del(closeStream).Result()
+		if err != nil {
+			logger.WithError(err).Error("Failed to delete Redis key")
+		}
+	}()
+	for {
+		_, err := q.Redis.XGroupCreateMkStream(upStream, q.Group, "0").Result()
+		if err != nil && !ttnredis.IsConsumerGroupExistsErr(err) {
+			return ttnredis.ConvertError(err)
+		}
+
+		var timeout time.Duration
+		if hasDL {
+			timeout = time.Until(dl)
+			if timeout <= 0 {
+				return context.DeadlineExceeded
+			}
+		}
+		rets, err := q.Redis.XReadGroup(&redis.XReadGroupArgs{
+			Group:    q.Group,
+			Consumer: q.ID,
+			Streams:  []string{closeStream, upStream, upStream, ">", "0", ">"},
+			Block:    timeout,
+		}).Result()
+		if err != nil {
+			return ttnredis.ConvertError(err)
+		}
+		for _, ret := range rets {
+			switch ret.Stream {
+			case closeStream:
+				return ctx.Err()
+
+			case upStream:
+				for _, msg := range ret.Messages {
+					v, ok := msg.Values[payloadKey]
+					if !ok {
+						return errMissingPayload
+					}
+					s, ok := v.(string)
+					if !ok {
+						return errInvalidPayload
+					}
+					up := &ttnpb.ApplicationUp{}
+					if err = ttnredis.UnmarshalProto(s, up); err != nil {
+						return err
+					}
+					if err = f(ctx, up); err != nil {
+						return err
+					}
+					_, err = q.Redis.XAck(upStream, q.Group, msg.ID).Result()
+					if err != nil {
+						return ttnredis.ConvertError(err)
+					}
+				}
+			}
+		}
+	}
+}

--- a/pkg/networkserver/redis/application_uplink_queue_test.go
+++ b/pkg/networkserver/redis/application_uplink_queue_test.go
@@ -1,0 +1,22 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redis_test
+
+import (
+	"go.thethings.network/lorawan-stack/pkg/networkserver"
+	. "go.thethings.network/lorawan-stack/pkg/networkserver/redis"
+)
+
+var _ networkserver.ApplicationUplinkQueue = &ApplicationUplinkQueue{}

--- a/pkg/networkserver/redis/downlink_task_queue.go
+++ b/pkg/networkserver/redis/downlink_task_queue.go
@@ -48,7 +48,7 @@ func (q *DownlinkTaskQueue) Add(ctx context.Context, devID ttnpb.EndDeviceIdenti
 	return q.TaskQueue.Add(unique.ID(ctx, devID), startAt, replace)
 }
 
-// Pop calls f on the most recent downlink task in the schedule, for which timestamp is in range [0, time.Now()],
+// Pop calls f on the earliest downlink task in the schedule, for which timestamp is in range [0, time.Now()],
 // if such is available, otherwise it blocks until it is.
 func (q *DownlinkTaskQueue) Pop(ctx context.Context, f func(context.Context, ttnpb.EndDeviceIdentifiers, time.Time) error) error {
 	return q.TaskQueue.Pop(ctx, func(uid string, startAt time.Time) error {

--- a/pkg/networkserver/registry_test.go
+++ b/pkg/networkserver/registry_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	. "go.thethings.network/lorawan-stack/pkg/networkserver"
-	"go.thethings.network/lorawan-stack/pkg/networkserver/redis"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/types"
 	"go.thethings.network/lorawan-stack/pkg/util/test"
@@ -317,10 +316,6 @@ func handleRegistryTest(t *testing.T, reg DeviceRegistry) {
 func TestRegistries(t *testing.T) {
 	t.Parallel()
 
-	namespace := [...]string{
-		"networkserver_test",
-	}
-
 	for _, tc := range []struct {
 		Name string
 		New  func(t testing.TB) (reg DeviceRegistry, closeFn func() error)
@@ -328,15 +323,8 @@ func TestRegistries(t *testing.T) {
 	}{
 		{
 			Name: "Redis",
-			New: func(t testing.TB) (DeviceRegistry, func() error) {
-				cl, flush := test.NewRedis(t, namespace[:]...)
-				reg := &redis.DeviceRegistry{Redis: cl}
-				return reg, func() error {
-					flush()
-					return cl.Close()
-				}
-			},
-			N: 8,
+			New:  NewRedisDeviceRegistry,
+			N:    8,
 		},
 	} {
 		for i := 0; i < int(tc.N); i++ {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #560 

#### Changes
<!-- What are the changes made in this pull request? -->

- Queue application uplinks
- Add application uplink queue implementation using a persistent queue driven by Redis streams

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Tried different approaches, but implementation with streams turned out to be the simplest and IMHO best.
Note that this implementation also allows for multiple NS instances to generate application uplinks concurrently, while only the instance holding the link will be sending them to the AS in proper order.
