### PR TITLE
Initialize UDP data regardless of payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Gateway events subscription release in the Console.
 - Entity events subscription release in the Console (Firefox).
 - RekeyInd handling for LoRaWAN 1.1 devices.
+- Panic when receiving a UDP `PUSH_DATA` frame from a gateway without payload.
 
 ### Security
 

--- a/pkg/ttnpb/udp/packet.go
+++ b/pkg/ttnpb/udp/packet.go
@@ -116,38 +116,36 @@ func (p Packet) BuildAck() (Packet, error) {
 }
 
 // UnmarshalBinary implements the encoding.BinaryUnmarshaler
-func (p *Packet) UnmarshalBinary(b []byte) (err error) {
+func (p *Packet) UnmarshalBinary(b []byte) error {
 	if len(b) < 4 {
 		return io.EOF
 	}
 	p.ProtocolVersion = ProtocolVersion(b[0])
 	copy(p.Token[:], b[1:3])
 	p.PacketType = PacketType(b[3])
-
 	i := 4
 
 	if p.PacketType.HasGatewayEUI() {
 		if len(b) < i+8 {
 			return errNoEUI
 		}
-
 		p.GatewayEUI = new(types.EUI64)
-		err = p.GatewayEUI.UnmarshalBinary(b[i : i+8])
-		if err != nil {
+		if err := p.GatewayEUI.UnmarshalBinary(b[i : i+8]); err != nil {
 			return errEUI.WithCause(err)
 		}
 		i += 8
 	}
 
-	if p.PacketType.HasData() && len(b)-i > 0 {
+	if p.PacketType.HasData() {
 		p.Data = new(Data)
-		err = json.Unmarshal(b[i:], p.Data)
-		if err != nil {
-			return err
+		if len(b)-i > 0 {
+			if err := json.Unmarshal(b[i:], p.Data); err != nil {
+				return err
+			}
 		}
 	}
 
-	return
+	return nil
 }
 
 // MarshalBinary implements the encoding.BinaryMarshaler

--- a/pkg/ttnpb/udp/packet_test.go
+++ b/pkg/ttnpb/udp/packet_test.go
@@ -50,21 +50,36 @@ func TestPacket(t *testing.T) {
 }
 
 func TestFailedPackets(t *testing.T) {
-	var p Packet
-
 	a := assertions.New(t)
 
-	b := []byte{}
-	err := p.UnmarshalBinary(b)
-	a.So(err, should.NotBeNil)
+	{
+		p := new(Packet)
+		b := []byte{}
+		err := p.UnmarshalBinary(b)
+		a.So(err, should.NotBeNil)
+	}
 
-	b = []byte{0, 0, 0, 0}
-	err = p.UnmarshalBinary(b)
-	a.So(err, should.NotBeNil)
+	{
+		p := new(Packet)
+		b := []byte{0, 0, 0, 0}
+		err := p.UnmarshalBinary(b)
+		a.So(err, should.NotBeNil)
+	}
 
-	b = bytes.Repeat([]byte{0x0}, 9)
-	err = p.UnmarshalBinary(b)
-	a.So(err, should.NotBeNil)
+	{
+		p := new(Packet)
+		b := bytes.Repeat([]byte{0x0}, 9)
+		err := p.UnmarshalBinary(b)
+		a.So(err, should.NotBeNil)
+	}
+
+	{
+		p := new(Packet)
+		b := []byte{1, 0, 0, byte(PushData), 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8}
+		err := p.UnmarshalBinary(b)
+		a.So(err, should.BeNil)
+		a.So(p.Data, should.NotBeNil)
+	}
 }
 
 func TestPacketType(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Initialize UDP data regardless of payload

#### Changes
<!-- What are the changes made in this pull request? -->

- Initialize `Data` always, even if there's no payload. Note that payload is optional; `TX_ACK` for example, doesn't need to carry payload. Theoretically, `PUSH_DATA` could now come without actual `rxpk` objects, and we've seen that crashing the V2 offloading bridge. This fixes a panic in GS where the packet handler assumed `Data` to be set when processing `PUSH_DATA` packets

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
