### PR TITLE
Remove propagation of typed nil identifiers from GS and GCS

### DIFF
--- a/pkg/basicstation/cups/server.go
+++ b/pkg/basicstation/cups/server.go
@@ -74,7 +74,16 @@ func (s *Server) getRegistry(ctx context.Context, ids *ttnpb.GatewayIdentifiers)
 	if s.registry != nil {
 		return s.registry, nil
 	}
-	cc, err := s.component.GetPeerConn(ctx, ttnpb.ClusterRole_ENTITY_REGISTRY, ids)
+	var (
+		cc  *grpc.ClientConn
+		err error
+	)
+	if ids != nil {
+		cc, err = s.component.GetPeerConn(ctx, ttnpb.ClusterRole_ENTITY_REGISTRY, ids)
+	} else {
+		// Don't pass a (*ttnpb.GatewayIdentifiers)(nil) to GetPeerConn.
+		cc, err = s.component.GetPeerConn(ctx, ttnpb.ClusterRole_ENTITY_REGISTRY, nil)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +94,16 @@ func (s *Server) getAccess(ctx context.Context, ids *ttnpb.GatewayIdentifiers) (
 	if s.access != nil {
 		return s.access, nil
 	}
-	cc, err := s.component.GetPeerConn(ctx, ttnpb.ClusterRole_ACCESS, ids)
+	var (
+		cc  *grpc.ClientConn
+		err error
+	)
+	if ids != nil {
+		cc, err = s.component.GetPeerConn(ctx, ttnpb.ClusterRole_ACCESS, ids)
+	} else {
+		// Don't pass a (*ttnpb.GatewayIdentifiers)(nil) to GetPeerConn.
+		cc, err = s.component.GetPeerConn(ctx, ttnpb.ClusterRole_ACCESS, nil)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gatewayconfigurationserver/v2/server.go
+++ b/pkg/gatewayconfigurationserver/v2/server.go
@@ -39,7 +39,16 @@ func (s *Server) getRegistry(ctx context.Context, ids *ttnpb.GatewayIdentifiers)
 	if s.registry != nil {
 		return s.registry, nil
 	}
-	cc, err := s.component.GetPeerConn(ctx, ttnpb.ClusterRole_ENTITY_REGISTRY, ids)
+	var (
+		cc  *grpc.ClientConn
+		err error
+	)
+	if ids != nil {
+		cc, err = s.component.GetPeerConn(ctx, ttnpb.ClusterRole_ENTITY_REGISTRY, ids)
+	} else {
+		// Don't pass a (*ttnpb.GatewayIdentifiers)(nil) to GetPeerConn.
+		cc, err = s.component.GetPeerConn(ctx, ttnpb.ClusterRole_ENTITY_REGISTRY, nil)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -82,7 +82,16 @@ func (gs *GatewayServer) getRegistry(ctx context.Context, ids *ttnpb.GatewayIden
 	if gs.registry != nil {
 		return gs.registry, nil
 	}
-	cc, err := gs.GetPeerConn(ctx, ttnpb.ClusterRole_ENTITY_REGISTRY, ids)
+	var (
+		cc  *grpc.ClientConn
+		err error
+	)
+	if ids != nil {
+		cc, err = gs.GetPeerConn(ctx, ttnpb.ClusterRole_ENTITY_REGISTRY, ids)
+	} else {
+		// Don't pass a (*ttnpb.GatewayIdentifiers)(nil) to GetPeerConn.
+		cc, err = gs.GetPeerConn(ctx, ttnpb.ClusterRole_ENTITY_REGISTRY, nil)
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This quickfix catches `nil` `*ttnpb.GatewayIdentifiers` before propagating them as typed nil `ttnpb.Identifiers`.

See also https://golang.org/doc/faq#nil_error