### PR TITLE
CLI create user config dir if missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrading guide in docs
 - Unset end device fields using the CLI (see `--unset` option)
 - Join EUI and Dev EUI columns to the end device table in the Console.
+- CLI creates user configuration directory if it does not exist when generating configuration file.
 
 ### Changed
 

--- a/cmd/ttn-lw-cli/commands/use.go
+++ b/cmd/ttn-lw-cli/commands/use.go
@@ -78,6 +78,9 @@ var (
 					if err != nil {
 						return "", err
 					}
+					if err = os.MkdirAll(dir, 0755); err != nil {
+						return "", err
+					}
 					fileName = filepath.Join(dir, base)
 				}
 				_, err := os.Stat(fileName)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2355 

#### Changes
<!-- What are the changes made in this pull request? -->

- Create user config directory if it does not exist, so that the config file generation does not fail.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Do we need a flag for disable this? e.g. `--no-make-dirs`

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [X] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [X] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
