### PR TITLE
Save template fields in webhooks

### DIFF
--- a/pkg/webui/console/components/webhook-template-form/index.js
+++ b/pkg/webui/console/components/webhook-template-form/index.js
@@ -69,6 +69,7 @@ export default class WebhookTemplateForm extends Component {
       template_ids: template.ids,
       format: template.format,
       headers,
+      template_fields: fields,
       base_url: urlTemplate.parse(template.base_url).expand(fields),
       uplink_message: pathExpand(template.uplink_message, fields),
       join_accept: pathExpand(template.join_accept, fields),


### PR DESCRIPTION
#### Summary
This quickfix PR will also store the template fields in the webhook, when it is created by a webhook template. This will enable us to add a special edit view for those webhooks later.

#### Changes
- Save webhook template fields as well when creating a webhook via template

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
