### PR TITLE
Add config flag to enable TLS in webpack dev server

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -200,8 +200,15 @@ TTN_LW_CONSOLE_UI_ASSETS_BASE_URL="http://localhost:8080/assets"
 Disable [Hot Module Replacement](https://webpack.js.org/concepts/hot-module-replacement/)
 
 ```bash
-WEBPACK_DISABLE_HMR="true"
+WEBPACK_DEV_SERVER_DISABLE_HMR="true"
 ```
+
+Enable TLS in `webpack-dev-server`, using the key and certificate set via `TTN_LW_TLS_KEY` and `TTN_LW_TLS_CERTIFICATE` environment variables. Useful when developing functionalities that rely on TLS.
+
+```bash
+WEBPACK_DEV_SERVER_USE_TLS="true"
+```
+Note: To use this option, The Things Stack for LoRaWAN must be properly setup for TLS. You can obtain more information about this in the **Getting Started** section of the The Things Stack for LoRaWAN documentation.
 
 ## Code Style
 


### PR DESCRIPTION
#### Summary
This quickfix PR will add a env config flag which will enable TLS when using the webpack dev server. Additionally, it streamlines the naming of webpack related configs env variables.

#### Changes
- Extend webpack config to use TLS when `WEBPACK_DEV_SERVER_USE_TLS` is set to `true`
- Clean up webpack related env variable naming
- Update development documentaion

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
