### PR TITLE
cli: Include missing enum values in help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Too strict webhook base URL validation in the Console.
 - Webhook and PubSub total count in the Console.
 - DevEUI is set when creating ABP devices via CLI.
+- CLI now shows all supported enum values for LoraWAN fields.
 
 ### Security
 

--- a/cmd/ttn-lw-cli/internal/util/flags.go
+++ b/cmd/ttn-lw-cli/internal/util/flags.go
@@ -177,15 +177,12 @@ func enumValues(t reflect.Type) []string {
 		valueMap := make(map[string]int32)
 		implementsStringer := t.Implements(reflect.TypeOf((*fmt.Stringer)(nil)).Elem())
 		for s, v := range proto.EnumValueMap(fmt.Sprintf("ttn.lorawan.v3.%s", t.Name())) {
+			valueMap[s] = v
 			if implementsStringer {
 				// If the enum implements Stringer, then the String might be different than the official name.
 				rv := reflect.New(t).Elem()
 				rv.SetInt(int64(v))
-				s := rv.Interface().(fmt.Stringer).String()
-				valueMap[s] = v
-			} else {
-				// Otherwise we use the official name.
-				valueMap[s] = v
+				valueMap[rv.Interface().(fmt.Stringer).String()] = v
 			}
 		}
 		values := make([]string, 0, len(valueMap))
@@ -271,6 +268,7 @@ func addField(fs *pflag.FlagSet, name string, t reflect.Type, maskOnly bool) {
 			for value := range proto.EnumValueMap(enumType) {
 				values = append(values, value)
 			}
+			sort.Strings(values)
 			fs.String(name, "", strings.Join(values, "|"))
 			return
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2340

#### Changes
<!-- What are the changes made in this pull request? -->

- Add missing enum values in help text. (If enum type implements stringer, then add both values, not only the one returned from the stringer)

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- Did a quick check with entities other than end devices, no flags seem to be affected.
- Tested `--lorawan-version`, `--lorawan-mac-version`, `--mac-state.desired-parameters.rx1-delay`
- Help text now shows all enum values for all device fields. Please verify that I have not missed anything

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [X] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [X] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
