### PR TITLE
Fix header items styling

### DIFF
--- a/pkg/webui/components/header/header.styl
+++ b/pkg/webui/components/header/header.styl
@@ -36,7 +36,7 @@
 .nav-list
   display: flex
   align-items: stretch
-  justify-content: space-between
+  justify-content: flex-start
   padding: 0 $ls.m
   flex-grow: 2
   height: 100%


### PR DESCRIPTION
#### Summary
This quickfix PR fixes the styling of the nav items in the header bar. With fewer navigation items available (e.g. due to fewer user rights), the list would be spread out, resulting in a wonky look.

#### Changes
- Change `justify-content` prop to `flex-start`

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
