### PR TITLE
Change rxpk.brd from uint8 to uint16

### DIFF
--- a/pkg/ttnpb/udp/packet_data.go
+++ b/pkg/ttnpb/udp/packet_data.go
@@ -45,17 +45,17 @@ type RxPacket struct {
 	Size uint16       `json:"size"`           // RF packet payload size in bytes (unsigned integer)
 	Data string       `json:"data"`           // Base64 encoded RF packet payload, padded
 	RSig []RSig       `json:"rsig"`           // Received signal information, per antenna (Optional)
-	Brd  uint8        `json:"brd"`            // Concentrator board used for Rx (unsigned integer)
-	Aesk uint8        `json:"aesk"`           // AES key index used for encrypting fine timestamps
+	Brd  uint         `json:"brd"`            // Concentrator board used for Rx (unsigned integer)
+	Aesk uint         `json:"aesk"`           // AES key index used for encrypting fine timestamps (unsigned integer)
 }
 
 // RSig contains the metadata associated with the received signal
 type RSig struct {
 	Ant    uint8   `json:"ant"`    // Antenna number on which signal has been received
-	Chan   uint8   `json:"chan"`   // Concentrator "IF" channel used for Rx (unsigned integer)
-	RSSIC  int16   `json:"rssic"`  // RSSI in dBm of the channel (signed integer, 1 dB precision)
-	RSSIS  *int16  `json:"rssis"`  // RSSI in dBm of the signal (signed integer, 1 DB precision) (Optional)
-	RSSISD *uint16 `json:"rssisd"` // Standard deviation of RSSI during preamble (unsigned integer) (Optional)
+	Chan   uint    `json:"chan"`   // Concentrator "IF" channel used for Rx (unsigned integer)
+	RSSIC  int     `json:"rssic"`  // RSSI in dBm of the channel (signed integer, 1 dB precision)
+	RSSIS  *int    `json:"rssis"`  // RSSI in dBm of the signal (signed integer, 1 dB precision) (Optional)
+	RSSISD *uint   `json:"rssisd"` // Standard deviation of RSSI during preamble (unsigned integer) (Optional)
 	LSNR   float64 `json:"lsnr"`   // Lora SNR ratio in dB (signed float, 0.1 dB precision)
 	ETime  string  `json:"etime"`  // Encrypted fine timestamp, ns precision [0..999999999] (Optional)
 	FTime  *uint32 `json:"ftime"`  // Fine timestamp, ns precision [0..999999999] (Optional)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Kerlink Wirnet with latest firmware and common packet forwarder sends `rxpk.brd`, which are higher than `255`:
```
 DEBUG Failed to unmarshal packet               error=json: cannot unmarshal number 261 into Go struct field RxPacket.rxpk.brd of type uint8 namespace=gatewayserver/io/udp remote_addr=192.168.188.130:41067
 DEBUG Failed to unmarshal packet               error=json: cannot unmarshal number 261 into Go struct field RxPacket.rxpk.brd of type uint8 namespace=gatewayserver/io/udp remote_addr=192.168.188.130:41067
 DEBUG Failed to unmarshal packet               error=json: cannot unmarshal number 261 into Go struct field RxPacket.rxpk.brd of type uint8 namespace=gatewayserver/io/udp remote_addr=192.168.188.130:41067
 DEBUG Failed to unmarshal packet               error=json: cannot unmarshal number 261 into Go struct field RxPacket.rxpk.brd of type uint8 namespace=gatewayserver/io/udp remote_addr=192.168.188.130:41067
 DEBUG Failed to unmarshal packet               error=json: cannot unmarshal number 263 into Go struct field RxPacket.rxpk.brd of type uint8 namespace=gatewayserver/io/udp remote_addr=192.168.188.130:41067
 DEBUG Failed to unmarshal packet               error=json: cannot unmarshal number 261 into Go struct field RxPacket.rxpk.brd of type uint8 namespace=gatewayserver/io/udp remote_addr=192.168.188.130:41067
 DEBUG Failed to unmarshal packet               error=json: cannot unmarshal number 261 into Go struct field RxPacket.rxpk.brd of type uint8 namespace=gatewayserver/io/udp remote_addr=192.168.188.130:41067
 DEBUG Failed to unmarshal packet               error=json: cannot unmarshal number 263 into Go struct field RxPacket.rxpk.brd of type uint8 namespace=gatewayserver/io/udp remote_addr=192.168.188.130:41067
```

An example of packet:
```
r{"rxpk":[{"aesk":0,"brd":261,"codr":"4/5","data":"QPsdAAKAiwIF7PZTQHNtWCiieyG44Zdahmf9obM=","datr":"SF10BW125","freq":868.1,"jver":2,"modu":"LORA","rsig":[{"ant":0,"chan":5,"lsnr":7.2,"rssic":-109}],"size":29,"stat":1,"time":"2019-11-21T14:32:02.686758Z","tmst":524852500}]}
```

#### Changes
<!-- What are the changes made in this pull request? -->

- Increase `rxpk.brd` size from `uint8` to `uint16`

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I could not find a specification for this

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
