### PR TITLE
Fix race condition in NS test

### DIFF
--- a/pkg/networkserver/grpc_gsns_test.go
+++ b/pkg/networkserver/grpc_gsns_test.go
@@ -1253,6 +1253,7 @@ func TestHandleUplink(t *testing.T) {
 				joinResp := makeJoinResponse(ttnpb.MAC_V1_1)
 
 				now := clock.Add(time.Nanosecond)
+				joinAt := now
 
 				var joinReq *ttnpb.JoinRequest
 				if !a.So(AssertInteropClientHandleJoinRequestRequest(ctx, env.InteropClient.HandleJoinRequest,
@@ -1289,13 +1290,13 @@ func TestHandleUplink(t *testing.T) {
 					return false
 				}
 
-				now = clock.Add(time.Nanosecond)
-
 				if !a.So(test.AssertEventPubSubPublishRequest(ctx, env.Events, func(ev events.Event) bool {
 					return a.So(ev, should.ResembleEvent, EvtForwardJoinRequest(reqCtx, makeOTAAIdentifiers(nil), nil))
 				}), should.BeTrue) {
 					return false
 				}
+
+				now = clock.Add(time.Nanosecond)
 
 				mds := sendUplinkDuplicates(ctx, handle, env.DeduplicationDone, makeJoinRequest, start, duplicateCount)
 				mds = append(mds, msg.RxMetadata...)
@@ -1391,7 +1392,7 @@ func TestHandleUplink(t *testing.T) {
 										makeApplicationDownlink(),
 									},
 									SessionKeyID: makeSessionKeys(ttnpb.MAC_V1_1).SessionKeyID,
-									ReceivedAt:   now,
+									ReceivedAt:   joinAt,
 								}},
 							},
 						})


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fixes race condition introduced in https://github.com/TheThingsNetwork/lorawan-stack/pull/1605

The clock is incremented concurrently with NS reading the clock - test should wait for NS to "do something" to sync - send event in this case

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix test race condition

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
