### PR TITLE
Network Server uplink handling fixes and testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handling of uplink frame counters exceeding 65535.
 - Gateway events subscription release in the Console.
 - Entity events subscription release in the Console (Firefox).
+- RekeyInd handling for LoRaWAN 1.1 devices.
 
 ### Security
 

--- a/pkg/encoding/lorawan/mac.go
+++ b/pkg/encoding/lorawan/mac.go
@@ -803,7 +803,7 @@ var DefaultMACCommands = MACCommandSpec{
 	},
 
 	ttnpb.CID_BEACON_TIMING: &MACCommandDescriptor{
-		InitiatedByDevice: false,
+		InitiatedByDevice: true,
 
 		UplinkLength: 0,
 		AppendUplink: func(phy band.Band, b []byte, _ ttnpb.MACCommand) ([]byte, error) {

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -536,7 +536,7 @@ matchLoop:
 				logger.WithField("kek_label", session.NwkSEncKey.KEKLabel).WithError(err).Warn("Failed to unwrap NwkSEncKey, skip")
 				continue
 			}
-			macBuf, err = crypto.DecryptUplink(key, pld.DevAddr, pld.FCnt, macBuf)
+			macBuf, err = crypto.DecryptUplink(key, pld.DevAddr, match.FCnt, macBuf)
 			if err != nil {
 				logger.WithError(err).Warn("Failed to decrypt uplink, skip")
 				continue

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -838,6 +838,7 @@ var handleDataUplinkGetPaths = [...]string{
 	"session",
 	"supports_class_b",
 	"supports_class_c",
+	"supports_join",
 }
 
 func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkMessage) (err error) {

--- a/pkg/networkserver/grpc_gsns_test.go
+++ b/pkg/networkserver/grpc_gsns_test.go
@@ -80,6 +80,7 @@ func TestHandleUplink(t *testing.T) {
 		"session",
 		"supports_class_b",
 		"supports_class_c",
+		"supports_join",
 	}
 	dataRangeByAddrPaths := dataSetByIDGetPaths
 

--- a/pkg/util/test/events.go
+++ b/pkg/util/test/events.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"go.thethings.network/lorawan-stack/pkg/events"
+	"go.thethings.network/lorawan-stack/pkg/ttnpb"
 )
 
 type MockEventPubSub struct {
@@ -125,6 +126,17 @@ func EventEqual(a, b events.Event) bool {
 	ap.Time = time.Time{}
 	bp.Time = time.Time{}
 	return reflect.DeepEqual(ap, bp)
+}
+
+func EventDefinitionDataClosureEqual(a, b events.DefinitionDataClosure) bool {
+	ctx := Context()
+	ids := &ttnpb.EndDeviceIdentifiers{
+		DeviceID: "test-dev",
+		ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{
+			ApplicationID: "test-app",
+		},
+	}
+	return EventEqual(a(ctx, ids), b(ctx, ids))
 }
 
 var (


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/960
Closes #2171 

#### Changes
<!-- What are the changes made in this pull request? -->

- Improve Network Server uplink handling test coverage
- Fix decryption of frames for `FCnt` values exceeding `0xffff`
- Add `test.EventDefinitionDataClosureEqual`
- Fix BeaconTiming MAC definition
- Fix handling of `RekeyInd` in 1.1

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
