### PR TITLE
Improve CLI handling of updating values to null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Unknown` and `Other cluster` connection statuses to the gateways table in the Console.
 - LoRaWAN 2.4 GHz band `ISM2400`.
 - Upgrading guide in docs
+- Unset end device fields using the CLI (see `--unset` option)
 
 ### Changed
 

--- a/cmd/ttn-lw-cli/commands/end_devices_split.go
+++ b/cmd/ttn-lw-cli/commands/end_devices_split.go
@@ -177,7 +177,7 @@ func getEndDevice(ids ttnpb.EndDeviceIdentifiers, nsPaths, asPaths, jsPaths []st
 	return &res, nil
 }
 
-func setEndDevice(device *ttnpb.EndDevice, isPaths, nsPaths, asPaths, jsPaths []string, isCreate, touch bool) (*ttnpb.EndDevice, error) {
+func setEndDevice(device *ttnpb.EndDevice, isPaths, nsPaths, asPaths, jsPaths, unsetPaths []string, isCreate, touch bool) (*ttnpb.EndDevice, error) {
 	var res ttnpb.EndDevice
 	res.SetFields(device, "ids", "created_at", "updated_at")
 
@@ -188,7 +188,7 @@ func setEndDevice(device *ttnpb.EndDevice, isPaths, nsPaths, asPaths, jsPaths []
 		}
 		var isDevice ttnpb.EndDevice
 		logger.WithField("paths", isPaths).Debug("Set end device on Identity Server")
-		isDevice.SetFields(device, append(isPaths, "ids")...)
+		isDevice.SetFields(device, append(ttnpb.ExcludeFields(isPaths, unsetPaths...), "ids")...)
 		isRes, err := ttnpb.NewEndDeviceRegistryClient(is).Update(ctx, &ttnpb.UpdateEndDeviceRequest{
 			EndDevice: isDevice,
 			FieldMask: types.FieldMask{Paths: isPaths},
@@ -214,7 +214,7 @@ func setEndDevice(device *ttnpb.EndDevice, isPaths, nsPaths, asPaths, jsPaths []
 		}
 		var jsDevice ttnpb.EndDevice
 		logger.WithField("paths", jsPaths).Debug("Set end device on Join Server")
-		jsDevice.SetFields(device, append(jsPaths, "ids")...)
+		jsDevice.SetFields(device, append(ttnpb.ExcludeFields(jsPaths, unsetPaths...), "ids")...)
 		jsRes, err := ttnpb.NewJsEndDeviceRegistryClient(js).Set(ctx, &ttnpb.SetEndDeviceRequest{
 			EndDevice: jsDevice,
 			FieldMask: types.FieldMask{Paths: jsPaths},
@@ -240,7 +240,7 @@ func setEndDevice(device *ttnpb.EndDevice, isPaths, nsPaths, asPaths, jsPaths []
 		}
 		var nsDevice ttnpb.EndDevice
 		logger.WithField("paths", nsPaths).Debug("Set end device on Network Server")
-		nsDevice.SetFields(device, append(nsPaths, "ids")...)
+		nsDevice.SetFields(device, append(ttnpb.ExcludeFields(nsPaths, unsetPaths...), "ids")...)
 		nsRes, err := ttnpb.NewNsEndDeviceRegistryClient(ns).Set(ctx, &ttnpb.SetEndDeviceRequest{
 			EndDevice: nsDevice,
 			FieldMask: types.FieldMask{Paths: nsPaths},
@@ -266,7 +266,7 @@ func setEndDevice(device *ttnpb.EndDevice, isPaths, nsPaths, asPaths, jsPaths []
 		}
 		var asDevice ttnpb.EndDevice
 		logger.WithField("paths", asPaths).Debug("Set end device on Application Server")
-		asDevice.SetFields(device, append(asPaths, "ids")...)
+		asDevice.SetFields(device, append(ttnpb.ExcludeFields(asPaths, unsetPaths...), "ids")...)
 		asRes, err := ttnpb.NewAsEndDeviceRegistryClient(as).Set(ctx, &ttnpb.SetEndDeviceRequest{
 			EndDevice: asDevice,
 			FieldMask: types.FieldMask{Paths: asPaths},

--- a/cmd/ttn-lw-cli/internal/util/flags.go
+++ b/cmd/ttn-lw-cli/internal/util/flags.go
@@ -56,6 +56,15 @@ var (
 	toUnderscore = strings.NewReplacer("-", "_")
 )
 
+// NormalizePaths converts arguments to field mask paths, replacing '-' with '_'
+func NormalizePaths(paths []string) []string {
+	normalized := make([]string, len(paths))
+	for i, path := range paths {
+		normalized[i] = toUnderscore.Replace(path)
+	}
+	return normalized
+}
+
 func NormalizeFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
 	return pflag.NormalizedName(toDash.Replace(name))
 }
@@ -472,7 +481,9 @@ func SetFields(dst interface{}, flags *pflag.FlagSet, prefix ...string) error {
 	return nil
 }
 
-var textUnmarshalerType = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
+var (
+	textUnmarshalerType = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
+)
 
 func setField(rv reflect.Value, path []string, v reflect.Value) error {
 	rt := rv.Type()
@@ -684,5 +695,12 @@ func setField(rv reflect.Value, path []string, v reflect.Value) error {
 func SelectAllFlagSet(what string) *pflag.FlagSet {
 	flagSet := &pflag.FlagSet{}
 	flagSet.Bool("all", false, fmt.Sprintf("select all %s fields", what))
+	return flagSet
+}
+
+// UnsetFlagSet returns a flagset with the --unset flag
+func UnsetFlagSet() *pflag.FlagSet {
+	flagSet := &pflag.FlagSet{}
+	flagSet.StringSlice("unset", []string{}, "list of fields to unset")
 	return flagSet
 }

--- a/config/messages.json
+++ b/config/messages.json
@@ -1169,6 +1169,15 @@
       "file": "gateways.go"
     }
   },
+  "error:cmd/ttn-lw-cli/commands:conflicting_paths": {
+    "translations": {
+      "en": "conflicting set and unset field mask paths"
+    },
+    "description": {
+      "package": "cmd/ttn-lw-cli/commands",
+      "file": "end_devices.go"
+    }
+  },
   "error:cmd/ttn-lw-cli/commands:contact_info_exists": {
     "translations": {
       "en": "contact info already exists"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #2250 

#### Changes
<!-- What are the changes made in this pull request? -->

- Appends `null` as one of the optional values for null-able enums
- When value is `null`, do not set the proto field, effectively cleaning it up
- Fix a small error: For custom enum values (e.g. `RxDelayValue`) passing a random string would count as a zero or nil value (e.g. `--mac-settings.rx1-delay=random` would work). This has also been fixed.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Marking as a draft pull request for three reasons:

- Verify that the enum fields that can be set to `null` are properly recognised (please check the output of `ttn-lw-cli dev update --help` and make sure that there is no `null` value proposed for fields that it shouldn't.
- Currently, I have hard-coded field names that can not/should not be set to null (lorawan + mac versions). This could probably be done in a better way.  
- Doing the same for floating point values is a lot harder, as they are declared as floating point flags, so passing in null is not allowed. Example affected field: `--mac-settings.adr-margin`. An obvious solution would be to change these to string flags as well and parse the floating point value or null. Not sure if this would be required 

#### Testing

- I have tested that one can actually set and unset values for a number of fields.
- Probably needs more testing.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [X] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
