### PR TITLE
Fix caller simplification when not in lorawan-stack dir

### DIFF
--- a/pkg/errors/pkg_util.go
+++ b/pkg/errors/pkg_util.go
@@ -15,39 +15,30 @@
 package errors
 
 import (
-	"path/filepath"
 	"runtime"
 	"strings"
 )
 
-// rootPath is the root path of the project (usually go.thethings.network/lorawan-stack).
-var rootPath string
-
-func setRootPath() {
-	pc, _, _, ok := runtime.Caller(0)
+var pkgPrefix = func() string {
+	pc, _, _, ok := runtime.Caller(1)
 	if !ok {
-		panic("could not determine import path of errors package")
+		panic("could not determine package of pkg_util.go")
 	}
-	fun := runtime.FuncForPC(pc).Name()
-	rootPath = filepath.Dir(filepath.Dir(filepath.Join(filepath.Dir(fun), strings.Split(filepath.Base(fun), ".")[0]))) + "/"
-}
+	p := strings.TrimSuffix(runtime.FuncForPC(pc).Name(), "pkg/errors.init")
+	return p
+}()
 
 // namespace is called when errors are defined.
 // It returns the package path of the caller (skipping the first frames of the call stack)
-// and makes it relative to rootPath (so for example: pkg/errors).
+// and makes it relative (so for example: pkg/errors).
 func namespace(skip int) string {
 	pc, _, _, ok := runtime.Caller(skip)
 	if !ok {
 		panic("could not determine source of error")
 	}
 	fun := runtime.FuncForPC(pc).Name()
-	pkg := filepath.Join(filepath.Dir(fun), strings.Split(filepath.Base(fun), ".")[0])
-	if rootPath == "" {
-		setRootPath()
-	}
-	if strings.Contains(pkg, rootPath) {
-		split := strings.Split(pkg, rootPath)
-		pkg = split[len(split)-1]
-	}
-	return pkg
+	slashIdx := strings.LastIndexByte(fun, '/')
+	dotIdx := strings.IndexByte(fun[slashIdx:], '.')
+	pkg := fun[:slashIdx+dotIdx]
+	return strings.TrimPrefix(pkg, pkgPrefix)
 }

--- a/pkg/i18n/i18n.go
+++ b/pkg/i18n/i18n.go
@@ -56,6 +56,14 @@ func (m *MessageDescriptor) String() string {
 	return m.id
 }
 
+var pathPrefix = func() string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("could not determine location of i18n.go")
+	}
+	return strings.TrimSuffix(file, filepath.Join("pkg", "i18n", "i18n.go"))
+}()
+
 // SetSource sets the source package and file name of the message descriptor.
 // The argument skip is the number of stack frames to ascend, with 0 identifying the caller of SetSource.
 func (m *MessageDescriptor) SetSource(skip uint) {
@@ -63,11 +71,7 @@ func (m *MessageDescriptor) SetSource(skip uint) {
 	if !ok {
 		panic("could not determine source of message")
 	}
-	m.Description.Package = filepath.Dir(file)
-	if strings.Contains(m.Description.Package, "lorawan-stack/") {
-		split := strings.Split(m.Description.Package, "lorawan-stack/")
-		m.Description.Package = split[len(split)-1]
-	}
+	m.Description.Package = strings.TrimPrefix(filepath.Dir(file), pathPrefix)
 	m.Description.File = filepath.Base(file)
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quick refactoring of the code that determines the relative path of files and packages.

Previously this would break if the repository was cloned into a dir that was not called `lorawan-stack`.