### PR TITLE
Fix missing total count header when listing authorizations

### DIFF
--- a/pkg/identityserver/store/oauth_store.go
+++ b/pkg/identityserver/store/oauth_store.go
@@ -245,6 +245,7 @@ func (s *oauthStore) ListAccessTokens(ctx context.Context, userIDs *ttnpb.UserId
 	if err != nil {
 		return nil, err
 	}
+	setTotal(ctx, uint64(len(tokenModels)))
 	tokenProtos := make([]*ttnpb.OAuthAccessToken, len(tokenModels))
 	for i, tokenModel := range tokenModels {
 		tokenProto := tokenModel.toPB()

--- a/pkg/identityserver/store/oauth_store.go
+++ b/pkg/identityserver/store/oauth_store.go
@@ -50,6 +50,7 @@ func (s *oauthStore) ListAuthorizations(ctx context.Context, userIDs *ttnpb.User
 	if err != nil {
 		return nil, err
 	}
+	setTotal(ctx, uint64(len(authModels)))
 	authProtos := make([]*ttnpb.OAuthClientAuthorization, len(authModels))
 	for i, authModel := range authModels {
 		authProto := authModel.toPB()


### PR DESCRIPTION
#### Summary
This quickfix resolves the total count header always being `0` for the list authorizations RPC.

#### Changes
- Add `setTotal()` function to `ListAuthorizations` handler

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
