### PR TITLE
Fix merging device array values 

### DIFF
--- a/sdk/js/src/service/devices/merge.js
+++ b/sdk/js/src/service/devices/merge.js
@@ -49,12 +49,20 @@ export default function mergeDevice(
             // Ignore empty object values, as they might override legitimate values
             continue
           }
+
           traverse(val).forEach(function(e) {
+            if (Array.isArray(e) && e.length > 0) {
+              traverse(result).set(path, val)
+
+              return
+            }
+
             if (this.isLeaf) {
               if (typeof e === 'object' && Object.keys(e).length === 0) {
                 // Ignore empty object values
                 return
               }
+
               // Write the sub object leaf into the result
               traverse(result).set([...path, ...this.path], e)
             }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes how array values are merged in the `mergeDevice` function.
Without this fix the array value is returned as `{"0": value1, "1": value2}` instead of expected `[value1, value2]`.

#### Changes
<!-- What are the changes made in this pull request? -->

- Check for array fields and set them

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
