### PR TITLE
Various GS-related timing fixes

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -3437,6 +3437,15 @@
       "file": "io.go"
     }
   },
+  "error:pkg/gatewayserver/io:no_gps_sync": {
+    "translations": {
+      "en": "gateway time is not GPS synchronized"
+    },
+    "description": {
+      "package": "pkg/gatewayserver/io",
+      "file": "io.go"
+    }
+  },
   "error:pkg/gatewayserver/io:no_rx_delay": {
     "translations": {
       "en": "no Rx delay provided for class A downlink"

--- a/pkg/encoding/lorawan/mac_test.go
+++ b/pkg/encoding/lorawan/mac_test.go
@@ -259,7 +259,7 @@ func TestLoRaWANEncodingMAC(t *testing.T) {
 		{
 			"DeviceTimeAns",
 			&ttnpb.MACCommand_DeviceTimeAns{
-				Time: gpstime.Parse(0x42ffffff).Add(0x42 * time.Duration(math.Pow(0.5, 8)*float64(time.Second))).UTC(),
+				Time: gpstime.Parse(0x42ffffff*time.Second + 0x42*time.Duration(math.Pow(0.5, 8)*float64(time.Second))).UTC(),
 			},
 			[]byte{0x0D, 0xff, 0xff, 0xff, 0x42, 0x42},
 			false,
@@ -342,7 +342,7 @@ func TestLoRaWANEncodingMAC(t *testing.T) {
 		{
 			"BeaconFreqReq",
 			&ttnpb.MACCommand_BeaconFreqReq{
-				Frequency: 0x1a2bff9c, // 0x42ffff * 100
+				Frequency: 0x42ffff * 100,
 			},
 			[]byte{0x13, 0xff, 0xff, 0x42},
 			false,

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -372,8 +372,9 @@ func (c *Connection) ScheduleDown(path *ttnpb.DownlinkPath, msg *ttnpb.DownlinkM
 			rxErrs = append(rxErrs, errRxWindowSchedule.WithCause(err).WithAttributes("window", i+1))
 			continue
 		}
-		settings.Time = nil
-		settings.Timestamp = uint32(time.Duration(em.Starts()) / time.Microsecond)
+		if settings.Time == nil {
+			settings.Timestamp = uint32(time.Duration(em.Starts()) / time.Microsecond)
+		}
 		msg.Settings = &ttnpb.DownlinkMessage_Scheduled{
 			Scheduled: &settings,
 		}

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -213,6 +213,7 @@ var (
 	errNotAllowed       = errors.DefineFailedPrecondition("not_allowed", "downlink not allowed")
 	errNotTxRequest     = errors.DefineInvalidArgument("not_tx_request", "downlink message is not a Tx request")
 	errNoAbsoluteTime   = errors.DefineInvalidArgument("no_absolute_time", "no absolute time provided for class B downlink")
+	errNoGPSSync        = errors.DefineFailedPrecondition("no_gps_sync", "gateway time is not GPS synchronized")
 	errNoRxDelay        = errors.DefineInvalidArgument("no_rx_delay", "no Rx delay provided for class A downlink")
 	errNoUplinkToken    = errors.DefineInvalidArgument("no_uplink_token", "no uplink token provided for class A downlink")
 	errDownlinkPath     = errors.DefineInvalidArgument("downlink_path", "invalid downlink path")
@@ -354,6 +355,10 @@ func (c *Connection) ScheduleDown(path *ttnpb.DownlinkPath, msg *ttnpb.DownlinkM
 			if request.AbsoluteTime == nil {
 				return 0, errNoAbsoluteTime
 			}
+			if !c.scheduler.IsGatewayTimeSynced() {
+				rxErrs = append(rxErrs, errNoGPSSync)
+				continue
+			}
 			f = c.scheduler.ScheduleAt
 			settings.Time = request.AbsoluteTime
 		case ttnpb.CLASS_C:
@@ -372,8 +377,11 @@ func (c *Connection) ScheduleDown(path *ttnpb.DownlinkPath, msg *ttnpb.DownlinkM
 			rxErrs = append(rxErrs, errRxWindowSchedule.WithCause(err).WithAttributes("window", i+1))
 			continue
 		}
-		if settings.Time == nil {
+		if settings.Time == nil || !c.scheduler.IsGatewayTimeSynced() {
+			settings.Time = nil
 			settings.Timestamp = uint32(time.Duration(em.Starts()) / time.Microsecond)
+		} else {
+			settings.Timestamp = 0
 		}
 		msg.Settings = &ttnpb.DownlinkMessage_Scheduled{
 			Scheduled: &settings,

--- a/pkg/gatewayserver/scheduling/scheduler.go
+++ b/pkg/gatewayserver/scheduling/scheduler.go
@@ -349,6 +349,14 @@ func (s *Scheduler) SyncWithGatewayConcentrator(timestamp uint32, server time.Ti
 	s.mu.Unlock()
 }
 
+// IsGatewayTimeSynced reports whether scheduler clock is synchronized with gateway time.
+func (s *Scheduler) IsGatewayTimeSynced() bool {
+	s.mu.RLock()
+	ret := s.clock.IsSynced() && s.clock.gateway != nil
+	s.mu.RUnlock()
+	return ret
+}
+
 // Now returns an indication of the current concentrator time.
 // This method returns false if the clock is not synced with the server.
 func (s *Scheduler) Now() (ConcentratorTime, bool) {

--- a/pkg/gpstime/gpstime_internal_test.go
+++ b/pkg/gpstime/gpstime_internal_test.go
@@ -16,15 +16,22 @@ package gpstime
 
 import (
 	"testing"
+	"time"
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 )
 
-func TestIsGPSLeap(t *testing.T) {
+func TestIsLeapSecond(t *testing.T) {
 	a := assertions.New(t)
 	for _, v := range leaps {
-		a.So(IsLeap(v), should.BeTrue)
-		a.So(IsLeap(v+1), should.BeFalse)
+		a.So(IsLeapSecond(time.Duration(v)*time.Second-time.Millisecond), should.BeFalse)
+		a.So(IsLeapSecond(time.Duration(v)*time.Second-time.Microsecond), should.BeFalse)
+		a.So(IsLeapSecond(time.Duration(v)*time.Second-time.Nanosecond), should.BeFalse)
+		a.So(IsLeapSecond(time.Duration(v)*time.Second), should.BeTrue)
+		a.So(IsLeapSecond(time.Duration(v)*time.Second+time.Nanosecond), should.BeTrue)
+		a.So(IsLeapSecond(time.Duration(v)*time.Second+time.Microsecond), should.BeTrue)
+		a.So(IsLeapSecond(time.Duration(v)*time.Second+999*time.Millisecond), should.BeTrue)
+		a.So(IsLeapSecond(time.Duration(v)*time.Second+time.Second), should.BeFalse)
 	}
 }

--- a/pkg/ttnpb/udp/translation.go
+++ b/pkg/ttnpb/udp/translation.go
@@ -193,6 +193,7 @@ func convertUplink(rx RxPacket, md UpstreamMetadata) (ttnpb.UplinkMessage, error
 		for _, md := range up.RxMetadata {
 			md.Time = &goTime
 		}
+		up.Settings.Time = &goTime
 	}
 
 	up.Settings.DataRate = rx.DatR.DataRate

--- a/pkg/ttnpb/udp/translation.go
+++ b/pkg/ttnpb/udp/translation.go
@@ -325,8 +325,8 @@ func ToDownlinkMessage(tx *TxPacket) (*ttnpb.DownlinkMessage, error) {
 		scheduled.CodingRate = tx.CodR
 	}
 	if tx.Time != nil {
-		gpsTime := gpstime.Parse(int64(*tx.Tmms))
-		scheduled.Time = &gpsTime
+		t := gpstime.Parse(time.Duration(*tx.Tmms) * time.Millisecond)
+		scheduled.Time = &t
 	}
 	buf, err := base64.RawStdEncoding.DecodeString(strings.TrimRight(tx.Data, "="))
 	if err != nil {
@@ -356,8 +356,8 @@ func FromDownlinkMessage(msg *ttnpb.DownlinkMessage) (*TxPacket, error) {
 		Tmst: scheduled.Timestamp,
 	}
 	if scheduled.Time != nil {
-		gpsTime := uint64(gpstime.ToGPS(*scheduled.Time))
-		tx.Tmms = &gpsTime
+		t := uint64(gpstime.ToGPS(*scheduled.Time) / time.Millisecond)
+		tx.Tmms = &t
 	} else if scheduled.Timestamp == 0 {
 		tx.Imme = true
 	}

--- a/pkg/ttnpb/udp/translation_test.go
+++ b/pkg/ttnpb/udp/translation_test.go
@@ -260,6 +260,9 @@ func TestToGatewayUpRawMultiAntenna(t *testing.T) {
 	err := json.Unmarshal(rx, &rxData)
 	a.So(err, should.BeNil)
 
+	utcTime := timePtr(time.Date(2017, 7, 4, 13, 51, 17, 997099000, time.UTC))
+	const timestamp = 879148780
+
 	up, err := udp.ToGatewayUp(rxData, udp.UpstreamMetadata{ID: ids})
 	a.So(err, should.BeNil)
 	a.So(up, should.Resemble, &ttnpb.GatewayUp{
@@ -277,7 +280,8 @@ func TestToGatewayUpRawMultiAntenna(t *testing.T) {
 					},
 					CodingRate: "4/5",
 					Frequency:  868500000,
-					Timestamp:  879148780,
+					Time:       utcTime,
+					Timestamp:  timestamp,
 				},
 				RxMetadata: []*ttnpb.RxMetadata{
 					{
@@ -286,8 +290,8 @@ func TestToGatewayUpRawMultiAntenna(t *testing.T) {
 						},
 						AntennaIndex:                0,
 						ChannelIndex:                7,
-						Time:                        timePtr(time.Date(2017, 7, 4, 13, 51, 17, 997099000, time.UTC)),
-						Timestamp:                   879148780,
+						Time:                        utcTime,
+						Timestamp:                   timestamp,
 						FineTimestamp:               1255738435,
 						EncryptedFineTimestamp:      []byte{0xe3, 0x64, 0x0c, 0xcc, 0xe9, 0x58, 0x49, 0x23, 0xcc, 0x31, 0xea, 0x95, 0x3e, 0xb6, 0x34, 0x7d},
 						EncryptedFineTimestampKeyID: "42",
@@ -304,8 +308,8 @@ func TestToGatewayUpRawMultiAntenna(t *testing.T) {
 						},
 						AntennaIndex:                1,
 						ChannelIndex:                23,
-						Time:                        timePtr(time.Date(2017, 7, 4, 13, 51, 17, 997099000, time.UTC)),
-						Timestamp:                   879148780,
+						Time:                        utcTime,
+						Timestamp:                   timestamp,
 						FineTimestamp:               1252538436,
 						EncryptedFineTimestamp:      []byte{0x76, 0x31, 0xa2, 0x4b, 0x33, 0x82, 0xfa, 0x00, 0x93, 0xee, 0xf4, 0x4f, 0xbf, 0xbf, 0x80, 0xb3},
 						EncryptedFineTimestampKeyID: "42",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Refs #1611 

#### Changes
<!-- What are the changes made in this pull request? -->

- Support nanosecond precision in `gpstime` (a.k.a use `time.Duration`)
- Actually set `Settings.Time` from gateway RX packets.
- Use milisecond precision in `tmms` as specified in https://github.com/Lora-net/packet_forwarder/blob/d0226eae6e7b6bbaec6117d0d2372bf17819c438/PROTOCOL.TXT#L134
- Only set `Timestamp`(`tmst`) in downlink on GS if `Time` is not present

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

These are necessary for #1611
GS did not use `tmms` field at all up to now as far as I understand, so no reason to update changelog?

@johanstokking is the main reviewer
@KrishnaIyer please take a quick look at GS as well

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
