### PR TITLE
Fix Packet Broker Agent subscription group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Packet Broker Agent cluster ID is used as subscription group.
+
 ## [3.8.3] - 2020-06-05
 
 ### Added


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/infrastructure/issues/759#issuecomment-640611020

#### Changes
<!-- What are the changes made in this pull request? -->

Use cluster ID as subscription group; it was always empty.

Because of how Packet Broker works, there can be only a limited number of subscribers in the same group for load balancing to work effectively.


#### Testing

<!-- How did you verify that this change works? -->

Local

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
