### PR TITLE
Embed documentation as static assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support LoRa Alliance TR005 Draft 3 QR code format.
 - TLS support for application link in the Console.
+- Embedded documentation served at `/assets/doc`.
 
 ### Changed
 

--- a/doc/themes/the-things-stack/layouts/partials/head.html
+++ b/doc/themes/the-things-stack/layouts/partials/head.html
@@ -4,7 +4,7 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   {{ hugo.Generator }}
   <title>{{ with .Title }}{{ . }} | {{ end }}{{ .Site.Title }}</title>
-  <link rel="canonical" href="{{ .Permalink }}" />
+  {{- if hasPrefix .Permalink "http" }}<link rel="canonical" href="{{ .Permalink }}" />{{ end }}
   <link rel="icon" type="image/png" href="{{ "favicon.png" | relURL }}">
   {{- $style := resources.Get "css/theme.scss" | resources.ToCSS (dict "includePaths" (slice "node_modules")) | resources.Minify | resources.Fingerprint }}
   <link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}">

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -144,20 +144,25 @@ func New(ctx context.Context, opts ...Option) (*Server, error) {
 		middleware.FillContext(options.contextFillers...),
 	)
 
+	var rootGroupMiddleware []echo.MiddlewareFunc
+
 	if options.redirectToHost != "" {
-		server.Use(middleware.RedirectToHost(options.redirectToHost))
+		rootGroupMiddleware = append(rootGroupMiddleware, middleware.RedirectToHost(options.redirectToHost))
 	}
 
 	if options.redirectToHTTPS != nil {
-		server.Use(middleware.RedirectToHTTPS(options.redirectToHTTPS))
+		rootGroupMiddleware = append(rootGroupMiddleware, middleware.RedirectToHTTPS(options.redirectToHTTPS))
 	}
+
+	rootGroupMiddleware = append(rootGroupMiddleware, middleware.Log(logger))
+
+	rootGroupMiddleware = append(rootGroupMiddleware, middleware.Normalize(middleware.RedirectPermanent))
 
 	s := &Server{
 		rootGroup: &rootGroup{
 			Group: server.Group(
 				"",
-				middleware.Log(logger),
-				middleware.Normalize(middleware.RedirectPermanent),
+				rootGroupMiddleware...,
 			),
 		},
 		server: server,
@@ -212,8 +217,8 @@ func (s *Server) Static(prefix string, fs http.FileSystem, middleware ...echo.Mi
 	t := strings.TrimSuffix(prefix, "/")
 	path := path.Join(t, "*")
 	handler := echo.WrapHandler(http.StripPrefix(t, http.FileServer(fs)))
-	s.GET(path, handler, middleware...)
-	s.HEAD(path, handler, middleware...)
+	s.server.GET(path, handler, middleware...)
+	s.server.HEAD(path, handler, middleware...)
 }
 
 // Routes returns the defined routes.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR changes the build so that documentation is embedded as static assets by rendering it to `public/doc`, to be served by The Things Stack under `/assets/doc`.

#### Changes
<!-- What are the changes made in this pull request? -->

- Make build tooling build documentation to `public/doc`
- Omit canonical link for embedded documentation (since we don't know the location)
- Circumvent HTTP-HTTPS and host redirects for assets

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
	- Only manual
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
