### PR TITLE
Fix SDK faulty deletion of existing device during rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix device creation rollback potentially deleting existing device with same ID.
+
 ### Security
 
 ## [3.2.3] - 2019-10-24


### PR DESCRIPTION
#### Summary
Closes #1526

#### Changes
- Change `makeRequests` util logic to always return a result object with error information per component (instead of throwing right away)
- Use the new response object to determine which entries need to be deleted when rolling back device creation

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [ ] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
