### PR TITLE
Improve error reporting to Sentry

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -4076,6 +4076,15 @@
       "file": "store.go"
     }
   },
+  "error:pkg/identityserver/store:transaction_recovered": {
+    "translations": {
+      "en": "Internal Server Error"
+    },
+    "description": {
+      "package": "pkg/identityserver/store",
+      "file": "store.go"
+    }
+  },
   "error:pkg/identityserver/store:user_not_found": {
     "translations": {
       "en": "user `{user_id}` not found"

--- a/pkg/errors/sentry/sentry.go
+++ b/pkg/errors/sentry/sentry.go
@@ -26,6 +26,7 @@ func NewEvent(err error) *sentry.Event {
 		return evt
 	}
 
+	evt.Level = sentry.LevelError
 	evt.Message = err.Error()
 
 	// Error Tags.

--- a/pkg/errors/sentry/sentry.go
+++ b/pkg/errors/sentry/sentry.go
@@ -15,8 +15,6 @@
 package sentry
 
 import (
-	"fmt"
-
 	"github.com/getsentry/sentry-go"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 )
@@ -43,9 +41,7 @@ func NewEvent(err error) *sentry.Event {
 
 	// Error Attributes.
 	for k, v := range errors.Attributes(errStack...) {
-		if val := fmt.Sprint(v); len(val) < 64 {
-			evt.Extra["error.attributes."+k] = val
-		}
+		evt.Extra["error.attributes."+k] = v
 	}
 
 	// Error Stack.

--- a/pkg/errors/sentry/sentry.go
+++ b/pkg/errors/sentry/sentry.go
@@ -45,7 +45,8 @@ func NewEvent(err error) *sentry.Event {
 	}
 
 	// Error Stack.
-	for _, err := range errStack {
+	for i := len(errStack) - 1; i >= 0; i-- {
+		err := errStack[i]
 		exception := sentry.Exception{
 			Value: err.Error(),
 		}

--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -123,7 +123,12 @@ func New(ctx context.Context, opts ...Option) *Server {
 		grpc_recovery.WithRecoveryHandler(func(p interface{}) (err error) {
 			fmt.Fprintln(os.Stderr, p)
 			os.Stderr.Write(debug.Stack())
-			return ErrRPCRecovered.WithAttributes("panic", p)
+			if pErr, ok := p.(error); ok {
+				err = ErrRPCRecovered.WithCause(pErr)
+			} else {
+				err = ErrRPCRecovered.WithAttributes("panic", p)
+			}
+			return err
 		}),
 	}
 

--- a/pkg/web/middleware/recover.go
+++ b/pkg/web/middleware/recover.go
@@ -34,7 +34,11 @@ func Recover() echo.MiddlewareFunc {
 				if p := recover(); p != nil {
 					fmt.Fprintln(os.Stderr, p)
 					os.Stderr.Write(debug.Stack())
-					err = ErrHTTPRecovered.WithAttributes("panic", p)
+					if pErr, ok := p.(error); ok {
+						err = ErrHTTPRecovered.WithCause(pErr)
+					} else {
+						err = ErrHTTPRecovered.WithAttributes("panic", p)
+					}
 				}
 			}()
 			return next(c)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request makes some improvements to #2032 after testing with rc1.

Refs #2026 

#### Changes
<!-- What are the changes made in this pull request? -->

- Improve reporting of panics (especially panics that are `error`s)
- Improve reporting of panics in SQL transactions
- Fix `level` field (was info, now error)
- Fix ordering of exception list
- Improve the "extra" data by using the original types
