### PR TITLE
Fix error types in cluster package

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -2519,6 +2519,24 @@
       "file": "bucket.go"
     }
   },
+  "error:pkg/cluster:cluster_key": {
+    "translations": {
+      "en": "invalid cluster key"
+    },
+    "description": {
+      "package": "pkg/cluster",
+      "file": "cluster.go"
+    }
+  },
+  "error:pkg/cluster:key_length": {
+    "translations": {
+      "en": "invalid key length %d, must be 16, 24 or 32 bytes"
+    },
+    "description": {
+      "package": "pkg/cluster",
+      "file": "cluster.go"
+    }
+  },
   "error:pkg/cluster:peer_connection": {
     "translations": {
       "en": "connection to peer `{name}` on `{address}` failed"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quickfix that changes `fmt.Errorf`s in the `cluster` package to TTN errors. While at it, I also reduced the size of the `New` func.