### PR TITLE
Handle corrupted devices on downlink

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -5507,6 +5507,15 @@
       "file": "errors.go"
     }
   },
+  "error:pkg/networkserver:data_rate_index_not_found": {
+    "translations": {
+      "en": "data rate with index `{index}` not found"
+    },
+    "description": {
+      "package": "pkg/networkserver",
+      "file": "errors.go"
+    }
+  },
   "error:pkg/networkserver:data_rate_not_found": {
     "translations": {
       "en": "data rate not found"

--- a/pkg/networkserver/errors.go
+++ b/pkg/networkserver/errors.go
@@ -27,6 +27,7 @@ var (
 	errConfirmedMulticastDownlink = errors.DefineInvalidArgument("confirmed_multicast_downlink", "confirmed downlink queued for multicast device")
 	errCorruptedMACState          = errors.DefineCorruption("corrupted_mac_state", "MAC state is corrupted")
 	errDataRateNotFound           = errors.DefineNotFound("data_rate_not_found", "data rate not found")
+	errDataRateIndexNotFound      = errors.DefineNotFound("data_rate_index_not_found", "data rate with index `{index}` not found")
 	errDecodePayload              = errors.DefineInvalidArgument("decode_payload", "failed to decode payload")
 	errDeviceNotFound             = errors.DefineNotFound("device_not_found", "device not found")
 	errDuplicate                  = errors.DefineFailedPrecondition("duplicate", "uplink is a duplicate")

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -1337,7 +1337,7 @@ func (ns *NetworkServer) HandleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 			"spreading_factor", dr.LoRa.GetSpreadingFactor(),
 		))
 	default:
-		return nil, errDataRateNotFound
+		return nil, errDataRateNotFound.New()
 	}
 	ctx = log.NewContext(ctx, logger)
 

--- a/pkg/networkserver/grpc_test.go
+++ b/pkg/networkserver/grpc_test.go
@@ -154,8 +154,9 @@ func TestGenerateDevAddr(t *testing.T) {
 			seen := map[types.DevAddrPrefix]int{}
 			for i := 0; i < 100; i++ {
 				devAddr, err := ttnpb.NewNsClient(ns.LoopbackConn()).GenerateDevAddr(ctx, ttnpb.Empty)
-				a.So(err, should.BeNil)
-				a.So(hasOneOfPrefixes(devAddr.DevAddr, seen, tc.DevAddrPrefixes[0], tc.DevAddrPrefixes[1], tc.DevAddrPrefixes[2]), should.BeTrue)
+				if a.So(err, should.BeNil) {
+					a.So(hasOneOfPrefixes(devAddr.DevAddr, seen, tc.DevAddrPrefixes[0], tc.DevAddrPrefixes[1], tc.DevAddrPrefixes[2]), should.BeTrue)
+				}
 			}
 			a.So(seen[tc.DevAddrPrefixes[0]], should.BeGreaterThan, 0)
 			a.So(seen[tc.DevAddrPrefixes[1]], should.BeGreaterThan, 0)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://sentry.io/organizations/the-things-industries/issues/1603015076/?project=2682566

#### Changes
<!-- What are the changes made in this pull request? -->

- Do not fail class A downlink if either RX1 or RX2 parameters cannot be computed
- Improve error logging


#### Testing

<!-- How did you verify that this change works? -->

Unit tests


#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The errors will be still be published, but we will not get more details for debugging and downlink will still be attempted.
I believe the issue was caused by band package prior to #2427 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
