### PR TITLE
Fix service data webhooks messages

### DIFF
--- a/pkg/applicationserver/io/packages/loradms/v1/package.go
+++ b/pkg/applicationserver/io/packages/loradms/v1/package.go
@@ -108,7 +108,7 @@ func (p *DeviceManagementPackage) sendUplink(ctx context.Context, up *ttnpb.Appl
 	logger := log.FromContext(ctx)
 	eui := objects.EUI(*up.DevEUI)
 
-	client, err := api.New(http.DefaultClient, api.WithToken(data.token))
+	client, err := api.New(http.DefaultClient, api.WithToken(data.token), api.WithBaseURL(data.serverURL))
 	if err != nil {
 		logger.WithError(err).Debug("Failed to create API client")
 		return err
@@ -192,10 +192,10 @@ func (p *DeviceManagementPackage) mergePackageData(def *ttnpb.ApplicationPackage
 		&defaultData,
 		&associationData,
 	} {
-		if merged.serverURL == nil {
+		if data.serverURL != nil {
 			merged.serverURL = urlutil.CloneURL(data.serverURL)
 		}
-		if merged.token == "" {
+		if data.token != "" {
 			merged.token = data.token
 		}
 	}

--- a/pkg/applicationserver/io/web/webhooks.go
+++ b/pkg/applicationserver/io/web/webhooks.go
@@ -306,8 +306,8 @@ func (w *webhooks) handleUp(ctx context.Context, msg *ttnpb.ApplicationUp) error
 	hooks, err := w.registry.List(ctx, msg.ApplicationIdentifiers,
 		[]string{
 			"base_url",
-			"downlink_api_key",
 			"downlink_ack",
+			"downlink_api_key",
 			"downlink_failed",
 			"downlink_nack",
 			"downlink_queued",
@@ -316,6 +316,7 @@ func (w *webhooks) handleUp(ctx context.Context, msg *ttnpb.ApplicationUp) error
 			"headers",
 			"join_accept",
 			"location_solved",
+			"service_data",
 			"uplink_message",
 		},
 	)

--- a/pkg/applicationserver/io/web/webhooks_test.go
+++ b/pkg/applicationserver/io/web/webhooks_test.go
@@ -337,6 +337,8 @@ func TestWebhooks(t *testing.T) {
 										},
 									},
 								},
+								OK:  true,
+								URL: fmt.Sprintf("%s/service/data", baseURL),
 							},
 						} {
 							t.Run(tc.Name, func(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #2541 

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `service_data` field mask to webhook retrieval.
- Fix tests that previously didn't catch this.
- Fix package data merge logic (before this patch the values would not be overridden by per-device associations)

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I caught this while checking #2539 again.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
