### PR TITLE
Disable claim auth code field when JS is not selected in device import

### DIFF
--- a/pkg/webui/console/components/device-import-form/index.js
+++ b/pkg/webui/console/components/device-import-form/index.js
@@ -70,10 +70,18 @@ export default class DeviceBulkCreateForm extends Component {
     onSubmit: PropTypes.func.isRequired,
   }
 
-  state = {
-    allowedFileExtensions: undefined,
-    formatDescription: undefined,
-    formatSelected: false,
+  constructor(props) {
+    super(props)
+
+    const { initialValues } = props
+
+    this.state = {
+      allowedFileExtensions: undefined,
+      formatDescription: undefined,
+      formatSelected: false,
+      jsSelected: Boolean(initialValues.components.js),
+    }
+    this.formRef = React.createRef()
   }
 
   @bind
@@ -88,11 +96,31 @@ export default class DeviceBulkCreateForm extends Component {
     this.setState(newState)
   }
 
+  @bind
+  handleComponentChange(value) {
+    const { jsSelected } = this.state
+    const { state } = this.formRef.current
+    const { js } = value
+
+    if (js !== jsSelected) {
+      this.setState({ jsSelected: js }, () => {
+        if (state.values.set_claim_auth_code) {
+          const { setFieldValue } = this.formRef.current
+
+          // `claim_authentication_code` is stored in JS, so if JS option is not selected
+          // we dont want to include it in the paylaod
+          setFieldValue('set_claim_auth_code', false)
+        }
+      })
+    }
+  }
+
   render() {
     const { initialValues, onSubmit, components } = this.props
-    const { allowedFileExtensions, formatSelected, formatDescription } = this.state
+    const { allowedFileExtensions, formatSelected, formatDescription, jsSelected } = this.state
     return (
       <Form
+        formikRef={this.formRef}
         onSubmit={onSubmit}
         validationSchema={validationSchema}
         submitEnabledWhenInvalid
@@ -113,6 +141,7 @@ export default class DeviceBulkCreateForm extends Component {
           required
         />
         <Form.Field
+          onChange={this.handleComponentChange}
           component={Checkbox.Group}
           name="components"
           title={m.targetedComponents}
@@ -130,7 +159,7 @@ export default class DeviceBulkCreateForm extends Component {
           ))}
         </Form.Field>
         <Form.Field
-          disabled={!formatSelected}
+          disabled={!formatSelected || !jsSelected}
           title={m.claimAuthCode}
           component={Checkbox}
           name="set_claim_auth_code"

--- a/pkg/webui/console/components/device-import-form/index.js
+++ b/pkg/webui/console/components/device-import-form/index.js
@@ -60,6 +60,12 @@ export default class DeviceBulkCreateForm extends Component {
       format_id: PropTypes.string,
       data: PropTypes.string,
       set_claim_auth_code: PropTypes.bool,
+      components: PropTypes.shape({
+        is: PropTypes.bool,
+        ns: PropTypes.bool,
+        js: PropTypes.bool,
+        as: PropTypes.bool,
+      }),
     }).isRequired,
     onSubmit: PropTypes.func.isRequired,
   }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes handling of setting claim authentication code when JS is not selected in the device import form.

<img width="899" alt="Screenshot 2020-04-09 at 20 09 10" src="https://user-images.githubusercontent.com/16374166/78921728-070dfc80-7a9e-11ea-9005-94c9b3880729.png">


#### Changes
<!-- What are the changes made in this pull request? -->

- Disable and reset `set_claim_auth_code` field if JS is not selected in the `Target Components` section

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

`claim_authentication_code` is stored in JS and there is no reason to confuse the user if the JS is not selected.

cc @johanstokking is this correct?

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
