### PR TITLE
Add feature toggles to the console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for creating applications and gateway with an organization as the initial owner in the Console.
+- Hide views and features in the Console that the user and stack configuration does not meet the necessary requirements for.
 
 ### Changed
 

--- a/pkg/webui/components/navigation/bar/index.js
+++ b/pkg/webui/components/navigation/bar/index.js
@@ -26,7 +26,9 @@ const NavigationBar = function({ className, entries, anchored }) {
   return (
     <nav className={classnames(className, style.bar)}>
       {entries.map(function(entry, index) {
-        const { path, title, icon = null, exact = false } = entry
+        const { path, title, icon = null, exact = false, hidden } = entry
+
+        if (hidden) return null
 
         const Component = anchored ? NavigationAnchorLink : NavigationLink
 

--- a/pkg/webui/components/navigation/side/list/index.js
+++ b/pkg/webui/components/navigation/side/list/index.js
@@ -52,7 +52,10 @@ class SideNavigationList extends React.Component {
       <ul className={listClassNames}>
         {items.map(function(item, index) {
           const itemState = itemsExpanded[index] || {}
-          const { title, icon, path, exact = true, nested = false, items = [] } = item
+          const { title, icon, path, exact = true, nested = false, items = [], hidden } = item
+
+          if (hidden) return null
+
           const { isOpen = false, isLink = false } = itemState
 
           const isActive = nested && isLink
@@ -102,6 +105,7 @@ SideNavigationList.propTypes = {
         icon: PropTypes.string,
         nested: PropTypes.bool.isRequired,
         items: PropTypes.arrayOf(PropTypes.link).isRequired,
+        hidden: PropTypes.bool,
       }),
     ]),
   ).isRequired,

--- a/pkg/webui/console/containers/application-events/index.js
+++ b/pkg/webui/console/containers/application-events/index.js
@@ -18,6 +18,8 @@ import bind from 'autobind-decorator'
 
 import PropTypes from '../../../lib/prop-types'
 import EventsSubscription from '../../containers/events-subscription'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
+import { mayViewApplicationEvents } from '../../lib/feature-checks'
 
 import {
   clearApplicationEventsStream,
@@ -30,6 +32,7 @@ import {
   selectApplicationEventsError,
 } from '../../store/selectors/applications'
 
+@withFeatureRequirement(mayViewApplicationEvents)
 @connect(
   null,
   (dispatch, ownProps) => ({

--- a/pkg/webui/console/containers/applications-table/index.js
+++ b/pkg/webui/console/containers/applications-table/index.js
@@ -26,6 +26,7 @@ import {
   selectApplicationsFetching,
   selectApplicationsError,
 } from '../../store/selectors/applications'
+import { checkFromState, mayCreateApplications } from '../../lib/feature-checks'
 
 const headers = [
   {
@@ -59,6 +60,7 @@ export default class ApplicationsTable extends Component {
       totalCount: selectApplicationsTotalCount(state),
       fetching: selectApplicationsFetching(state),
       error: selectApplicationsError(state),
+      mayAdd: checkFromState(mayCreateApplications, state),
     }
   }
 

--- a/pkg/webui/console/containers/devices-table/index.js
+++ b/pkg/webui/console/containers/devices-table/index.js
@@ -23,11 +23,13 @@ import FetchTable from '../fetch-table'
 import DateTime from '../../../lib/components/date-time'
 import Button from '../../../components/button'
 import withRequest from '../../../lib/components/with-request'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
 
 import { getDevicesList } from '../../../console/store/actions/devices'
 import { getDeviceTemplateFormats } from '../../store/actions/device-template-formats'
 import { selectSelectedApplicationId } from '../../store/selectors/applications'
 import { selectDeviceTemplateFormats } from '../../store/selectors/device-template-formats'
+import { mayViewApplicationDevices } from '../../lib/feature-checks'
 
 import style from './devices-table.styl'
 
@@ -58,6 +60,7 @@ const headers = [
   },
   { getDeviceTemplateFormats },
 )
+@withFeatureRequirement(mayViewApplicationDevices)
 @withRequest(({ getDeviceTemplateFormats }) => getDeviceTemplateFormats())
 @bind
 class DevicesTable extends React.Component {

--- a/pkg/webui/console/containers/devices-table/index.js
+++ b/pkg/webui/console/containers/devices-table/index.js
@@ -29,7 +29,11 @@ import { getDevicesList } from '../../../console/store/actions/devices'
 import { getDeviceTemplateFormats } from '../../store/actions/device-template-formats'
 import { selectSelectedApplicationId } from '../../store/selectors/applications'
 import { selectDeviceTemplateFormats } from '../../store/selectors/device-template-formats'
-import { mayViewApplicationDevices } from '../../lib/feature-checks'
+import {
+  checkFromState,
+  mayCreateOrEditApplicationDevices,
+  mayViewApplicationDevices,
+} from '../../lib/feature-checks'
 
 import style from './devices-table.styl'
 
@@ -56,6 +60,7 @@ const headers = [
     return {
       appId: selectSelectedApplicationId(state),
       deviceTemplateFormats: selectDeviceTemplateFormats(state),
+      mayCreateDevices: checkFromState(mayCreateOrEditApplicationDevices, state),
     }
   },
   { getDeviceTemplateFormats },
@@ -68,6 +73,7 @@ class DevicesTable extends React.Component {
     appId: PropTypes.string.isRequired,
     devicePathPrefix: PropTypes.string,
     deviceTemplateFormats: PropTypes.shape({}).isRequired,
+    mayCreateDevices: PropTypes.bool.isRequired,
     totalCount: PropTypes.number,
   }
 
@@ -82,22 +88,28 @@ class DevicesTable extends React.Component {
     this.getDevicesList = filters => getDevicesList(props.appId, filters, ['name'])
   }
 
-  baseDataSelector({ devices }) {
-    return devices
+  baseDataSelector(state) {
+    const { mayCreateDevices } = this.props
+    return {
+      ...state.devices,
+      mayAdd: mayCreateDevices,
+    }
   }
 
   get importButton() {
-    const { deviceTemplateFormats, appId } = this.props
+    const { deviceTemplateFormats, mayCreateDevices, appId } = this.props
     const canBulkCreate = Object.keys(deviceTemplateFormats).length !== 0
 
     return (
-      <Button.Link
-        className={style.importDevices}
-        message={sharedMessages.importDevices}
-        icon="import_devices"
-        to={`/applications/${appId}/devices/import`}
-        disabled={!canBulkCreate}
-      />
+      mayCreateDevices && (
+        <Button.Link
+          className={style.importDevices}
+          message={sharedMessages.importDevices}
+          icon="import_devices"
+          to={`/applications/${appId}/devices/import`}
+          disabled={!canBulkCreate}
+        />
+      )
     )
   }
 

--- a/pkg/webui/console/containers/fetch-table/index.js
+++ b/pkg/webui/console/containers/fetch-table/index.js
@@ -67,6 +67,7 @@ const filterValidator = function(filters) {
     fetching: base.fetching,
     fetchingSearch: base.fetchingSearch,
     pathname: state.router.location.pathname,
+    mayAdd: 'mayAdd' in base ? base.mayAdd : true,
   }
 })
 @bind
@@ -200,6 +201,7 @@ class FetchTable extends Component {
       totalCount,
       fetching,
       fetchingSearch,
+      mayAdd,
       pageSize,
       addMessage,
       tableTitle,
@@ -245,12 +247,14 @@ class FetchTable extends Component {
               />
             )}
             {actionItems}
-            <Button.Link
-              className={style.addButton}
-              message={addMessage}
-              icon="add"
-              to={`${pathname}${itemPathPrefix}/add`}
-            />
+            {mayAdd && (
+              <Button.Link
+                className={style.addButton}
+                message={addMessage}
+                icon="add"
+                to={`${pathname}${itemPathPrefix}/add`}
+              />
+            )}
           </div>
         </div>
         <Tabular

--- a/pkg/webui/console/containers/gateways-table/index.js
+++ b/pkg/webui/console/containers/gateways-table/index.js
@@ -27,6 +27,7 @@ import {
   selectGatewaysFetching,
   selectGatewaysError,
 } from '../../store/selectors/gateways'
+import { checkFromState, mayCreateGateways } from '../../lib/feature-checks'
 
 const headers = [
   {
@@ -85,6 +86,7 @@ export default class GatewaysTable extends React.Component {
       totalCount: selectGatewaysTotalCount(state),
       fetching: selectGatewaysFetching(state),
       error: selectGatewaysError(state),
+      mayAdd: checkFromState(mayCreateGateways, state),
     }
   }
 

--- a/pkg/webui/console/containers/header/index.js
+++ b/pkg/webui/console/containers/header/index.js
@@ -17,20 +17,25 @@ import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
 import bind from 'autobind-decorator'
 
-import { logout } from '../../store/actions/user'
 import PropTypes from '../../../lib/prop-types'
 import sharedMessages from '../../../lib/shared-messages'
-
 import HeaderComponent from '../../../components/header'
+
+import { logout } from '../../store/actions/user'
+import { selectUser, selectUserRights } from '../../store/selectors/user'
+import {
+  mayViewApplications,
+  mayViewGateways,
+  mayViewOrganizations,
+} from '../../lib/feature-checks'
 
 @withRouter
 @connect(
   state => ({
-    user: state.user.user,
+    user: selectUser(state),
+    rights: selectUserRights(state),
   }),
-  dispatch => ({
-    handleLogout: () => dispatch(logout()),
-  }),
+  { handleLogout: logout },
 )
 @bind
 class Header extends Component {
@@ -48,10 +53,12 @@ class Header extends Component {
     searchable: PropTypes.bool,
     /** A flag identifying whether the header should display the search input */
     user: PropTypes.object,
+    /** The rights of the current user */
+    rights: PropTypes.rights,
   }
 
   render() {
-    const { user, anchored, handleSearchRequest, handleLogout, searchable } = this.props
+    const { user, anchored, handleSearchRequest, handleLogout, searchable, rights } = this.props
 
     const navigationEntries = [
       {
@@ -64,16 +71,19 @@ class Header extends Component {
         title: sharedMessages.applications,
         icon: 'application',
         path: '/applications',
+        hidden: !mayViewApplications.check(rights),
       },
       {
         title: sharedMessages.gateways,
         icon: 'gateway',
         path: '/gateways',
+        hidden: !mayViewGateways.check(rights),
       },
       {
         title: sharedMessages.organizations,
         icon: 'organization',
         path: '/organizations',
+        hidden: !mayViewOrganizations.check(rights),
       },
     ]
 

--- a/pkg/webui/console/containers/header/index.js
+++ b/pkg/webui/console/containers/header/index.js
@@ -22,19 +22,28 @@ import sharedMessages from '../../../lib/shared-messages'
 import HeaderComponent from '../../../components/header'
 
 import { logout } from '../../store/actions/user'
-import { selectUser, selectUserRights } from '../../store/selectors/user'
+import { selectUser } from '../../store/selectors/user'
 import {
+  checkFromState,
   mayViewApplications,
   mayViewGateways,
-  mayViewOrganizations,
+  mayViewOrganizationsOfUser,
 } from '../../lib/feature-checks'
 
 @withRouter
 @connect(
-  state => ({
-    user: selectUser(state),
-    rights: selectUserRights(state),
-  }),
+  function(state) {
+    const user = selectUser(state)
+    if (Boolean(user)) {
+      return {
+        user,
+        mayViewApplications: checkFromState(mayViewApplications, state),
+        mayViewGateways: checkFromState(mayViewGateways, state),
+        mayViewOrganizations: checkFromState(mayViewOrganizationsOfUser, state),
+      }
+    }
+    return { user }
+  },
   { handleLogout: logout },
 )
 @bind
@@ -58,7 +67,16 @@ class Header extends Component {
   }
 
   render() {
-    const { user, anchored, handleSearchRequest, handleLogout, searchable, rights } = this.props
+    const {
+      user,
+      anchored,
+      handleSearchRequest,
+      handleLogout,
+      searchable,
+      mayViewApplications,
+      mayViewGateways,
+      mayViewOrganizations,
+    } = this.props
 
     const navigationEntries = [
       {
@@ -71,19 +89,19 @@ class Header extends Component {
         title: sharedMessages.applications,
         icon: 'application',
         path: '/applications',
-        hidden: !mayViewApplications.check(rights),
+        hidden: !mayViewApplications,
       },
       {
         title: sharedMessages.gateways,
         icon: 'gateway',
         path: '/gateways',
-        hidden: !mayViewGateways.check(rights),
+        hidden: !mayViewGateways,
       },
       {
         title: sharedMessages.organizations,
         icon: 'organization',
         path: '/organizations',
-        hidden: !mayViewOrganizations.check(rights),
+        hidden: !mayViewOrganizations,
       },
     ]
 

--- a/pkg/webui/console/containers/organizations-table/index.js
+++ b/pkg/webui/console/containers/organizations-table/index.js
@@ -27,6 +27,7 @@ import {
   selectOrganizationsFetching,
   selectOrganizationsError,
 } from '../../store/selectors/organizations'
+import { checkFromState, mayCreateOrganizations } from '../../lib/feature-checks'
 
 const headers = [
   {
@@ -63,6 +64,7 @@ export default class OrganizationsTable extends Component {
       totalCount: selectOrganizationsTotalCount(state),
       fetching: selectOrganizationsFetching(state),
       error: selectOrganizationsError(state),
+      mayAdd: checkFromState(mayCreateOrganizations, state),
     }
   }
 

--- a/pkg/webui/console/lib/components/require.js
+++ b/pkg/webui/console/lib/components/require.js
@@ -1,0 +1,48 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Component } from 'react'
+import { connect } from 'react-redux'
+
+import PropTypes from '../../../lib/prop-types'
+
+@connect((state, props) => {
+  const { featureCheck, condition } = props
+  const rights = featureCheck && featureCheck.rightsSelector(state)
+  return {
+    condition: condition || featureCheck.check(rights),
+  }
+})
+export default class Require extends Component {
+  static propTypes = {
+    alternativeRender: PropTypes.func,
+    children: PropTypes.node.isRequired,
+    condition: PropTypes.bool.isRequired,
+  }
+  static defaultProps = {
+    alternativeRender: undefined,
+  }
+  render() {
+    const { condition, children, alternativeRender } = this.props
+
+    if (!condition) {
+      if (typeof alternativeRender === 'function') {
+        return alternativeRender()
+      }
+      return null
+    }
+
+    return children
+  }
+}

--- a/pkg/webui/console/lib/components/with-feature-requirement.js
+++ b/pkg/webui/console/lib/components/with-feature-requirement.js
@@ -1,0 +1,60 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import { Redirect } from 'react-router-dom'
+import bind from 'autobind-decorator'
+
+import Require from './require'
+
+/**
+ * `withFeatureRequirement` is a HOC that checks whether the current has the
+ * necessary authorization to view the wrapped component. It can be set up to
+ * either redirect to another route, to render something different or to not
+ * render anything if the requirement is not met.
+ * @param {Object} featureCheck - The feature check object containing the right
+ * selector as well as the check itself.
+ * @param {Object} otherwise - A configuration object determining what should be
+ * rendered if the requirement was not met. If not set, nothing will be rendered.
+ * @returns {Function} - An instance of the `withFeatureRequirement` HOC.
+ */
+const withFeatureRequirement = (featureCheck, otherwise) => Component =>
+  class WithFeatureRequirement extends React.Component {
+    @bind
+    alternativeRender() {
+      if (typeof otherwise === 'object') {
+        const { render, redirect } = otherwise
+
+        if (typeof redirect === 'function') {
+          return <Redirect to={redirect(this.props)} />
+        } else if (typeof redirect === 'string') {
+          return <Redirect to={redirect} />
+        } else if (typeof render === 'function') {
+          return render()
+        }
+      }
+
+      return null
+    }
+
+    render() {
+      return (
+        <Require featureCheck={featureCheck} alternativeRender={this.alternativeRender}>
+          <Component {...this.props} />
+        </Require>
+      )
+    }
+  }
+
+export default withFeatureRequirement

--- a/pkg/webui/console/lib/feature-checks.js
+++ b/pkg/webui/console/lib/feature-checks.js
@@ -1,0 +1,75 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { selectStackConfig } from '../../lib/selectors/env'
+import { selectApplicationRights } from '../store/selectors/applications'
+
+const stackConfig = selectStackConfig()
+const asEnabled = stackConfig.as.enabled
+const jsEnabled = stackConfig.js.enabled
+const nsEnabled = stackConfig.ns.enabled
+
+// Applications
+export const mayViewApplicationInfo = {
+  rightsSelector: selectApplicationRights,
+  check: rights => rights.includes('RIGHT_APPLICATION_INFO'),
+}
+export const mayEditBasicApplicationInfo = {
+  rightsSelector: selectApplicationRights,
+  check: rights => rights.includes('RIGHT_APPLICATION_SETTINGS_BASIC'),
+}
+export const mayLinkApplication = {
+  rightsSelector: selectApplicationRights,
+  check: rights => rights.includes('RIGHT_APPLICATION_LINK') && asEnabled,
+}
+export const maySetApplicationPayloadFormatters = {
+  rightsSelector: selectApplicationRights,
+  check: mayLinkApplication.check,
+}
+export const mayViewApplicationEvents = {
+  rightsSelector: selectApplicationRights,
+  check: rights => rights.includes('RIGHT_APPLICATION_TRAFFIC_READ'),
+}
+export const mayViewOrEditApplicationApiKeys = {
+  rightsSelector: selectApplicationRights,
+  check: rights => rights.includes('RIGHT_APPLICATION_SETTINGS_API_KEYS'),
+}
+export const mayViewApplicationDevices = {
+  rightsSelector: selectApplicationRights,
+  check: rights => rights.includes('RIGHT_APPLICATION_DEVICES_READ'),
+}
+export const mayCreateOrEditApplicationDevices = {
+  rightsSelector: selectApplicationRights,
+  check: rights => rights.includes('RIGHT_APPLICATION_DEVICES_WRITE'),
+}
+export const mayCreateOrEditApplicationIntegrations = {
+  rightsSelector: selectApplicationRights,
+  check: rights => mayEditBasicApplicationInfo.check(rights) && asEnabled,
+}
+export const mayViewMqttConnectionInfo = {
+  rightsSelector: selectApplicationRights,
+  check: rights => mayViewApplicationInfo.check(rights) && asEnabled,
+}
+export const mayViewOrEditApplicationCollaborators = {
+  rightsSelector: selectApplicationRights,
+  check: rights => rights.includes('RIGHT_APPLICATION_SETTINGS_COLLABORATORS'),
+}
+export const mayDeleteApplication = {
+  rightsSelector: selectApplicationRights,
+  check: rights => rights.includes('RIGHT_APPLICATION_DELETE'),
+}
+export const mayReadApplicationDeviceKeys = {
+  rightsSelector: selectApplicationRights,
+  check: rights => rights.includes('RIGHT_APPLICATION_DEVICES_READ_KEYS'),
+}

--- a/pkg/webui/console/lib/feature-checks.js
+++ b/pkg/webui/console/lib/feature-checks.js
@@ -168,11 +168,31 @@ export const mayCreateApplicationsUnderOrganization = {
   rightsSelector: selectOrganizationRights,
   check: rights => rights.includes('RIGHT_ORGANIZATION_APPLICATIONS_CREATE'),
 }
+export const mayViewApplicationsOfOrganization = {
+  rightsSelector: selectOrganizationRights,
+  check: rights => rights.includes('RIGHT_ORGANIZATION_APPLICATIONS_LIST'),
+}
 export const mayCreateGatewaysUnderOrganization = {
   rightsSelector: selectOrganizationRights,
   check: rights => rights.includes('RIGHT_ORGANIZATION_GATEWAYS_CREATE'),
 }
+export const mayViewGatewaysOfOrganization = {
+  rightsSelector: selectOrganizationRights,
+  check: rights => rights.includes('RIGHT_ORGANIZATION_GATEWAYS_LIST'),
+}
 export const mayAddOrganizationAsCollaborator = {
   rightsSelector: selectOrganizationRights,
   check: rights => rights.includes('RIGHT_ORGANIZATION_ADD_AS_COLLABORATOR'),
+}
+
+// Composite
+export const mayViewApplications = {
+  rightsSelector: state => [...selectUserRights(state), ...selectOrganizationRights(state)],
+  check: rights =>
+    mayViewApplicationsOfUser.check(rights) || mayViewApplicationsOfOrganization.check(rights),
+}
+export const mayViewGateways = {
+  rightsSelector: state => [...selectUserRights(state), ...selectOrganizationRights(state)],
+  check: rights =>
+    mayViewApplicationsOfUser.check(rights) || mayViewApplicationsOfOrganization.check(rights),
 }

--- a/pkg/webui/console/lib/feature-checks.js
+++ b/pkg/webui/console/lib/feature-checks.js
@@ -22,6 +22,9 @@ const stackConfig = selectStackConfig()
 const asEnabled = stackConfig.as.enabled
 const gsEnabled = stackConfig.gs.enabled
 
+export const checkFromState = (featureCheck, state) =>
+  featureCheck.check(featureCheck.rightsSelector(state))
+
 // User
 export const mayViewApplicationsOfUser = {
   rightsSelector: selectUserRights,

--- a/pkg/webui/console/lib/feature-checks.js
+++ b/pkg/webui/console/lib/feature-checks.js
@@ -15,6 +15,7 @@
 import { selectStackConfig } from '../../lib/selectors/env'
 import { selectApplicationRights } from '../store/selectors/applications'
 import { selectGatewayRights } from '../store/selectors/gateways'
+import { selectOrganizationRights } from '../store/selectors/organizations'
 
 const stackConfig = selectStackConfig()
 const asEnabled = stackConfig.as.enabled
@@ -110,4 +111,38 @@ export const mayViewGatewayStatus = {
 export const mayViewOrEditGatewayLocation = {
   rightsSelector: selectGatewayRights,
   check: rights => rights.includes('RIGHT_GATEWAY_LOCATION_READ'),
+}
+
+// Organizations
+export const mayViewOrganizationInformation = {
+  rightsSelector: selectOrganizationRights,
+  check: rights => rights.includes('RIGHT_ORGANIZATION_INFO'),
+}
+export const mayEditBasicOrganizationInformation = {
+  rightsSelector: selectOrganizationRights,
+  check: rights => rights.includes('RIGHT_ORGANIZATION_SETTINGS_BASIC'),
+}
+export const mayViewOrEditOrganizationApiKeys = {
+  rightsSelector: selectOrganizationRights,
+  check: rights => rights.includes('RIGHT_ORGANIZATION_SETTINGS_API_KEYS'),
+}
+export const mayViewOrEditOrganizationCollaborators = {
+  rightsSelector: selectOrganizationRights,
+  check: rights => rights.includes('RIGHT_ORGANIZATION_SETTINGS_MEMBERS'),
+}
+export const mayDeleteOrganization = {
+  rightsSelector: selectOrganizationRights,
+  check: rights => rights.includes('RIGHT_ORGANIZATION_DELETE'),
+}
+export const mayCreateApplicationsUnderOrganization = {
+  rightsSelector: selectOrganizationRights,
+  check: rights => rights.includes('RIGHT_ORGANIZATION_APPLICATIONS_CREATE'),
+}
+export const mayCreateGatewaysUnderOrganization = {
+  rightsSelector: selectOrganizationRights,
+  check: rights => rights.includes('RIGHT_ORGANIZATION_GATEWAYS_CREATE'),
+}
+export const mayAddOrganizationAsCollaborator = {
+  rightsSelector: selectOrganizationRights,
+  check: rights => rights.includes('RIGHT_ORGANIZATION_ADD_AS_COLLABORATOR'),
 }

--- a/pkg/webui/console/lib/feature-checks.js
+++ b/pkg/webui/console/lib/feature-checks.js
@@ -14,11 +14,11 @@
 
 import { selectStackConfig } from '../../lib/selectors/env'
 import { selectApplicationRights } from '../store/selectors/applications'
+import { selectGatewayRights } from '../store/selectors/gateways'
 
 const stackConfig = selectStackConfig()
 const asEnabled = stackConfig.as.enabled
-const jsEnabled = stackConfig.js.enabled
-const nsEnabled = stackConfig.ns.enabled
+const gsEnabled = stackConfig.gs.enabled
 
 // Applications
 export const mayViewApplicationInfo = {
@@ -72,4 +72,42 @@ export const mayDeleteApplication = {
 export const mayReadApplicationDeviceKeys = {
   rightsSelector: selectApplicationRights,
   check: rights => rights.includes('RIGHT_APPLICATION_DEVICES_READ_KEYS'),
+}
+
+// Gateways
+export const mayViewGatewayInfo = {
+  rightsSelector: selectGatewayRights,
+  check: rights => rights.includes('RIGHT_GATEWAY_INFO'),
+}
+export const mayEditBasicGatewayInformation = {
+  rightsSelector: selectGatewayRights,
+  check: rights => rights.includes('RIGHT_GATEWAY_SETTINGS_BASIC'),
+}
+export const mayViewOrEditGatewayApiKeys = {
+  rightsSelector: selectGatewayRights,
+  check: rights => rights.includes('RIGHT_GATEWAY_SETTINGS_API_KEYS'),
+}
+export const mayViewOrEditGatewayCollaborators = {
+  rightsSelector: selectGatewayRights,
+  check: rights => rights.includes('RIGHT_GATEWAY_SETTINGS_COLLABORATORS'),
+}
+export const mayDeleteGateway = {
+  rightsSelector: selectGatewayRights,
+  check: rights => rights.includes('RIGHT_GATEWAY_DELETE'),
+}
+export const mayViewGatewayEvents = {
+  rightsSelector: selectGatewayRights,
+  check: rights => rights.includes('RIGHT_GATEWAY_TRAFFIC_READ'),
+}
+export const mayLinkGateway = {
+  rightsSelector: selectGatewayRights,
+  check: rights => rights.includes('RIGHT_GATEWAY_LINK') && gsEnabled,
+}
+export const mayViewGatewayStatus = {
+  rightsSelector: selectGatewayRights,
+  check: rights => rights.includes('RIGHT_GATEWAY_STATUS_READ') && gsEnabled,
+}
+export const mayViewOrEditGatewayLocation = {
+  rightsSelector: selectGatewayRights,
+  check: rights => rights.includes('RIGHT_GATEWAY_LOCATION_READ'),
 }

--- a/pkg/webui/console/lib/feature-checks.js
+++ b/pkg/webui/console/lib/feature-checks.js
@@ -16,10 +16,37 @@ import { selectStackConfig } from '../../lib/selectors/env'
 import { selectApplicationRights } from '../store/selectors/applications'
 import { selectGatewayRights } from '../store/selectors/gateways'
 import { selectOrganizationRights } from '../store/selectors/organizations'
+import { selectUserRights } from '../store/selectors/user'
 
 const stackConfig = selectStackConfig()
 const asEnabled = stackConfig.as.enabled
 const gsEnabled = stackConfig.gs.enabled
+
+// User
+export const mayViewApplicationsOfUser = {
+  rightsSelector: selectUserRights,
+  check: rights => rights.includes('RIGHT_USER_APPLICATIONS_LIST'),
+}
+export const mayCreateApplications = {
+  rightsSelector: selectUserRights,
+  check: rights => rights.includes('RIGHT_USER_APPLICATIONS_CREATE'),
+}
+export const mayViewGatewaysOfUser = {
+  rightsSelector: selectUserRights,
+  check: rights => rights.includes('RIGHT_USER_GATEWAYS_LIST'),
+}
+export const mayCreateGateways = {
+  rightsSelector: selectUserRights,
+  check: rights => rights.includes('RIGHT_USER_GATEWAYS_CREATE'),
+}
+export const mayViewOrganizationsOfUser = {
+  rightsSelector: selectUserRights,
+  check: rights => rights.includes('RIGHT_USER_ORGANIZATIONS_LIST'),
+}
+export const mayCreateOrganizations = {
+  rightsSelector: selectUserRights,
+  check: rights => rights.includes('RIGHT_USER_ORGANIZATIONS_CREATE'),
+}
 
 // Applications
 export const mayViewApplicationInfo = {

--- a/pkg/webui/console/store/actions/user.js
+++ b/pkg/webui/console/store/actions/user.js
@@ -20,6 +20,12 @@ export const [
   { request: getUserMe, success: getUserMeSuccess, failure: getUserMeFailure },
 ] = createRequestActions(GET_USER_ME_BASE)
 
+export const GET_USER_RIGHTS_BASE = 'GET_USER_RIGHTS'
+export const [
+  { request: GET_USER_RIGHTS, success: GET_USER_RIGHTS_SUCCESS, failure: GET_USER_RIGHTS_FAILURE },
+  { request: getUserRights, success: getUserRightsSuccess, failure: getUserRightsFailure },
+] = createRequestActions(GET_USER_RIGHTS_BASE)
+
 export const LOGOUT_BASE = 'LOGOUT'
 export const [
   { request: LOGOUT, success: LOGOUT_SUCCESS, failure: LOGOUT_FAILURE },

--- a/pkg/webui/console/store/middleware/logics/init.js
+++ b/pkg/webui/console/store/middleware/logics/init.js
@@ -21,19 +21,32 @@ import createRequestLogic from './lib'
 const consoleAppLogic = createRequestLogic({
   type: init.INITIALIZE,
   async process(_, dispatch) {
+    dispatch(user.getUserRights())
     dispatch(user.getUserMe())
+
+    let info
 
     try {
       // there is no way to retrieve the current user directly
       // within the console app, so first get the authentication info
       // and only afterwards fetch the user
-      const info = await api.users.authInfo()
-      const userId = info.data.oauth_access_token.user_ids.user_id
-      const result = await api.users.get(userId)
-      dispatch(user.getUserMeSuccess(result.data))
+      info = await api.users.authInfo()
+      const rights = info.data.oauth_access_token.rights
+      dispatch(user.getUserRightsSuccess(rights))
     } catch (error) {
-      dispatch(user.getUserMeFailure())
+      dispatch(user.getUserRightsFailure())
       accessToken.clear()
+    }
+
+    if (info) {
+      try {
+        const userId = info.data.oauth_access_token.user_ids.user_id
+        const result = await api.users.get(userId)
+        dispatch(user.getUserMeSuccess(result.data))
+      } catch (error) {
+        dispatch(user.getUserMeFailure())
+        accessToken.clear()
+      }
     }
 
     // eslint-disable-next-line no-console

--- a/pkg/webui/console/store/reducers/user.js
+++ b/pkg/webui/console/store/reducers/user.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { GET_USER_ME_SUCCESS, LOGOUT_SUCCESS } from '../actions/user'
+import { GET_USER_ME_SUCCESS, LOGOUT_SUCCESS, GET_USER_RIGHTS_SUCCESS } from '../actions/user'
 
 const defaultState = {
   user: undefined,
@@ -25,10 +25,16 @@ const user = function(state = defaultState, { type, payload }) {
         ...state,
         user: payload,
       }
+    case GET_USER_RIGHTS_SUCCESS:
+      return {
+        ...state,
+        rights: payload,
+      }
     case LOGOUT_SUCCESS:
       return {
         ...state,
         user: undefined,
+        authInfo: undefined,
       }
     default:
       return state

--- a/pkg/webui/console/store/selectors/user.js
+++ b/pkg/webui/console/store/selectors/user.js
@@ -22,3 +22,5 @@ export const selectUserId = function(state) {
 
   return ids.user_id
 }
+
+export const selectUserRights = state => selectUserStore(state).rights

--- a/pkg/webui/console/views/application-add/index.js
+++ b/pkg/webui/console/views/application-add/index.js
@@ -26,7 +26,6 @@ import Checkbox from '../../../components/checkbox'
 import SubmitButton from '../../../components/submit-button'
 import toast from '../../../components/toast'
 import SubmitBar from '../../../components/submit-bar'
-
 import Message from '../../../lib/components/message'
 import IntlHelmet from '../../../lib/components/intl-helmet'
 import PropTypes from '../../../lib/prop-types'
@@ -35,8 +34,10 @@ import { id as applicationIdRegexp, address } from '../../lib/regexp'
 import { getApplicationId } from '../../../lib/selectors/id'
 import { selectAsConfig } from '../../../lib/selectors/env'
 import OwnersSelect from '../../containers/owners-select'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
 
 import { selectUserId } from '../../store/selectors/user'
+import { mayCreateApplications } from '../../lib/feature-checks'
 
 import api from '../../api'
 
@@ -70,6 +71,7 @@ const validationSchema = Yup.object().shape({
   }),
 })
 
+@withFeatureRequirement(mayCreateApplications, { redirect: '/applications' })
 @connect(
   state => ({
     userId: selectUserId(state),

--- a/pkg/webui/console/views/application-api-key-add/index.js
+++ b/pkg/webui/console/views/application-api-key-add/index.js
@@ -24,7 +24,6 @@ import sharedMessages from '../../../lib/shared-messages'
 import Message from '../../../lib/components/message'
 import IntlHelmet from '../../../lib/components/intl-helmet'
 import { ApiKeyCreateForm } from '../../components/api-key-form'
-import withRequest from '../../../lib/components/with-request'
 
 import { getApplicationsRightsList } from '../../store/actions/applications'
 import {
@@ -49,10 +48,6 @@ import api from '../../api'
     getApplicationsRightsList: appId => dispatch(getApplicationsRightsList(appId)),
     navigateToList: appId => dispatch(replace(`/applications/${appId}/api-keys`)),
   }),
-)
-@withRequest(
-  ({ appId, getApplicationsRightsList }) => getApplicationsRightsList(appId),
-  ({ fetching, rights }) => fetching || !Boolean(rights.length),
 )
 @withBreadcrumb('apps.single.api-keys.add', function(props) {
   const appId = props.appId

--- a/pkg/webui/console/views/application-api-key-edit/index.js
+++ b/pkg/webui/console/views/application-api-key-edit/index.js
@@ -26,7 +26,7 @@ import IntlHelmet from '../../../lib/components/intl-helmet'
 import { ApiKeyEditForm } from '../../components/api-key-form'
 import withRequest from '../../../lib/components/with-request'
 
-import { getApplicationApiKey, getApplicationsRightsList } from '../../store/actions/applications'
+import { getApplicationApiKey } from '../../store/actions/applications'
 import {
   selectSelectedApplicationId,
   selectApplicationRights,
@@ -60,15 +60,14 @@ import api from '../../api'
     }
   },
   dispatch => ({
-    loadData(appId, apiKeyId) {
-      dispatch(getApplicationsRightsList(appId))
+    getApplicationApiKey(appId, apiKeyId) {
       dispatch(getApplicationApiKey(appId, apiKeyId))
     },
     deleteSuccess: appId => dispatch(replace(`/applications/${appId}/api-keys`)),
   }),
 )
 @withRequest(
-  ({ loadData, appId, keyId }) => loadData(appId, keyId),
+  ({ getApplicationApiKey, appId, keyId }) => getApplicationApiKey(appId, keyId),
   ({ fetching, apiKey }) => fetching || !Boolean(apiKey),
 )
 @withBreadcrumb('apps.single.api-keys.edit', function(props) {

--- a/pkg/webui/console/views/application-api-keys/index.js
+++ b/pkg/webui/console/views/application-api-keys/index.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import React from 'react'
+import { connect } from 'react-redux'
 import { Switch, Route } from 'react-router'
 
 import sharedMessages from '../../../lib/shared-messages'
@@ -20,23 +21,25 @@ import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
 import { withBreadcrumb } from '../../../components/breadcrumbs/context'
 import ErrorView from '../../../lib/components/error-view'
 import SubViewError from '../error/sub-view'
-
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
 import ApplicationApiKeysList from '../application-api-keys-list'
 import ApplicationApiKeyEdit from '../application-api-key-edit'
 import ApplicationApiKeyAdd from '../application-api-key-add'
 
-@withBreadcrumb('apps.single.api-keys', function(props) {
-  const { match } = props
-  const appId = match.params.appId
+import { mayViewOrEditApplicationApiKeys } from '../../lib/feature-checks'
+import { selectSelectedApplicationId } from '../../store/selectors/applications'
 
-  return (
-    <Breadcrumb
-      path={`/applications/${appId}/api-keys`}
-      icon="api_keys"
-      content={sharedMessages.apiKeys}
-    />
-  )
+@connect(state => ({ appId: selectSelectedApplicationId(state) }))
+@withFeatureRequirement(mayViewOrEditApplicationApiKeys, {
+  redirect: ({ appId }) => `/applications/${appId}`,
 })
+@withBreadcrumb('apps.single.api-keys', ({ appId }) => (
+  <Breadcrumb
+    path={`/applications/${appId}/api-keys`}
+    icon="api_keys"
+    content={sharedMessages.apiKeys}
+  />
+))
 export default class ApplicationAccess extends React.Component {
   render() {
     const { match } = this.props

--- a/pkg/webui/console/views/application-collaborator-add/index.js
+++ b/pkg/webui/console/views/application-collaborator-add/index.js
@@ -24,9 +24,7 @@ import sharedMessages from '../../../lib/shared-messages'
 import CollaboratorForm from '../../components/collaborator-form'
 import Message from '../../../lib/components/message'
 import IntlHelmet from '../../../lib/components/intl-helmet'
-import withRequest from '../../../lib/components/with-request'
 
-import { getApplicationsRightsList } from '../../store/actions/applications'
 import {
   selectSelectedApplicationId,
   selectApplicationRights,
@@ -50,19 +48,13 @@ import api from '../../api'
   },
   (dispatch, ownProps) => ({
     redirectToList: appId => dispatch(push(`/applications/${appId}/collaborators`)),
-    getApplicationsRightsList: appId => dispatch(getApplicationsRightsList(appId)),
   }),
   (stateProps, dispatchProps, ownProps) => ({
     ...stateProps,
     ...dispatchProps,
     ...ownProps,
     redirectToList: () => dispatchProps.redirectToList(stateProps.appId),
-    getApplicationsRightsList: () => dispatchProps.getApplicationsRightsList(stateProps.appId),
   }),
-)
-@withRequest(
-  ({ getApplicationsRightsList }) => getApplicationsRightsList(),
-  ({ fetching, rights }) => fetching || !Boolean(rights.length),
 )
 @withBreadcrumb('apps.single.collaborators.add', function(props) {
   const appId = props.appId

--- a/pkg/webui/console/views/application-collaborator-edit/index.js
+++ b/pkg/webui/console/views/application-collaborator-edit/index.js
@@ -27,10 +27,7 @@ import IntlHelmet from '../../../lib/components/intl-helmet'
 import toast from '../../../components/toast'
 import withRequest from '../../../lib/components/with-request'
 
-import {
-  getApplicationCollaborator,
-  getApplicationsRightsList,
-} from '../../store/actions/applications'
+import { getApplicationCollaborator } from '../../store/actions/applications'
 import {
   selectSelectedApplicationId,
   selectApplicationRights,
@@ -71,8 +68,7 @@ import api from '../../api'
     }
   },
   (dispatch, ownProps) => ({
-    loadData(appId, collaboratorId, isUser) {
-      dispatch(getApplicationsRightsList(appId))
+    getApplicationCollaborator(appId, collaboratorId, isUser) {
       dispatch(getApplicationCollaborator(appId, collaboratorId, isUser))
     },
     redirectToList(appId) {
@@ -83,8 +79,8 @@ import api from '../../api'
     ...stateProps,
     ...dispatchProps,
     ...ownProps,
-    loadData: () =>
-      dispatchProps.loadData(
+    getApplicationCollaborator: () =>
+      dispatchProps.getApplicationCollaborator(
         stateProps.appId,
         stateProps.collaboratorId,
         stateProps.collaboratorType === 'user',
@@ -93,7 +89,7 @@ import api from '../../api'
   }),
 )
 @withRequest(
-  ({ loadData }) => loadData(),
+  ({ getApplicationCollaborator }) => getApplicationCollaborator(),
   ({ fetching, collaborator }) => fetching || !Boolean(collaborator),
 )
 @withBreadcrumb('apps.single.collaborators.edit', function(props) {

--- a/pkg/webui/console/views/application-collaborators/index.js
+++ b/pkg/webui/console/views/application-collaborators/index.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import React from 'react'
+import { connect } from 'react-redux'
 import { Switch, Route } from 'react-router'
 
 import sharedMessages from '../../../lib/shared-messages'
@@ -21,23 +22,25 @@ import { withBreadcrumb } from '../../../components/breadcrumbs/context'
 import ErrorView from '../../../lib/components/error-view'
 import SubViewError from '../error/sub-view'
 import NotFoundRoute from '../../../lib/components/not-found-route'
-
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
 import ApplicationCollaboratorsList from '../application-collaborators-list'
 import ApplicationCollaboratorAdd from '../application-collaborator-add'
 import ApplicationCollaboratorEdit from '../application-collaborator-edit'
 
-@withBreadcrumb('apps.single.collaborators', function(props) {
-  const { match } = props
-  const appId = match.params.appId
+import { mayViewOrEditApplicationCollaborators } from '../../lib/feature-checks'
+import { selectSelectedApplicationId } from '../../store/selectors/applications'
 
-  return (
-    <Breadcrumb
-      path={`/applications/${appId}/collaborators`}
-      icon="organization"
-      content={sharedMessages.collaborators}
-    />
-  )
+@connect(state => ({ appId: selectSelectedApplicationId(state) }))
+@withFeatureRequirement(mayViewOrEditApplicationCollaborators, {
+  redirect: ({ appId }) => `/applications/${appId}`,
 })
+@withBreadcrumb('apps.single.collaborators', ({ appId }) => (
+  <Breadcrumb
+    path={`/applications/${appId}/collaborators`}
+    icon="organization"
+    content={sharedMessages.collaborators}
+  />
+))
 export default class ApplicationCollaborators extends React.Component {
   render() {
     const { match } = this.props

--- a/pkg/webui/console/views/application-data/index.js
+++ b/pkg/webui/console/views/application-data/index.js
@@ -23,7 +23,9 @@ import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
 import { withBreadcrumb } from '../../../components/breadcrumbs/context'
 import Message from '../../../lib/components/message'
 import ApplicationEvents from '../../containers/application-events'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
 
+import { mayViewApplicationEvents } from '../../lib/feature-checks'
 import { selectSelectedApplicationId } from '../../store/selectors/applications'
 
 import style from './application-data.styl'
@@ -33,6 +35,9 @@ const m = defineMessages({
 })
 
 @connect(state => ({ appId: selectSelectedApplicationId(state) }))
+@withFeatureRequirement(mayViewApplicationEvents, {
+  redirect: ({ appId }) => `/applications/${appId}`,
+})
 @withBreadcrumb('apps.single.data', function(props) {
   return (
     <Breadcrumb

--- a/pkg/webui/console/views/application-general-settings/index.js
+++ b/pkg/webui/console/views/application-general-settings/index.js
@@ -33,8 +33,13 @@ import ModalButton from '../../../components/button/modal-button'
 import diff from '../../../lib/diff'
 import toast from '../../../components/toast'
 import SubmitBar from '../../../components/submit-bar'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
 
-import { selectSelectedApplication } from '../../store/selectors/applications'
+import { mayEditBasicApplicationInfo } from '../../lib/feature-checks'
+import {
+  selectSelectedApplication,
+  selectSelectedApplicationId,
+} from '../../store/selectors/applications'
 import { updateApplication, deleteApplication } from '../../store/actions/applications'
 import { attachPromise } from '../../store/actions/lib'
 import PropTypes from '../../../lib/prop-types'
@@ -56,6 +61,7 @@ const validationSchema = Yup.object().shape({
 
 @connect(
   state => ({
+    appId: selectSelectedApplicationId(state),
     application: selectSelectedApplication(state),
   }),
   dispatch => ({
@@ -69,6 +75,9 @@ const validationSchema = Yup.object().shape({
     onDeleteSuccess: () => dispatch(replace(`/applications`)),
   }),
 )
+@withFeatureRequirement(mayEditBasicApplicationInfo, {
+  redirect: ({ appId }) => `/applications/${appId}`,
+})
 @withBreadcrumb('apps.single.general-settings', function(props) {
   const { appId } = props
 

--- a/pkg/webui/console/views/application-general-settings/index.js
+++ b/pkg/webui/console/views/application-general-settings/index.js
@@ -34,8 +34,9 @@ import diff from '../../../lib/diff'
 import toast from '../../../components/toast'
 import SubmitBar from '../../../components/submit-bar'
 import withFeatureRequirement from '../../lib/components/with-feature-requirement'
+import Require from '../../lib/components/require'
 
-import { mayEditBasicApplicationInfo } from '../../lib/feature-checks'
+import { mayEditBasicApplicationInfo, mayDeleteApplication } from '../../lib/feature-checks'
 import {
   selectSelectedApplication,
   selectSelectedApplicationId,
@@ -166,24 +167,26 @@ export default class ApplicationGeneralSettings extends React.Component {
               <Form.Field title={sharedMessages.description} name="description" component={Input} />
               <SubmitBar>
                 <Form.Submit component={SubmitButton} message={sharedMessages.saveChanges} />
-                <ModalButton
-                  type="button"
-                  icon="delete"
-                  danger
-                  naked
-                  message={m.deleteApp}
-                  modalData={{
-                    message: {
-                      values: {
-                        appName: application.name
-                          ? application.name
-                          : application.ids.application_id,
+                <Require featureCheck={mayDeleteApplication}>
+                  <ModalButton
+                    type="button"
+                    icon="delete"
+                    danger
+                    naked
+                    message={m.deleteApp}
+                    modalData={{
+                      message: {
+                        values: {
+                          appName: application.name
+                            ? application.name
+                            : application.ids.application_id,
+                        },
+                        ...m.modalWarning,
                       },
-                      ...m.modalWarning,
-                    },
-                  }}
-                  onApprove={this.handleDelete}
-                />
+                    }}
+                    onApprove={this.handleDelete}
+                  />
+                </Require>
               </SubmitBar>
             </Form>
           </Col>

--- a/pkg/webui/console/views/application-integrations-mqtt/index.js
+++ b/pkg/webui/console/views/application-integrations-mqtt/index.js
@@ -29,7 +29,10 @@ import IntlHelmet from '../../../lib/components/intl-helmet'
 import DataSheet from '../../../components/data-sheet'
 import Button from '../../../components/button'
 import api from '../../api'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
+
 import { selectSelectedApplicationId } from '../../store/selectors/applications'
+import { mayViewMqttConnectionInfo } from '../../lib/feature-checks'
 
 import style from './application-integrations-mqtt.styl'
 
@@ -47,6 +50,9 @@ const m = defineMessages({
 @connect(state => ({
   appId: selectSelectedApplicationId(state),
 }))
+@withFeatureRequirement(mayViewMqttConnectionInfo, {
+  redirect: ({ appId }) => `/applications/${appId}`,
+})
 @withBreadcrumb('apps.single.integrations.mqtt', function(props) {
   const { appId } = props
 

--- a/pkg/webui/console/views/application-integrations-pubsubs/index.js
+++ b/pkg/webui/console/views/application-integrations-pubsubs/index.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import React from 'react'
+import { connect } from 'react-redux'
 import { Switch, Route } from 'react-router'
 
 import sharedMessages from '../../../lib/shared-messages'
@@ -20,23 +21,25 @@ import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
 import { withBreadcrumb } from '../../../components/breadcrumbs/context'
 import ErrorView from '../../../lib/components/error-view'
 import SubViewError from '../error/sub-view'
-
 import ApplicationPubsubsList from '../application-integrations-pubsubs-list'
 import ApplicationPubsubAdd from '../application-integrations-pubsub-add'
 import ApplicationPubsubEdit from '../application-integrations-pubsub-edit'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
 
-@withBreadcrumb('apps.single.integrations.pubsubs', function(props) {
-  const { match } = props
-  const appId = match.params.appId
+import { mayViewApplicationEvents } from '../../lib/feature-checks'
+import { selectSelectedApplicationId } from '../../store/selectors/applications'
 
-  return (
-    <Breadcrumb
-      path={`/applications/${appId}/integrations/pubsubs`}
-      icon="extension"
-      content={sharedMessages.pubsubs}
-    />
-  )
+@connect(state => ({ appId: selectSelectedApplicationId(state) }))
+@withFeatureRequirement(mayViewApplicationEvents, {
+  redirect: ({ appId }) => `/applications/${appId}`,
 })
+@withBreadcrumb('apps.single.integrations.pubsubs', ({ appId }) => (
+  <Breadcrumb
+    path={`/applications/${appId}/integrations/pubsubs`}
+    icon="extension"
+    content={sharedMessages.pubsubs}
+  />
+))
 export default class ApplicationPubsubs extends React.Component {
   render() {
     const { match } = this.props

--- a/pkg/webui/console/views/application-integrations-webhooks/index.js
+++ b/pkg/webui/console/views/application-integrations-webhooks/index.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import React from 'react'
+import { connect } from 'react-redux'
 import { Switch, Route } from 'react-router'
 
 import sharedMessages from '../../../lib/shared-messages'
@@ -20,23 +21,25 @@ import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
 import { withBreadcrumb } from '../../../components/breadcrumbs/context'
 import ErrorView from '../../../lib/components/error-view'
 import SubViewError from '../error/sub-view'
-
 import ApplicationWebhooksList from '../application-integrations-webhooks-list'
 import ApplicationWebhookAdd from '../application-integrations-webhook-add'
 import ApplicationWebhookEdit from '../application-integrations-webhook-edit'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
 
-@withBreadcrumb('apps.single.integrations.webhooks', function(props) {
-  const { match } = props
-  const appId = match.params.appId
+import { mayViewApplicationEvents } from '../../lib/feature-checks'
+import { selectSelectedApplicationId } from '../../store/selectors/applications'
 
-  return (
-    <Breadcrumb
-      path={`/applications/${appId}/integrations/webhooks`}
-      icon="extension"
-      content={sharedMessages.webhooks}
-    />
-  )
+@connect(state => ({ appId: selectSelectedApplicationId(state) }))
+@withFeatureRequirement(mayViewApplicationEvents, {
+  redirect: ({ appId }) => `/applications/${appId}`,
 })
+@withBreadcrumb('apps.single.integrations.webhooks', ({ appId }) => (
+  <Breadcrumb
+    path={`/applications/${appId}/integrations/webhooks`}
+    icon="extension"
+    content={sharedMessages.webhooks}
+  />
+))
 export default class ApplicationWebhooks extends React.Component {
   render() {
     const { match } = this.props

--- a/pkg/webui/console/views/application-link/index.js
+++ b/pkg/webui/console/views/application-link/index.js
@@ -34,6 +34,7 @@ import Icon from '../../../components/icon'
 import SubmitBar from '../../../components/submit-bar'
 import withRequest from '../../../lib/components/with-request'
 import Checkbox from '../../../components/checkbox'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
 
 import { apiKey, address } from '../../lib/regexp'
 import sharedMessages from '../../../lib/shared-messages'
@@ -52,6 +53,7 @@ import {
   selectApplicationLinkError,
   selectSelectedApplicationId,
 } from '../../store/selectors/applications'
+import { mayLinkApplication } from '../../lib/feature-checks'
 
 import api from '../../api'
 
@@ -83,22 +85,23 @@ const validationSchema = Yup.object().shape({
 })
 
 @connect(
-  function(state) {
-    return {
-      appId: selectSelectedApplicationId(state),
-      link: selectApplicationLink(state),
-      stats: selectApplicationLinkStats(state),
-      fetching: selectApplicationLinkFetching(state),
-      linked: selectApplicationIsLinked(state),
-      linkError: selectApplicationLinkError(state),
-    }
-  },
+  state => ({
+    appId: selectSelectedApplicationId(state),
+    link: selectApplicationLink(state),
+    stats: selectApplicationLinkStats(state),
+    fetching: selectApplicationLinkFetching(state),
+    linked: selectApplicationIsLinked(state),
+    linkError: selectApplicationLinkError(state),
+  }),
   dispatch => ({
     getLink: (id, selector) => dispatch(getApplicationLink(id, selector)),
     updateLinkSuccess: (link, stats) => dispatch(updateApplicationLinkSuccess(link, stats)),
     deleteLinkSuccess: () => dispatch(deleteApplicationLinkSuccess()),
   }),
 )
+@withFeatureRequirement(mayLinkApplication, {
+  redirect: ({ appId }) => `/applications/${appId}`,
+})
 @withRequest(
   ({ getLink, appId }) => getLink(appId, ['api_key', 'network_server_address', 'tls']),
   ({ fetching }) => fetching,

--- a/pkg/webui/console/views/application-overview/index.js
+++ b/pkg/webui/console/views/application-overview/index.js
@@ -23,21 +23,31 @@ import DateTime from '../../../lib/components/date-time'
 import DevicesTable from '../../containers/devices-table'
 import DataSheet from '../../../components/data-sheet'
 import ApplicationEvents from '../../containers/application-events'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
 
 import PAGE_SIZES from '../../constants/page-sizes'
-import { getApplicationId } from '../../../lib/selectors/id'
-import { selectSelectedApplication } from '../../store/selectors/applications'
+import {
+  selectSelectedApplication,
+  selectSelectedApplicationId,
+} from '../../store/selectors/applications'
+import { mayViewApplicationInfo } from '../../lib/feature-checks'
 
 import style from './application-overview.styl'
 
 @connect(function(state) {
   return {
+    appId: selectSelectedApplicationId(state),
     application: selectSelectedApplication(state),
   }
 })
+@withFeatureRequirement(mayViewApplicationInfo, {
+  redirect: '/',
+})
 class ApplicationOverview extends React.Component {
   get applicationInfo() {
-    const { ids, name, description, created_at, updated_at } = this.props.application
+    const {
+      application: { ids, name, description, created_at, updated_at },
+    } = this.props
 
     const sheetData = [
       {
@@ -62,8 +72,7 @@ class ApplicationOverview extends React.Component {
   }
 
   render() {
-    const { application } = this.props
-    const appId = getApplicationId(application)
+    const { appId } = this.props
 
     return (
       <Container>

--- a/pkg/webui/console/views/application/index.js
+++ b/pkg/webui/console/views/application/index.js
@@ -37,12 +37,29 @@ import ApplicationIntegrationsWebhooks from '../application-integrations-webhook
 import ApplicationIntegrationsPubsubs from '../application-integrations-pubsubs'
 import ApplicationIntegrationsMqtt from '../application-integrations-mqtt'
 
-import { getApplication, stopApplicationEventsStream } from '../../store/actions/applications'
+import {
+  getApplication,
+  stopApplicationEventsStream,
+  getApplicationsRightsList,
+} from '../../store/actions/applications'
 import {
   selectSelectedApplication,
   selectApplicationFetching,
   selectApplicationError,
+  selectApplicationRights,
+  selectApplicationRightsFetching,
+  selectApplicationRightsError,
 } from '../../store/selectors/applications'
+import {
+  mayViewApplicationInfo,
+  mayViewApplicationEvents,
+  mayLinkApplication,
+  mayViewApplicationDevices,
+  mayCreateOrEditApplicationIntegrations,
+  mayEditBasicApplicationInfo,
+  mayViewOrEditApplicationApiKeys,
+  mayViewOrEditApplicationCollaborators,
+} from '../../lib/feature-checks'
 
 import Devices from '../devices'
 
@@ -50,22 +67,27 @@ import Devices from '../devices'
   function(state, props) {
     return {
       appId: props.match.params.appId,
-      fetching: selectApplicationFetching(state),
+      fetching: selectApplicationFetching(state) && selectApplicationRightsFetching(state),
       application: selectSelectedApplication(state),
-      error: selectApplicationError(state),
+      error: selectApplicationError(state) || selectApplicationRightsError(state),
+      rights: selectApplicationRights(state),
     }
   },
   dispatch => ({
     stopStream: id => dispatch(stopApplicationEventsStream(id)),
-    getApplication: id => dispatch(getApplication(id, 'name,description')),
+    loadData: id => {
+      dispatch(getApplication(id, 'name,description'))
+      dispatch(getApplicationsRightsList(id))
+    },
   }),
 )
 @withRequest(
-  ({ appId, getApplication }) => getApplication(appId),
+  ({ appId, loadData }) => loadData(appId),
   ({ fetching, application }) => fetching || !Boolean(application),
 )
 @withSideNavigation(function(props) {
   const matchedUrl = props.match.url
+  const { rights } = props
 
   return {
     header: { title: props.appId, icon: 'application' },
@@ -74,28 +96,34 @@ import Devices from '../devices'
         title: sharedMessages.overview,
         path: matchedUrl,
         icon: 'overview',
+        hidden: !mayViewApplicationInfo.check(rights),
       },
       {
         title: sharedMessages.devices,
         path: `${matchedUrl}/devices`,
         icon: 'devices',
         exact: false,
+        hidden: !mayViewApplicationDevices.check(rights),
       },
       {
         title: sharedMessages.data,
         path: `${matchedUrl}/data`,
         icon: 'data',
+        exact: false,
+        hidden: !mayViewApplicationEvents.check(rights),
       },
       {
         title: sharedMessages.link,
         path: `${matchedUrl}/link`,
         icon: 'link',
+        hidden: !mayLinkApplication.check(rights),
       },
       {
         title: sharedMessages.payloadFormatters,
         icon: 'code',
         nested: true,
         exact: false,
+        hidden: !mayLinkApplication.check(rights),
         items: [
           {
             title: sharedMessages.uplink,
@@ -114,6 +142,7 @@ import Devices from '../devices'
         icon: 'integration',
         nested: true,
         exact: false,
+        hidden: !mayCreateOrEditApplicationIntegrations.check(rights),
         items: [
           {
             title: sharedMessages.mqtt,
@@ -140,17 +169,20 @@ import Devices from '../devices'
         path: `${matchedUrl}/collaborators`,
         icon: 'organization',
         exact: false,
+        hidden: !mayViewOrEditApplicationCollaborators.check(rights),
       },
       {
         title: sharedMessages.apiKeys,
         path: `${matchedUrl}/api-keys`,
         icon: 'api_keys',
         exact: false,
+        hidden: !mayViewOrEditApplicationApiKeys.check(rights),
       },
       {
         title: sharedMessages.generalSettings,
         path: `${matchedUrl}/general-settings`,
         icon: 'general_settings',
+        hidden: !mayEditBasicApplicationInfo.check(rights),
       },
     ],
   }

--- a/pkg/webui/console/views/application/index.js
+++ b/pkg/webui/console/views/application/index.js
@@ -67,7 +67,7 @@ import Devices from '../devices'
   function(state, props) {
     return {
       appId: props.match.params.appId,
-      fetching: selectApplicationFetching(state) && selectApplicationRightsFetching(state),
+      fetching: selectApplicationFetching(state) || selectApplicationRightsFetching(state),
       application: selectSelectedApplication(state),
       error: selectApplicationError(state) || selectApplicationRightsError(state),
       rights: selectApplicationRights(state),

--- a/pkg/webui/console/views/applications/index.js
+++ b/pkg/webui/console/views/applications/index.js
@@ -22,7 +22,11 @@ import Application from '../application'
 import sharedMessages from '../../../lib/shared-messages'
 import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
 import { withBreadcrumb } from '../../../components/breadcrumbs/context'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
 
+import { mayViewApplications } from '../../lib/feature-checks'
+
+@withFeatureRequirement(mayViewApplications, { redirect: '/' })
 @withBreadcrumb('apps', function(props) {
   return <Breadcrumb path="/applications" content={sharedMessages.applications} />
 })

--- a/pkg/webui/console/views/devices/index.js
+++ b/pkg/webui/console/views/devices/index.js
@@ -14,6 +14,7 @@
 
 import React from 'react'
 import { Switch, Route } from 'react-router-dom'
+import { connect } from 'react-redux'
 
 import DeviceList from '../device-list'
 import DeviceAdd from '../device-add'
@@ -23,9 +24,15 @@ import Device from '../device'
 import sharedMessages from '../../../lib/shared-messages'
 import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
 import { withBreadcrumb } from '../../../components/breadcrumbs/context'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
+import { mayViewApplicationDevices } from '../../lib/feature-checks'
+import { selectSelectedApplicationId } from '../../store/selectors/applications'
 
-@withBreadcrumb('devices', function(props) {
-  const { appId } = props.match.params
+@connect(state => ({ appId: selectSelectedApplicationId(state) }))
+@withFeatureRequirement(mayViewApplicationDevices, {
+  redirect: ({ appId }) => `/applications/${appId}`,
+})
+@withBreadcrumb('devices', function({ appId }) {
   return <Breadcrumb path={`/applications/${appId}/devices`} content={sharedMessages.devices} />
 })
 export default class Devices extends React.Component {

--- a/pkg/webui/console/views/gateway-add/index.js
+++ b/pkg/webui/console/views/gateway-add/index.js
@@ -31,7 +31,7 @@ import withFeatureRequirement from '../../lib/components/with-feature-requiremen
 
 import api from '../../api'
 import { selectUserId } from '../../store/selectors/user'
-import { mayEditBasicGatewayInformation } from '../../lib/feature-checks'
+import { mayCreateGateways } from '../../lib/feature-checks'
 
 import style from './gateway-add.styl'
 
@@ -50,9 +50,7 @@ const m = defineMessages({
     createSuccess: gtwId => dispatch(push(`/gateways/${gtwId}`)),
   }),
 )
-@withFeatureRequirement(mayEditBasicGatewayInformation, {
-  redirect: ({ gtwId }) => `/gateway/${gtwId}`,
-})
+@withFeatureRequirement(mayCreateGateways, { redirect: '/gateways' })
 export default class GatewayAdd extends React.Component {
   static propTypes = {
     createSuccess: PropTypes.func.isRequired,

--- a/pkg/webui/console/views/gateway-add/index.js
+++ b/pkg/webui/console/views/gateway-add/index.js
@@ -22,16 +22,16 @@ import { push } from 'connected-react-router'
 import FormSubmit from '../../../components/form/submit'
 import SubmitButton from '../../../components/submit-button'
 import GatewayDataForm from '../../components/gateway-data-form'
-
 import sharedMessages from '../../../lib/shared-messages'
 import Message from '../../../lib/components/message'
 import PropTypes from '../../../lib/prop-types'
 import IntlHelmet from '../../../lib/components/intl-helmet'
 import { withEnv } from '../../../lib/components/env'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
 
 import api from '../../api'
-
 import { selectUserId } from '../../store/selectors/user'
+import { mayEditBasicGatewayInformation } from '../../lib/feature-checks'
 
 import style from './gateway-add.styl'
 
@@ -50,6 +50,9 @@ const m = defineMessages({
     createSuccess: gtwId => dispatch(push(`/gateways/${gtwId}`)),
   }),
 )
+@withFeatureRequirement(mayEditBasicGatewayInformation, {
+  redirect: ({ gtwId }) => `/gateway/${gtwId}`,
+})
 export default class GatewayAdd extends React.Component {
   static propTypes = {
     createSuccess: PropTypes.func.isRequired,

--- a/pkg/webui/console/views/gateway-api-key-add/index.js
+++ b/pkg/webui/console/views/gateway-api-key-add/index.js
@@ -24,6 +24,7 @@ import sharedMessages from '../../../lib/shared-messages'
 import Message from '../../../lib/components/message'
 import IntlHelmet from '../../../lib/components/intl-helmet'
 import { ApiKeyCreateForm } from '../../components/api-key-form'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
 
 import {
   selectSelectedGatewayId,
@@ -32,6 +33,7 @@ import {
   selectGatewayRightsFetching,
   selectGatewayPseudoRights,
 } from '../../store/selectors/gateways'
+import { mayViewOrEditGatewayApiKeys } from '../../lib/feature-checks'
 
 import api from '../../api'
 
@@ -47,6 +49,9 @@ import api from '../../api'
     navigateToList: gtwId => dispatch(replace(`/gateways/${gtwId}/api-keys`)),
   }),
 )
+@withFeatureRequirement(mayViewOrEditGatewayApiKeys, {
+  redirect: ({ gtwId }) => `/gateway/${gtwId}`,
+})
 @withBreadcrumb('gtws.single.api-keys.add', function(props) {
   const gtwId = props.gtwId
 

--- a/pkg/webui/console/views/gateway-api-key-add/index.js
+++ b/pkg/webui/console/views/gateway-api-key-add/index.js
@@ -24,9 +24,7 @@ import sharedMessages from '../../../lib/shared-messages'
 import Message from '../../../lib/components/message'
 import IntlHelmet from '../../../lib/components/intl-helmet'
 import { ApiKeyCreateForm } from '../../components/api-key-form'
-import withRequest from '../../../lib/components/with-request'
 
-import { getGatewaysRightsList } from '../../store/actions/gateways'
 import {
   selectSelectedGatewayId,
   selectGatewayRights,
@@ -46,13 +44,8 @@ import api from '../../api'
     pseudoRights: selectGatewayPseudoRights(state),
   }),
   dispatch => ({
-    getGatewaysRightsList: gtwId => dispatch(getGatewaysRightsList(gtwId)),
     navigateToList: gtwId => dispatch(replace(`/gateways/${gtwId}/api-keys`)),
   }),
-)
-@withRequest(
-  ({ gtwId, getGatewaysRightsList }) => getGatewaysRightsList(gtwId),
-  ({ fetching, rights }) => fetching || !Boolean(rights.length),
 )
 @withBreadcrumb('gtws.single.api-keys.add', function(props) {
   const gtwId = props.gtwId

--- a/pkg/webui/console/views/gateway-api-key-edit/index.js
+++ b/pkg/webui/console/views/gateway-api-key-edit/index.js
@@ -26,7 +26,7 @@ import IntlHelmet from '../../../lib/components/intl-helmet'
 import { ApiKeyEditForm } from '../../components/api-key-form'
 import withRequest from '../../../lib/components/with-request'
 
-import { getGatewayApiKey, getGatewaysRightsList } from '../../store/actions/gateways'
+import { getGatewayApiKey } from '../../store/actions/gateways'
 import {
   selectSelectedGatewayId,
   selectGatewayRights,
@@ -59,15 +59,14 @@ import api from '../../api'
     }
   },
   dispatch => ({
-    loadData(gtwId, apiKeyId) {
-      dispatch(getGatewaysRightsList(gtwId))
+    getGatewayApiKey(gtwId, apiKeyId) {
       dispatch(getGatewayApiKey(gtwId, apiKeyId))
     },
     deleteSuccess: gtwId => dispatch(replace(`/gateways/${gtwId}/api-keys`)),
   }),
 )
 @withRequest(
-  ({ gtwId, keyId, loadData }) => loadData(gtwId, keyId),
+  ({ gtwId, keyId, getGatewayApiKey }) => getGatewayApiKey(gtwId, keyId),
   ({ fetching, apiKey }) => fetching || !Boolean(apiKey),
 )
 @withBreadcrumb('gtws.single.api-keys.edit', function(props) {

--- a/pkg/webui/console/views/gateway-api-keys/index.js
+++ b/pkg/webui/console/views/gateway-api-keys/index.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import React from 'react'
+import { connect } from 'react-redux'
 import { Switch, Route } from 'react-router'
 
 import sharedMessages from '../../../lib/shared-messages'
@@ -20,22 +21,25 @@ import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
 import { withBreadcrumb } from '../../../components/breadcrumbs/context'
 import ErrorView from '../../../lib/components/error-view'
 import SubViewError from '../error/sub-view'
-
 import GatewayApiKeysList from '../gateway-api-keys-list'
 import GatewayApiKeyAdd from '../gateway-api-key-add'
 import GatewayApiKeyEdit from '../gateway-api-key-edit'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
 
-@withBreadcrumb('gateways.single.api-keys', function(props) {
-  const gtwId = props.match.params.gtwId
+import { mayViewOrEditGatewayApiKeys } from '../../lib/feature-checks'
+import { selectSelectedGatewayId } from '../../store/selectors/gateways'
 
-  return (
-    <Breadcrumb
-      path={`/gateways/${gtwId}/api-keys`}
-      icon="api_keys"
-      content={sharedMessages.apiKeys}
-    />
-  )
+@connect(state => ({ gtwId: selectSelectedGatewayId(state) }))
+@withFeatureRequirement(mayViewOrEditGatewayApiKeys, {
+  redirect: ({ gtwId }) => `/gateways/${gtwId}`,
 })
+@withBreadcrumb('gateways.single.api-keys', ({ gtwId }) => (
+  <Breadcrumb
+    path={`/gateways/${gtwId}/api-keys`}
+    icon="api_keys"
+    content={sharedMessages.apiKeys}
+  />
+))
 export default class GatewayApiKeys extends React.Component {
   render() {
     const { match } = this.props

--- a/pkg/webui/console/views/gateway-collaborator-add/index.js
+++ b/pkg/webui/console/views/gateway-collaborator-add/index.js
@@ -24,7 +24,6 @@ import sharedMessages from '../../../lib/shared-messages'
 import Message from '../../../lib/components/message'
 import IntlHelmet from '../../../lib/components/intl-helmet'
 import CollaboratorForm from '../../components/collaborator-form'
-import withRequest from '../../../lib/components/with-request'
 
 import {
   selectSelectedGatewayId,
@@ -61,10 +60,6 @@ import api from '../../api'
     getGatewaysRightsList: () => dispatchProps.getGatewaysRightsList(stateProps.gtwId),
     redirectToList: () => dispatchProps.redirectToList(stateProps.gtwId),
   }),
-)
-@withRequest(
-  ({ getGatewaysRightsList }) => getGatewaysRightsList(),
-  ({ fetching, rights }) => fetching || !Boolean(rights.length),
 )
 @withBreadcrumb('gtws.single.collaborators.add', function(props) {
   const gtwId = props.gtwId

--- a/pkg/webui/console/views/gateway-collaborator-edit/index.js
+++ b/pkg/webui/console/views/gateway-collaborator-edit/index.js
@@ -27,7 +27,7 @@ import IntlHelmet from '../../../lib/components/intl-helmet'
 import toast from '../../../components/toast'
 import withRequest from '../../../lib/components/with-request'
 
-import { getGatewayCollaborator, getGatewaysRightsList } from '../../store/actions/gateways'
+import { getGatewayCollaborator } from '../../store/actions/gateways'
 import {
   selectSelectedGatewayId,
   selectGatewayRights,
@@ -68,8 +68,7 @@ import api from '../../api'
     }
   },
   (dispatch, ownProps) => ({
-    loadData(gtwId, collaboratorId, isUser) {
-      dispatch(getGatewaysRightsList(gtwId))
+    getGatewayCollaborator(gtwId, collaboratorId, isUser) {
       dispatch(getGatewayCollaborator(gtwId, collaboratorId, isUser))
     },
     redirectToList(gtwId) {
@@ -80,8 +79,8 @@ import api from '../../api'
     ...stateProps,
     ...dispatchProps,
     ...ownProps,
-    loadData: () =>
-      dispatchProps.loadData(
+    getGatewayCollaborator: () =>
+      dispatchProps.getGatewayCollaborator(
         stateProps.gtwId,
         stateProps.collaboratorId,
         stateProps.collaboratorType === 'user',
@@ -90,7 +89,7 @@ import api from '../../api'
   }),
 )
 @withRequest(
-  ({ loadData }) => loadData(),
+  ({ getGatewayCollaborator }) => getGatewayCollaborator(),
   ({ fetching, collaborator }) => fetching || !Boolean(collaborator),
 )
 @withBreadcrumb('gtws.single.collaborators.edit', function(props) {

--- a/pkg/webui/console/views/gateway-collaborators/index.js
+++ b/pkg/webui/console/views/gateway-collaborators/index.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import React from 'react'
+import { connect } from 'react-redux'
 import { Switch, Route } from 'react-router'
 
 import sharedMessages from '../../../lib/shared-messages'
@@ -21,23 +22,25 @@ import { withBreadcrumb } from '../../../components/breadcrumbs/context'
 import ErrorView from '../../../lib/components/error-view'
 import SubViewError from '../error/sub-view'
 import NotFoundRoute from '../../../lib/components/not-found-route'
-
 import GatewayCollaboratorsList from '../gateway-collaborators-list'
 import GatewayCollaboratorAdd from '../gateway-collaborator-add'
 import GatewayCollaboratorEdit from '../gateway-collaborator-edit'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
+import { mayViewOrEditGatewayCollaborators } from '../../lib/feature-checks'
 
-@withBreadcrumb('gtws.single.collaborators', function(props) {
-  const { match } = props
-  const gtwId = match.params.gtwId
+import { selectSelectedGatewayId } from '../../store/selectors/gateways'
 
-  return (
-    <Breadcrumb
-      path={`/gateways/${gtwId}/collaborators`}
-      icon="organization"
-      content={sharedMessages.collaborators}
-    />
-  )
+@connect(state => ({ gtwId: selectSelectedGatewayId(state) }))
+@withFeatureRequirement(mayViewOrEditGatewayCollaborators, {
+  redirect: ({ gtwId }) => `/gateways/${gtwId}`,
 })
+@withBreadcrumb('gtws.single.collaborators', ({ gtwId }) => (
+  <Breadcrumb
+    path={`/gateways/${gtwId}/collaborators`}
+    icon="organization"
+    content={sharedMessages.collaborators}
+  />
+))
 export default class GatewayCollaborators extends React.Component {
   render() {
     const { match } = this.props

--- a/pkg/webui/console/views/gateway-data/index.js
+++ b/pkg/webui/console/views/gateway-data/index.js
@@ -23,8 +23,10 @@ import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
 import { withBreadcrumb } from '../../../components/breadcrumbs/context'
 import Message from '../../../lib/components/message'
 import GatewayEvents from '../../containers/gateway-events'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
 
 import { selectSelectedGatewayId } from '../../store/selectors/gateways'
+import { mayViewGatewayEvents } from '../../lib/feature-checks'
 
 import style from './gateway-data.styl'
 
@@ -32,14 +34,13 @@ const m = defineMessages({
   gtwData: 'Gateway Data',
 })
 
-@connect(state => ({
-  gtwId: selectSelectedGatewayId(state),
-}))
-@withBreadcrumb('gateways.single.data', function(props) {
-  return (
-    <Breadcrumb path={`/gateways/${props.gtwId}/data`} icon="data" content={sharedMessages.data} />
-  )
+@connect(state => ({ gtwId: selectSelectedGatewayId(state) }))
+@withFeatureRequirement(mayViewGatewayEvents, {
+  redirect: ({ gtwId }) => `/gateways/${gtwId}`,
 })
+@withBreadcrumb('gateways.single.data', ({ gtwId }) => (
+  <Breadcrumb path={`/gateways/${gtwId}/data`} icon="data" content={sharedMessages.data} />
+))
 export default class Data extends React.Component {
   render() {
     const { gtwId } = this.props

--- a/pkg/webui/console/views/gateway-general-settings/index.js
+++ b/pkg/webui/console/views/gateway-general-settings/index.js
@@ -31,12 +31,13 @@ import ModalButton from '../../../components/button/modal-button'
 import FormSubmit from '../../../components/form/submit'
 import SubmitButton from '../../../components/submit-button'
 import IntlHelmet from '../../../lib/components/intl-helmet'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
 import diff from '../../../lib/diff'
 
 import { updateGateway, deleteGateway } from '../../store/actions/gateways'
 import { attachPromise } from '../../store/actions/lib'
-import { getGatewayId } from '../../../lib/selectors/id'
-import { selectSelectedGateway } from '../../store/selectors/gateways'
+import { selectSelectedGateway, selectSelectedGatewayId } from '../../store/selectors/gateways'
+import { mayEditBasicGatewayInformation } from '../../lib/feature-checks'
 
 const m = defineMessages({
   updateSuccess: 'Successfully updated gateway',
@@ -45,14 +46,10 @@ const m = defineMessages({
 })
 
 @connect(
-  function(state) {
-    const gateway = selectSelectedGateway(state)
-
-    return {
-      gtwId: getGatewayId(gateway),
-      gateway,
-    }
-  },
+  state => ({
+    gateway: selectSelectedGateway(state),
+    gtwId: selectSelectedGatewayId(state),
+  }),
   dispatch => ({
     ...bindActionCreators(
       {
@@ -64,6 +61,9 @@ const m = defineMessages({
     onDeleteSuccess: () => dispatch(replace('/gateways')),
   }),
 )
+@withFeatureRequirement(mayEditBasicGatewayInformation, {
+  redirect: ({ gtwId }) => `/gateways/${gtwId}`,
+})
 @withBreadcrumb('gateways.single.general-settings', function(props) {
   const { gtwId } = props
 

--- a/pkg/webui/console/views/gateway-general-settings/index.js
+++ b/pkg/webui/console/views/gateway-general-settings/index.js
@@ -32,12 +32,13 @@ import FormSubmit from '../../../components/form/submit'
 import SubmitButton from '../../../components/submit-button'
 import IntlHelmet from '../../../lib/components/intl-helmet'
 import withFeatureRequirement from '../../lib/components/with-feature-requirement'
+import Require from '../../lib/components/require'
 import diff from '../../../lib/diff'
 
 import { updateGateway, deleteGateway } from '../../store/actions/gateways'
 import { attachPromise } from '../../store/actions/lib'
 import { selectSelectedGateway, selectSelectedGatewayId } from '../../store/selectors/gateways'
-import { mayEditBasicGatewayInformation } from '../../lib/feature-checks'
+import { mayEditBasicGatewayInformation, mayDeleteGateway } from '../../lib/feature-checks'
 
 const m = defineMessages({
   updateSuccess: 'Successfully updated gateway',
@@ -180,15 +181,17 @@ export default class GatewayGeneralSettings extends React.Component {
               update
             >
               <FormSubmit component={SubmitButton} message={sharedMessages.saveChanges} />
-              <ModalButton
-                type="button"
-                icon="delete"
-                danger
-                naked
-                message={m.deleteGateway}
-                modalData={{ message: { values: { gtwName: name || gtwId }, ...m.modalWarning } }}
-                onApprove={this.handleDelete}
-              />
+              <Require featureCheck={mayDeleteGateway}>
+                <ModalButton
+                  type="button"
+                  icon="delete"
+                  danger
+                  naked
+                  message={m.deleteGateway}
+                  modalData={{ message: { values: { gtwName: name || gtwId }, ...m.modalWarning } }}
+                  onApprove={this.handleDelete}
+                />
+              </Require>
             </GatewayDataForm>
           </Col>
         </Row>

--- a/pkg/webui/console/views/gateway-location/index.js
+++ b/pkg/webui/console/views/gateway-location/index.js
@@ -19,17 +19,17 @@ import bind from 'autobind-decorator'
 import { defineMessages } from 'react-intl'
 import * as Yup from 'yup'
 
-import sharedMessages from '../../../lib/shared-messages'
-import { getGatewayId } from '../../../lib/selectors/id'
-
 import LocationForm from '../../../components/location-form'
 import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
 import { withBreadcrumb } from '../../../components/breadcrumbs/context'
 import IntlHelmet from '../../../lib/components/intl-helmet'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
+import sharedMessages from '../../../lib/shared-messages'
 
 import { updateGateway } from '../../store/actions/gateways'
 import { attachPromise } from '../../store/actions/lib'
-import { selectSelectedGateway } from '../../store/selectors/gateways'
+import { selectSelectedGateway, selectSelectedGatewayId } from '../../store/selectors/gateways'
+import { mayViewOrEditGatewayLocation } from '../../lib/feature-checks'
 
 import {
   latitude as latitudeRegexp,
@@ -69,14 +69,10 @@ const getRegistryLocation = function(antennas) {
 }
 
 @connect(
-  function(state) {
-    const gateway = selectSelectedGateway(state)
-
-    return {
-      gateway,
-      gtwId: getGatewayId(gateway),
-    }
-  },
+  state => ({
+    gateway: selectSelectedGateway(state),
+    gtwId: selectSelectedGatewayId(state),
+  }),
   { updateGateway: attachPromise(updateGateway) },
 )
 @withBreadcrumb('gateway.single.data', function(props) {
@@ -88,6 +84,9 @@ const getRegistryLocation = function(antennas) {
       content={sharedMessages.location}
     />
   )
+})
+@withFeatureRequirement(mayViewOrEditGatewayLocation, {
+  redirect: ({ gtwId }) => `/gateways/${gtwId}`,
 })
 @bind
 export default class GatewayLocation extends React.Component {

--- a/pkg/webui/console/views/gateway-overview/index.js
+++ b/pkg/webui/console/views/gateway-overview/index.js
@@ -28,19 +28,19 @@ import DateTime from '../../../lib/components/date-time'
 import Message from '../../../lib/components/message'
 import PropTypes from '../../../lib/prop-types'
 import GatewayMap from '../../components/gateway-map'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
 
-import { selectSelectedGateway as gatewaySelector } from '../../store/selectors/gateways'
-import { getGatewayId as idSelector } from '../../../lib/selectors/id'
+import { selectSelectedGateway, selectSelectedGatewayId } from '../../store/selectors/gateways'
+import { mayEditBasicGatewayInformation } from '../../lib/feature-checks'
 
 import style from './gateway-overview.styl'
 
-@connect(function(state, props) {
-  const gtw = gatewaySelector(state, props)
-
-  return {
-    gtwId: idSelector(gtw),
-    gateway: gtw,
-  }
+@connect(state => ({
+  gtwId: selectSelectedGatewayId(state),
+  gateway: selectSelectedGateway(state),
+}))
+@withFeatureRequirement(mayEditBasicGatewayInformation, {
+  redirect: '/',
 })
 @bind
 export default class GatewayOverview extends React.Component {

--- a/pkg/webui/console/views/gateways/index.js
+++ b/pkg/webui/console/views/gateways/index.js
@@ -22,7 +22,11 @@ import Gateway from '../gateway'
 import sharedMessages from '../../../lib/shared-messages'
 import { withBreadcrumb } from '../../../components/breadcrumbs/context'
 import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
 
+import { mayViewGateways } from '../../lib/feature-checks'
+
+@withFeatureRequirement(mayViewGateways, { redirect: '/' })
 @withBreadcrumb('gateways', function(props) {
   return <Breadcrumb path="/gateways" content={sharedMessages.gateways} />
 })

--- a/pkg/webui/console/views/organization-add/organization-add.js
+++ b/pkg/webui/console/views/organization-add/organization-add.js
@@ -21,12 +21,14 @@ import OrganizationForm from '../../components/organization-form'
 import SubmitBar from '../../../components/submit-bar'
 import SubmitButton from '../../../components/submit-button'
 import Form from '../../../components/form'
-
 import PropTypes from '../../../lib/prop-types'
 import Message from '../../../lib/components/message'
 import IntlHelmet from '../../../lib/components/intl-helmet'
 import sharedMessages from '../../../lib/shared-messages'
 import { getOrganizationId } from '../../../lib/selectors/id'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
+
+import { mayCreateOrganizations } from '../../lib/feature-checks'
 
 import style from './organization-add.styl'
 
@@ -42,6 +44,7 @@ const m = defineMessages({
   createOrganization: 'Create Organization',
 })
 
+@withFeatureRequirement(mayCreateOrganizations, { redirect: '/organizations' })
 class Add extends React.Component {
   static propTypes = {
     createOrganization: PropTypes.func.isRequired,

--- a/pkg/webui/console/views/organization-api-key-add/connect.js
+++ b/pkg/webui/console/views/organization-api-key-add/connect.js
@@ -15,9 +15,6 @@
 import { connect } from 'react-redux'
 import { replace } from 'connected-react-router'
 
-import withRequest from '../../../lib/components/with-request'
-
-import { getOrganizationsRightsList } from '../../store/actions/organizations'
 import {
   selectSelectedOrganizationId,
   selectOrganizationRights,
@@ -38,7 +35,6 @@ export default OrganizationApiKeyAdd =>
       pseudoRights: selectOrganizationPseudoRights(state),
     }),
     dispatch => ({
-      getOrganizationsRightsList: orgId => dispatch(getOrganizationsRightsList(orgId)),
       navigateToList: orgId => dispatch(replace(`/organizations/${orgId}/api-keys`)),
       createOrganizationApiKey: api.organization.apiKeys.create,
     }),
@@ -51,9 +47,4 @@ export default OrganizationApiKeyAdd =>
       createOrganizationApiKey: key =>
         dispatchProps.createOrganizationApiKey(stateProps.orgId, key),
     }),
-  )(
-    withRequest(
-      ({ getOrganizationsRightsList }) => getOrganizationsRightsList(),
-      ({ fetching, rights }) => fetching || !Boolean(rights.length),
-    )(OrganizationApiKeyAdd),
-  )
+  )(OrganizationApiKeyAdd)

--- a/pkg/webui/console/views/organization-api-key-edit/connect.js
+++ b/pkg/webui/console/views/organization-api-key-edit/connect.js
@@ -17,10 +17,7 @@ import { replace } from 'connected-react-router'
 
 import withRequest from '../../../lib/components/with-request'
 
-import {
-  getOrganizationApiKey,
-  getOrganizationsRightsList,
-} from '../../store/actions/organizations'
+import { getOrganizationApiKey } from '../../store/actions/organizations'
 import {
   selectSelectedOrganizationId,
   selectOrganizationRights,
@@ -55,8 +52,7 @@ export default OrganizationApiKeyEdit =>
       }
     },
     dispatch => ({
-      loadData(orgId, apiKeyId) {
-        dispatch(getOrganizationsRightsList(orgId))
+      getOrganizationApiKey(orgId, apiKeyId) {
         dispatch(getOrganizationApiKey(orgId, apiKeyId))
       },
       deleteOrganizationApiKeySuccess: orgId =>
@@ -77,7 +73,7 @@ export default OrganizationApiKeyEdit =>
     }),
   )(
     withRequest(
-      ({ loadData, orgId, keyId }) => loadData(orgId, keyId),
+      ({ getOrganizationApiKey, orgId, keyId }) => getOrganizationApiKey(orgId, keyId),
       ({ fetching, apiKey }) => fetching || !Boolean(apiKey),
     )(OrganizationApiKeyEdit),
   )

--- a/pkg/webui/console/views/organization-api-keys/index.js
+++ b/pkg/webui/console/views/organization-api-keys/index.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import React from 'react'
+import { connect } from 'react-redux'
 import { Switch, Route } from 'react-router'
 
 import sharedMessages from '../../../lib/shared-messages'
@@ -25,19 +26,22 @@ import SubViewError from '../error/sub-view'
 import OrganizationApiKeysList from '../organization-api-keys-list'
 import OrganizationApiKeyAdd from '../organization-api-key-add'
 import OrganizationApiKeyEdit from '../organization-api-key-edit'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
 
-@withBreadcrumb('org.single.api-keys', function(props) {
-  const { match } = props
-  const orgId = match.params.orgId
+import { mayViewOrEditOrganizationApiKeys } from '../../lib/feature-checks'
+import { selectSelectedOrganizationId } from '../../store/selectors/organizations'
 
-  return (
-    <Breadcrumb
-      path={`/organizations/${orgId}/api-keys`}
-      icon="api_keys"
-      content={sharedMessages.apiKeys}
-    />
-  )
+@connect(state => ({ orgId: selectSelectedOrganizationId(state) }))
+@withFeatureRequirement(mayViewOrEditOrganizationApiKeys, {
+  redirect: ({ orgId }) => `/organizations/${orgId}`,
 })
+@withBreadcrumb('org.single.api-keys', ({ orgId }) => (
+  <Breadcrumb
+    path={`/organizations/${orgId}/api-keys`}
+    icon="api_keys"
+    content={sharedMessages.apiKeys}
+  />
+))
 class OrganizationApiKeys extends React.Component {
   static propTypes = {
     match: PropTypes.match.isRequired,

--- a/pkg/webui/console/views/organization-collaborator-add/connect.js
+++ b/pkg/webui/console/views/organization-collaborator-add/connect.js
@@ -15,8 +15,6 @@
 import { connect } from 'react-redux'
 import { push } from 'connected-react-router'
 
-import withRequest from '../../../lib/components/with-request'
-
 import {
   selectSelectedOrganizationId,
   selectOrganizationRights,
@@ -51,9 +49,4 @@ export default OrganizationCollaboratorAdd =>
       addOrganizationCollaborator: collaborator =>
         dispatchProps.addOrganizationCollaborator(stateProps.orgId, collaborator),
     }),
-  )(
-    withRequest(
-      ({ getOrganizationsRightsList }) => getOrganizationsRightsList(),
-      ({ fetching, rights }) => fetching || !Boolean(rights.length),
-    )(OrganizationCollaboratorAdd),
-  )
+  )(OrganizationCollaboratorAdd)

--- a/pkg/webui/console/views/organization-collaborator-edit/connect.js
+++ b/pkg/webui/console/views/organization-collaborator-edit/connect.js
@@ -17,10 +17,7 @@ import { replace } from 'connected-react-router'
 
 import withRequest from '../../../lib/components/with-request'
 
-import {
-  getOrganizationCollaborator,
-  getOrganizationsRightsList,
-} from '../../store/actions/organizations'
+import { getOrganizationCollaborator } from '../../store/actions/organizations'
 import {
   selectSelectedOrganizationId,
   selectOrganizationRights,
@@ -64,8 +61,7 @@ export default OrganizationCollaboratorEdit =>
       }
     },
     dispatch => ({
-      loadData(orgId, collaboratorId, isUser) {
-        dispatch(getOrganizationsRightsList(orgId))
+      getOrganizationCollaborator(orgId, collaboratorId, isUser) {
         dispatch(getOrganizationCollaborator(orgId, collaboratorId, isUser))
       },
       redirectToList(orgId) {
@@ -80,8 +76,8 @@ export default OrganizationCollaboratorEdit =>
       ...stateProps,
       ...dispatchProps,
       ...ownProps,
-      loadData: () =>
-        dispatchProps.loadData(
+      getOrganizationCollaborator: () =>
+        dispatchProps.getOrganizationCollaborator(
           stateProps.orgId,
           stateProps.collaboratorId,
           stateProps.collaboratorType === 'user',
@@ -94,7 +90,7 @@ export default OrganizationCollaboratorEdit =>
     }),
   )(
     withRequest(
-      ({ loadData }) => loadData(),
+      ({ getOrganizationCollaborator }) => getOrganizationCollaborator(),
       ({ fetching, collaborator }) => fetching || !Boolean(collaborator),
     )(OrganizationCollaboratorEdit),
   )

--- a/pkg/webui/console/views/organization-collaborators/index.js
+++ b/pkg/webui/console/views/organization-collaborators/index.js
@@ -13,21 +13,28 @@
 // limitations under the License.
 
 import React from 'react'
+import { connect } from 'react-redux'
 import { Switch, Route } from 'react-router'
 
 import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
 import { withBreadcrumb } from '../../../components/breadcrumbs/context'
-
 import sharedMessages from '../../../lib/shared-messages'
 import ErrorView from '../../../lib/components/error-view'
 import NotFoundRoute from '../../../lib/components/not-found-route'
 import PropTypes from '../../../lib/prop-types'
-
 import SubViewError from '../error/sub-view'
 import OrganizationCollaboratorsList from '../organization-collaborators-list'
 import OrganizationCollaboratorAdd from '../organization-collaborator-add'
 import OrganizationCollaboratorEdit from '../organization-collaborator-edit'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
 
+import { mayViewOrEditOrganizationApiKeys } from '../../lib/feature-checks'
+import { selectSelectedOrganizationId } from '../../store/selectors/organizations'
+
+@connect(state => ({ orgId: selectSelectedOrganizationId(state) }))
+@withFeatureRequirement(mayViewOrEditOrganizationApiKeys, {
+  redirect: ({ orgId }) => `/organizations/${orgId}`,
+})
 @withBreadcrumb('orgs.single.collaborators', function(props) {
   const { match } = props
   const { orgId } = match.params

--- a/pkg/webui/console/views/organization-general-settings/organization-general-settings.js
+++ b/pkg/webui/console/views/organization-general-settings/organization-general-settings.js
@@ -32,8 +32,12 @@ import Message from '../../../lib/components/message'
 import PropTypes from '../../../lib/prop-types'
 import sharedMessages from '../../../lib/shared-messages'
 import withFeatureRequirement from '../../lib/components/with-feature-requirement'
+import Require from '../../lib/components/require'
 
-import { mayEditBasicOrganizationInformation } from '../../lib/feature-checks'
+import {
+  mayEditBasicOrganizationInformation,
+  mayDeleteOrganization,
+} from '../../lib/feature-checks'
 
 const m = defineMessages({
   deleteOrg: 'Delete organization',
@@ -144,17 +148,22 @@ class GeneralSettings extends React.PureComponent {
             >
               <SubmitBar>
                 <Form.Submit message={sharedMessages.saveChanges} component={SubmitButton} />
-                <ModalButton
-                  type="button"
-                  icon="delete"
-                  danger
-                  naked
-                  message={m.deleteOrg}
-                  modalData={{
-                    message: { values: { orgName: organization.name || orgId }, ...m.modalWarning },
-                  }}
-                  onApprove={this.handleDelete}
-                />
+                <Require featureCheck={mayDeleteOrganization}>
+                  <ModalButton
+                    type="button"
+                    icon="delete"
+                    danger
+                    naked
+                    message={m.deleteOrg}
+                    modalData={{
+                      message: {
+                        values: { orgName: organization.name || orgId },
+                        ...m.modalWarning,
+                      },
+                    }}
+                    onApprove={this.handleDelete}
+                  />
+                </Require>
               </SubmitBar>
             </OrganizationForm>
           </Col>

--- a/pkg/webui/console/views/organization-general-settings/organization-general-settings.js
+++ b/pkg/webui/console/views/organization-general-settings/organization-general-settings.js
@@ -31,6 +31,9 @@ import diff from '../../../lib/diff'
 import Message from '../../../lib/components/message'
 import PropTypes from '../../../lib/prop-types'
 import sharedMessages from '../../../lib/shared-messages'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
+
+import { mayEditBasicOrganizationInformation } from '../../lib/feature-checks'
 
 const m = defineMessages({
   deleteOrg: 'Delete organization',
@@ -39,17 +42,16 @@ const m = defineMessages({
   updateSuccess: 'Successfully updated organization',
 })
 
-@withBreadcrumb('orgs.single.general-settings', function(props) {
-  const { orgId } = props
-
-  return (
-    <Breadcrumb
-      path={`/organizations/${orgId}/general-settings`}
-      icon="general_settings"
-      content={sharedMessages.generalSettings}
-    />
-  )
+@withFeatureRequirement(mayEditBasicOrganizationInformation, {
+  redirect: ({ orgId }) => `/organizations/${orgId}`,
 })
+@withBreadcrumb('orgs.single.general-settings', ({ orgId }) => (
+  <Breadcrumb
+    path={`/organizations/${orgId}/general-settings`}
+    icon="general_settings"
+    content={sharedMessages.generalSettings}
+  />
+))
 class GeneralSettings extends React.PureComponent {
   static propTypes = {
     deleteOrganization: PropTypes.func.isRequired,

--- a/pkg/webui/console/views/organization-overview/organization-overview.js
+++ b/pkg/webui/console/views/organization-overview/organization-overview.js
@@ -16,17 +16,21 @@ import React from 'react'
 import { Col, Row, Container } from 'react-grid-system'
 
 import sharedMessages from '../../../lib/shared-messages'
-
 import DateTime from '../../../lib/components/date-time'
 import IntlHelmet from '../../../lib/components/intl-helmet'
 import PropTypes from '../../../lib/prop-types'
 import { getOrganizationId } from '../../../lib/selectors/id'
-
 import OrganizationEvents from '../../containers/organization-events'
 import DataSheet from '../../../components/data-sheet'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
+
+import { mayViewOrganizationInformation } from '../../lib/feature-checks'
 
 import style from './organization-overview.styl'
 
+@withFeatureRequirement(mayViewOrganizationInformation, {
+  redirect: '/',
+})
 class Overview extends React.Component {
   static propTypes = {
     organization: PropTypes.organization.isRequired,

--- a/pkg/webui/console/views/organization/connect.js
+++ b/pkg/webui/console/views/organization/connect.js
@@ -18,21 +18,32 @@ import {
   selectSelectedOrganization,
   selectOrganizationFetching,
   selectOrganizationError,
+  selectOrganizationRights,
+  selectOrganizationRightsFetching,
+  selectOrganizationRightsError,
 } from '../../store/selectors/organizations'
-import { getOrganization, stopOrganizationEventsStream } from '../../store/actions/organizations'
+import {
+  getOrganization,
+  stopOrganizationEventsStream,
+  getOrganizationsRightsList,
+} from '../../store/actions/organizations'
 
 import withRequest from '../../../lib/components/with-request'
 
 const mapStateToProps = (state, props) => ({
   orgId: props.match.params.orgId,
-  fetching: selectOrganizationFetching(state),
+  fetching: selectOrganizationFetching(state) || selectOrganizationRightsFetching(state),
   organization: selectSelectedOrganization(state),
-  error: selectOrganizationError(state),
+  error: selectOrganizationError(state) || selectOrganizationRightsError(state),
+  rights: selectOrganizationRights(state),
 })
 
 const mapDispatchToProps = dispatch => ({
   stopStream: id => dispatch(stopOrganizationEventsStream(id)),
-  getOrganization: id => dispatch(getOrganization(id, 'name,description')),
+  loadData: id => {
+    dispatch(getOrganization(id, 'name,description'))
+    dispatch(getOrganizationsRightsList(id))
+  },
 })
 
 export default Organization =>
@@ -41,7 +52,7 @@ export default Organization =>
     mapDispatchToProps,
   )(
     withRequest(
-      ({ orgId, getOrganization }) => getOrganization(orgId),
+      ({ orgId, loadData }) => loadData(orgId),
       ({ fetching, organization }) => fetching || !Boolean(organization),
     )(Organization),
   )

--- a/pkg/webui/console/views/organization/organization.js
+++ b/pkg/webui/console/views/organization/organization.js
@@ -24,17 +24,23 @@ import BreadcrumbView from '../../../lib/components/breadcrumb-view'
 import sharedMessages from '../../../lib/shared-messages'
 import PropTypes from '../../../lib/prop-types'
 import NotFoundRoute from '../../../lib/components/not-found-route'
-
 import OrganizationOverview from '../organization-overview'
 import OrganizationData from '../organization-data'
 import OrganizationGeneralSettings from '../organization-general-settings'
 import OrganizationApiKeys from '../organization-api-keys'
 import OrganizationCollaborators from '../organization-collaborators'
 
+import {
+  mayViewOrganizationInformation,
+  mayViewOrEditOrganizationApiKeys,
+  mayViewOrEditOrganizationCollaborators,
+  mayEditBasicOrganizationInformation,
+} from '../../lib/feature-checks'
+
 @withEnv
 @withSideNavigation(function(props) {
   const matchedUrl = props.match.url
-
+  const { rights } = props
   return {
     header: { title: props.orgId, icon: 'organization' },
     entries: [
@@ -42,6 +48,7 @@ import OrganizationCollaborators from '../organization-collaborators'
         title: sharedMessages.overview,
         path: matchedUrl,
         icon: 'overview',
+        hidden: !mayViewOrganizationInformation.check(rights),
       },
       {
         title: sharedMessages.data,
@@ -53,17 +60,20 @@ import OrganizationCollaborators from '../organization-collaborators'
         path: `${matchedUrl}/api-keys`,
         icon: 'api_keys',
         exact: false,
+        hidden: !mayViewOrEditOrganizationApiKeys.check(rights),
       },
       {
         title: sharedMessages.collaborators,
         path: `${matchedUrl}/collaborators`,
         icon: 'organization',
         exact: false,
+        hidden: !mayViewOrEditOrganizationCollaborators.check(rights),
       },
       {
         title: sharedMessages.generalSettings,
         path: `${matchedUrl}/general-settings`,
         icon: 'general_settings',
+        hidden: !mayEditBasicOrganizationInformation.check(rights),
       },
     ],
   }

--- a/pkg/webui/console/views/organizations/index.js
+++ b/pkg/webui/console/views/organizations/index.js
@@ -22,7 +22,11 @@ import Organization from '../organization'
 import sharedMessages from '../../../lib/shared-messages'
 import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
 import { withBreadcrumb } from '../../../components/breadcrumbs/context'
+import withFeatureRequirement from '../../lib/components/with-feature-requirement'
 
+import { mayViewOrganizationsOfUser } from '../../lib/feature-checks'
+
+@withFeatureRequirement(mayViewOrganizationsOfUser, { redirect: '/' })
 @withBreadcrumb('orgs', function(props) {
   return <Breadcrumb path="/organizations" content={sharedMessages.organizations} />
 })

--- a/pkg/webui/lib/prop-types.js
+++ b/pkg/webui/lib/prop-types.js
@@ -54,6 +54,7 @@ PropTypes.link = PropTypes.shape({
   icon: PropTypes.string,
   path: PropTypes.string.isRequired,
   exact: PropTypes.bool,
+  hidden: PropTypes.bool,
 })
 
 // Entities and entity-related prop-types


### PR DESCRIPTION
#### Summary
Closes #1200 

This PR will add feature toggles to the console. All views that the user is not allowed to view will automatically redirect back. Navigation links will not be displayed and specific components inside views will be hidden if the feature requirements are not met.

#### Changes
- Add user rights to redux store
- Add `<Require />` component for conditionally rendering children based on feature availability
- Add `withFeatureRequirement()` HOC that basically wraps the `<Require />` component but also adds simplified redirection
- Add `feature-check.js` module that provides the requirement checks for specific features, based on the rights of the user as well as enabled stack components
- Add a `hidden` flag to side navigation and navbar items
- Refactor entity rights fetching (fetch at top level together with the entity)
- Add feature toggles to gateway / application / organization / general views
- Add feature toggles to various elements inside components and views

#### Notes for Reviewers

Note that I did not refactor the side nav to use the compound layout, as this would be a bigger refactor that is lower priority and I would rather do that in another PR. For now, I just added a simple visibility flag.
@htdvisser please check specifically https://github.com/TheThingsNetwork/lorawan-stack/blob/88e6916bfa5be962a0ad6299fec23cec5fd40347/pkg/webui/console/lib/feature-checks.js to see whether the conditions there make sense to you

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [ ] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
