### PR TITLE
Use a map to determine the queried stack component based on the api endpoint URI prefix

### DIFF
--- a/sdk/js/src/api/http.js
+++ b/sdk/js/src/api/http.js
@@ -14,7 +14,7 @@
 
 import axios from 'axios'
 
-import { STACK_COMPONENTS } from '../util/constants'
+import { URI_PREFIX_STACK_COMPONENT_MAP } from '../util/constants'
 import stream from './stream/stream-node'
 
 /**
@@ -132,7 +132,9 @@ class Http {
   _parseStackComponent(endpoint) {
     try {
       const component = endpoint.split('/')[1]
-      return STACK_COMPONENTS.includes(component) ? component : 'is'
+      return Boolean(URI_PREFIX_STACK_COMPONENT_MAP[component])
+        ? URI_PREFIX_STACK_COMPONENT_MAP[component]
+        : 'is'
     } catch (err) {
       throw new Error('Unable to extract The Things Stack component:', endpoint)
     }

--- a/sdk/js/src/util/constants.js
+++ b/sdk/js/src/util/constants.js
@@ -12,8 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/* eslint-disable import/prefer-default-export */
+export const STACK_COMPONENTS = ['as', 'is', 'ns', 'js', 'gs', 'edtc', 'qrg']
 
-const STACK_COMPONENTS = ['as', 'is', 'ns', 'js', 'gs', 'edtc', 'qrg']
-
-export { STACK_COMPONENTS }
+export const URI_PREFIX_STACK_COMPONENT_MAP = {
+  as: 'as',
+  ns: 'ns',
+  js: 'js',
+  gs: 'gs',
+  edtc: 'edtc',
+  qrg: 'qrg',
+}


### PR DESCRIPTION
#### Summary
This PR will introduce a map to determine which component needs to be queried based on the request URI provided from the api definition. This is necessary since the prefix of the request URI will not always match the name of the component to be queried, so with this PR, we can already account for that.

References https://github.com/TheThingsIndustries/lorawan-stack/issues/1800

#### Changes
- Introduce a map from request uri prefix to stack component name
- Use the map in the http handler of the SDK api

#### Notes for Reviewers
This will not change any behavior, the mappings we have now are 1:1 (as in: prefix equals stack component name). Please check whether this results in any issues when using the console.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [ ] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.

cc @htdvisser 