### PR TITLE
Add frontend build command before "Starting The Things Stack"

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -68,6 +68,10 @@ Redis is an in-memory data store that we use as a database for "hot" data.
 
 You can use `tools/bin/mage dev:dbRedisCli` to enter a Redis-CLI shell.
 
+## Building the frontend
+
+You can use `tools/bin/mage js:build` to build the frontend.
+
 ## Starting The Things Stack
 
 You can use `go run ./cmd/ttn-lw-stack start` to start The Things Stack.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -68,7 +68,7 @@ Redis is an in-memory data store that we use as a database for "hot" data.
 
 You can use `tools/bin/mage dev:dbRedisCli` to enter a Redis-CLI shell.
 
-## Building the frontend
+## Building the Frontend
 
 You can use `tools/bin/mage js:build` to build the frontend.
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
Related to #1538 that is closed but still not fixed in the documentation. 

#### Changes
The command for building the frontend is added above the command for running TTS.

#### Testing
I followed existing DEVELOPMENT.md and running TTS wouldn't work if the frontend wasn't built before.

##### Regressions
...

#### Notes for Reviewers
...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
