### PR TITLE
Use correct config on OAuth client logout

### DIFF
--- a/pkg/web/oauthclient/logout.go
+++ b/pkg/web/oauthclient/logout.go
@@ -45,11 +45,14 @@ func (oc *OAuthClient) HandleLogout(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	u, err := url.Parse(oc.config.LogoutURL)
+
+	config := oc.configFromContext(c.Request().Context())
+
+	u, err := url.Parse(config.LogoutURL)
 	if err != nil {
 		return err
 	}
-	logoutURL := oc.config.LogoutURL
+	logoutURL := config.LogoutURL
 
 	// If a logout URL is configured, return a decorated logout URI so the client
 	// can decide to additionally logout of the OAuth server itself.
@@ -58,7 +61,7 @@ func (oc *OAuthClient) HandleLogout(c echo.Context) error {
 		if err != nil {
 			return err
 		}
-		redirectURL := stripCommonRoot(logoutURL, oc.config.RootURL)
+		redirectURL := stripCommonRoot(logoutURL, config.RootURL)
 		query := url.Values{
 			"access_token_id":          []string{tokenID},
 			"post_logout_redirect_uri": []string{redirectURL},


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quickfix that makes the oauth client logout use the config from the context.