### PR TITLE
Fix device id selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handling OTAA devices registered on an external Join Server in the Console.
 - RxMetadata Location field from Gateway Server.
 - Channel mask encoding in LinkADR MAC command.
+- Device location and payload formatter form submits in the Console.
 
 ### Security
 

--- a/pkg/webui/console/store/selectors/devices.js
+++ b/pkg/webui/console/store/selectors/devices.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { GET_DEV_BASE, GET_DEVICES_LIST_BASE } from '../actions/devices'
-import { combineDeviceIds } from '../../../lib/selectors/id'
+import { combineDeviceIds, extractDeviceIdFromCombinedId } from '../../../lib/selectors/id'
 
 import {
   createEventsSelector,
@@ -36,8 +36,11 @@ export const selectDeviceEntitiesStore = state => selectDeviceStore(state).entit
 export const selectDeviceByIds = (state, appId, devId) =>
   selectDeviceById(state, combineDeviceIds(appId, devId))
 export const selectDeviceById = (state, id) => selectDeviceEntitiesStore(state)[id]
-export const selectSelectedDeviceId = state => selectDeviceStore(state).selectedDevice
-export const selectSelectedDevice = state => selectDeviceById(state, selectSelectedDeviceId(state))
+export const selectSelectedDeviceId = state =>
+  extractDeviceIdFromCombinedId(selectDeviceStore(state).selectedDevice)
+export const selectSelectedCombinedDeviceId = state => selectDeviceStore(state).selectedDevice
+export const selectSelectedDevice = state =>
+  selectDeviceById(state, selectSelectedCombinedDeviceId(state))
 export const selectSelectedDeviceFormatters = state => selectSelectedDevice(state).formatters
 export const selectDeviceFetching = createFetchingSelector(GET_DEV_BASE)
 export const selectDeviceError = createErrorSelector(GET_DEV_BASE)

--- a/pkg/webui/lib/selectors/id.js
+++ b/pkg/webui/lib/selectors/id.js
@@ -31,6 +31,15 @@ export const getDeviceId = function(device = {}) {
 }
 
 export const combineDeviceIds = (appId, devId) => `${appId}/${devId}`
+export const extractDeviceIdFromCombinedId = function(combinedId) {
+  if (typeof combinedId === 'string') {
+    const parts = combinedId.split('/')
+    if (parts.length === 2) {
+      return parts[1]
+    }
+  }
+  return combinedId
+}
 export const getCombinedDeviceId = function(device = {}) {
   const appId = getByPath(device, 'ids.application_ids.application_id')
   const devId = getByPath(device, 'ids.device_id')


### PR DESCRIPTION
#### Summary
This quickfix PR will fix a faulty device ID selector, which returns a combined ID of the application and device instead of just the device (introduced via #1772). This lead to some issues like device location settings being broken.

#### Changes
- Ensure that the selector returns only the device ID
- Add a combined id selector, needed for store logic

#### Notes for Reviewers
Together with #1887, this will fix saving location settings for devices, which was reported broken recently. Device payload format settings were also affected by this.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
