### PR TITLE
gs: Only update statistics for new traffic

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -3662,6 +3662,24 @@
       "file": "io.go"
     }
   },
+  "error:pkg/gatewayserver/redis:invalid_stats": {
+    "translations": {
+      "en": "invalid `{type}` stats in store"
+    },
+    "description": {
+      "package": "pkg/gatewayserver/redis",
+      "file": "registry.go"
+    }
+  },
+  "error:pkg/gatewayserver/redis:stats_not_found": {
+    "translations": {
+      "en": "gateway stats not found"
+    },
+    "description": {
+      "package": "pkg/gatewayserver/redis",
+      "file": "registry.go"
+    }
+  },
   "error:pkg/gatewayserver/scheduling:conflict": {
     "translations": {
       "en": "scheduling conflict"

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -653,19 +653,24 @@ func (gs *GatewayServer) handleUpstream(conn connectionEntry) {
 	}
 }
 
-// UpdateConnectionStats updates the stats for a single gateway connection.
-func (gs *GatewayServer) UpdateConnectionStats(ctx context.Context, conn *io.Connection) error {
-	return gs.statsRegistry.Set(ctx, conn.Gateway().GatewayIdentifiers, conn.Stats())
-}
-
 func (gs *GatewayServer) updateConnStats(conn connectionEntry) {
 	ctx := conn.Context()
 	logger := log.FromContext(ctx)
 
+	// Initial dummy update, so that gateway appears connected
+	if err := gs.UpdateConnectionStats(conn.Connection, false, false, true); err != nil {
+		logger.WithError(err).Error("Failed to initialize connection stats")
+	}
+
+	var (
+		lastUpdateUp, lastUpdateDown, lastUpdateStatus time.Time
+		newUp, newDown, newStatus                      bool
+	)
+
 	defer func() {
 		logger.Debug("Delete connection stats")
-		err := gs.statsRegistry.Set(ctx, conn.Gateway().GatewayIdentifiers, nil)
-		if err != nil {
+
+		if err := gs.ClearConnectionStats(conn.Connection, newUp, newDown, true); err != nil {
 			logger.WithError(err).Error("Failed to delete connection stats")
 		}
 	}()
@@ -674,17 +679,31 @@ func (gs *GatewayServer) updateConnStats(conn connectionEntry) {
 		case <-ctx.Done():
 			return
 		case <-conn.StatsChanged():
-			err := gs.UpdateConnectionStats(ctx, conn.Connection)
-			if err != nil {
-				logger.WithError(err).Error("Failed to update connection stats")
-			}
+		}
 
-			timeout := time.After(gs.updateConnectionStatsDebounceTime)
-			select {
-			case <-ctx.Done():
-				return
-			case <-timeout:
-			}
+		stats := conn.Stats()
+		if stats.LastUplinkReceivedAt != nil && stats.LastUplinkReceivedAt.After(lastUpdateUp) {
+			newUp = true
+			lastUpdateUp = *stats.LastUplinkReceivedAt
+		}
+		if stats.LastDownlinkReceivedAt != nil && stats.LastDownlinkReceivedAt.After(lastUpdateDown) {
+			newDown = true
+			lastUpdateDown = *stats.LastDownlinkReceivedAt
+		}
+		if stats.LastStatusReceivedAt != nil && stats.LastStatusReceivedAt.After(lastUpdateStatus) {
+			newStatus = true
+			lastUpdateStatus = *stats.LastStatusReceivedAt
+		}
+
+		if err := gs.UpdateConnectionStats(conn.Connection, newUp, newDown, newStatus); err != nil {
+			logger.WithError(err).Error("Failed to update connection stats")
+		}
+
+		timeout := time.After(gs.updateConnectionStatsDebounceTime)
+		select {
+		case <-ctx.Done():
+			return
+		case <-timeout:
 		}
 	}
 }
@@ -831,4 +850,14 @@ func recoverHandler(ctx context.Context) error {
 		return err
 	}
 	return nil
+}
+
+// UpdateConnectionStats updates the connection stats for a gateway
+func (gs *GatewayServer) UpdateConnectionStats(conn *io.Connection, up, down, status bool) error {
+	return gs.statsRegistry.Set(conn.Context(), conn.Gateway().GatewayIdentifiers, conn.Stats(), up, down, status)
+}
+
+// ClearConnectionStats clears the connection stats for a gateway
+func (gs *GatewayServer) ClearConnectionStats(conn *io.Connection, up, down, status bool) error {
+	return gs.statsRegistry.Set(conn.Context(), conn.Gateway().GatewayIdentifiers, nil, up, down, status)
 }

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -313,6 +313,8 @@ func (c *Connection) SendDown(msg *ttnpb.DownlinkMessage) error {
 	case c.downCh <- msg:
 		atomic.AddUint64(&c.downlinks, 1)
 		atomic.StoreInt64(&c.lastDownlinkTime, time.Now().UnixNano())
+
+		c.notifyStatsChanged()
 	default:
 		return errBufferFull.New()
 	}

--- a/pkg/gatewayserver/redis/registry.go
+++ b/pkg/gatewayserver/redis/registry.go
@@ -16,7 +16,10 @@ package redis
 
 import (
 	"context"
+	"runtime/trace"
 
+	"github.com/go-redis/redis"
+	"go.thethings.network/lorawan-stack/pkg/errors"
 	ttnredis "go.thethings.network/lorawan-stack/pkg/redis"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/pkg/unique"
@@ -27,28 +30,94 @@ type GatewayConnectionStatsRegistry struct {
 	Redis *ttnredis.Client
 }
 
-func (r *GatewayConnectionStatsRegistry) key(uid string) string {
-	return r.Redis.Key("uid", uid)
+var (
+	down            = "down"
+	up              = "up"
+	status          = "status"
+	errNotFound     = errors.DefineNotFound("stats_not_found", "gateway stats not found")
+	errInvalidStats = errors.DefineCorruption("invalid_stats", "invalid `{type}` stats in store")
+)
+
+func (r *GatewayConnectionStatsRegistry) key(which string, uid string) string {
+	return r.Redis.Key(which, "uid", uid)
 }
 
 // Set sets or clears the connection stats for a gateway.
-func (r *GatewayConnectionStatsRegistry) Set(ctx context.Context, ids ttnpb.GatewayIdentifiers, stats *ttnpb.GatewayConnectionStats) error {
+func (r *GatewayConnectionStatsRegistry) Set(ctx context.Context, ids ttnpb.GatewayIdentifiers, stats *ttnpb.GatewayConnectionStats, updateUp bool, updateDown bool, updateStatus bool) error {
 	uid := unique.ID(ctx, ids)
-	if stats == nil {
-		return r.Redis.Del(r.key(uid)).Err()
-	}
 
-	_, err := ttnredis.SetProto(r.Redis, r.key(uid), stats, 0)
-	return err
+	defer trace.StartRegion(ctx, "set gateway connection stats").End()
+
+	_, err := r.Redis.Pipelined(func(p redis.Pipeliner) error {
+		for _, this := range []struct {
+			key    string
+			update bool
+		}{
+			{r.key(up, uid), updateUp},
+			{r.key(down, uid), updateDown},
+			{r.key(status, uid), updateStatus},
+		} {
+			if this.update {
+				if stats == nil {
+					p.Del(this.key)
+				} else {
+					ttnredis.SetProto(p, this.key, stats, 0)
+				}
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		return ttnredis.ConvertError(err)
+	}
+	return nil
 }
 
 // Get returns the connection stats for a gateway.
 func (r *GatewayConnectionStatsRegistry) Get(ctx context.Context, ids ttnpb.GatewayIdentifiers) (*ttnpb.GatewayConnectionStats, error) {
 	uid := unique.ID(ctx, ids)
+	result := &ttnpb.GatewayConnectionStats{}
 	stats := &ttnpb.GatewayConnectionStats{}
-	err := ttnredis.GetProto(r.Redis, r.key(uid)).ScanProto(stats)
+
+	retrieved, err := r.Redis.MGet(r.key(up, uid), r.key(down, uid), r.key(status, uid)).Result()
 	if err != nil {
-		stats = nil
+		return nil, ttnredis.ConvertError(err)
 	}
-	return stats, err
+
+	if retrieved[0] == nil && retrieved[1] == nil && retrieved[2] == nil {
+		return nil, errNotFound
+	}
+
+	// Retrieve uplink stats.
+	if retrieved[0] != nil {
+		if err = ttnredis.UnmarshalProto(retrieved[0].(string), stats); err != nil {
+			return nil, errInvalidStats.WithAttributes("type", "uplink").WithCause(err)
+		}
+		result.LastUplinkReceivedAt = stats.LastUplinkReceivedAt
+		result.UplinkCount = stats.UplinkCount
+		result.RoundTripTimes = stats.RoundTripTimes
+	}
+
+	// Retrieve downlink stats.
+	if retrieved[1] != nil {
+		if err = ttnredis.UnmarshalProto(retrieved[1].(string), stats); err != nil {
+			return nil, errInvalidStats.WithAttributes("type", "downlink").WithCause(err)
+		}
+		result.LastDownlinkReceivedAt = stats.LastDownlinkReceivedAt
+		result.DownlinkCount = stats.DownlinkCount
+	}
+
+	// Retrieve gateway status.
+	if retrieved[2] != nil {
+		if err = ttnredis.UnmarshalProto(retrieved[2].(string), stats); err != nil {
+			return nil, errInvalidStats.WithAttributes("type", "status").WithCause(err)
+		}
+		result.ConnectedAt = stats.ConnectedAt
+		result.Protocol = stats.Protocol
+		result.LastStatus = stats.LastStatus
+		result.LastStatusReceivedAt = stats.LastStatusReceivedAt
+	}
+
+	return result, nil
 }

--- a/pkg/gatewayserver/redis/registry_test.go
+++ b/pkg/gatewayserver/redis/registry_test.go
@@ -1,0 +1,252 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redis
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mohae/deepcopy"
+	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/pkg/errors"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/pkg/types"
+	"go.thethings.network/lorawan-stack/pkg/util/test"
+	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
+)
+
+var (
+	Timeout = 10 * test.Delay
+)
+
+func TestRegistry(t *testing.T) {
+	a := assertions.New(t)
+
+	ctx := test.Context()
+
+	cl, flush := test.NewRedis(t, "redis_test")
+	defer flush()
+	defer cl.Close()
+
+	ids := ttnpb.GatewayIdentifiers{
+		GatewayID: "gtw1",
+		EUI:       &types.EUI64{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+	}
+	ids2 := ttnpb.GatewayIdentifiers{
+		GatewayID: "gtw2",
+		EUI:       &types.EUI64{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+	}
+	ids3 := ttnpb.GatewayIdentifiers{
+		GatewayID: "gtw3",
+		EUI:       &types.EUI64{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02},
+	}
+	registry := &GatewayConnectionStatsRegistry{
+		Redis: cl,
+	}
+
+	now := time.Now().UTC()
+	initialStats := &ttnpb.GatewayConnectionStats{
+		ConnectedAt:            &now,
+		Protocol:               "dummy",
+		LastDownlinkReceivedAt: &now,
+		DownlinkCount:          1,
+		LastUplinkReceivedAt:   &now,
+		UplinkCount:            1,
+		LastStatusReceivedAt:   nil,
+		LastStatus:             nil,
+	}
+
+	emptyStats := &ttnpb.GatewayConnectionStats{
+		ConnectedAt:          &now,
+		Protocol:             "dummy",
+		LastStatusReceivedAt: nil,
+		LastStatus:           nil,
+	}
+
+	t.Run("GetNonExisting", func(t *testing.T) {
+		stats, err := registry.Get(ctx, ids)
+		a.So(stats, should.BeNil)
+		a.So(errors.IsNotFound(err), should.BeTrue)
+	})
+
+	t.Run("EmptyStats", func(t *testing.T) {
+		err := registry.Set(ctx, ids3, emptyStats, false, false, false)
+		a.So(err, should.BeNil)
+		retrieved, err := registry.Get(ctx, ids3)
+		a.So(retrieved, should.BeNil)
+		a.So(errors.IsNotFound(err), should.BeTrue)
+	})
+
+	t.Run("SetAndClear", func(t *testing.T) {
+		err := registry.Set(ctx, ids, initialStats, true, true, true)
+		a.So(err, should.BeNil)
+		retrieved, err := registry.Get(ctx, ids)
+		a.So(err, should.BeNil)
+		a.So(retrieved, should.Resemble, initialStats)
+
+		// Other gateways not affected
+		stats, err := registry.Get(ctx, ids2)
+		a.So(stats, should.BeNil)
+		a.So(errors.IsNotFound(err), should.BeTrue)
+
+		// Unset
+		err = registry.Set(ctx, ids, nil, true, true, true)
+		a.So(err, should.BeNil)
+		retrieved, err = registry.Get(ctx, ids)
+		a.So(errors.IsNotFound(err), should.BeTrue)
+		a.So(retrieved, should.BeNil)
+	})
+
+	t.Run("ClearManyTimes", func(t *testing.T) {
+		a.So(registry.Set(ctx, ids, nil, true, true, true), should.BeNil)
+		a.So(registry.Set(ctx, ids, nil, true, true, true), should.BeNil)
+	})
+
+	t.Run("UpdateUplink", func(t *testing.T) {
+		now := time.Now().UTC().Add(time.Minute)
+		stats := deepcopy.Copy(initialStats).(*ttnpb.GatewayConnectionStats)
+
+		// Update uplink stats, make sure they work
+		stats.UplinkCount = 10
+		stats.LastUplinkReceivedAt = &now
+		err := registry.Set(ctx, ids, stats, true, true, true)
+		a.So(err, should.BeNil)
+		retrieved, err := registry.Get(ctx, ids)
+		a.So(err, should.BeNil)
+		a.So(retrieved, should.Resemble, stats)
+
+		// Keep a copy of the uplink stats
+		correct := deepcopy.Copy(stats)
+
+		// Update downlink stats as well, expect no change
+		stats.DownlinkCount += 100
+		err = registry.Set(ctx, ids, stats, true, false, false)
+		a.So(err, should.BeNil)
+		retrieved, err = registry.Get(ctx, ids)
+		a.So(err, should.BeNil)
+		a.So(retrieved, should.Resemble, correct)
+
+		// Now update downlink also
+		stats.LastDownlinkReceivedAt = &now
+		err = registry.Set(ctx, ids, stats, true, true, false)
+		a.So(err, should.BeNil)
+		retrieved, err = registry.Get(ctx, ids)
+		a.So(err, should.BeNil)
+		a.So(retrieved, should.Resemble, stats)
+
+		// Unset uplink
+		stats.LastUplinkReceivedAt = nil
+		stats.UplinkCount = 0
+		err = registry.Set(ctx, ids, nil, true, false, false)
+		a.So(err, should.BeNil)
+		retrieved, err = registry.Get(ctx, ids)
+		a.So(err, should.BeNil)
+		a.So(retrieved, should.Resemble, stats)
+	})
+
+	t.Run("UpdateDownlink", func(t *testing.T) {
+		now := time.Now().UTC().Add(2 * time.Minute)
+		stats := deepcopy.Copy(initialStats).(*ttnpb.GatewayConnectionStats)
+
+		// Reset stats from previous test
+		a.So(registry.Set(ctx, ids, nil, true, true, true), should.BeNil)
+		a.So(registry.Set(ctx, ids, stats, true, true, true), should.BeNil)
+		retrieved, err := registry.Get(ctx, ids)
+		a.So(err, should.BeNil)
+		a.So(retrieved, should.Resemble, stats)
+
+		// Update downlink stats, make sure they work
+		stats.DownlinkCount = 10
+		stats.LastDownlinkReceivedAt = &now
+		err = registry.Set(ctx, ids, stats, false, true, false)
+		a.So(err, should.BeNil)
+		retrieved, err = registry.Get(ctx, ids)
+		a.So(err, should.BeNil)
+		a.So(retrieved, should.Resemble, stats)
+
+		// Keep a copy of the dowlink stats
+		correct := deepcopy.Copy(stats)
+
+		// Update uplink stats as well, expect no change
+		stats.UplinkCount += 100
+		err = registry.Set(ctx, ids, stats, false, true, false)
+		a.So(err, should.BeNil)
+		retrieved, err = registry.Get(ctx, ids)
+		a.So(err, should.BeNil)
+		a.So(retrieved, should.Resemble, correct)
+
+		// Now update uplink also
+		err = registry.Set(ctx, ids, stats, true, true, false)
+		a.So(err, should.BeNil)
+		retrieved, err = registry.Get(ctx, ids)
+		a.So(err, should.BeNil)
+		a.So(retrieved, should.Resemble, stats)
+
+		// Unset downlink
+		stats.LastDownlinkReceivedAt = nil
+		stats.DownlinkCount = 0
+		err = registry.Set(ctx, ids, nil, false, true, false)
+		a.So(err, should.BeNil)
+		retrieved, err = registry.Get(ctx, ids)
+		a.So(err, should.BeNil)
+		a.So(retrieved, should.Resemble, stats)
+	})
+
+	t.Run("UpdateStats", func(t *testing.T) {
+		now := time.Now().UTC().Add(3 * time.Minute)
+		stats := deepcopy.Copy(initialStats).(*ttnpb.GatewayConnectionStats)
+
+		// Reset stats from previous test
+		a.So(registry.Set(ctx, ids, nil, true, true, true), should.BeNil)
+		a.So(registry.Set(ctx, ids, stats, true, true, true), should.BeNil)
+		retrieved, err := registry.Get(ctx, ids)
+		a.So(err, should.BeNil)
+		a.So(retrieved, should.Resemble, stats)
+
+		// Update status
+		stats.LastStatusReceivedAt = &now
+		stats.LastStatus = &ttnpb.GatewayStatus{
+			IP:   []string{"10.10.10.10"},
+			Time: now,
+			Metrics: map[string]float32{
+				"a": 3.22,
+				"b": 3.42,
+			},
+		}
+
+		// Keep correct stats
+		correct := deepcopy.Copy(stats).(*ttnpb.GatewayConnectionStats)
+
+		// Mess with the uplink and downlink stats
+		stats.UplinkCount += 100
+		stats.DownlinkCount += 1000
+
+		// Update gateway status only
+		err = registry.Set(ctx, ids, stats, false, false, true)
+		a.So(err, should.BeNil)
+		retrieved, err = registry.Get(ctx, ids)
+		a.So(err, should.BeNil)
+		a.So(retrieved, should.Resemble, correct)
+
+		// Now update uplink and downlink
+		stats.LastUplinkReceivedAt = &now
+		stats.LastDownlinkReceivedAt = &now
+		err = registry.Set(ctx, ids, stats, true, true, true)
+		a.So(err, should.BeNil)
+		retrieved, err = registry.Get(ctx, ids)
+		a.So(err, should.BeNil)
+		a.So(retrieved, should.Resemble, stats)
+	})
+}

--- a/pkg/gatewayserver/registry.go
+++ b/pkg/gatewayserver/registry.go
@@ -24,6 +24,6 @@ import (
 type GatewayConnectionStatsRegistry interface {
 	// Get returns connection stats for a gateway.
 	Get(ctx context.Context, ids ttnpb.GatewayIdentifiers) (*ttnpb.GatewayConnectionStats, error)
-	// Set updates the connection stats for a gateway.
-	Set(ctx context.Context, ids ttnpb.GatewayIdentifiers, stats *ttnpb.GatewayConnectionStats) error
+	// Set sets or clears the connection stats for a gateway.
+	Set(ctx context.Context, ids ttnpb.GatewayIdentifiers, stats *ttnpb.GatewayConnectionStats, up, down, status bool) error
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Original issue: https://github.com/TheThingsIndustries/lorawan-stack/issues/1949

#### Changes
<!-- What are the changes made in this pull request? -->

- `GatewayConnectionStatsRegistry.Set()` only updates the relevant stats and does not overwrite the other values.
- Also added a forgotten `notifyStatsChanged()` called when sending downlinks

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
