### PR TITLE
Move config structs to appropriate packages

### DIFF
--- a/cmd/internal/shared/config.go
+++ b/cmd/internal/shared/config.go
@@ -17,6 +17,7 @@ package shared
 import (
 	"time"
 
+	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/redis"
@@ -43,7 +44,7 @@ var DefaultTLSConfig = config.TLS{
 }
 
 // DefaultClusterConfig is the default cluster configuration.
-var DefaultClusterConfig = config.Cluster{}
+var DefaultClusterConfig = cluster.Config{}
 
 // DefaultHTTPConfig is the default HTTP config.
 var DefaultHTTPConfig = config.HTTP{

--- a/cmd/internal/shared/config.go
+++ b/cmd/internal/shared/config.go
@@ -19,6 +19,7 @@ import (
 
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/log"
+	"go.thethings.network/lorawan-stack/pkg/redis"
 	"golang.org/x/crypto/acme"
 )
 
@@ -75,10 +76,10 @@ var DefaultGRPCConfig = config.GRPC{
 }
 
 // DefaultRedisConfig is the default config for Redis.
-var DefaultRedisConfig = config.Redis{
-	Address:   "localhost:6379",
-	Database:  0,
-	Namespace: []string{"ttn", "v3"},
+var DefaultRedisConfig = redis.Config{
+	Address:       "localhost:6379",
+	Database:      0,
+	RootNamespace: []string{"ttn", "v3"},
 }
 
 // DefaultEventsConfig is the default config for Events.

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -133,10 +133,7 @@ var startCommand = &cobra.Command{
 				return shared.ErrInitializeIdentityServer.WithCause(err)
 			}
 			if config.Cache.Service == "redis" {
-				is.SetRedisCache(redis.New(&redis.Config{
-					Redis:     config.Cache.Redis,
-					Namespace: []string{"is", "cache"},
-				}))
+				is.SetRedisCache(redis.New(config.Cache.Redis.WithNamespace("is", "cache")))
 			}
 			if oauthMount := config.IS.OAuth.UI.MountPath(); oauthMount != "/" {
 				rootRedirect = web.Redirect("/", http.StatusFound, oauthMount)
@@ -156,18 +153,17 @@ var startCommand = &cobra.Command{
 			redisConsumerGroup := "ns"
 
 			logger.Info("Setting up Network Server")
-			config.NS.ApplicationUplinks = nsredis.NewApplicationUplinkQueue(redis.New(&redis.Config{
-				Redis:     config.Redis,
-				Namespace: []string{"ns", "application-uplinks"},
-			}), 100, redisConsumerGroup, redisConsumerID)
-			config.NS.Devices = &nsredis.DeviceRegistry{Redis: redis.New(&redis.Config{
-				Redis:     config.Redis,
-				Namespace: []string{"ns", "devices"},
-			})}
-			nsDownlinkTasks := nsredis.NewDownlinkTaskQueue(redis.New(&redis.Config{
-				Redis:     config.Redis,
-				Namespace: []string{"ns", "tasks"},
-			}), 100000, redisConsumerGroup, redisConsumerID)
+			config.NS.ApplicationUplinks = nsredis.NewApplicationUplinkQueue(
+				redis.New(config.Redis.WithNamespace("ns", "application-uplinks")),
+				100, redisConsumerGroup, redisConsumerID,
+			)
+			config.NS.Devices = &nsredis.DeviceRegistry{
+				Redis: redis.New(config.Redis.WithNamespace("ns", "devices")),
+			}
+			nsDownlinkTasks := nsredis.NewDownlinkTaskQueue(
+				redis.New(config.Redis.WithNamespace("ns", "tasks")),
+				100000, redisConsumerGroup, redisConsumerID,
+			)
 			if err := nsDownlinkTasks.Init(); err != nil {
 				return shared.ErrInitializeNetworkServer.WithCause(err)
 			}
@@ -181,27 +177,22 @@ var startCommand = &cobra.Command{
 
 		if start.ApplicationServer || startDefault {
 			logger.Info("Setting up Application Server")
-			config.AS.Links = &asredis.LinkRegistry{Redis: redis.New(&redis.Config{
-				Redis:     config.Redis,
-				Namespace: []string{"as", "links"},
-			})}
-			config.AS.Devices = &asredis.DeviceRegistry{Redis: redis.New(&redis.Config{
-				Redis:     config.Redis,
-				Namespace: []string{"as", "devices"},
-			})}
-			config.AS.PubSub.Registry = &asiopsredis.PubSubRegistry{Redis: redis.New(&redis.Config{
-				Redis:     config.Redis,
-				Namespace: []string{"as", "io", "pubsub"},
-			})}
-			config.AS.ApplicationPackages.Registry = &asioapredis.ApplicationPackagesRegistry{Redis: redis.New(&redis.Config{
-				Redis:     config.Redis,
-				Namespace: []string{"as", "io", "applicationpackages"},
-			})}
+			config.AS.Links = &asredis.LinkRegistry{
+				Redis: redis.New(config.Redis.WithNamespace("as", "links")),
+			}
+			config.AS.Devices = &asredis.DeviceRegistry{
+				Redis: redis.New(config.Redis.WithNamespace("as", "devices")),
+			}
+			config.AS.PubSub.Registry = &asiopsredis.PubSubRegistry{
+				Redis: redis.New(config.Redis.WithNamespace("as", "io", "pubsub")),
+			}
+			config.AS.ApplicationPackages.Registry = &asioapredis.ApplicationPackagesRegistry{
+				Redis: redis.New(config.Redis.WithNamespace("as", "io", "applicationpackages")),
+			}
 			if config.AS.Webhooks.Target != "" {
-				config.AS.Webhooks.Registry = &asiowebredis.WebhookRegistry{Redis: redis.New(&redis.Config{
-					Redis:     config.Redis,
-					Namespace: []string{"as", "io", "webhooks"},
-				})}
+				config.AS.Webhooks.Registry = &asiowebredis.WebhookRegistry{
+					Redis: redis.New(config.Redis.WithNamespace("as", "io", "webhooks")),
+				}
 			}
 			as, err := applicationserver.New(c, &config.AS)
 			if err != nil {
@@ -212,14 +203,12 @@ var startCommand = &cobra.Command{
 
 		if start.JoinServer || startDefault {
 			logger.Info("Setting up Join Server")
-			config.JS.Devices = &jsredis.DeviceRegistry{Redis: redis.New(&redis.Config{
-				Redis:     config.Redis,
-				Namespace: []string{"js", "devices"},
-			})}
-			config.JS.Keys = &jsredis.KeyRegistry{Redis: redis.New(&redis.Config{
-				Redis:     config.Redis,
-				Namespace: []string{"js", "keys"},
-			})}
+			config.JS.Devices = &jsredis.DeviceRegistry{
+				Redis: redis.New(config.Redis.WithNamespace("js", "devices")),
+			}
+			config.JS.Keys = &jsredis.KeyRegistry{
+				Redis: redis.New(config.Redis.WithNamespace("js", "keys")),
+			}
 			js, err := joinserver.New(c, &config.JS)
 			if err != nil {
 				return shared.ErrInitializeJoinServer.WithCause(err)

--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -37,6 +37,7 @@ import (
 	iopubsubredis "go.thethings.network/lorawan-stack/pkg/applicationserver/io/pubsub/redis"
 	iowebredis "go.thethings.network/lorawan-stack/pkg/applicationserver/io/web/redis"
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/redis"
+	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
@@ -250,7 +251,7 @@ hardware_versions:
 			HTTP: config.HTTP{
 				Listen: ":8099",
 			},
-			Cluster: config.Cluster{
+			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 				JoinServer:     jsAddr,
 				NetworkServer:  nsAddr,

--- a/pkg/applicationserver/io/grpc/grpc_test.go
+++ b/pkg/applicationserver/io/grpc/grpc_test.go
@@ -25,6 +25,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io"
 	. "go.thethings.network/lorawan-stack/pkg/applicationserver/io/grpc"
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/mock"
+	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
@@ -58,7 +59,7 @@ func TestAuthentication(t *testing.T) {
 				Listen:                      ":0",
 				AllowInsecureForCredentials: true,
 			},
-			Cluster: config.Cluster{
+			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
 		},
@@ -143,7 +144,7 @@ func TestTraffic(t *testing.T) {
 				Listen:                      ":0",
 				AllowInsecureForCredentials: true,
 			},
-			Cluster: config.Cluster{
+			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
 		},
@@ -369,7 +370,7 @@ func TestMQTTConfig(t *testing.T) {
 				Listen:                      ":0",
 				AllowInsecureForCredentials: true,
 			},
-			Cluster: config.Cluster{
+			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
 		},

--- a/pkg/applicationserver/io/mqtt/mqtt_test.go
+++ b/pkg/applicationserver/io/mqtt/mqtt_test.go
@@ -26,6 +26,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io"
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/mock"
 	. "go.thethings.network/lorawan-stack/pkg/applicationserver/io/mqtt"
+	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
@@ -65,7 +66,7 @@ func TestAuthentication(t *testing.T) {
 				Listen:                      ":0",
 				AllowInsecureForCredentials: true,
 			},
-			Cluster: config.Cluster{
+			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
 		},
@@ -142,7 +143,7 @@ func TestTraffic(t *testing.T) {
 				Listen:                      ":0",
 				AllowInsecureForCredentials: true,
 			},
-			Cluster: config.Cluster{
+			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
 		},

--- a/pkg/applicationserver/io/packages/grpc_test.go
+++ b/pkg/applicationserver/io/packages/grpc_test.go
@@ -26,6 +26,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/mock"
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/packages"
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/packages/redis"
+	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
@@ -89,7 +90,7 @@ func TestAuthentication(t *testing.T) {
 				Listen:                      ":0",
 				AllowInsecureForCredentials: true,
 			},
-			Cluster: config.Cluster{
+			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
 		},
@@ -168,7 +169,7 @@ func TestAssociations(t *testing.T) {
 				Listen:                      ":0",
 				AllowInsecureForCredentials: true,
 			},
-			Cluster: config.Cluster{
+			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
 		},

--- a/pkg/applicationserver/io/pubsub/integrate_test.go
+++ b/pkg/applicationserver/io/pubsub/integrate_test.go
@@ -25,6 +25,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/pubsub/provider"
 	mock_provider "go.thethings.network/lorawan-stack/pkg/applicationserver/io/pubsub/provider/mock"
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/pubsub/redis"
+	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
@@ -87,7 +88,7 @@ func TestIntegrate(t *testing.T) {
 				Listen:                      ":9185",
 				AllowInsecureForCredentials: true,
 			},
-			Cluster: config.Cluster{
+			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
 		},

--- a/pkg/applicationserver/io/web/grpc_webhooks_test.go
+++ b/pkg/applicationserver/io/web/grpc_webhooks_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/web"
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/web/redis"
+	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
@@ -46,7 +47,7 @@ func TestWebhookRegistryRPC(t *testing.T) {
 				Listen:                      ":0",
 				AllowInsecureForCredentials: true,
 			},
-			Cluster: config.Cluster{
+			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
 		},

--- a/pkg/applicationserver/io/web/webhooks_test.go
+++ b/pkg/applicationserver/io/web/webhooks_test.go
@@ -29,6 +29,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/mock"
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/web"
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/io/web/redis"
+	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
@@ -343,7 +344,7 @@ func TestWebhooks(t *testing.T) {
 					Listen:                      ":0",
 					AllowInsecureForCredentials: true,
 				},
-				Cluster: config.Cluster{
+				Cluster: cluster.Config{
 					IdentityServer: isAddr,
 				},
 				HTTP: config.HTTP{

--- a/pkg/applicationserver/linking_test.go
+++ b/pkg/applicationserver/linking_test.go
@@ -24,6 +24,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/applicationserver"
 	"go.thethings.network/lorawan-stack/pkg/applicationserver/redis"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
+	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
@@ -67,7 +68,7 @@ func TestLink(t *testing.T) {
 
 	c := componenttest.NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
-			Cluster: config.Cluster{
+			Cluster: cluster.Config{
 				NetworkServer: nsAddr,
 			},
 			GRPC: config.GRPC{

--- a/pkg/cluster/auth_test.go
+++ b/pkg/cluster/auth_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/smartystreets/assertions/should"
 	clusterauth "go.thethings.network/lorawan-stack/pkg/auth/cluster"
 	. "go.thethings.network/lorawan-stack/pkg/cluster"
-	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/util/test"
@@ -37,7 +36,7 @@ func TestVerifySource(t *testing.T) {
 
 	key := []byte{0x2A, 0x9C, 0x2C, 0x3C, 0x2A, 0x9C, 0x2A, 0x9C, 0x2A, 0x9C, 0x2A, 0x9C, 0x2A, 0x9C, 0x2A, 0x9C}
 
-	c, err := New(ctx, &config.Cluster{
+	c, err := New(ctx, &Config{
 		Keys: []string{
 			hex.EncodeToString(key),
 		},

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/smartystreets/assertions"
 	. "go.thethings.network/lorawan-stack/pkg/cluster"
-	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/log"
 	"go.thethings.network/lorawan-stack/pkg/rpcmiddleware/rpclog"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
@@ -55,7 +54,7 @@ func TestCluster(t *testing.T) {
 
 	go grpc.NewServer().Serve(lis)
 
-	config := config.Cluster{
+	config := Config{
 		Address:           lis.Addr().String(),
 		IdentityServer:    lis.Addr().String(),
 		GatewayServer:     lis.Addr().String(),

--- a/pkg/component/cluster_test.go
+++ b/pkg/component/cluster_test.go
@@ -49,7 +49,7 @@ func TestPeers(t *testing.T) {
 	var c *component.Component
 
 	config := &component.Config{
-		ServiceBase: config.ServiceBase{Cluster: config.Cluster{
+		ServiceBase: config.ServiceBase{Cluster: cluster.Config{
 			Name:          "test-cluster",
 			NetworkServer: lis.Addr().String(),
 			TLS:           false,

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -60,7 +60,7 @@ type Component struct {
 	logger log.Stack
 
 	cluster    cluster.Cluster
-	clusterNew func(ctx context.Context, config *config.Cluster, options ...cluster.Option) (cluster.Cluster, error)
+	clusterNew func(ctx context.Context, config *cluster.Config, options ...cluster.Option) (cluster.Cluster, error)
 
 	grpc           *rpcserver.Server
 	grpcSubsystems []rpcserver.Registerer
@@ -95,7 +95,7 @@ type Option func(*Component)
 // setting up the cluster.
 // This allows extending the cluster configuration with custom logic based on
 // information in the context.
-func WithClusterNew(f func(ctx context.Context, config *config.Cluster, options ...cluster.Option) (cluster.Cluster, error)) Option {
+func WithClusterNew(f func(ctx context.Context, config *cluster.Config, options ...cluster.Option) (cluster.Cluster, error)) Option {
 	return func(c *Component) {
 		c.clusterNew = f
 	}

--- a/pkg/component/grpc_test.go
+++ b/pkg/component/grpc_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware"
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/smartystreets/assertions"
 	clusterauth "go.thethings.network/lorawan-stack/pkg/auth/cluster"
 	"go.thethings.network/lorawan-stack/pkg/cluster"
@@ -82,7 +82,7 @@ func TestHooks(t *testing.T) {
 	defer lis.Close()
 
 	config := &component.Config{
-		ServiceBase: config.ServiceBase{Cluster: config.Cluster{
+		ServiceBase: config.ServiceBase{Cluster: cluster.Config{
 			Name:          "test-cluster",
 			NetworkServer: lis.Addr().String(),
 			Keys:          []string{clusterKey},

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -28,6 +28,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/fetch"
 	"go.thethings.network/lorawan-stack/pkg/log"
+	"go.thethings.network/lorawan-stack/pkg/redis"
 	"gocloud.dev/blob"
 )
 
@@ -116,30 +117,6 @@ type HTTP struct {
 	Health          Health           `name:"health"`
 }
 
-// RedisFailover represents Redis failover configuration.
-type RedisFailover struct {
-	Enable     bool     `name:"enable" description:"Enable failover using Redis Sentinel"`
-	Addresses  []string `name:"addresses" description:"Redis Sentinel server addresses"`
-	MasterName string   `name:"master-name" description:"Redis Sentinel master name"`
-}
-
-// Redis represents Redis configuration.
-type Redis struct {
-	Address   string        `name:"address" description:"Address of the Redis server"`
-	Password  string        `name:"password" description:"Password of the Redis server"`
-	Database  int           `name:"database" description:"Redis database to use"`
-	Namespace []string      `name:"namespace" description:"Namespace for Redis keys"`
-	PoolSize  int           `name:"pool-size" description:"The maximum number of database connections"`
-	Failover  RedisFailover `name:"failover" description:"Redis failover configuration"`
-}
-
-// IsZero returns whether the Redis configuration is empty.
-func (r Redis) IsZero() bool {
-	return r.Database == 0 && len(r.Namespace) == 0 &&
-		(r.Failover.Enable && r.Failover.MasterName == "" && len(r.Failover.Addresses) == 0 ||
-			!r.Failover.Enable && r.Address == "")
-}
-
 // CloudEvents represents configuration for the cloud events backend.
 type CloudEvents struct {
 	PublishURL   string `name:"publish-url" description:"URL for the topic to send events"`
@@ -148,15 +125,15 @@ type CloudEvents struct {
 
 // Cache represents configuration for a caching system.
 type Cache struct {
-	Service string `name:"service" description:"Service used for caching (redis)"`
-	Redis   Redis  `name:"redis"`
+	Service string       `name:"service" description:"Service used for caching (redis)"`
+	Redis   redis.Config `name:"redis"`
 }
 
 // Events represents configuration for the events system.
 type Events struct {
-	Backend string      `name:"backend" description:"Backend to use for events (internal, redis, cloud)"`
-	Redis   Redis       `name:"redis"`
-	Cloud   CloudEvents `name:"cloud"`
+	Backend string       `name:"backend" description:"Backend to use for events (internal, redis, cloud)"`
+	Redis   redis.Config `name:"redis"`
+	Cloud   CloudEvents  `name:"cloud"`
 }
 
 // Rights represents the configuration to apply when fetching entity rights.
@@ -443,7 +420,7 @@ type ServiceBase struct {
 	Base             `name:",squash"`
 	Cluster          Cluster                `name:"cluster"`
 	Cache            Cache                  `name:"cache"`
-	Redis            Redis                  `name:"redis"`
+	Redis            redis.Config           `name:"redis"`
 	Events           Events                 `name:"events"`
 	GRPC             GRPC                   `name:"grpc"`
 	HTTP             HTTP                   `name:"http"`

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	ttnblob "go.thethings.network/lorawan-stack/pkg/blob"
+	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/crypto"
 	"go.thethings.network/lorawan-stack/pkg/crypto/cryptoutil"
 	"go.thethings.network/lorawan-stack/pkg/errors"
@@ -46,21 +47,6 @@ type Log struct {
 // Sentry represents configuration for error tracking using Sentry.
 type Sentry struct {
 	DSN string `name:"dsn" description:"Sentry Data Source Name"`
-}
-
-// Cluster represents clustering configuration.
-type Cluster struct {
-	Join              []string `name:"join" description:"Addresses of cluster peers to join"`
-	Name              string   `name:"name" description:"Name of the current cluster peer (default: $HOSTNAME)"`
-	Address           string   `name:"address" description:"Address to use for cluster communication"`
-	IdentityServer    string   `name:"identity-server" description:"Address for the Identity Server"`
-	GatewayServer     string   `name:"gateway-server" description:"Address for the Gateway Server"`
-	NetworkServer     string   `name:"network-server" description:"Address for the Network Server"`
-	ApplicationServer string   `name:"application-server" description:"Address for the Application Server"`
-	JoinServer        string   `name:"join-server" description:"Address for the Join Server"`
-	CryptoServer      string   `name:"crypto-server" description:"Address for the Crypto Server"`
-	TLS               bool     `name:"tls" description:"Do cluster gRPC over TLS"`
-	Keys              []string `name:"keys" description:"Keys used to communicate between components of the cluster. The first one will be used by the cluster to identify itself"`
 }
 
 // GRPC represents gRPC listener configuration.
@@ -418,7 +404,7 @@ type InteropServer struct {
 // ServiceBase represents base service configuration.
 type ServiceBase struct {
 	Base             `name:",squash"`
-	Cluster          Cluster                `name:"cluster"`
+	Cluster          cluster.Config         `name:"cluster"`
 	Cache            Cache                  `name:"cache"`
 	Redis            redis.Config           `name:"redis"`
 	Events           Events                 `name:"events"`

--- a/pkg/encoding/lorawan/lorawan_test.go
+++ b/pkg/encoding/lorawan/lorawan_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/smartystreets/assertions"
+	_ "go.thethings.network/lorawan-stack/pkg/crypto" // Needed to make the populators work.
 	. "go.thethings.network/lorawan-stack/pkg/encoding/lorawan"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"

--- a/pkg/events/redis/redis_test.go
+++ b/pkg/events/redis/redis_test.go
@@ -21,21 +21,21 @@ import (
 	"time"
 
 	"github.com/smartystreets/assertions"
-	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/events"
 	"go.thethings.network/lorawan-stack/pkg/events/redis"
+	ttnredis "go.thethings.network/lorawan-stack/pkg/redis"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/util/test"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 )
 
 // redisConfig returns a new redis config for testing
-func redisConfig() config.Redis {
+func redisConfig() ttnredis.Config {
 	var err error
-	config := config.Redis{
-		Address:   "localhost:6379",
-		Database:  1,
-		Namespace: []string{"test"},
+	config := ttnredis.Config{
+		Address:       "localhost:6379",
+		Database:      1,
+		RootNamespace: []string{"test"},
 	}
 	if address := os.Getenv("REDIS_ADDRESS"); address != "" {
 		config.Address = address
@@ -47,14 +47,14 @@ func redisConfig() config.Redis {
 		}
 	}
 	if prefix := os.Getenv("REDIS_PREFIX"); prefix != "" {
-		config.Namespace = []string{prefix}
+		config.RootNamespace = []string{prefix}
 	}
 	return config
 }
 
 func Example() {
 	// This sends all events received from Redis to the default pubsub.
-	redisPubSub := redis.WrapPubSub(events.DefaultPubSub(), config.Redis{
+	redisPubSub := redis.WrapPubSub(events.DefaultPubSub(), ttnredis.Config{
 		// Config here...
 	})
 	// Replace the default pubsub so that we will now publish to Redis.

--- a/pkg/gatewayconfigurationserver/gatewayconfigurationserver_test.go
+++ b/pkg/gatewayconfigurationserver/gatewayconfigurationserver_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/auth/rights"
+	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
@@ -90,7 +91,7 @@ func TestWeb(t *testing.T) {
 				Listen: httpAddress,
 			},
 			FrequencyPlans: fpConf,
-			Cluster: config.Cluster{
+			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
 		},

--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -26,7 +26,8 @@ import (
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/gorilla/websocket"
 	"github.com/smartystreets/assertions"
-	"go.thethings.network/lorawan-stack/pkg/auth/cluster"
+	clusterauth "go.thethings.network/lorawan-stack/pkg/auth/cluster"
+	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
@@ -77,7 +78,7 @@ func TestGatewayServer(t *testing.T) {
 				Listen:                      ":9187",
 				AllowInsecureForCredentials: true,
 			},
-			Cluster: config.Cluster{
+			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 				NetworkServer:  nsAddr,
 			},
@@ -933,7 +934,7 @@ func TestGatewayServer(t *testing.T) {
 				})
 
 				t.Run("Downstream", func(t *testing.T) {
-					ctx := cluster.NewContext(test.Context(), nil)
+					ctx := clusterauth.NewContext(test.Context(), nil)
 					downlinkCount := 0
 					for _, tc := range []struct {
 						Name                     string

--- a/pkg/gatewayserver/io/basicstationlns/basicstationlns_test.go
+++ b/pkg/gatewayserver/io/basicstationlns/basicstationlns_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/basicstation"
+	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
@@ -78,7 +79,7 @@ func TestClientTokenAuth(t *testing.T) {
 				Listen:                      ":0",
 				AllowInsecureForCredentials: true,
 			},
-			Cluster: config.Cluster{
+			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
 		},
@@ -182,7 +183,7 @@ func TestDiscover(t *testing.T) {
 				Listen:                      ":0",
 				AllowInsecureForCredentials: true,
 			},
-			Cluster: config.Cluster{
+			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
 		},
@@ -420,7 +421,7 @@ func TestVersion(t *testing.T) {
 				Listen:                      ":0",
 				AllowInsecureForCredentials: true,
 			},
-			Cluster: config.Cluster{
+			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
 		},
@@ -681,7 +682,7 @@ func TestTraffic(t *testing.T) {
 				Listen:                      ":0",
 				AllowInsecureForCredentials: true,
 			},
-			Cluster: config.Cluster{
+			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
 		},
@@ -1013,7 +1014,7 @@ func TestRTT(t *testing.T) {
 				Listen:                      ":0",
 				AllowInsecureForCredentials: true,
 			},
-			Cluster: config.Cluster{
+			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
 		},
@@ -1290,7 +1291,7 @@ func TestPingPong(t *testing.T) {
 				Listen:                      ":0",
 				AllowInsecureForCredentials: true,
 			},
-			Cluster: config.Cluster{
+			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
 		},

--- a/pkg/gatewayserver/io/grpc/grpc_test.go
+++ b/pkg/gatewayserver/io/grpc/grpc_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
@@ -63,7 +64,7 @@ func TestAuthentication(t *testing.T) {
 				Listen:                      ":0",
 				AllowInsecureForCredentials: true,
 			},
-			Cluster: config.Cluster{
+			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
 		},
@@ -159,7 +160,7 @@ func TestTraffic(t *testing.T) {
 				Listen:                      ":0",
 				AllowInsecureForCredentials: true,
 			},
-			Cluster: config.Cluster{
+			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
 		},
@@ -478,7 +479,7 @@ func TestConcentratorConfig(t *testing.T) {
 				Listen:                      ":0",
 				AllowInsecureForCredentials: true,
 			},
-			Cluster: config.Cluster{
+			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
 		},
@@ -531,7 +532,7 @@ func TestMQTTConfig(t *testing.T) {
 				Listen:                      ":0",
 				AllowInsecureForCredentials: true,
 			},
-			Cluster: config.Cluster{
+			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
 		},

--- a/pkg/gatewayserver/io/mqtt/mqtt_test.go
+++ b/pkg/gatewayserver/io/mqtt/mqtt_test.go
@@ -24,6 +24,7 @@ import (
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/gogo/protobuf/proto"
 	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
@@ -63,7 +64,7 @@ func TestAuthentication(t *testing.T) {
 				Listen:                      ":0",
 				AllowInsecureForCredentials: true,
 			},
-			Cluster: config.Cluster{
+			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
 		},
@@ -141,7 +142,7 @@ func TestTraffic(t *testing.T) {
 				Listen:                      ":0",
 				AllowInsecureForCredentials: true,
 			},
-			Cluster: config.Cluster{
+			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
 		},

--- a/pkg/gatewayserver/upstream/ns/ns_test.go
+++ b/pkg/gatewayserver/upstream/ns/ns_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/band"
+	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
 	"go.thethings.network/lorawan-stack/pkg/config"
@@ -46,7 +47,7 @@ func TestNSHandler(t *testing.T) {
 				Listen:                      ":0",
 				AllowInsecureForCredentials: true,
 			},
-			Cluster: config.Cluster{
+			Cluster: cluster.Config{
 				NetworkServer: nsAddr,
 			},
 		},

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -30,7 +30,6 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
-	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/crypto"
 	"go.thethings.network/lorawan-stack/pkg/encoding/lorawan"
 	"go.thethings.network/lorawan-stack/pkg/errors"
@@ -6408,7 +6407,7 @@ func TestGenerateDownlink(t *testing.T) {
 			c := component.MustNew(
 				log.Noop,
 				&component.Config{},
-				component.WithClusterNew(func(context.Context, *config.Cluster, ...cluster.Option) (cluster.Cluster, error) {
+				component.WithClusterNew(func(context.Context, *cluster.Config, ...cluster.Option) (cluster.Cluster, error) {
 					return &test.MockCluster{
 						JoinFunc: test.ClusterJoinNilFunc,
 					}, nil

--- a/pkg/networkserver/networkserver_util_test.go
+++ b/pkg/networkserver/networkserver_util_test.go
@@ -29,7 +29,6 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/cluster"
 	"go.thethings.network/lorawan-stack/pkg/component"
 	componenttest "go.thethings.network/lorawan-stack/pkg/component/test"
-	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/crypto"
 	"go.thethings.network/lorawan-stack/pkg/events"
 	"go.thethings.network/lorawan-stack/pkg/frequencyplans"
@@ -1312,7 +1311,7 @@ func StartTest(t *testing.T, conf Config, timeout time.Duration, stubDeduplicati
 		componenttest.NewComponent(
 			t,
 			&component.Config{},
-			component.WithClusterNew(func(context.Context, *config.Cluster, ...cluster.Option) (cluster.Cluster, error) {
+			component.WithClusterNew(func(context.Context, *cluster.Config, ...cluster.Option) (cluster.Cluster, error) {
 				return &test.MockCluster{
 					AuthFunc:    test.MakeClusterAuthChFunc(authCh),
 					GetPeerFunc: test.MakeClusterGetPeerChFunc(getPeerCh),

--- a/pkg/ttnpb/populate_test.go
+++ b/pkg/ttnpb/populate_test.go
@@ -1,0 +1,21 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ttnpb_test
+
+import (
+	// These imports are needed to make the populators work.
+	_ "go.thethings.network/lorawan-stack/pkg/crypto"
+	_ "go.thethings.network/lorawan-stack/pkg/encoding/lorawan"
+)

--- a/pkg/util/test/redis.go
+++ b/pkg/util/test/redis.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/go-redis/redis"
 	ulid "github.com/oklog/ulid/v2"
-	"go.thethings.network/lorawan-stack/pkg/config"
 	ttnredis "go.thethings.network/lorawan-stack/pkg/redis"
 )
 
@@ -46,21 +45,18 @@ func NewRedis(t testing.TB, namespace ...string) (*ttnredis.Client, func()) {
 		panic("New called outside test")
 	}
 
-	conf := &ttnredis.Config{
-		Redis: config.Redis{
-			Address:   defaultAddress,
-			Database:  defaultDatabase,
-			Namespace: defaultNamespace[:],
-		},
-		Namespace: append(append([]string{ulid.MustNew(ulid.Now(), Randy).String()}, namespace...), t.Name()),
-	}
+	conf := ttnredis.Config{
+		Address:       defaultAddress,
+		Database:      defaultDatabase,
+		RootNamespace: defaultNamespace[:],
+	}.WithNamespace(append(append([]string{ulid.MustNew(ulid.Now(), Randy).String()}, namespace...), t.Name())...)
 
 	if addr := os.Getenv("REDIS_ADDRESS"); addr != "" {
-		conf.Redis.Address = addr
+		conf.Address = addr
 	}
 	if db := os.Getenv("REDIS_DB"); db != "" {
 		var err error
-		conf.Redis.Database, err = strconv.Atoi(db)
+		conf.Database, err = strconv.Atoi(db)
 		if err != nil {
 			t.Fatalf("Expected REDIS_DB to be an integer, got `%s`", db)
 			return nil, nil


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR moves the Redis and Cluster config structs to their respective packages in order to avoid import cycles.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
