### PR TITLE
Support multiple copyright years in headers check

### DIFF
--- a/.mage/header.yml
+++ b/.mage/header.yml
@@ -3,19 +3,19 @@ rules:
   exclude: [.snap,.json,.goreleaser.yml]
   header:
     |
-    Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+    Copyright © 20\d\d The Things Network Foundation, The Things Industries B\.V\.
 
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
+    Licensed under the Apache License, Version 2\.0 \(the "License"\);
+    you may not use this file except in compliance with the License\.
     You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+        http://www\.apache\.org/licenses/LICENSE-2\.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied\.
     See the License for the specific language governing permissions and
-    limitations under the License.
+    limitations under the License\.
   prefix: '// '
 - include: [.make,Makefile]
   prefix: '# '


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Let's avoid the yearly diff for updating copyright headers from 2020.

We don't have to do that anyway as copyright lasts for decades.

Developers can now bump the year as they like, i.e. when touching the file or not.

#### Changes
<!-- What are the changes made in this pull request? -->

- Support regexp in headers check

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [ ] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
