### PR TITLE
Fix external JS check for end devices in Console

### DIFF
--- a/pkg/webui/console/views/device-general-settings/index.js
+++ b/pkg/webui/console/views/device-general-settings/index.js
@@ -24,9 +24,10 @@ import diff from '../../../lib/diff'
 import Breadcrumb from '../../../components/breadcrumbs/breadcrumb'
 import { withBreadcrumb } from '../../../components/breadcrumbs/context'
 import IntlHelmet from '../../../lib/components/intl-helmet'
+import getHostnameFromUrl from '../../../lib/host-from-url'
 import PropTypes from '../../../lib/prop-types'
-import api from '../../api'
 import toast from '../../../components/toast'
+import api from '../../api'
 
 import { updateDevice } from '../../store/actions/devices'
 import { attachPromise } from '../../store/actions/lib'
@@ -53,14 +54,6 @@ import NetworkServerForm from './network-server-form'
 import Collapse from './collapse'
 
 import style from './device-general-settings.styl'
-
-const getComponentBaseUrl = config => {
-  try {
-    const { base_url } = config
-
-    return new URL(base_url).hostname
-  } catch (e) {}
-}
 
 @connect(
   state => ({
@@ -185,9 +178,9 @@ export default class DeviceGeneralSettings extends React.Component {
 
     const isOTAA = isDeviceOTAA(device)
     const { enabled: isEnabled } = isConfig
-    const { enabled: asEnabled } = asConfig
-    const { enabled: jsEnabled } = jsConfig
-    const { enabled: nsEnabled } = nsConfig
+    const { enabled: asEnabled, base_url: stackAsUrl } = asConfig
+    const { enabled: jsEnabled, base_url: stackJsUrl } = jsConfig
+    const { enabled: nsEnabled, base_url: stackNsUrl } = nsConfig
 
     // 1. Disable the section if IS is not in cluster.
     const isDisabled = !isEnabled
@@ -200,7 +193,7 @@ export default class DeviceGeneralSettings extends React.Component {
     // 2. Disable the section if the device is OTAA and joined since no fields are stored in the AS.
     // 3. Disable the section if NS is not in cluster, since activation mode is unknown.
     // 4. Disable the seciton if `application_server_address` is not equal to the cluster AS address.
-    const sameAsAddress = getComponentBaseUrl(asConfig) === device.application_server_address
+    const sameAsAddress = getHostnameFromUrl(stackAsUrl) === device.application_server_address
     const isJoined = isDeviceJoined(device)
     const asDisabled = !asEnabled || (isOTAA && !isJoined) || !nsEnabled || !sameAsAddress
     let asDescription = m.asDescription
@@ -218,7 +211,7 @@ export default class DeviceGeneralSettings extends React.Component {
     // 2. Disable the section if the device is ABP/Multicast, since JS does not store ABP/Multicast
     // devices.
     // 3. Disable the seciton if `join_server_address` is not equal to the cluster JS address.
-    const sameJsAddress = getComponentBaseUrl(jsConfig) === device.join_server_address
+    const sameJsAddress = getHostnameFromUrl(stackJsUrl) === device.join_server_address
     const jsDisabled = !jsEnabled || !isOTAA || !sameJsAddress
     let jsDescription = m.jsDescription
     if (!jsEnabled) {
@@ -231,7 +224,7 @@ export default class DeviceGeneralSettings extends React.Component {
 
     // 1. Disable the section if NS is not in cluster.
     // 2. Disable the seciton if `network_server_address` is not equal to the cluster NS address.
-    const sameNsAddress = getComponentBaseUrl(nsConfig) === device.network_server_address
+    const sameNsAddress = getHostnameFromUrl(stackNsUrl) === device.network_server_address
     const nsDisabled = !nsEnabled || !sameNsAddress
     let nsDescription = m.nsDescription
     if (!nsEnabled) {

--- a/pkg/webui/console/views/device-general-settings/utils.js
+++ b/pkg/webui/console/views/device-general-settings/utils.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import { selectJsConfig } from '../../../lib/selectors/env'
+import getHostnameFromUrl from '../../../lib/host-from-url'
 
 const lwRegexp = /^[1-9].[0-9].[0-9]$/
 const lwCache = {}
@@ -75,20 +76,17 @@ export const isDeviceABP = device =>
 export const isDeviceMulticast = device => Boolean(device) && Boolean(device.multicast)
 
 /**
- * Returns whether device keys are provisioned on external join server. Note: It is possible
- * to create end devices with root keys being provisioned by an external Join Server.
- * In this case both `root_keys.nwk_key` and `root_keys.app_key` must be missing in the payload.
+ * Returns whether an end device is provisioned on an external join server.
  * @param {Object} device - The device object.
- * @returns {boolean} `true` if device keys are provisioned on an external join server, `false` otherwise.
+ * @returns {boolean} `true` if the end device is provisioned on an external join server, `false` otherwise.
  */
 export const hasExternalJs = device => {
-  const jsEnabled = selectJsConfig().enabled
-  const noRootKeys =
-    Boolean(device) &&
-    (!Boolean(device.root_keys) || !Boolean(Object.keys(device.root_keys).length))
+  const { enabled, base_url } = selectJsConfig()
 
-  // If Join Server is not available then `root_keys` wont be in the device payload.
-  return jsEnabled && noRootKeys
+  const deviceJs = device.join_server_address
+  const stackJs = getHostnameFromUrl(base_url)
+
+  return !enabled || typeof deviceJs === 'undefined' || deviceJs !== stackJs
 }
 
 export const isDeviceJoined = device =>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/2039
This PR fixes the way we check for devices registered on an external join server. Previously we checked for the root keys, however checking for addresses is more robust way to determine if the device is not in cluster JS. This fixes issues for users with only `RIGHT_APPLICATION_DEVICES_WRITE_KEYS` right, so they can still view JS related fields except for keys.

#### Changes
<!-- What are the changes made in this pull request? -->

- Check for addresses instead of root keys
- Use `host-from-url` utility in the device general settings view

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The main issue here is that otaa devices:
1. Can be registered on an external join server, which means that the cluster js (if exists) doesnt have the entry for the device (even if it has, we ignore it in the Console). With this PR we handle this case
2. Can have root keys provisioned by an external join server, which means that the cluster can have the entry for the device without the keys. Unexposed root keys are handler in the join server form of the device general settings separately.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
