### PR TITLE
Fix Application Server uplink metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packet Broker Agent cluster ID is used as subscription group.
 - LinkADR handling in 72-channel bands.
+- Data uplink metrics reported by Application Server.
 
 ## [3.8.3] - 2020-06-05
 

--- a/pkg/applicationserver/observability.go
+++ b/pkg/applicationserver/observability.go
@@ -280,6 +280,8 @@ func registerReceiveUp(ctx context.Context, msg *ttnpb.ApplicationUp, ns string)
 		events.Publish(evtReceiveJoinAccept(ctx, msg.EndDeviceIdentifiers, nil))
 	case *ttnpb.ApplicationUp_UplinkMessage:
 		events.Publish(evtReceiveDataUp(ctx, msg.EndDeviceIdentifiers, nil))
+	default:
+		return
 	}
 	asMetrics.uplinkReceived.WithLabelValues(ctx, ns).Inc()
 }
@@ -290,6 +292,8 @@ func registerForwardUp(ctx context.Context, msg *ttnpb.ApplicationUp) {
 		events.Publish(evtForwardJoinAccept(ctx, msg.EndDeviceIdentifiers, msg))
 	case *ttnpb.ApplicationUp_UplinkMessage:
 		events.Publish(evtForwardDataUp(ctx, msg.EndDeviceIdentifiers, msg))
+	default:
+		return
 	}
 	asMetrics.uplinkForwarded.WithLabelValues(ctx, msg.ApplicationID).Inc()
 }
@@ -300,6 +304,8 @@ func registerDropUp(ctx context.Context, msg *ttnpb.ApplicationUp, err error) {
 		events.Publish(evtDropJoinAccept(ctx, msg.EndDeviceIdentifiers, err))
 	case *ttnpb.ApplicationUp_UplinkMessage:
 		events.Publish(evtDropDataUp(ctx, msg.EndDeviceIdentifiers, err))
+	default:
+		return
 	}
 	if ttnErr, ok := errors.From(err); ok {
 		asMetrics.uplinkDropped.WithLabelValues(ctx, ttnErr.FullName()).Inc()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fix Application Server uplink metrics

#### Changes
<!-- What are the changes made in this pull request? -->

The events and metrics only apply to data uplink messages. The events were correct, but the metrics (counter of number of uplink messages) was increased on all upstream messages, including join-accepts and downlink events.


#### Testing

<!-- How did you verify that this change works? -->

N/A

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
