### PR TITLE
Attempt to fix the GS flaky test

### DIFF
--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -670,7 +670,13 @@ func (gs *GatewayServer) updateConnStats(conn connectionEntry) {
 	logger := log.FromContext(ctx)
 
 	// Initial dummy update, so that gateway appears connected
-	if err := gs.UpdateConnectionStats(conn.Connection, false, false, true); err != nil {
+	if err := gs.statsRegistry.Set(
+		ctx,
+		conn.Connection.Gateway().GatewayIdentifiers,
+		&ttnpb.GatewayConnectionStats{
+			ConnectedAt: func(t time.Time) *time.Time { return &t }(conn.Connection.ConnectTime()),
+			Protocol:    conn.Connection.Frontend().Protocol(),
+		}, false, false, true); err != nil {
 		logger.WithError(err).Error("Failed to initialize connection stats")
 	}
 
@@ -878,12 +884,12 @@ func recoverHandler(ctx context.Context) error {
 	return nil
 }
 
-// UpdateConnectionStats updates the connection stats for a gateway
+// UpdateConnectionStats updates the connection stats for a gateway.
 func (gs *GatewayServer) UpdateConnectionStats(conn *io.Connection, up, down, status bool) error {
 	return gs.statsRegistry.Set(conn.Context(), conn.Gateway().GatewayIdentifiers, conn.Stats(), up, down, status)
 }
 
-// ClearConnectionStats clears the connection stats for a gateway
+// ClearConnectionStats clears the connection stats for a gateway.
 func (gs *GatewayServer) ClearConnectionStats(conn *io.Connection, up, down, status bool) error {
 	return gs.statsRegistry.Set(conn.Context(), conn.Gateway().GatewayIdentifiers, nil, up, down, status)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #1332 

#### Changes
<!-- What are the changes made in this pull request? -->

- Take a safer route on the connection stats intiialization 

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This took a lot of time. I cannot reproduce this on any local environment, even when connecting/disconnecting a gateway repeatedly. This seems to really be a flake that appears in the tests only.

The change does things differently on the connection stats intiialization, to try and avoid de-referencing stuff that it should not.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [X] Testing: The changes are covered with unit tests. The changes are tested manually as well.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
