### PR TITLE
Reset pagination in second stage of search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Respect stack components on different hosts when connected to event sources in the Console.
+- Pagination of search results.
 
 ### Security
 

--- a/pkg/identityserver/registry_search.go
+++ b/pkg/identityserver/registry_search.go
@@ -75,6 +75,7 @@ func (rs *registrySearch) SearchApplications(ctx context.Context, req *ttnpb.Sea
 		if len(ids) == 0 {
 			return nil
 		}
+		ctx = store.WithPagination(ctx, 0, 0, nil) // Reset pagination (already done in FindEntities).
 		res.Applications, err = store.GetApplicationStore(db).FindApplications(ctx, ids, &req.FieldMask)
 		if err != nil {
 			return err
@@ -117,6 +118,7 @@ func (rs *registrySearch) SearchClients(ctx context.Context, req *ttnpb.SearchEn
 		if len(ids) == 0 {
 			return nil
 		}
+		ctx = store.WithPagination(ctx, 0, 0, nil) // Reset pagination (already done in FindEntities).
 		res.Clients, err = store.GetClientStore(db).FindClients(ctx, ids, &req.FieldMask)
 		if err != nil {
 			return err
@@ -159,6 +161,7 @@ func (rs *registrySearch) SearchGateways(ctx context.Context, req *ttnpb.SearchE
 		if len(ids) == 0 {
 			return nil
 		}
+		ctx = store.WithPagination(ctx, 0, 0, nil) // Reset pagination (already done in FindEntities).
 		res.Gateways, err = store.GetGatewayStore(db).FindGateways(ctx, ids, &req.FieldMask)
 		if err != nil {
 			return err
@@ -201,6 +204,7 @@ func (rs *registrySearch) SearchOrganizations(ctx context.Context, req *ttnpb.Se
 		if len(ids) == 0 {
 			return nil
 		}
+		ctx = store.WithPagination(ctx, 0, 0, nil) // Reset pagination (already done in FindEntities).
 		res.Organizations, err = store.GetOrganizationStore(db).FindOrganizations(ctx, ids, &req.FieldMask)
 		if err != nil {
 			return err
@@ -246,6 +250,7 @@ func (rs *registrySearch) SearchUsers(ctx context.Context, req *ttnpb.SearchEnti
 		if len(ids) == 0 {
 			return nil
 		}
+		ctx = store.WithPagination(ctx, 0, 0, nil) // Reset pagination (already done in FindEntities).
 		res.Users, err = store.GetUserStore(db).FindUsers(ctx, ids, &req.FieldMask)
 		if err != nil {
 			return err
@@ -281,6 +286,7 @@ func (rs *registrySearch) SearchEndDevices(ctx context.Context, req *ttnpb.Searc
 		if len(ids) == 0 {
 			return nil
 		}
+		ctx = store.WithPagination(ctx, 0, 0, nil) // Reset pagination (already done in FindEndDevices).
 		res.EndDevices, err = store.GetEndDeviceStore(db).FindEndDevices(ctx, ids, &req.FieldMask)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quickfix that closes #1814 by resetting pagination for the second stage of search. The correct page is already selected by the first stage, so we can just return all results.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
