### PR TITLE
cli: Use SNAP_USER_COMMON for config files if available

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -118,11 +118,20 @@ snapcrafts:
     grade: stable
     confinement: strict
     publish: true
+    extra_files:
+      - source: config/snap/ttn-lw-stack.wrapper
+        destination: ttn-lw-stack.wrapper
+        mode: 0755
+      - source: config/snap/ttn-lw-cli.wrapper
+        destination: ttn-lw-cli.wrapper
+        mode: 0755
     apps:
       ttn-lw-stack:
         plugs: [ home, network, network-bind ]
+        command: ttn-lw-stack.wrapper
       ttn-lw-cli:
         plugs: [ home, network, network-bind ]
+        command: ttn-lw-cli.wrapper
 
 brews:
   - name: ttn-lw-stack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - JSON uplink message doc edited for clarity.
+- The CLI snap version uses the `$SNAP_USER_COMMON` directory for config by default, so that it is preserved between revisions.
 
 ### Deprecated
 

--- a/config/snap/ttn-lw-cli.wrapper
+++ b/config/snap/ttn-lw-cli.wrapper
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ -z "$XDG_CONFIG_HOME" ]; then
+    /usr/bin/env XDG_CONFIG_HOME="$SNAP_USER_COMMON" "$SNAP/ttn-lw-cli" "$@"
+else
+    "$SNAP/ttn-lw-cli" "$@"
+fi

--- a/config/snap/ttn-lw-stack.wrapper
+++ b/config/snap/ttn-lw-stack.wrapper
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ -z "$XDG_CONFIG_HOME" ]; then
+    /usr/bin/env XDG_CONFIG_HOME="$SNAP_USER_COMMON" "$SNAP/ttn-lw-stack" "$@"
+else
+    "$SNAP/ttn-lw-stack" "$@"
+fi


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2355

#### Changes
<!-- What are the changes made in this pull request? -->

- Write configuration files in `SNAP_USER_COMMON` directory. This is so that config is using the common snap directory instead of the revision specific one.
- Read config from `SNAP_USER_COMMON` as well, if that is available.  

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

We should probably be doing something similar with the cache as well.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [X] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [X] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
