### PR TITLE
End Device Claiming API Reference

### DIFF
--- a/doc/content/reference/api/end_device_claiming.md
+++ b/doc/content/reference/api/end_device_claiming.md
@@ -1,0 +1,25 @@
+---
+title: "End Device Claiming APIs"
+description: ""
+weight: 8
+---
+
+## The `EndDeviceClaimingServer` service
+
+{{< proto/method service="EndDeviceClaimingServer" method="AuthorizeApplication" >}}
+
+{{< proto/method service="EndDeviceClaimingServer" method="UnauthorizeApplication" >}}
+
+{{< proto/method service="EndDeviceClaimingServer" method="Claim" >}}
+
+## Messages
+
+{{< proto/message message="ApplicationIdentifiers" >}}
+
+{{< proto/message message="AuthorizeApplicationRequest" >}}
+
+{{< proto/message message="ClaimEndDeviceRequest" >}}
+
+{{< proto/message message="ClaimEndDeviceRequest.AuthenticatedIdentifiers" >}}
+
+{{< proto/message message="EndDeviceIdentifiers" >}}

--- a/doc/data/api/ttn.lorawan.v3/messages.yml
+++ b/doc/data/api/ttn.lorawan.v3/messages.yml
@@ -271,6 +271,13 @@ ApplicationJoinAccept:
        rejoin-request.
     type: bool
     default: false
+  - name: received_at
+    comment: |2
+       Server time when the Network Server received the message.
+    message:
+      package: google.protobuf
+      name: Timestamp
+    default: "0001-01-01T00:00:00Z"
 ApplicationLink:
   name: ApplicationLink
   fields:
@@ -653,6 +660,8 @@ ApplicationUp:
         max_len: 100
     default: []
   - name: received_at
+    comment: |2
+       Server time when the Application Server received the message.
     message:
       package: google.protobuf
       name: Timestamp
@@ -747,6 +756,13 @@ ApplicationUplink:
     rules:
       required: true
     default: {}
+  - name: received_at
+    comment: |2
+       Server time when the Network Server received the message.
+    message:
+      package: google.protobuf
+      name: Timestamp
+    default: "0001-01-01T00:00:00Z"
 ApplicationWebhook:
   name: ApplicationWebhook
   fields:
@@ -2021,6 +2037,12 @@ EndDevice:
     map_value:
       message:
         name: Location
+    default: {}
+  - name: picture
+    comment: |2
+       Stored in Entity Registry.
+    message:
+      name: Picture
     default: {}
   - name: supports_class_b
     comment: |2

--- a/doc/themes/the-things-stack/layouts/shortcodes/proto/method.html
+++ b/doc/themes/the-things-stack/layouts/shortcodes/proto/method.html
@@ -13,7 +13,7 @@
 </p>
 
 {{- range .http }}
-<p><code>{{ .method }}</code> <code>{{ .path }}</code></p>
+<p><code>{{ .method }}</code> <code>/api/v3{{ .path }}</code></p>
 {{- end }}
 {{- else -}}
 {{ errorf "method %s of service %s of package %s not found: %s" $method $service $package .Position }}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR adds a reference page for the End Device Claiming APIs.

Related to #206 

#### Changes
<!-- What are the changes made in this pull request? -->

- Add reference for End Device Claiming API

Loosly related changes:

- Update proto reference template to include `/api/v3`
- Regenerate API data for doc content (have to do that by hand until https://github.com/TheThingsIndustries/docker-protobuf/issues/33)
