### PR TITLE
Fix panic in GS stats update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - End device location display bug when deleting the location entry in the Console.
+- GS could panic when gateway connection stats were updated while updating the registry.
 
 ### Security
 

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -20,6 +20,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/mohae/deepcopy"
 	"go.thethings.network/lorawan-stack/pkg/band"
 	"go.thethings.network/lorawan-stack/pkg/config"
 	"go.thethings.network/lorawan-stack/pkg/errorcontext"
@@ -238,7 +239,7 @@ func (c *Connection) HandleStatus(status *ttnpb.GatewayStatus) error {
 	case <-c.ctx.Done():
 		return c.ctx.Err()
 	case c.statusCh <- status:
-		c.lastStatus.Store(status)
+		c.lastStatus.Store(deepcopy.Copy(status))
 		atomic.StoreInt64(&c.lastStatusTime, time.Now().UnixNano())
 		c.notifyStatsChanged()
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #1332 

Marshalling the connection stats object could panic if stats are updated at the same time. Reason was that the gateway status returned was a pointer. Change `io.Connection.StatusStats()` to create a deep copy of the `GatewayStatus` instead.

#### Changes
<!-- What are the changes made in this pull request? -->

- `io.Connection.StatusStats()` to create a deep copy of the `GatewayStatus` instead of returning pointer.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The `GatewayStatus.Advanced` field is a `pbtypes.Struct` object. Not sure how to deepcopy that one except for marshalling/unmarshalling. That could pose the same risk as the one we are trying to solve (marshal will panic if the Advanced field changes).

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [X] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
