### PR TITLE
Lower class B/C downlink frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Default DevStatus periodicity is increased, which means that, by default, DevStatusReq will be scheduled less often.
+- Default class B and C timeouts are increased, which means that, by default, if the Network Server expects an uplink from the device after a downlink, it will wait longer before rescheduling the downlink.
+- In case downlink frame carries MAC requests, Network Server will not force the downlink to be sent confirmed in class B and C.
+
 ### Deprecated
 
 ### Removed

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -430,12 +430,6 @@ func (ns *NetworkServer) generateDataDownlink(ctx context.Context, dev *ttnpb.En
 	default:
 		return nil, genState, errNoDownlink.New()
 	}
-	if mType == ttnpb.MType_UNCONFIRMED_DOWN && len(dev.MACState.PendingRequests) > 0 &&
-		(dev.MACState.DeviceClass == ttnpb.CLASS_B ||
-			dev.MACState.DeviceClass == ttnpb.CLASS_C && dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0) {
-		logger.Debug("Use confirmed downlink to get immediate answer")
-		mType = ttnpb.MType_CONFIRMED_DOWN
-	}
 
 	logger = logger.WithFields(log.Fields(
 		"f_cnt", pld.FHDR.FCnt,

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -2802,6 +2802,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 						SessionKeys:   *sessionKeys,
 						QueuedApplicationDownlinks: []*ttnpb.ApplicationDownlink{
 							{
+								Confirmed:      true,
 								CorrelationIDs: []string{"correlation-app-down-1", "correlation-app-down-2"},
 								FCnt:           0x42,
 								FPort:          0x1,
@@ -2943,6 +2944,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				setDevice := CopyEndDevice(getDevice)
 				setDevice.MACState.LastConfirmedDownlinkAt = &downAt
 				setDevice.MACState.LastNetworkInitiatedDownlinkAt = &downAt
+				setDevice.MACState.PendingApplicationDownlink = setDevice.Session.QueuedApplicationDownlinks[0]
 				setDevice.MACState.PendingRequests = []*ttnpb.MACCommand{
 					{
 						CID: ttnpb.CID_DEV_STATUS,
@@ -2951,6 +2953,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 				setDevice.MACState.RecentDownlinks = append(setDevice.MACState.RecentDownlinks, lastDown)
 				setDevice.RecentDownlinks = append(setDevice.RecentDownlinks, lastDown)
 				setDevice.Session.QueuedApplicationDownlinks = []*ttnpb.ApplicationDownlink{}
+				setDevice.Session.LastConfFCntDown = 0x42
 
 				select {
 				case <-ctx.Done():

--- a/pkg/networkserver/utils.go
+++ b/pkg/networkserver/utils.go
@@ -67,7 +67,7 @@ func deviceUseADR(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings) bool {
 
 // DefaultClassBTimeout is the default time-out for the device to respond to class B downlink messages.
 // When waiting for a response times out, the downlink message is considered lost, and the downlink task triggers again.
-const DefaultClassBTimeout = time.Minute
+const DefaultClassBTimeout = 10 * time.Minute
 
 func deviceClassBTimeout(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings) time.Duration {
 	if dev.MACSettings != nil && dev.MACSettings.ClassBTimeout != nil {
@@ -81,7 +81,7 @@ func deviceClassBTimeout(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings) time.
 
 // DefaultClassCTimeout is the default time-out for the device to respond to class C downlink messages.
 // When waiting for a response times out, the downlink message is considered lost, and the downlink task triggers again.
-const DefaultClassCTimeout = 15 * time.Second
+const DefaultClassCTimeout = 5 * time.Minute
 
 func deviceClassCTimeout(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings) time.Duration {
 	if dev.MACSettings != nil && dev.MACSettings.ClassCTimeout != nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Lower class B/C downlink frequency

#### Changes
<!-- What are the changes made in this pull request? -->

- Default class B and C timeouts are increased, which means that, by default, if the Network Server expects an uplink from the device after a downlink, it will wait longer before rescheduling the downlink.
- In case downlink frame carries MAC requests, Network Server will not force the downlink to be sent confirmed in class B and C. This hack is not effective, hence no reason to do it.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Added the changelog entry missed in #2237 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
