### PR TITLE
Clarify base path usage in LoRaCloud DAS

### DIFF
--- a/doc/content/integrations/application-packages/lora-cloud-device-and-application-services.md
+++ b/doc/content/integrations/application-packages/lora-cloud-device-and-application-services.md
@@ -76,7 +76,7 @@ Output:
   "updated_at": "2020-05-14T02:04:45.286874524Z",
   "package_name": "lora-cloud-device-management-v1",
   "data": {
-      "server_url": "https://app.example.com/",
+      "server_url": "https://app.example.com",
       "token": "AQEAdqwV67..."
     }
 }
@@ -90,6 +90,6 @@ The package data format is common between both default associations and associat
 | Field | Type | Description | Required | Default value |
 |-------|------|-------------|---------|---------------|
 | `token` | `string` | The acces token to be used by the package to submit uplinks to the LoRa Cloud Device & Application Services | Yes | None. |
-| `server_url` | `URL` | The custom base URL to be used for service communication | No | `https://das.loracloud.com/api/v1`
+| `server_url` | `URL` | The custom base URL to be used for service communication | No | `https://das.loracloud.com`
 
 Fields can be customized on a per device basis, by overriding the field in the package data of the association.

--- a/pkg/applicationserver/io/packages/loradms/v1/api/client.go
+++ b/pkg/applicationserver/io/packages/loradms/v1/api/client.go
@@ -47,7 +47,8 @@ type Client struct {
 
 const (
 	contentType      = "application/json"
-	defaultServerURL = "https://das.loracloud.com/api/v1"
+	defaultServerURL = "https://das.loracloud.com"
+	basePath         = "/api/v1"
 )
 
 var (
@@ -61,7 +62,7 @@ type queryParam struct {
 
 func (c *Client) newRequest(method, category, entity, operation string, body io.Reader, queryParams ...queryParam) (*http.Request, error) {
 	u := urlutil.CloneURL(c.baseURL)
-	u.Path = path.Join(u.Path, category, entity, operation)
+	u.Path = path.Join(basePath, category, entity, operation)
 	q := u.Query()
 	for _, p := range queryParams {
 		q.Add(p.key, p.value)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2643 

#### Changes
<!-- What are the changes made in this pull request? -->

- Base path is now fixated at `/api/v1`
- Server URL now expects only `protocol://server`.


#### Testing

<!-- How did you verify that this change works? -->

Already existing unit tests.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Server overrides can (but should not) be affected by this.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

None. cc @Oliv4945 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
