### PR TITLE
Rename remaining universal rights to pseudo rights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support for creating applications and gateway with an organization as the initial owner in the Console. 
+- Support for creating applications and gateway with an organization as the initial owner in the Console.
 
 ### Changed
 
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
+- Fix gateway API key forms being broken in the Console.
 
 ### Security
 

--- a/pkg/webui/console/store/selectors/gateways.js
+++ b/pkg/webui/console/store/selectors/gateways.js
@@ -91,7 +91,7 @@ export const selectGatewayApiKeyError = createErrorSelector(GET_GTW_API_KEY_BASE
 
 // Rights
 export const selectGatewayRights = createRightsSelector(ENTITY)
-export const selectGatewayUniversalRights = createPseudoRightsSelector(ENTITY)
+export const selectGatewayPseudoRights = createPseudoRightsSelector(ENTITY)
 export const selectGatewayRightsError = createErrorSelector(ENTITY)
 export const selectGatewayRightsFetching = createFetchingSelector(GET_GTWS_RIGHTS_LIST_BASE)
 

--- a/pkg/webui/console/views/gateway-api-key-add/index.js
+++ b/pkg/webui/console/views/gateway-api-key-add/index.js
@@ -32,7 +32,7 @@ import {
   selectGatewayRights,
   selectGatewayRightsError,
   selectGatewayRightsFetching,
-  selectGatewayUniversalRights,
+  selectGatewayPseudoRights,
 } from '../../store/selectors/gateways'
 
 import api from '../../api'
@@ -43,7 +43,7 @@ import api from '../../api'
     fetching: selectGatewayRightsFetching(state),
     error: selectGatewayRightsError(state),
     rights: selectGatewayRights(state),
-    universalRights: selectGatewayUniversalRights(state),
+    pseudoRights: selectGatewayPseudoRights(state),
   }),
   dispatch => ({
     getGatewaysRightsList: gtwId => dispatch(getGatewaysRightsList(gtwId)),
@@ -76,7 +76,7 @@ export default class GatewayApiKeyAdd extends React.Component {
   }
 
   render() {
-    const { rights, universalRights } = this.props
+    const { rights, pseudoRights } = this.props
 
     return (
       <Container>
@@ -90,7 +90,7 @@ export default class GatewayApiKeyAdd extends React.Component {
           <Col lg={8} md={12}>
             <ApiKeyCreateForm
               rights={rights}
-              universalRights={universalRights}
+              pseudoRights={pseudoRights}
               onCreate={this.createGatewayKey}
               onCreateSuccess={this.handleApprove}
             />

--- a/pkg/webui/console/views/gateway-api-key-edit/index.js
+++ b/pkg/webui/console/views/gateway-api-key-edit/index.js
@@ -30,7 +30,7 @@ import { getGatewayApiKey, getGatewaysRightsList } from '../../store/actions/gat
 import {
   selectSelectedGatewayId,
   selectGatewayRights,
-  selectGatewayUniversalRights,
+  selectGatewayPseudoRights,
   selectGatewayRightsError,
   selectGatewayRightsFetching,
   selectGatewayApiKey,
@@ -53,7 +53,7 @@ import api from '../../api'
       gtwId: selectSelectedGatewayId(state),
       apiKey: selectGatewayApiKey(state),
       rights: selectGatewayRights(state),
-      universalRights: selectGatewayUniversalRights(state),
+      pseudoRights: selectGatewayPseudoRights(state),
       fetching: keyFetching || rightsFetching,
       error: keyError || rightsError,
     }
@@ -97,7 +97,7 @@ export default class GatewayApiKeyEdit extends React.Component {
   }
 
   render() {
-    const { apiKey, rights, universalRights } = this.props
+    const { apiKey, rights, pseudoRights } = this.props
 
     return (
       <Container>
@@ -111,7 +111,7 @@ export default class GatewayApiKeyEdit extends React.Component {
           <Col lg={8} md={12}>
             <ApiKeyEditForm
               rights={rights}
-              universalRights={universalRights}
+              pseudoRights={pseudoRights}
               apiKey={apiKey}
               onEdit={this.editGatewayKey}
               onDelete={this.deleteGatewayKey}

--- a/pkg/webui/console/views/gateway-collaborator-add/index.js
+++ b/pkg/webui/console/views/gateway-collaborator-add/index.js
@@ -29,7 +29,7 @@ import withRequest from '../../../lib/components/with-request'
 import {
   selectSelectedGatewayId,
   selectGatewayRights,
-  selectGatewayUniversalRights,
+  selectGatewayPseudoRights,
   selectGatewayRightsFetching,
   selectGatewayRightsError,
 } from '../../store/selectors/gateways'
@@ -47,7 +47,7 @@ import api from '../../api'
       fetching: selectGatewayRightsFetching(state),
       error: selectGatewayRightsError(state),
       rights: selectGatewayRights(state),
-      universalRights: selectGatewayUniversalRights(state),
+      pseudoRights: selectGatewayPseudoRights(state),
     }
   },
   (dispatch, ownProps) => ({
@@ -89,7 +89,7 @@ export default class GatewayCollaboratorAdd extends React.Component {
   }
 
   render() {
-    const { rights, redirectToList, universalRights } = this.props
+    const { rights, redirectToList, pseudoRights } = this.props
 
     return (
       <Container>
@@ -105,7 +105,7 @@ export default class GatewayCollaboratorAdd extends React.Component {
               error={this.state.error}
               onSubmit={this.handleSubmit}
               onSubmitSuccess={redirectToList}
-              universalRights={universalRights}
+              pseudoRights={pseudoRights}
               rights={rights}
             />
           </Col>

--- a/pkg/webui/console/views/gateway-collaborator-edit/index.js
+++ b/pkg/webui/console/views/gateway-collaborator-edit/index.js
@@ -31,7 +31,7 @@ import { getGatewayCollaborator, getGatewaysRightsList } from '../../store/actio
 import {
   selectSelectedGatewayId,
   selectGatewayRights,
-  selectGatewayUniversalRights,
+  selectGatewayPseudoRights,
   selectGatewayRightsFetching,
   selectGatewayRightsError,
   selectGatewayUserCollaborator,
@@ -62,7 +62,7 @@ import api from '../../api'
       collaborator,
       gtwId,
       rights: selectGatewayRights(state),
-      universalRights: selectGatewayUniversalRights(state),
+      pseudoRights: selectGatewayPseudoRights(state),
       fetching,
       error,
     }
@@ -130,7 +130,7 @@ export default class GatewayCollaboratorEdit extends React.Component {
   }
 
   render() {
-    const { collaborator, rights, redirectToList, universalRights } = this.props
+    const { collaborator, rights, redirectToList, pseudoRights } = this.props
 
     return (
       <Container>
@@ -156,7 +156,7 @@ export default class GatewayCollaboratorEdit extends React.Component {
               onDelete={this.handleDelete}
               onDeleteSuccess={redirectToList}
               collaborator={collaborator}
-              universalRights={universalRights}
+              pseudoRights={pseudoRights}
               rights={rights}
               update
             />


### PR DESCRIPTION
#### Summary
This quickfix PR renames remaining "universal" to "pseudo" rights, which fixes the gateway API key forms being broken due to wrong props being passed to the rights group component.

#### Changes
- Rename occurrences of "universal" rights to "pseudo" rights

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [ ] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
