### PR TITLE
Fix panic in AsNs for 1.1+ devices

### DIFF
--- a/pkg/networkserver/networkserver_util_test.go
+++ b/pkg/networkserver/networkserver_util_test.go
@@ -129,6 +129,16 @@ func CopyUplinkMessages(pbs ...*ttnpb.UplinkMessage) []*ttnpb.UplinkMessage {
 	return deepcopy.Copy(pbs).([]*ttnpb.UplinkMessage)
 }
 
+// CopyDownlinkMessage returns a deep copy of ttnpb.DownlinkMessage pb.
+func CopyDownlinkMessage(pb *ttnpb.DownlinkMessage) *ttnpb.DownlinkMessage {
+	return deepcopy.Copy(pb).(*ttnpb.DownlinkMessage)
+}
+
+// CopyDownlinkMessages returns a deep copy of ...*ttnpb.DownlinkMessage pbs.
+func CopyDownlinkMessages(pbs ...*ttnpb.DownlinkMessage) []*ttnpb.DownlinkMessage {
+	return deepcopy.Copy(pbs).([]*ttnpb.DownlinkMessage)
+}
+
 // CopyMACParameters returns a deep copy of ttnpb.MACParameters pb.
 func CopyMACParameters(pb *ttnpb.MACParameters) *ttnpb.MACParameters {
 	return deepcopy.Copy(pb).(*ttnpb.MACParameters)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fix panic in AsNs for 1.1+ devices

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix panic on validating 1.1+ device downlinks

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

NS does not store unmarshaled payload of downlinks it schedules, only the PHY payload, hence, decode to obtain `FCnt`

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
