### PR TITLE
Improve byte input UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+<<<<<<< HEAD
 - OAuth authorization page crashing.
+=======
+- Byte input in scheduling downlink view
+>>>>>>> doc: Update CHANGELOG
 
 ### Security
 

--- a/pkg/webui/components/input/byte.js
+++ b/pkg/webui/components/input/byte.js
@@ -67,6 +67,7 @@ export default class ByteInput extends React.Component {
     onChange: PropTypes.func.isRequired,
     placeholder: PropTypes.message,
     showPerChar: PropTypes.bool,
+    unbounded: PropTypes.bool,
     value: PropTypes.string.isRequired,
   }
 
@@ -77,6 +78,7 @@ export default class ByteInput extends React.Component {
     placeholder: undefined,
     showPerChar: false,
     onBlur: () => null,
+    unbounded: false,
   }
 
   input = React.createRef()
@@ -97,6 +99,7 @@ export default class ByteInput extends React.Component {
       onChange,
       placeholder,
       showPerChar,
+      unbounded,
       ...rest
     } = this.props
 
@@ -118,7 +121,9 @@ export default class ByteInput extends React.Component {
         onCopy={this.onCopy}
         onCut={this.onCut}
         onBlur={this.onBlur}
-        showMask={!placeholder}
+        onPaste={this.onPaste}
+        showMask={!placeholder && !unbounded}
+        guide={!unbounded}
         {...rest}
       />
     )
@@ -167,6 +172,17 @@ export default class ByteInput extends React.Component {
     )
     evt.clipboardData.setData('text/plain', clean(value))
     evt.preventDefault()
+  }
+
+  @bind
+  onPaste(evt) {
+    const { min, showPerChar, unbounded } = this.props
+    if (unbounded) {
+      evt.preventDefault()
+      this.input.current.inputElement.value = evt.clipboardData.getData('text/plain')
+      mask(min, evt.clipboardData.getData('text/plain').length, showPerChar)
+      this.onChange(evt)
+    }
   }
 
   @bind

--- a/pkg/webui/console/components/downlink-form/index.js
+++ b/pkg/webui/console/components/downlink-form/index.js
@@ -122,6 +122,7 @@ const DownlinkForm = ({ appId, devId }) => {
         component={Input}
         type="byte"
         required
+        unbounded
       />
       <SubmitBar>
         <Form.Submit component={SubmitButton} message={m.scheduleDownlink} />

--- a/pkg/webui/console/components/downlink-form/index.js
+++ b/pkg/webui/console/components/downlink-form/index.js
@@ -32,6 +32,7 @@ import { hexToBase64 } from '../../lib/bytes'
 const m = defineMessages({
   insertMode: 'Insert Mode',
   insertModeDescription: 'Messages can either replace the downlink queue or append to it',
+  lengthMustBeEven: 'Payload must be complete',
   replace: 'Replace',
   push: 'Push',
   validateFPort: 'FPort must be between 1 and 223',
@@ -51,7 +52,11 @@ const validationSchema = Yup.object({
     .max(223, m.validateFPort)
     .required(sharedMessages.validateRequired),
   confirmed: Yup.bool().required(),
-  frm_payload: Yup.string(),
+  frm_payload: Yup.string().test(
+    'len',
+    m.lengthMustBeEven,
+    val => !Boolean(val) || val.length % 2 === 0,
+  ),
 })
 
 const DownlinkForm = ({ appId, devId }) => {

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -96,6 +96,7 @@
   "console.components.device-import-form.index.targetedComponents": "Targeted components",
   "console.components.downlink-form.index.insertMode": "Insert Mode",
   "console.components.downlink-form.index.insertModeDescription": "Messages can either replace the downlink queue or append to it",
+  "console.components.downlink-form.index.lengthMustBeEven": "Payload must be complete",
   "console.components.downlink-form.index.replace": "Replace",
   "console.components.downlink-form.index.push": "Push",
   "console.components.downlink-form.index.validateFPort": "FPort must be between 1 and 223",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -96,6 +96,7 @@
   "console.components.device-import-form.index.targetedComponents": "Xxxxxxxx xxxxxxxxxx",
   "console.components.downlink-form.index.insertMode": "Xxxxxx Xxxx",
   "console.components.downlink-form.index.insertModeDescription": "Xxxxxxxx xxx xxxxxx xxxxxxx xxx xxxxxxxx xxxxx xx xxxxxx xx xx",
+  "console.components.downlink-form.index.lengthMustBeEven": "Xxxxxxx xxxx xx xxxxxxxx",
   "console.components.downlink-form.index.replace": "Xxxxxxx",
   "console.components.downlink-form.index.push": "Xxxx",
   "console.components.downlink-form.index.validateFPort": "XXxxx xxxx xx xxxxxxx x xxx xxx",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2404 

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix the issue with showing placeholder chars when input is unbounded
- Fix the issue with pasting values when input is unbounded

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

cc @kschiffer . I have looked into moving `ByteInput` to a separate component, but I am not sure this is the best idea. It would include a lot of replication since there is still a lot of similarities with the `Input` component. I have managed to fix this issue by combination of `showMask` and `guide` flags in the input. I think then most of the issues with this input are solved.

However, if you still prefer moving the `ByteInput` to a separate component, we can discuss this.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
