### PR TITLE
Prevent auth flow loops due to invalid access tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Endless authentication refresh loop in the Console in some rare situations.
+- Logout operation not working properly in the Console in some rare situations.
+
 ## [3.8.4] - 2020-06-12
 
 ### Added

--- a/pkg/webui/console/store/middleware/logics/init.js
+++ b/pkg/webui/console/store/middleware/logics/init.js
@@ -14,6 +14,8 @@
 
 import api from '@console/api'
 
+import { clear as clearAccessToken } from '@console/lib/access-token'
+
 import * as user from '@console/store/actions/user'
 import * as init from '@console/store/actions/init'
 
@@ -34,6 +36,11 @@ const consoleAppLogic = createRequestLogic({
       rights = info.oauth_access_token.rights
       dispatch(user.getUserRightsSuccess(rights))
     } catch (error) {
+      if (error.code === 16) {
+        // The access token was not found, so we can delete it from local
+        // storage to obtain a new one.
+        clearAccessToken()
+      }
       dispatch(user.getUserRightsFailure())
       info = undefined
     }

--- a/pkg/webui/console/store/middleware/logics/lib.js
+++ b/pkg/webui/console/store/middleware/logics/lib.js
@@ -15,6 +15,8 @@
 import { createLogic } from 'redux-logic'
 import * as Sentry from '@sentry/browser'
 
+import { clear as clearAccessToken } from '@console/lib/access-token'
+
 import { error } from '@ttn-lw/lib/log'
 import { isUnauthenticatedError, isInvalidArgumentError, isUnknown } from '@ttn-lw/lib/errors/utils'
 
@@ -80,7 +82,9 @@ const createRequestLogic = function(
 
         if (isUnauthenticatedError(e)) {
           // If there was an unauthenticated error, the access token is not
-          // valid. Reloading will then initiate the auth flow.
+          // valid and we can delete it. Reloading will then initiate the auth
+          // flow.
+          clearAccessToken()
           window.location.reload()
         } else {
           // Otherwise, dispatch the fail action and report it to Sentry.


### PR DESCRIPTION
#### Summary
This quickfix PR fixes a bug that could lead to endless loops of the auth flow of the console in some rare situations.

#### Changes
- Clear the access token if it has proven to be invalid
  - In the init logic
  - In the `createRequestLogic` utility

#### Testing

1. Login to the console
2. Alter the value of the access token in local storage
3. Perform any action that triggers an API request to backend
4. Observe the auth flow being run once and a new access token being obtained

Try again without this patch and observe the auth flow looping infinitely.

##### Regressions

It could affect the auth flow of the Console, which I tested in various setups.

#### Notes for Reviewers
The access token was not cleared if an endpoint returned an unauthorized error and instead just reloaded the page. Consequent requests would be retried with the same invalid access token, leading to an endless loop. If the access token is cleared from local storage, the access token lib will try to obtain fresh one before making a request.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
