### PR TITLE
Fix device creation for users w/o RIGHT_APPLICATION_DEVICES_WRITE_KEYS right

### DIFF
--- a/pkg/webui/console/components/device-data-form/validation-schema.js
+++ b/pkg/webui/console/components/device-data-form/validation-schema.js
@@ -16,13 +16,10 @@ import * as Yup from 'yup'
 
 import sharedMessages from '../../../lib/shared-messages'
 import { id as deviceIdRegexp, address as addressRegexp } from '../../lib/regexp'
-import randomByteString from '../../lib/random-bytes'
 import m from './messages'
 
-const random16BytesString = () => randomByteString(32)
 const isABP = mode => mode === 'abp'
 const isOTAA = mode => mode === 'otaa'
-const toUndefined = value => (!Boolean(value) ? undefined : value)
 
 const validationSchema = Yup.object({
   name: Yup.string()
@@ -92,27 +89,19 @@ const validationSchema = Yup.object({
       (mode, externalJs, mayEditKeys, schema) => {
         if (isOTAA(mode) && !externalJs && mayEditKeys) {
           return schema.shape({
-            nwk_key: Yup.lazy(
-              value =>
-                value !== undefined
-                  ? Yup.object().shape({
-                      key: Yup.string()
-                        .emptyOrLength(16 * 2, m.validate32) // 16 Byte hex
-                        .transform(toUndefined)
-                        .default(random16BytesString),
-                    })
-                  : Yup.object().strip(), // Avoid generating when key is unexposed
+            nwk_key: Yup.lazy(value =>
+              Boolean(value) && Boolean(value.key)
+                ? Yup.object().shape({
+                    key: Yup.string().emptyOrLength(16 * 2, m.validate32), // 16 Byte hex
+                  })
+                : Yup.object().strip(),
             ),
-            app_key: Yup.lazy(
-              value =>
-                value !== undefined
-                  ? Yup.object().shape({
-                      key: Yup.string()
-                        .emptyOrLength(16 * 2, m.validate32) // 16 Byte hex
-                        .transform(toUndefined)
-                        .default(random16BytesString),
-                    })
-                  : Yup.object().strip(), // Avoid generating when key is unexposed
+            app_key: Yup.lazy(value =>
+              Boolean(value) && Boolean(value.key)
+                ? Yup.object().shape({
+                    key: Yup.string().emptyOrLength(16 * 2, m.validate32), // 16 Byte hex
+                  })
+                : Yup.object().strip(),
             ),
           })
         }
@@ -163,17 +152,20 @@ const validationSchema = Yup.object({
           keys: Yup.object().shape({
             f_nwk_s_int_key: Yup.object().shape({
               key: Yup.string()
-                .emptyOrLength(16 * 2, m.validate32) // 16 Byte hex
-                .transform(toUndefined)
-                .default(random16BytesString),
+                .length(16 * 2, m.validate32) // 16 Byte hex
+                .required(sharedMessages.validateRequired),
+            }),
+            app_s_key: Yup.object().shape({
+              key: Yup.string()
+                .length(16 * 2, m.validate32) // 16 Byte hex
+                .required(sharedMessages.validateRequired),
             }),
             s_nwk_s_int_key: Yup.lazy(() =>
               isNewVersion
                 ? Yup.object().shape({
                     key: Yup.string()
-                      .emptyOrLength(16 * 2, m.validate32) // 16 Byte hex
-                      .transform(toUndefined)
-                      .default(random16BytesString),
+                      .length(16 * 2, m.validate32) // 16 Byte hex
+                      .required(sharedMessages.validateRequired),
                   })
                 : Yup.object().strip(),
             ),
@@ -181,18 +173,11 @@ const validationSchema = Yup.object({
               isNewVersion
                 ? Yup.object().shape({
                     key: Yup.string()
-                      .emptyOrLength(16 * 2, m.validate32) // 16 Byte hex
-                      .transform(toUndefined)
-                      .default(random16BytesString),
+                      .length(16 * 2, m.validate32) // 16 Byte hex
+                      .required(sharedMessages.validateRequired),
                   })
                 : Yup.object().strip(),
             ),
-            app_s_key: Yup.object().shape({
-              key: Yup.string()
-                .emptyOrLength(16 * 2, m.validate32) // 16 Byte hex
-                .transform(toUndefined)
-                .default(random16BytesString),
-            }),
           }),
         })
       }

--- a/pkg/webui/console/views/device-add/index.js
+++ b/pkg/webui/console/views/device-add/index.js
@@ -26,11 +26,14 @@ import sharedMessages from '../../../lib/shared-messages'
 import { selectSelectedApplicationId } from '../../store/selectors/applications'
 import { getDeviceId } from '../../../lib/selectors/id'
 import PropTypes from '../../../lib/prop-types'
+import { mayEditApplicationDeviceKeys, checkFromState } from '../../lib/feature-checks'
+
 import api from '../../api'
 
 @connect(
   state => ({
     appId: selectSelectedApplicationId(state),
+    mayEditKeys: checkFromState(mayEditApplicationDeviceKeys, state),
   }),
   dispatch => ({
     redirectToList: (appId, deviceId) =>
@@ -44,16 +47,16 @@ import api from '../../api'
 export default class DeviceAdd extends Component {
   static propTypes = {
     appId: PropTypes.string.isRequired,
+    mayEditKeys: PropTypes.bool.isRequired,
     redirectToList: PropTypes.func.isRequired,
   }
 
   @bind
-  async handleSubmit(values) {
+  async handleSubmit(device) {
     const { appId } = this.props
-    const { activation_mode, ...device } = values
 
     return api.device.create(appId, device, {
-      otaa: activation_mode === 'otaa',
+      otaa: device.supports_join,
     })
   }
 
@@ -66,6 +69,8 @@ export default class DeviceAdd extends Component {
   }
 
   render() {
+    const { mayEditKeys } = this.props
+
     return (
       <Container>
         <PageTitle title={sharedMessages.addDevice} />
@@ -74,6 +79,7 @@ export default class DeviceAdd extends Component {
             <DeviceDataForm
               onSubmit={this.handleSubmit}
               onSubmitSuccess={this.handleSubmitSuccess}
+              mayEditKeys={mayEditKeys}
             />
           </Col>
         </Row>

--- a/pkg/webui/console/views/device-overview/index.js
+++ b/pkg/webui/console/views/device-overview/index.js
@@ -125,12 +125,14 @@ class DeviceOverview extends React.Component {
           ]
         } else {
           infoEntry.subItems = [
-            {
-              key: sharedMessages.appKey,
-              value: root_keys.app_key.key,
-              type: 'byte',
-              sensitive: true,
-            },
+            ...(root_keys.app_key
+              ? {
+                  key: sharedMessages.appKey,
+                  value: root_keys.app_key.key,
+                  type: 'byte',
+                  sensitive: true,
+                }
+              : { key: sharedMessages.appKey, value: undefined }),
             ...(root_keys.nwk_key
               ? {
                   key: sharedMessages.nwkKey,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes behavior of the Device Add page for users without the right to set device keys.
Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/2039

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove update logic from `<DeviceDataForm />` since now the general settings page does not use this form 
- Disable the ABP option if the user has no write right on the keys, see https://github.com/TheThingsNetwork/lorawan-stack/issues/2039#issuecomment-596673714
- Do not validate/send `root_keys` if the user has no write right on the keys
- Remove automatic generation of keys if left empty, explicitly force users to generate the keys if needed
- Fix the device overview page in case `app_key` is not set

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

~~See also https://github.com/TheThingsNetwork/lorawan-stack/pull/2116, this improves ux when editing the abp section~~

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
