### PR TITLE
Increase ScheduleTimeLong to 500 ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Increase time that class C messages are scheduled in advance from 300 to 500 ms to support higher latency gateway backhauls.
+
 ### Deprecated
 
 ### Removed

--- a/pkg/gatewayserver/scheduling/scheduler.go
+++ b/pkg/gatewayserver/scheduling/scheduler.go
@@ -42,7 +42,7 @@ var (
 	// ScheduleTimeLong is a long time to send a downlink message to the gateway before it has to be transmitted.
 	// This time is comprised of a higher network latency and QueueDelay. This delay is used for pseudo-immediate
 	// scheduling, see ScheduleAnytime.
-	ScheduleTimeLong = 300*time.Millisecond + QueueDelay
+	ScheduleTimeLong = 500*time.Millisecond + QueueDelay
 )
 
 // TimeSource is a source for getting a current time.
@@ -139,9 +139,7 @@ func (s *Scheduler) findSubBand(frequency uint64) (*SubBand, error) {
 	return nil, errSubBandNotFound.WithAttributes("frequency", frequency)
 }
 
-var (
-	errDwellTime = errors.DefineFailedPrecondition("dwell_time", "packet exceeds dwell time restriction")
-)
+var errDwellTime = errors.DefineFailedPrecondition("dwell_time", "packet exceeds dwell time restriction")
 
 func (s *Scheduler) newEmission(payloadSize int, settings ttnpb.TxSettings, starts ConcentratorTime) (Emission, error) {
 	d, err := toa.Compute(payloadSize, settings)
@@ -172,7 +170,7 @@ func (s *Scheduler) ScheduleAt(ctx context.Context, payloadSize int, settings tt
 	if !s.clock.IsSynced() {
 		return Emission{}, errNoClockSync
 	}
-	var minScheduleTime = ScheduleTimeShort
+	minScheduleTime := ScheduleTimeShort
 	var medianRTT *time.Duration
 	if rtts != nil {
 		if _, max, median, n := rtts.Stats(); n > 0 {
@@ -246,7 +244,7 @@ func (s *Scheduler) ScheduleAnytime(ctx context.Context, payloadSize int, settin
 	if !s.clock.IsSynced() {
 		return Emission{}, errNoClockSync
 	}
-	var minScheduleTime = ScheduleTimeShort
+	minScheduleTime := ScheduleTimeShort
 	if rtts != nil {
 		if _, max, _, n := rtts.Stats(); n > 0 {
 			minScheduleTime = max + QueueDelay


### PR DESCRIPTION

<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This increases the chance that packets arrive on time on gateways with a high latency backhauls, like 3G.

This is a trade-off between delay in transmitting class C downlink messages and making sure the packet arrives on time on the gateway. This should serve as a reasonable default value for all gateways.

#### Changes
<!-- What are the changes made in this pull request? -->

- Increase `ScheduleTimeLong` to 500 ms

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
