### PR TITLE
Fix OAuth token exchange/refresh issues when using TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - OAuth authorization page crashing.
-- Byte input in scheduling downlink view
+- Byte input in scheduling downlink view.
+- OAuth client token exchange and refresh issues when using TLS with a RootCA.
 
 ### Security
 

--- a/pkg/web/oauthclient/callback.go
+++ b/pkg/web/oauthclient/callback.go
@@ -59,7 +59,11 @@ func (oc *OAuthClient) HandleCallback(c echo.Context) error {
 	}
 
 	// Exchange token.
-	token, err := oc.oauth(c).Exchange(c.Request().Context(), code)
+	ctx, err := oc.withTLSClientConfig(c.Request().Context())
+	if err != nil {
+		return err
+	}
+	token, err := oc.oauth(c).Exchange(ctx, code)
 	if err != nil {
 		var retrieveError *oauth2.RetrieveError
 		if stderrors.As(err, &retrieveError) {

--- a/pkg/web/oauthclient/oauthclient.go
+++ b/pkg/web/oauthclient/oauthclient.go
@@ -17,6 +17,7 @@ package oauthclient
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 
@@ -49,6 +50,18 @@ func (oc *OAuthClient) getMountPath() string {
 	}
 
 	return path
+}
+
+func (oc *OAuthClient) withTLSClientConfig(ctx context.Context) (context.Context, error) {
+	config, err := oc.component.GetTLSClientConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return context.WithValue(ctx, oauth2.HTTPClient, &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: config,
+		},
+	}), nil
 }
 
 // New returns a new OAuth client instance.

--- a/pkg/web/oauthclient/token.go
+++ b/pkg/web/oauthclient/token.go
@@ -39,7 +39,11 @@ func (oc *OAuthClient) freshToken(c echo.Context) (*oauth2.Token, error) {
 		Expiry:       time.Now(),
 	}
 
-	freshToken, err := oc.oauth(c).TokenSource(c.Request().Context(), token).Token()
+	ctx, err := oc.withTLSClientConfig(c.Request().Context())
+	if err != nil {
+		return nil, err
+	}
+	freshToken, err := oc.oauth(c).TokenSource(ctx, token).Token()
 	if err != nil {
 		var retrieveError *oauth2.RetrieveError
 		if stderrors.As(err, &retrieveError) {


### PR DESCRIPTION
#### Summary
This quickfix PR fixes issues during the token exchange/refresh of the OAuth flow, caused by the TLS config not being passed to backend-side requests made by the `oauth2` package. This caused the `token exchange refused` error (mentioned in #2353)  in setups using a root CA certificate, since the request could not check the server certificate against the root CA.

#### Changes
- Extend `oauthclient` config to include the TLS client config
- Attaching the decorated HTTP client to the context used by the oauth2 package
- Update console config to pass the TLS config of the component

#### Notes for Reviewers
This is how I reproduced the issue:
1. Configure the stack to use TLS with a root CA
2. Temporarily distrust this root CA using mac keychain (if not already so)
3. Start the stack
4. Trust the certificate using mac keychain (to make the browser trust the webUI, while still leaving the certificate untrusted in the already started stack)
5. Login to the console
6. See the `token exchange refused` error

If you restart the stack then, without untrusting the root CA again, the login will work, since the certificate is now trusted by your root, getting picked up during the stack restart.

After applying this PR, it should work either way, since the root CA is now being checked as well.

Main reviewer: @htdvisser 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
