### PR TITLE
Use tables for proto message formatting

### DIFF
--- a/doc/content/download.html
+++ b/doc/content/download.html
@@ -9,7 +9,7 @@ menu:
 
 <h1 class="title is-size-2">Open Source LoRaWAN® Network Server</h1>
 
-<table class="table has-text-in-td-centered is-size-7-mobile">
+<table class="table has-text-in-td-centered is-size-7-mobile" style="margin-top:100px;">
   <thead>
     <tr>
       <th class="is-borderless" width="25%"></th>

--- a/doc/themes/the-things-stack/assets/css/theme.scss
+++ b/doc/themes/the-things-stack/assets/css/theme.scss
@@ -200,10 +200,6 @@ body {
     flex: 1;
   }
 
-  table{
-    margin-top:100px;
-  }
-
   tbody{
     border: 1px solid $white-ter;
   }

--- a/doc/themes/the-things-stack/layouts/shortcodes/proto/message.html
+++ b/doc/themes/the-things-stack/layouts/shortcodes/proto/message.html
@@ -5,37 +5,62 @@
 <p>{{ . | markdownify }}</p>
 {{- end }}
 
-<dl>
-{{- range .fields }}
-  <dt>
-    <code>{{ .name }}</code>
-    (
-    {{- if and .map_key .map_value -}}
-    map of {{ partial "proto/field-type" .map_key }} to {{ partial "proto/field-type" .map_value }}
-    {{- else if .repeated -}}
-    repeated {{ partial "proto/field-type" .repeated }}
-    {{- else -}}
-    {{- partial "proto/field-type" . -}}
-    {{- end -}}
-    )
-  </dt>
-  <dd>
-    {{- range $rule, $value := .rules }}
-      <p><code>{{ $rule }}</code>{{ if not (eq $value true)}}: <code>{{ $value }}</code>{{ end }}</p>
+<table>
+  <thead>
+    <tr>
+      <th style="width: 175px">Field</th>
+      <th style="width: 250px">Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    {{- range .fields }}
+    <tr>
+      <td>
+        <code>{{ .name }}</code>
+      </td>
+      <td>
+        {{- if and .map_key .map_value -}}
+        map of {{ partial "proto/field-type" .map_key }} to {{ partial "proto/field-type" .map_value }}
+        {{- else if .repeated -}}
+        repeated {{ partial "proto/field-type" .repeated }}
+        {{- else -}}
+        {{- partial "proto/field-type" . -}}
+        {{- end -}}
+      </td>
+      <td>
+        {{- with .comment }}
+          <p>{{ . | markdownify }}</p>
+        {{- end }}
+        {{- range $rule, $value := .rules }}
+          <p><code>{{ $rule }}</code>{{ if not (eq $value true)}}: <code>{{ $value }}</code>{{ end }}</p>
+        {{- end }}
+        {{- if .repeated }}
+          {{- range $rule, $value := .repeated.rules }}
+            <p><code>{{ $rule }}</code>{{ if not (eq $value true)}}: <code>{{ $value }}</code>{{ end }}</p>
+          {{- end }}
+        {{ end }}
+      </td>
+    </tr>
     {{- end }}
-    {{- if .repeated }}
-    {{- range $rule, $value := .repeated.rules }}
-      <p><code>{{ $rule }}</code>{{ if not (eq $value true)}}: <code>{{ $value }}</code>{{ end }}</p>
-    {{- end }}{{ end }}
-    {{- with .comment }}
-      <p>{{ . | markdownify }}</p>
-    {{- end }}
-  </dd>
-{{- end }}
-</dl>
+  </tbody>
+</table>
 
-{{- range .oneofs }}
-  <p><code>{{ .name }}</code>: only one of {{ range $i, $name := .field_names }}{{ if gt $i 0 }}, {{ end }}<code>{{ $name }}</code>{{ end}} can be set.</p>
+{{- if .oneofs }}
+<table>
+  <thead>
+    <th>Restrictions</th>
+  </thead>
+  <tbody>
+    {{- range .oneofs }}
+    <tr>
+      <td>
+        Only one of {{ range $i, $name := .field_names }}{{ if gt $i 0 }}, {{ end }}<code>{{ $name }}</code>{{ end}} can be set.
+      </td>
+    </tr>
+    {{- end }}
+  </tbody>
+</table>
 {{- end }}
 
 <details><summary>Show object example</summary>

--- a/doc/themes/the-things-stack/layouts/shortcodes/proto/method.html
+++ b/doc/themes/the-things-stack/layouts/shortcodes/proto/method.html
@@ -1,20 +1,54 @@
 {{ $package := or (.Get "package") "ttn.lorawan.v3" }}{{ $service := .Get "service" }}{{ $method := .Get "method" }}
 {{ with index .Site.Data "api" $package "services" $service "methods" $method -}}
-<h3>Method <code>{{ $service }}.{{ .name }}</code></h3>
 
-{{- with .comment }}
-<p>{{ . | markdownify }}</p>
-{{- end }}
-
-<p>
-  Request: {{ if not .input.package }}<a href="#message:{{ .input.name }}">{{ end }}<code>{{ with .input.package }}{{ . }}.{{end}}{{ .input.name }}</code>{{ if not .input.package }}</a>{{ end }}
-  <br>
-  Response: {{ if not .output.package }}<a href="#message:{{ .output.name }}">{{ end }}<code>{{ with .output.package }}{{ . }}.{{end}}{{ .output.name }}</code>{{ if not .output.package }}</a>{{ end }}
-</p>
-
-{{- range .http }}
-<p><code>{{ .method }}</code> <code>/api/v3{{ .path }}</code></p>
-{{- end }}
-{{- else -}}
-{{ errorf "method %s of service %s of package %s not found: %s" $method $service $package .Position }}
-{{- end }}
+<table>
+  <tbody>
+    <tr>
+      <th style="width: 150px">
+        Method
+      </th>
+      <td>
+        <code>{{ $service }}.{{ .name }}</code>
+      </td>
+    </tr>
+    {{- with .comment }}
+    <tr>
+      <th>
+        Description
+      </th>
+      <td>
+        {{ . | markdownify }}
+      </td>
+    </tr>
+    {{- end }}
+    <tr>
+      <th>
+        Request type
+      </th>
+      <td>
+        {{ if not .input.package }}<a href="#message:{{ .input.name }}">{{ end }}<code>{{ with .input.package }}{{ . }}.{{end}}{{ .input.name }}</code>{{ if not .input.package }}</a>{{ end }}
+      </td>
+    </tr>
+    <tr>
+      <th>
+        Response type
+      </th>
+      <td>
+        {{ if not .output.package }}<a href="#message:{{ .output.name }}">{{ end }}<code>{{ with .output.package }}{{ . }}.{{end}}{{ .output.name }}</code>{{ if not .output.package }}</a>{{ end }}
+      </td>
+    </tr>
+    <tr>
+      <th>
+        HTTP bindings
+      </th>
+      <td>
+        {{- range .http }}
+        <p><code>{{ .method }}</code> <code>/api/v3{{ .path }}</code></p>
+        {{- end }}
+        {{- else -}}
+        {{ errorf "method %s of service %s of package %s not found: %s" $method $service $package .Position }}
+        {{- end }}
+      </td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR changes the formatting of the generated API reference from description lists to tables, since `bulma` supports these better.

#### Changes
<!-- What are the changes made in this pull request? -->

- Reformatted the messages as tables.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

![image](https://user-images.githubusercontent.com/36161392/74949805-86684380-53fe-11ea-980c-5b0fb0c68559.png)

![image](https://user-images.githubusercontent.com/36161392/74950036-d5ae7400-53fe-11ea-9083-e1b8816160ca.png)

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
