### PR TITLE
Fix non-unique device key in event store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix organization collaborator view not being accessible in the Console.
 - Error display on Data pages in the Console.
 - Fix too restrictive MQTT client validation in PubSub form in the Console.
+- Fix faulty display of device event stream data for end devices with the same ID in different applications.
 
 ### Security
 

--- a/pkg/webui/console/containers/device-events/index.js
+++ b/pkg/webui/console/containers/device-events/index.js
@@ -17,7 +17,7 @@ import { connect } from 'react-redux'
 import bind from 'autobind-decorator'
 
 import PropTypes from '../../../lib/prop-types'
-import { getApplicationId, getDeviceId } from '../../../lib/selectors/id'
+import { getApplicationId, getDeviceId, combineDeviceIds } from '../../../lib/selectors/id'
 import EventsSubscription from '../../containers/events-subscription'
 
 import { clearDeviceEventsStream, startDeviceEventsStream } from '../../store/actions/devices'
@@ -57,10 +57,11 @@ class DeviceEvents extends React.Component {
 
     const devId = getDeviceId(devIds)
     const appId = getApplicationId(devIds)
+    const combinedDeviceId = combineDeviceIds(appId, devId)
 
     return (
       <EventsSubscription
-        id={devId}
+        id={combinedDeviceId}
         widget={widget}
         eventsSelector={selectDeviceEvents}
         statusSelector={selectDeviceEventsStatus}

--- a/pkg/webui/console/store/middleware/logics/events.js
+++ b/pkg/webui/console/store/middleware/logics/events.js
@@ -28,7 +28,7 @@ import {
 } from '../../actions/events'
 import { createEventsStatusSelector } from '../../selectors/events'
 import { isUnauthenticatedError } from '../../../../lib/errors/utils'
-import { getDeviceId } from '../../../../lib/selectors/id'
+import { getCombinedDeviceId } from '../../../../lib/selectors/id'
 import user from './user'
 
 /**
@@ -67,7 +67,7 @@ const createEventsConnectLogics = function(reducerName, entityName, onEventsStar
           return
         }
 
-        const id = typeof action.id === 'object' ? getDeviceId(action.id) : action.id
+        const id = typeof action.id === 'object' ? getCombinedDeviceId(action.id) : action.id
 
         // only proceed if not already connected
         const status = selectEntityEventsStatus(getState(), id)
@@ -107,7 +107,7 @@ const createEventsConnectLogics = function(reducerName, entityName, onEventsStar
           return
         }
 
-        const id = typeof action.id === 'object' ? getDeviceId(action.id) : action.id
+        const id = typeof action.id === 'object' ? getCombinedDeviceId(action.id) : action.id
 
         // only proceed if connected
         const status = selectEntityEventsStatus(getState(), id)

--- a/pkg/webui/console/store/reducers/events.js
+++ b/pkg/webui/console/store/reducers/events.js
@@ -23,7 +23,7 @@ import {
   createClearEventsActionType,
 } from '../actions/events'
 
-import { getDeviceId } from '../../../lib/selectors/id'
+import { getCombinedDeviceId } from '../../../lib/selectors/id'
 
 const defaultState = {
   events: [],
@@ -96,7 +96,7 @@ const createNamedEventsReducer = function(reducerName = '') {
       return state
     }
 
-    const id = typeof action.id === 'object' ? getDeviceId(action.id) : action.id
+    const id = typeof action.id === 'object' ? getCombinedDeviceId(action.id) : action.id
 
     switch (action.type) {
       case START_EVENTS:

--- a/pkg/webui/lib/selectors/id.js
+++ b/pkg/webui/lib/selectors/id.js
@@ -41,8 +41,10 @@ export const extractDeviceIdFromCombinedId = function(combinedId) {
   return combinedId
 }
 export const getCombinedDeviceId = function(device = {}) {
-  const appId = getByPath(device, 'ids.application_ids.application_id')
-  const devId = getByPath(device, 'ids.device_id')
+  const appId =
+    getByPath(device, 'ids.application_ids.application_id') ||
+    getByPath(device, 'application_ids.application_id')
+  const devId = getDeviceId(device)
   return combineDeviceIds(appId, devId)
 }
 


### PR DESCRIPTION
#### Summary
Closes #2223 

#### Changes
- Replace usage of `getDeviceId` selector with `getCombinedDeviceId` selector in device event related logic
- Update changelog

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
