### PR TITLE
Generate local session key ID if interop JS didn't

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Crashes on Gateway Server start when traffic flow started while The Things Stack was still starting.
+- Not detecting session change in Application Server when interop Join Server did not provide a `SessionKeyID`.
 
 ### Security
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -4391,6 +4391,15 @@
       "file": "errors.go"
     }
   },
+  "error:pkg/interop:generate_session_key_id": {
+    "translations": {
+      "en": "failed to generate session key ID"
+    },
+    "description": {
+      "package": "pkg/interop",
+      "file": "client.go"
+    }
+  },
   "error:pkg/interop:invalid_length": {
     "translations": {
       "en": "invalid length"

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -489,7 +489,7 @@ func (as *ApplicationServer) fetchAppSKey(ctx context.Context, ids ttnpb.EndDevi
 			return ttnpb.KeyEnvelope{}, err
 		}
 	}
-	if as.interopClient != nil {
+	if as.interopClient != nil && !interop.GeneratedSessionKeyID(sessionKeyID) {
 		res, err := as.interopClient.GetAppSKey(ctx, as.interopID, req)
 		if err == nil {
 			return res.AppSKey, nil

--- a/pkg/interop/client.go
+++ b/pkg/interop/client.go
@@ -17,6 +17,7 @@ package interop
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -29,6 +30,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/oklog/ulid/v2"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/encoding/lorawan"
 	"go.thethings.network/lorawan-stack/pkg/errors"
@@ -236,6 +238,12 @@ func (cl joinServerHTTPClient) GetAppSKey(ctx context.Context, asID string, req 
 	}, nil
 }
 
+var (
+	errGenerateSessionKeyID = errors.Define("generate_session_key_id", "failed to generate session key ID")
+
+	generatedSessionKeyIDPrefix = []byte("ttn-lw-interop-generated:")
+)
+
 // HandleJoinRequest performs Join request according to LoRaWAN Backend Interfaces specification.
 func (cl joinServerHTTPClient) HandleJoinRequest(ctx context.Context, netID types.NetID, req *ttnpb.JoinRequest) (*ttnpb.JoinResponse, error) {
 	pld := req.Payload.GetJoinRequestPayload()
@@ -285,10 +293,22 @@ func (cl joinServerHTTPClient) HandleJoinRequest(ctx context.Context, netID type
 	if req.SelectedMACVersion.Compare(ttnpb.MAC_V1_1) <= 0 {
 		fNwkSIntKey = interopAns.NwkSKey
 	}
+
+	sessionKeyID := []byte(interopAns.SessionKeyID)
+	if len(sessionKeyID) == 0 {
+		log.FromContext(ctx).Debug("Interop join-accept does not contain session key ID, use random ID")
+		id, err := ulid.New(ulid.Timestamp(time.Now()), rand.Reader)
+		if err != nil {
+			return nil, errGenerateSessionKeyID
+		}
+		sessionKeyID = make([]byte, 0, len(generatedSessionKeyIDPrefix)+len(id))
+		sessionKeyID = append(sessionKeyID, generatedSessionKeyIDPrefix...)
+		sessionKeyID = append(sessionKeyID, id[:]...)
+	}
 	return &ttnpb.JoinResponse{
 		RawPayload: interopAns.PHYPayload,
 		SessionKeys: ttnpb.SessionKeys{
-			SessionKeyID: []byte(interopAns.SessionKeyID),
+			SessionKeyID: sessionKeyID,
 			FNwkSIntKey:  (*ttnpb.KeyEnvelope)(fNwkSIntKey),
 			SNwkSIntKey:  (*ttnpb.KeyEnvelope)(interopAns.SNwkSIntKey),
 			NwkSEncKey:   (*ttnpb.KeyEnvelope)(interopAns.NwkSEncKey),
@@ -296,6 +316,11 @@ func (cl joinServerHTTPClient) HandleJoinRequest(ctx context.Context, netID type
 		},
 		Lifetime: time.Duration(interopAns.Lifetime) * time.Second,
 	}, nil
+}
+
+// GeneratedSessionKeyID returns whether the session key ID is generated locally and not by the Join Server.
+func GeneratedSessionKeyID(id []byte) bool {
+	return bytes.HasPrefix(id, generatedSessionKeyIDPrefix)
 }
 
 func makeJoinServerHTTPRequestFunc(scheme, dns, fqdn string, port uint32, rpcPaths jsRPCPaths, headers map[string]string) func(types.EUI64, func(jsRPCPaths) string, interface{}) (*http.Request, error) {

--- a/pkg/interop/client.go
+++ b/pkg/interop/client.go
@@ -296,7 +296,7 @@ func (cl joinServerHTTPClient) HandleJoinRequest(ctx context.Context, netID type
 
 	sessionKeyID := []byte(interopAns.SessionKeyID)
 	if len(sessionKeyID) == 0 {
-		log.FromContext(ctx).Debug("Interop join-accept does not contain session key ID, use random ID")
+		log.FromContext(ctx).Debug("Interop join-accept does not contain session key ID, generate random ID")
 		id, err := ulid.New(ulid.Timestamp(time.Now()), rand.Reader)
 		if err != nil {
 			return nil, errGenerateSessionKeyID


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fix #1928

#### Changes
<!-- What are the changes made in this pull request? -->

- According to BI 1.0, either `AppSKey`, or `SessionKeyID`, or both are sent in `JoinAns`
- If `SessionKeyID` is not sent, we still need to have one for AS to detect session changes. We cannot reliably use `DevAddr` for that (as it may return to an old one while the AS wasn't up)
- We are now, in the interop client, generating a `SessionKeyID`. This is prepended with an identifier
- AS uses this identifier to not try to get the `AppSKey` from the interop JS

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
