### PR TITLE
UDP firewall flood checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Device Claim Authentication Code page in the Console.
 - Update gateway antenna location from incoming status message (see `update_location_from_status` gateway field and `--gs.update-gateway-location-debounce-time` option).
   - This requires a database migration (`ttn-lw-stack is-db migrate`) because of the added columns.
+- Gateway Server rate limiting support for the UDP frontend, see (`--gs.udp.rate-limiting` options).
 
 ### Changed
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -3482,6 +3482,15 @@
       "file": "firewall.go"
     }
   },
+  "error:pkg/gatewayserver/io/udp:rate_exceeded": {
+    "translations": {
+      "en": "gateway traffic exceeded allowed rate"
+    },
+    "description": {
+      "package": "pkg/gatewayserver/io/udp",
+      "file": "firewall_ratelimit.go"
+    }
+  },
   "error:pkg/gatewayserver/io:buffer_full": {
     "translations": {
       "en": "buffer is full"

--- a/doc/content/reference/configuration/gateway-server.md
+++ b/doc/content/reference/configuration/gateway-server.md
@@ -73,3 +73,11 @@ Using the `packet-buffer` and `packet-handlers` options, the throughput of UDP p
 Specify options for gateway connection statistics:
 
 - `gs.update-connection-stats-debounce-time`: Time before repeated refresh of the gateway connection stats
+
+## UDP Rate Limiting Options
+
+The Gateway Server supports rate limiting traffic for gateways that are using the Semtech UDP protocol.
+
+- `gs.udp.rate-limiting.enable`: Enable rate limiting for gateways
+- `gs.udp.rate-limiting.messages`: Number of past messages to check timestamp for
+- `gs.udp.rate-limiting.threshold`: Filter packet if timestamp is not newer than the older timestamps of the previous messages by this threshold

--- a/pkg/gatewayserver/io/udp/firewall_ratelimit.go
+++ b/pkg/gatewayserver/io/udp/firewall_ratelimit.go
@@ -1,0 +1,75 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package udp
+
+import (
+	"sync"
+	"time"
+
+	"go.thethings.network/lorawan-stack/pkg/errors"
+	encoding "go.thethings.network/lorawan-stack/pkg/ttnpb/udp"
+)
+
+type rateLimitingFirewall struct {
+	f Firewall
+
+	m sync.Map // string to timestamps
+
+	messages  int
+	threshold time.Duration
+}
+
+// NewRateLimitingFirewall returns a Firewall with rate limiting capabilities.
+func NewRateLimitingFirewall(firewall Firewall, messages int, threshold time.Duration) Firewall {
+	return &rateLimitingFirewall{
+		f:         firewall,
+		messages:  messages,
+		threshold: threshold,
+	}
+}
+
+var (
+	errRateExceeded = errors.DefineResourceExhausted("rate_exceeded", "gateway traffic exceeded allowed rate")
+)
+
+func (f *rateLimitingFirewall) Filter(packet encoding.Packet) error {
+	if packet.GatewayEUI == nil {
+		return errNoEUI
+	}
+	if packet.GatewayAddr == nil {
+		return errNoAddress
+	}
+	now := time.Now().UTC()
+	eui := *packet.GatewayEUI
+	val, ok := f.m.Load(eui)
+	var ts *timestamps
+	if ok {
+		ts = val.(*timestamps)
+	} else {
+		ts = newTimestamps(f.messages)
+		f.m.Store(eui, ts)
+	}
+
+	oldestTimestamp := ts.Append(now)
+	if !oldestTimestamp.IsZero() && now.Sub(oldestTimestamp) < f.threshold {
+		return errRateExceeded
+	}
+
+	// Continue filtering
+	if f.f != nil {
+		return f.f.Filter(packet)
+	}
+	return nil
+}

--- a/pkg/gatewayserver/io/udp/firewall_ratelimit_test.go
+++ b/pkg/gatewayserver/io/udp/firewall_ratelimit_test.go
@@ -1,0 +1,88 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package udp_test
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/pkg/errors"
+	. "go.thethings.network/lorawan-stack/pkg/gatewayserver/io/udp"
+	encoding "go.thethings.network/lorawan-stack/pkg/ttnpb/udp"
+	"go.thethings.network/lorawan-stack/pkg/types"
+	"go.thethings.network/lorawan-stack/pkg/util/test"
+	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
+)
+
+func TestRateLimitingFirewall(t *testing.T) {
+	ctx := test.Context()
+
+	eui1 := &types.EUI64{0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01}
+	eui2 := &types.EUI64{0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02}
+
+	t.Run("FloodCheck", func(t *testing.T) {
+		for _, tc := range []struct {
+			rateLimiting   bool
+			errorAssertion func(error) bool
+		}{
+			{
+				rateLimiting:   true,
+				errorAssertion: errors.IsResourceExhausted,
+			},
+			{
+				rateLimiting:   false,
+				errorAssertion: func(err error) bool { return err == nil },
+			},
+		} {
+			t.Run(fmt.Sprintf("RateLimiting=%v", tc.rateLimiting), func(t *testing.T) {
+				a := assertions.New(t)
+				f := NewMemoryFirewall(ctx, time.Hour)
+				if tc.rateLimiting {
+					f = NewRateLimitingFirewall(f, 3, time.Hour)
+				}
+
+				for i := 0; i < 4; i++ {
+					err := f.Filter(encoding.Packet{
+						GatewayEUI: eui1,
+						GatewayAddr: &net.UDPAddr{
+							IP:   []byte{0x03, 0x03, 0x03, 0x03},
+							Port: 3,
+						},
+						PacketType: encoding.PullData,
+					})
+
+					if i < 3 {
+						a.So(err, should.BeNil)
+					} else {
+						a.So(tc.errorAssertion(err), should.BeTrue)
+					}
+				}
+
+				// Ensure other gateways are not affected
+				a.So(f.Filter(encoding.Packet{
+					GatewayEUI: eui2,
+					GatewayAddr: &net.UDPAddr{
+						IP:   []byte{0x03, 0x03, 0x03, 0x04},
+						Port: 4,
+					},
+					PacketType: encoding.PullData,
+				}), should.BeNil)
+			})
+		}
+	})
+}

--- a/pkg/gatewayserver/io/udp/firewall_ratelimit_test.go
+++ b/pkg/gatewayserver/io/udp/firewall_ratelimit_test.go
@@ -73,6 +73,17 @@ func TestRateLimitingFirewall(t *testing.T) {
 					}
 				}
 
+				// Ensure filtering is not affected by port
+				err := f.Filter(encoding.Packet{
+					GatewayEUI: eui1,
+					GatewayAddr: &net.UDPAddr{
+						IP:   []byte{0x03, 0x03, 0x03, 0x03},
+						Port: 4,
+					},
+					PacketType: encoding.PullData,
+				})
+				a.So(tc.errorAssertion(err), should.BeTrue)
+
 				// Ensure other gateways are not affected
 				a.So(f.Filter(encoding.Packet{
 					GatewayEUI: eui2,

--- a/pkg/gatewayserver/io/udp/timestamps.go
+++ b/pkg/gatewayserver/io/udp/timestamps.go
@@ -1,0 +1,43 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package udp
+
+import (
+	"sync"
+	"time"
+)
+
+type timestamps struct {
+	position int
+	mu       sync.RWMutex
+	items    []time.Time
+}
+
+func newTimestamps(count int) *timestamps {
+	return &timestamps{
+		items: make([]time.Time, count),
+	}
+}
+
+// Append adds new timestamp and returns oldest.
+func (i *timestamps) Append(val time.Time) time.Time {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	result := i.items[i.position]
+	i.items[i.position] = val
+	i.position = (i.position + 1) % len(i.items)
+
+	return result
+}

--- a/pkg/gatewayserver/io/udp/timestamps_test.go
+++ b/pkg/gatewayserver/io/udp/timestamps_test.go
@@ -1,0 +1,42 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package udp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
+)
+
+func TestTimestamps(t *testing.T) {
+	a := assertions.New(t)
+
+	timestamps := newTimestamps(4)
+
+	ret := timestamps.Append(time.Now())
+	a.So(ret, should.BeZeroValue)
+	for i := 0; i < 3; i++ {
+		ret := timestamps.Append(time.Now().Add(time.Hour))
+		a.So(ret, should.BeZeroValue)
+	}
+
+	val := timestamps.Append(time.Now())
+	a.So(val.Before(time.Now()), should.BeTrue)
+
+	val = timestamps.Append(time.Now())
+	a.So(val.After(time.Now()), should.BeTrue)
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2079

#### Changes
<!-- What are the changes made in this pull request? -->

- Add a circular buffer of timestamps on UDP firewall per gateway
- Drop messages that exceed a specified rate limit.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- Naming is all over the place, please suggest better names where possible
- Current limits are hard-coded in the code. Should probably be GS configuration options?
- Relevant tests have been added.
- Circular buffer implementation is based on `./pkg/gatewayserver/rtts.go`. In this case, maybe mutexes are not required at all?

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [X] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
