### PR TITLE
Improve error stacks

### DIFF
--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -449,10 +449,10 @@ func (as *ApplicationServer) DownlinkQueueList(ctx context.Context, ids ttnpb.En
 			}
 		}
 		if session == nil {
-			return nil, errNoDeviceSession
+			return nil, errNoDeviceSession.New()
 		}
 		if session.AppSKey == nil {
-			return nil, errNoAppSKey
+			return nil, errNoAppSKey.New()
 		}
 		if !dev.SkipPayloadCrypto {
 			// TODO: Cache unwrapped keys (https://github.com/TheThingsNetwork/lorawan-stack/issues/36)
@@ -735,7 +735,7 @@ func (as *ApplicationServer) decryptDownlinkMessage(ctx context.Context, ids ttn
 		return nil
 	}
 	if dev.Session == nil || !bytes.Equal(dev.Session.SessionKeyID, msg.SessionKeyID) || dev.Session.AppSKey == nil {
-		return errNoAppSKey
+		return errNoAppSKey.New()
 	}
 	appSKey, err := cryptoutil.UnwrapAES128Key(ctx, *dev.Session.AppSKey, as.KeyVault)
 	if err != nil {
@@ -761,7 +761,7 @@ func (as *ApplicationServer) recalculateDownlinkQueue(ctx context.Context, dev *
 		newSession = dev.PendingSession
 	}
 	if newSession == nil || newSession.AppSKey == nil {
-		return errNoAppSKey
+		return errNoAppSKey.New()
 	}
 	newSession.LastAFCntDown = nextAFCntDown - 1
 	if len(invalid) == 0 {
@@ -794,7 +794,7 @@ func (as *ApplicationServer) recalculateDownlinkQueue(ctx context.Context, dev *
 		}
 	}()
 	if dev.SkipPayloadCrypto {
-		return errPayloadCryptoDisabled
+		return errPayloadCryptoDisabled.New()
 	}
 	logger.Debug("Recalculate downlink queue")
 	newAppSKey, err := cryptoutil.UnwrapAES128Key(ctx, *newSession.AppSKey, as.KeyVault)

--- a/pkg/applicationserver/config.go
+++ b/pkg/applicationserver/config.go
@@ -121,7 +121,7 @@ func (c WebhooksConfig) NewWebhooks(ctx context.Context, server io.Server) (web.
 		return nil, errWebhooksTarget.WithAttributes("target", c.Target)
 	}
 	if c.Registry == nil {
-		return nil, errWebhooksRegistry
+		return nil, errWebhooksRegistry.New()
 	}
 	if c.QueueSize > 0 || c.Workers > 0 {
 		target = &web.QueuedSink{

--- a/pkg/applicationserver/grpc_deviceregistry_test.go
+++ b/pkg/applicationserver/grpc_deviceregistry_test.go
@@ -163,7 +163,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 				a.So(paths, should.HaveSameElementsDeep, []string{
 					"formatters",
 				})
-				return nil, errNotFound
+				return nil, errNotFound.New()
 			},
 			DeviceRequest: &ttnpb.GetEndDeviceRequest{
 				EndDeviceIdentifiers: registeredDevice.EndDeviceIdentifiers,

--- a/pkg/applicationserver/io/grpc/grpc.go
+++ b/pkg/applicationserver/io/grpc/grpc.go
@@ -137,7 +137,7 @@ func (s *impl) GetMQTTConnectionInfo(ctx context.Context, ids *ttnpb.Application
 		return nil, err
 	}
 	if s.mqttConfigProvider == nil {
-		return nil, errNoMQTTConfigProvider
+		return nil, errNoMQTTConfigProvider.New()
 	}
 	config, err := s.mqttConfigProvider.GetMQTTConfig(ctx)
 	if err != nil {

--- a/pkg/applicationserver/io/grpc/grpc_util_test.go
+++ b/pkg/applicationserver/io/grpc/grpc_util_test.go
@@ -96,7 +96,7 @@ func (is *mockIS) Get(ctx context.Context, req *ttnpb.GetApplicationRequest) (*t
 	uid := unique.ID(ctx, req.ApplicationIdentifiers)
 	app, ok := is.applications[uid]
 	if !ok {
-		return nil, errNotFound
+		return nil, errNotFound.New()
 	}
 	return app, nil
 }

--- a/pkg/applicationserver/io/io.go
+++ b/pkg/applicationserver/io/io.go
@@ -101,7 +101,7 @@ func (s *Subscription) SendUp(ctx context.Context, up *ttnpb.ApplicationUp) erro
 		ApplicationUp: up,
 	}:
 	default:
-		return errBufferFull
+		return errBufferFull.New()
 	}
 	return nil
 }

--- a/pkg/applicationserver/io/mqtt/mqtt_util_test.go
+++ b/pkg/applicationserver/io/mqtt/mqtt_util_test.go
@@ -77,7 +77,7 @@ func (is *mockIS) Get(ctx context.Context, req *ttnpb.GetApplicationRequest) (*t
 	uid := unique.ID(ctx, req.ApplicationIdentifiers)
 	app, ok := is.applications[uid]
 	if !ok {
-		return nil, errNotFound
+		return nil, errNotFound.New()
 	}
 	return app, nil
 }

--- a/pkg/applicationserver/io/packages/redis/registry.go
+++ b/pkg/applicationserver/io/packages/redis/registry.go
@@ -213,7 +213,7 @@ func (r ApplicationPackagesRegistry) Set(ctx context.Context, ids ttnpb.Applicat
 					return err
 				}
 				if updated.ApplicationID != ids.ApplicationID || updated.DeviceID != ids.DeviceID || updated.FPort != ids.FPort {
-					return errInvalidIdentifiers
+					return errInvalidIdentifiers.New()
 				}
 			} else {
 				if ttnpb.HasAnyField(sets, "ids.end_device_ids.application_ids.application_id") && pb.ApplicationID != stored.ApplicationID {

--- a/pkg/applicationserver/io/packages/util_test.go
+++ b/pkg/applicationserver/io/packages/util_test.go
@@ -79,7 +79,7 @@ func (is *mockIS) Get(ctx context.Context, req *ttnpb.GetApplicationRequest) (*t
 	uid := unique.ID(ctx, req.ApplicationIdentifiers)
 	app, ok := is.applications[uid]
 	if !ok {
-		return nil, errNotFound
+		return nil, errNotFound.New()
 	}
 	return app, nil
 }

--- a/pkg/applicationserver/io/pubsub/provider/mqtt/driver.go
+++ b/pkg/applicationserver/io/pubsub/provider/mqtt/driver.go
@@ -47,7 +47,7 @@ func OpenTopic(client mqtt.Client, topicName string, timeout time.Duration, qos 
 
 func openDriverTopic(client mqtt.Client, topicName string, timeout time.Duration, qos byte) (driver.Topic, error) {
 	if client == nil {
-		return nil, errNilClient
+		return nil, errNilClient.New()
 	}
 	dt := &topic{
 		client:  client,
@@ -63,7 +63,7 @@ var errPublishFailed = errors.Define("publish_failed", "publish to MQTT topic fa
 // SendBatch implements driver.Topic.
 func (t *topic) SendBatch(ctx context.Context, msgs []*driver.Message) error {
 	if t == nil || t.client == nil {
-		return errNilClient
+		return errNilClient.New()
 	}
 	for _, msg := range msgs {
 		if ctx.Err() != nil {
@@ -177,7 +177,7 @@ var errSubscribeFailed = errors.Define("subscribe_failed", "subscribe to MQTT to
 
 func openDriverSubscription(client mqtt.Client, topicName string, timeout time.Duration, qos byte) (driver.Subscription, error) {
 	if client == nil {
-		return nil, errNilClient
+		return nil, errNilClient.New()
 	}
 	subCh := make(chan mqtt.Message, subscriptionQueueSize)
 	handler := func(_ mqtt.Client, msg mqtt.Message) {
@@ -201,7 +201,7 @@ func openDriverSubscription(client mqtt.Client, topicName string, timeout time.D
 // ReceiveBatch implements driver.Subscription.
 func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*driver.Message, error) {
 	if s == nil || s.client == nil {
-		return nil, errNilClient
+		return nil, errNilClient.New()
 	}
 	var messages []*driver.Message
 outer:
@@ -275,7 +275,7 @@ func (s *subscription) Close() error {
 }
 
 func toErrorCode(err error) gcerrors.ErrorCode {
-	if d, ok := err.(errors.Definition); ok && d.FullName() == errNilClient.FullName() {
+	if errors.Resemble(err, errNilClient) {
 		return gcerrors.NotFound
 	}
 	switch err {

--- a/pkg/applicationserver/io/pubsub/provider/mqtt/tls.go
+++ b/pkg/applicationserver/io/pubsub/provider/mqtt/tls.go
@@ -30,7 +30,7 @@ func createTLSConfig(caPEM []byte, certPEM []byte, keyPEM []byte) (*tls.Config, 
 	if len(caPEM) != 0 {
 		certPool = x509.NewCertPool()
 		if !certPool.AppendCertsFromPEM(caPEM) {
-			return nil, errInvalidCAPEMData
+			return nil, errInvalidCAPEMData.New()
 		}
 	}
 	cert, err := tls.X509KeyPair(certPEM, keyPEM)

--- a/pkg/applicationserver/io/pubsub/redis/registry.go
+++ b/pkg/applicationserver/io/pubsub/redis/registry.go
@@ -222,7 +222,7 @@ func (r PubSubRegistry) Set(ctx context.Context, ids ttnpb.ApplicationPubSubIden
 					return err
 				}
 				if updated.ApplicationID != ids.ApplicationID || updated.PubSubID != ids.PubSubID {
-					return errInvalidIdentifiers
+					return errInvalidIdentifiers.New()
 				}
 			} else {
 				if ttnpb.HasAnyField(sets, "ids.application_ids.application_id") && pb.ApplicationID != stored.ApplicationID {

--- a/pkg/applicationserver/io/pubsub/util_test.go
+++ b/pkg/applicationserver/io/pubsub/util_test.go
@@ -126,7 +126,7 @@ func (is *mockIS) Get(ctx context.Context, req *ttnpb.GetApplicationRequest) (*t
 	uid := unique.ID(ctx, req.ApplicationIdentifiers)
 	app, ok := is.applications[uid]
 	if !ok {
-		return nil, errNotFound
+		return nil, errNotFound.New()
 	}
 	return app, nil
 }

--- a/pkg/applicationserver/io/web/redis/registry.go
+++ b/pkg/applicationserver/io/web/redis/registry.go
@@ -173,7 +173,7 @@ func (r WebhookRegistry) Set(ctx context.Context, ids ttnpb.ApplicationWebhookId
 					return err
 				}
 				if updated.ApplicationID != ids.ApplicationID || updated.WebhookID != ids.WebhookID {
-					return errInvalidIdentifiers
+					return errInvalidIdentifiers.New()
 				}
 			} else {
 				if ttnpb.HasAnyField(sets, "ids.application_ids.application_id") && pb.ApplicationID != stored.ApplicationID {

--- a/pkg/applicationserver/io/web/util_test.go
+++ b/pkg/applicationserver/io/web/util_test.go
@@ -123,7 +123,7 @@ func (is *mockIS) Get(ctx context.Context, req *ttnpb.GetApplicationRequest) (*t
 	uid := unique.ID(ctx, req.ApplicationIdentifiers)
 	app, ok := is.applications[uid]
 	if !ok {
-		return nil, errNotFound
+		return nil, errNotFound.New()
 	}
 	return app, nil
 }

--- a/pkg/applicationserver/io/web/webhooks.go
+++ b/pkg/applicationserver/io/web/webhooks.go
@@ -129,7 +129,7 @@ func (s *QueuedSink) Process(req *http.Request) error {
 	case s.Queue <- req:
 		return nil
 	default:
-		return errQueueFull
+		return errQueueFull.New()
 	}
 }
 
@@ -427,7 +427,7 @@ func (w *webhooks) handleDown(c echo.Context, op func(io.Server, context.Context
 		return err
 	}
 	if hook == nil {
-		return errWebhookNotFound
+		return errWebhookNotFound.New()
 	}
 	format, ok := formats[hook.Format]
 	if !ok {

--- a/pkg/applicationserver/payload.go
+++ b/pkg/applicationserver/payload.go
@@ -31,10 +31,10 @@ var errNoPayload = errors.Define("no_payload", "no payload")
 
 func (as *ApplicationServer) encodeAndEncrypt(ctx context.Context, dev *ttnpb.EndDevice, session *ttnpb.Session, downlink *ttnpb.ApplicationDownlink, defaultFormatters *ttnpb.MessagePayloadFormatters) error {
 	if session == nil || session.AppSKey == nil {
-		return errNoAppSKey
+		return errNoAppSKey.New()
 	}
 	if downlink.FRMPayload == nil && downlink.DecodedPayload == nil {
-		return errNoPayload
+		return errNoPayload.New()
 	}
 	if downlink.FRMPayload == nil && downlink.DecodedPayload != nil {
 		var formatter ttnpb.PayloadFormatter
@@ -64,7 +64,7 @@ func (as *ApplicationServer) encodeAndEncrypt(ctx context.Context, dev *ttnpb.En
 
 func (as *ApplicationServer) decryptAndDecode(ctx context.Context, dev *ttnpb.EndDevice, uplink *ttnpb.ApplicationUplink, defaultFormatters *ttnpb.MessagePayloadFormatters) error {
 	if dev.Session == nil || dev.Session.AppSKey == nil {
-		return errNoAppSKey
+		return errNoAppSKey.New()
 	}
 	appSKey, err := cryptoutil.UnwrapAES128Key(ctx, *dev.Session.AppSKey, as.KeyVault)
 	if err != nil {
@@ -104,7 +104,7 @@ var (
 
 func (p payloadFormatter) getRepositoryFormatters(version *ttnpb.EndDeviceVersionIdentifiers) (*ttnpb.MessagePayloadFormatters, error) {
 	if version == nil || p.repository == nil {
-		return nil, errNoVersion
+		return nil, errNoVersion.New()
 	}
 	versions, err := p.repository.DeviceVersions(version.BrandID, version.ModelID)
 	if err != nil {
@@ -115,7 +115,7 @@ func (p payloadFormatter) getRepositoryFormatters(version *ttnpb.EndDeviceVersio
 			return &v.DefaultFormatters, nil
 		}
 	}
-	return nil, errVersionUnavailable
+	return nil, errVersionUnavailable.New()
 }
 
 var errFormatterNotConfigured = errors.DefineFailedPrecondition("formatter_not_configured", "formatter `{formatter}` is not configured")

--- a/pkg/applicationserver/redis/registry.go
+++ b/pkg/applicationserver/redis/registry.go
@@ -136,7 +136,7 @@ func (r *DeviceRegistry) Set(ctx context.Context, ids ttnpb.EndDeviceIdentifiers
 			}
 
 			if pb.ApplicationIdentifiers != ids.ApplicationIdentifiers || pb.DeviceID != ids.DeviceID {
-				return errInvalidIdentifiers
+				return errInvalidIdentifiers.New()
 			}
 
 			pb.UpdatedAt = time.Now().UTC()
@@ -161,7 +161,7 @@ func (r *DeviceRegistry) Set(ctx context.Context, ids ttnpb.EndDeviceIdentifiers
 					return err
 				}
 				if updated.ApplicationIdentifiers != ids.ApplicationIdentifiers || updated.DeviceID != ids.DeviceID {
-					return errInvalidIdentifiers
+					return errInvalidIdentifiers.New()
 				}
 			} else {
 				if ttnpb.HasAnyField(sets, "ids.application_ids.application_id") && pb.ApplicationID != stored.ApplicationID {
@@ -199,7 +199,7 @@ func (r *DeviceRegistry) Set(ctx context.Context, ids ttnpb.EndDeviceIdentifiers
 						return err
 					}
 					if i != 0 {
-						return errDuplicateIdentifiers
+						return errDuplicateIdentifiers.New()
 					}
 					p.SetNX(ek, uid, 0)
 				}

--- a/pkg/applicationserver/util_test.go
+++ b/pkg/applicationserver/util_test.go
@@ -95,7 +95,7 @@ func (ns *mockNS) LinkApplication(stream ttnpb.AsNs_LinkApplicationServer) error
 		return err
 	}
 	if !ns.validateAuth(md) {
-		return errPermissionDenied
+		return errPermissionDenied.New()
 	}
 
 	select {
@@ -199,7 +199,7 @@ func (is *mockIS) Get(ctx context.Context, req *ttnpb.GetApplicationRequest) (*t
 	uid := unique.ID(ctx, req.ApplicationIdentifiers)
 	app, ok := is.applications[uid]
 	if !ok {
-		return nil, errNotFound
+		return nil, errNotFound.New()
 	}
 	return app, nil
 }
@@ -258,7 +258,7 @@ func (js *mockJS) add(ctx context.Context, devEUI types.EUI64, sessionKeyID []by
 func (js *mockJS) GetAppSKey(ctx context.Context, req *ttnpb.SessionKeyRequest) (*ttnpb.AppSKeyResponse, error) {
 	key, ok := js.keys[fmt.Sprintf("%v:%v", req.DevEUI, req.SessionKeyID)]
 	if !ok {
-		return nil, errNotFound
+		return nil, errNotFound.New()
 	}
 	return &ttnpb.AppSKeyResponse{
 		AppSKey: key,

--- a/pkg/auth/cluster/cluster.go
+++ b/pkg/auth/cluster/cluster.go
@@ -60,7 +60,7 @@ func verifySource(ctx context.Context, validKeys [][]byte) error {
 	switch md.AuthType {
 	case AuthType:
 	case "":
-		return errNoClusterKey
+		return errNoClusterKey.New()
 	default:
 		return errUnsupportedAuthType.WithAttributes("auth_type", md.AuthType)
 	}
@@ -73,7 +73,7 @@ func verifySource(ctx context.Context, validKeys [][]byte) error {
 			return nil
 		}
 	}
-	return errInvalidClusterKey
+	return errInvalidClusterKey.New()
 }
 
 // Authorized returns whether the context has been identified as a cluster call.

--- a/pkg/auth/password.go
+++ b/pkg/auth/password.go
@@ -86,7 +86,7 @@ func Validate(hashed, plain string) (bool, error) {
 	parts := strings.SplitN(hashed, "$", 2)
 
 	if len(parts) < 2 {
-		return false, errInvalidHash
+		return false, errInvalidHash.New()
 	}
 
 	typ := parts[0]

--- a/pkg/auth/rights/fetcher.go
+++ b/pkg/auth/rights/fetcher.go
@@ -113,7 +113,7 @@ var errNoISConn = errors.DefineUnavailable("no_identity_server_conn", "no connec
 func (f accessFetcher) ApplicationRights(ctx context.Context, appID ttnpb.ApplicationIdentifiers) (*ttnpb.Rights, error) {
 	cc := f.getConn(ctx)
 	if cc == nil {
-		return nil, errNoISConn
+		return nil, errNoISConn.New()
 	}
 	callOpt, err := rpcmetadata.WithForwardedAuth(ctx, f.allowInsecure)
 	if err != nil {
@@ -130,7 +130,7 @@ func (f accessFetcher) ApplicationRights(ctx context.Context, appID ttnpb.Applic
 func (f accessFetcher) ClientRights(ctx context.Context, clientID ttnpb.ClientIdentifiers) (*ttnpb.Rights, error) {
 	cc := f.getConn(ctx)
 	if cc == nil {
-		return nil, errNoISConn
+		return nil, errNoISConn.New()
 	}
 	callOpt, err := rpcmetadata.WithForwardedAuth(ctx, f.allowInsecure)
 	if err != nil {
@@ -147,7 +147,7 @@ func (f accessFetcher) ClientRights(ctx context.Context, clientID ttnpb.ClientId
 func (f accessFetcher) GatewayRights(ctx context.Context, gtwID ttnpb.GatewayIdentifiers) (*ttnpb.Rights, error) {
 	cc := f.getConn(ctx)
 	if cc == nil {
-		return nil, errNoISConn
+		return nil, errNoISConn.New()
 	}
 	callOpt, err := rpcmetadata.WithForwardedAuth(ctx, f.allowInsecure)
 	if err != nil {
@@ -164,7 +164,7 @@ func (f accessFetcher) GatewayRights(ctx context.Context, gtwID ttnpb.GatewayIde
 func (f accessFetcher) OrganizationRights(ctx context.Context, orgID ttnpb.OrganizationIdentifiers) (*ttnpb.Rights, error) {
 	cc := f.getConn(ctx)
 	if cc == nil {
-		return nil, errNoISConn
+		return nil, errNoISConn.New()
 	}
 	callOpt, err := rpcmetadata.WithForwardedAuth(ctx, f.allowInsecure)
 	if err != nil {
@@ -181,7 +181,7 @@ func (f accessFetcher) OrganizationRights(ctx context.Context, orgID ttnpb.Organ
 func (f accessFetcher) UserRights(ctx context.Context, userID ttnpb.UserIdentifiers) (*ttnpb.Rights, error) {
 	cc := f.getConn(ctx)
 	if cc == nil {
-		return nil, errNoISConn
+		return nil, errNoISConn.New()
 	}
 	callOpt, err := rpcmetadata.WithForwardedAuth(ctx, f.allowInsecure)
 	if err != nil {

--- a/pkg/band/band.go
+++ b/pkg/band/band.go
@@ -440,7 +440,7 @@ func boolsTo16BoolArray(vs ...bool) [16]bool {
 
 func generateChMask16(currentChs, desiredChs []bool) ([]ChMaskCntlPair, error) {
 	if len(currentChs) != 16 || len(desiredChs) != 16 {
-		return nil, errInvalidChannelCount
+		return nil, errInvalidChannelCount.New()
 	}
 	// NOTE: ChMaskCntl==6 never provides a more optimal ChMask sequence than ChMaskCntl==0.
 	return []ChMaskCntlPair{
@@ -466,7 +466,7 @@ func equalChMasks(a, b []bool) bool {
 func generateChMaskMatrix(pairs []ChMaskCntlPair, currentChs, desiredChs []bool) ([]ChMaskCntlPair, error) {
 	n := len(currentChs)
 	if n%16 != 0 || len(desiredChs) != n {
-		return nil, errInvalidChannelCount
+		return nil, errInvalidChannelCount.New()
 	}
 	for i := 0; i < n/16; i++ {
 		for j := 0; j < 16; j++ {
@@ -494,7 +494,7 @@ func trueCount(vs ...bool) int {
 
 func generateChMask72Generic(currentChs, desiredChs []bool) ([]ChMaskCntlPair, error) {
 	if len(currentChs) != 72 || len(desiredChs) != 72 {
-		return nil, errInvalidChannelCount
+		return nil, errInvalidChannelCount.New()
 	}
 	if equalChMasks(currentChs, desiredChs) {
 		return []ChMaskCntlPair{
@@ -648,7 +648,7 @@ func makeGenerateChMask72(supportChMaskCntl5 bool) func([]bool, []bool) ([]ChMas
 
 func generateChMask96(currentChs, desiredChs []bool) ([]ChMaskCntlPair, error) {
 	if len(currentChs) != 96 || len(desiredChs) != 96 {
-		return nil, errInvalidChannelCount
+		return nil, errInvalidChannelCount.New()
 	}
 	if equalChMasks(currentChs, desiredChs) {
 		return []ChMaskCntlPair{

--- a/pkg/basicstation/cups/server.go
+++ b/pkg/basicstation/cups/server.go
@@ -298,7 +298,7 @@ func (s *Server) getTrust(address string) (*x509.Certificate, error) {
 		if s.trust != nil {
 			return s.trust, nil
 		}
-		return nil, errNoTrust
+		return nil, errNoTrust.New()
 	}
 	_, host, port, err := parseAddress("https", address)
 	if err != nil {
@@ -337,7 +337,7 @@ func (s *Server) getTrust(address string) (*x509.Certificate, error) {
 			return trust, nil
 		}
 
-		return nil, errNoTrust
+		return nil, errNoTrust.New()
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/basicstation/cups/update_info.go
+++ b/pkg/basicstation/cups/update_info.go
@@ -195,7 +195,7 @@ func (s *Server) UpdateInfo(c echo.Context) error {
 		}
 	} else if gtw.Attributes[cupsAuthHeaderAttribute] != "" {
 		if subtle.ConstantTimeCompare([]byte(getAuthHeader(ctx)), []byte(gtw.Attributes[cupsAuthHeaderAttribute])) != 1 {
-			return errInvalidToken
+			return errInvalidToken.New()
 		}
 		logger.Debug("Authorized with CUPS Auth Header")
 		md := rpcmetadata.FromIncomingContext(ctx)
@@ -203,7 +203,7 @@ func (s *Server) UpdateInfo(c echo.Context) error {
 		md.AllowInsecure = s.component.AllowInsecureForCredentials()
 		gatewayAuth = grpc.PerRPCCredentials(md)
 	} else {
-		return errUnauthenticated
+		return errUnauthenticated.New()
 	}
 
 	if gtw.Attributes == nil {

--- a/pkg/basicstation/eui.go
+++ b/pkg/basicstation/eui.go
@@ -97,5 +97,5 @@ func (eui *EUI) UnmarshalJSON(data []byte) error {
 		}
 		return nil
 	}
-	return errFormat
+	return errFormat.New()
 }

--- a/pkg/component/acme.go
+++ b/pkg/component/acme.go
@@ -31,10 +31,10 @@ func (c *Component) initACME() error {
 		return nil
 	}
 	if c.config.TLS.ACME.Endpoint == "" {
-		return errMissingACMEEndpoint
+		return errMissingACMEEndpoint.New()
 	}
 	if c.config.TLS.ACME.Dir == "" {
-		return errMissingACMEDir
+		return errMissingACMEDir.New()
 	}
 	c.acme = &autocert.Manager{
 		Cache:      autocert.DirCache(c.config.TLS.ACME.Dir),

--- a/pkg/component/tls.go
+++ b/pkg/component/tls.go
@@ -133,7 +133,7 @@ func (c *Component) GetTLSServerConfig(ctx context.Context, opts ...TLSConfigOpt
 	case "key-vault":
 		certificateGetter = func() (func(*tls.ClientHelloInfo) (*tls.Certificate, error), error) {
 			if conf.KeyVault.ID == "" {
-				return nil, errTLSKeyVaultID
+				return nil, errTLSKeyVaultID.New()
 			}
 			return func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
 				return c.KeyVault.ExportCertificate(ctx, conf.KeyVault.ID)
@@ -141,7 +141,7 @@ func (c *Component) GetTLSServerConfig(ctx context.Context, opts ...TLSConfigOpt
 		}
 	}
 	if certificateGetter == nil {
-		return nil, errEmptyTLSConfig
+		return nil, errEmptyTLSConfig.New()
 	}
 	fn, err := certificateGetter()
 	if err != nil {

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -211,7 +211,7 @@ func (c BlobConfig) Bucket(ctx context.Context, bucket string) (*blob.Bucket, er
 				return nil, err
 			}
 		} else {
-			return nil, errMissingBlobConfig
+			return nil, errMissingBlobConfig.New()
 		}
 		return ttnblob.GCP(ctx, bucket, jsonCreds)
 	default:

--- a/pkg/crypto/cryptoservices/mem.go
+++ b/pkg/crypto/cryptoservices/mem.go
@@ -42,12 +42,12 @@ func (d *mem) getNwkKey(version ttnpb.MACVersion) (*types.AES128Key, error) {
 	switch {
 	case version.Compare(ttnpb.MAC_V1_1) >= 0:
 		if d.nwkKey == nil {
-			return nil, errNoNwkKey
+			return nil, errNoNwkKey.New()
 		}
 		return d.nwkKey, nil
 	default:
 		if d.appKey == nil {
-			return nil, errNoAppKey
+			return nil, errNoAppKey.New()
 		}
 		return d.appKey, nil
 	}
@@ -98,7 +98,7 @@ func (d *mem) EncryptJoinAccept(ctx context.Context, dev *ttnpb.EndDevice, versi
 		return nil, err
 	}
 	if key == nil {
-		return nil, errNoNwkKey
+		return nil, errNoNwkKey.New()
 	}
 	return crypto.EncryptJoinAccept(*key, payload)
 }
@@ -108,13 +108,13 @@ func (d *mem) EncryptRejoinAccept(ctx context.Context, dev *ttnpb.EndDevice, ver
 		panic("This statement is unreachable. Please version check.")
 	}
 	if dev.JoinEUI == nil {
-		return nil, errNoJoinEUI
+		return nil, errNoJoinEUI.New()
 	}
 	if dev.DevEUI == nil || dev.DevEUI.IsZero() {
-		return nil, errNoDevEUI
+		return nil, errNoDevEUI.New()
 	}
 	if d.nwkKey == nil {
-		return nil, errNoNwkKey
+		return nil, errNoNwkKey.New()
 	}
 	jsEncKey := crypto.DeriveJSEncKey(*d.nwkKey, *dev.DevEUI)
 	return crypto.EncryptJoinAccept(jsEncKey, payload)
@@ -150,7 +150,7 @@ func (d *mem) DeriveNwkSKeys(ctx context.Context, dev *ttnpb.EndDevice, version 
 
 func (d *mem) GetNwkKey(ctx context.Context, dev *ttnpb.EndDevice) (*types.AES128Key, error) {
 	if d.nwkKey == nil {
-		return nil, errNoNwkKey
+		return nil, errNoNwkKey.New()
 	}
 	return d.nwkKey, nil
 }
@@ -178,7 +178,7 @@ func (d *mem) DeriveAppSKey(ctx context.Context, dev *ttnpb.EndDevice, version t
 
 func (d *mem) GetAppKey(ctx context.Context, dev *ttnpb.EndDevice) (*types.AES128Key, error) {
 	if d.appKey == nil {
-		return nil, errNoAppKey
+		return nil, errNoAppKey.New()
 	}
 	return d.appKey, nil
 }

--- a/pkg/crypto/cryptoutil/cryptoutil.go
+++ b/pkg/crypto/cryptoutil/cryptoutil.go
@@ -57,7 +57,7 @@ func UnwrapAES128Key(ctx context.Context, wrapped ttnpb.KeyEnvelope, v crypto.Ke
 	}
 	if wrapped.KEKLabel == "" {
 		if len(wrapped.EncryptedKey) != 16 {
-			return key, errInvalidLength
+			return key, errInvalidLength.New()
 		}
 		copy(key[:], wrapped.EncryptedKey)
 	} else {
@@ -66,7 +66,7 @@ func UnwrapAES128Key(ctx context.Context, wrapped ttnpb.KeyEnvelope, v crypto.Ke
 			return key, err
 		}
 		if len(keyBytes) != 16 {
-			return key, errInvalidLength
+			return key, errInvalidLength.New()
 		}
 		copy(key[:], keyBytes)
 	}

--- a/pkg/crypto/keywrap.go
+++ b/pkg/crypto/keywrap.go
@@ -128,7 +128,7 @@ func UnwrapKey(ciphertext, kek []byte) ([]byte, error) {
 
 	// Check for corruption
 	if a != iv {
-		return nil, errCorruptKey
+		return nil, errCorruptKey.New()
 	}
 
 	// Build the result

--- a/pkg/devicetemplates/microchip.go
+++ b/pkg/devicetemplates/microchip.go
@@ -161,7 +161,7 @@ func (m *microchipATECC608AMAHTNT) Convert(ctx context.Context, r io.Reader, ch 
 		return errMicrochipData.WithCause(err)
 	}
 	if _, ok := delim.(json.Delim); !ok {
-		return errMicrochipData
+		return errMicrochipData.New()
 	}
 
 	for dec.More() {
@@ -244,7 +244,7 @@ func (m *microchipATECC608TNGLORA) Convert(ctx context.Context, r io.Reader, ch 
 		return errMicrochipData.WithCause(err)
 	}
 	if _, ok := delim.(json.Delim); !ok {
-		return errMicrochipData
+		return errMicrochipData.New()
 	}
 
 	for dec.More() {

--- a/pkg/errors/attributes.go
+++ b/pkg/errors/attributes.go
@@ -48,7 +48,7 @@ func supported(v interface{}) interface{} {
 
 func kvToMap(kv ...interface{}) (map[string]interface{}, error) {
 	if len(kv)%2 != 0 {
-		return nil, errOddKV
+		return nil, errOddKV.New()
 	}
 	m := make(map[string]interface{}, len(kv)/2)
 	var key string

--- a/pkg/errors/definitions.go
+++ b/pkg/errors/definitions.go
@@ -249,3 +249,9 @@ func DefineUnauthenticated(name, messageFormat string, publicAttributes ...strin
 	def := define(uint32(codes.Unauthenticated), name, messageFormat, publicAttributes...)
 	return def
 }
+
+// New returns a new error from the definition. This is not required, but will
+// add a stack trace for improved debugging.
+func (d Definition) New() Error {
+	return build(d, 0) // Don't refactor this to build(...).WithCause(...)
+}

--- a/pkg/fetch/basepath.go
+++ b/pkg/fetch/basepath.go
@@ -25,7 +25,7 @@ type basePathFetcher struct {
 
 func (f basePathFetcher) File(pathElements ...string) ([]byte, error) {
 	if len(pathElements) == 0 {
-		return nil, errFilenameNotSpecified
+		return nil, errFilenameNotSpecified.New()
 	}
 
 	// NOTE: filepath.IsAbs returns true for paths starting with '/' on all supported operating systems.

--- a/pkg/fetch/bucket.go
+++ b/pkg/fetch/bucket.go
@@ -32,7 +32,7 @@ type bucketFetcher struct {
 
 func (f *bucketFetcher) File(pathElements ...string) ([]byte, error) {
 	if len(pathElements) == 0 {
-		return nil, errFilenameNotSpecified
+		return nil, errFilenameNotSpecified.New()
 	}
 
 	start := time.Now()

--- a/pkg/fetch/fs.go
+++ b/pkg/fetch/fs.go
@@ -28,7 +28,7 @@ type fsFetcher struct {
 
 func (f fsFetcher) File(pathElements ...string) ([]byte, error) {
 	if len(pathElements) == 0 {
-		return nil, errFilenameNotSpecified
+		return nil, errFilenameNotSpecified.New()
 	}
 
 	start := time.Now()

--- a/pkg/fetch/http.go
+++ b/pkg/fetch/http.go
@@ -35,7 +35,7 @@ type httpFetcher struct {
 
 func (f httpFetcher) File(pathElements ...string) ([]byte, error) {
 	if len(pathElements) == 0 {
-		return nil, errFilenameNotSpecified
+		return nil, errFilenameNotSpecified.New()
 	}
 
 	start := time.Now()
@@ -77,7 +77,7 @@ func FromHTTP(rootURL string, cache bool) (Interface, error) {
 			return nil, err
 		}
 		if !root.IsAbs() {
-			return nil, errSchemeNotSpecified
+			return nil, errSchemeNotSpecified.New()
 		}
 	}
 	return httpFetcher{

--- a/pkg/fetch/mem.go
+++ b/pkg/fetch/mem.go
@@ -28,7 +28,7 @@ type memFetcher struct {
 // File gets content from memory.
 func (f *memFetcher) File(pathElements ...string) ([]byte, error) {
 	if len(pathElements) == 0 {
-		return nil, errFilenameNotSpecified
+		return nil, errFilenameNotSpecified.New()
 	}
 
 	start := time.Now()

--- a/pkg/frequencyplans/frequencyplans.go
+++ b/pkg/frequencyplans/frequencyplans.go
@@ -206,7 +206,7 @@ func (lsc *LoRaStandardChannel) ToConcentratorConfig(phy band.Band) (*ttnpb.Conc
 	}
 	dr, ok := phy.DataRates[ttnpb.DataRateIndex(lsc.DataRate)]
 	if !ok {
-		return nil, errInvalidDataRateIndex
+		return nil, errInvalidDataRateIndex.New()
 	}
 	lora := dr.Rate.GetLoRa()
 	return &ttnpb.ConcentratorConfig_LoRaStandardChannel{
@@ -428,7 +428,7 @@ func (fp FrequencyPlan) Validate() error {
 	}
 	fpdt := fp.DwellTime
 	if (fpdt.GetUplinks() || fpdt.GetDownlinks()) && fpdt.Duration == nil {
-		return errNoDwellTimeDuration
+		return errNoDwellTimeDuration.New()
 	}
 	for _, channels := range [][]Channel{fp.UplinkChannels, fp.DownlinkChannels} {
 		for i, channel := range channels {
@@ -687,7 +687,7 @@ func (s *Store) getByID(id string) (*FrequencyPlan, error) {
 // GetByID retrieves the frequency plan that has the given ID.
 func (s *Store) GetByID(id string) (*FrequencyPlan, error) {
 	if s == nil {
-		return nil, errNotConfigured
+		return nil, errNotConfigured.New()
 	}
 
 	if id == "" {
@@ -711,7 +711,7 @@ func (s *Store) GetByID(id string) (*FrequencyPlan, error) {
 // GetAllIDs returns the list of IDs of the available frequency plans.
 func (s *Store) GetAllIDs() ([]string, error) {
 	if s == nil {
-		return nil, errNotConfigured
+		return nil, errNotConfigured.New()
 	}
 
 	descriptions, err := s.descriptions()

--- a/pkg/gatewayconfigurationserver/gcsv2/get_gateway.go
+++ b/pkg/gatewayconfigurationserver/gcsv2/get_gateway.go
@@ -103,7 +103,7 @@ func (s *Server) handleGetGateway(c echo.Context) error {
 	case "key":
 		keyAttr, ok := gateway.Attributes["key"]
 		if !ok || md.AuthValue != keyAttr {
-			return errUnauthenticated
+			return errUnauthenticated.New()
 		}
 	default:
 		gateway = gateway.PublicSafe()

--- a/pkg/gatewayconfigurationserver/gcsv2/middleware.go
+++ b/pkg/gatewayconfigurationserver/gcsv2/middleware.go
@@ -33,7 +33,7 @@ func (s *Server) normalizeAuthorization(next echo.HandlerFunc) echo.HandlerFunc 
 		}
 		authorizationParts := strings.SplitN(authorization, " ", 2)
 		if len(authorizationParts) != 2 {
-			return errUnauthenticated
+			return errUnauthenticated.New()
 		}
 		authType, authValue := strings.ToLower(authorizationParts[0]), authorizationParts[1]
 		switch authType {
@@ -45,7 +45,7 @@ func (s *Server) normalizeAuthorization(next echo.HandlerFunc) echo.HandlerFunc 
 				authType = "key"
 			}
 		default:
-			return errUnauthenticated
+			return errUnauthenticated.New()
 		}
 		md := metadata.New(map[string]string{
 			"authorization": fmt.Sprintf("%s %s", authType, authValue),

--- a/pkg/gatewayserver/gatewayserver_util_test.go
+++ b/pkg/gatewayserver/gatewayserver_util_test.go
@@ -93,7 +93,7 @@ func (is *mockIS) Get(ctx context.Context, req *ttnpb.GetGatewayRequest) (*ttnpb
 	uid := unique.ID(ctx, req.GatewayIdentifiers)
 	gtw, ok := is.gateways[uid]
 	if !ok {
-		return nil, errNotFound
+		return nil, errNotFound.New()
 	}
 	return gtw, nil
 }
@@ -102,7 +102,7 @@ func (is *mockIS) Update(ctx context.Context, req *ttnpb.UpdateGatewayRequest) (
 	uid := unique.ID(ctx, req.Gateway.GatewayIdentifiers)
 	gtw, ok := is.gateways[uid]
 	if !ok {
-		return nil, errNotFound
+		return nil, errNotFound.New()
 	}
 	// Just update antennas
 	gtw.Antennas = req.Antennas
@@ -116,7 +116,7 @@ func (is *mockIS) GetIdentifiersForEUI(ctx context.Context, req *ttnpb.GetGatewa
 			EUI:       &registeredGatewayEUI,
 		}, nil
 	}
-	return nil, errNotFound
+	return nil, errNotFound.New()
 }
 
 func (is *mockIS) ListRights(ctx context.Context, ids *ttnpb.GatewayIdentifiers) (res *ttnpb.Rights, err error) {

--- a/pkg/gatewayserver/grpc_nsgs.go
+++ b/pkg/gatewayserver/grpc_nsgs.go
@@ -45,7 +45,7 @@ func (gs *GatewayServer) ScheduleDownlink(ctx context.Context, down *ttnpb.Downl
 	}
 	request := down.GetRequest()
 	if request == nil {
-		return nil, errNotTxRequest
+		return nil, errNotTxRequest.New()
 	}
 
 	var pathErrs []errors.ErrorDetails

--- a/pkg/gatewayserver/io/basicstationlns/basicstationlns.go
+++ b/pkg/gatewayserver/io/basicstationlns/basicstationlns.go
@@ -130,7 +130,7 @@ func (s *srv) handleDiscover(c echo.Context) error {
 
 	if req.EUI.IsZero() {
 		writeDiscoverError(ctx, ws, "Empty router EUI provided")
-		return errEmptyGatewayEUI
+		return errEmptyGatewayEUI.New()
 	}
 
 	ids := ttnpb.GatewayIdentifiers{

--- a/pkg/gatewayserver/io/basicstationlns/messages/upstream.go
+++ b/pkg/gatewayserver/io/basicstationlns/messages/upstream.go
@@ -211,13 +211,13 @@ func (req *JoinRequest) FromUplinkMessage(up *ttnpb.UplinkMessage, bandID string
 	var payload ttnpb.Message
 	err := lorawan.UnmarshalMessage(up.RawPayload, &payload)
 	if err != nil {
-		return errUplinkMessage
+		return errUplinkMessage.New()
 	}
 	req.MHdr = (uint(payload.MHDR.GetMType()) << 5) | uint(payload.MHDR.GetMajor())
 	req.MIC = int32(binary.LittleEndian.Uint32(payload.MIC[:]))
 	jreqPayload := payload.GetJoinRequestPayload()
 	if jreqPayload == nil {
-		return errUplinkMessage
+		return errUplinkMessage.New()
 	}
 
 	req.DevEUI = basicstation.EUI{
@@ -272,7 +272,7 @@ func (updf *UplinkDataFrame) ToUplinkMessage(ids ttnpb.GatewayIdentifiers, bandI
 		return nil, errUplinkDataFrame.WithCause(err)
 	}
 	if parsedMHDR.MType != ttnpb.MType_UNCONFIRMED_UP && parsedMHDR.MType != ttnpb.MType_CONFIRMED_UP {
-		return nil, errUplinkDataFrame
+		return nil, errUplinkDataFrame.New()
 	}
 
 	micBytes, err := getInt32AsByteSlice(updf.MIC)
@@ -382,13 +382,13 @@ func (updf *UplinkDataFrame) FromUplinkMessage(up *ttnpb.UplinkMessage, bandID s
 	var payload ttnpb.Message
 	err := lorawan.UnmarshalMessage(up.RawPayload, &payload)
 	if err != nil {
-		return errUplinkMessage
+		return errUplinkMessage.New()
 	}
 	updf.MHdr = (uint(payload.MHDR.GetMType()) << 5) | uint(payload.MHDR.GetMajor())
 
 	macPayload := payload.GetMACPayload()
 	if macPayload == nil {
-		return errUplinkMessage
+		return errUplinkMessage.New()
 	}
 
 	updf.FPort = int(macPayload.GetFPort())

--- a/pkg/gatewayserver/io/grpc/grpc.go
+++ b/pkg/gatewayserver/io/grpc/grpc.go
@@ -190,7 +190,7 @@ func getMQTTConnectionProvider(ctx context.Context, ids *ttnpb.GatewayIdentifier
 		return nil, err
 	}
 	if provider == nil {
-		return nil, errNoMQTTConfigProvider
+		return nil, errNoMQTTConfigProvider.New()
 	}
 	config, err := provider.GetMQTTConfig(ctx)
 	if err != nil {

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -116,7 +116,7 @@ func NewConnection(ctx context.Context, frontend Frontend, gateway *ttnpb.Gatewa
 
 	if len(gateway.FrequencyPlanIDs) > 0 {
 		if gateway.FrequencyPlanIDs[0] != fp0ID {
-			return nil, errInconsistentFrequencyPlans
+			return nil, errInconsistentFrequencyPlans.New()
 		}
 		for i := 1; i < len(gateway.FrequencyPlanIDs); i++ {
 			fpn, err := fps.GetByID(gateway.FrequencyPlanIDs[i])
@@ -124,7 +124,7 @@ func NewConnection(ctx context.Context, frontend Frontend, gateway *ttnpb.Gatewa
 				return nil, err
 			}
 			if fpn.BandID != fp0.BandID {
-				return nil, errFrequencyPlansNotFromSameBand
+				return nil, errFrequencyPlansNotFromSameBand.New()
 			}
 			gatewayFPs[gateway.FrequencyPlanIDs[i]] = fpn
 		}
@@ -227,7 +227,7 @@ func (c *Connection) HandleUp(up *ttnpb.UplinkMessage) error {
 		atomic.StoreInt64(&c.lastUplinkTime, up.ReceivedAt.UnixNano())
 		c.notifyStatsChanged()
 	default:
-		return errBufferFull
+		return errBufferFull.New()
 	}
 	return nil
 }
@@ -249,7 +249,7 @@ func (c *Connection) HandleStatus(status *ttnpb.GatewayStatus) error {
 			}
 		}
 	default:
-		return errBufferFull
+		return errBufferFull.New()
 	}
 	return nil
 }
@@ -262,7 +262,7 @@ func (c *Connection) HandleTxAck(ack *ttnpb.TxAcknowledgment) error {
 	case c.txAckCh <- ack:
 		c.notifyStatsChanged()
 	default:
-		return errBufferFull
+		return errBufferFull.New()
 	}
 	return nil
 }
@@ -314,7 +314,7 @@ func (c *Connection) SendDown(msg *ttnpb.DownlinkMessage) error {
 		atomic.AddUint64(&c.downlinks, 1)
 		atomic.StoreInt64(&c.lastDownlinkTime, time.Now().UnixNano())
 	default:
-		return errBufferFull
+		return errBufferFull.New()
 	}
 	return nil
 }

--- a/pkg/gatewayserver/io/mock/entity_registry.go
+++ b/pkg/gatewayserver/io/mock/entity_registry.go
@@ -69,7 +69,7 @@ func (is *IdentityServer) Get(ctx context.Context, req *ttnpb.GetGatewayRequest)
 	uid := unique.ID(ctx, req.GatewayIdentifiers)
 	app, ok := is.gateways[uid]
 	if !ok {
-		return nil, errNotFound
+		return nil, errNotFound.New()
 	}
 	return app, nil
 }

--- a/pkg/gatewayserver/io/mqtt/format_protobufv2.go
+++ b/pkg/gatewayserver/io/mqtt/format_protobufv2.go
@@ -69,7 +69,7 @@ type protobufv2 struct {
 func (protobufv2) FromDownlink(down *ttnpb.DownlinkMessage, _ ttnpb.GatewayIdentifiers) ([]byte, error) {
 	settings := down.GetScheduled()
 	if settings == nil {
-		return nil, errNotScheduled
+		return nil, errNotScheduled.New()
 	}
 	lorawan := &ttnpbv2.LoRaWANTxConfiguration{}
 	if pld, ok := down.GetPayload().GetPayload().(*ttnpb.Message_MACPayload); ok && pld != nil {
@@ -84,7 +84,7 @@ func (protobufv2) FromDownlink(down *ttnpb.DownlinkMessage, _ ttnpb.GatewayIdent
 		lorawan.Modulation = ttnpbv2.Modulation_FSK
 		lorawan.BitRate = dr.FSK.BitRate
 	default:
-		return nil, errModulation
+		return nil, errModulation.New()
 	}
 
 	v2downlink := &ttnpbv2.DownlinkMessage{
@@ -111,7 +111,7 @@ func (protobufv2) ToUplink(message []byte, ids ttnpb.GatewayIdentifiers) (*ttnpb
 	}
 
 	if v2uplink.ProtocolMetadata.LoRaWAN == nil {
-		return nil, errLoRaWANMetadata
+		return nil, errLoRaWANMetadata.New()
 	}
 	lorawanMetadata := v2uplink.ProtocolMetadata.LoRaWAN
 	gwMetadata := v2uplink.GatewayMetadata
@@ -254,7 +254,7 @@ func (protobufv2) ToStatus(message []byte, _ ttnpb.GatewayIdentifiers) (*ttnpb.G
 }
 
 func (protobufv2) ToTxAck(message []byte, _ ttnpb.GatewayIdentifiers) (*ttnpb.TxAcknowledgment, error) {
-	return nil, errNotSupported
+	return nil, errNotSupported.New()
 }
 
 // NewProtobufV2 returns a format that uses the legacy The Things Stack V2 Protocol Buffers marshaling and unmarshaling.

--- a/pkg/gatewayserver/io/udp/firewall.go
+++ b/pkg/gatewayserver/io/udp/firewall.go
@@ -68,10 +68,10 @@ var (
 
 func (f *memoryFirewall) Filter(packet encoding.Packet) error {
 	if packet.GatewayEUI == nil {
-		return errNoEUI
+		return errNoEUI.New()
 	}
 	if packet.GatewayAddr == nil {
-		return errNoAddress
+		return errNoAddress.New()
 	}
 	now := time.Now().UTC()
 	eui := *packet.GatewayEUI

--- a/pkg/gatewayserver/io/udp/firewall_ratelimit.go
+++ b/pkg/gatewayserver/io/udp/firewall_ratelimit.go
@@ -46,10 +46,10 @@ var (
 
 func (f *rateLimitingFirewall) Filter(packet encoding.Packet) error {
 	if packet.GatewayEUI == nil {
-		return errNoEUI
+		return errNoEUI.New()
 	}
 	if packet.GatewayAddr == nil {
-		return errNoAddress
+		return errNoAddress.New()
 	}
 	now := time.Now().UTC()
 	eui := *packet.GatewayEUI
@@ -64,7 +64,7 @@ func (f *rateLimitingFirewall) Filter(packet encoding.Packet) error {
 
 	oldestTimestamp := ts.Append(now)
 	if !oldestTimestamp.IsZero() && now.Sub(oldestTimestamp) < f.threshold {
-		return errRateExceeded
+		return errRateExceeded.New()
 	}
 
 	// Continue filtering

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -243,7 +243,7 @@ func (s *srv) connect(ctx context.Context, eui types.EUI64) (*state, error) {
 		select {
 		case <-cs.ioWait:
 		default:
-			return nil, errConnectionNotReady
+			return nil, errConnectionNotReady.New()
 		}
 		if cs.ioErr != nil {
 			return nil, cs.ioErr
@@ -413,7 +413,7 @@ func (s *srv) handleDown(ctx context.Context, state *state) error {
 				state.startHandleDownMu.Lock()
 				state.startHandleDown = &sync.Once{}
 				state.startHandleDownMu.Unlock()
-				return errDownlinkPathExpired
+				return errDownlinkPathExpired.New()
 			}
 		}
 	}

--- a/pkg/gatewayserver/scheduling/scheduler.go
+++ b/pkg/gatewayserver/scheduling/scheduler.go
@@ -91,7 +91,7 @@ func NewScheduler(ctx context.Context, fps map[string]*frequencyplans.FrequencyP
 	var toa *frequencyplans.TimeOffAir
 	for _, fp := range fps {
 		if toa != nil && fp.TimeOffAir != *toa {
-			return nil, errFrequencyPlansTimeOffAir
+			return nil, errFrequencyPlansTimeOffAir.New()
 		}
 		toa = &fp.TimeOffAir
 	}
@@ -124,7 +124,7 @@ func NewScheduler(ctx context.Context, fps map[string]*frequencyplans.FrequencyP
 							break
 						}
 						if subBand.HasOverlap(sb) {
-							return nil, errFrequencyPlansOverlapSubBand
+							return nil, errFrequencyPlansOverlapSubBand.New()
 						}
 					}
 					if !isIdentical {
@@ -150,7 +150,7 @@ func NewScheduler(ctx context.Context, fps map[string]*frequencyplans.FrequencyP
 							break
 						}
 						if subBand.HasOverlap(sb) {
-							return nil, errFrequencyPlansOverlapSubBand
+							return nil, errFrequencyPlansOverlapSubBand.New()
 						}
 					}
 					if !isIdentical {

--- a/pkg/identityserver/contact_info_registry.go
+++ b/pkg/identityserver/contact_info_registry.go
@@ -144,7 +144,7 @@ func (cir *contactInfoRegistry) RequestValidation(ctx context.Context, ids *ttnp
 	case *ttnpb.UserIdentifiers:
 		err = rights.RequireUser(ctx, *id, ttnpb.RIGHT_USER_SETTINGS_BASIC)
 	default:
-		return nil, errNoContactInfoForEntity
+		return nil, errNoContactInfoForEntity.New()
 	}
 	if err != nil {
 		return nil, err

--- a/pkg/identityserver/entity_access.go
+++ b/pkg/identityserver/entity_access.go
@@ -85,7 +85,7 @@ func (is *IdentityServer) authInfo(ctx context.Context) (info *ttnpb.AuthInfoRes
 		}, nil
 	}
 	if strings.ToLower(md.AuthType) != "bearer" {
-		return nil, errUnsupportedAuthorization
+		return nil, errUnsupportedAuthorization.New()
 	}
 
 	token := md.AuthValue
@@ -118,7 +118,7 @@ func (is *IdentityServer) authInfo(ctx context.Context) (info *ttnpb.AuthInfoRes
 				return errInvalidAuthorization.WithCause(err)
 			}
 			if !valid {
-				return errInvalidAuthorization
+				return errInvalidAuthorization.New()
 			}
 			apiKey.Key = ""
 			apiKey.Rights = ttnpb.RightsFrom(apiKey.Rights...).Implied().GetRights()
@@ -156,10 +156,10 @@ func (is *IdentityServer) authInfo(ctx context.Context) (info *ttnpb.AuthInfoRes
 				return errInvalidAuthorization.WithCause(err)
 			}
 			if !valid {
-				return errInvalidAuthorization
+				return errInvalidAuthorization.New()
 			}
 			if accessToken.ExpiresAt.Before(time.Now()) {
-				return errTokenExpired
+				return errTokenExpired.New()
 			}
 			accessToken.AccessToken, accessToken.RefreshToken = "", ""
 			accessToken.Rights = ttnpb.RightsFrom(accessToken.Rights...).Implied().GetRights()
@@ -186,11 +186,11 @@ func (is *IdentityServer) authInfo(ctx context.Context) (info *ttnpb.AuthInfoRes
 			case ttnpb.STATE_APPROVED:
 				// Normal OAuth client.
 			case ttnpb.STATE_REJECTED:
-				return errOAuthClientRejected
+				return errOAuthClientRejected.New()
 			case ttnpb.STATE_FLAGGED:
 				// Innocent until proven guilty.
 			case ttnpb.STATE_SUSPENDED:
-				return errOAuthClientSuspended
+				return errOAuthClientSuspended.New()
 			default:
 				panic(fmt.Sprintf("Unhandled client state: %s", client.State.String()))
 			}
@@ -198,7 +198,7 @@ func (is *IdentityServer) authInfo(ctx context.Context) (info *ttnpb.AuthInfoRes
 			return nil
 		}
 	default:
-		return nil, errUnsupportedAuthorization
+		return nil, errUnsupportedAuthorization.New()
 	}
 
 	if err = is.withDatabase(ctx, fetch); err != nil {
@@ -265,11 +265,11 @@ func (is *IdentityServer) RequireAuthenticated(ctx context.Context) error {
 				// Flagged users have the same authentication presence as approved users until proven guilty.
 				return nil
 			case ttnpb.STATE_REQUESTED:
-				return errUserRequested
+				return errUserRequested.New()
 			case ttnpb.STATE_REJECTED:
-				return errUserRejected
+				return errUserRejected.New()
 			case ttnpb.STATE_SUSPENDED:
-				return errUserSuspended
+				return errUserSuspended.New()
 			default:
 				panic(fmt.Sprintf("Unhandled user state: %s", user.State.String()))
 			}
@@ -286,7 +286,7 @@ func (is *IdentityServer) RequireAuthenticated(ctx context.Context) error {
 	if len(authInfo.UniversalRights.GetRights()) > 0 {
 		return nil
 	}
-	return errUnauthenticated
+	return errUnauthenticated.New()
 }
 
 // UniversalRights returns the universal rights (that apply to any entity or
@@ -312,7 +312,7 @@ func (is *IdentityServer) IsAdmin(ctx context.Context) bool {
 // RequireAdmin returns an error when the caller is not an admin.
 func (is *IdentityServer) RequireAdmin(ctx context.Context) error {
 	if !is.IsAdmin(ctx) {
-		return errPermissionDenied
+		return errPermissionDenied.New()
 	}
 	return nil
 }

--- a/pkg/identityserver/entity_access.go
+++ b/pkg/identityserver/entity_access.go
@@ -115,7 +115,7 @@ func (is *IdentityServer) authInfo(ctx context.Context) (info *ttnpb.AuthInfoRes
 			valid, err := auth.Validate(apiKey.GetKey(), tokenKey)
 			region.End()
 			if err != nil {
-				return err
+				return errInvalidAuthorization.WithCause(err)
 			}
 			if !valid {
 				return errInvalidAuthorization
@@ -153,7 +153,7 @@ func (is *IdentityServer) authInfo(ctx context.Context) (info *ttnpb.AuthInfoRes
 			valid, err := auth.Validate(accessToken.GetAccessToken(), tokenKey)
 			region.End()
 			if err != nil {
-				return err
+				return errInvalidAuthorization.WithCause(err)
 			}
 			if !valid {
 				return errInvalidAuthorization

--- a/pkg/identityserver/invitation_registry.go
+++ b/pkg/identityserver/invitation_registry.go
@@ -43,7 +43,7 @@ func (is *IdentityServer) sendInvitation(ctx context.Context, in *ttnpb.SendInvi
 		return nil, err
 	}
 	if !authInfo.GetUniversalRights().IncludesAll(ttnpb.RIGHT_SEND_INVITES) {
-		return nil, errNoInviteRights
+		return nil, errNoInviteRights.New()
 	}
 	token, err := auth.GenerateKey(ctx)
 	if err != nil {
@@ -81,7 +81,7 @@ func (is *IdentityServer) listInvitations(ctx context.Context, req *ttnpb.ListIn
 		return nil, err
 	}
 	if !authInfo.GetUniversalRights().IncludesAll(ttnpb.RIGHT_SEND_INVITES) {
-		return nil, errNoInviteRights
+		return nil, errNoInviteRights.New()
 	}
 	invitations = &ttnpb.Invitations{}
 	err = is.withDatabase(ctx, func(db *gorm.DB) (err error) {
@@ -100,7 +100,7 @@ func (is *IdentityServer) deleteInvitation(ctx context.Context, in *ttnpb.Delete
 		return nil, err
 	}
 	if !authInfo.GetUniversalRights().IncludesAll(ttnpb.RIGHT_SEND_INVITES) {
-		return nil, errNoInviteRights
+		return nil, errNoInviteRights.New()
 	}
 	err = is.withDatabase(ctx, func(db *gorm.DB) error {
 		return store.GetInvitationStore(db).DeleteInvitation(ctx, in.Email)

--- a/pkg/identityserver/oauth_registry.go
+++ b/pkg/identityserver/oauth_registry.go
@@ -115,7 +115,7 @@ func (is *IdentityServer) deleteOAuthAccessToken(ctx context.Context, req *ttnpb
 				return err
 			}
 			if accessToken.UserIDs.UserID != req.UserIDs.UserID || accessToken.ClientIDs.ClientID != req.ClientIDs.ClientID {
-				return errAccessTokenMismatch
+				return errAccessTokenMismatch.New()
 			}
 		}
 		return oauthStore.DeleteAccessToken(ctx, req.ID)

--- a/pkg/identityserver/organization_registry.go
+++ b/pkg/identityserver/organization_registry.go
@@ -53,7 +53,7 @@ func (is *IdentityServer) createOrganization(ctx context.Context, req *ttnpb.Cre
 			return nil, err
 		}
 	} else if orgIDs := req.Collaborator.GetOrganizationIDs(); orgIDs != nil {
-		return nil, errNestedOrganizations
+		return nil, errNestedOrganizations.New()
 	}
 	if err := validateContactInfo(req.Organization.ContactInfo); err != nil {
 		return nil, err
@@ -138,7 +138,7 @@ func (is *IdentityServer) listOrganizations(ctx context.Context, req *ttnpb.List
 			return nil, err
 		}
 	} else if orgIDs := req.Collaborator.GetOrganizationIDs(); orgIDs != nil {
-		return nil, errNestedOrganizations
+		return nil, errNestedOrganizations.New()
 	}
 	ctx = store.WithOrder(ctx, req.Order)
 	var total uint64

--- a/pkg/identityserver/registry_search.go
+++ b/pkg/identityserver/registry_search.go
@@ -42,7 +42,7 @@ func (rs *registrySearch) memberForSearch(ctx context.Context) (*ttnpb.Organizat
 	if member != nil {
 		return member, nil
 	}
-	return nil, errSearchForbidden
+	return nil, errSearchForbidden.New()
 }
 
 func (rs *registrySearch) SearchApplications(ctx context.Context, req *ttnpb.SearchEntitiesRequest) (*ttnpb.Applications, error) {
@@ -223,7 +223,7 @@ func (rs *registrySearch) SearchUsers(ctx context.Context, req *ttnpb.SearchEnti
 		return nil, err
 	}
 	if member != nil {
-		return nil, errSearchForbidden
+		return nil, errSearchForbidden.New()
 	}
 	req.FieldMask.Paths = cleanFieldMaskPaths(ttnpb.UserFieldPathsNested, req.FieldMask.Paths, getPaths, nil)
 	ctx = store.WithOrder(ctx, req.Order)

--- a/pkg/identityserver/store/api_key_store.go
+++ b/pkg/identityserver/store/api_key_store.go
@@ -118,7 +118,7 @@ func (s *apiKeyStore) UpdateAPIKey(ctx context.Context, entityID ttnpb.Identifie
 	}).First(&keyModel).Error
 	if err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return nil, errAPIKeyNotFound
+			return nil, errAPIKeyNotFound.New()
 		}
 		return nil, err
 	}

--- a/pkg/identityserver/store/contact_info_store.go
+++ b/pkg/identityserver/store/contact_info_store.go
@@ -197,13 +197,13 @@ func (s *contactInfoStore) Validate(ctx context.Context, validation *ttnpb.Conta
 	}).Find(&model).Error
 	if err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return errValidationTokenNotFound
+			return errValidationTokenNotFound.New()
 		}
 		return err
 	}
 
 	if model.ExpiresAt.Before(time.Now()) {
-		return errValidationTokenExpired
+		return errValidationTokenExpired.New()
 	}
 
 	err = s.query(ctx, ContactInfo{}).Where(ContactInfo{

--- a/pkg/identityserver/store/end_device_store.go
+++ b/pkg/identityserver/store/end_device_store.go
@@ -127,7 +127,7 @@ func (s *deviceStore) FindEndDevices(ctx context.Context, ids []*ttnpb.EndDevice
 	var applicationID string
 	for i, id := range ids {
 		if applicationID != "" && applicationID != id.GetApplicationID() {
-			return nil, errMultipleApplicationIDs
+			return nil, errMultipleApplicationIDs.New()
 		}
 		applicationID = id.GetApplicationID()
 		idStrings[i] = id.GetDeviceID()

--- a/pkg/identityserver/store/invitation_store.go
+++ b/pkg/identityserver/store/invitation_store.go
@@ -45,7 +45,7 @@ func (s *invitationStore) CreateInvitation(ctx context.Context, invitation *ttnp
 	if err := s.createEntity(ctx, &model); err != nil {
 		err = convertError(err)
 		if errors.IsAlreadyExists(err) {
-			return nil, errInvitationAlreadySent
+			return nil, errInvitationAlreadySent.New()
 		}
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func (s *invitationStore) GetInvitation(ctx context.Context, token string) (*ttn
 	var invitationModel Invitation
 	if err := s.query(ctx, Invitation{}).Where(Invitation{Token: token}).First(&invitationModel).Error; err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return nil, errInvitationNotFound
+			return nil, errInvitationNotFound.New()
 		}
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (s *invitationStore) SetInvitationAcceptedBy(ctx context.Context, token str
 	var invitationModel Invitation
 	if err := s.query(ctx, Invitation{}).Where(Invitation{Token: token}).First(&invitationModel).Error; err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return errInvitationNotFound
+			return errInvitationNotFound.New()
 		}
 		return err
 	}
@@ -105,7 +105,7 @@ func (s *invitationStore) SetInvitationAcceptedBy(ctx context.Context, token str
 		id := user.PrimaryKey()
 		invitationModel.AcceptedByID = &id
 	} else {
-		return errInvitationAlreadyAccepted
+		return errInvitationAlreadyAccepted.New()
 	}
 
 	acceptedAt := cleanTime(time.Now())
@@ -119,12 +119,12 @@ func (s *invitationStore) DeleteInvitation(ctx context.Context, email string) er
 	var invitationModel Invitation
 	if err := s.query(ctx, Invitation{}).Where(Invitation{Email: email}).First(&invitationModel).Error; err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return errInvitationNotFound
+			return errInvitationNotFound.New()
 		}
 		return err
 	}
 	if invitationModel.AcceptedByID != nil {
-		return errInvitationAlreadyAccepted
+		return errInvitationAlreadyAccepted.New()
 	}
 	return s.query(ctx, Invitation{}).Delete(&invitationModel).Error
 }

--- a/pkg/identityserver/store/oauth_store.go
+++ b/pkg/identityserver/store/oauth_store.go
@@ -169,7 +169,7 @@ func (s *oauthStore) CreateAuthorizationCode(ctx context.Context, code *ttnpb.OA
 func (s *oauthStore) GetAuthorizationCode(ctx context.Context, code string) (*ttnpb.OAuthAuthorizationCode, error) {
 	defer trace.StartRegion(ctx, "get authorization code").End()
 	if code == "" {
-		return nil, errAuthorizationCodeNotFound
+		return nil, errAuthorizationCodeNotFound.New()
 	}
 	var codeModel AuthorizationCode
 	err := s.query(ctx, AuthorizationCode{}).Where(AuthorizationCode{
@@ -177,7 +177,7 @@ func (s *oauthStore) GetAuthorizationCode(ctx context.Context, code string) (*tt
 	}).Preload("Client").Preload("User.Account").First(&codeModel).Error
 	if err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return nil, errAuthorizationCodeNotFound
+			return nil, errAuthorizationCodeNotFound.New()
 		}
 	}
 	return codeModel.toPB(), nil
@@ -185,7 +185,7 @@ func (s *oauthStore) GetAuthorizationCode(ctx context.Context, code string) (*tt
 
 func (s *oauthStore) DeleteAuthorizationCode(ctx context.Context, code string) error {
 	if code == "" {
-		return errAuthorizationCodeNotFound
+		return errAuthorizationCodeNotFound.New()
 	}
 	defer trace.StartRegion(ctx, "delete authorization code").End()
 	err := s.query(ctx, AuthorizationCode{}).Where(AuthorizationCode{
@@ -193,7 +193,7 @@ func (s *oauthStore) DeleteAuthorizationCode(ctx context.Context, code string) e
 	}).Delete(&AuthorizationCode{}).Error
 	if err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return errAuthorizationCodeNotFound
+			return errAuthorizationCodeNotFound.New()
 		}
 		return err
 	}
@@ -264,7 +264,7 @@ func (s *oauthStore) ListAccessTokens(ctx context.Context, userIDs *ttnpb.UserId
 
 func (s *oauthStore) GetAccessToken(ctx context.Context, id string) (*ttnpb.OAuthAccessToken, error) {
 	if id == "" {
-		return nil, errAccessTokenNotFound
+		return nil, errAccessTokenNotFound.New()
 	}
 	defer trace.StartRegion(ctx, "get access token").End()
 	var tokenModel struct {
@@ -279,7 +279,7 @@ func (s *oauthStore) GetAccessToken(ctx context.Context, id string) (*ttnpb.OAut
 		Where(AccessToken{TokenID: id}).Scan(&tokenModel).Error
 	if err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return nil, errAccessTokenNotFound
+			return nil, errAccessTokenNotFound.New()
 		}
 	}
 	tokenProto := tokenModel.AccessToken.toPB()
@@ -290,7 +290,7 @@ func (s *oauthStore) GetAccessToken(ctx context.Context, id string) (*ttnpb.OAut
 
 func (s *oauthStore) DeleteAccessToken(ctx context.Context, id string) error {
 	if id == "" {
-		return errAccessTokenNotFound
+		return errAccessTokenNotFound.New()
 	}
 	defer trace.StartRegion(ctx, "delete access token").End()
 	err := s.query(ctx, AccessToken{}).Where(AccessToken{
@@ -298,7 +298,7 @@ func (s *oauthStore) DeleteAccessToken(ctx context.Context, id string) error {
 	}).Delete(&AccessToken{}).Error
 	if err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return errAccessTokenNotFound
+			return errAccessTokenNotFound.New()
 		}
 		return err
 	}

--- a/pkg/interop/client.go
+++ b/pkg/interop/client.go
@@ -91,7 +91,7 @@ func (p *JoinServerProtocol) UnmarshalYAML(unmarshal func(interface{}) error) er
 		*p = LoRaWANJoinServerProtocol1_0
 		return nil
 	default:
-		return errUnknownProtocol
+		return errUnknownProtocol.New()
 	}
 }
 
@@ -248,7 +248,7 @@ var (
 func (cl joinServerHTTPClient) HandleJoinRequest(ctx context.Context, netID types.NetID, req *ttnpb.JoinRequest) (*ttnpb.JoinResponse, error) {
 	pld := req.Payload.GetJoinRequestPayload()
 	if pld == nil {
-		return nil, ErrMalformedMessage
+		return nil, ErrMalformedMessage.New()
 	}
 
 	dlSettings, err := lorawan.MarshalDLSettings(req.DownlinkSettings)
@@ -299,7 +299,7 @@ func (cl joinServerHTTPClient) HandleJoinRequest(ctx context.Context, netID type
 		log.FromContext(ctx).Debug("Interop join-accept does not contain session key ID, generate random ID")
 		id, err := ulid.New(ulid.Timestamp(time.Now()), rand.Reader)
 		if err != nil {
-			return nil, errGenerateSessionKeyID
+			return nil, errGenerateSessionKeyID.New()
 		}
 		sessionKeyID = make([]byte, 0, len(generatedSessionKeyIDPrefix)+len(id))
 		sessionKeyID = append(sessionKeyID, generatedSessionKeyIDPrefix...)
@@ -418,7 +418,7 @@ func NewClient(ctx context.Context, conf config.InteropClient) (*Client, error) 
 		return nil, err
 	}
 	if fetcher == nil {
-		return nil, errUnknownConfig
+		return nil, errUnknownConfig.New()
 	}
 	confFileBytes, err := fetcher.File(InteropClientConfigurationName)
 	if err != nil {
@@ -487,7 +487,7 @@ func NewClient(ctx context.Context, conf config.InteropClient) (*Client, error) 
 				Protocol:       yamlJSConf.Protocol,
 			}
 		default:
-			return nil, errUnknownProtocol
+			return nil, errUnknownProtocol.New()
 		}
 		for _, pre := range jsConf.JoinEUIs {
 			jss = append(jss, prefixJoinServerClient{
@@ -522,7 +522,7 @@ func (cl Client) joinServer(joinEUI types.EUI64) (joinServerClient, bool) {
 func (cl Client) GetAppSKey(ctx context.Context, asID string, req *ttnpb.SessionKeyRequest) (*ttnpb.AppSKeyResponse, error) {
 	js, ok := cl.joinServer(req.JoinEUI)
 	if !ok {
-		return nil, errNotRegistered
+		return nil, errNotRegistered.New()
 	}
 	return js.GetAppSKey(ctx, asID, req)
 }
@@ -531,11 +531,11 @@ func (cl Client) GetAppSKey(ctx context.Context, asID string, req *ttnpb.Session
 func (cl Client) HandleJoinRequest(ctx context.Context, netID types.NetID, req *ttnpb.JoinRequest) (*ttnpb.JoinResponse, error) {
 	pld := req.Payload.GetJoinRequestPayload()
 	if pld == nil {
-		return nil, ErrMalformedMessage
+		return nil, ErrMalformedMessage.New()
 	}
 	js, ok := cl.joinServer(pld.JoinEUI)
 	if !ok {
-		return nil, errNotRegistered
+		return nil, errNotRegistered.New()
 	}
 	return js.HandleJoinRequest(ctx, netID, req)
 }

--- a/pkg/interop/messages.go
+++ b/pkg/interop/messages.go
@@ -242,7 +242,7 @@ func parseMessage() echo.MiddlewareFunc {
 			switch header.ProtocolVersion {
 			case "1.0", "1.1":
 			default:
-				return ErrProtocolVersion
+				return ErrProtocolVersion.New()
 			}
 			var msg interface{}
 			switch header.MessageType {
@@ -259,10 +259,10 @@ func parseMessage() echo.MiddlewareFunc {
 			case MessageTypeHomeNSAns:
 				msg = &HomeNSAns{}
 			default:
-				return ErrMalformedMessage
+				return ErrMalformedMessage.New()
 			}
 			if err := json.Unmarshal(buf, msg); err != nil {
-				return ErrMalformedMessage
+				return ErrMalformedMessage.New()
 			}
 			c.Set(messageKey, msg)
 			return next(c)
@@ -278,7 +278,7 @@ func verifySenderID(getSenderClientCAs func(string) []*x509.Certificate) echo.Mi
 			header := c.Get(headerKey).(*RawMessageHeader)
 			senderClientCAs := getSenderClientCAs(header.SenderID)
 			if len(senderClientCAs) == 0 {
-				return ErrUnknownSender
+				return ErrUnknownSender.New()
 			}
 			if state := c.Request().TLS; state != nil {
 				for _, chain := range state.VerifiedChains {
@@ -292,7 +292,7 @@ func verifySenderID(getSenderClientCAs func(string) []*x509.Certificate) echo.Mi
 				}
 			}
 			// TODO: Check headers (https://github.com/TheThingsNetwork/lorawan-stack/issues/717)
-			return ErrUnknownSender
+			return ErrUnknownSender.New()
 		}
 	}
 }

--- a/pkg/interop/server.go
+++ b/pkg/interop/server.go
@@ -70,15 +70,15 @@ type ApplicationServer interface {
 type noopServer struct{}
 
 func (noopServer) JoinRequest(context.Context, *JoinReq) (*JoinAns, error) {
-	return nil, errNotRegistered
+	return nil, errNotRegistered.New()
 }
 
 func (noopServer) AppSKeyRequest(context.Context, *AppSKeyReq) (*AppSKeyAns, error) {
-	return nil, errNotRegistered
+	return nil, errNotRegistered.New()
 }
 
 func (noopServer) HomeNSRequest(context.Context, *HomeNSReq) (*HomeNSAns, error) {
-	return nil, errNotRegistered
+	return nil, errNotRegistered.New()
 }
 
 // Server is the server.
@@ -277,7 +277,7 @@ func (s *Server) handleRequest(c echo.Context) error {
 	case *AppSKeyReq:
 		ans, err = s.js.AppSKeyRequest(ctx, req)
 	default:
-		return ErrMalformedMessage
+		return ErrMalformedMessage.New()
 	}
 	if err != nil {
 		return err

--- a/pkg/interop/types.go
+++ b/pkg/interop/types.go
@@ -101,7 +101,7 @@ func (v MACVersion) MarshalJSON() ([]byte, error) {
 	case ttnpb.MAC_V1_1:
 		res = "1.1"
 	default:
-		return nil, errUnknownMACVersion
+		return nil, errUnknownMACVersion.New()
 	}
 	return []byte(fmt.Sprintf(`"%s"`, res)), nil
 }
@@ -123,7 +123,7 @@ func (v *MACVersion) UnmarshalJSON(data []byte) error {
 	case "1.1":
 		res = ttnpb.MAC_V1_1
 	default:
-		return errUnknownMACVersion
+		return errUnknownMACVersion.New()
 	}
 	*v = MACVersion(res)
 	return nil
@@ -140,7 +140,7 @@ func (b Buffer) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON unmarshals a hexadecimal string to binary data.
 func (b *Buffer) UnmarshalJSON(data []byte) error {
 	if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
-		return errInvalidLength
+		return errInvalidLength.New()
 	}
 	buf, err := hex.DecodeString(strings.TrimPrefix(string(data[1:len(data)-1]), "0x"))
 	if err != nil {
@@ -211,7 +211,7 @@ func (n *NetID) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if len(buf) != 3 {
-		return errInvalidLength
+		return errInvalidLength.New()
 	}
 	copy(n[:], buf)
 	return nil
@@ -233,7 +233,7 @@ func (n *EUI64) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if len(buf) != 8 {
-		return errInvalidLength
+		return errInvalidLength.New()
 	}
 	copy(n[:], buf)
 	return nil
@@ -255,7 +255,7 @@ func (n *DevAddr) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if len(buf) != 4 {
-		return errInvalidLength
+		return errInvalidLength.New()
 	}
 	copy(n[:], buf)
 	return nil

--- a/pkg/joinserver/grpc_deviceregistry.go
+++ b/pkg/joinserver/grpc_deviceregistry.go
@@ -84,13 +84,13 @@ func (srv jsEndDeviceRegistryServer) Get(ctx context.Context, req *ttnpb.GetEndD
 	logger := log.FromContext(ctx)
 	dev, err := srv.JS.devices.GetByID(ctx, req.ApplicationIdentifiers, req.DeviceID, gets)
 	if errors.IsNotFound(err) {
-		return nil, errDeviceNotFound
+		return nil, errDeviceNotFound.New()
 	}
 	if err != nil {
 		return nil, err
 	}
 	if !dev.ApplicationIdentifiers.Equal(req.ApplicationIdentifiers) {
-		return nil, errDeviceNotFound
+		return nil, errDeviceNotFound.New()
 	}
 	if ttnpb.HasAnyField(req.FieldMask.Paths,
 		"root_keys.app_key.key",
@@ -173,10 +173,10 @@ var (
 // Set implements ttnpb.JsEndDeviceRegistryServer.
 func (srv jsEndDeviceRegistryServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest) (dev *ttnpb.EndDevice, err error) {
 	if req.EndDevice.JoinEUI == nil {
-		return nil, errNoJoinEUI
+		return nil, errNoJoinEUI.New()
 	}
 	if req.EndDevice.DevEUI == nil || req.EndDevice.DevEUI.IsZero() {
-		return nil, errNoDevEUI
+		return nil, errNoDevEUI.New()
 	}
 
 	if err = rights.RequireApplication(ctx, req.EndDevice.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_DEVICES_WRITE); err != nil {

--- a/pkg/joinserver/grpc_deviceregistry_test.go
+++ b/pkg/joinserver/grpc_deviceregistry_test.go
@@ -129,7 +129,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 				})
 				a.So(devID, should.Equal, unregisteredDeviceID)
 				a.So(paths, should.HaveSameElementsDeep, []string{"ids"})
-				return nil, errNotFound
+				return nil, errNotFound.New()
 			},
 			DeviceRequest: &ttnpb.GetEndDeviceRequest{
 				EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -951,7 +951,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 				})
 				a.So(devID, should.Equal, unregisteredDeviceID)
 				a.So(paths, should.BeNil)
-				return nil, errNotFound
+				return nil, errNotFound.New()
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
 				a := assertions.New(t)

--- a/pkg/joinserver/http_interop_internal_test.go
+++ b/pkg/joinserver/http_interop_internal_test.go
@@ -276,7 +276,7 @@ func TestInteropJoinRequest(t *testing.T) {
 				},
 			},
 			HandleJoinFunc: func() (*ttnpb.JoinResponse, error) {
-				return nil, errDecodePayload
+				return nil, errDecodePayload.New()
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
 				a := assertions.New(t)
@@ -320,7 +320,7 @@ func TestInteropJoinRequest(t *testing.T) {
 				},
 			},
 			HandleJoinFunc: func() (*ttnpb.JoinResponse, error) {
-				return nil, errMICMismatch
+				return nil, errMICMismatch.New()
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
 				a := assertions.New(t)
@@ -364,7 +364,7 @@ func TestInteropJoinRequest(t *testing.T) {
 				},
 			},
 			HandleJoinFunc: func() (*ttnpb.JoinResponse, error) {
-				return nil, errReuseDevNonce
+				return nil, errReuseDevNonce.New()
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
 				a := assertions.New(t)

--- a/pkg/joinserver/joinserver.go
+++ b/pkg/joinserver/joinserver.go
@@ -252,10 +252,10 @@ func (js *JoinServer) HandleJoin(ctx context.Context, req *ttnpb.JoinRequest) (r
 
 	pld := req.Payload.GetJoinRequestPayload()
 	if pld == nil {
-		return nil, errNoJoinRequest
+		return nil, errNoJoinRequest.New()
 	}
 	if pld.DevEUI.IsZero() {
-		return nil, errNoDevEUI
+		return nil, errNoDevEUI.New()
 	}
 	logger = logger.WithFields(log.Fields(
 		"join_eui", pld.JoinEUI,
@@ -270,7 +270,7 @@ func (js *JoinServer) HandleJoin(ctx context.Context, req *ttnpb.JoinRequest) (r
 		}
 	}
 	if !match {
-		return nil, errUnknownJoinEUI
+		return nil, errUnknownJoinEUI.New()
 	}
 
 	var handled bool
@@ -562,13 +562,13 @@ func (js *JoinServer) GetNwkSKeys(ctx context.Context, req *ttnpb.SessionKeyRequ
 	}
 
 	if ks.NwkSEncKey == nil {
-		return nil, errNoNwkSEncKey
+		return nil, errNoNwkSEncKey.New()
 	}
 	if ks.FNwkSIntKey == nil {
-		return nil, errNoFNwkSIntKey
+		return nil, errNoFNwkSIntKey.New()
 	}
 	if ks.SNwkSIntKey == nil {
-		return nil, errNoSNwkSIntKey
+		return nil, errNoSNwkSIntKey.New()
 	}
 
 	return &ttnpb.NwkSKeysResponse{
@@ -599,7 +599,7 @@ func (js *JoinServer) GetAppSKey(ctx context.Context, req *ttnpb.SessionKeyReque
 				return nil, err
 			}
 		} else {
-			return nil, errNoApplicationServerID
+			return nil, errNoApplicationServerID.New()
 		}
 	} else if err := clusterauth.Authorized(ctx); err != nil {
 		return nil, err
@@ -614,7 +614,7 @@ func (js *JoinServer) GetAppSKey(ctx context.Context, req *ttnpb.SessionKeyReque
 		return nil, errRegistryOperation.WithCause(err)
 	}
 	if ks.AppSKey == nil {
-		return nil, errNoAppSKey
+		return nil, errNoAppSKey.New()
 	}
 	return &ttnpb.AppSKeyResponse{
 		AppSKey: *ks.AppSKey,

--- a/pkg/joinserver/joinserver_test.go
+++ b/pkg/joinserver/joinserver_test.go
@@ -1960,7 +1960,7 @@ func TestGetNwkSKeys(t *testing.T) {
 					"nwk_s_enc_key",
 					"s_nwk_s_int_key",
 				})
-				return nil, errTest
+				return nil, errTest.New()
 			},
 			KeyRequest: &ttnpb.SessionKeyRequest{
 				JoinEUI:      types.EUI64{0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
@@ -2164,7 +2164,7 @@ func TestGetAppSKey(t *testing.T) {
 				a.So(paths, should.HaveSameElementsDeep, []string{
 					"app_s_key",
 				})
-				return nil, errTest
+				return nil, errTest.New()
 			},
 			KeyRequest: &ttnpb.SessionKeyRequest{
 				JoinEUI:      types.EUI64{0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
@@ -2443,7 +2443,7 @@ func TestGetHomeNetID(t *testing.T) {
 					"net_id",
 					"network_server_address",
 				})
-				return nil, errTest
+				return nil, errTest.New()
 			},
 			JoinEUI: types.EUI64{0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 			DevEUI:  types.EUI64{0x42, 0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},

--- a/pkg/joinserver/redis/registry.go
+++ b/pkg/joinserver/redis/registry.go
@@ -89,7 +89,7 @@ func (r *DeviceRegistry) GetByID(ctx context.Context, appID ttnpb.ApplicationIde
 // GetByEUI gets device by joinEUI, devEUI.
 func (r *DeviceRegistry) GetByEUI(ctx context.Context, joinEUI, devEUI types.EUI64, paths []string) (*ttnpb.ContextualEndDevice, error) {
 	if devEUI.IsZero() {
-		return nil, errInvalidIdentifiers
+		return nil, errInvalidIdentifiers.New()
 	}
 
 	defer trace.StartRegion(ctx, "get end device by eui").End()
@@ -220,7 +220,7 @@ func (r *DeviceRegistry) set(ctx context.Context, tx *redis.Tx, uid string, gets
 				return nil, err
 			}
 			if updated.JoinEUI == nil || updated.DevEUI == nil || updated.DevEUI.IsZero() {
-				return nil, errInvalidIdentifiers
+				return nil, errInvalidIdentifiers.New()
 			}
 		} else {
 			if ttnpb.HasAnyField(sets, "ids.application_ids.application_id") && pb.ApplicationID != stored.ApplicationID {
@@ -264,7 +264,7 @@ func (r *DeviceRegistry) set(ctx context.Context, tx *redis.Tx, uid string, gets
 					return err
 				}
 				if i != 0 {
-					return errDuplicateIdentifiers
+					return errDuplicateIdentifiers.New()
 				}
 				p.SetNX(ek, uid, 0)
 			}
@@ -279,7 +279,7 @@ func (r *DeviceRegistry) set(ctx context.Context, tx *redis.Tx, uid string, gets
 					return err
 				}
 				if i != 0 {
-					return errAlreadyProvisioned
+					return errAlreadyProvisioned.New()
 				}
 				p.SetNX(pk, uid, 0)
 			}
@@ -309,7 +309,7 @@ func (r *DeviceRegistry) set(ctx context.Context, tx *redis.Tx, uid string, gets
 // SetByEUI will only succeed if the device is set via SetByID first.
 func (r *DeviceRegistry) SetByEUI(ctx context.Context, joinEUI types.EUI64, devEUI types.EUI64, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.ContextualEndDevice, error) {
 	if devEUI.IsZero() {
-		return nil, errInvalidIdentifiers
+		return nil, errInvalidIdentifiers.New()
 	}
 	ek := r.euiKey(joinEUI, devEUI)
 
@@ -379,7 +379,7 @@ func (r *KeyRegistry) idKey(joinEUI, devEUI types.EUI64, id []byte) string {
 // GetByID gets session keys by joinEUI, devEUI, id.
 func (r *KeyRegistry) GetByID(ctx context.Context, joinEUI, devEUI types.EUI64, id []byte, paths []string) (*ttnpb.SessionKeys, error) {
 	if devEUI.IsZero() || len(id) == 0 {
-		return nil, errInvalidIdentifiers
+		return nil, errInvalidIdentifiers.New()
 	}
 
 	defer trace.StartRegion(ctx, "get session keys").End()
@@ -394,7 +394,7 @@ func (r *KeyRegistry) GetByID(ctx context.Context, joinEUI, devEUI types.EUI64, 
 // SetByID sets session keys by joinEUI, devEUI, id.
 func (r *KeyRegistry) SetByID(ctx context.Context, joinEUI, devEUI types.EUI64, id []byte, gets []string, f func(*ttnpb.SessionKeys) (*ttnpb.SessionKeys, []string, error)) (*ttnpb.SessionKeys, error) {
 	if devEUI.IsZero() || len(id) == 0 {
-		return nil, errInvalidIdentifiers
+		return nil, errInvalidIdentifiers.New()
 	}
 	ik := r.idKey(joinEUI, devEUI, id)
 
@@ -458,7 +458,7 @@ func (r *KeyRegistry) SetByID(ctx context.Context, joinEUI, devEUI types.EUI64, 
 					return err
 				}
 				if !bytes.Equal(updated.SessionKeyID, id) {
-					return errInvalidIdentifiers
+					return errInvalidIdentifiers.New()
 				}
 			} else {
 				if err := ttnpb.ProhibitFields(sets,

--- a/pkg/messageprocessors/javascript/javascript.go
+++ b/pkg/messageprocessors/javascript/javascript.go
@@ -85,7 +85,7 @@ func (h *host) Encode(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, versi
 		return err
 	}
 	if value == nil || reflect.TypeOf(value).Kind() != reflect.Slice {
-		return errOutputType
+		return errOutputType.New()
 	}
 	slice := reflect.ValueOf(value)
 	frmPayload := make([]byte, slice.Len())
@@ -144,7 +144,7 @@ func (h *host) Decode(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, versi
 	}
 	m, ok := value.(map[string]interface{})
 	if !ok {
-		return errOutput
+		return errOutput.New()
 	}
 	s, err := gogoproto.Struct(m)
 	if err != nil {

--- a/pkg/networkserver/adr.go
+++ b/pkg/networkserver/adr.go
@@ -177,7 +177,7 @@ func adaptDataRate(dev *ttnpb.EndDevice, phy band.Band, defaults ttnpb.MACSettin
 		var ok bool
 		df, ok = demodulationFloor[dr.SpreadingFactor][dr.Bandwidth]
 		if !ok {
-			return errInvalidDataRate
+			return errInvalidDataRate.New()
 		}
 	}
 

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -701,7 +701,7 @@ func nonRetryableFixedPathGatewayError(err error) bool {
 // scheduleDownlinkByPaths returns the scheduled downlink or error.
 func (ns *NetworkServer) scheduleDownlinkByPaths(ctx context.Context, req *ttnpb.TxRequest, b []byte, paths ...downlinkPath) (*scheduledDownlink, error) {
 	if len(paths) == 0 {
-		return nil, errNoPath
+		return nil, errNoPath.New()
 	}
 
 	logger := log.FromContext(ctx)
@@ -824,7 +824,7 @@ func appendRecentDownlink(recent []*ttnpb.DownlinkMessage, down *ttnpb.DownlinkM
 // txRequestFromUplink does not set the priority.
 func txRequestFromUplink(phy band.Band, macState *ttnpb.MACState, rx1, rx2 bool, rxDelay time.Duration, up *ttnpb.UplinkMessage) (*ttnpb.TxRequest, error) {
 	if !rx1 && !rx2 {
-		return nil, errNoPath
+		return nil, errNoPath.New()
 	}
 	req := &ttnpb.TxRequest{
 		Class:    ttnpb.CLASS_A,
@@ -832,7 +832,7 @@ func txRequestFromUplink(phy band.Band, macState *ttnpb.MACState, rx1, rx2 bool,
 	}
 	if rx1 {
 		if up.DeviceChannelIndex > math.MaxUint8 {
-			return nil, errInvalidChannelIndex
+			return nil, errInvalidChannelIndex.New()
 		}
 		rx1ChIdx, err := phy.Rx1Channel(uint8(up.DeviceChannelIndex))
 		if err != nil {
@@ -840,7 +840,7 @@ func txRequestFromUplink(phy band.Band, macState *ttnpb.MACState, rx1, rx2 bool,
 		}
 		if uint(rx1ChIdx) >= uint(len(macState.CurrentParameters.Channels)) ||
 			macState.CurrentParameters.Channels[int(rx1ChIdx)].GetDownlinkFrequency() == 0 {
-			return nil, errCorruptedMACState
+			return nil, errCorruptedMACState.New()
 		}
 		rx1DRIdx, err := phy.Rx1DataRate(up.Settings.DataRateIndex, macState.CurrentParameters.Rx1DataRateOffset, macState.CurrentParameters.DownlinkDwellTime.GetValue())
 		if err != nil {

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -138,7 +138,7 @@ func makeDeferredMACHandler(dev *ttnpb.EndDevice, f macHandler) macHandler {
 	return func(ctx context.Context, dev *ttnpb.EndDevice, up *ttnpb.UplinkMessage) ([]events.DefinitionDataClosure, error) {
 		switch n := len(dev.MACState.QueuedResponses); {
 		case n < queuedLength:
-			return nil, errCorruptedMACState
+			return nil, errCorruptedMACState.New()
 		case n == queuedLength:
 			return f(ctx, dev, up)
 		default:
@@ -180,7 +180,7 @@ type contextualEndDevice struct {
 // matchAndHandleDataUplink tries to match the data uplink message with a device and returns the matched device.
 func (ns *NetworkServer) matchAndHandleDataUplink(up *ttnpb.UplinkMessage, deduplicated bool, devs ...contextualEndDevice) (*matchedDevice, error) {
 	if len(up.RawPayload) < 4 {
-		return nil, errRawPayloadTooShort
+		return nil, errRawPayloadTooShort.New()
 	}
 	pld := up.Payload.GetMACPayload()
 
@@ -808,7 +808,7 @@ matchLoop:
 		)
 		return &match.matchedDevice, nil
 	}
-	return nil, errDeviceNotFound
+	return nil, errDeviceNotFound.New()
 }
 
 // MACHandler defines the behavior of a MAC command on a device.
@@ -1049,7 +1049,7 @@ func (ns *NetworkServer) sendJoinRequest(ctx context.Context, ids ttnpb.EndDevic
 			return nil, err
 		}
 	}
-	return nil, errJoinServerNotFound
+	return nil, errJoinServerNotFound.New()
 }
 
 func (ns *NetworkServer) deduplicationDone(ctx context.Context, up *ttnpb.UplinkMessage) <-chan time.Time {
@@ -1106,7 +1106,7 @@ func (ns *NetworkServer) handleJoinRequest(ctx context.Context, up *ttnpb.Uplink
 
 	if !matched.SupportsJoin {
 		logger.Warn("ABP device sent a join-request, drop")
-		return errABPJoinRequest
+		return errABPJoinRequest.New()
 	}
 
 	ctx = log.NewContext(ctx, logger)
@@ -1174,7 +1174,7 @@ func (ns *NetworkServer) handleJoinRequest(ctx context.Context, up *ttnpb.Uplink
 
 	drIdx, _, ok := phy.FindUplinkDataRate(up.Settings.DataRate)
 	if !ok {
-		return errDataRateNotFound
+		return errDataRateNotFound.New()
 	}
 	up.Settings.DataRateIndex = drIdx
 
@@ -1279,7 +1279,7 @@ func (ns *NetworkServer) handleRejoinRequest(ctx context.Context, up *ttnpb.Upli
 		}
 	}()
 	// TODO: Implement https://github.com/TheThingsNetwork/lorawan-stack/issues/8
-	return errRejoinRequest
+	return errRejoinRequest.New()
 }
 
 // HandleUplink is called by the Gateway Server when an uplink message arrives.

--- a/pkg/networkserver/mac.go
+++ b/pkg/networkserver/mac.go
@@ -59,7 +59,7 @@ func handleMACResponse(cid ttnpb.MACCommandIdentifier, f func(*ttnpb.MACCommand)
 		}
 		return append(cmds[:i], cmds[i+1:]...), nil
 	}
-	return cmds, errMACRequestNotFound
+	return cmds, errMACRequestNotFound.New()
 }
 
 // handleMACResponse searches for first MAC command block in cmds with CID equal to cid and calls f for each found value as argument.
@@ -87,7 +87,7 @@ outer:
 	}
 
 	if first < 0 {
-		return cmds, errMACRequestNotFound
+		return cmds, errMACRequestNotFound.New()
 	}
 	return append(cmds[:first], cmds[last+1:]...), nil
 }

--- a/pkg/networkserver/mac_beacon_freq.go
+++ b/pkg/networkserver/mac_beacon_freq.go
@@ -69,7 +69,7 @@ func enqueueBeaconFreqReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen,
 
 func handleBeaconFreqAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_BeaconFreqAns) ([]events.DefinitionDataClosure, error) {
 	if pld == nil {
-		return nil, errNoPayload
+		return nil, errNoPayload.New()
 	}
 
 	evt := evtReceiveBeaconFreqAccept

--- a/pkg/networkserver/mac_dev_status.go
+++ b/pkg/networkserver/mac_dev_status.go
@@ -108,7 +108,7 @@ func enqueueDevStatusReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, 
 
 func handleDevStatusAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_DevStatusAns, fCntUp uint32, recvAt time.Time) ([]events.DefinitionDataClosure, error) {
 	if pld == nil {
-		return nil, errNoPayload
+		return nil, errNoPayload.New()
 	}
 
 	var err error

--- a/pkg/networkserver/mac_device_mode.go
+++ b/pkg/networkserver/mac_device_mode.go
@@ -28,7 +28,7 @@ var (
 
 func handleDeviceModeInd(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_DeviceModeInd) ([]events.DefinitionDataClosure, error) {
 	if pld == nil {
-		return nil, errNoPayload
+		return nil, errNoPayload.New()
 	}
 
 	evs := []events.DefinitionDataClosure{

--- a/pkg/networkserver/mac_dl_channel.go
+++ b/pkg/networkserver/mac_dl_channel.go
@@ -92,7 +92,7 @@ func enqueueDLChannelReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, 
 
 func handleDLChannelAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_DLChannelAns) ([]events.DefinitionDataClosure, error) {
 	if pld == nil {
-		return nil, errNoPayload
+		return nil, errNoPayload.New()
 	}
 
 	var err error

--- a/pkg/networkserver/mac_link_adr.go
+++ b/pkg/networkserver/mac_link_adr.go
@@ -141,7 +141,7 @@ func enqueueLinkADRReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, ma
 
 func handleLinkADRAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_LinkADRAns, dupCount uint, fps *frequencyplans.Store) ([]events.DefinitionDataClosure, error) {
 	if pld == nil {
-		return nil, errNoPayload
+		return nil, errNoPayload.New()
 	}
 
 	handler := handleMACResponseBlock
@@ -150,7 +150,7 @@ func handleLinkADRAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACC
 	}
 
 	if (dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_0_2) < 0 || dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) >= 0) && dupCount != 0 {
-		return nil, errInvalidPayload
+		return nil, errInvalidPayload.New()
 	}
 
 	evt := evtReceiveLinkADRAccept
@@ -168,7 +168,7 @@ func handleLinkADRAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACC
 	var req *ttnpb.MACCommand_LinkADRReq
 	dev.MACState.PendingRequests, err = handler(ttnpb.CID_LINK_ADR, func(cmd *ttnpb.MACCommand) error {
 		if dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_0_2) >= 0 && dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 && n > dupCount+1 {
-			return errInvalidPayload
+			return errInvalidPayload.New()
 		}
 		n++
 

--- a/pkg/networkserver/mac_link_check.go
+++ b/pkg/networkserver/mac_link_check.go
@@ -36,7 +36,7 @@ func handleLinkCheckReq(ctx context.Context, dev *ttnpb.EndDevice, msg *ttnpb.Up
 	if dr, ok := msg.Settings.DataRate.Modulation.(*ttnpb.DataRate_LoRa); ok {
 		floor, ok = demodulationFloor[dr.LoRa.SpreadingFactor][dr.LoRa.Bandwidth]
 		if !ok {
-			return evs, errInvalidDataRate
+			return evs, errInvalidDataRate.New()
 		}
 	}
 	if len(msg.RxMetadata) == 0 {

--- a/pkg/networkserver/mac_new_channel.go
+++ b/pkg/networkserver/mac_new_channel.go
@@ -110,7 +110,7 @@ func enqueueNewChannelReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen,
 
 func handleNewChannelAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_NewChannelAns) ([]events.DefinitionDataClosure, error) {
 	if pld == nil {
-		return nil, errNoPayload
+		return nil, errNoPayload.New()
 	}
 
 	var err error

--- a/pkg/networkserver/mac_ping_slot_channel.go
+++ b/pkg/networkserver/mac_ping_slot_channel.go
@@ -78,7 +78,7 @@ func enqueuePingSlotChannelReq(ctx context.Context, dev *ttnpb.EndDevice, maxDow
 
 func handlePingSlotChannelAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_PingSlotChannelAns) ([]events.DefinitionDataClosure, error) {
 	if pld == nil {
-		return nil, errNoPayload
+		return nil, errNoPayload.New()
 	}
 
 	var err error

--- a/pkg/networkserver/mac_ping_slot_info.go
+++ b/pkg/networkserver/mac_ping_slot_info.go
@@ -29,7 +29,7 @@ var (
 
 func handlePingSlotInfoReq(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_PingSlotInfoReq) ([]events.DefinitionDataClosure, error) {
 	if pld == nil {
-		return nil, errNoPayload
+		return nil, errNoPayload.New()
 	}
 
 	evs := []events.DefinitionDataClosure{

--- a/pkg/networkserver/mac_rejoin_param_setup.go
+++ b/pkg/networkserver/mac_rejoin_param_setup.go
@@ -71,7 +71,7 @@ func enqueueRejoinParamSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDo
 
 func handleRejoinParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_RejoinParamSetupAns) ([]events.DefinitionDataClosure, error) {
 	if pld == nil {
-		return nil, errNoPayload
+		return nil, errNoPayload.New()
 	}
 
 	var err error

--- a/pkg/networkserver/mac_rekey.go
+++ b/pkg/networkserver/mac_rekey.go
@@ -28,7 +28,7 @@ var (
 
 func handleRekeyInd(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_RekeyInd) ([]events.DefinitionDataClosure, error) {
 	if pld == nil {
-		return nil, errNoPayload
+		return nil, errNoPayload.New()
 	}
 
 	evs := []events.DefinitionDataClosure{

--- a/pkg/networkserver/mac_reset.go
+++ b/pkg/networkserver/mac_reset.go
@@ -29,7 +29,7 @@ var (
 
 func handleResetInd(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_ResetInd, fps *frequencyplans.Store, defaults ttnpb.MACSettings) ([]events.DefinitionDataClosure, error) {
 	if pld == nil {
-		return nil, errNoPayload
+		return nil, errNoPayload.New()
 	}
 
 	evs := []events.DefinitionDataClosure{

--- a/pkg/networkserver/mac_rx_param_setup.go
+++ b/pkg/networkserver/mac_rx_param_setup.go
@@ -73,7 +73,7 @@ func enqueueRxParamSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLe
 
 func handleRxParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_RxParamSetupAns) ([]events.DefinitionDataClosure, error) {
 	if pld == nil {
-		return nil, errNoPayload
+		return nil, errNoPayload.New()
 	}
 
 	var err error

--- a/pkg/networkserver/redis/application_uplink_queue.go
+++ b/pkg/networkserver/redis/application_uplink_queue.go
@@ -121,11 +121,11 @@ func (q *ApplicationUplinkQueue) Subscribe(ctx context.Context, appID ttnpb.Appl
 			for _, msg := range ret.Messages {
 				v, ok := msg.Values[payloadKey]
 				if !ok {
-					return errMissingPayload
+					return errMissingPayload.New()
 				}
 				s, ok := v.(string)
 				if !ok {
-					return errInvalidPayload
+					return errInvalidPayload.New()
 				}
 				up := &ttnpb.ApplicationUp{}
 				if err = ttnredis.UnmarshalProto(s, up); err != nil {

--- a/pkg/networkserver/redis/registry.go
+++ b/pkg/networkserver/redis/registry.go
@@ -238,7 +238,7 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIde
 					return err
 				}
 				if updated.ApplicationIdentifiers != appID || updated.DeviceID != devID {
-					return errInvalidIdentifiers
+					return errInvalidIdentifiers.New()
 				}
 			} else {
 				if ttnpb.HasAnyField(sets, "ids.application_ids.application_id") && pb.ApplicationID != stored.ApplicationID {
@@ -275,7 +275,7 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIde
 						return err
 					}
 					if i != 0 {
-						return errDuplicateIdentifiers
+						return errDuplicateIdentifiers.New()
 					}
 					p.SetNX(ek, uid, 0)
 				}

--- a/pkg/networkserver/utils.go
+++ b/pkg/networkserver/utils.go
@@ -457,7 +457,7 @@ func newMACState(dev *ttnpb.EndDevice, fps *frequencyplans.Store, defaults ttnpb
 		} else if dev.SupportsClassB {
 			class = ttnpb.CLASS_B
 		} else {
-			return nil, errClassAMulticast
+			return nil, errClassAMulticast.New()
 		}
 	} else if dev.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 && dev.SupportsClassC {
 		class = ttnpb.CLASS_C

--- a/pkg/networkserver/utils_internal_test.go
+++ b/pkg/networkserver/utils_internal_test.go
@@ -74,7 +74,7 @@ func TestNewMACState(t *testing.T) {
 			},
 			FrequencyPlanStore: frequencyplans.NewStore(test.FrequencyPlansFetcher),
 			ErrorAssertion: func(t *testing.T, err error) bool {
-				return assertions.New(t).So(err, should.Resemble, errClassAMulticast)
+				return assertions.New(t).So(err, should.HaveSameErrorDefinitionAs, errClassAMulticast)
 			},
 		},
 		{
@@ -155,7 +155,7 @@ func TestNewMACState(t *testing.T) {
 			},
 			FrequencyPlanStore: frequencyplans.NewStore(test.FrequencyPlansFetcher),
 			ErrorAssertion: func(t *testing.T, err error) bool {
-				return assertions.New(t).So(err, should.Resemble, errClassAMulticast)
+				return assertions.New(t).So(err, should.HaveSameErrorDefinitionAs, errClassAMulticast)
 			},
 		},
 		{

--- a/pkg/oauth/middleware.go
+++ b/pkg/oauth/middleware.go
@@ -30,7 +30,7 @@ func (s *server) requireLogin(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		_, err := s.getSession(c)
 		if err != nil {
-			return errUnauthenticated
+			return errUnauthenticated.New()
 		}
 		return next(c)
 	}

--- a/pkg/oauth/storage.go
+++ b/pkg/oauth/storage.go
@@ -168,7 +168,7 @@ func (s *storage) SaveAccess(data *osin.AccessData) error {
 		return err
 	}
 	if tokenType != auth.AccessToken {
-		return errNoAccessToken
+		return errNoAccessToken.New()
 	}
 	accessHash, err = auth.Hash(s.ctx, accessKey)
 	if err != nil {
@@ -180,7 +180,7 @@ func (s *storage) SaveAccess(data *osin.AccessData) error {
 			return err
 		}
 		if tokenType != auth.RefreshToken {
-			return errNoRefreshToken
+			return errNoRefreshToken.New()
 		}
 		if refreshID != accessID {
 			return errTokenMismatch.WithAttributes("refresh_token_id", refreshID, "access_token_id", accessID)
@@ -252,7 +252,7 @@ func (s *storage) LoadAccess(token string) (*osin.AccessData, error) {
 func (s *storage) RemoveAccess(token string) error {
 	if tokenType, id, _, err := auth.SplitToken(token); err == nil {
 		if tokenType != auth.AccessToken {
-			return errNoAccessToken
+			return errNoAccessToken.New()
 		}
 		return s.oauth.DeleteAccessToken(s.ctx, id)
 	}
@@ -265,7 +265,7 @@ func (s *storage) LoadRefresh(token string) (*osin.AccessData, error) {
 		return nil, err
 	}
 	if tokenType != auth.RefreshToken {
-		return nil, errNoRefreshToken
+		return nil, errNoRefreshToken.New()
 	}
 	data, err := s.loadAccess(id)
 	if err != nil {
@@ -273,7 +273,7 @@ func (s *storage) LoadRefresh(token string) (*osin.AccessData, error) {
 	}
 	valid, err := auth.Validate(data.RefreshToken, tokenKey)
 	if !valid || err != nil {
-		return nil, errInvalidToken
+		return nil, errInvalidToken.New()
 	}
 	return data, nil
 }
@@ -281,7 +281,7 @@ func (s *storage) LoadRefresh(token string) (*osin.AccessData, error) {
 func (s *storage) RemoveRefresh(token string) error {
 	if tokenType, id, _, err := auth.SplitToken(token); err == nil {
 		if tokenType != auth.RefreshToken {
-			return errNoRefreshToken
+			return errNoRefreshToken.New()
 		}
 		return s.oauth.DeleteAccessToken(s.ctx, id)
 	}

--- a/pkg/oauth/user.go
+++ b/pkg/oauth/user.go
@@ -54,7 +54,7 @@ func (s *server) getAuthCookie(c echo.Context) (cookie authCookie, err error) {
 		return cookie, err
 	}
 	if !ok {
-		return cookie, errAuthCookie
+		return cookie, errAuthCookie.New()
 	}
 	return cookie, nil
 }
@@ -97,7 +97,7 @@ func (s *server) getSession(c echo.Context) (*ttnpb.UserSession, error) {
 		return nil, err
 	}
 	if session.ExpiresAt != nil && session.ExpiresAt.Before(time.Now()) {
-		return nil, errSessionExpired
+		return nil, errSessionExpired.New()
 	}
 	c.Set(userSessionKey, session)
 	return session, nil
@@ -165,7 +165,7 @@ func (s *server) doLogin(ctx context.Context, userID, password string) error {
 	)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return errIncorrectPasswordOrUserID
+			return errIncorrectPasswordOrUserID.New()
 		}
 		return err
 	}
@@ -174,7 +174,7 @@ func (s *server) doLogin(ctx context.Context, userID, password string) error {
 	region.End()
 	if err != nil || !ok {
 		events.Publish(evtUserLoginFailed(ctx, user.UserIdentifiers, nil))
-		return errIncorrectPasswordOrUserID
+		return errIncorrectPasswordOrUserID.New()
 	}
 	return nil
 }

--- a/pkg/qrcode/lora_alliance_tr005d2.go
+++ b/pkg/qrcode/lora_alliance_tr005d2.go
@@ -39,10 +39,10 @@ type LoRaAllianceTR005Draft2 struct {
 // Encode implements the Data interface.
 func (m *LoRaAllianceTR005Draft2) Encode(dev *ttnpb.EndDevice) error {
 	if dev.JoinEUI == nil {
-		return errNoJoinEUI
+		return errNoJoinEUI.New()
 	}
 	if dev.DevEUI == nil {
-		return errNoDevEUI
+		return errNoDevEUI.New()
 	}
 	*m = LoRaAllianceTR005Draft2{
 		JoinEUI:              *dev.JoinEUI,
@@ -106,7 +106,7 @@ func (m *LoRaAllianceTR005Draft2) UnmarshalText(text []byte) error {
 		!bytes.Equal(parts[0], []byte("URN")) ||
 		!bytes.Equal(parts[1], []byte("LW")) ||
 		!bytes.Equal(parts[2], []byte("DP")) {
-		return errFormat
+		return errFormat.New()
 	}
 	*m = LoRaAllianceTR005Draft2{}
 	if err := m.JoinEUI.UnmarshalText(parts[3]); err != nil {
@@ -120,7 +120,7 @@ func (m *LoRaAllianceTR005Draft2) UnmarshalText(text []byte) error {
 		copy(m.VendorID[:], prodID[:2])
 		copy(m.ModelID[:], prodID[2:])
 	} else if n != 4 {
-		return errFormat
+		return errFormat.New()
 	} else {
 		return err
 	}

--- a/pkg/qrcode/lora_alliance_tr005d3.go
+++ b/pkg/qrcode/lora_alliance_tr005d3.go
@@ -39,10 +39,10 @@ type LoRaAllianceTR005Draft3 struct {
 // Encode implements the Data interface.
 func (m *LoRaAllianceTR005Draft3) Encode(dev *ttnpb.EndDevice) error {
 	if dev.JoinEUI == nil {
-		return errNoJoinEUI
+		return errNoJoinEUI.New()
 	}
 	if dev.DevEUI == nil {
-		return errNoDevEUI
+		return errNoDevEUI.New()
 	}
 	*m = LoRaAllianceTR005Draft3{
 		JoinEUI:              *dev.JoinEUI,
@@ -103,11 +103,11 @@ func (m *LoRaAllianceTR005Draft3) UnmarshalText(text []byte) error {
 		!bytes.Equal(parts[0], []byte("URN")) ||
 		!bytes.Equal(parts[1], []byte("DEV")) ||
 		!bytes.Equal(parts[2], []byte("LW")) {
-		return errFormat
+		return errFormat.New()
 	}
 	parts = bytes.SplitN(parts[3], []byte("_"), 4)
 	if len(parts) < 3 {
-		return errFormat
+		return errFormat.New()
 	}
 	*m = LoRaAllianceTR005Draft3{}
 	if err := m.JoinEUI.UnmarshalText(parts[0]); err != nil {
@@ -121,7 +121,7 @@ func (m *LoRaAllianceTR005Draft3) UnmarshalText(text []byte) error {
 		copy(m.VendorID[:], prodID[:2])
 		copy(m.ModelID[:], prodID[2:])
 	} else if n != 4 {
-		return errFormat
+		return errFormat.New()
 	} else {
 		return err
 	}

--- a/pkg/qrcode/qrcode.go
+++ b/pkg/qrcode/qrcode.go
@@ -59,7 +59,7 @@ func Parse(data []byte) (Data, error) {
 			return model, nil
 		}
 	}
-	return nil, errFormat
+	return nil, errFormat.New()
 }
 
 // EndDeviceFormat is a end device QR code format.

--- a/pkg/qrcodegenerator/grpc.go
+++ b/pkg/qrcodegenerator/grpc.go
@@ -30,7 +30,7 @@ type endDeviceQRCodeGeneratorServer struct {
 func (s *endDeviceQRCodeGeneratorServer) GetFormat(ctx context.Context, req *ttnpb.GetQRCodeFormatRequest) (*ttnpb.QRCodeFormat, error) {
 	format := qrcode.GetEndDeviceFormat(req.FormatID)
 	if format == nil {
-		return nil, errFormatNotFound
+		return nil, errFormatNotFound.New()
 	}
 	return format.Format(), nil
 }
@@ -48,7 +48,7 @@ func (s *endDeviceQRCodeGeneratorServer) ListFormats(ctx context.Context, _ *pbt
 func (s *endDeviceQRCodeGeneratorServer) Generate(ctx context.Context, req *ttnpb.GenerateEndDeviceQRCodeRequest) (*ttnpb.GenerateQRCodeResponse, error) {
 	formatter := qrcode.GetEndDeviceFormat(req.FormatID)
 	if formatter == nil {
-		return nil, errFormatNotFound
+		return nil, errFormatNotFound.New()
 	}
 	data := formatter.New()
 	if err := data.Encode(&req.EndDevice); err != nil {

--- a/pkg/redis/errors.go
+++ b/pkg/redis/errors.go
@@ -39,9 +39,9 @@ func ConvertError(err error) error {
 	case nil:
 		return nil
 	case redis.Nil:
-		return errNotFound
+		return errNotFound.New()
 	case redis.TxFailedErr:
-		return errTransactionFailed
+		return errTransactionFailed.New()
 	}
 	return errStore.WithCause(err)
 }

--- a/pkg/redis/redis.go
+++ b/pkg/redis/redis.go
@@ -706,7 +706,7 @@ func DeduplicateProtos(ctx context.Context, r Scripter, k string, window time.Du
 	}
 	res, ok := v.(int64)
 	if !ok {
-		return false, errStore
+		return false, errStore.New()
 	}
 	return res == 1, nil
 }

--- a/pkg/redis/redis_test.go
+++ b/pkg/redis/redis_test.go
@@ -384,9 +384,9 @@ func TestPopTask(t *testing.T) {
 		a.So(payload, should.Equal, "testPayload")
 		a.So(startAt, should.Equal, time.Unix(0, 41).UTC())
 		fCalls++
-		return errTest
+		return errTest.New()
 	}, cl.Key("testKey"))
-	a.So(err, should.Resemble, errTest)
+	a.So(err, should.HaveSameErrorDefinitionAs, errTest)
 
 	err = PopTask(cl, cl.Key("testGroup"), "testID", -1, func(k string, payload string, startAt time.Time) error {
 		a.So(fCalls, should.Equal, 3)

--- a/pkg/rpcmetadata/request.go
+++ b/pkg/rpcmetadata/request.go
@@ -39,7 +39,7 @@ var errUnauthenticated = errors.DefineUnauthenticated("unauthenticated", "the co
 func WithForwardedAuth(ctx context.Context, allowInsecure bool) (grpc.CallOption, error) {
 	md := FromIncomingContext(ctx)
 	if md.AuthType == "" || md.AuthValue == "" {
-		return nil, errUnauthenticated
+		return nil, errUnauthenticated.New()
 	}
 	md.AllowInsecure = allowInsecure
 	return grpc.PerRPCCredentials(md), nil

--- a/pkg/rpcmiddleware/validator/validator.go
+++ b/pkg/rpcmiddleware/validator/validator.go
@@ -106,7 +106,7 @@ func validateMessage(ctx context.Context, fullMethod string, msg interface{}) er
 		return nil
 
 	default:
-		return errNoValidator
+		return errNoValidator.New()
 	}
 }
 

--- a/pkg/ttnpb/udp/packet.go
+++ b/pkg/ttnpb/udp/packet.go
@@ -128,7 +128,7 @@ func (p *Packet) UnmarshalBinary(b []byte) (err error) {
 
 	if p.PacketType.HasGatewayEUI() {
 		if len(b) < i+8 {
-			return errNoEUI
+			return errNoEUI.New()
 		}
 
 		p.GatewayEUI = new(types.EUI64)

--- a/pkg/ttnpb/udp/translation.go
+++ b/pkg/ttnpb/udp/translation.go
@@ -352,7 +352,7 @@ func FromDownlinkMessage(msg *ttnpb.DownlinkMessage) (*TxPacket, error) {
 	payload := msg.GetRawPayload()
 	scheduled := msg.GetScheduled()
 	if scheduled == nil {
-		return nil, errNotScheduled
+		return nil, errNotScheduled.New()
 	}
 	tx := &TxPacket{
 		Freq: float64(scheduled.Frequency) / 1000000,

--- a/pkg/types/devaddr.go
+++ b/pkg/types/devaddr.go
@@ -287,13 +287,13 @@ func (prefix *DevAddrPrefix) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	if len(data) != 12 && len(data) != 13 {
-		return errInvalidDevAddrPrefix
+		return errInvalidDevAddrPrefix.New()
 	}
 	if data[0] != '"' || data[len(data)-1] != '"' {
 		return errInvalidJSON.WithAttributes("json", string(data))
 	}
 	if data[9] != '/' {
-		return errInvalidDevAddrPrefix
+		return errInvalidDevAddrPrefix.New()
 	}
 	b := make([]byte, hex.DecodedLen(8))
 	n, err := hex.Decode(b, data[1:9])
@@ -301,7 +301,7 @@ func (prefix *DevAddrPrefix) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if n != 4 || copy(prefix.DevAddr[:], b) != 4 {
-		return errInvalidDevAddrPrefix
+		return errInvalidDevAddrPrefix.New()
 	}
 	length, err := strconv.Atoi(string(data[10 : len(data)-1]))
 	if err != nil {
@@ -323,7 +323,7 @@ func (prefix *DevAddrPrefix) UnmarshalBinary(data []byte) error {
 		return nil
 	}
 	if len(data) != 5 {
-		return errInvalidDevAddrPrefix
+		return errInvalidDevAddrPrefix.New()
 	}
 	if err := prefix.DevAddr.Unmarshal(data[:4]); err != nil {
 		return err
@@ -348,10 +348,10 @@ func (prefix *DevAddrPrefix) UnmarshalText(data []byte) error {
 		return nil
 	}
 	if len(data) != 10 && len(data) != 11 {
-		return errInvalidDevAddrPrefix
+		return errInvalidDevAddrPrefix.New()
 	}
 	if data[8] != '/' {
-		return errInvalidDevAddrPrefix
+		return errInvalidDevAddrPrefix.New()
 	}
 	if err := prefix.DevAddr.UnmarshalText(data[:8]); err != nil {
 		return err

--- a/pkg/types/eui.go
+++ b/pkg/types/eui.go
@@ -142,13 +142,13 @@ func (prefix *EUI64Prefix) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	if len(data) != 20 && len(data) != 21 {
-		return errInvalidEUIPrefix
+		return errInvalidEUIPrefix.New()
 	}
 	if data[0] != '"' || data[len(data)-1] != '"' {
 		return errInvalidJSON.WithAttributes("json", string(data))
 	}
 	if data[17] != '/' {
-		return errInvalidEUIPrefix
+		return errInvalidEUIPrefix.New()
 	}
 	b := make([]byte, hex.DecodedLen(16))
 	n, err := hex.Decode(b, data[1:17])
@@ -156,7 +156,7 @@ func (prefix *EUI64Prefix) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	if n != 8 || copy(prefix.EUI64[:], b) != 8 {
-		return errInvalidEUIPrefix
+		return errInvalidEUIPrefix.New()
 	}
 	length, err := strconv.Atoi(string(data[18 : len(data)-1]))
 	if err != nil {
@@ -178,7 +178,7 @@ func (prefix *EUI64Prefix) UnmarshalBinary(data []byte) error {
 		return nil
 	}
 	if len(data) != 9 {
-		return errInvalidEUIPrefix
+		return errInvalidEUIPrefix.New()
 	}
 	if err := prefix.EUI64.Unmarshal(data[:8]); err != nil {
 		return err
@@ -204,10 +204,10 @@ func (prefix *EUI64Prefix) UnmarshalText(data []byte) error {
 		return nil
 	}
 	if len(data) != 18 && len(data) != 19 {
-		return errInvalidEUIPrefix
+		return errInvalidEUIPrefix.New()
 	}
 	if data[16] != '/' {
-		return errInvalidEUIPrefix
+		return errInvalidEUIPrefix.New()
 	}
 	if err := prefix.EUI64.UnmarshalText(data[:16]); err != nil {
 		return err

--- a/pkg/types/netid.go
+++ b/pkg/types/netid.go
@@ -88,7 +88,7 @@ var errNetIDOverflow = errors.DefineInvalidArgument("net_id_overflow", "NetID ov
 func (id *NetID) UnmarshalNumber(netID uint32) error {
 	*id = [3]byte{}
 	if netID > 0xFFFFFF {
-		return errNetIDOverflow
+		return errNetIDOverflow.New()
 	}
 	id[0] = byte(netID >> 16)
 	id[1] = byte(netID >> 8)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -83,7 +83,7 @@ func unmarshalTextBytes(dst, data []byte) error {
 		return err
 	}
 	if n != len(dst) || copy(dst, b) != len(dst) {
-		return errInvalidLength
+		return errInvalidLength.New()
 	}
 	return nil
 }
@@ -106,7 +106,7 @@ func unmarshalBinaryBytes(dst, data []byte) error {
 		return nil
 	}
 	if len(data) != len(dst) || copy(dst[:], data) != len(dst) {
-		return errInvalidLength
+		return errInvalidLength.New()
 	}
 	return nil
 }

--- a/pkg/validate/min_length.go
+++ b/pkg/validate/min_length.go
@@ -33,7 +33,7 @@ var (
 func MinLength(length int) validateFn { // nolint: golint, returns unexported type on purpose
 	return func(v interface{}) error {
 		if v == nil {
-			return errNil
+			return errNil.New()
 		}
 
 		typ := reflect.TypeOf(v)

--- a/pkg/validate/password.go
+++ b/pkg/validate/password.go
@@ -35,7 +35,7 @@ func Password(v interface{}) error {
 	}
 
 	if !passwordRegex.MatchString(password) {
-		return errPasswordLength
+		return errPasswordLength.New()
 	}
 
 	return nil

--- a/pkg/validate/required.go
+++ b/pkg/validate/required.go
@@ -189,7 +189,7 @@ var errFieldSet = errors.DefineInvalidArgument("field_set", "field is set")
 // It uses IsZero, if v implements IsZeroer interface.
 func Empty(v interface{}) error {
 	if !isZero(v) {
-		return errFieldSet
+		return errFieldSet.New()
 	}
 	return nil
 }
@@ -213,7 +213,7 @@ func NotRequired(v interface{}) error {
 // It uses IsZero, if v implements IsZeroer interface.
 func Required(v interface{}) error {
 	if isZero(v) {
-		return errRequired
+		return errRequired.New()
 	}
 	return nil
 }

--- a/pkg/web/oauthclient/callback.go
+++ b/pkg/web/oauthclient/callback.go
@@ -41,12 +41,12 @@ func (oc *OAuthClient) HandleCallback(c echo.Context) error {
 
 	state := c.QueryParam("state")
 	if state == "" {
-		return errNoStateParam
+		return errNoStateParam.New()
 	}
 
 	code := c.QueryParam("code")
 	if code == "" {
-		return errNoCodeParam
+		return errNoCodeParam.New()
 	}
 
 	stateCookie, err := oc.getStateCookie(c)
@@ -55,7 +55,7 @@ func (oc *OAuthClient) HandleCallback(c echo.Context) error {
 	}
 
 	if stateCookie.Secret != state {
-		return errInvalidState
+		return errInvalidState.New()
 	}
 
 	// Exchange token.

--- a/pkg/web/oauthclient/oauthclient.go
+++ b/pkg/web/oauthclient/oauthclient.go
@@ -67,7 +67,7 @@ func (oc *OAuthClient) getMountPath() string {
 // New returns a new OAuth client instance.
 func New(c *component.Component, config Config) (*OAuthClient, error) {
 	if config.isZero() {
-		return nil, errNoOAuthConfig
+		return nil, errNoOAuthConfig.New()
 	}
 
 	oc := &OAuthClient{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR introduces a `New` function on `errors.Definition` that builds and returns an `errors.Error`, which then also contains a stack trace. In many other places, we use `(errors.Definition).WithAttributes` or `(errors.Definition).WithCause`, which does the same. This PR makes sure we also have stack traces for other errors.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This is a relatively simple pull request, but it touches a lot of files, sorry for that.
