### PR TITLE
Fix organization collaborator edit view crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix crashing of organization collaborator edit page.
+
 ### Security
 
 - Keep session keys separate by `JoinEUI` to avoid conditions where session keys are retrieved only by `DevEUI` and the session key identifier. This breaks retrieving session keys of devices that have been activated on a deployment running a previous version. Since the Application Server instances are currently in-cluster, there is no need for an Application Server to retrieve the `AppSKey` from the Join Server, making this breaking change ineffective.

--- a/pkg/webui/console/views/organization-collaborator-edit/organization-collaborator-edit.js
+++ b/pkg/webui/console/views/organization-collaborator-edit/organization-collaborator-edit.js
@@ -15,6 +15,7 @@
 import React from 'react'
 import { Container, Col, Row } from 'react-grid-system'
 
+import PageTitle from '../../../components/page-title'
 import { withBreadcrumb } from '../../../components/breadcrumbs/context'
 import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
 import CollaboratorForm from '../../components/collaborator-form'


### PR DESCRIPTION
#### Summary
This quickfix PR adds a missing `PageTitle` import in the organization collaborator edit view.

#### Changes
- Add missing `PageTitle` import

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
