### PR TITLE
Fix disabled and narrow tabs styling

### DIFF
--- a/pkg/webui/components/tabs/index.js
+++ b/pkg/webui/components/tabs/index.js
@@ -22,25 +22,23 @@ import Tab from './tab'
 
 import style from './tabs.styl'
 
-const Tabs = function({ className, active, tabs, onTabChange, divider }) {
+const Tabs = function({ className, active, tabs, onTabChange, divider, narrow }) {
   return (
     <ul className={classnames(className, style.tabs, { [style.divider]: divider })}>
       {tabs.map(function(tab, index) {
-        const { disabled, title, name, icon, narrow, link, exact } = tab
-
         return (
           <Tab
             key={index}
-            active={name === active}
-            name={name}
-            disabled={disabled}
+            active={tab.name === active}
+            name={tab.name}
+            disabled={tab.disabled}
             onClick={onTabChange}
-            narrow={narrow}
-            link={link}
-            exact={exact}
+            narrow={tab.narrow || narrow}
+            link={tab.link}
+            exact={tab.exact}
           >
-            {icon && <Icon icon={icon} className={style.icon} />}
-            <Message content={title} />
+            {tab.icon && <Icon icon={tab.icon} className={style.icon} />}
+            <Message content={tab.title} />
           </Tab>
         )
       })}
@@ -58,8 +56,9 @@ Tabs.propTypes = {
    * A click handler to be called when the selected tab changes. Passes
    * the name of the new active tab as an argument.
    */
-  onTabChange: PropTypes.func,
+  narrow: PropTypes.bool,
   /** A list of tabs */
+  onTabChange: PropTypes.func,
   tabs: PropTypes.arrayOf(
     PropTypes.shape({
       title: PropTypes.message.isRequired,
@@ -75,6 +74,7 @@ Tabs.defaultProps = {
   className: undefined,
   onTabChange: () => null,
   divider: false,
+  narrow: false,
 }
 
 export default Tabs

--- a/pkg/webui/components/tabs/story.js
+++ b/pkg/webui/components/tabs/story.js
@@ -63,13 +63,18 @@ storiesOf('Tabs', module)
 
     return <Example tabs={tabs} active={tabs[0].name} />
   })
+  .add('Default (narrow)', function() {
+    const tabs = [{ title: 'All', name: 'all' }, { title: 'Starred', name: 'starred' }]
+
+    return <Example tabs={tabs} active={tabs[0].name} narrow />
+  })
   .add('With icons', function() {
     const tabs = [
       { title: 'People', name: 'people', icon: 'organization' },
       { title: 'Data', name: 'data', icon: 'data' },
     ]
 
-    return <Example tabs={tabs} active={tabs[0].name} />
+    return <Example tabs={tabs} active={tabs[0].name} narrow />
   })
   .add('With icons (disabled)', function() {
     const tabs = [
@@ -78,4 +83,28 @@ storiesOf('Tabs', module)
     ]
 
     return <Example tabs={tabs} active={tabs[0].name} />
+  })
+  .add('Link', function() {
+    const tabs = [
+      { title: 'People', name: 'people', link: '/people' },
+      { title: 'Data', name: 'data', link: '/data' },
+    ]
+
+    return <Example tabs={tabs} />
+  })
+  .add('Link (disabled)', function() {
+    const tabs = [
+      { title: 'People', name: 'people', link: '/people' },
+      { title: 'Data', name: 'data', link: '/data', disabled: true },
+    ]
+
+    return <Example tabs={tabs} />
+  })
+  .add('Link (narrow)', function() {
+    const tabs = [
+      { title: 'People', name: 'people', link: '/people' },
+      { title: 'Data', name: 'data', link: '/data' },
+    ]
+
+    return <Example tabs={tabs} narrow />
   })

--- a/pkg/webui/components/tabs/tab/index.js
+++ b/pkg/webui/components/tabs/tab/index.js
@@ -81,13 +81,18 @@ class Tab extends React.PureComponent {
       [style.tabItemDisabled]: disabled,
     })
 
-    const Component = link ? NavLink : 'span'
+    // There is no support for disabled on anchors in html and hence in `react-router`. So, do
+    // not render the link component if the tab is disabled, but render regular tab item instead.
+    const canRenderLink = link && !disabled
+
+    const Component = canRenderLink ? NavLink : 'span'
     const props = {
       role: 'button',
       className: tabItemClassNames,
       children,
     }
-    if (link) {
+
+    if (canRenderLink) {
       props.exact = exact
       props.to = link
       props.activeClassName = style.tabItemActive

--- a/pkg/webui/components/tabs/tab/tab.styl
+++ b/pkg/webui/components/tabs/tab/tab.styl
@@ -22,7 +22,7 @@
 .tab-item
   display: flex
   white-space: nowrap
-  padding: $cs.s $cs.l
+  padding: $cs.m $cs.l
   text-align: center
   position: relative
   cursor: pointer
@@ -34,7 +34,7 @@
     color: $tc-deep-gray
 
   &-narrow
-    padding: $cs.l $cs.m
+    padding: $cs.s $cs.m
 
   &-disabled
     cursor: not-allowed


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes `disabled` and `narrow` styling of the `<Tabs />` component

#### Changes
<!-- What are the changes made in this pull request? -->

- Do not render `<NavLink />` if tab is disabled, otherwise it is still possible to navigate
- Fix `narrow` styles. Styles were not applied to the tab components, as well as the values seemed incorrect.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
