### PR TITLE
Fix events error selector

### DIFF
--- a/pkg/webui/console/store/selectors/events.js
+++ b/pkg/webui/console/store/selectors/events.js
@@ -32,7 +32,7 @@ export const createEventsErrorSelector = entity =>
   function(state, entityId) {
     const store = selectEventsStore(state.events[entity], entityId)
 
-    return store.error
+    return store ? store.error : undefined
   }
 
 export const createLatestEventSelector = function(entity) {


### PR DESCRIPTION
#### Summary
This quickfix PR fixes a missing fallback value for the event error selector.  Basically the selector will throw if the event store does not exist (yet). It should rather always fall back to `undefined` like the fetching selector already does.

#### Changes
- Check whether the event store exists and return `undefined` otherwise

#### Notes for Reviewers
I experienced crashes resulting from this issue occasionally (though I cannot provide exact repro steps). It happened when directly navigating between applications.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [ ] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
