### PR TITLE
Touch devices in JS, NS and AS on set

### DIFF
--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -467,7 +467,7 @@ var (
 
 			device.SetFields(isRes, append(isPaths, "created_at", "updated_at")...)
 
-			res, err := setEndDevice(&device, nil, nsPaths, asPaths, jsPaths, true)
+			res, err := setEndDevice(&device, nil, nsPaths, asPaths, jsPaths, true, false)
 			if err != nil {
 				logger.WithError(err).Error("Could not create end device, rolling back...")
 				if err := deleteEndDevice(context.Background(), &device.EndDeviceIdentifiers); err != nil {
@@ -572,7 +572,8 @@ var (
 				return errAddressMismatchEndDevice
 			}
 
-			res, err := setEndDevice(&device, isPaths, nsPaths, asPaths, jsPaths, false)
+			touch, _ := cmd.Flags().GetBool("touch")
+			res, err := setEndDevice(&device, isPaths, nsPaths, asPaths, jsPaths, false, touch)
 			if err != nil {
 				return err
 			}
@@ -1027,6 +1028,7 @@ func init() {
 	endDevicesUpdateCommand.Flags().AddFlagSet(endDeviceIDFlags())
 	endDevicesUpdateCommand.Flags().AddFlagSet(setEndDeviceFlags)
 	endDevicesUpdateCommand.Flags().AddFlagSet(attributesFlags())
+	endDevicesUpdateCommand.Flags().Bool("touch", false, "set in all registries even if no fields are specified")
 	endDevicesCommand.AddCommand(endDevicesUpdateCommand)
 	endDevicesProvisionCommand.Flags().AddFlagSet(applicationIDFlags())
 	endDevicesProvisionCommand.Flags().AddFlagSet(dataFlags("", ""))

--- a/cmd/ttn-lw-cli/commands/end_devices_split.go
+++ b/cmd/ttn-lw-cli/commands/end_devices_split.go
@@ -177,7 +177,7 @@ func getEndDevice(ids ttnpb.EndDeviceIdentifiers, nsPaths, asPaths, jsPaths []st
 	return &res, nil
 }
 
-func setEndDevice(device *ttnpb.EndDevice, isPaths, nsPaths, asPaths, jsPaths []string, isCreate bool) (*ttnpb.EndDevice, error) {
+func setEndDevice(device *ttnpb.EndDevice, isPaths, nsPaths, asPaths, jsPaths []string, isCreate, touch bool) (*ttnpb.EndDevice, error) {
 	var res ttnpb.EndDevice
 	res.SetFields(device, "ids", "created_at", "updated_at")
 
@@ -207,7 +207,7 @@ func setEndDevice(device *ttnpb.EndDevice, isPaths, nsPaths, asPaths, jsPaths []
 
 	if len(jsPaths) > 0 && !config.JoinServerEnabled {
 		logger.WithField("paths", jsPaths).Warn("Join Server disabled but fields specified to set")
-	} else if len(jsPaths) > 0 {
+	} else if (len(jsPaths) > 0 || touch && device.SupportsJoin) && config.JoinServerEnabled {
 		js, err := api.Dial(ctx, config.JoinServerGRPCAddress)
 		if err != nil {
 			return nil, err
@@ -233,7 +233,7 @@ func setEndDevice(device *ttnpb.EndDevice, isPaths, nsPaths, asPaths, jsPaths []
 
 	if len(nsPaths) > 0 && !config.NetworkServerEnabled {
 		logger.WithField("paths", nsPaths).Warn("Network Server disabled but fields specified to set")
-	} else if (len(nsPaths) > 0 || isCreate) && config.NetworkServerEnabled {
+	} else if (len(nsPaths) > 0 || isCreate || touch) && config.NetworkServerEnabled {
 		ns, err := api.Dial(ctx, config.NetworkServerGRPCAddress)
 		if err != nil {
 			return nil, err
@@ -259,7 +259,7 @@ func setEndDevice(device *ttnpb.EndDevice, isPaths, nsPaths, asPaths, jsPaths []
 
 	if len(asPaths) > 0 && !config.ApplicationServerEnabled {
 		logger.WithField("paths", asPaths).Warn("Application Server disabled but fields specified to set")
-	} else if (len(asPaths) > 0 || isCreate) && config.ApplicationServerEnabled {
+	} else if (len(asPaths) > 0 || isCreate || touch) && config.ApplicationServerEnabled {
 		as, err := api.Dial(ctx, config.ApplicationServerGRPCAddress)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Touch devices in NS and AS on set if field mask is empty

#### Changes
<!-- What are the changes made in this pull request? -->

- Hit NS and AS set even if there are no field masks defined

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This is draft and discussion, although it's a small and pretty harmless change.

The rationale behind this is that routing component device registries don't make a different between create and update. So when the device does exist in ER and JS, but not in NS and AS (because of cluster configurations), we can neither use the `ttn-lw-cli end-device`'s `create` nor `update` commands to get the devices created in NS and AS. That only works when field masks are specified, which in case of AS doesn't make sense.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
