### PR TITLE
Fix unwanted overwrite of unexposed root keys in (device settings)

### DIFF
--- a/pkg/webui/console/components/device-data-form/index.js
+++ b/pkg/webui/console/components/device-data-form/index.js
@@ -229,7 +229,21 @@ class DeviceDataForm extends Component {
 
   get OTAASection() {
     const { resets_join_nonces, external_js } = this.state
-    const { update } = this.props
+    const {
+      update,
+      initialValues: { root_keys },
+    } = this.props
+
+    const rootKeysNotExposed =
+      root_keys && root_keys.root_key_id && !root_keys.nwk_key && !root_keys.app_key
+
+    let rootKeyPlaceholder = m.leaveBlankPlaceholder
+    if (external_js) {
+      rootKeyPlaceholder = sharedMessages.provisionedOnExternalJoinServer
+    } else if (rootKeysNotExposed) {
+      rootKeyPlaceholder = m.unexposed
+    }
+
     return (
       <React.Fragment>
         <JoinEUIPrefixesInput
@@ -271,12 +285,10 @@ class DeviceDataForm extends Component {
           type="byte"
           min={16}
           max={16}
-          placeholder={
-            external_js ? sharedMessages.provisionedOnExternalJoinServer : m.leaveBlankPlaceholder
-          }
+          placeholder={rootKeyPlaceholder}
           description={m.appKeyDescription}
           component={Input}
-          disabled={external_js}
+          disabled={external_js || rootKeysNotExposed}
         />
         <Form.Field
           title={sharedMessages.nwkKey}
@@ -284,12 +296,10 @@ class DeviceDataForm extends Component {
           type="byte"
           min={16}
           max={16}
-          placeholder={
-            external_js ? sharedMessages.provisionedOnExternalJoinServer : m.leaveBlankPlaceholder
-          }
+          placeholder={rootKeyPlaceholder}
           description={m.nwkKeyDescription}
           component={Input}
-          disabled={external_js}
+          disabled={external_js || rootKeysNotExposed}
         />
         <Form.Field
           title={m.resetsJoinNonces}
@@ -328,8 +338,8 @@ class DeviceDataForm extends Component {
       supports_class_c: false,
       resets_join_nonces: false,
       root_keys: {
-        nwk_key: {},
-        app_key: {},
+        nwk_key: { key: undefined },
+        app_key: { key: undefined },
       },
       session: {
         dev_addr: undefined,
@@ -492,6 +502,7 @@ const initialValuesPropType = PropTypes.shape({
   root_keys: PropTypes.shape({
     nwk_key: keyPropType,
     app_key: keyPropType,
+    root_key_id: PropTypes.string,
   }),
   session: PropTypes.shape({
     dev_addr: PropTypes.string,

--- a/pkg/webui/console/components/device-data-form/messages.js
+++ b/pkg/webui/console/components/device-data-form/messages.js
@@ -48,6 +48,7 @@ export default defineMessages({
   sNtwkSIKeyDescription: 'Serving Network Session Integrity Key (only for LoRaWAN 1.1+)',
   supportsClassC: 'Supports Class C',
   updateSuccess: 'Successfully updated end device',
+  unexposed: 'Unexposed',
   validate16: 'This value needs to be exactly 16 characters long',
   validate32: 'This value needs to be exactly 32 characters long',
   validate8: 'This value needs to be exactly 8 characters long',

--- a/pkg/webui/console/components/device-data-form/validation-schema.js
+++ b/pkg/webui/console/components/device-data-form/validation-schema.js
@@ -85,18 +85,28 @@ const validationSchema = Yup.object({
       is: (mode, externalJs) => isOTAA(mode) && !externalJs,
       then: schema =>
         schema.shape({
-          nwk_key: Yup.object().shape({
-            key: Yup.string()
-              .emptyOrLength(16 * 2, m.validate32) // 16 Byte hex
-              .transform(toUndefined)
-              .default(random16BytesString),
-          }),
-          app_key: Yup.object().shape({
-            key: Yup.string()
-              .emptyOrLength(16 * 2, m.validate32) // 16 Byte hex
-              .transform(toUndefined)
-              .default(random16BytesString),
-          }),
+          nwk_key: Yup.lazy(
+            value =>
+              value !== undefined
+                ? Yup.object().shape({
+                    key: Yup.string()
+                      .emptyOrLength(16 * 2, m.validate32) // 16 Byte hex
+                      .transform(toUndefined)
+                      .default(random16BytesString),
+                  })
+                : Yup.object().strip(), // Avoid generating when key is unexposed
+          ),
+          app_key: Yup.lazy(
+            value =>
+              value !== undefined
+                ? Yup.object().shape({
+                    key: Yup.string()
+                      .emptyOrLength(16 * 2, m.validate32) // 16 Byte hex
+                      .transform(toUndefined)
+                      .default(random16BytesString),
+                  })
+                : Yup.object().strip(), // Avoid generating when key is unexposed
+          ),
         }),
       otherwise: schema =>
         schema.shape({

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -70,6 +70,7 @@
   "console.components.device-data-form.messages.sNtwkSIKeyDescription": "Serving Network Session Integrity Key (only for LoRaWAN 1.1+)",
   "console.components.device-data-form.messages.supportsClassC": "Supports Class C",
   "console.components.device-data-form.messages.updateSuccess": "Successfully updated end device",
+  "console.components.device-data-form.messages.unexposed": "Unexposed",
   "console.components.device-data-form.messages.validate16": "This value needs to be exactly 16 characters long",
   "console.components.device-data-form.messages.validate32": "This value needs to be exactly 32 characters long",
   "console.components.device-data-form.messages.validate8": "This value needs to be exactly 8 characters long",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -70,6 +70,7 @@
   "console.components.device-data-form.messages.sNtwkSIKeyDescription": "Xxxxxxx Xxxxxxx Xxxxxxx Xxxxxxxxx Xxx (xxxx xxx XxXxXXX x.x+)",
   "console.components.device-data-form.messages.supportsClassC": "Xxxxxxxx Xxxxx X",
   "console.components.device-data-form.messages.updateSuccess": "Xxxxxxxxxxxx xxxxxxx xxx xxxxxx",
+  "console.components.device-data-form.messages.unexposed": "Xxxxxxxxx",
   "console.components.device-data-form.messages.validate16": "Xxxx xxxxx xxxxx xx xx xxxxxxx xx xxxxxxxxxx xxxx",
   "console.components.device-data-form.messages.validate32": "Xxxx xxxxx xxxxx xx xx xxxxxxx xx xxxxxxxxxx xxxx",
   "console.components.device-data-form.messages.validate8": "Xxxx xxxxx xxxxx xx xx xxxxxxx x xxxxxxxxxx xxxx",


### PR DESCRIPTION
#### Summary
Closes #1521 

#### Changes
- Extend validation schema to not generate the random value when the root keys are unexposed
- Disable the input when the root keys are unexposed
- Add an input placeholder to inform about unexposed keys

#### Notes for Reviewers
@johanstokking I tried to keep the UX as it was (generating root keys when field is empty) for consistency. Only difference now is that the input will be disabled and no keys will be generated when root keys are unexposed.

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [ ] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
