### PR TITLE
gRPC discovery resolver

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -6452,6 +6452,15 @@
       "file": "discover.go"
     }
   },
+  "error:pkg/rpcmiddleware/discover:role": {
+    "translations": {
+      "en": "service role `{role}` not discoverable"
+    },
+    "description": {
+      "package": "pkg/rpcmiddleware/discover",
+      "file": "discover.go"
+    }
+  },
   "error:pkg/rpcmiddleware/validator:field_mask_paths": {
     "translations": {
       "en": "forbidden path(s) in field mask"

--- a/pkg/rpcclient/rpcclient.go
+++ b/pkg/rpcclient/rpcclient.go
@@ -30,6 +30,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/metrics"
 	"go.thethings.network/lorawan-stack/v3/pkg/rpcmiddleware"
+	_ "go.thethings.network/lorawan-stack/v3/pkg/rpcmiddleware/discover" // Register service discovery resolvers
 	"go.thethings.network/lorawan-stack/v3/pkg/rpcmiddleware/rpclog"
 	"go.thethings.network/lorawan-stack/v3/pkg/rpcmiddleware/warning"
 	"go.thethings.network/lorawan-stack/v3/pkg/version"

--- a/pkg/rpcmiddleware/discover/discover_internal_test.go
+++ b/pkg/rpcmiddleware/discover/discover_internal_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	"github.com/smartystreets/assertions"
-	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+	"github.com/smartystreets/assertions/should"
 )
 
 func TestDefaultPort(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #138

#### Changes
<!-- What are the changes made in this pull request? -->

Replaced the discovery dialer by a resolver. This seems the gRPC-native way of doing this, and this was about resolving anyway. The actual lookup runs in the background and is debounced.

This change is needed to validate the server name against the discovered target.

This also decouples resolving from load balancing; the default "pick first" strategy is now fed with the sorted discovered addresses.

Usage of discovery mechanism is made explicit by using the `ttn-v3-{service}:///{target}` scheme.

#### Testing

<!-- How did you verify that this change works? -->

Tested against Global Join Server lookup via JoinEUI DNS. This worked before, but now server name validation is against the target.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
