### PR TITLE
Fix gateway initial status display

### DIFF
--- a/pkg/webui/console/views/gateway/index.js
+++ b/pkg/webui/console/views/gateway/index.js
@@ -64,8 +64,8 @@ import PropTypes from '../../../lib/prop-types'
     return {
       gtwId,
       gateway,
-      error: selectGatewayError(state) && selectGatewayRightsError(state),
-      fetching: selectGatewayFetching(state) && selectGatewayRightsFetching(state),
+      error: selectGatewayError(state) || selectGatewayRightsError(state),
+      fetching: selectGatewayFetching(state) || selectGatewayRightsFetching(state),
       rights: selectGatewayRights(state),
     }
   },


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes issue with dispalying gateway status on the initial render. Currently, when accessing the gateway overview page from the gateways list page the status is always `unknown` regardless of the actual status:
<img width="434" alt="Screenshot 2020-03-22 at 16 37 28" src="https://user-images.githubusercontent.com/16374166/77252308-a8eab800-6c5b-11ea-8ab8-cfd143efadf2.png">

Besides that, errors are ignored.


#### Changes
<!-- What are the changes made in this pull request? -->

- Use logical OR when selecting the `fetching` or `error` states.


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
