### PR TITLE
Use default gRPC dial options in the loopback connection

### DIFF
--- a/pkg/component/grpc.go
+++ b/pkg/component/grpc.go
@@ -24,6 +24,7 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/metrics"
+	"go.thethings.network/lorawan-stack/pkg/rpcclient"
 	"go.thethings.network/lorawan-stack/pkg/rpcmiddleware/hooks"
 	"go.thethings.network/lorawan-stack/pkg/rpcmiddleware/rpclog"
 	"go.thethings.network/lorawan-stack/pkg/rpcserver"
@@ -47,7 +48,7 @@ func (c *Component) setupGRPC() (err error) {
 	}
 	metrics.InitializeServerMetrics(c.grpc.Server)
 	c.logger.Debug("Starting loopback connection")
-	c.loopback, err = rpcserver.StartLoopback(c.ctx, c.grpc.Server)
+	c.loopback, err = rpcserver.StartLoopback(c.ctx, c.grpc.Server, rpcclient.DefaultDialOptions(c.ctx)...)
 	if err != nil {
 		return errors.New("could not start loopback connection").WithCause(err)
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Reintroduced the `rpcclient.DefaultDialOptions` to the component loopback connection. This change allows loopback connections to have correct error handling behavior (among the other interceptors).

This issue was discovered while I was debugging the missing error details - the server would send an TTN error but the client wouldn't see it (since the translation interceptor was not used by the loopback connection provided by the peer).

#### Changes
<!-- What are the changes made in this pull request? -->

- Use the default gRPC dial options in the loopback connection

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Tested the following possible breakages:
- `grpc-gateway` not working - The main user of the gateway, the Console, works correctly in my tests.
- Telemetry not working - I've setup a Prometheus collector and I can see all of the available stats.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
