### PR TITLE
Fix joining profile picture bucket URL

### DIFF
--- a/pkg/identityserver/user_registry.go
+++ b/pkg/identityserver/user_registry.go
@@ -16,7 +16,6 @@ package identityserver
 
 import (
 	"context"
-	"path"
 	"runtime/trace"
 	"strings"
 	"time"
@@ -269,10 +268,11 @@ func (is *IdentityServer) setFullProfilePictureURL(ctx context.Context, usr *ttn
 	if bucketURL == "" {
 		return
 	}
+	bucketURL = strings.TrimSuffix(bucketURL, "/") + "/"
 	if usr != nil && usr.ProfilePicture != nil {
 		for size, file := range usr.ProfilePicture.Sizes {
 			if !strings.Contains(file, "://") {
-				usr.ProfilePicture.Sizes[size] = path.Join(bucketURL, file)
+				usr.ProfilePicture.Sizes[size] = bucketURL + strings.TrimPrefix(file, "/")
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quickfix for the public profile picture URL in case an absolute bucket URL is used. Previously the `//` in `https://` would be "cleaned" to `https:/`.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Similar change needed in #1581