### PR TITLE
Remove obsolete pagination fields from headers

### DIFF
--- a/pkg/identityserver/store/pagination.go
+++ b/pkg/identityserver/store/pagination.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	"github.com/jinzhu/gorm"
-	"go.thethings.network/lorawan-stack/pkg/rpcmetadata"
 )
 
 type paginationOptionsKeyType struct{}
@@ -36,13 +35,6 @@ type paginationOptions struct {
 // WithPagination instructs the store to paginate the results, and set the total
 // number of results into total.
 func WithPagination(ctx context.Context, limit, page uint32, total *uint64) context.Context {
-	md := rpcmetadata.FromIncomingContext(ctx)
-	if limit == 0 && md.Limit != 0 {
-		limit = uint32(md.Limit)
-	}
-	if page == 0 && md.Page != 0 {
-		page = uint32(md.Page)
-	}
 	if page == 0 {
 		page = 1
 	}

--- a/pkg/identityserver/store/pagination_test.go
+++ b/pkg/identityserver/store/pagination_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/smartystreets/assertions"
 	"github.com/smartystreets/assertions/should"
-	"go.thethings.network/lorawan-stack/pkg/rpcmetadata"
 	"go.thethings.network/lorawan-stack/pkg/util/test"
 )
 
@@ -28,53 +27,44 @@ func TestPagination(t *testing.T) {
 	a := assertions.New(t)
 
 	for _, tc := range []struct {
-		md     rpcmetadata.MD
-		limit  uint64
-		offset uint64
+		limit          uint32
+		page           uint32
+		expectedLimit  uint64
+		expectedOffset uint64
 	}{
 		{
-			md:     rpcmetadata.MD{Limit: 10, Page: 1},
-			limit:  10,
-			offset: 0,
+			limit:          0,
+			page:           0,
+			expectedLimit:  0,
+			expectedOffset: 0,
 		},
 		{
-			md:     rpcmetadata.MD{Limit: 10, Page: 2},
-			limit:  10,
-			offset: 10,
+			limit:          10,
+			page:           0,
+			expectedLimit:  10,
+			expectedOffset: 0,
 		},
 		{
-			md:     rpcmetadata.MD{Limit: 10, Page: 3},
-			limit:  10,
-			offset: 20,
+			limit:          10,
+			page:           1,
+			expectedLimit:  10,
+			expectedOffset: 0,
 		},
 		{
-			md:     rpcmetadata.MD{Limit: 0, Page: 1},
-			limit:  0,
-			offset: 0,
-		},
-		{
-			md:     rpcmetadata.MD{Limit: 0, Page: 2},
-			limit:  0,
-			offset: 0,
+			limit:          10,
+			page:           2,
+			expectedLimit:  10,
+			expectedOffset: 10,
 		},
 	} {
-		t.Run(fmt.Sprintf("limitAndOffsetFromContext, limit:%v, offset:%v", tc.md.Limit, tc.md.Page),
+		t.Run(fmt.Sprintf("limitAndOffsetFromContext, limit:%v, offset:%v", tc.limit, tc.page),
 			func(t *testing.T) {
-				ctx := tc.md.ToIncomingContext(test.Context())
-
-				ctx = WithPagination(ctx, 0, 0, nil)
+				ctx := WithPagination(test.Context(), tc.limit, tc.page, nil)
 
 				limit, offset := limitAndOffsetFromContext(ctx)
 
-				a.So(limit, should.Equal, tc.limit)
-				a.So(offset, should.Equal, tc.offset)
-
-				ctx = WithPagination(test.Context(), uint32(tc.md.Limit), uint32(tc.md.Page), nil)
-
-				limit, offset = limitAndOffsetFromContext(ctx)
-
-				a.So(limit, should.Equal, tc.limit)
-				a.So(offset, should.Equal, tc.offset)
+				a.So(limit, should.Equal, tc.expectedLimit)
+				a.So(offset, should.Equal, tc.expectedOffset)
 			},
 		)
 	}

--- a/pkg/redis/pagination.go
+++ b/pkg/redis/pagination.go
@@ -16,8 +16,6 @@ package redis
 
 import (
 	"context"
-
-	"go.thethings.network/lorawan-stack/pkg/rpcmetadata"
 )
 
 type paginationOptionsKeyType struct{}
@@ -32,13 +30,6 @@ type paginationOptions struct {
 
 // NewContextWithPagination instructs the store to paginate the results.
 func NewContextWithPagination(ctx context.Context, limit, page int64, total *int64) context.Context {
-	md := rpcmetadata.FromIncomingContext(ctx)
-	if limit == 0 && md.Limit != 0 {
-		limit = int64(md.Limit)
-	}
-	if page == 0 && md.Page != 0 {
-		page = int64(md.Page)
-	}
 	if page == 0 {
 		page = 1
 	}

--- a/pkg/redis/pagination_test.go
+++ b/pkg/redis/pagination_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/smartystreets/assertions"
 	"github.com/smartystreets/assertions/should"
 	"go.thethings.network/lorawan-stack/pkg/redis"
-	"go.thethings.network/lorawan-stack/pkg/rpcmetadata"
 	"go.thethings.network/lorawan-stack/pkg/util/test"
 )
 
@@ -29,53 +28,44 @@ func TestPagination(t *testing.T) {
 	a := assertions.New(t)
 
 	for _, tc := range []struct {
-		md     rpcmetadata.MD
-		limit  int64
-		offset int64
+		limit          int64
+		page           int64
+		expectedLimit  uint64
+		expectedOffset uint64
 	}{
 		{
-			md:     rpcmetadata.MD{Limit: 10, Page: 1},
-			limit:  10,
-			offset: 0,
+			limit:          0,
+			page:           0,
+			expectedLimit:  0,
+			expectedOffset: 0,
 		},
 		{
-			md:     rpcmetadata.MD{Limit: 10, Page: 2},
-			limit:  10,
-			offset: 10,
+			limit:          10,
+			page:           0,
+			expectedLimit:  10,
+			expectedOffset: 0,
 		},
 		{
-			md:     rpcmetadata.MD{Limit: 10, Page: 3},
-			limit:  10,
-			offset: 20,
+			limit:          10,
+			page:           1,
+			expectedLimit:  10,
+			expectedOffset: 0,
 		},
 		{
-			md:     rpcmetadata.MD{Limit: 0, Page: 1},
-			limit:  0,
-			offset: 0,
-		},
-		{
-			md:     rpcmetadata.MD{Limit: 0, Page: 2},
-			limit:  0,
-			offset: 0,
+			limit:          10,
+			page:           2,
+			expectedLimit:  10,
+			expectedOffset: 10,
 		},
 	} {
-		t.Run(fmt.Sprintf("limitAndOffsetFromContext, limit:%v, offset:%v", tc.md.Limit, tc.md.Page),
+		t.Run(fmt.Sprintf("limitAndOffsetFromContext, limit:%v, offset:%v", tc.limit, tc.page),
 			func(t *testing.T) {
-				ctx := tc.md.ToIncomingContext(test.Context())
-
-				ctx = redis.NewContextWithPagination(ctx, 0, 0, nil)
+				ctx := redis.NewContextWithPagination(test.Context(), tc.limit, tc.page, nil)
 
 				limit, offset := redis.PaginationLimitAndOffsetFromContext(ctx)
 
-				a.So(limit, should.Equal, tc.limit)
-				a.So(offset, should.Equal, tc.offset)
-
-				ctx = redis.NewContextWithPagination(test.Context(), int64(tc.md.Limit), int64(tc.md.Page), nil)
-
-				limit, offset = redis.PaginationLimitAndOffsetFromContext(ctx)
-
-				a.So(limit, should.Equal, tc.limit)
-				a.So(offset, should.Equal, tc.offset)
+				a.So(limit, should.Equal, tc.expectedLimit)
+				a.So(offset, should.Equal, tc.expectedOffset)
 			},
 		)
 	}

--- a/pkg/rpcmetadata/metadata.go
+++ b/pkg/rpcmetadata/metadata.go
@@ -17,7 +17,6 @@ package rpcmetadata
 
 import (
 	"context"
-	"strconv"
 	"strings"
 
 	"google.golang.org/grpc/metadata"
@@ -32,12 +31,6 @@ type MD struct {
 	ServiceVersion string
 	NetAddress     string
 	AllowInsecure  bool
-
-	// Limit is the limit of elements to display per-page.
-	Limit uint64
-
-	// Page is the page of elements to display.
-	Page uint64
 
 	// Host is the hostname the request is directed to.
 	Host string
@@ -74,12 +67,6 @@ func (m MD) ToMetadata() metadata.MD {
 	}
 	if m.URI != "" {
 		pairs = append(pairs, "uri", m.URI)
-	}
-	if m.Limit != 0 {
-		pairs = append(pairs, "limit", strconv.FormatUint(m.Limit, 10))
-	}
-	if m.Page != 0 {
-		pairs = append(pairs, "page", strconv.FormatUint(m.Page, 10))
 	}
 	return metadata.Pairs(pairs...)
 }
@@ -122,12 +109,6 @@ func FromMetadata(md metadata.MD) (m MD) {
 	}
 	if uri, ok := md["uri"]; ok && len(uri) > 0 {
 		m.URI = uri[len(uri)-1]
-	}
-	if limit, ok := md["limit"]; ok && len(limit) > 0 {
-		m.Limit, _ = strconv.ParseUint(limit[len(limit)-1], 10, 64)
-	}
-	if page, ok := md["page"]; ok && len(page) > 0 {
-		m.Page, _ = strconv.ParseUint(page[len(page)-1], 10, 64)
 	}
 	return
 }

--- a/pkg/rpcmetadata/metadata_test.go
+++ b/pkg/rpcmetadata/metadata_test.go
@@ -34,8 +34,6 @@ func TestMD(t *testing.T) {
 		ServiceType:    "component",
 		ServiceVersion: "1.2.3-dev",
 		NetAddress:     "localhost",
-		Limit:          12,
-		Page:           34,
 		Host:           "hostfoo",
 		URI:            "fooURI",
 	}
@@ -51,8 +49,6 @@ func TestMD(t *testing.T) {
 	a.So(md2.ServiceType, should.Equal, md1.ServiceType)
 	a.So(md2.ServiceVersion, should.Equal, md1.ServiceVersion)
 	a.So(md2.NetAddress, should.Equal, md1.NetAddress)
-	a.So(md2.Limit, should.Equal, md1.Limit)
-	a.So(md2.Page, should.Equal, md1.Page)
 	a.So(md2.Host, should.Equal, md1.Host)
 	a.So(md2.URI, should.Equal, md1.URI)
 

--- a/pkg/rpcmetadata/request_test.go
+++ b/pkg/rpcmetadata/request_test.go
@@ -37,8 +37,6 @@ func TestRequestMetadata(t *testing.T) {
 		ServiceType:    "component",
 		ServiceVersion: "1.2.3-dev",
 		NetAddress:     "localhost",
-		Limit:          12,
-		Page:           34,
 		Host:           "hostfoo",
 		URI:            "fooURI",
 	}

--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"os"
 	"runtime/debug"
-	"strconv"
 	"time"
 
 	"github.com/getsentry/raven-go"
@@ -195,14 +194,6 @@ func New(ctx context.Context, opts ...Option) *Server {
 				Host: req.Host,
 				URI:  req.RequestURI,
 			}
-
-			q := req.URL.Query()
-			md.Page, _ = strconv.ParseUint(q.Get("page"), 10, 64)
-			if md.Page == 0 {
-				md.Page = 1
-			}
-			md.Limit, _ = strconv.ParseUint(q.Get("limit"), 10, 64)
-
 			return md.ToMetadata()
 		}),
 		runtime.WithOutgoingHeaderMatcher(func(s string) (string, bool) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request removes the obsolete limit and offset from the rpc metadata. These fields are always part of the request messages, and extracting them from the header as well was causing issues with pagination.

This should fix #1814.

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove `Limit` and `Offset` fields from `rpcmetadta.MD`
- Remove all remaining usage

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
