### PR TITLE
Gateway Server ignores cache options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Network and Application Servers now maintain application downlink queue per-session.
 - Gateway Server skips setting up an upstream if the DevAddr prefixes to forward are empty.
-- Gateway connection stats are stored in Redis (see `--gs.update-connections-stats-debounce-time` option).
+- Gateway connection stats are now cached in Redis (see `--cache.service` and `--gs.update-connections-stats-debounce-time` options).
 
 ### Deprecated
 

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -143,8 +143,11 @@ var startCommand = &cobra.Command{
 
 		if start.GatewayServer || startDefault {
 			logger.Info("Setting up Gateway Server")
-			config.GS.Stats = &gsredis.GatewayConnectionStatsRegistry{
-				Redis: redis.New(config.Cache.Redis.WithNamespace("gs", "connection", "stats")),
+			switch config.Cache.Service {
+			case "redis":
+				config.GS.Stats = &gsredis.GatewayConnectionStatsRegistry{
+					Redis: redis.New(config.Cache.Redis.WithNamespace("gs", "cache", "connstats")),
+				}
 			}
 			gs, err := gatewayserver.New(c, &config.GS)
 			if err != nil {

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -447,8 +447,9 @@ func (gs *GatewayServer) Connect(ctx context.Context, frontend io.Frontend, ids 
 	registerGatewayConnect(ctx, ids, frontend.Protocol())
 	logger.Info("Connected")
 	go gs.handleUpstream(connEntry)
-	go gs.updateConnStats(connEntry)
-
+	if gs.statsRegistry != nil {
+		go gs.updateConnStats(connEntry)
+	}
 	if gtw.UpdateLocationFromStatus {
 		go gs.handleLocationUpdates(connEntry)
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2100

#### Changes
<!-- What are the changes made in this pull request? -->

- Gateway Server only uses the Redis cache if the cache service is configured to Redis 

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [X] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
