### PR TITLE
Various pub/sub improvements

### DIFF
--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -904,6 +904,9 @@ func (as *ApplicationServer) handleUplink(ctx context.Context, ids ttnpb.EndDevi
 }
 
 func (as *ApplicationServer) handleDownlinkQueueInvalidated(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, invalid *ttnpb.ApplicationInvalidatedDownlinks, link *link) error {
+	if len(invalid.Downlinks) == 0 {
+		return nil
+	}
 	_, err := as.deviceRegistry.Set(ctx, ids,
 		[]string{
 			"session",

--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -2117,16 +2117,34 @@ func TestSkipPayloadCrypto(t *testing.T) {
 						},
 						AssertUp: func(t *testing.T, up *ttnpb.ApplicationUp) {
 							a := assertions.New(t)
-							a.So(up, should.Resemble, &ttnpb.ApplicationUp{
-								EndDeviceIdentifiers: withDevAddr(registeredDevice.EndDeviceIdentifiers, types.DevAddr{0x22, 0x22, 0x22, 0x22}),
-								Up: &ttnpb.ApplicationUp_JoinAccept{
-									JoinAccept: &ttnpb.ApplicationJoinAccept{
-										SessionKeyID: []byte{0x22},
+							if effectiveSkip {
+								a.So(up, should.Resemble, &ttnpb.ApplicationUp{
+									EndDeviceIdentifiers: withDevAddr(registeredDevice.EndDeviceIdentifiers, types.DevAddr{0x22, 0x22, 0x22, 0x22}),
+									Up: &ttnpb.ApplicationUp_JoinAccept{
+										JoinAccept: &ttnpb.ApplicationJoinAccept{
+											SessionKeyID: []byte{0x22},
+											AppSKey: &ttnpb.KeyEnvelope{
+												// AppSKey is []byte{0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22}
+												EncryptedKey: []byte{0x39, 0x11, 0x40, 0x98, 0xa1, 0x5d, 0x6f, 0x92, 0xd7, 0xf0, 0x13, 0x21, 0x5b, 0x5b, 0x41, 0xa8, 0x98, 0x2d, 0xac, 0x59, 0x34, 0x76, 0x36, 0x18},
+												KEKLabel:     "test",
+											},
+										},
 									},
-								},
-								CorrelationIDs: up.CorrelationIDs,
-								ReceivedAt:     up.ReceivedAt,
-							})
+									CorrelationIDs: up.CorrelationIDs,
+									ReceivedAt:     up.ReceivedAt,
+								})
+							} else {
+								a.So(up, should.Resemble, &ttnpb.ApplicationUp{
+									EndDeviceIdentifiers: withDevAddr(registeredDevice.EndDeviceIdentifiers, types.DevAddr{0x22, 0x22, 0x22, 0x22}),
+									Up: &ttnpb.ApplicationUp_JoinAccept{
+										JoinAccept: &ttnpb.ApplicationJoinAccept{
+											SessionKeyID: []byte{0x22},
+										},
+									},
+									CorrelationIDs: up.CorrelationIDs,
+									ReceivedAt:     up.ReceivedAt,
+								})
+							}
 						},
 						AssertDevice: func(t *testing.T, dev *ttnpb.EndDevice) {
 							a := assertions.New(t)

--- a/pkg/applicationserver/io/pubsub/pubsub.go
+++ b/pkg/applicationserver/io/pubsub/pubsub.go
@@ -243,7 +243,7 @@ func (ps *PubSub) start(ctx context.Context, pb *ttnpb.ApplicationPubSub) (err e
 		server:            ps.server,
 	}
 	if _, loaded := ps.integrations.LoadOrStore(psUID, i); loaded {
-		log.FromContext(ctx).Warn("Integration already started")
+		log.FromContext(ctx).Debug("Integration already started")
 		return errAlreadyConfigured.WithAttributes("application_uid", appUID, "pub_sub_id", pb.PubSubID)
 	}
 	go func() {

--- a/pkg/applicationserver/linking.go
+++ b/pkg/applicationserver/linking.go
@@ -336,10 +336,7 @@ func (l *link) sendUp(ctx context.Context, up *ttnpb.ApplicationUp, ack func() e
 		return err
 	}
 
-	switch p := up.Up.(type) {
-	case *ttnpb.ApplicationUp_JoinAccept:
-		p.JoinAccept.AppSKey = nil
-		p.JoinAccept.InvalidatedDownlinks = nil
+	switch up.Up.(type) {
 	case *ttnpb.ApplicationUp_DownlinkQueueInvalidated:
 		return nil
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Groundwork for https://github.com/TheThingsIndustries/lorawan-stack/issues/2165

#### Changes
<!-- What are the changes made in this pull request? -->

- Reduce log level of already started integration. TTS was printing warnings in a normal flow; when the task scheduler was restarting a failed task, updating the pub/sub might fix that. The update itself also starts a task, so that there are effectively two tasks started. That's fine, but it's not worth warning for
- Clear AppSKey conditionally in a join-accept. This is useful to send the AppSKey upstream when skipping payload crypto
- On each join-accept, there's an invalidated downlink queue. When it is empty, however, there's no reason to recalculate it and replace it on NS. The queue is already gone in NS. This saves an unnecessary rpc on each join-accept

#### Testing

<!-- How did you verify that this change works? -->

Tested locally with simulated devices

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Not aware of any

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
