### PR TITLE
Add ReadTimeouts to HTTP servers, Remove cmux

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -99,7 +99,6 @@ require (
 	github.com/sendgrid/sendgrid-go v3.5.0+incompatible
 	github.com/skip2/go-qrcode v0.0.0-20191027152451-9434209cb086
 	github.com/smartystreets/assertions v1.0.1
-	github.com/soheilhy/cmux v0.1.4
 	github.com/spf13/cast v1.3.1
 	github.com/spf13/cobra v0.0.6
 	github.com/spf13/pflag v1.0.5

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -329,12 +329,12 @@ func (c *Component) Close() {
 	c.tcpListenersMu.Lock()
 	defer c.tcpListenersMu.Unlock()
 	for _, l := range c.tcpListeners {
-		err := l.lis.Close()
+		err := l.Close()
 		if err != nil && c.ctx.Err() == nil {
-			c.logger.WithError(err).Errorf("Error while stopping to listen on %s", l.lis.Addr())
+			c.logger.WithError(err).Errorf("Error while stopping to listen on %s", l.Addr())
 			continue
 		}
-		c.logger.Debugf("Stopped listening on %s", l.lis.Addr())
+		c.logger.Debugf("Stopped listening on %s", l.Addr())
 	}
 
 	if c.grpc != nil {

--- a/pkg/component/interop.go
+++ b/pkg/component/interop.go
@@ -32,6 +32,7 @@ func (c *Component) RegisterInterop(s interop.Registerer) {
 func (c *Component) serveInterop(lis net.Listener) error {
 	srv := http.Server{
 		Handler:           c.interop,
+		ReadTimeout:       120 * time.Second,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 	go func() {

--- a/pkg/component/listeners.go
+++ b/pkg/component/listeners.go
@@ -18,7 +18,6 @@ import (
 	"crypto/tls"
 	"net"
 
-	"github.com/soheilhy/cmux"
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/log"
 )
@@ -32,41 +31,49 @@ var (
 type Listener interface {
 	TLS(opts ...TLSConfigOption) (net.Listener, error)
 	TCP() (net.Listener, error)
+	Addr() net.Addr
 	Close() error
 }
 
 type listener struct {
-	c       *Component
-	lis     net.Listener
-	mux     cmux.CMux
+	c *Component
+
 	tcp     net.Listener
 	tcpUsed bool
 	tls     net.Listener
 	tlsUsed bool
 }
 
+func (l *listener) Addr() net.Addr {
+	return l.tcp.Addr()
+}
+
 func (l *listener) TLS(opts ...TLSConfigOption) (net.Listener, error) {
-	if l.tlsUsed {
-		return nil, errors.New("TLS listener already in use")
+	if l.tcpUsed || l.tlsUsed {
+		return nil, errors.New("listener already in use")
 	}
 	config, err := l.c.GetTLSServerConfig(l.c.Context(), opts...)
 	if err != nil {
 		return nil, err
 	}
+	l.tls = tls.NewListener(l.tcp, config)
 	l.tlsUsed = true
-	return tls.NewListener(l.tls, config), nil
+	return l.tls, nil
 }
 
 func (l *listener) TCP() (net.Listener, error) {
-	if l.tcpUsed {
-		return nil, errors.New("TCP listener already in use")
+	if l.tcpUsed || l.tlsUsed {
+		return nil, errors.New("listener already in use")
 	}
 	l.tcpUsed = true
 	return l.tcp, nil
 }
 
 func (l *listener) Close() error {
-	return l.lis.Close()
+	if l.tlsUsed {
+		return l.tls.Close()
+	}
+	return l.tcp.Close()
 }
 
 // ListenTCP listens on a TCP address and allows for TCP and TLS on the same port.
@@ -80,22 +87,11 @@ func (c *Component) ListenTCP(address string) (Listener, error) {
 		if err != nil {
 			return nil, err
 		}
-		mux := cmux.New(lis)
 		l = &listener{
 			c:   c,
-			lis: lis,
-			mux: mux,
-			tls: mux.Match(cmux.TLS()),
-			tcp: mux.Match(cmux.Any()),
+			tcp: lis,
 		}
 		c.tcpListeners[address] = l
-		go func() {
-			logger := c.logger.WithField("address", l.lis.Addr().String())
-			logger.Debug("Start serving")
-			if err := l.mux.Serve(); err != nil && c.ctx.Err() == nil {
-				logger.WithError(err).Errorf("Serve failed")
-			}
-		}()
 	}
 	return l, nil
 }

--- a/pkg/component/web.go
+++ b/pkg/component/web.go
@@ -88,6 +88,7 @@ func (c *Component) RegisterReadinessCheck(name string, check healthcheck.Check)
 func (c *Component) serveWeb(lis net.Listener) error {
 	srv := http.Server{
 		Handler:           c,
+		ReadTimeout:       120 * time.Second,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 	go func() {

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -259,6 +259,7 @@ func New(c *component.Component, conf *Config, opts ...Option) (gs *GatewayServe
 
 				srv := http.Server{
 					Handler:           bsWebServer,
+					ReadTimeout:       120 * time.Second,
 					ReadHeaderTimeout: 5 * time.Second,
 				}
 				go func() {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This quickfix adds read timeouts to the HTTP servers. When using TLS listeners, the existing `ReadHeaderTimeout`s are not sufficient, since those timeouts only kick in _after_ doing the TLS handshake. This means that connections that don't perform a TLS handshake would not time out if they're too slow.

The 120 second timeout is consistent with what our gRPC listeners already have. Our MQTT listeners have a 5 second timeout.

---

In addition, this removes `cmux`, which we didn't use anyway.