### PR TITLE
Display error in payload formatters form on failed request

### DIFF
--- a/pkg/webui/console/components/payload-formatters-form/index.js
+++ b/pkg/webui/console/components/payload-formatters-form/index.js
@@ -75,6 +75,8 @@ class PayloadFormattersForm extends React.Component {
   async handleSubmit(values, { resetForm }) {
     const { onSubmit, onSubmitSuccess, onSubmitFailure } = this.props
 
+    this.setState({ error: '' })
+
     const {
       [FIELD_NAMES.RADIO]: type,
       [FIELD_NAMES.JAVASCRIPT]: javascriptParameter,
@@ -106,7 +108,7 @@ class PayloadFormattersForm extends React.Component {
     } catch (error) {
       resetForm(resetValues)
 
-      await this.setState({ error })
+      this.setState({ error })
       await onSubmitFailure(error)
     }
   }
@@ -154,6 +156,7 @@ class PayloadFormattersForm extends React.Component {
 
   render() {
     const { initialType, initialParameter, linked, uplink } = this.props
+    const { error } = this.state
 
     const initialValues = {
       [FIELD_NAMES.RADIO]: initialType,
@@ -172,6 +175,7 @@ class PayloadFormattersForm extends React.Component {
           onSubmit={this.handleSubmit}
           initialValues={initialValues}
           validationSchema={validationSchema}
+          error={error}
         >
           <Form.Field
             name={FIELD_NAMES.RADIO}

--- a/pkg/webui/console/containers/device-payload-formatters/downlink.js
+++ b/pkg/webui/console/containers/device-payload-formatters/downlink.js
@@ -60,13 +60,8 @@ class DevicePayloadFormatters extends React.PureComponent {
   static propTypes = {
     appId: PropTypes.string.isRequired,
     devId: PropTypes.string.isRequired,
-    error: PropTypes.error,
     formatters: PropTypes.formatters.isRequired,
     updateDevice: PropTypes.func.isRequired,
-  }
-
-  static defaultProps = {
-    error: undefined,
   }
 
   async onSubmit(values) {
@@ -89,7 +84,7 @@ class DevicePayloadFormatters extends React.PureComponent {
   }
 
   render() {
-    const { formatters, error } = this.props
+    const { formatters } = this.props
 
     return (
       <React.Fragment>
@@ -97,7 +92,6 @@ class DevicePayloadFormatters extends React.PureComponent {
         <PayloadFormattersForm
           uplink={false}
           linked
-          error={error}
           onSubmit={this.onSubmit}
           title={sharedMessages.payloadFormattersDownlink}
           initialType={formatters.down_formatter || PAYLOAD_FORMATTER_TYPES.NONE}

--- a/pkg/webui/console/containers/device-payload-formatters/uplink.js
+++ b/pkg/webui/console/containers/device-payload-formatters/uplink.js
@@ -60,13 +60,8 @@ class DevicePayloadFormatters extends React.PureComponent {
   static propTypes = {
     appId: PropTypes.string.isRequired,
     devId: PropTypes.string.isRequired,
-    error: PropTypes.error,
     formatters: PropTypes.formatters.isRequired,
     updateDevice: PropTypes.func.isRequired,
-  }
-
-  static defaultProps = {
-    error: undefined,
   }
 
   async onSubmit(values) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes error display in the payload formatters for both applications and end devices

#### Changes
<!-- What are the changes made in this pull request? -->

- Pass error to the `<Form />` component
- Reset error on consecutive submission

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
