### PR TITLE
is: Include antenna location source in store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Gateway antenna locations are not ignored by the Identity Server.
+  - This requires a database migration (`ttn-lw-stack is-db migrate`) because of the added columns.
+
 ### Security
 
 ## [3.7.0] (2020-03-19)
@@ -38,7 +41,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix faulty display of device event stream data for end devices with the same ID in different applications.
 - Trailing slashes handling in webhook paths.
 - Limited throughput in upstream handlers in Gateway Server when one gateway's upstream handler is busy.
-
 
 ## [3.6.2] (2020-03-19)
 

--- a/pkg/identityserver/store/gateway_antenna.go
+++ b/pkg/identityserver/store/gateway_antenna.go
@@ -29,6 +29,8 @@ type GatewayAntenna struct {
 	Gain float32
 
 	Location
+
+	Source int32 `gorm:"default:3 not null"`
 }
 
 func init() {
@@ -36,6 +38,10 @@ func init() {
 }
 
 func (a GatewayAntenna) toPB() ttnpb.GatewayAntenna {
+	source := ttnpb.LocationSource(a.Source)
+	if source == ttnpb.SOURCE_UNKNOWN {
+		source = ttnpb.SOURCE_REGISTRY
+	}
 	return ttnpb.GatewayAntenna{
 		Gain: a.Gain,
 		Location: ttnpb.Location{
@@ -43,7 +49,7 @@ func (a GatewayAntenna) toPB() ttnpb.GatewayAntenna {
 			Longitude: a.Longitude,
 			Altitude:  a.Altitude,
 			Accuracy:  a.Accuracy,
-			Source:    ttnpb.SOURCE_REGISTRY,
+			Source:    source,
 		},
 		Attributes: attributes(a.Attributes).toMap(),
 	}
@@ -57,5 +63,6 @@ func (a *GatewayAntenna) fromPB(pb ttnpb.GatewayAntenna) {
 		Altitude:  pb.Location.Altitude,
 		Accuracy:  pb.Location.Accuracy,
 	}
+	a.Source = int32(pb.Location.Source)
 	a.Attributes = attributes(a.Attributes).updateFromMap(pb.Attributes)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Identity server now stores antenna location as well.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `Source` field in `GatewayAntenna`.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- Field was not added in `Location` type, because it breaks the `EndDevice` struct (which has a `Location` and a separate `Source` field).

- Testing:
  - Unit tests are passing
  - Tested updating gateway location. Without change, whatever is used as source is ignored. With change, the correct location source is returned.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [X] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
