### PR TITLE
Increase connection timeout in AS tests

### DIFF
--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -816,7 +816,7 @@ hardware_versions:
 				},
 			} {
 				t.Run(ctc.Name, func(t *testing.T) {
-					ctx, cancel := context.WithDeadline(ctx, time.Now().Add(Timeout))
+					ctx, cancel := context.WithDeadline(ctx, time.Now().Add(2*Timeout))
 					chs := &connChannels{
 						up:          make(chan *ttnpb.ApplicationUp, 1),
 						downPush:    make(chan *ttnpb.DownlinkQueueRequest),
@@ -855,7 +855,7 @@ hardware_versions:
 				}
 			}()
 			// Wait for connection to establish.
-			time.Sleep(Timeout)
+			time.Sleep(2 * Timeout)
 
 			t.Run("Upstream", func(t *testing.T) {
 				ns.reset()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #1445

#### Changes
<!-- What are the changes made in this pull request? -->

- Increase the timeout of the connection setup time in AS tests.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The code is `unknown` because the error itself is wrapped by a gRPC error coming from the `Subscribe` call. The way I see it is that `Subscribe` reaches the timeout while still setting up the gRPC stream, and since the error is wrapped the code is not clearly defined.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
