### PR TITLE
Fix path generation in devices service for array values

### DIFF
--- a/sdk/js/src/service/devices/index.js
+++ b/sdk/js/src/service/devices/index.js
@@ -365,6 +365,13 @@ class Devices {
 
     const deviceMap = traverse(deviceEntityMap)
     const paths = traverse(patch).reduce(function(acc) {
+      // Only add the top level path for arrays, otherwise
+      // paths are generated for each item in the array.
+      if (Array.isArray(this.node)) {
+        acc.push(this.path)
+        this.update(this.node, true)
+      }
+
       if (this.isLeaf) {
         const path = this.path
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/2047

#### Changes
<!-- What are the changes made in this pull request? -->

- Check if array nodes and skip traverse into array items

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Consider the `mac_settings.factory_preset_frequencies` field: 
```
{
  mac_settings: {
    factory_preset_frequencies: [863000000, 865000000]
  }
}
```
Without this fix results in the following path:
```
[['mac_settings', 'factory_preset_frequencies', '0'], ['mac_settings', 'factory_preset_frequencies', '1']]
```

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
