### PR TITLE
Return device context from registry in Network Server

### DIFF
--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -1104,7 +1104,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 		var queuedApplicationUplinks []*ttnpb.ApplicationUp
 		var queuedEvents []events.Event
 		var nextDownlinkAt time.Time
-		_, err := ns.devices.SetByID(ctx, devID.ApplicationIdentifiers, devID.DeviceID,
+		_, ctx, err := ns.devices.SetByID(ctx, devID.ApplicationIdentifiers, devID.DeviceID,
 			[]string{
 				"frequency_plan_id",
 				"last_dev_status_received_at",
@@ -1118,7 +1118,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 				"recent_uplinks",
 				"session",
 			},
-			func(dev *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
+			func(ctx context.Context, dev *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
 				if dev == nil {
 					logger.Warn("Device not found")
 					return nil, nil, nil

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -281,6 +281,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				}
 
 				var setRespCh chan<- DeviceRegistrySetByIDResponse
+				var setCtx context.Context
 				setFuncRespCh := make(chan DeviceRegistrySetByIDRequestFuncResponse)
 				select {
 				case <-ctx.Done():
@@ -289,13 +290,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case req := <-env.DeviceRegistry.SetByID:
 					setRespCh = req.Response
+					setCtx = req.Context
 					a.So(req.Context, should.HaveParentContextOrEqual, ctx)
 					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
 					a.So(req.DeviceID, should.Resemble, devID)
 					a.So(req.Paths, should.Resemble, getPaths)
 
 					go func() {
-						dev, sets, err := req.Func(nil)
+						dev, sets, err := req.Func(req.Context, nil)
 						setFuncRespCh <- DeviceRegistrySetByIDRequestFuncResponse{
 							Device: dev,
 							Paths:  sets,
@@ -319,7 +321,9 @@ func TestProcessDownlinkTask(t *testing.T) {
 				case <-ctx.Done():
 					t.Error("Timed out while waiting for DeviceRegistry.SetByID response to be processed")
 
-				case setRespCh <- DeviceRegistrySetByIDResponse{}:
+				case setRespCh <- DeviceRegistrySetByIDResponse{
+					Context: setCtx,
+				}:
 				}
 
 				select {
@@ -407,6 +411,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				}
 
 				var setRespCh chan<- DeviceRegistrySetByIDResponse
+				var setCtx context.Context
 				setFuncRespCh := make(chan DeviceRegistrySetByIDRequestFuncResponse)
 				select {
 				case <-ctx.Done():
@@ -415,13 +420,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case req := <-env.DeviceRegistry.SetByID:
 					setRespCh = req.Response
+					setCtx = req.Context
 					a.So(req.Context, should.HaveParentContextOrEqual, ctx)
 					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
 					a.So(req.DeviceID, should.Resemble, devID)
 					a.So(req.Paths, should.Resemble, getPaths)
 
 					go func() {
-						dev, sets, err := req.Func(CopyEndDevice(getDevice))
+						dev, sets, err := req.Func(req.Context, CopyEndDevice(getDevice))
 						setFuncRespCh <- DeviceRegistrySetByIDRequestFuncResponse{
 							Device: dev,
 							Paths:  sets,
@@ -446,7 +452,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Error("Timed out while waiting for DeviceRegistry.SetByID response to be processed")
 
 				case setRespCh <- DeviceRegistrySetByIDResponse{
-					Device: getDevice,
+					Device:  getDevice,
+					Context: setCtx,
 				}:
 				}
 
@@ -541,6 +548,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				}
 
 				var setRespCh chan<- DeviceRegistrySetByIDResponse
+				var setCtx context.Context
 				setFuncRespCh := make(chan DeviceRegistrySetByIDRequestFuncResponse)
 				select {
 				case <-ctx.Done():
@@ -549,13 +557,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case req := <-env.DeviceRegistry.SetByID:
 					setRespCh = req.Response
+					setCtx = req.Context
 					a.So(req.Context, should.HaveParentContextOrEqual, ctx)
 					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
 					a.So(req.DeviceID, should.Resemble, devID)
 					a.So(req.Paths, should.Resemble, getPaths)
 
 					go func() {
-						dev, sets, err := req.Func(CopyEndDevice(getDevice))
+						dev, sets, err := req.Func(req.Context, CopyEndDevice(getDevice))
 						setFuncRespCh <- DeviceRegistrySetByIDRequestFuncResponse{
 							Device: dev,
 							Paths:  sets,
@@ -580,7 +589,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Error("Timed out while waiting for DeviceRegistry.SetByID response to be processed")
 
 				case setRespCh <- DeviceRegistrySetByIDResponse{
-					Device: getDevice,
+					Device:  getDevice,
+					Context: setCtx,
 				}:
 				}
 
@@ -656,6 +666,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				}
 
 				var setRespCh chan<- DeviceRegistrySetByIDResponse
+				var setCtx context.Context
 				setFuncRespCh := make(chan DeviceRegistrySetByIDRequestFuncResponse)
 				select {
 				case <-ctx.Done():
@@ -664,13 +675,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case req := <-env.DeviceRegistry.SetByID:
 					setRespCh = req.Response
+					setCtx = req.Context
 					a.So(req.Context, should.HaveParentContextOrEqual, ctx)
 					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
 					a.So(req.DeviceID, should.Resemble, devID)
 					a.So(req.Paths, should.Resemble, getPaths)
 
 					go func() {
-						dev, sets, err := req.Func(CopyEndDevice(getDevice))
+						dev, sets, err := req.Func(req.Context, CopyEndDevice(getDevice))
 						setFuncRespCh <- DeviceRegistrySetByIDRequestFuncResponse{
 							Device: dev,
 							Paths:  sets,
@@ -698,7 +710,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Error("Timed out while waiting for DeviceRegistry.SetByID response to be processed")
 
 				case setRespCh <- DeviceRegistrySetByIDResponse{
-					Device: getDevice,
+					Device:  getDevice,
+					Context: setCtx,
 				}:
 				}
 
@@ -768,6 +781,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				}
 
 				var setRespCh chan<- DeviceRegistrySetByIDResponse
+				var setCtx context.Context
 				setFuncRespCh := make(chan DeviceRegistrySetByIDRequestFuncResponse)
 				select {
 				case <-ctx.Done():
@@ -776,13 +790,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case req := <-env.DeviceRegistry.SetByID:
 					setRespCh = req.Response
+					setCtx = req.Context
 					a.So(req.Context, should.HaveParentContextOrEqual, ctx)
 					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
 					a.So(req.DeviceID, should.Resemble, devID)
 					a.So(req.Paths, should.Resemble, getPaths)
 
 					go func() {
-						dev, sets, err := req.Func(CopyEndDevice(getDevice))
+						dev, sets, err := req.Func(req.Context, CopyEndDevice(getDevice))
 						setFuncRespCh <- DeviceRegistrySetByIDRequestFuncResponse{
 							Device: dev,
 							Paths:  sets,
@@ -807,7 +822,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Error("Timed out while waiting for DeviceRegistry.SetByID response to be processed")
 
 				case setRespCh <- DeviceRegistrySetByIDResponse{
-					Device: getDevice,
+					Device:  getDevice,
+					Context: setCtx,
 				}:
 				}
 
@@ -907,6 +923,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				}
 
 				var setRespCh chan<- DeviceRegistrySetByIDResponse
+				var setCtx context.Context
 				setFuncRespCh := make(chan DeviceRegistrySetByIDRequestFuncResponse)
 				select {
 				case <-ctx.Done():
@@ -915,13 +932,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case req := <-env.DeviceRegistry.SetByID:
 					setRespCh = req.Response
+					setCtx = req.Context
 					a.So(req.Context, should.HaveParentContextOrEqual, ctx)
 					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
 					a.So(req.DeviceID, should.Resemble, devID)
 					a.So(req.Paths, should.Resemble, getPaths)
 
 					go func() {
-						dev, sets, err := req.Func(CopyEndDevice(getDevice))
+						dev, sets, err := req.Func(req.Context, CopyEndDevice(getDevice))
 						setFuncRespCh <- DeviceRegistrySetByIDRequestFuncResponse{
 							Device: dev,
 							Paths:  sets,
@@ -951,7 +969,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Error("Timed out while waiting for DeviceRegistry.SetByID response to be processed")
 
 				case setRespCh <- DeviceRegistrySetByIDResponse{
-					Device: getDevice,
+					Device:  getDevice,
+					Context: setCtx,
 				}:
 				}
 
@@ -1051,6 +1070,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				}
 
 				var setRespCh chan<- DeviceRegistrySetByIDResponse
+				var setCtx context.Context
 				setFuncRespCh := make(chan DeviceRegistrySetByIDRequestFuncResponse)
 				select {
 				case <-ctx.Done():
@@ -1059,13 +1079,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case req := <-env.DeviceRegistry.SetByID:
 					setRespCh = req.Response
+					setCtx = req.Context
 					a.So(req.Context, should.HaveParentContextOrEqual, ctx)
 					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
 					a.So(req.DeviceID, should.Resemble, devID)
 					a.So(req.Paths, should.Resemble, getPaths)
 
 					go func() {
-						dev, sets, err := req.Func(CopyEndDevice(getDevice))
+						dev, sets, err := req.Func(req.Context, CopyEndDevice(getDevice))
 						setFuncRespCh <- DeviceRegistrySetByIDRequestFuncResponse{
 							Device: dev,
 							Paths:  sets,
@@ -1090,7 +1111,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Error("Timed out while waiting for DeviceRegistry.SetByID response to be processed")
 
 				case setRespCh <- DeviceRegistrySetByIDResponse{
-					Device: getDevice,
+					Device:  getDevice,
+					Context: setCtx,
 				}:
 				}
 
@@ -1208,6 +1230,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				}
 
 				var setRespCh chan<- DeviceRegistrySetByIDResponse
+				var setCtx context.Context
 				setFuncRespCh := make(chan DeviceRegistrySetByIDRequestFuncResponse)
 				select {
 				case <-ctx.Done():
@@ -1216,13 +1239,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case req := <-env.DeviceRegistry.SetByID:
 					setRespCh = req.Response
+					setCtx = req.Context
 					a.So(req.Context, should.HaveParentContextOrEqual, ctx)
 					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
 					a.So(req.DeviceID, should.Resemble, devID)
 					a.So(req.Paths, should.Resemble, getPaths)
 
 					go func() {
-						dev, sets, err := req.Func(CopyEndDevice(getDevice))
+						dev, sets, err := req.Func(req.Context, CopyEndDevice(getDevice))
 						setFuncRespCh <- DeviceRegistrySetByIDRequestFuncResponse{
 							Device: dev,
 							Paths:  sets,
@@ -1254,7 +1278,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Error("Timed out while waiting for DeviceRegistry.SetByID response to be processed")
 
 				case setRespCh <- DeviceRegistrySetByIDResponse{
-					Device: setDevice,
+					Device:  setDevice,
+					Context: setCtx,
 				}:
 				}
 
@@ -1385,6 +1410,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				}
 
 				var setRespCh chan<- DeviceRegistrySetByIDResponse
+				var setCtx context.Context
 				setFuncRespCh := make(chan DeviceRegistrySetByIDRequestFuncResponse)
 				select {
 				case <-ctx.Done():
@@ -1393,13 +1419,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case req := <-env.DeviceRegistry.SetByID:
 					setRespCh = req.Response
+					setCtx = req.Context
 					a.So(req.Context, should.HaveParentContextOrEqual, ctx)
 					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
 					a.So(req.DeviceID, should.Resemble, devID)
 					a.So(req.Paths, should.Resemble, getPaths)
 
 					go func() {
-						dev, sets, err := req.Func(CopyEndDevice(getDevice))
+						dev, sets, err := req.Func(req.Context, CopyEndDevice(getDevice))
 						setFuncRespCh <- DeviceRegistrySetByIDRequestFuncResponse{
 							Device: dev,
 							Paths:  sets,
@@ -1431,7 +1458,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Error("Timed out while waiting for DeviceRegistry.SetByID response to be processed")
 
 				case setRespCh <- DeviceRegistrySetByIDResponse{
-					Device: setDevice,
+					Device:  setDevice,
+					Context: setCtx,
 				}:
 				}
 
@@ -1567,6 +1595,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				}
 
 				var setRespCh chan<- DeviceRegistrySetByIDResponse
+				var setCtx context.Context
 				setFuncRespCh := make(chan DeviceRegistrySetByIDRequestFuncResponse)
 				select {
 				case <-ctx.Done():
@@ -1575,13 +1604,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case req := <-env.DeviceRegistry.SetByID:
 					setRespCh = req.Response
+					setCtx = req.Context
 					a.So(req.Context, should.HaveParentContextOrEqual, ctx)
 					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
 					a.So(req.DeviceID, should.Resemble, devID)
 					a.So(req.Paths, should.Resemble, getPaths)
 
 					go func() {
-						dev, sets, err := req.Func(CopyEndDevice(getDevice))
+						dev, sets, err := req.Func(req.Context, CopyEndDevice(getDevice))
 						setFuncRespCh <- DeviceRegistrySetByIDRequestFuncResponse{
 							Device: dev,
 							Paths:  sets,
@@ -1705,7 +1735,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Error("Timed out while waiting for DeviceRegistry.SetByID response to be processed")
 
 				case setRespCh <- DeviceRegistrySetByIDResponse{
-					Device: getDevice,
+					Device:  getDevice,
+					Context: setCtx,
 				}:
 				}
 
@@ -1822,6 +1853,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				}
 
 				var setRespCh chan<- DeviceRegistrySetByIDResponse
+				var setCtx context.Context
 				setFuncRespCh := make(chan DeviceRegistrySetByIDRequestFuncResponse)
 				select {
 				case <-ctx.Done():
@@ -1830,13 +1862,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case req := <-env.DeviceRegistry.SetByID:
 					setRespCh = req.Response
+					setCtx = req.Context
 					a.So(req.Context, should.HaveParentContextOrEqual, ctx)
 					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
 					a.So(req.DeviceID, should.Resemble, devID)
 					a.So(req.Paths, should.Resemble, getPaths)
 
 					go func() {
-						dev, sets, err := req.Func(CopyEndDevice(getDevice))
+						dev, sets, err := req.Func(req.Context, CopyEndDevice(getDevice))
 						setFuncRespCh <- DeviceRegistrySetByIDRequestFuncResponse{
 							Device: dev,
 							Paths:  sets,
@@ -2014,7 +2047,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Error("Timed out while waiting for DeviceRegistry.SetByID response to be processed")
 
 				case setRespCh <- DeviceRegistrySetByIDResponse{
-					Device: setDevice,
+					Device:  setDevice,
+					Context: setCtx,
 				}:
 				}
 
@@ -2132,6 +2166,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				}
 
 				var setRespCh chan<- DeviceRegistrySetByIDResponse
+				var setCtx context.Context
 				setFuncRespCh := make(chan DeviceRegistrySetByIDRequestFuncResponse)
 				select {
 				case <-ctx.Done():
@@ -2140,13 +2175,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case req := <-env.DeviceRegistry.SetByID:
 					setRespCh = req.Response
+					setCtx = req.Context
 					a.So(req.Context, should.HaveParentContextOrEqual, ctx)
 					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
 					a.So(req.DeviceID, should.Resemble, devID)
 					a.So(req.Paths, should.Resemble, getPaths)
 
 					go func() {
-						dev, sets, err := req.Func(CopyEndDevice(getDevice))
+						dev, sets, err := req.Func(req.Context, CopyEndDevice(getDevice))
 						setFuncRespCh <- DeviceRegistrySetByIDRequestFuncResponse{
 							Device: dev,
 							Paths:  sets,
@@ -2327,7 +2363,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Error("Timed out while waiting for DeviceRegistry.SetByID response to be processed")
 
 				case setRespCh <- DeviceRegistrySetByIDResponse{
-					Device: setDevice,
+					Device:  setDevice,
+					Context: setCtx,
 				}:
 				}
 
@@ -2445,6 +2482,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				}
 
 				var setRespCh chan<- DeviceRegistrySetByIDResponse
+				var setCtx context.Context
 				setFuncRespCh := make(chan DeviceRegistrySetByIDRequestFuncResponse)
 				select {
 				case <-ctx.Done():
@@ -2453,13 +2491,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case req := <-env.DeviceRegistry.SetByID:
 					setRespCh = req.Response
+					setCtx = req.Context
 					a.So(req.Context, should.HaveParentContextOrEqual, ctx)
 					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
 					a.So(req.DeviceID, should.Resemble, devID)
 					a.So(req.Paths, should.Resemble, getPaths)
 
 					go func() {
-						dev, sets, err := req.Func(CopyEndDevice(getDevice))
+						dev, sets, err := req.Func(req.Context, CopyEndDevice(getDevice))
 						setFuncRespCh <- DeviceRegistrySetByIDRequestFuncResponse{
 							Device: dev,
 							Paths:  sets,
@@ -2635,7 +2674,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Error("Timed out while waiting for DeviceRegistry.SetByID response to be processed")
 
 				case setRespCh <- DeviceRegistrySetByIDResponse{
-					Device: setDevice,
+					Device:  setDevice,
+					Context: setCtx,
 				}:
 				}
 
@@ -2730,6 +2770,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				}
 
 				var setRespCh chan<- DeviceRegistrySetByIDResponse
+				var setCtx context.Context
 				setFuncRespCh := make(chan DeviceRegistrySetByIDRequestFuncResponse)
 				select {
 				case <-ctx.Done():
@@ -2738,13 +2779,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case req := <-env.DeviceRegistry.SetByID:
 					setRespCh = req.Response
+					setCtx = req.Context
 					a.So(req.Context, should.HaveParentContextOrEqual, ctx)
 					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
 					a.So(req.DeviceID, should.Resemble, devID)
 					a.So(req.Paths, should.Resemble, getPaths)
 
 					go func() {
-						dev, sets, err := req.Func(CopyEndDevice(getDevice))
+						dev, sets, err := req.Func(req.Context, CopyEndDevice(getDevice))
 						setFuncRespCh <- DeviceRegistrySetByIDRequestFuncResponse{
 							Device: dev,
 							Paths:  sets,
@@ -2769,7 +2811,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Error("Timed out while waiting for DeviceRegistry.SetByID response to be processed")
 
 				case setRespCh <- DeviceRegistrySetByIDResponse{
-					Device: getDevice,
+					Device:  getDevice,
+					Context: setCtx,
 				}:
 				}
 
@@ -2889,6 +2932,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				}
 
 				var setRespCh chan<- DeviceRegistrySetByIDResponse
+				var setCtx context.Context
 				setFuncRespCh := make(chan DeviceRegistrySetByIDRequestFuncResponse)
 				select {
 				case <-ctx.Done():
@@ -2897,13 +2941,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case req := <-env.DeviceRegistry.SetByID:
 					setRespCh = req.Response
+					setCtx = req.Context
 					a.So(req.Context, should.HaveParentContextOrEqual, ctx)
 					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
 					a.So(req.DeviceID, should.Resemble, devID)
 					a.So(req.Paths, should.Resemble, getPaths)
 
 					go func() {
-						dev, sets, err := req.Func(CopyEndDevice(getDevice))
+						dev, sets, err := req.Func(req.Context, CopyEndDevice(getDevice))
 						setFuncRespCh <- DeviceRegistrySetByIDRequestFuncResponse{
 							Device: dev,
 							Paths:  sets,
@@ -3084,7 +3129,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Error("Timed out while waiting for DeviceRegistry.SetByID response to be processed")
 
 				case setRespCh <- DeviceRegistrySetByIDResponse{
-					Device: setDevice,
+					Device:  setDevice,
+					Context: setCtx,
 				}:
 				}
 
@@ -3219,6 +3265,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				}
 
 				var setRespCh chan<- DeviceRegistrySetByIDResponse
+				var setCtx context.Context
 				setFuncRespCh := make(chan DeviceRegistrySetByIDRequestFuncResponse)
 				select {
 				case <-ctx.Done():
@@ -3227,13 +3274,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case req := <-env.DeviceRegistry.SetByID:
 					setRespCh = req.Response
+					setCtx = req.Context
 					a.So(req.Context, should.HaveParentContextOrEqual, ctx)
 					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
 					a.So(req.DeviceID, should.Resemble, devID)
 					a.So(req.Paths, should.Resemble, getPaths)
 
 					go func() {
-						dev, sets, err := req.Func(CopyEndDevice(getDevice))
+						dev, sets, err := req.Func(req.Context, CopyEndDevice(getDevice))
 						setFuncRespCh <- DeviceRegistrySetByIDRequestFuncResponse{
 							Device: dev,
 							Paths:  sets,
@@ -3481,7 +3529,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Error("Timed out while waiting for DeviceRegistry.SetByID response to be processed")
 
 				case setRespCh <- DeviceRegistrySetByIDResponse{
-					Device: setDevice,
+					Device:  setDevice,
+					Context: setCtx,
 				}:
 				}
 
@@ -3612,6 +3661,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				}
 
 				var setRespCh chan<- DeviceRegistrySetByIDResponse
+				var setCtx context.Context
 				setFuncRespCh := make(chan DeviceRegistrySetByIDRequestFuncResponse)
 				select {
 				case <-ctx.Done():
@@ -3620,13 +3670,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case req := <-env.DeviceRegistry.SetByID:
 					setRespCh = req.Response
+					setCtx = req.Context
 					a.So(req.Context, should.HaveParentContextOrEqual, ctx)
 					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
 					a.So(req.DeviceID, should.Resemble, devID)
 					a.So(req.Paths, should.Resemble, getPaths)
 
 					go func() {
-						dev, sets, err := req.Func(CopyEndDevice(getDevice))
+						dev, sets, err := req.Func(req.Context, CopyEndDevice(getDevice))
 						setFuncRespCh <- DeviceRegistrySetByIDRequestFuncResponse{
 							Device: dev,
 							Paths:  sets,
@@ -3799,7 +3850,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Error("Timed out while waiting for DeviceRegistry.SetByID response to be processed")
 
 				case setRespCh <- DeviceRegistrySetByIDResponse{
-					Device: setDevice,
+					Device:  setDevice,
+					Context: setCtx,
 				}:
 				}
 
@@ -3930,6 +3982,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				}
 
 				var setRespCh chan<- DeviceRegistrySetByIDResponse
+				var setCtx context.Context
 				setFuncRespCh := make(chan DeviceRegistrySetByIDRequestFuncResponse)
 				select {
 				case <-ctx.Done():
@@ -3938,13 +3991,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case req := <-env.DeviceRegistry.SetByID:
 					setRespCh = req.Response
+					setCtx = req.Context
 					a.So(req.Context, should.HaveParentContextOrEqual, ctx)
 					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
 					a.So(req.DeviceID, should.Resemble, devID)
 					a.So(req.Paths, should.Resemble, getPaths)
 
 					go func() {
-						dev, sets, err := req.Func(CopyEndDevice(getDevice))
+						dev, sets, err := req.Func(req.Context, CopyEndDevice(getDevice))
 						setFuncRespCh <- DeviceRegistrySetByIDRequestFuncResponse{
 							Device: dev,
 							Paths:  sets,
@@ -4080,7 +4134,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Error("Timed out while waiting for DeviceRegistry.SetByID response to be processed")
 
 				case setRespCh <- DeviceRegistrySetByIDResponse{
-					Device: setDevice,
+					Device:  setDevice,
+					Context: setCtx,
 				}:
 				}
 
@@ -4234,6 +4289,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				}
 
 				var setRespCh chan<- DeviceRegistrySetByIDResponse
+				var setCtx context.Context
 				setFuncRespCh := make(chan DeviceRegistrySetByIDRequestFuncResponse)
 				select {
 				case <-ctx.Done():
@@ -4242,13 +4298,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case req := <-env.DeviceRegistry.SetByID:
 					setRespCh = req.Response
+					setCtx = req.Context
 					a.So(req.Context, should.HaveParentContextOrEqual, ctx)
 					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
 					a.So(req.DeviceID, should.Resemble, devID)
 					a.So(req.Paths, should.Resemble, getPaths)
 
 					go func() {
-						dev, sets, err := req.Func(CopyEndDevice(getDevice))
+						dev, sets, err := req.Func(req.Context, CopyEndDevice(getDevice))
 						setFuncRespCh <- DeviceRegistrySetByIDRequestFuncResponse{
 							Device: dev,
 							Paths:  sets,
@@ -4379,7 +4436,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Error("Timed out while waiting for DeviceRegistry.SetByID response to be processed")
 
 				case setRespCh <- DeviceRegistrySetByIDResponse{
-					Device: CopyEndDevice(getDevice),
+					Device:  CopyEndDevice(getDevice),
+					Context: setCtx,
 				}:
 				}
 
@@ -4510,6 +4568,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				}
 
 				var setRespCh chan<- DeviceRegistrySetByIDResponse
+				var setCtx context.Context
 				setFuncRespCh := make(chan DeviceRegistrySetByIDRequestFuncResponse)
 				select {
 				case <-ctx.Done():
@@ -4518,13 +4577,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case req := <-env.DeviceRegistry.SetByID:
 					setRespCh = req.Response
+					setCtx = req.Context
 					a.So(req.Context, should.HaveParentContextOrEqual, ctx)
 					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
 					a.So(req.DeviceID, should.Resemble, devID)
 					a.So(req.Paths, should.Resemble, getPaths)
 
 					go func() {
-						dev, sets, err := req.Func(CopyEndDevice(getDevice))
+						dev, sets, err := req.Func(req.Context, CopyEndDevice(getDevice))
 						setFuncRespCh <- DeviceRegistrySetByIDRequestFuncResponse{
 							Device: dev,
 							Paths:  sets,
@@ -4548,7 +4608,9 @@ func TestProcessDownlinkTask(t *testing.T) {
 				case <-ctx.Done():
 					t.Error("Timed out while waiting for DeviceRegistry.SetByID response to be processed")
 
-				case setRespCh <- DeviceRegistrySetByIDResponse{}:
+				case setRespCh <- DeviceRegistrySetByIDResponse{
+					Context: setCtx,
+				}:
 				}
 
 				if !AssertDownlinkTaskAddRequest(ctx, env.DownlinkTasks.Add, func(reqCtx context.Context, ids ttnpb.EndDeviceIdentifiers, startAt time.Time, replace bool) bool {
@@ -4687,6 +4749,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				}
 
 				var setRespCh chan<- DeviceRegistrySetByIDResponse
+				var setCtx context.Context
 				setFuncRespCh := make(chan DeviceRegistrySetByIDRequestFuncResponse)
 				select {
 				case <-ctx.Done():
@@ -4695,13 +4758,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case req := <-env.DeviceRegistry.SetByID:
 					setRespCh = req.Response
+					setCtx = req.Context
 					a.So(req.Context, should.HaveParentContextOrEqual, ctx)
 					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
 					a.So(req.DeviceID, should.Resemble, devID)
 					a.So(req.Paths, should.Resemble, getPaths)
 
 					go func() {
-						dev, sets, err := req.Func(CopyEndDevice(getDevice))
+						dev, sets, err := req.Func(req.Context, CopyEndDevice(getDevice))
 						setFuncRespCh <- DeviceRegistrySetByIDRequestFuncResponse{
 							Device: dev,
 							Paths:  sets,
@@ -4731,7 +4795,9 @@ func TestProcessDownlinkTask(t *testing.T) {
 				case <-ctx.Done():
 					t.Error("Timed out while waiting for DeviceRegistry.SetByID response to be processed")
 
-				case setRespCh <- DeviceRegistrySetByIDResponse{}:
+				case setRespCh <- DeviceRegistrySetByIDResponse{
+					Context: setCtx,
+				}:
 				}
 
 				select {
@@ -4875,6 +4941,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				}
 
 				var setRespCh chan<- DeviceRegistrySetByIDResponse
+				var setCtx context.Context
 				setFuncRespCh := make(chan DeviceRegistrySetByIDRequestFuncResponse)
 				select {
 				case <-ctx.Done():
@@ -4883,13 +4950,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				case req := <-env.DeviceRegistry.SetByID:
 					setRespCh = req.Response
+					setCtx = req.Context
 					a.So(req.Context, should.HaveParentContextOrEqual, ctx)
 					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
 					a.So(req.DeviceID, should.Resemble, devID)
 					a.So(req.Paths, should.Resemble, getPaths)
 
 					go func() {
-						dev, sets, err := req.Func(CopyEndDevice(getDevice))
+						dev, sets, err := req.Func(req.Context, CopyEndDevice(getDevice))
 						setFuncRespCh <- DeviceRegistrySetByIDRequestFuncResponse{
 							Device: dev,
 							Paths:  sets,
@@ -5017,7 +5085,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					t.Error("Timed out while waiting for DeviceRegistry.SetByID response to be processed")
 
 				case setRespCh <- DeviceRegistrySetByIDResponse{
-					Device: setDevice,
+					Device:  setDevice,
+					Context: setCtx,
 				}:
 				}
 

--- a/pkg/networkserver/grpc_asns.go
+++ b/pkg/networkserver/grpc_asns.go
@@ -223,8 +223,8 @@ func (ns *NetworkServer) DownlinkQueueReplace(ctx context.Context, req *ttnpb.Do
 		)
 	}
 
-	dev, err := ns.devices.SetByID(ctx, req.EndDeviceIdentifiers.ApplicationIdentifiers, req.EndDeviceIdentifiers.DeviceID, gets,
-		func(dev *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
+	dev, ctx, err := ns.devices.SetByID(ctx, req.EndDeviceIdentifiers.ApplicationIdentifiers, req.EndDeviceIdentifiers.DeviceID, gets,
+		func(ctx context.Context, dev *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
 			if dev == nil {
 				return nil, nil, errDeviceNotFound
 			}
@@ -280,7 +280,7 @@ func (ns *NetworkServer) DownlinkQueuePush(ctx context.Context, req *ttnpb.Downl
 
 	logger := log.FromContext(ctx).WithField("device_uid", unique.ID(ctx, req.EndDeviceIdentifiers))
 
-	dev, err := ns.devices.SetByID(ctx, req.EndDeviceIdentifiers.ApplicationIdentifiers, req.EndDeviceIdentifiers.DeviceID,
+	dev, ctx, err := ns.devices.SetByID(ctx, req.EndDeviceIdentifiers.ApplicationIdentifiers, req.EndDeviceIdentifiers.DeviceID,
 		[]string{
 			"frequency_plan_id",
 			"last_dev_status_received_at",
@@ -294,7 +294,7 @@ func (ns *NetworkServer) DownlinkQueuePush(ctx context.Context, req *ttnpb.Downl
 			"recent_uplinks",
 			"session",
 		},
-		func(dev *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
+		func(ctx context.Context, dev *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
 			if dev == nil {
 				return nil, nil, errDeviceNotFound
 			}
@@ -342,7 +342,7 @@ func (ns *NetworkServer) DownlinkQueueList(ctx context.Context, ids *ttnpb.EndDe
 	if err := rights.RequireApplication(ctx, ids.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_LINK); err != nil {
 		return nil, err
 	}
-	dev, err := ns.devices.GetByID(ctx, ids.ApplicationIdentifiers, ids.DeviceID, []string{"queued_application_downlinks"})
+	dev, ctx, err := ns.devices.GetByID(ctx, ids.ApplicationIdentifiers, ids.DeviceID, []string{"queued_application_downlinks"})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/networkserver/grpc_asns_test.go
+++ b/pkg/networkserver/grpc_asns_test.go
@@ -284,7 +284,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 		Name           string
 		ContextFunc    func(context.Context) context.Context
 		AddFunc        func(context.Context, ttnpb.EndDeviceIdentifiers, time.Time, bool) error
-		SetByIDFunc    func(context.Context, ttnpb.ApplicationIdentifiers, string, []string, func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error)
+		SetByIDFunc    func(context.Context, ttnpb.ApplicationIdentifiers, string, []string, func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error)
 		Request        *ttnpb.DownlinkQueueRequest
 		ErrorAssertion func(*testing.T, error) bool
 		AddCalls       uint64
@@ -308,10 +308,10 @@ func TestDownlinkQueueReplace(t *testing.T) {
 				test.MustTFromContext(ctx).Error(err)
 				return err
 			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				err := errors.New("SetByIDFunc must not be called")
 				test.MustTFromContext(ctx).Error(err)
-				return nil, err
+				return nil, ctx, err
 			},
 			Request: &ttnpb.DownlinkQueueRequest{
 				EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -349,7 +349,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 				test.MustTFromContext(ctx).Error(err)
 				return err
 			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
@@ -367,14 +367,14 @@ func TestDownlinkQueueReplace(t *testing.T) {
 					"recent_uplinks",
 					"session",
 				})
-				dev, sets, err := f(nil)
+				dev, sets, err := f(ctx, nil)
 				if !a.So(err, should.BeError) {
 					t.Error("Error was expected")
-					return nil, errors.New("Error was expected")
+					return nil, ctx, errors.New("Error was expected")
 				}
 				a.So(sets, should.BeNil)
 				a.So(dev, should.BeNil)
-				return nil, err
+				return nil, ctx, err
 			},
 			Request: &ttnpb.DownlinkQueueRequest{
 				EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -413,7 +413,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 				test.MustTFromContext(ctx).Error(err)
 				return err
 			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
@@ -430,7 +430,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 					"recent_uplinks",
 					"session",
 				})
-				dev, sets, err := f(&ttnpb.EndDevice{
+				dev, sets, err := f(ctx, &ttnpb.EndDevice{
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -451,11 +451,11 @@ func TestDownlinkQueueReplace(t *testing.T) {
 				})
 				if !a.So(err, should.BeError) {
 					t.Error("Error was expected")
-					return nil, errors.New("Error was expected")
+					return nil, ctx, errors.New("Error was expected")
 				}
 				a.So(sets, should.BeNil)
 				a.So(dev, should.BeNil)
-				return nil, err
+				return nil, ctx, err
 			},
 			Request: &ttnpb.DownlinkQueueRequest{
 				EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -495,7 +495,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 				test.MustTFromContext(ctx).Error(err)
 				return err
 			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
@@ -512,7 +512,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 					"recent_uplinks",
 					"session",
 				})
-				dev, sets, err := f(&ttnpb.EndDevice{
+				dev, sets, err := f(ctx, &ttnpb.EndDevice{
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -536,7 +536,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 					},
 				})
 				if !a.So(err, should.BeNil) {
-					return nil, err
+					return nil, ctx, err
 				}
 				a.So(sets, should.HaveSameElementsDeep, []string{
 					"queued_application_downlinks",
@@ -562,7 +562,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 						{SessionKeyID: []byte("testSession"), FCnt: 42},
 					},
 				})
-				return dev, nil
+				return dev, ctx, nil
 			},
 			Request: &ttnpb.DownlinkQueueRequest{
 				EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -600,7 +600,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 				a.So([]time.Time{start, at.Add(NSScheduleWindow()), time.Now()}, should.BeChronological)
 				return nil
 			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
@@ -617,7 +617,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 					"recent_uplinks",
 					"session",
 				})
-				dev, sets, err := f(&ttnpb.EndDevice{
+				dev, sets, err := f(ctx, &ttnpb.EndDevice{
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -641,7 +641,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 					},
 				})
 				if !a.So(err, should.BeNil) {
-					return nil, err
+					return nil, ctx, err
 				}
 				a.So(sets, should.HaveSameElementsDeep, []string{
 					"queued_application_downlinks",
@@ -667,7 +667,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 						{SessionKeyID: []byte("testSession"), FCnt: 42},
 					},
 				})
-				return dev, nil
+				return dev, ctx, nil
 			},
 			Request: &ttnpb.DownlinkQueueRequest{
 				EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -701,7 +701,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 				test.MustTFromContext(ctx).Error(err)
 				return err
 			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
@@ -713,7 +713,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 					"queued_application_downlinks",
 					"session",
 				})
-				dev, sets, err := f(&ttnpb.EndDevice{
+				dev, sets, err := f(ctx, &ttnpb.EndDevice{
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -737,7 +737,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 					"queued_application_downlinks",
 				})
 				a.So(dev.QueuedApplicationDownlinks, should.BeNil)
-				return dev, nil
+				return dev, ctx, nil
 			},
 			Request: &ttnpb.DownlinkQueueRequest{
 				EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -766,7 +766,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 				test.MustTFromContext(ctx).Error(err)
 				return err
 			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
@@ -778,7 +778,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 					"queued_application_downlinks",
 					"session",
 				})
-				dev, sets, err := f(&ttnpb.EndDevice{
+				dev, sets, err := f(ctx, &ttnpb.EndDevice{
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -802,7 +802,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 					},
 				})
 				if !a.So(err, should.BeNil) {
-					return nil, err
+					return nil, ctx, err
 				}
 				a.So(sets, should.HaveSameElementsDeep, []string{
 					"queued_application_downlinks",
@@ -824,7 +824,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 						},
 					},
 				})
-				return dev, nil
+				return dev, ctx, nil
 			},
 			Request: &ttnpb.DownlinkQueueRequest{
 				EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -853,7 +853,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 				test.MustTFromContext(ctx).Error(err)
 				return err
 			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
@@ -865,7 +865,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 					"queued_application_downlinks",
 					"session",
 				})
-				dev, sets, err := f(&ttnpb.EndDevice{
+				dev, sets, err := f(ctx, &ttnpb.EndDevice{
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -889,7 +889,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 					},
 				})
 				if !a.So(err, should.BeNil) {
-					return nil, err
+					return nil, ctx, err
 				}
 				a.So(sets, should.HaveSameElementsDeep, []string{
 					"queued_application_downlinks",
@@ -911,7 +911,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 						},
 					},
 				})
-				return dev, nil
+				return dev, ctx, nil
 			},
 			Request: &ttnpb.DownlinkQueueRequest{
 				EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -931,7 +931,7 @@ func TestDownlinkQueueReplace(t *testing.T) {
 				componenttest.NewComponent(t, &component.Config{}),
 				&Config{
 					Devices: &MockDeviceRegistry{
-						SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+						SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 							atomic.AddUint64(&setByIDCalls, 1)
 							return tc.SetByIDFunc(ctx, appID, devID, gets, f)
 						},
@@ -982,7 +982,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 		Name           string
 		ContextFunc    func(context.Context) context.Context
 		AddFunc        func(context.Context, ttnpb.EndDeviceIdentifiers, time.Time, bool) error
-		SetByIDFunc    func(context.Context, ttnpb.ApplicationIdentifiers, string, []string, func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error)
+		SetByIDFunc    func(context.Context, ttnpb.ApplicationIdentifiers, string, []string, func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error)
 		Request        *ttnpb.DownlinkQueueRequest
 		ErrorAssertion func(*testing.T, error) bool
 		AddCalls       uint64
@@ -1006,10 +1006,10 @@ func TestDownlinkQueuePush(t *testing.T) {
 				test.MustTFromContext(ctx).Error(err)
 				return err
 			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				err := errors.New("SetByIDFunc must not be called")
 				test.MustTFromContext(ctx).Error(err)
-				return nil, err
+				return nil, ctx, err
 			},
 			Request: &ttnpb.DownlinkQueueRequest{
 				EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -1047,7 +1047,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 				test.MustTFromContext(ctx).Error(err)
 				return err
 			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
@@ -1066,14 +1066,14 @@ func TestDownlinkQueuePush(t *testing.T) {
 					"session",
 				})
 
-				dev, sets, err := f(nil)
+				dev, sets, err := f(ctx, nil)
 				if !a.So(err, should.BeError) {
 					t.Error("Error was expected")
-					return nil, errors.New("Error was expected")
+					return nil, ctx, errors.New("Error was expected")
 				}
 				a.So(sets, should.BeNil)
 				a.So(dev, should.BeNil)
-				return nil, err
+				return nil, ctx, err
 			},
 			Request: &ttnpb.DownlinkQueueRequest{
 				EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -1112,7 +1112,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 				test.MustTFromContext(ctx).Error(err)
 				return err
 			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
@@ -1129,7 +1129,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 					"recent_uplinks",
 					"session",
 				})
-				dev, sets, err := f(&ttnpb.EndDevice{
+				dev, sets, err := f(ctx, &ttnpb.EndDevice{
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -1150,11 +1150,11 @@ func TestDownlinkQueuePush(t *testing.T) {
 				})
 				if !a.So(err, should.BeError) {
 					t.Error("Error was expected")
-					return nil, errors.New("Error was expected")
+					return nil, ctx, errors.New("Error was expected")
 				}
 				a.So(sets, should.BeNil)
 				a.So(dev, should.BeNil)
-				return nil, err
+				return nil, ctx, err
 			},
 			Request: &ttnpb.DownlinkQueueRequest{
 				EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -1194,7 +1194,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 				test.MustTFromContext(ctx).Error(err)
 				return err
 			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
@@ -1211,7 +1211,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 					"recent_uplinks",
 					"session",
 				})
-				dev, sets, err := f(&ttnpb.EndDevice{
+				dev, sets, err := f(ctx, &ttnpb.EndDevice{
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -1235,7 +1235,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 					},
 				})
 				if !a.So(err, should.BeNil) {
-					return nil, err
+					return nil, ctx, err
 				}
 				a.So(sets, should.HaveSameElementsDeep, []string{
 					"queued_application_downlinks",
@@ -1265,7 +1265,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 						{SessionKeyID: []byte("testSession"), FCnt: 42},
 					},
 				})
-				return dev, nil
+				return dev, ctx, nil
 			},
 			Request: &ttnpb.DownlinkQueueRequest{
 				EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -1298,7 +1298,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 				test.MustTFromContext(ctx).Error(err)
 				return err
 			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
@@ -1315,7 +1315,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 					"recent_uplinks",
 					"session",
 				})
-				dev, sets, err := f(&ttnpb.EndDevice{
+				dev, sets, err := f(ctx, &ttnpb.EndDevice{
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -1344,7 +1344,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 					},
 				})
 				if !a.So(err, should.BeNil) {
-					return nil, err
+					return nil, ctx, err
 				}
 				a.So(sets, should.Resemble, []string{
 					"queued_application_downlinks",
@@ -1379,7 +1379,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 						{SessionKeyID: []byte("testSession"), FCnt: 42},
 					},
 				})
-				return dev, nil
+				return dev, ctx, nil
 			},
 			Request: &ttnpb.DownlinkQueueRequest{
 				EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -1417,7 +1417,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 				a.So([]time.Time{start, at, time.Now()}, should.BeChronological)
 				return nil
 			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
@@ -1434,7 +1434,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 					"recent_uplinks",
 					"session",
 				})
-				dev, sets, err := f(&ttnpb.EndDevice{
+				dev, sets, err := f(ctx, &ttnpb.EndDevice{
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -1459,11 +1459,11 @@ func TestDownlinkQueuePush(t *testing.T) {
 				})
 				if !a.So(err, should.BeError) {
 					t.Error("Error was expected")
-					return nil, errors.New("Error was expected")
+					return nil, ctx, errors.New("Error was expected")
 				}
 				a.So(sets, should.BeNil)
 				a.So(dev, should.BeNil)
-				return nil, err
+				return nil, ctx, err
 			},
 			Request: &ttnpb.DownlinkQueueRequest{
 				EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -1508,7 +1508,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 				a.So([]time.Time{start, at, time.Now()}, should.BeChronological)
 				return nil
 			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
@@ -1525,7 +1525,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 					"recent_uplinks",
 					"session",
 				})
-				dev, sets, err := f(&ttnpb.EndDevice{
+				dev, sets, err := f(ctx, &ttnpb.EndDevice{
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -1546,11 +1546,11 @@ func TestDownlinkQueuePush(t *testing.T) {
 				})
 				if !a.So(err, should.BeError) {
 					t.Error("Error was expected")
-					return nil, errors.New("Error was expected")
+					return nil, ctx, errors.New("Error was expected")
 				}
 				a.So(sets, should.BeNil)
 				a.So(dev, should.BeNil)
-				return nil, err
+				return nil, ctx, err
 			},
 			Request: &ttnpb.DownlinkQueueRequest{
 				EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -1595,7 +1595,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 				a.So([]time.Time{start, at, time.Now()}, should.BeChronological)
 				return nil
 			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
@@ -1612,7 +1612,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 					"recent_uplinks",
 					"session",
 				})
-				dev, sets, err := f(&ttnpb.EndDevice{
+				dev, sets, err := f(ctx, &ttnpb.EndDevice{
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -1627,11 +1627,11 @@ func TestDownlinkQueuePush(t *testing.T) {
 				})
 				if !a.So(err, should.BeError) {
 					t.Error("Error was expected")
-					return nil, errors.New("Error was expected")
+					return nil, ctx, errors.New("Error was expected")
 				}
 				a.So(sets, should.BeNil)
 				a.So(dev, should.BeNil)
-				return nil, err
+				return nil, ctx, err
 			},
 			Request: &ttnpb.DownlinkQueueRequest{
 				EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -1662,7 +1662,7 @@ func TestDownlinkQueuePush(t *testing.T) {
 				componenttest.NewComponent(t, &component.Config{}),
 				&Config{
 					Devices: &MockDeviceRegistry{
-						SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+						SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 							atomic.AddUint64(&setByIDCalls, 1)
 							return tc.SetByIDFunc(ctx, appID, devID, gets, f)
 						},
@@ -1710,7 +1710,7 @@ func TestDownlinkQueueList(t *testing.T) {
 	for _, tc := range []struct {
 		Name           string
 		ContextFunc    func(context.Context) context.Context
-		GetByIDFunc    func(context.Context, ttnpb.ApplicationIdentifiers, string, []string) (*ttnpb.EndDevice, error)
+		GetByIDFunc    func(context.Context, ttnpb.ApplicationIdentifiers, string, []string) (*ttnpb.EndDevice, context.Context, error)
 		Request        *ttnpb.EndDeviceIdentifiers
 		Downlinks      *ttnpb.ApplicationDownlinks
 		ErrorAssertion func(*testing.T, error) bool
@@ -1729,10 +1729,10 @@ func TestDownlinkQueueList(t *testing.T) {
 					},
 				})
 			},
-			GetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, error) {
+			GetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, context.Context, error) {
 				err := errors.New("GetByIDFunc must not be called")
 				test.MustTFromContext(ctx).Error(err)
-				return nil, err
+				return nil, ctx, err
 			},
 			Request: &ttnpb.EndDeviceIdentifiers{
 				DeviceID:               "test-dev-id",
@@ -1760,7 +1760,7 @@ func TestDownlinkQueueList(t *testing.T) {
 					},
 				})
 			},
-			GetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, error) {
+			GetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, context.Context, error) {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
@@ -1773,7 +1773,7 @@ func TestDownlinkQueueList(t *testing.T) {
 						DeviceID:               "test-dev-id",
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
 					},
-				}, nil
+				}, ctx, nil
 			},
 			Request: &ttnpb.EndDeviceIdentifiers{
 				DeviceID:               "test-dev-id",
@@ -1796,7 +1796,7 @@ func TestDownlinkQueueList(t *testing.T) {
 					},
 				})
 			},
-			GetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, error) {
+			GetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, context.Context, error) {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
@@ -1818,7 +1818,7 @@ func TestDownlinkQueueList(t *testing.T) {
 						{SessionKeyID: []byte("testSession"), FCnt: 0},
 						{SessionKeyID: []byte("testSession"), FCnt: 42},
 					},
-				}, nil
+				}, ctx, nil
 			},
 			Request: &ttnpb.EndDeviceIdentifiers{
 				DeviceID:               "test-dev-id",
@@ -1842,7 +1842,7 @@ func TestDownlinkQueueList(t *testing.T) {
 				componenttest.NewComponent(t, &component.Config{}),
 				&Config{
 					Devices: &MockDeviceRegistry{
-						GetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, error) {
+						GetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, context.Context, error) {
 							atomic.AddUint64(&getByIDCalls, 1)
 							return tc.GetByIDFunc(ctx, appID, devID, gets)
 						},

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -173,7 +173,7 @@ func (ns *NetworkServer) Get(ctx context.Context, req *ttnpb.GetEndDeviceRequest
 		gets = ttnpb.AddFields(gets, "mac_state.desired_parameters.ping_slot_data_rate_index_value")
 	}
 
-	dev, err := ns.devices.GetByID(ctx, req.ApplicationIdentifiers, req.DeviceID, gets)
+	dev, ctx, err := ns.devices.GetByID(ctx, req.ApplicationIdentifiers, req.DeviceID, gets)
 	if err != nil {
 		return nil, err
 	}
@@ -402,7 +402,7 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 	}
 
 	var evt events.Event
-	dev, err = ns.devices.SetByID(ctx, req.EndDevice.EndDeviceIdentifiers.ApplicationIdentifiers, req.EndDevice.EndDeviceIdentifiers.DeviceID, gets, func(dev *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
+	dev, ctx, err = ns.devices.SetByID(ctx, req.EndDevice.EndDeviceIdentifiers.ApplicationIdentifiers, req.EndDevice.EndDeviceIdentifiers.DeviceID, gets, func(ctx context.Context, dev *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
 		if ttnpb.HasAnyField(sets, "version_ids") {
 			// TODO: Apply version IDs (https://github.com/TheThingsIndustries/lorawan-stack/issues/1544)
 		}
@@ -589,7 +589,7 @@ func (ns *NetworkServer) Delete(ctx context.Context, req *ttnpb.EndDeviceIdentif
 		return nil, err
 	}
 	var evt events.Event
-	_, err := ns.devices.SetByID(ctx, req.ApplicationIdentifiers, req.DeviceID, nil, func(dev *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
+	_, _, err := ns.devices.SetByID(ctx, req.ApplicationIdentifiers, req.DeviceID, nil, func(ctx context.Context, dev *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
 		if dev != nil {
 			evt = evtDeleteEndDevice(ctx, req, nil)
 		}

--- a/pkg/networkserver/grpc_deviceregistry_test.go
+++ b/pkg/networkserver/grpc_deviceregistry_test.go
@@ -42,7 +42,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 	for _, tc := range []struct {
 		Name           string
 		ContextFunc    func(context.Context) context.Context
-		GetByIDFunc    func(context.Context, ttnpb.ApplicationIdentifiers, string, []string) (*ttnpb.EndDevice, error)
+		GetByIDFunc    func(context.Context, ttnpb.ApplicationIdentifiers, string, []string) (*ttnpb.EndDevice, context.Context, error)
 		KeyVault       map[string][]byte
 		Request        *ttnpb.GetEndDeviceRequest
 		Device         *ttnpb.EndDevice
@@ -62,10 +62,10 @@ func TestDeviceRegistryGet(t *testing.T) {
 					},
 				})
 			},
-			GetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, error) {
+			GetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, context.Context, error) {
 				err := errors.New("GetByIDFunc must not be called")
 				test.MustTFromContext(ctx).Error(err)
-				return nil, err
+				return nil, ctx, err
 			},
 			Request: &ttnpb.GetEndDeviceRequest{
 				EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -100,7 +100,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 					},
 				})
 			},
-			GetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, error) {
+			GetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
@@ -113,7 +113,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
 					},
 					FrequencyPlanID: test.EUFrequencyPlanID,
-				}, nil
+				}, ctx, nil
 			},
 			Request: &ttnpb.GetEndDeviceRequest{
 				EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -150,7 +150,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 					},
 				})
 			},
-			GetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, error) {
+			GetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
@@ -172,7 +172,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 							},
 						},
 					},
-				}, nil
+				}, ctx, nil
 			},
 			KeyVault: map[string][]byte{
 				"test": {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17},
@@ -220,7 +220,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 					},
 				})
 			},
-			GetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, error) {
+			GetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
@@ -240,7 +240,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 							},
 						},
 					},
-				}, nil
+				}, ctx, nil
 			},
 			KeyVault: map[string][]byte{
 				"test": {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17},
@@ -286,7 +286,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 					},
 				})
 			},
-			GetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, error) {
+			GetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
@@ -308,7 +308,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 							},
 						},
 					},
-				}, nil
+				}, ctx, nil
 			},
 			KeyVault: map[string][]byte{
 				"test": {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17},
@@ -356,7 +356,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 				}),
 				&Config{
 					Devices: &MockDeviceRegistry{
-						GetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, error) {
+						GetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string) (*ttnpb.EndDevice, context.Context, error) {
 							atomic.AddUint64(&getByIDCalls, 1)
 							return tc.GetByIDFunc(ctx, appID, devID, gets)
 						},
@@ -399,7 +399,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 		Name           string
 		ContextFunc    func(context.Context) context.Context
 		AddFunc        func(context.Context, ttnpb.EndDeviceIdentifiers, time.Time, bool) error
-		SetByIDFunc    func(context.Context, ttnpb.ApplicationIdentifiers, string, []string, func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error)
+		SetByIDFunc    func(context.Context, ttnpb.ApplicationIdentifiers, string, []string, func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error)
 		Request        *ttnpb.SetEndDeviceRequest
 		Device         *ttnpb.EndDevice
 		ErrorAssertion func(*testing.T, error) bool
@@ -424,10 +424,10 @@ func TestDeviceRegistrySet(t *testing.T) {
 				test.MustTFromContext(ctx).Error(err)
 				return err
 			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				err := errors.New("SetByIDFunc must not be called")
 				test.MustTFromContext(ctx).Error(err)
-				return nil, err
+				return nil, ctx, err
 			},
 			Request: &ttnpb.SetEndDeviceRequest{
 				EndDevice: ttnpb.EndDevice{
@@ -478,7 +478,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 				test.MustTFromContext(ctx).Error(err)
 				return err
 			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
@@ -492,14 +492,14 @@ func TestDeviceRegistrySet(t *testing.T) {
 					"supports_join",
 				})
 
-				dev, sets, err := f(nil)
+				dev, sets, err := f(ctx, nil)
 				if !a.So(err, should.NotBeNil) {
-					return nil, errors.New("test failed")
+					return nil, ctx, errors.New("test failed")
 				}
 				a.So(dev, should.BeNil)
 				a.So(sets, should.BeNil)
 				a.So(errors.IsInvalidArgument(err), should.BeTrue)
-				return nil, err
+				return nil, ctx, err
 			},
 			Request: &ttnpb.SetEndDeviceRequest{
 				EndDevice: ttnpb.EndDevice{
@@ -549,7 +549,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 				test.MustTFromContext(ctx).Error(err)
 				return err
 			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
@@ -573,9 +573,9 @@ func TestDeviceRegistrySet(t *testing.T) {
 					"supports_join",
 				})
 
-				dev, sets, err := f(nil)
+				dev, sets, err := f(ctx, nil)
 				if !a.So(err, should.BeNil) {
-					return nil, err
+					return nil, ctx, err
 				}
 				a.So(sets, should.HaveSameElementsDeep, []string{
 					"frequency_plan_id",
@@ -605,7 +605,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 						ADRMargin: &pbtypes.FloatValue{Value: 4},
 					},
 				})
-				return dev, nil
+				return dev, ctx, nil
 			},
 			Request: &ttnpb.SetEndDeviceRequest{
 				EndDevice: ttnpb.EndDevice{
@@ -673,7 +673,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 				test.MustTFromContext(ctx).Error(err)
 				return err
 			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
@@ -698,9 +698,9 @@ func TestDeviceRegistrySet(t *testing.T) {
 					"supports_join",
 				})
 
-				dev, sets, err := f(nil)
+				dev, sets, err := f(ctx, nil)
 				if !a.So(err, should.BeNil) {
-					return nil, err
+					return nil, ctx, err
 				}
 				a.So(sets, should.HaveSameElementsDeep, []string{
 					"frequency_plan_id",
@@ -768,7 +768,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 				}
 				expected.MACState = macState
 				a.So(dev, should.Resemble, expected)
-				return dev, nil
+				return dev, ctx, nil
 			},
 			Request: &ttnpb.SetEndDeviceRequest{
 				EndDevice: ttnpb.EndDevice{
@@ -865,7 +865,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 				test.MustTFromContext(ctx).Error(err)
 				return err
 			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
@@ -890,9 +890,9 @@ func TestDeviceRegistrySet(t *testing.T) {
 					"supports_join",
 				})
 
-				dev, sets, err := f(nil)
+				dev, sets, err := f(ctx, nil)
 				if !a.So(err, should.BeNil) {
-					return nil, err
+					return nil, ctx, err
 				}
 				a.So(sets, should.HaveSameElementsDeep, []string{
 					"frequency_plan_id",
@@ -955,7 +955,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 				}
 				expected.MACState = macState
 				a.So(dev, should.Resemble, expected)
-				return dev, nil
+				return dev, ctx, nil
 			},
 			Request: &ttnpb.SetEndDeviceRequest{
 				EndDevice: ttnpb.EndDevice{
@@ -1047,7 +1047,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 				test.MustTFromContext(ctx).Error(err)
 				return err
 			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
@@ -1072,9 +1072,9 @@ func TestDeviceRegistrySet(t *testing.T) {
 					"supports_join",
 				})
 
-				dev, sets, err := f(nil)
+				dev, sets, err := f(ctx, nil)
 				if !a.So(err, should.BeNil) {
-					return nil, err
+					return nil, ctx, err
 				}
 				a.So(sets, should.HaveSameElementsDeep, []string{
 					"frequency_plan_id",
@@ -1141,7 +1141,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 				}
 				expected.MACState = macState
 				a.So(dev, should.Resemble, expected)
-				return dev, nil
+				return dev, ctx, nil
 			},
 			Request: &ttnpb.SetEndDeviceRequest{
 				EndDevice: ttnpb.EndDevice{
@@ -1235,7 +1235,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 				test.MustTFromContext(ctx).Error(err)
 				return err
 			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
@@ -1255,7 +1255,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 					"session.last_n_f_cnt_down",
 				})
 
-				dev, sets, err := f(&ttnpb.EndDevice{
+				dev, sets, err := f(ctx, &ttnpb.EndDevice{
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
 						DeviceID:               "test-dev-id",
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
@@ -1273,7 +1273,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 					},
 				})
 				if !a.So(err, should.BeNil) {
-					return nil, err
+					return nil, ctx, err
 				}
 				a.So(sets, should.HaveSameElementsDeep, []string{
 					"mac_state.desired_parameters.rx2_frequency",
@@ -1305,7 +1305,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 							Rx2Frequency: 123456789,
 						},
 					},
-				}, nil
+				}, ctx, nil
 			},
 			Request: &ttnpb.SetEndDeviceRequest{
 				EndDevice: ttnpb.EndDevice{
@@ -1348,7 +1348,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 				componenttest.NewComponent(t, &component.Config{}),
 				&Config{
 					Devices: &MockDeviceRegistry{
-						SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+						SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 							atomic.AddUint64(&setByIDCalls, 1)
 							return tc.SetByIDFunc(ctx, appID, devID, gets, f)
 						},
@@ -1397,7 +1397,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 	for _, tc := range []struct {
 		Name           string
 		ContextFunc    func(context.Context) context.Context
-		SetByIDFunc    func(context.Context, ttnpb.ApplicationIdentifiers, string, []string, func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error)
+		SetByIDFunc    func(context.Context, ttnpb.ApplicationIdentifiers, string, []string, func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error)
 		Request        *ttnpb.EndDeviceIdentifiers
 		ErrorAssertion func(*testing.T, error) bool
 		SetByIDCalls   uint64
@@ -1415,10 +1415,10 @@ func TestDeviceRegistryDelete(t *testing.T) {
 					},
 				})
 			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				err := errors.New("SetByIDFunc must not be called")
 				test.MustTFromContext(ctx).Error(err)
-				return nil, err
+				return nil, ctx, err
 			},
 			Request: &ttnpb.EndDeviceIdentifiers{
 				DeviceID:               "test-dev-id",
@@ -1446,20 +1446,20 @@ func TestDeviceRegistryDelete(t *testing.T) {
 					},
 				})
 			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				t := test.MustTFromContext(ctx)
 				a := assertions.New(t)
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.BeNil)
 
-				dev, sets, err := f(nil)
+				dev, sets, err := f(ctx, nil)
 				if !a.So(err, should.BeNil) {
-					return nil, err
+					return nil, ctx, err
 				}
 				a.So(sets, should.BeNil)
 				a.So(dev, should.BeNil)
-				return nil, nil
+				return nil, ctx, nil
 			},
 			Request: &ttnpb.EndDeviceIdentifiers{
 				DeviceID:               "test-dev-id",
@@ -1481,24 +1481,24 @@ func TestDeviceRegistryDelete(t *testing.T) {
 					},
 				})
 			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
 				a.So(devID, should.Equal, "test-dev-id")
 				a.So(gets, should.BeNil)
 
-				dev, sets, err := f(&ttnpb.EndDevice{
+				dev, sets, err := f(ctx, &ttnpb.EndDevice{
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
 						DeviceID:               "test-dev-id",
 						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
 					},
 				})
 				if !a.So(err, should.BeNil) {
-					return nil, err
+					return nil, ctx, err
 				}
 				a.So(sets, should.BeNil)
 				a.So(dev, should.BeNil)
-				return nil, nil
+				return nil, ctx, nil
 			},
 			Request: &ttnpb.EndDeviceIdentifiers{
 				DeviceID:               "test-dev-id",
@@ -1516,7 +1516,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 				componenttest.NewComponent(t, &component.Config{}),
 				&Config{
 					Devices: &MockDeviceRegistry{
-						SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
+						SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 							atomic.AddUint64(&setByIDCalls, 1)
 							return tc.SetByIDFunc(ctx, appID, devID, gets, f)
 						},

--- a/pkg/networkserver/registry.go
+++ b/pkg/networkserver/registry.go
@@ -23,14 +23,8 @@ import (
 
 // DeviceRegistry is a registry, containing devices.
 type DeviceRegistry interface {
-	GetByEUI(ctx context.Context, joinEUI, devEUI types.EUI64, paths []string) (*ttnpb.EndDevice, error)
-	GetByID(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, paths []string) (*ttnpb.EndDevice, error)
-	RangeByAddr(ctx context.Context, devAddr types.DevAddr, paths []string, f func(*ttnpb.EndDevice) bool) error
-	SetByID(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, paths []string, f func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error)
-}
-
-// DeleteDevice deletes device identified by appID, devID from r.
-func DeleteDevice(ctx context.Context, r DeviceRegistry, appID ttnpb.ApplicationIdentifiers, devID string) error {
-	_, err := r.SetByID(ctx, appID, devID, nil, func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) { return nil, nil, nil })
-	return err
+	GetByEUI(ctx context.Context, joinEUI, devEUI types.EUI64, paths []string) (*ttnpb.EndDevice, context.Context, error)
+	GetByID(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, paths []string) (*ttnpb.EndDevice, context.Context, error)
+	RangeByAddr(ctx context.Context, devAddr types.DevAddr, paths []string, f func(context.Context, *ttnpb.EndDevice) bool) error
+	SetByID(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, paths []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/issues/1924

#### Changes
<!-- What are the changes made in this pull request? -->

- Expose stored device context in registry transactions

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
