### PR TITLE
Fix LoRaWAN 1.1 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - End device claim display bug when claim dates not set.
+- DeviceModeInd handling for LoRaWAN 1.1 devices.
 
 ### Security
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -25,7 +25,7 @@
 
 # Security
 /pkg/auth @johanstokking @htdvisser
-/pkg/crypto @johanstokking @htdvisser
+/pkg/crypto @johanstokking @htdvisser @rvolosatovs
 
 # Shared components
 /pkg/component @johanstokking @htdvisser

--- a/pkg/encoding/lorawan/mac.go
+++ b/pkg/encoding/lorawan/mac.go
@@ -880,7 +880,7 @@ var DefaultMACCommands = MACCommandSpec{
 	},
 
 	ttnpb.CID_DEVICE_MODE: &MACCommandDescriptor{
-		InitiatedByDevice: false,
+		InitiatedByDevice: true,
 
 		UplinkLength: 1,
 		AppendUplink: func(phy band.Band, b []byte, cmd ttnpb.MACCommand) ([]byte, error) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/2171

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix 1.1 uplink MIC calculation naming (aligned it with the spec directly) - block called `b0` currently is actually `b1` according to the spec, that also caused the confusion in making me think that the implementation is incorrect, let's fix this to avoid this happening in the future.
- Fix `DeviceModeInd` being marked as "initiated by NS"
- Add myself to `pkg/crypto` `CODEOWNERS`


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [ ] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
