### PR TITLE
Harmonize DevAddr validation with NS

### DIFF
--- a/pkg/applicationserver/grpc_deviceregistry.go
+++ b/pkg/applicationserver/grpc_deviceregistry.go
@@ -176,9 +176,13 @@ func (r asEndDeviceRegistryServer) Set(ctx context.Context, req *ttnpb.SetEndDev
 		}
 
 		evt = evtCreateEndDevice(ctx, req.EndDevice.EndDeviceIdentifiers, nil)
-		if req.EndDevice.DevAddr != nil && !req.EndDevice.DevAddr.IsZero() {
-			return nil, nil, errInvalidFieldValue.WithAttributes("field", "ids.dev_addr")
+
+		if req.EndDevice.DevAddr != nil {
+			if !ttnpb.HasAnyField(sets, "session.dev_addr") || !req.EndDevice.DevAddr.Equal(req.EndDevice.Session.DevAddr) {
+				return nil, nil, errInvalidFieldValue.WithAttributes("field", "ids.dev_addr")
+			}
 		}
+
 		sets = ttnpb.AddFields(sets,
 			"ids.application_ids",
 			"ids.device_id",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Harmonize DevAddr validation with NS

This fixes creating ABP devices via CLI with `--abp --with-session`

#### Changes
<!-- What are the changes made in this pull request? -->

- Check DevAddr like it's checked in NS

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Please make sure that NS device registry changes are applied in AS and JS, when applicable, and vice-versa.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
