### PR TITLE
Fix end device deletion notification for failed requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - End device location display bug when deleting the location entry in the Console.
 - GS could panic when gateway connection stats were updated while updating the registry.
 - Local CLI and stack config files now properly override global config.
+- Error display on failed end device deletion in the Console.
 
 ### Security
 

--- a/sdk/js/src/service/devices/index.js
+++ b/sdk/js/src/service/devices/index.js
@@ -275,6 +275,14 @@ class Devices {
   }
 
   async _deleteDevice(applicationId, deviceId, components = ['is', 'ns', 'as', 'js']) {
+    if (!Boolean(applicationId)) {
+      throw new Error('Missing application ID for device')
+    }
+
+    if (!Boolean(deviceId)) {
+      throw new Error('Missing end device ID')
+    }
+
     const params = {
       routeParams: {
         'application_ids.application_id': applicationId,
@@ -298,6 +306,7 @@ class Devices {
       undefined,
       true,
     )
+
     return deleteParts.every(e => Boolean(e.device) && Object.keys(e.device).length === 0)
       ? {}
       : deleteParts
@@ -557,7 +566,13 @@ class Devices {
   }
 
   async deleteById(applicationId, deviceId) {
-    const result = this._deleteDevice(applicationId, deviceId)
+    const result = await this._deleteDevice(applicationId, deviceId)
+
+    // Filter out errored requests
+    const errors = result.filter(part => part.hasErrored)
+    if (errors.length > 0) {
+      throw errors[0].error
+    }
 
     return result
   }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR makes sure that the error notification is shown on failed end device deletion
References: https://github.com/TheThingsNetwork/lorawan-stack/issues/2273

#### Changes
<!-- What are the changes made in this pull request? -->

- Check for errors in the `deleteById` method in the js sdk

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Will refactor the delete method to improve recoverability of delete requests in another PR, so not closing the issue

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
