### PR TITLE
Pending session downlink queue support in the Application Server

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -2222,6 +2222,15 @@
       "file": "applicationserver.go"
     }
   },
+  "error:pkg/applicationserver:unknown_session": {
+    "translations": {
+      "en": "unknown session"
+    },
+    "description": {
+      "package": "pkg/applicationserver",
+      "file": "applicationserver.go"
+    }
+  },
   "error:pkg/applicationserver:version_unavailable": {
     "translations": {
       "en": "end device version is unavailable in the repository"

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -861,7 +861,7 @@ func (as *ApplicationServer) handleUplink(ctx context.Context, ids ttnpb.EndDevi
 				client := ttnpb.NewAsNsClient(link.conn)
 				res, err := client.DownlinkQueueList(ctx, &ids, link.callOpts...)
 				if err != nil {
-					logger.WithError(err).Warn("Failed to list downlink queue for recalculation; clearing the downlink queue")
+					logger.WithError(err).Warn("Failed to list downlink queue for recalculation; clear the downlink queue")
 					as.resetInvalidDownlinkQueue(ctx, ids, link)
 				} else {
 					previousQueue, _ := ttnpb.PartitionDownlinksBySessionKeyIDEquality(previousSession.SessionKeyID, res.Downlinks...)

--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -1067,7 +1067,7 @@ hardware_versions:
 										KEKLabel:     "test",
 									},
 								},
-								LastAFCntDown: 2,
+								LastAFCntDown: 0,
 								StartedAt:     dev.Session.StartedAt,
 							})
 							a.So(dev.PendingSession, should.Resemble, &ttnpb.Session{
@@ -1079,20 +1079,20 @@ hardware_versions:
 										KEKLabel:     "test",
 									},
 								},
-								LastAFCntDown: 0,
+								LastAFCntDown: 2,
 								StartedAt:     dev.PendingSession.StartedAt,
 							})
 							a.So(queue, should.Resemble, []*ttnpb.ApplicationDownlink{
 								{
 									SessionKeyID: []byte{0x22},
 									FPort:        11,
-									FCnt:         1,
+									FCnt:         11,
 									FRMPayload:   []byte{0x1, 0x1, 0x1, 0x1},
 								},
 								{
 									SessionKeyID: []byte{0x22},
 									FPort:        22,
-									FCnt:         2,
+									FCnt:         22,
 									FRMPayload:   []byte{0x2, 0x2, 0x2, 0x2},
 								},
 							})
@@ -1342,6 +1342,20 @@ hardware_versions:
 										KEKLabel:     "test",
 									},
 									PendingSession: true,
+									InvalidatedDownlinks: []*ttnpb.ApplicationDownlink{
+										{
+											SessionKeyID: []byte{0x33},
+											FPort:        11,
+											FCnt:         2,
+											FRMPayload:   []byte{0x91, 0xfd, 0x90, 0xf6},
+										},
+										{
+											SessionKeyID: []byte{0x33},
+											FPort:        22,
+											FCnt:         3,
+											FRMPayload:   []byte{0x2f, 0x3f, 0x31, 0x2c},
+										},
+									},
 								},
 							},
 						},
@@ -1382,7 +1396,7 @@ hardware_versions:
 										KEKLabel:     "test",
 									},
 								},
-								LastAFCntDown: 0,
+								LastAFCntDown: 2,
 								StartedAt:     dev.PendingSession.StartedAt,
 							})
 							a.So(queue, should.Resemble, []*ttnpb.ApplicationDownlink{

--- a/pkg/applicationserver/util_test.go
+++ b/pkg/applicationserver/util_test.go
@@ -114,12 +114,6 @@ func (ns *mockNS) LinkApplication(stream ttnpb.AsNs_LinkApplicationServer) error
 		case <-stream.Context().Done():
 			return nil
 		case up := <-ns.upCh:
-			if joinAccept := up.GetJoinAccept(); joinAccept != nil && !joinAccept.PendingSession {
-				// Reset the downlink queue on join-accept; it's invalid and AS will replace it.
-				ns.downlinkQueueMu.Lock()
-				ns.downlinkQueue[unique.ID(stream.Context(), up.EndDeviceIdentifiers)] = nil
-				ns.downlinkQueueMu.Unlock()
-			}
 			if err := stream.Send(up); err != nil {
 				return err
 			}

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -342,7 +342,7 @@ func (ns *NetworkServer) generateDataDownlink(ctx context.Context, dev *ttnpb.En
 
 			case down.FCnt <= dev.Session.LastNFCntDown && dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0:
 				logger.WithField("last_f_cnt_down", dev.Session.LastNFCntDown).Debug("Drop application downlink with too low FCnt")
-				invalid, rest := partitionDownlinksBySessionKeyIDEquality(dev.Session.SessionKeyID, dev.Session.QueuedApplicationDownlinks[i:]...)
+				invalid, rest := ttnpb.PartitionDownlinksBySessionKeyIDEquality(dev.Session.SessionKeyID, dev.Session.QueuedApplicationDownlinks[i:]...)
 				genState.baseApplicationUps = append(genState.baseApplicationUps, &ttnpb.ApplicationUp{
 					EndDeviceIdentifiers: dev.EndDeviceIdentifiers,
 					CorrelationIDs:       events.CorrelationIDsFromContext(ctx),

--- a/pkg/networkserver/grpc_asns.go
+++ b/pkg/networkserver/grpc_asns.go
@@ -137,7 +137,7 @@ func matchApplicationDownlinks(session *ttnpb.Session, macState *ttnpb.MACState,
 	if session == nil {
 		return downs, nil
 	}
-	downs, unmatched = partitionDownlinksBySessionKeyIDEquality(session.SessionKeyID, downs...)
+	downs, unmatched = ttnpb.PartitionDownlinksBySessionKeyIDEquality(session.SessionKeyID, downs...)
 	switch {
 	case len(downs) == 0:
 		return unmatched, nil

--- a/pkg/networkserver/utils.go
+++ b/pkg/networkserver/utils.go
@@ -15,7 +15,6 @@
 package networkserver
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"math"
@@ -154,26 +153,6 @@ func deviceRejectedADRTXPowerIndex(dev *ttnpb.EndDevice, idx uint32) bool {
 func deviceRejectedFrequency(dev *ttnpb.EndDevice, freq uint64) bool {
 	i := searchUint64(freq, dev.MACState.RejectedFrequencies...)
 	return i < len(dev.MACState.RejectedFrequencies) && dev.MACState.RejectedFrequencies[i] == freq
-}
-
-func partitionDownlinks(p func(down *ttnpb.ApplicationDownlink) bool, downs ...*ttnpb.ApplicationDownlink) (t, f []*ttnpb.ApplicationDownlink) {
-	t, f = downs[:0:0], downs[:0:0]
-	for _, down := range downs {
-		if p(down) {
-			t = append(t, down)
-		} else {
-			f = append(f, down)
-		}
-	}
-	return t, f
-}
-
-func paritionDownlinksBySessionKeyID(p func([]byte) bool, downs ...*ttnpb.ApplicationDownlink) (t, f []*ttnpb.ApplicationDownlink) {
-	return partitionDownlinks(func(down *ttnpb.ApplicationDownlink) bool { return p(down.SessionKeyID) }, downs...)
-}
-
-func partitionDownlinksBySessionKeyIDEquality(id []byte, downs ...*ttnpb.ApplicationDownlink) (t, f []*ttnpb.ApplicationDownlink) {
-	return paritionDownlinksBySessionKeyID(func(downID []byte) bool { return bytes.Equal(downID, id) }, downs...)
 }
 
 func deviceNeedsMACRequestsAt(ctx context.Context, dev *ttnpb.EndDevice, earliestAt time.Time, phy band.Band, defaults ttnpb.MACSettings) bool {

--- a/pkg/ttnpb/messages.go
+++ b/pkg/ttnpb/messages.go
@@ -15,6 +15,7 @@
 package ttnpb
 
 import (
+	"bytes"
 	"strconv"
 	"strings"
 )
@@ -79,4 +80,27 @@ func (v *TxAcknowledgment_Result) UnmarshalJSON(b []byte) error {
 	}
 	*v = TxAcknowledgment_Result(i)
 	return nil
+}
+
+// PartitionDownlinks partitions downlinks based on the general predicate p.
+func PartitionDownlinks(p func(down *ApplicationDownlink) bool, downs ...*ApplicationDownlink) (t, f []*ApplicationDownlink) {
+	t, f = downs[:0:0], downs[:0:0]
+	for _, down := range downs {
+		if p(down) {
+			t = append(t, down)
+		} else {
+			f = append(f, down)
+		}
+	}
+	return t, f
+}
+
+// PartitionDownlinksBySessionKeyID partitions the downlinks based on the session key ID predicate p.
+func PartitionDownlinksBySessionKeyID(p func([]byte) bool, downs ...*ApplicationDownlink) (t, f []*ApplicationDownlink) {
+	return PartitionDownlinks(func(down *ApplicationDownlink) bool { return p(down.SessionKeyID) }, downs...)
+}
+
+// PartitionDownlinksBySessionKeyIDEquality partitions the downlinks based on the equality to the given session key ID.
+func PartitionDownlinksBySessionKeyIDEquality(id []byte, downs ...*ApplicationDownlink) (t, f []*ApplicationDownlink) {
+	return PartitionDownlinksBySessionKeyID(func(downID []byte) bool { return bytes.Equal(downID, id) }, downs...)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #1954 
Closes #1971

#### Changes
<!-- What are the changes made in this pull request? -->

- Downlink queue operations are now done on both sessions (pending + current).
- Downlink queue listing returns only the queue of the current session.
- On join-accept, the pending downlink queue is recomputed, but the current downlink queue is unchanged.
- Full downlink queue invalidations (`DownlinkQueueInvalidated` event) and individual downlink message nacks result in the computation of the both queues, if the pending session is present. If there is no pending session, only the current session queue is updated.
- On session restore a full replace is still required, and may result in a downlink queue invalidation. The replace occurs only for the current session (since there is no pending session after session restore).

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@rvolosatovs I've moved the `Partition*` utilities to `pkg/ttnpb` from `pkg/networkserver` since both components use them. Is this location correct or should I make a new package in `pkg/util` ?

~I think the only part missing from #1954 is the switch between the pending and the current session in the NS on the first uplink. (cc @rvolosatovs)~

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
