### PR TITLE
Clean byte input value in onBlur handler

### DIFF
--- a/pkg/webui/components/input/byte.js
+++ b/pkg/webui/components/input/byte.js
@@ -63,6 +63,7 @@ export default class ByteInput extends React.Component {
     className: PropTypes.string,
     max: PropTypes.number,
     min: PropTypes.number,
+    onBlur: PropTypes.func,
     onChange: PropTypes.func.isRequired,
     placeholder: PropTypes.message,
     showPerChar: PropTypes.bool,
@@ -75,6 +76,7 @@ export default class ByteInput extends React.Component {
     max: 256,
     placeholder: undefined,
     showPerChar: false,
+    onBlur: () => null,
   }
 
   input = React.createRef()
@@ -86,7 +88,17 @@ export default class ByteInput extends React.Component {
   }
 
   render() {
-    const { value, className, min, max, onChange, placeholder, showPerChar, ...rest } = this.props
+    const {
+      onBlur,
+      value,
+      className,
+      min,
+      max,
+      onChange,
+      placeholder,
+      showPerChar,
+      ...rest
+    } = this.props
 
     return (
       <MaskedInput
@@ -102,6 +114,7 @@ export default class ByteInput extends React.Component {
         placeholder={placeholder}
         onCopy={this.onCopy}
         onCut={this.onCut}
+        onBlur={this.onBlur}
         showMask={!placeholder}
         {...rest}
       />
@@ -127,6 +140,15 @@ export default class ByteInput extends React.Component {
   @bind
   onChange(evt) {
     this.props.onChange({
+      target: {
+        value: clean(evt.target.value),
+      },
+    })
+  }
+
+  @bind
+  onBlur(evt) {
+    this.props.onBlur({
       target: {
         value: clean(evt.target.value),
       },


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR makes sure that the value passed to `onBlur` is cleaned from the mask in the `<Byte />` component. 

#### Changes
<!-- What are the changes made in this pull request? -->

- Clean `evt.target.value` in `onBlur` from placeholder characters

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This will improve ux of field validations for all empty byte inputs without placeholder text provided. 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
