### PR TITLE
Fix payload size limits used by Network Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Blocking UDP packet handling while the gateway was still connecting. Traffic is now dropped while the connection is in progress, so that traffic from already connected gateways keep flowing.
 - Join-request transmission parameters.
 - ADR in 72-channel regions.
+- Payload length limits used by Network Server being too low.
 
 ### Security
 

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -86,6 +86,7 @@ var (
 	errEndDeviceEUIUpdate           = errors.DefineInvalidArgument("end_device_eui_update", "end device EUIs can not be updated")
 	errEndDeviceKeysWithProvisioner = errors.DefineInvalidArgument("end_device_keys_provisioner", "end device ABP or OTAA keys cannot be set when there is a provisioner")
 	errInconsistentEndDeviceEUI     = errors.DefineInvalidArgument("inconsistent_end_device_eui", "given end device EUIs do not match registered EUIs")
+	errInvalidDataRateIndex         = errors.DefineInvalidArgument("data_rate_index", "Data rate index is invalid")
 	errInvalidMACVerson             = errors.DefineInvalidArgument("mac_version", "LoRaWAN MAC version is invalid")
 	errInvalidPHYVerson             = errors.DefineInvalidArgument("phy_version", "LoRaWAN PHY version is invalid")
 	errNoEndDeviceEUI               = errors.DefineInvalidArgument("no_end_device_eui", "no end device EUIs set")

--- a/cmd/ttn-lw-cli/commands/simulate.go
+++ b/cmd/ttn-lw-cli/commands/simulate.go
@@ -83,12 +83,16 @@ func (m *simulateMetadataParams) setDefaults() error {
 		}
 	}
 	if m.Bandwidth == 0 || m.SpreadingFactor == 0 {
-		drIdx := int(m.DataRateIndex)
-		if drIdx < int(phy.UplinkChannels[0].MinDataRate) || drIdx > int(phy.UplinkChannels[0].MaxDataRate) {
-			drIdx = int(phy.UplinkChannels[0].MaxDataRate)
+		drIdx := ttnpb.DataRateIndex(m.DataRateIndex)
+		if drIdx < phy.UplinkChannels[0].MinDataRate || drIdx > phy.UplinkChannels[0].MaxDataRate {
+			drIdx = phy.UplinkChannels[0].MaxDataRate
 		}
-		dr := phy.DataRates[drIdx].Rate.GetLoRa()
-		m.SpreadingFactor, m.Bandwidth = dr.SpreadingFactor, dr.Bandwidth
+		dr, ok := phy.DataRates[drIdx]
+		if !ok {
+			return errInvalidDataRateIndex
+		}
+		lora := dr.Rate.GetLoRa()
+		m.SpreadingFactor, m.Bandwidth = lora.SpreadingFactor, lora.Bandwidth
 	} else if m.DataRateIndex == 0 {
 		for i, dr := range phy.DataRates {
 			if dr.Rate.GetLoRa().SpreadingFactor == m.SpreadingFactor && dr.Rate.GetLoRa().Bandwidth == m.Bandwidth {

--- a/config/messages.json
+++ b/config/messages.json
@@ -1187,6 +1187,15 @@
       "file": "contact_info.go"
     }
   },
+  "error:cmd/ttn-lw-cli/commands:data_rate_index": {
+    "translations": {
+      "en": "Data rate index is invalid"
+    },
+    "description": {
+      "package": "cmd/ttn-lw-cli/commands",
+      "file": "end_devices.go"
+    }
+  },
   "error:cmd/ttn-lw-cli/commands:end_device_eui_update": {
     "translations": {
       "en": "end device EUIs can not be updated"
@@ -3107,6 +3116,15 @@
   "error:pkg/frequencyplans:channel": {
     "translations": {
       "en": "invalid frequency plan channel `{index}`"
+    },
+    "description": {
+      "package": "pkg/frequencyplans",
+      "file": "frequencyplans.go"
+    }
+  },
+  "error:pkg/frequencyplans:data_rate_index": {
+    "translations": {
+      "en": "Data rate index is invalid"
     },
     "description": {
       "package": "pkg/frequencyplans",
@@ -5230,11 +5248,11 @@
   },
   "error:pkg/networkserver:application_downlink_too_long": {
     "translations": {
-      "en": "application downlink payload is too long"
+      "en": "application downlink payload length '{length}' exceeds maximum '{max}'"
     },
     "description": {
       "package": "pkg/networkserver",
-      "file": "downlink.go"
+      "file": "errors.go"
     }
   },
   "error:pkg/networkserver:channel_index": {

--- a/pkg/band/as_923.go
+++ b/pkg/band/as_923.go
@@ -56,34 +56,34 @@ func init() {
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 12,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: dwellTimePayloadSizer{59, 0}},
+			}}}, MaximumMACPayloadSize: makeDwellTimeMaximumMACPayloadSizeFunc(59, 0)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 11,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: dwellTimePayloadSizer{59, 0}},
+			}}}, MaximumMACPayloadSize: makeDwellTimeMaximumMACPayloadSizeFunc(59, 0)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 10,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: dwellTimePayloadSizer{59, 19}},
+			}}}, MaximumMACPayloadSize: makeDwellTimeMaximumMACPayloadSizeFunc(59, 19)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 9,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: dwellTimePayloadSizer{123, 61}},
+			}}}, MaximumMACPayloadSize: makeDwellTimeMaximumMACPayloadSizeFunc(123, 61)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 8,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: dwellTimePayloadSizer{230, 133}},
+			}}}, MaximumMACPayloadSize: makeDwellTimeMaximumMACPayloadSizeFunc(230, 133)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 7,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: dwellTimePayloadSizer{230, 250}},
+			}}}, MaximumMACPayloadSize: makeDwellTimeMaximumMACPayloadSizeFunc(230, 250)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 7,
 				Bandwidth:       250000,
-			}}}, DefaultMaxSize: dwellTimePayloadSizer{230, 250}},
+			}}}, MaximumMACPayloadSize: makeDwellTimeMaximumMACPayloadSizeFunc(230, 250)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_FSK{FSK: &ttnpb.FSKDataRate{
 				BitRate: 50000,
-			}}}, DefaultMaxSize: dwellTimePayloadSizer{230, 250}},
+			}}}, MaximumMACPayloadSize: makeDwellTimeMaximumMACPayloadSizeFunc(230, 250)},
 			{}, {}, {}, {}, {}, {}, {}, // RFU
 			{}, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU before
 		},

--- a/pkg/band/as_923.go
+++ b/pkg/band/as_923.go
@@ -52,40 +52,15 @@ func init() {
 			},
 		},
 
-		DataRates: [16]DataRate{
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 12,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeDwellTimeMaximumMACPayloadSizeFunc(59, 0)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 11,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeDwellTimeMaximumMACPayloadSizeFunc(59, 0)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 10,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeDwellTimeMaximumMACPayloadSizeFunc(59, 19)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 9,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeDwellTimeMaximumMACPayloadSizeFunc(123, 61)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 8,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeDwellTimeMaximumMACPayloadSizeFunc(230, 133)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 7,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeDwellTimeMaximumMACPayloadSizeFunc(230, 250)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 7,
-				Bandwidth:       250000,
-			}}}, MaximumMACPayloadSize: makeDwellTimeMaximumMACPayloadSizeFunc(230, 250)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_FSK{FSK: &ttnpb.FSKDataRate{
-				BitRate: 50000,
-			}}}, MaximumMACPayloadSize: makeDwellTimeMaximumMACPayloadSizeFunc(230, 250)},
-			{}, {}, {}, {}, {}, {}, {}, // RFU
-			{}, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU before
+		DataRates: map[ttnpb.DataRateIndex]DataRate{
+			0: makeLoRaDataRate(12, 125000, makeDwellTimeMaxMACPayloadSizeFunc(59, 0)),
+			1: makeLoRaDataRate(11, 125000, makeDwellTimeMaxMACPayloadSizeFunc(59, 0)),
+			2: makeLoRaDataRate(10, 125000, makeDwellTimeMaxMACPayloadSizeFunc(59, 19)),
+			3: makeLoRaDataRate(9, 125000, makeDwellTimeMaxMACPayloadSizeFunc(123, 61)),
+			4: makeLoRaDataRate(8, 125000, makeDwellTimeMaxMACPayloadSizeFunc(230, 133)),
+			5: makeLoRaDataRate(7, 125000, makeDwellTimeMaxMACPayloadSizeFunc(230, 250)),
+			6: makeLoRaDataRate(7, 250000, makeDwellTimeMaxMACPayloadSizeFunc(230, 250)),
+			7: makeFSKDataRate(50000, makeDwellTimeMaxMACPayloadSizeFunc(230, 250)),
 		},
 		MaxADRDataRateIndex: 5,
 

--- a/pkg/band/au_915_928.go
+++ b/pkg/band/au_915_928.go
@@ -82,61 +82,21 @@ func init() {
 			},
 		},
 
-		DataRates: [16]DataRate{
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 12,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 11,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 10,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 9,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(123)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 8,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 7,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 8,
-				Bandwidth:       500000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{}, // RFU
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 12,
-				Bandwidth:       500000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(41)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 11,
-				Bandwidth:       500000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(117)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 10,
-				Bandwidth:       500000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 9,
-				Bandwidth:       500000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 8,
-				Bandwidth:       500000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 7,
-				Bandwidth:       500000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{}, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU for previous versions
+		DataRates: map[ttnpb.DataRateIndex]DataRate{
+			0: makeLoRaDataRate(12, 125000, makeConstMaxMACPayloadSizeFunc(59)),
+			1: makeLoRaDataRate(11, 125000, makeConstMaxMACPayloadSizeFunc(59)),
+			2: makeLoRaDataRate(10, 125000, makeConstMaxMACPayloadSizeFunc(59)),
+			3: makeLoRaDataRate(9, 125000, makeConstMaxMACPayloadSizeFunc(123)),
+			4: makeLoRaDataRate(8, 125000, makeConstMaxMACPayloadSizeFunc(230)),
+			5: makeLoRaDataRate(7, 125000, makeConstMaxMACPayloadSizeFunc(230)),
+			6: makeLoRaDataRate(8, 500000, makeConstMaxMACPayloadSizeFunc(230)),
+
+			8:  makeLoRaDataRate(12, 500000, makeConstMaxMACPayloadSizeFunc(41)),
+			9:  makeLoRaDataRate(11, 500000, makeConstMaxMACPayloadSizeFunc(117)),
+			10: makeLoRaDataRate(10, 500000, makeConstMaxMACPayloadSizeFunc(230)),
+			11: makeLoRaDataRate(9, 500000, makeConstMaxMACPayloadSizeFunc(230)),
+			12: makeLoRaDataRate(8, 500000, makeConstMaxMACPayloadSizeFunc(230)),
+			13: makeLoRaDataRate(7, 500000, makeConstMaxMACPayloadSizeFunc(230)),
 		},
 		MaxADRDataRateIndex: 5,
 

--- a/pkg/band/au_915_928.go
+++ b/pkg/band/au_915_928.go
@@ -86,56 +86,56 @@ func init() {
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 12,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(59)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 11,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(59)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 10,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(59)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 9,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(123)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(123)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 8,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 7,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 8,
 				Bandwidth:       500000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{}, // RFU
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 12,
 				Bandwidth:       500000,
-			}}}, DefaultMaxSize: constPayloadSizer(41)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(41)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 11,
 				Bandwidth:       500000,
-			}}}, DefaultMaxSize: constPayloadSizer(117)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(117)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 10,
 				Bandwidth:       500000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 9,
 				Bandwidth:       500000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 8,
 				Bandwidth:       500000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 7,
 				Bandwidth:       500000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{}, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU for previous versions
 		},
 		MaxADRDataRateIndex: 5,

--- a/pkg/band/band.go
+++ b/pkg/band/band.go
@@ -27,37 +27,27 @@ import (
 // eirpDelta is the delta between EIRP and ERP.
 const eirpDelta = 2.15
 
-// PayloadSizer abstracts the acceptable payload size depending on contextual parameters.
-type PayloadSizer interface {
-	PayloadSize(dwellTime bool) uint16
-}
+type MaxMACPayloadSizeFunc func(bool) uint16
 
-type constPayloadSizer uint16
-
-func (p constPayloadSizer) PayloadSize(_ bool) uint16 {
-	return uint16(p)
-}
-
-type dwellTimePayloadSizer struct {
-	NoDwellTime uint16
-	DwellTime   uint16
-}
-
-//revive:disable:flag-parameter
-
-func (p dwellTimePayloadSizer) PayloadSize(dwellTime bool) uint16 {
-	if dwellTime {
-		return p.DwellTime
+func makeConstMaxMACPayloadSizeFunc(v uint16) MaxMACPayloadSizeFunc {
+	return func(_ bool) uint16 {
+		return v
 	}
-	return p.NoDwellTime
 }
 
-//revive:enable:flag-parameter
+func makeDwellTimeMaxMACPayloadSizeFunc(noDwellTimeSize, dwellTimeSize uint16) MaxMACPayloadSizeFunc {
+	return func(dwellTime bool) uint16 {
+		if dwellTime {
+			return dwellTimeSize
+		}
+		return noDwellTimeSize
+	}
+}
 
 // DataRate indicates the properties of a band's data rate.
 type DataRate struct {
-	Rate           ttnpb.DataRate
-	DefaultMaxSize PayloadSizer
+	Rate              ttnpb.DataRate
+	MaxMACPayloadSize MaxMACPayloadSizeFunc
 }
 
 // Channel abstracts a band's channel properties.

--- a/pkg/band/cn_470_510.go
+++ b/pkg/band/cn_470_510.go
@@ -74,33 +74,13 @@ func init() {
 			},
 		},
 
-		DataRates: [16]DataRate{
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 12,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 11,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 10,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 9,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(123)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 8,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 7,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{}, {}, {}, {}, {}, {}, {}, {}, {}, // RFU
-			{}, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU before
+		DataRates: map[ttnpb.DataRateIndex]DataRate{
+			0: makeLoRaDataRate(12, 125000, makeConstMaxMACPayloadSizeFunc(59)),
+			1: makeLoRaDataRate(11, 125000, makeConstMaxMACPayloadSizeFunc(59)),
+			2: makeLoRaDataRate(10, 125000, makeConstMaxMACPayloadSizeFunc(59)),
+			3: makeLoRaDataRate(9, 125000, makeConstMaxMACPayloadSizeFunc(123)),
+			4: makeLoRaDataRate(8, 125000, makeConstMaxMACPayloadSizeFunc(230)),
+			5: makeLoRaDataRate(7, 125000, makeConstMaxMACPayloadSizeFunc(230)),
 		},
 		MaxADRDataRateIndex: 5,
 

--- a/pkg/band/cn_470_510.go
+++ b/pkg/band/cn_470_510.go
@@ -78,27 +78,27 @@ func init() {
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 12,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(59)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 11,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(59)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 10,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(59)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 9,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(123)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(123)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 8,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 7,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{}, {}, {}, {}, {}, {}, {}, {}, {}, // RFU
 			{}, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU before
 		},

--- a/pkg/band/cn_779_787.go
+++ b/pkg/band/cn_779_787.go
@@ -72,34 +72,34 @@ func init() {
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 12,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(59)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 11,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(59)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 10,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(59)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 9,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(123)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(123)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 8,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 7,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 7,
 				Bandwidth:       250000,
-			}}}, DefaultMaxSize: constPayloadSizer(250)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(250)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_FSK{FSK: &ttnpb.FSKDataRate{
 				BitRate: 50000,
-			}}}, DefaultMaxSize: constPayloadSizer(250)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(250)},
 			{}, {}, {}, {}, {}, {}, {}, // RFU
 			{}, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU before
 		},

--- a/pkg/band/cn_779_787.go
+++ b/pkg/band/cn_779_787.go
@@ -68,40 +68,15 @@ func init() {
 			},
 		},
 
-		DataRates: [16]DataRate{
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 12,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 11,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 10,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 9,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(123)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 8,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 7,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 7,
-				Bandwidth:       250000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(250)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_FSK{FSK: &ttnpb.FSKDataRate{
-				BitRate: 50000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(250)},
-			{}, {}, {}, {}, {}, {}, {}, // RFU
-			{}, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU before
+		DataRates: map[ttnpb.DataRateIndex]DataRate{
+			0: makeLoRaDataRate(12, 125000, makeConstMaxMACPayloadSizeFunc(59)),
+			1: makeLoRaDataRate(11, 125000, makeConstMaxMACPayloadSizeFunc(59)),
+			2: makeLoRaDataRate(10, 125000, makeConstMaxMACPayloadSizeFunc(59)),
+			3: makeLoRaDataRate(9, 125000, makeConstMaxMACPayloadSizeFunc(123)),
+			4: makeLoRaDataRate(8, 125000, makeConstMaxMACPayloadSizeFunc(230)),
+			5: makeLoRaDataRate(7, 125000, makeConstMaxMACPayloadSizeFunc(230)),
+			6: makeLoRaDataRate(7, 250000, makeConstMaxMACPayloadSizeFunc(250)),
+			7: makeFSKDataRate(50000, makeConstMaxMACPayloadSizeFunc(230)),
 		},
 		MaxADRDataRateIndex: 5,
 

--- a/pkg/band/downgrades.go
+++ b/pkg/band/downgrades.go
@@ -14,6 +14,8 @@
 
 package band
 
+import "go.thethings.network/lorawan-stack/pkg/ttnpb"
+
 // LoRaWAN 1.0.3rA -> 1.0.2rB downgrades
 
 func disableCFList1_0_2(b Band) Band {
@@ -43,7 +45,7 @@ func makeSetMaxTxPowerIndexFunc(idx uint8) func(Band) Band {
 // LoRaWAN 1.0.2rB -> 1.0.2rA downgrades
 
 func auDataRates1_0_2(b Band) Band {
-	for i := 0; i < 4; i++ {
+	for i := ttnpb.DataRateIndex(0); i < 4; i++ {
 		b.DataRates[i] = b.DataRates[i+2]
 	}
 	b.DataRates[5] = DataRate{}

--- a/pkg/band/eu_433.go
+++ b/pkg/band/eu_433.go
@@ -69,34 +69,34 @@ func init() {
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 12,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(59)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 11,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(59)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 10,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(59)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 9,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(123)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(123)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 8,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 7,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 7,
 				Bandwidth:       250000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_FSK{FSK: &ttnpb.FSKDataRate{
 				BitRate: 50000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{}, {}, {}, {}, {}, {}, {}, // RFU
 			{}, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU before
 		},

--- a/pkg/band/eu_433.go
+++ b/pkg/band/eu_433.go
@@ -65,40 +65,15 @@ func init() {
 			},
 		},
 
-		DataRates: [16]DataRate{
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 12,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 11,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 10,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 9,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(123)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 8,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 7,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 7,
-				Bandwidth:       250000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_FSK{FSK: &ttnpb.FSKDataRate{
-				BitRate: 50000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{}, {}, {}, {}, {}, {}, {}, // RFU
-			{}, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU before
+		DataRates: map[ttnpb.DataRateIndex]DataRate{
+			0: makeLoRaDataRate(12, 125000, makeConstMaxMACPayloadSizeFunc(59)),
+			1: makeLoRaDataRate(11, 125000, makeConstMaxMACPayloadSizeFunc(59)),
+			2: makeLoRaDataRate(10, 125000, makeConstMaxMACPayloadSizeFunc(59)),
+			3: makeLoRaDataRate(9, 125000, makeConstMaxMACPayloadSizeFunc(123)),
+			4: makeLoRaDataRate(8, 125000, makeConstMaxMACPayloadSizeFunc(230)),
+			5: makeLoRaDataRate(7, 125000, makeConstMaxMACPayloadSizeFunc(230)),
+			6: makeLoRaDataRate(7, 250000, makeConstMaxMACPayloadSizeFunc(250)),
+			7: makeFSKDataRate(50000, makeConstMaxMACPayloadSizeFunc(230)),
 		},
 		MaxADRDataRateIndex: 5,
 

--- a/pkg/band/eu_863_870.go
+++ b/pkg/band/eu_863_870.go
@@ -102,40 +102,15 @@ func init() {
 			},
 		},
 
-		DataRates: [16]DataRate{
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 12,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 11,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 10,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 9,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(123)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 8,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 7,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 7,
-				Bandwidth:       250000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_FSK{FSK: &ttnpb.FSKDataRate{
-				BitRate: 50000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{}, {}, {}, {}, {}, {}, {}, // RFU
-			{}, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU before
+		DataRates: map[ttnpb.DataRateIndex]DataRate{
+			0: makeLoRaDataRate(12, 125000, makeConstMaxMACPayloadSizeFunc(59)),
+			1: makeLoRaDataRate(11, 125000, makeConstMaxMACPayloadSizeFunc(59)),
+			2: makeLoRaDataRate(10, 125000, makeConstMaxMACPayloadSizeFunc(59)),
+			3: makeLoRaDataRate(9, 125000, makeConstMaxMACPayloadSizeFunc(123)),
+			4: makeLoRaDataRate(8, 125000, makeConstMaxMACPayloadSizeFunc(230)),
+			5: makeLoRaDataRate(7, 125000, makeConstMaxMACPayloadSizeFunc(230)),
+			6: makeLoRaDataRate(7, 250000, makeConstMaxMACPayloadSizeFunc(230)),
+			7: makeFSKDataRate(50000, makeConstMaxMACPayloadSizeFunc(230)),
 		},
 		MaxADRDataRateIndex: 5,
 

--- a/pkg/band/eu_863_870.go
+++ b/pkg/band/eu_863_870.go
@@ -106,34 +106,34 @@ func init() {
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 12,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(59)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 11,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(59)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 10,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(59)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 9,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(123)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(123)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 8,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 7,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 7,
 				Bandwidth:       250000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_FSK{FSK: &ttnpb.FSKDataRate{
 				BitRate: 50000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{}, {}, {}, {}, {}, {}, {}, // RFU
 			{}, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU before
 		},

--- a/pkg/band/in_865_867.go
+++ b/pkg/band/in_865_867.go
@@ -57,31 +57,31 @@ func init() {
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 12,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(59)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 11,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(59)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 10,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(59)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 9,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(123)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(123)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 8,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 7,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{}, // RFU
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_FSK{FSK: &ttnpb.FSKDataRate{
 				BitRate: 50000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{}, {}, {}, {}, {}, {}, {}, // RFU
 			{}, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU before
 		},

--- a/pkg/band/in_865_867.go
+++ b/pkg/band/in_865_867.go
@@ -53,37 +53,14 @@ func init() {
 			},
 		},
 
-		DataRates: [16]DataRate{
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 12,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 11,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 10,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 9,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(123)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 8,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 7,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{}, // RFU
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_FSK{FSK: &ttnpb.FSKDataRate{
-				BitRate: 50000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{}, {}, {}, {}, {}, {}, {}, // RFU
-			{}, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU before
+		DataRates: map[ttnpb.DataRateIndex]DataRate{
+			0: makeLoRaDataRate(12, 125000, makeConstMaxMACPayloadSizeFunc(59)),
+			1: makeLoRaDataRate(11, 125000, makeConstMaxMACPayloadSizeFunc(59)),
+			2: makeLoRaDataRate(10, 125000, makeConstMaxMACPayloadSizeFunc(59)),
+			3: makeLoRaDataRate(9, 125000, makeConstMaxMACPayloadSizeFunc(123)),
+			4: makeLoRaDataRate(8, 125000, makeConstMaxMACPayloadSizeFunc(230)),
+			5: makeLoRaDataRate(7, 125000, makeConstMaxMACPayloadSizeFunc(230)),
+			7: makeFSKDataRate(50000, makeConstMaxMACPayloadSizeFunc(230)),
 		},
 		MaxADRDataRateIndex: 5,
 

--- a/pkg/band/kr_920_923.go
+++ b/pkg/band/kr_920_923.go
@@ -62,33 +62,13 @@ func init() {
 			},
 		},
 
-		DataRates: [16]DataRate{
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 12,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 11,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 10,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 9,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(123)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 8,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 7,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{}, {}, {}, {}, {}, {}, {}, {}, {},
-			{}, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU before
+		DataRates: map[ttnpb.DataRateIndex]DataRate{
+			0: makeLoRaDataRate(12, 125000, makeConstMaxMACPayloadSizeFunc(59)),
+			1: makeLoRaDataRate(11, 125000, makeConstMaxMACPayloadSizeFunc(59)),
+			2: makeLoRaDataRate(10, 125000, makeConstMaxMACPayloadSizeFunc(59)),
+			3: makeLoRaDataRate(9, 125000, makeConstMaxMACPayloadSizeFunc(123)),
+			4: makeLoRaDataRate(8, 125000, makeConstMaxMACPayloadSizeFunc(230)),
+			5: makeLoRaDataRate(7, 125000, makeConstMaxMACPayloadSizeFunc(230)),
 		},
 		MaxADRDataRateIndex: 5,
 

--- a/pkg/band/kr_920_923.go
+++ b/pkg/band/kr_920_923.go
@@ -66,27 +66,27 @@ func init() {
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 12,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(59)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 11,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(59)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 10,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(59)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 9,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(123)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(123)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 8,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 7,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{}, {}, {}, {}, {}, {}, {}, {}, {},
 			{}, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU before
 		},

--- a/pkg/band/ru_864_870.go
+++ b/pkg/band/ru_864_870.go
@@ -67,34 +67,34 @@ func init() {
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 12,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(59)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 11,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(59)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 10,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(59)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 9,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(123)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(123)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 8,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 7,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 7,
 				Bandwidth:       250000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_FSK{FSK: &ttnpb.FSKDataRate{
 				BitRate: 50000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{}, {}, {}, {}, {}, {}, {},
 			{}, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU before
 		},

--- a/pkg/band/ru_864_870.go
+++ b/pkg/band/ru_864_870.go
@@ -63,40 +63,15 @@ func init() {
 			},
 		},
 
-		DataRates: [16]DataRate{
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 12,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 11,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 10,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(59)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 9,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(123)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 8,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 7,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 7,
-				Bandwidth:       250000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_FSK{FSK: &ttnpb.FSKDataRate{
-				BitRate: 50000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{}, {}, {}, {}, {}, {}, {},
-			{}, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU before
+		DataRates: map[ttnpb.DataRateIndex]DataRate{
+			0: makeLoRaDataRate(12, 125000, makeConstMaxMACPayloadSizeFunc(59)),
+			1: makeLoRaDataRate(11, 125000, makeConstMaxMACPayloadSizeFunc(59)),
+			2: makeLoRaDataRate(10, 125000, makeConstMaxMACPayloadSizeFunc(59)),
+			3: makeLoRaDataRate(9, 125000, makeConstMaxMACPayloadSizeFunc(123)),
+			4: makeLoRaDataRate(8, 125000, makeConstMaxMACPayloadSizeFunc(230)),
+			5: makeLoRaDataRate(7, 125000, makeConstMaxMACPayloadSizeFunc(230)),
+			6: makeLoRaDataRate(7, 250000, makeConstMaxMACPayloadSizeFunc(230)),
+			7: makeFSKDataRate(50000, makeConstMaxMACPayloadSizeFunc(230)),
 		},
 		MaxADRDataRateIndex: 5,
 

--- a/pkg/band/us_902_928.go
+++ b/pkg/band/us_902_928.go
@@ -90,48 +90,48 @@ func init() {
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 10,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(19)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(19)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 9,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(61)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(61)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 8,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(133)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(133)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 7,
 				Bandwidth:       125000,
-			}}}, DefaultMaxSize: constPayloadSizer(250)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(250)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 8,
 				Bandwidth:       500000,
-			}}}, DefaultMaxSize: constPayloadSizer(250)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(250)},
 			{}, {}, {}, // RFU
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 12,
 				Bandwidth:       500000,
-			}}}, DefaultMaxSize: constPayloadSizer(41)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(41)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 11,
 				Bandwidth:       500000,
-			}}}, DefaultMaxSize: constPayloadSizer(117)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(117)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 10,
 				Bandwidth:       500000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 9,
 				Bandwidth:       500000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 8,
 				Bandwidth:       500000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
 				SpreadingFactor: 7,
 				Bandwidth:       500000,
-			}}}, DefaultMaxSize: constPayloadSizer(230)},
+			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
 			{}, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU before
 		},
 		MaxADRDataRateIndex: 3,

--- a/pkg/band/us_902_928.go
+++ b/pkg/band/us_902_928.go
@@ -86,53 +86,19 @@ func init() {
 			},
 		},
 
-		DataRates: [16]DataRate{
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 10,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(19)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 9,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(61)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 8,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(133)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 7,
-				Bandwidth:       125000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(250)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 8,
-				Bandwidth:       500000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(250)},
-			{}, {}, {}, // RFU
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 12,
-				Bandwidth:       500000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(41)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 11,
-				Bandwidth:       500000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(117)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 10,
-				Bandwidth:       500000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 9,
-				Bandwidth:       500000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 8,
-				Bandwidth:       500000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{Rate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{
-				SpreadingFactor: 7,
-				Bandwidth:       500000,
-			}}}, MaximumMACPayloadSize: makeConstMaximumMACPayloadSizeFunc(230)},
-			{}, // Used by LinkADRReq starting from LoRaWAN Regional Parameters 1.1, RFU before
+		DataRates: map[ttnpb.DataRateIndex]DataRate{
+			0: makeLoRaDataRate(10, 125000, makeConstMaxMACPayloadSizeFunc(19)),
+			1: makeLoRaDataRate(9, 125000, makeConstMaxMACPayloadSizeFunc(61)),
+			2: makeLoRaDataRate(8, 125000, makeConstMaxMACPayloadSizeFunc(133)),
+			3: makeLoRaDataRate(7, 125000, makeConstMaxMACPayloadSizeFunc(250)),
+			4: makeLoRaDataRate(8, 500000, makeConstMaxMACPayloadSizeFunc(250)),
+
+			8:  makeLoRaDataRate(12, 500000, makeConstMaxMACPayloadSizeFunc(41)),
+			9:  makeLoRaDataRate(11, 500000, makeConstMaxMACPayloadSizeFunc(117)),
+			10: makeLoRaDataRate(10, 500000, makeConstMaxMACPayloadSizeFunc(230)),
+			11: makeLoRaDataRate(9, 500000, makeConstMaxMACPayloadSizeFunc(230)),
+			12: makeLoRaDataRate(8, 500000, makeConstMaxMACPayloadSizeFunc(230)),
+			13: makeLoRaDataRate(7, 500000, makeConstMaxMACPayloadSizeFunc(230)),
 		},
 		MaxADRDataRateIndex: 3,
 

--- a/pkg/gatewayserver/io/mqtt/format_protobufv2.go
+++ b/pkg/gatewayserver/io/mqtt/format_protobufv2.go
@@ -127,7 +127,7 @@ func (protobufv2) ToUplink(message []byte, ids ttnpb.GatewayIdentifiers) (*ttnpb
 		if !ok {
 			return nil, errFrequencyPlan.WithAttributes("frequency_plan", lorawanMetadata.FrequencyPlan)
 		}
-		band, err := band.GetByID(bandID)
+		phy, err := band.GetByID(bandID)
 		if err != nil {
 			return nil, err
 		}
@@ -137,10 +137,10 @@ func (protobufv2) ToUplink(message []byte, ids ttnpb.GatewayIdentifiers) (*ttnpb
 		if err != nil {
 			return nil, err
 		}
-		for bandDRIndex, bandDR := range band.DataRates {
+		for bandDRIndex, bandDR := range phy.DataRates {
 			if bandDR.Rate.Equal(loraDr.DataRate) {
 				found = true
-				drIndex = ttnpb.DataRateIndex(bandDRIndex)
+				drIndex = bandDRIndex
 				break
 			}
 		}

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -71,7 +71,6 @@ func loggerWithApplicationDownlinkFields(logger log.Interface, down *ttnpb.Appli
 	return logger.WithFields(log.Fields(pairs...))
 }
 
-var errApplicationDownlinkTooLong = errors.DefineInvalidArgument("application_downlink_too_long", "application downlink payload is too long")
 var errNoDownlink = errors.Define("no_downlink", "no downlink to send")
 
 type generatedDownlink struct {
@@ -392,7 +391,7 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 						Up: &ttnpb.ApplicationUp_DownlinkFailed{
 							DownlinkFailed: &ttnpb.ApplicationDownlinkFailed{
 								ApplicationDownlink: *down,
-								Error:               *ttnpb.ErrorDetailsToProto(errApplicationDownlinkTooLong),
+								Error:               *ttnpb.ErrorDetailsToProto(errApplicationDownlinkTooLong.WithAttributes("length", len(down.FRMPayload), "max", maxDownLen)),
 							},
 						},
 					})

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -871,7 +871,7 @@ loop:
 			break loop
 		}
 	}
-	dr, ok := phy.DataRates[uint8(maxUpDRIdx)]
+	dr, ok := phy.DataRates[maxUpDRIdx]
 	if !ok {
 		return 0, errDataRateNotFound
 	}
@@ -1016,7 +1016,7 @@ func (ns *NetworkServer) attemptClassADataDownlink(ctx context.Context, dev *ttn
 		maxDRIdx = req.Rx2DataRateIndex
 	}
 
-	maxDR, ok := phy.DataRates[uint8(maxDRIdx)]
+	maxDR, ok := phy.DataRates[maxDRIdx]
 	if !ok {
 		logger.WithField("data_rate_index", maxDRIdx).Error("Data rate not found")
 		return downlinkAttemptResult{
@@ -1053,11 +1053,11 @@ func (ns *NetworkServer) attemptClassADataDownlink(ctx context.Context, dev *ttn
 	}
 
 	if attemptRx1 && attemptRx2 {
-		dr1, ok := phy.DataRates[uint8(req.Rx1DataRateIndex)]
+		dr1, ok := phy.DataRates[req.Rx1DataRateIndex]
 		if !ok {
 			logger.WithField("data_rate_index", req.Rx1DataRateIndex).Error("Rx1 data rate not found")
 		}
-		dr2, ok := phy.DataRates[uint8(req.Rx2DataRateIndex)]
+		dr2, ok := phy.DataRates[req.Rx2DataRateIndex]
 		if !ok {
 			logger.WithField("data_rate_index", req.Rx2DataRateIndex).Error("Rx2 data rate not found")
 		}
@@ -1356,7 +1356,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 					panic(fmt.Sprintf("unmatched downlink class: '%s'", class))
 				}
 
-				dr, ok := phy.DataRates[uint8(drIdx)]
+				dr, ok := phy.DataRates[drIdx]
 				if !ok {
 					logger.WithField("data_rate_index", drIdx).Error("Rx2 data rate not found")
 					return dev, sets, nil

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -127,19 +127,19 @@ func (ns *NetworkServer) updateDataDownlinkTask(ctx context.Context, dev *ttnpb.
 	return ns.downlinkTasks.Add(ctx, dev.EndDeviceIdentifiers, t, true)
 }
 
-// generateDownlink attempts to generate a downlink.
-// generateDownlink returns the generated downlink, application uplinks associated with the generation and error, if any.
-// generateDownlink may mutate the device in order to record the downlink generated.
-// maxDownLen and maxUpLen represent the maximum length of PHYPayload for the downlink and corresponding uplink respectively.
+// generateDataDownlink attempts to generate a downlink.
+// generateDataDownlink returns the generated downlink, application uplinks associated with the generation and error, if any.
+// generateDataDownlink may mutate the device in order to record the downlink generated.
+// maxDownLen and maxUpLen represent the maximum length of MACPayload for the downlink and corresponding uplink respectively.
 // If no downlink could be generated errNoDownlink is returned.
-// generateDownlink does not perform validation of dev.MACState.DesiredParameters,
+// generateDataDownlink does not perform validation of dev.MACState.DesiredParameters,
 // hence, it could potentially generate MAC command(s), which are not suported by the
 // regional parameters the device operates in.
 // For example, a sequence of 'NewChannel' MAC commands could be generated for a
 // device operating in a region where a fixed channel plan is defined in case
 // dev.MACState.CurrentParameters.Channels is not equal to dev.MACState.DesiredParameters.Channels.
-// Note, that generateDownlink assumes transmitAt is the earliest possible time a downlink can be transmitted to the device.
-func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDevice, phy band.Band, class ttnpb.Class, transmitAt time.Time, maxDownLen, maxUpLen uint16) (*generatedDownlink, generateDownlinkState, error) {
+// Note, that generateDataDownlink assumes transmitAt is the earliest possible time a downlink can be transmitted to the device.
+func (ns *NetworkServer) generateDataDownlink(ctx context.Context, dev *ttnpb.EndDevice, phy band.Band, class ttnpb.Class, transmitAt time.Time, maxDownLen, maxUpLen uint16) (*generatedDownlink, generateDownlinkState, error) {
 	if dev.MACState == nil {
 		return nil, generateDownlinkState{}, errUnknownMACState
 	}
@@ -150,16 +150,18 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 	ctx = log.NewContextWithFields(ctx, log.Fields(
 		"device_uid", unique.ID(ctx, dev.EndDeviceIdentifiers),
 		"mac_version", dev.MACState.LoRaWANVersion,
+		"max_downlink_length", maxDownLen,
 		"phy_version", dev.LoRaWANPHYVersion,
 		"transmit_at", transmitAt,
 	))
 	logger := log.FromContext(ctx)
 
-	// NOTE: len(MHDR) + len(FHDR) + len(MIC) = 1 + 7 + 4 = 12
-	if maxDownLen < 12 || maxUpLen < 12 {
-		panic("payload length limits too short to generate downlink")
+	// NOTE: len(FHDR) + len(FPort) = 7 + 1 = 8
+	if maxDownLen < 8 || maxUpLen < 8 {
+		log.FromContext(ctx).Error("Data rate MAC payload size limits too low for data downlink to be generated")
+		return nil, generateDownlinkState{}, errInvalidDataRate
 	}
-	maxDownLen, maxUpLen = maxDownLen-12, maxUpLen-12
+	maxDownLen, maxUpLen = maxDownLen-8, maxUpLen-8
 
 	var fPending bool
 	spec := lorawan.DefaultMACCommands
@@ -181,7 +183,7 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 				break
 			}
 			cmds = append(cmds, cmd)
-			maxDownLen -= desc.DownlinkLength
+			maxDownLen -= 1 + desc.DownlinkLength
 		}
 	}
 	dev.MACState.QueuedResponses = nil
@@ -270,7 +272,6 @@ func (ns *NetworkServer) generateDownlink(ctx context.Context, dev *ttnpb.EndDev
 	logger = logger.WithFields(log.Fields(
 		"mac_count", len(cmds),
 		"mac_len", len(cmdBuf),
-		"max_down_len", maxDownLen,
 	))
 	ctx = log.NewContext(ctx, logger)
 
@@ -855,7 +856,7 @@ func txRequestFromUplink(phy band.Band, macState *ttnpb.MACState, rx1, rx2 bool,
 }
 
 // maximumUplinkLength returns the maximum length of the next uplink after ups.
-func maximumUplinkLength(fp *frequencyplans.FrequencyPlan, phy band.Band, ups ...*ttnpb.UplinkMessage) uint16 {
+func maximumUplinkLength(fp *frequencyplans.FrequencyPlan, phy band.Band, ups ...*ttnpb.UplinkMessage) (uint16, error) {
 	// NOTE: If no data uplink is found, we assume ADR is off on the device and, hence, data rate index 0 is used in computation.
 	maxUpDRIdx := ttnpb.DATA_RATE_0
 loop:
@@ -870,7 +871,11 @@ loop:
 			break loop
 		}
 	}
-	return phy.DataRates[maxUpDRIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetUplinks())
+	dr, ok := phy.DataRates[uint8(maxUpDRIdx)]
+	if !ok {
+		return 0, errDataRateNotFound
+	}
+	return dr.MaxMACPayloadSize(fp.DwellTime.GetUplinks()), nil
 }
 
 // downlinkRetryInterval is the time interval, which defines the interval between downlink task retries.
@@ -993,26 +998,36 @@ func (ns *NetworkServer) attemptClassADataDownlink(ctx context.Context, dev *ttn
 
 	// transmitAt is the earliest time.Time when downlink will be transmitted to the device.
 	var transmitAt time.Time
-	var maxDR ttnpb.DataRateIndex
+	var maxDRIdx ttnpb.DataRateIndex
 	switch {
 	case attemptRx1 && attemptRx2:
 		transmitAt = rx1
-		maxDR = req.Rx1DataRateIndex
-		if req.Rx2DataRateIndex > maxDR {
-			maxDR = req.Rx2DataRateIndex
+		maxDRIdx = req.Rx1DataRateIndex
+		if req.Rx2DataRateIndex > maxDRIdx {
+			maxDRIdx = req.Rx2DataRateIndex
 		}
 
 	case attemptRx1:
 		transmitAt = rx1
-		maxDR = req.Rx1DataRateIndex
+		maxDRIdx = req.Rx1DataRateIndex
 
 	case attemptRx2:
 		transmitAt = rx2
-		maxDR = req.Rx2DataRateIndex
+		maxDRIdx = req.Rx2DataRateIndex
 	}
 
-	genDown, genState, err := ns.generateDownlink(ctx, dev, phy, ttnpb.CLASS_A, transmitAt,
-		phy.DataRates[maxDR].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
+	maxDR, ok := phy.DataRates[uint8(maxDRIdx)]
+	if !ok {
+		logger.WithField("data_rate_index", maxDRIdx).Error("Data rate not found")
+		return downlinkAttemptResult{
+			SetPaths: ttnpb.AddFields(sets,
+				"mac_state.queued_responses",
+				"mac_state.rx_windows_available",
+			),
+		}
+	}
+	genDown, genState, err := ns.generateDataDownlink(ctx, dev, phy, ttnpb.CLASS_A, transmitAt,
+		maxDR.MaxMACPayloadSize(fp.DwellTime.GetDownlinks()),
 		maxUpLength,
 	)
 	if genState.NeedsDownlinkQueueUpdate {
@@ -1038,8 +1053,16 @@ func (ns *NetworkServer) attemptClassADataDownlink(ctx context.Context, dev *ttn
 	}
 
 	if attemptRx1 && attemptRx2 {
-		attemptRx1 = len(genDown.Payload) <= int(phy.DataRates[req.Rx1DataRateIndex].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()))
-		attemptRx2 = len(genDown.Payload) <= int(phy.DataRates[req.Rx2DataRateIndex].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()))
+		dr1, ok := phy.DataRates[uint8(req.Rx1DataRateIndex)]
+		if !ok {
+			logger.WithField("data_rate_index", req.Rx1DataRateIndex).Error("Rx1 data rate not found")
+		}
+		dr2, ok := phy.DataRates[uint8(req.Rx2DataRateIndex)]
+		if !ok {
+			logger.WithField("data_rate_index", req.Rx2DataRateIndex).Error("Rx2 data rate not found")
+		}
+		attemptRx1 = len(genDown.Payload) <= int(dr1.MaxMACPayloadSize(fp.DwellTime.GetDownlinks()))
+		attemptRx2 = len(genDown.Payload) <= int(dr2.MaxMACPayloadSize(fp.DwellTime.GetDownlinks()))
 		if !attemptRx1 && !attemptRx2 {
 			logger.Error("Generated downlink payload size does not fit neither Rx1, nor Rx2, skip class A downlink slot")
 			dev.MACState.QueuedResponses = nil
@@ -1277,7 +1300,11 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 
 				var maxUpLength uint16 = math.MaxUint16
 				if dev.MACState.LoRaWANVersion == ttnpb.MAC_V1_1 {
-					maxUpLength = maximumUplinkLength(fp, phy, dev.MACState.RecentUplinks...)
+					maxUpLength, err = maximumUplinkLength(fp, phy, dev.MACState.RecentUplinks...)
+					if err != nil {
+						logger.WithError(err).Error("Failed to determine maximum uplink length")
+						return dev, nil, nil
+					}
 				}
 
 				var sets []string
@@ -1329,8 +1356,13 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 					panic(fmt.Sprintf("unmatched downlink class: '%s'", class))
 				}
 
-				genDown, genState, err := ns.generateDownlink(ctx, dev, phy, class, transmitAt,
-					phy.DataRates[drIdx].DefaultMaxSize.PayloadSize(fp.DwellTime.GetDownlinks()),
+				dr, ok := phy.DataRates[uint8(drIdx)]
+				if !ok {
+					logger.WithField("data_rate_index", drIdx).Error("Rx2 data rate not found")
+					return dev, sets, nil
+				}
+				genDown, genState, err := ns.generateDataDownlink(ctx, dev, phy, class, transmitAt,
+					dr.MaxMACPayloadSize(fp.DwellTime.GetDownlinks()),
 					maxUpLength,
 				)
 				if genState.NeedsDownlinkQueueUpdate {

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -1437,7 +1437,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 							CorrelationIDs: []string{"correlation-app-down-1", "correlation-app-down-2"},
 							FCnt:           0x42,
 							FPort:          0x1,
-							FRMPayload:     bytes.Repeat([]byte("x"), 256),
+							FRMPayload:     bytes.Repeat([]byte("x"), 250),
 							Priority:       ttnpb.TxSchedulePriority_HIGHEST,
 							SessionKeyID:   []byte{0x11, 0x22, 0x33, 0x44},
 						},
@@ -1516,7 +1516,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 							Up: &ttnpb.ApplicationUp_DownlinkFailed{
 								DownlinkFailed: &ttnpb.ApplicationDownlinkFailed{
 									ApplicationDownlink: *getDevice.QueuedApplicationDownlinks[0],
-									Error:               *ttnpb.ErrorDetailsToProto(errApplicationDownlinkTooLong),
+									Error:               *ttnpb.ErrorDetailsToProto(errApplicationDownlinkTooLong.WithAttributes("length", 250, "max", uint16(51))),
 								},
 							},
 						},
@@ -2156,7 +2156,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 					},
 				}
 
-				// NOTE: Maximum FRMPayload length in both Rx1(DR0) and RX2(DR1) is 51. There are 6 bytes of FOpts, hence maximum fitting application downlink length is 45.
+				// NOTE: Maximum MACPayload length in both Rx1(DR0) and RX2(DR1) is 59. There are 6 bytes of FOpts, hence maximum fitting application downlink length is 59-8-6 == 45.
 				getDevice := &ttnpb.EndDevice{
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
 						ApplicationIdentifiers: appID,
@@ -6458,7 +6458,7 @@ func TestGenerateDownlink(t *testing.T) {
 				return
 			}
 
-			genDown, genState, err := ns.generateDownlink(ctx, dev, phy, dev.MACState.DeviceClass, time.Now(), math.MaxUint16, math.MaxUint16)
+			genDown, genState, err := ns.generateDataDownlink(ctx, dev, phy, dev.MACState.DeviceClass, time.Now(), math.MaxUint16, math.MaxUint16)
 			if tc.Error != nil {
 				a.So(err, should.EqualErrorOrDefinition, tc.Error)
 				a.So(genDown, should.BeNil)

--- a/pkg/networkserver/errors.go
+++ b/pkg/networkserver/errors.go
@@ -20,6 +20,7 @@ import (
 
 var (
 	errABPJoinRequest             = errors.DefineInvalidArgument("abp_join_request", "received a join-request from ABP device")
+	errApplicationDownlinkTooLong = errors.DefineInvalidArgument("application_downlink_too_long", "application downlink payload length '{length}' exceeds maximum '{max}'")
 	errClassAMulticast            = errors.DefineInvalidArgument("class_a_multicast", "multicast device in class A mode")
 	errClassBCForClassA           = errors.DefineInvalidArgument("class_b_c_for_class_a", "class B/C downlink queued for device in class A mode")
 	errComputeMIC                 = errors.DefineInvalidArgument("compute_mic", "failed to compute MIC")

--- a/pkg/networkserver/utils.go
+++ b/pkg/networkserver/utils.go
@@ -115,12 +115,11 @@ func searchDataRate(dr ttnpb.DataRate, dev *ttnpb.EndDevice, fps *frequencyplans
 	if err != nil {
 		return 0, err
 	}
-	for i, bDR := range phy.DataRates {
-		if bDR.Rate.Equal(dr) {
-			return ttnpb.DataRateIndex(i), nil
-		}
+	idx, ok := phy.FindDataRate(dr)
+	if !ok {
+		return 0, errDataRateNotFound.WithAttributes("data_rate", dr)
 	}
-	return 0, errDataRateNotFound.WithAttributes("data_rate", dr)
+	return idx, nil
 }
 
 func searchUplinkChannel(freq uint64, macState *ttnpb.MACState) (uint8, error) {

--- a/pkg/pfconfig/basicstationlns/basicstationlns.go
+++ b/pkg/pfconfig/basicstationlns/basicstationlns.go
@@ -83,11 +83,11 @@ func GetRouterConfig(bandID string, fps map[string]*frequencyplans.FrequencyPlan
 	conf.JoinEUI = nil
 	conf.NetID = nil
 
-	band, err := band.GetByID(bandID)
+	phy, err := band.GetByID(bandID)
 	if err != nil {
 		return RouterConfig{}, errFrequencyPlan
 	}
-	s := strings.Split(band.ID, "_")
+	s := strings.Split(phy.ID, "_")
 	if len(s) < 2 {
 		return RouterConfig{}, errFrequencyPlan
 	}
@@ -135,7 +135,7 @@ func GetRouterConfig(bandID string, fps map[string]*frequencyplans.FrequencyPlan
 
 // getDataRatesFromBandID parses the available data rates from the band into DataRates.
 func getDataRatesFromBandID(id string) (DataRates, error) {
-	band, err := band.GetByID(id)
+	phy, err := band.GetByID(id)
 	if err != nil {
 		return DataRates{}, err
 	}
@@ -148,7 +148,7 @@ func getDataRatesFromBandID(id string) (DataRates, error) {
 		dr[2] = 0
 	}
 
-	for i, dr := range band.DataRates {
+	for i, dr := range phy.DataRates {
 		if loraDR := dr.Rate.GetLoRa(); loraDR != nil {
 			loraDR.GetSpreadingFactor()
 			drs[i][0] = int(loraDR.GetSpreadingFactor())

--- a/pkg/ttnpb/lorawan.go
+++ b/pkg/ttnpb/lorawan.go
@@ -769,3 +769,19 @@ func (v DataRateIndex) String() string {
 func (v RxDelay) String() string {
 	return strconv.Itoa(int(v))
 }
+
+func (v LoRaDataRate) DataRate() DataRate {
+	return DataRate{
+		Modulation: &DataRate_LoRa{
+			LoRa: &v,
+		},
+	}
+}
+
+func (v FSKDataRate) DataRate() DataRate {
+	return DataRate{
+		Modulation: &DataRate_FSK{
+			FSK: &v,
+		},
+	}
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fix payload size limits used by Network Server

#### Changes
<!-- What are the changes made in this pull request? -->

- Account for 1 byte of CID in MAC answers when generating downlink
- Log the maximum downlink length and application downlink length on length limit errors
- Refactor data rates in PHY to a `map[ttnpb.DataRateIndex]band.DataRate`
- Validate queued application downlink length according to PHY and frequency plan limitations
- Be explicit about payload length limits in PHY being MAC payload lengths and treat them as such in NS.
- De-obfuscate data rate definitions.
- Fix `band.Band` structs not being referred to as `phy`

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
