### PR TITLE
Add `--dump-requests` flag to the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- CLI can now dump JSON encoded `grpc_payload` field for unary requests (see `--dump-requests` flag).
+
 ### Changed
 
 ### Deprecated

--- a/cmd/ttn-lw-cli/commands/config.go
+++ b/cmd/ttn-lw-cli/commands/config.go
@@ -49,6 +49,7 @@ type Config struct {
 	QRCodeGeneratorGRPCAddress         string `name:"qr-code-generator-grpc-address" yaml:"qr-code-generator-grpc-address" description:"QR Code Generator address"`
 	Insecure                           bool   `name:"insecure" yaml:"insecure" description:"Connect without TLS"`
 	CA                                 string `name:"ca" yaml:"ca" description:"CA certificate file"`
+	DumpRequests                       bool   `name:"dump-requests" yaml:"dump-requests" description:"When log level is set to debug, also dump request payload as JSON"`
 }
 
 func (c Config) getHosts() []string {

--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -113,6 +113,9 @@ func preRun(tasks ...func() error) func(cmd *cobra.Command, args []string) error
 		if config.Insecure {
 			api.SetInsecure(true)
 		}
+		if config.DumpRequests {
+			api.SetDumpRequests(true)
+		}
 		if config.CA != "" {
 			pemBytes, err := ioutil.ReadFile(config.CA)
 			if err != nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #816

#### Changes
<!-- What are the changes made in this pull request? -->

- Introduces a new `DefaultDialOptionsWithDump()`. Passes a `dump` flag to the `rpclog.UnaryClientInterceptor`. When that is true, the interceptor adds a `grpc_request` log field with the request payload encoded as JSON

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The client uses the `DefaultDialOptions()`, which already includes a whole stack of middleware interceptors, so doing this directly on CLI-only code is not an option (as it would drop the other interceptors).

The new `--dump-requests` flag is turned off by default, maintaining backwards compatibility.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
