### PR TITLE
Reduce logs noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Suppress a few unexpected EOF errors, in order to reduce noise in the logs for health checks.
+
 ### Deprecated
 
 ### Removed

--- a/pkg/applicationserver/io/mqtt/mqtt.go
+++ b/pkg/applicationserver/io/mqtt/mqtt.go
@@ -73,7 +73,9 @@ func (s *srv) accept() error {
 			ctx := log.NewContextWithFields(s.ctx, log.Fields("remote_addr", mqttConn.RemoteAddr().String()))
 			conn := &connection{server: s.server, mqtt: mqttConn, format: s.format}
 			if err := conn.setup(ctx); err != nil {
-				if err != stdio.EOF {
+				switch err {
+				case stdio.EOF, stdio.ErrUnexpectedEOF:
+				default:
 					log.FromContext(ctx).WithError(err).Warn("Failed to setup connection")
 				}
 				mqttConn.Close()

--- a/pkg/gatewayserver/io/mqtt/mqtt.go
+++ b/pkg/gatewayserver/io/mqtt/mqtt.go
@@ -74,7 +74,9 @@ func (s *srv) accept() error {
 			ctx := log.NewContextWithFields(s.ctx, log.Fields("remote_addr", mqttConn.RemoteAddr().String()))
 			conn := &connection{server: s.server, mqtt: mqttConn, format: s.format}
 			if err := conn.setup(ctx); err != nil {
-				if err != stdio.EOF {
+				switch err {
+				case stdio.EOF, stdio.ErrUnexpectedEOF:
+				default:
 					log.FromContext(ctx).WithError(err).Warn("Failed to setup connection")
 				}
 				mqttConn.Close()

--- a/pkg/rpcmiddleware/rpclog/rpclog.go
+++ b/pkg/rpcmiddleware/rpclog/rpclog.go
@@ -36,6 +36,10 @@ var infoFilteredPrefixes = []string{
 	`ClientConn switching balancer`,
 }
 
+var warningFilteredPrefixes = []string{
+	`grpc: Server.Serve failed to create ServerTransport: connection error: desc = "transport: http2Server.HandleStreams failed to receive the preface from client: unexpected EOF`,
+}
+
 type ttnGrpcLogger struct {
 	logger log.Interface
 }
@@ -57,14 +61,22 @@ func (l *ttnGrpcLogger) Infoln(args ...interface{}) {
 func (l *ttnGrpcLogger) Infof(format string, args ...interface{}) {
 	l.info(fmt.Sprintf(format, args...))
 }
+func (l *ttnGrpcLogger) warn(msg string) {
+	for _, prefix := range warningFilteredPrefixes {
+		if strings.HasPrefix(msg, prefix) {
+			return
+		}
+	}
+	l.logger.Warn(msg)
+}
 func (l *ttnGrpcLogger) Warning(args ...interface{}) {
-	l.logger.Warn(fmt.Sprint(args...))
+	l.warn(fmt.Sprint(args...))
 }
 func (l *ttnGrpcLogger) Warningln(args ...interface{}) {
-	l.logger.Warn(fmt.Sprint(args...))
+	l.warn(fmt.Sprint(args...))
 }
 func (l *ttnGrpcLogger) Warningf(format string, args ...interface{}) {
-	l.logger.Warnf(format, args...)
+	l.warn(fmt.Sprintf(format, args...))
 }
 func (l *ttnGrpcLogger) Error(args ...interface{}) {
 	l.logger.Error(fmt.Sprint(args...))


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #2655

#### Changes
<!-- What are the changes made in this pull request? -->

- Suppress unexpected EOF errors in TLS MQTT endpoints for AS, GS 
- Suppress unexpected EOF errors during TLS handshake in grpc.


#### Testing

<!-- How did you verify that this change works? -->

- Run locally. Test ports 8882/8883/8884 with `echo "" | nc localhost $port`. With the introduced change we no longer get any log messages.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

- We will no longer get any logs for legitimate errors in the highly unlikely scenario that they ever occur

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- Only thing that remains for #2655 is the https endpoint. That one is tricky, supposedly you can set `ErrorLog` of the underlying http.Server, but that seems to not have any effect when I tried it.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
