### PR TITLE
Use unambiguous datetime format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Network and Application Servers now maintain application downlink queue per-session.
 - Gateway Server skips setting up an upstream if the DevAddr prefixes to forward are empty.
 - Gateway connection stats are now cached in Redis (see `--cache.service` and `--gs.update-connections-stats-debounce-time` options).
+- Change the date format in the Console to be unambiguous (`17 Mar, 2020`).
 
 ### Deprecated
 

--- a/pkg/webui/lib/components/date-time/index.js
+++ b/pkg/webui/lib/components/date-time/index.js
@@ -87,7 +87,11 @@ DateTime.propTypes = {
 DateTime.defaultProps = {
   date: true,
   time: true,
-  dateFormatOptions: {},
+  dateFormatOptions: {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  },
   timeFormatOptions: {
     hour: 'numeric',
     minute: 'numeric',


### PR DESCRIPTION
#### Summary
Closes https://github.com/TheThingsIndustries/lorawan-stack/issues/1972

This PR will change the date format to an unambiguous `Mar 16, 2020` one.

![image](https://user-images.githubusercontent.com/5710611/76828199-c38bee00-6863-11ea-8902-74d3bbbe8128.png)

#### Changes
- Change datetime utility format default prop

#### Notes for Reviewers
The original idea was to use the dateformat that corresponds to the locale that is provided by the browser. However, we currently limit the locales to the languages that we support, which is only `en-US`. We could change this for date formatting to allow all locales, but I realized it might be even more confusing when we mix language and date format locales. So I think the best solution here is to simply use a date format which is not ambiguous.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
