### PR TITLE
dev: Fix snap permissions errors for ttn-lw-cli

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -115,11 +115,16 @@ snapcrafts:
     grade: stable
     confinement: strict
     publish: true
+    plugs:
+      personal-files:
+        read:
+        - $HOME/.ttn-lw-stack.yml
+        - $HOME/.ttn-lw-cli.yml
     apps:
       ttn-lw-stack:
-        plugs: [ home, network, network-bind ]
+        plugs: [ home, network, network-bind, personal-files ]
       ttn-lw-cli:
-        plugs: [ home, network, network-bind ]
+        plugs: [ home, network, network-bind, personal-files ]
 
 brews:
   - name: ttn-lw-stack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Crashes on Gateway Server start when traffic flow started while The Things Stack was still starting.
 - Not detecting session change in Application Server when interop Join Server did not provide a `SessionKeyID`.
+- `ttn-lw-stack` and `ttn-lw-cli` file permission errors when installed using snap.
+  - You may need to run `sudo snap connect ttn-lw-stack:personal-files`
 
 ### Security
 

--- a/doc/content/guides/getting-started/cli/_index.md
+++ b/doc/content/guides/getting-started/cli/_index.md
@@ -24,6 +24,7 @@ $ brew install TheThingsNetwork/lorawan-stack/ttn-lw-stack
 ```bash
 $ sudo snap install ttn-lw-stack
 $ sudo snap alias ttn-lw-stack.ttn-lw-cli ttn-lw-cli
+$ sudo snap connect ttn-lw-stack:personal-files      # for $HOME/.ttn-lw-cli.yml
 ```
 
 ### Binaries


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #1670 

#### Changes
<!-- What are the changes made in this pull request? -->

- add `personal-files` plugin, with read permissions for `.ttn-lw-cli.yml` and `.ttn-lw-stack.yml` files

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [X] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [X] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
