### PR TITLE
Fix location of web UI branding guide

### DIFF
--- a/doc/content/guides/branding/_index.md
+++ b/doc/content/guides/branding/_index.md
@@ -1,7 +1,7 @@
 ---
-title: 'Branding'
+title: 'Web UI Branding'
 description: ''
-weight: 5
+weight: 50
 ---
 
 This reference gives details on how to customize the branding of the login pages and the Console.

--- a/doc/content/reference/configuration/identity-server.md
+++ b/doc/content/reference/configuration/identity-server.md
@@ -62,7 +62,7 @@ If you do not want to serve the OAuth user interface on `/oauth`, you may custom
 
 - `is.oauth.mount`: Path on the server where the OAuth server will be served
 
-If page assets for the OAuth UI are served from a CDN or on a different path on the server, the base URL needs to be customized as well. If you want to [customize the branding]({{< relref "../../branding" >}}) of the OAuth UI, you can set the base URL for where your branding assets are located.
+If page assets for the OAuth UI are served from a CDN or on a different path on the server, the base URL needs to be customized as well. If you want to [customize the branding]({{< ref "/guides/branding" >}}) of the OAuth UI, you can set the base URL for where your branding assets are located.
 
 - `is.oauth.ui.assets-base-url`: The base URL to the page assets
 - `is.oauth.ui.branding-base-url`: The base URL to the branding assets


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

The branding documentation shouldn't be a top-level document, so I moved it under guides.
