### PR TITLE
gs: Include antenna location in forwarded message RxMetadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Respect stack components on different hosts when connected to event sources in the Console.
 - Pagination of search results.
 - Handling OTAA devices registered on an external Join Server in the Console.
+- RxMetadata Location field from Gateway Server.
 
 ### Security
 

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -362,11 +362,11 @@ func (gs *GatewayServer) Connect(ctx context.Context, frontend io.Frontend, ids 
 		GatewayIdentifiers: ids,
 		FieldMask: pbtypes.FieldMask{
 			Paths: []string{
-				"location_public",
+				"antennas",
 				"downlink_path_constraint",
 				"enforce_duty_cycle",
-				"antennas",
 				"frequency_plan_id",
+				"location_public",
 				"schedule_anytime_delay",
 				"schedule_downlink_late",
 			},

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -362,6 +362,7 @@ func (gs *GatewayServer) Connect(ctx context.Context, frontend io.Frontend, ids 
 		GatewayIdentifiers: ids,
 		FieldMask: pbtypes.FieldMask{
 			Paths: []string{
+				"location_public",
 				"downlink_path_constraint",
 				"enforce_duty_cycle",
 				"antennas",
@@ -386,6 +387,7 @@ func (gs *GatewayServer) Connect(ctx context.Context, frontend io.Frontend, ids 
 			EnforceDutyCycle:       true,
 			DownlinkPathConstraint: ttnpb.DOWNLINK_PATH_CONSTRAINT_NONE,
 			Antennas:               []ttnpb.GatewayAntenna{},
+			LocationPublic:         false,
 		}
 	} else if err != nil {
 		return nil, err

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -364,6 +364,7 @@ func (gs *GatewayServer) Connect(ctx context.Context, frontend io.Frontend, ids 
 			Paths: []string{
 				"downlink_path_constraint",
 				"enforce_duty_cycle",
+				"antennas",
 				"frequency_plan_id",
 				"schedule_anytime_delay",
 				"schedule_downlink_late",
@@ -384,6 +385,7 @@ func (gs *GatewayServer) Connect(ctx context.Context, frontend io.Frontend, ids 
 			FrequencyPlanID:        fpID,
 			EnforceDutyCycle:       true,
 			DownlinkPathConstraint: ttnpb.DOWNLINK_PATH_CONSTRAINT_NONE,
+			Antennas:               []ttnpb.GatewayAntenna{},
 		}
 	} else if err != nil {
 		return nil, err

--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -665,6 +665,9 @@ func TestGatewayServer(t *testing.T) {
 											RSSI:               -69,
 											ChannelRSSI:        -69,
 											SNR:                11,
+											Location: &ttnpb.Location{
+												Source: ttnpb.SOURCE_REGISTRY,
+											},
 										},
 									},
 									RawPayload: randomUpDataPayload(types.DevAddr{0x26, 0x01, 0xff, 0xff}, 1, 6),
@@ -696,6 +699,9 @@ func TestGatewayServer(t *testing.T) {
 											RSSI:               -69,
 											ChannelRSSI:        -69,
 											SNR:                11,
+											Location: &ttnpb.Location{
+												Source: ttnpb.SOURCE_REGISTRY,
+											},
 										},
 									},
 									RawPayload: randomUpDataPayload(types.DevAddr{0x26, 0x01, 0xff, 0xff}, 1, 6),
@@ -729,6 +735,9 @@ func TestGatewayServer(t *testing.T) {
 											RSSI:               -112,
 											ChannelRSSI:        -112,
 											SNR:                2,
+											Location: &ttnpb.Location{
+												Source: ttnpb.SOURCE_REGISTRY,
+											},
 										},
 									},
 									RawPayload: []byte{0xff, 0x02, 0x03}, // Garbage; doesn't get forwarded.
@@ -754,6 +763,9 @@ func TestGatewayServer(t *testing.T) {
 											RSSI:               -69,
 											ChannelRSSI:        -69,
 											SNR:                11,
+											Location: &ttnpb.Location{
+												Source: ttnpb.SOURCE_REGISTRY,
+											},
 										},
 									},
 									RawPayload: randomUpDataPayload(types.DevAddr{0x26, 0x01, 0xff, 0xff}, 1, 6),
@@ -779,6 +791,9 @@ func TestGatewayServer(t *testing.T) {
 											RSSI:               -36,
 											ChannelRSSI:        -36,
 											SNR:                5,
+											Location: &ttnpb.Location{
+												Source: ttnpb.SOURCE_REGISTRY,
+											},
 										},
 									},
 									RawPayload: randomJoinRequestPayload(

--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -117,661 +117,806 @@ func TestGatewayServer(t *testing.T) {
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_NETWORK_SERVER)
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
-	is.add(ctx, ttnpb.GatewayIdentifiers{
-		GatewayID: registeredGatewayID,
-		EUI:       &registeredGatewayEUI,
-	}, registeredGatewayKey)
 
-	for _, ptc := range []struct {
-		Protocol               string
-		SupportsStatus         bool
-		DetectsInvalidMessages bool
-		ValidAuth              func(ctx context.Context, ids ttnpb.GatewayIdentifiers, key string) bool
-		Link                   func(ctx context.Context, t *testing.T, ids ttnpb.GatewayIdentifiers, key string, upCh <-chan *ttnpb.GatewayUp, downCh chan<- *ttnpb.GatewayDown) error
-	}{
-		{
-			Protocol:       "grpc",
-			SupportsStatus: true,
-			ValidAuth: func(ctx context.Context, ids ttnpb.GatewayIdentifiers, key string) bool {
-				return ids.GatewayID == registeredGatewayID && key == registeredGatewayKey
-			},
-			Link: func(ctx context.Context, t *testing.T, ids ttnpb.GatewayIdentifiers, key string, upCh <-chan *ttnpb.GatewayUp, downCh chan<- *ttnpb.GatewayDown) error {
-				conn, err := grpc.Dial(":9187", append(rpcclient.DefaultDialOptions(ctx), grpc.WithInsecure(), grpc.WithBlock())...)
-				if err != nil {
-					return err
-				}
-				defer conn.Close()
-				md := rpcmetadata.MD{
-					ID:            ids.GatewayID,
-					AuthType:      "Bearer",
-					AuthValue:     key,
-					AllowInsecure: true,
-				}
-				client := ttnpb.NewGtwGsClient(conn)
-				_, err = client.GetConcentratorConfig(ctx, ttnpb.Empty, grpc.PerRPCCredentials(md))
-				if err != nil {
-					return err
-				}
-				link, err := client.LinkGateway(ctx, grpc.PerRPCCredentials(md))
-				if err != nil {
-					return err
-				}
-				errCh := make(chan error, 2)
-				// Write upstream.
-				go func() {
-					for {
-						select {
-						case <-ctx.Done():
-							return
-						case msg := <-upCh:
-							if err := link.Send(msg); err != nil {
+	for _, publicLocation := range []bool{true, false} {
+		is.add(ctx, ttnpb.GatewayIdentifiers{
+			GatewayID: registeredGatewayID,
+			EUI:       &registeredGatewayEUI,
+		}, registeredGatewayKey, publicLocation)
+
+		for _, ptc := range []struct {
+			Protocol               string
+			SupportsStatus         bool
+			DetectsInvalidMessages bool
+			ValidAuth              func(ctx context.Context, ids ttnpb.GatewayIdentifiers, key string) bool
+			Link                   func(ctx context.Context, t *testing.T, ids ttnpb.GatewayIdentifiers, key string, upCh <-chan *ttnpb.GatewayUp, downCh chan<- *ttnpb.GatewayDown) error
+		}{
+			{
+				Protocol:       "grpc",
+				SupportsStatus: true,
+				ValidAuth: func(ctx context.Context, ids ttnpb.GatewayIdentifiers, key string) bool {
+					return ids.GatewayID == registeredGatewayID && key == registeredGatewayKey
+				},
+				Link: func(ctx context.Context, t *testing.T, ids ttnpb.GatewayIdentifiers, key string, upCh <-chan *ttnpb.GatewayUp, downCh chan<- *ttnpb.GatewayDown) error {
+					conn, err := grpc.Dial(":9187", append(rpcclient.DefaultDialOptions(ctx), grpc.WithInsecure(), grpc.WithBlock())...)
+					if err != nil {
+						return err
+					}
+					defer conn.Close()
+					md := rpcmetadata.MD{
+						ID:            ids.GatewayID,
+						AuthType:      "Bearer",
+						AuthValue:     key,
+						AllowInsecure: true,
+					}
+					client := ttnpb.NewGtwGsClient(conn)
+					_, err = client.GetConcentratorConfig(ctx, ttnpb.Empty, grpc.PerRPCCredentials(md))
+					if err != nil {
+						return err
+					}
+					link, err := client.LinkGateway(ctx, grpc.PerRPCCredentials(md))
+					if err != nil {
+						return err
+					}
+					errCh := make(chan error, 2)
+					// Write upstream.
+					go func() {
+						for {
+							select {
+							case <-ctx.Done():
+								return
+							case msg := <-upCh:
+								if err := link.Send(msg); err != nil {
+									errCh <- err
+									return
+								}
+							}
+						}
+					}()
+					// Read downstream.
+					go func() {
+						for {
+							msg, err := link.Recv()
+							if err != nil {
 								errCh <- err
 								return
 							}
+							downCh <- msg
 						}
+					}()
+					select {
+					case err := <-errCh:
+						return err
+					case <-ctx.Done():
+						return ctx.Err()
 					}
-				}()
-				// Read downstream.
-				go func() {
-					for {
-						msg, err := link.Recv()
-						if err != nil {
+				},
+			},
+			{
+				Protocol:       "mqtt",
+				SupportsStatus: true,
+				ValidAuth: func(ctx context.Context, ids ttnpb.GatewayIdentifiers, key string) bool {
+					return ids.GatewayID == registeredGatewayID && key == registeredGatewayKey
+				},
+				Link: func(ctx context.Context, t *testing.T, ids ttnpb.GatewayIdentifiers, key string, upCh <-chan *ttnpb.GatewayUp, downCh chan<- *ttnpb.GatewayDown) error {
+					if ids.GatewayID == "" {
+						t.SkipNow()
+					}
+					clientOpts := mqtt.NewClientOptions()
+					clientOpts.AddBroker("tcp://0.0.0.0:1882")
+					clientOpts.SetUsername(unique.ID(ctx, ids))
+					clientOpts.SetPassword(key)
+					client := mqtt.NewClient(clientOpts)
+					if token := client.Connect(); !token.WaitTimeout(timeout) {
+						return errors.New("connect timeout")
+					} else if token.Error() != nil {
+						return token.Error()
+					}
+					defer client.Disconnect(uint(timeout / time.Millisecond))
+					errCh := make(chan error, 2)
+					// Write upstream.
+					go func() {
+						for {
+							select {
+							case <-ctx.Done():
+								return
+							case up := <-upCh:
+								for _, msg := range up.UplinkMessages {
+									buf, err := msg.Marshal()
+									if err != nil {
+										errCh <- err
+										return
+									}
+									if token := client.Publish(fmt.Sprintf("v3/%v/up", unique.ID(ctx, ids)), 1, false, buf); token.Wait() && token.Error() != nil {
+										errCh <- token.Error()
+										return
+									}
+								}
+								if up.GatewayStatus != nil {
+									buf, err := up.GatewayStatus.Marshal()
+									if err != nil {
+										errCh <- err
+										return
+									}
+									if token := client.Publish(fmt.Sprintf("v3/%v/status", unique.ID(ctx, ids)), 1, false, buf); token.Wait() && token.Error() != nil {
+										errCh <- token.Error()
+										return
+									}
+								}
+								if up.TxAcknowledgment != nil {
+									buf, err := up.TxAcknowledgment.Marshal()
+									if err != nil {
+										errCh <- err
+										return
+									}
+									if token := client.Publish(fmt.Sprintf("v3/%v/down/ack", unique.ID(ctx, ids)), 1, false, buf); token.Wait() && token.Error() != nil {
+										errCh <- token.Error()
+										return
+									}
+								}
+							}
+						}
+					}()
+					// Read downstream.
+					token := client.Subscribe(fmt.Sprintf("v3/%v/down", unique.ID(ctx, ids)), 1, func(_ mqtt.Client, raw mqtt.Message) {
+						var msg ttnpb.GatewayDown
+						if err := msg.Unmarshal(raw.Payload()); err != nil {
 							errCh <- err
 							return
 						}
-						downCh <- msg
+						downCh <- &msg
+					})
+					if token.Wait() && token.Error() != nil {
+						return token.Error()
 					}
-				}()
-				select {
-				case err := <-errCh:
-					return err
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+					select {
+					case err := <-errCh:
+						return err
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+				},
 			},
-		},
-		{
-			Protocol:       "mqtt",
-			SupportsStatus: true,
-			ValidAuth: func(ctx context.Context, ids ttnpb.GatewayIdentifiers, key string) bool {
-				return ids.GatewayID == registeredGatewayID && key == registeredGatewayKey
-			},
-			Link: func(ctx context.Context, t *testing.T, ids ttnpb.GatewayIdentifiers, key string, upCh <-chan *ttnpb.GatewayUp, downCh chan<- *ttnpb.GatewayDown) error {
-				if ids.GatewayID == "" {
-					t.SkipNow()
-				}
-				clientOpts := mqtt.NewClientOptions()
-				clientOpts.AddBroker("tcp://0.0.0.0:1882")
-				clientOpts.SetUsername(unique.ID(ctx, ids))
-				clientOpts.SetPassword(key)
-				client := mqtt.NewClient(clientOpts)
-				if token := client.Connect(); !token.WaitTimeout(timeout) {
-					return errors.New("connect timeout")
-				} else if token.Error() != nil {
-					return token.Error()
-				}
-				defer client.Disconnect(uint(timeout / time.Millisecond))
-				errCh := make(chan error, 2)
-				// Write upstream.
-				go func() {
-					for {
-						select {
-						case <-ctx.Done():
-							return
-						case up := <-upCh:
-							for _, msg := range up.UplinkMessages {
-								buf, err := msg.Marshal()
+			{
+				Protocol:       "udp",
+				SupportsStatus: true,
+				ValidAuth: func(ctx context.Context, ids ttnpb.GatewayIdentifiers, key string) bool {
+					return ids.EUI != nil
+				},
+				Link: func(ctx context.Context, t *testing.T, ids ttnpb.GatewayIdentifiers, key string, upCh <-chan *ttnpb.GatewayUp, downCh chan<- *ttnpb.GatewayDown) error {
+					if ids.EUI == nil {
+						t.SkipNow()
+					}
+					upConn, err := net.Dial("udp", ":1700")
+					if err != nil {
+						return err
+					}
+					downConn, err := net.Dial("udp", ":1700")
+					if err != nil {
+						return err
+					}
+					errCh := make(chan error, 3)
+					// Write upstream.
+					go func() {
+						var token byte
+						var readBuf [65507]byte
+						for {
+							select {
+							case <-ctx.Done():
+								return
+							case up := <-upCh:
+								token++
+								packet := encoding.Packet{
+									GatewayEUI:      ids.EUI,
+									ProtocolVersion: encoding.Version1,
+									Token:           [2]byte{0x00, token},
+									PacketType:      encoding.PushData,
+									Data:            &encoding.Data{},
+								}
+								packet.Data.RxPacket, packet.Data.Stat, packet.Data.TxPacketAck = encoding.FromGatewayUp(up)
+								if packet.Data.TxPacketAck != nil {
+									packet.PacketType = encoding.TxAck
+								}
+								writeBuf, err := packet.MarshalBinary()
 								if err != nil {
 									errCh <- err
 									return
 								}
-								if token := client.Publish(fmt.Sprintf("v3/%v/up", unique.ID(ctx, ids)), 1, false, buf); token.Wait() && token.Error() != nil {
-									errCh <- token.Error()
-									return
+								switch packet.PacketType {
+								case encoding.PushData:
+									if _, err := upConn.Write(writeBuf); err != nil {
+										errCh <- err
+										return
+									}
+									if _, err := upConn.Read(readBuf[:]); err != nil {
+										errCh <- err
+										return
+									}
+								case encoding.TxAck:
+									if _, err := downConn.Write(writeBuf); err != nil {
+										errCh <- err
+										return
+									}
 								}
 							}
-							if up.GatewayStatus != nil {
-								buf, err := up.GatewayStatus.Marshal()
+						}
+					}()
+					// Engage downstream by sending PULL_DATA every 10ms.
+					go func() {
+						var token byte
+						ticker := time.NewTicker(10 * time.Millisecond)
+						for {
+							select {
+							case <-ctx.Done():
+								ticker.Stop()
+								return
+							case <-ticker.C:
+								token++
+								pull := encoding.Packet{
+									GatewayEUI:      ids.EUI,
+									ProtocolVersion: encoding.Version1,
+									Token:           [2]byte{0x01, token},
+									PacketType:      encoding.PullData,
+								}
+								buf, err := pull.MarshalBinary()
 								if err != nil {
 									errCh <- err
 									return
 								}
-								if token := client.Publish(fmt.Sprintf("v3/%v/status", unique.ID(ctx, ids)), 1, false, buf); token.Wait() && token.Error() != nil {
-									errCh <- token.Error()
-									return
-								}
-							}
-							if up.TxAcknowledgment != nil {
-								buf, err := up.TxAcknowledgment.Marshal()
-								if err != nil {
+								if _, err := downConn.Write(buf); err != nil {
 									errCh <- err
-									return
-								}
-								if token := client.Publish(fmt.Sprintf("v3/%v/down/ack", unique.ID(ctx, ids)), 1, false, buf); token.Wait() && token.Error() != nil {
-									errCh <- token.Error()
 									return
 								}
 							}
 						}
-					}
-				}()
-				// Read downstream.
-				token := client.Subscribe(fmt.Sprintf("v3/%v/down", unique.ID(ctx, ids)), 1, func(_ mqtt.Client, raw mqtt.Message) {
-					var msg ttnpb.GatewayDown
-					if err := msg.Unmarshal(raw.Payload()); err != nil {
-						errCh <- err
-						return
-					}
-					downCh <- &msg
-				})
-				if token.Wait() && token.Error() != nil {
-					return token.Error()
-				}
-				select {
-				case err := <-errCh:
-					return err
-				case <-ctx.Done():
-					return ctx.Err()
-				}
-			},
-		},
-		{
-			Protocol:       "udp",
-			SupportsStatus: true,
-			ValidAuth: func(ctx context.Context, ids ttnpb.GatewayIdentifiers, key string) bool {
-				return ids.EUI != nil
-			},
-			Link: func(ctx context.Context, t *testing.T, ids ttnpb.GatewayIdentifiers, key string, upCh <-chan *ttnpb.GatewayUp, downCh chan<- *ttnpb.GatewayDown) error {
-				if ids.EUI == nil {
-					t.SkipNow()
-				}
-				upConn, err := net.Dial("udp", ":1700")
-				if err != nil {
-					return err
-				}
-				downConn, err := net.Dial("udp", ":1700")
-				if err != nil {
-					return err
-				}
-				errCh := make(chan error, 3)
-				// Write upstream.
-				go func() {
-					var token byte
-					var readBuf [65507]byte
-					for {
-						select {
-						case <-ctx.Done():
-							return
-						case up := <-upCh:
-							token++
-							packet := encoding.Packet{
-								GatewayEUI:      ids.EUI,
-								ProtocolVersion: encoding.Version1,
-								Token:           [2]byte{0x00, token},
-								PacketType:      encoding.PushData,
-								Data:            &encoding.Data{},
-							}
-							packet.Data.RxPacket, packet.Data.Stat, packet.Data.TxPacketAck = encoding.FromGatewayUp(up)
-							if packet.Data.TxPacketAck != nil {
-								packet.PacketType = encoding.TxAck
-							}
-							writeBuf, err := packet.MarshalBinary()
+					}()
+					// Read downstream; PULL_RESP and PULL_ACK.
+					go func() {
+						var buf [65507]byte
+						for {
+							n, err := downConn.Read(buf[:])
 							if err != nil {
+								errCh <- err
+								return
+							}
+							packetBuf := make([]byte, n)
+							copy(packetBuf, buf[:])
+							var packet encoding.Packet
+							if err := packet.UnmarshalBinary(packetBuf); err != nil {
 								errCh <- err
 								return
 							}
 							switch packet.PacketType {
-							case encoding.PushData:
-								if _, err := upConn.Write(writeBuf); err != nil {
-									errCh <- err
-									return
-								}
-								if _, err := upConn.Read(readBuf[:]); err != nil {
-									errCh <- err
-									return
-								}
-							case encoding.TxAck:
-								if _, err := downConn.Write(writeBuf); err != nil {
-									errCh <- err
-									return
-								}
-							}
-						}
-					}
-				}()
-				// Engage downstream by sending PULL_DATA every 10ms.
-				go func() {
-					var token byte
-					ticker := time.NewTicker(10 * time.Millisecond)
-					for {
-						select {
-						case <-ctx.Done():
-							ticker.Stop()
-							return
-						case <-ticker.C:
-							token++
-							pull := encoding.Packet{
-								GatewayEUI:      ids.EUI,
-								ProtocolVersion: encoding.Version1,
-								Token:           [2]byte{0x01, token},
-								PacketType:      encoding.PullData,
-							}
-							buf, err := pull.MarshalBinary()
-							if err != nil {
-								errCh <- err
-								return
-							}
-							if _, err := downConn.Write(buf); err != nil {
-								errCh <- err
-								return
-							}
-						}
-					}
-				}()
-				// Read downstream; PULL_RESP and PULL_ACK.
-				go func() {
-					var buf [65507]byte
-					for {
-						n, err := downConn.Read(buf[:])
-						if err != nil {
-							errCh <- err
-							return
-						}
-						packetBuf := make([]byte, n)
-						copy(packetBuf, buf[:])
-						var packet encoding.Packet
-						if err := packet.UnmarshalBinary(packetBuf); err != nil {
-							errCh <- err
-							return
-						}
-						switch packet.PacketType {
-						case encoding.PullResp:
-							msg, err := encoding.ToDownlinkMessage(packet.Data.TxPacket)
-							if err != nil {
-								errCh <- err
-								return
-							}
-							downCh <- &ttnpb.GatewayDown{
-								DownlinkMessage: msg,
-							}
-						}
-					}
-				}()
-				select {
-				case err := <-errCh:
-					return err
-				case <-ctx.Done():
-					time.Sleep(config.UDP.ConnectionExpires * 150 / 100) // Ensure that connection expires.
-					return ctx.Err()
-				}
-			},
-		},
-		{
-			Protocol:               "basicstation",
-			SupportsStatus:         false,
-			DetectsInvalidMessages: true,
-			ValidAuth: func(ctx context.Context, ids ttnpb.GatewayIdentifiers, key string) bool {
-				return ids.EUI != nil
-			},
-			Link: func(ctx context.Context, t *testing.T, ids ttnpb.GatewayIdentifiers, key string, upCh <-chan *ttnpb.GatewayUp, downCh chan<- *ttnpb.GatewayDown) error {
-				if ids.EUI == nil {
-					t.SkipNow()
-				}
-				wsConn, _, err := websocket.DefaultDialer.Dial("ws://0.0.0.0:1887/traffic/"+registeredGatewayID, nil)
-				if err != nil {
-					return err
-				}
-				defer wsConn.Close()
-
-				errCh := make(chan error, 2)
-				// Write upstream.
-				go func() {
-					for {
-						select {
-						case <-ctx.Done():
-							return
-						case msg := <-upCh:
-							for _, uplink := range msg.UplinkMessages {
-								var payload ttnpb.Message
-								if err := lorawan.UnmarshalMessage(uplink.RawPayload, &payload); err != nil {
-									// Ignore invalid uplinks
-									continue
-								}
-								var bsUpstream []byte
-								if payload.GetMType() == ttnpb.MType_JOIN_REQUEST {
-									var jreq messages.JoinRequest
-									err := jreq.FromUplinkMessage(uplink, test.EUFrequencyPlanID)
-									if err != nil {
-										errCh <- err
-										return
-									}
-									bsUpstream, err = jreq.MarshalJSON()
-									if err != nil {
-										errCh <- err
-										return
-									}
-								}
-								if payload.GetMType() == ttnpb.MType_UNCONFIRMED_UP || payload.GetMType() == ttnpb.MType_CONFIRMED_UP {
-									var updf messages.UplinkDataFrame
-									err := updf.FromUplinkMessage(uplink, test.EUFrequencyPlanID)
-									if err != nil {
-										errCh <- err
-										return
-									}
-									bsUpstream, err = updf.MarshalJSON()
-									if err != nil {
-										errCh <- err
-										return
-									}
-								}
-
-								if err := wsConn.WriteMessage(websocket.TextMessage, bsUpstream); err != nil {
-									if err != nil {
-										errCh <- err
-										return
-									}
-								}
-							}
-							if msg.TxAcknowledgment != nil {
-								txConf := messages.TxConfirmation{
-									Diid:  0,
-									XTime: time.Now().Unix(),
-								}
-
-								bsUpstream, err := txConf.MarshalJSON()
+							case encoding.PullResp:
+								msg, err := encoding.ToDownlinkMessage(packet.Data.TxPacket)
 								if err != nil {
 									errCh <- err
 									return
 								}
+								downCh <- &ttnpb.GatewayDown{
+									DownlinkMessage: msg,
+								}
+							}
+						}
+					}()
+					select {
+					case err := <-errCh:
+						return err
+					case <-ctx.Done():
+						time.Sleep(config.UDP.ConnectionExpires * 150 / 100) // Ensure that connection expires.
+						return ctx.Err()
+					}
+				},
+			},
+			{
+				Protocol:               "basicstation",
+				SupportsStatus:         false,
+				DetectsInvalidMessages: true,
+				ValidAuth: func(ctx context.Context, ids ttnpb.GatewayIdentifiers, key string) bool {
+					return ids.EUI != nil
+				},
+				Link: func(ctx context.Context, t *testing.T, ids ttnpb.GatewayIdentifiers, key string, upCh <-chan *ttnpb.GatewayUp, downCh chan<- *ttnpb.GatewayDown) error {
+					if ids.EUI == nil {
+						t.SkipNow()
+					}
+					wsConn, _, err := websocket.DefaultDialer.Dial("ws://0.0.0.0:1887/traffic/"+registeredGatewayID, nil)
+					if err != nil {
+						return err
+					}
+					defer wsConn.Close()
 
-								if err := wsConn.WriteMessage(websocket.TextMessage, bsUpstream); err != nil {
+					errCh := make(chan error, 2)
+					// Write upstream.
+					go func() {
+						for {
+							select {
+							case <-ctx.Done():
+								return
+							case msg := <-upCh:
+								for _, uplink := range msg.UplinkMessages {
+									var payload ttnpb.Message
+									if err := lorawan.UnmarshalMessage(uplink.RawPayload, &payload); err != nil {
+										// Ignore invalid uplinks
+										continue
+									}
+									var bsUpstream []byte
+									if payload.GetMType() == ttnpb.MType_JOIN_REQUEST {
+										var jreq messages.JoinRequest
+										err := jreq.FromUplinkMessage(uplink, test.EUFrequencyPlanID)
+										if err != nil {
+											errCh <- err
+											return
+										}
+										bsUpstream, err = jreq.MarshalJSON()
+										if err != nil {
+											errCh <- err
+											return
+										}
+									}
+									if payload.GetMType() == ttnpb.MType_UNCONFIRMED_UP || payload.GetMType() == ttnpb.MType_CONFIRMED_UP {
+										var updf messages.UplinkDataFrame
+										err := updf.FromUplinkMessage(uplink, test.EUFrequencyPlanID)
+										if err != nil {
+											errCh <- err
+											return
+										}
+										bsUpstream, err = updf.MarshalJSON()
+										if err != nil {
+											errCh <- err
+											return
+										}
+									}
+
+									if err := wsConn.WriteMessage(websocket.TextMessage, bsUpstream); err != nil {
+										if err != nil {
+											errCh <- err
+											return
+										}
+									}
+								}
+								if msg.TxAcknowledgment != nil {
+									txConf := messages.TxConfirmation{
+										Diid:  0,
+										XTime: time.Now().Unix(),
+									}
+
+									bsUpstream, err := txConf.MarshalJSON()
 									if err != nil {
 										errCh <- err
 										return
 									}
+
+									if err := wsConn.WriteMessage(websocket.TextMessage, bsUpstream); err != nil {
+										if err != nil {
+											errCh <- err
+											return
+										}
+									}
 								}
 							}
 						}
-					}
-				}()
+					}()
 
-				// Read downstream.
-				go func() {
-					for {
-						_, data, err := wsConn.ReadMessage()
-						if err != nil {
-							if !websocket.IsUnexpectedCloseError(err) {
-								errCh <- err
+					// Read downstream.
+					go func() {
+						for {
+							_, data, err := wsConn.ReadMessage()
+							if err != nil {
+								if !websocket.IsUnexpectedCloseError(err) {
+									errCh <- err
+								}
+								return
 							}
-							return
+							var msg messages.DownlinkMessage
+							if err := json.Unmarshal(data, &msg); err != nil {
+								errCh <- err
+								return
+							}
+							dlmesg := msg.ToDownlinkMessage()
+							downCh <- &ttnpb.GatewayDown{
+								DownlinkMessage: &dlmesg,
+							}
 						}
-						var msg messages.DownlinkMessage
-						if err := json.Unmarshal(data, &msg); err != nil {
-							errCh <- err
-							return
-						}
-						dlmesg := msg.ToDownlinkMessage()
-						downCh <- &ttnpb.GatewayDown{
-							DownlinkMessage: &dlmesg,
-						}
-					}
-				}()
+					}()
 
-				select {
-				case err := <-errCh:
-					return err
-				case <-ctx.Done():
-					return ctx.Err()
-				}
+					select {
+					case err := <-errCh:
+						return err
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+				},
 			},
-		},
-	} {
-		t.Run(fmt.Sprintf("Authenticate/%v", ptc.Protocol), func(t *testing.T) {
-			for _, ctc := range []struct {
-				Name string
-				ID   ttnpb.GatewayIdentifiers
-				Key  string
-			}{
-				{
-					Name: "ValidIDAndKey",
-					ID:   ttnpb.GatewayIdentifiers{GatewayID: registeredGatewayID},
-					Key:  registeredGatewayKey,
-				},
-				{
-					Name: "InvalidKey",
-					ID:   ttnpb.GatewayIdentifiers{GatewayID: registeredGatewayID},
-					Key:  "invalid-key",
-				},
-				{
-					Name: "InvalidIDAndKey",
-					ID:   ttnpb.GatewayIdentifiers{GatewayID: "invalid-gateway"},
-					Key:  "invalid-key",
-				},
-				{
-					Name: "RegisteredEUI",
-					ID:   ttnpb.GatewayIdentifiers{EUI: &registeredGatewayEUI},
-				},
-				{
-					Name: "UnregisteredEUI",
-					ID:   ttnpb.GatewayIdentifiers{EUI: &unregisteredGatewayEUI},
-				},
-			} {
-				t.Run(ctc.Name, func(t *testing.T) {
-					ctx, cancel := context.WithDeadline(ctx, time.Now().Add(timeout))
-					upCh := make(chan *ttnpb.GatewayUp)
-					downCh := make(chan *ttnpb.GatewayDown)
-					err := ptc.Link(ctx, t, ctc.ID, ctc.Key, upCh, downCh)
-					cancel()
-					if errors.IsDeadlineExceeded(err) {
-						if !ptc.ValidAuth(ctx, ctc.ID, ctc.Key) {
-							t.Fatal("Expected link error due to invalid auth")
+		} {
+			t.Run(fmt.Sprintf("Authenticate/%v", ptc.Protocol), func(t *testing.T) {
+				for _, ctc := range []struct {
+					Name string
+					ID   ttnpb.GatewayIdentifiers
+					Key  string
+				}{
+					{
+						Name: "ValidIDAndKey",
+						ID:   ttnpb.GatewayIdentifiers{GatewayID: registeredGatewayID},
+						Key:  registeredGatewayKey,
+					},
+					{
+						Name: "InvalidKey",
+						ID:   ttnpb.GatewayIdentifiers{GatewayID: registeredGatewayID},
+						Key:  "invalid-key",
+					},
+					{
+						Name: "InvalidIDAndKey",
+						ID:   ttnpb.GatewayIdentifiers{GatewayID: "invalid-gateway"},
+						Key:  "invalid-key",
+					},
+					{
+						Name: "RegisteredEUI",
+						ID:   ttnpb.GatewayIdentifiers{EUI: &registeredGatewayEUI},
+					},
+					{
+						Name: "UnregisteredEUI",
+						ID:   ttnpb.GatewayIdentifiers{EUI: &unregisteredGatewayEUI},
+					},
+				} {
+					t.Run(ctc.Name, func(t *testing.T) {
+						ctx, cancel := context.WithDeadline(ctx, time.Now().Add(timeout))
+						upCh := make(chan *ttnpb.GatewayUp)
+						downCh := make(chan *ttnpb.GatewayDown)
+						err := ptc.Link(ctx, t, ctc.ID, ctc.Key, upCh, downCh)
+						cancel()
+						if errors.IsDeadlineExceeded(err) {
+							if !ptc.ValidAuth(ctx, ctc.ID, ctc.Key) {
+								t.Fatal("Expected link error due to invalid auth")
+							}
+						} else if ptc.ValidAuth(ctx, ctc.ID, ctc.Key) {
+							t.Fatalf("Expected deadline exceeded with valid auth, but have %v", err)
 						}
-					} else if ptc.ValidAuth(ctx, ctc.ID, ctc.Key) {
-						t.Fatalf("Expected deadline exceeded with valid auth, but have %v", err)
-					}
-				})
-			}
-		})
-
-		// Wait for gateway disconnection to be processed.
-		time.Sleep(timeout)
-
-		t.Run(fmt.Sprintf("Traffic/%v", ptc.Protocol), func(t *testing.T) {
-			a := assertions.New(t)
-
-			ctx, cancel := context.WithCancel(ctx)
-			upCh := make(chan *ttnpb.GatewayUp)
-			downCh := make(chan *ttnpb.GatewayDown)
-			ids := ttnpb.GatewayIdentifiers{
-				GatewayID: registeredGatewayID,
-				EUI:       &registeredGatewayEUI,
-			}
-			// Setup a stats client with independent context to query whether the gateway is connected and statistics on
-			// upstream and downstream.
-			statsConn, err := grpc.Dial(":9187", append(rpcclient.DefaultDialOptions(test.Context()), grpc.WithInsecure(), grpc.WithBlock())...)
-			if !a.So(err, should.BeNil) {
-				t.FailNow()
-			}
-			defer statsConn.Close()
-			statsCtx := metadata.AppendToOutgoingContext(test.Context(),
-				"id", ids.GatewayID,
-				"authorization", fmt.Sprintf("Bearer %v", registeredGatewayKey),
-			)
-			statsClient := ttnpb.NewGsClient(statsConn)
-
-			// The gateway should not be connected before testing traffic.
-			t.Run("NotConnected", func(t *testing.T) {
-				_, err := statsClient.GetGatewayConnectionStats(statsCtx, &ids)
-				if !a.So(errors.IsNotFound(err), should.BeTrue) {
-					t.Fatal("Expected gateway not to be connected yet, but it is")
+					})
 				}
 			})
 
-			wg := &sync.WaitGroup{}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				err := ptc.Link(ctx, t, ids, registeredGatewayKey, upCh, downCh)
-				if !errors.IsCanceled(err) {
-					t.Fatalf("Expected context canceled, but have %v", err)
-				}
-			}()
+			// Wait for gateway disconnection to be processed.
+			time.Sleep(timeout)
 
-			t.Run("Upstream", func(t *testing.T) {
-				uplinkCount := 0
-				for _, tc := range []struct {
-					Name     string
-					Up       *ttnpb.GatewayUp
-					Forwards []int // Indices of uplink messages in Up that are being forwarded.
-				}{
-					{
-						Name: "GatewayStatus",
-						Up: &ttnpb.GatewayUp{
-							GatewayStatus: &ttnpb.GatewayStatus{
-								Time: time.Unix(424242, 0),
-							},
-						},
-					},
-					{
-						Name: "TxAck",
-						Up: &ttnpb.GatewayUp{
-							TxAcknowledgment: &ttnpb.TxAcknowledgment{
-								Result: ttnpb.TxAcknowledgment_SUCCESS,
-							},
-						},
-					},
-					{
-						Name: "OneValidLoRa",
-						Up: &ttnpb.GatewayUp{
-							UplinkMessages: []*ttnpb.UplinkMessage{
-								{
-									Settings: ttnpb.TxSettings{
-										DataRate: ttnpb.DataRate{
-											Modulation: &ttnpb.DataRate_LoRa{
-												LoRa: &ttnpb.LoRaDataRate{
-													SpreadingFactor: 7,
-													Bandwidth:       250000,
-												},
-											},
-										},
-										CodingRate: "4/5",
-										Frequency:  867900000,
-										Timestamp:  4242000,
-									},
-									RxMetadata: []*ttnpb.RxMetadata{
-										{
-											GatewayIdentifiers: ids,
-											Timestamp:          4242000,
-											RSSI:               -69,
-											ChannelRSSI:        -69,
-											SNR:                11,
-											Location: &ttnpb.Location{
-												Source: ttnpb.SOURCE_REGISTRY,
-											},
-										},
-									},
-									RawPayload: randomUpDataPayload(types.DevAddr{0x26, 0x01, 0xff, 0xff}, 1, 6),
+			t.Run(fmt.Sprintf("Traffic/%v", ptc.Protocol), func(t *testing.T) {
+				a := assertions.New(t)
+
+				ctx, cancel := context.WithCancel(ctx)
+				upCh := make(chan *ttnpb.GatewayUp)
+				downCh := make(chan *ttnpb.GatewayDown)
+				ids := ttnpb.GatewayIdentifiers{
+					GatewayID: registeredGatewayID,
+					EUI:       &registeredGatewayEUI,
+				}
+				// Setup a stats client with independent context to query whether the gateway is connected and statistics on
+				// upstream and downstream.
+				statsConn, err := grpc.Dial(":9187", append(rpcclient.DefaultDialOptions(test.Context()), grpc.WithInsecure(), grpc.WithBlock())...)
+				if !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
+				defer statsConn.Close()
+				statsCtx := metadata.AppendToOutgoingContext(test.Context(),
+					"id", ids.GatewayID,
+					"authorization", fmt.Sprintf("Bearer %v", registeredGatewayKey),
+				)
+				statsClient := ttnpb.NewGsClient(statsConn)
+
+				// The gateway should not be connected before testing traffic.
+				t.Run("NotConnected", func(t *testing.T) {
+					_, err := statsClient.GetGatewayConnectionStats(statsCtx, &ids)
+					if !a.So(errors.IsNotFound(err), should.BeTrue) {
+						t.Fatal("Expected gateway not to be connected yet, but it is")
+					}
+				})
+
+				wg := &sync.WaitGroup{}
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					err := ptc.Link(ctx, t, ids, registeredGatewayKey, upCh, downCh)
+					if !errors.IsCanceled(err) {
+						t.Fatalf("Expected context canceled, but have %v", err)
+					}
+				}()
+
+				// Expected location for RxMetadata
+				location := &ttnpb.Location{
+					Source: ttnpb.SOURCE_REGISTRY,
+				}
+				if !publicLocation {
+					location = nil
+				}
+
+				t.Run("Upstream", func(t *testing.T) {
+					uplinkCount := 0
+					for _, tc := range []struct {
+						Name     string
+						Up       *ttnpb.GatewayUp
+						Forwards []int // Indices of uplink messages in Up that are being forwarded.
+					}{
+						{
+							Name: "GatewayStatus",
+							Up: &ttnpb.GatewayUp{
+								GatewayStatus: &ttnpb.GatewayStatus{
+									Time: time.Unix(424242, 0),
 								},
 							},
 						},
-						Forwards: []int{0},
-					},
-					{
-						Name: "OneValidFSK",
-						Up: &ttnpb.GatewayUp{
-							UplinkMessages: []*ttnpb.UplinkMessage{
-								{
-									Settings: ttnpb.TxSettings{
-										DataRate: ttnpb.DataRate{
-											Modulation: &ttnpb.DataRate_FSK{
-												FSK: &ttnpb.FSKDataRate{
-													BitRate: 50000,
-												},
-											},
-										},
-										Frequency: 867900000,
-										Timestamp: 4242000,
-									},
-									RxMetadata: []*ttnpb.RxMetadata{
-										{
-											GatewayIdentifiers: ids,
-											Timestamp:          4242000,
-											RSSI:               -69,
-											ChannelRSSI:        -69,
-											SNR:                11,
-											Location: &ttnpb.Location{
-												Source: ttnpb.SOURCE_REGISTRY,
-											},
-										},
-									},
-									RawPayload: randomUpDataPayload(types.DevAddr{0x26, 0x01, 0xff, 0xff}, 1, 6),
+						{
+							Name: "TxAck",
+							Up: &ttnpb.GatewayUp{
+								TxAcknowledgment: &ttnpb.TxAcknowledgment{
+									Result: ttnpb.TxAcknowledgment_SUCCESS,
 								},
 							},
 						},
-						Forwards: []int{0},
-					},
-					{
-						Name: "OneGarbageWithStatus",
-						Up: &ttnpb.GatewayUp{
-							UplinkMessages: []*ttnpb.UplinkMessage{
-								{
-									Settings: ttnpb.TxSettings{
-										DataRate: ttnpb.DataRate{
-											Modulation: &ttnpb.DataRate_LoRa{
-												LoRa: &ttnpb.LoRaDataRate{
-													SpreadingFactor: 9,
-													Bandwidth:       125000,
+						{
+							Name: "OneValidLoRa",
+							Up: &ttnpb.GatewayUp{
+								UplinkMessages: []*ttnpb.UplinkMessage{
+									{
+										Settings: ttnpb.TxSettings{
+											DataRate: ttnpb.DataRate{
+												Modulation: &ttnpb.DataRate_LoRa{
+													LoRa: &ttnpb.LoRaDataRate{
+														SpreadingFactor: 7,
+														Bandwidth:       250000,
+													},
 												},
 											},
+											CodingRate: "4/5",
+											Frequency:  867900000,
+											Timestamp:  4242000,
 										},
-										CodingRate: "4/5",
-										Frequency:  868500000,
-										Timestamp:  1234560000,
-									},
-									RxMetadata: []*ttnpb.RxMetadata{
-										{
-											GatewayIdentifiers: ids,
-											Timestamp:          1234560000,
-											RSSI:               -112,
-											ChannelRSSI:        -112,
-											SNR:                2,
-											Location: &ttnpb.Location{
-												Source: ttnpb.SOURCE_REGISTRY,
+										RxMetadata: []*ttnpb.RxMetadata{
+											{
+												GatewayIdentifiers: ids,
+												Timestamp:          4242000,
+												RSSI:               -69,
+												ChannelRSSI:        -69,
+												SNR:                11,
+												Location:           location,
 											},
 										},
+										RawPayload: randomUpDataPayload(types.DevAddr{0x26, 0x01, 0xff, 0xff}, 1, 6),
 									},
-									RawPayload: []byte{0xff, 0x02, 0x03}, // Garbage; doesn't get forwarded.
 								},
-								{
-									Settings: ttnpb.TxSettings{
-										DataRate: ttnpb.DataRate{
-											Modulation: &ttnpb.DataRate_LoRa{
-												LoRa: &ttnpb.LoRaDataRate{
-													SpreadingFactor: 7,
-													Bandwidth:       125000,
+							},
+							Forwards: []int{0},
+						},
+						{
+							Name: "OneValidFSK",
+							Up: &ttnpb.GatewayUp{
+								UplinkMessages: []*ttnpb.UplinkMessage{
+									{
+										Settings: ttnpb.TxSettings{
+											DataRate: ttnpb.DataRate{
+												Modulation: &ttnpb.DataRate_FSK{
+													FSK: &ttnpb.FSKDataRate{
+														BitRate: 50000,
+													},
 												},
 											},
+											Frequency: 867900000,
+											Timestamp: 4242000,
 										},
-										CodingRate: "4/5",
-										Frequency:  868100000,
-										Timestamp:  4242000,
-									},
-									RxMetadata: []*ttnpb.RxMetadata{
-										{
-											GatewayIdentifiers: ids,
-											Timestamp:          4242000,
-											RSSI:               -69,
-											ChannelRSSI:        -69,
-											SNR:                11,
-											Location: &ttnpb.Location{
-												Source: ttnpb.SOURCE_REGISTRY,
+										RxMetadata: []*ttnpb.RxMetadata{
+											{
+												GatewayIdentifiers: ids,
+												Timestamp:          4242000,
+												RSSI:               -69,
+												ChannelRSSI:        -69,
+												SNR:                11,
+												Location:           location,
 											},
 										},
+										RawPayload: randomUpDataPayload(types.DevAddr{0x26, 0x01, 0xff, 0xff}, 1, 6),
 									},
-									RawPayload: randomUpDataPayload(types.DevAddr{0x26, 0x01, 0xff, 0xff}, 1, 6),
 								},
-								{
-									Settings: ttnpb.TxSettings{
+							},
+							Forwards: []int{0},
+						},
+						{
+							Name: "OneGarbageWithStatus",
+							Up: &ttnpb.GatewayUp{
+								UplinkMessages: []*ttnpb.UplinkMessage{
+									{
+										Settings: ttnpb.TxSettings{
+											DataRate: ttnpb.DataRate{
+												Modulation: &ttnpb.DataRate_LoRa{
+													LoRa: &ttnpb.LoRaDataRate{
+														SpreadingFactor: 9,
+														Bandwidth:       125000,
+													},
+												},
+											},
+											CodingRate: "4/5",
+											Frequency:  868500000,
+											Timestamp:  1234560000,
+										},
+										RxMetadata: []*ttnpb.RxMetadata{
+											{
+												GatewayIdentifiers: ids,
+												Timestamp:          1234560000,
+												RSSI:               -112,
+												ChannelRSSI:        -112,
+												SNR:                2,
+												Location:           location,
+											},
+										},
+										RawPayload: []byte{0xff, 0x02, 0x03}, // Garbage; doesn't get forwarded.
+									},
+									{
+										Settings: ttnpb.TxSettings{
+											DataRate: ttnpb.DataRate{
+												Modulation: &ttnpb.DataRate_LoRa{
+													LoRa: &ttnpb.LoRaDataRate{
+														SpreadingFactor: 7,
+														Bandwidth:       125000,
+													},
+												},
+											},
+											CodingRate: "4/5",
+											Frequency:  868100000,
+											Timestamp:  4242000,
+										},
+										RxMetadata: []*ttnpb.RxMetadata{
+											{
+												GatewayIdentifiers: ids,
+												Timestamp:          4242000,
+												RSSI:               -69,
+												ChannelRSSI:        -69,
+												SNR:                11,
+												Location:           location,
+											},
+										},
+										RawPayload: randomUpDataPayload(types.DevAddr{0x26, 0x01, 0xff, 0xff}, 1, 6),
+									},
+									{
+										Settings: ttnpb.TxSettings{
+											DataRate: ttnpb.DataRate{
+												Modulation: &ttnpb.DataRate_LoRa{
+													LoRa: &ttnpb.LoRaDataRate{
+														SpreadingFactor: 12,
+														Bandwidth:       125000,
+													},
+												},
+											},
+											CodingRate: "4/5",
+											Frequency:  867700000,
+											Timestamp:  2424000,
+										},
+										RxMetadata: []*ttnpb.RxMetadata{
+											{
+												GatewayIdentifiers: ids,
+												Timestamp:          2424000,
+												RSSI:               -36,
+												ChannelRSSI:        -36,
+												SNR:                5,
+												Location:           location,
+											},
+										},
+										RawPayload: randomJoinRequestPayload(
+											types.EUI64{0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+											types.EUI64{0x42, 0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+										),
+									},
+								},
+								GatewayStatus: &ttnpb.GatewayStatus{
+									Time: time.Unix(4242424, 0),
+								},
+							},
+							Forwards: []int{1, 2},
+						},
+					} {
+						t.Run(tc.Name, func(t *testing.T) {
+							a := assertions.New(t)
+
+							upEvents := map[string]events.Channel{}
+							for _, event := range []string{"gs.up.receive", "gs.down.tx.success", "gs.down.tx.fail", "gs.status.receive"} {
+								upEvents[event] = make(events.Channel, 5)
+							}
+							defer test.SetDefaultEventsPubSub(&test.MockEventPubSub{
+								PublishFunc: func(ev events.Event) {
+									switch name := ev.Name(); name {
+									case "gs.up.receive", "gs.down.tx.success", "gs.down.tx.fail", "gs.status.receive":
+										go func() {
+											upEvents[name] <- ev
+										}()
+									default:
+										t.Logf("%s event published", name)
+									}
+								},
+							})()
+
+							select {
+							case upCh <- tc.Up:
+							case <-time.After(timeout):
+								t.Fatalf("Failed to send message to upstream channel")
+							}
+							if ptc.DetectsInvalidMessages {
+								uplinkCount += len(tc.Forwards)
+							} else {
+								uplinkCount += len(tc.Up.UplinkMessages)
+							}
+
+							for _, msgIdx := range tc.Forwards {
+								select {
+								case msg := <-ns.Up():
+									expected := tc.Up.UplinkMessages[msgIdx]
+									a.So(time.Since(msg.ReceivedAt), should.BeLessThan, timeout)
+									a.So(msg.Settings, should.Resemble, expected.Settings)
+									for _, md := range msg.RxMetadata {
+										a.So(md.UplinkToken, should.NotBeEmpty)
+										md.UplinkToken = nil
+									}
+									a.So(msg.RxMetadata, should.Resemble, expected.RxMetadata)
+									a.So(msg.RawPayload, should.Resemble, expected.RawPayload)
+								case <-time.After(timeout):
+									t.Fatal("Expected uplink timeout")
+								}
+								select {
+								case evt := <-upEvents["gs.up.receive"]:
+									a.So(evt.Name(), should.Equal, "gs.up.receive")
+								case <-time.After(timeout):
+									t.Fatal("Expected uplink event timeout")
+								}
+							}
+							if expected := tc.Up.TxAcknowledgment; expected != nil {
+								select {
+								case <-upEvents["gs.down.tx.success"]:
+								case evt := <-upEvents["gs.down.tx.fail"]:
+									received, ok := evt.Data().(ttnpb.TxAcknowledgment_Result)
+									if !ok {
+										t.Fatal("No acknowledgment attached to the downlink emission fail event")
+									}
+									a.So(received, should.Resemble, expected.Result)
+								case <-time.After(timeout):
+									t.Fatal("Expected Tx acknowledgment event timeout")
+								}
+							}
+							if tc.Up.GatewayStatus != nil && ptc.SupportsStatus {
+								select {
+								case <-upEvents["gs.status.receive"]:
+								case <-time.After(timeout):
+									t.Fatal("Expected gateway status event timeout")
+								}
+
+								// Wait for gateway status to be processed; no event available here.
+								time.Sleep(timeout)
+							}
+
+							stats, err := statsClient.GetGatewayConnectionStats(statsCtx, &ids)
+							if !a.So(err, should.BeNil) {
+								t.FailNow()
+							}
+							a.So(stats.UplinkCount, should.Equal, uplinkCount)
+
+							if tc.Up.GatewayStatus != nil && ptc.SupportsStatus {
+								if !a.So(stats.LastStatus, should.NotBeNil) {
+									t.FailNow()
+								}
+								a.So(stats.LastStatus.Time, should.Equal, tc.Up.GatewayStatus.Time)
+							}
+						})
+					}
+				})
+
+				t.Run("Downstream", func(t *testing.T) {
+					ctx := cluster.NewContext(test.Context(), nil)
+					downlinkCount := 0
+					for _, tc := range []struct {
+						Name                     string
+						Message                  *ttnpb.DownlinkMessage
+						ErrorAssertion           func(error) bool
+						RxWindowDetailsAssertion []func(error) bool
+					}{
+						{
+							Name: "InvalidSettingsType",
+							Message: &ttnpb.DownlinkMessage{
+								RawPayload: randomDownDataPayload(types.DevAddr{0x26, 0x01, 0xff, 0xff}, 1, 6),
+								Settings: &ttnpb.DownlinkMessage_Scheduled{
+									Scheduled: &ttnpb.TxSettings{
 										DataRate: ttnpb.DataRate{
 											Modulation: &ttnpb.DataRate_LoRa{
 												LoRa: &ttnpb.LoRaDataRate{
@@ -781,339 +926,195 @@ func TestGatewayServer(t *testing.T) {
 											},
 										},
 										CodingRate: "4/5",
-										Frequency:  867700000,
-										Timestamp:  2424000,
+										Frequency:  869525000,
+										Downlink: &ttnpb.TxSettings_Downlink{
+											TxPower: 10,
+										},
+										Timestamp: 100,
 									},
-									RxMetadata: []*ttnpb.RxMetadata{
-										{
-											GatewayIdentifiers: ids,
-											Timestamp:          2424000,
-											RSSI:               -36,
-											ChannelRSSI:        -36,
-											SNR:                5,
-											Location: &ttnpb.Location{
-												Source: ttnpb.SOURCE_REGISTRY,
+								},
+							},
+							ErrorAssertion: errors.IsInvalidArgument, // Network Server may send Tx request only.
+						},
+						{
+							Name: "NotConnected",
+							Message: &ttnpb.DownlinkMessage{
+								Settings: &ttnpb.DownlinkMessage_Request{
+									Request: &ttnpb.TxRequest{
+										Class: ttnpb.CLASS_C,
+										DownlinkPaths: []*ttnpb.DownlinkPath{
+											{
+												Path: &ttnpb.DownlinkPath_Fixed{
+													Fixed: &ttnpb.GatewayAntennaIdentifiers{
+														GatewayIdentifiers: ttnpb.GatewayIdentifiers{
+															GatewayID: "not-connected",
+														},
+													},
+												},
 											},
 										},
 									},
-									RawPayload: randomJoinRequestPayload(
-										types.EUI64{0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
-										types.EUI64{0x42, 0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
-									),
 								},
 							},
-							GatewayStatus: &ttnpb.GatewayStatus{
-								Time: time.Unix(4242424, 0),
+							ErrorAssertion: errors.IsAborted, // The gateway is not connected.
+						},
+						{
+							Name: "ValidClassA",
+							Message: &ttnpb.DownlinkMessage{
+								RawPayload: randomDownDataPayload(types.DevAddr{0x26, 0x01, 0xff, 0xff}, 1, 6),
+								Settings: &ttnpb.DownlinkMessage_Request{
+									Request: &ttnpb.TxRequest{
+										Class: ttnpb.CLASS_A,
+										DownlinkPaths: []*ttnpb.DownlinkPath{
+											{
+												Path: &ttnpb.DownlinkPath_UplinkToken{
+													UplinkToken: io.MustUplinkToken(ttnpb.GatewayAntennaIdentifiers{
+														GatewayIdentifiers: ttnpb.GatewayIdentifiers{
+															GatewayID: registeredGatewayID,
+														},
+													}, 10000000),
+												},
+											},
+										},
+										Priority:         ttnpb.TxSchedulePriority_NORMAL,
+										Rx1Delay:         ttnpb.RX_DELAY_1,
+										Rx1DataRateIndex: 5,
+										Rx1Frequency:     868100000,
+									},
+								},
 							},
 						},
-						Forwards: []int{1, 2},
-					},
-				} {
-					t.Run(tc.Name, func(t *testing.T) {
-						a := assertions.New(t)
-
-						upEvents := map[string]events.Channel{}
-						for _, event := range []string{"gs.up.receive", "gs.down.tx.success", "gs.down.tx.fail", "gs.status.receive"} {
-							upEvents[event] = make(events.Channel, 5)
-						}
-						defer test.SetDefaultEventsPubSub(&test.MockEventPubSub{
-							PublishFunc: func(ev events.Event) {
-								switch name := ev.Name(); name {
-								case "gs.up.receive", "gs.down.tx.success", "gs.down.tx.fail", "gs.status.receive":
-									go func() {
-										upEvents[name] <- ev
-									}()
-								default:
-									t.Logf("%s event published", name)
-								}
+						{
+							Name: "ConflictClassA",
+							Message: &ttnpb.DownlinkMessage{
+								RawPayload: randomDownDataPayload(types.DevAddr{0x26, 0x02, 0xff, 0xff}, 1, 6),
+								Settings: &ttnpb.DownlinkMessage_Request{
+									Request: &ttnpb.TxRequest{
+										Class: ttnpb.CLASS_A,
+										DownlinkPaths: []*ttnpb.DownlinkPath{
+											{
+												Path: &ttnpb.DownlinkPath_UplinkToken{
+													UplinkToken: io.MustUplinkToken(ttnpb.GatewayAntennaIdentifiers{
+														GatewayIdentifiers: ttnpb.GatewayIdentifiers{
+															GatewayID: registeredGatewayID,
+														},
+													}, 10000000),
+												},
+											},
+										},
+										Priority:         ttnpb.TxSchedulePriority_NORMAL,
+										Rx1Delay:         ttnpb.RX_DELAY_1,
+										Rx1DataRateIndex: 5,
+										Rx1Frequency:     868100000,
+									},
+								},
 							},
-						})()
+							ErrorAssertion: errors.IsAborted,
+							RxWindowDetailsAssertion: []func(error) bool{
+								errors.IsResourceExhausted,  // Rx1 conflicts with previous.
+								errors.IsFailedPrecondition, // Rx2 not provided.
+							},
+						},
+						{
+							Name: "ValidClassC",
+							Message: &ttnpb.DownlinkMessage{
+								RawPayload: randomDownDataPayload(types.DevAddr{0x26, 0x02, 0xff, 0xff}, 1, 6),
+								Settings: &ttnpb.DownlinkMessage_Request{
+									Request: &ttnpb.TxRequest{
+										Class: ttnpb.CLASS_C,
+										DownlinkPaths: []*ttnpb.DownlinkPath{
+											{
+												Path: &ttnpb.DownlinkPath_Fixed{
+													Fixed: &ttnpb.GatewayAntennaIdentifiers{
+														GatewayIdentifiers: ttnpb.GatewayIdentifiers{
+															GatewayID: registeredGatewayID,
+														},
+													},
+												},
+											},
+										},
+										Priority:         ttnpb.TxSchedulePriority_NORMAL,
+										Rx1Delay:         ttnpb.RX_DELAY_1,
+										Rx1DataRateIndex: 5,
+										Rx1Frequency:     868100000,
+									},
+								},
+							},
+						},
+					} {
+						t.Run(tc.Name, func(t *testing.T) {
+							a := assertions.New(t)
 
-						select {
-						case upCh <- tc.Up:
-						case <-time.After(timeout):
-							t.Fatalf("Failed to send message to upstream channel")
-						}
-						if ptc.DetectsInvalidMessages {
-							uplinkCount += len(tc.Forwards)
-						} else {
-							uplinkCount += len(tc.Up.UplinkMessages)
-						}
-
-						for _, msgIdx := range tc.Forwards {
-							select {
-							case msg := <-ns.Up():
-								expected := tc.Up.UplinkMessages[msgIdx]
-								a.So(time.Since(msg.ReceivedAt), should.BeLessThan, timeout)
-								a.So(msg.Settings, should.Resemble, expected.Settings)
-								for _, md := range msg.RxMetadata {
-									a.So(md.UplinkToken, should.NotBeEmpty)
-									md.UplinkToken = nil
+							_, err := gs.ScheduleDownlink(ctx, tc.Message)
+							if err != nil {
+								if tc.ErrorAssertion == nil || !a.So(tc.ErrorAssertion(err), should.BeTrue) {
+									t.Fatalf("Unexpected error: %v", err)
 								}
-								a.So(msg.RxMetadata, should.Resemble, expected.RxMetadata)
-								a.So(msg.RawPayload, should.Resemble, expected.RawPayload)
-							case <-time.After(timeout):
-								t.Fatal("Expected uplink timeout")
-							}
-							select {
-							case evt := <-upEvents["gs.up.receive"]:
-								a.So(evt.Name(), should.Equal, "gs.up.receive")
-							case <-time.After(timeout):
-								t.Fatal("Expected uplink event timeout")
-							}
-						}
-						if expected := tc.Up.TxAcknowledgment; expected != nil {
-							select {
-							case <-upEvents["gs.down.tx.success"]:
-							case evt := <-upEvents["gs.down.tx.fail"]:
-								received, ok := evt.Data().(ttnpb.TxAcknowledgment_Result)
-								if !ok {
-									t.Fatal("No acknowledgment attached to the downlink emission fail event")
+								if tc.RxWindowDetailsAssertion != nil {
+									a.So(err, should.HaveSameErrorDefinitionAs, gatewayserver.ErrSchedule)
+									if !a.So(errors.Details(err), should.HaveLength, 1) {
+										t.FailNow()
+									}
+									details := errors.Details(err)[0].(*ttnpb.ScheduleDownlinkErrorDetails)
+									if !a.So(details, should.NotBeNil) || !a.So(details.PathErrors, should.HaveLength, 1) {
+										t.FailNow()
+									}
+									errSchedulePathCause := errors.Cause(ttnpb.ErrorDetailsFromProto(details.PathErrors[0]))
+									a.So(errors.IsAborted(errSchedulePathCause), should.BeTrue)
+									for i, assert := range tc.RxWindowDetailsAssertion {
+										if !a.So(errors.Details(errSchedulePathCause), should.HaveLength, 1) {
+											t.FailNow()
+										}
+										errSchedulePathCauseDetails := errors.Details(errSchedulePathCause)[0].(*ttnpb.ScheduleDownlinkErrorDetails)
+										if !a.So(errSchedulePathCauseDetails, should.NotBeNil) {
+											t.FailNow()
+										}
+										if i >= len(errSchedulePathCauseDetails.PathErrors) {
+											t.Fatalf("Expected error in Rx window %d", i+1)
+										}
+										errRxWindow := ttnpb.ErrorDetailsFromProto(errSchedulePathCauseDetails.PathErrors[i])
+										if !a.So(assert(errRxWindow), should.BeTrue) {
+											t.Fatalf("Unexpected Rx window %d error: %v", i+1, errRxWindow)
+										}
+									}
 								}
-								a.So(received, should.Resemble, expected.Result)
-							case <-time.After(timeout):
-								t.Fatal("Expected Tx acknowledgment event timeout")
+								return
+							} else if tc.ErrorAssertion != nil {
+								t.Fatalf("Expected error")
 							}
-						}
-						if tc.Up.GatewayStatus != nil && ptc.SupportsStatus {
+							downlinkCount++
+
 							select {
-							case <-upEvents["gs.status.receive"]:
+							case msg := <-downCh:
+								settings := msg.DownlinkMessage.GetScheduled()
+								a.So(settings, should.NotBeNil)
 							case <-time.After(timeout):
-								t.Fatal("Expected gateway status event timeout")
+								t.Fatal("Expected downlink timeout")
 							}
 
-							// Wait for gateway status to be processed; no event available here.
-							time.Sleep(timeout)
-						}
-
-						stats, err := statsClient.GetGatewayConnectionStats(statsCtx, &ids)
-						if !a.So(err, should.BeNil) {
-							t.FailNow()
-						}
-						a.So(stats.UplinkCount, should.Equal, uplinkCount)
-
-						if tc.Up.GatewayStatus != nil && ptc.SupportsStatus {
-							if !a.So(stats.LastStatus, should.NotBeNil) {
+							stats, err := statsClient.GetGatewayConnectionStats(statsCtx, &ids)
+							if !a.So(err, should.BeNil) {
 								t.FailNow()
 							}
-							a.So(stats.LastStatus.Time, should.Equal, tc.Up.GatewayStatus.Time)
-						}
-					})
-				}
+							a.So(stats.DownlinkCount, should.Equal, downlinkCount)
+						})
+					}
+				})
+
+				cancel()
+				wg.Wait()
+
+				// Wait for disconnection to be processed.
+				time.Sleep(timeout)
+
+				// After canceling the context and awaiting the link, the connection should be gone.
+				t.Run("Disconnected", func(t *testing.T) {
+					_, err := statsClient.GetGatewayConnectionStats(statsCtx, &ids)
+					if !a.So(errors.IsNotFound(err), should.BeTrue) {
+						t.Fatalf("Expected gateway to be disconnected, but it's not")
+					}
+				})
 			})
-
-			t.Run("Downstream", func(t *testing.T) {
-				ctx := cluster.NewContext(test.Context(), nil)
-				downlinkCount := 0
-				for _, tc := range []struct {
-					Name                     string
-					Message                  *ttnpb.DownlinkMessage
-					ErrorAssertion           func(error) bool
-					RxWindowDetailsAssertion []func(error) bool
-				}{
-					{
-						Name: "InvalidSettingsType",
-						Message: &ttnpb.DownlinkMessage{
-							RawPayload: randomDownDataPayload(types.DevAddr{0x26, 0x01, 0xff, 0xff}, 1, 6),
-							Settings: &ttnpb.DownlinkMessage_Scheduled{
-								Scheduled: &ttnpb.TxSettings{
-									DataRate: ttnpb.DataRate{
-										Modulation: &ttnpb.DataRate_LoRa{
-											LoRa: &ttnpb.LoRaDataRate{
-												SpreadingFactor: 12,
-												Bandwidth:       125000,
-											},
-										},
-									},
-									CodingRate: "4/5",
-									Frequency:  869525000,
-									Downlink: &ttnpb.TxSettings_Downlink{
-										TxPower: 10,
-									},
-									Timestamp: 100,
-								},
-							},
-						},
-						ErrorAssertion: errors.IsInvalidArgument, // Network Server may send Tx request only.
-					},
-					{
-						Name: "NotConnected",
-						Message: &ttnpb.DownlinkMessage{
-							Settings: &ttnpb.DownlinkMessage_Request{
-								Request: &ttnpb.TxRequest{
-									Class: ttnpb.CLASS_C,
-									DownlinkPaths: []*ttnpb.DownlinkPath{
-										{
-											Path: &ttnpb.DownlinkPath_Fixed{
-												Fixed: &ttnpb.GatewayAntennaIdentifiers{
-													GatewayIdentifiers: ttnpb.GatewayIdentifiers{
-														GatewayID: "not-connected",
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-						ErrorAssertion: errors.IsAborted, // The gateway is not connected.
-					},
-					{
-						Name: "ValidClassA",
-						Message: &ttnpb.DownlinkMessage{
-							RawPayload: randomDownDataPayload(types.DevAddr{0x26, 0x01, 0xff, 0xff}, 1, 6),
-							Settings: &ttnpb.DownlinkMessage_Request{
-								Request: &ttnpb.TxRequest{
-									Class: ttnpb.CLASS_A,
-									DownlinkPaths: []*ttnpb.DownlinkPath{
-										{
-											Path: &ttnpb.DownlinkPath_UplinkToken{
-												UplinkToken: io.MustUplinkToken(ttnpb.GatewayAntennaIdentifiers{
-													GatewayIdentifiers: ttnpb.GatewayIdentifiers{
-														GatewayID: registeredGatewayID,
-													},
-												}, 10000000),
-											},
-										},
-									},
-									Priority:         ttnpb.TxSchedulePriority_NORMAL,
-									Rx1Delay:         ttnpb.RX_DELAY_1,
-									Rx1DataRateIndex: 5,
-									Rx1Frequency:     868100000,
-								},
-							},
-						},
-					},
-					{
-						Name: "ConflictClassA",
-						Message: &ttnpb.DownlinkMessage{
-							RawPayload: randomDownDataPayload(types.DevAddr{0x26, 0x02, 0xff, 0xff}, 1, 6),
-							Settings: &ttnpb.DownlinkMessage_Request{
-								Request: &ttnpb.TxRequest{
-									Class: ttnpb.CLASS_A,
-									DownlinkPaths: []*ttnpb.DownlinkPath{
-										{
-											Path: &ttnpb.DownlinkPath_UplinkToken{
-												UplinkToken: io.MustUplinkToken(ttnpb.GatewayAntennaIdentifiers{
-													GatewayIdentifiers: ttnpb.GatewayIdentifiers{
-														GatewayID: registeredGatewayID,
-													},
-												}, 10000000),
-											},
-										},
-									},
-									Priority:         ttnpb.TxSchedulePriority_NORMAL,
-									Rx1Delay:         ttnpb.RX_DELAY_1,
-									Rx1DataRateIndex: 5,
-									Rx1Frequency:     868100000,
-								},
-							},
-						},
-						ErrorAssertion: errors.IsAborted,
-						RxWindowDetailsAssertion: []func(error) bool{
-							errors.IsResourceExhausted,  // Rx1 conflicts with previous.
-							errors.IsFailedPrecondition, // Rx2 not provided.
-						},
-					},
-					{
-						Name: "ValidClassC",
-						Message: &ttnpb.DownlinkMessage{
-							RawPayload: randomDownDataPayload(types.DevAddr{0x26, 0x02, 0xff, 0xff}, 1, 6),
-							Settings: &ttnpb.DownlinkMessage_Request{
-								Request: &ttnpb.TxRequest{
-									Class: ttnpb.CLASS_C,
-									DownlinkPaths: []*ttnpb.DownlinkPath{
-										{
-											Path: &ttnpb.DownlinkPath_Fixed{
-												Fixed: &ttnpb.GatewayAntennaIdentifiers{
-													GatewayIdentifiers: ttnpb.GatewayIdentifiers{
-														GatewayID: registeredGatewayID,
-													},
-												},
-											},
-										},
-									},
-									Priority:         ttnpb.TxSchedulePriority_NORMAL,
-									Rx1Delay:         ttnpb.RX_DELAY_1,
-									Rx1DataRateIndex: 5,
-									Rx1Frequency:     868100000,
-								},
-							},
-						},
-					},
-				} {
-					t.Run(tc.Name, func(t *testing.T) {
-						a := assertions.New(t)
-
-						_, err := gs.ScheduleDownlink(ctx, tc.Message)
-						if err != nil {
-							if tc.ErrorAssertion == nil || !a.So(tc.ErrorAssertion(err), should.BeTrue) {
-								t.Fatalf("Unexpected error: %v", err)
-							}
-							if tc.RxWindowDetailsAssertion != nil {
-								a.So(err, should.HaveSameErrorDefinitionAs, gatewayserver.ErrSchedule)
-								if !a.So(errors.Details(err), should.HaveLength, 1) {
-									t.FailNow()
-								}
-								details := errors.Details(err)[0].(*ttnpb.ScheduleDownlinkErrorDetails)
-								if !a.So(details, should.NotBeNil) || !a.So(details.PathErrors, should.HaveLength, 1) {
-									t.FailNow()
-								}
-								errSchedulePathCause := errors.Cause(ttnpb.ErrorDetailsFromProto(details.PathErrors[0]))
-								a.So(errors.IsAborted(errSchedulePathCause), should.BeTrue)
-								for i, assert := range tc.RxWindowDetailsAssertion {
-									if !a.So(errors.Details(errSchedulePathCause), should.HaveLength, 1) {
-										t.FailNow()
-									}
-									errSchedulePathCauseDetails := errors.Details(errSchedulePathCause)[0].(*ttnpb.ScheduleDownlinkErrorDetails)
-									if !a.So(errSchedulePathCauseDetails, should.NotBeNil) {
-										t.FailNow()
-									}
-									if i >= len(errSchedulePathCauseDetails.PathErrors) {
-										t.Fatalf("Expected error in Rx window %d", i+1)
-									}
-									errRxWindow := ttnpb.ErrorDetailsFromProto(errSchedulePathCauseDetails.PathErrors[i])
-									if !a.So(assert(errRxWindow), should.BeTrue) {
-										t.Fatalf("Unexpected Rx window %d error: %v", i+1, errRxWindow)
-									}
-								}
-							}
-							return
-						} else if tc.ErrorAssertion != nil {
-							t.Fatalf("Expected error")
-						}
-						downlinkCount++
-
-						select {
-						case msg := <-downCh:
-							settings := msg.DownlinkMessage.GetScheduled()
-							a.So(settings, should.NotBeNil)
-						case <-time.After(timeout):
-							t.Fatal("Expected downlink timeout")
-						}
-
-						stats, err := statsClient.GetGatewayConnectionStats(statsCtx, &ids)
-						if !a.So(err, should.BeNil) {
-							t.FailNow()
-						}
-						a.So(stats.DownlinkCount, should.Equal, downlinkCount)
-					})
-				}
-			})
-
-			cancel()
-			wg.Wait()
-
-			// Wait for disconnection to be processed.
-			time.Sleep(timeout)
-
-			// After canceling the context and awaiting the link, the connection should be gone.
-			t.Run("Disconnected", func(t *testing.T) {
-				_, err := statsClient.GetGatewayConnectionStats(statsCtx, &ids)
-				if !a.So(errors.IsNotFound(err), should.BeTrue) {
-					t.Fatalf("Expected gateway to be disconnected, but it's not")
-				}
-			})
-		})
+		}
 	}
 }

--- a/pkg/gatewayserver/gatewayserver_util_test.go
+++ b/pkg/gatewayserver/gatewayserver_util_test.go
@@ -66,7 +66,7 @@ func startMockIS(ctx context.Context) (*mockIS, string) {
 	return is, lis.Addr().String()
 }
 
-func (is *mockIS) add(ctx context.Context, ids ttnpb.GatewayIdentifiers, key string) {
+func (is *mockIS) add(ctx context.Context, ids ttnpb.GatewayIdentifiers, key string, locationPublic bool) {
 	uid := unique.ID(ctx, ids)
 	is.gateways[uid] = &ttnpb.Gateway{
 		GatewayIdentifiers: ids,
@@ -78,6 +78,7 @@ func (is *mockIS) add(ctx context.Context, ids ttnpb.GatewayIdentifiers, key str
 				},
 			},
 		},
+		LocationPublic: locationPublic,
 	}
 	if key != "" {
 		is.gatewayAuths[uid] = []string{fmt.Sprintf("Bearer %v", key)}

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -162,7 +162,9 @@ func (c *Connection) HandleUp(up *ttnpb.UplinkMessage) error {
 
 		if len(c.gateway.Antennas) > int(md.AntennaIndex) {
 			location := c.gateway.Antennas[md.AntennaIndex].Location
-			md.Location = &location
+			if location.Source != ttnpb.SOURCE_UNKNOWN {
+				md.Location = &location
+			}
 		}
 	}
 

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -159,6 +159,11 @@ func (c *Connection) HandleUp(up *ttnpb.UplinkMessage) error {
 		}
 		md.UplinkToken = buf
 		md.DownlinkPathConstraint = c.gateway.DownlinkPathConstraint
+
+		if len(c.gateway.Antennas) > int(md.AntennaIndex) {
+			location := c.gateway.Antennas[md.AntennaIndex].Location
+			md.Location = &location
+		}
 	}
 
 	select {

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -160,7 +160,7 @@ func (c *Connection) HandleUp(up *ttnpb.UplinkMessage) error {
 		md.UplinkToken = buf
 		md.DownlinkPathConstraint = c.gateway.DownlinkPathConstraint
 
-		if len(c.gateway.Antennas) > int(md.AntennaIndex) {
+		if c.gateway.LocationPublic && len(c.gateway.Antennas) > int(md.AntennaIndex) {
 			location := c.gateway.Antennas[md.AntennaIndex].Location
 			if location.Source != ttnpb.SOURCE_UNKNOWN {
 				md.Location = &location


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Required for #1815 


#### Changes
<!-- What are the changes made in this pull request? -->

- Gateway Server properly adds antenna location on the `RxMetadata` field of uplink messages forwarded to the Network Server

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- Implementing this as a separate small fix.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
