### PR TITLE
Fail component start when interop server can't start

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -285,6 +285,7 @@ func (c *Component) Start() (err error) {
 	c.logger.Debug("Starting interop server")
 	if err = c.listenInterop(); err != nil {
 		c.logger.WithError(err).Error("Could not start interop server")
+		return err
 	}
 	c.logger.Debug("Started interop server")
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fail component start when interop server can't start

#### Changes
<!-- What are the changes made in this pull request? -->

- Return error from component `Start()` like with any other listener

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
