### PR TITLE
Fix incorrect clear of time field for downlink messages

### DIFF
--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -339,6 +339,7 @@ func (c *Connection) ScheduleDown(path *ttnpb.DownlinkPath, msg *ttnpb.DownlinkM
 			settings.Downlink.InvertPolarization = true
 		}
 		var f func(context.Context, int, ttnpb.TxSettings, scheduling.RTTs, ttnpb.TxSchedulePriority) (scheduling.Emission, error)
+		settings.Time = nil
 		switch request.Class {
 		case ttnpb.CLASS_A:
 			f = c.scheduler.ScheduleAt
@@ -362,7 +363,6 @@ func (c *Connection) ScheduleDown(path *ttnpb.DownlinkPath, msg *ttnpb.DownlinkM
 			rxErrs = append(rxErrs, errRxWindowSchedule.WithCause(err).WithAttributes("window", i+1))
 			continue
 		}
-		settings.Time = nil
 		settings.Timestamp = uint32(time.Duration(em.Starts()) / time.Microsecond)
 		msg.Settings = &ttnpb.DownlinkMessage_Scheduled{
 			Scheduled: &settings,


### PR DESCRIPTION
#### Summary
The NS was incorrectly dropping the time when scheduling a downlink and therefore not requesting the gateway to use gps/absolute time using the tmms field (for UDP forwarders)

#### Changes
Fix absolute time for class b/c downlinks

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [ ] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [X] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
