### PR TITLE
Fix events order in the Console

### DIFF
--- a/pkg/webui/console/store/reducers/events.js
+++ b/pkg/webui/console/store/reducers/events.js
@@ -30,11 +30,12 @@ const addEvent = (state, event) => {
   const currentEvents = state.events
   const eventTime = new Date(event.time).getTime()
 
+  // Keep events sorted in descending order by `time`.
   let insertIndex = 0
   while (insertIndex < currentEvents.length) {
     const currentEventTime = new Date(currentEvents[insertIndex].time).getTime()
 
-    if (eventTime > currentEventTime) {
+    if (eventTime < currentEventTime) {
       insertIndex += 1
     } else {
       break

--- a/pkg/webui/console/store/reducers/tests/events_test.js
+++ b/pkg/webui/console/store/reducers/tests/events_test.js
@@ -38,35 +38,35 @@ describe('events reducer', () => {
       newState = reducer(newState, successActionCreator(testId, event2))
 
       expect(newState[testId].events).toHaveLength(2)
-      expect(newState[testId].events[0]).toEqual(event1)
-      expect(newState[testId].events[1]).toEqual(event2)
+      expect(newState[testId].events[0]).toEqual(event2)
+      expect(newState[testId].events[1]).toEqual(event1)
 
       const event3 = { time: new Date(testDate.getTime() - 1000).toISOString() }
       newState = reducer(newState, successActionCreator(testId, event3))
 
       expect(newState[testId].events).toHaveLength(3)
-      expect(newState[testId].events[0]).toEqual(event3)
+      expect(newState[testId].events[0]).toEqual(event2)
       expect(newState[testId].events[1]).toEqual(event1)
-      expect(newState[testId].events[2]).toEqual(event2)
+      expect(newState[testId].events[2]).toEqual(event3)
 
       const event4 = { time: new Date(testDate.getTime() + 2000).toISOString() }
       newState = reducer(newState, successActionCreator(testId, event4))
 
       expect(newState[testId].events).toHaveLength(4)
-      expect(newState[testId].events[0]).toEqual(event3)
-      expect(newState[testId].events[1]).toEqual(event1)
-      expect(newState[testId].events[2]).toEqual(event2)
-      expect(newState[testId].events[3]).toEqual(event4)
+      expect(newState[testId].events[0]).toEqual(event4)
+      expect(newState[testId].events[1]).toEqual(event2)
+      expect(newState[testId].events[2]).toEqual(event1)
+      expect(newState[testId].events[3]).toEqual(event3)
 
       const event5 = { time: new Date(testDate.getTime()).toISOString() }
       newState = reducer(newState, successActionCreator(testId, event5))
 
       expect(newState[testId].events).toHaveLength(5)
-      expect(newState[testId].events[0]).toEqual(event3)
-      expect(newState[testId].events[1]).toEqual(event5)
-      expect(newState[testId].events[2]).toEqual(event1)
-      expect(newState[testId].events[3]).toEqual(event2)
-      expect(newState[testId].events[4]).toEqual(event4)
+      expect(newState[testId].events[0]).toEqual(event4)
+      expect(newState[testId].events[1]).toEqual(event2)
+      expect(newState[testId].events[2]).toEqual(event5)
+      expect(newState[testId].events[3]).toEqual(event1)
+      expect(newState[testId].events[4]).toEqual(event3)
     })
   })
 })


### PR DESCRIPTION
Make sure that events are rendered in descending order

<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes changes introduced in https://github.com/TheThingsNetwork/lorawan-stack/pull/2377. 

With fix:
<img width="1397" alt="Screenshot 2020-04-23 at 17 25 39" src="https://user-images.githubusercontent.com/16374166/80110634-8e23a000-8587-11ea-9d80-cd22a13122fe.png">

Currently:
<img width="1397" alt="Screenshot 2020-04-23 at 17 26 09" src="https://user-images.githubusercontent.com/16374166/80110637-8ebc3680-8587-11ea-86e6-239656fd8ef8.png">


#### Changes
<!-- What are the changes made in this pull request? -->

- Keep events sorted in descending order to make sure that the latest events are placed at the top of the list.


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
