### PR TITLE
Add NS/AS KEK labels, AS-ID, NetID to device create form

### DIFF
--- a/pkg/webui/console/components/device-data-form/index.js
+++ b/pkg/webui/console/components/device-data-form/index.js
@@ -309,6 +309,41 @@ class DeviceDataForm extends Component {
           component={Checkbox}
           disabled={external_js}
         />
+        <Form.Field
+          title={m.homeNetID}
+          description={m.homeNetIDDescription}
+          placeholder={external_js ? sharedMessages.provisionedOnExternalJoinServer : undefined}
+          name="net_id"
+          type="byte"
+          min={3}
+          max={3}
+          component={Input}
+          disabled={external_js}
+        />
+        <Form.Field
+          title={m.asServerID}
+          name="application_server_id"
+          description={m.asServerIDDescription}
+          placeholder={external_js ? sharedMessages.provisionedOnExternalJoinServer : undefined}
+          component={Input}
+          disabled={external_js}
+        />
+        <Form.Field
+          title={m.asServerKekLabel}
+          name="application_server_kek_label"
+          description={m.asServerKekLabelDescription}
+          placeholder={external_js ? sharedMessages.provisionedOnExternalJoinServer : undefined}
+          component={Input}
+          disabled={external_js}
+        />
+        <Form.Field
+          title={m.nsServerKekLabel}
+          name="network_server_kek_label"
+          description={m.nsServerKekLabelDescription}
+          placeholder={external_js ? sharedMessages.provisionedOnExternalJoinServer : undefined}
+          component={Input}
+          disabled={external_js}
+        />
       </React.Fragment>
     )
   }

--- a/pkg/webui/console/components/device-data-form/validation-schema.js
+++ b/pkg/webui/console/components/device-data-form/validation-schema.js
@@ -108,6 +108,18 @@ const validationSchema = Yup.object({
                 : Yup.object().strip(), // Avoid generating when key is unexposed
           ),
         }),
+      net_id: Yup.nullableString()
+        .emptyOrLength(3 * 2, m.validate6) // 3 Byte hex
+        .default(''),
+      application_server_id: Yup.string()
+        .max(100, sharedMessages.validateTooLong)
+        .default(''),
+      application_server_kek_label: Yup.string()
+        .max(2048, sharedMessages.validateTooLong)
+        .default(''),
+      network_server_kek_label: Yup.string()
+        .max(2048, sharedMessages.validateTooLong)
+        .default(''),
       otherwise: schema =>
         schema.shape({
           nwk_key: Yup.object().strip(),


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/1134

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `application_kek_label`, `network_kek_label`, `application_server_id` and `net_id` fields to the device create form
- Update validation schema accordingly

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Since https://github.com/TheThingsNetwork/lorawan-stack/issues/579 is taking longer than expected and still requires some work, I think we should make the create and edit forms consistent. After https://github.com/TheThingsNetwork/lorawan-stack/pull/1616 the user can edit those fields, while it is still not possible to edit them while creating an end device.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
