### PR TITLE
Add support for Redis custom connection pool size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Responsive side navigation (inside entity views) to the Console.
 - Overall responsiveness of the Console.
+- Support for custom Redis connection pool sizes (see `--redis.pool-size`).
 
 ### Changed
 

--- a/doc/content/reference/configuration/the-things-stack.md
+++ b/doc/content/reference/configuration/the-things-stack.md
@@ -110,6 +110,7 @@ Redis configuration options:
 - `redis.password`: Password of the Redis server
 - `redis.database`: Redis database to use
 - `redis.namespace`: Namespace for Redis keys
+- `redis.pool-size`: The maximum size of the connection pool
 
 If connecting to a single Redis instance:
 
@@ -154,6 +155,7 @@ When using the `redis` backend, the global [Redis configuration]({{< ref "#redis
 - `events.redis.password`: Password of the Redis server
 - `events.redis.database`: Redis database to use
 - `events.redis.namespace`: Namespace for Redis keys
+- `events.redis.pool-size`: The maximum size of the connection pool
 
 With the `cloud` backend, the configured publish and subscribe URLs are passed to [the Go CDK](https://gocloud.dev/howto/pubsub/).
 

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -129,6 +129,7 @@ type Redis struct {
 	Password  string        `name:"password" description:"Password of the Redis server"`
 	Database  int           `name:"database" description:"Redis database to use"`
 	Namespace []string      `name:"namespace" description:"Namespace for Redis keys"`
+	PoolSize  int           `name:"pool-size" description:"The maximum number of database connections"`
 	Failover  RedisFailover `name:"failover" description:"Redis failover configuration"`
 }
 

--- a/pkg/redis/redis.go
+++ b/pkg/redis/redis.go
@@ -89,12 +89,14 @@ func newRedisClient(conf config.Redis) *redis.Client {
 			SentinelAddrs: conf.Failover.Addresses,
 			Password:      conf.Password,
 			DB:            conf.Database,
+			PoolSize:      conf.PoolSize,
 		})
 	}
 	return redis.NewClient(&redis.Options{
 		Addr:     conf.Address,
 		Password: conf.Password,
 		DB:       conf.Database,
+		PoolSize: conf.PoolSize,
 	})
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->
#### Changes
<!-- What are the changes made in this pull request? -->

- Added support for Redis custom connection pool size

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

There are no changes to the default Redis configuration since 0 is automatically interpreted as `10 * runtime.NumCPU()`. See https://github.com/go-redis/redis/blob/2f96fd1378dcd55117e15a041d13448ff6b43b1e/options.go#L124-L126

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [ ] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
