### PR TITLE
Improve link component styling

### DIFF
--- a/pkg/webui/components/breadcrumbs/breadcrumb/breadcrumb.styl
+++ b/pkg/webui/components/breadcrumbs/breadcrumb/breadcrumb.styl
@@ -24,10 +24,6 @@
     content: 'keyboard_arrow_right'
     color: $tc-subtle-gray
 
-  &:hover
-    text-decoration: underline
-    color: $tc-deep-gray
-
   +focus-visible()
     text-decoration: underline
     color: $tc-deep-gray

--- a/pkg/webui/components/breadcrumbs/breadcrumb/index.js
+++ b/pkg/webui/components/breadcrumbs/breadcrumb/index.js
@@ -15,7 +15,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
-import { Link } from 'react-router-dom'
+import Link from '../../link'
 import Message from '../../../lib/components/message'
 import PropTypes from '../../../lib/prop-types'
 
@@ -27,7 +27,7 @@ const Breadcrumb = function({ className, path, content, isLast }) {
   let componentProps
   if (!isLast) {
     Component = Link
-    componentProps = { className: classnames(className, style.link), to: path }
+    componentProps = { className: classnames(className, style.link), to: path, secondary: true }
   } else {
     Component = 'span'
     componentProps = { className: classnames(className, style.last) }

--- a/pkg/webui/components/events/widget/index.js
+++ b/pkg/webui/components/events/widget/index.js
@@ -82,8 +82,8 @@ class EventsWidget extends React.PureComponent {
         <div className={style.header}>
           <Message className={style.headerTitle} content={m.latestEvents} />
           {!error && (
-            <Link to={toAllUrl}>
-              <Message className={style.seeAllMessage} content={m.seeAllActivity} />→
+            <Link className={style.seeAllMessage} secondary to={toAllUrl}>
+              <Message content={m.seeAllActivity} /> →
             </Link>
           )}
         </div>

--- a/pkg/webui/components/events/widget/widget.styl
+++ b/pkg/webui/components/events/widget/widget.styl
@@ -23,7 +23,7 @@
   margin-right: $cs.xs
 
 .see-all-message
-  padding-right: $cs.xxs
+  text-decoration: none
 
 .list
   min-height: 10rem

--- a/pkg/webui/components/footer/footer.styl
+++ b/pkg/webui/components/footer/footer.styl
@@ -24,7 +24,6 @@
 
 .link
   text-decoration: underline
-  color: $tc-subtle-gray
   margin-left: $ls.xxs
 
   &:first-of-type

--- a/pkg/webui/components/footer/index.js
+++ b/pkg/webui/components/footer/index.js
@@ -15,11 +15,11 @@
 import React from 'react'
 import classnames from 'classnames'
 import { defineMessages } from 'react-intl'
-import { Link } from 'react-router-dom'
 import PropTypes from '../../lib/prop-types'
 
 import Message from '../../lib/components/message'
 import Button from '../../components/button'
+import Link from '../../components/link'
 import OfflineStatus from '../../containers/offline-status'
 
 import style from './footer.styl'
@@ -36,15 +36,15 @@ const Footer = function({ className, links, supportLink }) {
         <span className={style.claim}>
           <Message content={m.footer} /> –{' '}
         </span>
-        <a className={style.link} href="https://www.thethingsnetwork.org">
+        <Link.Anchor secondary className={style.link} href="https://www.thethingsnetwork.org">
           The Things Network
-        </a>
+        </Link.Anchor>
       </div>
       <div>
         {links.map((item, key) => (
-          <Link key={key} className={style.link} to={item.link}>
+          <Link.Anchor secondary key={key} className={style.link} href={item.link}>
             <Message content={item.title} />
-          </Link>
+          </Link.Anchor>
         ))}
         <OfflineStatus showOfflineOnly showWarnings />
         <span className={style.version}>v{process.env.VERSION}</span>

--- a/pkg/webui/components/link/index.js
+++ b/pkg/webui/components/link/index.js
@@ -45,17 +45,24 @@ const Link = function(props) {
     showVisited,
     intl,
     onClick,
+    secondary,
+    primary,
   } = props
 
   const formattedTitle = formatTitle(title, titleValues, intl.formatMessage)
+  const classNames = classnames(style.link, className, {
+    [style.linkVisited]: showVisited,
+    [style.primary]: primary,
+    [style.secondary]: secondary,
+  })
+
+  if (disabled) {
+    return <span className={classnames(classNames, style.disabled)}>{children}</span>
+  }
 
   return (
     <RouterLink
-      className={
-        className
-          ? classnames(className, { [style.disabled]: disabled })
-          : classnames(style.link, { [style.linkVisited]: showVisited, [style.disabled]: disabled })
-      }
+      className={classNames}
       id={id}
       title={formattedTitle}
       replace={replace}
@@ -76,7 +83,10 @@ Link.propTypes = {
   intl: PropTypes.shape({
     formatMessage: PropTypes.func,
   }).isRequired,
+  onClick: PropTypes.func,
+  primary: PropTypes.bool,
   replace: PropTypes.bool,
+  secondary: PropTypes.bool,
   showVisited: PropTypes.bool,
   target: PropTypes.string,
   title: PropTypes.message,
@@ -97,8 +107,11 @@ Link.defaultProps = {
   className: undefined,
   disabled: false,
   id: undefined,
+  onClick: () => null,
+  primary: false,
   showVisited: false,
   replace: false,
+  secondary: false,
   target: undefined,
   title: undefined,
   titleValues: undefined,
@@ -116,15 +129,25 @@ const AnchorLink = function(props) {
     children,
     showVisited,
     intl,
+    secondary,
+    primary,
+    disabled,
   } = props
 
   const formattedTitle = formatTitle(title, titleValues, intl.formatMessage)
+  const classNames = classnames(style.link, className, {
+    [style.linkVisited]: showVisited,
+    [style.primary]: primary,
+    [style.secondary]: secondary,
+  })
+
+  if (disabled) {
+    return <span className={classnames(classNames, style.disabled)}>{children}</span>
+  }
 
   return (
     <a
-      className={
-        className ? className : classnames(style.link, { [style.linkVisited]: showVisited })
-      }
+      className={classNames}
       title={formattedTitle}
       id={id}
       href={href}

--- a/pkg/webui/components/link/link.styl
+++ b/pkg/webui/components/link/link.styl
@@ -13,17 +13,32 @@
 // limitations under the License.
 
 .link
-  color: $tc-subtle-gray
-  text-decoration: none
+  &:not(.primary):not(.secondary)
+    text-decoration: none
 
-  &:active,
-  &:hover
-    color: $tc-deep-gray
-    text-decoration: underline
+  &.primary
+    color: $c-active-blue
 
-  &-visited
-    &:visited
+    &:active,
+    &:hover
+      color: $c-active-blue-hover
+      text-decoration: underline
+
+    &.link-visited
+      &:visited
+        color: $c-active-blue-active
+
+  &.secondary
+    color: $tc-subtle-gray
+    &:active,
+    &:hover
       color: $tc-deep-gray
 
-.disabled
-  pointer-events: none
+    &.link-visited
+      &:visited
+        color: $tc-deep-gray
+
+  &.primary, &.secondary
+    &.disabled
+      opacity: .5
+      cursor: not-allowed

--- a/pkg/webui/components/link/story.js
+++ b/pkg/webui/components/link/story.js
@@ -17,9 +17,11 @@ import { storiesOf } from '@storybook/react'
 
 import Link from '.'
 
+const divStyle = { width: '100px', height: '100px', backgroundColor: 'lightblue' }
+
 const titleStyle = { marginRight: '20px' }
 storiesOf('Link', module)
-  .add('Default', () => (
+  .add('Default (Unstyled)', () => (
     <div>
       <div>
         <span style={titleStyle}>link:</span>
@@ -31,17 +33,81 @@ storiesOf('Link', module)
       </div>
     </div>
   ))
-  .add('Show Visited', () => (
+  .add('As wrapper', () => (
+    <div>
+      <div>
+        <span style={titleStyle}>linked block element:</span>
+        <Link to="/">
+          <div style={divStyle} />
+        </Link>
+      </div>
+      <div>
+        <span style={titleStyle}>anchor linked block element:</span>
+        <Link.Anchor href="/">
+          <div style={divStyle} />
+        </Link.Anchor>
+      </div>
+    </div>
+  ))
+  .add('Primary', () => (
     <div>
       <div>
         <span style={titleStyle}>link:</span>
-        <Link showVisited to="/">
+        <Link primary to="/">
           Show more
         </Link>
       </div>
       <div>
         <span style={titleStyle}>anchor link:</span>
-        <Link.Anchor showVisited href="/">
+        <Link.Anchor primary href="/">
+          Show more
+        </Link.Anchor>
+      </div>
+    </div>
+  ))
+  .add('Secondary', () => (
+    <div>
+      <div>
+        <span style={titleStyle}>link:</span>
+        <Link secondary to="/">
+          Show more
+        </Link>
+      </div>
+      <div>
+        <span style={titleStyle}>anchor link:</span>
+        <Link.Anchor secondary href="/">
+          Show more
+        </Link.Anchor>
+      </div>
+    </div>
+  ))
+  .add('Show Visited', () => (
+    <div>
+      <div>
+        <span style={titleStyle}>link:</span>
+        <Link primary showVisited to="/">
+          Show more
+        </Link>
+      </div>
+      <div>
+        <span style={titleStyle}>anchor link:</span>
+        <Link.Anchor primary showVisited href="/">
+          Show more
+        </Link.Anchor>
+      </div>
+    </div>
+  ))
+  .add('Disabled', () => (
+    <div>
+      <div>
+        <span style={titleStyle}>link:</span>
+        <Link primary disabled to="/">
+          Show more
+        </Link>
+      </div>
+      <div>
+        <span style={titleStyle}>anchor link:</span>
+        <Link.Anchor primary disabled href="/">
           Show more
         </Link.Anchor>
       </div>

--- a/pkg/webui/components/map/widget/index.js
+++ b/pkg/webui/components/map/widget/index.js
@@ -60,12 +60,8 @@ export default class MapWidget extends React.Component {
       <aside className={style.wrapper}>
         <div className={style.header}>
           <Message className={style.titleMessage} content={sharedMessages.location} />
-          <Link to={path}>
-            <Message
-              className={style.changeLocationMessage}
-              content={sharedMessages.changeLocation}
-            />
-            →
+          <Link className={style.changeLocation} secondary to={path}>
+            <Message content={sharedMessages.changeLocation} />→
           </Link>
         </div>
         {this.Map}

--- a/pkg/webui/components/map/widget/widget.styl
+++ b/pkg/webui/components/map/widget/widget.styl
@@ -25,8 +25,8 @@
   font-weight: 600
   margin-right: $cs.xs
 
-.change-location-message
-  padding-right: $cs.xxs
+.change-location
+  text-decoration: none
 
 .map-disabled
   border-normal()

--- a/pkg/webui/styles/main.styl
+++ b/pkg/webui/styles/main.styl
@@ -58,12 +58,6 @@ ul li
     text-decoration: none
     color: $tc-deep-gray
 
-a
-  color: $tc-active
-
-p a:hover
-  color: hoverize($tc-active)
-
 hr
   border-normal()
   background-color: $c-divider


### PR DESCRIPTION
#### Summary
This quickfix PR will improve the styling capabilities of the `<Link />` component as well as get rid of some styling ambiguity between the global links styles and the component styles.

#### Changes
- Add `secondary` and `primary` props that will apply respective stylings
- Fix handling and styling of disabled links
- Update `<Link />` story
- Update other components that use the `<Link />` component
- Remove global styling of `a` tags to avoid cross-styling issues (and since we should not be using them vanilla)

#### Notes for reviewers
The link component can also be used to wrap block elements, in which case, we do not want any styles applied. So basically now we have to explicitly set `secondary` / `primary` to control the styling of plain text links.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
