### PR TITLE
Fix disabled component description in device general settings

### DIFF
--- a/pkg/webui/console/views/device-general-settings/index.js
+++ b/pkg/webui/console/views/device-general-settings/index.js
@@ -216,10 +216,10 @@ export default class DeviceGeneralSettings extends React.Component {
     let jsDescription = m.jsDescription
     if (!jsEnabled) {
       jsDescription = m.jsDescriptionMissing
-    } else if (!sameJsAddress) {
-      jsDescription = m.notInCluster
     } else if (nsEnabled && !isOTAA) {
       jsDescription = m.jsDescriptionOTAA
+    } else if (!sameJsAddress) {
+      jsDescription = m.notInCluster
     }
 
     // 1. Disable the section if NS is not in cluster.

--- a/pkg/webui/console/views/device-general-settings/index.js
+++ b/pkg/webui/console/views/device-general-settings/index.js
@@ -201,10 +201,10 @@ export default class DeviceGeneralSettings extends React.Component {
       asDescription = m.asDescriptionMissing
     } else if (!nsEnabled) {
       asDescription = m.activationModeUnknown
-    } else if (!sameAsAddress) {
-      asDescription = m.notInCluster
     } else if (isOTAA && !isJoined) {
       asDescription = m.asDescriptionOTAA
+    } else if (!sameAsAddress) {
+      asDescription = m.notInCluster
     }
 
     // 1. Disable the section if JS is not in cluster.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR makes sure that more specifc reason for a disabled section in the device general settings page is shown.

#### Changes
<!-- What are the changes made in this pull request? -->

- Rearrange conditions such that more specific are checked first

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

In some cases, general `Not registered in this cluster` is shown on a disabled section while another more specific reason can be displayed. 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
