### PR TITLE
Use default LNS port for BasicStation CUPS Update Info request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Do not use `personal-files` plugin for snap package.
 - Network Server will never attempt RX1 for devices with `Rx1Delay` of `1` second.
 - Improved efficiency of ADR MAC commands.
+- Gateway Configuration Server will use the default WebSocket TLS port if none is set.
 
 ### Deprecated
 

--- a/pkg/basicstation/cups/server.go
+++ b/pkg/basicstation/cups/server.go
@@ -255,7 +255,7 @@ var errNoTrust = errors.DefineInternal("no_trust", "no trusted certificate found
 // It supports the typical format "host:port" (port being optional).
 // It allows schemes "http://host:port" to be present.
 // If schemes http/https/ws/wss are used, the port is inferred if not present.
-func parseAddress(address string) (scheme, host, port string, err error) {
+func parseAddress(defaultScheme, address string) (scheme, host, port string, err error) {
 	if address == "" {
 		return
 	}
@@ -275,12 +275,19 @@ func parseAddress(address string) (scheme, host, port string, err error) {
 	} else {
 		host = address
 	}
+	if scheme == "" {
+		scheme = defaultScheme
+	}
 	if port == "" {
 		switch scheme {
-		case "http", "ws":
+		case "http":
 			port = "80"
-		case "https", "wss":
+		case "ws":
+			port = "1887"
+		case "https":
 			port = "443"
+		case "wss":
+			port = "8887"
 		}
 	}
 	return
@@ -293,12 +300,9 @@ func (s *Server) getTrust(address string) (*x509.Certificate, error) {
 		}
 		return nil, errNoTrust
 	}
-	_, host, port, err := parseAddress(address)
+	_, host, port, err := parseAddress("https", address)
 	if err != nil {
 		return nil, err
-	}
-	if port == "" {
-		port = "443"
 	}
 	address = net.JoinHostPort(host, port)
 

--- a/pkg/basicstation/cups/update_info.go
+++ b/pkg/basicstation/cups/update_info.go
@@ -248,17 +248,11 @@ func (s *Server) UpdateInfo(c echo.Context) error {
 		}
 	}
 	if gtw.GatewayServerAddress != req.LNSURI {
-		scheme, host, port, err := parseAddress(gtw.GatewayServerAddress)
+		scheme, host, port, err := parseAddress("wss", gtw.GatewayServerAddress)
 		if err != nil {
 			return err
 		}
-		if scheme == "" {
-			scheme = "wss"
-		}
 		address := host
-		if port == "" {
-			port = "8887"
-		}
 		address = net.JoinHostPort(host, port)
 		res.LNSURI = fmt.Sprintf("%s://%s", scheme, address)
 	}

--- a/pkg/basicstation/cups/update_info.go
+++ b/pkg/basicstation/cups/update_info.go
@@ -256,9 +256,10 @@ func (s *Server) UpdateInfo(c echo.Context) error {
 			scheme = "wss"
 		}
 		address := host
-		if port != "" {
-			address = net.JoinHostPort(host, port)
+		if port == "" {
+			port = "8887"
 		}
+		address = net.JoinHostPort(host, port)
 		res.LNSURI = fmt.Sprintf("%s://%s", scheme, address)
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Use default LNS port for BasicStation CUPS Update Info request.

In most of our "standard" deployments, most users choose the pre-filled GatewayServerAddress when creating a gateway. This does not have any port info so Basic Station gateways complain. 

#### Changes
<!-- What are the changes made in this pull request? -->

- Use port 8887 in case no port is provided.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Users can just append the port in the console/cli but we should support a default port as we already support a default protocol (`wss`).
Users should only have to edit the port if they choose to customize.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [ ] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
