### PR TITLE
Fix key handling in device registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Join Server and Application Server device registries now return an error when deleting keys on `SET` operations. The operation was never supported and caused an error on `GET` instead.
+
 ### Security
 
 ## [3.8.0] - 2020-05-06

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -248,16 +248,16 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 	if ttnpb.HasAnyField(req.FieldMask.Paths, "session.dev_addr") && (req.EndDevice.Session == nil || req.EndDevice.Session.DevAddr.IsZero()) {
 		return nil, errInvalidFieldValue.WithAttributes("field", "session.dev_addr")
 	}
-	if ttnpb.HasAnyField(req.FieldMask.Paths, "session.keys.f_nwk_s_int_key.key") && (req.EndDevice.Session == nil || req.EndDevice.Session.GetFNwkSIntKey().GetKey().IsZero()) {
+	if ttnpb.HasAnyField(req.FieldMask.Paths, "session.keys.f_nwk_s_int_key.key") && (req.EndDevice.Session == nil || req.EndDevice.Session.FNwkSIntKey.GetKey().IsZero()) {
 		return nil, errInvalidFieldValue.WithAttributes("field", "session.keys.f_nwk_s_int_key.key")
 	}
-	if ttnpb.HasAnyField(req.FieldMask.Paths, "session.keys.nwk_s_enc_key.key") && (req.EndDevice.Session == nil || req.EndDevice.Session.GetNwkSEncKey().GetKey().IsZero()) {
+	if ttnpb.HasAnyField(req.FieldMask.Paths, "session.keys.nwk_s_enc_key.key") && (req.EndDevice.Session == nil || req.EndDevice.Session.NwkSEncKey.GetKey().IsZero()) {
 		return nil, errInvalidFieldValue.WithAttributes("field", "session.keys.nwk_s_enc_key.key")
 	}
-	if ttnpb.HasAnyField(req.FieldMask.Paths, "session.keys.s_nwk_s_int_key.key") && (req.EndDevice.Session == nil || req.EndDevice.Session.GetSNwkSIntKey().GetKey().IsZero()) {
+	if ttnpb.HasAnyField(req.FieldMask.Paths, "session.keys.s_nwk_s_int_key.key") && (req.EndDevice.Session == nil || req.EndDevice.Session.SNwkSIntKey.GetKey().IsZero()) {
 		return nil, errInvalidFieldValue.WithAttributes("field", "session.keys.s_nwk_s_int_key.key")
 	}
-	if ttnpb.HasAnyField(req.FieldMask.Paths, "session.keys.session_key_id") && (req.EndDevice.Session == nil || len(req.EndDevice.Session.GetSessionKeyID()) == 0) {
+	if ttnpb.HasAnyField(req.FieldMask.Paths, "session.keys.session_key_id") && (req.EndDevice.Session == nil || len(req.EndDevice.Session.SessionKeyID) == 0) {
 		return nil, errInvalidFieldValue.WithAttributes("field", "session.keys.session_key_id")
 	}
 
@@ -269,34 +269,12 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 		return nil, err
 	}
 	if ttnpb.HasAnyField(req.FieldMask.Paths,
-		"mac_state.queued_join_accept.keys.f_nwk_s_int_key.encrypted_key",
-		"mac_state.queued_join_accept.keys.f_nwk_s_int_key.kek_label",
 		"mac_state.queued_join_accept.keys.f_nwk_s_int_key.key",
-		"mac_state.queued_join_accept.keys.nwk_s_enc_key.encrypted_key",
-		"mac_state.queued_join_accept.keys.nwk_s_enc_key.kek_label",
 		"mac_state.queued_join_accept.keys.nwk_s_enc_key.key",
-		"mac_state.queued_join_accept.keys.s_nwk_s_int_key.encrypted_key",
-		"mac_state.queued_join_accept.keys.s_nwk_s_int_key.kek_label",
 		"mac_state.queued_join_accept.keys.s_nwk_s_int_key.key",
 		"mac_state.queued_join_accept.keys.session_key_id",
-		"pending_session.keys.f_nwk_s_int_key.encrypted_key",
-		"pending_session.keys.f_nwk_s_int_key.kek_label",
-		"pending_session.keys.f_nwk_s_int_key.key",
-		"pending_session.keys.nwk_s_enc_key.encrypted_key",
-		"pending_session.keys.nwk_s_enc_key.kek_label",
-		"pending_session.keys.nwk_s_enc_key.key",
-		"pending_session.keys.s_nwk_s_int_key.encrypted_key",
-		"pending_session.keys.s_nwk_s_int_key.kek_label",
-		"pending_session.keys.s_nwk_s_int_key.key",
-		"pending_session.keys.session_key_id",
-		"session.keys.f_nwk_s_int_key.encrypted_key",
-		"session.keys.f_nwk_s_int_key.kek_label",
 		"session.keys.f_nwk_s_int_key.key",
-		"session.keys.nwk_s_enc_key.encrypted_key",
-		"session.keys.nwk_s_enc_key.kek_label",
 		"session.keys.nwk_s_enc_key.key",
-		"session.keys.s_nwk_s_int_key.encrypted_key",
-		"session.keys.s_nwk_s_int_key.kek_label",
 		"session.keys.s_nwk_s_int_key.key",
 		"session.keys.session_key_id",
 	) {
@@ -398,7 +376,9 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 			}
 			if ttnpb.HasAnyField(sets, "session.dev_addr") {
 				req.EndDevice.DevAddr = &req.EndDevice.Session.DevAddr
-				sets = append(sets, "ids.dev_addr")
+				sets = ttnpb.AddFields(sets,
+					"ids.dev_addr",
+				)
 			}
 			if ttnpb.HasAnyField(sets,
 				"frequency_plan_id",
@@ -514,18 +494,14 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 			}
 		} else {
 			if err := ttnpb.ProhibitFields(sets,
-				"session.keys.nwk_s_enc_key.encrypted_key",
-				"session.keys.nwk_s_enc_key.kek_label",
 				"session.keys.nwk_s_enc_key.key",
-				"session.keys.s_nwk_s_int_key.encrypted_key",
-				"session.keys.s_nwk_s_int_key.kek_label",
 				"session.keys.s_nwk_s_int_key.key",
 			); err != nil {
 				return nil, nil, errInvalidFieldMask.WithCause(err)
 			}
 			req.EndDevice.Session.NwkSEncKey = req.EndDevice.Session.FNwkSIntKey
 			req.EndDevice.Session.SNwkSIntKey = req.EndDevice.Session.FNwkSIntKey
-			sets = append(sets,
+			sets = ttnpb.AddFields(sets,
 				"session.keys.nwk_s_enc_key.encrypted_key",
 				"session.keys.nwk_s_enc_key.kek_label",
 				"session.keys.s_nwk_s_int_key.encrypted_key",
@@ -537,7 +513,9 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 			return nil, nil, errInvalidFieldValue.WithAttributes("field", "session.started_at")
 		} else if !ttnpb.HasAnyField(sets, "session.started_at") {
 			req.EndDevice.Session.StartedAt = timeNow().UTC()
-			sets = append(sets, "session.started_at")
+			sets = ttnpb.AddFields(sets,
+				"session.started_at",
+			)
 		}
 
 		macState, err := newMACState(&req.EndDevice, ns.FrequencyPlans, ns.defaultMACSettings)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2403 

#### Changes
<!-- What are the changes made in this pull request? -->

- Make key handling in device registries consistent, deleting keys on `SET` is now disallowed.
	- For Join Server it does not make sense to have a device with no keys.
	- For Application Server there might be a use case to delete `AppSKey` if the user wants to migrate to an external AS, but we can add support for this later - currently deleting keys is broken anyway, so this makes the issue apparent instead of silently letting the device reach an invalid state in the registry.
- Remove unused/disallowed fieldpaths from checks

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I assume this is tested by existing test cases

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
