### PR TITLE
Allow creating gateways without `frequency_plan_id` in the Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Requirement to specify `frequency_plan_id` when creating gateways in the Console.
+
 ### Fixed
 
 - Endless authentication refresh loop in the Console in some rare situations.

--- a/pkg/webui/console/components/gateway-data-form/index.js
+++ b/pkg/webui/console/components/gateway-data-form/index.js
@@ -86,7 +86,7 @@ const validationSchema = Yup.object().shape({
     .min(2, Yup.passValues(sharedMessages.validateTooShort))
     .max(50, Yup.passValues(sharedMessages.validateTooLong)),
   description: Yup.string().max(2000, Yup.passValues(sharedMessages.validateTooLong)),
-  frequency_plan_id: Yup.string().required(sharedMessages.validateRequired),
+  frequency_plan_id: Yup.string(),
   gateway_server_address: Yup.string().matches(addressRegexp, sharedMessages.validateAddressFormat),
   location_public: Yup.boolean().default(false),
   status_public: Yup.boolean().default(false),
@@ -245,7 +245,7 @@ class GatewayDataForm extends React.Component {
           description={sharedMessages.attributeDescription}
         />
         <Message component="h4" content={sharedMessages.lorawanOptions} />
-        <GsFrequencyPlansSelect name="frequency_plan_id" menuPlacement="top" required />
+        <GsFrequencyPlansSelect name="frequency_plan_id" menuPlacement="top" />
         <Form.Field
           title={sharedMessages.gatewayScheduleDownlinkLate}
           name="schedule_downlink_late"

--- a/pkg/webui/console/views/gateway-overview/gateway-overview.js
+++ b/pkg/webui/console/views/gateway-overview/gateway-overview.js
@@ -118,7 +118,7 @@ export default class GatewayOverview extends React.Component {
         items: [
           {
             key: sharedMessages.frequencyPlan,
-            value: <Tag content={frequency_plan_id} />,
+            value: frequency_plan_id ? <Tag content={frequency_plan_id} /> : undefined,
           },
         ],
       },


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/1567

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove `required` from `frequency_plan_id` in the gateway form
- Do not render `<Tag />` when no `frequency_plan_id` provided


#### Testing

<!-- How did you verify that this change works? -->

1. Create gateway.
2. Disable GS and create gateway.
3. Open the overview page for a gateway without `frequency_plan_id`

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Gateway creation. Gateway overview page.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

There is no requirement to obligatory include `frequency_plan_id` when creating gateways on the backend. With IS+JS setup GS frequency plans cannot be fetched and hence users are not able to create gateways in such stack configuration.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
