### PR TITLE
Prevent selection of pseudo right when such right cannot be granted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- Fix selection of pseudo wildcard rights being possible (leading to crash) in the Console even when such right cannot be granted.
 
 ### Security
 

--- a/pkg/webui/console/components/rights-group/index.js
+++ b/pkg/webui/console/components/rights-group/index.js
@@ -48,7 +48,6 @@ const computeProps = function(props) {
   } else if (Boolean(grantablePseudoRight) && Array.isArray(grantablePseudoRight)) {
     derivedPseudoRight = value.filter(right => right !== RIGHT_ALL && right.endsWith('_ALL'))
   }
-
   // Filter out rights that the entity has but may not be granted by the user
   const outOfOwnScopeRights = !Boolean(grantablePseudoRight)
     ? value.filter(right => !grantableRights.includes(right))
@@ -250,7 +249,7 @@ class RightsGroup extends React.Component {
           name="grant_type"
           value={grantType}
           onChange={this.handleGrantTypeChange}
-          disabled={!Boolean(derivedPseudoRight)}
+          disabled={derivedPseudoRight.length === 0}
         >
           <Radio label={m.allCurrentAndFutureRights} value="pseudo" />
           <Radio label={m.selectIndividualRights} value="individual" />


### PR DESCRIPTION
#### Summary
This quickfix PR disables the pseudo wildcard right radio button inside the rights selection. This will prevent the rights page from crashing when a user selects this option when he/she actually cannot grant this right.

![image](https://user-images.githubusercontent.com/5710611/71675117-63fe6600-2d7d-11ea-93f7-e6430d75b394.png)

#### Changes
- Fix faulty check for determining the disabled state of the radio group

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
