### PR TITLE
Remove inconsistencies in webhook path handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Error display on Data pages in the Console.
 - Fix too restrictive MQTT client validation in PubSub form in the Console.
 - Fix faulty display of device event stream data for end devices with the same ID in different applications.
+- Trailing slashes handling in webhook paths.
 
 ### Security
 

--- a/pkg/applicationserver/io/web/webhooks.go
+++ b/pkg/applicationserver/io/web/webhooks.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"path"
 	"strings"
 	"sync"
 
@@ -377,15 +376,32 @@ func (w *webhooks) newRequest(ctx context.Context, msg *ttnpb.ApplicationUp, hoo
 	if cfg == nil {
 		return nil, nil
 	}
-	url, err := url.Parse(hook.BaseURL)
+	baseURL, err := url.Parse(hook.BaseURL)
 	if err != nil {
 		return nil, err
 	}
-	url.Path = path.Join(url.Path, cfg.Path)
-	expandVariables(url, msg)
+	expandVariables(baseURL, msg)
+	pathURL, err := url.Parse(cfg.Path)
 	if err != nil {
 		return nil, err
 	}
+	expandVariables(pathURL, msg)
+	if strings.HasPrefix(pathURL.Path, "/") {
+		// Trim the leading slash, in order to ensure that the path is not
+		// interpreted as relative to the root of the URL.
+		pathURL.Path = strings.TrimLeft(pathURL.Path, "/")
+		// Add the "/" suffix here instead of the condition below in order
+		// to treat the case in which the pathURL.Path is "/".
+		if !strings.HasSuffix(baseURL.Path, "/") {
+			baseURL.Path += "/"
+		}
+	}
+	// If the path URL contains an actual path (i.e. is not only a query)
+	// ensure that it does not override the top level path.
+	if pathURL.Path != "" && !strings.HasSuffix(baseURL.Path, "/") {
+		baseURL.Path += "/"
+	}
+	finalURL := baseURL.ResolveReference(pathURL)
 	format, ok := formats[hook.Format]
 	if !ok {
 		return nil, errFormatNotFound.WithAttributes("format", hook.Format)
@@ -394,7 +410,7 @@ func (w *webhooks) newRequest(ctx context.Context, msg *ttnpb.ApplicationUp, hoo
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest(http.MethodPost, url.String(), bytes.NewReader(buf))
+	req, err := http.NewRequest(http.MethodPost, finalURL.String(), bytes.NewReader(buf))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/applicationserver/io/web/webhooks_test.go
+++ b/pkg/applicationserver/io/web/webhooks_test.go
@@ -54,285 +54,309 @@ func TestWebhooks(t *testing.T) {
 		ApplicationIdentifiers: registeredApplicationID,
 		WebhookID:              registeredWebhookID,
 	}
-	_, err := registry.Set(ctx, ids, nil, func(_ *ttnpb.ApplicationWebhook) (*ttnpb.ApplicationWebhook, []string, error) {
-		return &ttnpb.ApplicationWebhook{
-				ApplicationWebhookIdentifiers: ids,
-				BaseURL:                       "https://myapp.com/api/ttn/v3{/appID,devID}",
-				Headers: map[string]string{
-					"Authorization": "key secret",
-				},
-				DownlinkAPIKey: "foo.secret",
-				Format:         "json",
-				UplinkMessage: &ttnpb.ApplicationWebhook_Message{
-					Path: "up",
-				},
-				JoinAccept: &ttnpb.ApplicationWebhook_Message{
-					Path: "join",
-				},
-				DownlinkAck: &ttnpb.ApplicationWebhook_Message{
-					Path: "down/ack",
-				},
-				DownlinkNack: &ttnpb.ApplicationWebhook_Message{
-					Path: "down/nack",
-				},
-				DownlinkSent: &ttnpb.ApplicationWebhook_Message{
-					Path: "down/sent",
-				},
-				DownlinkQueued: &ttnpb.ApplicationWebhook_Message{
-					Path: "down/queued",
-				},
-				DownlinkFailed: &ttnpb.ApplicationWebhook_Message{
-					Path: "down/failed",
-				},
-				LocationSolved: &ttnpb.ApplicationWebhook_Message{
-					Path: "location",
-				},
-			},
-			[]string{
-				"base_url",
-				"downlink_api_key",
-				"downlink_ack",
-				"downlink_failed",
-				"downlink_nack",
-				"downlink_queued",
-				"downlink_sent",
-				"format",
-				"headers",
-				"ids",
-				"join_accept",
-				"location_solved",
-				"uplink_message",
-			}, nil
-	})
-	if err != nil {
-		t.Fatalf("Failed to set webhook in registry: %s", err)
-	}
+	for _, tc := range []struct {
+		prefix string
+		suffix string
+	}{
+		{
+			prefix: "",
+			suffix: "",
+		},
+		{
+			prefix: "",
+			suffix: "/",
+		},
+		{
+			prefix: "/",
+			suffix: "",
+		},
+		{
+			prefix: "/",
+			suffix: "/",
+		},
+	} {
+		t.Run(fmt.Sprintf("Prefix%q/Suffix%q", tc.prefix, tc.suffix), func(t *testing.T) {
+			_, err := registry.Set(ctx, ids, nil, func(_ *ttnpb.ApplicationWebhook) (*ttnpb.ApplicationWebhook, []string, error) {
+				return &ttnpb.ApplicationWebhook{
+						ApplicationWebhookIdentifiers: ids,
+						BaseURL:                       "https://myapp.com/api/ttn/v3{/appID,devID}" + tc.suffix,
+						Headers: map[string]string{
+							"Authorization": "key secret",
+						},
+						DownlinkAPIKey: "foo.secret",
+						Format:         "json",
+						UplinkMessage: &ttnpb.ApplicationWebhook_Message{
+							Path: tc.prefix + "up",
+						},
+						JoinAccept: &ttnpb.ApplicationWebhook_Message{
+							Path: tc.prefix + "join",
+						},
+						DownlinkAck: &ttnpb.ApplicationWebhook_Message{
+							Path: tc.prefix + "down/ack",
+						},
+						DownlinkNack: &ttnpb.ApplicationWebhook_Message{
+							Path: tc.prefix + "down/nack",
+						},
+						DownlinkSent: &ttnpb.ApplicationWebhook_Message{
+							Path: tc.prefix + "down/sent",
+						},
+						DownlinkQueued: &ttnpb.ApplicationWebhook_Message{
+							Path: tc.prefix + "down/queued",
+						},
+						DownlinkFailed: &ttnpb.ApplicationWebhook_Message{
+							Path: tc.prefix + "down/failed",
+						},
+						LocationSolved: &ttnpb.ApplicationWebhook_Message{
+							Path: tc.prefix + "location",
+						},
+					},
+					[]string{
+						"base_url",
+						"downlink_api_key",
+						"downlink_ack",
+						"downlink_failed",
+						"downlink_nack",
+						"downlink_queued",
+						"downlink_sent",
+						"format",
+						"headers",
+						"ids",
+						"join_accept",
+						"location_solved",
+						"uplink_message",
+					}, nil
+			})
+			if err != nil {
+				t.Fatalf("Failed to set webhook in registry: %s", err)
+			}
 
-	t.Run("Upstream", func(t *testing.T) {
-		baseURL := fmt.Sprintf("https://myapp.com/api/ttn/v3/%s/%s", registeredApplicationID.ApplicationID, registeredDeviceID.DeviceID)
-		testSink := &mockSink{
-			ch: make(chan *http.Request, 1),
-		}
-		for _, sink := range []web.Sink{
-			testSink,
-			&web.QueuedSink{
-				Target:  testSink,
-				Queue:   make(chan *http.Request, 4),
-				Workers: 1,
-			},
-			&web.QueuedSink{
-				Target: &web.QueuedSink{
-					Target:  testSink,
-					Queue:   make(chan *http.Request, 4),
-					Workers: 1,
-				},
-				Queue:   make(chan *http.Request, 4),
-				Workers: 1,
-			},
-		} {
-			t.Run(fmt.Sprintf("%T", sink), func(t *testing.T) {
-				ctx, cancel := context.WithCancel(ctx)
-				defer cancel()
-				if controllable, ok := sink.(web.ControllableSink); ok {
-					go controllable.Run(ctx)
+			t.Run("Upstream", func(t *testing.T) {
+				baseURL := fmt.Sprintf("https://myapp.com/api/ttn/v3/%s/%s", registeredApplicationID.ApplicationID, registeredDeviceID.DeviceID)
+				testSink := &mockSink{
+					ch: make(chan *http.Request, 1),
 				}
-				w := web.NewWebhooks(ctx, nil, registry, sink, downlinks)
-				sub := w.NewSubscription()
-				for _, tc := range []struct {
-					Name    string
-					Message *ttnpb.ApplicationUp
-					OK      bool
-					URL     string
-				}{
-					{
-						Name: "UplinkMessage/RegisteredDevice",
-						Message: &ttnpb.ApplicationUp{
-							EndDeviceIdentifiers: registeredDeviceID,
-							Up: &ttnpb.ApplicationUp_UplinkMessage{
-								UplinkMessage: &ttnpb.ApplicationUplink{
-									SessionKeyID: []byte{0x11},
-									FPort:        42,
-									FCnt:         42,
-									FRMPayload:   []byte{0x1, 0x2, 0x3},
-								},
-							},
-						},
-						OK:  true,
-						URL: fmt.Sprintf("%s/up", baseURL),
+				for _, sink := range []web.Sink{
+					testSink,
+					&web.QueuedSink{
+						Target:  testSink,
+						Queue:   make(chan *http.Request, 4),
+						Workers: 1,
 					},
-					{
-						Name: "UplinkMessage/UnregisteredDevice",
-						Message: &ttnpb.ApplicationUp{
-							EndDeviceIdentifiers: unregisteredDeviceID,
-							Up: &ttnpb.ApplicationUp_UplinkMessage{
-								UplinkMessage: &ttnpb.ApplicationUplink{
-									SessionKeyID: []byte{0x22},
-									FPort:        42,
-									FCnt:         42,
-									FRMPayload:   []byte{0x1, 0x2, 0x3},
-								},
-							},
+					&web.QueuedSink{
+						Target: &web.QueuedSink{
+							Target:  testSink,
+							Queue:   make(chan *http.Request, 4),
+							Workers: 1,
 						},
-						OK: false,
-					},
-					{
-						Name: "JoinAccept",
-						Message: &ttnpb.ApplicationUp{
-							EndDeviceIdentifiers: registeredDeviceID,
-							Up: &ttnpb.ApplicationUp_JoinAccept{
-								JoinAccept: &ttnpb.ApplicationJoinAccept{
-									SessionKeyID: []byte{0x22},
-								},
-							},
-						},
-						OK:  true,
-						URL: fmt.Sprintf("%s/join", baseURL),
-					},
-					{
-						Name: "DownlinkMessage/Ack",
-						Message: &ttnpb.ApplicationUp{
-							EndDeviceIdentifiers: registeredDeviceID,
-							Up: &ttnpb.ApplicationUp_DownlinkAck{
-								DownlinkAck: &ttnpb.ApplicationDownlink{
-									SessionKeyID: []byte{0x22},
-									FCnt:         42,
-									FPort:        42,
-									FRMPayload:   []byte{0x1, 0x2, 0x3},
-								},
-							},
-						},
-						OK:  true,
-						URL: fmt.Sprintf("%s/down/ack", baseURL),
-					},
-					{
-						Name: "DownlinkMessage/Nack",
-						Message: &ttnpb.ApplicationUp{
-							EndDeviceIdentifiers: registeredDeviceID,
-							Up: &ttnpb.ApplicationUp_DownlinkNack{
-								DownlinkNack: &ttnpb.ApplicationDownlink{
-									SessionKeyID: []byte{0x22},
-									FCnt:         42,
-									FPort:        42,
-									FRMPayload:   []byte{0x1, 0x2, 0x3},
-								},
-							},
-						},
-						OK:  true,
-						URL: fmt.Sprintf("%s/down/nack", baseURL),
-					},
-					{
-						Name: "DownlinkMessage/Sent",
-						Message: &ttnpb.ApplicationUp{
-							EndDeviceIdentifiers: registeredDeviceID,
-							Up: &ttnpb.ApplicationUp_DownlinkSent{
-								DownlinkSent: &ttnpb.ApplicationDownlink{
-									SessionKeyID: []byte{0x22},
-									FCnt:         42,
-									FPort:        42,
-									FRMPayload:   []byte{0x1, 0x2, 0x3},
-								},
-							},
-						},
-						OK:  true,
-						URL: fmt.Sprintf("%s/down/sent", baseURL),
-					},
-					{
-						Name: "DownlinkMessage/Queued",
-						Message: &ttnpb.ApplicationUp{
-							EndDeviceIdentifiers: registeredDeviceID,
-							Up: &ttnpb.ApplicationUp_DownlinkQueued{
-								DownlinkQueued: &ttnpb.ApplicationDownlink{
-									SessionKeyID: []byte{0x22},
-									FCnt:         42,
-									FPort:        42,
-									FRMPayload:   []byte{0x1, 0x2, 0x3},
-								},
-							},
-						},
-						OK:  true,
-						URL: fmt.Sprintf("%s/down/queued", baseURL),
-					},
-					{
-						Name: "DownlinkMessage/Failed",
-						Message: &ttnpb.ApplicationUp{
-							EndDeviceIdentifiers: registeredDeviceID,
-							Up: &ttnpb.ApplicationUp_DownlinkFailed{
-								DownlinkFailed: &ttnpb.ApplicationDownlinkFailed{
-									ApplicationDownlink: ttnpb.ApplicationDownlink{
-										SessionKeyID: []byte{0x22},
-										FCnt:         42,
-										FPort:        42,
-										FRMPayload:   []byte{0x1, 0x2, 0x3},
-									},
-									Error: ttnpb.ErrorDetails{
-										Name: "test",
-									},
-								},
-							},
-						},
-						OK:  true,
-						URL: fmt.Sprintf("%s/down/failed", baseURL),
-					},
-					{
-						Name: "LocationSolved",
-						Message: &ttnpb.ApplicationUp{
-							EndDeviceIdentifiers: registeredDeviceID,
-							Up: &ttnpb.ApplicationUp_LocationSolved{
-								LocationSolved: &ttnpb.ApplicationLocation{
-									Location: ttnpb.Location{
-										Latitude:  10,
-										Longitude: 20,
-										Altitude:  30,
-									},
-									Service: "test",
-								},
-							},
-						},
-						OK:  true,
-						URL: fmt.Sprintf("%s/location", baseURL),
+						Queue:   make(chan *http.Request, 4),
+						Workers: 1,
 					},
 				} {
-					t.Run(tc.Name, func(t *testing.T) {
-						a := assertions.New(t)
-						err := sub.SendUp(ctx, tc.Message)
-						if !a.So(err, should.BeNil) {
-							t.FailNow()
+					t.Run(fmt.Sprintf("%T", sink), func(t *testing.T) {
+						ctx, cancel := context.WithCancel(ctx)
+						defer cancel()
+						if controllable, ok := sink.(web.ControllableSink); ok {
+							go controllable.Run(ctx)
 						}
-						var req *http.Request
-						select {
-						case req = <-testSink.ch:
-							if !tc.OK {
-								t.Fatalf("Did not expect message but received: %v", req)
-							}
-						case <-time.After(timeout):
-							if tc.OK {
-								t.Fatal("Expected message but nothing received")
-							} else {
-								return
-							}
+						w := web.NewWebhooks(ctx, nil, registry, sink, downlinks)
+						sub := w.NewSubscription()
+						for _, tc := range []struct {
+							Name    string
+							Message *ttnpb.ApplicationUp
+							OK      bool
+							URL     string
+						}{
+							{
+								Name: "UplinkMessage/RegisteredDevice",
+								Message: &ttnpb.ApplicationUp{
+									EndDeviceIdentifiers: registeredDeviceID,
+									Up: &ttnpb.ApplicationUp_UplinkMessage{
+										UplinkMessage: &ttnpb.ApplicationUplink{
+											SessionKeyID: []byte{0x11},
+											FPort:        42,
+											FCnt:         42,
+											FRMPayload:   []byte{0x1, 0x2, 0x3},
+										},
+									},
+								},
+								OK:  true,
+								URL: fmt.Sprintf("%s/up", baseURL),
+							},
+							{
+								Name: "UplinkMessage/UnregisteredDevice",
+								Message: &ttnpb.ApplicationUp{
+									EndDeviceIdentifiers: unregisteredDeviceID,
+									Up: &ttnpb.ApplicationUp_UplinkMessage{
+										UplinkMessage: &ttnpb.ApplicationUplink{
+											SessionKeyID: []byte{0x22},
+											FPort:        42,
+											FCnt:         42,
+											FRMPayload:   []byte{0x1, 0x2, 0x3},
+										},
+									},
+								},
+								OK: false,
+							},
+							{
+								Name: "JoinAccept",
+								Message: &ttnpb.ApplicationUp{
+									EndDeviceIdentifiers: registeredDeviceID,
+									Up: &ttnpb.ApplicationUp_JoinAccept{
+										JoinAccept: &ttnpb.ApplicationJoinAccept{
+											SessionKeyID: []byte{0x22},
+										},
+									},
+								},
+								OK:  true,
+								URL: fmt.Sprintf("%s/join", baseURL),
+							},
+							{
+								Name: "DownlinkMessage/Ack",
+								Message: &ttnpb.ApplicationUp{
+									EndDeviceIdentifiers: registeredDeviceID,
+									Up: &ttnpb.ApplicationUp_DownlinkAck{
+										DownlinkAck: &ttnpb.ApplicationDownlink{
+											SessionKeyID: []byte{0x22},
+											FCnt:         42,
+											FPort:        42,
+											FRMPayload:   []byte{0x1, 0x2, 0x3},
+										},
+									},
+								},
+								OK:  true,
+								URL: fmt.Sprintf("%s/down/ack", baseURL),
+							},
+							{
+								Name: "DownlinkMessage/Nack",
+								Message: &ttnpb.ApplicationUp{
+									EndDeviceIdentifiers: registeredDeviceID,
+									Up: &ttnpb.ApplicationUp_DownlinkNack{
+										DownlinkNack: &ttnpb.ApplicationDownlink{
+											SessionKeyID: []byte{0x22},
+											FCnt:         42,
+											FPort:        42,
+											FRMPayload:   []byte{0x1, 0x2, 0x3},
+										},
+									},
+								},
+								OK:  true,
+								URL: fmt.Sprintf("%s/down/nack", baseURL),
+							},
+							{
+								Name: "DownlinkMessage/Sent",
+								Message: &ttnpb.ApplicationUp{
+									EndDeviceIdentifiers: registeredDeviceID,
+									Up: &ttnpb.ApplicationUp_DownlinkSent{
+										DownlinkSent: &ttnpb.ApplicationDownlink{
+											SessionKeyID: []byte{0x22},
+											FCnt:         42,
+											FPort:        42,
+											FRMPayload:   []byte{0x1, 0x2, 0x3},
+										},
+									},
+								},
+								OK:  true,
+								URL: fmt.Sprintf("%s/down/sent", baseURL),
+							},
+							{
+								Name: "DownlinkMessage/Queued",
+								Message: &ttnpb.ApplicationUp{
+									EndDeviceIdentifiers: registeredDeviceID,
+									Up: &ttnpb.ApplicationUp_DownlinkQueued{
+										DownlinkQueued: &ttnpb.ApplicationDownlink{
+											SessionKeyID: []byte{0x22},
+											FCnt:         42,
+											FPort:        42,
+											FRMPayload:   []byte{0x1, 0x2, 0x3},
+										},
+									},
+								},
+								OK:  true,
+								URL: fmt.Sprintf("%s/down/queued", baseURL),
+							},
+							{
+								Name: "DownlinkMessage/Failed",
+								Message: &ttnpb.ApplicationUp{
+									EndDeviceIdentifiers: registeredDeviceID,
+									Up: &ttnpb.ApplicationUp_DownlinkFailed{
+										DownlinkFailed: &ttnpb.ApplicationDownlinkFailed{
+											ApplicationDownlink: ttnpb.ApplicationDownlink{
+												SessionKeyID: []byte{0x22},
+												FCnt:         42,
+												FPort:        42,
+												FRMPayload:   []byte{0x1, 0x2, 0x3},
+											},
+											Error: ttnpb.ErrorDetails{
+												Name: "test",
+											},
+										},
+									},
+								},
+								OK:  true,
+								URL: fmt.Sprintf("%s/down/failed", baseURL),
+							},
+							{
+								Name: "LocationSolved",
+								Message: &ttnpb.ApplicationUp{
+									EndDeviceIdentifiers: registeredDeviceID,
+									Up: &ttnpb.ApplicationUp_LocationSolved{
+										LocationSolved: &ttnpb.ApplicationLocation{
+											Location: ttnpb.Location{
+												Latitude:  10,
+												Longitude: 20,
+												Altitude:  30,
+											},
+											Service: "test",
+										},
+									},
+								},
+								OK:  true,
+								URL: fmt.Sprintf("%s/location", baseURL),
+							},
+						} {
+							t.Run(tc.Name, func(t *testing.T) {
+								a := assertions.New(t)
+								err := sub.SendUp(ctx, tc.Message)
+								if !a.So(err, should.BeNil) {
+									t.FailNow()
+								}
+								var req *http.Request
+								select {
+								case req = <-testSink.ch:
+									if !tc.OK {
+										t.Fatalf("Did not expect message but received: %v", req)
+									}
+								case <-time.After(timeout):
+									if tc.OK {
+										t.Fatal("Expected message but nothing received")
+									} else {
+										return
+									}
+								}
+								a.So(req.URL.String(), should.Equal, tc.URL)
+								a.So(req.Header.Get("Authorization"), should.Equal, "key secret")
+								a.So(req.Header.Get("Content-Type"), should.Equal, "application/json")
+								a.So(req.Header.Get("X-Downlink-Apikey"), should.Equal, "foo.secret")
+								a.So(req.Header.Get("X-Downlink-Push"), should.Equal,
+									"https://example.com/api/v3/as/applications/foo-app/webhooks/foo-hook/devices/foo-device/down/push")
+								a.So(req.Header.Get("X-Downlink-Replace"), should.Equal,
+									"https://example.com/api/v3/as/applications/foo-app/webhooks/foo-hook/devices/foo-device/down/replace")
+								actualBody, err := ioutil.ReadAll(req.Body)
+								if !a.So(err, should.BeNil) {
+									t.FailNow()
+								}
+								expectedBody, err := formatters.JSON.FromUp(tc.Message)
+								if !a.So(err, should.BeNil) {
+									t.FailNow()
+								}
+								a.So(actualBody, should.Resemble, expectedBody)
+							})
 						}
-						a.So(req.URL.String(), should.Equal, tc.URL)
-						a.So(req.Header.Get("Authorization"), should.Equal, "key secret")
-						a.So(req.Header.Get("Content-Type"), should.Equal, "application/json")
-						a.So(req.Header.Get("X-Downlink-Apikey"), should.Equal, "foo.secret")
-						a.So(req.Header.Get("X-Downlink-Push"), should.Equal,
-							"https://example.com/api/v3/as/applications/foo-app/webhooks/foo-hook/devices/foo-device/down/push")
-						a.So(req.Header.Get("X-Downlink-Replace"), should.Equal,
-							"https://example.com/api/v3/as/applications/foo-app/webhooks/foo-hook/devices/foo-device/down/replace")
-						actualBody, err := ioutil.ReadAll(req.Body)
-						if !a.So(err, should.BeNil) {
-							t.FailNow()
-						}
-						expectedBody, err := formatters.JSON.FromUp(tc.Message)
-						if !a.So(err, should.BeNil) {
-							t.FailNow()
-						}
-						a.So(actualBody, should.Resemble, expectedBody)
 					})
 				}
 			})
-		}
-	})
+		})
+	}
 
 	t.Run("Downstream", func(t *testing.T) {
 		is, isAddr := startMockIS(ctx)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #1995 

#### Changes
<!-- What are the changes made in this pull request? -->

- Changed the way the webhook paths are joined from `path.Join` to `url.ResolveReference`.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

First of all, there is an additional bug which currently exist in the latest master which is produced by the current `path.Join` usage: the path URL is being escaped even if it contains a query string. See [this](https://play.golang.org/p/wE-9kZC0oP1) example which can be replicated in master with a base URL of `http://localhost/test` and an uplink message path of `bar?something=else`.

Edited: I've solved the issues that were here originally. The proposed changes are backwards compatible.

Using path URLs such as `?variable=something` is also possible now, without URL encoding issues.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
