### PR TITLE
Prepare TLS client certificate wildcards in interop

### DIFF
--- a/pkg/crypto/cryptoutil/kek_labelers.go
+++ b/pkg/crypto/cryptoutil/kek_labelers.go
@@ -31,13 +31,14 @@ type ComponentPrefixKEKLabeler struct {
 	ReplaceOldNew []string
 }
 
-func hostFromAddr(addr string) string {
+// hostFromAddress returns the cluster host from the given address.
+func hostFromAddress(ctx context.Context, addr string) string {
 	host := addr
 	if url, err := url.Parse(addr); err == nil && url.Host != "" {
 		host = url.Host
 	}
 	if h, _, err := net.SplitHostPort(host); err == nil {
-		return h
+		host = h
 	}
 	return host
 }
@@ -65,7 +66,7 @@ func (c ComponentPrefixKEKLabeler) NsKEKLabel(ctx context.Context, netID *types.
 		parts = append(parts, netID.String())
 	}
 	if addr != "" {
-		parts = append(parts, hostFromAddr(addr))
+		parts = append(parts, hostFromAddress(ctx, addr))
 	}
 	return c.join(parts...)
 }
@@ -75,7 +76,7 @@ func (c ComponentPrefixKEKLabeler) AsKEKLabel(ctx context.Context, addr string) 
 	parts := make([]string, 0, 2)
 	parts = append(parts, "as")
 	if addr != "" {
-		parts = append(parts, hostFromAddr(addr))
+		parts = append(parts, hostFromAddress(ctx, addr))
 	}
 	return c.join(parts...)
 }

--- a/pkg/crypto/cryptoutil/kek_labelers_test.go
+++ b/pkg/crypto/cryptoutil/kek_labelers_test.go
@@ -35,9 +35,9 @@ func TestComponentPrefixKEKLabeler(t *testing.T) {
 		Expected      string
 	}{
 		{
-			Addr: "localhost",
+			Addr: "",
 			Func: func(ctx context.Context, labeler ComponentPrefixKEKLabeler, addr string) string {
-				return labeler.NsKEKLabel(ctx, nil, "")
+				return labeler.NsKEKLabel(ctx, nil, addr)
 			},
 			Expected: "ns",
 		},

--- a/pkg/joinserver/joinserver_test.go
+++ b/pkg/joinserver/joinserver_test.go
@@ -46,8 +46,8 @@ var (
 	}
 	nwkKey = types.AES128Key{0x42, 0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
 	appKey = types.AES128Key{0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
-	nsAddr = "66.66.66.66:1234"
-	asAddr = "66.66.66.255:1234"
+	nsAddr = "ns.test.org:1234"
+	asAddr = "as.test.org:1234"
 )
 
 func eui64Ptr(eui types.EUI64) *types.EUI64 { return &eui }
@@ -245,8 +245,8 @@ func TestHandleJoin(t *testing.T) {
 			Name:        "1.1.0/cluster auth/new device/wrapped keys/addr KEKs",
 			ContextFunc: func(ctx context.Context) context.Context { return clusterauth.NewContext(ctx, nil) },
 			KeyVault: map[string][]byte{
-				"ns:66.66.66.66":  {0x3f, 0x36, 0x7b, 0xa1, 0x16, 0x67, 0xd9, 0x8b, 0x89, 0x00, 0x47, 0x77, 0x84, 0xf6, 0xfe, 0x50, 0x56, 0x67, 0x12, 0xab, 0x71, 0x96, 0x04, 0x6b, 0x9f, 0x2b, 0xc2, 0x50, 0xdf, 0xc8, 0xc1, 0xa2},
-				"as:66.66.66.255": {0xed, 0x8a, 0x2e, 0x97, 0xf6, 0x8e, 0xbb, 0x79, 0x4d, 0x96, 0x4b, 0xd6, 0x14, 0xbb, 0xbc, 0xf2, 0x25, 0xc3, 0x7d, 0x61, 0xa9, 0xfe, 0xd0, 0x83, 0x7b, 0x07, 0xc0, 0x5f, 0x02, 0x52, 0x3c, 0x8b},
+				"ns:ns.test.org": {0x3f, 0x36, 0x7b, 0xa1, 0x16, 0x67, 0xd9, 0x8b, 0x89, 0x00, 0x47, 0x77, 0x84, 0xf6, 0xfe, 0x50, 0x56, 0x67, 0x12, 0xab, 0x71, 0x96, 0x04, 0x6b, 0x9f, 0x2b, 0xc2, 0x50, 0xdf, 0xc8, 0xc1, 0xa2},
+				"as:as.test.org": {0xed, 0x8a, 0x2e, 0x97, 0xf6, 0x8e, 0xbb, 0x79, 0x4d, 0x96, 0x4b, 0xd6, 0x14, 0xbb, 0xbc, 0xf2, 0x25, 0xc3, 0x7d, 0x61, 0xa9, 0xfe, 0xd0, 0x83, 0x7b, 0x07, 0xc0, 0x5f, 0x02, 0x52, 0x3c, 0x8b},
 			},
 			Device: &ttnpb.EndDevice{
 				EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -315,7 +315,7 @@ func TestHandleJoin(t *testing.T) {
 					})...),
 				SessionKeys: ttnpb.SessionKeys{
 					AppSKey: &ttnpb.KeyEnvelope{
-						KEKLabel: "as:66.66.66.255",
+						KEKLabel: "as:as.test.org",
 						EncryptedKey: MustWrapAES128Key(
 							crypto.DeriveAppSKey(
 								appKey,
@@ -327,7 +327,7 @@ func TestHandleJoin(t *testing.T) {
 						),
 					},
 					SNwkSIntKey: &ttnpb.KeyEnvelope{
-						KEKLabel: "ns:66.66.66.66",
+						KEKLabel: "ns:ns.test.org",
 						EncryptedKey: MustWrapAES128Key(
 							crypto.DeriveSNwkSIntKey(
 								nwkKey,
@@ -339,7 +339,7 @@ func TestHandleJoin(t *testing.T) {
 						),
 					},
 					FNwkSIntKey: &ttnpb.KeyEnvelope{
-						KEKLabel: "ns:66.66.66.66",
+						KEKLabel: "ns:ns.test.org",
 						EncryptedKey: MustWrapAES128Key(
 							crypto.DeriveFNwkSIntKey(
 								nwkKey,
@@ -351,7 +351,7 @@ func TestHandleJoin(t *testing.T) {
 						),
 					},
 					NwkSEncKey: &ttnpb.KeyEnvelope{
-						KEKLabel: "ns:66.66.66.66",
+						KEKLabel: "ns:ns.test.org",
 						EncryptedKey: MustWrapAES128Key(
 							crypto.DeriveNwkSEncKey(
 								nwkKey,
@@ -1085,7 +1085,7 @@ func TestHandleJoin(t *testing.T) {
 			Name: "1.0.0/TLS client auth/new device",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return auth.NewContextWithX509DN(ctx, pkix.Name{
-					CommonName: "66.66.66.66",
+					CommonName: "*.test.org",
 				})
 			},
 			Device: &ttnpb.EndDevice{
@@ -2099,7 +2099,7 @@ func TestGetAppSKey(t *testing.T) {
 			Name: "Matching request/TLS client auth/address ID",
 			ContextFunc: func(ctx context.Context) context.Context {
 				return auth.NewContextWithX509DN(ctx, pkix.Name{
-					CommonName: "66.66.66.255",
+					CommonName: "as.test.org",
 				})
 			},
 			GetKeyByID: func(ctx context.Context, devEUI types.EUI64, id []byte, paths []string) (*ttnpb.SessionKeys, error) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Needed for https://github.com/TheThingsIndustries/lorawan-stack/issues/1822

#### Changes
<!-- What are the changes made in this pull request? -->

- Make getting address in component KEK labeler context-aware
- Support TLS client certificate wildcards in interop