### PR TITLE
Ignore cluster JS for devices with external JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Respect stack components on different hosts when connected to event sources in the Console.
 - Pagination of search results.
+- Handling OTAA devices registered on an external Join Server in the Console.
 
 ### Security
 


### PR DESCRIPTION
handle the external js properly. do not leak any join fields to the stack join server

<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/1857

#### Changes
<!-- What are the changes made in this pull request? -->

- Augment the `setDevice` method in the device service in the js SDK.


#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Cases to test:
1. Check that a regular otaa device can be created and updated with appropriate js calls
2. Check that otaa device provisioned on an external js can be created/updated without any calls to the cluster js

@johanstokking please check if works as expected
@kschiffer The structure of the whole device service in the sdk is structured in such way that it is very hard to adjust/augment functionality there. I will try to address this while working on https://github.com/TheThingsNetwork/lorawan-stack/issues/1778.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
