### PR TITLE
Clean up documentation

### DIFF
--- a/doc/content/_index.html
+++ b/doc/content/_index.html
@@ -28,7 +28,7 @@ weight: 1
           </p>
         </div>
         <div class="buttons is-centered">
-          <a href="{{< ref "/guides/getting-started" >}}" class="button is-primary is-outlined">Get Started</a>
+          <a href="{{< ref "/guides" >}}" class="button is-primary is-outlined">Get Started</a>
         </div>
       </div>
     </div>

--- a/doc/content/components/_index.md
+++ b/doc/content/components/_index.md
@@ -9,4 +9,4 @@ menu:
 
 {{% tts %}} is composed of a number of components. The core components Network Server, Application Server and Join Server follow the LoRaWAN Network Reference Model. {{% tts %}} also contains an Identity Server, Gateway Server, Console and Command-line Interface.
 
-{{< figure src="components.png" alt="The Things Stack components" >}}
+{{< figure src="components.png" alt="Components" >}}

--- a/doc/content/guides/getting-started/cli/_index.md
+++ b/doc/content/guides/getting-started/cli/_index.md
@@ -4,6 +4,32 @@ description: ""
 weight: 10
 ---
 
+Although the web interface of {{% tts %}} (the Console) currently has support for all basic features of {{% tts %}}, for some actions, you need to use the command-line interface (CLI). The CLI allows you to manage all features of {{% tts %}}.
+You can use the CLI on your local machine and on the server.
+
+>Note: if you need help with any CLI command, use the `--help` flag to get a list of subcommands, flags and their description and aliases.
+
+## Installation
+
+### Package managers (recommended)
+
+#### macOS
+
+```bash
+$ brew install TheThingsNetwork/lorawan-stack/ttn-lw-stack
+```
+
+#### Linux
+
+```bash
+$ sudo snap install ttn-lw-stack
+$ sudo snap alias ttn-lw-stack.ttn-lw-cli ttn-lw-cli
+```
+
+### Binaries
+
+You can download [pre-built binaries](https://github.com/TheThingsNetwork/lorawan-stack/releases) for your operating system and processor architecture.
+
 ## Configuration
 
 The command-line needs to be configured to connect to your deployment on `thethings.example.com`. You have multiple options to make the configuration file available to the CLI:

--- a/doc/content/guides/getting-started/installation.md
+++ b/doc/content/guides/getting-started/installation.md
@@ -9,30 +9,3 @@ weight: 1
 Since we're going to install {{% tts %}} using Docker and Docker Compose, follow the guides to [install Docker](https://docs.docker.com/install/#supported-platforms) and to [install Docker Compose](https://docs.docker.com/compose/install/#install-compose).
 
 Most releases contain an example `docker-compose.yml` file. You can also find this file [in the Github repository of {{% tts %}}]({{% repo-file-url "raw" "docker-compose.yml" %}}). In this guide we'll use that example `docker-compose.yml` for our deployment.
-
-## Command-line Interface (optional)
-
-Although the web interface of {{% tts %}} (the Console) currently has support for all basic features of {{% tts %}}, for some actions, you need to use the command-line interface (CLI). The CLI allows you to manage all features of {{% tts %}}.
-
-You can use the CLI on your local machine and on the server.
-
->Note: if you need help with any CLI command, use the `--help` flag to get a list of subcommands, flags and their description and aliases.
-
-### Package managers (recommended)
-
-#### macOS
-
-```bash
-$ brew install TheThingsNetwork/lorawan-stack/ttn-lw-stack
-```
-
-#### Linux
-
-```bash
-$ sudo snap install ttn-lw-stack
-$ sudo snap alias ttn-lw-stack.ttn-lw-cli ttn-lw-cli
-```
-
-### Binaries
-
-You can download [pre-built binaries](https://github.com/TheThingsNetwork/lorawan-stack/releases) for your operating system and processor architecture.

--- a/doc/layouts/shortcodes/cli-only.html
+++ b/doc/layouts/shortcodes/cli-only.html
@@ -2,6 +2,6 @@
   <h3 class="has-text-light">Command-line interface only</h3>
   <p>The instructions below use the command-line interface (CLI).</p>
   <div class="buttons">
-    <a class="button is-primary is-inverted is-outlined" href="{{ ref . "/guides/getting-started/installation" }}">Learn how to install the CLI</a>
+    <a class="button is-primary is-inverted is-outlined" href="{{ ref . "/guides/getting-started/cli#installation" }}">Learn how to install the CLI</a>
   </div>
 </div>


### PR DESCRIPTION
#### Summary
Fixes #1831
Apply changes from https://github.com/TheThingsIndustries/lorawan-stack/pull/1845 belonging to 
 TheThingsNetwork/lorawan-stack.

#### Changes
Replace getting started link on index
Replace component image alt.
Move CLI installation from getting-started/installation to  getting-started/cli

