### PR TITLE
Release v3.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [3.6.3] (2020-03-30)
+
+### Fixed
+
+-  Limited throughput in upstream handlers in Gateway Server when one gateway's upstream handler is busy.
+
 ## [3.6.2] (2020-03-19)
 
 ### Fixed
@@ -678,7 +684,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 NOTE: These links should respect backports. See https://github.com/TheThingsNetwork/lorawan-stack/pull/1444/files#r333379706.
 -->
 
-[unreleased]: https://github.com/TheThingsNetwork/lorawan-stack/compare/v3.6.2...HEAD
+[unreleased]: https://github.com/TheThingsNetwork/lorawan-stack/compare/v3.6.3...HEAD
+[3.6.3]: https://github.com/TheThingsNetwork/lorawan-stack/compare/v3.6.2...v3.6.3
 [3.6.2]: https://github.com/TheThingsNetwork/lorawan-stack/compare/v3.6.1...v3.6.2
 [3.6.1]: https://github.com/TheThingsNetwork/lorawan-stack/compare/v3.6.0...v3.6.1
 [3.6.0]: https://github.com/TheThingsNetwork/lorawan-stack/compare/v3.5.3...v3.6.0

--- a/cmd/internal/shared/init.go
+++ b/cmd/internal/shared/init.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Initialize global packages.
-func Initialize(ctx context.Context, config config.ServiceBase) error {
+func Initialize(ctx context.Context, config *config.ServiceBase) error {
 	// Fallback to the default Redis configuration for the cache system
 	if config.Cache.Redis.IsZero() {
 		config.Cache.Redis = config.Redis
@@ -31,7 +31,7 @@ func Initialize(ctx context.Context, config config.ServiceBase) error {
 		config.Events.Redis = config.Redis
 	}
 
-	if err := InitializeEvents(ctx, config); err != nil {
+	if err := InitializeEvents(ctx, *config); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/ttn-lw-cli/commands/simulate.go
+++ b/cmd/ttn-lw-cli/commands/simulate.go
@@ -95,7 +95,7 @@ func (m *simulateMetadataParams) setDefaults() error {
 		m.SpreadingFactor, m.Bandwidth = lora.SpreadingFactor, lora.Bandwidth
 	} else if m.DataRateIndex == 0 {
 		for i, dr := range phy.DataRates {
-			if dr.Rate.GetLoRa().SpreadingFactor == m.SpreadingFactor && dr.Rate.GetLoRa().Bandwidth == m.Bandwidth {
+			if lora := dr.Rate.GetLoRa(); lora != nil && lora.SpreadingFactor == m.SpreadingFactor && lora.Bandwidth == m.Bandwidth {
 				m.DataRateIndex = uint32(i)
 				break
 			}

--- a/cmd/ttn-lw-stack/commands/root.go
+++ b/cmd/ttn-lw-stack/commands/root.go
@@ -84,7 +84,7 @@ var (
 			ctx = log.NewContext(ctx, logger)
 
 			// initialize shared packages
-			if err := shared.Initialize(ctx, config.ServiceBase); err != nil {
+			if err := shared.Initialize(ctx, &config.ServiceBase); err != nil {
 				return err
 			}
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -3392,6 +3392,15 @@
       "file": "format_protobufv2.go"
     }
   },
+  "error:pkg/gatewayserver/io/mqtt:mqtt_frontend_recovered": {
+    "translations": {
+      "en": "Internal Server Error"
+    },
+    "description": {
+      "package": "pkg/gatewayserver/io/mqtt",
+      "file": "mqtt.go"
+    }
+  },
   "error:pkg/gatewayserver/io/mqtt:not_authorized": {
     "translations": {
       "en": "not authorized"
@@ -3489,6 +3498,15 @@
     "description": {
       "package": "pkg/gatewayserver/io/udp",
       "file": "firewall_ratelimit.go"
+    }
+  },
+  "error:pkg/gatewayserver/io/udp:udp_frontend_recovered": {
+    "translations": {
+      "en": "Internal Server Error"
+    },
+    "description": {
+      "package": "pkg/gatewayserver/io/udp",
+      "file": "udp.go"
     }
   },
   "error:pkg/gatewayserver/io:buffer_full": {

--- a/config/messages.json
+++ b/config/messages.json
@@ -3394,7 +3394,7 @@
   },
   "error:pkg/gatewayserver/io/mqtt:mqtt_frontend_recovered": {
     "translations": {
-      "en": "Internal Server Error"
+      "en": "internal server error"
     },
     "description": {
       "package": "pkg/gatewayserver/io/mqtt",
@@ -3502,7 +3502,7 @@
   },
   "error:pkg/gatewayserver/io/udp:udp_frontend_recovered": {
     "translations": {
-      "en": "Internal Server Error"
+      "en": "internal server error"
     },
     "description": {
       "package": "pkg/gatewayserver/io/udp",

--- a/config/messages.json
+++ b/config/messages.json
@@ -3770,6 +3770,15 @@
       "file": "gatewayserver.go"
     }
   },
+  "error:pkg/gatewayserver:handler_recovered": {
+    "translations": {
+      "en": "internal server error"
+    },
+    "description": {
+      "package": "pkg/gatewayserver",
+      "file": "gatewayserver.go"
+    }
+  },
   "error:pkg/gatewayserver:host_handle": {
     "translations": {
       "en": "host `{host}` failed to handle message"

--- a/doc/config.toml
+++ b/doc/config.toml
@@ -27,7 +27,7 @@ pygmentsUseClasses = true
   keywords = []
   github_repository = "https://github.com/TheThingsNetwork/lorawan-stack"
   github_repository_edit = "https://github.com/TheThingsNetwork/lorawan-stack/edit/master/doc/content"
-  version = "v3.6.2"
+  version = "v3.6.3"
 
 [markup]
   [markup.goldmark]

--- a/doc/themes/the-things-stack/package.json
+++ b/doc/themes/the-things-stack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hugo-theme-the-things-stack",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "private": true,
   "description": "Hugo Theme for The Things Stack",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ttn-stack",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "description": "The Things Stack",
   "main": "index.js",
   "repository": "https://github.com/TheThingsNetwork/lorawan-stack.git",

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -511,6 +513,7 @@ func (gs *GatewayServer) handleUpstream(conn connectionEntry) {
 	}()
 
 	handleFn := func(host *upstreamHost) {
+		defer recoverHandler(ctx)
 		defer host.handleWg.Done()
 		defer atomic.AddInt32(&host.handlers, -1)
 		for {
@@ -755,4 +758,22 @@ func (gs *GatewayServer) GetMQTTConfig(ctx context.Context) (*config.MQTT, error
 		return nil, err
 	}
 	return &config.MQTT, nil
+}
+
+var errHandlerRecovered = errors.DefineInternal("handler_recovered", "internal server error")
+
+func recoverHandler(ctx context.Context) error {
+	if p := recover(); p != nil {
+		fmt.Fprintln(os.Stderr, p)
+		os.Stderr.Write(debug.Stack())
+		var err error
+		if pErr, ok := p.(error); ok {
+			err = errHandlerRecovered.WithCause(pErr)
+		} else {
+			err = errHandlerRecovered.WithAttributes("panic", p)
+		}
+		log.FromContext(ctx).WithError(err).Error("Handler failed")
+		return err
+	}
+	return nil
 }

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -482,8 +482,6 @@ var (
 	maxUpstreamHandlers = int32(1 << 5)
 	// upstreamHandlerIdleTimeout is the duration after which an idle upstream handler stops to save resources.
 	upstreamHandlerIdleTimeout = (1 << 7) * time.Millisecond
-	// upstreamHandlerBusyTimeout is the duration after traffic gets dropped if all upstream handlers are busy.
-	upstreamHandlerBusyTimeout = (1 << 6) * time.Millisecond
 )
 
 type upstreamHost struct {
@@ -582,7 +580,7 @@ func (gs *GatewayServer) handleUpstream(conn connectionEntry) {
 			}
 			return false
 		}
-		hosts = append(hosts, &upstreamHost{
+		host := &upstreamHost{
 			name: name,
 			handler: func(ids *ttnpb.EndDeviceIdentifiers) upstream.Handler {
 				if ids != nil && ids.DevAddr != nil && !passDevAddr(handler.GetDevAddrPrefixes(), *ids.DevAddr) {
@@ -591,10 +589,8 @@ func (gs *GatewayServer) handleUpstream(conn connectionEntry) {
 				return handler
 			},
 			handleCh: make(chan upstreamItem),
-		})
-	}
-
-	for _, host := range hosts {
+		}
+		hosts = append(hosts, host)
 		defer host.handleWg.Wait()
 	}
 
@@ -635,17 +631,17 @@ func (gs *GatewayServer) handleUpstream(conn connectionEntry) {
 					atomic.AddInt32(&host.handlers, 1)
 					host.handleWg.Add(1)
 					go handleFn(host)
+					go func(host *upstreamHost) {
+						host.handleCh <- item
+					}(host)
+					continue
 				}
-				select {
-				case host.handleCh <- item:
-				case <-time.After(upstreamHandlerBusyTimeout):
-					logger.WithField("name", host.name).Warn("Upstream handler busy, drop message")
-					switch msg := val.(type) {
-					case *ttnpb.UplinkMessage:
-						registerFailUplink(ctx, conn.Gateway(), msg, host.name)
-					case *ttnpb.GatewayStatus:
-						registerFailStatus(ctx, conn.Gateway(), msg, host.name)
-					}
+				logger.WithField("name", host.name).Warn("Upstream handler busy, drop message")
+				switch msg := val.(type) {
+				case *ttnpb.UplinkMessage:
+					registerFailUplink(ctx, conn.Gateway(), msg, host.name)
+				case *ttnpb.GatewayStatus:
+					registerFailStatus(ctx, conn.Gateway(), msg, host.name)
 				}
 			}
 		}

--- a/pkg/gatewayserver/gatewayserver_internal_test.go
+++ b/pkg/gatewayserver/gatewayserver_internal_test.go
@@ -14,10 +14,4 @@
 
 package gatewayserver
 
-var (
-	ErrSchedule = errSchedule
-)
-
-func init() {
-	maxUpstreamHandlers = 1
-}
+var ErrSchedule = errSchedule

--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -671,7 +671,7 @@ func TestGatewayServer(t *testing.T) {
 					for _, tc := range []struct {
 						Name     string
 						Up       *ttnpb.GatewayUp
-						Forwards []int // Indices of uplink messages in Up that are being forwarded.
+						Forwards []uint32 // Timestamps of uplink messages in Up that are being forwarded.
 					}{
 						{
 							Name: "GatewayStatus",
@@ -705,12 +705,12 @@ func TestGatewayServer(t *testing.T) {
 											},
 											CodingRate: "4/5",
 											Frequency:  867900000,
-											Timestamp:  4242000,
+											Timestamp:  100,
 										},
 										RxMetadata: []*ttnpb.RxMetadata{
 											{
 												GatewayIdentifiers: ids,
-												Timestamp:          4242000,
+												Timestamp:          100,
 												RSSI:               -69,
 												ChannelRSSI:        -69,
 												SNR:                11,
@@ -721,7 +721,7 @@ func TestGatewayServer(t *testing.T) {
 									},
 								},
 							},
-							Forwards: []int{0},
+							Forwards: []uint32{100},
 						},
 						{
 							Name: "OneValidFSK",
@@ -737,12 +737,12 @@ func TestGatewayServer(t *testing.T) {
 												},
 											},
 											Frequency: 867900000,
-											Timestamp: 4242000,
+											Timestamp: 100,
 										},
 										RxMetadata: []*ttnpb.RxMetadata{
 											{
 												GatewayIdentifiers: ids,
-												Timestamp:          4242000,
+												Timestamp:          100,
 												RSSI:               -69,
 												ChannelRSSI:        -69,
 												SNR:                11,
@@ -753,7 +753,7 @@ func TestGatewayServer(t *testing.T) {
 									},
 								},
 							},
-							Forwards: []int{0},
+							Forwards: []uint32{100},
 						},
 						{
 							Name: "OneGarbageWithStatus",
@@ -771,12 +771,12 @@ func TestGatewayServer(t *testing.T) {
 											},
 											CodingRate: "4/5",
 											Frequency:  868500000,
-											Timestamp:  1234560000,
+											Timestamp:  100,
 										},
 										RxMetadata: []*ttnpb.RxMetadata{
 											{
 												GatewayIdentifiers: ids,
-												Timestamp:          1234560000,
+												Timestamp:          100,
 												RSSI:               -112,
 												ChannelRSSI:        -112,
 												SNR:                2,
@@ -797,12 +797,12 @@ func TestGatewayServer(t *testing.T) {
 											},
 											CodingRate: "4/5",
 											Frequency:  868100000,
-											Timestamp:  4242000,
+											Timestamp:  200,
 										},
 										RxMetadata: []*ttnpb.RxMetadata{
 											{
 												GatewayIdentifiers: ids,
-												Timestamp:          4242000,
+												Timestamp:          200,
 												RSSI:               -69,
 												ChannelRSSI:        -69,
 												SNR:                11,
@@ -823,12 +823,12 @@ func TestGatewayServer(t *testing.T) {
 											},
 											CodingRate: "4/5",
 											Frequency:  867700000,
-											Timestamp:  2424000,
+											Timestamp:  300,
 										},
 										RxMetadata: []*ttnpb.RxMetadata{
 											{
 												GatewayIdentifiers: ids,
-												Timestamp:          2424000,
+												Timestamp:          300,
 												RSSI:               -36,
 												ChannelRSSI:        -36,
 												SNR:                5,
@@ -845,7 +845,7 @@ func TestGatewayServer(t *testing.T) {
 									Time: time.Unix(4242424, 0),
 								},
 							},
-							Forwards: []int{1, 2},
+							Forwards: []uint32{200, 300},
 						},
 					} {
 						t.Run(tc.Name, func(t *testing.T) {
@@ -879,10 +879,27 @@ func TestGatewayServer(t *testing.T) {
 								uplinkCount += len(tc.Up.UplinkMessages)
 							}
 
-							for _, msgIdx := range tc.Forwards {
+							notSeen := make(map[uint32]struct{})
+							for _, t := range tc.Forwards {
+								notSeen[t] = struct{}{}
+							}
+							for len(notSeen) > 0 {
 								select {
 								case msg := <-ns.Up():
-									expected := tc.Up.UplinkMessages[msgIdx]
+									var expected *ttnpb.UplinkMessage
+									for _, up := range tc.Up.UplinkMessages {
+										if ts := up.Settings.Timestamp; ts == msg.Settings.Timestamp {
+											if _, ok := notSeen[ts]; !ok {
+												t.Fatalf("Not expecting message %v", msg)
+											}
+											expected = up
+											delete(notSeen, ts)
+											break
+										}
+									}
+									if expected == nil {
+										t.Fatalf("Received unexpected message")
+									}
 									a.So(time.Since(msg.ReceivedAt), should.BeLessThan, timeout)
 									a.So(msg.Settings, should.Resemble, expected.Settings)
 									for _, md := range msg.RxMetadata {

--- a/pkg/gatewayserver/io/mqtt/mqtt.go
+++ b/pkg/gatewayserver/io/mqtt/mqtt.go
@@ -46,8 +46,7 @@ type srv struct {
 	lis    mqttnet.Listener
 }
 
-// ErrMQTTFrontendRecovered is returned when a panic is caught from the MQTT frontend.
-var ErrMQTTFrontendRecovered = errors.DefineInternal("mqtt_frontend_recovered", "Internal Server Error")
+var errMQTTFrontendRecovered = errors.DefineInternal("mqtt_frontend_recovered", "internal server error")
 
 // Serve serves the MQTT frontend.
 func Serve(ctx context.Context, server io.Server, listener net.Listener, format Format, protocol string) error {
@@ -325,10 +324,10 @@ func recoverMQTTFrontend(ctx context.Context) {
 		os.Stderr.Write(debug.Stack())
 		var err error
 		if pErr, ok := p.(error); ok {
-			err = ErrMQTTFrontendRecovered.WithCause(pErr)
+			err = errMQTTFrontendRecovered.WithCause(pErr)
 		} else {
-			err = ErrMQTTFrontendRecovered.WithAttributes("panic", p)
+			err = errMQTTFrontendRecovered.WithAttributes("panic", p)
 		}
-		log.FromContext(ctx).WithError(err).Error("MQTT Frontend failed")
+		log.FromContext(ctx).WithError(err).Error("MQTT frontend failed")
 	}
 }

--- a/pkg/gatewayserver/io/mqtt/mqtt.go
+++ b/pkg/gatewayserver/io/mqtt/mqtt.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	stdio "io"
 	"net"
+	"os"
+	"runtime/debug"
 
 	"github.com/TheThingsIndustries/mystique/pkg/auth"
 	mqttlog "github.com/TheThingsIndustries/mystique/pkg/log"
@@ -43,6 +45,9 @@ type srv struct {
 	format Format
 	lis    mqttnet.Listener
 }
+
+// ErrMQTTFrontendRecovered is returned when a panic is caught from the MQTT frontend.
+var ErrMQTTFrontendRecovered = errors.DefineInternal("mqtt_frontend_recovered", "Internal Server Error")
 
 // Serve serves the MQTT frontend.
 func Serve(ctx context.Context, server io.Server, listener net.Listener, format Format, protocol string) error {
@@ -93,6 +98,7 @@ func (*connection) SupportsDownlinkClaim() bool { return false }
 
 func (c *connection) setup(ctx context.Context) error {
 	ctx = auth.NewContextWithInterface(ctx, c)
+	defer recoverMQTTFrontend(ctx)
 	c.session = session.New(ctx, c.mqtt, c.deliver)
 	if err := c.session.ReadConnect(); err != nil {
 		return err
@@ -105,6 +111,7 @@ func (c *connection) setup(ctx context.Context) error {
 
 	// Read control packets
 	go func() {
+		defer recoverMQTTFrontend(ctx)
 		for {
 			pkt, err := c.session.ReadPacket()
 			if err != nil {
@@ -123,6 +130,7 @@ func (c *connection) setup(ctx context.Context) error {
 
 	// Publish downlinks
 	go func() {
+		defer recoverMQTTFrontend(ctx)
 		for {
 			select {
 			case <-c.io.Context().Done():
@@ -150,6 +158,7 @@ func (c *connection) setup(ctx context.Context) error {
 
 	// Write packets
 	go func() {
+		defer recoverMQTTFrontend(ctx)
 		for {
 			var err error
 			select {
@@ -273,6 +282,7 @@ func (c *connection) CanWrite(info *auth.Info, topicParts ...string) bool {
 
 func (c *connection) deliver(pkt *packet.PublishPacket) {
 	logger := log.FromContext(c.io.Context()).WithField("topic", pkt.TopicName)
+	defer recoverMQTTFrontend(c.io.Context())
 	switch {
 	case c.format.IsBirthTopic(pkt.TopicParts):
 	case c.format.IsLastWillTopic(pkt.TopicParts):
@@ -306,5 +316,19 @@ func (c *connection) deliver(pkt *packet.PublishPacket) {
 		}
 	default:
 		logger.Debug("Publish to invalid topic")
+	}
+}
+
+func recoverMQTTFrontend(ctx context.Context) {
+	if p := recover(); p != nil {
+		fmt.Fprintln(os.Stderr, p)
+		os.Stderr.Write(debug.Stack())
+		var err error
+		if pErr, ok := p.(error); ok {
+			err = ErrMQTTFrontendRecovered.WithCause(pErr)
+		} else {
+			err = ErrMQTTFrontendRecovered.WithAttributes("panic", p)
+		}
+		log.FromContext(ctx).WithError(err).Error("MQTT Frontend failed")
 	}
 }

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -321,7 +321,7 @@ func (s *srv) handleUp(ctx context.Context, state *state, packet encoding.Packet
 			logger.Debug("Received Tx acknowledgement, JIT queue supported")
 		}
 		var msg *ttnpb.GatewayUp
-		if packet.Data != nil {
+		if packet.Data.TxPacketAck != nil {
 			var err error
 			msg, err = encoding.ToGatewayUp(*packet.Data, md)
 			if err != nil {

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -95,8 +95,7 @@ type srv struct {
 func (*srv) Protocol() string            { return "udp" }
 func (*srv) SupportsDownlinkClaim() bool { return true }
 
-// ErrUDPFrontendRecovered is returned when a panic is caught from the UDP frontend.
-var ErrUDPFrontendRecovered = errors.DefineInternal("udp_frontend_recovered", "Internal Server Error")
+var errUDPFrontendRecovered = errors.DefineInternal("udp_frontend_recovered", "internal server error")
 
 // Serve serves the UDP frontend.
 func Serve(ctx context.Context, server io.Server, conn *net.UDPConn, config Config) error {
@@ -512,10 +511,10 @@ func recoverUDPFrontend(ctx context.Context) {
 		os.Stderr.Write(debug.Stack())
 		var err error
 		if pErr, ok := p.(error); ok {
-			err = ErrUDPFrontendRecovered.WithCause(pErr)
+			err = errUDPFrontendRecovered.WithCause(pErr)
 		} else {
-			err = ErrUDPFrontendRecovered.WithAttributes("panic", p)
+			err = errUDPFrontendRecovered.WithAttributes("panic", p)
 		}
-		log.FromContext(ctx).WithError(err).Error("UDP Frontend failed")
+		log.FromContext(ctx).WithError(err).Error("UDP frontend failed")
 	}
 }

--- a/pkg/version/ttn.go
+++ b/pkg/version/ttn.go
@@ -3,4 +3,4 @@
 package version
 
 // TTN Version
-var TTN = "3.6.2-dev"
+var TTN = "3.6.3-dev"

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ttn-lw",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "description": "The Things Stack for LoRaWAN JavaScript SDK",
   "url": "https://github.com/TheThingsNetwork/lorawan-stack/tree/master/sdk/js",
   "main": "dist/index.js",

--- a/sdk/js/src/api/stream/stream.js
+++ b/sdk/js/src/api/stream/stream.js
@@ -56,10 +56,11 @@ export default async function(payload, url) {
     Authorization = `Bearer ${token}`
   }
 
-  let reader = null
+  const abortController = new AbortController()
   const response = await fetch(url, {
     body: JSON.stringify(payload),
     method: 'POST',
+    signal: abortController.signal,
     headers: {
       Authorization,
     },
@@ -71,7 +72,7 @@ export default async function(payload, url) {
     throw 'error' in err ? err.error : err
   }
 
-  reader = response.body.getReader()
+  const reader = response.body.getReader()
   reader
     .read()
     .then(function(data) {
@@ -113,9 +114,9 @@ export default async function(payload, url) {
       return this
     },
     close() {
-      if (reader) {
-        reader.cancel()
-      }
+      reader.cancel().then(() => {
+        abortController.abort()
+      })
     },
   }
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Release v3.6.3

#### Changes
<!-- What are the changes made in this pull request? -->

- Backport:
  - Unblock from busy upstream handler - #2239

- Fixes:
  - Add defer/recover to UDP and MQTT frontends - #2219
  - Add handler worker recovery to Gateway Server - #2236 
  - Fix panic in enumerating data rates - #2209

- Regression:
  - Fix invalid Cache Redis configuration - #2161
  - Fix closing event streams in firefox - #2183

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The 2 regression PRs were mistakenly left out of the previous release due to a tiny bug in my cherry pick script so I'm adding them here. Not sure if this needs to reflect in the changelog.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [ ] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
