### PR TITLE
Refactor handling of deprecated fields in Network Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ADR in 72-channel regions.
 - Payload length limits used by Network Server being too low.
 - CLI ignores default config files that cannot be read.
-- Fix device creation rollback potentially deleting existing device with same ID.
+- Device creation rollback potentially deleting existing device with same ID.
+- Returned values not representing the effective state of the devices in Network Server when deprecated field paths are used.
 
 ### Security
 

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -201,7 +201,7 @@ func New(c *component.Component, conf *Config, opts ...Option) (*NetworkServer, 
 		applicationUplinks:   conf.ApplicationUplinks,
 		deduplicationDone:    makeWindowEndAfterFunc(conf.DeduplicationWindow),
 		collectionDone:       makeWindowEndAfterFunc(conf.DeduplicationWindow + conf.CooldownWindow),
-		devices:              conf.Devices,
+		devices:              wrapDeviceRegistryWithDeprecatedFields(conf.Devices, deprecatedDeviceFields...),
 		downlinkTasks:        conf.DownlinkTasks,
 		metadataAccumulators: &sync.Map{},
 		metadataAccumulatorPool: &sync.Pool{

--- a/pkg/networkserver/registry.go
+++ b/pkg/networkserver/registry.go
@@ -41,3 +41,216 @@ func logRegistryRPCError(ctx context.Context, err error, msg string) {
 	}
 	printLog(msg)
 }
+
+type deprecatedDeviceField struct {
+	Old          string
+	New          string
+	GetTransform func(dev *ttnpb.EndDevice)
+	SetTransform func(dev *ttnpb.EndDevice, useOld, useNew bool) error
+}
+
+type deprecatedDeviceFieldMatch struct {
+	deprecatedDeviceField
+	MatchedOld bool
+	MatchedNew bool
+}
+
+type deprecatedDeviceFieldRegistryWrapper struct {
+	fields   []deprecatedDeviceField
+	registry DeviceRegistry
+}
+
+func matchDeprecatedDeviceFields(paths []string, deprecated []deprecatedDeviceField) ([]string, []deprecatedDeviceFieldMatch) {
+	var matched []deprecatedDeviceFieldMatch
+	for _, f := range deprecated {
+		hasOld, hasNew := ttnpb.HasAnyField(paths, f.Old), ttnpb.HasAnyField(paths, f.New)
+		switch {
+		case !hasOld && !hasNew:
+			continue
+		case hasOld && hasNew:
+		case hasOld:
+			paths = ttnpb.AddFields(paths, f.New)
+		case hasNew:
+			paths = ttnpb.AddFields(paths, f.Old)
+		}
+		matched = append(matched, deprecatedDeviceFieldMatch{
+			deprecatedDeviceField: f,
+			MatchedOld:            hasOld,
+			MatchedNew:            hasNew,
+		})
+	}
+	return paths, matched
+}
+
+func (w deprecatedDeviceFieldRegistryWrapper) GetByEUI(ctx context.Context, joinEUI, devEUI types.EUI64, paths []string) (*ttnpb.EndDevice, context.Context, error) {
+	paths, deprecated := matchDeprecatedDeviceFields(paths, w.fields)
+	dev, ctx, err := w.registry.GetByEUI(ctx, joinEUI, devEUI, paths)
+	if err != nil || dev == nil {
+		return dev, ctx, err
+	}
+	for _, d := range deprecated {
+		d.GetTransform(dev)
+	}
+	return dev, ctx, nil
+}
+
+func (w deprecatedDeviceFieldRegistryWrapper) GetByID(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, paths []string) (*ttnpb.EndDevice, context.Context, error) {
+	paths, deprecated := matchDeprecatedDeviceFields(paths, w.fields)
+	dev, ctx, err := w.registry.GetByID(ctx, appID, devID, paths)
+	if err != nil || dev == nil {
+		return dev, ctx, err
+	}
+	for _, d := range deprecated {
+		d.GetTransform(dev)
+	}
+	return dev, ctx, nil
+}
+
+func (w deprecatedDeviceFieldRegistryWrapper) RangeByAddr(ctx context.Context, devAddr types.DevAddr, paths []string, f func(context.Context, *ttnpb.EndDevice) bool) error {
+	paths, deprecated := matchDeprecatedDeviceFields(paths, w.fields)
+	return w.registry.RangeByAddr(ctx, devAddr, paths, func(ctx context.Context, dev *ttnpb.EndDevice) bool {
+		if dev != nil {
+			for _, d := range deprecated {
+				d.GetTransform(dev)
+			}
+		}
+		return f(ctx, dev)
+	})
+}
+
+func (w deprecatedDeviceFieldRegistryWrapper) SetByID(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, paths []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
+	paths, deprecated := matchDeprecatedDeviceFields(paths, w.fields)
+	return w.registry.SetByID(ctx, appID, devID, paths, func(ctx context.Context, dev *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
+		if dev != nil {
+			for _, d := range deprecated {
+				d.GetTransform(dev)
+			}
+		}
+		dev, paths, err := f(ctx, dev)
+		if err != nil || dev == nil {
+			return dev, paths, err
+		}
+		for _, d := range deprecated {
+			d.SetTransform(dev, d.MatchedOld, d.MatchedNew)
+		}
+		return dev, paths, nil
+	})
+}
+
+func wrapDeviceRegistryWithDeprecatedFields(r DeviceRegistry, fields ...deprecatedDeviceField) DeviceRegistry {
+	return deprecatedDeviceFieldRegistryWrapper{
+		fields:   fields,
+		registry: r,
+	}
+}
+
+var deprecatedDeviceFields = []deprecatedDeviceField{
+	{
+		Old: "mac_state.current_parameters.adr_ack_delay",
+		New: "mac_state.current_parameters.adr_ack_delay_exponent",
+		GetTransform: func(dev *ttnpb.EndDevice) {
+			if dev.MACState == nil {
+				return
+			}
+			dev.MACState.CurrentParameters.ADRAckDelay = uint32(dev.MACState.CurrentParameters.ADRAckDelayExponent.GetValue())
+		},
+		SetTransform: func(dev *ttnpb.EndDevice, _, _ bool) error {
+			if dev.MACState == nil {
+				return nil
+			}
+			// Replicate old behavior for backwards-compatibility.
+			dev.MACState.CurrentParameters.ADRAckDelay = 0
+			return nil
+		},
+	},
+	{
+		Old: "mac_state.current_parameters.adr_ack_limit",
+		New: "mac_state.current_parameters.adr_ack_limit_exponent",
+		GetTransform: func(dev *ttnpb.EndDevice) {
+			if dev.MACState == nil {
+				return
+			}
+			dev.MACState.CurrentParameters.ADRAckLimit = uint32(dev.MACState.CurrentParameters.ADRAckLimitExponent.GetValue())
+		},
+		SetTransform: func(dev *ttnpb.EndDevice, _, _ bool) error {
+			if dev.MACState == nil {
+				return nil
+			}
+			// Replicate old behavior for backwards-compatibility.
+			dev.MACState.CurrentParameters.ADRAckLimit = 0
+			return nil
+		},
+	},
+	{
+		Old: "mac_state.current_parameters.ping_slot_data_rate_index",
+		New: "mac_state.current_parameters.ping_slot_data_rate_index_value",
+		GetTransform: func(dev *ttnpb.EndDevice) {
+			if dev.MACState == nil {
+				return
+			}
+			dev.MACState.CurrentParameters.PingSlotDataRateIndex = dev.MACState.CurrentParameters.PingSlotDataRateIndexValue.GetValue()
+		},
+		SetTransform: func(dev *ttnpb.EndDevice, _, _ bool) error {
+			if dev.MACState == nil {
+				return nil
+			}
+			// Replicate old behavior for backwards-compatibility.
+			dev.MACState.CurrentParameters.PingSlotDataRateIndex = 0
+			return nil
+		},
+	},
+	{
+		Old: "mac_state.desired_parameters.adr_ack_delay",
+		New: "mac_state.desired_parameters.adr_ack_delay_exponent",
+		GetTransform: func(dev *ttnpb.EndDevice) {
+			if dev.MACState == nil {
+				return
+			}
+			dev.MACState.DesiredParameters.ADRAckDelay = uint32(dev.MACState.DesiredParameters.ADRAckDelayExponent.GetValue())
+		},
+		SetTransform: func(dev *ttnpb.EndDevice, _, _ bool) error {
+			if dev.MACState == nil {
+				return nil
+			}
+			// Replicate old behavior for backwards-compatibility.
+			dev.MACState.DesiredParameters.ADRAckDelay = 0
+			return nil
+		},
+	},
+	{
+		Old: "mac_state.desired_parameters.adr_ack_limit",
+		New: "mac_state.desired_parameters.adr_ack_limit_exponent",
+		GetTransform: func(dev *ttnpb.EndDevice) {
+			if dev.MACState == nil {
+				return
+			}
+			dev.MACState.DesiredParameters.ADRAckLimit = uint32(dev.MACState.DesiredParameters.ADRAckLimitExponent.GetValue())
+		},
+		SetTransform: func(dev *ttnpb.EndDevice, _, _ bool) error {
+			if dev.MACState == nil {
+				return nil
+			}
+			// Replicate old behavior for backwards-compatibility.
+			dev.MACState.DesiredParameters.ADRAckLimit = 0
+			return nil
+		},
+	},
+	{
+		Old: "mac_state.desired_parameters.ping_slot_data_rate_index",
+		New: "mac_state.desired_parameters.ping_slot_data_rate_index_value",
+		GetTransform: func(dev *ttnpb.EndDevice) {
+			if dev.MACState == nil {
+				return
+			}
+			dev.MACState.DesiredParameters.PingSlotDataRateIndex = dev.MACState.DesiredParameters.PingSlotDataRateIndexValue.GetValue()
+		},
+		SetTransform: func(dev *ttnpb.EndDevice, _, _ bool) error {
+			if dev.MACState == nil {
+				return nil
+			}
+			// Replicate old behavior for backwards-compatibility.
+			dev.MACState.DesiredParameters.PingSlotDataRateIndex = 0
+			return nil
+		},
+	},
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Refactor handling of deprecated fields in Network Server.
Refs #1954 

#### Changes
<!-- What are the changes made in this pull request? -->

- Instead of manually specifying deprecated fields in RPCs, wrap the internal registry in a layer handling these
- Fix ineffective values being returned to the user

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Unfortunately, so far handling of deprecated fields was basically non-existent, as in the old values are just ignored by NS - the values are `SET`, but they have no effect on NS operation. Kept it that way for backwards-compatibility.
The `GET` logic is also weird and confusing, since values returned do not reflect the actual state of the device.
For example usage of this see https://github.com/TheThingsNetwork/lorawan-stack/pull/2052/commits/4e74f74b999da5d2cd3eec767993514fa49f5184#diff-41cf204f41bb63a20074d957c04b6d89R243-R293 from #2052
We may want to extract some of this into a shared package later.

Functionality here provides NS ability to seamlessly migrate from deprecated fields to newer format.
On SET, the migration is performed.
There's always at most 1 value set in registry (either `Old` or `New` field)

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
