### PR TITLE
Enforce newlines between import groups

### DIFF
--- a/config/eslintrc.yaml
+++ b/config/eslintrc.yaml
@@ -49,6 +49,7 @@ rules:
       - parent
       - sibling
       - index
+      newlines-between: always
       pathGroups:
       - pattern: "\\@{ttn-lw,console,oauth}/constants"
         group: internal

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
       "^\\@ttn-lw(.*)": "<rootDir>/pkg/webui$1",
       "^\\@console(.*)": "<rootDir>/pkg/webui/console$1",
       "^\\@oauth(.*)": "<rootDir>/pkg/webui/oauth$1",
-      "^\\@assets(.*)": "<rootDir>/pkg/webuiassets$1"
+      "^\\@assets(.*)": "<rootDir>/pkg/webui/assets$1"
     }
   },
   "eslintConfig": {

--- a/pkg/webui/components/map/index.js
+++ b/pkg/webui/components/map/index.js
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import React from 'react'
-
 import PropTypes from 'prop-types'
 import { Map, Marker, TileLayer } from 'react-leaflet'
 import classnames from 'classnames'

--- a/pkg/webui/components/map/widget/index.js
+++ b/pkg/webui/components/map/widget/index.js
@@ -16,8 +16,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import Link from '@ttn-lw/components/link'
-
 import LocationMap from '@ttn-lw/components/map'
+
 import Message from '@ttn-lw/lib/components/message'
 
 import sharedMessages from '@ttn-lw/lib/shared-messages'

--- a/pkg/webui/console/components/gateway-data-form/index.js
+++ b/pkg/webui/console/components/gateway-data-form/index.js
@@ -30,6 +30,9 @@ import Message from '@ttn-lw/lib/components/message'
 import { GsFrequencyPlansSelect } from '@console/containers/freq-plans-select'
 import OwnersSelect from '@console/containers/owners-select'
 
+import PropTypes from '@ttn-lw/lib/prop-types'
+import sharedMessages from '@ttn-lw/lib/shared-messages'
+
 import {
   id as gatewayIdRegexp,
   address as addressRegexp,
@@ -37,8 +40,6 @@ import {
   emptyDuration as emptyDurationRegexp,
   delay as delayRegexp,
 } from '@console/lib/regexp'
-import PropTypes from '@ttn-lw/lib/prop-types'
-import sharedMessages from '@ttn-lw/lib/shared-messages'
 
 const m = defineMessages({
   enforced: 'Enforced',

--- a/pkg/webui/console/views/app/index.js
+++ b/pkg/webui/console/views/app/index.js
@@ -26,7 +26,6 @@ import IntlHelmet from '@ttn-lw/lib/components/intl-helmet'
 import { withEnv } from '@ttn-lw/lib/components/env'
 import ErrorView from '@ttn-lw/lib/components/error-view'
 import ScrollToTop from '@ttn-lw/lib/components/scroll-to-top'
-
 import WithAuth from '@ttn-lw/lib/components/with-auth'
 
 import Header from '@console/containers/header'
@@ -36,11 +35,11 @@ import Applications from '@console/views/applications'
 import Gateways from '@console/views/gateways'
 import Organizations from '@console/views/organizations'
 import Admin from '@console/views/admin'
-
 import FullViewError, { FullViewErrorInner } from '@console/views/error'
 
 import PropTypes from '@ttn-lw/lib/prop-types'
 import dev from '@ttn-lw/lib/dev'
+
 import {
   selectUser,
   selectUserFetching,

--- a/sdk/js/src/service/devices/index.js
+++ b/sdk/js/src/service/devices/index.js
@@ -20,7 +20,6 @@ import { notify, EVENTS } from '../../api/stream/shared'
 import Marshaler from '../../util/marshaler'
 import combineStreams from '../../util/combine-streams'
 import deviceEntityMap from '../../../generated/device-entity-map.json'
-
 import DownlinkQueue from '../downlink-queue'
 
 import { splitSetPaths, splitGetPaths, makeRequests } from './split'


### PR DESCRIPTION
#### Summary
This quickfix PR adds the `newlines-between` option to our eslint import order setting. 

#### Changes
- Add eslint setting to enforce newlines between import groups
- Conform codebase to this setting

#### Notes for Reviewers
Should have been part of the original PR, but somehow got removed in there. We need this as otherwise, we will have inconsistencies again.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
