### PR TITLE
Fix LinkADR ChMask handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Do not use `personal-files` plugin for snap package.
 - Network Server will never attempt RX1 for devices with `Rx1Delay` of `1` second.
+- Improved efficiency of ADR MAC commands.
 
 ### Deprecated
 
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - End device events subscription release in the Console. 
 - Blocking UDP packet handling while the gateway was still connecting. Traffic is now dropped while the connection is in progress, so that traffic from already connected gateways keep flowing.
 - Join-request transmission parameters.
+- ADR in 72-channel regions.
 
 ### Security
 

--- a/pkg/band/au_915_928.go
+++ b/pkg/band/au_915_928.go
@@ -196,8 +196,9 @@ func init() {
 		regionalParameters1_0_2RevB: composeSwaps(
 			disableChMaskCntl51_0_2,
 			disableTxParamSetupReq,
+			makeSetMaxTxPowerIndexFunc(10),
 		),
-		regionalParameters1_0_3RevA: bandIdentity,
+		regionalParameters1_0_3RevA: makeSetMaxTxPowerIndexFunc(15),
 		regionalParameters1_1RevA:   bandIdentity,
 	}
 	All[AU_915_928] = au_915_928

--- a/pkg/band/downgrades.go
+++ b/pkg/band/downgrades.go
@@ -33,6 +33,13 @@ func disableTxParamSetupReq(b Band) Band {
 	return b
 }
 
+func makeSetMaxTxPowerIndexFunc(idx uint8) func(Band) Band {
+	return func(b Band) Band {
+		b.MaxTxPowerIndex = idx
+		return b
+	}
+}
+
 // LoRaWAN 1.0.2rB -> 1.0.2rA downgrades
 
 func auDataRates1_0_2(b Band) Band {

--- a/pkg/band/eu_863_870.go
+++ b/pkg/band/eu_863_870.go
@@ -188,7 +188,7 @@ func init() {
 
 		regionalParameters1_0:       bandIdentity,
 		regionalParameters1_0_1:     bandIdentity,
-		regionalParameters1_0_2RevA: bandIdentity,
+		regionalParameters1_0_2RevA: makeSetMaxTxPowerIndexFunc(5),
 		regionalParameters1_0_2RevB: bandIdentity,
 		regionalParameters1_0_3RevA: bandIdentity,
 		regionalParameters1_1RevA:   bandIdentity,

--- a/pkg/band/kr_920_923.go
+++ b/pkg/band/kr_920_923.go
@@ -141,7 +141,7 @@ func init() {
 
 		// No LoRaWAN 1.0
 		// No LoRaWAN 1.0.1
-		regionalParameters1_0_2RevA: bandIdentity,
+		regionalParameters1_0_2RevA: makeSetMaxTxPowerIndexFunc(6),
 		regionalParameters1_0_2RevB: bandIdentity,
 		regionalParameters1_0_3RevA: bandIdentity,
 		regionalParameters1_1RevA:   bandIdentity,

--- a/pkg/band/us_902_928.go
+++ b/pkg/band/us_902_928.go
@@ -187,8 +187,12 @@ func init() {
 		regionalParameters1_0:       bandIdentity,
 		regionalParameters1_0_1:     bandIdentity,
 		regionalParameters1_0_2RevA: usBeacon1_0_2,
-		regionalParameters1_0_2RevB: composeSwaps(disableCFList1_0_2, disableChMaskCntl51_0_2),
-		regionalParameters1_0_3RevA: bandIdentity,
+		regionalParameters1_0_2RevB: composeSwaps(
+			disableCFList1_0_2,
+			disableChMaskCntl51_0_2,
+			makeSetMaxTxPowerIndexFunc(10),
+		),
+		regionalParameters1_0_3RevA: makeSetMaxTxPowerIndexFunc(15),
 		regionalParameters1_1RevA:   bandIdentity,
 	}
 	All[US_902_928] = us_902_928

--- a/pkg/networkserver/adr.go
+++ b/pkg/networkserver/adr.go
@@ -15,7 +15,7 @@
 package networkserver
 
 import (
-	"go.thethings.network/lorawan-stack/pkg/frequencyplans"
+	"go.thethings.network/lorawan-stack/pkg/band"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 )
 
@@ -155,7 +155,7 @@ func uplinkMetadata(ups ...*ttnpb.UplinkMessage) []*ttnpb.RxMetadata {
 	return mds
 }
 
-func adaptDataRate(dev *ttnpb.EndDevice, fps *frequencyplans.Store, defaults ttnpb.MACSettings) error {
+func adaptDataRate(dev *ttnpb.EndDevice, phy band.Band, defaults ttnpb.MACSettings) error {
 	ups := dev.RecentADRUplinks
 	if len(ups) == 0 {
 		return nil
@@ -164,11 +164,6 @@ func adaptDataRate(dev *ttnpb.EndDevice, fps *frequencyplans.Store, defaults ttn
 	maxSNR, ok := maxSNRFromMetadata(uplinkMetadata(ups...)...)
 	if !ok {
 		return nil
-	}
-
-	_, phy, err := getDeviceBandVersion(dev, fps)
-	if err != nil {
-		return err
 	}
 
 	dev.MACState.DesiredParameters.ADRDataRateIndex = dev.MACState.CurrentParameters.ADRDataRateIndex

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -83,14 +83,17 @@ func TestProcessDownlinkTask(t *testing.T) {
 	}
 
 	rxMetadata := MakeRxMetadataSlice()
-	eu868macParameters := MakeDefaultEU868CurrentMACParameters()
-	eu868macParameters.Rx1Delay = ttnpb.RX_DELAY_2 // Due to infrastructureDelay being 1 second, Network Server never schedules Rx1 for devices with RxDelay == 1.
-	eu868macParameters.Channels = append(eu868macParameters.Channels, &ttnpb.MACParameters_Channel{
-		UplinkFrequency:   430000000,
-		DownlinkFrequency: 431000000,
-		MinDataRateIndex:  ttnpb.DATA_RATE_0,
-		MaxDataRateIndex:  ttnpb.DATA_RATE_3,
-	})
+	makeEU868macParameters := func(ver ttnpb.PHYVersion) ttnpb.MACParameters {
+		params := MakeDefaultEU868CurrentMACParameters(ver)
+		params.Rx1Delay = ttnpb.RX_DELAY_2 // Due to infrastructureDelay being 1 second, Network Server never schedules Rx1 for devices with RxDelay == 1.
+		params.Channels = append(params.Channels, &ttnpb.MACParameters_Channel{
+			UplinkFrequency:   430000000,
+			DownlinkFrequency: 431000000,
+			MinDataRateIndex:  ttnpb.DATA_RATE_0,
+			MaxDataRateIndex:  ttnpb.DATA_RATE_3,
+		})
+		return params
+	}
 
 	assertGetRxMetadataGatewayPeers := func(ctx context.Context, getPeerCh <-chan test.ClusterGetPeerRequest, peer124, peer3 cluster.Peer) bool {
 		t := test.MustTFromContext(ctx)
@@ -519,8 +522,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					MACState: &ttnpb.MACState{
-						CurrentParameters: *CopyMACParameters(&eu868macParameters),
-						DesiredParameters: *CopyMACParameters(&eu868macParameters),
+						CurrentParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
+						DesiredParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
 						DeviceClass:       ttnpb.CLASS_A,
 						LoRaWANVersion:    ttnpb.MAC_V1_1,
 						RecentUplinks: []*ttnpb.UplinkMessage{
@@ -641,8 +644,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					MACState: &ttnpb.MACState{
-						CurrentParameters:  *CopyMACParameters(&eu868macParameters),
-						DesiredParameters:  *CopyMACParameters(&eu868macParameters),
+						CurrentParameters:  makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
+						DesiredParameters:  makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
 						DeviceClass:        ttnpb.CLASS_A,
 						LoRaWANVersion:     ttnpb.MAC_V1_1,
 						RxWindowsAvailable: true,
@@ -785,8 +788,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					MACState: &ttnpb.MACState{
-						CurrentParameters: *CopyMACParameters(&eu868macParameters),
-						DesiredParameters: *CopyMACParameters(&eu868macParameters),
+						CurrentParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
+						DesiredParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
 						DeviceClass:       ttnpb.CLASS_A,
 						LoRaWANVersion:    ttnpb.MAC_V1_1,
 						RecentUplinks: []*ttnpb.UplinkMessage{
@@ -923,8 +926,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					MACState: &ttnpb.MACState{
-						CurrentParameters:  *CopyMACParameters(&eu868macParameters),
-						DesiredParameters:  *CopyMACParameters(&eu868macParameters),
+						CurrentParameters:  makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
+						DesiredParameters:  makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
 						DeviceClass:        ttnpb.CLASS_A,
 						LoRaWANVersion:     ttnpb.MAC_V1_1,
 						RxWindowsAvailable: true,
@@ -1076,8 +1079,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					MACState: &ttnpb.MACState{
-						CurrentParameters: *CopyMACParameters(&eu868macParameters),
-						DesiredParameters: *CopyMACParameters(&eu868macParameters),
+						CurrentParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
+						DesiredParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
 						DeviceClass:       ttnpb.CLASS_A,
 						LoRaWANVersion:    ttnpb.MAC_V1_1,
 						RecentUplinks: []*ttnpb.UplinkMessage{
@@ -1224,8 +1227,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_0_3_REV_A,
 					MACState: &ttnpb.MACState{
-						CurrentParameters: *CopyMACParameters(&eu868macParameters),
-						DesiredParameters: *CopyMACParameters(&eu868macParameters),
+						CurrentParameters: makeEU868macParameters(ttnpb.PHY_V1_0_3_REV_A),
+						DesiredParameters: makeEU868macParameters(ttnpb.PHY_V1_0_3_REV_A),
 						DeviceClass:       ttnpb.CLASS_A,
 						LoRaWANVersion:    ttnpb.MAC_V1_0_3,
 						RecentUplinks: []*ttnpb.UplinkMessage{
@@ -1416,8 +1419,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_0_3_REV_A,
 					MACState: &ttnpb.MACState{
-						CurrentParameters: *CopyMACParameters(&eu868macParameters),
-						DesiredParameters: *CopyMACParameters(&eu868macParameters),
+						CurrentParameters: makeEU868macParameters(ttnpb.PHY_V1_0_3_REV_A),
+						DesiredParameters: makeEU868macParameters(ttnpb.PHY_V1_0_3_REV_A),
 						DeviceClass:       ttnpb.CLASS_A,
 						LoRaWANVersion:    ttnpb.MAC_V1_0_3,
 						RecentUplinks: []*ttnpb.UplinkMessage{
@@ -1600,8 +1603,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					MACState: &ttnpb.MACState{
-						CurrentParameters: *CopyMACParameters(&eu868macParameters),
-						DesiredParameters: *CopyMACParameters(&eu868macParameters),
+						CurrentParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
+						DesiredParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
 						DeviceClass:       ttnpb.CLASS_A,
 						LoRaWANVersion:    ttnpb.MAC_V1_1,
 						QueuedResponses: []*ttnpb.MACCommand{
@@ -1869,8 +1872,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					MACState: &ttnpb.MACState{
-						CurrentParameters: *CopyMACParameters(&eu868macParameters),
-						DesiredParameters: *CopyMACParameters(&eu868macParameters),
+						CurrentParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
+						DesiredParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
 						DeviceClass:       ttnpb.CLASS_A,
 						LoRaWANVersion:    ttnpb.MAC_V1_1,
 						QueuedResponses: []*ttnpb.MACCommand{
@@ -2163,8 +2166,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					MACState: &ttnpb.MACState{
-						CurrentParameters: *CopyMACParameters(&eu868macParameters),
-						DesiredParameters: *CopyMACParameters(&eu868macParameters),
+						CurrentParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
+						DesiredParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
 						DeviceClass:       ttnpb.CLASS_A,
 						LoRaWANVersion:    ttnpb.MAC_V1_1,
 						QueuedResponses: []*ttnpb.MACCommand{
@@ -2450,8 +2453,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					MACState: &ttnpb.MACState{
-						CurrentParameters: *CopyMACParameters(&eu868macParameters),
-						DesiredParameters: *CopyMACParameters(&eu868macParameters),
+						CurrentParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
+						DesiredParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
 						DeviceClass:       ttnpb.CLASS_A,
 						LoRaWANVersion:    ttnpb.MAC_V1_1,
 						QueuedResponses: []*ttnpb.MACCommand{
@@ -2623,8 +2626,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					MACState: &ttnpb.MACState{
-						CurrentParameters:       *CopyMACParameters(&eu868macParameters),
-						DesiredParameters:       *CopyMACParameters(&eu868macParameters),
+						CurrentParameters:       makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
+						DesiredParameters:       makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
 						DeviceClass:             ttnpb.CLASS_A,
 						LoRaWANVersion:          ttnpb.MAC_V1_1,
 						LastConfirmedDownlinkAt: &downAt,
@@ -2770,8 +2773,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 						ClassBTimeout: DurationPtr(42 * time.Second),
 					},
 					MACState: &ttnpb.MACState{
-						CurrentParameters: *CopyMACParameters(&eu868macParameters),
-						DesiredParameters: *CopyMACParameters(&eu868macParameters),
+						CurrentParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
+						DesiredParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
 						DeviceClass:       ttnpb.CLASS_B,
 						LoRaWANVersion:    ttnpb.MAC_V1_1,
 						PingSlotPeriodicity: &ttnpb.PingSlotPeriodValue{
@@ -3072,8 +3075,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 						ClassCTimeout: DurationPtr(42 * time.Second),
 					},
 					MACState: &ttnpb.MACState{
-						CurrentParameters: *CopyMACParameters(&eu868macParameters),
-						DesiredParameters: *CopyMACParameters(&eu868macParameters),
+						CurrentParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
+						DesiredParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
 						DeviceClass:       ttnpb.CLASS_C,
 						LoRaWANVersion:    ttnpb.MAC_V1_1,
 						QueuedResponses: []*ttnpb.MACCommand{
@@ -3250,8 +3253,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 						ClassCTimeout: DurationPtr(42 * time.Second),
 					},
 					MACState: &ttnpb.MACState{
-						CurrentParameters:       *CopyMACParameters(&eu868macParameters),
-						DesiredParameters:       *CopyMACParameters(&eu868macParameters),
+						CurrentParameters:       makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
+						DesiredParameters:       makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
 						DeviceClass:             ttnpb.CLASS_C,
 						LastConfirmedDownlinkAt: &downAt,
 						LoRaWANVersion:          ttnpb.MAC_V1_1,
@@ -3403,8 +3406,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 						ClassCTimeout: DurationPtr(42 * time.Second),
 					},
 					MACState: &ttnpb.MACState{
-						CurrentParameters: *CopyMACParameters(&eu868macParameters),
-						DesiredParameters: *CopyMACParameters(&eu868macParameters),
+						CurrentParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
+						DesiredParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
 						DeviceClass:       ttnpb.CLASS_C,
 						LoRaWANVersion:    ttnpb.MAC_V1_1,
 						QueuedResponses: []*ttnpb.MACCommand{
@@ -3779,8 +3782,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 						StatusTimePeriodicity: DurationPtr(time.Hour),
 					},
 					MACState: &ttnpb.MACState{
-						CurrentParameters: *CopyMACParameters(&eu868macParameters),
-						DesiredParameters: *CopyMACParameters(&eu868macParameters),
+						CurrentParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
+						DesiredParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
 						DeviceClass:       ttnpb.CLASS_C,
 						LoRaWANVersion:    ttnpb.MAC_V1_1,
 						RecentUplinks: []*ttnpb.UplinkMessage{
@@ -4054,8 +4057,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 						ClassCTimeout: DurationPtr(42 * time.Second),
 					},
 					MACState: &ttnpb.MACState{
-						CurrentParameters: *CopyMACParameters(&eu868macParameters),
-						DesiredParameters: *CopyMACParameters(&eu868macParameters),
+						CurrentParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
+						DesiredParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
 						DeviceClass:       ttnpb.CLASS_C,
 						LoRaWANVersion:    ttnpb.MAC_V1_1,
 						RecentUplinks: []*ttnpb.UplinkMessage{
@@ -4466,8 +4469,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 						ClassCTimeout: DurationPtr(42 * time.Second),
 					},
 					MACState: &ttnpb.MACState{
-						CurrentParameters: *CopyMACParameters(&eu868macParameters),
-						DesiredParameters: *CopyMACParameters(&eu868macParameters),
+						CurrentParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
+						DesiredParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
 						DeviceClass:       ttnpb.CLASS_C,
 						LoRaWANVersion:    ttnpb.MAC_V1_1,
 						RecentUplinks: []*ttnpb.UplinkMessage{
@@ -4854,8 +4857,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 						StatusTimePeriodicity:  DurationPtr(0),
 					},
 					MACState: &ttnpb.MACState{
-						CurrentParameters: *CopyMACParameters(&eu868macParameters),
-						DesiredParameters: *CopyMACParameters(&eu868macParameters),
+						CurrentParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
+						DesiredParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
 						DeviceClass:       ttnpb.CLASS_C,
 						LoRaWANVersion:    ttnpb.MAC_V1_1,
 						RecentUplinks: []*ttnpb.UplinkMessage{
@@ -5028,8 +5031,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 						StatusTimePeriodicity:  DurationPtr(0),
 					},
 					MACState: &ttnpb.MACState{
-						CurrentParameters: *CopyMACParameters(&eu868macParameters),
-						DesiredParameters: *CopyMACParameters(&eu868macParameters),
+						CurrentParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
+						DesiredParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
 						DeviceClass:       ttnpb.CLASS_C,
 						LoRaWANVersion:    ttnpb.MAC_V1_1,
 						RecentUplinks: []*ttnpb.UplinkMessage{
@@ -5235,8 +5238,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					PendingMACState: &ttnpb.MACState{
-						CurrentParameters: *CopyMACParameters(&eu868macParameters),
-						DesiredParameters: *CopyMACParameters(&eu868macParameters),
+						CurrentParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
+						DesiredParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
 						DeviceClass:       ttnpb.CLASS_A,
 						LoRaWANVersion:    ttnpb.MAC_V1_1,
 						QueuedJoinAccept: &ttnpb.MACState_JoinAccept{
@@ -5356,8 +5359,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
 					PendingMACState: &ttnpb.MACState{
-						CurrentParameters: *CopyMACParameters(&eu868macParameters),
-						DesiredParameters: *CopyMACParameters(&eu868macParameters),
+						CurrentParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
+						DesiredParameters: makeEU868macParameters(ttnpb.PHY_V1_1_REV_B),
 						DeviceClass:       ttnpb.CLASS_A,
 						LoRaWANVersion:    ttnpb.MAC_V1_1,
 						PendingJoinRequest: &ttnpb.JoinRequest{

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -929,8 +929,7 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 			if !deviceUseADR(stored, ns.defaultMACSettings) {
 				return stored, paths, nil
 			}
-
-			if err := adaptDataRate(stored, ns.FrequencyPlans, ns.defaultMACSettings); err != nil {
+			if err := adaptDataRate(stored, matched.phy, ns.defaultMACSettings); err != nil {
 				handleErr = true
 				return nil, nil, err
 			}

--- a/pkg/networkserver/grpc_gsns_internal_test.go
+++ b/pkg/networkserver/grpc_gsns_internal_test.go
@@ -203,7 +203,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 						FrequencyPlanID:      test.EUFrequencyPlanID,
 						LoRaWANPHYVersion:    ttnpb.PHY_V1_1_REV_B,
 						LoRaWANVersion:       ttnpb.MAC_V1_1,
-						MACState:             MakeDefaultUS915FSB2MACState(ttnpb.CLASS_B, ttnpb.MAC_V1_1),
+						MACState:             MakeDefaultUS915FSB2MACState(ttnpb.CLASS_B, ttnpb.MAC_V1_1, ttnpb.PHY_V1_1_REV_B),
 						Session:              makeSession(ttnpb.MAC_V1_1, devAddr, 33),
 						MACSettings: &ttnpb.MACSettings{
 							ResetsFCnt:        &pbtypes.BoolValue{Value: true},
@@ -221,7 +221,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 				}
 				session := makeSession(ttnpb.MAC_V1_1, devAddr, 12)
 				session.StartedAt = dev.Device.Session.StartedAt
-				macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1)
+				macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1, ttnpb.PHY_V1_1_REV_B)
 				macState.RxWindowsAvailable = true
 				expectedDev := &matchedDevice{
 					phy:                 test.Must(band.All[band.EU_863_870].Version(ttnpb.PHY_V1_1_REV_B)).(band.Band),
@@ -317,7 +317,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 						LoRaWANPHYVersion:    ttnpb.PHY_V1_1_REV_B,
 						LoRaWANVersion:       ttnpb.MAC_V1_1,
 						MACState: func() *ttnpb.MACState {
-							macState := MakeDefaultUS915FSB2MACState(ttnpb.CLASS_B, ttnpb.MAC_V1_1)
+							macState := MakeDefaultUS915FSB2MACState(ttnpb.CLASS_B, ttnpb.MAC_V1_1, ttnpb.PHY_V1_1_REV_B)
 							macState.PendingApplicationDownlink = makeApplicationDownlink()
 							return macState
 						}(),
@@ -338,7 +338,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 				}
 				session := makeSession(ttnpb.MAC_V1_1, devAddr, 12)
 				session.StartedAt = dev.Device.Session.StartedAt
-				macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1)
+				macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1, ttnpb.PHY_V1_1_REV_B)
 				macState.RxWindowsAvailable = true
 				expectedDev := &matchedDevice{
 					phy:                 test.Must(band.All[band.EU_863_870].Version(ttnpb.PHY_V1_1_REV_B)).(band.Band),
@@ -435,7 +435,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 						FrequencyPlanID:      test.EUFrequencyPlanID,
 						LoRaWANPHYVersion:    ttnpb.PHY_V1_1_REV_B,
 						LoRaWANVersion:       ttnpb.MAC_V1_1,
-						MACState:             MakeDefaultUS915FSB2MACState(ttnpb.CLASS_B, ttnpb.MAC_V1_1),
+						MACState:             MakeDefaultUS915FSB2MACState(ttnpb.CLASS_B, ttnpb.MAC_V1_1, ttnpb.PHY_V1_1_REV_B),
 						Session:              makeSession(ttnpb.MAC_V1_1, devAddr, 33),
 						MACSettings: &ttnpb.MACSettings{
 							ResetsFCnt: &pbtypes.BoolValue{Value: true},
@@ -452,7 +452,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 				}
 				session := makeSession(ttnpb.MAC_V1_1, devAddr, 12)
 				session.StartedAt = dev.Device.Session.StartedAt
-				macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1)
+				macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1, ttnpb.PHY_V1_1_REV_B)
 				macState.RxWindowsAvailable = true
 				expectedDev := &matchedDevice{
 					phy:                 test.Must(band.All[band.EU_863_870].Version(ttnpb.PHY_V1_1_REV_B)).(band.Band),
@@ -549,7 +549,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 						LoRaWANPHYVersion:    ttnpb.PHY_V1_1_REV_B,
 						LoRaWANVersion:       ttnpb.MAC_V1_1,
 						MACState: func() *ttnpb.MACState {
-							macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1)
+							macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1, ttnpb.PHY_V1_1_REV_B)
 							macState.PendingApplicationDownlink = makeApplicationDownlink()
 							macState.RecentDownlinks = []*ttnpb.DownlinkMessage{
 								{
@@ -576,7 +576,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 					!a.So(dev.Device.Session, should.NotBeNil) {
 					return false
 				}
-				macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1)
+				macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1, ttnpb.PHY_V1_1_REV_B)
 				macState.RxWindowsAvailable = true
 				macState.RecentDownlinks = []*ttnpb.DownlinkMessage{
 					{

--- a/pkg/networkserver/grpc_gsns_test.go
+++ b/pkg/networkserver/grpc_gsns_test.go
@@ -1342,7 +1342,7 @@ func TestHandleUplink(t *testing.T) {
 					}
 					a.So(sets, should.HaveSameElementsDeep, joinSetByEUISetPaths[:])
 
-					macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1)
+					macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1, ttnpb.PHY_V1_1_REV_B)
 					macState.CurrentParameters.Rx1Delay = ttnpb.RX_DELAY_3
 					macState.DesiredParameters.Rx1Delay = ttnpb.RX_DELAY_3
 					macState.RxWindowsAvailable = true
@@ -1562,7 +1562,7 @@ func TestHandleUplink(t *testing.T) {
 					}
 					a.So(sets, should.HaveSameElementsDeep, joinSetByEUISetPaths[:])
 
-					macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_2)
+					macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_2, ttnpb.PHY_V1_0_2_REV_B)
 					macState.DesiredParameters.Rx1Delay = ttnpb.RX_DELAY_3
 					macState.RxWindowsAvailable = true
 					macState.QueuedJoinAccept = &ttnpb.MACState_JoinAccept{
@@ -1754,7 +1754,7 @@ func TestHandleUplink(t *testing.T) {
 					}
 					a.So(sets, should.HaveSameElementsDeep, joinSetByEUISetPaths[:])
 
-					macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1)
+					macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1, ttnpb.PHY_V1_1_REV_B)
 					macState.DesiredParameters.Rx1Delay = ttnpb.RX_DELAY_3
 					macState.RxWindowsAvailable = true
 					macState.QueuedJoinAccept = &ttnpb.MACState_JoinAccept{
@@ -1979,7 +1979,7 @@ func TestHandleUplink(t *testing.T) {
 					}
 					a.So(sets, should.HaveSameElementsDeep, joinSetByEUISetPaths[:])
 
-					macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_2)
+					macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_2, ttnpb.PHY_V1_0_2_REV_B)
 					macState.DesiredParameters.Rx1Delay = ttnpb.RX_DELAY_3
 					macState.RxWindowsAvailable = true
 					macState.QueuedJoinAccept = &ttnpb.MACState_JoinAccept{
@@ -2207,7 +2207,7 @@ func TestHandleUplink(t *testing.T) {
 					}
 					a.So(sets, should.HaveSameElementsDeep, joinSetByEUISetPaths[:])
 
-					macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1)
+					macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1, ttnpb.PHY_V1_1_REV_B)
 					macState.DesiredParameters.Rx1Delay = ttnpb.RX_DELAY_3
 					macState.RxWindowsAvailable = true
 					macState.QueuedJoinAccept = &ttnpb.MACState_JoinAccept{
@@ -2337,7 +2337,7 @@ func TestHandleUplink(t *testing.T) {
 				}
 
 				makeMACState := func() *ttnpb.MACState {
-					macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_2)
+					macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_2, ttnpb.PHY_V1_0_2_REV_B)
 					macState.RecentUplinks = makeRecentUplinks()
 					return macState
 				}
@@ -2569,7 +2569,7 @@ func TestHandleUplink(t *testing.T) {
 				}
 
 				makeMACState := func() *ttnpb.MACState {
-					macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1)
+					macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1, ttnpb.PHY_V1_1_REV_B)
 					macState.RecentUplinks = makeRecentUplinks()
 					return macState
 				}
@@ -2801,7 +2801,7 @@ func TestHandleUplink(t *testing.T) {
 				}
 
 				makeMACState := func() *ttnpb.MACState {
-					macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_2)
+					macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_2, ttnpb.PHY_V1_0_2_REV_B)
 					macState.RecentUplinks = makeRecentUplinks()
 					return macState
 				}
@@ -3036,7 +3036,7 @@ func TestHandleUplink(t *testing.T) {
 				}
 
 				makeMACState := func() *ttnpb.MACState {
-					macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_2)
+					macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_2, ttnpb.PHY_V1_0_2_REV_B)
 					macState.CurrentParameters.ADRNbTrans = 2
 					macState.DesiredParameters.ADRNbTrans = 2
 					macState.RecentUplinks = makeRecentUplinks()

--- a/pkg/networkserver/mac_link_adr.go
+++ b/pkg/networkserver/mac_link_adr.go
@@ -69,11 +69,15 @@ func enqueueLinkADRReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, ma
 		}, errCorruptedMACState
 	}
 
+	currentChs := make([]bool, phy.MaxUplinkChannels)
+	for i, ch := range dev.MACState.CurrentParameters.Channels {
+		currentChs[i] = ch.GetEnableUplink()
+	}
 	desiredChs := make([]bool, phy.MaxUplinkChannels)
 	for i, ch := range dev.MACState.DesiredParameters.Channels {
 		desiredChs[i] = ch.GetEnableUplink()
 	}
-	desiredMasks, err := phy.GenerateChMasks(desiredChs)
+	desiredMasks, err := phy.GenerateChMasks(currentChs, desiredChs)
 	if err != nil {
 		return macCommandEnqueueState{
 			MaxDownLen: maxDownLen,

--- a/pkg/networkserver/mac_link_adr_test.go
+++ b/pkg/networkserver/mac_link_adr_test.go
@@ -176,12 +176,12 @@ func TestEnqueueLinkADRReq(t *testing.T) {
 			Band: test.Must(test.Must(band.GetByID(band.US_902_928)).(band.Band).Version(ttnpb.PHY_V1_0_3_REV_A)).(band.Band),
 			InputDevice: &ttnpb.EndDevice{
 				FrequencyPlanID: test.USFrequencyPlanID,
-				MACState:        MakeDefaultUS915FSB2MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_3),
+				MACState:        MakeDefaultUS915FSB2MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_3, ttnpb.PHY_V1_0_3_REV_A),
 			},
 			ExpectedDevice: &ttnpb.EndDevice{
 				FrequencyPlanID: test.USFrequencyPlanID,
 				MACState: func() *ttnpb.MACState {
-					macState := MakeDefaultUS915FSB2MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_3)
+					macState := MakeDefaultUS915FSB2MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_3, ttnpb.PHY_V1_0_3_REV_A)
 					macState.PendingRequests = []*ttnpb.MACCommand{
 						(&ttnpb.MACCommand_LinkADRReq{
 							ChannelMask: []bool{
@@ -233,11 +233,11 @@ func TestEnqueueLinkADRReq(t *testing.T) {
 			Band: test.Must(test.Must(band.GetByID(band.US_902_928)).(band.Band).Version(ttnpb.PHY_V1_0_3_REV_A)).(band.Band),
 			InputDevice: &ttnpb.EndDevice{
 				FrequencyPlanID: test.USFrequencyPlanID,
-				MACState:        MakeDefaultUS915FSB2MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_3),
+				MACState:        MakeDefaultUS915FSB2MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_3, ttnpb.PHY_V1_0_3_REV_A),
 			},
 			ExpectedDevice: &ttnpb.EndDevice{
 				FrequencyPlanID: test.USFrequencyPlanID,
-				MACState:        MakeDefaultUS915FSB2MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_3),
+				MACState:        MakeDefaultUS915FSB2MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_3, ttnpb.PHY_V1_0_3_REV_A),
 			},
 			MaxDownlinkLength: 7,
 			MaxUplinkLength:   24,
@@ -252,11 +252,11 @@ func TestEnqueueLinkADRReq(t *testing.T) {
 			Band: test.Must(test.Must(band.GetByID(band.US_902_928)).(band.Band).Version(ttnpb.PHY_V1_1_REV_B)).(band.Band),
 			InputDevice: &ttnpb.EndDevice{
 				FrequencyPlanID: test.USFrequencyPlanID,
-				MACState:        MakeDefaultUS915FSB2MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1),
+				MACState:        MakeDefaultUS915FSB2MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1, ttnpb.PHY_V1_1_REV_B),
 			},
 			ExpectedDevice: &ttnpb.EndDevice{
 				FrequencyPlanID: test.USFrequencyPlanID,
-				MACState:        MakeDefaultUS915FSB2MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1),
+				MACState:        MakeDefaultUS915FSB2MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1, ttnpb.PHY_V1_1_REV_B),
 			},
 			MaxDownlinkLength: 42,
 			MaxUplinkLength:   1,

--- a/pkg/networkserver/mac_link_adr_test.go
+++ b/pkg/networkserver/mac_link_adr_test.go
@@ -186,18 +186,17 @@ func TestEnqueueLinkADRReq(t *testing.T) {
 						(&ttnpb.MACCommand_LinkADRReq{
 							ChannelMask: []bool{
 								false, false, false, false, false, false, false, false,
-								false, false, false, false, false, false, true, false,
+								false, false, false, false, false, false, false, false,
 							},
-							ChannelMaskControl: 5,
+							ChannelMaskControl: 7,
 							NbTrans:            1,
 						}).MACCommand(),
 						(&ttnpb.MACCommand_LinkADRReq{
 							ChannelMask: []bool{
 								false, false, false, false, false, false, false, false,
-								false, false, false, false, false, false, false, false,
+								true, true, true, true, true, true, true, true,
 							},
-							ChannelMaskControl: 4,
-							NbTrans:            1,
+							NbTrans: 1,
 						}).MACCommand(),
 					}
 					return macState
@@ -213,18 +212,17 @@ func TestEnqueueLinkADRReq(t *testing.T) {
 					evtEnqueueLinkADRRequest.BindData(&ttnpb.MACCommand_LinkADRReq{
 						ChannelMask: []bool{
 							false, false, false, false, false, false, false, false,
-							false, false, false, false, false, false, true, false,
+							false, false, false, false, false, false, false, false,
 						},
-						ChannelMaskControl: 5,
+						ChannelMaskControl: 7,
 						NbTrans:            1,
 					}),
 					evtEnqueueLinkADRRequest.BindData(&ttnpb.MACCommand_LinkADRReq{
 						ChannelMask: []bool{
 							false, false, false, false, false, false, false, false,
-							false, false, false, false, false, false, false, false,
+							true, true, true, true, true, true, true, true,
 						},
-						ChannelMaskControl: 4,
-						NbTrans:            1,
+						NbTrans: 1,
 					}),
 				},
 			},

--- a/pkg/networkserver/networkserver_util_test.go
+++ b/pkg/networkserver/networkserver_util_test.go
@@ -176,33 +176,7 @@ func MakeLinkCheckAns(mds ...*ttnpb.RxMetadata) *ttnpb.MACCommand {
 	}).MACCommand()
 }
 
-func MakeEU868Channels(chs ...*ttnpb.MACParameters_Channel) []*ttnpb.MACParameters_Channel {
-	return append([]*ttnpb.MACParameters_Channel{
-		{
-			UplinkFrequency:   868100000,
-			DownlinkFrequency: 868100000,
-			MinDataRateIndex:  ttnpb.DATA_RATE_0,
-			MaxDataRateIndex:  ttnpb.DATA_RATE_5,
-			EnableUplink:      true,
-		},
-		{
-			UplinkFrequency:   868300000,
-			DownlinkFrequency: 868300000,
-			MinDataRateIndex:  ttnpb.DATA_RATE_0,
-			MaxDataRateIndex:  ttnpb.DATA_RATE_5,
-			EnableUplink:      true,
-		},
-		{
-			UplinkFrequency:   868500000,
-			DownlinkFrequency: 868500000,
-			MinDataRateIndex:  ttnpb.DATA_RATE_0,
-			MaxDataRateIndex:  ttnpb.DATA_RATE_5,
-			EnableUplink:      true,
-		},
-	}, chs...)
-}
-
-func MakeDefaultEU868CurrentMACParameters() ttnpb.MACParameters {
+func MakeDefaultEU868CurrentMACParameters(ver ttnpb.PHYVersion) ttnpb.MACParameters {
 	return ttnpb.MACParameters{
 		ADRAckDelayExponent:        &ttnpb.ADRAckDelayExponentValue{Value: ttnpb.ADR_ACK_DELAY_32},
 		ADRAckLimitExponent:        &ttnpb.ADRAckLimitExponentValue{Value: ttnpb.ADR_ACK_LIMIT_64},
@@ -216,74 +190,84 @@ func MakeDefaultEU868CurrentMACParameters() ttnpb.MACParameters {
 		Rx1Delay:                   ttnpb.RX_DELAY_1,
 		Rx2DataRateIndex:           ttnpb.DATA_RATE_0,
 		Rx2Frequency:               869525000,
-		Channels:                   MakeEU868Channels(),
+		Channels: []*ttnpb.MACParameters_Channel{
+			{
+				UplinkFrequency:   868100000,
+				DownlinkFrequency: 868100000,
+				MinDataRateIndex:  ttnpb.DATA_RATE_0,
+				MaxDataRateIndex:  ttnpb.DATA_RATE_5,
+				EnableUplink:      true,
+			},
+			{
+				UplinkFrequency:   868300000,
+				DownlinkFrequency: 868300000,
+				MinDataRateIndex:  ttnpb.DATA_RATE_0,
+				MaxDataRateIndex:  ttnpb.DATA_RATE_5,
+				EnableUplink:      true,
+			},
+			{
+				UplinkFrequency:   868500000,
+				DownlinkFrequency: 868500000,
+				MinDataRateIndex:  ttnpb.DATA_RATE_0,
+				MaxDataRateIndex:  ttnpb.DATA_RATE_5,
+				EnableUplink:      true,
+			},
+		},
 	}
 }
 
-func MakeDefaultEU868DesiredMACParameters() ttnpb.MACParameters {
-	return ttnpb.MACParameters{
-		ADRAckDelayExponent:        &ttnpb.ADRAckDelayExponentValue{Value: ttnpb.ADR_ACK_DELAY_32},
-		ADRAckLimitExponent:        &ttnpb.ADRAckLimitExponentValue{Value: ttnpb.ADR_ACK_LIMIT_64},
-		ADRNbTrans:                 1,
-		MaxDutyCycle:               ttnpb.DUTY_CYCLE_1,
-		MaxEIRP:                    16,
-		PingSlotDataRateIndexValue: &ttnpb.DataRateIndexValue{Value: ttnpb.DATA_RATE_3},
-		PingSlotFrequency:          869525000,
-		RejoinCountPeriodicity:     ttnpb.REJOIN_COUNT_16,
-		RejoinTimePeriodicity:      ttnpb.REJOIN_TIME_0,
-		Rx1Delay:                   ttnpb.RX_DELAY_1,
-		Rx2DataRateIndex:           ttnpb.DATA_RATE_0,
-		Rx2Frequency:               869525000,
-		Channels: MakeEU868Channels(
-			&ttnpb.MACParameters_Channel{
-				UplinkFrequency:   867100000,
-				DownlinkFrequency: 867100000,
-				MinDataRateIndex:  ttnpb.DATA_RATE_0,
-				MaxDataRateIndex:  ttnpb.DATA_RATE_5,
-				EnableUplink:      true,
-			},
-			&ttnpb.MACParameters_Channel{
-				UplinkFrequency:   867300000,
-				DownlinkFrequency: 867300000,
-				MinDataRateIndex:  ttnpb.DATA_RATE_0,
-				MaxDataRateIndex:  ttnpb.DATA_RATE_5,
-				EnableUplink:      true,
-			},
-			&ttnpb.MACParameters_Channel{
-				UplinkFrequency:   867500000,
-				DownlinkFrequency: 867500000,
-				MinDataRateIndex:  ttnpb.DATA_RATE_0,
-				MaxDataRateIndex:  ttnpb.DATA_RATE_5,
-				EnableUplink:      true,
-			},
-			&ttnpb.MACParameters_Channel{
-				UplinkFrequency:   867700000,
-				DownlinkFrequency: 867700000,
-				MinDataRateIndex:  ttnpb.DATA_RATE_0,
-				MaxDataRateIndex:  ttnpb.DATA_RATE_5,
-				EnableUplink:      true,
-			},
-			&ttnpb.MACParameters_Channel{
-				UplinkFrequency:   867900000,
-				DownlinkFrequency: 867900000,
-				MinDataRateIndex:  ttnpb.DATA_RATE_0,
-				MaxDataRateIndex:  ttnpb.DATA_RATE_5,
-				EnableUplink:      true,
-			},
-		),
-	}
+func MakeDefaultEU868DesiredMACParameters(ver ttnpb.PHYVersion) ttnpb.MACParameters {
+	params := MakeDefaultEU868CurrentMACParameters(ver)
+	params.Channels = append(params.Channels,
+		&ttnpb.MACParameters_Channel{
+			UplinkFrequency:   867100000,
+			DownlinkFrequency: 867100000,
+			MinDataRateIndex:  ttnpb.DATA_RATE_0,
+			MaxDataRateIndex:  ttnpb.DATA_RATE_5,
+			EnableUplink:      true,
+		},
+		&ttnpb.MACParameters_Channel{
+			UplinkFrequency:   867300000,
+			DownlinkFrequency: 867300000,
+			MinDataRateIndex:  ttnpb.DATA_RATE_0,
+			MaxDataRateIndex:  ttnpb.DATA_RATE_5,
+			EnableUplink:      true,
+		},
+		&ttnpb.MACParameters_Channel{
+			UplinkFrequency:   867500000,
+			DownlinkFrequency: 867500000,
+			MinDataRateIndex:  ttnpb.DATA_RATE_0,
+			MaxDataRateIndex:  ttnpb.DATA_RATE_5,
+			EnableUplink:      true,
+		},
+		&ttnpb.MACParameters_Channel{
+			UplinkFrequency:   867700000,
+			DownlinkFrequency: 867700000,
+			MinDataRateIndex:  ttnpb.DATA_RATE_0,
+			MaxDataRateIndex:  ttnpb.DATA_RATE_5,
+			EnableUplink:      true,
+		},
+		&ttnpb.MACParameters_Channel{
+			UplinkFrequency:   867900000,
+			DownlinkFrequency: 867900000,
+			MinDataRateIndex:  ttnpb.DATA_RATE_0,
+			MaxDataRateIndex:  ttnpb.DATA_RATE_5,
+			EnableUplink:      true,
+		},
+	)
+	return params
 }
 
-func MakeDefaultEU868MACState(class ttnpb.Class, ver ttnpb.MACVersion) *ttnpb.MACState {
+func MakeDefaultEU868MACState(class ttnpb.Class, macVer ttnpb.MACVersion, phyVer ttnpb.PHYVersion) *ttnpb.MACState {
 	return &ttnpb.MACState{
 		DeviceClass:       class,
-		LoRaWANVersion:    ver,
-		CurrentParameters: MakeDefaultEU868CurrentMACParameters(),
-		DesiredParameters: MakeDefaultEU868DesiredMACParameters(),
+		LoRaWANVersion:    macVer,
+		CurrentParameters: MakeDefaultEU868CurrentMACParameters(phyVer),
+		DesiredParameters: MakeDefaultEU868DesiredMACParameters(phyVer),
 	}
 }
 
-func MakeUS915Channels() []*ttnpb.MACParameters_Channel {
+func MakeDefaultUS915CurrentMACParameters(ver ttnpb.PHYVersion) ttnpb.MACParameters {
 	var chs []*ttnpb.MACParameters_Channel
 	for i := 0; i < 64; i++ {
 		chs = append(chs, &ttnpb.MACParameters_Channel{
@@ -304,58 +288,47 @@ func MakeUS915Channels() []*ttnpb.MACParameters_Channel {
 	for i := 0; i < 72; i++ {
 		chs[i].DownlinkFrequency = uint64(923300000 + 600000*(i%8))
 	}
-	return chs
+	return ttnpb.MACParameters{
+		ADRAckDelayExponent:        &ttnpb.ADRAckDelayExponentValue{Value: ttnpb.ADR_ACK_DELAY_32},
+		ADRAckLimitExponent:        &ttnpb.ADRAckLimitExponentValue{Value: ttnpb.ADR_ACK_LIMIT_64},
+		ADRNbTrans:                 1,
+		MaxDutyCycle:               ttnpb.DUTY_CYCLE_1,
+		MaxEIRP:                    30,
+		PingSlotDataRateIndexValue: &ttnpb.DataRateIndexValue{Value: ttnpb.DATA_RATE_8},
+		RejoinCountPeriodicity:     ttnpb.REJOIN_COUNT_16,
+		RejoinTimePeriodicity:      ttnpb.REJOIN_TIME_0,
+		Rx1Delay:                   ttnpb.RX_DELAY_1,
+		Rx2DataRateIndex:           ttnpb.DATA_RATE_8,
+		Rx2Frequency:               923300000,
+		Channels:                   chs,
+	}
 }
 
-func MakeDefaultUS915FSB2MACState(class ttnpb.Class, ver ttnpb.MACVersion) *ttnpb.MACState {
+func MakeDefaultUS915FSB2DesiredMACParameters(ver ttnpb.PHYVersion) ttnpb.MACParameters {
+	params := MakeDefaultUS915CurrentMACParameters(ver)
+	for _, ch := range params.Channels {
+		switch ch.UplinkFrequency {
+		case 903900000,
+			904100000,
+			904300000,
+			904500000,
+			904700000,
+			904900000,
+			905100000,
+			905300000:
+			continue
+		}
+		ch.EnableUplink = false
+	}
+	return params
+}
+
+func MakeDefaultUS915FSB2MACState(class ttnpb.Class, macVer ttnpb.MACVersion, phyVer ttnpb.PHYVersion) *ttnpb.MACState {
 	return &ttnpb.MACState{
-		DeviceClass:    class,
-		LoRaWANVersion: ver,
-		CurrentParameters: ttnpb.MACParameters{
-			ADRAckDelayExponent:        &ttnpb.ADRAckDelayExponentValue{Value: ttnpb.ADR_ACK_DELAY_32},
-			ADRAckLimitExponent:        &ttnpb.ADRAckLimitExponentValue{Value: ttnpb.ADR_ACK_LIMIT_64},
-			ADRNbTrans:                 1,
-			MaxDutyCycle:               ttnpb.DUTY_CYCLE_1,
-			MaxEIRP:                    30,
-			PingSlotDataRateIndexValue: &ttnpb.DataRateIndexValue{Value: ttnpb.DATA_RATE_8},
-			RejoinCountPeriodicity:     ttnpb.REJOIN_COUNT_16,
-			RejoinTimePeriodicity:      ttnpb.REJOIN_TIME_0,
-			Rx1Delay:                   ttnpb.RX_DELAY_1,
-			Rx2DataRateIndex:           ttnpb.DATA_RATE_8,
-			Rx2Frequency:               923300000,
-			Channels:                   MakeUS915Channels(),
-		},
-		DesiredParameters: ttnpb.MACParameters{
-			ADRAckDelayExponent:        &ttnpb.ADRAckDelayExponentValue{Value: ttnpb.ADR_ACK_DELAY_32},
-			ADRAckLimitExponent:        &ttnpb.ADRAckLimitExponentValue{Value: ttnpb.ADR_ACK_LIMIT_64},
-			ADRNbTrans:                 1,
-			MaxDutyCycle:               ttnpb.DUTY_CYCLE_1,
-			MaxEIRP:                    30,
-			PingSlotDataRateIndexValue: &ttnpb.DataRateIndexValue{Value: ttnpb.DATA_RATE_8},
-			RejoinCountPeriodicity:     ttnpb.REJOIN_COUNT_16,
-			RejoinTimePeriodicity:      ttnpb.REJOIN_TIME_0,
-			Rx1Delay:                   ttnpb.RX_DELAY_1,
-			Rx2DataRateIndex:           ttnpb.DATA_RATE_8,
-			Rx2Frequency:               923300000,
-			Channels: func() []*ttnpb.MACParameters_Channel {
-				ret := MakeUS915Channels()
-				for _, ch := range ret {
-					switch ch.UplinkFrequency {
-					case 903900000,
-						904100000,
-						904300000,
-						904500000,
-						904700000,
-						904900000,
-						905100000,
-						905300000:
-						continue
-					}
-					ch.EnableUplink = false
-				}
-				return ret
-			}(),
-		},
+		DeviceClass:       class,
+		LoRaWANVersion:    macVer,
+		CurrentParameters: MakeDefaultUS915CurrentMACParameters(phyVer),
+		DesiredParameters: MakeDefaultUS915FSB2DesiredMACParameters(phyVer),
 	}
 }
 

--- a/pkg/networkserver/utils_internal_test.go
+++ b/pkg/networkserver/utils_internal_test.go
@@ -69,7 +69,7 @@ func TestNewMACState(t *testing.T) {
 				},
 			},
 			MACState: func() *ttnpb.MACState {
-				macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_2)
+				macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_2, ttnpb.PHY_V1_0_2_REV_B)
 				macState.DesiredParameters.Rx1Delay = ttnpb.RX_DELAY_13
 				return macState
 			}(),
@@ -108,7 +108,7 @@ func TestNewMACState(t *testing.T) {
 				SupportsClassB: true,
 			},
 			MACState: func() *ttnpb.MACState {
-				macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_2)
+				macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_2, ttnpb.PHY_V1_0_2_REV_B)
 				macState.DesiredParameters.Rx1Delay = ttnpb.RX_DELAY_13
 				macState.DeviceClass = ttnpb.CLASS_B
 				return macState
@@ -130,7 +130,7 @@ func TestNewMACState(t *testing.T) {
 				SupportsClassC: true,
 			},
 			MACState: func() *ttnpb.MACState {
-				macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_2)
+				macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_2, ttnpb.PHY_V1_0_2_REV_B)
 				macState.DesiredParameters.Rx1Delay = ttnpb.RX_DELAY_13
 				macState.DeviceClass = ttnpb.CLASS_C
 				return macState
@@ -150,7 +150,7 @@ func TestNewMACState(t *testing.T) {
 				},
 			},
 			MACState: func() *ttnpb.MACState {
-				macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1)
+				macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1, ttnpb.PHY_V1_1_REV_B)
 				macState.DesiredParameters.Rx1Delay = ttnpb.RX_DELAY_13
 				return macState
 			}(),
@@ -189,7 +189,7 @@ func TestNewMACState(t *testing.T) {
 				SupportsClassB: true,
 			},
 			MACState: func() *ttnpb.MACState {
-				macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1)
+				macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1, ttnpb.PHY_V1_1_REV_B)
 				macState.DesiredParameters.Rx1Delay = ttnpb.RX_DELAY_13
 				macState.DeviceClass = ttnpb.CLASS_B
 				return macState
@@ -211,7 +211,7 @@ func TestNewMACState(t *testing.T) {
 				SupportsClassC: true,
 			},
 			MACState: func() *ttnpb.MACState {
-				macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1)
+				macState := MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1, ttnpb.PHY_V1_1_REV_B)
 				macState.DesiredParameters.Rx1Delay = ttnpb.RX_DELAY_13
 				macState.DeviceClass = ttnpb.CLASS_C
 				return macState
@@ -219,7 +219,7 @@ func TestNewMACState(t *testing.T) {
 			FrequencyPlanStore: frequencyplans.NewStore(test.FrequencyPlansFetcher),
 		},
 		{
-			Name: "1.0.2/US915",
+			Name: "1.0.2/US915_FSB2",
 			Device: &ttnpb.EndDevice{
 				FrequencyPlanID:   test.USFrequencyPlanID,
 				LoRaWANVersion:    ttnpb.MAC_V1_0_2,
@@ -231,14 +231,14 @@ func TestNewMACState(t *testing.T) {
 				},
 			},
 			MACState: func() *ttnpb.MACState {
-				macState := MakeDefaultUS915FSB2MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_2)
+				macState := MakeDefaultUS915FSB2MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_2, ttnpb.PHY_V1_0_2_REV_B)
 				macState.DesiredParameters.Rx1Delay = ttnpb.RX_DELAY_13
 				return macState
 			}(),
 			FrequencyPlanStore: frequencyplans.NewStore(test.FrequencyPlansFetcher),
 		},
 		{
-			Name: "1.1/US915",
+			Name: "1.1/US915_FSB2",
 			Device: &ttnpb.EndDevice{
 				FrequencyPlanID:   test.USFrequencyPlanID,
 				LoRaWANVersion:    ttnpb.MAC_V1_1,
@@ -250,7 +250,7 @@ func TestNewMACState(t *testing.T) {
 				},
 			},
 			MACState: func() *ttnpb.MACState {
-				macState := MakeDefaultUS915FSB2MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1)
+				macState := MakeDefaultUS915FSB2MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1, ttnpb.PHY_V1_1_REV_B)
 				macState.DesiredParameters.Rx1Delay = ttnpb.RX_DELAY_13
 				return macState
 			}(),


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/2016

#### Changes
<!-- What are the changes made in this pull request? -->

- Simplify `ChMask` parsing and generation logic
- Always compute minimal, most generic `ChMask` sequence
- Fix `ChMaskCntl==5` endianness
- Add US915 OTAA 1.0.3 flow test
- Fix `MaxTxPowerIndex` in various bands/version combinations
- Assume `MaxTxPowerIndex` is the default `TxPowerIndex` as per LoRaWAN spec.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@adriansmares may want to take a look since you did https://github.com/TheThingsIndustries/lorawan-stack/pull/1401

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
