### PR TITLE
Fix AS goroutine leak

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -2024,15 +2024,6 @@
       "file": "linking.go"
     }
   },
-  "error:pkg/applicationserver:link_deleted": {
-    "translations": {
-      "en": "link deleted"
-    },
-    "description": {
-      "package": "pkg/applicationserver",
-      "file": "grpc.go"
-    }
-  },
   "error:pkg/applicationserver:link_mode": {
     "translations": {
       "en": "invalid link mode `{value}`"
@@ -2040,15 +2031,6 @@
     "description": {
       "package": "pkg/applicationserver",
       "file": "config.go"
-    }
-  },
-  "error:pkg/applicationserver:link_reset": {
-    "translations": {
-      "en": "link reset"
-    },
-    "description": {
-      "package": "pkg/applicationserver",
-      "file": "grpc.go"
     }
   },
   "error:pkg/applicationserver:listen_frontend": {

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -278,7 +278,10 @@ func (as *ApplicationServer) Subscribe(ctx context.Context, protocol string, ids
 	go func() {
 		select {
 		case <-l.ctx.Done():
+			// Disconnect the subscription in order to avoid leaking it,
+			// and skip the unsubscribe channel since it will get closed.
 			sub.Disconnect(l.ctx.Err())
+			return
 		case <-sub.Context().Done():
 		}
 		l.unsubscribeCh <- sub

--- a/pkg/applicationserver/grpc.go
+++ b/pkg/applicationserver/grpc.go
@@ -24,11 +24,6 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 )
 
-var (
-	errLinkDeleted = errors.DefineAborted("link_deleted", "link deleted")
-	errLinkReset   = errors.DefineUnavailable("link_reset", "link reset")
-)
-
 // GetLink implements ttnpb.AsServer.
 func (as *ApplicationServer) GetLink(ctx context.Context, req *ttnpb.GetApplicationLinkRequest) (*ttnpb.ApplicationLink, error) {
 	if err := rights.RequireApplication(ctx, req.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_LINK); err != nil {
@@ -51,7 +46,7 @@ func (as *ApplicationServer) SetLink(ctx context.Context, req *ttnpb.SetApplicat
 	if err != nil {
 		return nil, err
 	}
-	if err := as.cancelLink(ctx, req.ApplicationIdentifiers, errLinkReset); err != nil && !errors.IsNotFound(err) {
+	if err := as.cancelLink(ctx, req.ApplicationIdentifiers); err != nil && !errors.IsNotFound(err) {
 		log.FromContext(ctx).WithError(err).Warn("Failed to cancel link")
 	}
 	as.startLinkTask(as.Context(), req.ApplicationIdentifiers)
@@ -68,7 +63,7 @@ func (as *ApplicationServer) DeleteLink(ctx context.Context, ids *ttnpb.Applicat
 	if err := rights.RequireApplication(ctx, *ids, ttnpb.RIGHT_APPLICATION_LINK); err != nil {
 		return nil, err
 	}
-	if err := as.cancelLink(ctx, *ids, errLinkDeleted); err != nil && !errors.IsNotFound(err) {
+	if err := as.cancelLink(ctx, *ids); err != nil && !errors.IsNotFound(err) {
 		log.FromContext(ctx).WithError(err).Warn("Failed to cancel link")
 	}
 	_, err := as.linkRegistry.Set(ctx, *ids, nil, func(link *ttnpb.ApplicationLink) (*ttnpb.ApplicationLink, []string, error) { return nil, nil, nil })

--- a/pkg/applicationserver/linking.go
+++ b/pkg/applicationserver/linking.go
@@ -220,7 +220,10 @@ func (as *ApplicationServer) link(ctx context.Context, ids ttnpb.ApplicationIden
 		go func() {
 			select {
 			case <-l.ctx.Done():
-				// Default subscriptions should not be canceled on link failures.
+				// Default subscriptions should not be canceled on link failures,
+				// and they should skip the subscribe channel since it will get
+				// closed.
+				return
 			case <-sub.Context().Done():
 			}
 			l.unsubscribeCh <- sub


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #1831

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove the custom errors used for link reset/delete and revert back to `context.Canceled`.
- Change retry logic to retry only if a re-connection attempt is not guaranteed to fail.
- Skip the unsubscribe channel if the link context is stopped (since the goroutine which collects the subscriptions will already be closed).

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I've also tested this with link connection failures (spurious link shutdowns) and it works correctly - do keep in mind that we should retry every time we are not guaranteed to fail, since some errors on the remote side might not have a retry-able error code (`Unknown` is common).

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
