### PR TITLE
Fix frequency plan validation in Network Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Channel mask encoding in LinkADR MAC command.
+- Frequency plan validation in Network Server on device update.
 
 ### Security
 

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -424,7 +424,13 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 				"frequency_plan_id",
 				"lorawan_phy_version",
 			) {
-				_, _, err := getDeviceBandVersion(dev, ns.FrequencyPlans)
+				if !ttnpb.HasAnyField(sets, "frequency_plan_id") {
+					req.EndDevice.FrequencyPlanID = dev.FrequencyPlanID
+				}
+				if !ttnpb.HasAnyField(sets, "lorawan_phy_version") {
+					req.EndDevice.LoRaWANPHYVersion = dev.LoRaWANPHYVersion
+				}
+				_, _, err := getDeviceBandVersion(&req.EndDevice, ns.FrequencyPlans)
 				if err != nil {
 					return nil, nil, err
 				}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fix frequency plan validation in Network Server

#### Changes
<!-- What are the changes made in this pull request? -->

- Use the frequency plan in the request instead of stored frequency plan for validation on update
- Ensure both PHY version and frequency plan are available before validation takes place
- Add testing


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
