### PR TITLE
Require key read rights on key set

### DIFF
--- a/pkg/applicationserver/grpc_deviceregistry.go
+++ b/pkg/applicationserver/grpc_deviceregistry.go
@@ -123,6 +123,13 @@ func (r asEndDeviceRegistryServer) Set(ctx context.Context, req *ttnpb.SetEndDev
 		return nil, err
 	}
 	if ttnpb.HasAnyField(req.FieldMask.Paths,
+		"session.keys.session_key_id",
+	) {
+		if err := rights.RequireApplication(ctx, req.EndDevice.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_DEVICES_WRITE_KEYS); err != nil {
+			return nil, err
+		}
+	}
+	if ttnpb.HasAnyField(req.FieldMask.Paths,
 		"pending_session.keys.app_s_key.encrypted_key",
 		"pending_session.keys.app_s_key.kek_label",
 		"pending_session.keys.app_s_key.key",
@@ -130,9 +137,8 @@ func (r asEndDeviceRegistryServer) Set(ctx context.Context, req *ttnpb.SetEndDev
 		"session.keys.app_s_key.encrypted_key",
 		"session.keys.app_s_key.kek_label",
 		"session.keys.app_s_key.key",
-		"session.keys.session_key_id",
 	) {
-		if err := rights.RequireApplication(ctx, req.EndDevice.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_DEVICES_WRITE_KEYS); err != nil {
+		if err := rights.RequireApplication(ctx, req.EndDevice.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_DEVICES_READ_KEYS, ttnpb.RIGHT_APPLICATION_DEVICES_WRITE_KEYS); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/joinserver/grpc_deviceregistry.go
+++ b/pkg/joinserver/grpc_deviceregistry.go
@@ -183,15 +183,21 @@ func (srv jsEndDeviceRegistryServer) Set(ctx context.Context, req *ttnpb.SetEndD
 		return nil, err
 	}
 	if ttnpb.HasAnyField(req.FieldMask.Paths,
+		"root_keys.root_key_id",
+	) {
+		if err := rights.RequireApplication(ctx, req.EndDevice.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_DEVICES_WRITE_KEYS); err != nil {
+			return nil, err
+		}
+	}
+	if ttnpb.HasAnyField(req.FieldMask.Paths,
 		"root_keys.app_key.encrypted_key",
 		"root_keys.app_key.kek_label",
 		"root_keys.app_key.key",
 		"root_keys.nwk_key.encrypted_key",
 		"root_keys.nwk_key.kek_label",
 		"root_keys.nwk_key.key",
-		"root_keys.root_key_id",
 	) {
-		if err := rights.RequireApplication(ctx, req.EndDevice.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_DEVICES_WRITE_KEYS); err != nil {
+		if err := rights.RequireApplication(ctx, req.EndDevice.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_DEVICES_READ_KEYS, ttnpb.RIGHT_APPLICATION_DEVICES_WRITE_KEYS); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/joinserver/grpc_deviceregistry_test.go
+++ b/pkg/joinserver/grpc_deviceregistry_test.go
@@ -707,6 +707,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 					ApplicationRights: map[string]*ttnpb.Rights{
 						unique.ID(test.Context(), ttnpb.ApplicationIdentifiers{ApplicationID: registeredApplicationID}): ttnpb.RightsFrom(
 							ttnpb.RIGHT_APPLICATION_DEVICES_WRITE,
+							ttnpb.RIGHT_APPLICATION_DEVICES_READ_KEYS,
 							ttnpb.RIGHT_APPLICATION_DEVICES_WRITE_KEYS,
 						),
 					},

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -251,6 +251,15 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 		return nil, err
 	}
 	if ttnpb.HasAnyField(req.FieldMask.Paths,
+		"mac_state.queued_join_accept.keys.session_key_id",
+		"pending_session.keys.session_key_id",
+		"session.keys.session_key_id",
+	) {
+		if err = rights.RequireApplication(ctx, req.EndDevice.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_DEVICES_WRITE_KEYS); err != nil {
+			return nil, err
+		}
+	}
+	if ttnpb.HasAnyField(req.FieldMask.Paths,
 		"mac_state.queued_join_accept.keys.app_s_key.encrypted_key",
 		"mac_state.queued_join_accept.keys.app_s_key.kek_label",
 		"mac_state.queued_join_accept.keys.app_s_key.key",
@@ -263,7 +272,6 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 		"mac_state.queued_join_accept.keys.s_nwk_s_int_key.encrypted_key",
 		"mac_state.queued_join_accept.keys.s_nwk_s_int_key.kek_label",
 		"mac_state.queued_join_accept.keys.s_nwk_s_int_key.key",
-		"mac_state.queued_join_accept.keys.session_key_id",
 		"pending_session.keys.f_nwk_s_int_key.encrypted_key",
 		"pending_session.keys.f_nwk_s_int_key.kek_label",
 		"pending_session.keys.f_nwk_s_int_key.key",
@@ -273,7 +281,6 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 		"pending_session.keys.s_nwk_s_int_key.encrypted_key",
 		"pending_session.keys.s_nwk_s_int_key.kek_label",
 		"pending_session.keys.s_nwk_s_int_key.key",
-		"pending_session.keys.session_key_id",
 		"session.keys.f_nwk_s_int_key.encrypted_key",
 		"session.keys.f_nwk_s_int_key.kek_label",
 		"session.keys.f_nwk_s_int_key.key",
@@ -283,9 +290,8 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 		"session.keys.s_nwk_s_int_key.encrypted_key",
 		"session.keys.s_nwk_s_int_key.kek_label",
 		"session.keys.s_nwk_s_int_key.key",
-		"session.keys.session_key_id",
 	) {
-		if err = rights.RequireApplication(ctx, req.EndDevice.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_DEVICES_WRITE_KEYS); err != nil {
+		if err = rights.RequireApplication(ctx, req.EndDevice.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_DEVICES_READ_KEYS, ttnpb.RIGHT_APPLICATION_DEVICES_WRITE_KEYS); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/networkserver/grpc_deviceregistry_test.go
+++ b/pkg/networkserver/grpc_deviceregistry_test.go
@@ -747,6 +747,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 						unique.ID(test.Context(), ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"}): {
 							Rights: []ttnpb.Right{
 								ttnpb.RIGHT_APPLICATION_DEVICES_WRITE,
+								ttnpb.RIGHT_APPLICATION_DEVICES_READ_KEYS,
 								ttnpb.RIGHT_APPLICATION_DEVICES_WRITE_KEYS,
 							},
 						},
@@ -938,6 +939,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 						unique.ID(test.Context(), ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"}): {
 							Rights: []ttnpb.Right{
 								ttnpb.RIGHT_APPLICATION_DEVICES_WRITE,
+								ttnpb.RIGHT_APPLICATION_DEVICES_READ_KEYS,
 								ttnpb.RIGHT_APPLICATION_DEVICES_WRITE_KEYS,
 							},
 						},
@@ -1119,6 +1121,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 						unique.ID(test.Context(), ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"}): {
 							Rights: []ttnpb.Right{
 								ttnpb.RIGHT_APPLICATION_DEVICES_WRITE,
+								ttnpb.RIGHT_APPLICATION_DEVICES_READ_KEYS,
 								ttnpb.RIGHT_APPLICATION_DEVICES_WRITE_KEYS,
 							},
 						},


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/2102

#### Changes
<!-- What are the changes made in this pull request? -->

- Check for key read rights when setting keys in registries

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.