### PR TITLE
Support RekeyInd retransmissions and improve security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support for repeated `RekeyInd`. (happens when e.g. `RekeyConf` is lost)
+- Validate the `DevAddr` when switching session as a result of receiving `RekeyInd`.
+
 ### Changed
 
 ### Deprecated

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -660,7 +660,7 @@ matchLoop:
 			case ttnpb.CID_DL_CHANNEL:
 				evs, err = handleDLChannelAns(ctx, match.Device, cmd.GetDLChannelAns())
 			case ttnpb.CID_REKEY:
-				evs, err = handleRekeyInd(ctx, match.Device, cmd.GetRekeyInd())
+				evs, err = handleRekeyInd(ctx, match.Device, cmd.GetRekeyInd(), pld.DevAddr)
 			case ttnpb.CID_ADR_PARAM_SETUP:
 				evs, err = handleADRParamSetupAns(ctx, match.Device)
 			case ttnpb.CID_DEVICE_TIME:

--- a/pkg/networkserver/mac_rekey.go
+++ b/pkg/networkserver/mac_rekey.go
@@ -34,14 +34,15 @@ func handleRekeyInd(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCom
 	evs := []events.DefinitionDataClosure{
 		evtReceiveRekeyIndication.BindData(pld),
 	}
-	if !dev.SupportsJoin || dev.MACState.PendingJoinRequest == nil || dev.PendingSession == nil {
+	if !dev.SupportsJoin {
 		return evs, nil
 	}
-
-	dev.EndDeviceIdentifiers.DevAddr = &dev.PendingSession.DevAddr
+	if dev.PendingSession != nil {
+		dev.EndDeviceIdentifiers.DevAddr = &dev.PendingSession.DevAddr
+		dev.Session = dev.PendingSession
+	}
 	dev.MACState.LoRaWANVersion = ttnpb.MAC_V1_1
 	dev.MACState.PendingJoinRequest = nil
-	dev.Session = dev.PendingSession
 	dev.PendingMACState = nil
 	dev.PendingSession = nil
 

--- a/pkg/networkserver/mac_rekey.go
+++ b/pkg/networkserver/mac_rekey.go
@@ -19,6 +19,7 @@ import (
 
 	"go.thethings.network/lorawan-stack/pkg/events"
 	"go.thethings.network/lorawan-stack/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/pkg/types"
 )
 
 var (
@@ -26,7 +27,7 @@ var (
 	evtEnqueueRekeyConfirmation = defineEnqueueMACConfirmationEvent("rekey", "device rekey")()
 )
 
-func handleRekeyInd(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_RekeyInd) ([]events.DefinitionDataClosure, error) {
+func handleRekeyInd(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_RekeyInd, devAddr types.DevAddr) ([]events.DefinitionDataClosure, error) {
 	if pld == nil {
 		return nil, errNoPayload.New()
 	}
@@ -37,7 +38,7 @@ func handleRekeyInd(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCom
 	if !dev.SupportsJoin {
 		return evs, nil
 	}
-	if dev.PendingSession != nil {
+	if dev.PendingSession != nil && dev.MACState.PendingJoinRequest != nil && dev.PendingSession.DevAddr == devAddr {
 		dev.EndDeviceIdentifiers.DevAddr = &dev.PendingSession.DevAddr
 		dev.Session = dev.PendingSession
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Support `RekeyInd` retransmissions, improve security.
Related: #2171 #2307 

#### Changes
<!-- What are the changes made in this pull request? -->

- Support `RekeyInd` retransmissions
- Validate that the correct session is being switched to in `RekeyInd`

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

`RekeyInd` is "sticky" and is piggy-backed on all frames until `RekeyConf` is received

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, database and configuration, according to the stability commitments in `README.md`.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
