### PR TITLE
Hide pages for disabled stack components in Console

### DIFF
--- a/pkg/webui/console/views/device/index.js
+++ b/pkg/webui/console/views/device/index.js
@@ -25,7 +25,6 @@ import IntlHelmet from '../../../lib/components/intl-helmet'
 import withRequest from '../../../lib/components/with-request'
 import withEnv from '../../../lib/components/env'
 import NotFoundRoute from '../../../lib/components/not-found-route'
-import Require from '../../lib/components/require'
 
 import DeviceOverview from '../device-overview'
 import DeviceData from '../device-data'
@@ -143,7 +142,7 @@ export default class Device extends React.Component {
         params: { appId },
       },
       devId,
-      device: { name, description, join_server_address, supports_join },
+      device: { name, description, join_server_address, supports_join, root_keys },
       env: { siteName },
     } = this.props
 
@@ -151,7 +150,7 @@ export default class Device extends React.Component {
     const hasJs =
       jsConfig.enabled &&
       join_server_address === getHostnameFromUrl(jsConfig.base_url) &&
-      supports_join
+      (supports_join && Boolean(root_keys))
 
     const basePath = `/applications/${appId}/devices/${devId}`
 
@@ -196,9 +195,9 @@ export default class Device extends React.Component {
           <Route exact path={`${basePath}/location`} component={DeviceLocation} />
           <Route exact path={`${basePath}/general-settings`} component={DeviceGeneralSettings} />
           <Route path={`${basePath}/payload-formatters`} component={DevicePayloadFormatters} />
-          <Require condition={hasJs}>
+          {hasJs && (
             <Route path={`${basePath}/claim-auth-code`} component={DeviceClaimAuthenticationCode} />
-          </Require>
+          )}
           <NotFoundRoute />
         </Switch>
       </React.Fragment>

--- a/pkg/webui/console/views/device/index.js
+++ b/pkg/webui/console/views/device/index.js
@@ -40,7 +40,7 @@ import {
   selectDeviceFetching,
   selectDeviceError,
 } from '../../store/selectors/devices'
-import { selectJsConfig } from '../../../lib/selectors/env'
+import { selectJsConfig, selectAsConfig } from '../../../lib/selectors/env'
 
 import { mayReadApplicationDeviceKeys } from '../../lib/feature-checks'
 import PropTypes from '../../../lib/prop-types'
@@ -142,7 +142,14 @@ export default class Device extends React.Component {
         params: { appId },
       },
       devId,
-      device: { name, description, join_server_address, supports_join, root_keys },
+      device: {
+        name,
+        description,
+        join_server_address,
+        supports_join,
+        root_keys,
+        application_server_address,
+      },
       env: { siteName },
     } = this.props
 
@@ -151,6 +158,10 @@ export default class Device extends React.Component {
       jsConfig.enabled &&
       join_server_address === getHostnameFromUrl(jsConfig.base_url) &&
       (supports_join && Boolean(root_keys))
+
+    const asConfig = selectAsConfig()
+    const hasAs =
+      asConfig.enabled && application_server_address === getHostnameFromUrl(asConfig.base_url)
 
     const basePath = `/applications/${appId}/devices/${devId}`
 
@@ -168,6 +179,7 @@ export default class Device extends React.Component {
         name: 'develop',
         link: payloadFormattersLink,
         exact: false,
+        disabled: !hasAs,
       },
       {
         title: sharedMessages.claiming,
@@ -194,7 +206,9 @@ export default class Device extends React.Component {
           <Route exact path={`${basePath}/data`} component={DeviceData} />
           <Route exact path={`${basePath}/location`} component={DeviceLocation} />
           <Route exact path={`${basePath}/general-settings`} component={DeviceGeneralSettings} />
-          <Route path={`${basePath}/payload-formatters`} component={DevicePayloadFormatters} />
+          {hasAs && (
+            <Route path={`${basePath}/payload-formatters`} component={DevicePayloadFormatters} />
+          )}
           {hasJs && (
             <Route path={`${basePath}/claim-auth-code`} component={DeviceClaimAuthenticationCode} />
           )}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR disables the claim authentication code and payload formatters pages if JS/AS are not available.
References https://github.com/TheThingsNetwork/lorawan-stack/issues/1567

#### Changes
<!-- What are the changes made in this pull request? -->

- For the claim auth code page check if JS is in the cluster and the device is OTAA
- For the payload formatters page just check if AS is in the cluster
- Fix not found error rendering by removing `<Require />` since it is always rendered by `<Switch />`.


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
