### PR TITLE
Automatically reconnect frontends on link failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Channel mask encoding in LinkADR MAC command.
 - Device location and payload formatter form submits in the Console.
 - Events processing in the JS SDK.
+- Application Server frontends getting stuck after their associated link is closed.
 
 ### Security
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -2024,6 +2024,15 @@
       "file": "linking.go"
     }
   },
+  "error:pkg/applicationserver:link_deleted": {
+    "translations": {
+      "en": "link deleted"
+    },
+    "description": {
+      "package": "pkg/applicationserver",
+      "file": "grpc.go"
+    }
+  },
   "error:pkg/applicationserver:link_mode": {
     "translations": {
       "en": "invalid link mode `{value}`"
@@ -2031,6 +2040,15 @@
     "description": {
       "package": "pkg/applicationserver",
       "file": "config.go"
+    }
+  },
+  "error:pkg/applicationserver:link_reset": {
+    "translations": {
+      "en": "link reset"
+    },
+    "description": {
+      "package": "pkg/applicationserver",
+      "file": "grpc.go"
     }
   },
   "error:pkg/applicationserver:listen_frontend": {

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -195,7 +195,7 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 		}
 	}
 
-	if webhooks, err := conf.Webhooks.NewWebhooks(ctx, retryIO); err != nil {
+	if webhooks, err := conf.Webhooks.NewWebhooks(ctx, as); err != nil {
 		return nil, err
 	} else if webhooks != nil {
 		as.webhooks = webhooks
@@ -211,7 +211,7 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 		return nil, err
 	}
 
-	if as.appPackages, err = conf.ApplicationPackages.NewApplicationPackages(ctx, retryIO); err != nil {
+	if as.appPackages, err = conf.ApplicationPackages.NewApplicationPackages(ctx, as); err != nil {
 		return nil, err
 	} else if as.appPackages != nil {
 		as.defaultSubscribers = append(as.defaultSubscribers, as.appPackages.NewSubscription())

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -149,12 +149,13 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 		interopClient: interopCl,
 		interopID:     conf.Interop.ID,
 	}
+	retryIO := io.NewRetryServer(as)
 
 	as.grpc.asDevices = asEndDeviceRegistryServer{
 		AS:       as,
 		kekLabel: conf.DeviceKEKLabel,
 	}
-	as.grpc.appAs = iogrpc.New(as, iogrpc.WithMQTTConfigProvider(as))
+	as.grpc.appAs = iogrpc.New(retryIO, iogrpc.WithMQTTConfigProvider(as))
 
 	ctx, cancel := context.WithCancel(as.Context())
 	defer func() {
@@ -190,11 +191,11 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 					"protocol", endpoint.Protocol(),
 				)
 			}
-			mqtt.Start(ctx, as, lis, version.Format, endpoint.Protocol())
+			mqtt.Start(ctx, retryIO, lis, version.Format, endpoint.Protocol())
 		}
 	}
 
-	if webhooks, err := conf.Webhooks.NewWebhooks(ctx, as); err != nil {
+	if webhooks, err := conf.Webhooks.NewWebhooks(ctx, retryIO); err != nil {
 		return nil, err
 	} else if webhooks != nil {
 		as.webhooks = webhooks
@@ -206,11 +207,11 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 		return nil, err
 	}
 
-	if as.pubsub, err = conf.PubSub.NewPubSub(c, as); err != nil {
+	if as.pubsub, err = conf.PubSub.NewPubSub(c, retryIO); err != nil {
 		return nil, err
 	}
 
-	if as.appPackages, err = conf.ApplicationPackages.NewApplicationPackages(ctx, as); err != nil {
+	if as.appPackages, err = conf.ApplicationPackages.NewApplicationPackages(ctx, retryIO); err != nil {
 		return nil, err
 	} else if as.appPackages != nil {
 		as.defaultSubscribers = append(as.defaultSubscribers, as.appPackages.NewSubscription())

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -275,7 +275,11 @@ func (as *ApplicationServer) Subscribe(ctx context.Context, protocol string, ids
 	sub := io.NewSubscription(ctx, protocol, &ids)
 	l.subscribeCh <- sub
 	go func() {
-		<-sub.Context().Done()
+		select {
+		case <-l.ctx.Done():
+			sub.Disconnect(l.ctx.Err())
+		case <-sub.Context().Done():
+		}
 		l.unsubscribeCh <- sub
 	}()
 	return sub, nil

--- a/pkg/applicationserver/grpc.go
+++ b/pkg/applicationserver/grpc.go
@@ -24,6 +24,11 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 )
 
+var (
+	errLinkDeleted = errors.DefineAborted("link_deleted", "link deleted")
+	errLinkReset   = errors.DefineUnavailable("link_reset", "link reset")
+)
+
 // GetLink implements ttnpb.AsServer.
 func (as *ApplicationServer) GetLink(ctx context.Context, req *ttnpb.GetApplicationLinkRequest) (*ttnpb.ApplicationLink, error) {
 	if err := rights.RequireApplication(ctx, req.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_LINK); err != nil {
@@ -46,7 +51,7 @@ func (as *ApplicationServer) SetLink(ctx context.Context, req *ttnpb.SetApplicat
 	if err != nil {
 		return nil, err
 	}
-	if err := as.cancelLink(ctx, req.ApplicationIdentifiers); err != nil && !errors.IsNotFound(err) {
+	if err := as.cancelLink(ctx, req.ApplicationIdentifiers, errLinkReset); err != nil && !errors.IsNotFound(err) {
 		log.FromContext(ctx).WithError(err).Warn("Failed to cancel link")
 	}
 	as.startLinkTask(as.Context(), req.ApplicationIdentifiers)
@@ -63,7 +68,7 @@ func (as *ApplicationServer) DeleteLink(ctx context.Context, ids *ttnpb.Applicat
 	if err := rights.RequireApplication(ctx, *ids, ttnpb.RIGHT_APPLICATION_LINK); err != nil {
 		return nil, err
 	}
-	if err := as.cancelLink(ctx, *ids); err != nil && !errors.IsNotFound(err) {
+	if err := as.cancelLink(ctx, *ids, errLinkDeleted); err != nil && !errors.IsNotFound(err) {
 		log.FromContext(ctx).WithError(err).Warn("Failed to cancel link")
 	}
 	_, err := as.linkRegistry.Set(ctx, *ids, nil, func(link *ttnpb.ApplicationLink) (*ttnpb.ApplicationLink, []string, error) { return nil, nil, nil })

--- a/pkg/applicationserver/io/grpc/grpc.go
+++ b/pkg/applicationserver/io/grpc/grpc.go
@@ -85,6 +85,8 @@ func (s *impl) Subscribe(ids *ttnpb.ApplicationIdentifiers, stream ttnpb.AppAs_S
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
+		case <-sub.Context().Done():
+			return sub.Context().Err()
 		case up := <-sub.Up():
 			if err := stream.Send(up.ApplicationUp); err != nil {
 				logger.WithError(err).Warn("Failed to send message")

--- a/pkg/applicationserver/io/middleware.go
+++ b/pkg/applicationserver/io/middleware.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -110,53 +110,45 @@ func (rs RetryServer) Subscribe(ctx context.Context, protocol string, ids ttnpb.
 					logger.WithError(err).Warn("Failed to send the uplink downstream")
 				}
 			case <-ctx.Done():
-				{
-					err := ctx.Err()
-					downstreamSub.Disconnect(err)
-					upstreamSub.Disconnect(err)
-					logger.WithError(err).Debug("Parent context cancelled")
-					return
-				}
+				err := ctx.Err()
+				downstreamSub.Disconnect(err)
+				upstreamSub.Disconnect(err)
+				logger.WithError(err).Debug("Parent context canceled")
+				return
 			case <-upstreamSub.Context().Done():
-				{
-					err := upstreamSub.Context().Err()
-					if errors.IsCanceled(err) {
-						logger.Debug("Upstream subscription cancelled. Attempting to resubscribe")
+				err := upstreamSub.Context().Err()
+				if errors.IsUnavailable(err) {
+					logger.Debug("Upstream subscription canceled. Attempting to resubscribe")
 
-						for _, backoff := range rs.backoff {
-							delay := random.Jitter(backoff, rs.jitter)
-
-							select {
-							case <-ctx.Done():
-								err := ctx.Err()
-								logger.WithError(err).Debug("Parent context cancelled while attempting to resubscribe")
-								return
-							case <-downstreamSub.Context().Done():
-								err := downstreamSub.Context().Err()
-								logger.WithError(err).Debug("Downstream subscription cancelled while attempting to resubscribe")
-								return
-							case <-time.After(delay):
-							}
-
-							upstreamSub, err = rs.upstream.Subscribe(ctx, protocol, ids)
-							if err == nil {
-								logger.Debug("Resubscription successful")
-								continue nextUp
-							}
-							logger.WithError(err).WithField("delay", delay).Debug("Resubscription failed")
+					for _, backoff := range rs.backoff {
+						delay := random.Jitter(backoff, rs.jitter)
+						select {
+						case <-ctx.Done():
+							err := ctx.Err()
+							logger.WithError(err).Debug("Parent context canceled while attempting to resubscribe")
+							return
+						case <-downstreamSub.Context().Done():
+							err := downstreamSub.Context().Err()
+							logger.WithError(err).Debug("Downstream subscription canceled while attempting to resubscribe")
+							return
+						case <-time.After(delay):
 						}
+						upstreamSub, err = rs.upstream.Subscribe(ctx, protocol, ids)
+						if err == nil {
+							logger.Debug("Resubscription successful")
+							continue nextUp
+						}
+						logger.WithError(err).WithField("delay", delay).Debug("Resubscription failed")
 					}
-					downstreamSub.Disconnect(err)
-					logger.WithError(err).Debug("Upstream resubscription attempts failed. Downstream subscription cancelled")
-					return
 				}
+				downstreamSub.Disconnect(err)
+				logger.WithError(err).Debug("Upstream resubscription attempts failed. Downstream subscription canceled")
+				return
 			case <-downstreamSub.Context().Done():
-				{
-					err := downstreamSub.Context().Err()
-					upstreamSub.Disconnect(err)
-					logger.WithError(err).Debug("Downstream subscription cancelled")
-					return
-				}
+				err := downstreamSub.Context().Err()
+				upstreamSub.Disconnect(err)
+				logger.WithError(err).Debug("Downstream subscription canceled")
+				return
 			}
 		}
 	}()

--- a/pkg/applicationserver/io/middleware.go
+++ b/pkg/applicationserver/io/middleware.go
@@ -1,0 +1,154 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io
+
+import (
+	"context"
+	"time"
+
+	"go.thethings.network/lorawan-stack/pkg/config"
+	"go.thethings.network/lorawan-stack/pkg/errors"
+	"go.thethings.network/lorawan-stack/pkg/log"
+	"go.thethings.network/lorawan-stack/pkg/random"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+)
+
+var defaultBackoff = []time.Duration{100 * time.Millisecond, 1 * time.Second, 10 * time.Second}
+
+const defaultJitter = 0.15
+
+// RetryServer is a Server that attempts to automatically re-subscribe to the upstream server by
+// proxying Subscribe calls.
+type RetryServer struct {
+	backoff []time.Duration
+	jitter  float64
+
+	upstream Server
+}
+
+// Option represents an option for the retry backend.
+type Option interface {
+	apply(*RetryServer)
+}
+
+// OptionFunc is an option represented by a function.
+type OptionFunc func(*RetryServer)
+
+func (f OptionFunc) apply(rs *RetryServer) {
+	f(rs)
+}
+
+// WithBackoff configures the backoff interval for the reconnection attempts.
+func WithBackoff(backoff []time.Duration) Option {
+	return OptionFunc(func(rs *RetryServer) {
+		rs.backoff = backoff
+	})
+}
+
+// WithJitter configures the jitter to be added to the reconnection attempts.
+func WithJitter(jitter float64) Option {
+	return OptionFunc(func(rs *RetryServer) {
+		rs.jitter = jitter
+	})
+}
+
+// NewRetryServer creates a new RetryServer with the given upstream and options.
+func NewRetryServer(upstream Server, opts ...Option) Server {
+	rs := &RetryServer{
+		backoff:  defaultBackoff,
+		jitter:   defaultJitter,
+		upstream: upstream,
+	}
+	for _, opt := range opts {
+		opt.apply(rs)
+	}
+	return rs
+}
+
+// GetBaseConfig implements Server using the upstream Server.
+func (rs RetryServer) GetBaseConfig(ctx context.Context) config.ServiceBase {
+	return rs.upstream.GetBaseConfig(ctx)
+}
+
+// FillContext implements Server using the upstream Server.
+func (rs RetryServer) FillContext(ctx context.Context) context.Context {
+	return rs.upstream.FillContext(ctx)
+}
+
+// SendUp implements Server using the upstream Server.
+func (rs RetryServer) SendUp(ctx context.Context, up *ttnpb.ApplicationUp) error {
+	return rs.upstream.SendUp(ctx, up)
+}
+
+// Subscribe implements Server by proxying the Subscription object betwen the upstream server and the frontend.
+func (rs RetryServer) Subscribe(ctx context.Context, protocol string, ids ttnpb.ApplicationIdentifiers) (*Subscription, error) {
+	downstreamSub := NewSubscription(ctx, protocol, &ids)
+	upstreamSub, err := rs.upstream.Subscribe(ctx, protocol, ids)
+	if err != nil {
+		return nil, err
+	}
+	go func() {
+		logger := log.FromContext(ctx)
+	nextUp:
+		for {
+			select {
+			case up := <-upstreamSub.Up():
+				{
+					err := downstreamSub.SendUp(up.Context, up.ApplicationUp)
+					if err != nil {
+						logger.WithError(err).Error("Failed to send the uplink downstream")
+					}
+				}
+			case <-upstreamSub.Context().Done():
+				{
+					err := upstreamSub.Context().Err()
+					if errors.IsCanceled(err) {
+						for _, backoff := range rs.backoff {
+							upstreamSub, err = rs.upstream.Subscribe(ctx, protocol, ids)
+							if err == nil {
+								continue nextUp
+							}
+							time.Sleep(random.Jitter(backoff, rs.jitter))
+						}
+					}
+					downstreamSub.Disconnect(err)
+					return
+				}
+			case <-downstreamSub.Context().Done():
+				{
+					err := downstreamSub.Context().Err()
+					upstreamSub.Disconnect(err)
+					return
+				}
+			}
+		}
+	}()
+	return downstreamSub, nil
+}
+
+// DownlinkQueuePush implements Server using the upstream Server.
+func (rs RetryServer) DownlinkQueuePush(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, downlinks []*ttnpb.ApplicationDownlink) error {
+	return rs.upstream.DownlinkQueuePush(ctx, ids, downlinks)
+}
+
+// DownlinkQueueReplace implements Server using the upstream Server.
+func (rs RetryServer) DownlinkQueueReplace(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, downlinks []*ttnpb.ApplicationDownlink) error {
+	return rs.upstream.DownlinkQueueReplace(ctx, ids, downlinks)
+}
+
+// DownlinkQueueList implements Server using the upstream Server.
+func (rs RetryServer) DownlinkQueueList(ctx context.Context, ids ttnpb.EndDeviceIdentifiers) ([]*ttnpb.ApplicationDownlink, error) {
+	return rs.upstream.DownlinkQueueList(ctx, ids)
+}

--- a/pkg/applicationserver/io/middleware.go
+++ b/pkg/applicationserver/io/middleware.go
@@ -50,14 +50,14 @@ func (f OptionFunc) apply(rs *RetryServer) {
 	f(rs)
 }
 
-// WithBackoff configures the backoff interval for the reconnection attempts.
+// WithBackoff configures the backoff interval for the resubscription attempts.
 func WithBackoff(backoff []time.Duration) Option {
 	return OptionFunc(func(rs *RetryServer) {
 		rs.backoff = backoff
 	})
 }
 
-// WithJitter configures the jitter to be added to the reconnection attempts.
+// WithJitter configures the jitter to be added to the resubscription attempts.
 func WithJitter(jitter float64) Option {
 	return OptionFunc(func(rs *RetryServer) {
 		rs.jitter = jitter
@@ -92,7 +92,7 @@ func (rs RetryServer) SendUp(ctx context.Context, up *ttnpb.ApplicationUp) error
 	return rs.upstream.SendUp(ctx, up)
 }
 
-// Subscribe implements Server by proxying the Subscription object betwen the upstream server and the frontend.
+// Subscribe implements Server by proxying the Subscription object between the upstream server and the frontend.
 func (rs RetryServer) Subscribe(ctx context.Context, protocol string, ids ttnpb.ApplicationIdentifiers) (*Subscription, error) {
 	downstreamSub := NewSubscription(ctx, protocol, &ids)
 	upstreamSub, err := rs.upstream.Subscribe(ctx, protocol, ids)

--- a/pkg/applicationserver/io/middleware_internal_test.go
+++ b/pkg/applicationserver/io/middleware_internal_test.go
@@ -1,0 +1,126 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/pkg/applicationserver/io"
+	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/mock"
+	"go.thethings.network/lorawan-stack/pkg/auth/rights"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/pkg/util/test"
+	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
+)
+
+var (
+	registeredApplicationID = ttnpb.ApplicationIdentifiers{ApplicationID: "foo-app"}
+	registeredDeviceID      = ttnpb.EndDeviceIdentifiers{
+		ApplicationIdentifiers: registeredApplicationID,
+		DeviceID:               "foo-device",
+	}
+	registeredApplicationUp = &ttnpb.ApplicationUp{
+		EndDeviceIdentifiers: registeredDeviceID,
+		Up: &ttnpb.ApplicationUp_JoinAccept{
+			JoinAccept: &ttnpb.ApplicationJoinAccept{
+				SessionKeyID: []byte{0x11},
+			},
+		},
+	}
+	timeout     = (1 << 6) * test.Delay
+	backoff     = []time.Duration{(1 << 4) * test.Delay}
+	errConnLost = errors.New("connection lost")
+)
+
+func TestRetryServer(t *testing.T) {
+	a := assertions.New(t)
+	ctx := newContextWithRightsFetcher(test.Context())
+	server := mock.NewServer(nil)
+	retryServer := io.NewRetryServer(server, io.WithBackoff(backoff))
+
+	downstreamSub, err := retryServer.Subscribe(ctx, "foo", registeredApplicationID)
+	if !a.So(err, should.BeNil) {
+		t.FailNow()
+	}
+	a.So(downstreamSub, should.NotBeNil)
+
+	var upstreamSub *io.Subscription
+	select {
+	case <-time.After(timeout):
+		t.Fatal("Upstream subscription did not occur")
+	case upstreamSub = <-server.Subscriptions():
+	}
+
+	// Send uplink traffic from upstream to downstream.
+	err = upstreamSub.SendUp(ctx, registeredApplicationUp)
+	if !a.So(err, should.BeNil) {
+		t.FailNow()
+	}
+	downstreamUp := <-downstreamSub.Up()
+	a.So(downstreamUp.Context, should.HaveParentContextOrEqual, ctx)
+	a.So(downstreamUp.ApplicationUp, should.Resemble, registeredApplicationUp)
+
+	// Cancel upstream subscription gracefully.
+	upstreamSub.Disconnect(nil)
+	select {
+	case <-downstreamSub.Context().Done():
+		t.Fatal("Downstream context has been cancelled")
+	case <-time.After(timeout):
+	}
+
+	// Wait for reconnection.
+	select {
+	case <-time.After(timeout):
+		t.Fatal("Upstream subscription did not occur")
+	case upstreamSub = <-server.Subscriptions():
+	}
+
+	// Send uplink traffic over the reestablished link.
+	err = upstreamSub.SendUp(ctx, registeredApplicationUp)
+	if !a.So(err, should.BeNil) {
+		t.FailNow()
+	}
+	downstreamUp = <-downstreamSub.Up()
+	a.So(downstreamUp.Context, should.HaveParentContextOrEqual, ctx)
+	a.So(downstreamUp.ApplicationUp, should.Resemble, registeredApplicationUp)
+
+	// Shutdown the link completely.
+	server.SetSubscribeError(errConnLost)
+	upstreamSub.Disconnect(nil)
+
+	// Check that the downstream connection failed.
+	select {
+	case <-time.After(timeout):
+		t.Fatal("Waiting for downstream failure timed out")
+	case <-downstreamSub.Context().Done():
+	}
+	err = downstreamSub.Context().Err()
+	a.So(err, should.Equal, errConnLost)
+}
+
+func newContextWithRightsFetcher(ctx context.Context) context.Context {
+	return rights.NewContextWithFetcher(
+		ctx,
+		rights.FetcherFunc(func(ctx context.Context, ids ttnpb.Identifiers) (*ttnpb.Rights, error) {
+			return ttnpb.RightsFrom(
+				ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+			), nil
+		}),
+	)
+}

--- a/pkg/applicationserver/io/middleware_internal_test.go
+++ b/pkg/applicationserver/io/middleware_internal_test.go
@@ -84,7 +84,7 @@ func TestRetryServer(t *testing.T) {
 	case <-time.After(timeout):
 	}
 
-	// Wait for reconnection.
+	// Wait for resubscription.
 	select {
 	case <-time.After(timeout):
 		t.Fatal("Upstream subscription did not occur")

--- a/pkg/applicationserver/io/mqtt/mqtt.go
+++ b/pkg/applicationserver/io/mqtt/mqtt.go
@@ -29,6 +29,7 @@ import (
 	"github.com/TheThingsIndustries/mystique/pkg/topic"
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
+	"go.thethings.network/lorawan-stack/pkg/errorcontext"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/mqtt"
@@ -90,6 +91,7 @@ type connection struct {
 
 func (c *connection) setup(ctx context.Context) error {
 	ctx = auth.NewContextWithInterface(ctx, c)
+	ctx, cancel := errorcontext.New(ctx)
 	c.session = session.New(ctx, c.mqtt, c.deliver)
 	if err := c.session.ReadConnect(); err != nil {
 		return err
@@ -97,7 +99,6 @@ func (c *connection) setup(ctx context.Context) error {
 	ctx = c.io.Context()
 
 	logger := log.FromContext(ctx)
-	errCh := make(chan error)
 	controlCh := make(chan packet.ControlPacket)
 
 	// Read control packets
@@ -108,7 +109,7 @@ func (c *connection) setup(ctx context.Context) error {
 				if err != stdio.EOF {
 					logger.WithError(err).Warn("Error when reading packet")
 				}
-				errCh <- err
+				cancel(err)
 				return
 			}
 			if pkt != nil {
@@ -122,8 +123,12 @@ func (c *connection) setup(ctx context.Context) error {
 	go func() {
 		for {
 			select {
+			case <-ctx.Done():
+				return
 			case <-c.io.Context().Done():
-				logger.WithError(c.io.Context().Err()).Debug("Done sending upstream messages")
+				err := c.io.Context().Err()
+				cancel(err)
+				logger.WithError(err).Debug("Subscription cancelled")
 				return
 			case up := <-c.io.Up():
 				logger := logger.WithField("device_uid", unique.ID(up.Context, up.EndDeviceIdentifiers))
@@ -170,7 +175,8 @@ func (c *connection) setup(ctx context.Context) error {
 		for {
 			var err error
 			select {
-			case err = <-errCh:
+			case <-ctx.Done():
+				return
 			case pkt, ok := <-controlCh:
 				if !ok {
 					controlCh = nil
@@ -190,10 +196,18 @@ func (c *connection) setup(ctx context.Context) error {
 				} else {
 					logger.Info("Disconnected")
 				}
-				c.session.Close()
-				c.io.Disconnect(err)
+				cancel(err)
 				return
 			}
+		}
+	}()
+
+	// Close connection on context closure
+	go func() {
+		select {
+		case <-ctx.Done():
+			c.session.Close()
+			c.mqtt.Close()
 		}
 	}()
 

--- a/pkg/applicationserver/io/mqtt/mqtt.go
+++ b/pkg/applicationserver/io/mqtt/mqtt.go
@@ -128,7 +128,7 @@ func (c *connection) setup(ctx context.Context) error {
 			case <-c.io.Context().Done():
 				err := c.io.Context().Err()
 				cancel(err)
-				logger.WithError(err).Debug("Subscription cancelled")
+				logger.WithError(err).Debug("Subscription canceled")
 				return
 			case up := <-c.io.Up():
 				logger := logger.WithField("device_uid", unique.ID(up.Context, up.EndDeviceIdentifiers))

--- a/pkg/applicationserver/io/pubsub/pubsub.go
+++ b/pkg/applicationserver/io/pubsub/pubsub.go
@@ -269,7 +269,7 @@ func (ps *PubSub) start(ctx context.Context, pb *ttnpb.ApplicationPubSub) (err e
 		return err
 	}
 	go func() {
-		// Close the integration if the subscription is cancelled.
+		// Close the integration if the subscription is canceled.
 		select {
 		case <-i.sub.Context().Done():
 			err := i.sub.Context().Err()

--- a/pkg/applicationserver/io/pubsub/pubsub.go
+++ b/pkg/applicationserver/io/pubsub/pubsub.go
@@ -268,6 +268,15 @@ func (ps *PubSub) start(ctx context.Context, pb *ttnpb.ApplicationPubSub) (err e
 	if err != nil {
 		return err
 	}
+	go func() {
+		// Close the integration if the subscription is cancelled.
+		select {
+		case <-i.sub.Context().Done():
+			err := i.sub.Context().Err()
+			cancel(err)
+		case <-ctx.Done():
+		}
+	}()
 	format, ok := formats[pb.Format]
 	if !ok {
 		return errFormatNotFound.WithAttributes("format", pb.Format)

--- a/pkg/applicationserver/linking.go
+++ b/pkg/applicationserver/linking.go
@@ -220,7 +220,7 @@ func (as *ApplicationServer) link(ctx context.Context, ids ttnpb.ApplicationIden
 		go func() {
 			select {
 			case <-l.ctx.Done():
-				sub.Disconnect(l.ctx.Err())
+				// Default subscriptions should not be canceled on link failures.
 			case <-sub.Context().Done():
 			}
 			l.unsubscribeCh <- sub
@@ -251,12 +251,12 @@ var (
 	errLinkFailed = errors.DefineAborted("link", "link failed")
 )
 
-func (as *ApplicationServer) cancelLink(ctx context.Context, ids ttnpb.ApplicationIdentifiers) error {
+func (as *ApplicationServer) cancelLink(ctx context.Context, ids ttnpb.ApplicationIdentifiers, cause error) error {
 	uid := unique.ID(ctx, ids)
 	if val, ok := as.links.Load(uid); ok {
 		l := val.(*link)
 		log.FromContext(ctx).WithField("application_uid", uid).Debug("Unlink")
-		l.cancel(context.Canceled)
+		l.cancel(cause)
 		<-l.closed
 	} else {
 		as.linkErrors.Delete(uid)
@@ -269,7 +269,12 @@ func (as *ApplicationServer) getLink(ctx context.Context, ids ttnpb.ApplicationI
 	val, ok := as.links.Load(uid)
 	if !ok {
 		if val, ok := as.linkErrors.Load(uid); ok {
-			if err := val.(error); !errors.IsCanceled(err) {
+			err := val.(error)
+			switch {
+			case errors.IsAborted(err):
+			case errors.IsUnavailable(err):
+				break
+			default:
 				return nil, errLinkFailed.WithCause(err)
 			}
 		}

--- a/pkg/applicationserver/linking.go
+++ b/pkg/applicationserver/linking.go
@@ -218,7 +218,11 @@ func (as *ApplicationServer) link(ctx context.Context, ids ttnpb.ApplicationIden
 		sub := sub
 		l.subscribeCh <- sub
 		go func() {
-			<-sub.Context().Done()
+			select {
+			case <-l.ctx.Done():
+				sub.Disconnect(l.ctx.Err())
+			case <-sub.Context().Done():
+			}
 			l.unsubscribeCh <- sub
 		}()
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #1831 

#### Changes
<!-- What are the changes made in this pull request? -->

- Added a new `io.Server` that attempts to reconnect to the upstream server (Application Server) if the subscription fails.
- Subscriptions now automatically disconnect on link failure (before this PR they would just get stuck).

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

None.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
