### PR TITLE
cli: Allow including the CA in the ttn-lw-cli config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This requires a database migration (`ttn-lw-stack is-db migrate`) because of the added columns.
 - Gateway Server rate limiting support for the UDP frontend, see (`--gs.udp.rate-limiting` options).
 - Uplink deduplication via Redis in Network Server.
+- Setting the CA certificates inline in the CLI configuration file (see `--ca-cert` option).
 
 ### Changed
 

--- a/cmd/ttn-lw-cli/commands/config.go
+++ b/cmd/ttn-lw-cli/commands/config.go
@@ -47,7 +47,8 @@ type Config struct {
 	DeviceClaimingServerGRPCAddress    string `name:"device-claiming-server-grpc-address" description:"Device Claiming Server address"`
 	QRCodeGeneratorGRPCAddress         string `name:"qr-code-generator-grpc-address" description:"QR Code Generator address"`
 	Insecure                           bool   `name:"insecure" description:"Connect without TLS"`
-	CA                                 string `name:"ca" description:"CA certificate file"`
+	CAFile                             string `name:"ca" description:"CA certificate file"`
+	CA                                 string `name:"ca-cert" description:"CA certificate"`
 }
 
 func (c Config) getHosts() []string {

--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -113,11 +113,21 @@ func preRun(tasks ...func() error) func(cmd *cobra.Command, args []string) error
 		if config.Insecure {
 			api.SetInsecure(true)
 		}
-		if config.CA != "" {
-			pemBytes, err := ioutil.ReadFile(config.CA)
+
+		useCA := true
+		var pemBytes []byte
+		if config.CAFile != "" {
+			pemBytes, err = ioutil.ReadFile(config.CAFile)
 			if err != nil {
 				return err
 			}
+		} else if config.CA != "" {
+			pemBytes = []byte(config.CA)
+		} else {
+			useCA = false
+		}
+
+		if useCA {
 			rootCAs := http.DefaultTransport.(*http.Transport).TLSClientConfig.RootCAs
 			if rootCAs == nil {
 				if rootCAs, err = x509.SystemCertPool(); err != nil {

--- a/doc/content/reference/configuration/cli.md
+++ b/doc/content/reference/configuration/cli.md
@@ -10,9 +10,10 @@ Under normal circumstances, only `info`, `warn` and `error` logs are printed to 
 
 - `log.level`: The minimum level log messages must have to be shown
 
-By default the CLI assumes that it is connecting to servers that use TLS certificates that are trusted by the operating system. When connecting to servers with self-signed certificates or a custom CA, the `ca` option can be used to trust those certificates. When connecting servers that don't use TLS, the `insecure` option can be used.
+By default the CLI assumes that it is connecting to servers that use TLS certificates that are trusted by the operating system. When connecting to servers with self-signed certificates or a custom CA, the `ca` or `ca-cert` options can be used to trust those certificates. When connecting servers that don't use TLS, the `insecure` option can be used.
 
 - `ca`: CA certificate file
+- `ca-cert`: CA certificate
 - `insecure`: Connect without TLS
 
 The CLI can keep track of multiple configurations and multiple credentials. The `credentials-id` flag selects the set of credentials that are used to connect to servers. The `login` command registers the hosts that are configured at that moment, and will prevent leaking credentials to other hosts. This can be circumvented with the `allow-unknown-hosts` option.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #1240

#### Changes
<!-- What are the changes made in this pull request? -->

- Enable setting the stack CA inline in the CLI config file, so that we can have the CLI configuration bundled in a single file (and in the future have the stack server it under a public GET URL).

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The naming here might become a bit mixed. We can't really change `--ca` το `--ca-file` because that would break compatibility. What we can do is deprecate `--ca`, then add new `--cert-file` and `--cert` options. 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [X] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
