### PR TITLE
Make user delete warning consistent with others

### DIFF
--- a/pkg/webui/console/components/user-data-form/index.js
+++ b/pkg/webui/console/components/user-data-form/index.js
@@ -57,7 +57,7 @@ const m = defineMessages({
   emailAddressDescription:
     'Primary email address used for logging in; this address is not publicly visible',
   modalWarning:
-    'Are you sure you want to delete the user "{userId}". This action cannot be undone!',
+    'Are you sure you want to delete the user "{userId}". This action cannot be undone and it will not be possible to reuse the user ID!',
 })
 
 @injectIntl

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -140,7 +140,7 @@
   "console.components.user-data-form.index.userNamePlaceholder": "Jane Doe",
   "console.components.user-data-form.index.emailPlaceholder": "mail@example.com",
   "console.components.user-data-form.index.emailAddressDescription": "Primary email address used for logging in; this address is not publicly visible",
-  "console.components.user-data-form.index.modalWarning": "Are you sure you want to delete the user \"{userId}\". This action cannot be undone!",
+  "console.components.user-data-form.index.modalWarning": "Are you sure you want to delete the user \"{userId}\". This action cannot be undone and it will not be possible to reuse the user ID!",
   "console.components.webhook-form.index.idPlaceholder": "my-new-webhook",
   "console.components.webhook-form.index.messageInfo": "For each enabled message type, you can set an optional path that will be appended to the base URL.",
   "console.components.webhook-form.index.deleteWebhook": "Delete Webhook",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -140,7 +140,7 @@
   "console.components.user-data-form.index.userNamePlaceholder": "Xxxx Xxx",
   "console.components.user-data-form.index.emailPlaceholder": "xxxx@xxxxxxx.xxx",
   "console.components.user-data-form.index.emailAddressDescription": "Xxxxxxx xxxxx xxxxxxx xxxx xxx xxxxxxx xx; xxxx xxxxxxx xx xxx xxxxxxxx xxxxxxx",
-  "console.components.user-data-form.index.modalWarning": "Xxx xxx xxxx xxx xxxx xx xxxxxx xxx xxxx \"{userId}\". Xxxx xxxxxx xxxxxx xx xxxxxx!",
+  "console.components.user-data-form.index.modalWarning": "Xxx xxx xxxx xxx xxxx xx xxxxxx xxx xxxx \"{userId}\". Xxxx xxxxxx xxxxxx xx xxxxxx xxx xx xxxx xxx xx xxxxxxxx xx xxxxx xxx xxxx XX!",
   "console.components.webhook-form.index.idPlaceholder": "xx-xxx-xxxxxxx",
   "console.components.webhook-form.index.messageInfo": "Xxx xxxx xxxxxxx xxxxxxx xxxx, xxx xxx xxx xx xxxxxxxx xxxx xxxx xxxx xx xxxxxxxx xx xxx xxxx XXX.",
   "console.components.webhook-form.index.deleteWebhook": "Xxxxxx Xxxxxxx",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This makes the user delete warning consistent with the changes in #1625 

