### PR TITLE
Avoid unnecessary span rendering in message component

### DIFF
--- a/pkg/webui/components/dropdown/dropdown.styl
+++ b/pkg/webui/components/dropdown/dropdown.styl
@@ -60,8 +60,7 @@ ul.dropdown
       background-color: $c-active-blue
 
       a, button
-        span
-          color: white
+        color: white
 
       .icon
         color: white

--- a/pkg/webui/components/map/widget/index.js
+++ b/pkg/webui/components/map/widget/index.js
@@ -61,7 +61,7 @@ export default class MapWidget extends React.Component {
         <div className={style.header}>
           <Message className={style.titleMessage} content={sharedMessages.location} />
           <Link className={style.changeLocation} secondary to={path}>
-            <Message content={sharedMessages.changeLocation} />→
+            <Message content={sharedMessages.changeLocation} /> →
           </Link>
         </div>
         {this.Map}

--- a/pkg/webui/components/navigation/side/__snapshots__/index_test.js.snap
+++ b/pkg/webui/components/navigation/side/__snapshots__/index_test.js.snap
@@ -27,7 +27,6 @@ exports[`SideNavigation is flat should match snapshot 1`] = `
     <Message
       capitalize={false}
       className="message"
-      component="span"
       content="test-header-title"
       firstToLower={false}
       firstToUpper={false}
@@ -55,7 +54,6 @@ exports[`SideNavigation is flat should match snapshot 1`] = `
         <Message
           capitalize={false}
           className="message"
-          component="span"
           content="test-header-title"
           firstToLower={false}
           firstToUpper={false}
@@ -134,7 +132,6 @@ exports[`SideNavigation is nested should match snapshot 1`] = `
     <Message
       capitalize={false}
       className="message"
-      component="span"
       content="test-header-title"
       firstToLower={false}
       firstToUpper={false}
@@ -162,7 +159,6 @@ exports[`SideNavigation is nested should match snapshot 1`] = `
         <Message
           capitalize={false}
           className="message"
-          component="span"
           content="test-header-title"
           firstToLower={false}
           firstToUpper={false}

--- a/pkg/webui/components/table/cell/__snapshots__/index_test.js.snap
+++ b/pkg/webui/components/table/cell/__snapshots__/index_test.js.snap
@@ -22,7 +22,6 @@ exports[`HeadCell should match snapshot 1`] = `
 >
   <Message
     capitalize={false}
-    component="span"
     content="Head cell"
     firstToLower={false}
     firstToUpper={false}

--- a/pkg/webui/components/table/sort-button/__snapshots__/index_test.js.snap
+++ b/pkg/webui/components/table/sort-button/__snapshots__/index_test.js.snap
@@ -8,7 +8,6 @@ exports[`SortButton is active is in ascending direction should match snapshot 1`
 >
   <Message
     capitalize={false}
-    component="span"
     content="test-title"
     firstToLower={false}
     firstToUpper={false}
@@ -34,7 +33,6 @@ exports[`SortButton is active is in descending direction should match snapshot 1
 >
   <Message
     capitalize={false}
-    component="span"
     content="test-title"
     firstToLower={false}
     firstToUpper={false}
@@ -60,7 +58,6 @@ exports[`SortButton is not active should match snapshot 1`] = `
 >
   <Message
     capitalize={false}
-    component="span"
     content="test-title"
     firstToLower={false}
     firstToUpper={false}

--- a/pkg/webui/console/views/overview/index.js
+++ b/pkg/webui/console/views/overview/index.js
@@ -166,7 +166,10 @@ export default class Overview extends React.Component {
                 className={style.chooser}
               >
                 <Animation ref={this.appAnimationRef} animationData={AppAnimation} />
-                <Message content={hasEntities ? m.gotoApplications : m.createApplication} />
+                <Message
+                  component="span"
+                  content={hasEntities ? m.gotoApplications : m.createApplication}
+                />
               </div>
             </Link>
           </Col>
@@ -180,7 +183,10 @@ export default class Overview extends React.Component {
                 className={style.chooser}
               >
                 <Animation ref={this.gatewayAnimationRef} animationData={GatewayAnimation} />
-                <Message content={hasEntities ? m.gotoGateways : m.createGateway} />
+                <Message
+                  component="span"
+                  content={hasEntities ? m.gotoGateways : m.createGateway}
+                />
               </div>
             </Link>
           </Col>


### PR DESCRIPTION
#### Summary
This quickfix PR will get rid of unnecessary `<span/>`’s in which the `<Message />` contents are wrapped by default and which polluted the DOM. If there is no `className` passed, there's no reason to render a span.
It also removes the warning when plain strings are provided.

#### Changes
- Extend message component to avoid rendering spans when it is unnecessary
- Remove warning when a plain string is passed as `content`
- Fix display issues where the styling was relying on the span being rendered
- Updated snapshots

#### Notes for reviewers
I've checked all views for display issues.
Regarding the message warning: I feel like this does not reflect how we use the `<Message />` component. We frequently pass plain strings, e.g. for entity props, which will result in the logs being polluted with verbose warnings, which we have always just ignored. We could check in all places whether the message is a string and render it plainly then, but I feel like that is an unnecessary hassle.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
