### PR TITLE
Avoid unwanted renders with old data in withRequest() HOC

### DIFF
--- a/pkg/webui/lib/components/with-request.js
+++ b/pkg/webui/lib/components/with-request.js
@@ -33,11 +33,25 @@ const withRequest = (
   mapPropsToError = ({ error } = {}) => error,
 ) => Component =>
   class WithRequest extends React.Component {
+    state = { initialFetching: true }
     componentDidMount() {
       mapPropsToRequest(this.props)
     }
 
     componentDidUpdate(prevProps) {
+      const prevFetching = mapPropsToFetching(prevProps)
+      const fetching = mapPropsToFetching(this.props)
+      const { initialFetching } = this.state
+
+      // Avoid initial render with old data (when request has been performed
+      // before, thus fetching calculation being initially true, before the new
+      // request is being made).
+      if (initialFetching && prevFetching !== !fetching) {
+        // Remove internal fetching state as soon as the fetching calculation
+        // has switched.
+        this.setState({ initialFetching: false })
+      }
+
       const error = mapPropsToError(this.props)
       const prevError = mapPropsToError(prevProps)
 
@@ -48,7 +62,8 @@ const withRequest = (
     }
 
     render() {
-      if (mapPropsToFetching(this.props)) {
+      const { initialFetching } = this.state
+      if (initialFetching || mapPropsToFetching(this.props)) {
         return <Spinner center />
       }
 


### PR DESCRIPTION
### Summary
This quickfix PR fixes an issue with the `withRequest()` HOC, that resulted in an unwanted rendering of the passed component with old data. This happens when the `mapPropsToFetching()` function initially returns `false`, as the passed in fetching props from the state might be false from a previous request.

Basically the problem is that the HOC may render the passed component before the `mapPropsToRequest()` was made if the derived `fetching` is initially false:
```js
    render() {
      // The derived fetching value here might be false initially
      // causing the <Component /> to be rendered before the 
      // request was made
      if (mapPropsToFetching(this.props)) {
        return <Spinner center />
      }

      return <Component {...this.props} />
    }
```

If there are other `withRequest()`-decorated components in the hierarchy, this also leads to unnecessary re-requests with old data.

You can reproduce the issue e.g. when switching between applications: notice the `GET_DEVICES_LIST` request being made two times, once for the old app and once for the current app.

#### Changes
- Add an `initialFetching` state to the component, initially set to `true`
- Set this to `false` as soon as the derived `fetching` toggles (indicating that the request has started)

#### Notes for Reviewers
Consider this as a proposal. I'm not 100% happy with this solution. Had to implement something quickly to progress with #770.
Do you have a better idea for fixing this?

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [ ] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
