### PR TITLE
Fix table component prop-types

### DIFF
--- a/pkg/webui/components/table/index.js
+++ b/pkg/webui/components/table/index.js
@@ -195,7 +195,7 @@ Tabular.propTypes = {
     PropTypes.shape({
       displayName: PropTypes.message.isRequired,
       getValue: PropTypes.func,
-      name: PropTypes.string.isRequired,
+      name: PropTypes.string,
       render: PropTypes.func,
       centered: PropTypes.bool,
       sortable: PropTypes.bool,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Resolve warning caused by prop-types validation in the `<Table/>` component.
When visiting the pubsubs list page:
<img width="731" alt="Screenshot 2019-11-06 at 16 46 49" src="https://user-images.githubusercontent.com/16374166/68308417-82195400-00b5-11ea-8f7a-65e6d9a06947.png">

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove `isRequired` from the `name` prop

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The `name` prop is not needed when the `getValue` getter is passed to get name header name.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [ ] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
