### PR TITLE
Add option for root certificates to webpack config

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -197,18 +197,20 @@ TTN_LW_CONSOLE_UI_ASSETS_BASE_URL="http://localhost:8080/assets"
 
 #### Optional Configuration
 
-Disable [Hot Module Replacement](https://webpack.js.org/concepts/hot-module-replacement/)
+##### Disable [Hot Module Replacement](https://webpack.js.org/concepts/hot-module-replacement/)
 
 ```bash
 WEBPACK_DEV_SERVER_DISABLE_HMR="true"
 ```
 
-Enable TLS in `webpack-dev-server`, using the key and certificate set via `TTN_LW_TLS_KEY` and `TTN_LW_TLS_CERTIFICATE` environment variables. Useful when developing functionalities that rely on TLS.
+##### Enable TLS in `webpack-dev-server`
 
 ```bash
 WEBPACK_DEV_SERVER_USE_TLS="true"
 ```
-Note: To use this option, The Things Stack for LoRaWAN must be properly setup for TLS. You can obtain more information about this in the **Getting Started** section of the The Things Stack for LoRaWAN documentation.
+This option uses the key and certificate set via `TTN_LW_TLS_KEY` and `TTN_LW_TLS_CERTIFICATE` environment variables. Useful when developing functionalities that rely on TLS.
+
+> Note: To use this option, The Things Stack for LoRaWAN must be properly setup for TLS. You can obtain more information about this in the **Getting Started** section of the The Things Stack for LoRaWAN documentation.
 
 ## Code Style
 

--- a/config/webpack.config.babel.js
+++ b/config/webpack.config.babel.js
@@ -46,6 +46,7 @@ const WEBPACK_DEV_SERVER_DISABLE_HMR = process.env.WEBPACK_DEV_SERVER_DISABLE_HM
 const WEBPACK_DEV_SERVER_USE_TLS = process.env.WEBPACK_DEV_SERVER_USE_TLS === 'true'
 const TTN_LW_TLS_CERTIFICATE = process.env.TTN_LW_TLS_CERTIFICATE || './cert.pem'
 const TTN_LW_TLS_KEY = process.env.TTN_LW_TLS_KEY || './key.pem'
+const TTN_LW_TLS_ROOT_CA = process.env.TTN_LW_TLS_ROOT_CA || './cert.pem'
 
 const ASSETS_ROOT = '/assets'
 
@@ -136,6 +137,7 @@ export default {
           https: {
             cert: fs.readFileSync(TTN_LW_TLS_CERTIFICATE),
             key: fs.readFileSync(TTN_LW_TLS_KEY),
+            ca: fs.readFileSync(TTN_LW_TLS_ROOT_CA),
           },
         }
       : {}),


### PR DESCRIPTION
#### Summary
This quickfix PR will also add the root ca to the webpack dev server TLS config. This can be necessary to make TLS work in [certain situations](https://github.com/TheThingsIndustries/lorawan-stack/pull/2128#pullrequestreview-418122852).

#### Changes
- Add root certificate to webpack dev server TLS config
- Improve formatting of "Optional Configuration" section in DEVELOPMENT.md

#### Testing

Tested manually.

##### Regressions

Could affect running webpack dev server on TLS, I verified that it still works by testing manually.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
