### PR TITLE
Do not warn about EOF errors in MQTT

### DIFF
--- a/pkg/applicationserver/io/mqtt/mqtt.go
+++ b/pkg/applicationserver/io/mqtt/mqtt.go
@@ -73,7 +73,9 @@ func (s *srv) accept() error {
 			ctx := log.NewContextWithFields(s.ctx, log.Fields("remote_addr", mqttConn.RemoteAddr().String()))
 			conn := &connection{server: s.server, mqtt: mqttConn, format: s.format}
 			if err := conn.setup(ctx); err != nil {
-				log.FromContext(ctx).WithError(err).Warn("Failed to setup connection")
+				if err != stdio.EOF {
+					log.FromContext(ctx).WithError(err).Warn("Failed to setup connection")
+				}
 				mqttConn.Close()
 				return
 			}

--- a/pkg/gatewayserver/io/mqtt/mqtt.go
+++ b/pkg/gatewayserver/io/mqtt/mqtt.go
@@ -70,7 +70,9 @@ func (s *srv) accept() error {
 			ctx := log.NewContextWithFields(s.ctx, log.Fields("remote_addr", mqttConn.RemoteAddr().String()))
 			conn := &connection{server: s.server, mqtt: mqttConn, format: s.format}
 			if err := conn.setup(ctx); err != nil {
-				log.FromContext(ctx).WithError(err).Warn("Failed to setup connection")
+				if err != stdio.EOF {
+					log.FromContext(ctx).WithError(err).Warn("Failed to setup connection")
+				}
 				mqttConn.Close()
 				return
 			}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quickfix that bypasses the WARN log when an MQTT client closes the connection.