### PR TITLE
Ignore default config files that cannot be read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Join-request transmission parameters.
 - ADR in 72-channel regions.
 - Payload length limits used by Network Server being too low.
+- CLI ignores default config files that cannot be read.
 
 ### Security
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -259,9 +259,9 @@ func (m *Manager) inCLIFlags(path string) bool {
 func (m *Manager) ReadInConfig() error {
 	files := m.viper.GetStringSlice(m.configFlag)
 	for _, file := range files {
-		// ignore default config files that do not exist
+		// ignore default config files that are missing or do not have read permissions
 		if m.isDefault(file) && !m.inCLIFlags(file) {
-			if _, err := os.Stat(file); os.IsNotExist(err) {
+			if _, err := os.Stat(file); os.IsNotExist(err) || os.IsPermission(err) {
 				continue
 			}
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #1997 

#### Changes
<!-- What are the changes made in this pull request? -->

- CLI (+ the stack) does not exit with permission errors if any of the default config files cannot be read

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- Possible edge case is that if all default paths cannot be read then no error is displayed and the stack simply falls back to the default (localhost) config, without any indication to the user. This could be misleading or unclear

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [X] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [X] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
