### PR TITLE
Fix reconnecting UDP gateways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CSRF token validation issues preventing login and logout in some circumstances.
 - Typo in Application Server configuration documentation (webhook downlink).
 - Unset fields via CLI on Join Server, i.e. `--unset root-keys.nwk-key`.
+- Reconnecting UDP gateways that were disconnected by a new gateway connection.
 
 ### Security
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fix reconnecting UDP gateways

#### Changes
<!-- What are the changes made in this pull request? -->

When a UDP gateway gets disconnected, the connection state was preserved, with a done context. On each upstream message (uplink, status), this done context would be used to handle the upstream message, which would fail. This resulted in UDP gateways to effectively fail to reconnect.

This fixes the issue by deleting the connection state if the context is done in the garbage collector.

#### Testing

<!-- How did you verify that this change works? -->

Encountered this locally with a UDP gateway that gets disconnected by a GRPC connection from the same gateway ID. But this could happen with the same physical gateway too, i.e. when the packet forwarder restarts and then the gateway disconnects, and tries to connect again.

Verified with the aforementioned setup that these changes resolve the issue.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None I'm aware of

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

We could check the context status synchronously in `connect()`, but that would make it quite complicated to do goroutine-safe (i.e. loop on `LoadOrStore()`). I think we better pick that up when we refactor the accept logic in https://github.com/TheThingsNetwork/lorawan-stack/issues/2492.

We could also spin up a goroutine to wait for the context to become done and then delete the connection state, but we have enough goroutines per gateway connection already. The garbage collector is basically designed for that.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
