### PR TITLE
Fix IS registry search test for Postgres

### DIFF
--- a/pkg/identityserver/registry_search_test.go
+++ b/pkg/identityserver/registry_search_test.go
@@ -35,8 +35,8 @@ func TestRegistrySearch(t *testing.T) {
 		cli := ttnpb.NewEntityRegistrySearchClient(cc)
 
 		apps, err := cli.SearchApplications(ctx, &ttnpb.SearchEntitiesRequest{
-			NameContains: "%",
-			FieldMask:    types.FieldMask{Paths: []string{"ids"}},
+			DescriptionContains: "random",
+			FieldMask:           types.FieldMask{Paths: []string{"ids"}},
 		}, creds)
 
 		a.So(err, should.BeNil)
@@ -45,8 +45,8 @@ func TestRegistrySearch(t *testing.T) {
 		}
 
 		clis, err := cli.SearchClients(ctx, &ttnpb.SearchEntitiesRequest{
-			NameContains: "%",
-			FieldMask:    types.FieldMask{Paths: []string{"ids"}},
+			DescriptionContains: "random",
+			FieldMask:           types.FieldMask{Paths: []string{"ids"}},
 		}, creds)
 
 		a.So(err, should.BeNil)
@@ -55,8 +55,8 @@ func TestRegistrySearch(t *testing.T) {
 		}
 
 		gtws, err := cli.SearchGateways(ctx, &ttnpb.SearchEntitiesRequest{
-			NameContains: "%",
-			FieldMask:    types.FieldMask{Paths: []string{"ids"}},
+			DescriptionContains: "random",
+			FieldMask:           types.FieldMask{Paths: []string{"ids"}},
 		}, creds)
 
 		a.So(err, should.BeNil)
@@ -65,8 +65,8 @@ func TestRegistrySearch(t *testing.T) {
 		}
 
 		orgs, err := cli.SearchOrganizations(ctx, &ttnpb.SearchEntitiesRequest{
-			NameContains: "%",
-			FieldMask:    types.FieldMask{Paths: []string{"ids"}},
+			DescriptionContains: "random",
+			FieldMask:           types.FieldMask{Paths: []string{"ids"}},
 		}, creds)
 
 		a.So(err, should.BeNil)
@@ -75,8 +75,8 @@ func TestRegistrySearch(t *testing.T) {
 		}
 
 		usrs, err := cli.SearchUsers(ctx, &ttnpb.SearchEntitiesRequest{
-			NameContains: "%",
-			FieldMask:    types.FieldMask{Paths: []string{"ids"}},
+			DescriptionContains: "random",
+			FieldMask:           types.FieldMask{Paths: []string{"ids"}},
 		}, creds)
 
 		a.So(err, should.BeNil)

--- a/pkg/identityserver/store/populate.go
+++ b/pkg/identityserver/store/populate.go
@@ -16,6 +16,7 @@ package store
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 
 	"github.com/jinzhu/gorm"
@@ -35,6 +36,7 @@ func NewPopulator(size int, seed int64) *Populator {
 	}
 	for i := 0; i < size; i++ {
 		application := ttnpb.NewPopulatedApplication(randy, false)
+		application.Description = fmt.Sprintf("Random Application %d", i+1)
 		applicationID := application.EntityIdentifiers()
 		p.Applications = append(p.Applications, application)
 		p.APIKeys[applicationID] = append(
@@ -45,8 +47,10 @@ func NewPopulator(size int, seed int64) *Populator {
 			},
 		)
 		client := ttnpb.NewPopulatedClient(randy, false)
+		client.Description = fmt.Sprintf("Random Client %d", i+1)
 		p.Clients = append(p.Clients, client)
 		gateway := ttnpb.NewPopulatedGateway(randy, false)
+		gateway.Description = fmt.Sprintf("Random Gateway %d", i+1)
 		gatewayID := gateway.EntityIdentifiers()
 		p.Gateways = append(p.Gateways, gateway)
 		p.APIKeys[gatewayID] = append(
@@ -57,6 +61,7 @@ func NewPopulator(size int, seed int64) *Populator {
 			},
 		)
 		organization := ttnpb.NewPopulatedOrganization(randy, false)
+		organization.Description = fmt.Sprintf("Random Organization %d", i+1)
 		organizationID := organization.EntityIdentifiers()
 		p.Organizations = append(p.Organizations, organization)
 		p.APIKeys[organizationID] = append(
@@ -67,6 +72,7 @@ func NewPopulator(size int, seed int64) *Populator {
 			},
 		)
 		user := ttnpb.NewPopulatedUser(randy, false)
+		user.Description = fmt.Sprintf("Random User %d", i+1)
 		userID := user.EntityIdentifiers()
 		p.Users = append(p.Users, user)
 		p.APIKeys[userID] = append(


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quickfix for the Identity Server's search test, which failed when tested with Postgres instead of CockroachDB.

#### Changes
<!-- What are the changes made in this pull request? -->

- Search for "random" instead of "%"
- Update populator so that there are results

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
