### PR TITLE
Read gateway platform version from MQTT status messages

### DIFF
--- a/pkg/gatewayserver/io/mqtt/format_protobufv2.go
+++ b/pkg/gatewayserver/io/mqtt/format_protobufv2.go
@@ -231,6 +231,9 @@ func (protobufv2) ToStatus(message []byte, _ ttnpb.GatewayIdentifiers) (*ttnpb.G
 	if v2status.Hal != "" {
 		versions["hal"] = v2status.Hal
 	}
+	if v2status.Platform != "" {
+		versions["platform"] = v2status.Platform
+	}
 	var antennasLocation []*ttnpb.Location
 	if loc := v2status.Location; loc.Validate() {
 		antennasLocation = []*ttnpb.Location{

--- a/pkg/gatewayserver/io/mqtt/format_protobufv2_test.go
+++ b/pkg/gatewayserver/io/mqtt/format_protobufv2_test.go
@@ -275,9 +275,10 @@ func TestProtobufV2Status(t *testing.T) {
 		{
 			Name: "With versions",
 			input: &ttnpbv2.StatusMessage{
-				Dsp:  3,
-				Hal:  "v1.1",
-				Fpga: 4,
+				Platform: "The Things Gateway v1 - BL r9-12345678 (2006-01-02T15:04:05Z) - Firmware v1.2.3-12345678 (2006-01-02T15:04:05Z)",
+				Dsp:      3,
+				Hal:      "v1.1",
+				Fpga:     4,
 			},
 			Expected: &ttnpb.GatewayStatus{
 				BootTime: time.Unix(0, 0),
@@ -293,9 +294,10 @@ func TestProtobufV2Status(t *testing.T) {
 					"txok": 0.0,
 				},
 				Versions: map[string]string{
-					"dsp":  "3",
-					"fpga": "4",
-					"hal":  "v1.1",
+					"platform": "The Things Gateway v1 - BL r9-12345678 (2006-01-02T15:04:05Z) - Firmware v1.2.3-12345678 (2006-01-02T15:04:05Z)",
+					"dsp":      "3",
+					"fpga":     "4",
+					"hal":      "v1.1",
 				},
 			},
 		},


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quickfix that adds the "Platform" field from v2 MQTT gateway statuses to the "versions" map.