### PR TITLE
Improve JoinEUIPrefixInput

### DIFF
--- a/pkg/webui/components/input/byte.js
+++ b/pkg/webui/components/input/byte.js
@@ -149,6 +149,7 @@ export default class ByteInput extends React.Component {
   onChange(evt) {
     this.props.onChange({
       target: {
+        name: evt.target.name,
         value: clean(evt.target.value),
       },
     })
@@ -157,7 +158,9 @@ export default class ByteInput extends React.Component {
   @bind
   onBlur(evt) {
     this.props.onBlur({
+      relatedTarget: evt.relatedTarget,
       target: {
+        name: evt.target.name,
         value: clean(evt.target.value),
       },
     })

--- a/pkg/webui/console/containers/join-eui-prefixes-input/index.js
+++ b/pkg/webui/console/containers/join-eui-prefixes-input/index.js
@@ -29,6 +29,7 @@ const m = defineMessages({
 const JoinEUIPrefixesField = function({
   name,
   title,
+  description,
   required,
   horizontal,
   autoFocus,
@@ -47,6 +48,7 @@ const JoinEUIPrefixesField = function({
     <Field
       name={name}
       title={title}
+      description={description}
       required={required}
       autoFocus={autoFocus}
       horizontal={horizontal}
@@ -62,6 +64,7 @@ const JoinEUIPrefixesField = function({
 
 JoinEUIPrefixesField.propTypes = {
   autoFocus: PropTypes.bool,
+  description: PropTypes.message,
   disabled: PropTypes.bool,
   error: PropTypes.error,
   fetching: PropTypes.bool.isRequired,
@@ -87,6 +90,7 @@ JoinEUIPrefixesField.defaultProps = {
   prefixes: [],
   error: undefined,
   showPrefixes: true,
+  description: undefined,
 }
 
 export default connect(JoinEUIPrefixesField)

--- a/pkg/webui/console/containers/join-eui-prefixes-input/join-eui-prefixes-input.js
+++ b/pkg/webui/console/containers/join-eui-prefixes-input/join-eui-prefixes-input.js
@@ -120,7 +120,17 @@ class JoinEUIPrefixesInput extends React.PureComponent {
   }
 
   render() {
-    const { className, name, disabled, value, error, prefixes, fetching, showPrefixes } = this.props
+    const {
+      className,
+      name,
+      description,
+      disabled,
+      value,
+      error,
+      prefixes,
+      fetching,
+      showPrefixes,
+    } = this.props
     const { prefix } = this.state
 
     let selectComponent = null
@@ -160,6 +170,7 @@ class JoinEUIPrefixesInput extends React.PureComponent {
           value={inputValue}
           defaultValue={inputValue}
           name={name}
+          description={description}
           disabled={disabled}
           min={charsLeft}
           max={charsLeft}
@@ -175,6 +186,7 @@ class JoinEUIPrefixesInput extends React.PureComponent {
 
 JoinEUIPrefixesInput.propTypes = {
   className: PropTypes.string,
+  description: PropTypes.message,
   disabled: PropTypes.bool,
   error: PropTypes.error,
   fetching: PropTypes.bool,
@@ -200,6 +212,7 @@ JoinEUIPrefixesInput.defaultProps = {
   showPrefixes: true,
   value: undefined,
   error: undefined,
+  description: undefined,
 }
 
 export default JoinEUIPrefixesInput

--- a/pkg/webui/console/containers/join-eui-prefixes-input/join-eui-prefixes-input.js
+++ b/pkg/webui/console/containers/join-eui-prefixes-input/join-eui-prefixes-input.js
@@ -188,7 +188,7 @@ JoinEUIPrefixesInput.propTypes = {
   className: PropTypes.string,
   description: PropTypes.message,
   disabled: PropTypes.bool,
-  error: PropTypes.error,
+  error: PropTypes.bool,
   fetching: PropTypes.bool,
   name: PropTypes.string.isRequired,
   onBlur: PropTypes.func,
@@ -211,7 +211,7 @@ JoinEUIPrefixesInput.defaultProps = {
   prefixes: [],
   showPrefixes: true,
   value: undefined,
-  error: undefined,
+  error: false,
   description: undefined,
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR adds several improvements to `<JoinEUIPrefixInput />`

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `description` prop
- Fix `error` prop type warning
- Fix `blur` event handling. Make sure that the `onBlur` handler is called only when focus moves outside of the component and not between select and input components.


#### Testing

<!-- How did you verify that this change works? -->

Checked field validation in the device form

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

...


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
