### PR TITLE
Show template ID in webhook table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - CLI can now dump JSON encoded `grpc_payload` field for unary requests (see `--dump-requests` flag).
+- Template ID column in the webhook table in the Console.
 
 ### Changed
+
+- Styling improvements to webhook and pubsub table in Console.
 
 ### Deprecated
 

--- a/pkg/webui/console/containers/pubsubs-table/index.js
+++ b/pkg/webui/console/containers/pubsubs-table/index.js
@@ -39,29 +39,7 @@ const headers = [
   {
     name: 'ids.pub_sub_id',
     displayName: sharedMessages.id,
-    width: 25,
-  },
-  {
-    getValue(row) {
-      if (row.nats) {
-        return 'NATS'
-      } else if (row.mqtt) {
-        return 'MQTT'
-      }
-      return 'Not set'
-    },
-    displayName: sharedMessages.provider,
-    width: 10,
-  },
-  {
-    name: 'format',
-    displayName: m.format,
-    width: 10,
-  },
-  {
-    name: 'base_topic',
-    displayName: sharedMessages.pubsubBaseTopic,
-    width: 15,
+    width: 40,
   },
   {
     getValue(row) {
@@ -74,7 +52,29 @@ const headers = [
       return ''
     },
     displayName: m.host,
-    width: 40,
+    width: 33,
+  },
+  {
+    name: 'base_topic',
+    displayName: sharedMessages.pubsubBaseTopic,
+    width: 9,
+  },
+  {
+    getValue(row) {
+      if (row.nats) {
+        return 'NATS'
+      } else if (row.mqtt) {
+        return 'MQTT'
+      }
+      return 'Not set'
+    },
+    displayName: sharedMessages.provider,
+    width: 9,
+  },
+  {
+    name: 'format',
+    displayName: m.format,
+    width: 9,
   },
 ]
 

--- a/pkg/webui/console/containers/webhooks-table/index.js
+++ b/pkg/webui/console/containers/webhooks-table/index.js
@@ -29,6 +29,8 @@ import {
   selectWebhooksFetching,
 } from '../../../console/store/selectors/webhooks'
 
+import style from './webhooks-table.styl'
+
 const m = defineMessages({
   templateId: 'Template ID',
   format: 'Format',
@@ -42,20 +44,20 @@ const headers = [
     width: 40,
   },
   {
+    name: 'base_url',
+    displayName: m.baseUrl,
+    width: 37,
+  },
+  {
     name: 'template_ids.template_id',
     displayName: m.templateId,
     width: 15,
-    render: value => value || <i>none</i>,
+    render: value => value || <Message className={style.none} content={sharedMessages.none} />,
   },
   {
     name: 'format',
     displayName: m.format,
-    width: 15,
-  },
-  {
-    name: 'base_url',
-    displayName: m.baseUrl,
-    width: 30,
+    width: 8,
   },
 ]
 

--- a/pkg/webui/console/containers/webhooks-table/index.js
+++ b/pkg/webui/console/containers/webhooks-table/index.js
@@ -30,6 +30,7 @@ import {
 } from '../../../console/store/selectors/webhooks'
 
 const m = defineMessages({
+  templateId: 'Template ID',
   format: 'Format',
   baseUrl: 'Base URL',
 })
@@ -38,17 +39,23 @@ const headers = [
   {
     name: 'ids.webhook_id',
     displayName: sharedMessages.id,
-    width: 35,
+    width: 40,
+  },
+  {
+    name: 'template_ids.template_id',
+    displayName: m.templateId,
+    width: 15,
+    render: value => value || <i>none</i>,
   },
   {
     name: 'format',
     displayName: m.format,
-    width: 20,
+    width: 15,
   },
   {
     name: 'base_url',
     displayName: m.baseUrl,
-    width: 25,
+    width: 30,
   },
 ]
 
@@ -62,7 +69,7 @@ export default class WebhooksTable extends React.Component {
     super(props)
 
     const { appId } = props
-    this.getWebhooksList = () => getWebhooksList(appId)
+    this.getWebhooksList = () => getWebhooksList(appId, ['template_ids'])
   }
 
   baseDataSelector(state) {

--- a/pkg/webui/console/containers/webhooks-table/webhooks-table.styl
+++ b/pkg/webui/console/containers/webhooks-table/webhooks-table.styl
@@ -1,0 +1,16 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.none
+  color: $tc-subtle-gray

--- a/pkg/webui/console/store/actions/webhooks.js
+++ b/pkg/webui/console/store/actions/webhooks.js
@@ -32,7 +32,11 @@ export const [
     failure: GET_WEBHOOKS_LIST_FAILURE,
   },
   { request: getWebhooksList, success: getWebhooksListSuccess, failure: getWebhooksListFailure },
-] = createRequestActions(GET_WEBHOOKS_LIST_BASE, appId => ({ appId }))
+] = createRequestActions(
+  GET_WEBHOOKS_LIST_BASE,
+  appId => ({ appId }),
+  (appId, selector) => ({ selector }),
+)
 
 export const UPDATE_WEBHOOK_BASE = 'UPDATE_WEBHOOK'
 export const [

--- a/pkg/webui/console/store/middleware/logics/webhooks.js
+++ b/pkg/webui/console/store/middleware/logics/webhooks.js
@@ -32,8 +32,11 @@ const getWebhookLogic = createRequestLogic({
 const getWebhooksLogic = createRequestLogic({
   type: webhooks.GET_WEBHOOKS_LIST,
   async process({ action }) {
-    const { appId } = action.payload
-    const res = await api.application.webhooks.list(appId)
+    const {
+      payload: { appId },
+      meta: { selector },
+    } = action
+    const res = await api.application.webhooks.list(appId, selector)
     return { entities: res.webhooks, totalCount: res.totalCount }
   },
 })

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -220,6 +220,7 @@
   "console.containers.pubsubs-table.index.host": "Server Host",
   "console.containers.webhook-formats-select.index.title": "Webhook Format",
   "console.containers.webhook-formats-select.index.warning": "Could not retrieve the list of available webhook formats",
+  "console.containers.webhooks-table.index.templateId": "Template ID",
   "console.containers.webhooks-table.index.format": "Format",
   "console.containers.webhooks-table.index.baseUrl": "Base URL",
   "console.store.middleware.logics.init.errTooFewRights": "Your account does not possess sufficient rights to use the console.",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -220,6 +220,7 @@
   "console.containers.pubsubs-table.index.host": "Xxxxxx Xxxx",
   "console.containers.webhook-formats-select.index.title": "Xxxxxxx Xxxxxx",
   "console.containers.webhook-formats-select.index.warning": "Xxxxx xxx xxxxxxxx xxx xxxx xx xxxxxxxxx xxxxxxx xxxxxxx",
+  "console.containers.webhooks-table.index.templateId": "Xxxxxxxx XX",
   "console.containers.webhooks-table.index.format": "Xxxxxx",
   "console.containers.webhooks-table.index.baseUrl": "Xxxx XXX",
   "console.store.middleware.logics.init.errTooFewRights": "Xxxx xxxxxxx xxxx xxx xxxxxxx xxxxxxxxxx xxxxxx xx xxx xxx xxxxxxx.",


### PR DESCRIPTION
#### Summary
This quickfix PR will add the `template_ids.template_id` value to the webhook table. Additionally it improves the styling and order of values in the webhook table (and pubsub table, for consistency)

References #945 

#### Changes
- Add request selector to list webhook action and store logic
- Add value to webhook table
- Improve styling of the webhook table
- Respectively adapt the styling of the pubsub table

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
