### PR TITLE
Fix invalid Cache Redis configuration

### DIFF
--- a/cmd/internal/shared/init.go
+++ b/cmd/internal/shared/init.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Initialize global packages.
-func Initialize(ctx context.Context, config config.ServiceBase) error {
+func Initialize(ctx context.Context, config *config.ServiceBase) error {
 	// Fallback to the default Redis configuration for the cache system
 	if config.Cache.Redis.IsZero() {
 		config.Cache.Redis = config.Redis
@@ -31,7 +31,7 @@ func Initialize(ctx context.Context, config config.ServiceBase) error {
 		config.Events.Redis = config.Redis
 	}
 
-	if err := InitializeEvents(ctx, config); err != nil {
+	if err := InitializeEvents(ctx, *config); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/ttn-lw-stack/commands/root.go
+++ b/cmd/ttn-lw-stack/commands/root.go
@@ -84,7 +84,7 @@ var (
 			ctx = log.NewContext(ctx, logger)
 
 			// initialize shared packages
-			if err := shared.Initialize(ctx, config.ServiceBase); err != nil {
+			if err := shared.Initialize(ctx, &config.ServiceBase); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2160.

In #2104, The `Initialize` function on `config.ServiceBase` passes the config as a value. Hence, the default Cache config is locally updated and not propagated.


#### Changes
<!-- What are the changes made in this pull request? -->

- Use a pointer in the function instead.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
