### PR TITLE
all: Ensure shared TCP listeners do not race

### DIFF
--- a/pkg/component/listeners.go
+++ b/pkg/component/listeners.go
@@ -71,6 +71,8 @@ func (l *listener) Close() error {
 
 // ListenTCP listens on a TCP address and allows for TCP and TLS on the same port.
 func (c *Component) ListenTCP(address string) (Listener, error) {
+	c.tcpListenersMu.Lock()
+	defer c.tcpListenersMu.Unlock()
 	l, ok := c.tcpListeners[address]
 	if !ok {
 		c.logger.WithField("address", address).Debug("Creating listener")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #1927 

#### Changes
<!-- What are the changes made in this pull request? -->

- Guard `Component.tcpListeners` with a `sync.Mutex`

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The original proposal (https://play.golang.org/p/SLD1zyXKHFa) becomes quite hard to read when adding error handling for `net.Listen`, so I just guarded it with a mutex.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
