### PR TITLE
Fix device overview not displaying errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI now shows all supported enum values for LoraWAN fields.
 - Application Server does not crash when retrieving a webhook template that does not exist if no template repository has been configured.
 - Application Server does not crash when listing webhook templates if no template repository has been configured.
+- Error display on failed end device fetching in the Console.
 
 ### Security
 


### PR DESCRIPTION
Take into account failed requests in the getById method

<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/2321
This PR fixes error handling for the `getById` method in the devices service in JS SDK.
Currently, all errors for failed requests are ignored which results in infinite scrolling indicator.

#### Changes
<!-- What are the changes made in this pull request? -->

- Extend the `_getDevice` method in the devices service to accept additional parameter
- Check for errors in the `getById` method in the devices service

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I dont think that adding the `mergeResult` parameter to the `_getDevice` method is the best solution. While this solves the issue for now. I will follow up with an issue with suggestions how we can refactor device handling in the sdk

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
