### PR TITLE
Fix redundant header fetching on device search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updating `supports_class_c` field in the Device General Settings Page in the Console.
 - Updating MQTT pubsub configuration in the Console
 - Handling multiple consequent updates of MQTT pubsub/webhook integrations in the Console.
+- Displaying total device count in application overview section when using device search in the Console
 
 ### Security
 

--- a/pkg/webui/console/store/actions/applications.js
+++ b/pkg/webui/console/store/actions/applications.js
@@ -42,6 +42,20 @@ export const [
   { request: getApplication, success: getApplicationSuccess, failure: getApplicationFailure },
 ] = createRequestActions(GET_APP_BASE, id => ({ id }), (id, selector) => ({ selector }))
 
+export const GET_APP_DEV_COUNT_BASE = 'GET_APPLICATION_DEVICE_COUNT'
+export const [
+  {
+    request: GET_APP_DEV_COUNT,
+    success: GET_APP_DEV_COUNT_SUCCESS,
+    failure: GET_APP_DEV_COUNT_FAILURE,
+  },
+  {
+    request: getApplicationDeviceCount,
+    success: getApplicationDeviceCountSuccess,
+    failure: getApplicationDeviceCountFailure,
+  },
+] = createRequestActions(GET_APP_DEV_COUNT_BASE, id => ({ id }))
+
 export const UPDATE_APP_BASE = 'UPDATE_APPLICATION'
 export const [
   { request: UPDATE_APP, success: UPDATE_APP_SUCCESS, failure: UPDATE_APP_FAILURE },

--- a/pkg/webui/console/store/middleware/logics/applications.js
+++ b/pkg/webui/console/store/middleware/logics/applications.js
@@ -82,6 +82,16 @@ const getApplicationsLogic = createRequestLogic({
   },
 })
 
+const getApplicationDeviceCountLogic = createRequestLogic({
+  type: applications.GET_APP_DEV_COUNT,
+  async process({ action }) {
+    const { id: appId } = action.payload
+    const data = await api.devices.list(appId, { limit: 1 })
+
+    return { applicationDeviceCount: data.totalCount }
+  },
+})
+
 const getApplicationsRightsLogic = createRequestLogic({
   type: applications.GET_APPS_RIGHTS_LIST,
   async process({ action }) {
@@ -136,6 +146,7 @@ const getPubsubFormatsLogic = createRequestLogic({
 
 export default [
   getApplicationLogic,
+  getApplicationDeviceCountLogic,
   updateApplicationLogic,
   deleteApplicationLogic,
   getApplicationsLogic,

--- a/pkg/webui/console/store/reducers/applications.js
+++ b/pkg/webui/console/store/reducers/applications.js
@@ -16,6 +16,7 @@ import { getApplicationId } from '../../../lib/selectors/id'
 import {
   GET_APP,
   GET_APP_SUCCESS,
+  GET_APP_DEV_COUNT_SUCCESS,
   GET_APPS_LIST_SUCCESS,
   UPDATE_APP_SUCCESS,
   DELETE_APP_SUCCESS,
@@ -31,6 +32,7 @@ const application = function(state = {}, application) {
 const defaultState = {
   entities: {},
   selectedApplication: null,
+  applicationDeviceCount: undefined,
 }
 
 const applications = function(state = defaultState, { type, payload }) {
@@ -54,6 +56,11 @@ const applications = function(state = defaultState, { type, payload }) {
       return {
         ...state,
         entities,
+      }
+    case GET_APP_DEV_COUNT_SUCCESS:
+      return {
+        ...state,
+        applicationDeviceCount: payload.applicationDeviceCount,
       }
     case GET_APP_SUCCESS:
     case UPDATE_APP_SUCCESS:

--- a/pkg/webui/console/store/selectors/applications.js
+++ b/pkg/webui/console/store/selectors/applications.js
@@ -43,6 +43,8 @@ export const selectSelectedApplication = state =>
   selectApplicationById(state, selectSelectedApplicationId(state))
 export const selectApplicationFetching = createFetchingSelector(GET_APP_BASE)
 export const selectApplicationError = createErrorSelector(GET_APP_BASE)
+export const selectApplicationDeviceCount = state =>
+  selectApplicationStore(state).applicationDeviceCount
 
 // Applications
 const selectAppsIds = createPaginationIdsSelectorByEntity(ENTITY)

--- a/pkg/webui/console/views/application-overview/connect.js
+++ b/pkg/webui/console/views/application-overview/connect.js
@@ -19,16 +19,17 @@ import {
   selectSelectedApplicationId,
   selectApplicationLinkIndicator,
   selectApplicationLinkFetching,
+  selectApplicationDeviceCount,
 } from '../../store/selectors/applications'
 import {
   selectCollaboratorsTotalCount,
   selectCollaboratorsFetching,
 } from '../../store/selectors/collaborators'
 import { selectApiKeysTotalCount, selectApiKeysFetching } from '../../store/selectors/api-keys'
-import { selectDevicesTotalCount, selectDevicesFetching } from '../../store/selectors/devices'
 import { getCollaboratorsList } from '../../store/actions/collaborators'
 import { getApiKeysList } from '../../store/actions/api-keys'
 import { getApplicationLink } from '../../store/actions/link'
+import { getApplicationDeviceCount } from '../../store/actions/applications'
 
 import {
   checkFromState,
@@ -42,7 +43,7 @@ const mapStateToProps = (state, props) => {
   const appId = selectSelectedApplicationId(state)
   const collaboratorsTotalCount = selectCollaboratorsTotalCount(state, { id: appId })
   const apiKeysTotalCount = selectApiKeysTotalCount(state)
-  const devicesTotalCount = selectDevicesTotalCount(state)
+  const devicesTotalCount = selectApplicationDeviceCount(state)
   const mayViewApplicationApiKeys = checkFromState(mayViewOrEditApplicationApiKeys, state)
   const mayViewApplicationCollaborators = checkFromState(
     mayViewOrEditApplicationCollaborators,
@@ -55,8 +56,7 @@ const mapStateToProps = (state, props) => {
     selectCollaboratorsFetching(state)
   const apiKeysFetching =
     (mayViewApplicationApiKeys && apiKeysTotalCount === undefined) || selectApiKeysFetching(state)
-  const devicesFetching =
-    (mayViewDevices && devicesTotalCount === undefined) || selectDevicesFetching(state)
+  const devicesFetching = mayViewDevices && devicesTotalCount === undefined
 
   return {
     appId,
@@ -82,11 +82,13 @@ const mapDispatchToProps = dispatch => ({
     mayViewApplicationCollaborators,
     mayViewApplicationApiKeys,
     mayViewApplicationLink,
+    mayViewDevices,
     appId,
   ) {
     if (mayViewApplicationCollaborators) dispatch(getCollaboratorsList('application', appId))
     if (mayViewApplicationApiKeys) dispatch(getApiKeysList('application', appId))
     if (mayViewApplicationLink) dispatch(getApplicationLink(appId))
+    if (mayViewDevices) dispatch(getApplicationDeviceCount(appId))
   },
 })
 
@@ -99,6 +101,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => ({
       stateProps.mayViewApplicationCollaborators,
       stateProps.mayViewApplicationApiKeys,
       stateProps.mayViewApplicationLink,
+      stateProps.mayViewDevices,
       stateProps.appId,
     ),
 })


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Relevant issue #1910 (not closing the issue itself, but the discussion in the issue, also I think separating search and list requests is not necessary)

#### Changes
<!-- What are the changes made in this pull request? -->

- Create new redux request `getApplicationDeviceCount` and new store variable `applicationDeviceCount`
- Use `applicationDeviceCount` in application overview header instead of `totalCount` obtained via `getDeviceList` request
- also removed `selectDeviceFetching` selector from the application overview page since it's not relevant for the device count anymore

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
