### PR TITLE
Fix error display in device import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - End device claim display bug when claim dates not set.
 - DeviceModeInd handling for LoRaWAN 1.1 devices.
 - Do not perform unnecessary gateway location updates.
+- Error display on failed end device import in the Console.
 
 ### Security
 

--- a/pkg/webui/console/containers/device-importer/index.js
+++ b/pkg/webui/console/containers/device-importer/index.js
@@ -25,7 +25,7 @@ import { selectNsConfig, selectJsConfig, selectAsConfig } from '../../../lib/sel
 import DeviceImportForm from '../../components/device-import-form'
 import SubmitBar from '../../../components/submit-bar'
 import Button from '../../../components/button'
-import Notification from '../../../components/notification'
+import ErrorNotification from '../../../components/error-notification'
 import api from '../../api'
 import PropTypes from '../../../lib/prop-types'
 import Message from '../../../lib/components/message'
@@ -210,6 +210,7 @@ export default class DeviceImporter extends Component {
     } else if (status === 'finished') {
       statusMessage = m.operationFinished
     }
+
     return (
       <div>
         <Message className={style.title} component="h4" content={operationMessage} />
@@ -229,7 +230,7 @@ export default class DeviceImporter extends Component {
             />
           </React.Fragment>
         ) : (
-          <Notification small error={error} title={m.errorTitle} />
+          <ErrorNotification small content={error} title={m.errorTitle} />
         )}
         <CodeEditor
           className={style.logOutput}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes dispalying errors in the device import page.


#### Changes
<!-- What are the changes made in this pull request? -->

- User `<ErrorNotification />` to display errors

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

On `master` errors result in full page error view because `<Notification />` is used incorrectly. With this PR:
<img width="917" alt="Screenshot 2020-04-09 at 16 18 12" src="https://user-images.githubusercontent.com/16374166/78899217-bb4b5b00-7a7d-11ea-8734-bb18ae54f54d.png">


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
