### PR TITLE
Fix deadlock of application add form submit after error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix selection of pseudo wildcard rights being possible (leading to crash) in the Console even when such right cannot be granted.
 - Fix loading spinner being stuck infinitely in gateway / application / organization overview when some rights aren't granted to the collaborator.
+- Fix deadlock of application add form in the Console when the submit results in an error.
 
 ### Security
 

--- a/pkg/webui/console/views/application-add/index.js
+++ b/pkg/webui/console/views/application-add/index.js
@@ -99,7 +99,7 @@ export default class Add extends React.Component {
   }
 
   @bind
-  async handleSubmit(values, { resetForm }) {
+  async handleSubmit(values, { setSubmitting }) {
     const { userId, navigateToApplication } = this.props
     const { owner_id, application_id, name, description } = values
 
@@ -140,8 +140,7 @@ export default class Add extends React.Component {
 
       navigateToApplication(appId)
     } catch (error) {
-      const { application_id, name, description } = values
-      resetForm({ application_id, name, description })
+      setSubmitting(false)
 
       await this.setState({ error })
     }

--- a/pkg/webui/console/views/application-general-settings/index.js
+++ b/pkg/webui/console/views/application-general-settings/index.js
@@ -104,7 +104,7 @@ export default class ApplicationGeneralSettings extends React.Component {
     error: '',
   }
 
-  async handleSubmit(values, { resetForm }) {
+  async handleSubmit(values, { resetForm, setSubmitting }) {
     const { application, updateApplication } = this.props
 
     await this.setState({ error: '' })
@@ -123,7 +123,7 @@ export default class ApplicationGeneralSettings extends React.Component {
         type: toast.types.SUCCESS,
       })
     } catch (error) {
-      resetForm(values)
+      setSubmitting(false)
       await this.setState({ error })
     }
   }


### PR DESCRIPTION
#### Summary
This quickfix PR fixes an issue resulting in a deadlock of the application add form when the submit resulted in an error.

cc @neoaggelos 

#### Changes
- Use `setSubmitting(false)` rather then `resetForm()` to allow resubmitting after an error

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
