### PR TITLE
Revert api key display in safe inspector

### DIFF
--- a/pkg/webui/console/containers/api-keys-table/api-keys-table.styl
+++ b/pkg/webui/console/containers/api-keys-table/api-keys-table.styl
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+.key-id
+  font-family: $font-family-mono
+
 .right-tag-group
   display: flex
   justify-content: flex-end

--- a/pkg/webui/console/containers/api-keys-table/index.js
+++ b/pkg/webui/console/containers/api-keys-table/index.js
@@ -17,7 +17,6 @@ import { defineMessages } from 'react-intl'
 
 import Tag from '../../../components/tag'
 import TagGroup from '../../../components/tag/group'
-import SafeInspector from '../../../components/safe-inspector'
 import FetchTable from '../fetch-table'
 import PropTypes from '../../../lib/prop-types'
 import Message from '../../../lib/components/message'
@@ -44,22 +43,20 @@ const headers = [
   {
     name: 'id',
     displayName: m.keyId,
-    width: 35,
-    render(entityId) {
-      return (
-        <SafeInspector noCopyPopup disableResize data={entityId} hideable={false} isBytes={false} />
-      )
+    width: 30,
+    render(id) {
+      return <span className={style.keyId}>{id}</span>
     },
   },
   {
     name: 'name',
     displayName: sharedMessages.name,
-    width: 20,
+    width: 30,
   },
   {
     name: 'rights',
     displayName: m.grantedRights,
-    width: 45,
+    width: 40,
     render(rights) {
       const tags = rights.map(r => (
         <Tag className={style.rightTag} content={formatRight(r)} key={r} />


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #1832 

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove `SafeInspector`
- Adjust the column sizes to reduce the number of displayed API Key ID characters

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- @kschiffer regarding the number of characters displayed, is this satisfying or should it hide more characters? then there should be some logic for hiding characters independent of the column size.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
