### PR TITLE
Add and use `randutil.LockedRand`

### DIFF
--- a/pkg/identityserver/picture.go
+++ b/pkg/identityserver/picture.go
@@ -37,7 +37,7 @@ const maxEndDevicePictureStoredDimensions = 1024
 var profilePictureDimensions = []int{64, 128, 256, 512}
 var endDevicePictureDimensions = []int{64, 128, 256, 512}
 
-var pictureRand = rand.New(randutil.NewLockedSource(rand.NewSource(time.Now().UnixNano())))
+var pictureRand = randutil.NewLockedRand(rand.NewSource(time.Now().UnixNano()))
 
 func fillGravatar(ctx context.Context, usr *ttnpb.User) (err error) {
 	if usr == nil || usr.ProfilePicture != nil || usr.PrimaryEmailAddress == "" {

--- a/pkg/identityserver/store/populate.go
+++ b/pkg/identityserver/store/populate.go
@@ -29,7 +29,7 @@ import (
 // NewPopulator returns a new database populator with a population of the given size.
 // It is seeded by the given seed.
 func NewPopulator(size int, seed int64) *Populator {
-	randy := rand.New(randutil.NewLockedSource(rand.NewSource(seed)))
+	randy := randutil.NewLockedRand(rand.NewSource(seed))
 	p := &Populator{
 		APIKeys:     make(map[*ttnpb.EntityIdentifiers][]*ttnpb.APIKey),
 		Memberships: make(map[*ttnpb.EntityIdentifiers][]*ttnpb.Collaborator),

--- a/pkg/ttnpb/public_test.go
+++ b/pkg/ttnpb/public_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	"github.com/smartystreets/assertions"
-	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	. "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
 )
@@ -26,9 +26,9 @@ import (
 func TestApplicationPublicSafe(t *testing.T) {
 	a := assertions.New(t)
 
-	a.So(((*ttnpb.Application)(nil)).PublicSafe(), should.BeNil)
+	a.So(((*Application)(nil)).PublicSafe(), should.BeNil)
 
-	src := ttnpb.NewPopulatedApplication(test.Randy, true)
+	src := NewPopulatedApplication(test.Randy, true)
 	safe := src.PublicSafe()
 
 	a.So(safe, should.NotResemble, src)
@@ -38,9 +38,9 @@ func TestApplicationPublicSafe(t *testing.T) {
 func TestClientPublicSafe(t *testing.T) {
 	a := assertions.New(t)
 
-	a.So(((*ttnpb.Client)(nil)).PublicSafe(), should.BeNil)
+	a.So(((*Client)(nil)).PublicSafe(), should.BeNil)
 
-	src := ttnpb.NewPopulatedClient(test.Randy, true)
+	src := NewPopulatedClient(test.Randy, true)
 	safe := src.PublicSafe()
 
 	a.So(safe, should.NotResemble, src)
@@ -50,9 +50,9 @@ func TestClientPublicSafe(t *testing.T) {
 func TestGatewayPublicSafe(t *testing.T) {
 	a := assertions.New(t)
 
-	a.So(((*ttnpb.Gateway)(nil)).PublicSafe(), should.BeNil)
+	a.So(((*Gateway)(nil)).PublicSafe(), should.BeNil)
 
-	src := ttnpb.NewPopulatedGateway(test.Randy, true)
+	src := NewPopulatedGateway(test.Randy, true)
 	safe := src.PublicSafe()
 
 	a.So(safe, should.NotResemble, src)
@@ -62,9 +62,9 @@ func TestGatewayPublicSafe(t *testing.T) {
 func TestOrganizationPublicSafe(t *testing.T) {
 	a := assertions.New(t)
 
-	a.So(((*ttnpb.Organization)(nil)).PublicSafe(), should.BeNil)
+	a.So(((*Organization)(nil)).PublicSafe(), should.BeNil)
 
-	src := ttnpb.NewPopulatedOrganization(test.Randy, true)
+	src := NewPopulatedOrganization(test.Randy, true)
 	safe := src.PublicSafe()
 
 	a.So(safe, should.NotResemble, src)
@@ -74,9 +74,9 @@ func TestOrganizationPublicSafe(t *testing.T) {
 func TestUserPublicSafe(t *testing.T) {
 	a := assertions.New(t)
 
-	a.So(((*ttnpb.User)(nil)).PublicSafe(), should.BeNil)
+	a.So(((*User)(nil)).PublicSafe(), should.BeNil)
 
-	src := ttnpb.NewPopulatedUser(test.Randy, true)
+	src := NewPopulatedUser(test.Randy, true)
 	safe := src.PublicSafe()
 
 	a.So(safe, should.NotResemble, src)

--- a/pkg/util/test/random.go
+++ b/pkg/util/test/random.go
@@ -20,9 +20,8 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/util/randutil"
 )
 
-// Randy is global rand, which is (mostly) safe for concurrent use.
-// Read and Seed should not be called concurrently.
-var Randy = rand.New(randutil.NewLockedSource(rand.NewSource(42)))
+// Randy is global rand, which is safe for concurrent use.
+var Randy = randutil.NewLockedRand(rand.NewSource(42))
 
 func init() {
 	rand.Seed(42)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Just locking the default `rand.Source` is not enough to get a `rand.Rand`, which is safe for concurrent use. 2 reasons for it:
1. `rand.Rand` uses type assertions to non-exported `lockedSource` (e.g. https://github.com/golang/go/blob/e92be18fd8b525b642ca25bdb3e2056b35d9d73c/src/math/rand/rand.go#L261-L263) :hankey:
2. `rand.Rand.Read` in itself is not safe for concurrent use (https://golang.org/pkg/math/rand/#Rand.Read)

Refs this excellent comment: https://github.com/golang/go/issues/24121#issuecomment-618735923

#### Changes
<!-- What are the changes made in this pull request? -->

- Add and use `randutil.LockedRand`

#### Testing

<!-- How did you verify that this change works? -->

Unit tests

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None, this is a fix

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
