### PR TITLE
Fix Redis error handling and logging

### DIFF
--- a/pkg/applicationserver/io/web/redis/registry.go
+++ b/pkg/applicationserver/io/web/redis/registry.go
@@ -214,7 +214,7 @@ func (r WebhookRegistry) Set(ctx context.Context, ids ttnpb.ApplicationWebhookId
 		return nil
 	}, ik)
 	if err != nil {
-		return nil, err
+		return nil, ttnredis.ConvertError(err)
 	}
 	return pb, nil
 }

--- a/pkg/applicationserver/redis/registry.go
+++ b/pkg/applicationserver/redis/registry.go
@@ -196,7 +196,7 @@ func (r *DeviceRegistry) Set(ctx context.Context, ids ttnpb.EndDeviceIdentifiers
 					}
 					i, err := tx.Exists(ek).Result()
 					if err != nil {
-						return ttnredis.ConvertError(err)
+						return err
 					}
 					if i != 0 {
 						return errDuplicateIdentifiers
@@ -221,7 +221,7 @@ func (r *DeviceRegistry) Set(ctx context.Context, ids ttnpb.EndDeviceIdentifiers
 		return nil
 	}, uk)
 	if err != nil {
-		return nil, err
+		return nil, ttnredis.ConvertError(err)
 	}
 	return pb, nil
 }
@@ -265,7 +265,7 @@ func (r *LinkRegistry) Range(ctx context.Context, paths []string, f func(context
 
 	uids, err := r.Redis.SMembers(r.allKey(ctx)).Result()
 	if err != nil {
-		return err
+		return ttnredis.ConvertError(err)
 	}
 	for _, uid := range uids {
 		ctx, err := unique.WithContext(ctx, uid)
@@ -380,7 +380,7 @@ func (r *LinkRegistry) Set(ctx context.Context, ids ttnpb.ApplicationIdentifiers
 		return nil
 	}, uk)
 	if err != nil {
-		return nil, err
+		return nil, ttnredis.ConvertError(err)
 	}
 	return pb, nil
 }

--- a/pkg/joinserver/redis/registry.go
+++ b/pkg/joinserver/redis/registry.go
@@ -261,7 +261,7 @@ func (r *DeviceRegistry) set(ctx context.Context, tx *redis.Tx, uid string, gets
 				}
 				i, err := tx.Exists(ek).Result()
 				if err != nil {
-					return ttnredis.ConvertError(err)
+					return err
 				}
 				if i != 0 {
 					return errDuplicateIdentifiers
@@ -276,7 +276,7 @@ func (r *DeviceRegistry) set(ctx context.Context, tx *redis.Tx, uid string, gets
 				}
 				i, err := tx.Exists(pk).Result()
 				if err != nil {
-					return ttnredis.ConvertError(err)
+					return err
 				}
 				if i != 0 {
 					return errAlreadyProvisioned
@@ -297,7 +297,7 @@ func (r *DeviceRegistry) set(ctx context.Context, tx *redis.Tx, uid string, gets
 	}
 	_, err = tx.Pipelined(pipelined)
 	if err != nil {
-		return nil, err
+		return nil, ttnredis.ConvertError(err)
 	}
 	return &ttnpb.ContextualEndDevice{
 		Context:   ctx,
@@ -319,16 +319,16 @@ func (r *DeviceRegistry) SetByEUI(ctx context.Context, joinEUI types.EUI64, devE
 	err := r.Redis.Watch(func(tx *redis.Tx) error {
 		uid, err := tx.Get(ek).Result()
 		if err != nil {
-			return ttnredis.ConvertError(err)
+			return err
 		}
 		if err := tx.Watch(r.uidKey(uid)).Err(); err != nil {
-			return ttnredis.ConvertError(err)
+			return err
 		}
 		pb, err = r.set(ctx, tx, uid, gets, f)
 		return err
 	}, ek)
 	if err != nil {
-		return nil, err
+		return nil, ttnredis.ConvertError(err)
 	}
 	return pb, nil
 }
@@ -362,7 +362,7 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIde
 		return err
 	}, r.uidKey(uid))
 	if err != nil {
-		return nil, err
+		return nil, ttnredis.ConvertError(err)
 	}
 	return pb.EndDevice, nil
 }
@@ -497,7 +497,7 @@ func (r *KeyRegistry) SetByID(ctx context.Context, joinEUI, devEUI types.EUI64, 
 		return nil
 	}, ik)
 	if err != nil {
-		return nil, err
+		return nil, ttnredis.ConvertError(err)
 	}
 	return pb, nil
 }

--- a/pkg/networkserver/grpc_asns.go
+++ b/pkg/networkserver/grpc_asns.go
@@ -221,7 +221,7 @@ func (ns *NetworkServer) DownlinkQueueReplace(ctx context.Context, req *ttnpb.Do
 		return nil, err
 	}
 
-	logger := log.FromContext(ctx).WithField("device_uid", unique.ID(ctx, req.EndDeviceIdentifiers))
+	ctx = log.NewContextWithField(ctx, "device_uid", unique.ID(ctx, req.EndDeviceIdentifiers))
 
 	gets := []string{
 		"mac_state",
@@ -255,19 +255,19 @@ func (ns *NetworkServer) DownlinkQueueReplace(ctx context.Context, req *ttnpb.Do
 		},
 	)
 	if err != nil {
-		logger.WithError(err).Warn("Failed to replace application downlink queue")
+		logRegistryRPCError(ctx, err, "Failed to replace application downlink queue")
 		return nil, err
 	}
 
-	logger = logger.WithField("queue_length", len(dev.QueuedApplicationDownlinks))
-	logger.Debug("Replaced application downlink queue")
+	ctx = log.NewContextWithField(ctx, "queue_length", len(dev.QueuedApplicationDownlinks))
+	log.FromContext(ctx).Debug("Replaced application downlink queue")
 
 	if len(dev.QueuedApplicationDownlinks) == 0 || dev.MACState == nil {
 		return ttnpb.Empty, nil
 	}
 
 	if err := ns.updateDataDownlinkTask(ctx, dev, time.Time{}); err != nil {
-		logger.WithError(err).Error("Failed to update downlink task queue after downlink queue replace")
+		log.FromContext(ctx).WithError(err).Error("Failed to update downlink task queue after downlink queue replace")
 	}
 	return ttnpb.Empty, nil
 }
@@ -277,12 +277,11 @@ func (ns *NetworkServer) DownlinkQueuePush(ctx context.Context, req *ttnpb.Downl
 	if len(req.Downlinks) == 0 {
 		return ttnpb.Empty, nil
 	}
-
 	if err := rights.RequireApplication(ctx, req.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_LINK); err != nil {
 		return nil, err
 	}
 
-	logger := log.FromContext(ctx).WithField("device_uid", unique.ID(ctx, req.EndDeviceIdentifiers))
+	ctx = log.NewContextWithField(ctx, "device_uid", unique.ID(ctx, req.EndDeviceIdentifiers))
 
 	dev, ctx, err := ns.devices.SetByID(ctx, req.EndDeviceIdentifiers.ApplicationIdentifiers, req.EndDeviceIdentifiers.DeviceID,
 		[]string{
@@ -310,19 +309,19 @@ func (ns *NetworkServer) DownlinkQueuePush(ctx context.Context, req *ttnpb.Downl
 		},
 	)
 	if err != nil {
-		logger.WithError(err).Warn("Failed to push application downlink to queue")
+		logRegistryRPCError(ctx, err, "Failed to push application downlink to queue")
 		return nil, err
 	}
 
-	logger = logger.WithField("queue_length", len(dev.QueuedApplicationDownlinks))
-	logger.Debug("Pushed application downlink to queue")
+	ctx = log.NewContextWithField(ctx, "queue_length", len(dev.QueuedApplicationDownlinks))
+	log.FromContext(ctx).Debug("Pushed application downlink to queue")
 
 	if dev.MACState == nil {
 		return ttnpb.Empty, nil
 	}
 
 	if err := ns.updateDataDownlinkTask(ctx, dev, time.Time{}); err != nil {
-		logger.WithError(err).Error("Failed to update downlink task queue after downlink queue push")
+		log.FromContext(ctx).WithError(err).Error("Failed to update downlink task queue after downlink queue push")
 	}
 	return ttnpb.Empty, nil
 }
@@ -334,6 +333,7 @@ func (ns *NetworkServer) DownlinkQueueList(ctx context.Context, ids *ttnpb.EndDe
 	}
 	dev, ctx, err := ns.devices.GetByID(ctx, ids.ApplicationIdentifiers, ids.DeviceID, []string{"queued_application_downlinks"})
 	if err != nil {
+		logRegistryRPCError(ctx, err, "Failed to list application downlink queue")
 		return nil, err
 	}
 	return &ttnpb.ApplicationDownlinks{Downlinks: dev.QueuedApplicationDownlinks}, nil

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -175,6 +175,7 @@ func (ns *NetworkServer) Get(ctx context.Context, req *ttnpb.GetEndDeviceRequest
 
 	dev, ctx, err := ns.devices.GetByID(ctx, req.ApplicationIdentifiers, req.DeviceID, gets)
 	if err != nil {
+		logRegistryRPCError(ctx, err, "Failed to get device from registry")
 		return nil, err
 	}
 
@@ -561,6 +562,7 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 		return &req.EndDevice, sets, nil
 	})
 	if err != nil {
+		logRegistryRPCError(ctx, err, "Failed to set device in registry")
 		return nil, err
 	}
 	if evt != nil {
@@ -590,6 +592,7 @@ func (ns *NetworkServer) Delete(ctx context.Context, req *ttnpb.EndDeviceIdentif
 		return nil, nil, nil
 	})
 	if err != nil {
+		logRegistryRPCError(ctx, err, "Failed to delete device from registry")
 		return nil, err
 	}
 	if evt != nil {

--- a/pkg/networkserver/redis/registry.go
+++ b/pkg/networkserver/redis/registry.go
@@ -272,7 +272,7 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIde
 					}
 					i, err := tx.Exists(ek).Result()
 					if err != nil {
-						return ttnredis.ConvertError(err)
+						return err
 					}
 					if i != 0 {
 						return errDuplicateIdentifiers
@@ -315,7 +315,7 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIde
 		return nil
 	}, uk)
 	if err != nil {
-		return nil, ctx, err
+		return nil, ctx, ttnredis.ConvertError(err)
 	}
 	return pb, ctx, nil
 }

--- a/pkg/networkserver/registry.go
+++ b/pkg/networkserver/registry.go
@@ -17,6 +17,8 @@ package networkserver
 import (
 	"context"
 
+	"go.thethings.network/lorawan-stack/pkg/errors"
+	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/types"
 )
@@ -27,4 +29,15 @@ type DeviceRegistry interface {
 	GetByID(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, paths []string) (*ttnpb.EndDevice, context.Context, error)
 	RangeByAddr(ctx context.Context, devAddr types.DevAddr, paths []string, f func(context.Context, *ttnpb.EndDevice) bool) error
 	SetByID(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, paths []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error)
+}
+
+func logRegistryRPCError(ctx context.Context, err error, msg string) {
+	logger := log.FromContext(ctx).WithError(err)
+	var printLog func(string)
+	if errors.IsNotFound(err) || errors.IsInvalidArgument(err) {
+		printLog = logger.Debug
+	} else {
+		printLog = logger.Error
+	}
+	printLog(msg)
 }

--- a/pkg/redis/errors.go
+++ b/pkg/redis/errors.go
@@ -27,12 +27,15 @@ var (
 
 // ConvertError converts Redis error into errors.Error.
 func ConvertError(err error) error {
+	ttnErr, ok := errors.From(err)
+	if ok {
+		return ttnErr
+	}
 	switch err {
 	case nil:
 		return nil
 	case redis.Nil:
 		return errNotFound
-	default:
-		return errStore.WithCause(err)
 	}
+	return errStore.WithCause(err)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fix Redis error handling and logging

#### Changes
<!-- What are the changes made in this pull request? -->

- Convert all Redis errors in registries
- Do not convert ttn errors in `ttnredis.ConvertError`
- Log registry errors in NS RPCs as such

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

See https://sentry.io/organizations/the-things-industries/issues/1531554641/?project=2682566

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
