### PR TITLE
Fix mixed blockquotes

### DIFF
--- a/doc/content/reference/application-server-data/mqtt/_index.md
+++ b/doc/content/reference/application-server-data/mqtt/_index.md
@@ -24,9 +24,9 @@ Make sure to copy your API key now, since it will no longer be visible after lea
 
 There are many MQTT clients available. Great clients are `mosquitto_pub` and `mosquitto_sub`, part of [Mosquitto](https://mosquitto.org).
 
->Tip: when using `mosquitto_sub`, pass the `-d` flag to see the topics messages get published on. For example:
->
->```bash
+```bash
+# Tip: when using `mosquitto_sub`, pass the `-d` flag to see the topics messages get published on. 
+# For example:
 $ mosquitto_sub -h thethings.example.com -t "#" -u app1 -P "NNSXS.VEEBURF3KR77ZR.." -d
 ```
 
@@ -146,9 +146,8 @@ For example, to send an unconfirmed downlink message to the device `dev1` in app
 
 >Hint: Use [this handy tool](https://v2.cryptii.com/hexadecimal/base64) to convert hexadecimal to base64.
 
->If you use `mosquitto_pub`, use the following command:
->
->```bash
+```bash
+# If you use `mosquitto_pub`, use the following command:
 $ mosquitto_pub -h thethings.example.com \
   -t "v3/app1/devices/dev1/down/push" \
   -u app1 -P "NNSXS.VEEBURF3KR77ZR.." \

--- a/doc/content/reference/end-device-templates/executing.md
+++ b/doc/content/reference/end-device-templates/executing.md
@@ -8,8 +8,8 @@ weight: 4
 
 Once you created or converted a template, you can execute the template with the `end-device templates execute` command to obtain an end device that can be created.
 
->The examples use a template that has been created as follows:
->```bash
+```bash
+# The examples use a template that has been created as follows:
 $ ttn-lw-cli end-device template extend \
   --lorawan-version 1.0.3 \
   --lorawan-phy-version 1.0.3-a \


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #1836

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix block quotes in the MQTT and device template sections.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

See https://thethingsstack.io/v3.5.0/reference/application-server-data/mqtt/ to see the error (in the MQTT clients section). I guess the new Markdown template engine that Hugo uses since the upgrade no longer allows the mixing between `>` and other blocks.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
