### PR TITLE
Make CLI only send relevant end device fields to IS on create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Packet Broker Agent cluster ID is used as subscription group.
 - LinkADR handling in 72-channel bands.
 - Data uplink metrics reported by Application Server.
+- CLI now only sends relevant end device fields to Identity Server on create.
 
 ## [3.8.3] - 2020-06-05
 

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -512,8 +512,11 @@ var (
 			if err != nil {
 				return err
 			}
+			var isDevice ttnpb.EndDevice
+			logger.WithField("paths", isPaths).Debug("Create end device on Identity Server")
+			isDevice.SetFields(&device, append(isPaths, "ids")...)
 			isRes, err := ttnpb.NewEndDeviceRegistryClient(is).Create(ctx, &ttnpb.CreateEndDeviceRequest{
-				EndDevice: device,
+				EndDevice: isDevice,
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This quickfix makes that the CLI no longer sends irrelevant end device fields to the Identity Server on create.

#### Testing

<!-- How did you verify that this change works? -->

I reproduced the originally reported issue, and verified that it's no longer present with this change.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

It's possible that we now omit fields that the Identity Server was expecting. In this case that would be a bug in `pkg/ttnpb/field_mask_validation.go`.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This is now basically the same as what we already did on update.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
