### PR TITLE
Fix propagation of order flag in EndDevice search

### DIFF
--- a/cmd/ttn-lw-cli/commands/flags.go
+++ b/cmd/ttn-lw-cli/commands/flags.go
@@ -182,6 +182,7 @@ func getSearchEndDevicesRequest(flagSet *pflag.FlagSet) (req *ttnpb.SearchEndDev
 		DevAddrContains:     devAddrContains,
 		Limit:               baseReq.Limit,
 		Page:                baseReq.Page,
+		Order:               baseReq.Order,
 	}, opt, getTotal
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This quickfix resolves the issue of the CLI not propagating the "order" flag in EndDevice search.

I verified that sorting and pagination works correctly with the CLI, so I don't know what else we can do for your issue #1814, @kschiffer