### PR TITLE
Fix ADR data rate index limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Typo in Application Server configuration documentation (webhook downlink).
 - Unset fields via CLI on Join Server, i.e. `--unset root-keys.nwk-key`.
 - Reconnecting UDP gateways that were disconnected by a new gateway connection.
+- ADR in US915-like bands.
 
 ### Security
 

--- a/pkg/networkserver/networkserver_flow_test.go
+++ b/pkg/networkserver/networkserver_flow_test.go
@@ -884,9 +884,17 @@ func TestFlow(t *testing.T) {
 					NbTrans:       1,
 				},
 			}
+			us915LinkADRReqs := []*ttnpb.MACCommand_LinkADRReq{
+				{
+					ChannelMask:   []bool{false, false, false, false, false, false, false, false, true, true, true, true, true, true, true, true},
+					DataRateIndex: ttnpb.DATA_RATE_2,
+					TxPowerIndex:  1,
+					NbTrans:       1,
+				},
+			}
 			for flow, handleFlowTest := range map[string]func(context.Context, FlowTestEnvironment){
 				"Class C/OTAA/MAC:1.0.3/PHY:1.0.3-a/FP:EU868": makeClassCOTAAFlowTest(ttnpb.MAC_V1_0_3, ttnpb.PHY_V1_0_3_REV_A, test.EUFrequencyPlanID, eu868LinkADRReqs...),
-				"Class C/OTAA/MAC:1.0.4/PHY:1.0.3-a/FP:US915": makeClassCOTAAFlowTest(ttnpb.MAC_V1_0_4, ttnpb.PHY_V1_0_3_REV_A, test.USFrequencyPlanID),
+				"Class C/OTAA/MAC:1.0.4/PHY:1.0.3-a/FP:US915": makeClassCOTAAFlowTest(ttnpb.MAC_V1_0_4, ttnpb.PHY_V1_0_3_REV_A, test.USFrequencyPlanID, us915LinkADRReqs...),
 				"Class C/OTAA/MAC:1.1/PHY:1.1-b/FP:EU868":     makeClassCOTAAFlowTest(ttnpb.MAC_V1_1, ttnpb.PHY_V1_1_REV_B, test.EUFrequencyPlanID, eu868LinkADRReqs...),
 			} {
 				t.Run(flow, func(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://sentry.io/organizations/the-things-industries/issues/1665425190/?project=2682566
It does not fix the issue directly, but should drastically reduce the number of occurrences in production (similarly how https://sentry.io/organizations/the-things-industries/issues/1603015076/?project=2682566 is not directly "fixed", but it barely happens anymore in production, as NS is fixing the corrupted device states in registry over time)

#### Changes
<!-- What are the changes made in this pull request? -->

- Do not fail when channel maximum data rate index exceeds max PHY ADR DR index
- Only consider enabled channels for ADR


#### Testing

<!-- How did you verify that this change works? -->

Use actual device model causing the issue for local testing


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
