### PR TITLE
Fix changing pubsub provider in Console

### DIFF
--- a/pkg/webui/console/components/pubsub-form/index.js
+++ b/pkg/webui/console/components/pubsub-form/index.js
@@ -79,17 +79,19 @@ export default class PubsubForm extends Component {
 
   async handleSubmit(values, { setSubmitting, resetForm }) {
     const { appId, onSubmit, onSubmitSuccess, onSubmitFailure } = this.props
-    const pubsub = mapFormValuesToPubsub(values, appId)
+
+    const castedValues = validationSchema.cast(values)
+    const pubsub = mapFormValuesToPubsub(castedValues, appId)
 
     await this.setState({ error: '' })
 
     try {
       const result = await onSubmit(pubsub)
 
-      resetForm(values)
+      resetForm(castedValues)
       await onSubmitSuccess(result)
     } catch (error) {
-      resetForm(values)
+      resetForm(castedValues)
 
       await this.setState({ error })
       await onSubmitFailure(error)

--- a/pkg/webui/console/views/application-integrations-pubsub-edit/application-integrations-pubsub-edit.js
+++ b/pkg/webui/console/views/application-integrations-pubsub-edit/application-integrations-pubsub-edit.js
@@ -23,7 +23,6 @@ import PageTitle from '../../../components/page-title'
 import { withBreadcrumb } from '../../../components/breadcrumbs/context'
 import PubsubForm from '../../components/pubsub-form'
 import toast from '../../../components/toast'
-import diff from '../../../lib/diff'
 import sharedMessages from '../../../lib/shared-messages'
 
 import api from '../../api'
@@ -59,11 +58,9 @@ export default class ApplicationPubsubEdit extends Component {
 
   @bind
   async handleSubmit(pubsub) {
-    const { pubsub: originalPubsub, updatePubsub } = this.props
+    const { updatePubsub } = this.props
 
-    const patch = diff(originalPubsub, pubsub, ['ids'])
-
-    await updatePubsub(patch)
+    await updatePubsub(pubsub)
   }
 
   @bind

--- a/sdk/js/src/util/marshaler.js
+++ b/sdk/js/src/util/marshaler.js
@@ -142,7 +142,7 @@ class Marshaler {
     // whitelist allows and strip all other paths.
     if (whitelist) {
       paths = whitelist.reduce((acc, e) => {
-        if (paths.includes(e)) {
+        if (paths.some(path => path.startsWith(e))) {
           acc.push(e)
         }
         return acc


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/1956 and fixes the pubsub form to switch betwee nats/mqtt provider.
Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/2061

#### Changes
<!-- What are the changes made in this pull request? -->

- Properly handle changing provider in the pubsub form
- Fix resetting the form values when switching provider

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The problem is in the provider field mask. Basically, when we change the provider from `nats` to `mqtt` and vice versa, the backend expects the `provider` field mask (id doesnt matter if we include all nested field masks, e.g. `provider.mqtt` , `provider.mqtt.username`, …), however in case of just updating provider fields it is not needed and the backend accepts only the nested field masks. If we add `provider` when, say, updating just `username` the backend requires `server_url`  to be present as well.

The simplest solution is to sent the whole pubsub payload on update requests. In this case the `provider` field mask is always present in the payload as well as all required fields.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
