### PR TITLE
cli: Local config takes precedence over global

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - End device location display bug when deleting the location entry in the Console.
 - GS could panic when gateway connection stats were updated while updating the registry.
+- Local CLI and stack config files now properly override global config.
 
 ### Security
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -258,7 +258,10 @@ func (m *Manager) inCLIFlags(path string) bool {
 // The parsed config files will be merged into the config struct.
 func (m *Manager) ReadInConfig() error {
 	files := m.viper.GetStringSlice(m.configFlag)
-	for _, file := range files {
+	// read config files in reverse order, so config files listed first take precedence
+	for index := len(files) - 1; index >= 0; index-- {
+		file := files[index]
+
 		// ignore default config files that are missing or do not have read permissions
 		if m.isDefault(file) && !m.inCLIFlags(file) {
 			if _, err := os.Stat(file); os.IsNotExist(err) || os.IsPermission(err) {

--- a/pkg/config/files_test.go
+++ b/pkg/config/files_test.go
@@ -87,10 +87,10 @@ func TestReadMultiConfig(t *testing.T) {
 	err = mgr.Unmarshal(res)
 	a.So(err, should.BeNil)
 
-	a.So(res.Foo, should.Resemble, "20")
+	a.So(res.Foo, should.Resemble, "10")
 	a.So(res.Bar, should.Resemble, map[string]string{
 		"a": "baz",
-		"b": "hey",
+		"b": "quu",
 		"c": "yo!",
 	})
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2247

#### Changes
<!-- What are the changes made in this pull request? -->

- Read config files in reverse order (global -> local), so that configuration in local files takes precedence.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

~Before reviewing or merging this, please make sure #2247 is actually classified as a bug and not desired behaviour.~

Changed PR after discussion in #2247

Also updating tests.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [X] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
