### PR TITLE
Fix FOpts encryption and decryption in LoRaWAN 1.1 frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Do not perform unnecessary gateway location updates.
 - Error display on failed end device import in the Console.
 - Update password view not being accessible
+- FOpts encryption and decryption for LoRaWAN 1.1 devices.
 
 ### Security
 

--- a/cmd/ttn-lw-cli/commands/simulate.go
+++ b/cmd/ttn-lw-cli/commands/simulate.go
@@ -371,7 +371,7 @@ func processDownlink(dev *ttnpb.EndDevice) func(lastUpMsg *ttnpb.Message, downMs
 				key = *dev.Session.SessionKeys.GetAppSKey().Key
 			}
 
-			macPayload.FRMPayload, err = crypto.DecryptDownlink(key, macPayload.DevAddr, macPayload.FCnt, macPayload.FRMPayload)
+			macPayload.FRMPayload, err = crypto.DecryptDownlink(key, macPayload.DevAddr, macPayload.FCnt, macPayload.FRMPayload, false)
 			if err != nil {
 				return err
 			}
@@ -538,6 +538,7 @@ var (
 							dataUplinkParams.DevAddr,
 							dataUplinkParams.FCnt,
 							fOpts,
+							true,
 						)
 						if err != nil {
 							return err
@@ -556,6 +557,7 @@ var (
 						dataUplinkParams.DevAddr,
 						dataUplinkParams.FCnt,
 						dataUplinkParams.FRMPayload,
+						false,
 					)
 					if err != nil {
 						return err

--- a/cmd/ttn-lw-cli/commands/simulate.go
+++ b/cmd/ttn-lw-cli/commands/simulate.go
@@ -145,6 +145,12 @@ func simulateDownlinkFlags() *pflag.FlagSet {
 	return flagSet
 }
 
+func simulateDataDownlinkFlags() *pflag.FlagSet {
+	flagSet := &pflag.FlagSet{}
+	flagSet.Uint32("n_f_cnt_down", 0, "NFCntDown value for FOpts decryption of LoRaWAN 1.1+ frames")
+	return flagSet
+}
+
 func simulate(cmd *cobra.Command, forUp func(*ttnpb.UplinkMessage) error, forDown func(*ttnpb.DownlinkMessage) error) error {
 	gtwID, err := getGatewayID(cmd.Flags(), nil, true)
 	if err != nil {
@@ -242,160 +248,159 @@ func simulate(cmd *cobra.Command, forUp func(*ttnpb.UplinkMessage) error, forDow
 	return ctx.Err()
 }
 
-func processDownlink(dev *ttnpb.EndDevice) func(lastUpMsg *ttnpb.Message, downMsg *ttnpb.DownlinkMessage) error {
-	return func(lastUpMsg *ttnpb.Message, downMsg *ttnpb.DownlinkMessage) (err error) {
-		phy, err := band.GetByID(dev.FrequencyPlanID)
-		if err != nil {
-			return err
-		}
-		phy, err = phy.Version(dev.LoRaWANPHYVersion)
-		if err != nil {
-			return err
-		}
-
-		downMsg.Payload = &ttnpb.Message{}
-		if err = lorawan.UnmarshalMessage(downMsg.RawPayload, downMsg.Payload); err != nil {
-			return err
-		}
-		switch downMsg.Payload.MType {
-		case ttnpb.MType_JOIN_ACCEPT:
-			joinAcceptPayload := downMsg.Payload.GetJoinAcceptPayload()
-
-			var devEUI, joinEUI types.EUI64
-			var devNonce types.DevNonce
-			if joinReq := lastUpMsg.GetJoinRequestPayload(); joinReq != nil {
-				devEUI, joinEUI = joinReq.DevEUI, joinReq.JoinEUI
-				devNonce = joinReq.DevNonce
-			} else if rejoinReq := lastUpMsg.GetRejoinRequestPayload(); rejoinReq != nil {
-				devEUI, joinEUI = rejoinReq.DevEUI, rejoinReq.JoinEUI
-				devNonce = types.DevNonce{byte(rejoinReq.RejoinCnt), byte(rejoinReq.RejoinCnt >> 8)}
-			}
-
-			var key types.AES128Key
-			if dev.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) >= 0 {
-				key = *dev.GetRootKeys().GetNwkKey().Key
-			} else {
-				key = *dev.GetRootKeys().GetAppKey().Key
-			}
-
-			payload, err := crypto.DecryptJoinAccept(key, joinAcceptPayload.GetEncrypted())
-			if err != nil {
-				return err
-			}
-
-			joinAcceptBytes := payload[:len(payload)-4]
-			downMsg.Payload.MIC = payload[len(payload)-4:]
-
-			if err = lorawan.UnmarshalJoinAcceptPayload(joinAcceptBytes, joinAcceptPayload); err != nil {
-				return err
-			}
-
-			var expectedMIC [4]byte
-			if dev.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) >= 0 && joinAcceptPayload.OptNeg {
-				jsIntKey := crypto.DeriveJSIntKey(key, devEUI)
-				// TODO: Support RejoinRequest (https://github.com/TheThingsNetwork/lorawan-stack/issues/536)
-				expectedMIC, err = crypto.ComputeJoinAcceptMIC(
-					jsIntKey,
-					0xFF,
-					*dev.JoinEUI,
-					lastUpMsg.GetJoinRequestPayload().DevNonce,
-					append([]byte{downMsg.RawPayload[0]}, joinAcceptBytes...),
-				)
-			} else {
-				expectedMIC, err = crypto.ComputeLegacyJoinAcceptMIC(
-					key,
-					append([]byte{downMsg.RawPayload[0]}, joinAcceptBytes...),
-				)
-			}
-			if err != nil {
-				return err
-			}
-			if !bytes.Equal(downMsg.Payload.MIC, expectedMIC[:]) {
-				logger.Warnf("Expected MIC %x but got %x", expectedMIC, downMsg.Payload.MIC)
-			}
-
-			dev.DevAddr, dev.Session.DevAddr = &joinAcceptPayload.DevAddr, joinAcceptPayload.DevAddr
-
-			if dev.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) >= 0 && joinAcceptPayload.OptNeg {
-				var appKey types.AES128Key
-				appKey = *dev.GetRootKeys().GetAppKey().Key
-				appSKey := crypto.DeriveAppSKey(appKey, joinAcceptPayload.JoinNonce, joinEUI, devNonce)
-				dev.Session.SessionKeys.AppSKey = &ttnpb.KeyEnvelope{Key: &appSKey}
-				logger.Infof("Derived AppSKey %X (%s)", appSKey[:], base64.StdEncoding.EncodeToString(appSKey[:]))
-
-				var nwkKey types.AES128Key
-				nwkKey = *dev.GetRootKeys().GetNwkKey().Key
-				fNwkSIntKey := crypto.DeriveFNwkSIntKey(nwkKey, joinAcceptPayload.JoinNonce, joinEUI, devNonce)
-				dev.Session.SessionKeys.FNwkSIntKey = &ttnpb.KeyEnvelope{Key: &fNwkSIntKey}
-				logger.Infof("Derived FNwkSIntKey %X (%s)", fNwkSIntKey[:], base64.StdEncoding.EncodeToString(fNwkSIntKey[:]))
-				sNwkSIntKey := crypto.DeriveSNwkSIntKey(nwkKey, joinAcceptPayload.JoinNonce, joinEUI, devNonce)
-				dev.Session.SessionKeys.SNwkSIntKey = &ttnpb.KeyEnvelope{Key: &sNwkSIntKey}
-				logger.Infof("Derived SNwkSIntKey %X (%s)", sNwkSIntKey[:], base64.StdEncoding.EncodeToString(sNwkSIntKey[:]))
-				nwkSEncKey := crypto.DeriveNwkSEncKey(nwkKey, joinAcceptPayload.JoinNonce, joinEUI, devNonce)
-				dev.Session.SessionKeys.NwkSEncKey = &ttnpb.KeyEnvelope{Key: &nwkSEncKey}
-				logger.Infof("Derived NwkSEncKey %X (%s)", nwkSEncKey[:], base64.StdEncoding.EncodeToString(nwkSEncKey[:]))
-			} else {
-				appSKey := crypto.DeriveLegacyAppSKey(key, joinAcceptPayload.JoinNonce, joinAcceptPayload.NetID, devNonce)
-				dev.Session.SessionKeys.AppSKey = &ttnpb.KeyEnvelope{Key: &appSKey}
-				logger.Infof("Derived AppSKey %X (%s)", appSKey[:], base64.StdEncoding.EncodeToString(appSKey[:]))
-				nwkSKey := crypto.DeriveLegacyNwkSKey(key, joinAcceptPayload.JoinNonce, joinAcceptPayload.NetID, devNonce)
-				dev.Session.SessionKeys.FNwkSIntKey = &ttnpb.KeyEnvelope{Key: &nwkSKey}
-				dev.Session.SessionKeys.SNwkSIntKey = &ttnpb.KeyEnvelope{Key: &nwkSKey}
-				dev.Session.SessionKeys.NwkSEncKey = &ttnpb.KeyEnvelope{Key: &nwkSKey}
-				logger.Infof("Derived NwkSKey %X (%s)", nwkSKey[:], base64.StdEncoding.EncodeToString(nwkSKey[:]))
-			}
-		case ttnpb.MType_UNCONFIRMED_DOWN, ttnpb.MType_CONFIRMED_DOWN:
-			macPayload := downMsg.Payload.GetMACPayload()
-
-			var expectedMIC [4]byte
-			if dev.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 {
-				var key types.AES128Key
-				key = *dev.Session.SessionKeys.GetFNwkSIntKey().Key
-				expectedMIC, err = crypto.ComputeLegacyDownlinkMIC(key, macPayload.DevAddr, macPayload.FCnt, downMsg.RawPayload[:len(downMsg.RawPayload)-4])
-			} else {
-				var key types.AES128Key
-				key = *dev.Session.SessionKeys.GetSNwkSIntKey().Key
-				expectedMIC, err = crypto.ComputeDownlinkMIC(key, macPayload.DevAddr, lastUpMsg.GetMACPayload().FCnt, macPayload.FCnt, downMsg.RawPayload[:len(downMsg.RawPayload)-4])
-			}
-			if err != nil {
-				return err
-			}
-			if !bytes.Equal(downMsg.Payload.MIC, expectedMIC[:]) {
-				logger.Warnf("Expected MIC %x but got %x", expectedMIC, downMsg.Payload.MIC)
-			}
-
-			var key types.AES128Key
-			if macPayload.FPort == 0 {
-				key = *dev.Session.SessionKeys.GetNwkSEncKey().Key
-			} else {
-				key = *dev.Session.SessionKeys.GetAppSKey().Key
-			}
-
-			macPayload.FRMPayload, err = crypto.DecryptDownlink(key, macPayload.DevAddr, macPayload.FCnt, macPayload.FRMPayload, false)
-			if err != nil {
-				return err
-			}
-
-			mac := macPayload.FOpts
-			if macPayload.FPort == 0 {
-				mac = macPayload.FRMPayload
-			}
-			var cmds []*ttnpb.MACCommand
-			for r := bytes.NewReader(mac); r.Len() > 0; {
-				cmd := &ttnpb.MACCommand{}
-				if err := lorawan.DefaultMACCommands.ReadDownlink(phy, r, cmd); err != nil {
-					logger.WithFields(log.Fields(
-						"bytes_left", r.Len(),
-						"mac_count", len(cmds),
-					)).WithError(err).Warn("Failed to unmarshal MAC command")
-					break
-				}
-				logger.WithField("cid", cmd.CID).WithField("payload", cmd.GetPayload()).Info("Read MAC command")
-				cmds = append(cmds, cmd)
-			}
-		}
-		return nil
+func processDownlink(dev *ttnpb.EndDevice, lastUpMsg *ttnpb.Message, downMsg *ttnpb.DownlinkMessage) error {
+	phy, err := band.GetByID(dev.FrequencyPlanID)
+	if err != nil {
+		return err
 	}
+	phy, err = phy.Version(dev.LoRaWANPHYVersion)
+	if err != nil {
+		return err
+	}
+
+	downMsg.Payload = &ttnpb.Message{}
+	if err = lorawan.UnmarshalMessage(downMsg.RawPayload, downMsg.Payload); err != nil {
+		return err
+	}
+	switch downMsg.Payload.MType {
+	case ttnpb.MType_JOIN_ACCEPT:
+		joinAcceptPayload := downMsg.Payload.GetJoinAcceptPayload()
+
+		var devEUI, joinEUI types.EUI64
+		var devNonce types.DevNonce
+		if joinReq := lastUpMsg.GetJoinRequestPayload(); joinReq != nil {
+			devEUI, joinEUI = joinReq.DevEUI, joinReq.JoinEUI
+			devNonce = joinReq.DevNonce
+		} else if rejoinReq := lastUpMsg.GetRejoinRequestPayload(); rejoinReq != nil {
+			devEUI, joinEUI = rejoinReq.DevEUI, rejoinReq.JoinEUI
+			devNonce = types.DevNonce{byte(rejoinReq.RejoinCnt), byte(rejoinReq.RejoinCnt >> 8)}
+		}
+
+		var key types.AES128Key
+		if dev.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) >= 0 {
+			key = *dev.GetRootKeys().GetNwkKey().Key
+		} else {
+			key = *dev.GetRootKeys().GetAppKey().Key
+		}
+
+		payload, err := crypto.DecryptJoinAccept(key, joinAcceptPayload.GetEncrypted())
+		if err != nil {
+			return err
+		}
+
+		joinAcceptBytes := payload[:len(payload)-4]
+		downMsg.Payload.MIC = payload[len(payload)-4:]
+
+		if err = lorawan.UnmarshalJoinAcceptPayload(joinAcceptBytes, joinAcceptPayload); err != nil {
+			return err
+		}
+
+		var expectedMIC [4]byte
+		if dev.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) >= 0 && joinAcceptPayload.OptNeg {
+			jsIntKey := crypto.DeriveJSIntKey(key, devEUI)
+			// TODO: Support RejoinRequest (https://github.com/TheThingsNetwork/lorawan-stack/issues/536)
+			expectedMIC, err = crypto.ComputeJoinAcceptMIC(
+				jsIntKey,
+				0xFF,
+				*dev.JoinEUI,
+				lastUpMsg.GetJoinRequestPayload().DevNonce,
+				append([]byte{downMsg.RawPayload[0]}, joinAcceptBytes...),
+			)
+		} else {
+			expectedMIC, err = crypto.ComputeLegacyJoinAcceptMIC(
+				key,
+				append([]byte{downMsg.RawPayload[0]}, joinAcceptBytes...),
+			)
+		}
+		if err != nil {
+			return err
+		}
+		if !bytes.Equal(downMsg.Payload.MIC, expectedMIC[:]) {
+			logger.Warnf("Expected MIC %x but got %x", expectedMIC, downMsg.Payload.MIC)
+		}
+
+		dev.DevAddr, dev.Session.DevAddr = &joinAcceptPayload.DevAddr, joinAcceptPayload.DevAddr
+
+		if dev.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) >= 0 && joinAcceptPayload.OptNeg {
+			appSKey := crypto.DeriveAppSKey(*dev.GetRootKeys().GetAppKey().Key, joinAcceptPayload.JoinNonce, joinEUI, devNonce)
+			dev.Session.SessionKeys.AppSKey = &ttnpb.KeyEnvelope{Key: &appSKey}
+			logger.Infof("Derived AppSKey %X (%s)", appSKey[:], base64.StdEncoding.EncodeToString(appSKey[:]))
+
+			fNwkSIntKey := crypto.DeriveFNwkSIntKey(*dev.GetRootKeys().GetNwkKey().Key, joinAcceptPayload.JoinNonce, joinEUI, devNonce)
+			dev.Session.SessionKeys.FNwkSIntKey = &ttnpb.KeyEnvelope{Key: &fNwkSIntKey}
+			logger.Infof("Derived FNwkSIntKey %X (%s)", fNwkSIntKey[:], base64.StdEncoding.EncodeToString(fNwkSIntKey[:]))
+
+			sNwkSIntKey := crypto.DeriveSNwkSIntKey(*dev.GetRootKeys().GetNwkKey().Key, joinAcceptPayload.JoinNonce, joinEUI, devNonce)
+			dev.Session.SessionKeys.SNwkSIntKey = &ttnpb.KeyEnvelope{Key: &sNwkSIntKey}
+			logger.Infof("Derived SNwkSIntKey %X (%s)", sNwkSIntKey[:], base64.StdEncoding.EncodeToString(sNwkSIntKey[:]))
+
+			nwkSEncKey := crypto.DeriveNwkSEncKey(*dev.GetRootKeys().GetNwkKey().Key, joinAcceptPayload.JoinNonce, joinEUI, devNonce)
+			dev.Session.SessionKeys.NwkSEncKey = &ttnpb.KeyEnvelope{Key: &nwkSEncKey}
+			logger.Infof("Derived NwkSEncKey %X (%s)", nwkSEncKey[:], base64.StdEncoding.EncodeToString(nwkSEncKey[:]))
+		} else {
+			appSKey := crypto.DeriveLegacyAppSKey(key, joinAcceptPayload.JoinNonce, joinAcceptPayload.NetID, devNonce)
+			dev.Session.SessionKeys.AppSKey = &ttnpb.KeyEnvelope{Key: &appSKey}
+			logger.Infof("Derived AppSKey %X (%s)", appSKey[:], base64.StdEncoding.EncodeToString(appSKey[:]))
+
+			nwkSKey := crypto.DeriveLegacyNwkSKey(key, joinAcceptPayload.JoinNonce, joinAcceptPayload.NetID, devNonce)
+			dev.Session.SessionKeys.FNwkSIntKey = &ttnpb.KeyEnvelope{Key: &nwkSKey}
+			dev.Session.SessionKeys.SNwkSIntKey = &ttnpb.KeyEnvelope{Key: &nwkSKey}
+			dev.Session.SessionKeys.NwkSEncKey = &ttnpb.KeyEnvelope{Key: &nwkSKey}
+			logger.Infof("Derived NwkSKey %X (%s)", nwkSKey[:], base64.StdEncoding.EncodeToString(nwkSKey[:]))
+		}
+	case ttnpb.MType_UNCONFIRMED_DOWN, ttnpb.MType_CONFIRMED_DOWN:
+		macPayload := downMsg.Payload.GetMACPayload()
+
+		var expectedMIC [4]byte
+		if dev.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 {
+			expectedMIC, err = crypto.ComputeLegacyDownlinkMIC(*dev.Session.SessionKeys.GetFNwkSIntKey().Key, macPayload.DevAddr, macPayload.FCnt, downMsg.RawPayload[:len(downMsg.RawPayload)-4])
+		} else {
+			expectedMIC, err = crypto.ComputeDownlinkMIC(*dev.Session.SessionKeys.GetSNwkSIntKey().Key, macPayload.DevAddr, lastUpMsg.GetMACPayload().FCnt, macPayload.FCnt, downMsg.RawPayload[:len(downMsg.RawPayload)-4])
+		}
+		if err != nil {
+			return err
+		}
+		if !bytes.Equal(downMsg.Payload.MIC, expectedMIC[:]) {
+			logger.Warnf("Expected MIC %x but got %x", expectedMIC, downMsg.Payload.MIC)
+		}
+
+		var payloadKey types.AES128Key
+		if macPayload.FPort == 0 {
+			payloadKey = *dev.Session.SessionKeys.GetNwkSEncKey().Key
+		} else {
+			payloadKey = *dev.Session.SessionKeys.GetAppSKey().Key
+			if len(macPayload.FOpts) > 0 && dev.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) >= 0 {
+				fOpts, err := crypto.DecryptDownlink(*dev.Session.SessionKeys.GetNwkSEncKey().Key, macPayload.DevAddr, dev.Session.LastNFCntDown, macPayload.FOpts, true)
+				if err != nil {
+					return err
+				}
+				macPayload.FOpts = fOpts
+			}
+		}
+		macPayload.FRMPayload, err = crypto.DecryptDownlink(payloadKey, macPayload.DevAddr, macPayload.FCnt, macPayload.FRMPayload, false)
+		if err != nil {
+			return err
+		}
+
+		cmdBuf := macPayload.FOpts
+		if macPayload.FPort == 0 {
+			cmdBuf = macPayload.FRMPayload
+		}
+		var cmds []*ttnpb.MACCommand
+		for r := bytes.NewReader(cmdBuf); r.Len() > 0; {
+			cmd := &ttnpb.MACCommand{}
+			if err := lorawan.DefaultMACCommands.ReadDownlink(phy, r, cmd); err != nil {
+				logger.WithFields(log.Fields(
+					"bytes_left", r.Len(),
+					"mac_count", len(cmds),
+				)).WithError(err).Warn("Failed to unmarshal MAC command")
+				break
+			}
+			logger.WithField("cid", cmd.CID).WithField("payload", cmd.GetPayload()).Info("Read MAC command")
+			cmds = append(cmds, cmd)
+		}
+	}
+	return nil
 }
 
 var (
@@ -426,21 +431,6 @@ var (
 			if err := uplinkParams.LoRaWANPHYVersion.Validate(); err != nil {
 				return errInvalidPHYVerson
 			}
-
-			processDownlink := processDownlink(&ttnpb.EndDevice{
-				LoRaWANVersion:    uplinkParams.LoRaWANVersion,
-				LoRaWANPHYVersion: uplinkParams.LoRaWANPHYVersion,
-				FrequencyPlanID:   uplinkParams.BandID,
-				EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
-					JoinEUI: &joinParams.JoinEUI,
-					DevEUI:  &joinParams.DevEUI,
-				},
-				RootKeys: &ttnpb.RootKeys{
-					NwkKey: &ttnpb.KeyEnvelope{Key: &joinParams.NwkKey},
-					AppKey: &ttnpb.KeyEnvelope{Key: &joinParams.AppKey},
-				},
-				Session: &ttnpb.Session{},
-			})
 
 			var joinRequest *ttnpb.Message
 			return simulate(cmd,
@@ -478,7 +468,20 @@ var (
 					return nil
 				},
 				func(downMsg *ttnpb.DownlinkMessage) error {
-					if err := processDownlink(joinRequest, downMsg); err != nil {
+					if err := processDownlink(&ttnpb.EndDevice{
+						LoRaWANVersion:    uplinkParams.LoRaWANVersion,
+						LoRaWANPHYVersion: uplinkParams.LoRaWANPHYVersion,
+						FrequencyPlanID:   uplinkParams.BandID,
+						EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
+							JoinEUI: &joinParams.JoinEUI,
+							DevEUI:  &joinParams.DevEUI,
+						},
+						RootKeys: &ttnpb.RootKeys{
+							NwkKey: &ttnpb.KeyEnvelope{Key: &joinParams.NwkKey},
+							AppKey: &ttnpb.KeyEnvelope{Key: &joinParams.AppKey},
+						},
+						Session: &ttnpb.Session{},
+					}, joinRequest, downMsg); err != nil {
 						return err
 					}
 					// Here we can update a persistent end-device.
@@ -510,20 +513,6 @@ var (
 			if err := uplinkParams.LoRaWANPHYVersion.Validate(); err != nil {
 				return errInvalidPHYVerson
 			}
-
-			processDownlink := processDownlink(&ttnpb.EndDevice{
-				LoRaWANVersion:    uplinkParams.LoRaWANVersion,
-				LoRaWANPHYVersion: uplinkParams.LoRaWANPHYVersion,
-				FrequencyPlanID:   uplinkParams.BandID,
-				Session: &ttnpb.Session{
-					SessionKeys: ttnpb.SessionKeys{
-						FNwkSIntKey: &ttnpb.KeyEnvelope{Key: &dataUplinkParams.FNwkSIntKey},
-						SNwkSIntKey: &ttnpb.KeyEnvelope{Key: &dataUplinkParams.SNwkSIntKey},
-						NwkSEncKey:  &ttnpb.KeyEnvelope{Key: &dataUplinkParams.NwkSEncKey},
-						AppSKey:     &ttnpb.KeyEnvelope{Key: &dataUplinkParams.AppSKey},
-					},
-				},
-			})
 
 			var dataUplink *ttnpb.Message
 			return simulate(cmd,
@@ -619,7 +608,21 @@ var (
 					return nil
 				},
 				func(downMsg *ttnpb.DownlinkMessage) error {
-					if err := processDownlink(dataUplink, downMsg); err != nil {
+					lastNFCntDown, _ := cmd.Flags().GetUint32("last_n_f_cnt_down")
+					if err := processDownlink(&ttnpb.EndDevice{
+						LoRaWANVersion:    uplinkParams.LoRaWANVersion,
+						LoRaWANPHYVersion: uplinkParams.LoRaWANPHYVersion,
+						FrequencyPlanID:   uplinkParams.BandID,
+						Session: &ttnpb.Session{
+							LastNFCntDown: lastNFCntDown,
+							SessionKeys: ttnpb.SessionKeys{
+								FNwkSIntKey: &ttnpb.KeyEnvelope{Key: &dataUplinkParams.FNwkSIntKey},
+								SNwkSIntKey: &ttnpb.KeyEnvelope{Key: &dataUplinkParams.SNwkSIntKey},
+								NwkSEncKey:  &ttnpb.KeyEnvelope{Key: &dataUplinkParams.NwkSEncKey},
+								AppSKey:     &ttnpb.KeyEnvelope{Key: &dataUplinkParams.AppSKey},
+							},
+						},
+					}, dataUplink, downMsg); err != nil {
 						return err
 					}
 					// Here we can update a persistent end-device.
@@ -642,6 +645,7 @@ func init() {
 	simulateDataUplinkCommand.Flags().AddFlagSet(simulateUplinkFlags)
 	simulateDataUplinkCommand.Flags().AddFlagSet(simulateDownlinkFlags())
 	simulateDataUplinkCommand.Flags().AddFlagSet(simulateDataUplinkFlags)
+	simulateDataUplinkCommand.Flags().AddFlagSet(simulateDataDownlinkFlags())
 
 	simulateCommand.AddCommand(simulateDataUplinkCommand)
 

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -455,7 +455,7 @@ func (as *ApplicationServer) DownlinkQueueList(ctx context.Context, ids ttnpb.En
 			if err != nil {
 				return nil, err
 			}
-			item.FRMPayload, err = crypto.DecryptDownlink(appSKey, session.DevAddr, item.FCnt, item.FRMPayload)
+			item.FRMPayload, err = crypto.DecryptDownlink(appSKey, session.DevAddr, item.FCnt, item.FRMPayload, false)
 			if err != nil {
 				return nil, err
 			}
@@ -736,7 +736,7 @@ func (as *ApplicationServer) decryptDownlinkMessage(ctx context.Context, ids ttn
 	if err != nil {
 		return err
 	}
-	msg.FRMPayload, err = crypto.DecryptDownlink(appSKey, dev.Session.DevAddr, msg.FCnt, msg.FRMPayload)
+	msg.FRMPayload, err = crypto.DecryptDownlink(appSKey, dev.Session.DevAddr, msg.FCnt, msg.FRMPayload, false)
 	if err != nil {
 		return err
 	}
@@ -822,7 +822,7 @@ func (as *ApplicationServer) recalculateDownlinkQueue(ctx context.Context, dev *
 			registerDropDownlink(ctx, dev.EndDeviceIdentifiers, oldItem, err)
 			continue
 		}
-		frmPayload, err := crypto.DecryptDownlink(oldAppSKey, oldSession.DevAddr, oldItem.FCnt, oldItem.FRMPayload)
+		frmPayload, err := crypto.DecryptDownlink(oldAppSKey, oldSession.DevAddr, oldItem.FCnt, oldItem.FRMPayload, false)
 		if err != nil {
 			logger.WithError(err).Warn("Drop downlink message; failed to decrypt")
 			registerDropDownlink(ctx, dev.EndDeviceIdentifiers, oldItem, err)
@@ -837,7 +837,7 @@ func (as *ApplicationServer) recalculateDownlinkQueue(ctx context.Context, dev *
 			Priority:       oldItem.Priority,
 			CorrelationIDs: oldItem.CorrelationIDs,
 		}
-		newItem.FRMPayload, err = crypto.EncryptDownlink(newAppSKey, newSession.DevAddr, newItem.FCnt, frmPayload)
+		newItem.FRMPayload, err = crypto.EncryptDownlink(newAppSKey, newSession.DevAddr, newItem.FCnt, frmPayload, false)
 		if err != nil {
 			logger.WithError(err).Warn("Drop downlink message; failed to encrypt")
 			registerDropDownlink(ctx, dev.EndDeviceIdentifiers, oldItem, err)

--- a/pkg/applicationserver/payload.go
+++ b/pkg/applicationserver/payload.go
@@ -54,7 +54,7 @@ func (as *ApplicationServer) encodeAndEncrypt(ctx context.Context, dev *ttnpb.En
 	if err != nil {
 		return err
 	}
-	frmPayload, err := crypto.EncryptDownlink(appSKey, session.DevAddr, downlink.FCnt, downlink.FRMPayload)
+	frmPayload, err := crypto.EncryptDownlink(appSKey, session.DevAddr, downlink.FCnt, downlink.FRMPayload, false)
 	if err != nil {
 		return err
 	}
@@ -70,7 +70,7 @@ func (as *ApplicationServer) decryptAndDecode(ctx context.Context, dev *ttnpb.En
 	if err != nil {
 		return err
 	}
-	frmPayload, err := crypto.DecryptUplink(appSKey, dev.Session.DevAddr, uplink.FCnt, uplink.FRMPayload)
+	frmPayload, err := crypto.DecryptUplink(appSKey, dev.Session.DevAddr, uplink.FCnt, uplink.FRMPayload, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/crypto/data_messages.go
+++ b/pkg/crypto/data_messages.go
@@ -22,7 +22,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/types"
 )
 
-func encryptMessage(key types.AES128Key, dir uint8, addr types.DevAddr, fCnt uint32, payload []byte) ([]byte, error) {
+func encryptMessage(key types.AES128Key, dir uint8, addr types.DevAddr, fCnt uint32, payload []byte, isFOpts bool) ([]byte, error) {
 	k := len(payload) / aes.BlockSize
 	if len(payload)%aes.BlockSize != 0 {
 		k++
@@ -39,9 +39,13 @@ func encryptMessage(key types.AES128Key, dir uint8, addr types.DevAddr, fCnt uin
 	binary.LittleEndian.PutUint32(a[10:14], fCnt)
 	var s [aes.BlockSize]byte
 	var b [aes.BlockSize]byte
+	var f int
+	if isFOpts == false {
+		f = 1
+	}
 	for i := 0; i < k; i++ {
 		copy(b[:], payload[i*aes.BlockSize:])
-		a[15] = uint8(i + 1)
+		a[15] = uint8(i + f)
 		cipher.Encrypt(s[:], a[:])
 		for j := 0; j < aes.BlockSize; j++ {
 			b[j] = b[j] ^ s[j]
@@ -55,32 +59,32 @@ func encryptMessage(key types.AES128Key, dir uint8, addr types.DevAddr, fCnt uin
 // - The payload contains the FRMPayload bytes
 // - For FPort>0, the AppSKey is used
 // - For FPort=0, the NwkSEncKey/NwkSKey is used
-func EncryptUplink(key types.AES128Key, addr types.DevAddr, fCnt uint32, payload []byte) ([]byte, error) {
-	return encryptMessage(key, 0, addr, fCnt, payload)
+func EncryptUplink(key types.AES128Key, addr types.DevAddr, fCnt uint32, payload []byte, isFOpts bool) ([]byte, error) {
+	return encryptMessage(key, 0, addr, fCnt, payload, isFOpts)
 }
 
 // DecryptUplink decrypts an uplink payload
 // - The payload contains the FRMPayload bytes
 // - For FPort>0, the AppSKey is used
 // - For FPort=0, the NwkSEncKey/NwkSKey is used
-func DecryptUplink(key types.AES128Key, addr types.DevAddr, fCnt uint32, payload []byte) ([]byte, error) {
-	return encryptMessage(key, 0, addr, fCnt, payload)
+func DecryptUplink(key types.AES128Key, addr types.DevAddr, fCnt uint32, payload []byte, isFOpts bool) ([]byte, error) {
+	return encryptMessage(key, 0, addr, fCnt, payload, isFOpts)
 }
 
 // EncryptDownlink encrypts a downlink payload
 // - The payload contains the FRMPayload bytes
 // - For FPort>0, the AppSKey is used
 // - For FPort=0, the NwkSEncKey/NwkSKey is used
-func EncryptDownlink(key types.AES128Key, addr types.DevAddr, fCnt uint32, payload []byte) ([]byte, error) {
-	return encryptMessage(key, 1, addr, fCnt, payload)
+func EncryptDownlink(key types.AES128Key, addr types.DevAddr, fCnt uint32, payload []byte, isFOpts bool) ([]byte, error) {
+	return encryptMessage(key, 1, addr, fCnt, payload, isFOpts)
 }
 
 // DecryptDownlink decrypts a downlink payload
 // - The payload contains the FRMPayload bytes
 // - For FPort>0, the AppSKey is used
 // - For FPort=0, the NwkSEncKey/NwkSKey is used
-func DecryptDownlink(key types.AES128Key, addr types.DevAddr, fCnt uint32, payload []byte) ([]byte, error) {
-	return encryptMessage(key, 1, addr, fCnt, payload)
+func DecryptDownlink(key types.AES128Key, addr types.DevAddr, fCnt uint32, payload []byte, isFOpts bool) ([]byte, error) {
+	return encryptMessage(key, 1, addr, fCnt, payload, isFOpts)
 }
 
 func computeMIC(key types.AES128Key, dir uint8, confFCnt uint16, addr types.DevAddr, fCnt uint32, payload []byte) ([4]byte, error) {

--- a/pkg/crypto/data_messages_test.go
+++ b/pkg/crypto/data_messages_test.go
@@ -44,7 +44,7 @@ func TestUplinkDownlinkEncryption(t *testing.T) {
 
 	// FOpts
 	res, _ = EncryptUplink(key, addr, 1, []byte{1, 2, 3, 4}, true)
-	a.So(res, should.Resemble, []byte{0x33, 0xC9, 0x26, 0x22}) 
+	a.So(res, should.Resemble, []byte{0x33, 0xC9, 0x26, 0x22})
 	res, _ = DecryptUplink(key, addr, 1, []byte{0x33, 0xC9, 0x26, 0x22}, true)
 	a.So(res, should.Resemble, []byte{1, 2, 3, 4})
 

--- a/pkg/crypto/data_messages_test.go
+++ b/pkg/crypto/data_messages_test.go
@@ -31,14 +31,26 @@ func TestUplinkDownlinkEncryption(t *testing.T) {
 
 	var res []byte
 
-	res, _ = EncryptUplink(key, addr, 1, []byte{1, 2, 3, 4})
+	// FRM Payload
+	res, _ = EncryptUplink(key, addr, 1, []byte{1, 2, 3, 4}, false)
 	a.So(res, should.Resemble, []byte{0xCF, 0xF3, 0x0B, 0x4E})
-	res, _ = DecryptUplink(key, addr, 1, []byte{0xCF, 0xF3, 0x0B, 0x4E})
+	res, _ = DecryptUplink(key, addr, 1, []byte{0xCF, 0xF3, 0x0B, 0x4E}, false)
 	a.So(res, should.Resemble, []byte{1, 2, 3, 4})
 
-	res, _ = EncryptDownlink(key, addr, 1, []byte{1, 2, 3, 4})
+	res, _ = EncryptDownlink(key, addr, 1, []byte{1, 2, 3, 4}, false)
 	a.So(res, should.Resemble, []byte{0x4E, 0x75, 0xF4, 0x40})
-	res, _ = DecryptDownlink(key, addr, 1, []byte{0x4E, 0x75, 0xF4, 0x40})
+	res, _ = DecryptDownlink(key, addr, 1, []byte{0x4E, 0x75, 0xF4, 0x40}, false)
+	a.So(res, should.Resemble, []byte{1, 2, 3, 4})
+
+	// FOpts
+	res, _ = EncryptUplink(key, addr, 1, []byte{1, 2, 3, 4}, true)
+	a.So(res, should.Resemble, []byte{0x33, 0xC9, 0x26, 0x22}) 
+	res, _ = DecryptUplink(key, addr, 1, []byte{0x33, 0xC9, 0x26, 0x22}, true)
+	a.So(res, should.Resemble, []byte{1, 2, 3, 4})
+
+	res, _ = EncryptDownlink(key, addr, 1, []byte{1, 2, 3, 4}, true)
+	a.So(res, should.Resemble, []byte{0xCA, 0x6F, 0xDA, 0xBA})
+	res, _ = DecryptDownlink(key, addr, 1, []byte{0xCA, 0x6F, 0xDA, 0xBA}, true)
 	a.So(res, should.Resemble, []byte{1, 2, 3, 4})
 }
 

--- a/pkg/gatewayserver/gatewayserver_util_test.go
+++ b/pkg/gatewayserver/gatewayserver_util_test.go
@@ -187,7 +187,7 @@ func randomUpDataPayload(devAddr types.DevAddr, fPort uint32, size int) []byte {
 		FPort:      fPort,
 		FRMPayload: random.Bytes(size),
 	}
-	buf, err := crypto.EncryptUplink(appSKey, devAddr, pld.FCnt, pld.FRMPayload)
+	buf, err := crypto.EncryptUplink(appSKey, devAddr, pld.FCnt, pld.FRMPayload, false)
 	if err != nil {
 		panic(err)
 	}
@@ -228,7 +228,7 @@ func randomDownDataPayload(devAddr types.DevAddr, fPort uint32, size int) []byte
 		FPort:      fPort,
 		FRMPayload: random.Bytes(size),
 	}
-	buf, err := crypto.EncryptDownlink(appSKey, devAddr, pld.FCnt, pld.FRMPayload)
+	buf, err := crypto.EncryptDownlink(appSKey, devAddr, pld.FCnt, pld.FRMPayload, false)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -451,13 +451,11 @@ func (ns *NetworkServer) generateDataDownlink(ctx context.Context, dev *ttnpb.En
 			logger.WithField("kek_label", dev.Session.NwkSEncKey.KEKLabel).WithError(err).Warn("Failed to unwrap NwkSEncKey")
 			return nil, genState, err
 		}
-		var isFOpts bool
 		fCnt := pld.FHDR.FCnt
 		if pld.FPort != 0 {
 			fCnt = dev.Session.LastNFCntDown
-			isFOpts = true
 		}
-		cmdBuf, err = crypto.EncryptDownlink(key, dev.Session.DevAddr, fCnt, cmdBuf, isFOpts)
+		cmdBuf, err = crypto.EncryptDownlink(key, dev.Session.DevAddr, fCnt, cmdBuf, pld.FPort != 0)
 		if err != nil {
 			return nil, genState, errEncryptMAC.WithCause(err)
 		}

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -451,12 +451,13 @@ func (ns *NetworkServer) generateDataDownlink(ctx context.Context, dev *ttnpb.En
 			logger.WithField("kek_label", dev.Session.NwkSEncKey.KEKLabel).WithError(err).Warn("Failed to unwrap NwkSEncKey")
 			return nil, genState, err
 		}
-
+		var isFOpts bool
 		fCnt := pld.FHDR.FCnt
 		if pld.FPort != 0 {
 			fCnt = dev.Session.LastNFCntDown
+			isFOpts = true
 		}
-		cmdBuf, err = crypto.EncryptDownlink(key, dev.Session.DevAddr, fCnt, cmdBuf)
+		cmdBuf, err = crypto.EncryptDownlink(key, dev.Session.DevAddr, fCnt, cmdBuf, isFOpts)
 		if err != nil {
 			return nil, genState, errEncryptMAC.WithCause(err)
 		}

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -1752,6 +1752,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								/* DevStatusReq */
 								0x06,
 							},
+							true,
 						)).([]byte)...)
 
 						/** FPort **/
@@ -2022,6 +2023,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								/* DevStatusReq */
 								0x06,
 							},
+							true,
 						)).([]byte)...)
 
 						/** FPort **/
@@ -2317,6 +2319,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								/* DevStatusReq */
 								0x06,
 							},
+							false,
 						)).([]byte)...)
 
 						/* MIC */
@@ -2600,6 +2603,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								/* DevStatusReq */
 								0x06,
 							},
+							true,
 						)).([]byte)...)
 
 						/** FPort **/
@@ -2893,6 +2897,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								/* DevStatusReq */
 								0x06,
 							},
+							true,
 						)).([]byte)...)
 
 						/** FPort **/
@@ -3196,6 +3201,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								/* DevStatusReq */
 								0x06,
 							},
+							true,
 						)).([]byte)...)
 
 						/** FPort **/
@@ -3525,6 +3531,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								/* DevStatusReq */
 								0x06,
 							},
+							true,
 						)).([]byte)...)
 
 						/** FPort **/
@@ -3603,6 +3610,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								/* DevStatusReq */
 								0x06,
 							},
+							true,
 						)).([]byte)...)
 
 						/** FPort **/
@@ -4163,6 +4171,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								/* DevStatusReq */
 								0x06,
 							},
+							false,
 						)).([]byte)...)
 
 						/* MIC */
@@ -4257,6 +4266,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								/* DevStatusReq */
 								0x06,
 							},
+							true,
 						)).([]byte)...)
 
 						/** FPort **/
@@ -4574,6 +4584,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								/* DevStatusReq */
 								0x06,
 							},
+							false,
 						)).([]byte)...)
 
 						/* MIC */
@@ -4668,6 +4679,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 								/* DevStatusReq */
 								0x06,
 							},
+							true,
 						)).([]byte)...)
 
 						/** FPort **/
@@ -5490,7 +5502,7 @@ func TestGenerateDownlink(t *testing.T) {
 			}
 
 			var err error
-			mac.FRMPayload, err = crypto.EncryptDownlink(key, mac.DevAddr, mac.FCnt, mac.FRMPayload)
+			mac.FRMPayload, err = crypto.EncryptDownlink(key, mac.DevAddr, mac.FCnt, mac.FRMPayload, false)
 			if err != nil {
 				t.Fatal("Failed to encrypt downlink FRMPayload")
 			}

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -531,7 +531,7 @@ matchLoop:
 				logger.WithField("kek_label", session.NwkSEncKey.KEKLabel).WithError(err).Warn("Failed to unwrap NwkSEncKey, skip")
 				continue
 			}
-			macBuf, err = crypto.DecryptUplink(key, pld.DevAddr, match.FCnt, macBuf)
+			macBuf, err = crypto.DecryptUplink(key, pld.DevAddr, match.FCnt, macBuf, false)
 			if err != nil {
 				logger.WithError(err).Warn("Failed to decrypt uplink, skip")
 				continue

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -531,7 +531,7 @@ matchLoop:
 				logger.WithField("kek_label", session.NwkSEncKey.KEKLabel).WithError(err).Warn("Failed to unwrap NwkSEncKey, skip")
 				continue
 			}
-			macBuf, err = crypto.DecryptUplink(key, pld.DevAddr, match.FCnt, macBuf, false)
+			macBuf, err = crypto.DecryptUplink(key, pld.DevAddr, match.FCnt, macBuf, pld.FPort != 0)
 			if err != nil {
 				logger.WithError(err).Warn("Failed to decrypt uplink, skip")
 				continue

--- a/pkg/networkserver/networkserver_util_test.go
+++ b/pkg/networkserver/networkserver_util_test.go
@@ -576,8 +576,8 @@ func MakeDownlinkMACBuffer(phy band.Band, cmds ...MACCommander) []byte {
 	return b
 }
 
-func MustEncryptUplink(key types.AES128Key, devAddr types.DevAddr, fCnt uint32, b ...byte) []byte {
-	return test.Must(crypto.EncryptUplink(key, devAddr, fCnt, b)).([]byte)
+func MustEncryptUplink(key types.AES128Key, devAddr types.DevAddr, fCnt uint32, isFOpts bool, b ...byte) []byte {
+	return test.Must(crypto.EncryptUplink(key, devAddr, fCnt, b, isFOpts)).([]byte)
 }
 
 func MakeDataUplink(macVersion ttnpb.MACVersion, decodePayload, confirmed bool, devAddr types.DevAddr, fCtrl ttnpb.FCtrl, fCnt, confFCntDown uint32, fPort uint8, frmPayload, fOpts []byte, dr ttnpb.DataRate, drIdx ttnpb.DataRateIndex, freq uint64, chIdx uint8, mds ...*ttnpb.RxMetadata) *ttnpb.UplinkMessage {
@@ -595,9 +595,9 @@ func MakeDataUplink(macVersion ttnpb.MACVersion, decodePayload, confirmed bool, 
 	}
 	keys := MakeSessionKeys(macVersion, false)
 	if fPort == 0 {
-		frmPayload = MustEncryptUplink(*keys.NwkSEncKey.Key, devAddr, fCnt, frmPayload...)
+		frmPayload = MustEncryptUplink(*keys.NwkSEncKey.Key, devAddr, fCnt, false, frmPayload...)
 	} else if len(fOpts) > 0 && macVersion.EncryptFOpts() {
-		fOpts = MustEncryptUplink(*keys.NwkSEncKey.Key, devAddr, fCnt, fOpts...)
+		fOpts = MustEncryptUplink(*keys.NwkSEncKey.Key, devAddr, fCnt, true, fOpts...)
 	}
 	fhdr := ttnpb.FHDR{
 		DevAddr: devAddr,
@@ -655,8 +655,8 @@ func WithMatchedUplinkSettings(msg *ttnpb.UplinkMessage, chIdx uint8, drIdx ttnp
 	return msg
 }
 
-func MustEncryptDownlink(key types.AES128Key, devAddr types.DevAddr, fCnt uint32, b ...byte) []byte {
-	return test.Must(crypto.EncryptDownlink(key, devAddr, fCnt, b)).([]byte)
+func MustEncryptDownlink(key types.AES128Key, devAddr types.DevAddr, fCnt uint32, isFOpts bool, b ...byte) []byte {
+	return test.Must(crypto.EncryptDownlink(key, devAddr, fCnt, b, isFOpts)).([]byte)
 }
 
 func MakeDataDownlink(macVersion ttnpb.MACVersion, confirmed bool, devAddr types.DevAddr, fCtrl ttnpb.FCtrl, fCnt, confFCntDown uint32, fPort uint8, frmPayload, fOpts []byte, txReq *ttnpb.TxRequest, cids ...string) *ttnpb.DownlinkMessage {
@@ -674,9 +674,9 @@ func MakeDataDownlink(macVersion ttnpb.MACVersion, confirmed bool, devAddr types
 	}
 	keys := MakeSessionKeys(macVersion, false)
 	if fPort == 0 {
-		frmPayload = MustEncryptDownlink(*keys.NwkSEncKey.Key, devAddr, fCnt, frmPayload...)
+		frmPayload = MustEncryptDownlink(*keys.NwkSEncKey.Key, devAddr, fCnt, false, frmPayload...)
 	} else if len(fOpts) > 0 && macVersion.EncryptFOpts() {
-		fOpts = MustEncryptDownlink(*keys.NwkSEncKey.Key, devAddr, fCnt, fOpts...)
+		fOpts = MustEncryptDownlink(*keys.NwkSEncKey.Key, devAddr, fCnt, true, fOpts...)
 	}
 	fhdr := ttnpb.FHDR{
 		DevAddr: devAddr,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->
Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/2171
The encryption scheme for FOpts is slightly different from that of the frame-payload, in the sense that the last byte in the one and only A block of FOpts is 0x00 and in the case of frame-payload the last byte in Ai block is 0x01,0x02,0x03...k, where k is the total number of blocks in frame-payload. Currently FOpts is considered as the 1st Ai block which meant the last byte in its A block was 0x01 rather than 0x00.

![image](https://user-images.githubusercontent.com/6441682/79016661-318ab300-7b8d-11ea-92a0-c02116a2849a.png)


#### Changes
<!-- What are the changes made in this pull request? -->
- Added one more boolean argument to `encryptMessage` function to see if its used for FOpts or frame-payload encryption and modified the function
- Refactored function accordingly in other files
- Added test scenario for FOpts encryption
- (@rvolosatovs) Fix uplink FOpts handling
- (@rvolosatovs) Fix data downlink MIC computation in `simulate`
- (@rvolosatovs) Add support for decoding `FOpts` in `simulate`

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->
Feel free to make changes as required

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
