### PR TITLE
Fix unsetting fields on Join Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unsetting NwkKey in Join Server.
 - CSRF token validation issues preventing login and logout in some circumstances.
 - Typo in Application Server configuration documentation (webhook downlink).
+- Unset fields via CLI on Join Server, i.e. `--unset root-keys.nwk-key`.
 
 ### Security
 

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -565,7 +565,7 @@ var (
 				return errConflictingPaths.WithAttributes("field_mask_paths", overlapPaths)
 			}
 			var device ttnpb.EndDevice
-			if ttnpb.HasAnyField(paths, setEndDeviceToJS...) {
+			if ttnpb.HasAnyField(paths, setEndDeviceToJS...) || ttnpb.HasAnyField(unsetPaths, setEndDeviceToJS...) {
 				device.SupportsJoin = true
 			}
 			if err = util.SetFields(&device, setEndDeviceFlags); err != nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fix unsetting fields on Join Server

#### Changes
<!-- What are the changes made in this pull request? -->

- Check also paths to unset for setting `SupportsJoin` which is used further on to contact Join Server


#### Testing

<!-- How did you verify that this change works? -->

Tested locally

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None I'm aware of

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
