### PR TITLE
Add timestamp to TxSettings of mqttv2 uplinks

### DIFF
--- a/pkg/gatewayserver/io/mqtt/format_protobufv2.go
+++ b/pkg/gatewayserver/io/mqtt/format_protobufv2.go
@@ -120,6 +120,7 @@ func (protobufv2) ToUplink(message []byte, ids ttnpb.GatewayIdentifiers) (*ttnpb
 
 	settings := ttnpb.TxSettings{
 		Frequency: gwMetadata.Frequency,
+		Timestamp: gwMetadata.Timestamp,
 	}
 	switch lorawanMetadata.Modulation {
 	case ttnpbv2.Modulation_LORA:

--- a/pkg/gatewayserver/io/mqtt/format_protobufv2_test.go
+++ b/pkg/gatewayserver/io/mqtt/format_protobufv2_test.go
@@ -101,6 +101,7 @@ func TestProtobufV2Uplinks(t *testing.T) {
 		},
 	}
 	validV3Settings := ttnpb.TxSettings{
+		Timestamp: 1000,
 		DataRate: ttnpb.DataRate{
 			Modulation: &ttnpb.DataRate_LoRa{
 				LoRa: &ttnpb.LoRaDataRate{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Add timestamp to TxSettings of mqttv2 uplinks. Refs https://github.com/TheThingsIndustries/lorawan-stack/issues/1796

#### Changes
<!-- What are the changes made in this pull request? -->

- Add the `timestamp` field and update test.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
