### PR TITLE
Fix end device location reset in Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- End device location display bug when deleting the location entry in the Console.
+
 ### Security
 
 ## [3.7.0] (2020-03-19)

--- a/pkg/webui/console/store/reducers/devices.js
+++ b/pkg/webui/console/store/reducers/devices.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { merge } from 'lodash'
+import { mergeWith } from 'lodash'
 
 import { getCombinedDeviceId, combineDeviceIds } from '../../../lib/selectors/id'
 import {
@@ -37,7 +37,12 @@ const devices = function(state = defaultState, { type, payload }) {
     case UPDATE_DEV_SUCCESS:
     case GET_DEV_SUCCESS:
       const id = getCombinedDeviceId(payload)
-      const mergedDevice = merge({}, state.entities[id], payload)
+      const mergedDevice = mergeWith({}, state.entities[id], payload, (_, __, key, ___, source) => {
+        // always set location from the payload
+        if (source === payload && key === 'locations') {
+          return source.locations
+        }
+      })
 
       return {
         ...state,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/2249

#### Changes
<!-- What are the changes made in this pull request? -->

- Always use `locations` entry from the response payload

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

> If we perform a deep merge, then the end device will not update the location value correctly. In other reducers we simply spread the patch over the current object, which will overwrite all top level properties of the object. In that case, the value would be applied correctly.

The problem here is not end device specific. It is about how we perform partial updates of deeply nested fields on entities.
In case of handling end devices, the problem is the object has many deeply nested fields that we allow updating in the general settings page. Think of `root_keys` with structure
```
	root_keys: {
		app_key: {
			key: ...
		}
	}
```
Now, in case when the user updates an end device from lw 1.0.0+ to 1.1.0 the `nwk_key` can be provided. We send it as `root_keys.nwk_key.key` and hence get the `root_keys.nwk_key.key` entry back. In order to preserve the `app_key` we need to perform a deep merge. With `session` it becomes even trickier.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
