### PR TITLE
Allow integer EUIs in BasicStation requests

### DIFF
--- a/pkg/basicstation/eui.go
+++ b/pkg/basicstation/eui.go
@@ -97,5 +97,9 @@ func (eui *EUI) UnmarshalJSON(data []byte) error {
 		}
 		return nil
 	}
+	if v, err := strconv.ParseUint(string(data), 10, 64); err == nil {
+		eui.EUI64.UnmarshalNumber(v)
+		return nil
+	}
 	return errFormat.New()
 }

--- a/pkg/basicstation/eui_test.go
+++ b/pkg/basicstation/eui_test.go
@@ -135,6 +135,15 @@ func TestUnmarshalEUI(t *testing.T) {
 			EUI64:  types.EUI64{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 			OK:     true,
 		},
+		{
+			Input: `12302426811387609088`,
+			EUI64: types.EUI64{0xaa, 0xbb, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00},
+			OK:    true,
+		},
+		{
+			Input: `-12302426811387609088`,
+			OK:    false,
+		},
 	} {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			a := assertions.New(t)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This small PR enables integer EUIs to be used by BasicStation gateways when connecting to the LNS. This behavior is shown by old firmwares that send the EUI in `uint64` form, which is valid per [documentation](https://doc.sm.tc/station/tcproto.html?highlight=integer#querying-the-lns-connection-end-point-discovery) .

#### Changes
<!-- What are the changes made in this pull request? -->

- Parse `uint64` EUIs when possible.


#### Testing

<!-- How did you verify that this change works? -->

Tested with a gateway with a very old BasicStation `station` binary (0.4).

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This shouldn't introduce regressions since we only loosened restrictions (and we trust `strconv`).

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
