### PR TITLE
Redis codec

### DIFF
--- a/pkg/redis/codec/main.go
+++ b/pkg/redis/codec/main.go
@@ -1,0 +1,80 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package codec provides a codec, which encodes and decodes protocol buffers
+// stored in Redis to/from JSON.
+package main
+
+import (
+	"flag"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/gogo/protobuf/proto"
+	"go.thethings.network/lorawan-stack/v3/pkg/jsonpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/redis"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+)
+
+var json = jsonpb.TTN()
+
+func init() {
+	log.SetOutput(os.Stderr)
+	log.SetFlags(0)
+}
+
+func main() {
+	typ := flag.String("type", "", "Proto type to be used (supported: ttnpb.EndDevice)")
+	encode := flag.Bool("encode", false, "Whether encoding should be performed (default: false)")
+
+	flag.Parse()
+
+	var pb proto.Message
+	switch *typ {
+	case "":
+		log.Print("Type cannot be empty")
+		flag.Usage()
+		os.Exit(1)
+
+	case "ttnpb.EndDevice":
+		pb = &ttnpb.EndDevice{}
+	default:
+		log.Printf("Unknown type: `%s`", *typ)
+		flag.Usage()
+		os.Exit(1)
+	}
+	if *encode {
+		if err := json.NewDecoder(os.Stdin).Decode(pb); err != nil {
+			log.Fatalf("Failed to read proto as JSON from stdin: %v", err)
+		}
+		s, err := redis.MarshalProto(pb)
+		if err != nil {
+			log.Fatalf("Failed to marshal proto: %v", err)
+		}
+		if _, err := os.Stdout.Write([]byte(s)); err != nil {
+			log.Fatalf("Failed to write to stdout: %v", err)
+		}
+	}
+	b, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		log.Fatalf("Failed to read from stdin: %v", err)
+	}
+	if err := redis.UnmarshalProto(string(b), pb); err != nil {
+		log.Fatalf("Failed to unmarshal proto: %v", err)
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(pb); err != nil {
+		log.Fatalf("Failed to write proto as JSON to stdout: %v", err)
+	}
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Add Redis codec for debugging

#### Changes
<!-- What are the changes made in this pull request? -->

- Add Redis codec for debugging

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This pull request is not closing an issue, because this tool was developed while debugging a deployment problem, for which issue was not filed.

Example usage:
```
$ redis-cli get ttn:v3:ns:devices:uid:test-app2.test-dev-c | go run ./pkg/redis/codec -type 'ttnpb.EndDevice' | jq
{
  "ids": {
    "device_id": "test-dev-c",
    "application_ids": {
      "application_id": "test-app2"
    },
    "dev_eui": "DEADBEEF01020304",
    "join_eui": "01020304DEADBEEF"
  },
  "created_at": "2020-05-15T09:12:20.066274774Z",
  "updated_at": "2020-05-15T09:12:20.066274774Z",
  "supports_class_c": true,
  "lorawan_version": "1.0.3",
  "lorawan_phy_version": "1.0.3-a",
  "frequency_plan_id": "EU_863_870",
  "supports_join": true
}
```

Not sure where to put this, but IMO `pkg/redis/codec` is fine for now. I guess when we build more tooling, we can find a better place for those.

Note that the JSON encoder/decoder is apparently not symmetric:
```
$ redis-cli get ttn:v3:ns:devices:uid:test-app2.test-dev-c@default | go run ./pkg/redis/codec -type 'ttnpb.EndDevice' | go run ./pkg/redis/codec -type 'ttnpb.EndDevice' -encode 
Ci0KCnRlc3QtZGV2LWMSCwoJdGVzdC1hcHAyIgjerb7vAQIDBCoIAQIDBN6tvu8SCwj0ufn1BRDWi80fGgsI9Ln59QUQ1ovNH3ABeAWAAQeKAQpFVV84NjNfODcwoAEB{"ids":{"application_ids":{}},"created_at":"0001-01-01T00:00:00Z","updated_at":"0001-01-01T00:00:00Z"}
```
cc @htdvisser 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
