### PR TITLE
Yield processor to other goroutines before flaky test assertions

### DIFF
--- a/pkg/events/handler_test.go
+++ b/pkg/events/handler_test.go
@@ -17,6 +17,7 @@ package events_test
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/smartystreets/assertions"
@@ -68,6 +69,8 @@ func TestChannelReceive(t *testing.T) {
 	eventChan.Notify(events.New(test.Context(), "evt", nil, nil))
 	eventChan.Notify(events.New(test.Context(), "evt", nil, nil))
 	eventChan.Notify(events.New(test.Context(), "overflow", nil, nil))
+
+	runtime.Gosched()
 
 	ctx, cancel := context.WithCancel(test.Context())
 

--- a/pkg/rpcserver/rpcserver_test.go
+++ b/pkg/rpcserver/rpcserver_test.go
@@ -16,6 +16,7 @@ package rpcserver_test
 
 import (
 	"context"
+	"runtime"
 	"testing"
 
 	"github.com/gogo/protobuf/types"
@@ -105,6 +106,8 @@ func TestNewRPCServer(t *testing.T) {
 		})
 		a.So(mock.pushCtx.Value(&mockKey2{}), should.Resemble, "bar")
 
+		runtime.Gosched()
+
 		a.So(logHandler.entries, should.HaveLength, 1)
 	})
 
@@ -129,6 +132,8 @@ func TestNewRPCServer(t *testing.T) {
 			"grpc.request.foo":    "bar",
 		})
 		a.So(mock.subCtx.Value(&mockKey2{}), should.Resemble, "foo")
+
+		runtime.Gosched()
 
 		a.So(logHandler.entries, should.HaveLength, 2)
 	})


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR yields the processor in some tests that rely on other goroutines to run.

Hopefully resolves #1349
Hopefully resolves #1666

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
