### PR TITLE
Extend webmiddleware.Log to allow suppressing log messages for specific URL paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Metrics for log messages, counted per level and namespace.
+- Allow suppressing logs on HTTP requests for user-defined paths (see `--http.log-ignore-paths` option).
 
 ### Changed
 

--- a/doc/content/reference/configuration/the-things-stack.md
+++ b/doc/content/reference/configuration/the-things-stack.md
@@ -84,6 +84,10 @@ If {{% tts %}} is deployed behind a reverse proxy that does not use a private ne
 
 - `http.trusted-proxies`: CIDRs of trusted reverse proxies
 
+You can suppress log messages for successful HTTP requests (e.g. to reduce the noise caused by the health checks in a production environment).
+
+- `http.log-ignore-paths`: List of URLs for which to suppress logs of successful requests.
+
 ## Interoperability Options
 
 {{% tts %}} supports interoperability according to LoRaWAN Backend Interfaces specification. The following options are used to configure the server for this.

--- a/pkg/component/web.go
+++ b/pkg/component/web.go
@@ -39,6 +39,7 @@ func (c *Component) initWeb() error {
 		web.WithTrustedProxies(c.config.HTTP.TrustedProxies...),
 		web.WithCookieKeys(c.config.HTTP.Cookie.HashKey, c.config.HTTP.Cookie.BlockKey),
 		web.WithStatic(c.config.HTTP.Static.Mount, c.config.HTTP.Static.SearchPath...),
+		web.WithLogIgnorePaths(c.config.HTTP.LogIgnorePaths),
 	}
 	if c.config.HTTP.RedirectToHost != "" {
 		webOptions = append(webOptions, web.WithRedirectToHost(c.config.HTTP.RedirectToHost))

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -97,6 +97,7 @@ type HTTP struct {
 	TrustedProxies  []string         `name:"trusted-proxies" description:"CIDRs of trusted reverse proxies"`
 	RedirectToHost  string           `name:"redirect-to-host" description:"Redirect all requests to one host"`
 	RedirectToHTTPS bool             `name:"redirect-to-tls" description:"Redirect HTTP requests to HTTPS"`
+	LogIgnorePaths  []string         `name:"log-ignore-paths" description:"List of paths for which successful requests will not be logged"`
 	Static          HTTPStaticConfig `name:"static"`
 	Cookie          Cookie           `name:"cookie"`
 	PProf           PProf            `name:"pprof"`

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -73,6 +73,8 @@ type options struct {
 
 	redirectToHost  string
 	redirectToHTTPS map[int]int
+
+	logIgnorePaths []string
 }
 
 // Option for the web server
@@ -123,6 +125,13 @@ func WithRedirectToHTTPS(from, to int) Option {
 	}
 }
 
+// WithLogIgnorePaths silences log messages for a list of URLs.
+func WithLogIgnorePaths(paths []string) Option {
+	return func(o *options) {
+		o.logIgnorePaths = paths
+	}
+}
+
 // New builds a new server.
 func New(ctx context.Context, opts ...Option) (*Server, error) {
 	logger := log.FromContext(ctx).WithField("namespace", "web")
@@ -165,7 +174,7 @@ func New(ctx context.Context, opts ...Option) (*Server, error) {
 		mux.MiddlewareFunc(webmiddleware.ProxyHeaders(proxyConfiguration)),
 		mux.MiddlewareFunc(webmiddleware.MaxBody(1<<24)), // 16 MB.
 		mux.MiddlewareFunc(webmiddleware.SecurityHeaders()),
-		mux.MiddlewareFunc(webmiddleware.Log(logger)),
+		mux.MiddlewareFunc(webmiddleware.Log(logger, options.logIgnorePaths)),
 	)
 
 	var redirectConfig webmiddleware.RedirectConfiguration

--- a/pkg/webmiddleware/log_test.go
+++ b/pkg/webmiddleware/log_test.go
@@ -33,83 +33,151 @@ func (ch logEntryChannel) HandleLog(e log.Entry) error {
 	return nil
 }
 
-func (ch logEntryChannel) Expect(t *testing.T, f func(log.Entry)) {
+func (ch logEntryChannel) Expect(t *testing.T, f func(*testing.T, log.Entry)) {
 	select {
 	case e := <-ch:
-		f(e)
+		f(t, e)
 	case <-time.After(time.Second):
 		t.Fatal("Missing log entry")
 	}
 }
 
+func (ch logEntryChannel) ExpectNoLog(t *testing.T) {
+	select {
+	case <-ch:
+		t.Fatal("Expected no log entry but received one")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func verifySuccess(t *testing.T, e log.Entry) {
+	a := assertions.New(t)
+	a.So(e.Level(), should.Equal, log.InfoLevel)
+	a.So(e.Message(), should.Equal, "Request handled")
+	fields := e.Fields().Fields()
+	for _, key := range []string{"method", "url", "remote_addr", "request_id", "status", "duration", "response_size"} {
+		a.So(fields, should.ContainKey, key)
+	}
+	a.So(fields["method"], should.Equal, http.MethodGet)
+	a.So(fields["url"], should.Equal, "/")
+	a.So(fields["status"], should.Equal, http.StatusOK)
+	a.So(fields["response_size"], should.Equal, 0)
+}
+
+func verifyClientError(t *testing.T, e log.Entry) {
+	a := assertions.New(t)
+	a.So(e.Level(), should.Equal, log.InfoLevel)
+	a.So(e.Message(), should.Equal, "Client error")
+}
+
+func verifyServerError(t *testing.T, e log.Entry) {
+	a := assertions.New(t)
+	a.So(e.Level(), should.Equal, log.ErrorLevel)
+	a.So(e.Message(), should.Equal, "Server error")
+}
+
 func TestLog(t *testing.T) {
+	a := assertions.New(t)
 	ch := make(logEntryChannel, 10)
 	m := Log(&log.Logger{
 		Handler: ch,
-	})
+	}, []string{"/path", "/ignorepath"})
 
-	t.Run("Normal Request", func(t *testing.T) {
-		a := assertions.New(t)
-
-		r := httptest.NewRequest(http.MethodGet, "/", nil)
-		rec := httptest.NewRecorder()
-		m(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			a.So(log.FromContext(r.Context()), should.NotEqual, log.Noop)
-			w.WriteHeader(http.StatusOK)
-		})).ServeHTTP(rec, r)
-		ch.Expect(t, func(e log.Entry) {
-			a.So(e.Level(), should.Equal, log.InfoLevel)
-			a.So(e.Message(), should.Equal, "Request handled")
-			fields := e.Fields().Fields()
-			for _, key := range []string{"method", "url", "remote_addr", "request_id", "status", "duration", "response_size"} {
-				a.So(fields, should.ContainKey, key)
-			}
-			a.So(fields["method"], should.Equal, http.MethodGet)
-			a.So(fields["url"], should.Equal, "/")
-			a.So(fields["status"], should.Equal, http.StatusOK)
-			a.So(fields["response_size"], should.Equal, 0)
+	for _, tc := range []struct {
+		name     string
+		path     string
+		validate func(t *testing.T)
+		handler  func(w http.ResponseWriter, r *http.Request)
+	}{
+		{
+			name: "NormalSuccess",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			},
+			path: "/",
+			validate: func(t *testing.T) {
+				ch.Expect(t, verifySuccess)
+			},
+		},
+		{
+			name: "IgnoreSuccess",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			},
+			path:     "/path",
+			validate: ch.ExpectNoLog,
+		},
+		{
+			name: "IgnoreSuccess",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			},
+			path:     "/ignorepath",
+			validate: ch.ExpectNoLog,
+		},
+		{
+			name: "ClientError",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+			},
+			path: "/",
+			validate: func(t *testing.T) {
+				ch.Expect(t, verifyClientError)
+			},
+		},
+		{
+			name: "ClientErrorWithIgnore",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+			},
+			path: "/path",
+			validate: func(t *testing.T) {
+				ch.Expect(t, verifyClientError)
+			},
+		},
+		{
+			name: "ServerError",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			path: "/",
+			validate: func(t *testing.T) {
+				ch.Expect(t, verifyServerError)
+			},
+		},
+		{
+			name: "ServerErrorWithIgnore",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			path: "/path",
+			validate: func(t *testing.T) {
+				ch.Expect(t, verifyServerError)
+			},
+		},
+		{
+			name: "RichError",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				webhandlers.NotFound(w, r)
+			},
+			path: "/path",
+			validate: func(t *testing.T) {
+				ch.Expect(t, func(t *testing.T, e log.Entry) {
+					a := assertions.New(t)
+					fields := e.Fields().Fields()
+					a.So(fields, should.ContainKey, "error")
+				})
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			rec := httptest.NewRecorder()
+			m(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				a.So(log.FromContext(r.Context()), should.NotEqual, log.Noop)
+				tc.handler(w, r)
+			})).ServeHTTP(rec, r)
+			tc.validate(t)
 		})
-	})
-
-	t.Run("Client Error", func(t *testing.T) {
-		a := assertions.New(t)
-
-		r := httptest.NewRequest(http.MethodGet, "/", nil)
-		rec := httptest.NewRecorder()
-		m(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusBadRequest)
-		})).ServeHTTP(rec, r)
-		ch.Expect(t, func(e log.Entry) {
-			a.So(e.Level(), should.Equal, log.InfoLevel)
-			a.So(e.Message(), should.Equal, "Client error")
-		})
-	})
-
-	t.Run("Server Error", func(t *testing.T) {
-		a := assertions.New(t)
-
-		r := httptest.NewRequest(http.MethodGet, "/", nil)
-		rec := httptest.NewRecorder()
-		m(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusInternalServerError)
-		})).ServeHTTP(rec, r)
-		ch.Expect(t, func(e log.Entry) {
-			a.So(e.Level(), should.Equal, log.ErrorLevel)
-			a.So(e.Message(), should.Equal, "Server error")
-		})
-	})
-
-	t.Run("Rich Error", func(t *testing.T) {
-		a := assertions.New(t)
-
-		r := httptest.NewRequest(http.MethodGet, "/", nil)
-		rec := httptest.NewRecorder()
-		m(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			webhandlers.NotFound(w, r)
-		})).ServeHTTP(rec, r)
-		ch.Expect(t, func(e log.Entry) {
-			fields := e.Fields().Fields()
-			a.So(fields, should.ContainKey, "error")
-		})
-	})
+	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #2655 
#### Changes
<!-- What are the changes made in this pull request? -->

- The `webmiddleware.Log` middleware now accepts a list of (regex) paths for which log messages are suppressed (unless the request failed).
- Refactored unit testing for `webmiddleware.Log` middleware.

#### Testing

<!-- How did you verify that this change works? -->

- Unit tests
- Test locally by setting `--http.ignore-log-paths=^/metrics$` and trying the metrics endpoint (logs are suppressed) and other endpoints (logged properly)

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

- There should be none, the ignore list is empty by default

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Currently, the stack panics in case an invalid regex is passed, maybe we would like to take care of this and show a proper error message instead.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [X] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
