### PR TITLE
Fix miss matched timezones in claim form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Packet Broker Agent cluster ID is used as subscription group.
 - LinkADR handling in 72-channel bands.
 - Data uplink metrics reported by Application Server.
+- Timezones issue in claim auth code form, causing time to reverse on submission
 
 ## [3.8.3] - 2020-06-05
 

--- a/pkg/webui/console/views/device-claim-authentication-code/index.js
+++ b/pkg/webui/console/views/device-claim-authentication-code/index.js
@@ -30,6 +30,7 @@ import IntlHelmet from '@ttn-lw/lib/components/intl-helmet'
 
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 import PropTypes from '@ttn-lw/lib/prop-types'
+import toInputDate from '@ttn-lw/lib/to-input-date'
 
 import { updateDevice } from '@console/store/actions/devices'
 import { attachPromise } from '@console/store/actions/lib'
@@ -74,11 +75,8 @@ const DeviceClaimAuthenticationCode = props => {
     if (claim_authentication_code) {
       const { value, valid_from, valid_to } = claim_authentication_code
 
-      // Convert ISO 8601 date time representation to just yyyy-MM-dd required by the
-      // date input. So, we pick only the data part from YYYY-MM-DDTHH:mm:ss.sssZ which is
-      // known to be fixed.
-      const validFrom = valid_from ? new Date(valid_from).toISOString().slice(0, 10) : undefined
-      const validTo = valid_to ? new Date(valid_to).toISOString().slice(0, 10) : undefined
+      const validFrom = toInputDate(new Date(valid_from))
+      const validTo = toInputDate(new Date(valid_to))
 
       return {
         claim_authentication_code: {

--- a/pkg/webui/lib/to-input-date.js
+++ b/pkg/webui/lib/to-input-date.js
@@ -1,0 +1,30 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Function to return a valid input date string from a Date object.
+ *
+ * @param {object} d - Date() object.
+ * @returns {string} 'yyyy-mm-dd' or undefined.
+ */
+
+export default function(d) {
+  if (Object.prototype.toString.call(d) !== '[object Date]' || isNaN(d.getTime())) {
+    return undefined
+  }
+  const mm = d.getMonth() + 1
+  const dd = d.getDate()
+  const yy = d.getFullYear()
+  return `${yy}-${`0${mm}`.slice(-2)}-${`0${dd}`.slice(-2)}`
+}

--- a/pkg/webui/lib/to-input-date_test.js
+++ b/pkg/webui/lib/to-input-date_test.js
@@ -1,0 +1,42 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import toInputDate from './to-input-date'
+
+describe('toInputDate', function() {
+  describe('with correct argument', function() {
+    const date = new Date('2020-09-24T12:00:00Z')
+
+    it('should return a string length equal to 10', function() {
+      expect(toInputDate(date)).toHaveLength(10)
+    })
+
+    it('should return a string of yyyy-mm--dd format', function() {
+      expect(toInputDate(date)).toMatch(/([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))/)
+    })
+  })
+
+  describe('with incorrect argument', function() {
+    const string = 'ABC123'
+    const date = new Date('ABC123')
+
+    it('random string should return undefined', function() {
+      expect(toInputDate(string)).toBe(undefined)
+    })
+
+    it('invalid date should return undefined', function() {
+      expect(toInputDate(date)).toBe(undefined)
+    })
+  })
+})


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2650 

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove `.toISOString()` on date object and replace with function that returns formatted local time


#### Testing

<!-- How did you verify that this change works? -->

Fill in form and make sure everything stays the same on multiple submissions of the same data. 

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The sdk assumes we are submitting local time for Amsterdam that is UTC+02:00 so that is converted in the sdk to UTC+00:00 before POST`in to the sever (simply it minuses 2 hours)

so 25/4/2020 00:00 is converted to 24/4/2020 10:00

When the time is return to the form from the server it receives 24/4/2020 10:00 which should be converted to local time but instead is displayed as is.

Using `.toISOString()` return the the date/time in UTC+00:00 and the time is removed.
Using the date object as is returns local time date/time as UTC+02:00.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
