### PR TITLE
Fix/stdin pipe read error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI now only sends relevant end device fields to Identity Server on create.
 - Maximum ADR data rate index used in 1.0.2a and earlier versions of AU915 band.
 - End device events stream restart in the Console.
+- CLI was unable to read input from pipes.
 
 ## [3.8.4] - 2020-06-12
 

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -15,7 +15,6 @@
 package commands
 
 import (
-	"bufio"
 	"context"
 	"encoding/hex"
 	"io/ioutil"
@@ -868,10 +867,11 @@ values will be stored in the Join Server.`,
 				if joinEUI != nil || devEUI != nil {
 					logger.Warn("Either target JoinEUI or DevEUI specified but need both, not considering any and using scan mode")
 				}
-				if !io.IsPipe(os.Stdin) {
+				rd, ok := io.BufferedPipe(os.Stdin)
+				if !ok {
 					logger.Info("Scan QR code")
 				}
-				qrCode, err := bufio.NewReader(os.Stdin).ReadBytes('\n')
+				qrCode, err := rd.ReadBytes('\n')
 				if err != nil {
 					return err
 				}

--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -83,8 +83,8 @@ func preRun(tasks ...func() error) func(cmd *cobra.Command, args []string) error
 		}
 
 		// create input decoder on Stdin
-		if io.IsPipe(os.Stdin) {
-			inputDecoder, err = getInputDecoder(os.Stdin)
+		if rd, ok := io.BufferedPipe(os.Stdin); ok {
+			inputDecoder, err = getInputDecoder(rd)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2545 

#### Changes
<!-- What are the changes made in this pull request? -->

- Use a buffered reader and peak for input in order to decide whether stdin is available
- Use that buffered reader for further input (since the original reader has consumed the first byte of input)


#### Testing

<!-- How did you verify that this change works? -->

```bash
$ cat file.json | ttn-lw-cli ... create        # works
$ ttn-lw-cli ..... create < file.json           # works
$ (create without tty as show in #1904)  # works
```

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

It could be possible that since we may drop the first byte from `os.Stdin` with this, other CLI commands that expect user input might break. Tested user create (ttn-lw-cli user create), login, login with callback=false (where we need to enter the oauth token from stdin) and they worked OK. Also updated the device claiming commands (which also used IsPipe())

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- Skipping the proposed check for `{` and `[`, since it breaks with whitespace. The decoder itself will fail if the input is in fact invalid.
- Returning the buffered reader is needed, otherwise we drop the first byte of the input

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [X] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
