### PR TITLE
Improve logging of errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add support for encrypting device keys at rest (see `as.device-kek-label`, `js.device-kek-label` and `ns.device-kek-label` options).
 - The Network Server now provides the timestamp at which it received join-accept or data uplink messages
+- Add more details to logs that contain errors.
 
 ### Changed
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -3239,6 +3239,15 @@
       "file": "format.go"
     }
   },
+  "error:pkg/gatewayserver/io/udp:already_connected": {
+    "translations": {
+      "en": "gateway is already connected"
+    },
+    "description": {
+      "package": "pkg/gatewayserver/io/udp",
+      "file": "firewall.go"
+    }
+  },
   "error:pkg/gatewayserver/io/udp:connection_expired": {
     "translations": {
       "en": "connection expired"
@@ -3264,6 +3273,24 @@
     "description": {
       "package": "pkg/gatewayserver/io/udp",
       "file": "udp.go"
+    }
+  },
+  "error:pkg/gatewayserver/io/udp:no_address": {
+    "translations": {
+      "en": "packet has no gateway address"
+    },
+    "description": {
+      "package": "pkg/gatewayserver/io/udp",
+      "file": "firewall.go"
+    }
+  },
+  "error:pkg/gatewayserver/io/udp:no_eui": {
+    "translations": {
+      "en": "packet has no gateway EUI"
+    },
+    "description": {
+      "package": "pkg/gatewayserver/io/udp",
+      "file": "firewall.go"
     }
   },
   "error:pkg/gatewayserver/io:buffer_full": {

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -60,6 +60,9 @@ func (e Error) Fields() map[string]interface{} {
 		res[pref] = cause.Error()
 		pref += "_cause"
 	}
+	for k, v := range Attributes(Stack(e)...) {
+		res[k] = v
+	}
 	return res
 }
 

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -60,7 +60,7 @@ var DefaultConfig = Config{
 	DownlinkPathExpires: 30 * time.Second,
 	ConnectionExpires:   5 * time.Minute,
 	ScheduleLateTime:    800 * time.Millisecond,
-	AddrChangeBlock:     5 * time.Minute,
+	AddrChangeBlock:     15 * time.Second, // Release source IP address after missing typically 3 PULL_DATA messages.
 }
 
 type srv struct {

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -164,9 +164,11 @@ func (s *srv) handlePackets() {
 				}
 			}
 
-			if s.firewall != nil && !s.firewall.Filter(packet) {
-				logger.Warn("Packet filtered")
-				break
+			if s.firewall != nil {
+				if err := s.firewall.Filter(packet); err != nil {
+					logger.WithError(err).Warn("Packet filtered")
+					break
+				}
 			}
 
 			cs, err := s.connect(ctx, eui)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quickfix to improve logging of errors, especially errors from the GS UDP firewall.

#### Changes
<!-- What are the changes made in this pull request? -->

- Include error attributes in log messages (including the ones that aren't part of the error messages)
- Return error from GS UDP Firewall instead of bool