### PR TITLE
Remove faulty login redirects in OAuth app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Clearing end device events list in the Console.
+- Some views not being accessible in the OAuth app (e.g. update password).
 
 ### Security
 

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -119,8 +119,5 @@ func (console *Console) RegisterRoutes(server *web.Server) {
 
 	group.GET("/login/ttn-stack", console.oc.HandleLogin)
 
-	if console.config.Mount != "" && console.config.Mount != "/" {
-		group.GET("", webui.Template.Handler)
-	}
 	group.GET("/*", webui.Template.Handler)
 }

--- a/pkg/oauth/server.go
+++ b/pkg/oauth/server.go
@@ -234,11 +234,11 @@ func (s *server) RegisterRoutes(server *web.Server) {
 	page.POST("/authorize", s.Authorize(webui.Template.Handler), s.redirectToLogin)
 
 	if s.config.Mount != "" && s.config.Mount != "/" {
-		group.GET("", webui.Template.Handler, s.redirectToLogin)
+		group.GET("", webui.Template.Handler)
 	} else {
-		server.GET(s.config.Mount, webui.Template.Handler, s.redirectToLogin)
+		server.GET(s.config.Mount, webui.Template.Handler)
 	}
-	group.GET("/*", webui.Template.Handler, s.redirectToLogin)
+	group.GET("/*", webui.Template.Handler)
 
 	// No CSRF here:
 	group.GET("/code", webui.Template.Handler)

--- a/pkg/oauth/server.go
+++ b/pkg/oauth/server.go
@@ -233,15 +233,10 @@ func (s *server) RegisterRoutes(server *web.Server) {
 	page.GET("/authorize", s.Authorize(webui.Template.Handler), s.redirectToLogin)
 	page.POST("/authorize", s.Authorize(webui.Template.Handler), s.redirectToLogin)
 
-	if s.config.Mount != "" && s.config.Mount != "/" {
-		group.GET("", webui.Template.Handler)
-	} else {
-		server.GET(s.config.Mount, webui.Template.Handler)
-	}
+	group.GET("/", webui.Template.Handler, s.redirectToLogin)
 	group.GET("/*", webui.Template.Handler)
 
 	// No CSRF here:
-	group.GET("/code", webui.Template.Handler)
 	group.GET("/local-callback", s.redirectToLocal)
 	group.POST("/token", s.Token)
 }

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -313,7 +313,9 @@ func (s *Server) Group(prefix string, middleware ...echo.MiddlewareFunc) *echo.G
 	pathWithSlash := path + "/"
 	router := s.getRouter(pathWithSlash)
 	router.PathPrefix(replaceEchoVars(pathWithSlash)).Handler(s.echo)
-	router.Handle(replaceEchoVars(path), http.RedirectHandler(pathWithSlash, http.StatusPermanentRedirect))
+	if path != "/" {
+		router.Handle(replaceEchoVars(path), http.RedirectHandler(pathWithSlash, http.StatusPermanentRedirect))
+	}
 	return s.echo.Group(path, middleware...)
 }
 


### PR DESCRIPTION
#### Summary
This quickfix PR removes `redirectToLogin` middleware for the root and `/*` handler which have been added via #2148. While it would be good to redirect to the login page by default, it's not possible to navigate to some unauthenticated views (e.g. update password) that way, unless navigation is done via react router.

#### Changes
- Remove `redirectToLogin` middleware from oauth root handlers.
- Simplify console routing
- Add a fix to the web package preventing redirect loops when using `Group()` using just`/` as prefix

#### Notes for reviewers
I also removed some additional routing logic used when serving the apps from root (`/`), which we don't actually support anyway.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
