### PR TITLE
Fix synchronizing Basic Station concentrator time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Creating 1.0.4 ABP end devices via the Console.
 - ADR uplink handling.
 - Uplink retransmission handling.
+- Synchronizing Basic Station concentrator time after reconnect or initial connect after long inactivity.
 
 ### Security
 

--- a/pkg/gatewayserver/io/basicstationlns/basicstationlns.go
+++ b/pkg/gatewayserver/io/basicstationlns/basicstationlns.go
@@ -299,7 +299,7 @@ func (s *srv) handleTraffic(c echo.Context) (err error) {
 					logger.Warn("No clock synchronization")
 					continue
 				}
-				xTime := int64(sID)<<48 | int64(concentratorTime)/int64(time.Microsecond)
+				xTime := int64(sID)<<48 | (int64(concentratorTime) / int64(time.Microsecond) & 0xFFFFFFFFFF)
 				dnmsg := messages.FromDownlinkMessage(ids, down.GetRawPayload(), scheduledMsg, int64(s.tokens.Next(down.CorrelationIDs, dlTime)), dlTime, xTime)
 				msg, err := dnmsg.MarshalJSON()
 				if err != nil {
@@ -327,7 +327,7 @@ func (s *srv) handleTraffic(c echo.Context) (err error) {
 				uint32(timestamp&0xFFFFFFFF),
 				server,
 				// The Basic Station epoch is the 48 LSB.
-				scheduling.ConcentratorTime(timestamp&0xFFFFFFFFFF),
+				scheduling.ConcentratorTime(time.Duration(timestamp&0xFFFFFFFFFF)*time.Microsecond),
 			)
 			syncedConcentratorTime = true
 		}

--- a/pkg/gatewayserver/scheduling/clock_test.go
+++ b/pkg/gatewayserver/scheduling/clock_test.go
@@ -112,3 +112,12 @@ func TestRolloverClock(t *testing.T) {
 		})
 	}
 }
+
+func TestSyncWithGatewayConcentrator(t *testing.T) {
+	a := assertions.New(t)
+
+	clock := &RolloverClock{}
+	clock.SyncWithGatewayConcentrator(0x496054D6, time.Now(), ConcentratorTime(0xAA496054D6)*ConcentratorTime(time.Microsecond))
+	v := int64(clock.FromTimestampTime(0x499D5DD6)) / int64(time.Microsecond)
+	a.So(v, should.Equal, int64(0xAA499D5DD6))
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2097 

#### Changes
<!-- What are the changes made in this pull request? -->

- Fixed synchronizing the gateway's concentrator time; it should have been interpreted as `ConcentratorTime` (in nanoseconds) and not microseconds

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
