### PR TITLE
Add text transform props to message component

### DIFF
--- a/pkg/webui/components/form/field/index.js
+++ b/pkg/webui/components/form/field/index.js
@@ -65,8 +65,10 @@ class FormField extends React.Component {
       }),
     ]).isRequired,
     description: PropTypes.message,
+    disabled: PropTypes.bool,
     name: PropTypes.string.isRequired,
     onChange: PropTypes.func,
+    readOnly: PropTypes.bool,
     required: PropTypes.bool,
     title: PropTypes.message.isRequired,
     warning: PropTypes.message,
@@ -74,9 +76,11 @@ class FormField extends React.Component {
 
   static defaultProps = {
     className: undefined,
+    disabled: false,
     onChange: () => null,
     warning: '',
     description: '',
+    readOnly: false,
     required: false,
   }
 
@@ -161,11 +165,11 @@ class FormField extends React.Component {
 
     const fieldMessage = showError ? (
       <div className={style.messages}>
-        <Err error={fieldError} />
+        <Err content={fieldError} title={name} />
       </div>
     ) : showWarning ? (
       <div className={style.messages}>
-        <Err warning={warning} />
+        <Err content={warning} title={name} warning />
       </div>
     ) : showDescription ? (
       <Message className={style.description} content={description} />
@@ -212,14 +216,9 @@ class FormField extends React.Component {
   }
 }
 
-const Err = function(props) {
-  const { error, warning, name, className } = props
-
-  const content = error || warning || ''
-  const contentValues = content.values || {}
-
+const Err = ({ content, error, warning, title, className }) => {
   const icon = error ? 'error' : 'warning'
-
+  const contentValues = content.values || {}
   const classname = classnames(style.message, className, {
     [style.show]: content && content !== '',
     [style.hide]: !content || content === '',
@@ -227,18 +226,34 @@ const Err = function(props) {
     [style.warn]: warning,
   })
 
+  if (title) {
+    contentValues.field = <Message content={title} className={style.name} />
+  }
+
   return (
     <div className={classname}>
       <Icon icon={icon} className={style.icon} />
       <Message
         content={content.format || content.error_description || content.message || content}
-        values={{
-          ...contentValues,
-          name: <Message content={name} className={style.name} />,
-        }}
+        values={contentValues}
       />
     </div>
   )
+}
+
+Err.propTypes = {
+  className: PropTypes.string,
+  content: PropTypes.error.isRequired,
+  error: PropTypes.bool,
+  title: PropTypes.message,
+  warning: PropTypes.bool,
+}
+
+Err.defaultProps = {
+  className: undefined,
+  title: undefined,
+  warning: false,
+  error: true,
 }
 
 export default FormField

--- a/pkg/webui/components/modal/index.js
+++ b/pkg/webui/components/modal/index.js
@@ -105,8 +105,8 @@ class Modal extends React.PureComponent {
 
     const name = formName ? { name: formName } : {}
     const RootComponent = this.props.method ? 'form' : 'div'
-    const messageElement = <Message content={message} className={style.message} />
-    const bottomLineElement = <Message content={bottomLine} />
+    const messageElement = message && <Message content={message} className={style.message} />
+    const bottomLineElement = bottomLine && <Message content={bottomLine} />
 
     const approveButtonMessage =
       buttonMessage !== undefined

--- a/pkg/webui/components/navigation/side/__snapshots__/index_test.js.snap
+++ b/pkg/webui/components/navigation/side/__snapshots__/index_test.js.snap
@@ -25,8 +25,14 @@ exports[`SideNavigation is flat should match snapshot 1`] = `
       small={false}
     />
     <Message
+      capitalize={false}
       className="message"
+      component="span"
       content="test-header-title"
+      firstToLower={false}
+      firstToUpper={false}
+      lowercase={false}
+      uppercase={false}
     />
   </div>
   <div
@@ -47,8 +53,14 @@ exports[`SideNavigation is flat should match snapshot 1`] = `
           small={false}
         />
         <Message
+          capitalize={false}
           className="message"
+          component="span"
           content="test-header-title"
+          firstToLower={false}
+          firstToUpper={false}
+          lowercase={false}
+          uppercase={false}
         />
       </div>
       <ContextProvider
@@ -120,8 +132,14 @@ exports[`SideNavigation is nested should match snapshot 1`] = `
       small={false}
     />
     <Message
+      capitalize={false}
       className="message"
+      component="span"
       content="test-header-title"
+      firstToLower={false}
+      firstToUpper={false}
+      lowercase={false}
+      uppercase={false}
     />
   </div>
   <div
@@ -142,8 +160,14 @@ exports[`SideNavigation is nested should match snapshot 1`] = `
           small={false}
         />
         <Message
+          capitalize={false}
           className="message"
+          component="span"
           content="test-header-title"
+          firstToLower={false}
+          firstToUpper={false}
+          lowercase={false}
+          uppercase={false}
         />
       </div>
       <ContextProvider

--- a/pkg/webui/components/status/index.js
+++ b/pkg/webui/components/status/index.js
@@ -54,7 +54,9 @@ const Status = function({
       className: classnames(label.props.className, style.statusLabel, { [style.flipped]: flipped }),
     })
   } else {
-    statusLabel = <Message className={style.statusLabel} content={label} values={labelValues} />
+    statusLabel = label && (
+      <Message className={style.statusLabel} content={label} values={labelValues} />
+    )
   }
 
   let translatedTitle

--- a/pkg/webui/components/table/cell/__snapshots__/index_test.js.snap
+++ b/pkg/webui/components/table/cell/__snapshots__/index_test.js.snap
@@ -21,7 +21,13 @@ exports[`HeadCell should match snapshot 1`] = `
   small={false}
 >
   <Message
+    capitalize={false}
+    component="span"
     content="Head cell"
+    firstToLower={false}
+    firstToUpper={false}
+    lowercase={false}
+    uppercase={false}
   />
 </Cell>
 `;

--- a/pkg/webui/components/table/sort-button/__snapshots__/index_test.js.snap
+++ b/pkg/webui/components/table/sort-button/__snapshots__/index_test.js.snap
@@ -7,7 +7,13 @@ exports[`SortButton is active is in ascending direction should match snapshot 1`
   type="button"
 >
   <Message
+    capitalize={false}
+    component="span"
     content="test-title"
+    firstToLower={false}
+    firstToUpper={false}
+    lowercase={false}
+    uppercase={false}
   />
   <Icon
     className="icon"
@@ -27,7 +33,13 @@ exports[`SortButton is active is in descending direction should match snapshot 1
   type="button"
 >
   <Message
+    capitalize={false}
+    component="span"
     content="test-title"
+    firstToLower={false}
+    firstToUpper={false}
+    lowercase={false}
+    uppercase={false}
   />
   <Icon
     className="icon"
@@ -47,7 +59,13 @@ exports[`SortButton is not active should match snapshot 1`] = `
   type="button"
 >
   <Message
+    capitalize={false}
+    component="span"
     content="test-title"
+    firstToLower={false}
+    firstToUpper={false}
+    lowercase={false}
+    uppercase={false}
   />
   <Icon
     className="icon"

--- a/pkg/webui/console/components/api-key-modal/api-key-modal.styl
+++ b/pkg/webui/console/components/api-key-modal/api-key-modal.styl
@@ -43,10 +43,6 @@
   .right-name
     color: $tc-deep-gray
 
-    &::first-letter
-      text-transform: uppercase
-
-
 .right
   .secret-inspector
     width: 15rem

--- a/pkg/webui/console/components/api-key-modal/index.js
+++ b/pkg/webui/console/components/api-key-modal/index.js
@@ -58,7 +58,7 @@ const ApiKeyModal = function(props) {
           {rights.map(right => (
             <li key={right}>
               <Icon icon="check" className={style.icon} />
-              <Message className={style.rightName} content={{ id: `enum:${right}` }} />
+              <Message className={style.rightName} content={{ id: `enum:${right}` }} firstToUpper />
             </li>
           ))}
         </ul>

--- a/pkg/webui/console/components/device-data-form/messages.js
+++ b/pkg/webui/console/components/device-data-form/messages.js
@@ -50,6 +50,7 @@ export default defineMessages({
   homeNetIDDescription: 'ID to identify the LoRaWAN network',
   joinEUIDescription: 'JoinEUI identifies the Join Server',
   leaveBlankPlaceholder: 'Leave blank to generate automatically',
+  lorawanOptions: 'LoRaWAN Options',
   lorawanVersionDescription: 'The LoRaWAN MAC Version of the end device',
   lorawanPhyVersionDescription: 'The LoRaWAN PHY Version of the end device',
   multicast: 'Multicast',

--- a/pkg/webui/lib/components/error-message/error-message.styl
+++ b/pkg/webui/lib/components/error-message/error-message.styl
@@ -14,5 +14,3 @@
 
 .message
   display: block
-  &::first-letter
-    text-transform: uppercase

--- a/pkg/webui/lib/components/error-message/index.js
+++ b/pkg/webui/lib/components/error-message/index.js
@@ -26,6 +26,7 @@ import style from './error-message.styl'
 const ErrorMessage = function({ content, className, ...rest }) {
   const props = {
     className: classnames(className, style.message),
+    firstToUpper: true,
     ...toMessageProps(content),
     ...rest,
   }

--- a/pkg/webui/lib/components/message/index.js
+++ b/pkg/webui/lib/components/message/index.js
@@ -14,9 +14,12 @@
 
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
+import classnames from 'classnames'
 
 import { warn } from '../../log'
 import PropTypes from '../../prop-types'
+
+import style from './message.styl'
 
 const warned = {}
 const warning = function(message) {
@@ -26,11 +29,18 @@ const warning = function(message) {
   }
 }
 
-const Message = function({ content, values = {}, component: Component = 'span', ...rest }) {
-  if (!content && content !== 0) {
-    return null
-  }
-
+const Message = function({
+  content,
+  values = {},
+  component: Component,
+  lowercase,
+  uppercase,
+  firstToUpper,
+  firstToLower,
+  capitalize,
+  className,
+  ...rest
+}) {
   if (React.isValidElement(content)) {
     return content
   }
@@ -45,10 +55,22 @@ const Message = function({ content, values = {}, component: Component = 'span', 
     vals = content.values
   }
 
+  const cls = classnames(className, {
+    [style.lowercase]: lowercase,
+    [style.uppercase]: uppercase,
+    [style.firstToUpper]: firstToUpper,
+    [style.firstToLower]: firstToLower,
+    [style.capitalize]: capitalize,
+  })
+
   if (content.id) {
     return (
       <FormattedMessage {...content} values={vals}>
-        {(...children) => <Component {...rest}>{children}</Component>}
+        {(...children) => (
+          <Component className={cls} {...rest}>
+            {children}
+          </Component>
+        )}
       </FormattedMessage>
     )
   }
@@ -57,6 +79,15 @@ const Message = function({ content, values = {}, component: Component = 'span', 
 }
 
 Message.propTypes = {
+  /** Flag specifying whether the message should be capitalized */
+  capitalize: PropTypes.bool,
+  /** The className to be attached to the container */
+  className: PropTypes.string,
+  /**
+   * The wrapping element component can also be set explicitly
+   * (defaults to span). This can be useful to avoid unnecessary wrapping.
+   */
+  component: PropTypes.node,
   /**
    * The translatable message, should be an object (with `id` or
    * `defaultMessage` key). Additionally the content can contain a `values` key,
@@ -64,14 +95,39 @@ Message.propTypes = {
    * but output a warning. If a a valid dom/react element is passed it will be
    * passed through without any modifications.
    */
-  content: PropTypes.message,
-  /** Values can also be given as a separate property (will have precedence) */
-  values: PropTypes.object,
-  /**
-   * The wrapping element component can also be set explicitly
-   * (defaults to span). This can be useful to avoid unnecessary wrapping.
+  content: PropTypes.message.isRequired,
+  /** Flag specifying whether the first letter of the message should be
+   * transformed to lowercase
    */
-  component: PropTypes.node,
+  firstToLower: PropTypes.bool,
+  /**
+   * Flag specifying whether the first letter of the message should be
+   * transformed to uppercase
+   */
+  firstToUpper: PropTypes.bool,
+  /**
+   * Flag specifying whether the the message should be transformed to
+   * lowercase
+   */
+  lowercase: PropTypes.bool,
+  /**
+   * Flag specifying whether the the message should be transformed to
+   * uppercase
+   */
+  uppercase: PropTypes.bool,
+  /** Values can also be given as a separate property (will have precedence) */
+  values: PropTypes.shape({}),
+}
+
+Message.defaultProps = {
+  capitalize: false,
+  className: undefined,
+  component: 'span',
+  firstToLower: false,
+  firstToUpper: false,
+  lowercase: false,
+  uppercase: false,
+  values: undefined,
 }
 
 export default Message

--- a/pkg/webui/lib/components/message/message.md
+++ b/pkg/webui/lib/components/message/message.md
@@ -2,5 +2,4 @@ The `<Message />` component is used as a wrapper around `react-intl`'s
 `<FormattedMessage />` component and will make sure that also strings can be
 rendered (with a warning). The message can use placeholders which need to be
 defined in the `content.values` or `values`-prop. If an element is passed, the
-element will be passed through and rendered. No prop is required and the
-element will output null if it receives nothing.
+element will be passed through and rendered.

--- a/pkg/webui/lib/components/message/message.styl
+++ b/pkg/webui/lib/components/message/message.styl
@@ -1,0 +1,28 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.first-to-lower::first-letter
+  text-transform: lowercase
+
+.first-to-upper::first-letter
+  text-transform: uppercase
+
+.uppercase
+  text-transform: uppercase
+
+.lowercase
+  text-transform: lowercase
+
+.capitalize
+  text-transform: capitalize

--- a/pkg/webui/lib/components/message/story.js
+++ b/pkg/webui/lib/components/message/story.js
@@ -25,6 +25,11 @@ const exampleMessage = {
   defaultMessage: 'This is the default message',
 }
 
+const exampleLowercaseMessage = {
+  id: '$.some.other.id',
+  defaultMessage: 'this is the default message',
+}
+
 const placeholderMessage = {
   id: '$.placeholder',
   defaultMessage: 'There are {number} gateways.',
@@ -32,6 +37,7 @@ const placeholderMessage = {
 
 const messages = {
   '$.some.id': 'This is the translated message',
+  '$.some.other.id': 'this is the translated message',
   '$.placeholder': 'There are {number} gateways.',
 }
 
@@ -54,3 +60,12 @@ storiesOf('Utility Components/Message', module)
   .add('Default', () => <Message content={exampleMessage} />)
   .add('Placeholder', () => <Message content={placeholderMessage} values={{ number: 5 }} />)
   .add('String', () => <Message content="I can also be just a string, but will issue a warning" />)
+  .add('Transforms', () => (
+    <ul>
+      <Message capitalize component="li" content={exampleLowercaseMessage} />
+      <Message firstToUpper component="li" content={exampleLowercaseMessage} />
+      <Message firstToLower component="li" content={exampleMessage} />
+      <Message uppercase component="li" content={exampleLowercaseMessage} />
+      <Message lowercase component="li" content={exampleMessage} />
+    </ul>
+  ))

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -69,6 +69,7 @@
   "console.components.device-data-form.messages.homeNetIDDescription": "ID to identify the LoRaWAN network",
   "console.components.device-data-form.messages.joinEUIDescription": "JoinEUI identifies the Join Server",
   "console.components.device-data-form.messages.leaveBlankPlaceholder": "Leave blank to generate automatically",
+  "console.components.device-data-form.messages.lorawanOptions": "LoRaWAN Options",
   "console.components.device-data-form.messages.lorawanVersionDescription": "The LoRaWAN MAC Version of the end device",
   "console.components.device-data-form.messages.lorawanPhyVersionDescription": "The LoRaWAN PHY Version of the end device",
   "console.components.device-data-form.messages.multicast": "Multicast",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -69,6 +69,7 @@
   "console.components.device-data-form.messages.homeNetIDDescription": "XX xx xxxxxxxx xxx XxXxXXX xxxxxxx",
   "console.components.device-data-form.messages.joinEUIDescription": "XxxxXXX xxxxxxxxxx xxx Xxxx Xxxxxx",
   "console.components.device-data-form.messages.leaveBlankPlaceholder": "Xxxxx xxxxx xx xxxxxxxx xxxxxxxxxxxxx",
+  "console.components.device-data-form.messages.lorawanOptions": "XxXxXXX Xxxxxxx",
   "console.components.device-data-form.messages.lorawanVersionDescription": "Xxx XxXxXXX XXX Xxxxxxx xx xxx xxx xxxxxx",
   "console.components.device-data-form.messages.lorawanPhyVersionDescription": "Xxx XxXxXXX XXX Xxxxxxx xx xxx xxx xxxxxx",
   "console.components.device-data-form.messages.multicast": "Xxxxxxxxx",

--- a/pkg/webui/oauth/views/create-account/index.js
+++ b/pkg/webui/oauth/views/create-account/index.js
@@ -55,14 +55,13 @@ const validationSchema = Yup.object().shape({
     .min(3, sharedMessages.validateTooShort)
     .max(50, sharedMessages.validateTooLong),
   password: Yup.string()
-    .min(8)
+    .min(8, sharedMessages.validateTooShort)
     .required(sharedMessages.validateRequired),
   primary_email_address: Yup.string()
     .email(sharedMessages.validateEmail)
     .required(sharedMessages.validateRequired),
   password_confirm: Yup.string()
     .oneOf([Yup.ref('password'), null], sharedMessages.validatePasswordMatch)
-    .min(8)
     .required(sharedMessages.validateRequired),
 })
 


### PR DESCRIPTION
#### Summary
Closes #2302 
References #1086

#### Changes
- Add props to modify message casing
- Some cleanup work on the message component (making `content` required)
- Add missing default props
- Update message story

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
