### PR TITLE
Optimize Redis application uplink queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix active application link count being limited to 10 per CPU.
+
 ### Security
 
 ## [3.2.5] - 2019-11-15

--- a/pkg/networkserver/grpc_asns_test.go
+++ b/pkg/networkserver/grpc_asns_test.go
@@ -2015,10 +2015,9 @@ func handleApplicationUplinkQueueTest(t *testing.T, q ApplicationUplinkQueue) {
 	}
 
 	err, ok := assertAdd(ctx, pbs[0:1]...)
-	if !a.So(ok, should.BeTrue) {
+	if !a.So(ok, should.BeTrue) || !a.So(err, should.BeNil) {
 		t.FailNow()
 	}
-	a.So(err, should.BeNil)
 
 	app1SubFuncCh, app1SubErrCh, app1SubStop := subscribe(ctx, appID1)
 	select {
@@ -2029,8 +2028,9 @@ func handleApplicationUplinkQueueTest(t *testing.T, q ApplicationUplinkQueue) {
 		t.Fatalf("Received unexpected Subscribe error: %v", err)
 
 	case req := <-app1SubFuncCh:
-		a.So(req.Context, should.HaveParentContext, ctx)
-		a.So(req.Uplink, should.Resemble, pbs[0])
+		if !a.So(req.Context, should.HaveParentContext, ctx) || !a.So(req.Uplink, should.Resemble, pbs[0]) {
+			t.FailNow()
+		}
 		close(req.Response)
 	}
 
@@ -2048,8 +2048,9 @@ func handleApplicationUplinkQueueTest(t *testing.T, q ApplicationUplinkQueue) {
 		t.Fatalf("Received unexpected Subscribe error: %v", err)
 
 	case req := <-app1SubFuncCh:
-		a.So(req.Context, should.HaveParentContext, ctx)
-		a.So(req.Uplink, should.Resemble, pbs[1])
+		if !a.So(req.Context, should.HaveParentContext, ctx) || !a.So(req.Uplink, should.Resemble, pbs[1]) {
+			t.FailNow()
+		}
 		close(req.Response)
 	}
 
@@ -2062,8 +2063,9 @@ func handleApplicationUplinkQueueTest(t *testing.T, q ApplicationUplinkQueue) {
 		t.Fatalf("Received unexpected Subscribe error: %v", err)
 
 	case req := <-app2SubFuncCh:
-		a.So(req.Context, should.HaveParentContext, ctx)
-		a.So(req.Uplink, should.Resemble, pbs[2])
+		if !a.So(req.Context, should.HaveParentContext, ctx) || !a.So(req.Uplink, should.Resemble, pbs[2]) {
+			t.FailNow()
+		}
 		close(req.Response)
 	}
 	app1SubStop()

--- a/pkg/networkserver/redis/application_uplink_queue.go
+++ b/pkg/networkserver/redis/application_uplink_queue.go
@@ -16,13 +16,11 @@ package redis
 
 import (
 	"context"
-	"crypto/rand"
-	"time"
+	"fmt"
+	"sync"
 
 	"github.com/go-redis/redis"
-	ulid "github.com/oklog/ulid/v2"
 	"go.thethings.network/lorawan-stack/pkg/errors"
-	"go.thethings.network/lorawan-stack/pkg/log"
 	ttnredis "go.thethings.network/lorawan-stack/pkg/redis"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/unique"
@@ -33,6 +31,8 @@ type ApplicationUplinkQueue struct {
 	MaxLen int64
 	Group  string
 	ID     string
+
+	subscriptions sync.Map
 }
 
 // NewApplicationUplinkQueue returns new application uplink queue.
@@ -49,26 +49,33 @@ func (q *ApplicationUplinkQueue) uidUplinkKey(uid string) string {
 	return q.Redis.Key("uid", uid, "uplinks")
 }
 
-func (q *ApplicationUplinkQueue) uidCloseKey(uid, streamID string) string {
-	return q.Redis.Key("uid", uid, "close", streamID)
-}
-
 const payloadKey = "payload"
 
 func (q *ApplicationUplinkQueue) Add(ctx context.Context, ups ...*ttnpb.ApplicationUp) error {
 	for _, up := range ups {
+		uid := unique.ID(ctx, up.ApplicationIdentifiers)
+
 		s, err := ttnredis.MarshalProto(up)
 		if err != nil {
 			return err
 		}
-		if err := q.Redis.XAdd(&redis.XAddArgs{
-			Stream:       q.uidUplinkKey(unique.ID(ctx, up.ApplicationIdentifiers)),
+
+		if err = q.Redis.XAdd(&redis.XAddArgs{
+			Stream:       q.uidUplinkKey(uid),
 			MaxLenApprox: q.MaxLen,
 			Values: map[string]interface{}{
 				payloadKey: s,
 			},
 		}).Err(); err != nil {
 			return ttnredis.ConvertError(err)
+		}
+
+		upCh, ok := q.subscriptions.Load(uid)
+		if ok {
+			select {
+			case upCh.(chan *ttnpb.ApplicationUp) <- up:
+			default:
+			}
 		}
 	}
 	return nil
@@ -82,119 +89,62 @@ var (
 // Subscribe ranges over q.upStream(unique.ID(ctx, appID)) using f until ctx is done.
 // Subscribe assumes that there's at most 1 active consumer in q.Group per stream at all times.
 func (q *ApplicationUplinkQueue) Subscribe(ctx context.Context, appID ttnpb.ApplicationIdentifiers, f func(context.Context, *ttnpb.ApplicationUp) error) error {
-	streamULID, err := ulid.New(ulid.Now(), rand.Reader)
-	if err != nil {
-		return err
-	}
 	uid := unique.ID(ctx, appID)
 	upStream := q.uidUplinkKey(uid)
-	closeStream := q.uidCloseKey(uid, streamULID.String())
 
-	_, err = q.Redis.XGroupCreateMkStream(closeStream, q.Group, "0").Result()
-	if err != nil {
-		return ttnredis.ConvertError(err)
-	}
-
-	dl, hasDL := ctx.Deadline()
-	if hasDL {
-		_, err = q.Redis.ExpireAt(closeStream, dl).Result()
-		if err != nil {
-			return ttnredis.ConvertError(err)
-		}
-	}
-
-	doneCh := make(chan struct{})
-	defer func() {
-		close(doneCh)
-	}()
-	go func() {
-		logger := log.FromContext(ctx).WithField("key", closeStream)
-		select {
-		case <-ctx.Done():
-			_, err := q.Redis.XAdd(&redis.XAddArgs{
-				Stream: closeStream,
-				Values: map[string]interface{}{"": ""},
-			}).Result()
-			if err != nil {
-				logger.WithError(err).Error("Failed to add message to Redis stream")
-				return
-			}
-			<-doneCh
-
-		case <-doneCh:
-		}
-
-		_, err := q.Redis.Del(closeStream).Result()
-		if err != nil {
-			logger.WithError(err).Error("Failed to delete Redis key")
-		}
-	}()
-
-	_, err = q.Redis.XGroupCreateMkStream(upStream, q.Group, "0").Result()
+	_, err := q.Redis.XGroupCreateMkStream(upStream, q.Group, "0").Result()
 	if err != nil && !ttnredis.IsConsumerGroupExistsErr(err) {
 		return ttnredis.ConvertError(err)
 	}
 
-	processStreams := func(arg *redis.XReadGroupArgs) error {
-		rets, err := q.Redis.XReadGroup(arg).Result()
-		if err != nil {
+	upCh := make(chan *ttnpb.ApplicationUp, 1)
+	_, ok := q.subscriptions.LoadOrStore(uid, upCh)
+	if ok {
+		panic(fmt.Sprintf("duplicate subscription for application %s", uid))
+	}
+	defer q.subscriptions.Delete(uid)
+
+	for {
+		rets, err := q.Redis.XReadGroup(&redis.XReadGroupArgs{
+			Group:    q.Group,
+			Consumer: q.ID,
+			Streams:  []string{upStream, upStream, "0", ">"},
+		}).Result()
+		if err != nil && err != redis.Nil {
 			return ttnredis.ConvertError(err)
 		}
-
 		for _, ret := range rets {
-			switch ret.Stream {
-			case closeStream:
-				return ctx.Err()
+			if ret.Stream != upStream {
+				panic(fmt.Sprintf("unknown stream read %s", ret.Stream))
+			}
 
-			case upStream:
-				for _, msg := range ret.Messages {
-					v, ok := msg.Values[payloadKey]
-					if !ok {
-						return errMissingPayload
-					}
-					s, ok := v.(string)
-					if !ok {
-						return errInvalidPayload
-					}
-					up := &ttnpb.ApplicationUp{}
-					if err = ttnredis.UnmarshalProto(s, up); err != nil {
-						return err
-					}
-					if err = f(ctx, up); err != nil {
-						return err
-					}
-					_, err = q.Redis.XAck(upStream, q.Group, msg.ID).Result()
-					if err != nil {
-						return ttnredis.ConvertError(err)
-					}
+			for _, msg := range ret.Messages {
+				v, ok := msg.Values[payloadKey]
+				if !ok {
+					return errMissingPayload
+				}
+				s, ok := v.(string)
+				if !ok {
+					return errInvalidPayload
+				}
+				up := &ttnpb.ApplicationUp{}
+				if err = ttnredis.UnmarshalProto(s, up); err != nil {
+					return err
+				}
+				if err = f(ctx, up); err != nil {
+					return err
+				}
+				if err = q.Redis.XAck(upStream, q.Group, msg.ID).Err(); err != nil {
+					return ttnredis.ConvertError(err)
 				}
 			}
 		}
-		return nil
-	}
 
-	if err = processStreams(&redis.XReadGroupArgs{
-		Group:    q.Group,
-		Consumer: q.ID,
-		Streams:  []string{upStream, "0"},
-	}); err != nil {
-		return err
-	}
-	for {
-		var timeout time.Duration
-		if hasDL {
-			timeout = time.Until(dl)
-			if timeout <= 0 {
-				return context.DeadlineExceeded
-			}
-		}
-		if err = processStreams(&redis.XReadGroupArgs{
-			Group:    q.Group,
-			Consumer: q.ID,
-			Streams:  []string{closeStream, upStream, ">", ">"},
-			Block:    timeout,
-		}); err != nil {
-			return err
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+
+		case <-upCh:
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #1598 

#### Changes
<!-- What are the changes made in this pull request? -->

- Use a channel to block for new uplinks instead of TCP connection.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This implementation only works when there's 1 NS in the cluster and/or they're properly sharded, i.e. only NS holding link to application A should be generating uplinks for application A.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
