### PR TITLE
Fix propagation of Go tags to unconvert

### DIFF
--- a/.mage/go.go
+++ b/.mage/go.go
@@ -155,7 +155,11 @@ func (g Go) Unconvert() error {
 	if mg.Verbose() {
 		fmt.Printf("Removing unnecessary type conversions from %d Go packages\n", len(dirs))
 	}
-	return execGo("run", append([]string{"github.com/mdempsky/unconvert", "-safe", "-apply"}, dirs...)...)
+	args := []string{"github.com/mdempsky/unconvert", "-safe", "-apply"}
+	if goTags != "" {
+		args = append(args, "-tags", strings.Join(strings.Split(goTags, ","), " "))
+	}
+	return execGo("run", append(args, dirs...)...)
 }
 
 // Quality runs code quality checks on Go files.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR contains a quickfix for the tooling, so that Go tags are properly set in the call to `unconvert`.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
