### PR TITLE
Remove redundant app ID check

### DIFF
--- a/pkg/joinserver/grpc_deviceregistry.go
+++ b/pkg/joinserver/grpc_deviceregistry.go
@@ -286,7 +286,7 @@ func (srv jsEndDeviceRegistryServer) Delete(ctx context.Context, ids *ttnpb.EndD
 	}
 	var evt events.Event
 	_, err := srv.JS.devices.SetByID(ctx, ids.ApplicationIdentifiers, ids.DeviceID, nil, func(dev *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
-		if dev == nil || !dev.ApplicationIdentifiers.Equal(ids.ApplicationIdentifiers) {
+		if dev == nil {
 			return nil, nil, errDeviceNotFound.New()
 		}
 		evt = evtDeleteEndDevice(ctx, ids, nil)

--- a/pkg/joinserver/grpc_deviceregistry_test.go
+++ b/pkg/joinserver/grpc_deviceregistry_test.go
@@ -104,7 +104,8 @@ func TestDeviceRegistryGet(t *testing.T) {
 				EndDeviceIdentifiers: deepcopy.Copy(registeredDevice.EndDeviceIdentifiers).(ttnpb.EndDeviceIdentifiers),
 				FieldMask: pbtypes.FieldMask{
 					Paths: []string{"ids"},
-				}},
+				},
+			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
 				a := assertions.New(t)
 				return a.So(errors.IsPermissionDenied(err), should.BeTrue)
@@ -887,42 +888,6 @@ func TestDeviceRegistryDelete(t *testing.T) {
 				a := assertions.New(t)
 				return a.So(errors.IsPermissionDenied(err), should.BeTrue)
 			},
-		},
-
-		{
-			Name: "Invalid application ID",
-			ContextFunc: func(ctx context.Context) context.Context {
-				return rights.NewContext(ctx, rights.Rights{
-					ApplicationRights: map[string]*ttnpb.Rights{
-						unique.ID(test.Context(), ttnpb.ApplicationIdentifiers{ApplicationID: "bar-application"}): ttnpb.RightsFrom(
-							ttnpb.RIGHT_APPLICATION_DEVICES_WRITE,
-						),
-					},
-				})
-			},
-			DeviceRequest: &ttnpb.EndDeviceIdentifiers{
-				ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{
-					ApplicationID: "bar-application",
-				},
-				DeviceID: "bar-device",
-				JoinEUI:  registeredJoinEUI,
-				DevEUI:   registeredDevEUI,
-			},
-			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, paths []string, cb func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
-				a := assertions.New(test.MustTFromContext(ctx))
-				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{
-					ApplicationID: "bar-application",
-				})
-				a.So(devID, should.Equal, "bar-device")
-				a.So(paths, should.BeNil)
-				dev, _, err := cb(CopyEndDevice(registeredDevice))
-				return dev, err
-			},
-			ErrorAssertion: func(t *testing.T, err error) bool {
-				a := assertions.New(t)
-				return a.So(errors.IsNotFound(err), should.BeTrue)
-			},
-			SetByIDCalls: 1,
 		},
 
 		{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Refs https://github.com/TheThingsNetwork/lorawan-stack/issues/2323
https://github.com/TheThingsNetwork/lorawan-stack/pull/2342#discussion_r409434863
Fixup of https://github.com/TheThingsNetwork/lorawan-stack/commit/7f5ab3e4fa52db573902af96f147706a7f097e61 essentially

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove redundant app ID check in JS
#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->
The check makes no sense since https://github.com/TheThingsNetwork/lorawan-stack/commit/7f5ab3e4fa52db573902af96f147706a7f097e61, no functional changes here- removing this for consistency of AS/NS/JS registries.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
