### PR TITLE
Include pending downlink queue in invalidation

### DIFF
--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -1151,6 +1151,7 @@ func (ns *NetworkServer) handleJoinRequest(ctx context.Context, up *ttnpb.Uplink
 		[]string{
 			"frequency_plan_id",
 			"lorawan_phy_version",
+			"pending_session.queued_application_downlinks",
 			"recent_uplinks",
 			"session.queued_application_downlinks",
 		},
@@ -1159,7 +1160,7 @@ func (ns *NetworkServer) handleJoinRequest(ctx context.Context, up *ttnpb.Uplink
 				logger.Warn("Device deleted during join-request handling, drop")
 				return nil, nil, errOutdatedData
 			}
-			invalidatedQueue = stored.GetSession().GetQueuedApplicationDownlinks()
+			invalidatedQueue = append(stored.GetSession().GetQueuedApplicationDownlinks(), stored.GetPendingSession().GetQueuedApplicationDownlinks()...)
 			stored.PendingMACState = macState
 			stored.RecentUplinks = appendRecentUplink(stored.RecentUplinks, up, recentUplinkCount)
 			return stored, []string{

--- a/pkg/networkserver/grpc_gsns_test.go
+++ b/pkg/networkserver/grpc_gsns_test.go
@@ -153,6 +153,7 @@ func TestHandleUplink(t *testing.T) {
 	joinSetByIDGetPaths := [...]string{
 		"frequency_plan_id",
 		"lorawan_phy_version",
+		"pending_session.queued_application_downlinks",
 		"queued_application_downlinks",
 		"recent_uplinks",
 		"session.queued_application_downlinks",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #1954 

#### Changes
<!-- What are the changes made in this pull request? -->

- Include the pending session queue in NS queue invalidation

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Reported by @adriansmares 
Testing will be covered in #2110 due to uplink test refactor.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
