### PR TITLE
Fix displaying error in events subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix organization collaborator view not being accessible in the Console.
+- Error display on Data pages in the Console.
 
 ### Security
 

--- a/pkg/webui/components/events/index.js
+++ b/pkg/webui/components/events/index.js
@@ -59,13 +59,14 @@ class Events extends React.Component {
 
   shouldComponentUpdate(nextProps, nextState) {
     const { paused } = this.state
-    const { events, emitterId, onClear, limit } = this.props
+    const { events, emitterId, onClear, limit, error } = this.props
 
     if (
       emitterId !== nextProps.emitterId ||
       limit !== nextProps.limit ||
       onClear !== nextProps.onClear ||
-      paused !== nextState.paused
+      paused !== nextState.paused ||
+      error !== nextProps.error
     ) {
       return true
     }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fix displaying error notification in the `<Events />` component.

#### Changes
<!-- What are the changes made in this pull request? -->

- Check for `error` in `shouldComponentUpdate`

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Currently, the `<Events />` component displays an error only if the events stream failed before the component mounts. For example, if the user is on the entity overview page when the events stream closes because of an error and only then switches to the page with full events component, the error is shown. However, if the event stream fails while the user is on the page with full events component no indication of error is shown in the UI.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
