### PR TITLE
Load system CAs even if custom CA file used

### DIFF
--- a/pkg/component/tls.go
+++ b/pkg/component/tls.go
@@ -168,7 +168,9 @@ func (c *Component) GetTLSClientConfig(ctx context.Context, opts ...TLSConfigOpt
 		if err != nil {
 			return nil, err
 		}
-		res.RootCAs = x509.NewCertPool()
+		if res.RootCAs, err = x509.SystemCertPool(); err != nil {
+			res.RootCAs = x509.NewCertPool()
+		}
 		res.RootCAs.AppendCertsFromPEM(pem)
 	}
 	res.InsecureSkipVerify = conf.InsecureSkipVerify


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR is a quickfix for the shared logic that sets up the root CAs. Before this PR, all system roots would be forgotten when configuring a custom CA. This isn't desired behavior.