### PR TITLE
Fix organization API key deletion in the Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Endless authentication refresh loop in the Console in some rare situations.
 - Logout operation not working properly in the Console in some rare situations.
 - Handling API key deletion event for applications, gateways, organizations and users.
+- Organization API key deletion in the Console.
 
 ## [3.8.4] - 2020-06-12
 

--- a/pkg/webui/console/views/organization-api-key-edit/connect.js
+++ b/pkg/webui/console/views/organization-api-key-edit/connect.js
@@ -67,10 +67,10 @@ export default OrganizationApiKeyEdit =>
       ...stateProps,
       ...dispatchProps,
       ...ownProps,
-      deleteOrganizationApiKeySuccess: keyId =>
-        dispatchProps.deleteOrganizationApiKey(stateProps.orgId, stateProps.keyId),
-      deleteOrganizationApiKey: () =>
+      deleteOrganizationApiKeySuccess: () =>
         dispatchProps.deleteOrganizationApiKeySuccess(stateProps.orgId),
+      deleteOrganizationApiKey: () =>
+        dispatchProps.deleteOrganizationApiKey(stateProps.orgId, stateProps.keyId),
       updateOrganizationApiKey: key =>
         dispatchProps.updateOrganizationApiKey(stateProps.orgId, stateProps.keyId, key),
     }),


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/2738

#### Changes
<!-- What are the changes made in this pull request? -->

- Change usage of `deleteOrganizationApiKeySuccess` and `deleteOrganizationApiKey`


#### Testing

<!-- How did you verify that this change works? -->

Create and then delete organization api key, see no errors in the console and no API key in the keys list.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Organization API key deletion might be affected.


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
