### PR TITLE
Defer subscribing to events until first subscriber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - JSON uplink message doc edited for clarity.
 - The CLI snap version uses the `$SNAP_USER_COMMON` directory for config by default, so that it is preserved between revisions.
+- Defer events subscriptions until there is actual interest for events.
 
 ### Deprecated
 

--- a/pkg/events/grpc/grpc.go
+++ b/pkg/events/grpc/grpc.go
@@ -19,6 +19,7 @@ package grpc
 import (
 	"context"
 	"runtime"
+	"sync"
 
 	grpc_runtime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"go.thethings.network/lorawan-stack/v3/pkg/auth/rights"
@@ -40,12 +41,10 @@ func NewEventsServer(ctx context.Context, pubsub events.PubSub) *EventsServer {
 		events: make(events.Channel, 256),
 		filter: events.NewIdentifierFilter(),
 	}
+	srv.handler = events.ContextHandler(ctx, srv.events)
 
-	hander := events.ContextHandler(ctx, srv.events)
-	pubsub.Subscribe("**", hander)
 	go func() {
-		<-ctx.Done()
-		pubsub.Unsubscribe("**", hander)
+		<-srv.ctx.Done()
 		close(srv.events)
 	}()
 
@@ -74,10 +73,22 @@ type marshaledEvent struct {
 
 // EventsServer streams events from a PubSub over gRPC.
 type EventsServer struct {
-	ctx    context.Context
-	pubsub events.PubSub
-	events events.Channel
-	filter events.IdentifierFilter
+	ctx     context.Context
+	pubsub  events.PubSub
+	subOnce sync.Once
+	events  events.Channel
+	handler events.Handler
+	filter  events.IdentifierFilter
+}
+
+func (srv *EventsServer) subscribe() {
+	srv.subOnce.Do(func() {
+		srv.pubsub.Subscribe("**", srv.handler)
+		go func() {
+			<-srv.ctx.Done()
+			srv.pubsub.Unsubscribe("**", srv.handler)
+		}()
+	})
 }
 
 var (
@@ -96,6 +107,8 @@ func (srv *EventsServer) Stream(req *ttnpb.StreamEventsRequest, stream ttnpb.Eve
 	if err := rights.RequireAny(ctx, req.Identifiers...); err != nil {
 		return err
 	}
+
+	srv.subscribe()
 
 	ch := make(events.Channel, 8)
 	handler := events.ContextHandler(ctx, ch)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This quickfix makes some small changes in the events system, so that it only subscribes to events when the first subscriber indicates interest.

#### Changes
<!-- What are the changes made in this pull request? -->

- Don't start the Redis subscription until the first subscriber.
- Don't start the PubSub subscription until the first gRPC events stream.

#### Testing

<!-- How did you verify that this change works? -->

- The existing unit tests in `pkg/events/redis` are sufficient.
- Tested the gRPC handler by hand while observing the `MONITOR` command with `redis-cli`.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This should reduce the number of events subscribers in clustered deployments, where users typically only subscribe to events from the Console.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [ ] Documentation: Relevant documentation is added or updated.
	- No changes to external behavior.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
