### PR TITLE
Move web tests to _test package

### DIFF
--- a/pkg/webhandlers/error_test.go
+++ b/pkg/webhandlers/error_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package webhandlers
+package webhandlers_test
 
 import (
 	"io/ioutil"
@@ -24,6 +24,7 @@ import (
 	"go.thethings.network/lorawan-stack/pkg/errors"
 	"go.thethings.network/lorawan-stack/pkg/util/test"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
+	. "go.thethings.network/lorawan-stack/pkg/webhandlers"
 )
 
 func TestErrorHandler(t *testing.T) {

--- a/pkg/webmiddleware/max_body_internal_test.go
+++ b/pkg/webmiddleware/max_body_internal_test.go
@@ -1,0 +1,18 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webmiddleware
+
+// ErrRequestBodyTooLarge makes errRequestBodyTooLarge to the test package.
+var ErrRequestBodyTooLarge = errRequestBodyTooLarge

--- a/pkg/webmiddleware/max_body_test.go
+++ b/pkg/webmiddleware/max_body_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package webmiddleware
+package webmiddleware_test
 
 import (
 	"bytes"
@@ -24,6 +24,7 @@ import (
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
 	"go.thethings.network/lorawan-stack/pkg/webhandlers"
+	. "go.thethings.network/lorawan-stack/pkg/webmiddleware"
 )
 
 func TestMaxBody(t *testing.T) {
@@ -48,7 +49,7 @@ func TestMaxBody(t *testing.T) {
 		rec := httptest.NewRecorder()
 		m(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			_, err := ioutil.ReadAll(r.Body)
-			a.So(err, should.HaveSameErrorDefinitionAs, errRequestBodyTooLarge)
+			a.So(err, should.HaveSameErrorDefinitionAs, ErrRequestBodyTooLarge)
 			webhandlers.Error(w, r, err)
 		})).ServeHTTP(rec, r)
 		res := rec.Result()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quick fix to avoid import cycles in tests that import

```
"go.thethings.network/lorawan-stack/pkg/util/test"
"go.thethings.network/lorawan-stack/pkg/util/test/assertions/should"
```

Refs https://github.com/TheThingsIndustries/lorawan-stack/pull/2086#issuecomment-621787879