### PR TITLE
Allow nil and empty fields in should.ResembleFields

### DIFF
--- a/pkg/util/test/assertions/resemble_test.go
+++ b/pkg/util/test/assertions/resemble_test.go
@@ -16,7 +16,6 @@ package assertions_test
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/smartystreets/assertions"
@@ -124,11 +123,10 @@ func (dst *testSetFielder) SetFields(src *testSetFielder, paths ...string) error
 
 func TestShouldResembleFields(t *testing.T) {
 	for _, tc := range []struct {
-		A                interface{}
-		B                interface{}
-		Paths            []interface{}
-		Assertion        func(interface{}, ...interface{}) string
-		InverseAssertion func(interface{}, ...interface{}) string
+		A         interface{}
+		B         interface{}
+		Paths     []interface{}
+		Assertion func(interface{}, ...interface{}) string
 	}{
 		{
 			A:         &testSetFielder{},
@@ -140,7 +138,7 @@ func TestShouldResembleFields(t *testing.T) {
 				A: 42,
 			},
 			B:         &testSetFielder{},
-			Assertion: should.NotBeEmpty,
+			Assertion: should.BeEmpty,
 		},
 		{
 			A: &testSetFielder{
@@ -235,11 +233,6 @@ func TestShouldResembleFields(t *testing.T) {
 		t.Run(fmt.Sprintf("%+v/%+v/%+v", tc.A, tc.B, tc.Paths), func(t *testing.T) {
 			a := assertions.New(t)
 			a.So(ShouldResembleFields(tc.A, append([]interface{}{tc.B}, tc.Paths...)...), tc.Assertion)
-			if reflect.DeepEqual(tc.A, tc.B) {
-				a.So(ShouldResembleFields(tc.A, tc.B), should.BeEmpty)
-			} else {
-				a.So(ShouldResembleFields(tc.A, tc.B), should.NotBeEmpty)
-			}
 		})
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Allow `nil` and empty fields in `should.ResembleFields`

#### Changes
<!-- What are the changes made in this pull request? -->

- Allow `nil` and empty fields in `should.ResembleFields`

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
