### PR TITLE
Use NetID in join_accepted_total metric

### DIFF
--- a/pkg/joinserver/observability.go
+++ b/pkg/joinserver/observability.go
@@ -47,7 +47,7 @@ var jsMetrics = &messageMetrics{
 			Name:      "join_accepted_total",
 			Help:      "Total number of accepted joins",
 		},
-		[]string{"application_id"},
+		[]string{"net_id"},
 	),
 	joinRejected: metrics.NewContextualCounterVec(
 		prometheus.CounterOpts{
@@ -80,7 +80,7 @@ func (m messageMetrics) Collect(ch chan<- prometheus.Metric) {
 
 func registerAcceptJoin(ctx context.Context, dev *ttnpb.EndDevice, msg *ttnpb.JoinRequest) {
 	events.Publish(evtAcceptJoin(ctx, dev.EndDeviceIdentifiers, nil))
-	jsMetrics.joinAccepted.WithLabelValues(ctx, dev.ApplicationID).Inc()
+	jsMetrics.joinAccepted.WithLabelValues(ctx, msg.NetID.String()).Inc()
 }
 
 func registerRejectJoin(ctx context.Context, req *ttnpb.JoinRequest, err error) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This quickfix changes the label of the `ttn_lw_js_join_accepted_total` to NetID instead of ApplicationID, in order to reduce the cardinality of the metric. Without this we'd have a metric series for each ApplicationID, would be way too many.