### PR TITLE
Fix exact prop default value

### DIFF
--- a/pkg/webui/components/navigation/side/item/__snapshots__/index_test.js.snap
+++ b/pkg/webui/components/navigation/side/item/__snapshots__/index_test.js.snap
@@ -14,7 +14,7 @@ exports[`SideNavigationItem is collapsable should match snapshot 1`] = `
   >
     <SideNavigationItem
       depth={0}
-      exact={true}
+      exact={false}
       isActive={false}
       isMinimized={false}
       location={
@@ -27,7 +27,7 @@ exports[`SideNavigationItem is collapsable should match snapshot 1`] = `
     />
     <SideNavigationItem
       depth={0}
-      exact={true}
+      exact={false}
       isActive={false}
       isMinimized={false}
       location={
@@ -48,7 +48,7 @@ exports[`SideNavigationItem is flat should match snapshot 1`] = `
 >
   <LinkItem
     depth={0}
-    exact={true}
+    exact={false}
     path="/test-title"
     title="test-title"
   />

--- a/pkg/webui/components/navigation/side/item/index.js
+++ b/pkg/webui/components/navigation/side/item/index.js
@@ -49,7 +49,7 @@ export class SideNavigationItem extends React.PureComponent {
   static defaultProps = {
     className: undefined,
     children: undefined,
-    exact: true,
+    exact: false,
     icon: undefined,
     isActive: false,
     isMinimized: false,


### PR DESCRIPTION
#### Summary
This quickfix PR fixes a faulty default value for the `exact` props of side navigation items.

#### Changes
- Fix default prop

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
