### PR TITLE
Tweak Network Server downlink-related interval durations

### DIFF
--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -817,13 +817,13 @@ loop:
 }
 
 // downlinkRetryInterval is the time interval, which defines the interval between downlink task retries.
-const downlinkRetryInterval = time.Second
+const downlinkRetryInterval = 2 * time.Second
 
 // gsScheduleWindow is the time interval, which is sufficient for GS to ensure downlink is scheduled.
 const gsScheduleWindow = 30 * time.Second
 
 // nsScheduleWindow is the time interval, which is sufficient for NS to ensure downlink is scheduled.
-var nsScheduleWindow = time.Second
+var nsScheduleWindow = 100 * time.Millisecond
 
 func recordDataDownlink(dev *ttnpb.EndDevice, genDown *generatedDownlink, genState generateDownlinkState, down *scheduledDownlink, defaults ttnpb.MACSettings) {
 	if genState.ApplicationDownlink == nil || dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 && genDown.FCnt > dev.Session.LastNFCntDown {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

If a downlink fails with a retryable error, it is retried
Due to `downlinkRetryInterval == nsScheduleWindow` NS retries immediately, which is incorrect

#### Changes
<!-- What are the changes made in this pull request? -->

- Increase `downlinkRetryInterval` to 2 seconds
- Decrease `nsScheduleWindow` to 100 ms - that should be enough for NS to pop the element from the queue and send to GS