### PR TITLE
Describe EndDevice fields stored by IS/NS/AS/JS

### DIFF
--- a/doc/content/reference/api/end_device.md
+++ b/doc/content/reference/api/end_device.md
@@ -4,59 +4,114 @@ description: ""
 weight: 7
 ---
 
+End devices are registered in multiple registries. The Identity Server has a registry with end device metadata, the Network Server's registry contains the MAC configuration and MAC state (including network session keys), the Application Server keeps payload formatters and application session keys, the Join Server keeps the root keys.
+
+When registering end devices, we recommend registering them in the following order:
+
+- `EndDeviceRegistry.Create` (Identity Server)
+- `JsEndDeviceRegistry.Set` (Join Server, only for OTAA devices)
+- `NsEndDeviceRegistry.Set` (Network Server)
+- `AsEndDeviceRegistry.Set` (Application Server)
+
+When deleting end devices, we recommend deleting them in the reverse order
+
 ## The `EndDeviceRegistry` service
+
+The Identity Server's `EndDeviceRegistry` is the first place to register an end device. This registry stores the following [EndDevice fields](#message:EndDevice):
+
+- `ids` (with subfields)
+- `name`
+- `description`
+- `attributes`
+- `version_ids` (with subfields)
+- `network_server_address`
+- `application_server_address`
+- `join_server_address` (only for OTAA devices)
+- `service_profile_id`
+- `locations`
+- `picture`
 
 {{< proto/method service="EndDeviceRegistry" method="Create" >}}
 
-> TODO: [Document what fields to set to the IS.](https://github.com/TheThingsNetwork/lorawan-stack/issues/206)
-
 {{< proto/method service="EndDeviceRegistry" method="Get" >}}
-
-> TODO: [Document what fields to get from the IS.](https://github.com/TheThingsNetwork/lorawan-stack/issues/206)
 
 {{< proto/method service="EndDeviceRegistry" method="List" >}}
 
-> TODO: [Document what fields to get from the IS.](https://github.com/TheThingsNetwork/lorawan-stack/issues/206)
-
 {{< proto/method service="EndDeviceRegistry" method="Update" >}}
-
-> TODO: [Document what fields to set to the IS.](https://github.com/TheThingsNetwork/lorawan-stack/issues/206)
 
 {{< proto/method service="EndDeviceRegistry" method="Delete" >}}
 
 ## The `JsEndDeviceRegistry` service
 
+OTAA devices are registered in the Join Server's `JsEndDeviceRegistry`. This registry stores the following [EndDevice fields](#message:EndDevice):
+
+- `ids` (with subfields)
+- `provisioner_id` (when provisioning with secure elements)
+- `provisioning_data` (when provisioning with secure elements)
+- `resets_join_nonces`
+- `root_keys`:
+  - `root_key_id`
+  - `app_key`
+  - `nwk_key`
+- `net_id`
+- `network_server_address`
+- `network_server_kek_label`
+- `application_server_address`
+- `application_server_id`
+- `application_server_kek_label`
+- `claim_authentication_code` (when using [end device claiming]({{< relref "end_device_claiming.md" >}}))
+
 {{< proto/method service="JsEndDeviceRegistry" method="Set" >}}
 
-> TODO: [Document what fields to set to the JS.](https://github.com/TheThingsNetwork/lorawan-stack/issues/206)
-
 {{< proto/method service="JsEndDeviceRegistry" method="Get" >}}
-
-> TODO: [Document what fields to get from the JS.](https://github.com/TheThingsNetwork/lorawan-stack/issues/206)
 
 {{< proto/method service="JsEndDeviceRegistry" method="Delete" >}}
 
 ## The `NsEndDeviceRegistry` service
 
+The Network Server's `NsEndDeviceRegistry` stores the following [EndDevice fields](#message:EndDevice):
+
+- `ids` (with subfields)
+- `frequency_plan_id`
+- `lorawan_phy_version`
+- `lorawan_version`
+- `mac_settings` (with subfields)
+- `mac_state` (with subfields)
+- `supports_join`
+- `multicast`
+- `supports_class_b`
+- `supports_class_c`
+- `session.dev_addr`
+- `session.keys`:
+  - `session_key_id`
+  - `f_nwk_s_int_key`
+  - `s_nwk_s_int_key`
+  - `nwk_s_enc_key`
+
 {{< proto/method service="NsEndDeviceRegistry" method="Set" >}}
 
-> TODO: [Document what fields to set to the NS.](https://github.com/TheThingsNetwork/lorawan-stack/issues/206)
-
 {{< proto/method service="NsEndDeviceRegistry" method="Get" >}}
-
-> TODO: [Document what fields to get from the NS.](https://github.com/TheThingsNetwork/lorawan-stack/issues/206)
 
 {{< proto/method service="NsEndDeviceRegistry" method="Delete" >}}
 
 ## The `AsEndDeviceRegistry` service
 
+The Network Server's `NsEndDeviceRegistry` stores the following [EndDevice fields](#message:EndDevice):
+
+- `ids` (with subfields)
+- `formatters`:
+  - `up_formatter`
+  - `up_formatter_parameter`
+  - `down_formatter`
+  - `down_formatter_parameter`
+- `session.dev_addr`
+- `session.keys`:
+  - `session_key_id`
+  - `app_s_key`
+
 {{< proto/method service="AsEndDeviceRegistry" method="Set" >}}
 
-> TODO: [Document what fields to set to the AS.](https://github.com/TheThingsNetwork/lorawan-stack/issues/206)
-
 {{< proto/method service="AsEndDeviceRegistry" method="Get" >}}
-
-> TODO: [Document what fields to get from the AS.](https://github.com/TheThingsNetwork/lorawan-stack/issues/206)
 
 {{< proto/method service="AsEndDeviceRegistry" method="Delete" >}}
 

--- a/doc/content/reference/api/end_device.md
+++ b/doc/content/reference/api/end_device.md
@@ -4,7 +4,7 @@ description: ""
 weight: 7
 ---
 
-End devices are registered in multiple registries. The Identity Server has a registry with end device metadata, the Network Server's registry contains the MAC configuration and MAC state (including network session keys), the Application Server keeps payload formatters and application session keys, the Join Server keeps the root keys.
+End devices are registered in multiple registries. The Identity Server has a registry with end device metadata, the Network Server's registry contains the MAC configuration, MAC state and network session keys, the Application Server keeps payload formatters and application session keys, the Join Server keeps the root keys.
 
 When registering end devices, we recommend registering them in the following order:
 
@@ -17,7 +17,7 @@ When deleting end devices, we recommend deleting them in the reverse order
 
 ## The `EndDeviceRegistry` service
 
-The Identity Server's `EndDeviceRegistry` is the first place to register an end device. This registry stores the following [EndDevice fields](#message:EndDevice):
+The Identity Server's `EndDeviceRegistry` is the first service, where end device is registered. The following [EndDevice fields](#message:EndDevice) are registered in this registry:
 
 - `ids` (with subfields)
 - `name`
@@ -43,7 +43,7 @@ The Identity Server's `EndDeviceRegistry` is the first place to register an end 
 
 ## The `JsEndDeviceRegistry` service
 
-OTAA devices are registered in the Join Server's `JsEndDeviceRegistry`. This registry stores the following [EndDevice fields](#message:EndDevice):
+OTAA devices are registered in the Join Server's `JsEndDeviceRegistry`. The following [EndDevice fields](#message:EndDevice) are registered in this registry:
 
 - `ids` (with subfields)
 - `provisioner_id` (when provisioning with secure elements)
@@ -61,6 +61,8 @@ OTAA devices are registered in the Join Server's `JsEndDeviceRegistry`. This reg
 - `application_server_kek_label`
 - `claim_authentication_code` (when using [end device claiming]({{< relref "end_device_claiming.md" >}}))
 
+See the [EndDevice message](#message:EndDevice) and its sub-messages for additional fields that can be read from the Join Server's `JsEndDeviceRegistry`.
+
 {{< proto/method service="JsEndDeviceRegistry" method="Set" >}}
 
 {{< proto/method service="JsEndDeviceRegistry" method="Get" >}}
@@ -69,7 +71,7 @@ OTAA devices are registered in the Join Server's `JsEndDeviceRegistry`. This reg
 
 ## The `NsEndDeviceRegistry` service
 
-The Network Server's `NsEndDeviceRegistry` stores the following [EndDevice fields](#message:EndDevice):
+The following [EndDevice fields](#message:EndDevice) are registered in the Network Server's `NsEndDeviceRegistry`:
 
 - `ids` (with subfields)
 - `frequency_plan_id`
@@ -88,6 +90,8 @@ The Network Server's `NsEndDeviceRegistry` stores the following [EndDevice field
   - `s_nwk_s_int_key`
   - `nwk_s_enc_key`
 
+See the [EndDevice message](#message:EndDevice) and its sub-messages for additional fields that can be read from the Network Server's `NsEndDeviceRegistry`.
+
 {{< proto/method service="NsEndDeviceRegistry" method="Set" >}}
 
 {{< proto/method service="NsEndDeviceRegistry" method="Get" >}}
@@ -96,7 +100,7 @@ The Network Server's `NsEndDeviceRegistry` stores the following [EndDevice field
 
 ## The `AsEndDeviceRegistry` service
 
-The Network Server's `NsEndDeviceRegistry` stores the following [EndDevice fields](#message:EndDevice):
+The following [EndDevice fields](#message:EndDevice) are registered in the Application Server's `AsEndDeviceRegistry`:
 
 - `ids` (with subfields)
 - `formatters`:
@@ -108,6 +112,8 @@ The Network Server's `NsEndDeviceRegistry` stores the following [EndDevice field
 - `session.keys`:
   - `session_key_id`
   - `app_s_key`
+
+See the [EndDevice message](#message:EndDevice) and its sub-messages for additional fields that can be read from the Application Server's `AsEndDeviceRegistry`.
 
 {{< proto/method service="AsEndDeviceRegistry" method="Set" >}}
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR extends the EndDevice API reference with an explanation about how end devices are stored in multiple registries and adds details on (some of) the fields stored by each registry.

Closes #206

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This is not intended to be complete, just enough to get started with.

Feel free to add commits to this PR for anything essential that is still missing.