### PR TITLE
Fix device fields leak in JS SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handling multiple consequent updates of MQTT pubsub/webhook integrations in the Console.
 - Displaying total device count in application overview section when using device search in the Console
 - FQDN used for Backend Interfaces interoperability requests.
+- Exposing device sensitive fields to unrelated stack components in the Console.
 
 ### Security
 

--- a/sdk/js/src/service/devices/index.js
+++ b/sdk/js/src/service/devices/index.js
@@ -130,18 +130,7 @@ class Devices {
       return acc
     }, [])
 
-    // Make sure to write at least the ids, in case of creation
-    const mergeBase = create
-      ? {
-          ns: [['ids']],
-          as: [['ids']],
-          js: [['ids']],
-        }
-      : {}
-
-    const requestTree = requestTreeOverwrite
-      ? requestTreeOverwrite
-      : splitSetPaths(paths, mergeBase)
+    const requestTree = requestTreeOverwrite ? requestTreeOverwrite : splitSetPaths(paths)
 
     if (create) {
       if (device.join_server_address !== this._stackConfig.jsHost) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes issue in the devices service in the js sdk related to sending *all* device fields to all stack components.

References https://github.com/TheThingsNetwork/lorawan-stack/issues/579
Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/1778

#### Changes
<!-- What are the changes made in this pull request? -->

- Add the `pathsFromPatch` method and related tests
- Adjust the `makeRequests` function from the devices service to filter payload for each request according to the list of allowed field masks

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The logic of `splitPayload` resembles solution used in `splitPaths` very much, since both methods traverse the device entity map.

Im currently working on refactoring device handling in js sdk and will most probably change this bit later as it seems to be more of a dirty fix. However, exposing keys and other sensitive data should be fixed. I couldnt find another way of fixing the issue without doing a major refactoring mainly because of the structure of the device service. Let me know if you can find another solution.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
