### PR TITLE
Make Github Actions TEST_SLOWDOWN same as Travis

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -73,4 +73,5 @@ jobs:
         SQL_DB_ADDRESS: localhost:${{ job.services.postgres.ports['5432'] }}
         REDIS_ADDRESS: localhost:${{ job.services.redis.ports['6379'] }}
         TEST_REDIS: '1'
+        TEST_SLOWDOWN: '8'
       run: ./mage go:test


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Looks like those Standard_DS2_v2 machines that Github Actions uses aren't as fast as our development machines, so this quickfix sets the TEST_SLOWDOWN of Github Actions to 8, same as on Travis.