### PR TITLE
Added support for Redis Sentinel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add support for Redis Sentinel (see `redis.failover.enable`, `redis.failover.master-name`, `redis.failover.addresses` options).
+
 ### Changed
 
 ### Deprecated
@@ -33,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix an issue causing unexpected behavior surrounding login, logout and token management in the Console.
-- Fix an issue causing the application link page of the Console to load infinitely. 
+- Fix an issue causing the application link page of the Console to load infinitely.
 
 ## [3.2.6] - 2019-11-18
 

--- a/doc/content/reference/configuration/the-things-stack.md
+++ b/doc/content/reference/configuration/the-things-stack.md
@@ -105,10 +105,21 @@ The `blob` source loads from the given path in a bucket. This requires the globa
 
 Redis is the main data store for the [Network Server]({{< relref "network-server.md" >}}), [Application Server]({{< relref "application-server.md" >}}) and [Join Server]({{< relref "join-server.md" >}}). Redis is also used by the [Identity Server]({{< relref "identity-server.md" >}}) for caching and can be used by the [events system]({{< ref "#events-options" >}}) for exchanging events between components.
 
-- `redis.address`: Address of the Redis server
+Redis configuration options:
+
 - `redis.password`: Password of the Redis server
 - `redis.database`: Redis database to use
 - `redis.namespace`: Namespace for Redis keys
+
+If connecting to a single Redis instance:
+
+- `redis.address`: Address of the Redis server
+
+Or you can enable failover using [Redis Sentinel](https://redis.io/topics/sentinel):
+
+- `redis.failover.enable`: Set to `true`
+- `redis.failover.addresses`: List of addresses of the Redis Sentinel instances (required)
+- `redis.failover.master-name`: Redis Sentinel master name (required)
 
 ## Blob Options
 
@@ -170,7 +181,7 @@ The `blob` source loads from the given path in a bucket. This requires the globa
 
 ## Cluster Options
 
-The `cluster` options configure how The Things Stack communicates with other components in the cluster. These options do not need to be set when running a single instance of The Things Stack. The most important options are the ones to configure the addresses of the other components in the cluster. 
+The `cluster` options configure how The Things Stack communicates with other components in the cluster. These options do not need to be set when running a single instance of The Things Stack. The most important options are the ones to configure the addresses of the other components in the cluster.
 
 - `cluster.identity-server`: Address for the Identity Server
 - `cluster.gateway-server`: Address for the Gateway Server

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -116,16 +116,28 @@ type HTTP struct {
 	Health          Health           `name:"health"`
 }
 
+// RedisFailover represents Redis failover configuration.
+type RedisFailover struct {
+	Enable     bool     `name:"enable" description:"Enable failover using Redis Sentinel"`
+	Addresses  []string `name:"addresses" description:"Redis Sentinel server addresses"`
+	MasterName string   `name:"master-name" description:"Redis Sentinel master name"`
+}
+
 // Redis represents Redis configuration.
 type Redis struct {
-	Address   string   `name:"address" description:"Address of the Redis server"`
-	Password  string   `name:"password" description:"Password of the Redis server"`
-	Database  int      `name:"database" description:"Redis database to use"`
-	Namespace []string `name:"namespace" description:"Namespace for Redis keys"`
+	Address   string        `name:"address" description:"Address of the Redis server"`
+	Password  string        `name:"password" description:"Password of the Redis server"`
+	Database  int           `name:"database" description:"Redis database to use"`
+	Namespace []string      `name:"namespace" description:"Namespace for Redis keys"`
+	Failover  RedisFailover `name:"failover" description:"Redis failover configuration"`
 }
 
 // IsZero returns whether the Redis configuration is empty.
-func (r Redis) IsZero() bool { return r.Address == "" && r.Database == 0 && len(r.Namespace) == 0 }
+func (r Redis) IsZero() bool {
+	return r.Database == 0 && len(r.Namespace) == 0 &&
+		(r.Failover.Enable && r.Failover.MasterName == "" && len(r.Failover.Addresses) == 0 ||
+			!r.Failover.Enable && r.Address == "")
+}
 
 // CloudEvents represents configuration for the cloud events backend.
 type CloudEvents struct {

--- a/pkg/events/redis/redis.go
+++ b/pkg/events/redis/redis.go
@@ -22,17 +22,14 @@ import (
 	"github.com/go-redis/redis"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/events"
+	ttnredis "go.thethings.network/lorawan-stack/pkg/redis"
 )
 
 // WrapPubSub wraps an existing PubSub and publishes all events received from Redis to that PubSub.
 func WrapPubSub(wrapped events.PubSub, conf config.Redis) (ps *PubSub) {
 	ps = &PubSub{
-		PubSub: wrapped,
-		client: redis.NewClient(&redis.Options{
-			Addr:     conf.Address,
-			Password: conf.Password,
-			DB:       conf.Database,
-		}),
+		PubSub:       wrapped,
+		client:       ttnredis.New(&ttnredis.Config{Redis: conf}).Client,
 		eventChannel: strings.Join(append(conf.Namespace, "events"), ":"),
 		closeWait:    make(chan struct{}),
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Implements support for Redis Sentinel. Closes #1635 

#### Changes
<!-- What are the changes made in this pull request? -->

- Added new options `redis.failover.enable`, `redis.failover.addreses`, `redis.failover.master-name`
- When user uses the Redis Sentinel options, then a `redis.Client` is created using `redis.NewFailoverClient()` instead of `redis.NewClient()`.
- Updated `config.Redis.IsZero()`
- Updated relevant documentation

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- `redis.NewFailoverClient()` returns a `redis.Client`, just like `redis.NewClient()`. This means that The Things Stack can trasparently use either Redis or Redis Sentinel without further changes.
- It may be desired to rename the configuration options related to Redis Sentinel.
- Default value for `redis.enable-failover` is set to false, so that the change is backwards compatible and does not break existing installations.
- Some kind of test should be added.
- Redis Sentinel comes with some log messags printed out by default, mixed with log messages from the stack. This should probably be fixed as well. 
- meta: Is the `all` tag correct?

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [ ] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [X] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
