### PR TITLE
Avoid panic when rematching a device

### DIFF
--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -895,7 +895,7 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 			}
 
 			if !stored.CreatedAt.Equal(matched.Device.CreatedAt) || !stored.UpdatedAt.Equal(matched.Device.UpdatedAt) {
-				matched, err = ns.matchAndHandleDataUplink(up, true, contextualEndDevice{
+				rematched, err := ns.matchAndHandleDataUplink(up, true, contextualEndDevice{
 					Context:   ctx,
 					EndDevice: stored,
 				})
@@ -903,6 +903,7 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 					handleErr = true
 					return nil, nil, errOutdatedData.WithCause(err)
 				}
+				matched = rematched
 			}
 			queuedEvents = append(queuedEvents, matched.QueuedEvents...)
 			queuedApplicationUplinks = append(queuedApplicationUplinks, matched.QueuedApplicationUplinks...)

--- a/pkg/networkserver/networkserver_util_test.go
+++ b/pkg/networkserver/networkserver_util_test.go
@@ -49,11 +49,14 @@ var (
 
 	ErrABPJoinRequest            = errABPJoinRequest
 	ErrDecodePayload             = errDecodePayload
+	ErrDeviceNotFound            = errDeviceNotFound
+	ErrOutdatedData              = errOutdatedData
 	ErrUnsupportedLoRaWANVersion = errUnsupportedLoRaWANVersion
 
 	EvtBeginApplicationLink    = evtBeginApplicationLink
 	EvtCreateEndDevice         = evtCreateEndDevice
 	EvtDeleteEndDevice         = evtDeleteEndDevice
+	EvtDropDataUplink          = evtDropDataUplink
 	EvtDropJoinRequest         = evtDropJoinRequest
 	EvtEndApplicationLink      = evtEndApplicationLink
 	EvtEnqueueDevStatusRequest = evtEnqueueDevStatusRequest


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

In a very unlikely case that the device is updated after it's been matched and before it has been set when processing a data uplink *and* it does not match anymore, NS may panic - fix that.

#### Changes
<!-- What are the changes made in this pull request? -->

- Avoid panic when rematching a device

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
