### PR TITLE
Fix rendering of favicon tip

### DIFF
--- a/doc/content/guides/branding/_index.md
+++ b/doc/content/guides/branding/_index.md
@@ -16,21 +16,24 @@ The title, subtitle and description of the login pages and the console can be ch
 
 It is possible to change the logos of the web UI by changing the "branding base URL" to a location that contains the following files:
 
-| **Filename**           | **Size** | **Purpose**                                                                   |
-| ---------------------- | -------- | ----------------------------------------------------------------------------- |
-| console-favicon.ico    | multiple | The logo for the console that is shown in browser tabs and bookmarks.         |
-| console-og-image.png   | 1200x600 | The logo for the console that is shown when sharing links on social media     |
-| console-touch-icon.png | 400x400  | The logo for the console that is shown mobile devices                         |
-| logo.svg               | vector   | The logo for the console that is shown in the menu bar of the console         |
-| oauth-favicon.ico      | multiple | The logo for the login pages that is shown in browser tabs and bookmarks      |
+| **Filename**           | **Size** | **Purpose** |
+| ---------------------- | -------- | ----------- |
+| console-favicon.ico    | multiple | The logo for the console that is shown in browser tabs and bookmarks |
+| console-og-image.png   | 1200x600 | The logo for the console that is shown when sharing links on social media |
+| console-touch-icon.png | 400x400  | The logo for the console that is shown mobile devices |
+| logo.svg               | vector   | The logo for the console that is shown in the menu bar of the console |
+| oauth-favicon.ico      | multiple | The logo for the login pages that is shown in browser tabs and bookmarks |
 | oauth-og-image.png     | 1200x600 | The logo for the login pages that is shown when sharing links on social media |
-| oauth-touch-icon.png   | 400x400  | The logo for the login pages that is shown mobile devices                     |
+| oauth-touch-icon.png   | 400x400  | The logo for the login pages that is shown mobile devices |
 
 If the "branding base URL" option is set, "logo.svg" is used to display a secondary logo next to the logo of The Things Stack for LoRaWAN. It is recommended to use a logo with a wide (e.g. 5:1) or square (1:1) aspect ratio. Tall logos (e.g. 1:5; height larger than width) will be displayed very small, due to the limited height of the header bar.
 
 For the exact configuration options that are required to set a custom "branding base URL", see the [Identity Server configuration reference]({{< ref "/reference/configuration/identity-server#oauth-ui-options" >}}) and the [Console configuration reference]({{< ref "/reference/configuration/console" >}}).
 
-#### Hint
-
-If you have your favicon as a PNG, use ImageMagick to convert it to ICO:
-\$ convert console-favicon.png -define icon:auto-resize=64,48,32,16 console-favicon.ico
+> **TIP:** If you have your favicon as a PNG, use ImageMagick to convert it to ICO:
+> 
+> ```bash
+> $ convert console-favicon.png \
+>     -define icon:auto-resize=64,48,32,16 \
+>     console-favicon.ico
+> ```


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quickfix for how the "favicon" tip is rendered to HTML.

It also removes unnecessary spacing at the end of the table.