### PR TITLE
Fix end device claim display bug when claim dates are not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- End device claim display bug when claim dates not set.
+
 ### Security
 
 ## [3.7.0] (2020-04-02)

--- a/pkg/webui/console/views/device-claim-authentication-code/index.js
+++ b/pkg/webui/console/views/device-claim-authentication-code/index.js
@@ -51,16 +51,14 @@ const validationSchema = Yup.object({
     value: Yup.string()
       .matches(/^[A-Z0-9]{1,32}$/, m.validateCode)
       .required(sharedMessages.validateRequired),
-    valid_from: Yup.date().required(sharedMessages.validateRequired),
-    valid_to: Yup.date()
-      .required(sharedMessages.validateRequired)
-      .when('valid_from', (validFrom, schema) => {
-        if (validFrom) {
-          return schema.min(validFrom, m.validateToDate)
-        }
+    valid_from: Yup.date(),
+    valid_to: Yup.date().when('valid_from', (validFrom, schema) => {
+      if (validFrom) {
+        return schema.min(validFrom, m.validateToDate)
+      }
 
-        return schema
-      }),
+      return schema
+    }),
   }),
 })
 
@@ -78,7 +76,7 @@ const DeviceClaimAuthenticationCode = props => {
       // date input. So, we pick only the data part from YYYY-MM-DDTHH:mm:ss.sssZ which is
       // known to be fixed.
       const validFrom = valid_from ? new Date(valid_from).toISOString().slice(0, 10) : undefined
-      const validTo = valid_from ? new Date(valid_to).toISOString().slice(0, 10) : undefined
+      const validTo = valid_to ? new Date(valid_to).toISOString().slice(0, 10) : undefined
 
       return {
         claim_authentication_code: {
@@ -101,6 +99,11 @@ const DeviceClaimAuthenticationCode = props => {
   const handleSubmit = React.useCallback(
     async (values, { resetForm, setSubmitting }) => {
       setError('')
+
+      // Convert any false value to undefined
+      for (const [key, value] of Object.entries(values.claim_authentication_code)) {
+        values.claim_authentication_code[key] = value ? value : undefined
+      }
 
       try {
         await updateDevice(appId, devId, validationSchema.cast(values))
@@ -166,14 +169,12 @@ const DeviceClaimAuthenticationCode = props => {
               name="claim_authentication_code.valid_from"
               component={Input}
               type="date"
-              required
             />
             <Form.Field
               title={sharedMessages.validTo}
               name="claim_authentication_code.valid_to"
               type="date"
               component={Input}
-              required
             />
             <SubmitBar>
               <Form.Submit component={SubmitButton} message={sharedMessages.saveChanges} />

--- a/pkg/webui/console/views/device-claim-authentication-code/index.js
+++ b/pkg/webui/console/views/device-claim-authentication-code/index.js
@@ -77,8 +77,8 @@ const DeviceClaimAuthenticationCode = props => {
       // Convert ISO 8601 date time representation to just yyyy-MM-dd required by the
       // date input. So, we pick only the data part from YYYY-MM-DDTHH:mm:ss.sssZ which is
       // known to be fixed.
-      const validFrom = new Date(valid_from).toISOString().slice(0, 10)
-      const validTo = new Date(valid_to).toISOString().slice(0, 10)
+      const validFrom = valid_from ? new Date(valid_from).toISOString().slice(0, 10) : undefined
+      const validTo = valid_from ? new Date(valid_to).toISOString().slice(0, 10) : undefined
 
       return {
         claim_authentication_code: {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2281
#### Changes
<!-- What are the changes made in this pull request? -->

- Check validFrom and validTo have values before manipulating.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
