### PR TITLE
Attach root path hashes to localStorage keys

### DIFF
--- a/pkg/webui/console/lib/access-token.js
+++ b/pkg/webui/console/lib/access-token.js
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 import api from '../api'
+import * as cache from './cache'
 
 export default async function() {
-  const storedToken = localStorage.accessToken ? JSON.parse(localStorage.accessToken) : undefined
+  const storedToken = cache.get('accessToken')
   let token
 
   if (!storedToken || Date.parse(storedToken.expiry) < Date.now()) {
@@ -29,14 +30,12 @@ export default async function() {
 
   // We want to make sure the stored token is the correct one
   if (!storedToken || storedToken.access_token !== token.access_token) {
-    localStorage.setItem('accessToken', JSON.stringify(token))
+    cache.set('accessToken', token)
   }
 
   return token
 }
 
 export function clear() {
-  if (localStorage.accessToken) {
-    localStorage.removeItem('accessToken')
-  }
+  cache.remove('accessToken')
 }

--- a/pkg/webui/console/lib/cache.js
+++ b/pkg/webui/console/lib/cache.js
@@ -12,8 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { selectApplicationRootPath } from '../../lib/selectors/env'
+import stringToHash from '../../lib/string-to-hash'
+
+const hash = stringToHash(selectApplicationRootPath())
+const hashKey = key => `${key}-${hash}`
+
 export function get(key) {
-  const value = localStorage.getItem(key)
+  const hashedKey = hashKey(key)
+  const value = localStorage.getItem(hashedKey)
   try {
     return JSON.parse(value)
   } catch (e) {
@@ -22,12 +29,14 @@ export function get(key) {
 }
 
 export function set(key, val) {
+  const hashedKey = hashKey(key)
   const value = JSON.stringify(val)
-  localStorage.setItem(key, value)
+  localStorage.setItem(hashedKey, value)
 }
 
 export function remove(key) {
-  return localStorage.removeItem(key)
+  const hashedKey = hashKey(key)
+  return localStorage.removeItem(hashedKey)
 }
 
 export function clearAll() {

--- a/pkg/webui/lib/string-to-hash.js
+++ b/pkg/webui/lib/string-to-hash.js
@@ -1,0 +1,25 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export default function(string) {
+  let hash = 0
+  let chr = 0
+  if (string.length === 0) return hash
+  for (let i = 0; i < string.length; i++) {
+    chr = string.charCodeAt(i)
+    hash = (hash << 5) - hash + chr
+    hash |= 0 // Convert to 32bit integer
+  }
+  return hash
+}


### PR DESCRIPTION
#### Summary
Closes #1586 

#### Changes
- Add a string hashing utility function
- Refactor `lib/cache.js` utility to attach the hashed app root path to `window.localStorage`-keys
- Refactor `console/lib/access-token.js` utility to use the cache module

#### Notes for Reviewers
See the issue. Without this, access tokens may be picked up by other web clients on the same domain (e.g. another console instance)

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [ ] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
