### PR TITLE
Store gateway connection stats on Redis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Network and Application Servers now maintain application downlink queue per-session.
 - Gateway Server skips setting up an upstream if the DevAddr prefixes to forward are empty.
+- Gateway connection stats are stored in Redis (see `--gs.update-connections-stats-debounce-time` option).
 
 ### Deprecated
 

--- a/cmd/internal/shared/gatewayserver/config.go
+++ b/cmd/internal/shared/gatewayserver/config.go
@@ -48,6 +48,7 @@ var DefaultGatewayServerConfig = gatewayserver.Config{
 		PublicAddress:    fmt.Sprintf("%s:1882", shared.DefaultPublicHost),
 		PublicTLSAddress: fmt.Sprintf("%s:8882", shared.DefaultPublicHost),
 	},
+	UpdateConnectionStatsDebounceTime: 3 * time.Second,
 	BasicStation: gatewayserver.BasicStationConfig{
 		Listen:         ":1887",
 		ListenTLS:      ":8887",

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -35,6 +35,7 @@ import (
 	events_grpc "go.thethings.network/lorawan-stack/pkg/events/grpc"
 	"go.thethings.network/lorawan-stack/pkg/gatewayconfigurationserver"
 	"go.thethings.network/lorawan-stack/pkg/gatewayserver"
+	gsredis "go.thethings.network/lorawan-stack/pkg/gatewayserver/redis"
 	"go.thethings.network/lorawan-stack/pkg/identityserver"
 	"go.thethings.network/lorawan-stack/pkg/joinserver"
 	jsredis "go.thethings.network/lorawan-stack/pkg/joinserver/redis"
@@ -142,6 +143,9 @@ var startCommand = &cobra.Command{
 
 		if start.GatewayServer || startDefault {
 			logger.Info("Setting up Gateway Server")
+			config.GS.Stats = &gsredis.GatewayConnectionStatsRegistry{
+				Redis: redis.New(config.Cache.Redis.WithNamespace("gs", "connection", "stats")),
+			}
 			gs, err := gatewayserver.New(c, &config.GS)
 			if err != nil {
 				return shared.ErrInitializeGatewayServer.WithCause(err)

--- a/doc/content/reference/configuration/gateway-server.md
+++ b/doc/content/reference/configuration/gateway-server.md
@@ -62,3 +62,8 @@ Using the `packet-buffer` and `packet-handlers` options, the throughput of UDP p
 - `gs.udp.packet-buffer`: Buffer size of unhandled packets
 - `gs.udp.packet-handlers`: Number of concurrent packet handlers
 
+## Statistics Options
+
+Specify options for gateway connection statistics:
+
+- `gs.update-connection-stats-debounce-time`: Time before repeated refresh of the gateway connection stats

--- a/pkg/gatewayserver/config.go
+++ b/pkg/gatewayserver/config.go
@@ -41,6 +41,9 @@ type BasicStationConfig struct {
 type Config struct {
 	RequireRegisteredGateways bool `name:"require-registered-gateways" description:"Require the gateways to be registered in the Identity Server"`
 
+	Stats                             GatewayConnectionStatsRegistry `name:"-"`
+	UpdateConnectionStatsDebounceTime time.Duration                  `name:"update-connection-stats-debounce-time" description:"Time before repeated refresh of the gateway connection stats"`
+
 	Forward map[string][]string `name:"forward" description:"Forward the DevAddr prefixes to the specified hosts"`
 
 	MQTT         config.MQTT        `name:"mqtt"`

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -69,6 +69,9 @@ type GatewayServer struct {
 	upstreamHandlers map[string]upstream.Handler
 
 	connections sync.Map // string to connectionEntry
+
+	statsRegistry                     GatewayConnectionStatsRegistry
+	updateConnectionStatsDebounceTime time.Duration
 }
 
 func (gs *GatewayServer) getRegistry(ctx context.Context, ids *ttnpb.GatewayIdentifiers) (ttnpb.GatewayRegistryClient, error) {
@@ -119,12 +122,14 @@ func New(c *component.Component, conf *Config, opts ...Option) (gs *GatewayServe
 	}
 
 	gs = &GatewayServer{
-		Component:                 c,
-		ctx:                       log.NewContextWithField(c.Context(), "namespace", "gatewayserver"),
-		config:                    conf,
-		requireRegisteredGateways: conf.RequireRegisteredGateways,
-		forward:                   forward,
-		upstreamHandlers:          make(map[string]upstream.Handler),
+		Component:                         c,
+		ctx:                               log.NewContextWithField(c.Context(), "namespace", "gatewayserver"),
+		config:                            conf,
+		requireRegisteredGateways:         conf.RequireRegisteredGateways,
+		forward:                           forward,
+		upstreamHandlers:                  make(map[string]upstream.Handler),
+		statsRegistry:                     conf.Stats,
+		updateConnectionStatsDebounceTime: conf.UpdateConnectionStatsDebounceTime,
 	}
 	for _, opt := range opts {
 		opt(gs)
@@ -440,6 +445,7 @@ func (gs *GatewayServer) Connect(ctx context.Context, frontend io.Frontend, ids 
 	registerGatewayConnect(ctx, ids, frontend.Protocol())
 	logger.Info("Connected")
 	go gs.handleUpstream(connEntry)
+	go gs.updateConnStats(connEntry)
 
 	for name, handler := range gs.upstreamHandlers {
 		handler := handler
@@ -636,6 +642,43 @@ func (gs *GatewayServer) handleUpstream(conn connectionEntry) {
 						registerFailStatus(ctx, conn.Gateway(), msg, host.name)
 					}
 				}
+			}
+		}
+	}
+}
+
+// UpdateConnectionStats updates the stats for a single gateway connection.
+func (gs *GatewayServer) UpdateConnectionStats(ctx context.Context, conn *io.Connection) error {
+	return gs.statsRegistry.Set(ctx, conn.Gateway().GatewayIdentifiers, conn.Stats())
+}
+
+func (gs *GatewayServer) updateConnStats(conn connectionEntry) {
+	ctx := conn.Context()
+	logger := log.FromContext(ctx)
+
+	defer func() {
+		logger.Debug("Delete connection stats")
+		err := gs.statsRegistry.Set(ctx, conn.Gateway().GatewayIdentifiers, nil)
+		if err != nil {
+			logger.WithError(err).Error("Failed to delete connection stats")
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-conn.StatsChanged():
+			err := gs.UpdateConnectionStats(ctx, conn.Connection)
+			if err != nil {
+				logger.WithError(err).Error("Failed to update connection stats")
+			}
+
+			timeout := time.After(gs.updateConnectionStatsDebounceTime)
+			select {
+			case <-ctx.Done():
+				return
+			case <-timeout:
 			}
 		}
 	}

--- a/pkg/gatewayserver/redis/registry.go
+++ b/pkg/gatewayserver/redis/registry.go
@@ -1,0 +1,54 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redis
+
+import (
+	"context"
+
+	ttnredis "go.thethings.network/lorawan-stack/pkg/redis"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/pkg/unique"
+)
+
+// GatewayConnectionStatsRegistry implements the GatewayConnectionStatsRegistry interface.
+type GatewayConnectionStatsRegistry struct {
+	Redis *ttnredis.Client
+}
+
+func (r *GatewayConnectionStatsRegistry) key(uid string) string {
+	return r.Redis.Key("uid", uid)
+}
+
+// Set sets or clears the connection stats for a gateway.
+func (r *GatewayConnectionStatsRegistry) Set(ctx context.Context, ids ttnpb.GatewayIdentifiers, stats *ttnpb.GatewayConnectionStats) error {
+	uid := unique.ID(ctx, ids)
+	if stats == nil {
+		return r.Redis.Del(r.key(uid)).Err()
+	}
+
+	_, err := ttnredis.SetProto(r.Redis, r.key(uid), stats, 0)
+	return err
+}
+
+// Get returns the connection stats for a gateway.
+func (r *GatewayConnectionStatsRegistry) Get(ctx context.Context, ids ttnpb.GatewayIdentifiers) (*ttnpb.GatewayConnectionStats, error) {
+	uid := unique.ID(ctx, ids)
+	stats := &ttnpb.GatewayConnectionStats{}
+	err := ttnredis.GetProto(r.Redis, r.key(uid)).ScanProto(stats)
+	if err != nil {
+		stats = nil
+	}
+	return stats, err
+}

--- a/pkg/gatewayserver/registry.go
+++ b/pkg/gatewayserver/registry.go
@@ -1,0 +1,29 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gatewayserver
+
+import (
+	"context"
+
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+)
+
+// GatewayConnectionStatsRegistry stores, updates and cleans up gateway connection stats.
+type GatewayConnectionStatsRegistry interface {
+	// Get returns connection stats for a gateway.
+	Get(ctx context.Context, ids ttnpb.GatewayIdentifiers) (*ttnpb.GatewayConnectionStats, error)
+	// Set updates the connection stats for a gateway.
+	Set(ctx context.Context, ids ttnpb.GatewayIdentifiers, stats *ttnpb.GatewayConnectionStats) error
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2035 

#### Changes
<!-- What are the changes made in this pull request? -->

- Connection Stats are stored on Redis instead of in memory

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Code has a few changes, mostly to conform with other changes that have been made to the code since the initial patch (e.g. usage of connection entries)

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [X] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [X] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
