### PR TITLE
Display disabled APIs correctly

### DIFF
--- a/pkg/webui/console/views/overview/index.js
+++ b/pkg/webui/console/views/overview/index.js
@@ -55,7 +55,7 @@ const m = defineMessages({
   gotoApplications: 'Go to applications',
   gotoGateways: 'Go to gateways',
   welcome: 'Welcome to the Console!',
-  welcomeBack: 'Welcome back, {userId} 👋!',
+  welcomeBack: 'Welcome back, {userId}! 👋',
   getStarted: 'Get started right away by creating an application or registering a gateway.',
   continueWorking: 'Walk right through to your applications and/or gateways.',
   componentStatus: 'Component Status',

--- a/pkg/webui/console/views/overview/index.js
+++ b/pkg/webui/console/views/overview/index.js
@@ -251,7 +251,7 @@ export default class Overview extends React.Component {
                 }
                 const component = stackConfig[componentKey]
                 const name = componentMap[componentKey]
-                const host = new URL(component.base_url).host
+                const host = component.enabled ? new URL(component.base_url).host : undefined
                 return (
                   <ComponentCard
                     key={componentKey}
@@ -275,11 +275,10 @@ const ComponentCard = function({ name, enabled, host }) {
       <img src={ServerIcon} className={style.componentCardIcon} />
       <div className={style.componentCardDesc}>
         <div className={style.componentCardName}>
-          <Status status={enabled ? 'good' : 'bad'} />
-          <Message content={name} />
+          <Status label={name} status={enabled ? 'good' : 'unknown'} flipped />
         </div>
         <span className={style.componentCardHost} title={host}>
-          {host}
+          {enabled ? host : <Message content={sharedMessages.disabled} />}
         </span>
       </div>
     </div>
@@ -288,6 +287,10 @@ const ComponentCard = function({ name, enabled, host }) {
 
 ComponentCard.propTypes = {
   enabled: PropTypes.bool.isRequired,
-  host: PropTypes.string.isRequired,
+  host: PropTypes.string,
   name: PropTypes.message.isRequired,
+}
+
+ComponentCard.defaultProps = {
+  host: undefined,
 }

--- a/pkg/webui/console/views/overview/overview.styl
+++ b/pkg/webui/console/views/overview/overview.styl
@@ -71,7 +71,6 @@
 .component-card
   display: inline-flex
   margin: 0 $cs.xl $cs.xl 0
-  max-width: 18rem
   flex-shrink: 0
 
   &-icon
@@ -82,7 +81,6 @@
     margin-left: $cs.m
     display: flex
     flex-direction: column
-    overflow: hidden
 
     & > span
       display: block
@@ -98,8 +96,6 @@
   &-host
     font-family: $font-family-mono
     font-size: $fs.s
-    overflow: hidden
-    text-overflow: ellipsis
 
 .version-info-section
   display: flex

--- a/pkg/webui/lib/prop-types.js
+++ b/pkg/webui/lib/prop-types.js
@@ -135,7 +135,7 @@ PropTypes.user = PropTypes.shape({
 
 PropTypes.stackComponent = PropTypes.shape({
   enabled: PropTypes.bool.isRequired,
-  base_url: PropTypes.string.isRequired,
+  base_url: PropTypes.string,
 })
 
 PropTypes.env = PropTypes.shape({

--- a/pkg/webui/lib/shared-messages.js
+++ b/pkg/webui/lib/shared-messages.js
@@ -82,6 +82,7 @@ export default defineMessages({
   devices: 'Devices',
   devID: 'Device ID',
   devName: 'Device Name',
+  disabled: 'Disabled',
   disconnected: 'Disconnected',
   downlink: 'Downlink',
   downlinkAck: 'Downlink Ack',

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -257,7 +257,7 @@
   "console.views.overview.index.gotoApplications": "Go to applications",
   "console.views.overview.index.gotoGateways": "Go to gateways",
   "console.views.overview.index.welcome": "Welcome to the Console!",
-  "console.views.overview.index.welcomeBack": "Welcome back, {userId} 👋!",
+  "console.views.overview.index.welcomeBack": "Welcome back, {userId}! 👋",
   "console.views.overview.index.getStarted": "Get started right away by creating an application or registering a gateway.",
   "console.views.overview.index.continueWorking": "Walk right through to your applications and/or gateways.",
   "console.views.overview.index.componentStatus": "Component Status",

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -353,6 +353,7 @@
   "lib.shared-messages.devices": "Devices",
   "lib.shared-messages.devID": "Device ID",
   "lib.shared-messages.devName": "Device Name",
+  "lib.shared-messages.disabled": "Disabled",
   "lib.shared-messages.disconnected": "Disconnected",
   "lib.shared-messages.downlink": "Downlink",
   "lib.shared-messages.downlinkAck": "Downlink Ack",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -257,7 +257,7 @@
   "console.views.overview.index.gotoApplications": "Xx xx xxxxxxxxxxxx",
   "console.views.overview.index.gotoGateways": "Xx xx xxxxxxxx",
   "console.views.overview.index.welcome": "Xxxxxxx xx xxx Xxxxxxx!",
-  "console.views.overview.index.welcomeBack": "Xxxxxxx xxxx, {userId} xx!",
+  "console.views.overview.index.welcomeBack": "Xxxxxxx xxxx, {userId}! xx",
   "console.views.overview.index.getStarted": "Xxx xxxxxxx xxxxx xxxx xx xxxxxxxx xx xxxxxxxxxxx xx xxxxxxxxxxx x xxxxxxx.",
   "console.views.overview.index.continueWorking": "Xxxx xxxxx xxxxxxx xx xxxx xxxxxxxxxxxx xxx/xx xxxxxxxx.",
   "console.views.overview.index.componentStatus": "Xxxxxxxxx Xxxxxx",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -353,6 +353,7 @@
   "lib.shared-messages.devices": "Xxxxxxx",
   "lib.shared-messages.devID": "Xxxxxx XX",
   "lib.shared-messages.devName": "Xxxxxx Xxxx",
+  "lib.shared-messages.disabled": "Xxxxxxxx",
   "lib.shared-messages.disconnected": "Xxxxxxxxxxxx",
   "lib.shared-messages.downlink": "Xxxxxxxx",
   "lib.shared-messages.downlinkAck": "Xxxxxxxx Xxx",

--- a/pkg/webui/types.go
+++ b/pkg/webui/types.go
@@ -14,8 +14,25 @@
 
 package webui
 
+import "encoding/json"
+
 // APIConfig for upstream APIs.
 type APIConfig struct {
 	Enabled bool   `json:"enabled" name:"enabled" description:"Enable this API"`
 	BaseURL string `json:"base_url" name:"base-url" description:"Base URL to the HTTP API"`
+}
+
+// MarshalJSON implements json.Marshaler.
+func (c APIConfig) MarshalJSON() ([]byte, error) {
+	out := struct {
+		Enabled bool   `json:"enabled"`
+		BaseURL string `json:"base_url,omitempty"`
+	}{
+		Enabled: c.Enabled,
+		BaseURL: c.BaseURL,
+	}
+	if !out.Enabled {
+		out.BaseURL = ""
+	}
+	return json.Marshal(out)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #1614 

#### Changes
<!-- What are the changes made in this pull request? -->

- Restructure component card such that the component urls have enough space to be expanded
- Add a check if component base url is provided (cc @htdvisser )
- Change disabled component status to `unknown` (grey)
- Fix prop types accordingly

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@kschiffer I made changes to the component card since Hylke wanted it to be displayed fully. I organized it in a list one under each other to add some structure since if we expand it based on the length of the url it can get quite messy. Maybe the better way would be to expand the component urls on hover.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
