### PR TITLE
Translate MQTT server URLs to Paho compatible ones

### DIFF
--- a/pkg/applicationserver/io/pubsub/provider/mqtt/provider.go
+++ b/pkg/applicationserver/io/pubsub/provider/mqtt/provider.go
@@ -17,6 +17,7 @@ package mqtt
 
 import (
 	"context"
+	"net/url"
 	"time"
 
 	mqtt_topic "github.com/TheThingsIndustries/mystique/pkg/topic"
@@ -50,8 +51,12 @@ func (impl) OpenConnection(ctx context.Context, target provider.Target) (pc *pro
 	if !ok {
 		panic("wrong provider type provided to OpenConnection")
 	}
+	serverURL, err := adaptURLScheme(settings.MQTT.ServerURL)
+	if err != nil {
+		return nil, err
+	}
 	clientOpts := mqtt.NewClientOptions()
-	clientOpts.AddBroker(settings.MQTT.ServerURL)
+	clientOpts.AddBroker(serverURL)
 	clientOpts.SetClientID(settings.MQTT.ClientID)
 	clientOpts.SetUsername(settings.MQTT.Username)
 	clientOpts.SetPassword(settings.MQTT.Password)
@@ -151,6 +156,20 @@ func (impl) OpenConnection(ctx context.Context, target provider.Target) (pc *pro
 		}
 	}
 	return pc, nil
+}
+
+func adaptURLScheme(initial string) (string, error) {
+	u, err := url.Parse(initial)
+	if err != nil {
+		return "", err
+	}
+	switch u.Scheme {
+	case "mqtt":
+		u.Scheme = "tcp"
+	case "mqtts":
+		u.Scheme = "ssl"
+	}
+	return u.String(), nil
 }
 
 func init() {

--- a/pkg/applicationserver/io/pubsub/provider/mqtt/provider_test.go
+++ b/pkg/applicationserver/io/pubsub/provider/mqtt/provider_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"strconv"
 	"testing"
 	"time"
 
@@ -322,6 +323,44 @@ func TestOpenConnection(t *testing.T) {
 					})
 				}
 			})
+		})
+	}
+}
+
+func TestAdaptURLScheme(t *testing.T) {
+	for i, tc := range []struct {
+		ProvidedURL string
+		ExpectedURL string
+		ShouldError bool
+	}{
+		{
+			ProvidedURL: "mqtt://localhost:1885",
+			ExpectedURL: "tcp://localhost:1885",
+			ShouldError: false,
+		},
+		{
+			ProvidedURL: "mqtts://localhost:8885",
+			ExpectedURL: "ssl://localhost:8885",
+			ShouldError: false,
+		},
+		{
+			ProvidedURL: "bar!://foo",
+			ShouldError: true,
+		},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			a := assertions.New(t)
+			result, err := adaptURLScheme(tc.ProvidedURL)
+			if err != nil {
+				if !tc.ShouldError {
+					t.Fatal("Unexpected error", err)
+				}
+			} else {
+				if tc.ShouldError {
+					t.Fatal("Expected error but got nil")
+				}
+			}
+			a.So(result, should.Equal, tc.ExpectedURL)
 		})
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2516 

#### Changes
<!-- What are the changes made in this pull request? -->

- Adapt server URL scheme from `mqtt://` to `tcp://` and from `mqtts://` to `ssl://`

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@benolayinka please check if it works correctly on your local deployment (so without the Console override).

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
