### PR TITLE
Enable gRPC keep alive

### DIFF
--- a/pkg/rpcclient/rpcclient.go
+++ b/pkg/rpcclient/rpcclient.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_opentracing "github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
@@ -33,6 +34,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/rpcmiddleware/warning"
 	"go.thethings.network/lorawan-stack/pkg/version"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 )
 
 // DefaultDialOptions for gRPC clients
@@ -63,5 +65,10 @@ func DefaultDialOptions(ctx context.Context) []grpc.DialOption {
 		)),
 		grpc.WithStreamInterceptor(grpc_middleware.ChainStreamClient(streamInterceptors...)),
 		grpc.WithUnaryInterceptor(grpc_middleware.ChainUnaryClient(unaryInterceptors...)),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                5 * time.Minute,
+			Timeout:             20 * time.Second,
+			PermitWithoutStream: false,
+		}),
 	}
 }

--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -163,9 +163,15 @@ func New(ctx context.Context, opts ...Option) *Server {
 	baseOptions := []grpc.ServerOption{
 		grpc.StatsHandler(rpcmiddleware.StatsHandlers{new(ocgrpc.ServerHandler), metrics.StatsHandler}),
 		grpc.MaxConcurrentStreams(math.MaxUint16),
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime:             1 * time.Minute,
+			PermitWithoutStream: true,
+		}),
 		grpc.KeepaliveParams(keepalive.ServerParameters{
 			MaxConnectionIdle: 6 * time.Hour,
 			MaxConnectionAge:  24 * time.Hour,
+			Time:              1 * time.Minute,
+			Timeout:           20 * time.Second,
 		}),
 		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
 			append(


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Changes
<!-- What are the changes made in this pull request? -->

- Added the keep alive gRPC client call option with a period of 5 minutes. We use this value in order to conform to the default [enforcement policy](https://godoc.org/google.golang.org/grpc/keepalive#EnforcementPolicy), that we may encounter on external servers.
- Added the keep alive gRPC server option with a period of 1 minute.
- Lowered the enforcement policy of the gRPC server to 1 ping per minute. Pings can occur in the absence of an active stream.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
