### PR TITLE
Fix LinkADR ChMask encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Channel mask encoding in LinkADR MAC command.
+
 ### Security
 
 ## [3.5.1] (2020-01-29)

--- a/pkg/encoding/lorawan/mac.go
+++ b/pkg/encoding/lorawan/mac.go
@@ -192,7 +192,7 @@ var DefaultMACCommands = MACCommandSpec{
 			b = append(b, byte((pld.DataRateIndex&0xf)<<4)^byte(pld.TxPowerIndex&0xf))
 			chMask := make([]byte, 2)
 			for i, v := range pld.ChannelMask {
-				chMask[(15-i)/8] = chMask[(15-i)/8] ^ boolToByte(v)<<(i%8)
+				chMask[i/8] = chMask[i/8] ^ boolToByte(v)<<(i%8)
 			}
 			b = append(b, chMask...)
 			b = append(b, byte((pld.ChannelMaskControl&0x7)<<4)^byte(pld.NbTrans&0xf))
@@ -201,7 +201,7 @@ var DefaultMACCommands = MACCommandSpec{
 		UnmarshalDownlink: newMACUnmarshaler(ttnpb.CID_LINK_ADR, "LinkADRReq", 4, func(phy band.Band, b []byte, cmd *ttnpb.MACCommand) error {
 			var chMask [16]bool
 			for i := 0; i < 16; i++ {
-				chMask[i] = (b[1+(15-i)/8]>>(i%8))&1 == 1
+				chMask[i] = (b[1+i/8]>>(i%8))&1 == 1
 			}
 			cmd.Payload = &ttnpb.MACCommand_LinkADRReq_{
 				LinkADRReq: &ttnpb.MACCommand_LinkADRReq{

--- a/pkg/encoding/lorawan/mac_test.go
+++ b/pkg/encoding/lorawan/mac_test.go
@@ -82,7 +82,7 @@ func TestLoRaWANEncodingMAC(t *testing.T) {
 				ChannelMaskControl: 1,
 				NbTrans:            1,
 			},
-			[]byte{0x03, 0b0101_0010, 0b00000010, 0b00000100, 0b0_001_0001},
+			[]byte{0x03, 0b0101_0010, 0b00000100, 0b00000010, 0b0_001_0001},
 			false,
 		},
 		{

--- a/pkg/encoding/lorawan/messages.go
+++ b/pkg/encoding/lorawan/messages.go
@@ -232,13 +232,13 @@ func AppendCFList(dst []byte, msg ttnpb.CFList) ([]byte, error) {
 		// Fill remaining space with zeros.
 		dst = append(dst, bytes.Repeat([]byte{0x0}, 15-n*3)...)
 	case 1:
-		n := len(msg.ChMasks)
+		n := uint(len(msg.ChMasks))
 		if n > 96 {
 			return nil, errExpectedLengthLowerOrEqual("CFListChMasks", 96)(n)
 		}
-		for i := uint(0); i < uint(n); i += 8 {
+		for i := uint(0); i < n; i += 8 {
 			var b byte
-			for j := uint(0); j < 8; j++ {
+			for j := uint(0); j < 8 && i+j < n; j++ {
 				if msg.ChMasks[i+j] {
 					b |= (1 << j)
 				}
@@ -246,7 +246,7 @@ func AppendCFList(dst []byte, msg ttnpb.CFList) ([]byte, error) {
 			dst = append(dst, b)
 		}
 		// Fill remaining space with zeros.
-		dst = append(dst, bytes.Repeat([]byte{0x0}, 15-(n+7)/8)...)
+		dst = append(dst, bytes.Repeat([]byte{0x0}, int(15-(n+7)/8))...)
 	}
 	dst = append(dst, byte(msg.Type))
 	return dst, nil


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #1943 
Closes #1944 
References #1879 

#### Changes
<!-- What are the changes made in this pull request? -->

- Ensure `ChMask` is little endian (byte-wise, bits are big endian)
- Refactor `CFList` encoding for clarity
- Avoid possible panic when encoding `CFList`

#### Notes for reviewers

Thanks @pdubois22 for both reporting the issue in #1943 and fix in #1944 :heart: 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
