### PR TITLE
Clarify user search in Console

### DIFF
--- a/doc/content/guides/user-management/console/_index.md
+++ b/doc/content/guides/user-management/console/_index.md
@@ -16,7 +16,7 @@ The list of users is shown immediately after going to **User Management** in the
 
 ## Searching for Users
 
-It is currently not possible to search for users in the Console, but you can [do this with the CLI]({{< relref "../cli#searching-for-users" >}}).
+You can search for users by ID using the search field above the list of users. It is currently not possible to search for users by other fields than the user ID using the Console, but you can [do this with the CLI]({{< relref "../cli#searching-for-users" >}}).
 
 ## Creating Users
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quick fix for the documentation to clarify that the console can search users by ID (but only by ID).