### PR TITLE
util: Remove hardware specific values from BS router_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Hardware specific fields from Basic Station router config.
-
 ### Fixed
 
 - Telemetry and events for gateway statuses.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Hardware specific fields from Basic Station router config.
+
 ### Fixed
 
 - Telemetry and events for gateway statuses.

--- a/pkg/gatewayserver/io/basicstationlns/basicstationlns_test.go
+++ b/pkg/gatewayserver/io/basicstationlns/basicstationlns_test.go
@@ -491,22 +491,17 @@ func TestVersion(t *testing.T) {
 				SX1301Config: []shared.SX1301Config{
 					{
 						LoRaWANPublic: true,
-						ClockSource:   1,
 						AntennaGain:   0,
 						Radios: []shared.RFConfig{
 							{
-								Enable:     true,
-								Frequency:  867500000,
-								TxEnable:   true,
-								RSSIOffset: -166,
+								Enable:    true,
+								Frequency: 867500000,
 							},
 							{
-								Enable:     true,
-								Frequency:  868500000,
-								TxEnable:   false,
-								TxFreqMin:  0,
-								TxFreqMax:  0,
-								RSSIOffset: -166,
+								Enable:    true,
+								Frequency: 868500000,
+								TxFreqMin: 0,
+								TxFreqMax: 0,
 							},
 						},
 						Channels: []shared.IFConfig{
@@ -573,22 +568,17 @@ func TestVersion(t *testing.T) {
 				SX1301Config: []shared.SX1301Config{
 					{
 						LoRaWANPublic: true,
-						ClockSource:   1,
 						AntennaGain:   0,
 						Radios: []shared.RFConfig{
 							{
-								Enable:     true,
-								Frequency:  867500000,
-								TxEnable:   true,
-								RSSIOffset: -166,
+								Enable:    true,
+								Frequency: 867500000,
 							},
 							{
-								Enable:     true,
-								Frequency:  868500000,
-								TxEnable:   false,
-								TxFreqMin:  0,
-								TxFreqMax:  0,
-								RSSIOffset: -166,
+								Enable:    true,
+								Frequency: 868500000,
+								TxFreqMin: 0,
+								TxFreqMax: 0,
 							},
 						},
 						Channels: []shared.IFConfig{

--- a/pkg/pfconfig/basicstationlns/basicstationlns.go
+++ b/pkg/pfconfig/basicstationlns/basicstationlns.go
@@ -117,12 +117,12 @@ func GetRouterConfig(bandID string, fps map[string]*frequencyplans.FrequencyPlan
 		sx1301Conf.Radios[0].TxFreqMin = 0
 		sx1301Conf.Radios[0].TxFreqMax = 0
 		// Remove hardware specific values that are handled by the gateway itself.
-		sx1301Conf.ClockSource = 0
+		sx1301Conf.ClockSource = nil
 		sx1301Conf.TxLUTConfigs = nil
 		for i := range sx1301Conf.Radios {
 			sx1301Conf.Radios[i].Type = ""
-			sx1301Conf.Radios[i].TxEnable = false
-			sx1301Conf.Radios[i].RSSIOffset = 0
+			sx1301Conf.Radios[i].TxEnable = nil
+			sx1301Conf.Radios[i].RSSIOffset = nil
 		}
 		if err != nil {
 			return RouterConfig{}, err

--- a/pkg/pfconfig/basicstationlns/basicstationlns.go
+++ b/pkg/pfconfig/basicstationlns/basicstationlns.go
@@ -116,10 +116,13 @@ func GetRouterConfig(bandID string, fps map[string]*frequencyplans.FrequencyPlan
 		// These fields are not defined in the v1.5 ref design https://doc.sm.tc/station/gw_v1.5.html#rfconf-object and would cause a parsing error.
 		sx1301Conf.Radios[0].TxFreqMin = 0
 		sx1301Conf.Radios[0].TxFreqMax = 0
-		// Remove hardware specific values that are not necessary.
+		// Remove hardware specific values that are handled by the gateway itself.
+		sx1301Conf.ClockSource = 0
 		sx1301Conf.TxLUTConfigs = nil
 		for i := range sx1301Conf.Radios {
 			sx1301Conf.Radios[i].Type = ""
+			sx1301Conf.Radios[i].TxEnable = false
+			sx1301Conf.Radios[i].RSSIOffset = 0
 		}
 		if err != nil {
 			return RouterConfig{}, err

--- a/pkg/pfconfig/basicstationlns/basicstationlns_test.go
+++ b/pkg/pfconfig/basicstationlns/basicstationlns_test.go
@@ -109,12 +109,10 @@ func TestGetRouterConfig(t *testing.T) {
 							{
 								Enable:    true,
 								Frequency: 922300000,
-								TxEnable:  true,
 							},
 							{
 								Enable:    false,
 								Frequency: 923000000,
-								TxEnable:  false,
 							},
 						},
 						Channels: []shared.IFConfig{
@@ -184,12 +182,10 @@ func TestGetRouterConfig(t *testing.T) {
 							{
 								Enable:    true,
 								Frequency: 922300000,
-								TxEnable:  true,
 							},
 							{
 								Enable:    false,
 								Frequency: 923000000,
-								TxEnable:  false,
 							},
 						},
 						Channels: []shared.IFConfig{
@@ -312,12 +308,10 @@ func TestGetRouterConfigWithMultipleFP(t *testing.T) {
 							{
 								Enable:    true,
 								Frequency: 924300000,
-								TxEnable:  true,
 							},
 							{
 								Enable:    false,
 								Frequency: 925000000,
-								TxEnable:  false,
 							},
 						},
 						Channels: []shared.IFConfig{
@@ -341,12 +335,10 @@ func TestGetRouterConfigWithMultipleFP(t *testing.T) {
 							{
 								Enable:    true,
 								Frequency: 924300000,
-								TxEnable:  true,
 							},
 							{
 								Enable:    false,
 								Frequency: 925000000,
-								TxEnable:  false,
 							},
 						},
 						Channels: []shared.IFConfig{

--- a/pkg/pfconfig/basicstationlns/basicstationlns_test.go
+++ b/pkg/pfconfig/basicstationlns/basicstationlns_test.go
@@ -103,7 +103,6 @@ func TestGetRouterConfig(t *testing.T) {
 				SX1301Config: []shared.SX1301Config{
 					{
 						LoRaWANPublic: true,
-						ClockSource:   0,
 						AntennaGain:   0,
 						Radios: []shared.RFConfig{
 							{
@@ -176,7 +175,6 @@ func TestGetRouterConfig(t *testing.T) {
 				SX1301Config: []shared.SX1301Config{
 					{
 						LoRaWANPublic: true,
-						ClockSource:   0,
 						AntennaGain:   0,
 						Radios: []shared.RFConfig{
 							{
@@ -239,7 +237,8 @@ func TestGetRouterConfigWithMultipleFP(t *testing.T) {
 			Name:   "ValidFrequencyPlan",
 			BandID: "US_902_928",
 			FrequencyPlans: map[string]*frequencyplans.FrequencyPlan{test.USFrequencyPlanID: {
-				BandID: "US_902_928",
+				ClockSource: 0,
+				BandID:      "US_902_928",
 				Radios: []frequencyplans.Radio{
 					{
 						Enable:    true,
@@ -302,7 +301,6 @@ func TestGetRouterConfigWithMultipleFP(t *testing.T) {
 				SX1301Config: []shared.SX1301Config{
 					{
 						LoRaWANPublic: true,
-						ClockSource:   0,
 						AntennaGain:   0,
 						Radios: []shared.RFConfig{
 							{
@@ -329,7 +327,6 @@ func TestGetRouterConfigWithMultipleFP(t *testing.T) {
 					},
 					{
 						LoRaWANPublic: true,
-						ClockSource:   0,
 						AntennaGain:   0,
 						Radios: []shared.RFConfig{
 							{

--- a/pkg/pfconfig/shared/shared.go
+++ b/pkg/pfconfig/shared/shared.go
@@ -86,7 +86,7 @@ func (m orderedMap) MarshalJSON() ([]byte, error) {
 func (c SX1301Config) MarshalJSON() ([]byte, error) {
 	var m orderedMap
 	m.add("lorawan_public", c.LoRaWANPublic)
-	m.add("clksrc", c.ClockSource)
+	m.add("clksrc,omitempty", c.ClockSource)
 	m.add("antenna_gain", c.AntennaGain)
 	if c.LBTConfig != nil {
 		m.add("lbt_cfg", *c.LBTConfig)

--- a/pkg/pfconfig/shared/shared.go
+++ b/pkg/pfconfig/shared/shared.go
@@ -33,7 +33,7 @@ import (
 // SX1301Config contains the configuration for the SX1301 concentrator.
 type SX1301Config struct {
 	LoRaWANPublic       bool
-	ClockSource         uint8
+	ClockSource         uint8 `json:"omitempty"`
 	AntennaGain         float32
 	LBTConfig           *LBTConfig
 	Radios              []RFConfig
@@ -209,8 +209,8 @@ type RFConfig struct {
 	Enable      bool    `json:"enable"`
 	Type        string  `json:"type,omitempty"`
 	Frequency   uint64  `json:"freq"`
-	RSSIOffset  float32 `json:"rssi_offset"`
-	TxEnable    bool    `json:"tx_enable"`
+	RSSIOffset  float32 `json:"rssi_offset,omitempty"`
+	TxEnable    bool    `json:"tx_enable,omitempty"`
 	TxFreqMin   uint64  `json:"tx_freq_min,omitempty"`
 	TxFreqMax   uint64  `json:"tx_freq_max,omitempty"`
 	TxNotchFreq uint64  `json:"tx_notch_freq,omitempty"`

--- a/pkg/pfconfig/shared/shared.go
+++ b/pkg/pfconfig/shared/shared.go
@@ -28,12 +28,13 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/frequencyplans"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/pkg/util/pointers"
 )
 
 // SX1301Config contains the configuration for the SX1301 concentrator.
 type SX1301Config struct {
 	LoRaWANPublic       bool
-	ClockSource         uint8 `json:"omitempty"`
+	ClockSource         *uint8
 	AntennaGain         float32
 	LBTConfig           *LBTConfig
 	Radios              []RFConfig
@@ -206,14 +207,14 @@ type LBTChannelConfig struct {
 
 // RFConfig contains the configuration for one of the radios.
 type RFConfig struct {
-	Enable      bool    `json:"enable"`
-	Type        string  `json:"type,omitempty"`
-	Frequency   uint64  `json:"freq"`
-	RSSIOffset  float32 `json:"rssi_offset,omitempty"`
-	TxEnable    bool    `json:"tx_enable,omitempty"`
-	TxFreqMin   uint64  `json:"tx_freq_min,omitempty"`
-	TxFreqMax   uint64  `json:"tx_freq_max,omitempty"`
-	TxNotchFreq uint64  `json:"tx_notch_freq,omitempty"`
+	Enable      bool     `json:"enable"`
+	Type        string   `json:"type,omitempty"`
+	Frequency   uint64   `json:"freq"`
+	RSSIOffset  *float32 `json:"rssi_offset,omitempty"`
+	TxEnable    *bool    `json:"tx_enable,omitempty"`
+	TxFreqMin   uint64   `json:"tx_freq_min,omitempty"`
+	TxFreqMax   uint64   `json:"tx_freq_max,omitempty"`
+	TxNotchFreq uint64   `json:"tx_notch_freq,omitempty"`
 }
 
 // IFConfig contains the configuration for one of the channels.
@@ -285,7 +286,7 @@ func BuildSX1301Config(frequencyPlan *frequencyplans.FrequencyPlan) (*SX1301Conf
 	conf := new(SX1301Config)
 
 	conf.LoRaWANPublic = true
-	conf.ClockSource = frequencyPlan.ClockSource
+	conf.ClockSource = pointers.Uint8(frequencyPlan.ClockSource)
 
 	if frequencyPlan.LBT != nil {
 		lbtConfig := &LBTConfig{
@@ -311,10 +312,10 @@ func BuildSX1301Config(frequencyPlan *frequencyplans.FrequencyPlan) (*SX1301Conf
 			Enable:     radio.Enable,
 			Type:       radio.ChipType,
 			Frequency:  radio.Frequency,
-			RSSIOffset: radio.RSSIOffset,
+			RSSIOffset: &radio.RSSIOffset,
 		}
 		if radio.TxConfiguration != nil {
-			rfConfig.TxEnable = true
+			rfConfig.TxEnable = pointers.Bool(true)
 			rfConfig.TxFreqMin = radio.TxConfiguration.MinFrequency
 			rfConfig.TxFreqMax = radio.TxConfiguration.MaxFrequency
 			if radio.TxConfiguration.NotchFrequency != nil {

--- a/pkg/pfconfig/shared/shared_test.go
+++ b/pkg/pfconfig/shared/shared_test.go
@@ -23,6 +23,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/frequencyplans"
 	. "go.thethings.network/lorawan-stack/pkg/pfconfig/shared"
+	"go.thethings.network/lorawan-stack/pkg/util/pointers"
 )
 
 func TestSX1301Conf(t *testing.T) {
@@ -88,25 +89,24 @@ func TestSX1301Conf(t *testing.T) {
 			},
 			SX1301Config{
 				LoRaWANPublic: true,
-				ClockSource:   1,
+				ClockSource:   pointers.Uint8(1),
 				AntennaGain:   0,
 				Radios: []RFConfig{
 					{
 						Enable:     true,
 						Type:       "SX1257",
 						Frequency:  867500000,
-						TxEnable:   true,
+						TxEnable:   pointers.Bool(true),
 						TxFreqMin:  863000000,
 						TxFreqMax:  870000000,
-						RSSIOffset: -166,
+						RSSIOffset: pointers.Float32(-166),
 					},
 					{
 						Enable: true, Type: "SX1257",
 						Frequency:  868500000,
-						TxEnable:   false,
 						TxFreqMin:  0,
 						TxFreqMax:  0,
-						RSSIOffset: -166,
+						RSSIOffset: pointers.Float32(-166),
 					},
 				},
 				Channels: []IFConfig{

--- a/pkg/util/pointers/pointers.go
+++ b/pkg/util/pointers/pointers.go
@@ -1,0 +1,32 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pointers
+
+import "time"
+
+// Bool returns a boolean pointer for the given value.
+func Bool(v bool) *bool { return &v }
+
+// Duration returns a duration pointer for the given value.
+func Duration(d time.Duration) *time.Duration { return &d }
+
+// Time returns a time.Time pointer for the given value.
+func Time(t time.Time) *time.Time { return &t }
+
+// Float32 returns a float32 pointer for the given value.
+func Float32(v float32) *float32 { return &v }
+
+// Uint8 returns a uint8 pointer for the given value.
+func Uint8(v uint8) *uint8 { return &v }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closed #2130 

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `omitempty` to necessary fields and set type-default values to them.
- Update tests.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Pending testing on metal.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [ ] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
