### PR TITLE
Fix faulty default props

### DIFF
--- a/pkg/webui/components/event/types/crud/index.js
+++ b/pkg/webui/components/event/types/crud/index.js
@@ -34,9 +34,9 @@ class CRUDEvent extends React.PureComponent {
   }
 
   static defaultProps = {
-    className: PropTypes.string,
-    expandedClassName: PropTypes.string,
-    overviewClassName: PropTypes.string,
+    className: undefined,
+    expandedClassName: undefined,
+    overviewClassName: undefined,
     widget: false,
   }
 


### PR DESCRIPTION
#### Summary
This quickfix PR fixes PropType check functions that have been accidentally set as default props for the CRUD Event component.

#### Changes
- Fix faulty default props

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
