### PR TITLE
Fix js translate mage target dependency issue

### DIFF
--- a/.mage/js.go
+++ b/.mage/js.go
@@ -251,9 +251,9 @@ func (js Js) Messages() error {
 
 // Translations builds the frontend locale files.
 func (js Js) Translations() error {
+	mg.Deps(js.Messages)
 	changed, err := target.Dir("./pkg/webui/locales/en.json", "./.cache/messages")
 	if os.IsNotExist(err) || (err == nil && changed) {
-		mg.Deps(js.Messages)
 		if mg.Verbose() {
 			fmt.Println("Building frontend locale files...")
 		}


### PR DESCRIPTION
#### Summary
This quickfix PR fixes the `mage js:translate` target sometimes not updating the messages due to a missing target dependency. This forced us to use `mage js:clean js:translations` in some cases.

#### Changes
- Make `js:messages` target a mandatory dependency of the `js:translations` target

#### Notes for Reviewers
This should also fix the issue of message updates from other branches being applied, after checking out a branch.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
