### PR TITLE
Set DevEUI if available for ABP devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Retrieve LNS Trust without LNS Credentials attribute.
 - Too strict webhook base URL validation in the Console.
 - Webhook and PubSub total count in the Console.
+- DevEUI is set when creating ABP devices via CLI.
 
 ### Security
 

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -18,12 +18,13 @@ import (
 	"bufio"
 	"context"
 	"encoding/hex"
-	stdio "io"
 	"io/ioutil"
 	"mime"
 	"os"
 	"path"
 	"strings"
+
+	stdio "io"
 
 	pbtypes "github.com/gogo/protobuf/types"
 	"github.com/spf13/cobra"
@@ -475,13 +476,11 @@ var (
 				if devID.ApplicationID != "" {
 					device.ApplicationID = devID.ApplicationID
 				}
-				if device.SupportsJoin {
-					if devID.JoinEUI != nil {
-						device.JoinEUI = devID.JoinEUI
-					}
-					if devID.DevEUI != nil {
-						device.DevEUI = devID.DevEUI
-					}
+				if device.SupportsJoin && devID.JoinEUI != nil {
+					device.JoinEUI = devID.JoinEUI
+				}
+				if devID.DevEUI != nil {
+					device.DevEUI = devID.DevEUI
 				}
 			}
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Set DevEUI if available for ABP devices

#### Changes
<!-- What are the changes made in this pull request? -->

- Set DevEUI even if `supports_join` is false, i.e. ABP. Since LoRaWAN 1.0.4, DevEUIs are mandatory for all devices

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
