### PR TITLE
Initialize conn closed metric on conn open

### DIFF
--- a/pkg/metrics/grpc.go
+++ b/pkg/metrics/grpc.go
@@ -138,6 +138,7 @@ func (hdl statsHandler) HandleConn(ctx context.Context, s stats.ConnStats) {
 	case *stats.ConnBegin:
 		if s.IsClient() {
 			hdl.openedClientConns.WithLabelValues(peer).Inc()
+			hdl.closedClientConns.GetMetricWithLabelValues(peer) // Initialize the "closed" counter.
 		} else {
 			hdl.openedServerConns.Inc()
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This quickfix makes sure a "grpc connections closed" metric exists when a gRPC connection is opened. Without this fix we wouldn't always be able to correctly count the number of open gRPC connections.