### PR TITLE
Fixes for various downlink timing issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for ordering in `List` RPCs.
+- Detect existing Basic Station time epoch when the gateway was already running long before it (re)connected to the Gateway Server.
 
 ### Changed
+
+- Reduce the downlink path expiry window to 15 seconds, i.e. typically missing three `PULL_DATA` frames.
+- Reduce the connection expiry window to 1 minute.
+- Reduce default UDP address block time from 5 minutes to 1 minute. This allows for faster reconnecting if the gateway changes IP address. The downlink path and connection now expire before the UDP source address is released.
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- Fix class A downlink scheduling when an uplink message has been received between the triggering uplink message.
 
 ### Security
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -3464,6 +3464,15 @@
       "file": "scheduler.go"
     }
   },
+  "error:pkg/gatewayserver/scheduling:no_server_time": {
+    "translations": {
+      "en": "no server time"
+    },
+    "description": {
+      "package": "pkg/gatewayserver/scheduling",
+      "file": "scheduler.go"
+    }
+  },
   "error:pkg/gatewayserver/scheduling:sub_band_not_found": {
     "translations": {
       "en": "sub-band not found for frequency `{frequency}` Hz"

--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -957,7 +957,7 @@ func TestGatewayServer(t *testing.T) {
 													GatewayIdentifiers: ttnpb.GatewayIdentifiers{
 														GatewayID: registeredGatewayID,
 													},
-												}, 100),
+												}, 10000000),
 											},
 										},
 									},
@@ -983,7 +983,7 @@ func TestGatewayServer(t *testing.T) {
 													GatewayIdentifiers: ttnpb.GatewayIdentifiers{
 														GatewayID: registeredGatewayID,
 													},
-												}, 100),
+												}, 10000000),
 											},
 										},
 									},

--- a/pkg/gatewayserver/io/basicstationlns/basicstationlns.go
+++ b/pkg/gatewayserver/io/basicstationlns/basicstationlns.go
@@ -363,11 +363,11 @@ func (s *srv) handleTraffic(c echo.Context) (err error) {
 					logger.WithError(err).Debug("Failed to parse join-request message")
 					return nil
 				}
+				atomic.StoreInt32(&sessionID, int32(jreq.UpInfo.XTime>>48))
 				if err := conn.HandleUp(up); err != nil {
 					logger.WithError(err).Warn("Failed to handle uplink message")
 				}
 				recordRTT(conn, receivedAt, jreq.RefTime)
-				atomic.StoreInt32(&sessionID, int32(jreq.UpInfo.XTime>>48))
 
 			case messages.TypeUpstreamUplinkDataFrame:
 				var updf messages.UplinkDataFrame
@@ -380,11 +380,11 @@ func (s *srv) handleTraffic(c echo.Context) (err error) {
 					logger.WithError(err).Debug("Failed to parse uplink data frame")
 					return nil
 				}
+				atomic.StoreInt32(&sessionID, int32(updf.UpInfo.XTime>>48))
 				if err := conn.HandleUp(up); err != nil {
 					logger.WithError(err).Warn("Failed to handle uplink message")
 				}
 				recordRTT(conn, receivedAt, updf.RefTime)
-				atomic.StoreInt32(&sessionID, int32(updf.UpInfo.XTime>>48))
 
 			case messages.TypeUpstreamTxConfirmation:
 				var txConf messages.TxConfirmation
@@ -408,7 +408,6 @@ func (s *srv) handleTraffic(c echo.Context) (err error) {
 			default:
 				logger.WithField("message_type", typ).Debug("Unknown message type")
 			}
-
 		}
 	}
 }

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -130,7 +130,7 @@ var errBufferFull = errors.DefineInternal("buffer_full", "buffer is full")
 // HandleUp updates the uplink stats and sends the message to the upstream channel.
 func (c *Connection) HandleUp(up *ttnpb.UplinkMessage) error {
 	if up.Settings.Time != nil {
-		c.scheduler.SyncWithGateway(up.Settings.Timestamp, up.ReceivedAt, *up.Settings.Time)
+		c.scheduler.SyncWithGatewayAbsolute(up.Settings.Timestamp, up.ReceivedAt, *up.Settings.Time)
 		log.FromContext(c.ctx).WithFields(log.Fields(
 			"timestamp", up.Settings.Timestamp,
 			"server_time", up.ReceivedAt,
@@ -450,6 +450,12 @@ func (c *Connection) RTTStats() (min, max, median time.Duration, count int) {
 
 // FrequencyPlan returns the frequency plan for the gateway.
 func (c *Connection) FrequencyPlan() *frequencyplans.FrequencyPlan { return c.fp }
+
+// SyncWithGatewayConcentrator synchronizes the clock with the given concentrator timestamp, the server time and the
+// relative gateway time that corresponds to the given timestamp.
+func (c *Connection) SyncWithGatewayConcentrator(timestamp uint32, server time.Time, concentrator scheduling.ConcentratorTime) {
+	c.scheduler.SyncWithGatewayConcentrator(timestamp, server, concentrator)
+}
 
 // TimeFromTimestampTime returns the concentrator time by the given timestamp.
 // This method returns false if the clock is not synced with the server.

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -57,10 +57,10 @@ type Config struct {
 var DefaultConfig = Config{
 	PacketHandlers:      10,
 	PacketBuffer:        50,
-	DownlinkPathExpires: 30 * time.Second,
-	ConnectionExpires:   5 * time.Minute,
+	DownlinkPathExpires: 15 * time.Second, // Expire downlink after missing typically 3 PULL_DATA messages.
+	ConnectionExpires:   1 * time.Minute,  // Expire connection after missing typically 2 status messages.
 	ScheduleLateTime:    800 * time.Millisecond,
-	AddrChangeBlock:     15 * time.Second, // Release source IP address after missing typically 3 PULL_DATA messages.
+	AddrChangeBlock:     1 * time.Minute, // Release address when the connection expires.
 }
 
 type srv struct {

--- a/pkg/gatewayserver/scheduling/clock.go
+++ b/pkg/gatewayserver/scheduling/clock.go
@@ -82,7 +82,7 @@ func (c *RolloverClock) FromGatewayTime(gateway time.Time) (ConcentratorTime, bo
 // FromTimestampTime implements Clock.
 func (c *RolloverClock) FromTimestampTime(timestamp uint32) ConcentratorTime {
 	passed := int64(timestamp) - int64(c.relative)
-	if passed < 0 {
+	if passed < -math.MaxUint32/2 {
 		passed += math.MaxUint32
 	}
 	return c.absolute + ConcentratorTime(time.Duration(passed)*time.Microsecond)

--- a/pkg/gatewayserver/scheduling/clock.go
+++ b/pkg/gatewayserver/scheduling/clock.go
@@ -61,11 +61,21 @@ func (c *RolloverClock) Sync(timestamp uint32, server time.Time) {
 	c.synced = true
 }
 
-// SyncWithGateway synchronizes the clock with the given concentrator timestamp, the server time and the gateway time that
-// corresponds to the given timestamp.
-func (c *RolloverClock) SyncWithGateway(timestamp uint32, server, gateway time.Time) {
+// SyncWithGatewayAbsolute synchronizes the clock with the given concentrator timestamp, the server time and the
+// absolute gateway time that corresponds to the given timestamp.
+func (c *RolloverClock) SyncWithGatewayAbsolute(timestamp uint32, server, gateway time.Time) {
 	c.Sync(timestamp, server)
 	c.gateway = &gateway
+}
+
+// SyncWithGatewayConcentrator synchronizes the clock with the given concentrator timestamp, the server time and the
+// relative gateway time that corresponds to the given timestamp.
+func (c *RolloverClock) SyncWithGatewayConcentrator(timestamp uint32, server time.Time, concentrator ConcentratorTime) {
+	c.absolute = concentrator
+	c.relative = timestamp
+	c.server = &server
+	c.gateway = nil
+	c.synced = true
 }
 
 // FromServerTime implements Clock.

--- a/pkg/gatewayserver/scheduling/clock_test.go
+++ b/pkg/gatewayserver/scheduling/clock_test.go
@@ -24,7 +24,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 )
 
-func TestConcentratorClock(t *testing.T) {
+func TestRolloverClock(t *testing.T) {
 	a := assertions.New(t)
 	clock := &scheduling.RolloverClock{}
 
@@ -37,7 +37,15 @@ func TestConcentratorClock(t *testing.T) {
 	a.So(gatewayTime, should.Equal, 10000000*time.Microsecond+100)
 
 	{
+		// Test timestamp time without rollover.
+		a.So(clock.FromTimestampTime(9999999), should.Equal, 9999999*time.Microsecond)
+		a.So(clock.FromTimestampTime(10000000), should.Equal, 10000000*time.Microsecond)
+		a.So(clock.FromTimestampTime(10000001), should.Equal, 10000001*time.Microsecond)
+	}
+
+	{
 		// Test first roll-over to 4299967295 us (math.MaxUint32 + 5000000).
+		clock.Sync(math.MaxUint32, time.Unix(10, 0).Add(math.MaxUint32*time.Microsecond))
 		passed := time.Microsecond * (math.MaxUint32 + 5000000)
 		clock.SyncWithGateway(5000000, time.Unix(10, 0).Add(passed), time.Unix(0, 0).Add(passed))
 		a.So(clock.FromServerTime(time.Unix(10, 100).Add(passed)), should.Equal, passed+100)
@@ -45,13 +53,14 @@ func TestConcentratorClock(t *testing.T) {
 
 	{
 		// Test second roll-over to 8589934590 us (2 * math.MaxUint32).
+		clock.Sync(math.MaxUint32, time.Unix(10, 0).Add(2*math.MaxUint32*time.Microsecond))
 		passed := time.Microsecond * 2 * math.MaxUint32
 		clock.SyncWithGateway(0, time.Unix(10, 0).Add(passed), time.Unix(0, 0).Add(passed))
 		a.So(clock.FromServerTime(time.Unix(10, 100).Add(passed)), should.Equal, passed+100)
 	}
 
 	{
-		// Test reset of gateway time.
+		// Test reset of gateway time and rollover.
 		passed := time.Microsecond * (2*math.MaxUint32 + 5000000)
 		clock.Sync(5000000, time.Unix(10, 0).Add(passed))
 		_, ok := clock.FromGatewayTime(time.Unix(0, 100))

--- a/pkg/gatewayserver/scheduling/clock_test.go
+++ b/pkg/gatewayserver/scheduling/clock_test.go
@@ -16,54 +16,90 @@ package scheduling_test
 
 import (
 	"math"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/smartystreets/assertions"
-	"go.thethings.network/lorawan-stack/pkg/gatewayserver/scheduling"
+	. "go.thethings.network/lorawan-stack/pkg/gatewayserver/scheduling"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 )
 
 func TestRolloverClock(t *testing.T) {
-	a := assertions.New(t)
-	clock := &scheduling.RolloverClock{}
+	clock := &RolloverClock{}
 
-	clock.SyncWithGateway(10000000, time.Unix(10, 0), time.Unix(0, 0)) // The gateway has no idea of time.
-	a.So(clock.FromServerTime(time.Unix(10, 100)), should.Equal, 10000000*time.Microsecond+100)
-	a.So(clock.ToServerTime(scheduling.ConcentratorTime(10000000*time.Microsecond+100)), should.Equal, time.Unix(10, 100))
+	for i, stc := range []struct {
+		Absolute ConcentratorTime
+		Relative uint32
+	}{
+		{
+			Absolute: ConcentratorTime(10 * time.Second),
+			Relative: uint32(10000000),
+		},
+		{
+			// 1 rollover.
+			Absolute: ConcentratorTime(1<<32*time.Microsecond) + ConcentratorTime(5*time.Second),
+			Relative: uint32(5000000),
+		},
+		{
+			// 3 rollovers (1 existing + 2 server time rollovers).
+			Absolute: ConcentratorTime(3<<32*time.Microsecond) + ConcentratorTime(10*time.Second),
+			Relative: uint32(10000000),
+		},
+		{
+			// 5 rollovers (3 existing + 1 concentrator timestamp rollover + 1 server time rollover).
+			Absolute: ConcentratorTime(5<<32*time.Microsecond) + ConcentratorTime(1*time.Second),
+			Relative: uint32(1000000),
+		},
+		{
+			// 5 rollovers (5 existing) and advance to end of concentrator time epoch.
+			Absolute: ConcentratorTime(6<<32*time.Microsecond) - ConcentratorTime(1*time.Second),
+			Relative: uint32(4293967296),
+		},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			serverTime := time.Unix(0, 0).Add(time.Duration(stc.Absolute))
+			clock.Sync(stc.Relative, serverTime)
 
-	gatewayTime, ok := clock.FromGatewayTime(time.Unix(0, 100))
-	a.So(ok, should.BeTrue)
-	a.So(gatewayTime, should.Equal, 10000000*time.Microsecond+100)
+			for _, tc := range []struct {
+				D        time.Duration
+				Rollover bool
+			}{
+				{
+					D:        -5 * time.Second,
+					Rollover: false,
+				},
+				{
+					D:        5 * time.Second,
+					Rollover: false,
+				},
+				{
+					D:        30 * time.Minute,
+					Rollover: false,
+				},
+				{
+					D:        2 * time.Hour,
+					Rollover: true,
+				},
+			} {
+				t.Run(tc.D.String(), func(t *testing.T) {
+					a := assertions.New(t)
 
-	{
-		// Test timestamp time without rollover.
-		a.So(clock.FromTimestampTime(9999999), should.Equal, 9999999*time.Microsecond)
-		a.So(clock.FromTimestampTime(10000000), should.Equal, 10000000*time.Microsecond)
-		a.So(clock.FromTimestampTime(10000001), should.Equal, 10000001*time.Microsecond)
-	}
+					v, ok := clock.FromServerTime(serverTime.Add(tc.D))
+					a.So(ok, should.BeTrue)
+					a.So(v, should.Equal, stc.Absolute+ConcentratorTime(tc.D))
 
-	{
-		// Test first roll-over to 4299967295 us (math.MaxUint32 + 5000000).
-		clock.Sync(math.MaxUint32, time.Unix(10, 0).Add(math.MaxUint32*time.Microsecond))
-		passed := time.Microsecond * (math.MaxUint32 + 5000000)
-		clock.SyncWithGateway(5000000, time.Unix(10, 0).Add(passed), time.Unix(0, 0).Add(passed))
-		a.So(clock.FromServerTime(time.Unix(10, 100).Add(passed)), should.Equal, passed+100)
-	}
+					d := tc.D / time.Microsecond
+					rollover := d > math.MaxUint32/2 || d < -math.MaxUint32/2
+					a.So(rollover, should.Equal, tc.Rollover)
 
-	{
-		// Test second roll-over to 8589934590 us (2 * math.MaxUint32).
-		clock.Sync(math.MaxUint32, time.Unix(10, 0).Add(2*math.MaxUint32*time.Microsecond))
-		passed := time.Microsecond * 2 * math.MaxUint32
-		clock.SyncWithGateway(0, time.Unix(10, 0).Add(passed), time.Unix(0, 0).Add(passed))
-		a.So(clock.FromServerTime(time.Unix(10, 100).Add(passed)), should.Equal, passed+100)
-	}
-
-	{
-		// Test reset of gateway time and rollover.
-		passed := time.Microsecond * (2*math.MaxUint32 + 5000000)
-		clock.Sync(5000000, time.Unix(10, 0).Add(passed))
-		_, ok := clock.FromGatewayTime(time.Unix(0, 100))
-		a.So(ok, should.BeFalse)
+					if !rollover {
+						ts := uint32(time.Duration(stc.Relative) + tc.D/time.Microsecond)
+						v = clock.FromTimestampTime(ts)
+						a.So(v, should.Equal, stc.Absolute+ConcentratorTime(tc.D))
+					}
+				})
+			}
+		})
 	}
 }

--- a/pkg/gatewayserver/scheduling/scheduler.go
+++ b/pkg/gatewayserver/scheduling/scheduler.go
@@ -320,11 +320,19 @@ func (s *Scheduler) Sync(v uint32, server time.Time) {
 	s.mu.Unlock()
 }
 
-// SyncWithGateway synchronizes the clock with the given concentrator time v, the server time and the gateway time that
-// corresponds to the given v.
-func (s *Scheduler) SyncWithGateway(v uint32, server, gateway time.Time) {
+// SyncWithGatewayAbsolute synchronizes the clock with the given concentrator timestamp, the server time and the
+// absolute gateway time that corresponds to the given timestamp.
+func (s *Scheduler) SyncWithGatewayAbsolute(timestamp uint32, server, gateway time.Time) {
 	s.mu.Lock()
-	s.clock.SyncWithGateway(v, server, gateway)
+	s.clock.SyncWithGatewayAbsolute(timestamp, server, gateway)
+	s.mu.Unlock()
+}
+
+// SyncWithGatewayConcentrator synchronizes the clock with the given concentrator timestamp, the server time and the
+// relative gateway time that corresponds to the given timestamp.
+func (s *Scheduler) SyncWithGatewayConcentrator(timestamp uint32, server time.Time, concentrator ConcentratorTime) {
+	s.mu.Lock()
+	s.clock.SyncWithGatewayConcentrator(timestamp, server, concentrator)
 	s.mu.Unlock()
 }
 

--- a/pkg/gatewayserver/scheduling/scheduler_test.go
+++ b/pkg/gatewayserver/scheduling/scheduler_test.go
@@ -51,15 +51,15 @@ func TestScheduleAtWithBandDutyCycle(t *testing.T) {
 	a.So(err, should.BeNil)
 
 	for i, tc := range []struct {
-		SyncWithGateway bool
-		PayloadSize     int
-		Settings        ttnpb.TxSettings
-		Priority        ttnpb.TxSchedulePriority
-		MaxRTT          *time.Duration
-		MedianRTT       *time.Duration
-		ExpectedToa     time.Duration
-		ExpectedStarts  scheduling.ConcentratorTime
-		ExpectedError   *errors.Definition
+		SyncWithGatewayAbsolute bool
+		PayloadSize             int
+		Settings                ttnpb.TxSettings
+		Priority                ttnpb.TxSchedulePriority
+		MaxRTT                  *time.Duration
+		MedianRTT               *time.Duration
+		ExpectedToa             time.Duration
+		ExpectedStarts          scheduling.ConcentratorTime
+		ExpectedError           *errors.Definition
 	}{
 		{
 			PayloadSize: 10,
@@ -82,8 +82,8 @@ func TestScheduleAtWithBandDutyCycle(t *testing.T) {
 			ExpectedError: &scheduling.ErrTooLate,
 		},
 		{
-			SyncWithGateway: true,
-			PayloadSize:     51,
+			SyncWithGatewayAbsolute: true,
+			PayloadSize:             51,
 			Settings: ttnpb.TxSettings{
 				DataRate: ttnpb.DataRate{
 					Modulation: &ttnpb.DataRate_LoRa{
@@ -124,8 +124,8 @@ func TestScheduleAtWithBandDutyCycle(t *testing.T) {
 			ExpectedError: &scheduling.ErrTooLate,
 		},
 		{
-			SyncWithGateway: true,
-			PayloadSize:     51,
+			SyncWithGatewayAbsolute: true,
+			PayloadSize:             51,
 			Settings: ttnpb.TxSettings{
 				DataRate: ttnpb.DataRate{
 					Modulation: &ttnpb.DataRate_LoRa{
@@ -186,8 +186,8 @@ func TestScheduleAtWithBandDutyCycle(t *testing.T) {
 			ExpectedStarts: 1000000000 - 200000000/2 - 51456000,
 		},
 		{
-			SyncWithGateway: true,
-			PayloadSize:     16,
+			SyncWithGatewayAbsolute: true,
+			PayloadSize:             16,
 			Settings: ttnpb.TxSettings{
 				DataRate: ttnpb.DataRate{
 					Modulation: &ttnpb.DataRate_LoRa{
@@ -306,8 +306,8 @@ func TestScheduleAtWithBandDutyCycle(t *testing.T) {
 	} {
 		tcok := t.Run(strconv.Itoa(i), func(t *testing.T) {
 			a := assertions.New(t)
-			if tc.SyncWithGateway {
-				scheduler.SyncWithGateway(0, timeSource.Time, time.Unix(0, 0))
+			if tc.SyncWithGatewayAbsolute {
+				scheduler.SyncWithGatewayAbsolute(0, timeSource.Time, time.Unix(0, 0))
 			} else {
 				scheduler.Sync(0, timeSource.Time)
 			}
@@ -364,14 +364,14 @@ func TestScheduleAtWithFrequencyPlanDutyCycle(t *testing.T) {
 	a.So(err, should.BeNil)
 
 	for i, tc := range []struct {
-		SyncWithGateway bool
-		PayloadSize     int
-		Settings        ttnpb.TxSettings
-		Priority        ttnpb.TxSchedulePriority
-		MaxRTT          *time.Duration
-		MedianRTT       *time.Duration
-		ExpectedToa     time.Duration
-		ExpectedStarts  scheduling.ConcentratorTime
+		SyncWithGatewayAbsolute bool
+		PayloadSize             int
+		Settings                ttnpb.TxSettings
+		Priority                ttnpb.TxSchedulePriority
+		MaxRTT                  *time.Duration
+		MedianRTT               *time.Duration
+		ExpectedToa             time.Duration
+		ExpectedStarts          scheduling.ConcentratorTime
 	}{
 		{
 			PayloadSize: 20,
@@ -395,8 +395,8 @@ func TestScheduleAtWithFrequencyPlanDutyCycle(t *testing.T) {
 	} {
 		tcok := t.Run(strconv.Itoa(i), func(t *testing.T) {
 			a := assertions.New(t)
-			if tc.SyncWithGateway {
-				scheduler.SyncWithGateway(0, timeSource.Time, time.Unix(0, 0))
+			if tc.SyncWithGatewayAbsolute {
+				scheduler.SyncWithGatewayAbsolute(0, timeSource.Time, time.Unix(0, 0))
 			} else {
 				scheduler.Sync(0, timeSource.Time)
 			}
@@ -439,7 +439,7 @@ func TestScheduleAnytime(t *testing.T) {
 	}
 	scheduler, err := scheduling.NewScheduler(ctx, fp, true, nil)
 	a.So(err, should.BeNil)
-	scheduler.SyncWithGateway(0, time.Now(), time.Unix(0, 0))
+	scheduler.SyncWithGatewayAbsolute(0, time.Now(), time.Unix(0, 0))
 
 	settingsAt := func(frequency uint64, sf, t uint32) ttnpb.TxSettings {
 		return ttnpb.TxSettings{
@@ -552,7 +552,7 @@ func TestScheduleAnytimeShort(t *testing.T) {
 		}
 		scheduler, err := scheduling.NewScheduler(ctx, fp, true, timeSource)
 		a.So(err, should.BeNil)
-		scheduler.SyncWithGateway(0, timeSource.Time, time.Unix(0, 0))
+		scheduler.SyncWithGatewayAbsolute(0, timeSource.Time, time.Unix(0, 0))
 		em, err := scheduler.ScheduleAnytime(ctx, 10, settingsAt(869525000, 7, nil, 0), nil, ttnpb.TxSchedulePriority_NORMAL)
 		a.So(err, should.BeNil)
 		a.So(time.Duration(em.Starts()), should.Equal, scheduling.ScheduleTimeLong)
@@ -565,7 +565,7 @@ func TestScheduleAnytimeShort(t *testing.T) {
 		}
 		scheduler, err := scheduling.NewScheduler(ctx, fp, true, timeSource)
 		a.So(err, should.BeNil)
-		scheduler.SyncWithGateway(0, timeSource.Time, time.Unix(0, 0))
+		scheduler.SyncWithGatewayAbsolute(0, timeSource.Time, time.Unix(0, 0))
 		rtts := &mockRTTs{
 			Max:   40 * time.Millisecond,
 			Count: 1,
@@ -582,7 +582,7 @@ func TestScheduleAnytimeShort(t *testing.T) {
 		}
 		scheduler, err := scheduling.NewScheduler(ctx, fp, true, timeSource)
 		a.So(err, should.BeNil)
-		scheduler.SyncWithGateway(0, timeSource.Time, time.Unix(0, 0))
+		scheduler.SyncWithGatewayAbsolute(0, timeSource.Time, time.Unix(0, 0))
 		em, err := scheduler.ScheduleAnytime(ctx, 10, settingsAt(869525000, 7, nil, 100*1000), nil, ttnpb.TxSchedulePriority_NORMAL)
 		a.So(err, should.BeNil)
 		a.So(time.Duration(em.Starts()), should.Equal, scheduling.ScheduleTimeShort)
@@ -595,7 +595,7 @@ func TestScheduleAnytimeShort(t *testing.T) {
 		}
 		scheduler, err := scheduling.NewScheduler(ctx, fp, true, timeSource)
 		a.So(err, should.BeNil)
-		scheduler.SyncWithGateway(0, timeSource.Time, time.Unix(0, 0))
+		scheduler.SyncWithGatewayAbsolute(0, timeSource.Time, time.Unix(0, 0))
 		rtts := &mockRTTs{
 			Max:   40 * time.Millisecond,
 			Count: 1,

--- a/pkg/gatewayserver/scheduling/util_test.go
+++ b/pkg/gatewayserver/scheduling/util_test.go
@@ -35,8 +35,8 @@ type mockClock struct {
 func (c *mockClock) IsSynced() bool {
 	return c.t > 0
 }
-func (c *mockClock) FromServerTime(_ time.Time) scheduling.ConcentratorTime {
-	return c.t
+func (c *mockClock) FromServerTime(_ time.Time) (scheduling.ConcentratorTime, bool) {
+	return c.t, true
 }
 func (c *mockClock) ToServerTime(t scheduling.ConcentratorTime) time.Time {
 	return time.Unix(0, 0).Add(time.Duration(t - c.t))


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fixes #1351 
Fixes #1701
Fixes #1707 
Fixes #1708
Fixes #1709

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix class A downlink scheduling when an uplink message has been received between the triggering uplink message.
- Reduce the downlink path expiry window to 15 seconds, i.e. typically missing three `PULL_DATA` frames.
- Reduce the connection expiry window to 40 seconds.
- Reduce default UDP address block time from 5 minutes to 1 minute. This allows for faster reconnecting if the gateway changes IP address. The downlink path and connection now expire before the UDP source address is released.
- Detect existing Basic Station time epoch when the gateway was already running long before it (re)connected to the Gateway Server.

cc @beitler @ama9910 @ktsolakas 

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@KrishnaIyer is main reviewer

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
