### PR TITLE
per lorawan spec, the channel mask should be LSB

### DIFF
--- a/pkg/encoding/lorawan/mac.go
+++ b/pkg/encoding/lorawan/mac.go
@@ -192,7 +192,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = append(b, byte((pld.DataRateIndex&0xf)<<4)^byte(pld.TxPowerIndex&0xf))
 			chMask := make([]byte, 2)
 			for i, v := range pld.ChannelMask {
-				chMask[(15-i)/8] = chMask[(15-i)/8] ^ boolToByte(v)<<(i%8)
+				chMask[i/8] = chMask[i/8] ^ boolToByte(v)<<(i%8)
 			}
 			b = append(b, chMask...)
 			b = append(b, byte((pld.ChannelMaskControl&0x7)<<4)^byte(pld.NbTrans&0xf))
@@ -201,7 +201,7 @@ var DefaultMACCommands = MACCommandSpec{
 		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_LINK_ADR, "LinkADRReq", 4, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			var chMask [16]bool
 			for i := 0; i < 16; i++ {
-				chMask[i] = (b[1+(15-i)/8]>>(i%8))&1 == 1
+				chMask[i] = (b[i/8]>>(i%8))&1 == 1
 			}
 			cmd.Payload = &ttnpb.MACCommand_LinkADRReq_{
 				LinkADRReq: &ttnpb.MACCommand_LinkADRReq{


### PR DESCRIPTION
0xFF00 (LSB) = 0b00000000 11111111 (MSB) = ChMask = channels 1 thru 8

with the current code, channels 1-8 are encoded as 0x00FF (channels
9-16)

LinkADRReq are therefore rejected with pld.ChannelMaskAck = false, and
all other ADR settings (DR) are discarded.



#### Summary
fix #1943

...

#### Changes
pkg/encoding/lorawan/mac.go

#### Notes for Reviewers

...

#### Checklist
<!-- Make sure that this pull request is complete. -->
I have tested a LinkDRReq / LinkADRAns cycle, but I was not able to test the Unmarshalling portion.