### PR TITLE
Support maximum EIRP and duty-cycle from frequency plan sub-bands and band fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix crashing of organization collaborator edit page.
 - Correct `AU_915_928` maximum EIRP value to 30 dBm in 915.0 – 928.0 MHz (was 16.15 dBm).
+- Correct `US_902_928` maximum EIRP value to 23.15 dBm in 902.3 – 914.9 MHz (was 32.15 dBm) and 28.15 dBm in 923.3 – 927.5 MHz (was 32.15 dBm). This aligns with US915 Hybrid Mode.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix crashing of organization collaborator edit page.
 - Correct `AU_915_928` maximum EIRP value to 30 dBm in 915.0 – 928.0 MHz (was 16.15 dBm).
 - Correct `US_902_928` maximum EIRP value to 23.15 dBm in 902.3 – 914.9 MHz (was 32.15 dBm) and 28.15 dBm in 923.3 – 927.5 MHz (was 32.15 dBm). This aligns with US915 Hybrid Mode.
+- Correct `AS_923` maximum EIRP value to 16 dBm in 923.0 – 923.5 MHz (was 16.15 dBm).
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix crashing of organization collaborator edit page.
+- Correct `AU_915_928` maximum EIRP value to 30 dBm in 915.0 – 928.0 MHz (was 16.15 dBm).
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for searching end devices within an application.
 - Notification during login informing users of unapproved user accounts.
 - Support maximum EIRP value from frequency plans sub-bands.
+- Support duty-cycle value from frequency plans sub-bands.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Search is now also available to non-admin users.
 - Support for searching end devices within an application.
 - Notification during login informing users of unapproved user accounts.
+- Support maximum EIRP value from frequency plans sub-bands.
 
 ### Changed
 

--- a/pkg/band/as_923.go
+++ b/pkg/band/as_923.go
@@ -47,7 +47,7 @@ func init() {
 				MinFrequency: 923000000,
 				MaxFrequency: 923500000,
 				DutyCycle:    0.01,
-				MaxEIRP:      14.0 + eirpDelta,
+				MaxEIRP:      16,
 			},
 		},
 

--- a/pkg/band/au_915_928.go
+++ b/pkg/band/au_915_928.go
@@ -75,10 +75,10 @@ func init() {
 		// See Radiocommunications (Low Interference Potential Devices) Class Licence 2015
 		SubBands: []SubBandParameters{
 			{
-				MinFrequency: 902000000,
+				MinFrequency: 915000000,
 				MaxFrequency: 928000000,
 				DutyCycle:    1,
-				MaxEIRP:      14.0 + eirpDelta,
+				MaxEIRP:      30,
 			},
 		},
 

--- a/pkg/band/band_test.go
+++ b/pkg/band/band_test.go
@@ -141,14 +141,17 @@ func TestGenerateChMasksBands(t *testing.T) {
 }
 
 func TestFindSubBand(t *testing.T) {
-	a := assertions.New(t)
-
 	for _, b := range band.All {
-		for _, ch := range b.UplinkChannels {
-			sb, ok := b.FindSubBand(ch.Frequency)
-			a.So(ok, should.BeTrue)
-			a.So(sb.MinFrequency, should.BeLessThanOrEqualTo, ch.Frequency)
-			a.So(sb.MaxFrequency, should.BeGreaterThan, ch.Frequency)
-		}
+		t.Run(b.ID, func(t *testing.T) {
+			a := assertions.New(t)
+			for _, ch := range b.UplinkChannels {
+				sb, ok := b.FindSubBand(ch.Frequency)
+				if !a.So(ok, should.BeTrue) {
+					t.Fatalf("Frequency %d not found in sub-bands", ch.Frequency)
+				}
+				a.So(sb.MinFrequency, should.BeLessThanOrEqualTo, ch.Frequency)
+				a.So(sb.MaxFrequency, should.BeGreaterThanOrEqualTo, ch.Frequency)
+			}
+		})
 	}
 }

--- a/pkg/band/us_902_928.go
+++ b/pkg/band/us_902_928.go
@@ -73,10 +73,16 @@ func init() {
 		// As per FCC Rules for Unlicensed Wireless Equipment operating in the ISM bands
 		SubBands: []SubBandParameters{
 			{
-				MinFrequency: 902000000,
-				MaxFrequency: 928000000,
+				MinFrequency: 902300000,
+				MaxFrequency: 914900000,
 				DutyCycle:    1,
-				MaxEIRP:      30.0 + eirpDelta,
+				MaxEIRP:      21.0 + eirpDelta,
+			},
+			{
+				MinFrequency: 923300000,
+				MaxFrequency: 927500000,
+				DutyCycle:    1,
+				MaxEIRP:      26.0 + eirpDelta,
 			},
 		},
 

--- a/pkg/frequencyplans/frequencyplans_test.go
+++ b/pkg/frequencyplans/frequencyplans_test.go
@@ -124,7 +124,11 @@ uplink-channels:
 - frequency: 923000000
 `),
 		"US_915.yml": []byte(`invalid-yaml`),
-		"JP.yml": []byte(`listen-before-talk:
+		"JP.yml": []byte(`sub-bands:
+- min-frequency: 923000000
+  max-frequency: 923000000
+  max-eirp: 42
+listen-before-talk:
   rssi-target: 1.1
   rssi-offset: 2.2
   scan-time: 80
@@ -187,6 +191,11 @@ uplink-channels:
 		}
 
 		assertAS923Content(fp)
+		sb, ok := fp.FindSubBand(923000000)
+		if !a.So(ok, should.BeTrue) {
+			t.FailNow()
+		}
+		a.So(*sb.MaxEIRP, should.Equal, 42)
 		a.So(fp.LBT, should.NotBeNil)
 		a.So(fp.LBT.RSSIOffset, should.AlmostEqual, 2.2, 0.00001)
 		a.So(fp.LBT.ScanTime, should.Equal, 80)

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -316,9 +316,11 @@ func (c *Connection) ScheduleDown(path *ttnpb.DownlinkPath, msg *ttnpb.DownlinkM
 		if sb, ok := phy.FindSubBand(rx.frequency); ok {
 			eirp = sb.MaxEIRP
 		}
-		// TODO: Take frequency plan's sub-band MaxEIRP (https://github.com/TheThingsNetwork/lorawan-stack/issues/300)
 		if c.fp.MaxEIRP != nil {
 			eirp = *c.fp.MaxEIRP
+		}
+		if sb, ok := c.fp.FindSubBand(rx.frequency); ok && sb.MaxEIRP != nil {
+			eirp = *sb.MaxEIRP
 		}
 		settings := ttnpb.TxSettings{
 			DataRateIndex: rx.dataRateIndex,

--- a/pkg/gatewayserver/scheduling/sub_band_test.go
+++ b/pkg/gatewayserver/scheduling/sub_band_test.go
@@ -15,12 +15,12 @@
 package scheduling_test
 
 import (
+	"math"
 	"strconv"
 	"testing"
 	"time"
 
 	"github.com/smartystreets/assertions"
-	"go.thethings.network/lorawan-stack/pkg/band"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/gatewayserver/scheduling"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
@@ -30,11 +30,13 @@ import (
 
 func TestSubBandScheduleUnrestricted(t *testing.T) {
 	ctx := test.Context()
-	band := band.SubBandParameters{
-		DutyCycle: 1,
+	params := scheduling.SubBandParameters{
+		MinFrequency: 0,
+		MaxFrequency: math.MaxUint64,
+		DutyCycle:    1,
 	}
 	clock := &mockClock{}
-	sb := scheduling.NewSubBand(ctx, band, clock, nil)
+	sb := scheduling.NewSubBand(ctx, params, clock, nil)
 	for i, tc := range []struct {
 		Starts            scheduling.ConcentratorTime
 		Duration          time.Duration
@@ -92,15 +94,17 @@ func TestSubBandScheduleUnrestricted(t *testing.T) {
 
 func TestSubBandScheduleRestricted(t *testing.T) {
 	ctx := test.Context()
-	band := band.SubBandParameters{
-		DutyCycle: 0.5,
+	params := scheduling.SubBandParameters{
+		MinFrequency: 0,
+		MaxFrequency: math.MaxUint64,
+		DutyCycle:    0.5,
 	}
 	clock := &mockClock{}
 	ceilings := map[ttnpb.TxSchedulePriority]float32{
 		ttnpb.TxSchedulePriority_NORMAL:  0.5, // Duty-cycle <= 0.25
 		ttnpb.TxSchedulePriority_HIGHEST: 1.0, // Duty-cycle <= 0.50
 	}
-	sb := scheduling.NewSubBand(ctx, band, clock, ceilings)
+	sb := scheduling.NewSubBand(ctx, params, clock, ceilings)
 	for i, tc := range []struct {
 		Starts            scheduling.ConcentratorTime
 		Duration          time.Duration
@@ -173,15 +177,17 @@ func TestSubBandScheduleRestricted(t *testing.T) {
 func TestScheduleAnytimeRestricted(t *testing.T) {
 	a := assertions.New(t)
 	ctx := test.Context()
-	band := band.SubBandParameters{
-		DutyCycle: 0.5,
+	params := scheduling.SubBandParameters{
+		MinFrequency: 0,
+		MaxFrequency: math.MaxUint64,
+		DutyCycle:    0.5,
 	}
 	clock := &mockClock{}
 	ceilings := map[ttnpb.TxSchedulePriority]float32{
 		ttnpb.TxSchedulePriority_NORMAL:  0.5, // Duty-cycle <= 0.25
 		ttnpb.TxSchedulePriority_HIGHEST: 1.0, // Duty-cycle <= 0.50
 	}
-	sb := scheduling.NewSubBand(ctx, band, clock, ceilings)
+	sb := scheduling.NewSubBand(ctx, params, clock, ceilings)
 
 	for _, t := range []scheduling.ConcentratorTime{
 		scheduling.ConcentratorTime(6 * time.Second),

--- a/pkg/util/test/frequencyplans.go
+++ b/pkg/util/test/frequencyplans.go
@@ -31,6 +31,10 @@ const (
   name: US 902-928 MHz FSB2
   base-frequency: 915
   file: US_902_928_FSB_2.yml
+- id: AS_923_925_AU
+  name: Australia 923-925 MHz (AS923)
+  base-frequency: 915
+  file: AS_923_925_AU.yml
 - id: EXAMPLE
   name: Example 866.1 MHz
   base-frequency: 868
@@ -253,6 +257,94 @@ radios:
   rssi-offset: -166
 clock-source: 1`
 
+	// ASAUFrequencyPlanID is an AS923 for Australia frequency plan for testing.
+	ASAUFrequencyPlanID = "AS_923_925_AU"
+	asAUFrequencyPlan   = `band-id: AS_923
+sub-bands:
+- min-frequency: 915000000
+  max-frequency: 928000000
+  duty-cycle: 1
+  max-eirp: 30
+uplink-channels:
+- frequency: 923200000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 923400000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 923600000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 923800000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 924000000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 924200000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 924400000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 924600000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+downlink-channels:
+- frequency: 923200000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 923400000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 923600000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 923800000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 924000000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 924200000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 924400000
+  min-data-rate: 0
+  max-data-rate: 5
+- frequency: 924600000
+  min-data-rate: 0
+  max-data-rate: 5
+lora-standard-channel:
+  frequency: 924500000
+  data-rate: 6
+  radio: 1
+fsk-channel:
+  frequency: 924800000
+  data-rate: 7
+  radio: 1
+radios:
+- enable: true
+  chip-type: SX1257
+  frequency: 923600000
+  rssi-offset: -166
+  tx:
+    min-frequency: 923200000
+    max-frequency: 925000000
+- enable: true
+  chip-type: SX1257
+  frequency: 924600000
+  rssi-offset: -166
+clock-source: 1`
+
 	// ExampleFrequencyPlanID is an example frequency plan.
 	ExampleFrequencyPlanID = "EXAMPLE"
 	exampleFrequencyPlan   = `band-id: EU_863_870
@@ -314,5 +406,6 @@ var FrequencyPlansFetcher = fetch.NewMemFetcher(map[string][]byte{
 	"EU_863_870.yml":       []byte(euFrequencyPlan),
 	"KR_920_923.yml":       []byte(krFrequencyPlan),
 	"US_902_928_FSB_2.yml": []byte(usFrequencyPlan),
+	"AS_923_925_AU.yml":    []byte(asAUFrequencyPlan),
 	"EXAMPLE.yml":          []byte(exampleFrequencyPlan),
 })

--- a/pkg/util/test/frequencyplans.go
+++ b/pkg/util/test/frequencyplans.go
@@ -263,7 +263,6 @@ clock-source: 1`
 sub-bands:
 - min-frequency: 915000000
   max-frequency: 928000000
-  duty-cycle: 1
   max-eirp: 30
 uplink-channels:
 - frequency: 923200000


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #300
References https://github.com/TheThingsNetwork/lorawan-frequency-plans/pull/10
References https://github.com/TheThingsNetwork/lorawan-frequency-plans/pull/11
References https://github.com/TheThingsNetwork/lorawan-frequency-plans/pull/13

#### Changes
<!-- What are the changes made in this pull request? -->

- Support maximum EIRP value from frequency plans sub-bands.
- Support duty-cycle value from frequency plans sub-bands.
- Correct `AU_915_928` maximum EIRP value to 30 dBm in 915.0 – 928.0 MHz (was 16.15 dBm).
- Correct `US_902_928` maximum EIRP value to 23.15 dBm in 902.3 – 914.9 MHz (was 32.15 dBm) and 28.15 dBm in 923.3 – 927.5 MHz (was 32.15 dBm). This aligns with US915 Hybrid Mode.
- Correct `AS_923` maximum EIRP value to 16 dBm in 923.0 – 923.5 MHz (was 16.15 dBm).

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
