### PR TITLE
Revert setting Database paths in Docker Env

### DIFF
--- a/config/stack/ttn-lw-stack.yml
+++ b/config/stack/ttn-lw-stack.yml
@@ -1,8 +1,18 @@
 # Example ttn-lw-stack configuration file
 # Keep in sync with `doc/content/guides/getting-started/configuration.md`
 
+# Redis configuration
+redis:
+  address: 'redis:6379'
+
 # Identity Server configuration
-# is:
+is:
+  # If using CockroachDB
+  database-uri: 'postgres://root@cockroach:26257/ttn_lorawan?sslmode=disable'
+
+  # If using PostgreSQL:
+  # database-uri: 'postgres://root@postgres:5432/ttn_lorawan?sslmode=disable'
+
   # Email configuration for "thethings.example.com"
   # email:
     # sender-name: 'The Things Stack'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,13 +50,6 @@ services:
       - ./config/stack:/config:ro
       # If using Let's Encrypt:
       # - ./acme:/var/lib/acme
-    environment:
-      TTN_LW_BLOB_LOCAL_DIRECTORY: /srv/ttn-lorawan/public/blob
-      TTN_LW_REDIS_ADDRESS: redis:6379
-      # If using CockroachDB:
-      TTN_LW_IS_DATABASE_URL: postgres://root@cockroach:26257/ttn_lorawan?sslmode=disable
-      # # If using PostgreSQL:
-      # TTN_LW_IS_DATABASE_URL: postgres://root:root@postgres:5432/ttn_lorawan?sslmode=disable
 
     ports:
       # If deploying on a public server:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Reverts #2121 

The following is a log received from a community member upon update to `v3.6.1`
```
stack_1      |   WARN Finished unary call                      duration=7.439909ms error=error:pkg/redis:store (store error) error_cause=dial tcp 127.0.0.1:6379: connect: connection refused error_correlation_id=5e4c8803d7814cf3ab8498ba0cd7f9d9 error_name=store error_namespace=pkg/redis grpc_code=Unknown grpc_method=HandleUplink grpc_service=ttn.lorawan.v3.GsNs namespace=grpc request_id=01E3HNMFTXYASDKWKSG767JMRJ
```

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove docker env variables
- Re-insert the yaml config in `config/stack/ttn-lw-stack.yml`

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Please wait until tests are done. The fact that ` 127.0.0.1:6379` is picked up as the Redis address is fishy to me.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [ ] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
