### PR TITLE
Make submit buttons enabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed login page of the Console (now redirects straight to the OAuth login).
 - Network Server now records `LinkADRReq` rejections and will not retry rejected values.
 - Improved `NewChannelReq`, `DLChannelReq` and `LinkADRReq` efficiency.
+- Submit buttons are now always enabled in the Console, regardless of the form's validation state.
 
 ### Deprecated
 

--- a/pkg/webui/components/button/button.styl
+++ b/pkg/webui/components/button/button.styl
@@ -52,7 +52,7 @@ $button($color)
       background-color: activize($color)
       transition-duration: $ad.xs
 
-  &:disabled, &.disabled
+  &:disabled:not(.busy), &.disabled
     opacity: .4
     cursor: default
 

--- a/pkg/webui/components/button/index.js
+++ b/pkg/webui/components/button/index.js
@@ -78,20 +78,21 @@ class Button extends React.PureComponent {
   }
 
   render() {
-    const { autoFocus, disabled, name, type, value, title: rawTitle, intl } = this.props
+    const { autoFocus, disabled, name, type, value, title: rawTitle, intl, busy } = this.props
 
     let title = rawTitle
     if (typeof rawTitle === 'object' && rawTitle.id && rawTitle.defaultMessage) {
       title = intl.formatMessage(title)
     }
 
-    const htmlProps = { autoFocus, disabled, name, type, value, title }
+    const htmlProps = { autoFocus, name, type, value, title }
     const buttonClassNames = assembleClassnames(this.props)
     return (
       <button
         className={buttonClassNames}
         onClick={this.handleClick}
         children={buttonChildren(this.props)}
+        disabled={busy || disabled}
         {...htmlProps}
       />
     )

--- a/pkg/webui/components/submit-button/index.js
+++ b/pkg/webui/components/submit-button/index.js
@@ -20,7 +20,6 @@ import PropTypes from '@ttn-lw/lib/prop-types'
 
 class SubmitButton extends React.PureComponent {
   static propTypes = {
-    dirty: PropTypes.bool.isRequired,
     disabled: PropTypes.bool,
     icon: PropTypes.string,
     isSubmitting: PropTypes.bool.isRequired,
@@ -33,9 +32,8 @@ class SubmitButton extends React.PureComponent {
     icon: undefined,
   }
   render() {
-    const { message, icon, isSubmitting, isValidating, disabled, dirty } = this.props
+    const { message, icon, disabled, isSubmitting, isValidating } = this.props
 
-    const buttonDisabled = disabled || isSubmitting || !dirty
     const buttonLoading = isSubmitting || isValidating
 
     return (
@@ -43,7 +41,7 @@ class SubmitButton extends React.PureComponent {
         type="submit"
         icon={icon}
         message={message}
-        disabled={buttonDisabled}
+        disabled={disabled}
         busy={buttonLoading}
       />
     )

--- a/pkg/webui/console/components/webhook-template-form/index.js
+++ b/pkg/webui/console/components/webhook-template-form/index.js
@@ -127,13 +127,16 @@ export default class WebhookTemplateForm extends Component {
         {
           webhook_id: Yup.string()
             .matches(webhookIdRegexp, sharedMessages.validateIdFormat)
-            .min(2, sharedMessages.validateTooShort)
-            .max(25, sharedMessages.validateTooLong)
+            .min(2, Yup.passValues(sharedMessages.validateTooShort))
+            .max(25, Yup.passValues(sharedMessages.validateTooLong))
             .required(sharedMessages.validateRequired),
         },
       ),
     })
-    const initialValues = fields.reduce((acc, field) => ({ [field.id]: '' }), {})
+
+    const initialValues = fields.reduce((acc, field) => ({ ...acc, [field.id]: '' }), {
+      webhook_id: '',
+    })
     return (
       <div>
         <WebhookTemplateInfo webhookTemplate={webhookTemplate} />

--- a/pkg/webui/oauth/views/login/index.js
+++ b/pkg/webui/oauth/views/login/index.js
@@ -88,7 +88,6 @@ export default class OAuth extends React.PureComponent {
       this.setState({
         error: error.response.data,
       })
-    } finally {
       setSubmitting(false)
     }
   }


### PR DESCRIPTION
#### Summary
Closes #2389 

Also fixes a validation issue in the webhook template form I noticed alongside.

#### Changes
- Remove `dirty` and `isValid` check from submit button
- Fix missing entries in `initialValues` of the webhook template form
- Fix missing `yup.passValues` in webhook template form

#### Notes for Reviewers
It's still possible to render the submit button as disabled via the `disabled` prop, or when the form is disabled as a whole. But the default should be enabled now always.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
