### PR TITLE
console: Move webhook format logic middleware

### DIFF
--- a/pkg/webui/console/store/middleware/logics/applications.js
+++ b/pkg/webui/console/store/middleware/logics/applications.js
@@ -14,7 +14,6 @@
 
 import * as applications from '../../actions/applications'
 import * as link from '../../actions/link'
-import * as pubsubFormats from '../../actions/pubsub-formats'
 
 import api from '../../../api'
 import { isNotFoundError } from '../../../../lib/errors/utils'
@@ -127,14 +126,6 @@ const getApplicationLinkLogic = createRequestLogic({
   },
 })
 
-const getPubsubFormatsLogic = createRequestLogic({
-  type: pubsubFormats.GET_PUBSUB_FORMATS,
-  async process() {
-    const { formats } = await api.application.pubsubs.getFormats()
-    return formats
-  },
-})
-
 export default [
   getApplicationLogic,
   getApplicationDeviceCountLogic,
@@ -142,7 +133,6 @@ export default [
   deleteApplicationLogic,
   getApplicationsLogic,
   getApplicationsRightsLogic,
-  getPubsubFormatsLogic,
   getApplicationLinkLogic,
   ...createEventsConnectLogics(
     applications.SHARED_NAME,

--- a/pkg/webui/console/store/middleware/logics/applications.js
+++ b/pkg/webui/console/store/middleware/logics/applications.js
@@ -14,7 +14,6 @@
 
 import * as applications from '../../actions/applications'
 import * as link from '../../actions/link'
-import * as webhookFormats from '../../actions/webhook-formats'
 import * as pubsubFormats from '../../actions/pubsub-formats'
 
 import api from '../../../api'
@@ -128,14 +127,6 @@ const getApplicationLinkLogic = createRequestLogic({
   },
 })
 
-const getWebhookFormatsLogic = createRequestLogic({
-  type: webhookFormats.GET_WEBHOOK_FORMATS,
-  async process() {
-    const { formats } = await api.application.webhooks.getFormats()
-    return formats
-  },
-})
-
 const getPubsubFormatsLogic = createRequestLogic({
   type: pubsubFormats.GET_PUBSUB_FORMATS,
   async process() {
@@ -151,7 +142,6 @@ export default [
   deleteApplicationLogic,
   getApplicationsLogic,
   getApplicationsRightsLogic,
-  getWebhookFormatsLogic,
   getPubsubFormatsLogic,
   getApplicationLinkLogic,
   ...createEventsConnectLogics(

--- a/pkg/webui/console/store/middleware/logics/pubsubs.js
+++ b/pkg/webui/console/store/middleware/logics/pubsubs.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as pubsubs from '../../actions/pubsubs'
+import * as pubsubFormats from '../../actions/pubsub-formats'
 
 import api from '../../../api'
 import createRequestLogic from './lib'
@@ -46,4 +47,12 @@ const updatePubsubsLogic = createRequestLogic({
   },
 })
 
-export default [getPubsubLogic, getPubsubsLogic, updatePubsubsLogic]
+const getPubsubFormatsLogic = createRequestLogic({
+  type: pubsubFormats.GET_PUBSUB_FORMATS,
+  async process() {
+    const { formats } = await api.application.pubsubs.getFormats()
+    return formats
+  },
+})
+
+export default [getPubsubLogic, getPubsubsLogic, updatePubsubsLogic, getPubsubFormatsLogic]

--- a/pkg/webui/console/store/middleware/logics/webhooks.js
+++ b/pkg/webui/console/store/middleware/logics/webhooks.js
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as webhooks from '../../actions/webhooks'
+import * as webhookFormats from '../../actions/webhook-formats'
 
 import api from '../../../api'
 import createRequestLogic from './lib'
@@ -46,4 +47,12 @@ const updateWebhookLogic = createRequestLogic({
   },
 })
 
-export default [getWebhookLogic, getWebhooksLogic, updateWebhookLogic]
+const getWebhookFormatsLogic = createRequestLogic({
+  type: webhookFormats.GET_WEBHOOK_FORMATS,
+  async process() {
+    const { formats } = await api.application.webhooks.getFormats()
+    return formats
+  },
+})
+
+export default [getWebhookLogic, getWebhooksLogic, updateWebhookLogic, getWebhookFormatsLogic]


### PR DESCRIPTION
#### Summary
This quickfix PR moves the webhook and pubsub format logics into their respective `webhooks.js` / `pubsubs.js` logic modules.

References #945 

#### Changes
- Move webhook format logic into `webhook.js` logic module
- Move pubsub format logic into `pubsubs.js` logic module

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
