### PR TITLE
Subscribe to multiple events sources if necessary (JS SDK)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Respect stack components on different hosts when connected to event sources in the Console.
+
 ### Security
 
 ## [3.4.2] (2020-01-08)

--- a/sdk/js/src/service/gateways.js
+++ b/sdk/js/src/service/gateways.js
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 import Marshaler from '../util/marshaler'
+import { getComponentsWithDistinctBaseUrls } from '../util/stack-components'
+import combineStreams from '../util/combine-streams'
 import ApiKeys from './api-keys'
 import Collaborators from './collaborators'
 
@@ -130,7 +132,17 @@ class Gateways {
       after,
     }
 
-    return this._api.Events.Stream(undefined, payload)
+    // Event streams can come from multiple stack components. It is necessary to
+    // check for stack components on different hosts and open distinct stream
+    // connections for any distinct host if need be.
+    const distinctComponents = getComponentsWithDistinctBaseUrls(this._stackConfig, ['is', 'gs'])
+
+    const streams = distinctComponents.map(component =>
+      this._api.Events.Stream({ component }, payload),
+    )
+
+    // Combine all stream sources to one subscription generator.
+    return combineStreams(streams)
   }
 }
 

--- a/sdk/js/src/util/combine-streams.js
+++ b/sdk/js/src/util/combine-streams.js
@@ -1,0 +1,43 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** Combines multiple streams into a single subscription provider
+ * @param {Array} streams - An array of (async) stream functions.
+ * @returns {Object} The stream subscription object with the `on` function for
+ * attaching listeners and the `close` function to close the stream.
+ */
+const combinedStream = async function(streams) {
+  if (!(streams instanceof Array) || streams.length === 0) {
+    throw new Error('Cannot combine streams with invalid stream array.')
+  } else if (streams.length === 1) {
+    return streams[0]
+  }
+
+  const subscribers = await Promise.all(streams)
+
+  return {
+    on(eventName, callback) {
+      for (const subscriber of subscribers) {
+        subscriber.on(eventName, callback)
+      }
+    },
+    close() {
+      for (const subscriber of subscribers) {
+        subscriber.close()
+      }
+    },
+  }
+}
+
+export default combinedStream

--- a/sdk/js/src/util/stack-components.js
+++ b/sdk/js/src/util/stack-components.js
@@ -1,0 +1,42 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable import/prefer-default-export */
+
+import { STACK_COMPONENTS } from './constants'
+
+/** Takes a list of allowed components and only returns components that have
+ * distinct base urls. Used to subscribe to event streaming sources when the
+ * stack uses multiple hosts.
+ * @param {Array} stackConfig - The stack config object containing base urls per
+ * component.
+ * @param {Array} components - Components to return distinct ones from.
+ * @returns {Array} An array of components that have distinct base urls.
+ */
+export const getComponentsWithDistinctBaseUrls = function(
+  stackConfig,
+  components = STACK_COMPONENTS,
+) {
+  const distinctComponents = components.reduce((collection, component) => {
+    if (
+      Boolean(stackConfig[component]) &&
+      !Object.values(collection).includes(stackConfig[component])
+    ) {
+      return { ...collection, [component]: stackConfig[component] }
+    }
+    return collection
+  }, {})
+
+  return Object.keys(distinctComponents)
+}


### PR DESCRIPTION
#### Summary
Closes #1719 

#### Changes
- Add utility to combine streams to JS SDK
- Refactor streaming function in entity services to subscribe to multiple sources (if necessary)

#### Notes for Reviewers
The way this works now is that we can define what components are relevant per stream (eg. IS, GS for gateway streams) and the SDK will determine whether it would need to connect to multiple hosts to do so. It will then open a stream for every distinct host but keep the subscription interface as it is. See #1719 for more info.
The change is solely SDK scoped, no changes needed in the console to resolve the issue.

@johanstokking which components are relevant for the organization stream? I suppose it's only IS, but I'm not sure. For the device stream, I took the same as for applications: IS, AS, JS, NS, DTC. Please check whether this solves the issue.

In theory, this could mean that the SDK will open up to 6 different connections, which would block all other connections of the browser. However, it's very unlikely that all stack components are on different hosts. Still, it might be necessary to add logic to limit the number of connections.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
