### PR TITLE
Refactor TxOffset handling in band, add missing values

### DIFF
--- a/pkg/band/as_923.go
+++ b/pkg/band/as_923.go
@@ -100,12 +100,16 @@ func init() {
 		MaxAckTimeout:    defaultAckTimeout + defaultAckTimeoutMargin,
 
 		DefaultMaxEIRP: 16,
-		TxOffset: [16]float32{
-			0, -2, -4, -6, -8, -10, -12, -14,
-			0, 0, 0, 0, 0, 0, 0, // RFU
-			0, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU before
+		TxOffset: []float32{
+			0,
+			-2,
+			-4,
+			-6,
+			-8,
+			-10,
+			-12,
+			-14,
 		},
-		MaxTxPowerIndex: 7,
 
 		LoRaCodingRate: "4/5",
 

--- a/pkg/band/au_915_928.go
+++ b/pkg/band/au_915_928.go
@@ -151,14 +151,23 @@ func init() {
 		MaxAckTimeout:    defaultAckTimeout + defaultAckTimeoutMargin,
 
 		DefaultMaxEIRP: 30,
-		TxOffset: func() [16]float32 {
-			offset := [16]float32{}
-			for i := 0; i < 15; i++ {
-				offset[i] = float32(0 - 2*i)
-			}
-			return offset
-		}(),
-		MaxTxPowerIndex: 14,
+		TxOffset: []float32{
+			0,
+			-2,
+			-4,
+			-6,
+			-8,
+			-10,
+			-12,
+			-14,
+			-16,
+			-18,
+			-20,
+			-22,
+			-24,
+			-26,
+			-28,
+		},
 
 		LoRaCodingRate: "4/5",
 
@@ -198,8 +207,10 @@ func init() {
 			disableTxParamSetupReq,
 			makeSetMaxTxPowerIndexFunc(10),
 		),
-		regionalParameters1_0_3RevA: makeSetMaxTxPowerIndexFunc(15),
-		regionalParameters1_1RevA:   bandIdentity,
+		regionalParameters1_0_3RevA: composeSwaps(
+			makeAddTxPowerFunc(-30),
+		),
+		regionalParameters1_1RevA: bandIdentity,
 	}
 	All[AU_915_928] = au_915_928
 }

--- a/pkg/band/band.go
+++ b/pkg/band/band.go
@@ -162,10 +162,8 @@ type Band struct {
 	MinAckTimeout time.Duration
 	MaxAckTimeout time.Duration
 
-	// TxOffset in dB: A Tx's power is computed by taking the MaxEIRP (default: +16dBm) and subtracting the offset.
-	TxOffset [16]float32
-	// MaxTxPowerIndex represents the maximum non-RFU TxPowerIndex, which can be used according to the band's spec.
-	MaxTxPowerIndex uint8
+	// TxOffset in dB: Tx power is computed by taking the MaxEIRP (default: +16dBm) and subtracting the offset.
+	TxOffset []float32
 	// MaxADRDataRateIndex represents the maximum non-RFU DataRateIndex suitable for ADR, which can be used according to the band's spec.
 	MaxADRDataRateIndex uint8
 
@@ -202,6 +200,14 @@ type Band struct {
 	regionalParameters1_0_2RevB versionSwap
 	regionalParameters1_0_3RevA versionSwap
 	regionalParameters1_1RevA   versionSwap
+}
+
+func (b Band) MaxTxPowerIndex() uint8 {
+	n := len(b.TxOffset)
+	if n > math.MaxUint8 {
+		panic("length of TxOffset overflows uint8")
+	}
+	return uint8(n) - 1
 }
 
 // SubBandParameters contains the sub-band frequency range, duty cycle and Tx power.

--- a/pkg/band/cn_470_510.go
+++ b/pkg/band/cn_470_510.go
@@ -115,12 +115,16 @@ func init() {
 		MaxAckTimeout:    defaultAckTimeout + defaultAckTimeoutMargin,
 
 		DefaultMaxEIRP: 19.15,
-		TxOffset: [16]float32{
-			0, -2, -4, -6, -8, -10, -12, -14,
-			0, 0, 0, 0, 0, 0, 0, // RFU
-			0, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU before
+		TxOffset: []float32{
+			0,
+			-2,
+			-4,
+			-6,
+			-8,
+			-10,
+			-12,
+			-14,
 		},
-		MaxTxPowerIndex: 7,
 
 		Rx1Channel: channelIndexModulo(48),
 		Rx1DataRate: func(idx ttnpb.DataRateIndex, offset uint32, _ bool) (ttnpb.DataRateIndex, error) {

--- a/pkg/band/cn_779_787.go
+++ b/pkg/band/cn_779_787.go
@@ -116,12 +116,14 @@ func init() {
 		MaxAckTimeout:    defaultAckTimeout + defaultAckTimeoutMargin,
 
 		DefaultMaxEIRP: 12.15,
-		TxOffset: [16]float32{
-			0, -2, -4, -6, -8, -10,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, // RFU
-			0, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU before
+		TxOffset: []float32{
+			0,
+			-2,
+			-4,
+			-6,
+			-8,
+			-10,
 		},
-		MaxTxPowerIndex: 5,
 
 		Rx1Channel: channelIndexIdentity,
 		Rx1DataRate: func(idx ttnpb.DataRateIndex, offset uint32, _ bool) (ttnpb.DataRateIndex, error) {

--- a/pkg/band/downgrades.go
+++ b/pkg/band/downgrades.go
@@ -35,7 +35,14 @@ func disableTxParamSetupReq(b Band) Band {
 
 func makeSetMaxTxPowerIndexFunc(idx uint8) func(Band) Band {
 	return func(b Band) Band {
-		b.MaxTxPowerIndex = idx
+		b.TxOffset = b.TxOffset[:idx+1]
+		return b
+	}
+}
+
+func makeAddTxPowerFunc(offset float32) func(Band) Band {
+	return func(b Band) Band {
+		b.TxOffset = append(b.TxOffset, offset)
 		return b
 	}
 }

--- a/pkg/band/eu_433.go
+++ b/pkg/band/eu_433.go
@@ -113,12 +113,14 @@ func init() {
 		MaxAckTimeout:    defaultAckTimeout + defaultAckTimeoutMargin,
 
 		DefaultMaxEIRP: 12.15,
-		TxOffset: [16]float32{
-			0, -2, -4, -6, -8, -10,
-			0, 0, 0, 0, 0, 0, 0, 0, 0, // RFU
-			0, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU before
+		TxOffset: []float32{
+			0,
+			-2,
+			-4,
+			-6,
+			-8,
+			-10,
 		},
-		MaxTxPowerIndex: 5,
 
 		Rx1Channel: channelIndexIdentity,
 		Rx1DataRate: func(idx ttnpb.DataRateIndex, offset uint32, _ bool) (ttnpb.DataRateIndex, error) {

--- a/pkg/band/eu_863_870.go
+++ b/pkg/band/eu_863_870.go
@@ -150,12 +150,16 @@ func init() {
 		MaxAckTimeout:    defaultAckTimeout + defaultAckTimeoutMargin,
 
 		DefaultMaxEIRP: 16,
-		TxOffset: [16]float32{
-			0, -2, -4, -6, -8, -10, -12, -14,
-			0, 0, 0, 0, 0, 0, 0, // RFU
-			0, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU before
+		TxOffset: []float32{
+			0,
+			-2,
+			-4,
+			-6,
+			-8,
+			-10,
+			-12,
+			-14,
 		},
-		MaxTxPowerIndex: 7,
 
 		Rx1Channel: channelIndexIdentity,
 		Rx1DataRate: func(idx ttnpb.DataRateIndex, offset uint32, _ bool) (ttnpb.DataRateIndex, error) {
@@ -186,9 +190,11 @@ func init() {
 		},
 		PingSlotFrequency: uint64Ptr(euBeaconFrequency),
 
-		regionalParameters1_0:       bandIdentity,
-		regionalParameters1_0_1:     bandIdentity,
-		regionalParameters1_0_2RevA: makeSetMaxTxPowerIndexFunc(5),
+		regionalParameters1_0:   bandIdentity,
+		regionalParameters1_0_1: bandIdentity,
+		regionalParameters1_0_2RevA: composeSwaps(
+			makeSetMaxTxPowerIndexFunc(5),
+		),
 		regionalParameters1_0_2RevB: bandIdentity,
 		regionalParameters1_0_3RevA: bandIdentity,
 		regionalParameters1_1RevA:   bandIdentity,

--- a/pkg/band/in_865_867.go
+++ b/pkg/band/in_865_867.go
@@ -98,14 +98,19 @@ func init() {
 		MaxAckTimeout:    defaultAckTimeout + defaultAckTimeoutMargin,
 
 		DefaultMaxEIRP: 30,
-		TxOffset: func() [16]float32 {
-			offset := [16]float32{}
-			for i := 0; i < 11; i++ {
-				offset[i] = float32(0 - 2*i)
-			}
-			return offset
-		}(),
-		MaxTxPowerIndex: 10,
+		TxOffset: []float32{
+			0,
+			-2,
+			-4,
+			-6,
+			-8,
+			-10,
+			-12,
+			-14,
+			-16,
+			-18,
+			-20,
+		},
 
 		Rx1Channel: channelIndexIdentity,
 		Rx1DataRate: func(idx ttnpb.DataRateIndex, offset uint32, _ bool) (ttnpb.DataRateIndex, error) {

--- a/pkg/band/kr_920_923.go
+++ b/pkg/band/kr_920_923.go
@@ -103,12 +103,16 @@ func init() {
 		MaxAckTimeout:    defaultAckTimeout + defaultAckTimeoutMargin,
 
 		DefaultMaxEIRP: 14,
-		TxOffset: [16]float32{
-			0, -2, -4, -6, -8, -10, -12, -14,
-			0, 0, 0, 0, 0, 0, 0, // RFU
-			0, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU before
+		TxOffset: []float32{
+			0,
+			-2,
+			-4,
+			-6,
+			-8,
+			-10,
+			-12,
+			-14,
 		},
-		MaxTxPowerIndex: 7,
 
 		Rx1Channel: channelIndexIdentity,
 		Rx1DataRate: func(idx ttnpb.DataRateIndex, offset uint32, _ bool) (ttnpb.DataRateIndex, error) {

--- a/pkg/band/ru_864_870.go
+++ b/pkg/band/ru_864_870.go
@@ -111,12 +111,16 @@ func init() {
 		MaxAckTimeout:    defaultAckTimeout + defaultAckTimeoutMargin,
 
 		DefaultMaxEIRP: 14,
-		TxOffset: [16]float32{
-			0, -2, -4, -6, -8, -10, -12, -14,
-			0, 0, 0, 0, 0, 0, 0, // RFU
-			0, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU before
+		TxOffset: []float32{
+			0,
+			-2,
+			-4,
+			-6,
+			-8,
+			-10,
+			-12,
+			-14,
 		},
-		MaxTxPowerIndex: 7,
 
 		Rx1Channel: channelIndexIdentity,
 		Rx1DataRate: func(idx ttnpb.DataRateIndex, offset uint32, _ bool) (ttnpb.DataRateIndex, error) {

--- a/pkg/band/us_902_928.go
+++ b/pkg/band/us_902_928.go
@@ -147,14 +147,23 @@ func init() {
 		MaxAckTimeout:    defaultAckTimeout + defaultAckTimeoutMargin,
 
 		DefaultMaxEIRP: 30,
-		TxOffset: func() [16]float32 {
-			offset := [16]float32{}
-			for i := 0; i < 15; i++ {
-				offset[i] = float32(0 - 2*i)
-			}
-			return offset
-		}(),
-		MaxTxPowerIndex: 14,
+		TxOffset: []float32{
+			0,
+			-2,
+			-4,
+			-6,
+			-8,
+			-10,
+			-12,
+			-14,
+			-16,
+			-18,
+			-20,
+			-22,
+			-24,
+			-26,
+			-28,
+		},
 
 		Rx1Channel: channelIndexModulo(8),
 		Rx1DataRate: func(idx ttnpb.DataRateIndex, offset uint32, _ bool) (ttnpb.DataRateIndex, error) {
@@ -192,8 +201,10 @@ func init() {
 			disableChMaskCntl51_0_2,
 			makeSetMaxTxPowerIndexFunc(10),
 		),
-		regionalParameters1_0_3RevA: makeSetMaxTxPowerIndexFunc(15),
-		regionalParameters1_1RevA:   bandIdentity,
+		regionalParameters1_0_3RevA: composeSwaps(
+			makeAddTxPowerFunc(-30),
+		),
+		regionalParameters1_1RevA: bandIdentity,
 	}
 	All[US_902_928] = us_902_928
 }

--- a/pkg/networkserver/adr.go
+++ b/pkg/networkserver/adr.go
@@ -203,7 +203,7 @@ func adaptDataRate(dev *ttnpb.EndDevice, phy band.Band, defaults ttnpb.MACSettin
 	}
 
 	// If we still have margin left, we decrease the Tx power (increase the index).
-	for int(dev.MACState.DesiredParameters.ADRTxPowerIndex) < int(phy.MaxTxPowerIndex) {
+	for dev.MACState.DesiredParameters.ADRTxPowerIndex < uint32(phy.MaxTxPowerIndex()) {
 		newMargin := margin - (phy.TxOffset[dev.MACState.DesiredParameters.ADRTxPowerIndex] - phy.TxOffset[dev.MACState.DesiredParameters.ADRTxPowerIndex+1])
 		if newMargin < 0 {
 			break


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Refactor TxOffset handling in band and add some missing values.
Refs #2015 

#### Changes
<!-- What are the changes made in this pull request? -->

- Refactor `TxOffset` table - use a slice instead of array. Length of the slice then dictates the maximum `TxPowerIndex`
- Add some missing downgrades


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
