### PR TITLE
Scheduler with Multiple frequency plans

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -3500,6 +3500,24 @@
       "file": "scheduler.go"
     }
   },
+  "error:pkg/gatewayserver/scheduling:frequency_plans_overlap_sub_band": {
+    "translations": {
+      "en": "frequency plans must not have overlapping sub bands"
+    },
+    "description": {
+      "package": "pkg/gatewayserver/scheduling",
+      "file": "scheduler.go"
+    }
+  },
+  "error:pkg/gatewayserver/scheduling:frequency_plans_timeoffair": {
+    "translations": {
+      "en": "frequency plans must have the same time off air value"
+    },
+    "description": {
+      "package": "pkg/gatewayserver/scheduling",
+      "file": "scheduler.go"
+    }
+  },
   "error:pkg/gatewayserver/scheduling:no_absolute_gateway_time": {
     "translations": {
       "en": "no absolute gateway time"

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -91,7 +91,7 @@ type Connection struct {
 // NewConnection instantiates a new gateway connection.
 func NewConnection(ctx context.Context, frontend Frontend, gateway *ttnpb.Gateway, fps []*frequencyplans.FrequencyPlan, enforceDutyCycle bool, scheduleAnytimeDelay *time.Duration, fpStore *frequencyplans.Store) (*Connection, error) {
 	ctx, cancelCtx := errorcontext.New(ctx)
-	scheduler, err := scheduling.NewScheduler(ctx, fps[0], enforceDutyCycle, scheduleAnytimeDelay, nil)
+	scheduler, err := scheduling.NewScheduler(ctx, fps, enforceDutyCycle, scheduleAnytimeDelay, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gatewayserver/scheduling/scheduler.go
+++ b/pkg/gatewayserver/scheduling/scheduler.go
@@ -65,9 +65,12 @@ type RTTs interface {
 	Stats() (min, max, median time.Duration, count int)
 }
 
+var errFrequencyPlansTimeOffAir = errors.DefineInvalidArgument("frequency_plans_timeoffair", "frequency plans must have the same TimeOffAir value")
+var errFrequencyPlansOverlapSubBand = errors.DefineInvalidArgument("frequency_plans_overlap_subband", "frequency plans must not have overlapping sub bands")
+
 // NewScheduler instantiates a new Scheduler for the given frequency plan.
 // If no time source is specified, the system time is used.
-func NewScheduler(ctx context.Context, fp *frequencyplans.FrequencyPlan, enforceDutyCycle bool, scheduleAnytimeDelay *time.Duration, timeSource TimeSource) (*Scheduler, error) {
+func NewScheduler(ctx context.Context, fps []*frequencyplans.FrequencyPlan, enforceDutyCycle bool, scheduleAnytimeDelay *time.Duration, timeSource TimeSource) (*Scheduler, error) {
 	logger := log.FromContext(ctx)
 	if timeSource == nil {
 		timeSource = SystemTimeSource
@@ -83,41 +86,74 @@ func NewScheduler(ctx context.Context, fp *frequencyplans.FrequencyPlan, enforce
 		scheduleAnytimeDelay = &ScheduleTimeShort
 	}
 
-	toa := fp.TimeOffAir
+	for i := 0; i < len(fps)-1; i++ {
+		if fps[i].TimeOffAir != fps[i+1].TimeOffAir {
+			return nil, errFrequencyPlansTimeOffAir
+		}
+	}
+
+	toa := fps[0].TimeOffAir
 	if toa.Duration < QueueDelay {
 		toa.Duration = QueueDelay
 	}
+
 	s := &Scheduler{
 		clock:                &RolloverClock{},
-		respectsDwellTime:    fp.RespectsDwellTime,
 		timeOffAir:           toa,
+		fps:                  fps,
 		timeSource:           timeSource,
 		scheduleAnytimeDelay: *scheduleAnytimeDelay,
 	}
 	if enforceDutyCycle {
-		if subBands := fp.SubBands; len(subBands) > 0 {
-			for _, subBand := range subBands {
-				params := SubBandParameters{
-					MinFrequency: subBand.MinFrequency,
-					MaxFrequency: subBand.MaxFrequency,
-					DutyCycle:    subBand.DutyCycle,
+		for _, fp := range fps {
+			if subBands := fp.SubBands; len(subBands) > 0 {
+				for _, subBand := range subBands {
+					params := SubBandParameters{
+						MinFrequency: subBand.MinFrequency,
+						MaxFrequency: subBand.MaxFrequency,
+						DutyCycle:    subBand.DutyCycle,
+					}
+					sb := NewSubBand(ctx, params, s.clock, nil)
+					var isIdentical bool
+					for _, subBand := range s.subBands {
+						if subBand.IsIdentical(sb) {
+							isIdentical = true
+							break
+						}
+						if subBand.HasOverlap(sb) {
+							return nil, errFrequencyPlansOverlapSubBand
+						}
+					}
+					if !isIdentical {
+						s.subBands = append(s.subBands, sb)
+					}
 				}
-				sb := NewSubBand(ctx, params, s.clock, nil)
-				s.subBands = append(s.subBands, sb)
-			}
-		} else {
-			band, err := band.GetByID(fp.BandID)
-			if err != nil {
-				return nil, err
-			}
-			for _, subBand := range band.SubBands {
-				params := SubBandParameters{
-					MinFrequency: subBand.MinFrequency,
-					MaxFrequency: subBand.MaxFrequency,
-					DutyCycle:    subBand.DutyCycle,
+			} else {
+				band, err := band.GetByID(fp.BandID)
+				if err != nil {
+					return nil, err
 				}
-				sb := NewSubBand(ctx, params, s.clock, nil)
-				s.subBands = append(s.subBands, sb)
+				for _, subBand := range band.SubBands {
+					params := SubBandParameters{
+						MinFrequency: subBand.MinFrequency,
+						MaxFrequency: subBand.MaxFrequency,
+						DutyCycle:    subBand.DutyCycle,
+					}
+					sb := NewSubBand(ctx, params, s.clock, nil)
+					var isIdentical bool
+					for _, subBand := range s.subBands {
+						if subBand.IsIdentical(sb) {
+							isIdentical = true
+							break
+						}
+						if subBand.HasOverlap(sb) {
+							return nil, errFrequencyPlansOverlapSubBand
+						}
+					}
+					if !isIdentical {
+						s.subBands = append(s.subBands, sb)
+					}
+				}
 			}
 		}
 	} else {
@@ -134,7 +170,7 @@ func NewScheduler(ctx context.Context, fp *frequencyplans.FrequencyPlan, enforce
 // Scheduler is a packet scheduler that takes time conflicts and sub-band restrictions into account.
 type Scheduler struct {
 	clock                *RolloverClock
-	respectsDwellTime    func(isDownlink bool, frequency uint64, duration time.Duration) bool
+	fps                  []*frequencyplans.FrequencyPlan
 	timeOffAir           frequencyplans.TimeOffAir
 	timeSource           TimeSource
 	subBands             []*SubBand
@@ -161,10 +197,12 @@ func (s *Scheduler) newEmission(payloadSize int, settings ttnpb.TxSettings, star
 	if err != nil {
 		return Emission{}, err
 	}
-	if !s.respectsDwellTime(true, settings.Frequency, d) {
-		return Emission{}, errDwellTime
+	for _, fp := range s.fps {
+		if fp.RespectsDwellTime(true, settings.Frequency, d) {
+			return NewEmission(starts, d), nil
+		}
 	}
-	return NewEmission(starts, d), nil
+	return Emission{}, errDwellTime
 }
 
 var (

--- a/pkg/gatewayserver/scheduling/scheduler.go
+++ b/pkg/gatewayserver/scheduling/scheduler.go
@@ -205,6 +205,11 @@ func (s *Scheduler) newEmission(payloadSize int, settings ttnpb.TxSettings, star
 	return Emission{}, errDwellTime
 }
 
+// NoOfSubBands returns the number of sub bands in the scheduler
+func (s *Scheduler) NoOfSubBands() int {
+	return len(s.subBands)
+}
+
 var (
 	errConflict              = errors.DefineResourceExhausted("conflict", "scheduling conflict")
 	errTooLate               = errors.DefineFailedPrecondition("too_late", "too late to transmission scheduled time (delta is `{delta}`)")

--- a/pkg/gatewayserver/scheduling/scheduler.go
+++ b/pkg/gatewayserver/scheduling/scheduler.go
@@ -65,8 +65,10 @@ type RTTs interface {
 	Stats() (min, max, median time.Duration, count int)
 }
 
-var errFrequencyPlansTimeOffAir = errors.DefineInvalidArgument("frequency_plans_timeoffair", "frequency plans must have the same TimeOffAir value")
-var errFrequencyPlansOverlapSubBand = errors.DefineInvalidArgument("frequency_plans_overlap_subband", "frequency plans must not have overlapping sub bands")
+var (
+	errFrequencyPlansTimeOffAir     = errors.DefineInvalidArgument("frequency_plans_timeoffair", "frequency plans must have the same time off air value")
+	errFrequencyPlansOverlapSubBand = errors.DefineInvalidArgument("frequency_plans_overlap_sub_band", "frequency plans must not have overlapping sub bands")
+)
 
 // NewScheduler instantiates a new Scheduler for the given frequency plan.
 // If no time source is specified, the system time is used.
@@ -205,8 +207,8 @@ func (s *Scheduler) newEmission(payloadSize int, settings ttnpb.TxSettings, star
 	return Emission{}, errDwellTime
 }
 
-// NoOfSubBands returns the number of sub bands in the scheduler
-func (s *Scheduler) NoOfSubBands() int {
+// SubBandCount returns the number of sub bands in the scheduler.
+func (s *Scheduler) SubBandCount() int {
 	return len(s.subBands)
 }
 

--- a/pkg/gatewayserver/scheduling/scheduler_test.go
+++ b/pkg/gatewayserver/scheduling/scheduler_test.go
@@ -34,7 +34,7 @@ import (
 func TestScheduleAtWithBandDutyCycle(t *testing.T) {
 	a := assertions.New(t)
 	ctx := test.Context()
-	fps := []*frequencyplans.FrequencyPlan{&frequencyplans.FrequencyPlan{
+	fps := []*frequencyplans.FrequencyPlan{{
 		BandID: band.EU_863_870,
 		TimeOffAir: frequencyplans.TimeOffAir{
 			Duration: time.Second,
@@ -344,7 +344,7 @@ func TestScheduleAtWithBandDutyCycle(t *testing.T) {
 func TestScheduleAtWithFrequencyPlanDutyCycle(t *testing.T) {
 	a := assertions.New(t)
 	ctx := test.Context()
-	fps := []*frequencyplans.FrequencyPlan{&frequencyplans.FrequencyPlan{
+	fps := []*frequencyplans.FrequencyPlan{{
 		BandID: band.EU_863_870,
 		SubBands: []frequencyplans.SubBandParameters{
 			{
@@ -427,7 +427,7 @@ func TestScheduleAtWithFrequencyPlanDutyCycle(t *testing.T) {
 func TestScheduleAnytime(t *testing.T) {
 	a := assertions.New(t)
 	ctx := test.Context()
-	fps := []*frequencyplans.FrequencyPlan{&frequencyplans.FrequencyPlan{
+	fps := []*frequencyplans.FrequencyPlan{{
 		BandID: band.EU_863_870,
 		TimeOffAir: frequencyplans.TimeOffAir{
 			Duration: time.Second,
@@ -517,7 +517,7 @@ func TestScheduleAnytime(t *testing.T) {
 func TestScheduleAnytimeShort(t *testing.T) {
 	a := assertions.New(t)
 	ctx := test.Context()
-	fps := []*frequencyplans.FrequencyPlan{&frequencyplans.FrequencyPlan{
+	fps := []*frequencyplans.FrequencyPlan{{
 		BandID: band.EU_863_870,
 		TimeOffAir: frequencyplans.TimeOffAir{
 			Duration: time.Second,
@@ -651,7 +651,7 @@ func TestScheduleAnytimeShort(t *testing.T) {
 func TestScheduleAnytimeClassC(t *testing.T) {
 	a := assertions.New(t)
 	ctx := test.Context()
-	fps := []*frequencyplans.FrequencyPlan{&frequencyplans.FrequencyPlan{
+	fps := []*frequencyplans.FrequencyPlan{{
 		BandID: band.EU_863_870,
 		TimeOffAir: frequencyplans.TimeOffAir{
 			Duration: time.Second,
@@ -727,17 +727,16 @@ func TestScheduleAnytimeClassC(t *testing.T) {
 }
 
 func TestSchedulerWithMultipleFrequencyPlans(t *testing.T) {
-	a := assertions.New(t)
 	ctx := test.Context()
 	for _, tc := range []struct {
 		Name                 string
 		FrequencyPlans       []*frequencyplans.FrequencyPlan
-		ExpectedNoOfSubBands int
+		ExpectedSubBandCount int
 		ErrorAssertion       func(error) bool
 	}{
 		{
 			Name: "RepeatedNoOverlap",
-			FrequencyPlans: []*frequencyplans.FrequencyPlan{&frequencyplans.FrequencyPlan{
+			FrequencyPlans: []*frequencyplans.FrequencyPlan{{
 				BandID: band.EU_863_870,
 				TimeOffAir: frequencyplans.TimeOffAir{
 					Duration: time.Second,
@@ -747,7 +746,7 @@ func TestSchedulerWithMultipleFrequencyPlans(t *testing.T) {
 					Duration:  durationPtr(2 * time.Second),
 				},
 			},
-				&frequencyplans.FrequencyPlan{
+				{
 					BandID: band.EU_863_870,
 					TimeOffAir: frequencyplans.TimeOffAir{
 						Duration: time.Second,
@@ -758,11 +757,11 @@ func TestSchedulerWithMultipleFrequencyPlans(t *testing.T) {
 					},
 				},
 			},
-			ExpectedNoOfSubBands: 6,
+			ExpectedSubBandCount: 6,
 		},
 		{
 			Name: "UnionOfNonOverlapping",
-			FrequencyPlans: []*frequencyplans.FrequencyPlan{&frequencyplans.FrequencyPlan{
+			FrequencyPlans: []*frequencyplans.FrequencyPlan{{
 				BandID: band.EU_863_870,
 				TimeOffAir: frequencyplans.TimeOffAir{
 					Duration: time.Second,
@@ -773,7 +772,7 @@ func TestSchedulerWithMultipleFrequencyPlans(t *testing.T) {
 				},
 				SubBands: []frequencyplans.SubBandParameters{
 					// Fictional Band S
-					frequencyplans.SubBandParameters{
+					{
 						MinFrequency: 870000000,
 						MaxFrequency: 875000000,
 						DutyCycle:    0.01,
@@ -781,7 +780,7 @@ func TestSchedulerWithMultipleFrequencyPlans(t *testing.T) {
 					},
 				},
 			},
-				&frequencyplans.FrequencyPlan{
+				{
 					BandID: band.EU_863_870,
 					TimeOffAir: frequencyplans.TimeOffAir{
 						Duration: time.Second,
@@ -792,11 +791,11 @@ func TestSchedulerWithMultipleFrequencyPlans(t *testing.T) {
 					},
 				},
 			},
-			ExpectedNoOfSubBands: 7,
+			ExpectedSubBandCount: 7,
 		},
 		{
 			Name: "MismatchedTimeOffAir",
-			FrequencyPlans: []*frequencyplans.FrequencyPlan{&frequencyplans.FrequencyPlan{
+			FrequencyPlans: []*frequencyplans.FrequencyPlan{{
 				BandID: band.EU_863_870,
 				TimeOffAir: frequencyplans.TimeOffAir{
 					Duration: 2 * time.Second,
@@ -806,7 +805,7 @@ func TestSchedulerWithMultipleFrequencyPlans(t *testing.T) {
 					Duration:  durationPtr(2 * time.Second),
 				},
 			},
-				&frequencyplans.FrequencyPlan{
+				{
 					BandID: band.EU_863_870,
 					TimeOffAir: frequencyplans.TimeOffAir{
 						Duration: time.Second,
@@ -823,7 +822,7 @@ func TestSchedulerWithMultipleFrequencyPlans(t *testing.T) {
 		},
 		{
 			Name: "OverlappingSubBands",
-			FrequencyPlans: []*frequencyplans.FrequencyPlan{&frequencyplans.FrequencyPlan{
+			FrequencyPlans: []*frequencyplans.FrequencyPlan{{
 				BandID: band.EU_863_870,
 				TimeOffAir: frequencyplans.TimeOffAir{
 					Duration: time.Second,
@@ -834,7 +833,7 @@ func TestSchedulerWithMultipleFrequencyPlans(t *testing.T) {
 				},
 				SubBands: []frequencyplans.SubBandParameters{
 					// Fictional Band S
-					frequencyplans.SubBandParameters{
+					{
 						MinFrequency: 869000000,
 						MaxFrequency: 873000000,
 						DutyCycle:    0.01,
@@ -842,7 +841,7 @@ func TestSchedulerWithMultipleFrequencyPlans(t *testing.T) {
 					},
 				},
 			},
-				&frequencyplans.FrequencyPlan{
+				{
 					BandID: band.EU_863_870,
 					TimeOffAir: frequencyplans.TimeOffAir{
 						Duration: time.Second,
@@ -859,7 +858,7 @@ func TestSchedulerWithMultipleFrequencyPlans(t *testing.T) {
 		},
 		{
 			Name: "OverlappingSubBandsFromBand",
-			FrequencyPlans: []*frequencyplans.FrequencyPlan{&frequencyplans.FrequencyPlan{
+			FrequencyPlans: []*frequencyplans.FrequencyPlan{{
 				// This is a fictional test case since currently we don't support mix-band frequency plans (https://github.com/TheThingsNetwork/lorawan-stack/issues/1394).
 				BandID: band.AS_923,
 				TimeOffAir: frequencyplans.TimeOffAir{
@@ -870,7 +869,7 @@ func TestSchedulerWithMultipleFrequencyPlans(t *testing.T) {
 					Duration:  durationPtr(2 * time.Second),
 				},
 			},
-				&frequencyplans.FrequencyPlan{
+				{
 					BandID: band.AU_915_928,
 					TimeOffAir: frequencyplans.TimeOffAir{
 						Duration: time.Second,
@@ -887,6 +886,7 @@ func TestSchedulerWithMultipleFrequencyPlans(t *testing.T) {
 		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
+			a := assertions.New(t)
 			timeSource := &mockTimeSource{
 				Time: time.Unix(0, 0),
 			}
@@ -898,8 +898,8 @@ func TestSchedulerWithMultipleFrequencyPlans(t *testing.T) {
 			} else if tc.ErrorAssertion != nil {
 				t.Fatalf("Expected error")
 			} else {
-				if !a.So(scheduler.NoOfSubBands(), should.Equal, tc.ExpectedNoOfSubBands) {
-					t.Fatalf("Invalid no of sub bands: %v", scheduler.NoOfSubBands())
+				if !a.So(scheduler.SubBandCount(), should.Equal, tc.ExpectedSubBandCount) {
+					t.Fatalf("Invalid number of sub bands: %v", scheduler.SubBandCount())
 				}
 			}
 		})
@@ -909,7 +909,7 @@ func TestSchedulerWithMultipleFrequencyPlans(t *testing.T) {
 func TestSchedulingWithMultipleFrequencyPlans(t *testing.T) {
 	a := assertions.New(t)
 	ctx := test.Context()
-	fps := []*frequencyplans.FrequencyPlan{&frequencyplans.FrequencyPlan{
+	fps := []*frequencyplans.FrequencyPlan{{
 		BandID: band.EU_863_870,
 		TimeOffAir: frequencyplans.TimeOffAir{
 			Duration: time.Second,
@@ -920,7 +920,7 @@ func TestSchedulingWithMultipleFrequencyPlans(t *testing.T) {
 		},
 		SubBands: []frequencyplans.SubBandParameters{
 			// Fictional Band S
-			frequencyplans.SubBandParameters{
+			{
 				MinFrequency: 870000000,
 				MaxFrequency: 875000000,
 				DutyCycle:    0.01,
@@ -928,7 +928,7 @@ func TestSchedulingWithMultipleFrequencyPlans(t *testing.T) {
 			},
 		},
 	},
-		&frequencyplans.FrequencyPlan{
+		{
 			BandID: band.EU_863_870,
 			TimeOffAir: frequencyplans.TimeOffAir{
 				Duration: time.Second,

--- a/pkg/gatewayserver/scheduling/scheduler_test.go
+++ b/pkg/gatewayserver/scheduling/scheduler_test.go
@@ -34,7 +34,7 @@ import (
 func TestScheduleAtWithBandDutyCycle(t *testing.T) {
 	a := assertions.New(t)
 	ctx := test.Context()
-	fp := &frequencyplans.FrequencyPlan{
+	fps := []*frequencyplans.FrequencyPlan{&frequencyplans.FrequencyPlan{
 		BandID: band.EU_863_870,
 		TimeOffAir: frequencyplans.TimeOffAir{
 			Duration: time.Second,
@@ -43,11 +43,11 @@ func TestScheduleAtWithBandDutyCycle(t *testing.T) {
 			Downlinks: boolPtr(true),
 			Duration:  durationPtr(2 * time.Second),
 		},
-	}
+	}}
 	timeSource := &mockTimeSource{
 		Time: time.Unix(0, 0),
 	}
-	scheduler, err := scheduling.NewScheduler(ctx, fp, true, nil, timeSource)
+	scheduler, err := scheduling.NewScheduler(ctx, fps, true, nil, timeSource)
 	a.So(err, should.BeNil)
 
 	for i, tc := range []struct {
@@ -344,7 +344,7 @@ func TestScheduleAtWithBandDutyCycle(t *testing.T) {
 func TestScheduleAtWithFrequencyPlanDutyCycle(t *testing.T) {
 	a := assertions.New(t)
 	ctx := test.Context()
-	fp := &frequencyplans.FrequencyPlan{
+	fps := []*frequencyplans.FrequencyPlan{&frequencyplans.FrequencyPlan{
 		BandID: band.EU_863_870,
 		SubBands: []frequencyplans.SubBandParameters{
 			{
@@ -356,11 +356,11 @@ func TestScheduleAtWithFrequencyPlanDutyCycle(t *testing.T) {
 		TimeOffAir: frequencyplans.TimeOffAir{
 			Duration: time.Second,
 		},
-	}
+	}}
 	timeSource := &mockTimeSource{
 		Time: time.Unix(0, 0),
 	}
-	scheduler, err := scheduling.NewScheduler(ctx, fp, true, nil, timeSource)
+	scheduler, err := scheduling.NewScheduler(ctx, fps, true, nil, timeSource)
 	a.So(err, should.BeNil)
 
 	for i, tc := range []struct {
@@ -427,7 +427,7 @@ func TestScheduleAtWithFrequencyPlanDutyCycle(t *testing.T) {
 func TestScheduleAnytime(t *testing.T) {
 	a := assertions.New(t)
 	ctx := test.Context()
-	fp := &frequencyplans.FrequencyPlan{
+	fps := []*frequencyplans.FrequencyPlan{&frequencyplans.FrequencyPlan{
 		BandID: band.EU_863_870,
 		TimeOffAir: frequencyplans.TimeOffAir{
 			Duration: time.Second,
@@ -436,8 +436,8 @@ func TestScheduleAnytime(t *testing.T) {
 			Downlinks: boolPtr(true),
 			Duration:  durationPtr(2 * time.Second),
 		},
-	}
-	scheduler, err := scheduling.NewScheduler(ctx, fp, true, nil, nil)
+	}}
+	scheduler, err := scheduling.NewScheduler(ctx, fps, true, nil, nil)
 	a.So(err, should.BeNil)
 	scheduler.SyncWithGatewayAbsolute(0, time.Now(), time.Unix(0, 0))
 
@@ -517,7 +517,7 @@ func TestScheduleAnytime(t *testing.T) {
 func TestScheduleAnytimeShort(t *testing.T) {
 	a := assertions.New(t)
 	ctx := test.Context()
-	fp := &frequencyplans.FrequencyPlan{
+	fps := []*frequencyplans.FrequencyPlan{&frequencyplans.FrequencyPlan{
 		BandID: band.EU_863_870,
 		TimeOffAir: frequencyplans.TimeOffAir{
 			Duration: time.Second,
@@ -526,7 +526,7 @@ func TestScheduleAnytimeShort(t *testing.T) {
 			Downlinks: boolPtr(true),
 			Duration:  durationPtr(2 * time.Second),
 		},
-	}
+	}}
 
 	settingsAt := func(frequency uint64, sf uint32, time *time.Time, timestamp uint32) ttnpb.TxSettings {
 		return ttnpb.TxSettings{
@@ -550,7 +550,7 @@ func TestScheduleAnytimeShort(t *testing.T) {
 		timeSource := &mockTimeSource{
 			Time: time.Now(),
 		}
-		scheduler, err := scheduling.NewScheduler(ctx, fp, true, nil, timeSource)
+		scheduler, err := scheduling.NewScheduler(ctx, fps, true, nil, timeSource)
 		a.So(err, should.BeNil)
 		scheduler.SyncWithGatewayAbsolute(0, timeSource.Time, time.Unix(0, 0))
 		em, err := scheduler.ScheduleAnytime(ctx, 10, settingsAt(869525000, 7, nil, 0), nil, ttnpb.TxSchedulePriority_NORMAL)
@@ -564,7 +564,7 @@ func TestScheduleAnytimeShort(t *testing.T) {
 			Time: time.Now(),
 		}
 		scheduleAnytimeDelay := time.Second
-		scheduler, err := scheduling.NewScheduler(ctx, fp, true, &scheduleAnytimeDelay, timeSource)
+		scheduler, err := scheduling.NewScheduler(ctx, fps, true, &scheduleAnytimeDelay, timeSource)
 		a.So(err, should.BeNil)
 		scheduler.SyncWithGatewayAbsolute(0, timeSource.Time, time.Unix(0, 0))
 		em, err := scheduler.ScheduleAnytime(ctx, 10, settingsAt(869525000, 7, nil, 0), nil, ttnpb.TxSchedulePriority_NORMAL)
@@ -578,7 +578,7 @@ func TestScheduleAnytimeShort(t *testing.T) {
 			Time: time.Now(),
 		}
 		scheduleAnytimeDelay := time.Millisecond
-		scheduler, err := scheduling.NewScheduler(ctx, fp, true, &scheduleAnytimeDelay, timeSource)
+		scheduler, err := scheduling.NewScheduler(ctx, fps, true, &scheduleAnytimeDelay, timeSource)
 		a.So(err, should.BeNil)
 		scheduler.SyncWithGatewayAbsolute(0, timeSource.Time, time.Unix(0, 0))
 		em, err := scheduler.ScheduleAnytime(ctx, 10, settingsAt(869525000, 7, nil, 0), nil, ttnpb.TxSchedulePriority_NORMAL)
@@ -592,7 +592,7 @@ func TestScheduleAnytimeShort(t *testing.T) {
 			Time: time.Now(),
 		}
 		scheduleAnytimeDelay := time.Duration(0)
-		scheduler, err := scheduling.NewScheduler(ctx, fp, true, &scheduleAnytimeDelay, timeSource)
+		scheduler, err := scheduling.NewScheduler(ctx, fps, true, &scheduleAnytimeDelay, timeSource)
 		a.So(err, should.BeNil)
 		scheduler.SyncWithGatewayAbsolute(0, timeSource.Time, time.Unix(0, 0))
 		em, err := scheduler.ScheduleAnytime(ctx, 10, settingsAt(869525000, 7, nil, 0), nil, ttnpb.TxSchedulePriority_NORMAL)
@@ -605,7 +605,7 @@ func TestScheduleAnytimeShort(t *testing.T) {
 		timeSource := &mockTimeSource{
 			Time: time.Now(),
 		}
-		scheduler, err := scheduling.NewScheduler(ctx, fp, true, nil, timeSource)
+		scheduler, err := scheduling.NewScheduler(ctx, fps, true, nil, timeSource)
 		a.So(err, should.BeNil)
 		scheduler.SyncWithGatewayAbsolute(0, timeSource.Time, time.Unix(0, 0))
 		rtts := &mockRTTs{
@@ -622,7 +622,7 @@ func TestScheduleAnytimeShort(t *testing.T) {
 		timeSource := &mockTimeSource{
 			Time: time.Now(),
 		}
-		scheduler, err := scheduling.NewScheduler(ctx, fp, true, nil, timeSource)
+		scheduler, err := scheduling.NewScheduler(ctx, fps, true, nil, timeSource)
 		a.So(err, should.BeNil)
 		scheduler.SyncWithGatewayAbsolute(0, timeSource.Time, time.Unix(0, 0))
 		em, err := scheduler.ScheduleAnytime(ctx, 10, settingsAt(869525000, 7, nil, 100*1000), nil, ttnpb.TxSchedulePriority_NORMAL)
@@ -635,7 +635,7 @@ func TestScheduleAnytimeShort(t *testing.T) {
 		timeSource := &mockTimeSource{
 			Time: time.Now(),
 		}
-		scheduler, err := scheduling.NewScheduler(ctx, fp, true, nil, timeSource)
+		scheduler, err := scheduling.NewScheduler(ctx, fps, true, nil, timeSource)
 		a.So(err, should.BeNil)
 		scheduler.SyncWithGatewayAbsolute(0, timeSource.Time, time.Unix(0, 0))
 		rtts := &mockRTTs{
@@ -651,7 +651,7 @@ func TestScheduleAnytimeShort(t *testing.T) {
 func TestScheduleAnytimeClassC(t *testing.T) {
 	a := assertions.New(t)
 	ctx := test.Context()
-	fp := &frequencyplans.FrequencyPlan{
+	fps := []*frequencyplans.FrequencyPlan{&frequencyplans.FrequencyPlan{
 		BandID: band.EU_863_870,
 		TimeOffAir: frequencyplans.TimeOffAir{
 			Duration: time.Second,
@@ -660,12 +660,12 @@ func TestScheduleAnytimeClassC(t *testing.T) {
 			Downlinks: boolPtr(true),
 			Duration:  durationPtr(2 * time.Second),
 		},
-	}
+	}}
 
 	timeSource := &mockTimeSource{
 		Time: time.Unix(0, 0),
 	}
-	scheduler, err := scheduling.NewScheduler(ctx, fp, true, nil, timeSource)
+	scheduler, err := scheduling.NewScheduler(ctx, fps, true, nil, timeSource)
 	a.So(err, should.BeNil)
 	scheduler.Sync(0, timeSource.Time)
 

--- a/pkg/gatewayserver/scheduling/sub_band.go
+++ b/pkg/gatewayserver/scheduling/sub_band.go
@@ -215,17 +215,8 @@ func (sb *SubBand) ScheduleAnytime(d time.Duration, next func() ConcentratorTime
 
 // HasOverlap checks if the two sub bands have an overlap.
 func (sb *SubBand) HasOverlap(subBand *SubBand) bool {
-	if sb.MinFrequency < subBand.MinFrequency && subBand.MinFrequency < sb.MaxFrequency {
-		return true
-	} else if sb.MinFrequency < subBand.MaxFrequency && subBand.MaxFrequency < sb.MaxFrequency {
-		return true
-	}
-	if subBand.MinFrequency < sb.MinFrequency && sb.MinFrequency < subBand.MaxFrequency {
-		return true
-	} else if subBand.MinFrequency < sb.MaxFrequency && sb.MaxFrequency < subBand.MaxFrequency {
-		return true
-	}
-	return false
+	return subBand.MaxFrequency > sb.MinFrequency && subBand.MinFrequency < sb.MaxFrequency ||
+		subBand.MinFrequency < sb.MaxFrequency && subBand.MaxFrequency > sb.MaxFrequency
 }
 
 // IsIdentical checks if the two sub bands are identical.

--- a/pkg/gatewayserver/scheduling/sub_band.go
+++ b/pkg/gatewayserver/scheduling/sub_band.go
@@ -212,3 +212,23 @@ func (sb *SubBand) ScheduleAnytime(d time.Duration, next func() ConcentratorTime
 	sb.emissions = sb.emissions.Insert(em)
 	return em, nil
 }
+
+// HasOverlap checks if the two sub bands have an overlap.
+func (sb *SubBand) HasOverlap(subBand *SubBand) bool {
+	if sb.MinFrequency < subBand.MinFrequency && subBand.MinFrequency < sb.MaxFrequency {
+		return true
+	} else if sb.MinFrequency < subBand.MaxFrequency && subBand.MaxFrequency < sb.MaxFrequency {
+		return true
+	}
+	if subBand.MinFrequency < sb.MinFrequency && sb.MinFrequency < subBand.MaxFrequency {
+		return true
+	} else if subBand.MinFrequency < sb.MaxFrequency && sb.MaxFrequency < subBand.MaxFrequency {
+		return true
+	}
+	return false
+}
+
+// IsIdentical checks if the two sub bands are identical.
+func (sb *SubBand) IsIdentical(subBand *SubBand) bool {
+	return sb.MinFrequency == subBand.MinFrequency && sb.MaxFrequency == subBand.MaxFrequency
+}

--- a/pkg/gatewayserver/scheduling/util_test.go
+++ b/pkg/gatewayserver/scheduling/util_test.go
@@ -66,6 +66,7 @@ func (r *mockRTTs) Stats() (min, max, median time.Duration, count int) {
 func boolPtr(v bool) *bool                       { return &v }
 func durationPtr(d time.Duration) *time.Duration { return &d }
 func timePtr(t time.Time) *time.Time             { return &t }
+func float32Ptr(v float32) *float32              { return &v }
 
 func init() {
 	scheduling.DutyCycleWindow = 10 * time.Second


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #1824  Add multiple frequency plans support for the Scheduler

#### Changes
<!-- What are the changes made in this pull request? -->

- Ensure that fps have the same `TimeOffAir` value.
- Create a Union of sub bands and check for overlap.
- Check if new emissions respect the DwellTimeRestriction of at least one frequency plan.
- Tests

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This PR is targeted to the `feature/761-multi-fplan-gtw` branch.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
