### PR TITLE
Generate CLI config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- New `use` CLI command to automatically generate CLI configuration files.
+
 ### Changed
 
 ### Deprecated

--- a/cmd/ttn-lw-cli/commands/config.go
+++ b/cmd/ttn-lw-cli/commands/config.go
@@ -15,39 +15,40 @@
 package commands
 
 import (
+	"fmt"
+
 	"go.thethings.network/lorawan-stack/cmd/internal/commands"
 	conf "go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/log"
 )
 
 var (
-	clusterHost        = "localhost"
-	clusterGRPCAddress = clusterHost + ":8884"
-	clusterHTTPAddress = "https://" + clusterHost + ":8885"
+	defaultClusterHost = "localhost"
+	defaultInsecure    = false
 )
 
 // Config for the ttn-lw-cli binary.
 type Config struct {
 	conf.Base                          `name:",squash"`
-	CredentialsID                      string `name:"credentials-id" description:"Credentials ID (if using multiple configurations)"`
-	InputFormat                        string `name:"input-format" description:"Input format"`
-	OutputFormat                       string `name:"output-format" description:"Output format"`
-	AllowUnknownHosts                  bool   `name:"allow-unknown-hosts" description:"Allow sending credentials to unknown hosts"`
-	OAuthServerAddress                 string `name:"oauth-server-address" description:"OAuth Server address"`
-	IdentityServerGRPCAddress          string `name:"identity-server-grpc-address" description:"Identity Server address"`
-	GatewayServerEnabled               bool   `name:"gateway-server-enabled" description:"Gateway Server enabled"`
-	GatewayServerGRPCAddress           string `name:"gateway-server-grpc-address" description:"Gateway Server address"`
-	NetworkServerEnabled               bool   `name:"network-server-enabled" description:"Network Server enabled"`
-	NetworkServerGRPCAddress           string `name:"network-server-grpc-address" description:"Network Server address"`
-	ApplicationServerEnabled           bool   `name:"application-server-enabled" description:"Application Server enabled"`
-	ApplicationServerGRPCAddress       string `name:"application-server-grpc-address" description:"Application Server address"`
-	JoinServerEnabled                  bool   `name:"join-server-enabled" description:"Join Server enabled"`
-	JoinServerGRPCAddress              string `name:"join-server-grpc-address" description:"Join Server address"`
-	DeviceTemplateConverterGRPCAddress string `name:"device-template-converter-grpc-address" description:"Device Template Converter address"`
-	DeviceClaimingServerGRPCAddress    string `name:"device-claiming-server-grpc-address" description:"Device Claiming Server address"`
-	QRCodeGeneratorGRPCAddress         string `name:"qr-code-generator-grpc-address" description:"QR Code Generator address"`
-	Insecure                           bool   `name:"insecure" description:"Connect without TLS"`
-	CA                                 string `name:"ca" description:"CA certificate file"`
+	CredentialsID                      string `name:"credentials-id" yaml:"credentials-id" description:"Credentials ID (if using multiple configurations)"`
+	InputFormat                        string `name:"input-format" yaml:"input-format" description:"Input format"`
+	OutputFormat                       string `name:"output-format" yaml:"output-format" description:"Output format"`
+	AllowUnknownHosts                  bool   `name:"allow-unknown-hosts" yaml:"allow-unknown-hosts" description:"Allow sending credentials to unknown hosts"`
+	OAuthServerAddress                 string `name:"oauth-server-address" yaml:"oauth-server-address" description:"OAuth Server address"`
+	IdentityServerGRPCAddress          string `name:"identity-server-grpc-address" yaml:"identity-server-grpc-address" description:"Identity Server address"`
+	GatewayServerEnabled               bool   `name:"gateway-server-enabled" yaml:"gateway-server-enabled" description:"Gateway Server enabled"`
+	GatewayServerGRPCAddress           string `name:"gateway-server-grpc-address" yaml:"gateway-server-grpc-address" description:"Gateway Server address"`
+	NetworkServerEnabled               bool   `name:"network-server-enabled" yaml:"network-server-enabled" description:"Network Server enabled"`
+	NetworkServerGRPCAddress           string `name:"network-server-grpc-address" yaml:"network-server-grpc-address" description:"Network Server address"`
+	ApplicationServerEnabled           bool   `name:"application-server-enabled" yaml:"application-server-enabled" description:"Application Server enabled"`
+	ApplicationServerGRPCAddress       string `name:"application-server-grpc-address" yaml:"application-server-grpc-address" description:"Application Server address"`
+	JoinServerEnabled                  bool   `name:"join-server-enabled" yaml:"join-server-enabled" description:"Join Server enabled"`
+	JoinServerGRPCAddress              string `name:"join-server-grpc-address" yaml:"join-server-grpc-address" description:"Join Server address"`
+	DeviceTemplateConverterGRPCAddress string `name:"device-template-converter-grpc-address" yaml:"device-template-converter-grpc-address" description:"Device Template Converter address"`
+	DeviceClaimingServerGRPCAddress    string `name:"device-claiming-server-grpc-address" yaml:"device-claiming-server-grpc-address" description:"Device Claiming Server address"`
+	QRCodeGeneratorGRPCAddress         string `name:"qr-code-generator-grpc-address" yaml:"qr-code-generator-grpc-address" description:"QR Code Generator address"`
+	Insecure                           bool   `name:"insecure" yaml:"insecure" description:"Connect without TLS"`
+	CA                                 string `name:"ca" yaml:"ca" description:"CA certificate file"`
 }
 
 func (c Config) getHosts() []string {
@@ -71,29 +72,42 @@ func (c Config) getHosts() []string {
 	return getHosts(hosts...)
 }
 
-// DefaultConfig contains the default config for the ttn-lw-cli binary.
-var DefaultConfig = Config{
-	Base: conf.Base{
-		Log: conf.Log{
-			Level: log.InfoLevel,
+// MakeDefaultConfig builds the default config for the ttn-lw-cli binary for a given host.
+func MakeDefaultConfig(clusterHost string, insecure bool) Config {
+	clusterGRPCAddress := fmt.Sprintf("%s:8884", clusterHost)
+	clusterHTTPAddress := fmt.Sprintf("https://%s:8885", clusterHost)
+	if insecure {
+		clusterGRPCAddress = fmt.Sprintf("%s:1884", clusterHost)
+		clusterHTTPAddress = fmt.Sprintf("http://%s:1885", clusterHost)
+	}
+
+	return Config{
+		Base: conf.Base{
+			Log: conf.Log{
+				Level: log.InfoLevel,
+			},
 		},
-	},
-	InputFormat:                        "json",
-	OutputFormat:                       "json",
-	OAuthServerAddress:                 clusterHTTPAddress + "/oauth",
-	IdentityServerGRPCAddress:          clusterGRPCAddress,
-	GatewayServerEnabled:               true,
-	GatewayServerGRPCAddress:           clusterGRPCAddress,
-	NetworkServerEnabled:               true,
-	NetworkServerGRPCAddress:           clusterGRPCAddress,
-	ApplicationServerEnabled:           true,
-	ApplicationServerGRPCAddress:       clusterGRPCAddress,
-	JoinServerEnabled:                  true,
-	JoinServerGRPCAddress:              clusterGRPCAddress,
-	DeviceTemplateConverterGRPCAddress: clusterGRPCAddress,
-	DeviceClaimingServerGRPCAddress:    clusterGRPCAddress,
-	QRCodeGeneratorGRPCAddress:         clusterGRPCAddress,
+		InputFormat:                        "json",
+		OutputFormat:                       "json",
+		OAuthServerAddress:                 clusterHTTPAddress + "/oauth",
+		IdentityServerGRPCAddress:          clusterGRPCAddress,
+		GatewayServerEnabled:               true,
+		GatewayServerGRPCAddress:           clusterGRPCAddress,
+		NetworkServerEnabled:               true,
+		NetworkServerGRPCAddress:           clusterGRPCAddress,
+		ApplicationServerEnabled:           true,
+		ApplicationServerGRPCAddress:       clusterGRPCAddress,
+		JoinServerEnabled:                  true,
+		JoinServerGRPCAddress:              clusterGRPCAddress,
+		DeviceTemplateConverterGRPCAddress: clusterGRPCAddress,
+		DeviceClaimingServerGRPCAddress:    clusterGRPCAddress,
+		QRCodeGeneratorGRPCAddress:         clusterGRPCAddress,
+		Insecure:                           insecure,
+	}
 }
+
+// DefaultConfig contains the default config for the ttn-lw-cli binary.
+var DefaultConfig = MakeDefaultConfig(defaultClusterHost, defaultInsecure)
 
 var configCommand = commands.Config(mgr)
 

--- a/cmd/ttn-lw-cli/commands/use.go
+++ b/cmd/ttn-lw-cli/commands/use.go
@@ -1,0 +1,137 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"bytes"
+	"crypto/md5"
+	"crypto/tls"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"go.thethings.network/lorawan-stack/pkg/errors"
+	"gopkg.in/yaml.v2"
+)
+
+const configFileName = ".ttn-lw-cli.yml"
+
+var (
+	errNoHost     = errors.DefineInvalidArgument("no_host", "no host set")
+	errFileExists = errors.DefineAlreadyExists("file_exists", "`{file}` exists")
+	errFailWrite  = errors.DefinePermissionDenied("fail_write", "failed to write `{file}`")
+	useCommand    = &cobra.Command{
+		Use:               "use [host]",
+		Short:             "Use",
+		PersistentPreRunE: preRun(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return errNoHost
+			}
+			insecure, _ := cmd.Flags().GetBool("insecure")
+			fetchCA, _ := cmd.Flags().GetBool("fetch-ca")
+			user, _ := cmd.Flags().GetBool("user")
+			overwrite, _ := cmd.Flags().GetBool("overwrite")
+
+			destPath := func(base string, user bool, overwrite bool) (string, error) {
+				fileName := base
+				if user {
+					dir, err := os.UserConfigDir()
+					if err != nil {
+						return "", err
+					}
+					fileName = filepath.Join(dir, base)
+				}
+				_, err := os.Stat(fileName)
+				if !os.IsNotExist(err) && !overwrite {
+					logger.Warnf("%s already exists. Use --overwrite", fileName)
+					return "", errFileExists.WithAttributes("file", fileName)
+				}
+				return fileName, nil
+			}
+
+			host := args[0]
+			conf := MakeDefaultConfig(host, insecure)
+			conf.CredentialsID = host
+
+			// Get CA certificate from server
+			if !insecure && fetchCA {
+				h := md5.New()
+				io.WriteString(h, host)
+				caFileName := fmt.Sprintf("ca.%s.pem", hex.EncodeToString(h.Sum(nil))[:6])
+				caFile, err := destPath(caFileName, user, overwrite)
+				if err != nil {
+					return err
+				}
+
+				logger.Infof("Will retrieve certificate from %s", conf.NetworkServerGRPCAddress)
+				conn, err := tls.Dial("tcp", conf.NetworkServerGRPCAddress, &tls.Config{InsecureSkipVerify: true})
+				if err != nil {
+					return err
+				}
+				defer conn.Close()
+
+				buf := &bytes.Buffer{}
+				for _, cert := range conn.ConnectionState().PeerCertificates {
+					if !cert.IsCA {
+						continue
+					}
+					if err = pem.Encode(buf, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}); err != nil {
+						logger.Warnf("Could not retrieve certificate: %s", err)
+					}
+				}
+				if err = ioutil.WriteFile(caFile, buf.Bytes(), 0644); err != nil {
+					return errFailWrite.WithCause(err).WithAttributes("file", caFile)
+				}
+				logger.Infof("CA file for %s written in %s", host, caFile)
+				abs, err := filepath.Abs(caFile)
+				if err != nil {
+					return err
+				}
+				conf.CA = abs
+			}
+
+			b, err := yaml.Marshal(conf)
+			if err != nil {
+				return err
+			}
+
+			configFile, err := destPath(configFileName, user, overwrite)
+			if err != nil {
+				return err
+			}
+
+			if err = ioutil.WriteFile(configFile, b, 0644); err != nil {
+				return errFailWrite.WithCause(err).WithAttributes("file", configFile)
+			}
+			logger.Infof("Config file for %s written in %s", host, configFile)
+			return nil
+		},
+	}
+)
+
+func init() {
+	useCommand.Flags().Bool("insecure", defaultInsecure, "Connect without TLS")
+	useCommand.Flags().String("host", defaultClusterHost, "Server host name")
+	useCommand.Flags().Bool("fetch-ca", false, "Connect to server and retrieve CA")
+	useCommand.Flags().Bool("user", false, "Write config file in user config directory")
+	useCommand.Flags().Bool("overwrite", false, "Overwrite existing config files")
+	Root.AddCommand(useCommand)
+}

--- a/config/messages.json
+++ b/config/messages.json
@@ -1223,6 +1223,24 @@
       "file": "end_devices.go"
     }
   },
+  "error:cmd/ttn-lw-cli/commands:fail_write": {
+    "translations": {
+      "en": "failed to write `{file}`"
+    },
+    "description": {
+      "package": "cmd/ttn-lw-cli/commands",
+      "file": "use.go"
+    }
+  },
+  "error:cmd/ttn-lw-cli/commands:file_exists": {
+    "translations": {
+      "en": "`{file}` exists"
+    },
+    "description": {
+      "package": "cmd/ttn-lw-cli/commands",
+      "file": "use.go"
+    }
+  },
   "error:cmd/ttn-lw-cli/commands:gateway_server_address_mismatch": {
     "translations": {
       "en": "gateway server address mismatch"
@@ -1410,6 +1428,15 @@
     "description": {
       "package": "cmd/ttn-lw-cli/commands",
       "file": "gateways.go"
+    }
+  },
+  "error:cmd/ttn-lw-cli/commands:no_host": {
+    "translations": {
+      "en": "no host set"
+    },
+    "description": {
+      "package": "cmd/ttn-lw-cli/commands",
+      "file": "use.go"
     }
   },
   "error:cmd/ttn-lw-cli/commands:no_ids": {

--- a/doc/content/guides/getting-started/cli/_index.md
+++ b/doc/content/guides/getting-started/cli/_index.md
@@ -40,6 +40,24 @@ The command-line needs to be configured to connect to your deployment on `thethi
 
 > NOTE: When using the snap packages, `~/.ttn-lw-cli.yml` will fail with permission errors. Choose a different path.
 
+### Generate configuration file
+
+For a standard deployment on `thethings.example.com`, all you need is:
+
+```bash
+$ ttn-lw-cli use thethings.example.com [--fetch-ca] [--user] [--overwrite]
+```
+
+This will generate and save the required CLI config file. By default, the file is saved on the current directory, use the `--user` to save it under the user config directory.
+
+If using a CA that is not already trusted by your system, use the `--fetch-ca` flag to also connect to the server and retrieve the CA required for establishing secure communication.
+
+> NOTE: If the file exists already, it is not overwritten and an error is printed instead. You can use `--overwrite` to overwrite the existing configuration file.
+
+### Manually creating configuration file
+
+Alternatively, you can create a file named `.ttn-lw-cli.yml` and paste the following contents:
+
 ```yaml
 oauth-server-address: 'https://thethings.example.com/oauth'
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #1240

#### Changes
<!-- What are the changes made in this pull request? -->

- Adds a new `ttn-lw-cli use` command that can generate and write configuration file for the CLI, using sane defaults for a v3 cluster.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- This is on the CLI side only. We could add similar functionality to the v3 stack, but this is for a different PR, which is why I am not closing the initial issue.
- Still working on the documentation.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [X] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
