### PR TITLE
Pass message object values to page title

### DIFF
--- a/pkg/webui/lib/components/intl-helmet.js
+++ b/pkg/webui/lib/components/intl-helmet.js
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 import React from 'react'
-
 import { Helmet } from 'react-helmet'
 import { injectIntl } from 'react-intl'
 
+import PropTypes from '../prop-types'
 import { warn } from '../log'
 
 /**
@@ -25,6 +25,19 @@ import { warn } from '../log'
  */
 @injectIntl
 export default class IntlHelmet extends React.Component {
+  static propTypes = {
+    children: PropTypes.node,
+    intl: PropTypes.shape({
+      formatMessage: PropTypes.func.isRequired,
+    }).isRequired,
+    values: PropTypes.shape({}),
+  }
+
+  static defaultProps = {
+    children: undefined,
+    values: undefined,
+  }
+
   componentDidMount() {
     if (this.props.children) {
       warn(`Children of <IntlHelmet /> will not be translated. If you tried to
@@ -39,7 +52,7 @@ instead.`)
     for (const key in rest) {
       let prop = rest[key]
       if (typeof prop === 'object' && prop.id && prop.defaultMessage) {
-        const messageValues = values || {}
+        const messageValues = values || prop.values || {}
         const translatedMessageValues = {}
 
         for (const entry in messageValues) {


### PR DESCRIPTION
#### Summary
This quickfix PR will properly pipe the message values to the `<IntlHelmet />` utility component. Complementary to #2290 

References #1086 
References #2292 

#### Changes
- Extract `value` prop and pass to `intl.formatMessage()`
- Add missing prop types and default props

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
