### PR TITLE
Prefer entity names over ids in breadcrumbs

### DIFF
--- a/pkg/webui/console/views/application/index.js
+++ b/pkg/webui/console/views/application/index.js
@@ -188,8 +188,11 @@ import Devices from '../devices'
   }
 })
 @withBreadcrumb('apps.single', function(props) {
-  const { appId } = props
-  return <Breadcrumb path={`/applications/${appId}`} icon="application" content={appId} />
+  const {
+    appId,
+    application: { name },
+  } = props
+  return <Breadcrumb path={`/applications/${appId}`} icon="application" content={name || appId} />
 })
 @withEnv
 export default class Application extends React.Component {

--- a/pkg/webui/console/views/device/index.js
+++ b/pkg/webui/console/views/device/index.js
@@ -91,9 +91,17 @@ import style from './device.styl'
   ({ fetching, device }) => fetching || !Boolean(device),
 )
 @withBreadcrumb('device.single', function(props) {
-  const { devId, appId } = props
+  const {
+    devId,
+    appId,
+    device: { name },
+  } = props
   return (
-    <Breadcrumb path={`/applications/${appId}/devices/${devId}`} icon="device" content={devId} />
+    <Breadcrumb
+      path={`/applications/${appId}/devices/${devId}`}
+      icon="device"
+      content={name || devId}
+    />
   )
 })
 @withEnv

--- a/pkg/webui/console/views/gateway/index.js
+++ b/pkg/webui/console/views/gateway/index.js
@@ -141,9 +141,12 @@ import {
   }
 })
 @withBreadcrumb('gateways.single', function(props) {
-  const { gtwId } = props
+  const {
+    gtwId,
+    gateway: { name },
+  } = props
 
-  return <Breadcrumb path={`/gateways/${gtwId}`} icon="gateway" content={gtwId} />
+  return <Breadcrumb path={`/gateways/${gtwId}`} icon="gateway" content={name || gtwId} />
 })
 @withEnv
 export default class Gateway extends React.Component {

--- a/pkg/webui/console/views/organization/organization.js
+++ b/pkg/webui/console/views/organization/organization.js
@@ -79,8 +79,11 @@ import {
   }
 })
 @withBreadcrumb('orgs.single', function(props) {
-  const { orgId } = props
-  return <Breadcrumb path={`/organizations/${orgId}`} icon="organization" content={orgId} />
+  const {
+    orgId,
+    organization: { name },
+  } = props
+  return <Breadcrumb path={`/organizations/${orgId}`} icon="organization" content={name || orgId} />
 })
 class Organization extends React.Component {
   static propTypes = {


### PR DESCRIPTION
#### Summary
Small quickfix PR to ensure that entity names are displayed in the breadcrumbs, when set.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [ ] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
