### PR TITLE
Fix oauth CSRF cookie not using mount path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Some views not being accessible in the OAuth app (e.g. update password).
 - `LinkADRReq` scheduling.
 - Unsetting NwkKey in Join Server.
+- CSRF token validation issues preventing login and logout in some circumstances.
 
 ### Security
 

--- a/pkg/oauth/server.go
+++ b/pkg/oauth/server.go
@@ -220,12 +220,15 @@ func (s *server) RegisterRoutes(server *web.Server) {
 		}),
 	)
 
-	api := group.Group("/api", middleware.CSRF())
+	api := group.Group("/api", middleware.CSRFWithConfig(middleware.CSRFConfig{
+		CookiePath: s.config.Mount,
+	}))
 	api.POST("/auth/login", s.Login)
 	api.POST("/auth/logout", s.Logout, s.requireLogin)
 	api.GET("/me", s.CurrentUser, s.requireLogin)
 
 	page := group.Group("", middleware.CSRFWithConfig(middleware.CSRFConfig{
+		CookiePath:  s.config.Mount,
 		TokenLookup: "form:csrf",
 	}))
 	page.GET("/login", webui.Template.Handler, s.redirectToNext)
@@ -236,7 +239,8 @@ func (s *server) RegisterRoutes(server *web.Server) {
 	group.GET("/", webui.Template.Handler, s.redirectToLogin)
 	group.GET("/*", webui.Template.Handler)
 
-	// No CSRF here:
 	group.GET("/local-callback", s.redirectToLocal)
+
+	// No CSRF here:
 	group.POST("/token", s.Token)
 }

--- a/pkg/oauth/server.go
+++ b/pkg/oauth/server.go
@@ -221,6 +221,7 @@ func (s *server) RegisterRoutes(server *web.Server) {
 	)
 
 	api := group.Group("/api", middleware.CSRFWithConfig(middleware.CSRFConfig{
+		CookieName: "_oauth_csrf",
 		CookiePath: s.config.Mount,
 	}))
 	api.POST("/auth/login", s.Login)
@@ -228,6 +229,7 @@ func (s *server) RegisterRoutes(server *web.Server) {
 	api.GET("/me", s.CurrentUser, s.requireLogin)
 
 	page := group.Group("", middleware.CSRFWithConfig(middleware.CSRFConfig{
+		CookieName:  "_oauth_csrf",
 		CookiePath:  s.config.Mount,
 		TokenLookup: "form:csrf",
 	}))

--- a/pkg/oauth/server_test.go
+++ b/pkg/oauth/server_test.go
@@ -501,7 +501,7 @@ func TestOAuthFlow(t *testing.T) {
 
 			for _, c := range jar.Cookies(req.URL) {
 				req.AddCookie(c)
-				if c.Name == "_csrf" {
+				if c.Name == "_oauth_csrf" {
 					csrfToken = c.Value
 					req.Header.Set("X-CSRF-Token", c.Value)
 				}

--- a/pkg/webui/console/api/index.js
+++ b/pkg/webui/console/api/index.js
@@ -38,10 +38,7 @@ const stack = {
 
 const isBaseUrl = stackConfig.is.base_url
 
-const csrf = getCookieValue('_csrf')
-const instance = axios.create({
-  headers: { 'X-CSRF-Token': csrf },
-})
+const instance = axios.create()
 
 instance.interceptors.response.use(
   response => {

--- a/pkg/webui/oauth/api/index.js
+++ b/pkg/webui/oauth/api/index.js
@@ -21,7 +21,7 @@ const appRoot = selectApplicationRootPath()
 const stackConfig = selectStackConfig()
 const isBaseUrl = stackConfig.is.base_url
 
-const csrf = getCookieValue('_csrf')
+const csrf = getCookieValue('_oauth_csrf')
 const instance = axios.create({
   headers: { 'X-CSRF-Token': csrf },
 })

--- a/pkg/webui/oauth/views/authorize/index.js
+++ b/pkg/webui/oauth/views/authorize/index.js
@@ -118,7 +118,7 @@ export default class Authorize extends PureComponent {
           logo
         >
           <Fragment>
-            <input type="hidden" name="csrf" value={getCookieValue('_csrf')} />
+            <input type="hidden" name="csrf" value={getCookieValue('_oauth_csrf')} />
             <div className={style.left}>
               <ul>
                 {client.rights.map(right => (


### PR DESCRIPTION
#### Summary
This PR will fix an issue in our CSRF protection in the OAuth app that can lead to issues during login and logout in certain circumstances.

References: #2550

#### Changes
- Use the OAuth app mount path for the path attribute of the csrf cookie
- Rename the name of the csrf cookie to `_oauth_csrf`
- Remove unnecessary CSRF headers for non csrf protected routes in the console

#### Notes for Reviewers
The issue resulted from the fact that if no cookie path is being set explicitly, the cookie will take the current path. This resulted in multiple CSRF cookies being stored for different paths of the OAuth app, which will cause problems since the CSRF middleware arbitrarily picks one of the cookie values present in the request to check it against the CSRF-Header, in some circumstances leading to a mismatch and consequently a 403.

In the console, this has already been fixed via #2148.

I've also updated the name of the CSRF cookie to `_oauth_csrf` (complementary to `_console_csrf`) so that cookies already set in clients do not need to be flushed for the login to work again.

The whole issue can be reproduced like this:
- Flush all cookies for localhost
- Login and back out of the console (this will set cookies on both `/oauth` and `/oauth/api`)
- Back on the login screen, delete the current `_csrf` cookie using dev tools
- Try to login and see the `Invalid CSRF token` error
- Refresh and observe a fresh CSRF cookie being set (using dev tools)
- Try logging in again and still see the CSRF error
  - In the request, you can also see multiple cookies being sent under the name `_csrf` (one from `/oauth` and one from `/oauth/api`), which is what causes trouble for the CSRF middleware, when it tries to compare the cookie value to the header.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
