### PR TITLE
Apply join-request parameters on session confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - End device events subscription release in the Console. 
 - Blocking UDP packet handling while the gateway was still connecting. Traffic is now dropped while the connection is in progress, so that traffic from already connected gateways keep flowing.
+- Join-request transmission parameters.
 
 ### Security
 

--- a/pkg/networkserver/grpc_gsns_test.go
+++ b/pkg/networkserver/grpc_gsns_test.go
@@ -1343,9 +1343,8 @@ func TestHandleUplink(t *testing.T) {
 					a.So(sets, should.HaveSameElementsDeep, joinSetByEUISetPaths[:])
 
 					macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1)
+					macState.CurrentParameters.Rx1Delay = ttnpb.RX_DELAY_3
 					macState.DesiredParameters.Rx1Delay = ttnpb.RX_DELAY_3
-					macState.CurrentParameters.Rx1Delay = macState.DesiredParameters.Rx1Delay
-					macState.CurrentParameters.Channels = macState.DesiredParameters.Channels
 					macState.RxWindowsAvailable = true
 					macState.QueuedJoinAccept = &ttnpb.MACState_JoinAccept{
 						Keys:    *makeSessionKeys(ttnpb.MAC_V1_1),
@@ -1565,8 +1564,6 @@ func TestHandleUplink(t *testing.T) {
 
 					macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_2)
 					macState.DesiredParameters.Rx1Delay = ttnpb.RX_DELAY_3
-					macState.CurrentParameters.Rx1Delay = macState.DesiredParameters.Rx1Delay
-					macState.CurrentParameters.Channels = macState.DesiredParameters.Channels
 					macState.RxWindowsAvailable = true
 					macState.QueuedJoinAccept = &ttnpb.MACState_JoinAccept{
 						Keys:    *makeSessionKeys(ttnpb.MAC_V1_0_2),
@@ -1759,8 +1756,6 @@ func TestHandleUplink(t *testing.T) {
 
 					macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1)
 					macState.DesiredParameters.Rx1Delay = ttnpb.RX_DELAY_3
-					macState.CurrentParameters.Rx1Delay = macState.DesiredParameters.Rx1Delay
-					macState.CurrentParameters.Channels = macState.DesiredParameters.Channels
 					macState.RxWindowsAvailable = true
 					macState.QueuedJoinAccept = &ttnpb.MACState_JoinAccept{
 						Keys:    *makeSessionKeys(ttnpb.MAC_V1_1),
@@ -1986,8 +1981,6 @@ func TestHandleUplink(t *testing.T) {
 
 					macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_2)
 					macState.DesiredParameters.Rx1Delay = ttnpb.RX_DELAY_3
-					macState.CurrentParameters.Rx1Delay = macState.DesiredParameters.Rx1Delay
-					macState.CurrentParameters.Channels = macState.DesiredParameters.Channels
 					macState.RxWindowsAvailable = true
 					macState.QueuedJoinAccept = &ttnpb.MACState_JoinAccept{
 						Keys:    *makeSessionKeys(ttnpb.MAC_V1_0_2),
@@ -2216,8 +2209,6 @@ func TestHandleUplink(t *testing.T) {
 
 					macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1)
 					macState.DesiredParameters.Rx1Delay = ttnpb.RX_DELAY_3
-					macState.CurrentParameters.Rx1Delay = macState.DesiredParameters.Rx1Delay
-					macState.CurrentParameters.Channels = macState.DesiredParameters.Channels
 					macState.RxWindowsAvailable = true
 					macState.QueuedJoinAccept = &ttnpb.MACState_JoinAccept{
 						Keys:    *makeSessionKeys(ttnpb.MAC_V1_1),

--- a/pkg/networkserver/mac_rekey.go
+++ b/pkg/networkserver/mac_rekey.go
@@ -34,13 +34,15 @@ func handleRekeyInd(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCom
 	evs := []events.DefinitionDataClosure{
 		evtReceiveRekeyIndication.BindData(pld),
 	}
-	if !dev.SupportsJoin {
+	if !dev.SupportsJoin || dev.MACState.PendingJoinRequest == nil || dev.PendingSession == nil {
 		return evs, nil
 	}
 
-	dev.MACState.LoRaWANVersion = ttnpb.MAC_V1_1
 	dev.EndDeviceIdentifiers.DevAddr = &dev.PendingSession.DevAddr
+	dev.MACState.LoRaWANVersion = ttnpb.MAC_V1_1
+	dev.MACState.PendingJoinRequest = nil
 	dev.Session = dev.PendingSession
+	dev.PendingMACState = nil
 	dev.PendingSession = nil
 
 	conf := &ttnpb.MACCommand_RekeyConf{

--- a/pkg/networkserver/mac_rekey_test.go
+++ b/pkg/networkserver/mac_rekey_test.go
@@ -53,8 +53,10 @@ func TestHandleRekeyInd(t *testing.T) {
 					LastFCntUp:    42,
 					LastNFCntDown: 43,
 				},
+				PendingMACState: &ttnpb.MACState{},
 				MACState: &ttnpb.MACState{
-					QueuedResponses: []*ttnpb.MACCommand{},
+					PendingJoinRequest: &ttnpb.JoinRequest{},
+					QueuedResponses:    []*ttnpb.MACCommand{},
 				},
 			},
 			Expected: &ttnpb.EndDevice{
@@ -97,7 +99,9 @@ func TestHandleRekeyInd(t *testing.T) {
 					LastFCntUp:    42,
 					LastNFCntDown: 43,
 				},
+				PendingMACState: &ttnpb.MACState{},
 				MACState: &ttnpb.MACState{
+					PendingJoinRequest: &ttnpb.JoinRequest{},
 					QueuedResponses: []*ttnpb.MACCommand{
 						{},
 						{},


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/1988

#### Changes
<!-- What are the changes made in this pull request? -->

- Only apply join-request parameters to MAC state on session confirmation (first uplink in session)
- Now that `handleRekeyInd` can determine if the device has a pending join-request or not, improve handling of `RekeyInd`


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
