### PR TITLE
Remove legacy `.mage` and `.make` references

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,11 +11,9 @@
 /go.mod @johanstokking @htdvisser @rvolosatovs
 /go.sum @johanstokking @htdvisser @rvolosatovs
 
-# Build pipeline
+# Build pipeline and tooling
 /Makefile @htdvisser @rvolosatovs @johanstokking
-/magefile.go @htdvisser @rvolosatovs @johanstokking
-/.make @htdvisser @rvolosatovs @johanstokking
-/.mage @htdvisser @rvolosatovs @johanstokking
+/tools @htdvisser @rvolosatovs @johanstokking
 
 # API, configuration, CLI and storage compatibility
 /api @johanstokking @htdvisser @rvolosatovs

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -86,7 +86,7 @@ The folder structure of the project looks as follows:
 ├── Dockerfile          formula for building Docker images
 ├── LICENSE             the license that explains what you're allowed to do with this code
 ├── Makefile            dev/test/build tooling
-├── .mage               dev/test/build tooling
+├── tools               dev/test/build tooling
 ├── README.md           general information about this project
 │   ...
 ├── api                 contains the protocol buffer definitions for our API

--- a/tools/mage/dev.go
+++ b/tools/mage/dev.go
@@ -46,8 +46,6 @@ func (Dev) Misspell() error {
 		".editorconfig",
 		".gitignore",
 		".goreleaser.yml",
-		".mage",
-		".make",
 		".revive.toml",
 		".travis.yml",
 		"api",
@@ -59,13 +57,12 @@ func (Dev) Misspell() error {
 		"docker-compose.yml",
 		"Dockerfile",
 		"lorawan-stack.go",
-		"magefile.go",
 		"Makefile",
 		"pkg",
 		"README.md",
 		"sdk",
 		"SECURITY.md",
-		"tools.go",
+		"tools",
 	)
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Another follow-up of #2568 

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove legacy `.mage` and `.make` directory references

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
