### PR TITLE
Fix dropdown clickable area

### DIFF
--- a/pkg/webui/components/dropdown/dropdown.styl
+++ b/pkg/webui/components/dropdown/dropdown.styl
@@ -45,6 +45,7 @@ ul.dropdown
       color: $tc-deep-gray
       text-decoration: none
       padding: $cs.m
+      width: 100%
 
       span:last-child
         nudge('down')


### PR DESCRIPTION
#### Summary
Quickfix PR that fixes the clickable area of dropdown links, which needs to comprise the full area of the dropdown list entry. 

#### Changes
<!-- What are the changes made in this pull request? -->
- Fix clickable area of dropdowns

#### Notes for Reviewers
This issue was most notable with the logout entry in the user dropdown, where one has to click exactly on the logout text for the action to be triggered.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
