### PR TITLE
Add defaults emitter utility

### DIFF
--- a/sdk/js/.babelrc
+++ b/sdk/js/.babelrc
@@ -4,7 +4,8 @@
   ],
   "plugins": [
     "@babel/plugin-transform-runtime",
-    "@babel/plugin-transform-strict-mode"
+    "@babel/plugin-transform-strict-mode",
+    "lodash"
   ],
   "sourceMaps": "inline"
 }

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -25,6 +25,7 @@
     "@babel/plugin-transform-runtime": "^7.6.2",
     "@babel/plugin-transform-strict-mode": "^7.2.0",
     "@babel/preset-env": "^7.7.1",
+    "babel-plugin-lodash": "^3.3.4",
     "eslint": "^6.2.2",
     "jest": "^24.9.0",
     "prettier": "^1.18.2"
@@ -46,6 +47,7 @@
   "dependencies": {
     "arraybuffer-to-string": "^1.0.2",
     "axios": "^0.19.0",
+    "lodash": "^4.17.15",
     "proxy-polyfill": "^0.3.0",
     "query-string": "^6.2.0",
     "traverse": "^0.6.6",

--- a/sdk/js/src/util/create-defaults-emitter/create-defaults-emitter.test.js
+++ b/sdk/js/src/util/create-defaults-emitter/create-defaults-emitter.test.js
@@ -1,0 +1,221 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { createDefaultsEmitterFromFieldMask } from '.'
+
+describe('create-defaults-emitter', () => {
+  describe('createDefaultsEmitterFromFieldMask', () => {
+    it('should pass correct values and field mask to emitter', () => {
+      const obj = {
+        field1: '',
+        field2: null,
+        field3: undefined,
+        field4: false,
+        field5: {},
+        field6: [],
+        field7: { field1: '', field2: null, field3: undefined, field4: false },
+        field8: [42],
+        field9: 'string',
+        field10: 42,
+        field11: true,
+      }
+      const fieldMask = [
+        'field1',
+        'field2',
+        'field3',
+        'field4',
+        'field5',
+        'field6',
+        'field7',
+        'field7.field1',
+        'field7.field2',
+        'field7.field3',
+        'field7.field4',
+        'field8',
+        'field9',
+        'field10',
+        'field11',
+      ]
+
+      const defaultsEmitter = createDefaultsEmitterFromFieldMask((fmKey, value) => {
+        expect(fieldMask.includes(fmKey)).toBe(true)
+        const keys = fmKey.split('.')
+
+        let val
+        for (const k of keys) {
+          val = obj[k]
+        }
+
+        expect(val).toEqual(value)
+      })
+      defaultsEmitter(obj, fieldMask)
+    })
+
+    it('should set and update any falsy value except for `undefined`', () => {
+      const values = {
+        field1: '',
+        field2: null,
+        field3: false,
+        field4: undefined,
+      }
+
+      const obj = {}
+      const fieldMask = Object.keys(values)
+
+      const defaultsEmitter = createDefaultsEmitterFromFieldMask((fmKey, value) => {
+        return values[fmKey]
+      })
+      let withDefaults = defaultsEmitter(obj, fieldMask)
+
+      expect(Object.keys(withDefaults)).toHaveLength(3)
+      expect(withDefaults.field1).toBe(values.field1)
+      expect(withDefaults.field2).toBe(values.field2)
+      expect(withDefaults.field3).toBe(values.field3)
+      expect(withDefaults).not.toHaveProperty('field4')
+
+      obj.field1 = 'value1'
+      obj.field2 = 'value2'
+      obj.field3 = 'value3'
+      obj.field4 = 'value4'
+
+      withDefaults = defaultsEmitter(obj, fieldMask)
+
+      expect(Object.keys(withDefaults)).toHaveLength(4)
+      expect(withDefaults.field1).toBe(values.field1)
+      expect(withDefaults.field2).toBe(values.field2)
+      expect(withDefaults.field3).toBe(values.field3)
+      expect(withDefaults.field4).toBe(obj.field4)
+    })
+
+    it('should leave unrelated fields untouched', () => {
+      const fieldName1 = 'fieldName1'
+      const fieldName2 = 'fieldName2'
+      const fieldName3 = 'fieldName3'
+      const fieldValue1 = 'fieldValue1'
+      const fieldValue2 = {}
+      const fieldValue3 = 'fieldValue3'
+
+      const obj = {
+        [fieldName1]: fieldValue1,
+        [fieldName2]: fieldValue2,
+      }
+      const fieldMask = [fieldName3]
+
+      const defaultsEmitter = createDefaultsEmitterFromFieldMask(fmKey => {
+        if (fmKey === fieldName3) {
+          return fieldValue3
+        }
+      })
+      const withDefaults = defaultsEmitter(obj, fieldMask)
+
+      expect(withDefaults[fieldName1]).toBe(fieldValue1)
+      expect(withDefaults[fieldName2]).toBe(fieldValue2)
+      expect(withDefaults[fieldName2] === fieldValue2).toBe(true)
+    })
+
+    it('should set top-level fields', () => {
+      const fieldName1 = 'fieldName1'
+      const fieldName2 = 'fieldName2'
+      const fieldValue1 = 'fieldValue1'
+      const fieldValue2 = 'fieldValue2'
+
+      const obj = {}
+      const fieldMask = [fieldName1, fieldName2]
+
+      const defaultsEmitter = createDefaultsEmitterFromFieldMask((fmKey, value) => {
+        if (fmKey === fieldName1) {
+          return fieldValue1
+        }
+
+        if (fmKey === fieldName2) {
+          return fieldValue2
+        }
+      })
+      const withDefaults = defaultsEmitter(obj, fieldMask)
+
+      expect(Object.keys(withDefaults)).toHaveLength(2)
+      expect(withDefaults[fieldName1]).toBe(fieldValue1)
+      expect(withDefaults[fieldName2]).toBe(fieldValue2)
+    })
+
+    it('should update top-level fields', () => {
+      const fieldName1 = 'fieldName1'
+      const fieldValue1 = 'updatedFieldValue1'
+
+      const obj = { [fieldName1]: undefined }
+      const fieldMask = [fieldName1]
+
+      const defaultsEmitter = createDefaultsEmitterFromFieldMask(fmKey => {
+        if (fmKey === fieldName1) {
+          return fieldValue1
+        }
+      })
+      const withDefaults = defaultsEmitter(obj, fieldMask)
+
+      expect(Object.keys(withDefaults)).toHaveLength(1)
+      expect(withDefaults[fieldName1]).toBe(fieldValue1)
+    })
+
+    it('should set nested fields', () => {
+      const obj = {}
+      const fieldName1 = 'fieldName1'
+      const fieldName2 = 'fieldName2'
+      const fieldName3 = 'fieldName3'
+      const fieldValue = 'fieldValue'
+      const combinedFieldMask = `${fieldName1}.${fieldName2}.${fieldName3}`
+      const fieldMask = [combinedFieldMask]
+
+      const defaultsEmitter = createDefaultsEmitterFromFieldMask((fmKey, value) => {
+        if (fmKey === combinedFieldMask) {
+          return fieldValue
+        }
+      })
+      const withDefaults = defaultsEmitter(obj, fieldMask)
+
+      expect(Object.keys(withDefaults)).toHaveLength(1)
+      expect(Object.keys(withDefaults[fieldName1])).toHaveLength(1)
+      expect(Object.keys(withDefaults[fieldName1][fieldName2])).toHaveLength(1)
+      expect(withDefaults[fieldName1][fieldName2][fieldName3]).toBe(fieldValue)
+    })
+
+    it('should update nested fields', () => {
+      const fieldName1 = 'fieldName1'
+      const fieldName2 = 'fieldName2'
+      const fieldName3 = 'fieldName3'
+      const fieldValue = 'fieldValue'
+      const combinedFieldMask = `${fieldName1}.${fieldName2}`
+      const newFieldValue = { newFieldName: 'newFieldValue' }
+
+      const obj = {
+        [fieldName1]: {
+          [fieldName2]: {
+            [fieldName3]: fieldValue,
+          },
+        },
+      }
+      const fieldMask = [combinedFieldMask]
+
+      const defaultsEmitter = createDefaultsEmitterFromFieldMask((fmKey, value) => {
+        if (fmKey === combinedFieldMask) {
+          return newFieldValue
+        }
+      })
+      const withDefaults = defaultsEmitter(obj, fieldMask)
+
+      expect(Object.keys(withDefaults)).toHaveLength(1)
+      expect(Object.keys(withDefaults[fieldName1])).toHaveLength(1)
+      expect(withDefaults[fieldName1][fieldName2]).toBe(newFieldValue)
+    })
+  })
+})

--- a/sdk/js/src/util/create-defaults-emitter/index.js
+++ b/sdk/js/src/util/create-defaults-emitter/index.js
@@ -1,0 +1,64 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { set, get, toPath } from 'lodash'
+
+/**
+ * @example
+ *
+ * const userDefaultsEmitter = createDefaultsEmitterFromFieldMask((fmKey, value) => {
+ *  if (fmKey === 'state' && (!Boolean(value) || value === null)) {
+ *    return 'STATE_REQUESTED'
+ *  }
+ * })
+ *
+ * const user = { ids: { user_id: 'user' }, isAdmin: false}
+ * const fieldMask = ['isAdmin', state]
+ * const userWithDefaults = userDefaultsEmitter(user, fieldMask)
+ * // userWidthDefaults: { ids: { user_id: 'user' }, isAdmin: false, state: 'STATE_REQUESTED' }
+ *
+ * Creates a defaults emitter function. This could be helpful in cases when the http backend strips
+ * nullable/falsy/default values while these values are required.
+ * @param {Function} formatter - The customization function that defines how and which
+ * fields should be updated. The function is invoked with two arguments: fieldMaskKey, value. Where
+ * - `fieldMaskKey` is the field mask entry (string)
+ * - `value` is the value mapped to the `fieldMaskKey` (any)
+ * In order to update `formatter` should return a new value, if it returns `undefined` nothing is changed
+ * in `sourceObject`.
+ * @returns {Function} - The defaults emitter function. It accepts two arguments: sourceObject, fieldMask.
+ * Where:
+ * - `sourceObject` is the object to add default values to
+ * - `fieldMask` the field mask array
+ * The defaults emitter function returns the updated version copy of the `sourceObject`.
+ */
+const createDefaultsEmitterFromFieldMask = formatter => {
+  return function(object, fieldMask) {
+    const result = { ...object }
+
+    for (const fmKey of fieldMask) {
+      const path = toPath(fmKey)
+      const value = get(object, path)
+
+      const updated = formatter(fmKey, value)
+      if (typeof updated !== 'undefined') {
+        set(result, path, updated)
+      }
+    }
+
+    return result
+  }
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export { createDefaultsEmitterFromFieldMask }

--- a/sdk/js/yarn.lock
+++ b/sdk/js/yarn.lock
@@ -141,6 +141,13 @@
   dependencies:
     "@babel/types" "^7.7.0"
 
+"@babel/helper-module-imports@^7.0.0-beta.49":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz#7fe39589b39c016331b6b8c3f441e8f0b1419498"
+  integrity sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==
+  dependencies:
+    "@babel/types" "^7.8.3"
+
 "@babel/helper-module-transforms@^7.1.0", "@babel/helper-module-transforms@^7.7.0":
   version "7.7.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.7.0.tgz#154a69f0c5b8fd4d39e49750ff7ac4faa3f36786"
@@ -683,6 +690,15 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@babel/types@^7.0.0-beta.49", "@babel/types@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.8.3.tgz#5a383dffa5416db1b73dedffd311ffd0788fb31c"
+  integrity sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.3.tgz#099139eaec7ebf07a27c1786a3ff64f39464d2ef"
@@ -1150,6 +1166,17 @@ babel-plugin-jest-hoist@^24.9.0:
   integrity sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==
   dependencies:
     "@types/babel__traverse" "^7.0.6"
+
+babel-plugin-lodash@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz#4f6844358a1340baed182adbeffa8df9967bc196"
+  integrity sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0-beta.49"
+    "@babel/types" "^7.0.0-beta.49"
+    glob "^7.1.1"
+    lodash "^4.17.10"
+    require-package-name "^2.0.1"
 
 babel-preset-jest@^24.9.0:
   version "24.9.0"
@@ -3076,7 +3103,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
+lodash@^4.17.10, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -3896,6 +3923,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+require-package-name@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/require-package-name/-/require-package-name-2.0.1.tgz#c11e97276b65b8e2923f75dabf5fb2ef0c3841b9"
+  integrity sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk=
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/1935
Blocks https://github.com/TheThingsNetwork/lorawan-stack/pull/1936

#### Changes
<!-- What are the changes made in this pull request? -->

- Add lodash to the js sdk
- Add factory function to create custom `defaultsEmitter` function
- Refactor defaults handling for gateways
- Refactor defaults handling for users
- Add defaults handling for devices

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Unify handling default/nullable/falsy values swallowed by the grpc-gateway. Currently, we have different approaches scattered across the sdk, e.g. [here](https://github.com/TheThingsNetwork/lorawan-stack/blob/master/sdk/js/src/service/users.js#L22-L30) or [here](https://github.com/TheThingsNetwork/lorawan-stack/blob/master/sdk/js/src/service/pubsubs.js#L24-L49).
Didnt refactor [pubsubs](https://github.com/TheThingsNetwork/lorawan-stack/blob/master/sdk/js/src/service/pubsubs.js#L24-L49), because of https://github.com/TheThingsNetwork/lorawan-stack/issues/1956

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
