### PR TITLE
Update protoc image version

### DIFF
--- a/.mage/proto.go
+++ b/.mage/proto.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	protocName    = "thethingsindustries/protoc"
-	protocVersion = "3.1.16-ttn"
+	protocVersion = "3.1.17-ttn"
 
 	protocOut = "/out"
 )

--- a/pkg/ttnpb/application.pb.setters.fm.go
+++ b/pkg/ttnpb/application.pb.setters.fm.go
@@ -14,11 +14,11 @@ func (dst *Application) SetFields(src *Application, paths ...string) error {
 		switch name {
 		case "ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationIdentifiers
-				var newSrc *ApplicationIdentifiers
+				var newDst, newSrc *ApplicationIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationIdentifiers
 				}
+				newDst = &dst.ApplicationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -121,11 +121,11 @@ func (dst *GetApplicationRequest) SetFields(src *GetApplicationRequest, paths ..
 		switch name {
 		case "application_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationIdentifiers
-				var newSrc *ApplicationIdentifiers
+				var newDst, newSrc *ApplicationIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationIdentifiers
 				}
+				newDst = &dst.ApplicationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -160,14 +160,18 @@ func (dst *ListApplicationsRequest) SetFields(src *ListApplicationsRequest, path
 		switch name {
 		case "collaborator":
 			if len(subs) > 0 {
-				newDst := dst.Collaborator
-				if newDst == nil {
-					newDst = &OrganizationOrUserIdentifiers{}
-					dst.Collaborator = newDst
+				var newDst, newSrc *OrganizationOrUserIdentifiers
+				if (src == nil || src.Collaborator == nil) && dst.Collaborator == nil {
+					continue
 				}
-				var newSrc *OrganizationOrUserIdentifiers
 				if src != nil {
 					newSrc = src.Collaborator
+				}
+				if dst.Collaborator != nil {
+					newDst = dst.Collaborator
+				} else {
+					newDst = &OrganizationOrUserIdentifiers{}
+					dst.Collaborator = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -232,11 +236,11 @@ func (dst *CreateApplicationRequest) SetFields(src *CreateApplicationRequest, pa
 		switch name {
 		case "application":
 			if len(subs) > 0 {
-				newDst := &dst.Application
-				var newSrc *Application
+				var newDst, newSrc *Application
 				if src != nil {
 					newSrc = &src.Application
 				}
+				newDst = &dst.Application
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -250,11 +254,11 @@ func (dst *CreateApplicationRequest) SetFields(src *CreateApplicationRequest, pa
 			}
 		case "collaborator":
 			if len(subs) > 0 {
-				newDst := &dst.Collaborator
-				var newSrc *OrganizationOrUserIdentifiers
+				var newDst, newSrc *OrganizationOrUserIdentifiers
 				if src != nil {
 					newSrc = &src.Collaborator
 				}
+				newDst = &dst.Collaborator
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -279,11 +283,11 @@ func (dst *UpdateApplicationRequest) SetFields(src *UpdateApplicationRequest, pa
 		switch name {
 		case "application":
 			if len(subs) > 0 {
-				newDst := &dst.Application
-				var newSrc *Application
+				var newDst, newSrc *Application
 				if src != nil {
 					newSrc = &src.Application
 				}
+				newDst = &dst.Application
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -318,11 +322,11 @@ func (dst *ListApplicationAPIKeysRequest) SetFields(src *ListApplicationAPIKeysR
 		switch name {
 		case "application_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationIdentifiers
-				var newSrc *ApplicationIdentifiers
+				var newDst, newSrc *ApplicationIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationIdentifiers
 				}
+				newDst = &dst.ApplicationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -367,11 +371,11 @@ func (dst *GetApplicationAPIKeyRequest) SetFields(src *GetApplicationAPIKeyReque
 		switch name {
 		case "application_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationIdentifiers
-				var newSrc *ApplicationIdentifiers
+				var newDst, newSrc *ApplicationIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationIdentifiers
 				}
+				newDst = &dst.ApplicationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -406,11 +410,11 @@ func (dst *CreateApplicationAPIKeyRequest) SetFields(src *CreateApplicationAPIKe
 		switch name {
 		case "application_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationIdentifiers
-				var newSrc *ApplicationIdentifiers
+				var newDst, newSrc *ApplicationIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationIdentifiers
 				}
+				newDst = &dst.ApplicationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -454,11 +458,11 @@ func (dst *UpdateApplicationAPIKeyRequest) SetFields(src *UpdateApplicationAPIKe
 		switch name {
 		case "application_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationIdentifiers
-				var newSrc *ApplicationIdentifiers
+				var newDst, newSrc *ApplicationIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationIdentifiers
 				}
+				newDst = &dst.ApplicationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -472,11 +476,11 @@ func (dst *UpdateApplicationAPIKeyRequest) SetFields(src *UpdateApplicationAPIKe
 			}
 		case "api_key":
 			if len(subs) > 0 {
-				newDst := &dst.APIKey
-				var newSrc *APIKey
+				var newDst, newSrc *APIKey
 				if src != nil {
 					newSrc = &src.APIKey
 				}
+				newDst = &dst.APIKey
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -501,11 +505,11 @@ func (dst *ListApplicationCollaboratorsRequest) SetFields(src *ListApplicationCo
 		switch name {
 		case "application_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationIdentifiers
-				var newSrc *ApplicationIdentifiers
+				var newDst, newSrc *ApplicationIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationIdentifiers
 				}
+				newDst = &dst.ApplicationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -550,11 +554,11 @@ func (dst *GetApplicationCollaboratorRequest) SetFields(src *GetApplicationColla
 		switch name {
 		case "application_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationIdentifiers
-				var newSrc *ApplicationIdentifiers
+				var newDst, newSrc *ApplicationIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationIdentifiers
 				}
+				newDst = &dst.ApplicationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -568,11 +572,11 @@ func (dst *GetApplicationCollaboratorRequest) SetFields(src *GetApplicationColla
 			}
 		case "collaborator":
 			if len(subs) > 0 {
-				newDst := &dst.OrganizationOrUserIdentifiers
-				var newSrc *OrganizationOrUserIdentifiers
+				var newDst, newSrc *OrganizationOrUserIdentifiers
 				if src != nil {
 					newSrc = &src.OrganizationOrUserIdentifiers
 				}
+				newDst = &dst.OrganizationOrUserIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -597,11 +601,11 @@ func (dst *SetApplicationCollaboratorRequest) SetFields(src *SetApplicationColla
 		switch name {
 		case "application_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationIdentifiers
-				var newSrc *ApplicationIdentifiers
+				var newDst, newSrc *ApplicationIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationIdentifiers
 				}
+				newDst = &dst.ApplicationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -615,11 +619,11 @@ func (dst *SetApplicationCollaboratorRequest) SetFields(src *SetApplicationColla
 			}
 		case "collaborator":
 			if len(subs) > 0 {
-				newDst := &dst.Collaborator
-				var newSrc *Collaborator
+				var newDst, newSrc *Collaborator
 				if src != nil {
 					newSrc = &src.Collaborator
 				}
+				newDst = &dst.Collaborator
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}

--- a/pkg/ttnpb/applicationserver.pb.setters.fm.go
+++ b/pkg/ttnpb/applicationserver.pb.setters.fm.go
@@ -33,14 +33,18 @@ func (dst *ApplicationLink) SetFields(src *ApplicationLink, paths ...string) err
 			}
 		case "default_formatters":
 			if len(subs) > 0 {
-				newDst := dst.DefaultFormatters
-				if newDst == nil {
-					newDst = &MessagePayloadFormatters{}
-					dst.DefaultFormatters = newDst
+				var newDst, newSrc *MessagePayloadFormatters
+				if (src == nil || src.DefaultFormatters == nil) && dst.DefaultFormatters == nil {
+					continue
 				}
-				var newSrc *MessagePayloadFormatters
 				if src != nil {
 					newSrc = src.DefaultFormatters
+				}
+				if dst.DefaultFormatters != nil {
+					newDst = dst.DefaultFormatters
+				} else {
+					newDst = &MessagePayloadFormatters{}
+					dst.DefaultFormatters = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -75,11 +79,11 @@ func (dst *GetApplicationLinkRequest) SetFields(src *GetApplicationLinkRequest, 
 		switch name {
 		case "application_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationIdentifiers
-				var newSrc *ApplicationIdentifiers
+				var newDst, newSrc *ApplicationIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationIdentifiers
 				}
+				newDst = &dst.ApplicationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -114,11 +118,11 @@ func (dst *SetApplicationLinkRequest) SetFields(src *SetApplicationLinkRequest, 
 		switch name {
 		case "application_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationIdentifiers
-				var newSrc *ApplicationIdentifiers
+				var newDst, newSrc *ApplicationIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationIdentifiers
 				}
+				newDst = &dst.ApplicationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -132,11 +136,11 @@ func (dst *SetApplicationLinkRequest) SetFields(src *SetApplicationLinkRequest, 
 			}
 		case "link":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationLink
-				var newSrc *ApplicationLink
+				var newDst, newSrc *ApplicationLink
 				if src != nil {
 					newSrc = &src.ApplicationLink
 				}
+				newDst = &dst.ApplicationLink
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}

--- a/pkg/ttnpb/applicationserver_packages.pb.setters.fm.go
+++ b/pkg/ttnpb/applicationserver_packages.pb.setters.fm.go
@@ -65,11 +65,11 @@ func (dst *ApplicationPackageAssociationIdentifiers) SetFields(src *ApplicationP
 		switch name {
 		case "end_device_ids":
 			if len(subs) > 0 {
-				newDst := &dst.EndDeviceIdentifiers
-				var newSrc *EndDeviceIdentifiers
+				var newDst, newSrc *EndDeviceIdentifiers
 				if src != nil {
 					newSrc = &src.EndDeviceIdentifiers
 				}
+				newDst = &dst.EndDeviceIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -104,11 +104,11 @@ func (dst *ApplicationPackageAssociation) SetFields(src *ApplicationPackageAssoc
 		switch name {
 		case "ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationPackageAssociationIdentifiers
-				var newSrc *ApplicationPackageAssociationIdentifiers
+				var newDst, newSrc *ApplicationPackageAssociationIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationPackageAssociationIdentifiers
 				}
+				newDst = &dst.ApplicationPackageAssociationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -192,11 +192,11 @@ func (dst *GetApplicationPackageAssociationRequest) SetFields(src *GetApplicatio
 		switch name {
 		case "ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationPackageAssociationIdentifiers
-				var newSrc *ApplicationPackageAssociationIdentifiers
+				var newDst, newSrc *ApplicationPackageAssociationIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationPackageAssociationIdentifiers
 				}
+				newDst = &dst.ApplicationPackageAssociationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -231,11 +231,11 @@ func (dst *ListApplicationPackageAssociationRequest) SetFields(src *ListApplicat
 		switch name {
 		case "ids":
 			if len(subs) > 0 {
-				newDst := &dst.EndDeviceIdentifiers
-				var newSrc *EndDeviceIdentifiers
+				var newDst, newSrc *EndDeviceIdentifiers
 				if src != nil {
 					newSrc = &src.EndDeviceIdentifiers
 				}
+				newDst = &dst.EndDeviceIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -290,11 +290,11 @@ func (dst *SetApplicationPackageAssociationRequest) SetFields(src *SetApplicatio
 		switch name {
 		case "association":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationPackageAssociation
-				var newSrc *ApplicationPackageAssociation
+				var newDst, newSrc *ApplicationPackageAssociation
 				if src != nil {
 					newSrc = &src.ApplicationPackageAssociation
 				}
+				newDst = &dst.ApplicationPackageAssociation
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}

--- a/pkg/ttnpb/applicationserver_pubsub.pb.setters.fm.go
+++ b/pkg/ttnpb/applicationserver_pubsub.pb.setters.fm.go
@@ -14,11 +14,11 @@ func (dst *ApplicationPubSubIdentifiers) SetFields(src *ApplicationPubSubIdentif
 		switch name {
 		case "application_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationIdentifiers
-				var newSrc *ApplicationIdentifiers
+				var newDst, newSrc *ApplicationIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationIdentifiers
 				}
+				newDst = &dst.ApplicationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -53,11 +53,11 @@ func (dst *ApplicationPubSub) SetFields(src *ApplicationPubSub, paths ...string)
 		switch name {
 		case "ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationPubSubIdentifiers
-				var newSrc *ApplicationPubSubIdentifiers
+				var newDst, newSrc *ApplicationPubSubIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationPubSubIdentifiers
 				}
+				newDst = &dst.ApplicationPubSubIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -111,14 +111,18 @@ func (dst *ApplicationPubSub) SetFields(src *ApplicationPubSub, paths ...string)
 			}
 		case "downlink_push":
 			if len(subs) > 0 {
-				newDst := dst.DownlinkPush
-				if newDst == nil {
-					newDst = &ApplicationPubSub_Message{}
-					dst.DownlinkPush = newDst
+				var newDst, newSrc *ApplicationPubSub_Message
+				if (src == nil || src.DownlinkPush == nil) && dst.DownlinkPush == nil {
+					continue
 				}
-				var newSrc *ApplicationPubSub_Message
 				if src != nil {
 					newSrc = src.DownlinkPush
+				}
+				if dst.DownlinkPush != nil {
+					newDst = dst.DownlinkPush
+				} else {
+					newDst = &ApplicationPubSub_Message{}
+					dst.DownlinkPush = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -132,14 +136,18 @@ func (dst *ApplicationPubSub) SetFields(src *ApplicationPubSub, paths ...string)
 			}
 		case "downlink_replace":
 			if len(subs) > 0 {
-				newDst := dst.DownlinkReplace
-				if newDst == nil {
-					newDst = &ApplicationPubSub_Message{}
-					dst.DownlinkReplace = newDst
+				var newDst, newSrc *ApplicationPubSub_Message
+				if (src == nil || src.DownlinkReplace == nil) && dst.DownlinkReplace == nil {
+					continue
 				}
-				var newSrc *ApplicationPubSub_Message
 				if src != nil {
 					newSrc = src.DownlinkReplace
+				}
+				if dst.DownlinkReplace != nil {
+					newDst = dst.DownlinkReplace
+				} else {
+					newDst = &ApplicationPubSub_Message{}
+					dst.DownlinkReplace = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -153,14 +161,18 @@ func (dst *ApplicationPubSub) SetFields(src *ApplicationPubSub, paths ...string)
 			}
 		case "uplink_message":
 			if len(subs) > 0 {
-				newDst := dst.UplinkMessage
-				if newDst == nil {
-					newDst = &ApplicationPubSub_Message{}
-					dst.UplinkMessage = newDst
+				var newDst, newSrc *ApplicationPubSub_Message
+				if (src == nil || src.UplinkMessage == nil) && dst.UplinkMessage == nil {
+					continue
 				}
-				var newSrc *ApplicationPubSub_Message
 				if src != nil {
 					newSrc = src.UplinkMessage
+				}
+				if dst.UplinkMessage != nil {
+					newDst = dst.UplinkMessage
+				} else {
+					newDst = &ApplicationPubSub_Message{}
+					dst.UplinkMessage = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -174,14 +186,18 @@ func (dst *ApplicationPubSub) SetFields(src *ApplicationPubSub, paths ...string)
 			}
 		case "join_accept":
 			if len(subs) > 0 {
-				newDst := dst.JoinAccept
-				if newDst == nil {
-					newDst = &ApplicationPubSub_Message{}
-					dst.JoinAccept = newDst
+				var newDst, newSrc *ApplicationPubSub_Message
+				if (src == nil || src.JoinAccept == nil) && dst.JoinAccept == nil {
+					continue
 				}
-				var newSrc *ApplicationPubSub_Message
 				if src != nil {
 					newSrc = src.JoinAccept
+				}
+				if dst.JoinAccept != nil {
+					newDst = dst.JoinAccept
+				} else {
+					newDst = &ApplicationPubSub_Message{}
+					dst.JoinAccept = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -195,14 +211,18 @@ func (dst *ApplicationPubSub) SetFields(src *ApplicationPubSub, paths ...string)
 			}
 		case "downlink_ack":
 			if len(subs) > 0 {
-				newDst := dst.DownlinkAck
-				if newDst == nil {
-					newDst = &ApplicationPubSub_Message{}
-					dst.DownlinkAck = newDst
+				var newDst, newSrc *ApplicationPubSub_Message
+				if (src == nil || src.DownlinkAck == nil) && dst.DownlinkAck == nil {
+					continue
 				}
-				var newSrc *ApplicationPubSub_Message
 				if src != nil {
 					newSrc = src.DownlinkAck
+				}
+				if dst.DownlinkAck != nil {
+					newDst = dst.DownlinkAck
+				} else {
+					newDst = &ApplicationPubSub_Message{}
+					dst.DownlinkAck = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -216,14 +236,18 @@ func (dst *ApplicationPubSub) SetFields(src *ApplicationPubSub, paths ...string)
 			}
 		case "downlink_nack":
 			if len(subs) > 0 {
-				newDst := dst.DownlinkNack
-				if newDst == nil {
-					newDst = &ApplicationPubSub_Message{}
-					dst.DownlinkNack = newDst
+				var newDst, newSrc *ApplicationPubSub_Message
+				if (src == nil || src.DownlinkNack == nil) && dst.DownlinkNack == nil {
+					continue
 				}
-				var newSrc *ApplicationPubSub_Message
 				if src != nil {
 					newSrc = src.DownlinkNack
+				}
+				if dst.DownlinkNack != nil {
+					newDst = dst.DownlinkNack
+				} else {
+					newDst = &ApplicationPubSub_Message{}
+					dst.DownlinkNack = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -237,14 +261,18 @@ func (dst *ApplicationPubSub) SetFields(src *ApplicationPubSub, paths ...string)
 			}
 		case "downlink_sent":
 			if len(subs) > 0 {
-				newDst := dst.DownlinkSent
-				if newDst == nil {
-					newDst = &ApplicationPubSub_Message{}
-					dst.DownlinkSent = newDst
+				var newDst, newSrc *ApplicationPubSub_Message
+				if (src == nil || src.DownlinkSent == nil) && dst.DownlinkSent == nil {
+					continue
 				}
-				var newSrc *ApplicationPubSub_Message
 				if src != nil {
 					newSrc = src.DownlinkSent
+				}
+				if dst.DownlinkSent != nil {
+					newDst = dst.DownlinkSent
+				} else {
+					newDst = &ApplicationPubSub_Message{}
+					dst.DownlinkSent = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -258,14 +286,18 @@ func (dst *ApplicationPubSub) SetFields(src *ApplicationPubSub, paths ...string)
 			}
 		case "downlink_failed":
 			if len(subs) > 0 {
-				newDst := dst.DownlinkFailed
-				if newDst == nil {
-					newDst = &ApplicationPubSub_Message{}
-					dst.DownlinkFailed = newDst
+				var newDst, newSrc *ApplicationPubSub_Message
+				if (src == nil || src.DownlinkFailed == nil) && dst.DownlinkFailed == nil {
+					continue
 				}
-				var newSrc *ApplicationPubSub_Message
 				if src != nil {
 					newSrc = src.DownlinkFailed
+				}
+				if dst.DownlinkFailed != nil {
+					newDst = dst.DownlinkFailed
+				} else {
+					newDst = &ApplicationPubSub_Message{}
+					dst.DownlinkFailed = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -279,14 +311,18 @@ func (dst *ApplicationPubSub) SetFields(src *ApplicationPubSub, paths ...string)
 			}
 		case "downlink_queued":
 			if len(subs) > 0 {
-				newDst := dst.DownlinkQueued
-				if newDst == nil {
-					newDst = &ApplicationPubSub_Message{}
-					dst.DownlinkQueued = newDst
+				var newDst, newSrc *ApplicationPubSub_Message
+				if (src == nil || src.DownlinkQueued == nil) && dst.DownlinkQueued == nil {
+					continue
 				}
-				var newSrc *ApplicationPubSub_Message
 				if src != nil {
 					newSrc = src.DownlinkQueued
+				}
+				if dst.DownlinkQueued != nil {
+					newDst = dst.DownlinkQueued
+				} else {
+					newDst = &ApplicationPubSub_Message{}
+					dst.DownlinkQueued = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -300,14 +336,18 @@ func (dst *ApplicationPubSub) SetFields(src *ApplicationPubSub, paths ...string)
 			}
 		case "location_solved":
 			if len(subs) > 0 {
-				newDst := dst.LocationSolved
-				if newDst == nil {
-					newDst = &ApplicationPubSub_Message{}
-					dst.LocationSolved = newDst
+				var newDst, newSrc *ApplicationPubSub_Message
+				if (src == nil || src.LocationSolved == nil) && dst.LocationSolved == nil {
+					continue
 				}
-				var newSrc *ApplicationPubSub_Message
 				if src != nil {
 					newSrc = src.LocationSolved
+				}
+				if dst.LocationSolved != nil {
+					newDst = dst.LocationSolved
+				} else {
+					newDst = &ApplicationPubSub_Message{}
+					dst.LocationSolved = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -336,51 +376,69 @@ func (dst *ApplicationPubSub) SetFields(src *ApplicationPubSub, paths ...string)
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "nats":
-					if _, ok := dst.Provider.(*ApplicationPubSub_NATS); !ok {
-						dst.Provider = &ApplicationPubSub_NATS{}
+					_, srcOk := src.Provider.(*ApplicationPubSub_NATS)
+					if !srcOk && src.Provider != nil {
+						return fmt.Errorf("attempt to set oneof 'nats', while different oneof is set in source")
+					}
+					_, dstOk := dst.Provider.(*ApplicationPubSub_NATS)
+					if !dstOk && dst.Provider != nil {
+						return fmt.Errorf("attempt to set oneof 'nats', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Provider.(*ApplicationPubSub_NATS).NATS
-						if newDst == nil {
-							newDst = &ApplicationPubSub_NATSProvider{}
-							dst.Provider.(*ApplicationPubSub_NATS).NATS = newDst
+						var newDst, newSrc *ApplicationPubSub_NATSProvider
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *ApplicationPubSub_NATSProvider
-						if src != nil {
-							newSrc = src.GetNATS()
+						if srcOk {
+							newSrc = src.Provider.(*ApplicationPubSub_NATS).NATS
+						}
+						if dstOk {
+							newDst = dst.Provider.(*ApplicationPubSub_NATS).NATS
+						} else {
+							newDst = &ApplicationPubSub_NATSProvider{}
+							dst.Provider = &ApplicationPubSub_NATS{NATS: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Provider.(*ApplicationPubSub_NATS).NATS = src.GetNATS()
+							dst.Provider = src.Provider
 						} else {
-							dst.Provider.(*ApplicationPubSub_NATS).NATS = nil
+							dst.Provider = nil
 						}
 					}
 				case "mqtt":
-					if _, ok := dst.Provider.(*ApplicationPubSub_MQTT); !ok {
-						dst.Provider = &ApplicationPubSub_MQTT{}
+					_, srcOk := src.Provider.(*ApplicationPubSub_MQTT)
+					if !srcOk && src.Provider != nil {
+						return fmt.Errorf("attempt to set oneof 'mqtt', while different oneof is set in source")
+					}
+					_, dstOk := dst.Provider.(*ApplicationPubSub_MQTT)
+					if !dstOk && dst.Provider != nil {
+						return fmt.Errorf("attempt to set oneof 'mqtt', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Provider.(*ApplicationPubSub_MQTT).MQTT
-						if newDst == nil {
-							newDst = &ApplicationPubSub_MQTTProvider{}
-							dst.Provider.(*ApplicationPubSub_MQTT).MQTT = newDst
+						var newDst, newSrc *ApplicationPubSub_MQTTProvider
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *ApplicationPubSub_MQTTProvider
-						if src != nil {
-							newSrc = src.GetMQTT()
+						if srcOk {
+							newSrc = src.Provider.(*ApplicationPubSub_MQTT).MQTT
+						}
+						if dstOk {
+							newDst = dst.Provider.(*ApplicationPubSub_MQTT).MQTT
+						} else {
+							newDst = &ApplicationPubSub_MQTTProvider{}
+							dst.Provider = &ApplicationPubSub_MQTT{MQTT: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Provider.(*ApplicationPubSub_MQTT).MQTT = src.GetMQTT()
+							dst.Provider = src.Provider
 						} else {
-							dst.Provider.(*ApplicationPubSub_MQTT).MQTT = nil
+							dst.Provider = nil
 						}
 					}
 
@@ -441,11 +499,11 @@ func (dst *GetApplicationPubSubRequest) SetFields(src *GetApplicationPubSubReque
 		switch name {
 		case "ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationPubSubIdentifiers
-				var newSrc *ApplicationPubSubIdentifiers
+				var newDst, newSrc *ApplicationPubSubIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationPubSubIdentifiers
 				}
+				newDst = &dst.ApplicationPubSubIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -480,11 +538,11 @@ func (dst *ListApplicationPubSubsRequest) SetFields(src *ListApplicationPubSubsR
 		switch name {
 		case "application_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationIdentifiers
-				var newSrc *ApplicationIdentifiers
+				var newDst, newSrc *ApplicationIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationIdentifiers
 				}
+				newDst = &dst.ApplicationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -519,11 +577,11 @@ func (dst *SetApplicationPubSubRequest) SetFields(src *SetApplicationPubSubReque
 		switch name {
 		case "pubsub":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationPubSub
-				var newSrc *ApplicationPubSub
+				var newDst, newSrc *ApplicationPubSub
 				if src != nil {
 					newSrc = &src.ApplicationPubSub
 				}
+				newDst = &dst.ApplicationPubSub
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}

--- a/pkg/ttnpb/applicationserver_web.pb.setters.fm.go
+++ b/pkg/ttnpb/applicationserver_web.pb.setters.fm.go
@@ -14,11 +14,11 @@ func (dst *ApplicationWebhookIdentifiers) SetFields(src *ApplicationWebhookIdent
 		switch name {
 		case "application_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationIdentifiers
-				var newSrc *ApplicationIdentifiers
+				var newDst, newSrc *ApplicationIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationIdentifiers
 				}
+				newDst = &dst.ApplicationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -135,11 +135,11 @@ func (dst *ApplicationWebhookTemplate) SetFields(src *ApplicationWebhookTemplate
 		switch name {
 		case "ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationWebhookTemplateIdentifiers
-				var newSrc *ApplicationWebhookTemplateIdentifiers
+				var newDst, newSrc *ApplicationWebhookTemplateIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationWebhookTemplateIdentifiers
 				}
+				newDst = &dst.ApplicationWebhookTemplateIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -241,14 +241,18 @@ func (dst *ApplicationWebhookTemplate) SetFields(src *ApplicationWebhookTemplate
 			}
 		case "uplink_message":
 			if len(subs) > 0 {
-				newDst := dst.UplinkMessage
-				if newDst == nil {
-					newDst = &ApplicationWebhookTemplate_Message{}
-					dst.UplinkMessage = newDst
+				var newDst, newSrc *ApplicationWebhookTemplate_Message
+				if (src == nil || src.UplinkMessage == nil) && dst.UplinkMessage == nil {
+					continue
 				}
-				var newSrc *ApplicationWebhookTemplate_Message
 				if src != nil {
 					newSrc = src.UplinkMessage
+				}
+				if dst.UplinkMessage != nil {
+					newDst = dst.UplinkMessage
+				} else {
+					newDst = &ApplicationWebhookTemplate_Message{}
+					dst.UplinkMessage = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -262,14 +266,18 @@ func (dst *ApplicationWebhookTemplate) SetFields(src *ApplicationWebhookTemplate
 			}
 		case "join_accept":
 			if len(subs) > 0 {
-				newDst := dst.JoinAccept
-				if newDst == nil {
-					newDst = &ApplicationWebhookTemplate_Message{}
-					dst.JoinAccept = newDst
+				var newDst, newSrc *ApplicationWebhookTemplate_Message
+				if (src == nil || src.JoinAccept == nil) && dst.JoinAccept == nil {
+					continue
 				}
-				var newSrc *ApplicationWebhookTemplate_Message
 				if src != nil {
 					newSrc = src.JoinAccept
+				}
+				if dst.JoinAccept != nil {
+					newDst = dst.JoinAccept
+				} else {
+					newDst = &ApplicationWebhookTemplate_Message{}
+					dst.JoinAccept = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -283,14 +291,18 @@ func (dst *ApplicationWebhookTemplate) SetFields(src *ApplicationWebhookTemplate
 			}
 		case "downlink_ack":
 			if len(subs) > 0 {
-				newDst := dst.DownlinkAck
-				if newDst == nil {
-					newDst = &ApplicationWebhookTemplate_Message{}
-					dst.DownlinkAck = newDst
+				var newDst, newSrc *ApplicationWebhookTemplate_Message
+				if (src == nil || src.DownlinkAck == nil) && dst.DownlinkAck == nil {
+					continue
 				}
-				var newSrc *ApplicationWebhookTemplate_Message
 				if src != nil {
 					newSrc = src.DownlinkAck
+				}
+				if dst.DownlinkAck != nil {
+					newDst = dst.DownlinkAck
+				} else {
+					newDst = &ApplicationWebhookTemplate_Message{}
+					dst.DownlinkAck = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -304,14 +316,18 @@ func (dst *ApplicationWebhookTemplate) SetFields(src *ApplicationWebhookTemplate
 			}
 		case "downlink_nack":
 			if len(subs) > 0 {
-				newDst := dst.DownlinkNack
-				if newDst == nil {
-					newDst = &ApplicationWebhookTemplate_Message{}
-					dst.DownlinkNack = newDst
+				var newDst, newSrc *ApplicationWebhookTemplate_Message
+				if (src == nil || src.DownlinkNack == nil) && dst.DownlinkNack == nil {
+					continue
 				}
-				var newSrc *ApplicationWebhookTemplate_Message
 				if src != nil {
 					newSrc = src.DownlinkNack
+				}
+				if dst.DownlinkNack != nil {
+					newDst = dst.DownlinkNack
+				} else {
+					newDst = &ApplicationWebhookTemplate_Message{}
+					dst.DownlinkNack = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -325,14 +341,18 @@ func (dst *ApplicationWebhookTemplate) SetFields(src *ApplicationWebhookTemplate
 			}
 		case "downlink_sent":
 			if len(subs) > 0 {
-				newDst := dst.DownlinkSent
-				if newDst == nil {
-					newDst = &ApplicationWebhookTemplate_Message{}
-					dst.DownlinkSent = newDst
+				var newDst, newSrc *ApplicationWebhookTemplate_Message
+				if (src == nil || src.DownlinkSent == nil) && dst.DownlinkSent == nil {
+					continue
 				}
-				var newSrc *ApplicationWebhookTemplate_Message
 				if src != nil {
 					newSrc = src.DownlinkSent
+				}
+				if dst.DownlinkSent != nil {
+					newDst = dst.DownlinkSent
+				} else {
+					newDst = &ApplicationWebhookTemplate_Message{}
+					dst.DownlinkSent = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -346,14 +366,18 @@ func (dst *ApplicationWebhookTemplate) SetFields(src *ApplicationWebhookTemplate
 			}
 		case "downlink_failed":
 			if len(subs) > 0 {
-				newDst := dst.DownlinkFailed
-				if newDst == nil {
-					newDst = &ApplicationWebhookTemplate_Message{}
-					dst.DownlinkFailed = newDst
+				var newDst, newSrc *ApplicationWebhookTemplate_Message
+				if (src == nil || src.DownlinkFailed == nil) && dst.DownlinkFailed == nil {
+					continue
 				}
-				var newSrc *ApplicationWebhookTemplate_Message
 				if src != nil {
 					newSrc = src.DownlinkFailed
+				}
+				if dst.DownlinkFailed != nil {
+					newDst = dst.DownlinkFailed
+				} else {
+					newDst = &ApplicationWebhookTemplate_Message{}
+					dst.DownlinkFailed = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -367,14 +391,18 @@ func (dst *ApplicationWebhookTemplate) SetFields(src *ApplicationWebhookTemplate
 			}
 		case "downlink_queued":
 			if len(subs) > 0 {
-				newDst := dst.DownlinkQueued
-				if newDst == nil {
-					newDst = &ApplicationWebhookTemplate_Message{}
-					dst.DownlinkQueued = newDst
+				var newDst, newSrc *ApplicationWebhookTemplate_Message
+				if (src == nil || src.DownlinkQueued == nil) && dst.DownlinkQueued == nil {
+					continue
 				}
-				var newSrc *ApplicationWebhookTemplate_Message
 				if src != nil {
 					newSrc = src.DownlinkQueued
+				}
+				if dst.DownlinkQueued != nil {
+					newDst = dst.DownlinkQueued
+				} else {
+					newDst = &ApplicationWebhookTemplate_Message{}
+					dst.DownlinkQueued = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -388,14 +416,18 @@ func (dst *ApplicationWebhookTemplate) SetFields(src *ApplicationWebhookTemplate
 			}
 		case "location_solved":
 			if len(subs) > 0 {
-				newDst := dst.LocationSolved
-				if newDst == nil {
-					newDst = &ApplicationWebhookTemplate_Message{}
-					dst.LocationSolved = newDst
+				var newDst, newSrc *ApplicationWebhookTemplate_Message
+				if (src == nil || src.LocationSolved == nil) && dst.LocationSolved == nil {
+					continue
 				}
-				var newSrc *ApplicationWebhookTemplate_Message
 				if src != nil {
 					newSrc = src.LocationSolved
+				}
+				if dst.LocationSolved != nil {
+					newDst = dst.LocationSolved
+				} else {
+					newDst = &ApplicationWebhookTemplate_Message{}
+					dst.LocationSolved = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -440,11 +472,11 @@ func (dst *ApplicationWebhook) SetFields(src *ApplicationWebhook, paths ...strin
 		switch name {
 		case "ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationWebhookIdentifiers
-				var newSrc *ApplicationWebhookIdentifiers
+				var newDst, newSrc *ApplicationWebhookIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationWebhookIdentifiers
 				}
+				newDst = &dst.ApplicationWebhookIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -507,14 +539,18 @@ func (dst *ApplicationWebhook) SetFields(src *ApplicationWebhook, paths ...strin
 			}
 		case "template_ids":
 			if len(subs) > 0 {
-				newDst := dst.ApplicationWebhookTemplateIdentifiers
-				if newDst == nil {
-					newDst = &ApplicationWebhookTemplateIdentifiers{}
-					dst.ApplicationWebhookTemplateIdentifiers = newDst
+				var newDst, newSrc *ApplicationWebhookTemplateIdentifiers
+				if (src == nil || src.ApplicationWebhookTemplateIdentifiers == nil) && dst.ApplicationWebhookTemplateIdentifiers == nil {
+					continue
 				}
-				var newSrc *ApplicationWebhookTemplateIdentifiers
 				if src != nil {
 					newSrc = src.ApplicationWebhookTemplateIdentifiers
+				}
+				if dst.ApplicationWebhookTemplateIdentifiers != nil {
+					newDst = dst.ApplicationWebhookTemplateIdentifiers
+				} else {
+					newDst = &ApplicationWebhookTemplateIdentifiers{}
+					dst.ApplicationWebhookTemplateIdentifiers = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -537,14 +573,18 @@ func (dst *ApplicationWebhook) SetFields(src *ApplicationWebhook, paths ...strin
 			}
 		case "uplink_message":
 			if len(subs) > 0 {
-				newDst := dst.UplinkMessage
-				if newDst == nil {
-					newDst = &ApplicationWebhook_Message{}
-					dst.UplinkMessage = newDst
+				var newDst, newSrc *ApplicationWebhook_Message
+				if (src == nil || src.UplinkMessage == nil) && dst.UplinkMessage == nil {
+					continue
 				}
-				var newSrc *ApplicationWebhook_Message
 				if src != nil {
 					newSrc = src.UplinkMessage
+				}
+				if dst.UplinkMessage != nil {
+					newDst = dst.UplinkMessage
+				} else {
+					newDst = &ApplicationWebhook_Message{}
+					dst.UplinkMessage = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -558,14 +598,18 @@ func (dst *ApplicationWebhook) SetFields(src *ApplicationWebhook, paths ...strin
 			}
 		case "join_accept":
 			if len(subs) > 0 {
-				newDst := dst.JoinAccept
-				if newDst == nil {
-					newDst = &ApplicationWebhook_Message{}
-					dst.JoinAccept = newDst
+				var newDst, newSrc *ApplicationWebhook_Message
+				if (src == nil || src.JoinAccept == nil) && dst.JoinAccept == nil {
+					continue
 				}
-				var newSrc *ApplicationWebhook_Message
 				if src != nil {
 					newSrc = src.JoinAccept
+				}
+				if dst.JoinAccept != nil {
+					newDst = dst.JoinAccept
+				} else {
+					newDst = &ApplicationWebhook_Message{}
+					dst.JoinAccept = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -579,14 +623,18 @@ func (dst *ApplicationWebhook) SetFields(src *ApplicationWebhook, paths ...strin
 			}
 		case "downlink_ack":
 			if len(subs) > 0 {
-				newDst := dst.DownlinkAck
-				if newDst == nil {
-					newDst = &ApplicationWebhook_Message{}
-					dst.DownlinkAck = newDst
+				var newDst, newSrc *ApplicationWebhook_Message
+				if (src == nil || src.DownlinkAck == nil) && dst.DownlinkAck == nil {
+					continue
 				}
-				var newSrc *ApplicationWebhook_Message
 				if src != nil {
 					newSrc = src.DownlinkAck
+				}
+				if dst.DownlinkAck != nil {
+					newDst = dst.DownlinkAck
+				} else {
+					newDst = &ApplicationWebhook_Message{}
+					dst.DownlinkAck = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -600,14 +648,18 @@ func (dst *ApplicationWebhook) SetFields(src *ApplicationWebhook, paths ...strin
 			}
 		case "downlink_nack":
 			if len(subs) > 0 {
-				newDst := dst.DownlinkNack
-				if newDst == nil {
-					newDst = &ApplicationWebhook_Message{}
-					dst.DownlinkNack = newDst
+				var newDst, newSrc *ApplicationWebhook_Message
+				if (src == nil || src.DownlinkNack == nil) && dst.DownlinkNack == nil {
+					continue
 				}
-				var newSrc *ApplicationWebhook_Message
 				if src != nil {
 					newSrc = src.DownlinkNack
+				}
+				if dst.DownlinkNack != nil {
+					newDst = dst.DownlinkNack
+				} else {
+					newDst = &ApplicationWebhook_Message{}
+					dst.DownlinkNack = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -621,14 +673,18 @@ func (dst *ApplicationWebhook) SetFields(src *ApplicationWebhook, paths ...strin
 			}
 		case "downlink_sent":
 			if len(subs) > 0 {
-				newDst := dst.DownlinkSent
-				if newDst == nil {
-					newDst = &ApplicationWebhook_Message{}
-					dst.DownlinkSent = newDst
+				var newDst, newSrc *ApplicationWebhook_Message
+				if (src == nil || src.DownlinkSent == nil) && dst.DownlinkSent == nil {
+					continue
 				}
-				var newSrc *ApplicationWebhook_Message
 				if src != nil {
 					newSrc = src.DownlinkSent
+				}
+				if dst.DownlinkSent != nil {
+					newDst = dst.DownlinkSent
+				} else {
+					newDst = &ApplicationWebhook_Message{}
+					dst.DownlinkSent = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -642,14 +698,18 @@ func (dst *ApplicationWebhook) SetFields(src *ApplicationWebhook, paths ...strin
 			}
 		case "downlink_failed":
 			if len(subs) > 0 {
-				newDst := dst.DownlinkFailed
-				if newDst == nil {
-					newDst = &ApplicationWebhook_Message{}
-					dst.DownlinkFailed = newDst
+				var newDst, newSrc *ApplicationWebhook_Message
+				if (src == nil || src.DownlinkFailed == nil) && dst.DownlinkFailed == nil {
+					continue
 				}
-				var newSrc *ApplicationWebhook_Message
 				if src != nil {
 					newSrc = src.DownlinkFailed
+				}
+				if dst.DownlinkFailed != nil {
+					newDst = dst.DownlinkFailed
+				} else {
+					newDst = &ApplicationWebhook_Message{}
+					dst.DownlinkFailed = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -663,14 +723,18 @@ func (dst *ApplicationWebhook) SetFields(src *ApplicationWebhook, paths ...strin
 			}
 		case "downlink_queued":
 			if len(subs) > 0 {
-				newDst := dst.DownlinkQueued
-				if newDst == nil {
-					newDst = &ApplicationWebhook_Message{}
-					dst.DownlinkQueued = newDst
+				var newDst, newSrc *ApplicationWebhook_Message
+				if (src == nil || src.DownlinkQueued == nil) && dst.DownlinkQueued == nil {
+					continue
 				}
-				var newSrc *ApplicationWebhook_Message
 				if src != nil {
 					newSrc = src.DownlinkQueued
+				}
+				if dst.DownlinkQueued != nil {
+					newDst = dst.DownlinkQueued
+				} else {
+					newDst = &ApplicationWebhook_Message{}
+					dst.DownlinkQueued = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -684,14 +748,18 @@ func (dst *ApplicationWebhook) SetFields(src *ApplicationWebhook, paths ...strin
 			}
 		case "location_solved":
 			if len(subs) > 0 {
-				newDst := dst.LocationSolved
-				if newDst == nil {
-					newDst = &ApplicationWebhook_Message{}
-					dst.LocationSolved = newDst
+				var newDst, newSrc *ApplicationWebhook_Message
+				if (src == nil || src.LocationSolved == nil) && dst.LocationSolved == nil {
+					continue
 				}
-				var newSrc *ApplicationWebhook_Message
 				if src != nil {
 					newSrc = src.LocationSolved
+				}
+				if dst.LocationSolved != nil {
+					newDst = dst.LocationSolved
+				} else {
+					newDst = &ApplicationWebhook_Message{}
+					dst.LocationSolved = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -756,11 +824,11 @@ func (dst *GetApplicationWebhookRequest) SetFields(src *GetApplicationWebhookReq
 		switch name {
 		case "ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationWebhookIdentifiers
-				var newSrc *ApplicationWebhookIdentifiers
+				var newDst, newSrc *ApplicationWebhookIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationWebhookIdentifiers
 				}
+				newDst = &dst.ApplicationWebhookIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -795,11 +863,11 @@ func (dst *ListApplicationWebhooksRequest) SetFields(src *ListApplicationWebhook
 		switch name {
 		case "application_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationIdentifiers
-				var newSrc *ApplicationIdentifiers
+				var newDst, newSrc *ApplicationIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationIdentifiers
 				}
+				newDst = &dst.ApplicationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -834,11 +902,11 @@ func (dst *SetApplicationWebhookRequest) SetFields(src *SetApplicationWebhookReq
 		switch name {
 		case "webhook":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationWebhook
-				var newSrc *ApplicationWebhook
+				var newDst, newSrc *ApplicationWebhook
 				if src != nil {
 					newSrc = &src.ApplicationWebhook
 				}
+				newDst = &dst.ApplicationWebhook
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -873,11 +941,11 @@ func (dst *GetApplicationWebhookTemplateRequest) SetFields(src *GetApplicationWe
 		switch name {
 		case "ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationWebhookTemplateIdentifiers
-				var newSrc *ApplicationWebhookTemplateIdentifiers
+				var newDst, newSrc *ApplicationWebhookTemplateIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationWebhookTemplateIdentifiers
 				}
+				newDst = &dst.ApplicationWebhookTemplateIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}

--- a/pkg/ttnpb/client.pb.setters.fm.go
+++ b/pkg/ttnpb/client.pb.setters.fm.go
@@ -14,11 +14,11 @@ func (dst *Client) SetFields(src *Client, paths ...string) error {
 		switch name {
 		case "ids":
 			if len(subs) > 0 {
-				newDst := &dst.ClientIdentifiers
-				var newSrc *ClientIdentifiers
+				var newDst, newSrc *ClientIdentifiers
 				if src != nil {
 					newSrc = &src.ClientIdentifiers
 				}
+				newDst = &dst.ClientIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -188,11 +188,11 @@ func (dst *GetClientRequest) SetFields(src *GetClientRequest, paths ...string) e
 		switch name {
 		case "client_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ClientIdentifiers
-				var newSrc *ClientIdentifiers
+				var newDst, newSrc *ClientIdentifiers
 				if src != nil {
 					newSrc = &src.ClientIdentifiers
 				}
+				newDst = &dst.ClientIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -227,14 +227,18 @@ func (dst *ListClientsRequest) SetFields(src *ListClientsRequest, paths ...strin
 		switch name {
 		case "collaborator":
 			if len(subs) > 0 {
-				newDst := dst.Collaborator
-				if newDst == nil {
-					newDst = &OrganizationOrUserIdentifiers{}
-					dst.Collaborator = newDst
+				var newDst, newSrc *OrganizationOrUserIdentifiers
+				if (src == nil || src.Collaborator == nil) && dst.Collaborator == nil {
+					continue
 				}
-				var newSrc *OrganizationOrUserIdentifiers
 				if src != nil {
 					newSrc = src.Collaborator
+				}
+				if dst.Collaborator != nil {
+					newDst = dst.Collaborator
+				} else {
+					newDst = &OrganizationOrUserIdentifiers{}
+					dst.Collaborator = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -299,11 +303,11 @@ func (dst *CreateClientRequest) SetFields(src *CreateClientRequest, paths ...str
 		switch name {
 		case "client":
 			if len(subs) > 0 {
-				newDst := &dst.Client
-				var newSrc *Client
+				var newDst, newSrc *Client
 				if src != nil {
 					newSrc = &src.Client
 				}
+				newDst = &dst.Client
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -317,11 +321,11 @@ func (dst *CreateClientRequest) SetFields(src *CreateClientRequest, paths ...str
 			}
 		case "collaborator":
 			if len(subs) > 0 {
-				newDst := &dst.Collaborator
-				var newSrc *OrganizationOrUserIdentifiers
+				var newDst, newSrc *OrganizationOrUserIdentifiers
 				if src != nil {
 					newSrc = &src.Collaborator
 				}
+				newDst = &dst.Collaborator
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -346,11 +350,11 @@ func (dst *UpdateClientRequest) SetFields(src *UpdateClientRequest, paths ...str
 		switch name {
 		case "client":
 			if len(subs) > 0 {
-				newDst := &dst.Client
-				var newSrc *Client
+				var newDst, newSrc *Client
 				if src != nil {
 					newSrc = &src.Client
 				}
+				newDst = &dst.Client
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -385,11 +389,11 @@ func (dst *ListClientCollaboratorsRequest) SetFields(src *ListClientCollaborator
 		switch name {
 		case "client_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ClientIdentifiers
-				var newSrc *ClientIdentifiers
+				var newDst, newSrc *ClientIdentifiers
 				if src != nil {
 					newSrc = &src.ClientIdentifiers
 				}
+				newDst = &dst.ClientIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -434,11 +438,11 @@ func (dst *GetClientCollaboratorRequest) SetFields(src *GetClientCollaboratorReq
 		switch name {
 		case "client_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ClientIdentifiers
-				var newSrc *ClientIdentifiers
+				var newDst, newSrc *ClientIdentifiers
 				if src != nil {
 					newSrc = &src.ClientIdentifiers
 				}
+				newDst = &dst.ClientIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -452,11 +456,11 @@ func (dst *GetClientCollaboratorRequest) SetFields(src *GetClientCollaboratorReq
 			}
 		case "collaborator":
 			if len(subs) > 0 {
-				newDst := &dst.OrganizationOrUserIdentifiers
-				var newSrc *OrganizationOrUserIdentifiers
+				var newDst, newSrc *OrganizationOrUserIdentifiers
 				if src != nil {
 					newSrc = &src.OrganizationOrUserIdentifiers
 				}
+				newDst = &dst.OrganizationOrUserIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -481,11 +485,11 @@ func (dst *SetClientCollaboratorRequest) SetFields(src *SetClientCollaboratorReq
 		switch name {
 		case "client_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ClientIdentifiers
-				var newSrc *ClientIdentifiers
+				var newDst, newSrc *ClientIdentifiers
 				if src != nil {
 					newSrc = &src.ClientIdentifiers
 				}
+				newDst = &dst.ClientIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -499,11 +503,11 @@ func (dst *SetClientCollaboratorRequest) SetFields(src *SetClientCollaboratorReq
 			}
 		case "collaborator":
 			if len(subs) > 0 {
-				newDst := &dst.Collaborator
-				var newSrc *Collaborator
+				var newDst, newSrc *Collaborator
 				if src != nil {
 					newSrc = &src.Collaborator
 				}
+				newDst = &dst.Collaborator
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}

--- a/pkg/ttnpb/contact_info.pb.setters.fm.go
+++ b/pkg/ttnpb/contact_info.pb.setters.fm.go
@@ -89,14 +89,18 @@ func (dst *ContactInfoValidation) SetFields(src *ContactInfoValidation, paths ..
 			}
 		case "entity":
 			if len(subs) > 0 {
-				newDst := dst.Entity
-				if newDst == nil {
-					newDst = &EntityIdentifiers{}
-					dst.Entity = newDst
+				var newDst, newSrc *EntityIdentifiers
+				if (src == nil || src.Entity == nil) && dst.Entity == nil {
+					continue
 				}
-				var newSrc *EntityIdentifiers
 				if src != nil {
 					newSrc = src.Entity
+				}
+				if dst.Entity != nil {
+					newDst = dst.Entity
+				} else {
+					newDst = &EntityIdentifiers{}
+					dst.Entity = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err

--- a/pkg/ttnpb/deviceclaimingserver.pb.setters.fm.go
+++ b/pkg/ttnpb/deviceclaimingserver.pb.setters.fm.go
@@ -13,11 +13,11 @@ func (dst *ClaimEndDeviceRequest) SetFields(src *ClaimEndDeviceRequest, paths ..
 		switch name {
 		case "target_application_ids":
 			if len(subs) > 0 {
-				newDst := &dst.TargetApplicationIDs
-				var newSrc *ApplicationIdentifiers
+				var newDst, newSrc *ApplicationIdentifiers
 				if src != nil {
 					newSrc = &src.TargetApplicationIDs
 				}
+				newDst = &dst.TargetApplicationIDs
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -125,40 +125,54 @@ func (dst *ClaimEndDeviceRequest) SetFields(src *ClaimEndDeviceRequest, paths ..
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "authenticated_identifiers":
-					if _, ok := dst.SourceDevice.(*ClaimEndDeviceRequest_AuthenticatedIdentifiers_); !ok {
-						dst.SourceDevice = &ClaimEndDeviceRequest_AuthenticatedIdentifiers_{}
+					_, srcOk := src.SourceDevice.(*ClaimEndDeviceRequest_AuthenticatedIdentifiers_)
+					if !srcOk && src.SourceDevice != nil {
+						return fmt.Errorf("attempt to set oneof 'authenticated_identifiers', while different oneof is set in source")
+					}
+					_, dstOk := dst.SourceDevice.(*ClaimEndDeviceRequest_AuthenticatedIdentifiers_)
+					if !dstOk && dst.SourceDevice != nil {
+						return fmt.Errorf("attempt to set oneof 'authenticated_identifiers', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.SourceDevice.(*ClaimEndDeviceRequest_AuthenticatedIdentifiers_).AuthenticatedIdentifiers
-						if newDst == nil {
-							newDst = &ClaimEndDeviceRequest_AuthenticatedIdentifiers{}
-							dst.SourceDevice.(*ClaimEndDeviceRequest_AuthenticatedIdentifiers_).AuthenticatedIdentifiers = newDst
+						var newDst, newSrc *ClaimEndDeviceRequest_AuthenticatedIdentifiers
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *ClaimEndDeviceRequest_AuthenticatedIdentifiers
-						if src != nil {
-							newSrc = src.GetAuthenticatedIdentifiers()
+						if srcOk {
+							newSrc = src.SourceDevice.(*ClaimEndDeviceRequest_AuthenticatedIdentifiers_).AuthenticatedIdentifiers
+						}
+						if dstOk {
+							newDst = dst.SourceDevice.(*ClaimEndDeviceRequest_AuthenticatedIdentifiers_).AuthenticatedIdentifiers
+						} else {
+							newDst = &ClaimEndDeviceRequest_AuthenticatedIdentifiers{}
+							dst.SourceDevice = &ClaimEndDeviceRequest_AuthenticatedIdentifiers_{AuthenticatedIdentifiers: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.SourceDevice.(*ClaimEndDeviceRequest_AuthenticatedIdentifiers_).AuthenticatedIdentifiers = src.GetAuthenticatedIdentifiers()
+							dst.SourceDevice = src.SourceDevice
 						} else {
-							dst.SourceDevice.(*ClaimEndDeviceRequest_AuthenticatedIdentifiers_).AuthenticatedIdentifiers = nil
+							dst.SourceDevice = nil
 						}
 					}
 				case "qr_code":
-					if _, ok := dst.SourceDevice.(*ClaimEndDeviceRequest_QRCode); !ok {
-						dst.SourceDevice = &ClaimEndDeviceRequest_QRCode{}
+					_, srcOk := src.SourceDevice.(*ClaimEndDeviceRequest_QRCode)
+					if !srcOk && src.SourceDevice != nil {
+						return fmt.Errorf("attempt to set oneof 'qr_code', while different oneof is set in source")
+					}
+					_, dstOk := dst.SourceDevice.(*ClaimEndDeviceRequest_QRCode)
+					if !dstOk && dst.SourceDevice != nil {
+						return fmt.Errorf("attempt to set oneof 'qr_code', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						return fmt.Errorf("'qr_code' has no subfields, but %s were specified", oneofSubs)
 					}
 					if src != nil {
-						dst.SourceDevice.(*ClaimEndDeviceRequest_QRCode).QRCode = src.GetQRCode()
+						dst.SourceDevice = src.SourceDevice
 					} else {
-						dst.SourceDevice.(*ClaimEndDeviceRequest_QRCode).QRCode = nil
+						dst.SourceDevice = nil
 					}
 
 				default:
@@ -178,11 +192,11 @@ func (dst *AuthorizeApplicationRequest) SetFields(src *AuthorizeApplicationReque
 		switch name {
 		case "application_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationIdentifiers
-				var newSrc *ApplicationIdentifiers
+				var newDst, newSrc *ApplicationIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationIdentifiers
 				}
+				newDst = &dst.ApplicationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}

--- a/pkg/ttnpb/end_device.pb.setters.fm.go
+++ b/pkg/ttnpb/end_device.pb.setters.fm.go
@@ -25,11 +25,11 @@ func (dst *Session) SetFields(src *Session, paths ...string) error {
 			}
 		case "keys":
 			if len(subs) > 0 {
-				newDst := &dst.SessionKeys
-				var newSrc *SessionKeys
+				var newDst, newSrc *SessionKeys
 				if src != nil {
 					newSrc = &src.SessionKeys
 				}
+				newDst = &dst.SessionKeys
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -291,14 +291,18 @@ func (dst *MACParameters) SetFields(src *MACParameters, paths ...string) error {
 			}
 		case "adr_ack_limit_exponent":
 			if len(subs) > 0 {
-				newDst := dst.ADRAckLimitExponent
-				if newDst == nil {
-					newDst = &ADRAckLimitExponentValue{}
-					dst.ADRAckLimitExponent = newDst
+				var newDst, newSrc *ADRAckLimitExponentValue
+				if (src == nil || src.ADRAckLimitExponent == nil) && dst.ADRAckLimitExponent == nil {
+					continue
 				}
-				var newSrc *ADRAckLimitExponentValue
 				if src != nil {
 					newSrc = src.ADRAckLimitExponent
+				}
+				if dst.ADRAckLimitExponent != nil {
+					newDst = dst.ADRAckLimitExponent
+				} else {
+					newDst = &ADRAckLimitExponentValue{}
+					dst.ADRAckLimitExponent = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -312,14 +316,18 @@ func (dst *MACParameters) SetFields(src *MACParameters, paths ...string) error {
 			}
 		case "adr_ack_delay_exponent":
 			if len(subs) > 0 {
-				newDst := dst.ADRAckDelayExponent
-				if newDst == nil {
-					newDst = &ADRAckDelayExponentValue{}
-					dst.ADRAckDelayExponent = newDst
+				var newDst, newSrc *ADRAckDelayExponentValue
+				if (src == nil || src.ADRAckDelayExponent == nil) && dst.ADRAckDelayExponent == nil {
+					continue
 				}
-				var newSrc *ADRAckDelayExponentValue
 				if src != nil {
 					newSrc = src.ADRAckDelayExponent
+				}
+				if dst.ADRAckDelayExponent != nil {
+					newDst = dst.ADRAckDelayExponent
+				} else {
+					newDst = &ADRAckDelayExponentValue{}
+					dst.ADRAckDelayExponent = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -486,11 +494,11 @@ func (dst *EndDeviceVersion) SetFields(src *EndDeviceVersion, paths ...string) e
 		switch name {
 		case "ids":
 			if len(subs) > 0 {
-				newDst := &dst.EndDeviceVersionIdentifiers
-				var newSrc *EndDeviceVersionIdentifiers
+				var newDst, newSrc *EndDeviceVersionIdentifiers
 				if src != nil {
 					newSrc = &src.EndDeviceVersionIdentifiers
 				}
+				newDst = &dst.EndDeviceVersionIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -563,14 +571,18 @@ func (dst *EndDeviceVersion) SetFields(src *EndDeviceVersion, paths ...string) e
 			}
 		case "default_mac_settings":
 			if len(subs) > 0 {
-				newDst := dst.DefaultMACSettings
-				if newDst == nil {
-					newDst = &MACSettings{}
-					dst.DefaultMACSettings = newDst
+				var newDst, newSrc *MACSettings
+				if (src == nil || src.DefaultMACSettings == nil) && dst.DefaultMACSettings == nil {
+					continue
 				}
-				var newSrc *MACSettings
 				if src != nil {
 					newSrc = src.DefaultMACSettings
+				}
+				if dst.DefaultMACSettings != nil {
+					newDst = dst.DefaultMACSettings
+				} else {
+					newDst = &MACSettings{}
+					dst.DefaultMACSettings = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -624,11 +636,11 @@ func (dst *EndDeviceVersion) SetFields(src *EndDeviceVersion, paths ...string) e
 			}
 		case "default_formatters":
 			if len(subs) > 0 {
-				newDst := &dst.DefaultFormatters
-				var newSrc *MessagePayloadFormatters
+				var newDst, newSrc *MessagePayloadFormatters
 				if src != nil {
 					newSrc = &src.DefaultFormatters
 				}
+				newDst = &dst.DefaultFormatters
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -662,14 +674,18 @@ func (dst *MACSettings) SetFields(src *MACSettings, paths ...string) error {
 			}
 		case "ping_slot_periodicity":
 			if len(subs) > 0 {
-				newDst := dst.PingSlotPeriodicity
-				if newDst == nil {
-					newDst = &PingSlotPeriodValue{}
-					dst.PingSlotPeriodicity = newDst
+				var newDst, newSrc *PingSlotPeriodValue
+				if (src == nil || src.PingSlotPeriodicity == nil) && dst.PingSlotPeriodicity == nil {
+					continue
 				}
-				var newSrc *PingSlotPeriodValue
 				if src != nil {
 					newSrc = src.PingSlotPeriodicity
+				}
+				if dst.PingSlotPeriodicity != nil {
+					newDst = dst.PingSlotPeriodicity
+				} else {
+					newDst = &PingSlotPeriodValue{}
+					dst.PingSlotPeriodicity = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -683,14 +699,18 @@ func (dst *MACSettings) SetFields(src *MACSettings, paths ...string) error {
 			}
 		case "ping_slot_data_rate_index":
 			if len(subs) > 0 {
-				newDst := dst.PingSlotDataRateIndex
-				if newDst == nil {
-					newDst = &DataRateIndexValue{}
-					dst.PingSlotDataRateIndex = newDst
+				var newDst, newSrc *DataRateIndexValue
+				if (src == nil || src.PingSlotDataRateIndex == nil) && dst.PingSlotDataRateIndex == nil {
+					continue
 				}
-				var newSrc *DataRateIndexValue
 				if src != nil {
 					newSrc = src.PingSlotDataRateIndex
+				}
+				if dst.PingSlotDataRateIndex != nil {
+					newDst = dst.PingSlotDataRateIndex
+				} else {
+					newDst = &DataRateIndexValue{}
+					dst.PingSlotDataRateIndex = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -722,14 +742,18 @@ func (dst *MACSettings) SetFields(src *MACSettings, paths ...string) error {
 			}
 		case "rx1_delay":
 			if len(subs) > 0 {
-				newDst := dst.Rx1Delay
-				if newDst == nil {
-					newDst = &RxDelayValue{}
-					dst.Rx1Delay = newDst
+				var newDst, newSrc *RxDelayValue
+				if (src == nil || src.Rx1Delay == nil) && dst.Rx1Delay == nil {
+					continue
 				}
-				var newSrc *RxDelayValue
 				if src != nil {
 					newSrc = src.Rx1Delay
+				}
+				if dst.Rx1Delay != nil {
+					newDst = dst.Rx1Delay
+				} else {
+					newDst = &RxDelayValue{}
+					dst.Rx1Delay = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -752,14 +776,18 @@ func (dst *MACSettings) SetFields(src *MACSettings, paths ...string) error {
 			}
 		case "rx2_data_rate_index":
 			if len(subs) > 0 {
-				newDst := dst.Rx2DataRateIndex
-				if newDst == nil {
-					newDst = &DataRateIndexValue{}
-					dst.Rx2DataRateIndex = newDst
+				var newDst, newSrc *DataRateIndexValue
+				if (src == nil || src.Rx2DataRateIndex == nil) && dst.Rx2DataRateIndex == nil {
+					continue
 				}
-				var newSrc *DataRateIndexValue
 				if src != nil {
 					newSrc = src.Rx2DataRateIndex
+				}
+				if dst.Rx2DataRateIndex != nil {
+					newDst = dst.Rx2DataRateIndex
+				} else {
+					newDst = &DataRateIndexValue{}
+					dst.Rx2DataRateIndex = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -791,14 +819,18 @@ func (dst *MACSettings) SetFields(src *MACSettings, paths ...string) error {
 			}
 		case "max_duty_cycle":
 			if len(subs) > 0 {
-				newDst := dst.MaxDutyCycle
-				if newDst == nil {
-					newDst = &AggregatedDutyCycleValue{}
-					dst.MaxDutyCycle = newDst
+				var newDst, newSrc *AggregatedDutyCycleValue
+				if (src == nil || src.MaxDutyCycle == nil) && dst.MaxDutyCycle == nil {
+					continue
 				}
-				var newSrc *AggregatedDutyCycleValue
 				if src != nil {
 					newSrc = src.MaxDutyCycle
+				}
+				if dst.MaxDutyCycle != nil {
+					newDst = dst.MaxDutyCycle
+				} else {
+					newDst = &AggregatedDutyCycleValue{}
+					dst.MaxDutyCycle = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -866,14 +898,18 @@ func (dst *MACSettings) SetFields(src *MACSettings, paths ...string) error {
 			}
 		case "desired_rx1_delay":
 			if len(subs) > 0 {
-				newDst := dst.DesiredRx1Delay
-				if newDst == nil {
-					newDst = &RxDelayValue{}
-					dst.DesiredRx1Delay = newDst
+				var newDst, newSrc *RxDelayValue
+				if (src == nil || src.DesiredRx1Delay == nil) && dst.DesiredRx1Delay == nil {
+					continue
 				}
-				var newSrc *RxDelayValue
 				if src != nil {
 					newSrc = src.DesiredRx1Delay
+				}
+				if dst.DesiredRx1Delay != nil {
+					newDst = dst.DesiredRx1Delay
+				} else {
+					newDst = &RxDelayValue{}
+					dst.DesiredRx1Delay = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -896,14 +932,18 @@ func (dst *MACSettings) SetFields(src *MACSettings, paths ...string) error {
 			}
 		case "desired_rx2_data_rate_index":
 			if len(subs) > 0 {
-				newDst := dst.DesiredRx2DataRateIndex
-				if newDst == nil {
-					newDst = &DataRateIndexValue{}
-					dst.DesiredRx2DataRateIndex = newDst
+				var newDst, newSrc *DataRateIndexValue
+				if (src == nil || src.DesiredRx2DataRateIndex == nil) && dst.DesiredRx2DataRateIndex == nil {
+					continue
 				}
-				var newSrc *DataRateIndexValue
 				if src != nil {
 					newSrc = src.DesiredRx2DataRateIndex
+				}
+				if dst.DesiredRx2DataRateIndex != nil {
+					newDst = dst.DesiredRx2DataRateIndex
+				} else {
+					newDst = &DataRateIndexValue{}
+					dst.DesiredRx2DataRateIndex = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -926,14 +966,18 @@ func (dst *MACSettings) SetFields(src *MACSettings, paths ...string) error {
 			}
 		case "desired_max_duty_cycle":
 			if len(subs) > 0 {
-				newDst := dst.DesiredMaxDutyCycle
-				if newDst == nil {
-					newDst = &AggregatedDutyCycleValue{}
-					dst.DesiredMaxDutyCycle = newDst
+				var newDst, newSrc *AggregatedDutyCycleValue
+				if (src == nil || src.DesiredMaxDutyCycle == nil) && dst.DesiredMaxDutyCycle == nil {
+					continue
 				}
-				var newSrc *AggregatedDutyCycleValue
 				if src != nil {
 					newSrc = src.DesiredMaxDutyCycle
+				}
+				if dst.DesiredMaxDutyCycle != nil {
+					newDst = dst.DesiredMaxDutyCycle
+				} else {
+					newDst = &AggregatedDutyCycleValue{}
+					dst.DesiredMaxDutyCycle = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -947,14 +991,18 @@ func (dst *MACSettings) SetFields(src *MACSettings, paths ...string) error {
 			}
 		case "desired_adr_ack_limit_exponent":
 			if len(subs) > 0 {
-				newDst := dst.DesiredADRAckLimitExponent
-				if newDst == nil {
-					newDst = &ADRAckLimitExponentValue{}
-					dst.DesiredADRAckLimitExponent = newDst
+				var newDst, newSrc *ADRAckLimitExponentValue
+				if (src == nil || src.DesiredADRAckLimitExponent == nil) && dst.DesiredADRAckLimitExponent == nil {
+					continue
 				}
-				var newSrc *ADRAckLimitExponentValue
 				if src != nil {
 					newSrc = src.DesiredADRAckLimitExponent
+				}
+				if dst.DesiredADRAckLimitExponent != nil {
+					newDst = dst.DesiredADRAckLimitExponent
+				} else {
+					newDst = &ADRAckLimitExponentValue{}
+					dst.DesiredADRAckLimitExponent = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -968,14 +1016,18 @@ func (dst *MACSettings) SetFields(src *MACSettings, paths ...string) error {
 			}
 		case "desired_adr_ack_delay_exponent":
 			if len(subs) > 0 {
-				newDst := dst.DesiredADRAckDelayExponent
-				if newDst == nil {
-					newDst = &ADRAckDelayExponentValue{}
-					dst.DesiredADRAckDelayExponent = newDst
+				var newDst, newSrc *ADRAckDelayExponentValue
+				if (src == nil || src.DesiredADRAckDelayExponent == nil) && dst.DesiredADRAckDelayExponent == nil {
+					continue
 				}
-				var newSrc *ADRAckDelayExponentValue
 				if src != nil {
 					newSrc = src.DesiredADRAckDelayExponent
+				}
+				if dst.DesiredADRAckDelayExponent != nil {
+					newDst = dst.DesiredADRAckDelayExponent
+				} else {
+					newDst = &ADRAckDelayExponentValue{}
+					dst.DesiredADRAckDelayExponent = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -1000,11 +1052,11 @@ func (dst *MACState) SetFields(src *MACState, paths ...string) error {
 		switch name {
 		case "current_parameters":
 			if len(subs) > 0 {
-				newDst := &dst.CurrentParameters
-				var newSrc *MACParameters
+				var newDst, newSrc *MACParameters
 				if src != nil {
 					newSrc = &src.CurrentParameters
 				}
+				newDst = &dst.CurrentParameters
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -1018,11 +1070,11 @@ func (dst *MACState) SetFields(src *MACState, paths ...string) error {
 			}
 		case "desired_parameters":
 			if len(subs) > 0 {
-				newDst := &dst.DesiredParameters
-				var newSrc *MACParameters
+				var newDst, newSrc *MACParameters
 				if src != nil {
 					newSrc = &src.DesiredParameters
 				}
+				newDst = &dst.DesiredParameters
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -1085,14 +1137,18 @@ func (dst *MACState) SetFields(src *MACState, paths ...string) error {
 			}
 		case "pending_application_downlink":
 			if len(subs) > 0 {
-				newDst := dst.PendingApplicationDownlink
-				if newDst == nil {
-					newDst = &ApplicationDownlink{}
-					dst.PendingApplicationDownlink = newDst
+				var newDst, newSrc *ApplicationDownlink
+				if (src == nil || src.PendingApplicationDownlink == nil) && dst.PendingApplicationDownlink == nil {
+					continue
 				}
-				var newSrc *ApplicationDownlink
 				if src != nil {
 					newSrc = src.PendingApplicationDownlink
+				}
+				if dst.PendingApplicationDownlink != nil {
+					newDst = dst.PendingApplicationDownlink
+				} else {
+					newDst = &ApplicationDownlink{}
+					dst.PendingApplicationDownlink = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -1124,14 +1180,18 @@ func (dst *MACState) SetFields(src *MACState, paths ...string) error {
 			}
 		case "queued_join_accept":
 			if len(subs) > 0 {
-				newDst := dst.QueuedJoinAccept
-				if newDst == nil {
-					newDst = &MACState_JoinAccept{}
-					dst.QueuedJoinAccept = newDst
+				var newDst, newSrc *MACState_JoinAccept
+				if (src == nil || src.QueuedJoinAccept == nil) && dst.QueuedJoinAccept == nil {
+					continue
 				}
-				var newSrc *MACState_JoinAccept
 				if src != nil {
 					newSrc = src.QueuedJoinAccept
+				}
+				if dst.QueuedJoinAccept != nil {
+					newDst = dst.QueuedJoinAccept
+				} else {
+					newDst = &MACState_JoinAccept{}
+					dst.QueuedJoinAccept = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -1145,14 +1205,18 @@ func (dst *MACState) SetFields(src *MACState, paths ...string) error {
 			}
 		case "pending_join_request":
 			if len(subs) > 0 {
-				newDst := dst.PendingJoinRequest
-				if newDst == nil {
-					newDst = &JoinRequest{}
-					dst.PendingJoinRequest = newDst
+				var newDst, newSrc *JoinRequest
+				if (src == nil || src.PendingJoinRequest == nil) && dst.PendingJoinRequest == nil {
+					continue
 				}
-				var newSrc *JoinRequest
 				if src != nil {
 					newSrc = src.PendingJoinRequest
+				}
+				if dst.PendingJoinRequest != nil {
+					newDst = dst.PendingJoinRequest
+				} else {
+					newDst = &JoinRequest{}
+					dst.PendingJoinRequest = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -1244,11 +1308,11 @@ func (dst *EndDevice) SetFields(src *EndDevice, paths ...string) error {
 		switch name {
 		case "ids":
 			if len(subs) > 0 {
-				newDst := &dst.EndDeviceIdentifiers
-				var newSrc *EndDeviceIdentifiers
+				var newDst, newSrc *EndDeviceIdentifiers
 				if src != nil {
 					newSrc = &src.EndDeviceIdentifiers
 				}
+				newDst = &dst.EndDeviceIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -1311,14 +1375,18 @@ func (dst *EndDevice) SetFields(src *EndDevice, paths ...string) error {
 			}
 		case "version_ids":
 			if len(subs) > 0 {
-				newDst := dst.VersionIDs
-				if newDst == nil {
-					newDst = &EndDeviceVersionIdentifiers{}
-					dst.VersionIDs = newDst
+				var newDst, newSrc *EndDeviceVersionIdentifiers
+				if (src == nil || src.VersionIDs == nil) && dst.VersionIDs == nil {
+					continue
 				}
-				var newSrc *EndDeviceVersionIdentifiers
 				if src != nil {
 					newSrc = src.VersionIDs
+				}
+				if dst.VersionIDs != nil {
+					newDst = dst.VersionIDs
+				} else {
+					newDst = &EndDeviceVersionIdentifiers{}
+					dst.VersionIDs = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -1411,14 +1479,18 @@ func (dst *EndDevice) SetFields(src *EndDevice, paths ...string) error {
 			}
 		case "picture":
 			if len(subs) > 0 {
-				newDst := dst.Picture
-				if newDst == nil {
-					newDst = &Picture{}
-					dst.Picture = newDst
+				var newDst, newSrc *Picture
+				if (src == nil || src.Picture == nil) && dst.Picture == nil {
+					continue
 				}
-				var newSrc *Picture
 				if src != nil {
 					newSrc = src.Picture
+				}
+				if dst.Picture != nil {
+					newDst = dst.Picture
+				} else {
+					newDst = &Picture{}
+					dst.Picture = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -1522,14 +1594,18 @@ func (dst *EndDevice) SetFields(src *EndDevice, paths ...string) error {
 			}
 		case "root_keys":
 			if len(subs) > 0 {
-				newDst := dst.RootKeys
-				if newDst == nil {
-					newDst = &RootKeys{}
-					dst.RootKeys = newDst
+				var newDst, newSrc *RootKeys
+				if (src == nil || src.RootKeys == nil) && dst.RootKeys == nil {
+					continue
 				}
-				var newSrc *RootKeys
 				if src != nil {
 					newSrc = src.RootKeys
+				}
+				if dst.RootKeys != nil {
+					newDst = dst.RootKeys
+				} else {
+					newDst = &RootKeys{}
+					dst.RootKeys = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -1552,14 +1628,18 @@ func (dst *EndDevice) SetFields(src *EndDevice, paths ...string) error {
 			}
 		case "mac_settings":
 			if len(subs) > 0 {
-				newDst := dst.MACSettings
-				if newDst == nil {
-					newDst = &MACSettings{}
-					dst.MACSettings = newDst
+				var newDst, newSrc *MACSettings
+				if (src == nil || src.MACSettings == nil) && dst.MACSettings == nil {
+					continue
 				}
-				var newSrc *MACSettings
 				if src != nil {
 					newSrc = src.MACSettings
+				}
+				if dst.MACSettings != nil {
+					newDst = dst.MACSettings
+				} else {
+					newDst = &MACSettings{}
+					dst.MACSettings = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -1573,14 +1653,18 @@ func (dst *EndDevice) SetFields(src *EndDevice, paths ...string) error {
 			}
 		case "mac_state":
 			if len(subs) > 0 {
-				newDst := dst.MACState
-				if newDst == nil {
-					newDst = &MACState{}
-					dst.MACState = newDst
+				var newDst, newSrc *MACState
+				if (src == nil || src.MACState == nil) && dst.MACState == nil {
+					continue
 				}
-				var newSrc *MACState
 				if src != nil {
 					newSrc = src.MACState
+				}
+				if dst.MACState != nil {
+					newDst = dst.MACState
+				} else {
+					newDst = &MACState{}
+					dst.MACState = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -1594,14 +1678,18 @@ func (dst *EndDevice) SetFields(src *EndDevice, paths ...string) error {
 			}
 		case "pending_mac_state":
 			if len(subs) > 0 {
-				newDst := dst.PendingMACState
-				if newDst == nil {
-					newDst = &MACState{}
-					dst.PendingMACState = newDst
+				var newDst, newSrc *MACState
+				if (src == nil || src.PendingMACState == nil) && dst.PendingMACState == nil {
+					continue
 				}
-				var newSrc *MACState
 				if src != nil {
 					newSrc = src.PendingMACState
+				}
+				if dst.PendingMACState != nil {
+					newDst = dst.PendingMACState
+				} else {
+					newDst = &MACState{}
+					dst.PendingMACState = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -1615,14 +1703,18 @@ func (dst *EndDevice) SetFields(src *EndDevice, paths ...string) error {
 			}
 		case "session":
 			if len(subs) > 0 {
-				newDst := dst.Session
-				if newDst == nil {
-					newDst = &Session{}
-					dst.Session = newDst
+				var newDst, newSrc *Session
+				if (src == nil || src.Session == nil) && dst.Session == nil {
+					continue
 				}
-				var newSrc *Session
 				if src != nil {
 					newSrc = src.Session
+				}
+				if dst.Session != nil {
+					newDst = dst.Session
+				} else {
+					newDst = &Session{}
+					dst.Session = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -1636,14 +1728,18 @@ func (dst *EndDevice) SetFields(src *EndDevice, paths ...string) error {
 			}
 		case "pending_session":
 			if len(subs) > 0 {
-				newDst := dst.PendingSession
-				if newDst == nil {
-					newDst = &Session{}
-					dst.PendingSession = newDst
+				var newDst, newSrc *Session
+				if (src == nil || src.PendingSession == nil) && dst.PendingSession == nil {
+					continue
 				}
-				var newSrc *Session
 				if src != nil {
 					newSrc = src.PendingSession
+				}
+				if dst.PendingSession != nil {
+					newDst = dst.PendingSession
+				} else {
+					newDst = &Session{}
+					dst.PendingSession = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -1780,14 +1876,18 @@ func (dst *EndDevice) SetFields(src *EndDevice, paths ...string) error {
 			}
 		case "formatters":
 			if len(subs) > 0 {
-				newDst := dst.Formatters
-				if newDst == nil {
-					newDst = &MessagePayloadFormatters{}
-					dst.Formatters = newDst
+				var newDst, newSrc *MessagePayloadFormatters
+				if (src == nil || src.Formatters == nil) && dst.Formatters == nil {
+					continue
 				}
-				var newSrc *MessagePayloadFormatters
 				if src != nil {
 					newSrc = src.Formatters
+				}
+				if dst.Formatters != nil {
+					newDst = dst.Formatters
+				} else {
+					newDst = &MessagePayloadFormatters{}
+					dst.Formatters = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -1830,14 +1930,18 @@ func (dst *EndDevice) SetFields(src *EndDevice, paths ...string) error {
 			}
 		case "claim_authentication_code":
 			if len(subs) > 0 {
-				newDst := dst.ClaimAuthenticationCode
-				if newDst == nil {
-					newDst = &EndDeviceAuthenticationCode{}
-					dst.ClaimAuthenticationCode = newDst
+				var newDst, newSrc *EndDeviceAuthenticationCode
+				if (src == nil || src.ClaimAuthenticationCode == nil) && dst.ClaimAuthenticationCode == nil {
+					continue
 				}
-				var newSrc *EndDeviceAuthenticationCode
 				if src != nil {
 					newSrc = src.ClaimAuthenticationCode
+				}
+				if dst.ClaimAuthenticationCode != nil {
+					newDst = dst.ClaimAuthenticationCode
+				} else {
+					newDst = &EndDeviceAuthenticationCode{}
+					dst.ClaimAuthenticationCode = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -1882,11 +1986,11 @@ func (dst *CreateEndDeviceRequest) SetFields(src *CreateEndDeviceRequest, paths 
 		switch name {
 		case "end_device":
 			if len(subs) > 0 {
-				newDst := &dst.EndDevice
-				var newSrc *EndDevice
+				var newDst, newSrc *EndDevice
 				if src != nil {
 					newSrc = &src.EndDevice
 				}
+				newDst = &dst.EndDevice
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -1911,11 +2015,11 @@ func (dst *UpdateEndDeviceRequest) SetFields(src *UpdateEndDeviceRequest, paths 
 		switch name {
 		case "end_device":
 			if len(subs) > 0 {
-				newDst := &dst.EndDevice
-				var newSrc *EndDevice
+				var newDst, newSrc *EndDevice
 				if src != nil {
 					newSrc = &src.EndDevice
 				}
+				newDst = &dst.EndDevice
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -1950,11 +2054,11 @@ func (dst *GetEndDeviceRequest) SetFields(src *GetEndDeviceRequest, paths ...str
 		switch name {
 		case "end_device_ids":
 			if len(subs) > 0 {
-				newDst := &dst.EndDeviceIdentifiers
-				var newSrc *EndDeviceIdentifiers
+				var newDst, newSrc *EndDeviceIdentifiers
 				if src != nil {
 					newSrc = &src.EndDeviceIdentifiers
 				}
+				newDst = &dst.EndDeviceIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -2020,11 +2124,11 @@ func (dst *ListEndDevicesRequest) SetFields(src *ListEndDevicesRequest, paths ..
 		switch name {
 		case "application_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationIdentifiers
-				var newSrc *ApplicationIdentifiers
+				var newDst, newSrc *ApplicationIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationIdentifiers
 				}
+				newDst = &dst.ApplicationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -2089,11 +2193,11 @@ func (dst *SetEndDeviceRequest) SetFields(src *SetEndDeviceRequest, paths ...str
 		switch name {
 		case "end_device":
 			if len(subs) > 0 {
-				newDst := &dst.EndDevice
-				var newSrc *EndDevice
+				var newDst, newSrc *EndDevice
 				if src != nil {
 					newSrc = &src.EndDevice
 				}
+				newDst = &dst.EndDevice
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -2128,11 +2232,11 @@ func (dst *EndDeviceTemplate) SetFields(src *EndDeviceTemplate, paths ...string)
 		switch name {
 		case "end_device":
 			if len(subs) > 0 {
-				newDst := &dst.EndDevice
-				var newSrc *EndDevice
+				var newDst, newSrc *EndDevice
 				if src != nil {
 					newSrc = &src.EndDevice
 				}
+				newDst = &dst.EndDevice
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -2337,11 +2441,11 @@ func (dst *MACState_JoinAccept) SetFields(src *MACState_JoinAccept, paths ...str
 			}
 		case "request":
 			if len(subs) > 0 {
-				newDst := &dst.Request
-				var newSrc *JoinRequest
+				var newDst, newSrc *JoinRequest
 				if src != nil {
 					newSrc = &src.Request
 				}
+				newDst = &dst.Request
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -2355,11 +2459,11 @@ func (dst *MACState_JoinAccept) SetFields(src *MACState_JoinAccept, paths ...str
 			}
 		case "keys":
 			if len(subs) > 0 {
-				newDst := &dst.Keys
-				var newSrc *SessionKeys
+				var newDst, newSrc *SessionKeys
 				if src != nil {
 					newSrc = &src.Keys
 				}
+				newDst = &dst.Keys
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}

--- a/pkg/ttnpb/error.pb.setters.fm.go
+++ b/pkg/ttnpb/error.pb.setters.fm.go
@@ -58,14 +58,18 @@ func (dst *ErrorDetails) SetFields(src *ErrorDetails, paths ...string) error {
 			}
 		case "cause":
 			if len(subs) > 0 {
-				newDst := dst.Cause
-				if newDst == nil {
-					newDst = &ErrorDetails{}
-					dst.Cause = newDst
+				var newDst, newSrc *ErrorDetails
+				if (src == nil || src.Cause == nil) && dst.Cause == nil {
+					continue
 				}
-				var newSrc *ErrorDetails
 				if src != nil {
 					newSrc = src.Cause
+				}
+				if dst.Cause != nil {
+					newDst = dst.Cause
+				} else {
+					newDst = &ErrorDetails{}
+					dst.Cause = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err

--- a/pkg/ttnpb/events.pb.setters.fm.go
+++ b/pkg/ttnpb/events.pb.setters.fm.go
@@ -78,14 +78,18 @@ func (dst *Event) SetFields(src *Event, paths ...string) error {
 			}
 		case "visibility":
 			if len(subs) > 0 {
-				newDst := dst.Visibility
-				if newDst == nil {
-					newDst = &Rights{}
-					dst.Visibility = newDst
+				var newDst, newSrc *Rights
+				if (src == nil || src.Visibility == nil) && dst.Visibility == nil {
+					continue
 				}
-				var newSrc *Rights
 				if src != nil {
 					newSrc = src.Visibility
+				}
+				if dst.Visibility != nil {
+					newDst = dst.Visibility
+				} else {
+					newDst = &Rights{}
+					dst.Visibility = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err

--- a/pkg/ttnpb/gateway.pb.setters.fm.go
+++ b/pkg/ttnpb/gateway.pb.setters.fm.go
@@ -197,14 +197,18 @@ func (dst *GatewayRadio) SetFields(src *GatewayRadio, paths ...string) error {
 			}
 		case "tx_configuration":
 			if len(subs) > 0 {
-				newDst := dst.TxConfiguration
-				if newDst == nil {
-					newDst = &GatewayRadio_TxConfiguration{}
-					dst.TxConfiguration = newDst
+				var newDst, newSrc *GatewayRadio_TxConfiguration
+				if (src == nil || src.TxConfiguration == nil) && dst.TxConfiguration == nil {
+					continue
 				}
-				var newSrc *GatewayRadio_TxConfiguration
 				if src != nil {
 					newSrc = src.TxConfiguration
+				}
+				if dst.TxConfiguration != nil {
+					newDst = dst.TxConfiguration
+				} else {
+					newDst = &GatewayRadio_TxConfiguration{}
+					dst.TxConfiguration = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -229,11 +233,11 @@ func (dst *GatewayVersion) SetFields(src *GatewayVersion, paths ...string) error
 		switch name {
 		case "ids":
 			if len(subs) > 0 {
-				newDst := &dst.GatewayVersionIdentifiers
-				var newSrc *GatewayVersionIdentifiers
+				var newDst, newSrc *GatewayVersionIdentifiers
 				if src != nil {
 					newSrc = &src.GatewayVersionIdentifiers
 				}
+				newDst = &dst.GatewayVersionIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -286,11 +290,11 @@ func (dst *Gateway) SetFields(src *Gateway, paths ...string) error {
 		switch name {
 		case "ids":
 			if len(subs) > 0 {
-				newDst := &dst.GatewayIdentifiers
-				var newSrc *GatewayIdentifiers
+				var newDst, newSrc *GatewayIdentifiers
 				if src != nil {
 					newSrc = &src.GatewayIdentifiers
 				}
+				newDst = &dst.GatewayIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -362,11 +366,11 @@ func (dst *Gateway) SetFields(src *Gateway, paths ...string) error {
 			}
 		case "version_ids":
 			if len(subs) > 0 {
-				newDst := &dst.GatewayVersionIdentifiers
-				var newSrc *GatewayVersionIdentifiers
+				var newDst, newSrc *GatewayVersionIdentifiers
 				if src != nil {
 					newSrc = &src.GatewayVersionIdentifiers
 				}
+				newDst = &dst.GatewayVersionIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -510,11 +514,11 @@ func (dst *GetGatewayRequest) SetFields(src *GetGatewayRequest, paths ...string)
 		switch name {
 		case "gateway_ids":
 			if len(subs) > 0 {
-				newDst := &dst.GatewayIdentifiers
-				var newSrc *GatewayIdentifiers
+				var newDst, newSrc *GatewayIdentifiers
 				if src != nil {
 					newSrc = &src.GatewayIdentifiers
 				}
+				newDst = &dst.GatewayIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -570,14 +574,18 @@ func (dst *ListGatewaysRequest) SetFields(src *ListGatewaysRequest, paths ...str
 		switch name {
 		case "collaborator":
 			if len(subs) > 0 {
-				newDst := dst.Collaborator
-				if newDst == nil {
-					newDst = &OrganizationOrUserIdentifiers{}
-					dst.Collaborator = newDst
+				var newDst, newSrc *OrganizationOrUserIdentifiers
+				if (src == nil || src.Collaborator == nil) && dst.Collaborator == nil {
+					continue
 				}
-				var newSrc *OrganizationOrUserIdentifiers
 				if src != nil {
 					newSrc = src.Collaborator
+				}
+				if dst.Collaborator != nil {
+					newDst = dst.Collaborator
+				} else {
+					newDst = &OrganizationOrUserIdentifiers{}
+					dst.Collaborator = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -642,11 +650,11 @@ func (dst *CreateGatewayRequest) SetFields(src *CreateGatewayRequest, paths ...s
 		switch name {
 		case "gateway":
 			if len(subs) > 0 {
-				newDst := &dst.Gateway
-				var newSrc *Gateway
+				var newDst, newSrc *Gateway
 				if src != nil {
 					newSrc = &src.Gateway
 				}
+				newDst = &dst.Gateway
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -660,11 +668,11 @@ func (dst *CreateGatewayRequest) SetFields(src *CreateGatewayRequest, paths ...s
 			}
 		case "collaborator":
 			if len(subs) > 0 {
-				newDst := &dst.Collaborator
-				var newSrc *OrganizationOrUserIdentifiers
+				var newDst, newSrc *OrganizationOrUserIdentifiers
 				if src != nil {
 					newSrc = &src.Collaborator
 				}
+				newDst = &dst.Collaborator
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -689,11 +697,11 @@ func (dst *UpdateGatewayRequest) SetFields(src *UpdateGatewayRequest, paths ...s
 		switch name {
 		case "gateway":
 			if len(subs) > 0 {
-				newDst := &dst.Gateway
-				var newSrc *Gateway
+				var newDst, newSrc *Gateway
 				if src != nil {
 					newSrc = &src.Gateway
 				}
+				newDst = &dst.Gateway
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -728,11 +736,11 @@ func (dst *ListGatewayAPIKeysRequest) SetFields(src *ListGatewayAPIKeysRequest, 
 		switch name {
 		case "gateway_ids":
 			if len(subs) > 0 {
-				newDst := &dst.GatewayIdentifiers
-				var newSrc *GatewayIdentifiers
+				var newDst, newSrc *GatewayIdentifiers
 				if src != nil {
 					newSrc = &src.GatewayIdentifiers
 				}
+				newDst = &dst.GatewayIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -777,11 +785,11 @@ func (dst *GetGatewayAPIKeyRequest) SetFields(src *GetGatewayAPIKeyRequest, path
 		switch name {
 		case "gateway_ids":
 			if len(subs) > 0 {
-				newDst := &dst.GatewayIdentifiers
-				var newSrc *GatewayIdentifiers
+				var newDst, newSrc *GatewayIdentifiers
 				if src != nil {
 					newSrc = &src.GatewayIdentifiers
 				}
+				newDst = &dst.GatewayIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -816,11 +824,11 @@ func (dst *CreateGatewayAPIKeyRequest) SetFields(src *CreateGatewayAPIKeyRequest
 		switch name {
 		case "gateway_ids":
 			if len(subs) > 0 {
-				newDst := &dst.GatewayIdentifiers
-				var newSrc *GatewayIdentifiers
+				var newDst, newSrc *GatewayIdentifiers
 				if src != nil {
 					newSrc = &src.GatewayIdentifiers
 				}
+				newDst = &dst.GatewayIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -864,11 +872,11 @@ func (dst *UpdateGatewayAPIKeyRequest) SetFields(src *UpdateGatewayAPIKeyRequest
 		switch name {
 		case "gateway_ids":
 			if len(subs) > 0 {
-				newDst := &dst.GatewayIdentifiers
-				var newSrc *GatewayIdentifiers
+				var newDst, newSrc *GatewayIdentifiers
 				if src != nil {
 					newSrc = &src.GatewayIdentifiers
 				}
+				newDst = &dst.GatewayIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -882,11 +890,11 @@ func (dst *UpdateGatewayAPIKeyRequest) SetFields(src *UpdateGatewayAPIKeyRequest
 			}
 		case "api_key":
 			if len(subs) > 0 {
-				newDst := &dst.APIKey
-				var newSrc *APIKey
+				var newDst, newSrc *APIKey
 				if src != nil {
 					newSrc = &src.APIKey
 				}
+				newDst = &dst.APIKey
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -911,11 +919,11 @@ func (dst *ListGatewayCollaboratorsRequest) SetFields(src *ListGatewayCollaborat
 		switch name {
 		case "gateway_ids":
 			if len(subs) > 0 {
-				newDst := &dst.GatewayIdentifiers
-				var newSrc *GatewayIdentifiers
+				var newDst, newSrc *GatewayIdentifiers
 				if src != nil {
 					newSrc = &src.GatewayIdentifiers
 				}
+				newDst = &dst.GatewayIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -960,11 +968,11 @@ func (dst *GetGatewayCollaboratorRequest) SetFields(src *GetGatewayCollaboratorR
 		switch name {
 		case "gateway_ids":
 			if len(subs) > 0 {
-				newDst := &dst.GatewayIdentifiers
-				var newSrc *GatewayIdentifiers
+				var newDst, newSrc *GatewayIdentifiers
 				if src != nil {
 					newSrc = &src.GatewayIdentifiers
 				}
+				newDst = &dst.GatewayIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -978,11 +986,11 @@ func (dst *GetGatewayCollaboratorRequest) SetFields(src *GetGatewayCollaboratorR
 			}
 		case "collaborator":
 			if len(subs) > 0 {
-				newDst := &dst.OrganizationOrUserIdentifiers
-				var newSrc *OrganizationOrUserIdentifiers
+				var newDst, newSrc *OrganizationOrUserIdentifiers
 				if src != nil {
 					newSrc = &src.OrganizationOrUserIdentifiers
 				}
+				newDst = &dst.OrganizationOrUserIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -1007,11 +1015,11 @@ func (dst *SetGatewayCollaboratorRequest) SetFields(src *SetGatewayCollaboratorR
 		switch name {
 		case "gateway_ids":
 			if len(subs) > 0 {
-				newDst := &dst.GatewayIdentifiers
-				var newSrc *GatewayIdentifiers
+				var newDst, newSrc *GatewayIdentifiers
 				if src != nil {
 					newSrc = &src.GatewayIdentifiers
 				}
+				newDst = &dst.GatewayIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -1025,11 +1033,11 @@ func (dst *SetGatewayCollaboratorRequest) SetFields(src *SetGatewayCollaboratorR
 			}
 		case "collaborator":
 			if len(subs) > 0 {
-				newDst := &dst.Collaborator
-				var newSrc *Collaborator
+				var newDst, newSrc *Collaborator
 				if src != nil {
 					newSrc = &src.Collaborator
 				}
+				newDst = &dst.Collaborator
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -1064,11 +1072,11 @@ func (dst *GatewayAntenna) SetFields(src *GatewayAntenna, paths ...string) error
 			}
 		case "location":
 			if len(subs) > 0 {
-				newDst := &dst.Location
-				var newSrc *Location
+				var newDst, newSrc *Location
 				if src != nil {
 					newSrc = &src.Location
 				}
+				newDst = &dst.Location
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -1206,14 +1214,18 @@ func (dst *GatewayConnectionStats) SetFields(src *GatewayConnectionStats, paths 
 			}
 		case "last_status":
 			if len(subs) > 0 {
-				newDst := dst.LastStatus
-				if newDst == nil {
-					newDst = &GatewayStatus{}
-					dst.LastStatus = newDst
+				var newDst, newSrc *GatewayStatus
+				if (src == nil || src.LastStatus == nil) && dst.LastStatus == nil {
+					continue
 				}
-				var newSrc *GatewayStatus
 				if src != nil {
 					newSrc = src.LastStatus
+				}
+				if dst.LastStatus != nil {
+					newDst = dst.LastStatus
+				} else {
+					newDst = &GatewayStatus{}
+					dst.LastStatus = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -1265,14 +1277,18 @@ func (dst *GatewayConnectionStats) SetFields(src *GatewayConnectionStats, paths 
 			}
 		case "round_trip_times":
 			if len(subs) > 0 {
-				newDst := dst.RoundTripTimes
-				if newDst == nil {
-					newDst = &GatewayConnectionStats_RoundTripTimes{}
-					dst.RoundTripTimes = newDst
+				var newDst, newSrc *GatewayConnectionStats_RoundTripTimes
+				if (src == nil || src.RoundTripTimes == nil) && dst.RoundTripTimes == nil {
+					continue
 				}
-				var newSrc *GatewayConnectionStats_RoundTripTimes
 				if src != nil {
 					newSrc = src.RoundTripTimes
+				}
+				if dst.RoundTripTimes != nil {
+					newDst = dst.RoundTripTimes
+				} else {
+					newDst = &GatewayConnectionStats_RoundTripTimes{}
+					dst.RoundTripTimes = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err

--- a/pkg/ttnpb/gateway_services.pb.setters.fm.go
+++ b/pkg/ttnpb/gateway_services.pb.setters.fm.go
@@ -13,11 +13,11 @@ func (dst *PullGatewayConfigurationRequest) SetFields(src *PullGatewayConfigurat
 		switch name {
 		case "gateway_ids":
 			if len(subs) > 0 {
-				newDst := &dst.GatewayIdentifiers
-				var newSrc *GatewayIdentifiers
+				var newDst, newSrc *GatewayIdentifiers
 				if src != nil {
 					newSrc = &src.GatewayIdentifiers
 				}
+				newDst = &dst.GatewayIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}

--- a/pkg/ttnpb/gatewayserver.pb.setters.fm.go
+++ b/pkg/ttnpb/gatewayserver.pb.setters.fm.go
@@ -21,14 +21,18 @@ func (dst *GatewayUp) SetFields(src *GatewayUp, paths ...string) error {
 			}
 		case "gateway_status":
 			if len(subs) > 0 {
-				newDst := dst.GatewayStatus
-				if newDst == nil {
-					newDst = &GatewayStatus{}
-					dst.GatewayStatus = newDst
+				var newDst, newSrc *GatewayStatus
+				if (src == nil || src.GatewayStatus == nil) && dst.GatewayStatus == nil {
+					continue
 				}
-				var newSrc *GatewayStatus
 				if src != nil {
 					newSrc = src.GatewayStatus
+				}
+				if dst.GatewayStatus != nil {
+					newDst = dst.GatewayStatus
+				} else {
+					newDst = &GatewayStatus{}
+					dst.GatewayStatus = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -42,14 +46,18 @@ func (dst *GatewayUp) SetFields(src *GatewayUp, paths ...string) error {
 			}
 		case "tx_acknowledgment":
 			if len(subs) > 0 {
-				newDst := dst.TxAcknowledgment
-				if newDst == nil {
-					newDst = &TxAcknowledgment{}
-					dst.TxAcknowledgment = newDst
+				var newDst, newSrc *TxAcknowledgment
+				if (src == nil || src.TxAcknowledgment == nil) && dst.TxAcknowledgment == nil {
+					continue
 				}
-				var newSrc *TxAcknowledgment
 				if src != nil {
 					newSrc = src.TxAcknowledgment
+				}
+				if dst.TxAcknowledgment != nil {
+					newDst = dst.TxAcknowledgment
+				} else {
+					newDst = &TxAcknowledgment{}
+					dst.TxAcknowledgment = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -74,14 +82,18 @@ func (dst *GatewayDown) SetFields(src *GatewayDown, paths ...string) error {
 		switch name {
 		case "downlink_message":
 			if len(subs) > 0 {
-				newDst := dst.DownlinkMessage
-				if newDst == nil {
-					newDst = &DownlinkMessage{}
-					dst.DownlinkMessage = newDst
+				var newDst, newSrc *DownlinkMessage
+				if (src == nil || src.DownlinkMessage == nil) && dst.DownlinkMessage == nil {
+					continue
 				}
-				var newSrc *DownlinkMessage
 				if src != nil {
 					newSrc = src.DownlinkMessage
+				}
+				if dst.DownlinkMessage != nil {
+					newDst = dst.DownlinkMessage
+				} else {
+					newDst = &DownlinkMessage{}
+					dst.DownlinkMessage = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err

--- a/pkg/ttnpb/identifiers.pb.setters.fm.go
+++ b/pkg/ttnpb/identifiers.pb.setters.fm.go
@@ -61,11 +61,11 @@ func (dst *EndDeviceIdentifiers) SetFields(src *EndDeviceIdentifiers, paths ...s
 			}
 		case "application_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationIdentifiers
-				var newSrc *ApplicationIdentifiers
+				var newDst, newSrc *ApplicationIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationIdentifiers
 				}
+				newDst = &dst.ApplicationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -214,51 +214,69 @@ func (dst *OrganizationOrUserIdentifiers) SetFields(src *OrganizationOrUserIdent
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "organization_ids":
-					if _, ok := dst.Ids.(*OrganizationOrUserIdentifiers_OrganizationIDs); !ok {
-						dst.Ids = &OrganizationOrUserIdentifiers_OrganizationIDs{}
+					_, srcOk := src.Ids.(*OrganizationOrUserIdentifiers_OrganizationIDs)
+					if !srcOk && src.Ids != nil {
+						return fmt.Errorf("attempt to set oneof 'organization_ids', while different oneof is set in source")
+					}
+					_, dstOk := dst.Ids.(*OrganizationOrUserIdentifiers_OrganizationIDs)
+					if !dstOk && dst.Ids != nil {
+						return fmt.Errorf("attempt to set oneof 'organization_ids', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Ids.(*OrganizationOrUserIdentifiers_OrganizationIDs).OrganizationIDs
-						if newDst == nil {
-							newDst = &OrganizationIdentifiers{}
-							dst.Ids.(*OrganizationOrUserIdentifiers_OrganizationIDs).OrganizationIDs = newDst
+						var newDst, newSrc *OrganizationIdentifiers
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *OrganizationIdentifiers
-						if src != nil {
-							newSrc = src.GetOrganizationIDs()
+						if srcOk {
+							newSrc = src.Ids.(*OrganizationOrUserIdentifiers_OrganizationIDs).OrganizationIDs
+						}
+						if dstOk {
+							newDst = dst.Ids.(*OrganizationOrUserIdentifiers_OrganizationIDs).OrganizationIDs
+						} else {
+							newDst = &OrganizationIdentifiers{}
+							dst.Ids = &OrganizationOrUserIdentifiers_OrganizationIDs{OrganizationIDs: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Ids.(*OrganizationOrUserIdentifiers_OrganizationIDs).OrganizationIDs = src.GetOrganizationIDs()
+							dst.Ids = src.Ids
 						} else {
-							dst.Ids.(*OrganizationOrUserIdentifiers_OrganizationIDs).OrganizationIDs = nil
+							dst.Ids = nil
 						}
 					}
 				case "user_ids":
-					if _, ok := dst.Ids.(*OrganizationOrUserIdentifiers_UserIDs); !ok {
-						dst.Ids = &OrganizationOrUserIdentifiers_UserIDs{}
+					_, srcOk := src.Ids.(*OrganizationOrUserIdentifiers_UserIDs)
+					if !srcOk && src.Ids != nil {
+						return fmt.Errorf("attempt to set oneof 'user_ids', while different oneof is set in source")
+					}
+					_, dstOk := dst.Ids.(*OrganizationOrUserIdentifiers_UserIDs)
+					if !dstOk && dst.Ids != nil {
+						return fmt.Errorf("attempt to set oneof 'user_ids', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Ids.(*OrganizationOrUserIdentifiers_UserIDs).UserIDs
-						if newDst == nil {
-							newDst = &UserIdentifiers{}
-							dst.Ids.(*OrganizationOrUserIdentifiers_UserIDs).UserIDs = newDst
+						var newDst, newSrc *UserIdentifiers
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *UserIdentifiers
-						if src != nil {
-							newSrc = src.GetUserIDs()
+						if srcOk {
+							newSrc = src.Ids.(*OrganizationOrUserIdentifiers_UserIDs).UserIDs
+						}
+						if dstOk {
+							newDst = dst.Ids.(*OrganizationOrUserIdentifiers_UserIDs).UserIDs
+						} else {
+							newDst = &UserIdentifiers{}
+							dst.Ids = &OrganizationOrUserIdentifiers_UserIDs{UserIDs: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Ids.(*OrganizationOrUserIdentifiers_UserIDs).UserIDs = src.GetUserIDs()
+							dst.Ids = src.Ids
 						} else {
-							dst.Ids.(*OrganizationOrUserIdentifiers_UserIDs).UserIDs = nil
+							dst.Ids = nil
 						}
 					}
 
@@ -294,147 +312,201 @@ func (dst *EntityIdentifiers) SetFields(src *EntityIdentifiers, paths ...string)
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "application_ids":
-					if _, ok := dst.Ids.(*EntityIdentifiers_ApplicationIDs); !ok {
-						dst.Ids = &EntityIdentifiers_ApplicationIDs{}
+					_, srcOk := src.Ids.(*EntityIdentifiers_ApplicationIDs)
+					if !srcOk && src.Ids != nil {
+						return fmt.Errorf("attempt to set oneof 'application_ids', while different oneof is set in source")
+					}
+					_, dstOk := dst.Ids.(*EntityIdentifiers_ApplicationIDs)
+					if !dstOk && dst.Ids != nil {
+						return fmt.Errorf("attempt to set oneof 'application_ids', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Ids.(*EntityIdentifiers_ApplicationIDs).ApplicationIDs
-						if newDst == nil {
-							newDst = &ApplicationIdentifiers{}
-							dst.Ids.(*EntityIdentifiers_ApplicationIDs).ApplicationIDs = newDst
+						var newDst, newSrc *ApplicationIdentifiers
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *ApplicationIdentifiers
-						if src != nil {
-							newSrc = src.GetApplicationIDs()
+						if srcOk {
+							newSrc = src.Ids.(*EntityIdentifiers_ApplicationIDs).ApplicationIDs
+						}
+						if dstOk {
+							newDst = dst.Ids.(*EntityIdentifiers_ApplicationIDs).ApplicationIDs
+						} else {
+							newDst = &ApplicationIdentifiers{}
+							dst.Ids = &EntityIdentifiers_ApplicationIDs{ApplicationIDs: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Ids.(*EntityIdentifiers_ApplicationIDs).ApplicationIDs = src.GetApplicationIDs()
+							dst.Ids = src.Ids
 						} else {
-							dst.Ids.(*EntityIdentifiers_ApplicationIDs).ApplicationIDs = nil
+							dst.Ids = nil
 						}
 					}
 				case "client_ids":
-					if _, ok := dst.Ids.(*EntityIdentifiers_ClientIDs); !ok {
-						dst.Ids = &EntityIdentifiers_ClientIDs{}
+					_, srcOk := src.Ids.(*EntityIdentifiers_ClientIDs)
+					if !srcOk && src.Ids != nil {
+						return fmt.Errorf("attempt to set oneof 'client_ids', while different oneof is set in source")
+					}
+					_, dstOk := dst.Ids.(*EntityIdentifiers_ClientIDs)
+					if !dstOk && dst.Ids != nil {
+						return fmt.Errorf("attempt to set oneof 'client_ids', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Ids.(*EntityIdentifiers_ClientIDs).ClientIDs
-						if newDst == nil {
-							newDst = &ClientIdentifiers{}
-							dst.Ids.(*EntityIdentifiers_ClientIDs).ClientIDs = newDst
+						var newDst, newSrc *ClientIdentifiers
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *ClientIdentifiers
-						if src != nil {
-							newSrc = src.GetClientIDs()
+						if srcOk {
+							newSrc = src.Ids.(*EntityIdentifiers_ClientIDs).ClientIDs
+						}
+						if dstOk {
+							newDst = dst.Ids.(*EntityIdentifiers_ClientIDs).ClientIDs
+						} else {
+							newDst = &ClientIdentifiers{}
+							dst.Ids = &EntityIdentifiers_ClientIDs{ClientIDs: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Ids.(*EntityIdentifiers_ClientIDs).ClientIDs = src.GetClientIDs()
+							dst.Ids = src.Ids
 						} else {
-							dst.Ids.(*EntityIdentifiers_ClientIDs).ClientIDs = nil
+							dst.Ids = nil
 						}
 					}
 				case "device_ids":
-					if _, ok := dst.Ids.(*EntityIdentifiers_DeviceIDs); !ok {
-						dst.Ids = &EntityIdentifiers_DeviceIDs{}
+					_, srcOk := src.Ids.(*EntityIdentifiers_DeviceIDs)
+					if !srcOk && src.Ids != nil {
+						return fmt.Errorf("attempt to set oneof 'device_ids', while different oneof is set in source")
+					}
+					_, dstOk := dst.Ids.(*EntityIdentifiers_DeviceIDs)
+					if !dstOk && dst.Ids != nil {
+						return fmt.Errorf("attempt to set oneof 'device_ids', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Ids.(*EntityIdentifiers_DeviceIDs).DeviceIDs
-						if newDst == nil {
-							newDst = &EndDeviceIdentifiers{}
-							dst.Ids.(*EntityIdentifiers_DeviceIDs).DeviceIDs = newDst
+						var newDst, newSrc *EndDeviceIdentifiers
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *EndDeviceIdentifiers
-						if src != nil {
-							newSrc = src.GetDeviceIDs()
+						if srcOk {
+							newSrc = src.Ids.(*EntityIdentifiers_DeviceIDs).DeviceIDs
+						}
+						if dstOk {
+							newDst = dst.Ids.(*EntityIdentifiers_DeviceIDs).DeviceIDs
+						} else {
+							newDst = &EndDeviceIdentifiers{}
+							dst.Ids = &EntityIdentifiers_DeviceIDs{DeviceIDs: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Ids.(*EntityIdentifiers_DeviceIDs).DeviceIDs = src.GetDeviceIDs()
+							dst.Ids = src.Ids
 						} else {
-							dst.Ids.(*EntityIdentifiers_DeviceIDs).DeviceIDs = nil
+							dst.Ids = nil
 						}
 					}
 				case "gateway_ids":
-					if _, ok := dst.Ids.(*EntityIdentifiers_GatewayIDs); !ok {
-						dst.Ids = &EntityIdentifiers_GatewayIDs{}
+					_, srcOk := src.Ids.(*EntityIdentifiers_GatewayIDs)
+					if !srcOk && src.Ids != nil {
+						return fmt.Errorf("attempt to set oneof 'gateway_ids', while different oneof is set in source")
+					}
+					_, dstOk := dst.Ids.(*EntityIdentifiers_GatewayIDs)
+					if !dstOk && dst.Ids != nil {
+						return fmt.Errorf("attempt to set oneof 'gateway_ids', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Ids.(*EntityIdentifiers_GatewayIDs).GatewayIDs
-						if newDst == nil {
-							newDst = &GatewayIdentifiers{}
-							dst.Ids.(*EntityIdentifiers_GatewayIDs).GatewayIDs = newDst
+						var newDst, newSrc *GatewayIdentifiers
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *GatewayIdentifiers
-						if src != nil {
-							newSrc = src.GetGatewayIDs()
+						if srcOk {
+							newSrc = src.Ids.(*EntityIdentifiers_GatewayIDs).GatewayIDs
+						}
+						if dstOk {
+							newDst = dst.Ids.(*EntityIdentifiers_GatewayIDs).GatewayIDs
+						} else {
+							newDst = &GatewayIdentifiers{}
+							dst.Ids = &EntityIdentifiers_GatewayIDs{GatewayIDs: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Ids.(*EntityIdentifiers_GatewayIDs).GatewayIDs = src.GetGatewayIDs()
+							dst.Ids = src.Ids
 						} else {
-							dst.Ids.(*EntityIdentifiers_GatewayIDs).GatewayIDs = nil
+							dst.Ids = nil
 						}
 					}
 				case "organization_ids":
-					if _, ok := dst.Ids.(*EntityIdentifiers_OrganizationIDs); !ok {
-						dst.Ids = &EntityIdentifiers_OrganizationIDs{}
+					_, srcOk := src.Ids.(*EntityIdentifiers_OrganizationIDs)
+					if !srcOk && src.Ids != nil {
+						return fmt.Errorf("attempt to set oneof 'organization_ids', while different oneof is set in source")
+					}
+					_, dstOk := dst.Ids.(*EntityIdentifiers_OrganizationIDs)
+					if !dstOk && dst.Ids != nil {
+						return fmt.Errorf("attempt to set oneof 'organization_ids', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Ids.(*EntityIdentifiers_OrganizationIDs).OrganizationIDs
-						if newDst == nil {
-							newDst = &OrganizationIdentifiers{}
-							dst.Ids.(*EntityIdentifiers_OrganizationIDs).OrganizationIDs = newDst
+						var newDst, newSrc *OrganizationIdentifiers
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *OrganizationIdentifiers
-						if src != nil {
-							newSrc = src.GetOrganizationIDs()
+						if srcOk {
+							newSrc = src.Ids.(*EntityIdentifiers_OrganizationIDs).OrganizationIDs
+						}
+						if dstOk {
+							newDst = dst.Ids.(*EntityIdentifiers_OrganizationIDs).OrganizationIDs
+						} else {
+							newDst = &OrganizationIdentifiers{}
+							dst.Ids = &EntityIdentifiers_OrganizationIDs{OrganizationIDs: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Ids.(*EntityIdentifiers_OrganizationIDs).OrganizationIDs = src.GetOrganizationIDs()
+							dst.Ids = src.Ids
 						} else {
-							dst.Ids.(*EntityIdentifiers_OrganizationIDs).OrganizationIDs = nil
+							dst.Ids = nil
 						}
 					}
 				case "user_ids":
-					if _, ok := dst.Ids.(*EntityIdentifiers_UserIDs); !ok {
-						dst.Ids = &EntityIdentifiers_UserIDs{}
+					_, srcOk := src.Ids.(*EntityIdentifiers_UserIDs)
+					if !srcOk && src.Ids != nil {
+						return fmt.Errorf("attempt to set oneof 'user_ids', while different oneof is set in source")
+					}
+					_, dstOk := dst.Ids.(*EntityIdentifiers_UserIDs)
+					if !dstOk && dst.Ids != nil {
+						return fmt.Errorf("attempt to set oneof 'user_ids', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Ids.(*EntityIdentifiers_UserIDs).UserIDs
-						if newDst == nil {
-							newDst = &UserIdentifiers{}
-							dst.Ids.(*EntityIdentifiers_UserIDs).UserIDs = newDst
+						var newDst, newSrc *UserIdentifiers
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *UserIdentifiers
-						if src != nil {
-							newSrc = src.GetUserIDs()
+						if srcOk {
+							newSrc = src.Ids.(*EntityIdentifiers_UserIDs).UserIDs
+						}
+						if dstOk {
+							newDst = dst.Ids.(*EntityIdentifiers_UserIDs).UserIDs
+						} else {
+							newDst = &UserIdentifiers{}
+							dst.Ids = &EntityIdentifiers_UserIDs{UserIDs: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Ids.(*EntityIdentifiers_UserIDs).UserIDs = src.GetUserIDs()
+							dst.Ids = src.Ids
 						} else {
-							dst.Ids.(*EntityIdentifiers_UserIDs).UserIDs = nil
+							dst.Ids = nil
 						}
 					}
 

--- a/pkg/ttnpb/identityserver.pb.setters.fm.go
+++ b/pkg/ttnpb/identityserver.pb.setters.fm.go
@@ -9,14 +9,18 @@ func (dst *AuthInfoResponse) SetFields(src *AuthInfoResponse, paths ...string) e
 		switch name {
 		case "universal_rights":
 			if len(subs) > 0 {
-				newDst := dst.UniversalRights
-				if newDst == nil {
-					newDst = &Rights{}
-					dst.UniversalRights = newDst
+				var newDst, newSrc *Rights
+				if (src == nil || src.UniversalRights == nil) && dst.UniversalRights == nil {
+					continue
 				}
-				var newSrc *Rights
 				if src != nil {
 					newSrc = src.UniversalRights
+				}
+				if dst.UniversalRights != nil {
+					newDst = dst.UniversalRights
+				} else {
+					newDst = &Rights{}
+					dst.UniversalRights = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -55,51 +59,69 @@ func (dst *AuthInfoResponse) SetFields(src *AuthInfoResponse, paths ...string) e
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "api_key":
-					if _, ok := dst.AccessMethod.(*AuthInfoResponse_APIKey); !ok {
-						dst.AccessMethod = &AuthInfoResponse_APIKey{}
+					_, srcOk := src.AccessMethod.(*AuthInfoResponse_APIKey)
+					if !srcOk && src.AccessMethod != nil {
+						return fmt.Errorf("attempt to set oneof 'api_key', while different oneof is set in source")
+					}
+					_, dstOk := dst.AccessMethod.(*AuthInfoResponse_APIKey)
+					if !dstOk && dst.AccessMethod != nil {
+						return fmt.Errorf("attempt to set oneof 'api_key', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.AccessMethod.(*AuthInfoResponse_APIKey).APIKey
-						if newDst == nil {
-							newDst = &AuthInfoResponse_APIKeyAccess{}
-							dst.AccessMethod.(*AuthInfoResponse_APIKey).APIKey = newDst
+						var newDst, newSrc *AuthInfoResponse_APIKeyAccess
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *AuthInfoResponse_APIKeyAccess
-						if src != nil {
-							newSrc = src.GetAPIKey()
+						if srcOk {
+							newSrc = src.AccessMethod.(*AuthInfoResponse_APIKey).APIKey
+						}
+						if dstOk {
+							newDst = dst.AccessMethod.(*AuthInfoResponse_APIKey).APIKey
+						} else {
+							newDst = &AuthInfoResponse_APIKeyAccess{}
+							dst.AccessMethod = &AuthInfoResponse_APIKey{APIKey: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.AccessMethod.(*AuthInfoResponse_APIKey).APIKey = src.GetAPIKey()
+							dst.AccessMethod = src.AccessMethod
 						} else {
-							dst.AccessMethod.(*AuthInfoResponse_APIKey).APIKey = nil
+							dst.AccessMethod = nil
 						}
 					}
 				case "oauth_access_token":
-					if _, ok := dst.AccessMethod.(*AuthInfoResponse_OAuthAccessToken); !ok {
-						dst.AccessMethod = &AuthInfoResponse_OAuthAccessToken{}
+					_, srcOk := src.AccessMethod.(*AuthInfoResponse_OAuthAccessToken)
+					if !srcOk && src.AccessMethod != nil {
+						return fmt.Errorf("attempt to set oneof 'oauth_access_token', while different oneof is set in source")
+					}
+					_, dstOk := dst.AccessMethod.(*AuthInfoResponse_OAuthAccessToken)
+					if !dstOk && dst.AccessMethod != nil {
+						return fmt.Errorf("attempt to set oneof 'oauth_access_token', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.AccessMethod.(*AuthInfoResponse_OAuthAccessToken).OAuthAccessToken
-						if newDst == nil {
-							newDst = &OAuthAccessToken{}
-							dst.AccessMethod.(*AuthInfoResponse_OAuthAccessToken).OAuthAccessToken = newDst
+						var newDst, newSrc *OAuthAccessToken
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *OAuthAccessToken
-						if src != nil {
-							newSrc = src.GetOAuthAccessToken()
+						if srcOk {
+							newSrc = src.AccessMethod.(*AuthInfoResponse_OAuthAccessToken).OAuthAccessToken
+						}
+						if dstOk {
+							newDst = dst.AccessMethod.(*AuthInfoResponse_OAuthAccessToken).OAuthAccessToken
+						} else {
+							newDst = &OAuthAccessToken{}
+							dst.AccessMethod = &AuthInfoResponse_OAuthAccessToken{OAuthAccessToken: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.AccessMethod.(*AuthInfoResponse_OAuthAccessToken).OAuthAccessToken = src.GetOAuthAccessToken()
+							dst.AccessMethod = src.AccessMethod
 						} else {
-							dst.AccessMethod.(*AuthInfoResponse_OAuthAccessToken).OAuthAccessToken = nil
+							dst.AccessMethod = nil
 						}
 					}
 
@@ -120,11 +142,11 @@ func (dst *AuthInfoResponse_APIKeyAccess) SetFields(src *AuthInfoResponse_APIKey
 		switch name {
 		case "api_key":
 			if len(subs) > 0 {
-				newDst := &dst.APIKey
-				var newSrc *APIKey
+				var newDst, newSrc *APIKey
 				if src != nil {
 					newSrc = &src.APIKey
 				}
+				newDst = &dst.APIKey
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -138,11 +160,11 @@ func (dst *AuthInfoResponse_APIKeyAccess) SetFields(src *AuthInfoResponse_APIKey
 			}
 		case "entity_ids":
 			if len(subs) > 0 {
-				newDst := &dst.EntityIDs
-				var newSrc *EntityIdentifiers
+				var newDst, newSrc *EntityIdentifiers
 				if src != nil {
 					newSrc = &src.EntityIDs
 				}
+				newDst = &dst.EntityIDs
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}

--- a/pkg/ttnpb/join.pb.setters.fm.go
+++ b/pkg/ttnpb/join.pb.setters.fm.go
@@ -23,14 +23,18 @@ func (dst *JoinRequest) SetFields(src *JoinRequest, paths ...string) error {
 			}
 		case "payload":
 			if len(subs) > 0 {
-				newDst := dst.Payload
-				if newDst == nil {
-					newDst = &Message{}
-					dst.Payload = newDst
+				var newDst, newSrc *Message
+				if (src == nil || src.Payload == nil) && dst.Payload == nil {
+					continue
 				}
-				var newSrc *Message
 				if src != nil {
 					newSrc = src.Payload
+				}
+				if dst.Payload != nil {
+					newDst = dst.Payload
+				} else {
+					newDst = &Message{}
+					dst.Payload = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -74,11 +78,11 @@ func (dst *JoinRequest) SetFields(src *JoinRequest, paths ...string) error {
 			}
 		case "downlink_settings":
 			if len(subs) > 0 {
-				newDst := &dst.DownlinkSettings
-				var newSrc *DLSettings
+				var newDst, newSrc *DLSettings
 				if src != nil {
 					newSrc = &src.DownlinkSettings
 				}
+				newDst = &dst.DownlinkSettings
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -102,14 +106,18 @@ func (dst *JoinRequest) SetFields(src *JoinRequest, paths ...string) error {
 			}
 		case "cf_list":
 			if len(subs) > 0 {
-				newDst := dst.CFList
-				if newDst == nil {
-					newDst = &CFList{}
-					dst.CFList = newDst
+				var newDst, newSrc *CFList
+				if (src == nil || src.CFList == nil) && dst.CFList == nil {
+					continue
 				}
-				var newSrc *CFList
 				if src != nil {
 					newSrc = src.CFList
+				}
+				if dst.CFList != nil {
+					newDst = dst.CFList
+				} else {
+					newDst = &CFList{}
+					dst.CFList = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -152,11 +160,11 @@ func (dst *JoinResponse) SetFields(src *JoinResponse, paths ...string) error {
 			}
 		case "session_keys":
 			if len(subs) > 0 {
-				newDst := &dst.SessionKeys
-				var newSrc *SessionKeys
+				var newDst, newSrc *SessionKeys
 				if src != nil {
 					newSrc = &src.SessionKeys
 				}
+				newDst = &dst.SessionKeys
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}

--- a/pkg/ttnpb/joinserver.pb.setters.fm.go
+++ b/pkg/ttnpb/joinserver.pb.setters.fm.go
@@ -53,11 +53,11 @@ func (dst *NwkSKeysResponse) SetFields(src *NwkSKeysResponse, paths ...string) e
 		switch name {
 		case "f_nwk_s_int_key":
 			if len(subs) > 0 {
-				newDst := &dst.FNwkSIntKey
-				var newSrc *KeyEnvelope
+				var newDst, newSrc *KeyEnvelope
 				if src != nil {
 					newSrc = &src.FNwkSIntKey
 				}
+				newDst = &dst.FNwkSIntKey
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -71,11 +71,11 @@ func (dst *NwkSKeysResponse) SetFields(src *NwkSKeysResponse, paths ...string) e
 			}
 		case "s_nwk_s_int_key":
 			if len(subs) > 0 {
-				newDst := &dst.SNwkSIntKey
-				var newSrc *KeyEnvelope
+				var newDst, newSrc *KeyEnvelope
 				if src != nil {
 					newSrc = &src.SNwkSIntKey
 				}
+				newDst = &dst.SNwkSIntKey
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -89,11 +89,11 @@ func (dst *NwkSKeysResponse) SetFields(src *NwkSKeysResponse, paths ...string) e
 			}
 		case "nwk_s_enc_key":
 			if len(subs) > 0 {
-				newDst := &dst.NwkSEncKey
-				var newSrc *KeyEnvelope
+				var newDst, newSrc *KeyEnvelope
 				if src != nil {
 					newSrc = &src.NwkSEncKey
 				}
+				newDst = &dst.NwkSEncKey
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -118,11 +118,11 @@ func (dst *AppSKeyResponse) SetFields(src *AppSKeyResponse, paths ...string) err
 		switch name {
 		case "app_s_key":
 			if len(subs) > 0 {
-				newDst := &dst.AppSKey
-				var newSrc *KeyEnvelope
+				var newDst, newSrc *KeyEnvelope
 				if src != nil {
 					newSrc = &src.AppSKey
 				}
+				newDst = &dst.AppSKey
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -147,11 +147,11 @@ func (dst *CryptoServicePayloadRequest) SetFields(src *CryptoServicePayloadReque
 		switch name {
 		case "ids":
 			if len(subs) > 0 {
-				newDst := &dst.EndDeviceIdentifiers
-				var newSrc *EndDeviceIdentifiers
+				var newDst, newSrc *EndDeviceIdentifiers
 				if src != nil {
 					newSrc = &src.EndDeviceIdentifiers
 				}
+				newDst = &dst.EndDeviceIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -234,11 +234,11 @@ func (dst *JoinAcceptMICRequest) SetFields(src *JoinAcceptMICRequest, paths ...s
 		switch name {
 		case "payload_request":
 			if len(subs) > 0 {
-				newDst := &dst.CryptoServicePayloadRequest
-				var newSrc *CryptoServicePayloadRequest
+				var newDst, newSrc *CryptoServicePayloadRequest
 				if src != nil {
 					newSrc = &src.CryptoServicePayloadRequest
 				}
+				newDst = &dst.CryptoServicePayloadRequest
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -283,11 +283,11 @@ func (dst *DeriveSessionKeysRequest) SetFields(src *DeriveSessionKeysRequest, pa
 		switch name {
 		case "ids":
 			if len(subs) > 0 {
-				newDst := &dst.EndDeviceIdentifiers
-				var newSrc *EndDeviceIdentifiers
+				var newDst, newSrc *EndDeviceIdentifiers
 				if src != nil {
 					newSrc = &src.EndDeviceIdentifiers
 				}
+				newDst = &dst.EndDeviceIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -371,11 +371,11 @@ func (dst *GetRootKeysRequest) SetFields(src *GetRootKeysRequest, paths ...strin
 		switch name {
 		case "ids":
 			if len(subs) > 0 {
-				newDst := &dst.EndDeviceIdentifiers
-				var newSrc *EndDeviceIdentifiers
+				var newDst, newSrc *EndDeviceIdentifiers
 				if src != nil {
 					newSrc = &src.EndDeviceIdentifiers
 				}
+				newDst = &dst.EndDeviceIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -419,11 +419,11 @@ func (dst *ProvisionEndDevicesRequest) SetFields(src *ProvisionEndDevicesRequest
 		switch name {
 		case "application_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationIdentifiers
-				var newSrc *ApplicationIdentifiers
+				var newDst, newSrc *ApplicationIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationIdentifiers
 				}
+				newDst = &dst.ApplicationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -471,75 +471,102 @@ func (dst *ProvisionEndDevicesRequest) SetFields(src *ProvisionEndDevicesRequest
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "list":
-					if _, ok := dst.EndDevices.(*ProvisionEndDevicesRequest_List); !ok {
-						dst.EndDevices = &ProvisionEndDevicesRequest_List{}
+					_, srcOk := src.EndDevices.(*ProvisionEndDevicesRequest_List)
+					if !srcOk && src.EndDevices != nil {
+						return fmt.Errorf("attempt to set oneof 'list', while different oneof is set in source")
+					}
+					_, dstOk := dst.EndDevices.(*ProvisionEndDevicesRequest_List)
+					if !dstOk && dst.EndDevices != nil {
+						return fmt.Errorf("attempt to set oneof 'list', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.EndDevices.(*ProvisionEndDevicesRequest_List).List
-						if newDst == nil {
-							newDst = &ProvisionEndDevicesRequest_IdentifiersList{}
-							dst.EndDevices.(*ProvisionEndDevicesRequest_List).List = newDst
+						var newDst, newSrc *ProvisionEndDevicesRequest_IdentifiersList
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *ProvisionEndDevicesRequest_IdentifiersList
-						if src != nil {
-							newSrc = src.GetList()
+						if srcOk {
+							newSrc = src.EndDevices.(*ProvisionEndDevicesRequest_List).List
+						}
+						if dstOk {
+							newDst = dst.EndDevices.(*ProvisionEndDevicesRequest_List).List
+						} else {
+							newDst = &ProvisionEndDevicesRequest_IdentifiersList{}
+							dst.EndDevices = &ProvisionEndDevicesRequest_List{List: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.EndDevices.(*ProvisionEndDevicesRequest_List).List = src.GetList()
+							dst.EndDevices = src.EndDevices
 						} else {
-							dst.EndDevices.(*ProvisionEndDevicesRequest_List).List = nil
+							dst.EndDevices = nil
 						}
 					}
 				case "range":
-					if _, ok := dst.EndDevices.(*ProvisionEndDevicesRequest_Range); !ok {
-						dst.EndDevices = &ProvisionEndDevicesRequest_Range{}
+					_, srcOk := src.EndDevices.(*ProvisionEndDevicesRequest_Range)
+					if !srcOk && src.EndDevices != nil {
+						return fmt.Errorf("attempt to set oneof 'range', while different oneof is set in source")
+					}
+					_, dstOk := dst.EndDevices.(*ProvisionEndDevicesRequest_Range)
+					if !dstOk && dst.EndDevices != nil {
+						return fmt.Errorf("attempt to set oneof 'range', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.EndDevices.(*ProvisionEndDevicesRequest_Range).Range
-						if newDst == nil {
-							newDst = &ProvisionEndDevicesRequest_IdentifiersRange{}
-							dst.EndDevices.(*ProvisionEndDevicesRequest_Range).Range = newDst
+						var newDst, newSrc *ProvisionEndDevicesRequest_IdentifiersRange
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *ProvisionEndDevicesRequest_IdentifiersRange
-						if src != nil {
-							newSrc = src.GetRange()
+						if srcOk {
+							newSrc = src.EndDevices.(*ProvisionEndDevicesRequest_Range).Range
+						}
+						if dstOk {
+							newDst = dst.EndDevices.(*ProvisionEndDevicesRequest_Range).Range
+						} else {
+							newDst = &ProvisionEndDevicesRequest_IdentifiersRange{}
+							dst.EndDevices = &ProvisionEndDevicesRequest_Range{Range: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.EndDevices.(*ProvisionEndDevicesRequest_Range).Range = src.GetRange()
+							dst.EndDevices = src.EndDevices
 						} else {
-							dst.EndDevices.(*ProvisionEndDevicesRequest_Range).Range = nil
+							dst.EndDevices = nil
 						}
 					}
 				case "from_data":
-					if _, ok := dst.EndDevices.(*ProvisionEndDevicesRequest_FromData); !ok {
-						dst.EndDevices = &ProvisionEndDevicesRequest_FromData{}
+					_, srcOk := src.EndDevices.(*ProvisionEndDevicesRequest_FromData)
+					if !srcOk && src.EndDevices != nil {
+						return fmt.Errorf("attempt to set oneof 'from_data', while different oneof is set in source")
+					}
+					_, dstOk := dst.EndDevices.(*ProvisionEndDevicesRequest_FromData)
+					if !dstOk && dst.EndDevices != nil {
+						return fmt.Errorf("attempt to set oneof 'from_data', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.EndDevices.(*ProvisionEndDevicesRequest_FromData).FromData
-						if newDst == nil {
-							newDst = &ProvisionEndDevicesRequest_IdentifiersFromData{}
-							dst.EndDevices.(*ProvisionEndDevicesRequest_FromData).FromData = newDst
+						var newDst, newSrc *ProvisionEndDevicesRequest_IdentifiersFromData
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *ProvisionEndDevicesRequest_IdentifiersFromData
-						if src != nil {
-							newSrc = src.GetFromData()
+						if srcOk {
+							newSrc = src.EndDevices.(*ProvisionEndDevicesRequest_FromData).FromData
+						}
+						if dstOk {
+							newDst = dst.EndDevices.(*ProvisionEndDevicesRequest_FromData).FromData
+						} else {
+							newDst = &ProvisionEndDevicesRequest_IdentifiersFromData{}
+							dst.EndDevices = &ProvisionEndDevicesRequest_FromData{FromData: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.EndDevices.(*ProvisionEndDevicesRequest_FromData).FromData = src.GetFromData()
+							dst.EndDevices = src.EndDevices
 						} else {
-							dst.EndDevices.(*ProvisionEndDevicesRequest_FromData).FromData = nil
+							dst.EndDevices = nil
 						}
 					}
 

--- a/pkg/ttnpb/keys.pb.setters.fm.go
+++ b/pkg/ttnpb/keys.pb.setters.fm.go
@@ -58,14 +58,18 @@ func (dst *RootKeys) SetFields(src *RootKeys, paths ...string) error {
 			}
 		case "app_key":
 			if len(subs) > 0 {
-				newDst := dst.AppKey
-				if newDst == nil {
-					newDst = &KeyEnvelope{}
-					dst.AppKey = newDst
+				var newDst, newSrc *KeyEnvelope
+				if (src == nil || src.AppKey == nil) && dst.AppKey == nil {
+					continue
 				}
-				var newSrc *KeyEnvelope
 				if src != nil {
 					newSrc = src.AppKey
+				}
+				if dst.AppKey != nil {
+					newDst = dst.AppKey
+				} else {
+					newDst = &KeyEnvelope{}
+					dst.AppKey = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -79,14 +83,18 @@ func (dst *RootKeys) SetFields(src *RootKeys, paths ...string) error {
 			}
 		case "nwk_key":
 			if len(subs) > 0 {
-				newDst := dst.NwkKey
-				if newDst == nil {
-					newDst = &KeyEnvelope{}
-					dst.NwkKey = newDst
+				var newDst, newSrc *KeyEnvelope
+				if (src == nil || src.NwkKey == nil) && dst.NwkKey == nil {
+					continue
 				}
-				var newSrc *KeyEnvelope
 				if src != nil {
 					newSrc = src.NwkKey
+				}
+				if dst.NwkKey != nil {
+					newDst = dst.NwkKey
+				} else {
+					newDst = &KeyEnvelope{}
+					dst.NwkKey = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -120,14 +128,18 @@ func (dst *SessionKeys) SetFields(src *SessionKeys, paths ...string) error {
 			}
 		case "f_nwk_s_int_key":
 			if len(subs) > 0 {
-				newDst := dst.FNwkSIntKey
-				if newDst == nil {
-					newDst = &KeyEnvelope{}
-					dst.FNwkSIntKey = newDst
+				var newDst, newSrc *KeyEnvelope
+				if (src == nil || src.FNwkSIntKey == nil) && dst.FNwkSIntKey == nil {
+					continue
 				}
-				var newSrc *KeyEnvelope
 				if src != nil {
 					newSrc = src.FNwkSIntKey
+				}
+				if dst.FNwkSIntKey != nil {
+					newDst = dst.FNwkSIntKey
+				} else {
+					newDst = &KeyEnvelope{}
+					dst.FNwkSIntKey = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -141,14 +153,18 @@ func (dst *SessionKeys) SetFields(src *SessionKeys, paths ...string) error {
 			}
 		case "s_nwk_s_int_key":
 			if len(subs) > 0 {
-				newDst := dst.SNwkSIntKey
-				if newDst == nil {
-					newDst = &KeyEnvelope{}
-					dst.SNwkSIntKey = newDst
+				var newDst, newSrc *KeyEnvelope
+				if (src == nil || src.SNwkSIntKey == nil) && dst.SNwkSIntKey == nil {
+					continue
 				}
-				var newSrc *KeyEnvelope
 				if src != nil {
 					newSrc = src.SNwkSIntKey
+				}
+				if dst.SNwkSIntKey != nil {
+					newDst = dst.SNwkSIntKey
+				} else {
+					newDst = &KeyEnvelope{}
+					dst.SNwkSIntKey = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -162,14 +178,18 @@ func (dst *SessionKeys) SetFields(src *SessionKeys, paths ...string) error {
 			}
 		case "nwk_s_enc_key":
 			if len(subs) > 0 {
-				newDst := dst.NwkSEncKey
-				if newDst == nil {
-					newDst = &KeyEnvelope{}
-					dst.NwkSEncKey = newDst
+				var newDst, newSrc *KeyEnvelope
+				if (src == nil || src.NwkSEncKey == nil) && dst.NwkSEncKey == nil {
+					continue
 				}
-				var newSrc *KeyEnvelope
 				if src != nil {
 					newSrc = src.NwkSEncKey
+				}
+				if dst.NwkSEncKey != nil {
+					newDst = dst.NwkSEncKey
+				} else {
+					newDst = &KeyEnvelope{}
+					dst.NwkSEncKey = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -183,14 +203,18 @@ func (dst *SessionKeys) SetFields(src *SessionKeys, paths ...string) error {
 			}
 		case "app_s_key":
 			if len(subs) > 0 {
-				newDst := dst.AppSKey
-				if newDst == nil {
-					newDst = &KeyEnvelope{}
-					dst.AppSKey = newDst
+				var newDst, newSrc *KeyEnvelope
+				if (src == nil || src.AppSKey == nil) && dst.AppSKey == nil {
+					continue
 				}
-				var newSrc *KeyEnvelope
 				if src != nil {
 					newSrc = src.AppSKey
+				}
+				if dst.AppSKey != nil {
+					newDst = dst.AppSKey
+				} else {
+					newDst = &KeyEnvelope{}
+					dst.AppSKey = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err

--- a/pkg/ttnpb/lorawan.pb.setters.fm.go
+++ b/pkg/ttnpb/lorawan.pb.setters.fm.go
@@ -14,11 +14,11 @@ func (dst *Message) SetFields(src *Message, paths ...string) error {
 		switch name {
 		case "m_hdr":
 			if len(subs) > 0 {
-				newDst := &dst.MHDR
-				var newSrc *MHDR
+				var newDst, newSrc *MHDR
 				if src != nil {
 					newSrc = &src.MHDR
 				}
+				newDst = &dst.MHDR
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -56,99 +56,135 @@ func (dst *Message) SetFields(src *Message, paths ...string) error {
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "mac_payload":
-					if _, ok := dst.Payload.(*Message_MACPayload); !ok {
-						dst.Payload = &Message_MACPayload{}
+					_, srcOk := src.Payload.(*Message_MACPayload)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'mac_payload', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*Message_MACPayload)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'mac_payload', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*Message_MACPayload).MACPayload
-						if newDst == nil {
-							newDst = &MACPayload{}
-							dst.Payload.(*Message_MACPayload).MACPayload = newDst
+						var newDst, newSrc *MACPayload
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACPayload
-						if src != nil {
-							newSrc = src.GetMACPayload()
+						if srcOk {
+							newSrc = src.Payload.(*Message_MACPayload).MACPayload
+						}
+						if dstOk {
+							newDst = dst.Payload.(*Message_MACPayload).MACPayload
+						} else {
+							newDst = &MACPayload{}
+							dst.Payload = &Message_MACPayload{MACPayload: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*Message_MACPayload).MACPayload = src.GetMACPayload()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*Message_MACPayload).MACPayload = nil
+							dst.Payload = nil
 						}
 					}
 				case "join_request_payload":
-					if _, ok := dst.Payload.(*Message_JoinRequestPayload); !ok {
-						dst.Payload = &Message_JoinRequestPayload{}
+					_, srcOk := src.Payload.(*Message_JoinRequestPayload)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'join_request_payload', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*Message_JoinRequestPayload)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'join_request_payload', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*Message_JoinRequestPayload).JoinRequestPayload
-						if newDst == nil {
-							newDst = &JoinRequestPayload{}
-							dst.Payload.(*Message_JoinRequestPayload).JoinRequestPayload = newDst
+						var newDst, newSrc *JoinRequestPayload
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *JoinRequestPayload
-						if src != nil {
-							newSrc = src.GetJoinRequestPayload()
+						if srcOk {
+							newSrc = src.Payload.(*Message_JoinRequestPayload).JoinRequestPayload
+						}
+						if dstOk {
+							newDst = dst.Payload.(*Message_JoinRequestPayload).JoinRequestPayload
+						} else {
+							newDst = &JoinRequestPayload{}
+							dst.Payload = &Message_JoinRequestPayload{JoinRequestPayload: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*Message_JoinRequestPayload).JoinRequestPayload = src.GetJoinRequestPayload()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*Message_JoinRequestPayload).JoinRequestPayload = nil
+							dst.Payload = nil
 						}
 					}
 				case "join_accept_payload":
-					if _, ok := dst.Payload.(*Message_JoinAcceptPayload); !ok {
-						dst.Payload = &Message_JoinAcceptPayload{}
+					_, srcOk := src.Payload.(*Message_JoinAcceptPayload)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'join_accept_payload', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*Message_JoinAcceptPayload)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'join_accept_payload', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*Message_JoinAcceptPayload).JoinAcceptPayload
-						if newDst == nil {
-							newDst = &JoinAcceptPayload{}
-							dst.Payload.(*Message_JoinAcceptPayload).JoinAcceptPayload = newDst
+						var newDst, newSrc *JoinAcceptPayload
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *JoinAcceptPayload
-						if src != nil {
-							newSrc = src.GetJoinAcceptPayload()
+						if srcOk {
+							newSrc = src.Payload.(*Message_JoinAcceptPayload).JoinAcceptPayload
+						}
+						if dstOk {
+							newDst = dst.Payload.(*Message_JoinAcceptPayload).JoinAcceptPayload
+						} else {
+							newDst = &JoinAcceptPayload{}
+							dst.Payload = &Message_JoinAcceptPayload{JoinAcceptPayload: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*Message_JoinAcceptPayload).JoinAcceptPayload = src.GetJoinAcceptPayload()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*Message_JoinAcceptPayload).JoinAcceptPayload = nil
+							dst.Payload = nil
 						}
 					}
 				case "rejoin_request_payload":
-					if _, ok := dst.Payload.(*Message_RejoinRequestPayload); !ok {
-						dst.Payload = &Message_RejoinRequestPayload{}
+					_, srcOk := src.Payload.(*Message_RejoinRequestPayload)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'rejoin_request_payload', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*Message_RejoinRequestPayload)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'rejoin_request_payload', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*Message_RejoinRequestPayload).RejoinRequestPayload
-						if newDst == nil {
-							newDst = &RejoinRequestPayload{}
-							dst.Payload.(*Message_RejoinRequestPayload).RejoinRequestPayload = newDst
+						var newDst, newSrc *RejoinRequestPayload
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *RejoinRequestPayload
-						if src != nil {
-							newSrc = src.GetRejoinRequestPayload()
+						if srcOk {
+							newSrc = src.Payload.(*Message_RejoinRequestPayload).RejoinRequestPayload
+						}
+						if dstOk {
+							newDst = dst.Payload.(*Message_RejoinRequestPayload).RejoinRequestPayload
+						} else {
+							newDst = &RejoinRequestPayload{}
+							dst.Payload = &Message_RejoinRequestPayload{RejoinRequestPayload: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*Message_RejoinRequestPayload).RejoinRequestPayload = src.GetRejoinRequestPayload()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*Message_RejoinRequestPayload).RejoinRequestPayload = nil
+							dst.Payload = nil
 						}
 					}
 
@@ -200,11 +236,11 @@ func (dst *MACPayload) SetFields(src *MACPayload, paths ...string) error {
 		switch name {
 		case "f_hdr":
 			if len(subs) > 0 {
-				newDst := &dst.FHDR
-				var newSrc *FHDR
+				var newDst, newSrc *FHDR
 				if src != nil {
 					newSrc = &src.FHDR
 				}
+				newDst = &dst.FHDR
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -267,11 +303,11 @@ func (dst *FHDR) SetFields(src *FHDR, paths ...string) error {
 			}
 		case "f_ctrl":
 			if len(subs) > 0 {
-				newDst := &dst.FCtrl
-				var newSrc *FCtrl
+				var newDst, newSrc *FCtrl
 				if src != nil {
 					newSrc = &src.FCtrl
 				}
+				newDst = &dst.FCtrl
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -517,11 +553,11 @@ func (dst *JoinAcceptPayload) SetFields(src *JoinAcceptPayload, paths ...string)
 			}
 		case "dl_settings":
 			if len(subs) > 0 {
-				newDst := &dst.DLSettings
-				var newSrc *DLSettings
+				var newDst, newSrc *DLSettings
 				if src != nil {
 					newSrc = &src.DLSettings
 				}
+				newDst = &dst.DLSettings
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -545,14 +581,18 @@ func (dst *JoinAcceptPayload) SetFields(src *JoinAcceptPayload, paths ...string)
 			}
 		case "cf_list":
 			if len(subs) > 0 {
-				newDst := dst.CFList
-				if newDst == nil {
-					newDst = &CFList{}
-					dst.CFList = newDst
+				var newDst, newSrc *CFList
+				if (src == nil || src.CFList == nil) && dst.CFList == nil {
+					continue
 				}
-				var newSrc *CFList
 				if src != nil {
 					newSrc = src.CFList
+				}
+				if dst.CFList != nil {
+					newDst = dst.CFList
+				} else {
+					newDst = &CFList{}
+					dst.CFList = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -724,51 +764,69 @@ func (dst *DataRate) SetFields(src *DataRate, paths ...string) error {
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "lora":
-					if _, ok := dst.Modulation.(*DataRate_LoRa); !ok {
-						dst.Modulation = &DataRate_LoRa{}
+					_, srcOk := src.Modulation.(*DataRate_LoRa)
+					if !srcOk && src.Modulation != nil {
+						return fmt.Errorf("attempt to set oneof 'lora', while different oneof is set in source")
+					}
+					_, dstOk := dst.Modulation.(*DataRate_LoRa)
+					if !dstOk && dst.Modulation != nil {
+						return fmt.Errorf("attempt to set oneof 'lora', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Modulation.(*DataRate_LoRa).LoRa
-						if newDst == nil {
-							newDst = &LoRaDataRate{}
-							dst.Modulation.(*DataRate_LoRa).LoRa = newDst
+						var newDst, newSrc *LoRaDataRate
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *LoRaDataRate
-						if src != nil {
-							newSrc = src.GetLoRa()
+						if srcOk {
+							newSrc = src.Modulation.(*DataRate_LoRa).LoRa
+						}
+						if dstOk {
+							newDst = dst.Modulation.(*DataRate_LoRa).LoRa
+						} else {
+							newDst = &LoRaDataRate{}
+							dst.Modulation = &DataRate_LoRa{LoRa: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Modulation.(*DataRate_LoRa).LoRa = src.GetLoRa()
+							dst.Modulation = src.Modulation
 						} else {
-							dst.Modulation.(*DataRate_LoRa).LoRa = nil
+							dst.Modulation = nil
 						}
 					}
 				case "fsk":
-					if _, ok := dst.Modulation.(*DataRate_FSK); !ok {
-						dst.Modulation = &DataRate_FSK{}
+					_, srcOk := src.Modulation.(*DataRate_FSK)
+					if !srcOk && src.Modulation != nil {
+						return fmt.Errorf("attempt to set oneof 'fsk', while different oneof is set in source")
+					}
+					_, dstOk := dst.Modulation.(*DataRate_FSK)
+					if !dstOk && dst.Modulation != nil {
+						return fmt.Errorf("attempt to set oneof 'fsk', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Modulation.(*DataRate_FSK).FSK
-						if newDst == nil {
-							newDst = &FSKDataRate{}
-							dst.Modulation.(*DataRate_FSK).FSK = newDst
+						var newDst, newSrc *FSKDataRate
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *FSKDataRate
-						if src != nil {
-							newSrc = src.GetFSK()
+						if srcOk {
+							newSrc = src.Modulation.(*DataRate_FSK).FSK
+						}
+						if dstOk {
+							newDst = dst.Modulation.(*DataRate_FSK).FSK
+						} else {
+							newDst = &FSKDataRate{}
+							dst.Modulation = &DataRate_FSK{FSK: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Modulation.(*DataRate_FSK).FSK = src.GetFSK()
+							dst.Modulation = src.Modulation
 						} else {
-							dst.Modulation.(*DataRate_FSK).FSK = nil
+							dst.Modulation = nil
 						}
 					}
 
@@ -789,11 +847,11 @@ func (dst *TxSettings) SetFields(src *TxSettings, paths ...string) error {
 		switch name {
 		case "data_rate":
 			if len(subs) > 0 {
-				newDst := &dst.DataRate
-				var newSrc *DataRate
+				var newDst, newSrc *DataRate
 				if src != nil {
 					newSrc = &src.DataRate
 				}
+				newDst = &dst.DataRate
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -866,14 +924,18 @@ func (dst *TxSettings) SetFields(src *TxSettings, paths ...string) error {
 			}
 		case "downlink":
 			if len(subs) > 0 {
-				newDst := dst.Downlink
-				if newDst == nil {
-					newDst = &TxSettings_Downlink{}
-					dst.Downlink = newDst
+				var newDst, newSrc *TxSettings_Downlink
+				if (src == nil || src.Downlink == nil) && dst.Downlink == nil {
+					continue
 				}
-				var newSrc *TxSettings_Downlink
 				if src != nil {
 					newSrc = src.Downlink
+				}
+				if dst.Downlink != nil {
+					newDst = dst.Downlink
+				} else {
+					newDst = &TxSettings_Downlink{}
+					dst.Downlink = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -898,11 +960,11 @@ func (dst *GatewayAntennaIdentifiers) SetFields(src *GatewayAntennaIdentifiers, 
 		switch name {
 		case "gateway_ids":
 			if len(subs) > 0 {
-				newDst := &dst.GatewayIdentifiers
-				var newSrc *GatewayIdentifiers
+				var newDst, newSrc *GatewayIdentifiers
 				if src != nil {
 					newSrc = &src.GatewayIdentifiers
 				}
+				newDst = &dst.GatewayIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -937,11 +999,11 @@ func (dst *UplinkToken) SetFields(src *UplinkToken, paths ...string) error {
 		switch name {
 		case "ids":
 			if len(subs) > 0 {
-				newDst := &dst.GatewayAntennaIdentifiers
-				var newSrc *GatewayAntennaIdentifiers
+				var newDst, newSrc *GatewayAntennaIdentifiers
 				if src != nil {
 					newSrc = &src.GatewayAntennaIdentifiers
 				}
+				newDst = &dst.GatewayAntennaIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -991,39 +1053,53 @@ func (dst *DownlinkPath) SetFields(src *DownlinkPath, paths ...string) error {
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "uplink_token":
-					if _, ok := dst.Path.(*DownlinkPath_UplinkToken); !ok {
-						dst.Path = &DownlinkPath_UplinkToken{}
+					_, srcOk := src.Path.(*DownlinkPath_UplinkToken)
+					if !srcOk && src.Path != nil {
+						return fmt.Errorf("attempt to set oneof 'uplink_token', while different oneof is set in source")
+					}
+					_, dstOk := dst.Path.(*DownlinkPath_UplinkToken)
+					if !dstOk && dst.Path != nil {
+						return fmt.Errorf("attempt to set oneof 'uplink_token', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						return fmt.Errorf("'uplink_token' has no subfields, but %s were specified", oneofSubs)
 					}
 					if src != nil {
-						dst.Path.(*DownlinkPath_UplinkToken).UplinkToken = src.GetUplinkToken()
+						dst.Path = src.Path
 					} else {
-						dst.Path.(*DownlinkPath_UplinkToken).UplinkToken = nil
+						dst.Path = nil
 					}
 				case "fixed":
-					if _, ok := dst.Path.(*DownlinkPath_Fixed); !ok {
-						dst.Path = &DownlinkPath_Fixed{}
+					_, srcOk := src.Path.(*DownlinkPath_Fixed)
+					if !srcOk && src.Path != nil {
+						return fmt.Errorf("attempt to set oneof 'fixed', while different oneof is set in source")
+					}
+					_, dstOk := dst.Path.(*DownlinkPath_Fixed)
+					if !dstOk && dst.Path != nil {
+						return fmt.Errorf("attempt to set oneof 'fixed', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Path.(*DownlinkPath_Fixed).Fixed
-						if newDst == nil {
-							newDst = &GatewayAntennaIdentifiers{}
-							dst.Path.(*DownlinkPath_Fixed).Fixed = newDst
+						var newDst, newSrc *GatewayAntennaIdentifiers
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *GatewayAntennaIdentifiers
-						if src != nil {
-							newSrc = src.GetFixed()
+						if srcOk {
+							newSrc = src.Path.(*DownlinkPath_Fixed).Fixed
+						}
+						if dstOk {
+							newDst = dst.Path.(*DownlinkPath_Fixed).Fixed
+						} else {
+							newDst = &GatewayAntennaIdentifiers{}
+							dst.Path = &DownlinkPath_Fixed{Fixed: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Path.(*DownlinkPath_Fixed).Fixed = src.GetFixed()
+							dst.Path = src.Path
 						} else {
-							dst.Path.(*DownlinkPath_Fixed).Fixed = nil
+							dst.Path = nil
 						}
 					}
 
@@ -1177,735 +1253,1010 @@ func (dst *MACCommand) SetFields(src *MACCommand, paths ...string) error {
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "raw_payload":
-					if _, ok := dst.Payload.(*MACCommand_RawPayload); !ok {
-						dst.Payload = &MACCommand_RawPayload{}
+					_, srcOk := src.Payload.(*MACCommand_RawPayload)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'raw_payload', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_RawPayload)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'raw_payload', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						return fmt.Errorf("'raw_payload' has no subfields, but %s were specified", oneofSubs)
 					}
 					if src != nil {
-						dst.Payload.(*MACCommand_RawPayload).RawPayload = src.GetRawPayload()
+						dst.Payload = src.Payload
 					} else {
-						dst.Payload.(*MACCommand_RawPayload).RawPayload = nil
+						dst.Payload = nil
 					}
 				case "reset_ind":
-					if _, ok := dst.Payload.(*MACCommand_ResetInd_); !ok {
-						dst.Payload = &MACCommand_ResetInd_{}
+					_, srcOk := src.Payload.(*MACCommand_ResetInd_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'reset_ind', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_ResetInd_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'reset_ind', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_ResetInd_).ResetInd
-						if newDst == nil {
-							newDst = &MACCommand_ResetInd{}
-							dst.Payload.(*MACCommand_ResetInd_).ResetInd = newDst
+						var newDst, newSrc *MACCommand_ResetInd
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_ResetInd
-						if src != nil {
-							newSrc = src.GetResetInd()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_ResetInd_).ResetInd
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_ResetInd_).ResetInd
+						} else {
+							newDst = &MACCommand_ResetInd{}
+							dst.Payload = &MACCommand_ResetInd_{ResetInd: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_ResetInd_).ResetInd = src.GetResetInd()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_ResetInd_).ResetInd = nil
+							dst.Payload = nil
 						}
 					}
 				case "reset_conf":
-					if _, ok := dst.Payload.(*MACCommand_ResetConf_); !ok {
-						dst.Payload = &MACCommand_ResetConf_{}
+					_, srcOk := src.Payload.(*MACCommand_ResetConf_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'reset_conf', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_ResetConf_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'reset_conf', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_ResetConf_).ResetConf
-						if newDst == nil {
-							newDst = &MACCommand_ResetConf{}
-							dst.Payload.(*MACCommand_ResetConf_).ResetConf = newDst
+						var newDst, newSrc *MACCommand_ResetConf
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_ResetConf
-						if src != nil {
-							newSrc = src.GetResetConf()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_ResetConf_).ResetConf
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_ResetConf_).ResetConf
+						} else {
+							newDst = &MACCommand_ResetConf{}
+							dst.Payload = &MACCommand_ResetConf_{ResetConf: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_ResetConf_).ResetConf = src.GetResetConf()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_ResetConf_).ResetConf = nil
+							dst.Payload = nil
 						}
 					}
 				case "link_check_ans":
-					if _, ok := dst.Payload.(*MACCommand_LinkCheckAns_); !ok {
-						dst.Payload = &MACCommand_LinkCheckAns_{}
+					_, srcOk := src.Payload.(*MACCommand_LinkCheckAns_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'link_check_ans', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_LinkCheckAns_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'link_check_ans', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_LinkCheckAns_).LinkCheckAns
-						if newDst == nil {
-							newDst = &MACCommand_LinkCheckAns{}
-							dst.Payload.(*MACCommand_LinkCheckAns_).LinkCheckAns = newDst
+						var newDst, newSrc *MACCommand_LinkCheckAns
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_LinkCheckAns
-						if src != nil {
-							newSrc = src.GetLinkCheckAns()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_LinkCheckAns_).LinkCheckAns
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_LinkCheckAns_).LinkCheckAns
+						} else {
+							newDst = &MACCommand_LinkCheckAns{}
+							dst.Payload = &MACCommand_LinkCheckAns_{LinkCheckAns: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_LinkCheckAns_).LinkCheckAns = src.GetLinkCheckAns()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_LinkCheckAns_).LinkCheckAns = nil
+							dst.Payload = nil
 						}
 					}
 				case "link_adr_req":
-					if _, ok := dst.Payload.(*MACCommand_LinkADRReq_); !ok {
-						dst.Payload = &MACCommand_LinkADRReq_{}
+					_, srcOk := src.Payload.(*MACCommand_LinkADRReq_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'link_adr_req', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_LinkADRReq_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'link_adr_req', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_LinkADRReq_).LinkADRReq
-						if newDst == nil {
-							newDst = &MACCommand_LinkADRReq{}
-							dst.Payload.(*MACCommand_LinkADRReq_).LinkADRReq = newDst
+						var newDst, newSrc *MACCommand_LinkADRReq
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_LinkADRReq
-						if src != nil {
-							newSrc = src.GetLinkADRReq()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_LinkADRReq_).LinkADRReq
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_LinkADRReq_).LinkADRReq
+						} else {
+							newDst = &MACCommand_LinkADRReq{}
+							dst.Payload = &MACCommand_LinkADRReq_{LinkADRReq: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_LinkADRReq_).LinkADRReq = src.GetLinkADRReq()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_LinkADRReq_).LinkADRReq = nil
+							dst.Payload = nil
 						}
 					}
 				case "link_adr_ans":
-					if _, ok := dst.Payload.(*MACCommand_LinkADRAns_); !ok {
-						dst.Payload = &MACCommand_LinkADRAns_{}
+					_, srcOk := src.Payload.(*MACCommand_LinkADRAns_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'link_adr_ans', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_LinkADRAns_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'link_adr_ans', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_LinkADRAns_).LinkADRAns
-						if newDst == nil {
-							newDst = &MACCommand_LinkADRAns{}
-							dst.Payload.(*MACCommand_LinkADRAns_).LinkADRAns = newDst
+						var newDst, newSrc *MACCommand_LinkADRAns
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_LinkADRAns
-						if src != nil {
-							newSrc = src.GetLinkADRAns()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_LinkADRAns_).LinkADRAns
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_LinkADRAns_).LinkADRAns
+						} else {
+							newDst = &MACCommand_LinkADRAns{}
+							dst.Payload = &MACCommand_LinkADRAns_{LinkADRAns: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_LinkADRAns_).LinkADRAns = src.GetLinkADRAns()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_LinkADRAns_).LinkADRAns = nil
+							dst.Payload = nil
 						}
 					}
 				case "duty_cycle_req":
-					if _, ok := dst.Payload.(*MACCommand_DutyCycleReq_); !ok {
-						dst.Payload = &MACCommand_DutyCycleReq_{}
+					_, srcOk := src.Payload.(*MACCommand_DutyCycleReq_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'duty_cycle_req', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_DutyCycleReq_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'duty_cycle_req', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_DutyCycleReq_).DutyCycleReq
-						if newDst == nil {
-							newDst = &MACCommand_DutyCycleReq{}
-							dst.Payload.(*MACCommand_DutyCycleReq_).DutyCycleReq = newDst
+						var newDst, newSrc *MACCommand_DutyCycleReq
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_DutyCycleReq
-						if src != nil {
-							newSrc = src.GetDutyCycleReq()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_DutyCycleReq_).DutyCycleReq
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_DutyCycleReq_).DutyCycleReq
+						} else {
+							newDst = &MACCommand_DutyCycleReq{}
+							dst.Payload = &MACCommand_DutyCycleReq_{DutyCycleReq: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_DutyCycleReq_).DutyCycleReq = src.GetDutyCycleReq()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_DutyCycleReq_).DutyCycleReq = nil
+							dst.Payload = nil
 						}
 					}
 				case "rx_param_setup_req":
-					if _, ok := dst.Payload.(*MACCommand_RxParamSetupReq_); !ok {
-						dst.Payload = &MACCommand_RxParamSetupReq_{}
+					_, srcOk := src.Payload.(*MACCommand_RxParamSetupReq_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'rx_param_setup_req', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_RxParamSetupReq_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'rx_param_setup_req', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_RxParamSetupReq_).RxParamSetupReq
-						if newDst == nil {
-							newDst = &MACCommand_RxParamSetupReq{}
-							dst.Payload.(*MACCommand_RxParamSetupReq_).RxParamSetupReq = newDst
+						var newDst, newSrc *MACCommand_RxParamSetupReq
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_RxParamSetupReq
-						if src != nil {
-							newSrc = src.GetRxParamSetupReq()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_RxParamSetupReq_).RxParamSetupReq
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_RxParamSetupReq_).RxParamSetupReq
+						} else {
+							newDst = &MACCommand_RxParamSetupReq{}
+							dst.Payload = &MACCommand_RxParamSetupReq_{RxParamSetupReq: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_RxParamSetupReq_).RxParamSetupReq = src.GetRxParamSetupReq()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_RxParamSetupReq_).RxParamSetupReq = nil
+							dst.Payload = nil
 						}
 					}
 				case "rx_param_setup_ans":
-					if _, ok := dst.Payload.(*MACCommand_RxParamSetupAns_); !ok {
-						dst.Payload = &MACCommand_RxParamSetupAns_{}
+					_, srcOk := src.Payload.(*MACCommand_RxParamSetupAns_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'rx_param_setup_ans', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_RxParamSetupAns_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'rx_param_setup_ans', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_RxParamSetupAns_).RxParamSetupAns
-						if newDst == nil {
-							newDst = &MACCommand_RxParamSetupAns{}
-							dst.Payload.(*MACCommand_RxParamSetupAns_).RxParamSetupAns = newDst
+						var newDst, newSrc *MACCommand_RxParamSetupAns
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_RxParamSetupAns
-						if src != nil {
-							newSrc = src.GetRxParamSetupAns()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_RxParamSetupAns_).RxParamSetupAns
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_RxParamSetupAns_).RxParamSetupAns
+						} else {
+							newDst = &MACCommand_RxParamSetupAns{}
+							dst.Payload = &MACCommand_RxParamSetupAns_{RxParamSetupAns: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_RxParamSetupAns_).RxParamSetupAns = src.GetRxParamSetupAns()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_RxParamSetupAns_).RxParamSetupAns = nil
+							dst.Payload = nil
 						}
 					}
 				case "dev_status_ans":
-					if _, ok := dst.Payload.(*MACCommand_DevStatusAns_); !ok {
-						dst.Payload = &MACCommand_DevStatusAns_{}
+					_, srcOk := src.Payload.(*MACCommand_DevStatusAns_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'dev_status_ans', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_DevStatusAns_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'dev_status_ans', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_DevStatusAns_).DevStatusAns
-						if newDst == nil {
-							newDst = &MACCommand_DevStatusAns{}
-							dst.Payload.(*MACCommand_DevStatusAns_).DevStatusAns = newDst
+						var newDst, newSrc *MACCommand_DevStatusAns
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_DevStatusAns
-						if src != nil {
-							newSrc = src.GetDevStatusAns()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_DevStatusAns_).DevStatusAns
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_DevStatusAns_).DevStatusAns
+						} else {
+							newDst = &MACCommand_DevStatusAns{}
+							dst.Payload = &MACCommand_DevStatusAns_{DevStatusAns: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_DevStatusAns_).DevStatusAns = src.GetDevStatusAns()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_DevStatusAns_).DevStatusAns = nil
+							dst.Payload = nil
 						}
 					}
 				case "new_channel_req":
-					if _, ok := dst.Payload.(*MACCommand_NewChannelReq_); !ok {
-						dst.Payload = &MACCommand_NewChannelReq_{}
+					_, srcOk := src.Payload.(*MACCommand_NewChannelReq_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'new_channel_req', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_NewChannelReq_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'new_channel_req', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_NewChannelReq_).NewChannelReq
-						if newDst == nil {
-							newDst = &MACCommand_NewChannelReq{}
-							dst.Payload.(*MACCommand_NewChannelReq_).NewChannelReq = newDst
+						var newDst, newSrc *MACCommand_NewChannelReq
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_NewChannelReq
-						if src != nil {
-							newSrc = src.GetNewChannelReq()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_NewChannelReq_).NewChannelReq
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_NewChannelReq_).NewChannelReq
+						} else {
+							newDst = &MACCommand_NewChannelReq{}
+							dst.Payload = &MACCommand_NewChannelReq_{NewChannelReq: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_NewChannelReq_).NewChannelReq = src.GetNewChannelReq()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_NewChannelReq_).NewChannelReq = nil
+							dst.Payload = nil
 						}
 					}
 				case "new_channel_ans":
-					if _, ok := dst.Payload.(*MACCommand_NewChannelAns_); !ok {
-						dst.Payload = &MACCommand_NewChannelAns_{}
+					_, srcOk := src.Payload.(*MACCommand_NewChannelAns_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'new_channel_ans', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_NewChannelAns_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'new_channel_ans', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_NewChannelAns_).NewChannelAns
-						if newDst == nil {
-							newDst = &MACCommand_NewChannelAns{}
-							dst.Payload.(*MACCommand_NewChannelAns_).NewChannelAns = newDst
+						var newDst, newSrc *MACCommand_NewChannelAns
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_NewChannelAns
-						if src != nil {
-							newSrc = src.GetNewChannelAns()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_NewChannelAns_).NewChannelAns
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_NewChannelAns_).NewChannelAns
+						} else {
+							newDst = &MACCommand_NewChannelAns{}
+							dst.Payload = &MACCommand_NewChannelAns_{NewChannelAns: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_NewChannelAns_).NewChannelAns = src.GetNewChannelAns()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_NewChannelAns_).NewChannelAns = nil
+							dst.Payload = nil
 						}
 					}
 				case "dl_channel_req":
-					if _, ok := dst.Payload.(*MACCommand_DLChannelReq_); !ok {
-						dst.Payload = &MACCommand_DLChannelReq_{}
+					_, srcOk := src.Payload.(*MACCommand_DLChannelReq_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'dl_channel_req', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_DLChannelReq_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'dl_channel_req', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_DLChannelReq_).DLChannelReq
-						if newDst == nil {
-							newDst = &MACCommand_DLChannelReq{}
-							dst.Payload.(*MACCommand_DLChannelReq_).DLChannelReq = newDst
+						var newDst, newSrc *MACCommand_DLChannelReq
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_DLChannelReq
-						if src != nil {
-							newSrc = src.GetDLChannelReq()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_DLChannelReq_).DLChannelReq
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_DLChannelReq_).DLChannelReq
+						} else {
+							newDst = &MACCommand_DLChannelReq{}
+							dst.Payload = &MACCommand_DLChannelReq_{DLChannelReq: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_DLChannelReq_).DLChannelReq = src.GetDLChannelReq()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_DLChannelReq_).DLChannelReq = nil
+							dst.Payload = nil
 						}
 					}
 				case "dl_channel_ans":
-					if _, ok := dst.Payload.(*MACCommand_DLChannelAns_); !ok {
-						dst.Payload = &MACCommand_DLChannelAns_{}
+					_, srcOk := src.Payload.(*MACCommand_DLChannelAns_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'dl_channel_ans', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_DLChannelAns_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'dl_channel_ans', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_DLChannelAns_).DLChannelAns
-						if newDst == nil {
-							newDst = &MACCommand_DLChannelAns{}
-							dst.Payload.(*MACCommand_DLChannelAns_).DLChannelAns = newDst
+						var newDst, newSrc *MACCommand_DLChannelAns
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_DLChannelAns
-						if src != nil {
-							newSrc = src.GetDLChannelAns()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_DLChannelAns_).DLChannelAns
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_DLChannelAns_).DLChannelAns
+						} else {
+							newDst = &MACCommand_DLChannelAns{}
+							dst.Payload = &MACCommand_DLChannelAns_{DLChannelAns: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_DLChannelAns_).DLChannelAns = src.GetDLChannelAns()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_DLChannelAns_).DLChannelAns = nil
+							dst.Payload = nil
 						}
 					}
 				case "rx_timing_setup_req":
-					if _, ok := dst.Payload.(*MACCommand_RxTimingSetupReq_); !ok {
-						dst.Payload = &MACCommand_RxTimingSetupReq_{}
+					_, srcOk := src.Payload.(*MACCommand_RxTimingSetupReq_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'rx_timing_setup_req', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_RxTimingSetupReq_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'rx_timing_setup_req', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_RxTimingSetupReq_).RxTimingSetupReq
-						if newDst == nil {
-							newDst = &MACCommand_RxTimingSetupReq{}
-							dst.Payload.(*MACCommand_RxTimingSetupReq_).RxTimingSetupReq = newDst
+						var newDst, newSrc *MACCommand_RxTimingSetupReq
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_RxTimingSetupReq
-						if src != nil {
-							newSrc = src.GetRxTimingSetupReq()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_RxTimingSetupReq_).RxTimingSetupReq
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_RxTimingSetupReq_).RxTimingSetupReq
+						} else {
+							newDst = &MACCommand_RxTimingSetupReq{}
+							dst.Payload = &MACCommand_RxTimingSetupReq_{RxTimingSetupReq: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_RxTimingSetupReq_).RxTimingSetupReq = src.GetRxTimingSetupReq()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_RxTimingSetupReq_).RxTimingSetupReq = nil
+							dst.Payload = nil
 						}
 					}
 				case "tx_param_setup_req":
-					if _, ok := dst.Payload.(*MACCommand_TxParamSetupReq_); !ok {
-						dst.Payload = &MACCommand_TxParamSetupReq_{}
+					_, srcOk := src.Payload.(*MACCommand_TxParamSetupReq_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'tx_param_setup_req', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_TxParamSetupReq_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'tx_param_setup_req', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_TxParamSetupReq_).TxParamSetupReq
-						if newDst == nil {
-							newDst = &MACCommand_TxParamSetupReq{}
-							dst.Payload.(*MACCommand_TxParamSetupReq_).TxParamSetupReq = newDst
+						var newDst, newSrc *MACCommand_TxParamSetupReq
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_TxParamSetupReq
-						if src != nil {
-							newSrc = src.GetTxParamSetupReq()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_TxParamSetupReq_).TxParamSetupReq
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_TxParamSetupReq_).TxParamSetupReq
+						} else {
+							newDst = &MACCommand_TxParamSetupReq{}
+							dst.Payload = &MACCommand_TxParamSetupReq_{TxParamSetupReq: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_TxParamSetupReq_).TxParamSetupReq = src.GetTxParamSetupReq()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_TxParamSetupReq_).TxParamSetupReq = nil
+							dst.Payload = nil
 						}
 					}
 				case "rekey_ind":
-					if _, ok := dst.Payload.(*MACCommand_RekeyInd_); !ok {
-						dst.Payload = &MACCommand_RekeyInd_{}
+					_, srcOk := src.Payload.(*MACCommand_RekeyInd_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'rekey_ind', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_RekeyInd_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'rekey_ind', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_RekeyInd_).RekeyInd
-						if newDst == nil {
-							newDst = &MACCommand_RekeyInd{}
-							dst.Payload.(*MACCommand_RekeyInd_).RekeyInd = newDst
+						var newDst, newSrc *MACCommand_RekeyInd
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_RekeyInd
-						if src != nil {
-							newSrc = src.GetRekeyInd()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_RekeyInd_).RekeyInd
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_RekeyInd_).RekeyInd
+						} else {
+							newDst = &MACCommand_RekeyInd{}
+							dst.Payload = &MACCommand_RekeyInd_{RekeyInd: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_RekeyInd_).RekeyInd = src.GetRekeyInd()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_RekeyInd_).RekeyInd = nil
+							dst.Payload = nil
 						}
 					}
 				case "rekey_conf":
-					if _, ok := dst.Payload.(*MACCommand_RekeyConf_); !ok {
-						dst.Payload = &MACCommand_RekeyConf_{}
+					_, srcOk := src.Payload.(*MACCommand_RekeyConf_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'rekey_conf', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_RekeyConf_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'rekey_conf', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_RekeyConf_).RekeyConf
-						if newDst == nil {
-							newDst = &MACCommand_RekeyConf{}
-							dst.Payload.(*MACCommand_RekeyConf_).RekeyConf = newDst
+						var newDst, newSrc *MACCommand_RekeyConf
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_RekeyConf
-						if src != nil {
-							newSrc = src.GetRekeyConf()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_RekeyConf_).RekeyConf
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_RekeyConf_).RekeyConf
+						} else {
+							newDst = &MACCommand_RekeyConf{}
+							dst.Payload = &MACCommand_RekeyConf_{RekeyConf: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_RekeyConf_).RekeyConf = src.GetRekeyConf()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_RekeyConf_).RekeyConf = nil
+							dst.Payload = nil
 						}
 					}
 				case "adr_param_setup_req":
-					if _, ok := dst.Payload.(*MACCommand_ADRParamSetupReq_); !ok {
-						dst.Payload = &MACCommand_ADRParamSetupReq_{}
+					_, srcOk := src.Payload.(*MACCommand_ADRParamSetupReq_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'adr_param_setup_req', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_ADRParamSetupReq_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'adr_param_setup_req', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_ADRParamSetupReq_).ADRParamSetupReq
-						if newDst == nil {
-							newDst = &MACCommand_ADRParamSetupReq{}
-							dst.Payload.(*MACCommand_ADRParamSetupReq_).ADRParamSetupReq = newDst
+						var newDst, newSrc *MACCommand_ADRParamSetupReq
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_ADRParamSetupReq
-						if src != nil {
-							newSrc = src.GetADRParamSetupReq()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_ADRParamSetupReq_).ADRParamSetupReq
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_ADRParamSetupReq_).ADRParamSetupReq
+						} else {
+							newDst = &MACCommand_ADRParamSetupReq{}
+							dst.Payload = &MACCommand_ADRParamSetupReq_{ADRParamSetupReq: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_ADRParamSetupReq_).ADRParamSetupReq = src.GetADRParamSetupReq()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_ADRParamSetupReq_).ADRParamSetupReq = nil
+							dst.Payload = nil
 						}
 					}
 				case "device_time_ans":
-					if _, ok := dst.Payload.(*MACCommand_DeviceTimeAns_); !ok {
-						dst.Payload = &MACCommand_DeviceTimeAns_{}
+					_, srcOk := src.Payload.(*MACCommand_DeviceTimeAns_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'device_time_ans', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_DeviceTimeAns_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'device_time_ans', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_DeviceTimeAns_).DeviceTimeAns
-						if newDst == nil {
-							newDst = &MACCommand_DeviceTimeAns{}
-							dst.Payload.(*MACCommand_DeviceTimeAns_).DeviceTimeAns = newDst
+						var newDst, newSrc *MACCommand_DeviceTimeAns
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_DeviceTimeAns
-						if src != nil {
-							newSrc = src.GetDeviceTimeAns()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_DeviceTimeAns_).DeviceTimeAns
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_DeviceTimeAns_).DeviceTimeAns
+						} else {
+							newDst = &MACCommand_DeviceTimeAns{}
+							dst.Payload = &MACCommand_DeviceTimeAns_{DeviceTimeAns: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_DeviceTimeAns_).DeviceTimeAns = src.GetDeviceTimeAns()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_DeviceTimeAns_).DeviceTimeAns = nil
+							dst.Payload = nil
 						}
 					}
 				case "force_rejoin_req":
-					if _, ok := dst.Payload.(*MACCommand_ForceRejoinReq_); !ok {
-						dst.Payload = &MACCommand_ForceRejoinReq_{}
+					_, srcOk := src.Payload.(*MACCommand_ForceRejoinReq_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'force_rejoin_req', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_ForceRejoinReq_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'force_rejoin_req', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_ForceRejoinReq_).ForceRejoinReq
-						if newDst == nil {
-							newDst = &MACCommand_ForceRejoinReq{}
-							dst.Payload.(*MACCommand_ForceRejoinReq_).ForceRejoinReq = newDst
+						var newDst, newSrc *MACCommand_ForceRejoinReq
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_ForceRejoinReq
-						if src != nil {
-							newSrc = src.GetForceRejoinReq()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_ForceRejoinReq_).ForceRejoinReq
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_ForceRejoinReq_).ForceRejoinReq
+						} else {
+							newDst = &MACCommand_ForceRejoinReq{}
+							dst.Payload = &MACCommand_ForceRejoinReq_{ForceRejoinReq: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_ForceRejoinReq_).ForceRejoinReq = src.GetForceRejoinReq()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_ForceRejoinReq_).ForceRejoinReq = nil
+							dst.Payload = nil
 						}
 					}
 				case "rejoin_param_setup_req":
-					if _, ok := dst.Payload.(*MACCommand_RejoinParamSetupReq_); !ok {
-						dst.Payload = &MACCommand_RejoinParamSetupReq_{}
+					_, srcOk := src.Payload.(*MACCommand_RejoinParamSetupReq_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'rejoin_param_setup_req', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_RejoinParamSetupReq_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'rejoin_param_setup_req', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_RejoinParamSetupReq_).RejoinParamSetupReq
-						if newDst == nil {
-							newDst = &MACCommand_RejoinParamSetupReq{}
-							dst.Payload.(*MACCommand_RejoinParamSetupReq_).RejoinParamSetupReq = newDst
+						var newDst, newSrc *MACCommand_RejoinParamSetupReq
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_RejoinParamSetupReq
-						if src != nil {
-							newSrc = src.GetRejoinParamSetupReq()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_RejoinParamSetupReq_).RejoinParamSetupReq
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_RejoinParamSetupReq_).RejoinParamSetupReq
+						} else {
+							newDst = &MACCommand_RejoinParamSetupReq{}
+							dst.Payload = &MACCommand_RejoinParamSetupReq_{RejoinParamSetupReq: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_RejoinParamSetupReq_).RejoinParamSetupReq = src.GetRejoinParamSetupReq()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_RejoinParamSetupReq_).RejoinParamSetupReq = nil
+							dst.Payload = nil
 						}
 					}
 				case "rejoin_param_setup_ans":
-					if _, ok := dst.Payload.(*MACCommand_RejoinParamSetupAns_); !ok {
-						dst.Payload = &MACCommand_RejoinParamSetupAns_{}
+					_, srcOk := src.Payload.(*MACCommand_RejoinParamSetupAns_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'rejoin_param_setup_ans', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_RejoinParamSetupAns_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'rejoin_param_setup_ans', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_RejoinParamSetupAns_).RejoinParamSetupAns
-						if newDst == nil {
-							newDst = &MACCommand_RejoinParamSetupAns{}
-							dst.Payload.(*MACCommand_RejoinParamSetupAns_).RejoinParamSetupAns = newDst
+						var newDst, newSrc *MACCommand_RejoinParamSetupAns
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_RejoinParamSetupAns
-						if src != nil {
-							newSrc = src.GetRejoinParamSetupAns()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_RejoinParamSetupAns_).RejoinParamSetupAns
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_RejoinParamSetupAns_).RejoinParamSetupAns
+						} else {
+							newDst = &MACCommand_RejoinParamSetupAns{}
+							dst.Payload = &MACCommand_RejoinParamSetupAns_{RejoinParamSetupAns: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_RejoinParamSetupAns_).RejoinParamSetupAns = src.GetRejoinParamSetupAns()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_RejoinParamSetupAns_).RejoinParamSetupAns = nil
+							dst.Payload = nil
 						}
 					}
 				case "ping_slot_info_req":
-					if _, ok := dst.Payload.(*MACCommand_PingSlotInfoReq_); !ok {
-						dst.Payload = &MACCommand_PingSlotInfoReq_{}
+					_, srcOk := src.Payload.(*MACCommand_PingSlotInfoReq_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'ping_slot_info_req', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_PingSlotInfoReq_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'ping_slot_info_req', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_PingSlotInfoReq_).PingSlotInfoReq
-						if newDst == nil {
-							newDst = &MACCommand_PingSlotInfoReq{}
-							dst.Payload.(*MACCommand_PingSlotInfoReq_).PingSlotInfoReq = newDst
+						var newDst, newSrc *MACCommand_PingSlotInfoReq
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_PingSlotInfoReq
-						if src != nil {
-							newSrc = src.GetPingSlotInfoReq()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_PingSlotInfoReq_).PingSlotInfoReq
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_PingSlotInfoReq_).PingSlotInfoReq
+						} else {
+							newDst = &MACCommand_PingSlotInfoReq{}
+							dst.Payload = &MACCommand_PingSlotInfoReq_{PingSlotInfoReq: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_PingSlotInfoReq_).PingSlotInfoReq = src.GetPingSlotInfoReq()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_PingSlotInfoReq_).PingSlotInfoReq = nil
+							dst.Payload = nil
 						}
 					}
 				case "ping_slot_channel_req":
-					if _, ok := dst.Payload.(*MACCommand_PingSlotChannelReq_); !ok {
-						dst.Payload = &MACCommand_PingSlotChannelReq_{}
+					_, srcOk := src.Payload.(*MACCommand_PingSlotChannelReq_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'ping_slot_channel_req', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_PingSlotChannelReq_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'ping_slot_channel_req', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_PingSlotChannelReq_).PingSlotChannelReq
-						if newDst == nil {
-							newDst = &MACCommand_PingSlotChannelReq{}
-							dst.Payload.(*MACCommand_PingSlotChannelReq_).PingSlotChannelReq = newDst
+						var newDst, newSrc *MACCommand_PingSlotChannelReq
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_PingSlotChannelReq
-						if src != nil {
-							newSrc = src.GetPingSlotChannelReq()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_PingSlotChannelReq_).PingSlotChannelReq
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_PingSlotChannelReq_).PingSlotChannelReq
+						} else {
+							newDst = &MACCommand_PingSlotChannelReq{}
+							dst.Payload = &MACCommand_PingSlotChannelReq_{PingSlotChannelReq: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_PingSlotChannelReq_).PingSlotChannelReq = src.GetPingSlotChannelReq()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_PingSlotChannelReq_).PingSlotChannelReq = nil
+							dst.Payload = nil
 						}
 					}
 				case "ping_slot_channel_ans":
-					if _, ok := dst.Payload.(*MACCommand_PingSlotChannelAns_); !ok {
-						dst.Payload = &MACCommand_PingSlotChannelAns_{}
+					_, srcOk := src.Payload.(*MACCommand_PingSlotChannelAns_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'ping_slot_channel_ans', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_PingSlotChannelAns_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'ping_slot_channel_ans', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_PingSlotChannelAns_).PingSlotChannelAns
-						if newDst == nil {
-							newDst = &MACCommand_PingSlotChannelAns{}
-							dst.Payload.(*MACCommand_PingSlotChannelAns_).PingSlotChannelAns = newDst
+						var newDst, newSrc *MACCommand_PingSlotChannelAns
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_PingSlotChannelAns
-						if src != nil {
-							newSrc = src.GetPingSlotChannelAns()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_PingSlotChannelAns_).PingSlotChannelAns
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_PingSlotChannelAns_).PingSlotChannelAns
+						} else {
+							newDst = &MACCommand_PingSlotChannelAns{}
+							dst.Payload = &MACCommand_PingSlotChannelAns_{PingSlotChannelAns: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_PingSlotChannelAns_).PingSlotChannelAns = src.GetPingSlotChannelAns()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_PingSlotChannelAns_).PingSlotChannelAns = nil
+							dst.Payload = nil
 						}
 					}
 				case "beacon_timing_ans":
-					if _, ok := dst.Payload.(*MACCommand_BeaconTimingAns_); !ok {
-						dst.Payload = &MACCommand_BeaconTimingAns_{}
+					_, srcOk := src.Payload.(*MACCommand_BeaconTimingAns_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'beacon_timing_ans', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_BeaconTimingAns_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'beacon_timing_ans', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_BeaconTimingAns_).BeaconTimingAns
-						if newDst == nil {
-							newDst = &MACCommand_BeaconTimingAns{}
-							dst.Payload.(*MACCommand_BeaconTimingAns_).BeaconTimingAns = newDst
+						var newDst, newSrc *MACCommand_BeaconTimingAns
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_BeaconTimingAns
-						if src != nil {
-							newSrc = src.GetBeaconTimingAns()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_BeaconTimingAns_).BeaconTimingAns
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_BeaconTimingAns_).BeaconTimingAns
+						} else {
+							newDst = &MACCommand_BeaconTimingAns{}
+							dst.Payload = &MACCommand_BeaconTimingAns_{BeaconTimingAns: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_BeaconTimingAns_).BeaconTimingAns = src.GetBeaconTimingAns()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_BeaconTimingAns_).BeaconTimingAns = nil
+							dst.Payload = nil
 						}
 					}
 				case "beacon_freq_req":
-					if _, ok := dst.Payload.(*MACCommand_BeaconFreqReq_); !ok {
-						dst.Payload = &MACCommand_BeaconFreqReq_{}
+					_, srcOk := src.Payload.(*MACCommand_BeaconFreqReq_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'beacon_freq_req', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_BeaconFreqReq_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'beacon_freq_req', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_BeaconFreqReq_).BeaconFreqReq
-						if newDst == nil {
-							newDst = &MACCommand_BeaconFreqReq{}
-							dst.Payload.(*MACCommand_BeaconFreqReq_).BeaconFreqReq = newDst
+						var newDst, newSrc *MACCommand_BeaconFreqReq
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_BeaconFreqReq
-						if src != nil {
-							newSrc = src.GetBeaconFreqReq()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_BeaconFreqReq_).BeaconFreqReq
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_BeaconFreqReq_).BeaconFreqReq
+						} else {
+							newDst = &MACCommand_BeaconFreqReq{}
+							dst.Payload = &MACCommand_BeaconFreqReq_{BeaconFreqReq: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_BeaconFreqReq_).BeaconFreqReq = src.GetBeaconFreqReq()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_BeaconFreqReq_).BeaconFreqReq = nil
+							dst.Payload = nil
 						}
 					}
 				case "beacon_freq_ans":
-					if _, ok := dst.Payload.(*MACCommand_BeaconFreqAns_); !ok {
-						dst.Payload = &MACCommand_BeaconFreqAns_{}
+					_, srcOk := src.Payload.(*MACCommand_BeaconFreqAns_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'beacon_freq_ans', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_BeaconFreqAns_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'beacon_freq_ans', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_BeaconFreqAns_).BeaconFreqAns
-						if newDst == nil {
-							newDst = &MACCommand_BeaconFreqAns{}
-							dst.Payload.(*MACCommand_BeaconFreqAns_).BeaconFreqAns = newDst
+						var newDst, newSrc *MACCommand_BeaconFreqAns
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_BeaconFreqAns
-						if src != nil {
-							newSrc = src.GetBeaconFreqAns()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_BeaconFreqAns_).BeaconFreqAns
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_BeaconFreqAns_).BeaconFreqAns
+						} else {
+							newDst = &MACCommand_BeaconFreqAns{}
+							dst.Payload = &MACCommand_BeaconFreqAns_{BeaconFreqAns: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_BeaconFreqAns_).BeaconFreqAns = src.GetBeaconFreqAns()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_BeaconFreqAns_).BeaconFreqAns = nil
+							dst.Payload = nil
 						}
 					}
 				case "device_mode_ind":
-					if _, ok := dst.Payload.(*MACCommand_DeviceModeInd_); !ok {
-						dst.Payload = &MACCommand_DeviceModeInd_{}
+					_, srcOk := src.Payload.(*MACCommand_DeviceModeInd_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'device_mode_ind', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_DeviceModeInd_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'device_mode_ind', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_DeviceModeInd_).DeviceModeInd
-						if newDst == nil {
-							newDst = &MACCommand_DeviceModeInd{}
-							dst.Payload.(*MACCommand_DeviceModeInd_).DeviceModeInd = newDst
+						var newDst, newSrc *MACCommand_DeviceModeInd
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_DeviceModeInd
-						if src != nil {
-							newSrc = src.GetDeviceModeInd()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_DeviceModeInd_).DeviceModeInd
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_DeviceModeInd_).DeviceModeInd
+						} else {
+							newDst = &MACCommand_DeviceModeInd{}
+							dst.Payload = &MACCommand_DeviceModeInd_{DeviceModeInd: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_DeviceModeInd_).DeviceModeInd = src.GetDeviceModeInd()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_DeviceModeInd_).DeviceModeInd = nil
+							dst.Payload = nil
 						}
 					}
 				case "device_mode_conf":
-					if _, ok := dst.Payload.(*MACCommand_DeviceModeConf_); !ok {
-						dst.Payload = &MACCommand_DeviceModeConf_{}
+					_, srcOk := src.Payload.(*MACCommand_DeviceModeConf_)
+					if !srcOk && src.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'device_mode_conf', while different oneof is set in source")
+					}
+					_, dstOk := dst.Payload.(*MACCommand_DeviceModeConf_)
+					if !dstOk && dst.Payload != nil {
+						return fmt.Errorf("attempt to set oneof 'device_mode_conf', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Payload.(*MACCommand_DeviceModeConf_).DeviceModeConf
-						if newDst == nil {
-							newDst = &MACCommand_DeviceModeConf{}
-							dst.Payload.(*MACCommand_DeviceModeConf_).DeviceModeConf = newDst
+						var newDst, newSrc *MACCommand_DeviceModeConf
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *MACCommand_DeviceModeConf
-						if src != nil {
-							newSrc = src.GetDeviceModeConf()
+						if srcOk {
+							newSrc = src.Payload.(*MACCommand_DeviceModeConf_).DeviceModeConf
+						}
+						if dstOk {
+							newDst = dst.Payload.(*MACCommand_DeviceModeConf_).DeviceModeConf
+						} else {
+							newDst = &MACCommand_DeviceModeConf{}
+							dst.Payload = &MACCommand_DeviceModeConf_{DeviceModeConf: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Payload.(*MACCommand_DeviceModeConf_).DeviceModeConf = src.GetDeviceModeConf()
+							dst.Payload = src.Payload
 						} else {
-							dst.Payload.(*MACCommand_DeviceModeConf_).DeviceModeConf = nil
+							dst.Payload = nil
 						}
 					}
 

--- a/pkg/ttnpb/message_services.pb.setters.fm.go
+++ b/pkg/ttnpb/message_services.pb.setters.fm.go
@@ -9,11 +9,11 @@ func (dst *ProcessUplinkMessageRequest) SetFields(src *ProcessUplinkMessageReque
 		switch name {
 		case "ids":
 			if len(subs) > 0 {
-				newDst := &dst.EndDeviceIdentifiers
-				var newSrc *EndDeviceIdentifiers
+				var newDst, newSrc *EndDeviceIdentifiers
 				if src != nil {
 					newSrc = &src.EndDeviceIdentifiers
 				}
+				newDst = &dst.EndDeviceIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -27,11 +27,11 @@ func (dst *ProcessUplinkMessageRequest) SetFields(src *ProcessUplinkMessageReque
 			}
 		case "end_device_version_ids":
 			if len(subs) > 0 {
-				newDst := &dst.EndDeviceVersionIDs
-				var newSrc *EndDeviceVersionIdentifiers
+				var newDst, newSrc *EndDeviceVersionIdentifiers
 				if src != nil {
 					newSrc = &src.EndDeviceVersionIDs
 				}
+				newDst = &dst.EndDeviceVersionIDs
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -45,11 +45,11 @@ func (dst *ProcessUplinkMessageRequest) SetFields(src *ProcessUplinkMessageReque
 			}
 		case "message":
 			if len(subs) > 0 {
-				newDst := &dst.Message
-				var newSrc *ApplicationUplink
+				var newDst, newSrc *ApplicationUplink
 				if src != nil {
 					newSrc = &src.Message
 				}
+				newDst = &dst.Message
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -84,11 +84,11 @@ func (dst *ProcessDownlinkMessageRequest) SetFields(src *ProcessDownlinkMessageR
 		switch name {
 		case "ids":
 			if len(subs) > 0 {
-				newDst := &dst.EndDeviceIdentifiers
-				var newSrc *EndDeviceIdentifiers
+				var newDst, newSrc *EndDeviceIdentifiers
 				if src != nil {
 					newSrc = &src.EndDeviceIdentifiers
 				}
+				newDst = &dst.EndDeviceIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -102,11 +102,11 @@ func (dst *ProcessDownlinkMessageRequest) SetFields(src *ProcessDownlinkMessageR
 			}
 		case "end_device_version_ids":
 			if len(subs) > 0 {
-				newDst := &dst.EndDeviceVersionIDs
-				var newSrc *EndDeviceVersionIdentifiers
+				var newDst, newSrc *EndDeviceVersionIdentifiers
 				if src != nil {
 					newSrc = &src.EndDeviceVersionIDs
 				}
+				newDst = &dst.EndDeviceVersionIDs
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -120,11 +120,11 @@ func (dst *ProcessDownlinkMessageRequest) SetFields(src *ProcessDownlinkMessageR
 			}
 		case "message":
 			if len(subs) > 0 {
-				newDst := &dst.Message
-				var newSrc *ApplicationDownlink
+				var newDst, newSrc *ApplicationDownlink
 				if src != nil {
 					newSrc = &src.Message
 				}
+				newDst = &dst.Message
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}

--- a/pkg/ttnpb/messages.pb.setters.fm.go
+++ b/pkg/ttnpb/messages.pb.setters.fm.go
@@ -21,14 +21,18 @@ func (dst *UplinkMessage) SetFields(src *UplinkMessage, paths ...string) error {
 			}
 		case "payload":
 			if len(subs) > 0 {
-				newDst := dst.Payload
-				if newDst == nil {
-					newDst = &Message{}
-					dst.Payload = newDst
+				var newDst, newSrc *Message
+				if (src == nil || src.Payload == nil) && dst.Payload == nil {
+					continue
 				}
-				var newSrc *Message
 				if src != nil {
 					newSrc = src.Payload
+				}
+				if dst.Payload != nil {
+					newDst = dst.Payload
+				} else {
+					newDst = &Message{}
+					dst.Payload = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -42,11 +46,11 @@ func (dst *UplinkMessage) SetFields(src *UplinkMessage, paths ...string) error {
 			}
 		case "settings":
 			if len(subs) > 0 {
-				newDst := &dst.Settings
-				var newSrc *TxSettings
+				var newDst, newSrc *TxSettings
 				if src != nil {
 					newSrc = &src.Settings
 				}
+				newDst = &dst.Settings
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -118,14 +122,18 @@ func (dst *DownlinkMessage) SetFields(src *DownlinkMessage, paths ...string) err
 			}
 		case "payload":
 			if len(subs) > 0 {
-				newDst := dst.Payload
-				if newDst == nil {
-					newDst = &Message{}
-					dst.Payload = newDst
+				var newDst, newSrc *Message
+				if (src == nil || src.Payload == nil) && dst.Payload == nil {
+					continue
 				}
-				var newSrc *Message
 				if src != nil {
 					newSrc = src.Payload
+				}
+				if dst.Payload != nil {
+					newDst = dst.Payload
+				} else {
+					newDst = &Message{}
+					dst.Payload = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -139,14 +147,18 @@ func (dst *DownlinkMessage) SetFields(src *DownlinkMessage, paths ...string) err
 			}
 		case "end_device_ids":
 			if len(subs) > 0 {
-				newDst := dst.EndDeviceIDs
-				if newDst == nil {
-					newDst = &EndDeviceIdentifiers{}
-					dst.EndDeviceIDs = newDst
+				var newDst, newSrc *EndDeviceIdentifiers
+				if (src == nil || src.EndDeviceIDs == nil) && dst.EndDeviceIDs == nil {
+					continue
 				}
-				var newSrc *EndDeviceIdentifiers
 				if src != nil {
 					newSrc = src.EndDeviceIDs
+				}
+				if dst.EndDeviceIDs != nil {
+					newDst = dst.EndDeviceIDs
+				} else {
+					newDst = &EndDeviceIdentifiers{}
+					dst.EndDeviceIDs = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -184,51 +196,69 @@ func (dst *DownlinkMessage) SetFields(src *DownlinkMessage, paths ...string) err
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "request":
-					if _, ok := dst.Settings.(*DownlinkMessage_Request); !ok {
-						dst.Settings = &DownlinkMessage_Request{}
+					_, srcOk := src.Settings.(*DownlinkMessage_Request)
+					if !srcOk && src.Settings != nil {
+						return fmt.Errorf("attempt to set oneof 'request', while different oneof is set in source")
+					}
+					_, dstOk := dst.Settings.(*DownlinkMessage_Request)
+					if !dstOk && dst.Settings != nil {
+						return fmt.Errorf("attempt to set oneof 'request', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Settings.(*DownlinkMessage_Request).Request
-						if newDst == nil {
-							newDst = &TxRequest{}
-							dst.Settings.(*DownlinkMessage_Request).Request = newDst
+						var newDst, newSrc *TxRequest
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *TxRequest
-						if src != nil {
-							newSrc = src.GetRequest()
+						if srcOk {
+							newSrc = src.Settings.(*DownlinkMessage_Request).Request
+						}
+						if dstOk {
+							newDst = dst.Settings.(*DownlinkMessage_Request).Request
+						} else {
+							newDst = &TxRequest{}
+							dst.Settings = &DownlinkMessage_Request{Request: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Settings.(*DownlinkMessage_Request).Request = src.GetRequest()
+							dst.Settings = src.Settings
 						} else {
-							dst.Settings.(*DownlinkMessage_Request).Request = nil
+							dst.Settings = nil
 						}
 					}
 				case "scheduled":
-					if _, ok := dst.Settings.(*DownlinkMessage_Scheduled); !ok {
-						dst.Settings = &DownlinkMessage_Scheduled{}
+					_, srcOk := src.Settings.(*DownlinkMessage_Scheduled)
+					if !srcOk && src.Settings != nil {
+						return fmt.Errorf("attempt to set oneof 'scheduled', while different oneof is set in source")
+					}
+					_, dstOk := dst.Settings.(*DownlinkMessage_Scheduled)
+					if !dstOk && dst.Settings != nil {
+						return fmt.Errorf("attempt to set oneof 'scheduled', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Settings.(*DownlinkMessage_Scheduled).Scheduled
-						if newDst == nil {
-							newDst = &TxSettings{}
-							dst.Settings.(*DownlinkMessage_Scheduled).Scheduled = newDst
+						var newDst, newSrc *TxSettings
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *TxSettings
-						if src != nil {
-							newSrc = src.GetScheduled()
+						if srcOk {
+							newSrc = src.Settings.(*DownlinkMessage_Scheduled).Scheduled
+						}
+						if dstOk {
+							newDst = dst.Settings.(*DownlinkMessage_Scheduled).Scheduled
+						} else {
+							newDst = &TxSettings{}
+							dst.Settings = &DownlinkMessage_Scheduled{Scheduled: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Settings.(*DownlinkMessage_Scheduled).Scheduled = src.GetScheduled()
+							dst.Settings = src.Settings
 						} else {
-							dst.Settings.(*DownlinkMessage_Scheduled).Scheduled = nil
+							dst.Settings = nil
 						}
 					}
 
@@ -335,11 +365,11 @@ func (dst *ApplicationUplink) SetFields(src *ApplicationUplink, paths ...string)
 			}
 		case "settings":
 			if len(subs) > 0 {
-				newDst := &dst.Settings
-				var newSrc *TxSettings
+				var newDst, newSrc *TxSettings
 				if src != nil {
 					newSrc = &src.Settings
 				}
+				newDst = &dst.Settings
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -384,11 +414,11 @@ func (dst *ApplicationLocation) SetFields(src *ApplicationLocation, paths ...str
 			}
 		case "location":
 			if len(subs) > 0 {
-				newDst := &dst.Location
-				var newSrc *Location
+				var newDst, newSrc *Location
 				if src != nil {
 					newSrc = &src.Location
 				}
+				newDst = &dst.Location
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -431,14 +461,18 @@ func (dst *ApplicationJoinAccept) SetFields(src *ApplicationJoinAccept, paths ..
 			}
 		case "app_s_key":
 			if len(subs) > 0 {
-				newDst := dst.AppSKey
-				if newDst == nil {
-					newDst = &KeyEnvelope{}
-					dst.AppSKey = newDst
+				var newDst, newSrc *KeyEnvelope
+				if (src == nil || src.AppSKey == nil) && dst.AppSKey == nil {
+					continue
 				}
-				var newSrc *KeyEnvelope
 				if src != nil {
 					newSrc = src.AppSKey
+				}
+				if dst.AppSKey != nil {
+					newDst = dst.AppSKey
+				} else {
+					newDst = &KeyEnvelope{}
+					dst.AppSKey = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -549,14 +583,18 @@ func (dst *ApplicationDownlink) SetFields(src *ApplicationDownlink, paths ...str
 			}
 		case "class_b_c":
 			if len(subs) > 0 {
-				newDst := dst.ClassBC
-				if newDst == nil {
-					newDst = &ApplicationDownlink_ClassBC{}
-					dst.ClassBC = newDst
+				var newDst, newSrc *ApplicationDownlink_ClassBC
+				if (src == nil || src.ClassBC == nil) && dst.ClassBC == nil {
+					continue
 				}
-				var newSrc *ApplicationDownlink_ClassBC
 				if src != nil {
 					newSrc = src.ClassBC
+				}
+				if dst.ClassBC != nil {
+					newDst = dst.ClassBC
+				} else {
+					newDst = &ApplicationDownlink_ClassBC{}
+					dst.ClassBC = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -620,11 +658,11 @@ func (dst *ApplicationDownlinkFailed) SetFields(src *ApplicationDownlinkFailed, 
 		switch name {
 		case "downlink":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationDownlink
-				var newSrc *ApplicationDownlink
+				var newDst, newSrc *ApplicationDownlink
 				if src != nil {
 					newSrc = &src.ApplicationDownlink
 				}
+				newDst = &dst.ApplicationDownlink
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -638,11 +676,11 @@ func (dst *ApplicationDownlinkFailed) SetFields(src *ApplicationDownlinkFailed, 
 			}
 		case "error":
 			if len(subs) > 0 {
-				newDst := &dst.Error
-				var newSrc *ErrorDetails
+				var newDst, newSrc *ErrorDetails
 				if src != nil {
 					newSrc = &src.Error
 				}
+				newDst = &dst.Error
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -697,11 +735,11 @@ func (dst *ApplicationUp) SetFields(src *ApplicationUp, paths ...string) error {
 		switch name {
 		case "end_device_ids":
 			if len(subs) > 0 {
-				newDst := &dst.EndDeviceIdentifiers
-				var newSrc *EndDeviceIdentifiers
+				var newDst, newSrc *EndDeviceIdentifiers
 				if src != nil {
 					newSrc = &src.EndDeviceIdentifiers
 				}
+				newDst = &dst.EndDeviceIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -748,219 +786,300 @@ func (dst *ApplicationUp) SetFields(src *ApplicationUp, paths ...string) error {
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "uplink_message":
-					if _, ok := dst.Up.(*ApplicationUp_UplinkMessage); !ok {
-						dst.Up = &ApplicationUp_UplinkMessage{}
+					_, srcOk := src.Up.(*ApplicationUp_UplinkMessage)
+					if !srcOk && src.Up != nil {
+						return fmt.Errorf("attempt to set oneof 'uplink_message', while different oneof is set in source")
+					}
+					_, dstOk := dst.Up.(*ApplicationUp_UplinkMessage)
+					if !dstOk && dst.Up != nil {
+						return fmt.Errorf("attempt to set oneof 'uplink_message', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Up.(*ApplicationUp_UplinkMessage).UplinkMessage
-						if newDst == nil {
-							newDst = &ApplicationUplink{}
-							dst.Up.(*ApplicationUp_UplinkMessage).UplinkMessage = newDst
+						var newDst, newSrc *ApplicationUplink
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *ApplicationUplink
-						if src != nil {
-							newSrc = src.GetUplinkMessage()
+						if srcOk {
+							newSrc = src.Up.(*ApplicationUp_UplinkMessage).UplinkMessage
+						}
+						if dstOk {
+							newDst = dst.Up.(*ApplicationUp_UplinkMessage).UplinkMessage
+						} else {
+							newDst = &ApplicationUplink{}
+							dst.Up = &ApplicationUp_UplinkMessage{UplinkMessage: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Up.(*ApplicationUp_UplinkMessage).UplinkMessage = src.GetUplinkMessage()
+							dst.Up = src.Up
 						} else {
-							dst.Up.(*ApplicationUp_UplinkMessage).UplinkMessage = nil
+							dst.Up = nil
 						}
 					}
 				case "join_accept":
-					if _, ok := dst.Up.(*ApplicationUp_JoinAccept); !ok {
-						dst.Up = &ApplicationUp_JoinAccept{}
+					_, srcOk := src.Up.(*ApplicationUp_JoinAccept)
+					if !srcOk && src.Up != nil {
+						return fmt.Errorf("attempt to set oneof 'join_accept', while different oneof is set in source")
+					}
+					_, dstOk := dst.Up.(*ApplicationUp_JoinAccept)
+					if !dstOk && dst.Up != nil {
+						return fmt.Errorf("attempt to set oneof 'join_accept', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Up.(*ApplicationUp_JoinAccept).JoinAccept
-						if newDst == nil {
-							newDst = &ApplicationJoinAccept{}
-							dst.Up.(*ApplicationUp_JoinAccept).JoinAccept = newDst
+						var newDst, newSrc *ApplicationJoinAccept
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *ApplicationJoinAccept
-						if src != nil {
-							newSrc = src.GetJoinAccept()
+						if srcOk {
+							newSrc = src.Up.(*ApplicationUp_JoinAccept).JoinAccept
+						}
+						if dstOk {
+							newDst = dst.Up.(*ApplicationUp_JoinAccept).JoinAccept
+						} else {
+							newDst = &ApplicationJoinAccept{}
+							dst.Up = &ApplicationUp_JoinAccept{JoinAccept: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Up.(*ApplicationUp_JoinAccept).JoinAccept = src.GetJoinAccept()
+							dst.Up = src.Up
 						} else {
-							dst.Up.(*ApplicationUp_JoinAccept).JoinAccept = nil
+							dst.Up = nil
 						}
 					}
 				case "downlink_ack":
-					if _, ok := dst.Up.(*ApplicationUp_DownlinkAck); !ok {
-						dst.Up = &ApplicationUp_DownlinkAck{}
+					_, srcOk := src.Up.(*ApplicationUp_DownlinkAck)
+					if !srcOk && src.Up != nil {
+						return fmt.Errorf("attempt to set oneof 'downlink_ack', while different oneof is set in source")
+					}
+					_, dstOk := dst.Up.(*ApplicationUp_DownlinkAck)
+					if !dstOk && dst.Up != nil {
+						return fmt.Errorf("attempt to set oneof 'downlink_ack', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Up.(*ApplicationUp_DownlinkAck).DownlinkAck
-						if newDst == nil {
-							newDst = &ApplicationDownlink{}
-							dst.Up.(*ApplicationUp_DownlinkAck).DownlinkAck = newDst
+						var newDst, newSrc *ApplicationDownlink
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *ApplicationDownlink
-						if src != nil {
-							newSrc = src.GetDownlinkAck()
+						if srcOk {
+							newSrc = src.Up.(*ApplicationUp_DownlinkAck).DownlinkAck
+						}
+						if dstOk {
+							newDst = dst.Up.(*ApplicationUp_DownlinkAck).DownlinkAck
+						} else {
+							newDst = &ApplicationDownlink{}
+							dst.Up = &ApplicationUp_DownlinkAck{DownlinkAck: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Up.(*ApplicationUp_DownlinkAck).DownlinkAck = src.GetDownlinkAck()
+							dst.Up = src.Up
 						} else {
-							dst.Up.(*ApplicationUp_DownlinkAck).DownlinkAck = nil
+							dst.Up = nil
 						}
 					}
 				case "downlink_nack":
-					if _, ok := dst.Up.(*ApplicationUp_DownlinkNack); !ok {
-						dst.Up = &ApplicationUp_DownlinkNack{}
+					_, srcOk := src.Up.(*ApplicationUp_DownlinkNack)
+					if !srcOk && src.Up != nil {
+						return fmt.Errorf("attempt to set oneof 'downlink_nack', while different oneof is set in source")
+					}
+					_, dstOk := dst.Up.(*ApplicationUp_DownlinkNack)
+					if !dstOk && dst.Up != nil {
+						return fmt.Errorf("attempt to set oneof 'downlink_nack', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Up.(*ApplicationUp_DownlinkNack).DownlinkNack
-						if newDst == nil {
-							newDst = &ApplicationDownlink{}
-							dst.Up.(*ApplicationUp_DownlinkNack).DownlinkNack = newDst
+						var newDst, newSrc *ApplicationDownlink
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *ApplicationDownlink
-						if src != nil {
-							newSrc = src.GetDownlinkNack()
+						if srcOk {
+							newSrc = src.Up.(*ApplicationUp_DownlinkNack).DownlinkNack
+						}
+						if dstOk {
+							newDst = dst.Up.(*ApplicationUp_DownlinkNack).DownlinkNack
+						} else {
+							newDst = &ApplicationDownlink{}
+							dst.Up = &ApplicationUp_DownlinkNack{DownlinkNack: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Up.(*ApplicationUp_DownlinkNack).DownlinkNack = src.GetDownlinkNack()
+							dst.Up = src.Up
 						} else {
-							dst.Up.(*ApplicationUp_DownlinkNack).DownlinkNack = nil
+							dst.Up = nil
 						}
 					}
 				case "downlink_sent":
-					if _, ok := dst.Up.(*ApplicationUp_DownlinkSent); !ok {
-						dst.Up = &ApplicationUp_DownlinkSent{}
+					_, srcOk := src.Up.(*ApplicationUp_DownlinkSent)
+					if !srcOk && src.Up != nil {
+						return fmt.Errorf("attempt to set oneof 'downlink_sent', while different oneof is set in source")
+					}
+					_, dstOk := dst.Up.(*ApplicationUp_DownlinkSent)
+					if !dstOk && dst.Up != nil {
+						return fmt.Errorf("attempt to set oneof 'downlink_sent', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Up.(*ApplicationUp_DownlinkSent).DownlinkSent
-						if newDst == nil {
-							newDst = &ApplicationDownlink{}
-							dst.Up.(*ApplicationUp_DownlinkSent).DownlinkSent = newDst
+						var newDst, newSrc *ApplicationDownlink
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *ApplicationDownlink
-						if src != nil {
-							newSrc = src.GetDownlinkSent()
+						if srcOk {
+							newSrc = src.Up.(*ApplicationUp_DownlinkSent).DownlinkSent
+						}
+						if dstOk {
+							newDst = dst.Up.(*ApplicationUp_DownlinkSent).DownlinkSent
+						} else {
+							newDst = &ApplicationDownlink{}
+							dst.Up = &ApplicationUp_DownlinkSent{DownlinkSent: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Up.(*ApplicationUp_DownlinkSent).DownlinkSent = src.GetDownlinkSent()
+							dst.Up = src.Up
 						} else {
-							dst.Up.(*ApplicationUp_DownlinkSent).DownlinkSent = nil
+							dst.Up = nil
 						}
 					}
 				case "downlink_failed":
-					if _, ok := dst.Up.(*ApplicationUp_DownlinkFailed); !ok {
-						dst.Up = &ApplicationUp_DownlinkFailed{}
+					_, srcOk := src.Up.(*ApplicationUp_DownlinkFailed)
+					if !srcOk && src.Up != nil {
+						return fmt.Errorf("attempt to set oneof 'downlink_failed', while different oneof is set in source")
+					}
+					_, dstOk := dst.Up.(*ApplicationUp_DownlinkFailed)
+					if !dstOk && dst.Up != nil {
+						return fmt.Errorf("attempt to set oneof 'downlink_failed', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Up.(*ApplicationUp_DownlinkFailed).DownlinkFailed
-						if newDst == nil {
-							newDst = &ApplicationDownlinkFailed{}
-							dst.Up.(*ApplicationUp_DownlinkFailed).DownlinkFailed = newDst
+						var newDst, newSrc *ApplicationDownlinkFailed
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *ApplicationDownlinkFailed
-						if src != nil {
-							newSrc = src.GetDownlinkFailed()
+						if srcOk {
+							newSrc = src.Up.(*ApplicationUp_DownlinkFailed).DownlinkFailed
+						}
+						if dstOk {
+							newDst = dst.Up.(*ApplicationUp_DownlinkFailed).DownlinkFailed
+						} else {
+							newDst = &ApplicationDownlinkFailed{}
+							dst.Up = &ApplicationUp_DownlinkFailed{DownlinkFailed: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Up.(*ApplicationUp_DownlinkFailed).DownlinkFailed = src.GetDownlinkFailed()
+							dst.Up = src.Up
 						} else {
-							dst.Up.(*ApplicationUp_DownlinkFailed).DownlinkFailed = nil
+							dst.Up = nil
 						}
 					}
 				case "downlink_queued":
-					if _, ok := dst.Up.(*ApplicationUp_DownlinkQueued); !ok {
-						dst.Up = &ApplicationUp_DownlinkQueued{}
+					_, srcOk := src.Up.(*ApplicationUp_DownlinkQueued)
+					if !srcOk && src.Up != nil {
+						return fmt.Errorf("attempt to set oneof 'downlink_queued', while different oneof is set in source")
+					}
+					_, dstOk := dst.Up.(*ApplicationUp_DownlinkQueued)
+					if !dstOk && dst.Up != nil {
+						return fmt.Errorf("attempt to set oneof 'downlink_queued', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Up.(*ApplicationUp_DownlinkQueued).DownlinkQueued
-						if newDst == nil {
-							newDst = &ApplicationDownlink{}
-							dst.Up.(*ApplicationUp_DownlinkQueued).DownlinkQueued = newDst
+						var newDst, newSrc *ApplicationDownlink
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *ApplicationDownlink
-						if src != nil {
-							newSrc = src.GetDownlinkQueued()
+						if srcOk {
+							newSrc = src.Up.(*ApplicationUp_DownlinkQueued).DownlinkQueued
+						}
+						if dstOk {
+							newDst = dst.Up.(*ApplicationUp_DownlinkQueued).DownlinkQueued
+						} else {
+							newDst = &ApplicationDownlink{}
+							dst.Up = &ApplicationUp_DownlinkQueued{DownlinkQueued: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Up.(*ApplicationUp_DownlinkQueued).DownlinkQueued = src.GetDownlinkQueued()
+							dst.Up = src.Up
 						} else {
-							dst.Up.(*ApplicationUp_DownlinkQueued).DownlinkQueued = nil
+							dst.Up = nil
 						}
 					}
 				case "downlink_queue_invalidated":
-					if _, ok := dst.Up.(*ApplicationUp_DownlinkQueueInvalidated); !ok {
-						dst.Up = &ApplicationUp_DownlinkQueueInvalidated{}
+					_, srcOk := src.Up.(*ApplicationUp_DownlinkQueueInvalidated)
+					if !srcOk && src.Up != nil {
+						return fmt.Errorf("attempt to set oneof 'downlink_queue_invalidated', while different oneof is set in source")
+					}
+					_, dstOk := dst.Up.(*ApplicationUp_DownlinkQueueInvalidated)
+					if !dstOk && dst.Up != nil {
+						return fmt.Errorf("attempt to set oneof 'downlink_queue_invalidated', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Up.(*ApplicationUp_DownlinkQueueInvalidated).DownlinkQueueInvalidated
-						if newDst == nil {
-							newDst = &ApplicationInvalidatedDownlinks{}
-							dst.Up.(*ApplicationUp_DownlinkQueueInvalidated).DownlinkQueueInvalidated = newDst
+						var newDst, newSrc *ApplicationInvalidatedDownlinks
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *ApplicationInvalidatedDownlinks
-						if src != nil {
-							newSrc = src.GetDownlinkQueueInvalidated()
+						if srcOk {
+							newSrc = src.Up.(*ApplicationUp_DownlinkQueueInvalidated).DownlinkQueueInvalidated
+						}
+						if dstOk {
+							newDst = dst.Up.(*ApplicationUp_DownlinkQueueInvalidated).DownlinkQueueInvalidated
+						} else {
+							newDst = &ApplicationInvalidatedDownlinks{}
+							dst.Up = &ApplicationUp_DownlinkQueueInvalidated{DownlinkQueueInvalidated: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Up.(*ApplicationUp_DownlinkQueueInvalidated).DownlinkQueueInvalidated = src.GetDownlinkQueueInvalidated()
+							dst.Up = src.Up
 						} else {
-							dst.Up.(*ApplicationUp_DownlinkQueueInvalidated).DownlinkQueueInvalidated = nil
+							dst.Up = nil
 						}
 					}
 				case "location_solved":
-					if _, ok := dst.Up.(*ApplicationUp_LocationSolved); !ok {
-						dst.Up = &ApplicationUp_LocationSolved{}
+					_, srcOk := src.Up.(*ApplicationUp_LocationSolved)
+					if !srcOk && src.Up != nil {
+						return fmt.Errorf("attempt to set oneof 'location_solved', while different oneof is set in source")
+					}
+					_, dstOk := dst.Up.(*ApplicationUp_LocationSolved)
+					if !dstOk && dst.Up != nil {
+						return fmt.Errorf("attempt to set oneof 'location_solved', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
-						newDst := dst.Up.(*ApplicationUp_LocationSolved).LocationSolved
-						if newDst == nil {
-							newDst = &ApplicationLocation{}
-							dst.Up.(*ApplicationUp_LocationSolved).LocationSolved = newDst
+						var newDst, newSrc *ApplicationLocation
+						if !srcOk && !dstOk {
+							continue
 						}
-						var newSrc *ApplicationLocation
-						if src != nil {
-							newSrc = src.GetLocationSolved()
+						if srcOk {
+							newSrc = src.Up.(*ApplicationUp_LocationSolved).LocationSolved
+						}
+						if dstOk {
+							newDst = dst.Up.(*ApplicationUp_LocationSolved).LocationSolved
+						} else {
+							newDst = &ApplicationLocation{}
+							dst.Up = &ApplicationUp_LocationSolved{LocationSolved: newDst}
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
 						if src != nil {
-							dst.Up.(*ApplicationUp_LocationSolved).LocationSolved = src.GetLocationSolved()
+							dst.Up = src.Up
 						} else {
-							dst.Up.(*ApplicationUp_LocationSolved).LocationSolved = nil
+							dst.Up = nil
 						}
 					}
 
@@ -1032,11 +1151,11 @@ func (dst *DownlinkQueueRequest) SetFields(src *DownlinkQueueRequest, paths ...s
 		switch name {
 		case "end_device_ids":
 			if len(subs) > 0 {
-				newDst := &dst.EndDeviceIdentifiers
-				var newSrc *EndDeviceIdentifiers
+				var newDst, newSrc *EndDeviceIdentifiers
 				if src != nil {
 					newSrc = &src.EndDeviceIdentifiers
 				}
+				newDst = &dst.EndDeviceIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}

--- a/pkg/ttnpb/metadata.pb.setters.fm.go
+++ b/pkg/ttnpb/metadata.pb.setters.fm.go
@@ -9,11 +9,11 @@ func (dst *RxMetadata) SetFields(src *RxMetadata, paths ...string) error {
 		switch name {
 		case "gateway_ids":
 			if len(subs) > 0 {
-				newDst := &dst.GatewayIdentifiers
-				var newSrc *GatewayIdentifiers
+				var newDst, newSrc *GatewayIdentifiers
 				if src != nil {
 					newSrc = &src.GatewayIdentifiers
 				}
+				newDst = &dst.GatewayIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -144,14 +144,18 @@ func (dst *RxMetadata) SetFields(src *RxMetadata, paths ...string) error {
 			}
 		case "location":
 			if len(subs) > 0 {
-				newDst := dst.Location
-				if newDst == nil {
-					newDst = &Location{}
-					dst.Location = newDst
+				var newDst, newSrc *Location
+				if (src == nil || src.Location == nil) && dst.Location == nil {
+					continue
 				}
-				var newSrc *Location
 				if src != nil {
 					newSrc = src.Location
+				}
+				if dst.Location != nil {
+					newDst = dst.Location
+				} else {
+					newDst = &Location{}
+					dst.Location = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err

--- a/pkg/ttnpb/oauth.pb.setters.fm.go
+++ b/pkg/ttnpb/oauth.pb.setters.fm.go
@@ -12,11 +12,11 @@ func (dst *OAuthClientAuthorizationIdentifiers) SetFields(src *OAuthClientAuthor
 		switch name {
 		case "user_ids":
 			if len(subs) > 0 {
-				newDst := &dst.UserIDs
-				var newSrc *UserIdentifiers
+				var newDst, newSrc *UserIdentifiers
 				if src != nil {
 					newSrc = &src.UserIDs
 				}
+				newDst = &dst.UserIDs
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -30,11 +30,11 @@ func (dst *OAuthClientAuthorizationIdentifiers) SetFields(src *OAuthClientAuthor
 			}
 		case "client_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ClientIDs
-				var newSrc *ClientIdentifiers
+				var newDst, newSrc *ClientIdentifiers
 				if src != nil {
 					newSrc = &src.ClientIDs
 				}
+				newDst = &dst.ClientIDs
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -59,11 +59,11 @@ func (dst *OAuthClientAuthorization) SetFields(src *OAuthClientAuthorization, pa
 		switch name {
 		case "user_ids":
 			if len(subs) > 0 {
-				newDst := &dst.UserIDs
-				var newSrc *UserIdentifiers
+				var newDst, newSrc *UserIdentifiers
 				if src != nil {
 					newSrc = &src.UserIDs
 				}
+				newDst = &dst.UserIDs
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -77,11 +77,11 @@ func (dst *OAuthClientAuthorization) SetFields(src *OAuthClientAuthorization, pa
 			}
 		case "client_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ClientIDs
-				var newSrc *ClientIdentifiers
+				var newDst, newSrc *ClientIdentifiers
 				if src != nil {
 					newSrc = &src.ClientIDs
 				}
+				newDst = &dst.ClientIDs
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -155,11 +155,11 @@ func (dst *ListOAuthClientAuthorizationsRequest) SetFields(src *ListOAuthClientA
 		switch name {
 		case "user_ids":
 			if len(subs) > 0 {
-				newDst := &dst.UserIdentifiers
-				var newSrc *UserIdentifiers
+				var newDst, newSrc *UserIdentifiers
 				if src != nil {
 					newSrc = &src.UserIdentifiers
 				}
+				newDst = &dst.UserIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -214,11 +214,11 @@ func (dst *OAuthAuthorizationCode) SetFields(src *OAuthAuthorizationCode, paths 
 		switch name {
 		case "user_ids":
 			if len(subs) > 0 {
-				newDst := &dst.UserIDs
-				var newSrc *UserIdentifiers
+				var newDst, newSrc *UserIdentifiers
 				if src != nil {
 					newSrc = &src.UserIDs
 				}
+				newDst = &dst.UserIDs
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -232,11 +232,11 @@ func (dst *OAuthAuthorizationCode) SetFields(src *OAuthAuthorizationCode, paths 
 			}
 		case "client_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ClientIDs
-				var newSrc *ClientIdentifiers
+				var newDst, newSrc *ClientIdentifiers
 				if src != nil {
 					newSrc = &src.ClientIDs
 				}
+				newDst = &dst.ClientIDs
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -320,11 +320,11 @@ func (dst *OAuthAccessTokenIdentifiers) SetFields(src *OAuthAccessTokenIdentifie
 		switch name {
 		case "user_ids":
 			if len(subs) > 0 {
-				newDst := &dst.UserIDs
-				var newSrc *UserIdentifiers
+				var newDst, newSrc *UserIdentifiers
 				if src != nil {
 					newSrc = &src.UserIDs
 				}
+				newDst = &dst.UserIDs
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -338,11 +338,11 @@ func (dst *OAuthAccessTokenIdentifiers) SetFields(src *OAuthAccessTokenIdentifie
 			}
 		case "client_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ClientIDs
-				var newSrc *ClientIdentifiers
+				var newDst, newSrc *ClientIdentifiers
 				if src != nil {
 					newSrc = &src.ClientIDs
 				}
+				newDst = &dst.ClientIDs
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -377,11 +377,11 @@ func (dst *OAuthAccessToken) SetFields(src *OAuthAccessToken, paths ...string) e
 		switch name {
 		case "user_ids":
 			if len(subs) > 0 {
-				newDst := &dst.UserIDs
-				var newSrc *UserIdentifiers
+				var newDst, newSrc *UserIdentifiers
 				if src != nil {
 					newSrc = &src.UserIDs
 				}
+				newDst = &dst.UserIDs
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -395,11 +395,11 @@ func (dst *OAuthAccessToken) SetFields(src *OAuthAccessToken, paths ...string) e
 			}
 		case "client_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ClientIDs
-				var newSrc *ClientIdentifiers
+				var newDst, newSrc *ClientIdentifiers
 				if src != nil {
 					newSrc = &src.ClientIDs
 				}
+				newDst = &dst.ClientIDs
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -503,11 +503,11 @@ func (dst *ListOAuthAccessTokensRequest) SetFields(src *ListOAuthAccessTokensReq
 		switch name {
 		case "user_ids":
 			if len(subs) > 0 {
-				newDst := &dst.UserIDs
-				var newSrc *UserIdentifiers
+				var newDst, newSrc *UserIdentifiers
 				if src != nil {
 					newSrc = &src.UserIDs
 				}
+				newDst = &dst.UserIDs
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -521,11 +521,11 @@ func (dst *ListOAuthAccessTokensRequest) SetFields(src *ListOAuthAccessTokensReq
 			}
 		case "client_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ClientIDs
-				var newSrc *ClientIdentifiers
+				var newDst, newSrc *ClientIdentifiers
 				if src != nil {
 					newSrc = &src.ClientIDs
 				}
+				newDst = &dst.ClientIDs
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}

--- a/pkg/ttnpb/organization.pb.setters.fm.go
+++ b/pkg/ttnpb/organization.pb.setters.fm.go
@@ -14,11 +14,11 @@ func (dst *Organization) SetFields(src *Organization, paths ...string) error {
 		switch name {
 		case "ids":
 			if len(subs) > 0 {
-				newDst := &dst.OrganizationIdentifiers
-				var newSrc *OrganizationIdentifiers
+				var newDst, newSrc *OrganizationIdentifiers
 				if src != nil {
 					newSrc = &src.OrganizationIdentifiers
 				}
+				newDst = &dst.OrganizationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -121,11 +121,11 @@ func (dst *GetOrganizationRequest) SetFields(src *GetOrganizationRequest, paths 
 		switch name {
 		case "organization_ids":
 			if len(subs) > 0 {
-				newDst := &dst.OrganizationIdentifiers
-				var newSrc *OrganizationIdentifiers
+				var newDst, newSrc *OrganizationIdentifiers
 				if src != nil {
 					newSrc = &src.OrganizationIdentifiers
 				}
+				newDst = &dst.OrganizationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -160,14 +160,18 @@ func (dst *ListOrganizationsRequest) SetFields(src *ListOrganizationsRequest, pa
 		switch name {
 		case "collaborator":
 			if len(subs) > 0 {
-				newDst := dst.Collaborator
-				if newDst == nil {
-					newDst = &OrganizationOrUserIdentifiers{}
-					dst.Collaborator = newDst
+				var newDst, newSrc *OrganizationOrUserIdentifiers
+				if (src == nil || src.Collaborator == nil) && dst.Collaborator == nil {
+					continue
 				}
-				var newSrc *OrganizationOrUserIdentifiers
 				if src != nil {
 					newSrc = src.Collaborator
+				}
+				if dst.Collaborator != nil {
+					newDst = dst.Collaborator
+				} else {
+					newDst = &OrganizationOrUserIdentifiers{}
+					dst.Collaborator = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -232,11 +236,11 @@ func (dst *CreateOrganizationRequest) SetFields(src *CreateOrganizationRequest, 
 		switch name {
 		case "organization":
 			if len(subs) > 0 {
-				newDst := &dst.Organization
-				var newSrc *Organization
+				var newDst, newSrc *Organization
 				if src != nil {
 					newSrc = &src.Organization
 				}
+				newDst = &dst.Organization
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -250,11 +254,11 @@ func (dst *CreateOrganizationRequest) SetFields(src *CreateOrganizationRequest, 
 			}
 		case "collaborator":
 			if len(subs) > 0 {
-				newDst := &dst.Collaborator
-				var newSrc *OrganizationOrUserIdentifiers
+				var newDst, newSrc *OrganizationOrUserIdentifiers
 				if src != nil {
 					newSrc = &src.Collaborator
 				}
+				newDst = &dst.Collaborator
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -279,11 +283,11 @@ func (dst *UpdateOrganizationRequest) SetFields(src *UpdateOrganizationRequest, 
 		switch name {
 		case "organization":
 			if len(subs) > 0 {
-				newDst := &dst.Organization
-				var newSrc *Organization
+				var newDst, newSrc *Organization
 				if src != nil {
 					newSrc = &src.Organization
 				}
+				newDst = &dst.Organization
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -318,11 +322,11 @@ func (dst *ListOrganizationAPIKeysRequest) SetFields(src *ListOrganizationAPIKey
 		switch name {
 		case "organization_ids":
 			if len(subs) > 0 {
-				newDst := &dst.OrganizationIdentifiers
-				var newSrc *OrganizationIdentifiers
+				var newDst, newSrc *OrganizationIdentifiers
 				if src != nil {
 					newSrc = &src.OrganizationIdentifiers
 				}
+				newDst = &dst.OrganizationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -367,11 +371,11 @@ func (dst *GetOrganizationAPIKeyRequest) SetFields(src *GetOrganizationAPIKeyReq
 		switch name {
 		case "organization_ids":
 			if len(subs) > 0 {
-				newDst := &dst.OrganizationIdentifiers
-				var newSrc *OrganizationIdentifiers
+				var newDst, newSrc *OrganizationIdentifiers
 				if src != nil {
 					newSrc = &src.OrganizationIdentifiers
 				}
+				newDst = &dst.OrganizationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -406,11 +410,11 @@ func (dst *CreateOrganizationAPIKeyRequest) SetFields(src *CreateOrganizationAPI
 		switch name {
 		case "organization_ids":
 			if len(subs) > 0 {
-				newDst := &dst.OrganizationIdentifiers
-				var newSrc *OrganizationIdentifiers
+				var newDst, newSrc *OrganizationIdentifiers
 				if src != nil {
 					newSrc = &src.OrganizationIdentifiers
 				}
+				newDst = &dst.OrganizationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -454,11 +458,11 @@ func (dst *UpdateOrganizationAPIKeyRequest) SetFields(src *UpdateOrganizationAPI
 		switch name {
 		case "organization_ids":
 			if len(subs) > 0 {
-				newDst := &dst.OrganizationIdentifiers
-				var newSrc *OrganizationIdentifiers
+				var newDst, newSrc *OrganizationIdentifiers
 				if src != nil {
 					newSrc = &src.OrganizationIdentifiers
 				}
+				newDst = &dst.OrganizationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -472,11 +476,11 @@ func (dst *UpdateOrganizationAPIKeyRequest) SetFields(src *UpdateOrganizationAPI
 			}
 		case "api_key":
 			if len(subs) > 0 {
-				newDst := &dst.APIKey
-				var newSrc *APIKey
+				var newDst, newSrc *APIKey
 				if src != nil {
 					newSrc = &src.APIKey
 				}
+				newDst = &dst.APIKey
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -501,11 +505,11 @@ func (dst *ListOrganizationCollaboratorsRequest) SetFields(src *ListOrganization
 		switch name {
 		case "organization_ids":
 			if len(subs) > 0 {
-				newDst := &dst.OrganizationIdentifiers
-				var newSrc *OrganizationIdentifiers
+				var newDst, newSrc *OrganizationIdentifiers
 				if src != nil {
 					newSrc = &src.OrganizationIdentifiers
 				}
+				newDst = &dst.OrganizationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -550,11 +554,11 @@ func (dst *GetOrganizationCollaboratorRequest) SetFields(src *GetOrganizationCol
 		switch name {
 		case "organization_ids":
 			if len(subs) > 0 {
-				newDst := &dst.OrganizationIdentifiers
-				var newSrc *OrganizationIdentifiers
+				var newDst, newSrc *OrganizationIdentifiers
 				if src != nil {
 					newSrc = &src.OrganizationIdentifiers
 				}
+				newDst = &dst.OrganizationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -568,11 +572,11 @@ func (dst *GetOrganizationCollaboratorRequest) SetFields(src *GetOrganizationCol
 			}
 		case "collaborator":
 			if len(subs) > 0 {
-				newDst := &dst.OrganizationOrUserIdentifiers
-				var newSrc *OrganizationOrUserIdentifiers
+				var newDst, newSrc *OrganizationOrUserIdentifiers
 				if src != nil {
 					newSrc = &src.OrganizationOrUserIdentifiers
 				}
+				newDst = &dst.OrganizationOrUserIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -597,11 +601,11 @@ func (dst *SetOrganizationCollaboratorRequest) SetFields(src *SetOrganizationCol
 		switch name {
 		case "organization_ids":
 			if len(subs) > 0 {
-				newDst := &dst.OrganizationIdentifiers
-				var newSrc *OrganizationIdentifiers
+				var newDst, newSrc *OrganizationIdentifiers
 				if src != nil {
 					newSrc = &src.OrganizationIdentifiers
 				}
+				newDst = &dst.OrganizationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -615,11 +619,11 @@ func (dst *SetOrganizationCollaboratorRequest) SetFields(src *SetOrganizationCol
 			}
 		case "collaborator":
 			if len(subs) > 0 {
-				newDst := &dst.Collaborator
-				var newSrc *Collaborator
+				var newDst, newSrc *Collaborator
 				if src != nil {
 					newSrc = &src.Collaborator
 				}
+				newDst = &dst.Collaborator
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}

--- a/pkg/ttnpb/picture.pb.setters.fm.go
+++ b/pkg/ttnpb/picture.pb.setters.fm.go
@@ -9,14 +9,18 @@ func (dst *Picture) SetFields(src *Picture, paths ...string) error {
 		switch name {
 		case "embedded":
 			if len(subs) > 0 {
-				newDst := dst.Embedded
-				if newDst == nil {
-					newDst = &Picture_Embedded{}
-					dst.Embedded = newDst
+				var newDst, newSrc *Picture_Embedded
+				if (src == nil || src.Embedded == nil) && dst.Embedded == nil {
+					continue
 				}
-				var newSrc *Picture_Embedded
 				if src != nil {
 					newSrc = src.Embedded
+				}
+				if dst.Embedded != nil {
+					newDst = dst.Embedded
+				} else {
+					newDst = &Picture_Embedded{}
+					dst.Embedded = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err

--- a/pkg/ttnpb/qrcodegenerator.pb.setters.fm.go
+++ b/pkg/ttnpb/qrcodegenerator.pb.setters.fm.go
@@ -105,11 +105,11 @@ func (dst *GenerateEndDeviceQRCodeRequest) SetFields(src *GenerateEndDeviceQRCod
 			}
 		case "end_device":
 			if len(subs) > 0 {
-				newDst := &dst.EndDevice
-				var newSrc *EndDevice
+				var newDst, newSrc *EndDevice
 				if src != nil {
 					newSrc = &src.EndDevice
 				}
+				newDst = &dst.EndDevice
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -123,14 +123,18 @@ func (dst *GenerateEndDeviceQRCodeRequest) SetFields(src *GenerateEndDeviceQRCod
 			}
 		case "image":
 			if len(subs) > 0 {
-				newDst := dst.Image
-				if newDst == nil {
-					newDst = &GenerateEndDeviceQRCodeRequest_Image{}
-					dst.Image = newDst
+				var newDst, newSrc *GenerateEndDeviceQRCodeRequest_Image
+				if (src == nil || src.Image == nil) && dst.Image == nil {
+					continue
 				}
-				var newSrc *GenerateEndDeviceQRCodeRequest_Image
 				if src != nil {
 					newSrc = src.Image
+				}
+				if dst.Image != nil {
+					newDst = dst.Image
+				} else {
+					newDst = &GenerateEndDeviceQRCodeRequest_Image{}
+					dst.Image = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -165,14 +169,18 @@ func (dst *GenerateQRCodeResponse) SetFields(src *GenerateQRCodeResponse, paths 
 			}
 		case "image":
 			if len(subs) > 0 {
-				newDst := dst.Image
-				if newDst == nil {
-					newDst = &Picture{}
-					dst.Image = newDst
+				var newDst, newSrc *Picture
+				if (src == nil || src.Image == nil) && dst.Image == nil {
+					continue
 				}
-				var newSrc *Picture
 				if src != nil {
 					newSrc = src.Image
+				}
+				if dst.Image != nil {
+					newDst = dst.Image
+				} else {
+					newDst = &Picture{}
+					dst.Image = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err

--- a/pkg/ttnpb/regional.pb.setters.fm.go
+++ b/pkg/ttnpb/regional.pb.setters.fm.go
@@ -21,14 +21,18 @@ func (dst *ConcentratorConfig) SetFields(src *ConcentratorConfig, paths ...strin
 			}
 		case "lora_standard_channel":
 			if len(subs) > 0 {
-				newDst := dst.LoRaStandardChannel
-				if newDst == nil {
-					newDst = &ConcentratorConfig_LoRaStandardChannel{}
-					dst.LoRaStandardChannel = newDst
+				var newDst, newSrc *ConcentratorConfig_LoRaStandardChannel
+				if (src == nil || src.LoRaStandardChannel == nil) && dst.LoRaStandardChannel == nil {
+					continue
 				}
-				var newSrc *ConcentratorConfig_LoRaStandardChannel
 				if src != nil {
 					newSrc = src.LoRaStandardChannel
+				}
+				if dst.LoRaStandardChannel != nil {
+					newDst = dst.LoRaStandardChannel
+				} else {
+					newDst = &ConcentratorConfig_LoRaStandardChannel{}
+					dst.LoRaStandardChannel = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -42,14 +46,18 @@ func (dst *ConcentratorConfig) SetFields(src *ConcentratorConfig, paths ...strin
 			}
 		case "fsk_channel":
 			if len(subs) > 0 {
-				newDst := dst.FSKChannel
-				if newDst == nil {
-					newDst = &ConcentratorConfig_FSKChannel{}
-					dst.FSKChannel = newDst
+				var newDst, newSrc *ConcentratorConfig_FSKChannel
+				if (src == nil || src.FSKChannel == nil) && dst.FSKChannel == nil {
+					continue
 				}
-				var newSrc *ConcentratorConfig_FSKChannel
 				if src != nil {
 					newSrc = src.FSKChannel
+				}
+				if dst.FSKChannel != nil {
+					newDst = dst.FSKChannel
+				} else {
+					newDst = &ConcentratorConfig_FSKChannel{}
+					dst.FSKChannel = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -63,14 +71,18 @@ func (dst *ConcentratorConfig) SetFields(src *ConcentratorConfig, paths ...strin
 			}
 		case "lbt":
 			if len(subs) > 0 {
-				newDst := dst.LBT
-				if newDst == nil {
-					newDst = &ConcentratorConfig_LBTConfiguration{}
-					dst.LBT = newDst
+				var newDst, newSrc *ConcentratorConfig_LBTConfiguration
+				if (src == nil || src.LBT == nil) && dst.LBT == nil {
+					continue
 				}
-				var newSrc *ConcentratorConfig_LBTConfiguration
 				if src != nil {
 					newSrc = src.LBT
+				}
+				if dst.LBT != nil {
+					newDst = dst.LBT
+				} else {
+					newDst = &ConcentratorConfig_LBTConfiguration{}
+					dst.LBT = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -84,14 +96,18 @@ func (dst *ConcentratorConfig) SetFields(src *ConcentratorConfig, paths ...strin
 			}
 		case "ping_slot":
 			if len(subs) > 0 {
-				newDst := dst.PingSlot
-				if newDst == nil {
-					newDst = &ConcentratorConfig_Channel{}
-					dst.PingSlot = newDst
+				var newDst, newSrc *ConcentratorConfig_Channel
+				if (src == nil || src.PingSlot == nil) && dst.PingSlot == nil {
+					continue
 				}
-				var newSrc *ConcentratorConfig_Channel
 				if src != nil {
 					newSrc = src.PingSlot
+				}
+				if dst.PingSlot != nil {
+					newDst = dst.PingSlot
+				} else {
+					newDst = &ConcentratorConfig_Channel{}
+					dst.PingSlot = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err

--- a/pkg/ttnpb/rights.pb.setters.fm.go
+++ b/pkg/ttnpb/rights.pb.setters.fm.go
@@ -99,11 +99,11 @@ func (dst *Collaborator) SetFields(src *Collaborator, paths ...string) error {
 		switch name {
 		case "ids":
 			if len(subs) > 0 {
-				newDst := &dst.OrganizationOrUserIdentifiers
-				var newSrc *OrganizationOrUserIdentifiers
+				var newDst, newSrc *OrganizationOrUserIdentifiers
 				if src != nil {
 					newSrc = &src.OrganizationOrUserIdentifiers
 				}
+				newDst = &dst.OrganizationOrUserIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -137,11 +137,11 @@ func (dst *GetCollaboratorResponse) SetFields(src *GetCollaboratorResponse, path
 		switch name {
 		case "ids":
 			if len(subs) > 0 {
-				newDst := &dst.OrganizationOrUserIdentifiers
-				var newSrc *OrganizationOrUserIdentifiers
+				var newDst, newSrc *OrganizationOrUserIdentifiers
 				if src != nil {
 					newSrc = &src.OrganizationOrUserIdentifiers
 				}
+				newDst = &dst.OrganizationOrUserIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}

--- a/pkg/ttnpb/search_services.pb.setters.fm.go
+++ b/pkg/ttnpb/search_services.pb.setters.fm.go
@@ -103,11 +103,11 @@ func (dst *SearchEndDevicesRequest) SetFields(src *SearchEndDevicesRequest, path
 		switch name {
 		case "application_ids":
 			if len(subs) > 0 {
-				newDst := &dst.ApplicationIdentifiers
-				var newSrc *ApplicationIdentifiers
+				var newDst, newSrc *ApplicationIdentifiers
 				if src != nil {
 					newSrc = &src.ApplicationIdentifiers
 				}
+				newDst = &dst.ApplicationIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}

--- a/pkg/ttnpb/user.pb.setters.fm.go
+++ b/pkg/ttnpb/user.pb.setters.fm.go
@@ -14,11 +14,11 @@ func (dst *User) SetFields(src *User, paths ...string) error {
 		switch name {
 		case "ids":
 			if len(subs) > 0 {
-				newDst := &dst.UserIdentifiers
-				var newSrc *UserIdentifiers
+				var newDst, newSrc *UserIdentifiers
 				if src != nil {
 					newSrc = &src.UserIdentifiers
 				}
+				newDst = &dst.UserIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -186,14 +186,18 @@ func (dst *User) SetFields(src *User, paths ...string) error {
 			}
 		case "profile_picture":
 			if len(subs) > 0 {
-				newDst := dst.ProfilePicture
-				if newDst == nil {
-					newDst = &Picture{}
-					dst.ProfilePicture = newDst
+				var newDst, newSrc *Picture
+				if (src == nil || src.ProfilePicture == nil) && dst.ProfilePicture == nil {
+					continue
 				}
-				var newSrc *Picture
 				if src != nil {
 					newSrc = src.ProfilePicture
+				}
+				if dst.ProfilePicture != nil {
+					newDst = dst.ProfilePicture
+				} else {
+					newDst = &Picture{}
+					dst.ProfilePicture = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -238,11 +242,11 @@ func (dst *GetUserRequest) SetFields(src *GetUserRequest, paths ...string) error
 		switch name {
 		case "user_ids":
 			if len(subs) > 0 {
-				newDst := &dst.UserIdentifiers
-				var newSrc *UserIdentifiers
+				var newDst, newSrc *UserIdentifiers
 				if src != nil {
 					newSrc = &src.UserIdentifiers
 				}
+				newDst = &dst.UserIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -328,11 +332,11 @@ func (dst *CreateUserRequest) SetFields(src *CreateUserRequest, paths ...string)
 		switch name {
 		case "user":
 			if len(subs) > 0 {
-				newDst := &dst.User
-				var newSrc *User
+				var newDst, newSrc *User
 				if src != nil {
 					newSrc = &src.User
 				}
+				newDst = &dst.User
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -367,11 +371,11 @@ func (dst *UpdateUserRequest) SetFields(src *UpdateUserRequest, paths ...string)
 		switch name {
 		case "user":
 			if len(subs) > 0 {
-				newDst := &dst.User
-				var newSrc *User
+				var newDst, newSrc *User
 				if src != nil {
 					newSrc = &src.User
 				}
+				newDst = &dst.User
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -406,11 +410,11 @@ func (dst *CreateTemporaryPasswordRequest) SetFields(src *CreateTemporaryPasswor
 		switch name {
 		case "user_ids":
 			if len(subs) > 0 {
-				newDst := &dst.UserIdentifiers
-				var newSrc *UserIdentifiers
+				var newDst, newSrc *UserIdentifiers
 				if src != nil {
 					newSrc = &src.UserIdentifiers
 				}
+				newDst = &dst.UserIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -435,11 +439,11 @@ func (dst *UpdateUserPasswordRequest) SetFields(src *UpdateUserPasswordRequest, 
 		switch name {
 		case "user_ids":
 			if len(subs) > 0 {
-				newDst := &dst.UserIdentifiers
-				var newSrc *UserIdentifiers
+				var newDst, newSrc *UserIdentifiers
 				if src != nil {
 					newSrc = &src.UserIdentifiers
 				}
+				newDst = &dst.UserIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -494,11 +498,11 @@ func (dst *ListUserAPIKeysRequest) SetFields(src *ListUserAPIKeysRequest, paths 
 		switch name {
 		case "user_ids":
 			if len(subs) > 0 {
-				newDst := &dst.UserIdentifiers
-				var newSrc *UserIdentifiers
+				var newDst, newSrc *UserIdentifiers
 				if src != nil {
 					newSrc = &src.UserIdentifiers
 				}
+				newDst = &dst.UserIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -543,11 +547,11 @@ func (dst *GetUserAPIKeyRequest) SetFields(src *GetUserAPIKeyRequest, paths ...s
 		switch name {
 		case "user_ids":
 			if len(subs) > 0 {
-				newDst := &dst.UserIdentifiers
-				var newSrc *UserIdentifiers
+				var newDst, newSrc *UserIdentifiers
 				if src != nil {
 					newSrc = &src.UserIdentifiers
 				}
+				newDst = &dst.UserIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -582,11 +586,11 @@ func (dst *CreateUserAPIKeyRequest) SetFields(src *CreateUserAPIKeyRequest, path
 		switch name {
 		case "user_ids":
 			if len(subs) > 0 {
-				newDst := &dst.UserIdentifiers
-				var newSrc *UserIdentifiers
+				var newDst, newSrc *UserIdentifiers
 				if src != nil {
 					newSrc = &src.UserIdentifiers
 				}
+				newDst = &dst.UserIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -630,11 +634,11 @@ func (dst *UpdateUserAPIKeyRequest) SetFields(src *UpdateUserAPIKeyRequest, path
 		switch name {
 		case "user_ids":
 			if len(subs) > 0 {
-				newDst := &dst.UserIdentifiers
-				var newSrc *UserIdentifiers
+				var newDst, newSrc *UserIdentifiers
 				if src != nil {
 					newSrc = &src.UserIdentifiers
 				}
+				newDst = &dst.UserIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -648,11 +652,11 @@ func (dst *UpdateUserAPIKeyRequest) SetFields(src *UpdateUserAPIKeyRequest, path
 			}
 		case "api_key":
 			if len(subs) > 0 {
-				newDst := &dst.APIKey
-				var newSrc *APIKey
+				var newDst, newSrc *APIKey
 				if src != nil {
 					newSrc = &src.APIKey
 				}
+				newDst = &dst.APIKey
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -736,14 +740,18 @@ func (dst *Invitation) SetFields(src *Invitation, paths ...string) error {
 			}
 		case "accepted_by":
 			if len(subs) > 0 {
-				newDst := dst.AcceptedBy
-				if newDst == nil {
-					newDst = &UserIdentifiers{}
-					dst.AcceptedBy = newDst
+				var newDst, newSrc *UserIdentifiers
+				if (src == nil || src.AcceptedBy == nil) && dst.AcceptedBy == nil {
+					continue
 				}
-				var newSrc *UserIdentifiers
 				if src != nil {
 					newSrc = src.AcceptedBy
+				}
+				if dst.AcceptedBy != nil {
+					newDst = dst.AcceptedBy
+				} else {
+					newDst = &UserIdentifiers{}
+					dst.AcceptedBy = newDst
 				}
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
@@ -861,11 +869,11 @@ func (dst *UserSessionIdentifiers) SetFields(src *UserSessionIdentifiers, paths 
 		switch name {
 		case "user_ids":
 			if len(subs) > 0 {
-				newDst := &dst.UserIdentifiers
-				var newSrc *UserIdentifiers
+				var newDst, newSrc *UserIdentifiers
 				if src != nil {
 					newSrc = &src.UserIdentifiers
 				}
+				newDst = &dst.UserIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -900,11 +908,11 @@ func (dst *UserSession) SetFields(src *UserSession, paths ...string) error {
 		switch name {
 		case "user_ids":
 			if len(subs) > 0 {
-				newDst := &dst.UserIdentifiers
-				var newSrc *UserIdentifiers
+				var newDst, newSrc *UserIdentifiers
 				if src != nil {
 					newSrc = &src.UserIdentifiers
 				}
+				newDst = &dst.UserIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}
@@ -988,11 +996,11 @@ func (dst *ListUserSessionsRequest) SetFields(src *ListUserSessionsRequest, path
 		switch name {
 		case "user_ids":
 			if len(subs) > 0 {
-				newDst := &dst.UserIdentifiers
-				var newSrc *UserIdentifiers
+				var newDst, newSrc *UserIdentifiers
 				if src != nil {
 					newSrc = &src.UserIdentifiers
 				}
+				newDst = &dst.UserIdentifiers
 				if err := newDst.SetFields(newSrc, subs...); err != nil {
 					return err
 				}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/1382

#### Changes
<!-- What are the changes made in this pull request? -->

- Update protoc image version

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

https://github.com/TheThingsIndustries/protoc-gen-fieldmask/pull/34 change fieldmask utility behavior, such that intermediary paths are not guaranteed to be initialized. That means that we need to make sure that all components check for `nil` before accessing fields returned from registries. For example, if `session.keys.f_nwk_s_int_key.key` is requested from registry a component must check that `session.keys.f_nwk_s_int_key` path is non-nil before accessing `session.keys.f_nwk_s_int_key.key`. Note, that "simply" using proto-generated getters does not work in generic case, since sometimes we have non-nullable fields in the path(like the path in the example - `keys` is non-nullable, and hence this would `panic` if `session` were `nil`: `GetSession().GetFNwkSIntKey().GetKey()`).

NS and JS seem fine. I briefly checked AS, which looked fine to me as well.
Did some integration testing with ff1705 in class C.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
