### PR TITLE
Network Server configure default MAC settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The header of the sidebar is now clickable in the Console.
 - Overall layout and behavior of the sidebar in the Console improved.
 - Improved layout and screen space utilization of event data views in the Console.
+- Allow setting all default MAC settings of the Network Server. Support setting enum values using strings where applicable.
 
 ### Deprecated
 

--- a/doc/content/reference/configuration/network-server.md
+++ b/doc/content/reference/configuration/network-server.md
@@ -28,9 +28,13 @@ The `ns.default-mac-settings` options configure default device MAC configuration
 - `ns.default-mac-settings.adr-margin`: The default margin Network Server should add in ADR requests
 - `ns.default-mac-settings.class-b-timeout`: Deadline for a device in class B mode to respond to requests from the Network Server
 - `ns.default-mac-settings.class-c-timeout`: Deadline for a device in class C mode to respond to requests from the Network Server
-- `ns.default-mac-settings.desired-rx1-delay`: Desired Rx1Delay value Network Server should use
+- `ns.default-mac-settings.desired-adr-ack-delay-exponent`: The desired ADR ACK delay exponent (`ADR_ACK_DELAY_<X>`). Not set by default
+- `ns.default-mac-settings.desired-adr-ack-limit-exponent`: The desired ADR ACK limit exponent (`ADR_ACK_LIMIT_<X>`). Not set by default
+- `ns.default-mac-settings.desired-max-duty-cycle`: The desired maximum Duty Cycle, (`DUTY_CYCLE_<X>`). Not set by default
+- `ns.default-mac-settings.desired-rx1-delay`: Desired Rx1Delay value Network Server should use (`RX_DELAY_<X>`)
 - `ns.default-mac-settings.status-count-periodicity`: Number of uplink messages after which a DevStatusReq MACCommand shall be sent by Network Server
 - `ns.default-mac-settings.status-time-periodicity`: The interval after which a DevStatusReq MACCommand shall be sent by Network Server
+
 
 ## Interoperability
 

--- a/pkg/config/hooks.go
+++ b/pkg/config/hooks.go
@@ -18,11 +18,13 @@ import (
 	"encoding/hex"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/mitchellh/mapstructure"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 )
 
 var errFormat = errors.DefineInvalidArgument("format", "invalid format `{input}`")
@@ -242,4 +244,96 @@ func stringToByteArrayHook(f reflect.Type, t reflect.Type, data interface{}) (in
 		rv.Index(i).SetUint(uint64(v))
 	}
 	return rv.Interface(), nil
+}
+
+func stringToTimeDurationPointerHook(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+	if f != nil && f.Kind() != reflect.String {
+		return data, nil
+	}
+	if s, ok := data.(string); ok {
+		d := time.Duration(1)
+		if t == reflect.TypeOf(&d) {
+			if s == "" {
+				return nil, nil
+			}
+			return time.ParseDuration(s)
+		}
+	}
+	return data, nil
+}
+
+func stringToRxDelayPointerHook(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+	if f != nil && f.Kind() != reflect.String {
+		return data, nil
+	}
+	if s, ok := data.(string); ok {
+		var enum ttnpb.RxDelay
+		if t == reflect.TypeOf(&enum) {
+			if s == "" {
+				return nil, nil
+			}
+			if err := enum.UnmarshalText([]byte(s)); err != nil {
+				return strconv.ParseInt(s, 10, 32)
+			}
+			return enum, nil
+		}
+	}
+	return data, nil
+}
+
+func stringToADRAckDelayExponentPointerHook(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+	if f != nil && f.Kind() != reflect.String {
+		return data, nil
+	}
+	if s, ok := data.(string); ok {
+		var enum ttnpb.ADRAckDelayExponent
+		if t == reflect.TypeOf(&enum) {
+			if s == "" {
+				return nil, nil
+			}
+			if err := enum.UnmarshalText([]byte(s)); err != nil {
+				return strconv.ParseInt(s, 10, 32)
+			}
+			return enum, nil
+		}
+	}
+	return data, nil
+}
+
+func stringToADRAckLimitExponentPointerHook(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+	if f != nil && f.Kind() != reflect.String {
+		return data, nil
+	}
+	if s, ok := data.(string); ok {
+		var enum ttnpb.ADRAckLimitExponent
+		if t == reflect.TypeOf(&enum) {
+			if s == "" {
+				return nil, nil
+			}
+			if err := enum.UnmarshalText([]byte(s)); err != nil {
+				return strconv.ParseInt(s, 10, 32)
+			}
+			return enum, nil
+		}
+	}
+	return data, nil
+}
+
+func stringToAggregatedDutyCyclePointerHook(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+	if f != nil && f.Kind() != reflect.String {
+		return data, nil
+	}
+	if s, ok := data.(string); ok {
+		var enum ttnpb.AggregatedDutyCycle
+		if t == reflect.TypeOf(&enum) {
+			if s == "" {
+				return nil, nil
+			}
+			if err := enum.UnmarshalText([]byte(s)); err != nil {
+				return strconv.ParseInt(s, 10, 32)
+			}
+			return enum, nil
+		}
+	}
+	return data, nil
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #1386, #2859 

#### Changes
<!-- What are the changes made in this pull request? -->

- Refactor config handling in `pkg/config` for existing types
- Add extra handling for `*ttnpb.ADRAckDelayExponent`, `*ttnpb.ADRAckLimitExponent`, `*ttnpb.AggregatedDutyCycle`, `ttnpb.RxDelay`, and `*time.Duration` values. Hooks work with `string` values, and set the value to `nil` when the string is empty.
- Add `mapstructure` hooks for these types, support both integer values (already existing) as well as string enum values.

#### Testing

<!-- How did you verify that this change works? -->

- Start stack with configuration, add extra debug messages during test to print and verify configuration values
- Set values from command line arguments, environment variables and config file.
- Test both integer and string values (also in config file) where applicable
- Test other commands (e.g. `ttn-lw-cli devices set --mac-settings.desired-rx1-delay=X`) are not affected.
- Also add a TODO for `*tls.Config`, pointing to #2925. We might work on that issue differently, added an empty case to not print an error message for `*tls.Config` during stack start.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Should be covered by testing. 

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [X] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
