### PR TITLE
Fix scheme and port for The Things Kickstarter Gateway

### DIFF
--- a/doc/content/guides/connecting-gateways/thethingskickstartergateway/_index.md
+++ b/doc/content/guides/connecting-gateways/thethingskickstartergateway/_index.md
@@ -23,7 +23,7 @@ Open the front panel of the gateway casing.
 
 While the gateway is powered on, hold the pink reset button for 5 seconds (until each of the 5 LEDs illuminate). This erases the existing configuration on the gateway.
 
-The gateway will now expose a WiFi Access Point whose SSID is of the form `TheThings-Gateway-xxxxx`, to which you should now connect.
+The gateway will now expose a WiFi Access Point whose SSID is of the form `TheThings-Gateway-xxxxx`, to which you should now connect using password `thethings`.
 
 In a web browser, open the gateway's configuration page by navigating to http://192.168.84.1/
 

--- a/doc/content/guides/connecting-gateways/thethingskickstartergateway/_index.md
+++ b/doc/content/guides/connecting-gateways/thethingskickstartergateway/_index.md
@@ -36,11 +36,11 @@ Enter the following fields:
 
 Click the **Show Advanced Options** button and enter the following fields:
 
-1. **Account Server**: The URL of The Things Stack. If you're using a port other than `:443` then append that to the URL.
+1. **Account Server**: The URL of The Things Stack. If you followed the [Getting Started guide]({{< ref "/guides/getting-started" >}}) this is the same as what you use instead of `https://thethings.example.com`.
 2. **Gateway Key**: The API Key that you created earlier.
 3. Click **Save** when done.
 
-This will apply the setting and reboot the gateway. If all the steps have been followed correctly, your gateway will now connect The Things Stack.
+This will apply the setting and reboot the gateway. If all the steps have been followed correctly, your gateway will now connect to The Things Stack.
 
 ## Troubleshooting
 

--- a/pkg/thethingsgateway/cups/handlers.go
+++ b/pkg/thethingsgateway/cups/handlers.go
@@ -118,7 +118,7 @@ func adaptGatewayAddress(address string) (result string, err error) {
 	if strings.Contains(address, "://") {
 		return address, nil
 	}
-	var host, port string
+	var scheme, host, port string
 	if strings.Contains(address, ":") {
 		host, port, err = net.SplitHostPort(address)
 		if err != nil {
@@ -128,9 +128,15 @@ func adaptGatewayAddress(address string) (result string, err error) {
 		host = address
 	}
 	if port == "" {
-		port = "8882"
+		port = "8881"
 	}
-	return fmt.Sprintf("mqtts://%v:%v", host, port), nil
+	switch port {
+	case "1881", "1882", "1883":
+		scheme = "mqtt"
+	case "8881", "8882", "8883":
+		scheme = "mqtts"
+	}
+	return fmt.Sprintf("%s://%s:%s", scheme, host, port), nil
 }
 
 // adaptAuthorization removes the Authorization prefix.

--- a/pkg/thethingsgateway/cups/handlers.go
+++ b/pkg/thethingsgateway/cups/handlers.go
@@ -74,6 +74,8 @@ func (s *Server) handleGatewayInfo(c echo.Context) error {
 				hostport = host
 			case "8885":
 				scheme = "https"
+			default:
+				scheme = "https"
 			}
 		}
 		freqPlanURL := &url.URL{
@@ -124,9 +126,8 @@ func (s *Server) adaptUpdateChannel(channel string) string {
 	return channel
 }
 
-// adaptGatewayAddress prepends the gateway address with the scheme "mqtts" and appends
-// the port "8882" if they have not been mentioned. If the scheme has been given, no
-// changes are done to the address.
+// adaptGatewayAddress infers the scheme and port for the gateway address if not
+// already present.
 func adaptGatewayAddress(address string) (result string, err error) {
 	if address == "" {
 		return address, nil
@@ -134,7 +135,7 @@ func adaptGatewayAddress(address string) (result string, err error) {
 	if strings.Contains(address, "://") {
 		return address, nil
 	}
-	var scheme, host, port string
+	var host, port string
 	if strings.Contains(address, ":") {
 		host, port, err = net.SplitHostPort(address)
 		if err != nil {
@@ -148,11 +149,11 @@ func adaptGatewayAddress(address string) (result string, err error) {
 	}
 	switch port {
 	case "1881", "1882", "1883":
-		scheme = "mqtt"
+		return fmt.Sprintf("mqtt://%s:%s", host, port), nil
 	case "8881", "8882", "8883":
-		scheme = "mqtts"
+		return fmt.Sprintf("mqtts://%s:%s", host, port), nil
 	}
-	return fmt.Sprintf("%s://%s:%s", scheme, host, port), nil
+	return fmt.Sprintf("%s:%s", host, port), nil
 }
 
 // adaptAuthorization removes the Authorization prefix.

--- a/pkg/thethingsgateway/cups/handlers.go
+++ b/pkg/thethingsgateway/cups/handlers.go
@@ -60,9 +60,25 @@ func (s *Server) handleGatewayInfo(c echo.Context) error {
 	}, s.getAuth(c)); err != nil {
 		return err
 	} else {
+		scheme := c.Scheme()
+		hostport := c.Request().Host
+		if host, port, err := net.SplitHostPort(hostport); err == nil {
+			switch port {
+			case "80":
+				scheme = "http"
+				hostport = host
+			case "1885":
+				scheme = "http"
+			case "443":
+				scheme = "https"
+				hostport = host
+			case "8885":
+				scheme = "https"
+			}
+		}
 		freqPlanURL := &url.URL{
-			Scheme: c.Scheme(),
-			Host:   c.Request().Host,
+			Scheme: scheme,
+			Host:   hostport,
 			Path:   fmt.Sprintf("%v/frequency-plans/%v", compatAPIPrefix, gateway.FrequencyPlanID),
 		}
 		response := &gatewayInfoResponse{

--- a/pkg/thethingsgateway/cups/handlers_test.go
+++ b/pkg/thethingsgateway/cups/handlers_test.go
@@ -94,11 +94,19 @@ func TestAdaptGatewayAddress(t *testing.T) {
 			Address: "localhost",
 			Assert: func(a *assertions.Assertion, address string, err error) {
 				a.So(err, assertions.ShouldBeNil)
-				a.So(address, assertions.ShouldEqual, "mqtts://localhost:8882")
+				a.So(address, assertions.ShouldEqual, "mqtts://localhost:8881")
 			},
 		},
 		{
-			Name:    "Host and port, no scheme",
+			Name:    "Host and MQTT port, no scheme",
+			Address: "localhost:1881",
+			Assert: func(a *assertions.Assertion, address string, err error) {
+				a.So(err, assertions.ShouldBeNil)
+				a.So(address, assertions.ShouldEqual, "mqtt://localhost:1881")
+			},
+		},
+		{
+			Name:    "Host and MQTTS port, no scheme",
 			Address: "localhost:8881",
 			Assert: func(a *assertions.Assertion, address string, err error) {
 				a.So(err, assertions.ShouldBeNil)
@@ -107,18 +115,18 @@ func TestAdaptGatewayAddress(t *testing.T) {
 		},
 		{
 			Name:    "Full mqtts address",
-			Address: "mqtts://localhost:8882",
+			Address: "mqtts://localhost:8871",
 			Assert: func(a *assertions.Assertion, address string, err error) {
 				a.So(err, assertions.ShouldBeNil)
-				a.So(address, assertions.ShouldEqual, "mqtts://localhost:8882")
+				a.So(address, assertions.ShouldEqual, "mqtts://localhost:8871")
 			},
 		},
 		{
 			Name:    "Full mqtt address",
-			Address: "mqtt://localhost:1882",
+			Address: "mqtt://localhost:1871",
 			Assert: func(a *assertions.Assertion, address string, err error) {
 				a.So(err, assertions.ShouldBeNil)
-				a.So(address, assertions.ShouldEqual, "mqtt://localhost:1882")
+				a.So(address, assertions.ShouldEqual, "mqtt://localhost:1871")
 			},
 		},
 		{

--- a/pkg/thethingsgateway/cups/server_test.go
+++ b/pkg/thethingsgateway/cups/server_test.go
@@ -75,7 +75,7 @@ func mockGateway() *ttnpb.Gateway {
 		},
 		UpdateChannel:        "stable",
 		FrequencyPlanID:      "EU_863_870",
-		GatewayServerAddress: "mqtts://localhost:8883",
+		GatewayServerAddress: "mqtts://localhost:8881",
 	}
 }
 
@@ -136,7 +136,7 @@ func TestServer(t *testing.T) {
 				a.So(resp["frequency_plan_url"], should.Equal, "http://example.com/api/v2/frequency-plans/EU_863_870")
 				a.So(resp["firmware_url"], should.Equal, "https://thethingsproducts.blob.core.windows.net/the-things-gateway/v1/stable")
 				a.So(resp["router"], should.Resemble, map[string]interface{}{
-					"mqtt_address": "mqtts://localhost:8883",
+					"mqtt_address": "mqtts://localhost:8881",
 				})
 				a.So(resp["auto_update"], should.Equal, false)
 			},


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR is a quickfix for the derivation of the scheme and port for The Things Kickstarter Gateway's CUPS.

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix default port (1881, not 1882)
- Fix MQTT scheme derivation (188x is mqtt, 888x is mqtts)
- Fix HTTP scheme derivation (80/1885 is http, 443/8885 is https) 
- Clarify documentation

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
