### PR TITLE
Fix too strict url validation in Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Application Server returns an error when trying to delete a device that does not exist.
 - Network Server returns an error when trying to delete a device that does not exist.
 - Retrieve LNS Trust without LNS Credentials attribute.
+- Too strict webhook base URL validation.
 
 ### Security
 

--- a/pkg/webui/console/components/webhook-form/index.js
+++ b/pkg/webui/console/components/webhook-form/index.js
@@ -29,6 +29,7 @@ import ModalButton from '../../../components/button/modal-button'
 import WebhookFormatSelector from '../../containers/webhook-formats-select'
 import sharedMessages from '../../../lib/shared-messages'
 import { id as webhookIdRegexp, apiKey as webhookAPIKeyRegexp } from '../../lib/regexp'
+import { url as urlRegexp } from '../../../lib/regexp'
 import PropTypes from '../../../lib/prop-types'
 
 import { mapWebhookToFormValues, mapFormValuesToWebhook, blankValues } from './mapping'
@@ -67,7 +68,7 @@ const validationSchema = Yup.object().shape({
   format: Yup.string().required(sharedMessages.validateRequired),
   headers: Yup.array().test('has no empty string values', m.headersValidateRequired, headerCheck),
   base_url: Yup.string()
-    .url(sharedMessages.validateUrl)
+    .matches(urlRegexp, sharedMessages.validateUrl)
     .required(sharedMessages.validateRequired),
   downlink_api_key: Yup.string().matches(webhookAPIKeyRegexp, sharedMessages.validateFormat),
 })

--- a/pkg/webui/lib/regexp.js
+++ b/pkg/webui/lib/regexp.js
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export const url = /[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)?/gi
+export const url = /\b((http|https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))/
 export const id = /^[a-z0-9](?:[-]?[a-z0-9]){2,}$/


### PR DESCRIPTION
#### Summary
Closes #2347 

#### Changes
- Update URL validation regexp
- Replace yups URL validation with regexp validation

#### Notes for Reviewers
The new regex is now very restrictive. It will only ensure the basic structure of the URL. I think it's better to be least restrictive in the frontend and let the backend handle more specific validation issues. Otherwise, this will become a neverending story of fine-tuning the validation for edge cases.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
