### PR TITLE
Remove v prefix from development versions

### DIFF
--- a/.mage/version.go
+++ b/.mage/version.go
@@ -72,11 +72,11 @@ func (Version) Files() error {
 		fmt.Println("Writing version files")
 	}
 	mg.Deps(Version.getCurrent)
-	err := ioutil.WriteFile(goVersionFilePath, []byte(fmt.Sprintf(goVersionFile, currentVersion)), 0644)
+	version := strings.TrimPrefix(currentVersion, "v")
+	err := ioutil.WriteFile(goVersionFilePath, []byte(fmt.Sprintf(goVersionFile, version)), 0644)
 	if err != nil {
 		return err
 	}
-	version := strings.TrimPrefix(currentVersion, "v")
 	for _, packageJSONFile := range packageJSONFilePaths {
 		err = sh.Run(
 			nodeBin("json"),

--- a/pkg/version/ttn.go
+++ b/pkg/version/ttn.go
@@ -3,4 +3,4 @@
 package version
 
 // TTN Version
-var TTN = "v3.3.1-dev"
+var TTN = "3.3.1-dev"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,12 +17,11 @@ package version
 
 import (
 	"fmt"
-	"strings"
 )
 
 // String returns the version string.
 func String() string {
-	version := strings.TrimPrefix(TTN, "v")
+	version := TTN
 	if GitCommit != "" && BuildDate != "" {
 		version += fmt.Sprintf(" (%s, %s)", GitCommit, BuildDate)
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This quickfix removes the `v` from `version.TTN` in development builds. In production builds it already didn't have a `v`.