### PR TITLE
Fix device general settings for users w/o RIGHT_APPLICATION_DEVICES_{READ|WRITE}_KEYS rights

### DIFF
--- a/pkg/webui/console/lib/feature-checks.js
+++ b/pkg/webui/console/lib/feature-checks.js
@@ -104,6 +104,10 @@ export const mayReadApplicationDeviceKeys = {
   rightsSelector: selectApplicationRights,
   check: rights => rights.includes('RIGHT_APPLICATION_DEVICES_READ_KEYS'),
 }
+export const mayEditApplicationDeviceKeys = {
+  rightsSelector: selectApplicationRights,
+  check: rights => rights.includes('RIGHT_APPLICATION_DEVICES_WRITE_KEYS'),
+}
 
 // Gateways
 export const mayViewGatewayInfo = {

--- a/pkg/webui/console/views/device-general-settings/application-server-form/index.js
+++ b/pkg/webui/console/views/device-general-settings/application-server-form/index.js
@@ -29,16 +29,12 @@ import PropTypes from '../../../../lib/prop-types'
 import sharedMessages from '../../../../lib/shared-messages'
 
 const random16BytesString = () => randomByteString(32)
-const toUndefined = value => (!Boolean(value) ? undefined : value)
 
 const validationSchema = Yup.object().shape({
   session: Yup.object().shape({
     keys: Yup.object().shape({
       app_s_key: Yup.object().shape({
-        key: Yup.string()
-          .emptyOrLength(16 * 2, m.validate32) // 16 Byte hex
-          .transform(toUndefined)
-          .default(random16BytesString),
+        key: Yup.string().emptyOrLength(16 * 2, m.validate32), // 16 Byte hex
       }),
     }),
   }),
@@ -53,7 +49,9 @@ const ApplicationServerForm = React.memo(props => {
     const { session = {} } = device
     const {
       keys = {
-        app_s_key: {},
+        app_s_key: {
+          key: '',
+        },
       },
     } = session
 
@@ -104,9 +102,10 @@ const ApplicationServerForm = React.memo(props => {
         type="byte"
         min={16}
         max={16}
-        placeholder={m.leaveBlankPlaceholder}
         description={m.appSKeyDescription}
-        component={Input}
+        component={Input.Generate}
+        mayGenerateValue={mayEditKeys}
+        onGenerateValue={random16BytesString}
       />
       <SubmitBar>
         <Form.Submit component={SubmitButton} message={sharedMessages.saveChanges} />

--- a/pkg/webui/console/views/device-general-settings/application-server-form/index.js
+++ b/pkg/webui/console/views/device-general-settings/application-server-form/index.js
@@ -19,14 +19,17 @@ import SubmitButton from '../../../../components/submit-button'
 import SubmitBar from '../../../../components/submit-bar'
 import Input from '../../../../components/input'
 import Form from '../../../../components/form'
+import Notification from '../../../../components/notification'
 
 import diff from '../../../../lib/diff'
 import m from '../../../components/device-data-form/messages'
+import messages from '../messages'
 import randomByteString from '../../../lib/random-bytes'
 import PropTypes from '../../../../lib/prop-types'
 import sharedMessages from '../../../../lib/shared-messages'
 
-const random16BytesString = () => randomByteString(32) const toUndefined = value => (!Boolean(value) ? undefined : value)
+const random16BytesString = () => randomByteString(32)
+const toUndefined = value => (!Boolean(value) ? undefined : value)
 
 const validationSchema = Yup.object().shape({
   session: Yup.object().shape({
@@ -42,12 +45,12 @@ const validationSchema = Yup.object().shape({
 })
 
 const ApplicationServerForm = React.memo(props => {
-  const { device, onSubmit, onSubmitSuccess } = props
+  const { device, onSubmit, onSubmitSuccess, mayEditKeys, mayReadKeys } = props
 
   const [error, setError] = React.useState('')
 
   const initialValues = React.useMemo(() => {
-    const { session = {}, } = device
+    const { session = {} } = device
     const {
       keys = {
         app_s_key: {},
@@ -81,6 +84,10 @@ const ApplicationServerForm = React.memo(props => {
     [initialValues, onSubmit, onSubmitSuccess],
   )
 
+  // Notify the user that the session keys might be there, but since there are no rights
+  // to read the keys we cannot display them.
+  const showResetNotification = !mayReadKeys && mayEditKeys && !Boolean(device.session)
+
   return (
     <Form
       validationSchema={validationSchema}
@@ -88,7 +95,9 @@ const ApplicationServerForm = React.memo(props => {
       onSubmit={onFormSubmit}
       error={error}
       enableReinitialize
+      disabled={!mayEditKeys}
     >
+      {showResetNotification && <Notification content={messages.keysResetWarning} info small />}
       <Form.Field
         title={sharedMessages.appSKey}
         name="session.keys.app_s_key.key"
@@ -108,6 +117,8 @@ const ApplicationServerForm = React.memo(props => {
 
 ApplicationServerForm.propTypes = {
   device: PropTypes.device.isRequired,
+  mayEditKeys: PropTypes.bool.isRequired,
+  mayReadKeys: PropTypes.bool.isRequired,
   onSubmit: PropTypes.func.isRequired,
   onSubmitSuccess: PropTypes.func.isRequired,
 }

--- a/pkg/webui/console/views/device-general-settings/application-server-form/index.js
+++ b/pkg/webui/console/views/device-general-settings/application-server-form/index.js
@@ -19,7 +19,6 @@ import SubmitButton from '../../../../components/submit-button'
 import SubmitBar from '../../../../components/submit-bar'
 import Input from '../../../../components/input'
 import Form from '../../../../components/form'
-import DevAddrInput from '../../../containers/dev-addr-input'
 
 import diff from '../../../../lib/diff'
 import m from '../../../components/device-data-form/messages'
@@ -27,14 +26,10 @@ import randomByteString from '../../../lib/random-bytes'
 import PropTypes from '../../../../lib/prop-types'
 import sharedMessages from '../../../../lib/shared-messages'
 
-const random16BytesString = () => randomByteString(32)
-const toUndefined = value => (!Boolean(value) ? undefined : value)
+const random16BytesString = () => randomByteString(32) const toUndefined = value => (!Boolean(value) ? undefined : value)
 
 const validationSchema = Yup.object().shape({
   session: Yup.object().shape({
-    dev_addr: Yup.string()
-      .length(4 * 2, m.validate8) // 4 Byte hex
-      .required(sharedMessages.validateRequired),
     keys: Yup.object().shape({
       app_s_key: Yup.object().shape({
         key: Yup.string()
@@ -52,7 +47,7 @@ const ApplicationServerForm = React.memo(props => {
   const [error, setError] = React.useState('')
 
   const initialValues = React.useMemo(() => {
-    const { session = {}, ids } = device
+    const { session = {}, } = device
     const {
       keys = {
         app_s_key: {},
@@ -61,7 +56,6 @@ const ApplicationServerForm = React.memo(props => {
 
     return {
       session: {
-        dev_addr: session.dev_addr || ids.dev_addr,
         keys: {
           app_s_key: keys.app_s_key,
         },
@@ -95,14 +89,6 @@ const ApplicationServerForm = React.memo(props => {
       error={error}
       enableReinitialize
     >
-      <DevAddrInput
-        title={sharedMessages.devAddr}
-        name="session.dev_addr"
-        placeholder={m.leaveBlankPlaceholder}
-        description={m.deviceAddrDescription}
-        disabled
-        required
-      />
       <Form.Field
         title={sharedMessages.appSKey}
         name="session.keys.app_s_key.key"

--- a/pkg/webui/console/views/device-general-settings/identity-server-form/index.js
+++ b/pkg/webui/console/views/device-general-settings/identity-server-form/index.js
@@ -36,23 +36,31 @@ const messages = defineMessages({
 })
 
 const IdentityServerForm = React.memo(props => {
-  const { device, onSubmit, onSubmitSuccess, onDelete, onDeleteSuccess, onDeleteFailure } = props
+  const {
+    device,
+    onSubmit,
+    onSubmitSuccess,
+    onDelete,
+    onDeleteSuccess,
+    onDeleteFailure,
+    mayReadKeys,
+  } = props
   const { name, ids } = device
 
   const formRef = React.useRef(null)
   const [error, setError] = React.useState('')
-  const [externalJs, setExternaljs] = React.useState(hasExternalJs(device))
+  const [externalJs, setExternaljs] = React.useState(hasExternalJs(device) && mayReadKeys)
 
   const initialValues = React.useMemo(() => {
     const initialValues = {
       ...device,
-      _external_js: hasExternalJs(device),
+      _external_js: hasExternalJs(device) && mayReadKeys,
       _lorawan_version: device.lorawan_version,
       _supports_join: device.supports_join,
     }
 
     return validationSchema.cast(initialValues)
-  }, [device])
+  }, [device, mayReadKeys])
 
   const handleExternalJsChange = React.useCallback(evt => {
     const { checked: externalJsChecked } = evt.target
@@ -218,6 +226,7 @@ const IdentityServerForm = React.memo(props => {
 
 IdentityServerForm.propTypes = {
   device: PropTypes.device.isRequired,
+  mayReadKeys: PropTypes.bool.isRequired,
   onDelete: PropTypes.func.isRequired,
   onDeleteFailure: PropTypes.func.isRequired,
   onDeleteSuccess: PropTypes.func.isRequired,

--- a/pkg/webui/console/views/device-general-settings/index.js
+++ b/pkg/webui/console/views/device-general-settings/index.js
@@ -200,9 +200,12 @@ export default class DeviceGeneralSettings extends React.Component {
     // 2. Disable the section if the device is OTAA and joined since no fields are stored in the AS.
     // 3. Disable the section if NS is not in cluster, since activation mode is unknown.
     // 4. Disable the seciton if `application_server_address` is not equal to the cluster AS address.
+    // 5. Disable the section if the user has no appropriate rights to edit keys.
     const sameAsAddress = getComponentBaseUrl(asConfig) === device.application_server_address
     const isJoined = isDeviceJoined(device)
-    const asDisabled = !asEnabled || (isOTAA && !isJoined) || !nsEnabled || !sameAsAddress
+    const showKeys = mayReadKeys && mayEditKeys
+    const asDisabled =
+      !asEnabled || (isOTAA && !isJoined) || !nsEnabled || !sameAsAddress || !showKeys
     let asDescription = m.asDescription
     if (!asEnabled) {
       asDescription = m.asDescriptionMissing
@@ -268,6 +271,8 @@ export default class DeviceGeneralSettings extends React.Component {
                 device={device}
                 onSubmit={this.handleSubmit}
                 onSubmitSuccess={this.handleSubmitSuccess}
+                mayEditKeys={mayEditKeys}
+                mayReadKeys={mayReadKeys}
               />
             </Collapse>
             <Collapse title={m.asTitle} description={asDescription} disabled={asDisabled}>

--- a/pkg/webui/console/views/device-general-settings/index.js
+++ b/pkg/webui/console/views/device-general-settings/index.js
@@ -38,6 +38,11 @@ import {
   selectJsConfig,
   selectNsConfig,
 } from '../../../lib/selectors/env'
+import {
+  mayEditApplicationDeviceKeys,
+  mayReadApplicationDeviceKeys,
+} from '../../lib/feature-checks'
+
 import { hasExternalJs, isDeviceOTAA, isDeviceJoined } from './utils'
 import m from './messages'
 
@@ -66,6 +71,12 @@ const getComponentBaseUrl = config => {
     asConfig: selectAsConfig(),
     jsConfig: selectJsConfig(),
     nsConfig: selectNsConfig(),
+    mayReadKeys: mayReadApplicationDeviceKeys.check(
+      mayReadApplicationDeviceKeys.rightsSelector(state),
+    ),
+    mayEditKeys: mayEditApplicationDeviceKeys.check(
+      mayEditApplicationDeviceKeys.rightsSelector(state),
+    ),
   }),
   dispatch => ({
     ...bindActionCreators({ updateDevice: attachPromise(updateDevice) }, dispatch),
@@ -94,6 +105,8 @@ export default class DeviceGeneralSettings extends React.Component {
     device: PropTypes.device.isRequired,
     isConfig: PropTypes.stackComponent.isRequired,
     jsConfig: PropTypes.stackComponent.isRequired,
+    mayEditKeys: PropTypes.bool.isRequired,
+    mayReadKeys: PropTypes.bool.isRequired,
     nsConfig: PropTypes.stackComponent.isRequired,
     onDeleteSuccess: PropTypes.func.isRequired,
     updateDevice: PropTypes.func.isRequired,
@@ -168,7 +181,7 @@ export default class DeviceGeneralSettings extends React.Component {
   }
 
   render() {
-    const { device, isConfig, asConfig, jsConfig, nsConfig } = this.props
+    const { device, isConfig, asConfig, jsConfig, nsConfig, mayEditKeys, mayReadKeys } = this.props
 
     const isOTAA = isDeviceOTAA(device)
     const { enabled: isEnabled } = isConfig
@@ -207,7 +220,7 @@ export default class DeviceGeneralSettings extends React.Component {
     // 3. Disable the seciton if `join_server_address` is not equal to the cluster JS address.
     // 4. Disable the seciton if an external JS is used.
     const sameJsAddress = getComponentBaseUrl(jsConfig) === device.join_server_address
-    const externalJs = hasExternalJs(device)
+    const externalJs = hasExternalJs(device) && mayReadKeys
     const jsDisabled = !jsEnabled || !isOTAA || !sameJsAddress || externalJs
     let jsDescription = m.jsDescription
     if (!jsEnabled) {
@@ -269,6 +282,8 @@ export default class DeviceGeneralSettings extends React.Component {
                 device={device}
                 onSubmit={this.handleSubmit}
                 onSubmitSuccess={this.handleSubmitSuccess}
+                mayEditKeys={mayEditKeys}
+                mayReadKeys={mayReadKeys}
               />
             </Collapse>
           </Col>

--- a/pkg/webui/console/views/device-general-settings/index.js
+++ b/pkg/webui/console/views/device-general-settings/index.js
@@ -259,6 +259,7 @@ export default class DeviceGeneralSettings extends React.Component {
                 onDeleteSuccess={this.handleDeleteSuccess}
                 onDeleteFailure={this.handleDeleteFailure}
                 jsConfig={jsConfig}
+                mayReadKeys={mayReadKeys}
               />
             </Collapse>
             <Collapse title={m.nsTitle} description={nsDescription} disabled={nsDisabled}>

--- a/pkg/webui/console/views/device-general-settings/index.js
+++ b/pkg/webui/console/views/device-general-settings/index.js
@@ -200,12 +200,9 @@ export default class DeviceGeneralSettings extends React.Component {
     // 2. Disable the section if the device is OTAA and joined since no fields are stored in the AS.
     // 3. Disable the section if NS is not in cluster, since activation mode is unknown.
     // 4. Disable the seciton if `application_server_address` is not equal to the cluster AS address.
-    // 5. Disable the section if the user has no appropriate rights to edit keys.
     const sameAsAddress = getComponentBaseUrl(asConfig) === device.application_server_address
     const isJoined = isDeviceJoined(device)
-    const showKeys = mayReadKeys && mayEditKeys
-    const asDisabled =
-      !asEnabled || (isOTAA && !isJoined) || !nsEnabled || !sameAsAddress || !showKeys
+    const asDisabled = !asEnabled || (isOTAA && !isJoined) || !nsEnabled || !sameAsAddress
     let asDescription = m.asDescription
     if (!asEnabled) {
       asDescription = m.asDescriptionMissing
@@ -278,6 +275,8 @@ export default class DeviceGeneralSettings extends React.Component {
                 device={device}
                 onSubmit={this.handleSubmit}
                 onSubmitSuccess={this.handleSubmitSuccess}
+                mayEditKeys={mayEditKeys}
+                mayReadKeys={mayReadKeys}
               />
             </Collapse>
             <Collapse title={m.jsTitle} description={jsDescription} disabled={jsDisabled}>

--- a/pkg/webui/console/views/device-general-settings/index.js
+++ b/pkg/webui/console/views/device-general-settings/index.js
@@ -43,7 +43,7 @@ import {
   mayReadApplicationDeviceKeys,
 } from '../../lib/feature-checks'
 
-import { hasExternalJs, isDeviceOTAA, isDeviceJoined } from './utils'
+import { isDeviceOTAA, isDeviceJoined } from './utils'
 import m from './messages'
 
 import IdentityServerForm from './identity-server-form'
@@ -221,14 +221,12 @@ export default class DeviceGeneralSettings extends React.Component {
     // 2. Disable the section if the device is ABP/Multicast, since JS does not store ABP/Multicast
     // devices.
     // 3. Disable the seciton if `join_server_address` is not equal to the cluster JS address.
-    // 4. Disable the seciton if an external JS is used.
     const sameJsAddress = getComponentBaseUrl(jsConfig) === device.join_server_address
-    const externalJs = hasExternalJs(device) && mayReadKeys
-    const jsDisabled = !jsEnabled || !isOTAA || !sameJsAddress || externalJs
+    const jsDisabled = !jsEnabled || !isOTAA || !sameJsAddress
     let jsDescription = m.jsDescription
     if (!jsEnabled) {
       jsDescription = m.jsDescriptionMissing
-    } else if (!sameJsAddress || externalJs) {
+    } else if (!sameJsAddress) {
       jsDescription = m.notInCluster
     } else if (nsEnabled && !isOTAA) {
       jsDescription = m.jsDescriptionOTAA

--- a/pkg/webui/console/views/device-general-settings/join-server-form/index.js
+++ b/pkg/webui/console/views/device-general-settings/join-server-form/index.js
@@ -26,9 +26,12 @@ import m from '../../../components/device-data-form/messages'
 import messages from '../messages'
 import PropTypes from '../../../../lib/prop-types'
 import sharedMessages from '../../../../lib/shared-messages'
+import randomByteString from '../../../lib/random-bytes'
 
 import { parseLorawanMacVersion, hasExternalJs } from '../utils'
 import validationSchema from './validation-schema'
+
+const random16BytesString = () => randomByteString(32)
 
 // The Join Server can store end device fields while not exposing the root keys. This means
 // that the `root_keys` object is present, same for `root_keys.nwk_key` and `root_keys.app_key`,
@@ -57,6 +60,7 @@ const JoinServerForm = React.memo(props => {
       _external_js: hasExternalJs(device) && mayReadKeys,
       _lorawan_version: device.lorawan_version,
       _may_edit_keys: mayEditKeys,
+      _may_read_keys: mayReadKeys,
     }
 
     return validationSchema.cast(values)
@@ -77,6 +81,7 @@ const JoinServerForm = React.memo(props => {
         '_external_js',
         '_lorawan_version',
         '_may_edit_keys',
+        '_may_read_keys',
       ])
 
       setError('')
@@ -95,14 +100,14 @@ const JoinServerForm = React.memo(props => {
   const nwkKeyHidden = isNwkKeyHidden(device)
   const appKeyHidden = isAppKeyHidden(device)
 
-  let appKeyPlaceholder = m.leaveBlankPlaceholder
+  let appKeyPlaceholder
   if (externalJs) {
     appKeyPlaceholder = sharedMessages.provisionedOnExternalJoinServer
   } else if (appKeyHidden) {
     appKeyPlaceholder = m.unexposed
   }
 
-  let nwkKeyPlaceholder = m.leaveBlankPlaceholder
+  let nwkKeyPlaceholder
   if (externalJs) {
     nwkKeyPlaceholder = sharedMessages.provisionedOnExternalJoinServer
   } else if (nwkKeyHidden) {
@@ -167,8 +172,10 @@ const JoinServerForm = React.memo(props => {
         max={16}
         placeholder={appKeyPlaceholder}
         description={isNewLorawanVersion ? m.appKeyNewDescription : m.appKeyDescription}
-        component={Input}
+        component={Input.Generate}
         disabled={appKeyHidden || !mayEditKeys}
+        mayGenerateValue={mayEditKeys && !appKeyHidden}
+        onGenerateValue={random16BytesString}
       />
       {isNewLorawanVersion && (
         <Form.Field
@@ -179,8 +186,10 @@ const JoinServerForm = React.memo(props => {
           max={16}
           placeholder={nwkKeyPlaceholder}
           description={m.nwkKeyDescription}
-          component={Input}
+          component={Input.Generate}
           disabled={nwkKeyHidden || !mayEditKeys}
+          mayGenerateValue={mayEditKeys && !nwkKeyHidden}
+          onGenerateValue={random16BytesString}
         />
       )}
       <SubmitBar>

--- a/pkg/webui/console/views/device-general-settings/join-server-form/validation-schema.js
+++ b/pkg/webui/console/views/device-general-settings/join-server-form/validation-schema.js
@@ -29,8 +29,8 @@ const validationSchema = Yup.object()
       .emptyOrLength(3 * 2, m.validate6) // 3 Byte hex
       .default(''),
     root_keys: Yup.object().when(
-      ['_external_js', '_lorawan_version'],
-      (externalJs, version, schema) => {
+      ['_external_js', '_lorawan_version', '_generate_keys'],
+      (externalJs, version, generateKeys, schema) => {
         const strippedSchema = Yup.object().strip()
         const keySchema = Yup.lazy(() => {
           return !externalJs
@@ -42,6 +42,10 @@ const validationSchema = Yup.object()
               })
             : Yup.object().strip()
         })
+
+        if (!generateKeys) {
+          return schema.strip()
+        }
 
         if (externalJs) {
           return schema.shape({

--- a/pkg/webui/console/views/device-general-settings/join-server-form/validation-schema.js
+++ b/pkg/webui/console/views/device-general-settings/join-server-form/validation-schema.js
@@ -14,14 +14,10 @@
 
 import * as Yup from 'yup'
 
-import randomByteString from '../../../lib/random-bytes'
 import m from '../../../components/device-data-form/messages'
 import sharedMessages from '../../../../lib/shared-messages'
 
 import { parseLorawanMacVersion } from '../utils'
-
-const random16BytesString = () => randomByteString(32)
-const toUndefined = value => (!Boolean(value) ? undefined : value)
 
 const validationSchema = Yup.object()
   .shape({
@@ -29,21 +25,18 @@ const validationSchema = Yup.object()
       .emptyOrLength(3 * 2, m.validate6) // 3 Byte hex
       .default(''),
     root_keys: Yup.object().when(
-      ['_external_js', '_lorawan_version', '_may_edit_keys'],
-      (externalJs, version, mayEditKeys, schema) => {
+      ['_external_js', '_lorawan_version', '_may_edit_keys', '_may_read_keys'],
+      (externalJs, version, mayEditKeys, mayReadKeys, schema) => {
         const strippedSchema = Yup.object().strip()
-        const keySchema = Yup.lazy(() => {
-          return !externalJs
+        const keySchema = Yup.lazy(value => {
+          return !externalJs && Boolean(value) && Boolean(value.key)
             ? Yup.object().shape({
-                key: Yup.string()
-                  .emptyOrLength(16 * 2, m.validate32) // 16 Byte hex
-                  .transform(toUndefined)
-                  .default(random16BytesString),
+                key: Yup.string().emptyOrLength(16 * 2, m.validate32), // 16 Byte hex
               })
             : Yup.object().strip()
         })
 
-        if (!mayEditKeys) {
+        if (!mayEditKeys && !mayReadKeys) {
           return schema.strip()
         }
 
@@ -85,6 +78,7 @@ const validationSchema = Yup.object()
     _external_js: Yup.boolean().default(false),
     _lorawan_version: Yup.string().default('1.1.0'),
     _may_edit_keys: Yup.boolean().default(false),
+    _may_read_keys: Yup.boolean().default(false),
   })
   .noUnknown()
 

--- a/pkg/webui/console/views/device-general-settings/join-server-form/validation-schema.js
+++ b/pkg/webui/console/views/device-general-settings/join-server-form/validation-schema.js
@@ -29,8 +29,8 @@ const validationSchema = Yup.object()
       .emptyOrLength(3 * 2, m.validate6) // 3 Byte hex
       .default(''),
     root_keys: Yup.object().when(
-      ['_external_js', '_lorawan_version', '_generate_keys'],
-      (externalJs, version, generateKeys, schema) => {
+      ['_external_js', '_lorawan_version', '_may_edit_keys'],
+      (externalJs, version, mayEditKeys, schema) => {
         const strippedSchema = Yup.object().strip()
         const keySchema = Yup.lazy(() => {
           return !externalJs
@@ -43,7 +43,7 @@ const validationSchema = Yup.object()
             : Yup.object().strip()
         })
 
-        if (!generateKeys) {
+        if (!mayEditKeys) {
           return schema.strip()
         }
 
@@ -84,6 +84,7 @@ const validationSchema = Yup.object()
       .default(''),
     _external_js: Yup.boolean().default(false),
     _lorawan_version: Yup.string().default('1.1.0'),
+    _may_edit_keys: Yup.boolean().default(false),
   })
   .noUnknown()
 

--- a/pkg/webui/console/views/device-general-settings/messages.js
+++ b/pkg/webui/console/views/device-general-settings/messages.js
@@ -34,6 +34,8 @@ const messages = defineMessages({
   activationModeUnknown: 'Activation mode unknown because Network Server is not available',
   notInCluster: 'Not registered in this cluster',
   updateSuccess: 'The end device has been updated successfully',
+  keysResetWarning:
+    "You're not authorized to view the end device keys. However, overwriting is allowed.",
 })
 
 export default messages

--- a/pkg/webui/console/views/device-general-settings/network-server-form/validation-schema.js
+++ b/pkg/webui/console/views/device-general-settings/network-server-form/validation-schema.js
@@ -37,9 +37,12 @@ const validationSchema = Yup.object()
     frequency_plan_id: Yup.string().required(sharedMessages.validateRequired),
     supports_class_c: Yup.boolean().default(false),
     session: Yup.object().when(
-      ['_activation_mode', 'lorawan_version', '_joined'],
-      (mode, version, isJoined, schema) => {
-        if (mode === ACTIVATION_MODES.ABP || mode === ACTIVATION_MODES.MULTICAST || isJoined) {
+      ['_activation_mode', 'lorawan_version', '_joined', '_generate_keys'],
+      (mode, version, isJoined, generateKeys, schema) => {
+        if (
+          generateKeys &&
+          (mode === ACTIVATION_MODES.ABP || mode === ACTIVATION_MODES.MULTICAST || isJoined)
+        ) {
           const isNewVersion = parseLorawanMacVersion(version) >= 110
           return schema.shape({
             dev_addr: Yup.string()
@@ -88,9 +91,9 @@ const validationSchema = Yup.object()
       return schema.strip()
     }),
     root_keys: Yup.object().when(
-      ['_external_js', 'lorawan_version', '_activation_mode'],
-      (externalJs, version, mode, schema) => {
-        if (mode === ACTIVATION_MODES.OTAA) {
+      ['_external_js', 'lorawan_version', '_activation_mode', '_generate_keys'],
+      (externalJs, version, mode, generateKeys, schema) => {
+        if (generateKeys && mode === ACTIVATION_MODES.OTAA) {
           const strippedSchema = Yup.object().strip()
           const keySchema = Yup.lazy(() => {
             return !externalJs

--- a/pkg/webui/console/views/device-general-settings/network-server-form/validation-schema.js
+++ b/pkg/webui/console/views/device-general-settings/network-server-form/validation-schema.js
@@ -32,15 +32,16 @@ const validationSchema = Yup.object()
       ACTIVATION_MODES.OTAA,
       ACTIVATION_MODES.MULTICAST,
     ]),
+    _may_edit_keys: Yup.boolean().default(false),
     lorawan_version: Yup.string().required(sharedMessages.validateRequired),
     lorawan_phy_version: Yup.string().required(sharedMessages.validateRequired),
     frequency_plan_id: Yup.string().required(sharedMessages.validateRequired),
     supports_class_c: Yup.boolean().default(false),
     session: Yup.object().when(
-      ['_activation_mode', 'lorawan_version', '_joined', '_generate_keys'],
-      (mode, version, isJoined, generateKeys, schema) => {
+      ['_activation_mode', 'lorawan_version', '_joined', '_may_edit_keys'],
+      (mode, version, isJoined, mayEditKeys, schema) => {
         if (
-          generateKeys &&
+          mayEditKeys &&
           (mode === ACTIVATION_MODES.ABP || mode === ACTIVATION_MODES.MULTICAST || isJoined)
         ) {
           const isNewVersion = parseLorawanMacVersion(version) >= 110
@@ -91,9 +92,9 @@ const validationSchema = Yup.object()
       return schema.strip()
     }),
     root_keys: Yup.object().when(
-      ['_external_js', 'lorawan_version', '_activation_mode', '_generate_keys'],
-      (externalJs, version, mode, generateKeys, schema) => {
-        if (generateKeys && mode === ACTIVATION_MODES.OTAA) {
+      ['_external_js', 'lorawan_version', '_activation_mode', '_may_edit_keys'],
+      (externalJs, version, mode, mayEditKeys, schema) => {
+        if (mayEditKeys && mode === ACTIVATION_MODES.OTAA) {
           const strippedSchema = Yup.object().strip()
           const keySchema = Yup.lazy(() => {
             return !externalJs

--- a/pkg/webui/console/views/device-general-settings/network-server-form/validation-schema.js
+++ b/pkg/webui/console/views/device-general-settings/network-server-form/validation-schema.js
@@ -14,15 +14,11 @@
 
 import * as Yup from 'yup'
 
-import randomByteString from '../../../lib/random-bytes'
 import sharedMessages from '../../../../lib/shared-messages'
 
 import m from '../../../components/device-data-form/messages'
 
 import { parseLorawanMacVersion, ACTIVATION_MODES } from '../utils'
-
-const random16BytesString = () => randomByteString(32)
-const toUndefined = value => (!Boolean(value) ? undefined : value)
 
 const validationSchema = Yup.object()
   .shape({
@@ -33,46 +29,49 @@ const validationSchema = Yup.object()
       ACTIVATION_MODES.MULTICAST,
     ]),
     _may_edit_keys: Yup.boolean().default(false),
+    _may_read_keys: Yup.boolean().default(false),
+    _joined: Yup.boolean().default(false),
     lorawan_version: Yup.string().required(sharedMessages.validateRequired),
     lorawan_phy_version: Yup.string().required(sharedMessages.validateRequired),
     frequency_plan_id: Yup.string().required(sharedMessages.validateRequired),
     supports_class_c: Yup.boolean().default(false),
     session: Yup.object().when(
-      ['_activation_mode', 'lorawan_version', '_joined', '_may_edit_keys'],
-      (mode, version, isJoined, mayEditKeys, schema) => {
-        if (
-          mayEditKeys &&
-          (mode === ACTIVATION_MODES.ABP || mode === ACTIVATION_MODES.MULTICAST || isJoined)
-        ) {
+      ['_activation_mode', 'lorawan_version', '_joined', '_may_edit_keys', '_may_read_keys'],
+      (mode, version, isJoined, mayEditKeys, mayReadKeys, schema) => {
+        if (mode === ACTIVATION_MODES.ABP || mode === ACTIVATION_MODES.MULTICAST || isJoined) {
           const isNewVersion = parseLorawanMacVersion(version) >= 110
           return schema.shape({
-            dev_addr: Yup.string()
-              .length(4 * 2, m.validate8) // 4 Byte hex
-              .required(sharedMessages.validateRequired),
+            dev_addr: Yup.lazy(() => {
+              const schema = Yup.string().length(4 * 2, m.validate8) // 4 Byte hex
+
+              if (mayReadKeys && mayEditKeys) {
+                // Force the field to be required only if the user can see and edit the `dev_addr`,
+                // otherwise the user is not able to edit any other fields in the NS form without
+                // resetting the `dev_addr`.
+                return schema.required(sharedMessages.validateRequired)
+              }
+
+              return schema
+            }),
             keys: Yup.object().shape({
-              f_nwk_s_int_key: Yup.object().shape({
-                key: Yup.string()
-                  .emptyOrLength(16 * 2, m.validate32) // 16 Byte hex
-                  .transform(toUndefined)
-                  .default(random16BytesString),
-              }),
-              s_nwk_s_int_key: Yup.lazy(() =>
-                isNewVersion
+              f_nwk_s_int_key: Yup.lazy(value =>
+                Boolean(value) && Boolean(value.key)
                   ? Yup.object().shape({
-                      key: Yup.string()
-                        .emptyOrLength(16 * 2, m.validate32) // 16 Byte hex
-                        .transform(toUndefined)
-                        .default(random16BytesString),
+                      key: Yup.string().length(16 * 2, m.validate32), // 16 Byte hex
                     })
                   : Yup.object().strip(),
               ),
-              nwk_s_enc_key: Yup.lazy(() =>
-                isNewVersion
+              s_nwk_s_int_key: Yup.lazy(value =>
+                isNewVersion && Boolean(value) && Boolean(value.key)
                   ? Yup.object().shape({
-                      key: Yup.string()
-                        .emptyOrLength(16 * 2, m.validate32) // 16 Byte hex
-                        .transform(toUndefined)
-                        .default(random16BytesString),
+                      key: Yup.string().length(16 * 2, m.validate32), // 16 Byte hex
+                    })
+                  : Yup.object().strip(),
+              ),
+              nwk_s_enc_key: Yup.lazy(value =>
+                isNewVersion && Boolean(value) && Boolean(value.key)
+                  ? Yup.object().shape({
+                      key: Yup.string().length(16 * 2, m.validate32), // 16 Byte hex
                     })
                   : Yup.object().strip(),
               ),
@@ -91,45 +90,6 @@ const validationSchema = Yup.object()
 
       return schema.strip()
     }),
-    root_keys: Yup.object().when(
-      ['_external_js', 'lorawan_version', '_activation_mode', '_may_edit_keys'],
-      (externalJs, version, mode, mayEditKeys, schema) => {
-        if (mayEditKeys && mode === ACTIVATION_MODES.OTAA) {
-          const strippedSchema = Yup.object().strip()
-          const keySchema = Yup.lazy(() => {
-            return !externalJs
-              ? Yup.object().shape({
-                  key: Yup.string()
-                    .emptyOrLength(16 * 2, m.validate32) // 16 Byte hex
-                    .transform(toUndefined)
-                    .default(random16BytesString),
-                })
-              : strippedSchema
-          })
-
-          if (externalJs) {
-            return schema.shape({
-              nwk_key: strippedSchema,
-              app_key: strippedSchema,
-            })
-          }
-
-          if (parseLorawanMacVersion(version) < 110) {
-            return schema.shape({
-              nwk_key: strippedSchema,
-              app_key: keySchema,
-            })
-          }
-
-          return schema.shape({
-            nwk_key: keySchema,
-            app_key: keySchema,
-          })
-        }
-
-        return schema.strip()
-      },
-    ),
   })
   .noUnknown()
 

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -294,6 +294,7 @@
   "console.views.device-general-settings.messages.activationModeUnknown": "Activation mode unknown because Network Server is not available",
   "console.views.device-general-settings.messages.notInCluster": "Not registered in this cluster",
   "console.views.device-general-settings.messages.updateSuccess": "The end device has been updated successfully",
+  "console.views.device-general-settings.messages.keysResetWarning": "You're not authorized to view the end device keys. However, overwriting is allowed.",
   "console.views.device-location.index.setDeviceLocation": "Set Device Location",
   "console.views.device-overview.index.activationInfo": "Activation Information",
   "console.views.device-overview.index.rootKeyId": "Root Key ID",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -294,6 +294,7 @@
   "console.views.device-general-settings.messages.activationModeUnknown": "Xxxxxxxxxx xxxx xxxxxxx xxxxxxx Xxxxxxx Xxxxxx xx xxx xxxxxxxxx",
   "console.views.device-general-settings.messages.notInCluster": "Xxx xxxxxxxxxx xx xxxx xxxxxxx",
   "console.views.device-general-settings.messages.updateSuccess": "Xxx xxx xxxxxx xxx xxxx xxxxxxx xxxxxxxxxxxx",
+  "console.views.device-general-settings.messages.keysResetWarning": "Xxx'xx xxx xxxxxxxxxx xx xxxx xxx xxx xxxxxx xxxx. Xxxxxxx, xxxxxxxxxxx xx xxxxxxx.",
   "console.views.device-location.index.setDeviceLocation": "Xxx Xxxxxx Xxxxxxxx",
   "console.views.device-overview.index.activationInfo": "Xxxxxxxxxx Xxxxxxxxxxx",
   "console.views.device-overview.index.rootKeyId": "Xxxx Xxx XX",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR adjusts the device general settings page to check for `RIGHT_APPLICATION_DEVICES_{READ|WRITE}_KEYS` rights to adjust the UI and behavior accordingly avoiding unnecessary faulty requests, incosistent device state, etc.

References https://github.com/TheThingsNetwork/lorawan-stack/issues/2039

<details>
<summary>Screenshots</summary>
ABP device view for the user with only `RIGHT_APPLICATION_DEVICES_WRITE_KEYS`
<img width="1015" alt="Screenshot 2020-03-04 at 12 59 46" src="https://user-images.githubusercontent.com/16374166/75873281-536b7a00-5e18-11ea-8eb3-d45cdc77e88f.png">

OTAA device view for the user with only `RIGHT_APPLICATION_DEVICES_WRITE_KEYS`
<img width="1015" alt="Screenshot 2020-03-04 at 13 00 03" src="https://user-images.githubusercontent.com/16374166/75873296-5a928800-5e18-11ea-9363-57d2b9578ddb.png">

MULTICAST device view for the user with only `RIGHT_APPLICATION_DEVICES_WRITE_KEYS`
<img width="1015" alt="Screenshot 2020-03-04 at 13 01 44" src="https://user-images.githubusercontent.com/16374166/75873304-5f573c00-5e18-11ea-916c-18a8294ec847.png">

ABP device view for the user with only `RIGHT_APPLICATION_DEVICES_READ_KEYS`
<img width="1015" alt="Screenshot 2020-03-04 at 13 04 02" src="https://user-images.githubusercontent.com/16374166/75873549-bf4de280-5e18-11ea-9e76-14f2b075eb8e.png">

OTAA device view for the user with only `RIGHT_APPLICATION_DEVICES_READ_KEYS `
<img width="1015" alt="Screenshot 2020-03-04 at 13 04 17" src="https://user-images.githubusercontent.com/16374166/75873580-cffe5880-5e18-11ea-8e7a-7ff83a040884.png">

MULTICAST device view for the user with only `RIGHT_APPLICATION_DEVICES_WRITE_KEYS`
<img width="1015" alt="Screenshot 2020-03-04 at 13 04 35" src="https://user-images.githubusercontent.com/16374166/75873602-d987c080-5e18-11ea-8e50-bb9906424543.png">


</details>

#### Changes
<!-- What are the changes made in this pull request? -->

- Do not generate `root_keys` or `session` keys if the user has no appropriate rigths
- Hide key fields if the user has no appropriate rights
- Extend application feature checks

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Quick summary:
1. Show notification if the user has only the write right to inform that the keys might be there.
2. Disable key inputs if the user has no write rights
3. Force the users to explicitly generate root/session keys instead of doing this automatically on empty fields
5. Do not fetch `root_keys` and `session` fields if the user has no rights to read device keys to avoid `403` errors, since the user should able to see other fields from js/ns/as.

You can use [this script](https://gist.github.com/htdvisser/2d146748d01e56feea480b322bb0c400) to generate a bunch of devices for tests.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
