### PR TITLE
Check if migration returned an error

### DIFF
--- a/cmd/ttn-lw-stack/commands/is_db.go
+++ b/cmd/ttn-lw-stack/commands/is_db.go
@@ -81,6 +81,9 @@ var (
 				}
 				return nil
 			})
+			if err != nil {
+				return err
+			}
 
 			logger.Info("Successfully migrated")
 			return nil

--- a/cmd/ttn-lw-stack/commands/is_db.go
+++ b/cmd/ttn-lw-stack/commands/is_db.go
@@ -72,14 +72,14 @@ var (
 
 			err = store.Transact(ctx, db, func(db *gorm.DB) error {
 				logger.Info("Migrating table structure...")
-				if err = store.AutoMigrate(db).Error; err != nil {
-					return err
-				}
+				return store.AutoMigrate(db).Error
+			})
+			if err != nil {
+				return err
+			}
+			err = store.Transact(ctx, db, func(db *gorm.DB) error {
 				logger.Info("Migrating table contents...")
-				if err = migrations.Apply(ctx, db, migrations.All...); err != nil {
-					return err
-				}
-				return nil
+				return migrations.Apply(ctx, db, migrations.All...)
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #2398 

#### Changes
<!-- What are the changes made in this pull request? -->

- Check the error returned by the migration transaction.
- Run table structure migrations in a separate migration from the table contents migrations.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->
@rvolosatovs, @johanstokking  no need to review, but feel free to thoroughly sanity check.

The transaction separation was required since the fields introduced by `gorm.AutoMigrate` were not visible until the transaction was done (observed while developing https://github.com/TheThingsIndustries/lorawan-stack/pull/2024). May be related to https://github.com/cockroachdb/cockroach/issues/12123

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
