### PR TITLE
Fix creating 1.0.4 ABP devices in the Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Telemetry and events for gateway statuses.
 - Handling of downlink frame counters exceeding 65535.
+- Creating 1.0.4 ABP end devices via the Console.
 
 ### Security
 

--- a/pkg/webui/console/components/device-data-form/index.js
+++ b/pkg/webui/console/components/device-data-form/index.js
@@ -146,11 +146,22 @@ class DeviceDataForm extends Component {
   get ABPSection() {
     const { resets_f_cnt, lorawan_version } = this.state
 
-    const isNewVersion =
-      Boolean(lorawan_version) && parseInt(lorawan_version.replace(/\D/g, '').padEnd(3, 0)) >= 110
+    const lwVersion = Boolean(lorawan_version)
+      ? parseInt(lorawan_version.replace(/\D/g, '').padEnd(3, 0))
+      : 0
 
     return (
       <>
+        <Form.Field
+          title={sharedMessages.devEUI}
+          name="ids.dev_eui"
+          type="byte"
+          min={8}
+          max={8}
+          description={m.deviceEUIDescription}
+          required={lwVersion === 104}
+          component={Input}
+        />
         <DevAddrInput
           title={sharedMessages.devAddr}
           name="session.dev_addr"
@@ -180,7 +191,7 @@ class DeviceDataForm extends Component {
           onGenerateValue={random16BytesString}
           required
         />
-        {isNewVersion && (
+        {lwVersion >= 110 && (
           <>
             <Form.Field
               title={sharedMessages.sNwkSIKey}

--- a/pkg/webui/console/views/device-overview/index.js
+++ b/pkg/webui/console/views/device-overview/index.js
@@ -57,6 +57,7 @@ class DeviceOverview extends React.Component {
       root_keys = {},
       session = {},
       created_at,
+      supports_join,
     } = this.props.device
 
     // Get session keys
@@ -144,7 +145,7 @@ class DeviceOverview extends React.Component {
           ]
         }
         activationInfoData.items.push(infoEntry)
-      } else {
+      } else if (supports_join) {
         activationInfoData.items.push({
           key: m.rootKeys,
           value: <Message content={sharedMessages.provisionedOnExternalJoinServer} />,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/2112

#### Changes
<!-- What are the changes made in this pull request? -->

- Always show the `dev_eui` field and make it `required` only if the activation mode is OTAA or if the lorawan version is 1.0.4
- Adjust the device overview page to hide `root_keys` for ABP devices

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
