### PR TITLE
Process MAC requests in retransmissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix gateway API key forms being broken in the Console.
+- Fix MAC command handling in retransmissions.
 
 ### Security
 

--- a/pkg/networkserver/grpc_gsns_test.go
+++ b/pkg/networkserver/grpc_gsns_test.go
@@ -3007,6 +3007,9 @@ func TestHandleUplink(t *testing.T) {
 
 					macState := makeMACState()
 					macState.RxWindowsAvailable = true
+					macState.QueuedResponses = []*ttnpb.MACCommand{
+						MakeLinkCheckAns(mds...),
+					}
 					a.So(dev.MACState, should.Resemble, macState)
 					a.So(dev.PendingMACState, should.BeNil)
 					a.So(dev.PendingSession, should.BeNil)
@@ -3053,6 +3056,18 @@ func TestHandleUplink(t *testing.T) {
 
 				if !a.So(test.AssertEventPubSubPublishRequest(ctx, env.Events, func(ev events.Event) bool {
 					return a.So(ev, should.ResembleEvent, EvtMergeMetadata(upCtx, rangeDevice.EndDeviceIdentifiers, len(mds)))
+				}), should.BeTrue) {
+					return false
+				}
+
+				if !a.So(test.AssertEventPubSubPublishRequest(ctx, env.Events, func(ev events.Event) bool {
+					return a.So(ev, should.ResembleEvent, EvtReceiveLinkCheckRequest(upCtx, rangeDevice.EndDeviceIdentifiers, nil))
+				}), should.BeTrue) {
+					return false
+				}
+
+				if !a.So(test.AssertEventPubSubPublishRequest(ctx, env.Events, func(ev events.Event) bool {
+					return a.So(ev, should.ResembleEvent, EvtEnqueueLinkCheckAnswer(upCtx, rangeDevice.EndDeviceIdentifiers, MakeLinkCheckAns(mds...).GetLinkCheckAns()))
 				}), should.BeTrue) {
 					return false
 				}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #1111 (irrelevant in latest 1.0.4 draft)
Current implementation incorrectly assumes that MAC commands in retransmissions can be discarded - that is only partially true. MAC answers in retransmissions are already processed by the NS when the original uplink was received, but the MAC requests still have to be answered, since the downlink following the previous transmission(and carrying answers) was not received/processed by the device.

#### Changes
<!-- What are the changes made in this pull request? -->

- Process MAC requests in retransmissions

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The diff is quite unfortunate, but it's mostly just the spacing due to the removal of `else` statement.
All this is does is basically skip MAC answers in the buffer.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
