### PR TITLE
Retrieve matched device context from registry in Network Server

### DIFF
--- a/pkg/networkserver/grpc_gsns_internal_test.go
+++ b/pkg/networkserver/grpc_gsns_internal_test.go
@@ -156,11 +156,13 @@ func TestMatchAndHandleUplink(t *testing.T) {
 		}
 	}
 
+	deviceCtx := context.WithValue(test.Context(), struct{}{}, 42)
+
 	for _, tc := range []struct {
 		Name            string
 		Uplink          *ttnpb.UplinkMessage
 		Deduplicated    bool
-		Devices         []*ttnpb.EndDevice
+		Devices         []contextualEndDevice
 		DeviceAssertion func(ctx context.Context, dev *matchedDevice, up *ttnpb.UplinkMessage) bool
 		ErrorAssertion  func(ctx context.Context, err error) bool
 	}{
@@ -193,17 +195,20 @@ func TestMatchAndHandleUplink(t *testing.T) {
 					Timestamp: 42,
 				},
 			),
-			Devices: []*ttnpb.EndDevice{
+			Devices: []contextualEndDevice{
 				{
-					EndDeviceIdentifiers: *makeABPIdentifiers(devAddr),
-					FrequencyPlanID:      test.EUFrequencyPlanID,
-					LoRaWANPHYVersion:    ttnpb.PHY_V1_1_REV_B,
-					LoRaWANVersion:       ttnpb.MAC_V1_1,
-					MACState:             MakeDefaultUS915FSB2MACState(ttnpb.CLASS_B, ttnpb.MAC_V1_1),
-					Session:              makeSession(ttnpb.MAC_V1_1, devAddr, 33),
-					MACSettings: &ttnpb.MACSettings{
-						ResetsFCnt:        &pbtypes.BoolValue{Value: true},
-						Supports32BitFCnt: &pbtypes.BoolValue{Value: false},
+					Context: deviceCtx,
+					EndDevice: &ttnpb.EndDevice{
+						EndDeviceIdentifiers: *makeABPIdentifiers(devAddr),
+						FrequencyPlanID:      test.EUFrequencyPlanID,
+						LoRaWANPHYVersion:    ttnpb.PHY_V1_1_REV_B,
+						LoRaWANVersion:       ttnpb.MAC_V1_1,
+						MACState:             MakeDefaultUS915FSB2MACState(ttnpb.CLASS_B, ttnpb.MAC_V1_1),
+						Session:              makeSession(ttnpb.MAC_V1_1, devAddr, 33),
+						MACSettings: &ttnpb.MACSettings{
+							ResetsFCnt:        &pbtypes.BoolValue{Value: true},
+							Supports32BitFCnt: &pbtypes.BoolValue{Value: false},
+						},
 					},
 				},
 			},
@@ -219,8 +224,8 @@ func TestMatchAndHandleUplink(t *testing.T) {
 				macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1)
 				macState.RxWindowsAvailable = true
 				expectedDev := &matchedDevice{
-					logger:              dev.logger,
 					phy:                 test.Must(band.All[band.EU_863_870].Version(ttnpb.PHY_V1_1_REV_B)).(band.Band),
+					Context:             dev.Context,
 					ChannelIndex:        1,
 					DataRateIndex:       ttnpb.DATA_RATE_2,
 					DeferredMACHandlers: dev.DeferredMACHandlers,
@@ -249,6 +254,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 
 				if !a.So([]time.Time{start, dev.Device.Session.StartedAt, time.Now()}, should.BeChronological) ||
 					!a.So(dev.DeferredMACHandlers, should.HaveLength, 1) ||
+					!a.So(dev.Context, should.HaveParentContext, deviceCtx) ||
 					!a.So(dev, should.HaveEmptyDiff, expectedDev) {
 					return false
 				}
@@ -302,21 +308,24 @@ func TestMatchAndHandleUplink(t *testing.T) {
 					Timestamp: 42,
 				},
 			),
-			Devices: []*ttnpb.EndDevice{
+			Devices: []contextualEndDevice{
 				{
-					EndDeviceIdentifiers: *makeABPIdentifiers(devAddr),
-					FrequencyPlanID:      test.EUFrequencyPlanID,
-					LoRaWANPHYVersion:    ttnpb.PHY_V1_1_REV_B,
-					LoRaWANVersion:       ttnpb.MAC_V1_1,
-					MACState: func() *ttnpb.MACState {
-						macState := MakeDefaultUS915FSB2MACState(ttnpb.CLASS_B, ttnpb.MAC_V1_1)
-						macState.PendingApplicationDownlink = makeApplicationDownlink()
-						return macState
-					}(),
-					Session: makeSession(ttnpb.MAC_V1_1, devAddr, 33),
-					MACSettings: &ttnpb.MACSettings{
-						ResetsFCnt:        &pbtypes.BoolValue{Value: true},
-						Supports32BitFCnt: &pbtypes.BoolValue{Value: false},
+					Context: deviceCtx,
+					EndDevice: &ttnpb.EndDevice{
+						EndDeviceIdentifiers: *makeABPIdentifiers(devAddr),
+						FrequencyPlanID:      test.EUFrequencyPlanID,
+						LoRaWANPHYVersion:    ttnpb.PHY_V1_1_REV_B,
+						LoRaWANVersion:       ttnpb.MAC_V1_1,
+						MACState: func() *ttnpb.MACState {
+							macState := MakeDefaultUS915FSB2MACState(ttnpb.CLASS_B, ttnpb.MAC_V1_1)
+							macState.PendingApplicationDownlink = makeApplicationDownlink()
+							return macState
+						}(),
+						Session: makeSession(ttnpb.MAC_V1_1, devAddr, 33),
+						MACSettings: &ttnpb.MACSettings{
+							ResetsFCnt:        &pbtypes.BoolValue{Value: true},
+							Supports32BitFCnt: &pbtypes.BoolValue{Value: false},
+						},
 					},
 				},
 			},
@@ -332,8 +341,8 @@ func TestMatchAndHandleUplink(t *testing.T) {
 				macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1)
 				macState.RxWindowsAvailable = true
 				expectedDev := &matchedDevice{
-					logger:              dev.logger,
 					phy:                 test.Must(band.All[band.EU_863_870].Version(ttnpb.PHY_V1_1_REV_B)).(band.Band),
+					Context:             dev.Context,
 					ChannelIndex:        1,
 					DataRateIndex:       ttnpb.DATA_RATE_2,
 					DeferredMACHandlers: dev.DeferredMACHandlers,
@@ -364,6 +373,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 				}
 				if !a.So([]time.Time{start, dev.Device.Session.StartedAt, time.Now()}, should.BeChronological) ||
 					!a.So(dev.DeferredMACHandlers, should.HaveLength, 1) ||
+					!a.So(dev.Context, should.HaveParentContext, deviceCtx) ||
 					!a.So(dev, should.HaveEmptyDiff, expectedDev) {
 					return false
 				}
@@ -417,16 +427,19 @@ func TestMatchAndHandleUplink(t *testing.T) {
 					Timestamp: 42,
 				},
 			),
-			Devices: []*ttnpb.EndDevice{
+			Devices: []contextualEndDevice{
 				{
-					EndDeviceIdentifiers: *makeABPIdentifiers(devAddr),
-					FrequencyPlanID:      test.EUFrequencyPlanID,
-					LoRaWANPHYVersion:    ttnpb.PHY_V1_1_REV_B,
-					LoRaWANVersion:       ttnpb.MAC_V1_1,
-					MACState:             MakeDefaultUS915FSB2MACState(ttnpb.CLASS_B, ttnpb.MAC_V1_1),
-					Session:              makeSession(ttnpb.MAC_V1_1, devAddr, 33),
-					MACSettings: &ttnpb.MACSettings{
-						ResetsFCnt: &pbtypes.BoolValue{Value: true},
+					Context: deviceCtx,
+					EndDevice: &ttnpb.EndDevice{
+						EndDeviceIdentifiers: *makeABPIdentifiers(devAddr),
+						FrequencyPlanID:      test.EUFrequencyPlanID,
+						LoRaWANPHYVersion:    ttnpb.PHY_V1_1_REV_B,
+						LoRaWANVersion:       ttnpb.MAC_V1_1,
+						MACState:             MakeDefaultUS915FSB2MACState(ttnpb.CLASS_B, ttnpb.MAC_V1_1),
+						Session:              makeSession(ttnpb.MAC_V1_1, devAddr, 33),
+						MACSettings: &ttnpb.MACSettings{
+							ResetsFCnt: &pbtypes.BoolValue{Value: true},
+						},
 					},
 				},
 			},
@@ -442,8 +455,8 @@ func TestMatchAndHandleUplink(t *testing.T) {
 				macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1)
 				macState.RxWindowsAvailable = true
 				expectedDev := &matchedDevice{
-					logger:              dev.logger,
 					phy:                 test.Must(band.All[band.EU_863_870].Version(ttnpb.PHY_V1_1_REV_B)).(band.Band),
+					Context:             dev.Context,
 					ChannelIndex:        1,
 					DataRateIndex:       ttnpb.DATA_RATE_2,
 					DeferredMACHandlers: dev.DeferredMACHandlers,
@@ -470,6 +483,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 				}
 				if !a.So([]time.Time{start, dev.Device.Session.StartedAt, time.Now()}, should.BeChronological) ||
 					!a.So(dev.DeferredMACHandlers, should.HaveLength, 1) ||
+					!a.So(dev.Context, should.HaveParentContext, deviceCtx) ||
 					!a.So(dev, should.HaveEmptyDiff, expectedDev) {
 					return false
 				}
@@ -526,30 +540,33 @@ func TestMatchAndHandleUplink(t *testing.T) {
 					Timestamp: 42,
 				},
 			),
-			Devices: []*ttnpb.EndDevice{
+			Devices: []contextualEndDevice{
 				{
-					EndDeviceIdentifiers: *makeABPIdentifiers(devAddr),
-					FrequencyPlanID:      test.EUFrequencyPlanID,
-					LoRaWANPHYVersion:    ttnpb.PHY_V1_1_REV_B,
-					LoRaWANVersion:       ttnpb.MAC_V1_1,
-					MACState: func() *ttnpb.MACState {
-						macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1)
-						macState.PendingApplicationDownlink = makeApplicationDownlink()
-						macState.RecentDownlinks = []*ttnpb.DownlinkMessage{
-							{
-								Payload: &ttnpb.Message{
-									MHDR: ttnpb.MHDR{
-										MType: ttnpb.MType_CONFIRMED_DOWN,
-									},
-									Payload: &ttnpb.Message_MACPayload{
-										MACPayload: &ttnpb.MACPayload{},
+					Context: deviceCtx,
+					EndDevice: &ttnpb.EndDevice{
+						EndDeviceIdentifiers: *makeABPIdentifiers(devAddr),
+						FrequencyPlanID:      test.EUFrequencyPlanID,
+						LoRaWANPHYVersion:    ttnpb.PHY_V1_1_REV_B,
+						LoRaWANVersion:       ttnpb.MAC_V1_1,
+						MACState: func() *ttnpb.MACState {
+							macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1)
+							macState.PendingApplicationDownlink = makeApplicationDownlink()
+							macState.RecentDownlinks = []*ttnpb.DownlinkMessage{
+								{
+									Payload: &ttnpb.Message{
+										MHDR: ttnpb.MHDR{
+											MType: ttnpb.MType_CONFIRMED_DOWN,
+										},
+										Payload: &ttnpb.Message_MACPayload{
+											MACPayload: &ttnpb.MACPayload{},
+										},
 									},
 								},
-							},
-						}
-						return macState
-					}(),
-					Session: makeSession(ttnpb.MAC_V1_1, devAddr, 10),
+							}
+							return macState
+						}(),
+						Session: makeSession(ttnpb.MAC_V1_1, devAddr, 10),
+					},
 				},
 			},
 			DeviceAssertion: func(ctx context.Context, dev *matchedDevice, up *ttnpb.UplinkMessage) bool {
@@ -574,8 +591,8 @@ func TestMatchAndHandleUplink(t *testing.T) {
 					},
 				}
 				expectedDev := &matchedDevice{
-					logger:              dev.logger,
 					phy:                 test.Must(band.All[band.EU_863_870].Version(ttnpb.PHY_V1_1_REV_B)).(band.Band),
+					Context:             dev.Context,
 					ChannelIndex:        1,
 					DataRateIndex:       ttnpb.DATA_RATE_2,
 					DeferredMACHandlers: dev.DeferredMACHandlers,
@@ -600,6 +617,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 					},
 				}
 				if !a.So(dev.DeferredMACHandlers, should.HaveLength, 1) ||
+					!a.So(dev.Context, should.HaveParentContext, deviceCtx) ||
 					!a.So(dev, should.HaveEmptyDiff, expectedDev) {
 					return false
 				}
@@ -632,7 +650,14 @@ func TestMatchAndHandleUplink(t *testing.T) {
 
 			<-env.DownlinkTasks.Pop
 
-			dev, err := ns.matchAndHandleDataUplink(ctx, CopyUplinkMessage(tc.Uplink), tc.Deduplicated, CopyEndDevices(tc.Devices...)...)
+			devs := append(tc.Devices[:0:0], tc.Devices...)
+			for i, dev := range devs {
+				devs[i] = contextualEndDevice{
+					Context:   dev.Context,
+					EndDevice: CopyEndDevice(dev.EndDevice),
+				}
+			}
+			dev, err := ns.matchAndHandleDataUplink(CopyUplinkMessage(tc.Uplink), tc.Deduplicated, devs...)
 			a.So(tc.DeviceAssertion(ctx, dev, CopyUplinkMessage(tc.Uplink)), should.BeTrue)
 			a.So(tc.ErrorAssertion(ctx, err), should.BeTrue)
 		})

--- a/pkg/networkserver/grpc_gsns_test.go
+++ b/pkg/networkserver/grpc_gsns_test.go
@@ -2363,7 +2363,7 @@ func TestHandleUplink(t *testing.T) {
 					UpdatedAt:            start,
 				}
 
-				var upCtx context.Context
+				var rangeCtx context.Context
 				var upCorrelationIDs []string
 				select {
 				case <-ctx.Done():
@@ -2371,7 +2371,6 @@ func TestHandleUplink(t *testing.T) {
 					return false
 
 				case req := <-env.DeviceRegistry.RangeByAddr:
-					upCtx = req.Context
 					upCorrelationIDs = events.CorrelationIDsFromContext(req.Context)
 					for _, id := range correlationIDs {
 						a.So(upCorrelationIDs, should.Contain, id)
@@ -2379,17 +2378,18 @@ func TestHandleUplink(t *testing.T) {
 					a.So(upCorrelationIDs, should.HaveLength, len(correlationIDs)+2)
 					a.So(req.DevAddr, should.Resemble, devAddr)
 					a.So(req.Paths, should.HaveSameElementsDeep, dataGetPaths[:])
-					a.So(req.Func(ctx, CopyEndDevice(rangeDevice)), should.BeTrue)
+					rangeCtx = context.WithValue(req.Context, struct{}{}, "range")
+					a.So(req.Func(rangeCtx, CopyEndDevice(rangeDevice)), should.BeTrue)
 					multicastDevice := CopyEndDevice(rangeDevice)
 					multicastDevice.EndDeviceIdentifiers.DeviceID += "-multicast"
 					multicastDevice.Multicast = true
-					a.So(req.Func(ctx, multicastDevice), should.BeTrue)
+					a.So(req.Func(context.WithValue(ctx, struct{}{}, "multicast"), multicastDevice), should.BeTrue)
 					fCntTooHighDevice := CopyEndDevice(rangeDevice)
 					fCntTooHighDevice.EndDeviceIdentifiers.DeviceID += "-too-high"
 					fCntTooHighDevice.MACState.RecentUplinks = append(fCntTooHighDevice.MACState.RecentUplinks, makeLegacyDataUplink(42, true))
 					fCntTooHighDevice.RecentUplinks = append(fCntTooHighDevice.RecentUplinks, makeLegacyDataUplink(42, true))
 					fCntTooHighDevice.Session.LastFCntUp = 42
-					a.So(req.Func(ctx, fCntTooHighDevice), should.BeTrue)
+					a.So(req.Func(context.WithValue(ctx, struct{}{}, "fcnt-too-high"), fCntTooHighDevice), should.BeTrue)
 					req.Response <- nil
 				}
 
@@ -2407,7 +2407,7 @@ func TestHandleUplink(t *testing.T) {
 					return false
 
 				case req := <-env.DeviceRegistry.SetByID:
-					a.So(req.Context, should.HaveParentContextOrEqual, upCtx)
+					a.So(req.Context, should.HaveParentContextOrEqual, rangeCtx)
 					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
 					a.So(req.DeviceID, should.Resemble, devID)
 					a.So(req.Paths, should.HaveSameElementsDeep, dataGetPaths[:])
@@ -2595,7 +2595,7 @@ func TestHandleUplink(t *testing.T) {
 					UpdatedAt:            start,
 				}
 
-				var upCtx context.Context
+				var rangeCtx context.Context
 				var upCorrelationIDs []string
 				select {
 				case <-ctx.Done():
@@ -2603,7 +2603,6 @@ func TestHandleUplink(t *testing.T) {
 					return false
 
 				case req := <-env.DeviceRegistry.RangeByAddr:
-					upCtx = req.Context
 					upCorrelationIDs = events.CorrelationIDsFromContext(req.Context)
 					for _, id := range correlationIDs {
 						a.So(upCorrelationIDs, should.Contain, id)
@@ -2611,17 +2610,18 @@ func TestHandleUplink(t *testing.T) {
 					a.So(upCorrelationIDs, should.HaveLength, len(correlationIDs)+2)
 					a.So(req.DevAddr, should.Resemble, devAddr)
 					a.So(req.Paths, should.HaveSameElementsDeep, dataGetPaths[:])
-					a.So(req.Func(ctx, CopyEndDevice(rangeDevice)), should.BeTrue)
+					rangeCtx = context.WithValue(req.Context, struct{}{}, "range")
+					a.So(req.Func(rangeCtx, CopyEndDevice(rangeDevice)), should.BeTrue)
 					multicastDevice := CopyEndDevice(rangeDevice)
 					multicastDevice.EndDeviceIdentifiers.DeviceID += "-multicast"
 					multicastDevice.Multicast = true
-					a.So(req.Func(ctx, multicastDevice), should.BeTrue)
+					a.So(req.Func(context.WithValue(req.Context, struct{}{}, "multicast"), multicastDevice), should.BeTrue)
 					fCntTooHighDevice := CopyEndDevice(rangeDevice)
 					fCntTooHighDevice.EndDeviceIdentifiers.DeviceID += "-too-high"
 					fCntTooHighDevice.MACState.RecentUplinks = append(fCntTooHighDevice.MACState.RecentUplinks, makeLegacyDataUplink(42, true))
 					fCntTooHighDevice.RecentUplinks = append(fCntTooHighDevice.RecentUplinks, makeLegacyDataUplink(42, true))
 					fCntTooHighDevice.Session.LastFCntUp = 42
-					a.So(req.Func(ctx, fCntTooHighDevice), should.BeTrue)
+					a.So(req.Func(context.WithValue(req.Context, struct{}{}, "fcnt-too-high"), fCntTooHighDevice), should.BeTrue)
 					req.Response <- nil
 				}
 
@@ -2639,7 +2639,7 @@ func TestHandleUplink(t *testing.T) {
 					return false
 
 				case req := <-env.DeviceRegistry.SetByID:
-					a.So(req.Context, should.HaveParentContextOrEqual, upCtx)
+					a.So(req.Context, should.HaveParentContextOrEqual, rangeCtx)
 					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
 					a.So(req.DeviceID, should.Resemble, devID)
 					a.So(req.Paths, should.HaveSameElementsDeep, dataGetPaths[:])
@@ -2827,7 +2827,7 @@ func TestHandleUplink(t *testing.T) {
 					UpdatedAt:            start,
 				}
 
-				var upCtx context.Context
+				var rangeCtx context.Context
 				var upCorrelationIDs []string
 				select {
 				case <-ctx.Done():
@@ -2835,7 +2835,6 @@ func TestHandleUplink(t *testing.T) {
 					return false
 
 				case req := <-env.DeviceRegistry.RangeByAddr:
-					upCtx = req.Context
 					upCorrelationIDs = events.CorrelationIDsFromContext(req.Context)
 					for _, id := range correlationIDs {
 						a.So(upCorrelationIDs, should.Contain, id)
@@ -2843,17 +2842,18 @@ func TestHandleUplink(t *testing.T) {
 					a.So(upCorrelationIDs, should.HaveLength, len(correlationIDs)+2)
 					a.So(req.DevAddr, should.Resemble, devAddr)
 					a.So(req.Paths, should.HaveSameElementsDeep, dataGetPaths[:])
-					a.So(req.Func(ctx, CopyEndDevice(rangeDevice)), should.BeTrue)
+					rangeCtx = context.WithValue(req.Context, struct{}{}, "range")
+					a.So(req.Func(rangeCtx, CopyEndDevice(rangeDevice)), should.BeTrue)
 					multicastDevice := CopyEndDevice(rangeDevice)
 					multicastDevice.EndDeviceIdentifiers.DeviceID += "-multicast"
 					multicastDevice.Multicast = true
-					a.So(req.Func(ctx, multicastDevice), should.BeTrue)
+					a.So(req.Func(context.WithValue(ctx, struct{}{}, "multicast"), multicastDevice), should.BeTrue)
 					fCntTooHighDevice := CopyEndDevice(rangeDevice)
 					fCntTooHighDevice.EndDeviceIdentifiers.DeviceID += "-too-high"
 					fCntTooHighDevice.MACState.RecentUplinks = append(fCntTooHighDevice.MACState.RecentUplinks, makeLegacyDataUplink(42, true))
 					fCntTooHighDevice.RecentUplinks = append(fCntTooHighDevice.RecentUplinks, makeLegacyDataUplink(42, true))
 					fCntTooHighDevice.Session.LastFCntUp = 42
-					a.So(req.Func(ctx, fCntTooHighDevice), should.BeTrue)
+					a.So(req.Func(context.WithValue(ctx, struct{}{}, "fcnt-too-high"), fCntTooHighDevice), should.BeTrue)
 					req.Response <- nil
 				}
 
@@ -2871,7 +2871,7 @@ func TestHandleUplink(t *testing.T) {
 					return false
 
 				case req := <-env.DeviceRegistry.SetByID:
-					a.So(req.Context, should.HaveParentContextOrEqual, upCtx)
+					a.So(req.Context, should.HaveParentContextOrEqual, rangeCtx)
 					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
 					a.So(req.DeviceID, should.Resemble, devID)
 					a.So(req.Paths, should.HaveSameElementsDeep, dataGetPaths[:])
@@ -3064,7 +3064,7 @@ func TestHandleUplink(t *testing.T) {
 					UpdatedAt:            start,
 				}
 
-				var upCtx context.Context
+				var rangeCtx context.Context
 				var upCorrelationIDs []string
 				select {
 				case <-ctx.Done():
@@ -3072,7 +3072,6 @@ func TestHandleUplink(t *testing.T) {
 					return false
 
 				case req := <-env.DeviceRegistry.RangeByAddr:
-					upCtx = req.Context
 					upCorrelationIDs = events.CorrelationIDsFromContext(req.Context)
 					for _, id := range correlationIDs {
 						a.So(upCorrelationIDs, should.Contain, id)
@@ -3080,16 +3079,17 @@ func TestHandleUplink(t *testing.T) {
 					a.So(upCorrelationIDs, should.HaveLength, len(correlationIDs)+2)
 					a.So(req.DevAddr, should.Resemble, devAddr)
 					a.So(req.Paths, should.HaveSameElementsDeep, dataGetPaths[:])
-					a.So(req.Func(ctx, CopyEndDevice(rangeDevice)), should.BeTrue)
+					rangeCtx = context.WithValue(req.Context, struct{}{}, "range")
+					a.So(req.Func(rangeCtx, CopyEndDevice(rangeDevice)), should.BeTrue)
 					multicastDevice := CopyEndDevice(rangeDevice)
 					multicastDevice.EndDeviceIdentifiers.DeviceID += "-multicast"
 					multicastDevice.Multicast = true
-					a.So(req.Func(ctx, multicastDevice), should.BeTrue)
+					a.So(req.Func(context.WithValue(ctx, struct{}{}, "multicast"), multicastDevice), should.BeTrue)
 					fCntTooHighDevice := CopyEndDevice(rangeDevice)
 					fCntTooHighDevice.EndDeviceIdentifiers.DeviceID += "-too-high"
 					fCntTooHighDevice.RecentUplinks = append(fCntTooHighDevice.RecentUplinks, makeLegacyDataUplink(42, true))
 					fCntTooHighDevice.Session.LastFCntUp = 42
-					a.So(req.Func(ctx, fCntTooHighDevice), should.BeTrue)
+					a.So(req.Func(context.WithValue(ctx, struct{}{}, "fcnt-too-high"), fCntTooHighDevice), should.BeTrue)
 					req.Response <- nil
 				}
 
@@ -3107,7 +3107,7 @@ func TestHandleUplink(t *testing.T) {
 					return false
 
 				case req := <-env.DeviceRegistry.SetByID:
-					a.So(req.Context, should.HaveParentContextOrEqual, upCtx)
+					a.So(req.Context, should.HaveParentContextOrEqual, rangeCtx)
 					a.So(req.ApplicationIdentifiers, should.Resemble, appID)
 					a.So(req.DeviceID, should.Resemble, devID)
 					a.So(req.Paths, should.HaveSameElementsDeep, dataGetPaths[:])


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/1921 https://github.com/TheThingsIndustries/lorawan-stack/issues/1924

#### Changes
<!-- What are the changes made in this pull request? -->

- Retrieve device context from registry when matching by DevAddr

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
