### PR TITLE
Do not convert context errors

### DIFF
--- a/pkg/identityserver/store/store.go
+++ b/pkg/identityserver/store/store.go
@@ -95,8 +95,9 @@ var (
 var uniqueViolationRegex = regexp.MustCompile(`duplicate key value \(([^)]+)\)=\(([^)]+)\)`)
 
 func convertError(err error) error {
-	if err == nil {
-		return nil
+	switch err {
+	case nil, context.Canceled, context.DeadlineExceeded:
+		return err
 	}
 	if ttnErr, ok := errors.From(err); ok {
 		return ttnErr


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quickfix for the Identity Server. Previously, context errors (canceled, timeout) were wrapped in database errors. Now they're forwarded as-is.
