### PR TITLE
Improve form field labels

### DIFF
--- a/pkg/webui/components/checkbox/checkbox.js
+++ b/pkg/webui/components/checkbox/checkbox.js
@@ -135,12 +135,14 @@ class Checkbox extends React.PureComponent {
       checkboxProps.onFocus = this.context.onFocus
       checkboxProps.disabled = disabled || this.context.disabled
       checkboxProps.checked = this.context.getValue(name)
+      checkboxProps.id = `${this.context.name}-${name}`
       groupCls = this.context.className
     } else {
       checkboxProps.onBlur = onBlur
       checkboxProps.onFocus = onFocus
       checkboxProps.disabled = disabled
       checkboxProps.checked = checked
+      checkboxProps.id = name
     }
 
     const cls = classnames(className, style.wrapper, groupCls, {
@@ -149,7 +151,7 @@ class Checkbox extends React.PureComponent {
     })
 
     return (
-      <label className={cls}>
+      <label className={cls} htmlFor={checkboxProps.id}>
         <span className={style.checkbox}>
           <input
             type="checkbox"

--- a/pkg/webui/components/checkbox/group/index.js
+++ b/pkg/webui/components/checkbox/group/index.js
@@ -33,6 +33,7 @@ class CheckboxGroup extends React.Component {
     onChange: PropTypes.func,
     onFocus: PropTypes.func,
     value: PropTypes.shape({}),
+    name: PropTypes.string.isRequired,
   }
 
   static defaultProps = {
@@ -91,7 +92,7 @@ class CheckboxGroup extends React.Component {
   }
 
   render() {
-    const { className, disabled, onFocus, onBlur, horizontal, children } = this.props
+    const { className, name, disabled, onFocus, onBlur, horizontal, children } = this.props
 
     const ctx = {
       className: style.groupCheckbox,
@@ -100,6 +101,7 @@ class CheckboxGroup extends React.Component {
       onBlur,
       onFocus,
       disabled,
+      name,
     }
 
     const cls = classnames(className, style.group, {

--- a/pkg/webui/components/form/field/field.styl
+++ b/pkg/webui/components/form/field/field.styl
@@ -42,21 +42,20 @@
   .label
     font-weight: 600
 
+    ::after
+      display: none
+
+  &.required
+    .label::after
+      content: '·'
+      display: inline
+      margin-left: $cs.xxs
+      color: $c-active-blue
+      font-weight: 800
+
   &.horizontal
-    .title
+    .title, .info-area, .label::after
       padding-top: $cs.xxs
-
-    .info-area
-      padding-top: $cs.xxs
-
-.reqicon
-  display: none
-  margin-left: $cs.xxs
-  color: $c-active-blue
-  font-weight: 800
-
-  .required &
-    display: inline
 
 .label
   display: block

--- a/pkg/webui/components/form/field/index.js
+++ b/pkg/webui/components/form/field/index.js
@@ -212,7 +212,6 @@ class FormField extends React.Component {
       <div className={cls} data-needs-focus={showError}>
         <label className={style.label}>
           <Message content={title} className={style.title} />
-          <span className={style.reqicon}>&middot;</span>
         </label>
         <div className={style.componentArea}>
           <Component

--- a/pkg/webui/components/form/field/index.js
+++ b/pkg/webui/components/form/field/index.js
@@ -190,6 +190,7 @@ class FormField extends React.Component {
       error: showError,
       warning: showWarning,
       name,
+      id: name,
       horizontal,
       disabled: fieldDisabled,
       onChange: this.handleChange,
@@ -210,7 +211,7 @@ class FormField extends React.Component {
 
     return (
       <div className={cls} data-needs-focus={showError}>
-        <label className={style.label}>
+        <label className={style.label} htmlFor={fieldComponentProps.id}>
           <Message content={title} className={style.title} />
         </label>
         <div className={style.componentArea}>

--- a/pkg/webui/components/form/field/story.js
+++ b/pkg/webui/components/form/field/story.js
@@ -590,6 +590,7 @@ storiesOf('Fields/Input', module)
     <FieldsWrapperExample
       initialValues={{
         default: 'something...',
+        required: 'something...',
         description: 'something...',
         warning: 'something...',
         error: 'something...',
@@ -597,6 +598,7 @@ storiesOf('Fields/Input', module)
       }}
     >
       <Form.Field name="default" title="Default" component={Input} />
+      <Form.Field name="required" title="Required" component={Input} required />
       <Form.Field
         name="description"
         title="With Description"
@@ -612,6 +614,7 @@ storiesOf('Fields/Input', module)
     <FieldsWrapperExample
       initialValues={{
         default: 'something...',
+        required: 'something...',
         description: 'something...',
         warning: 'something...',
         error: 'something...',
@@ -620,6 +623,7 @@ storiesOf('Fields/Input', module)
       horizontal={false}
     >
       <Form.Field name="default" title="Default" component={Input} />
+      <Form.Field name="required" title="Required" component={Input} required />
       <Form.Field
         name="description"
         title="With Description"

--- a/pkg/webui/components/radio-button/radio.js
+++ b/pkg/webui/components/radio-button/radio.js
@@ -19,6 +19,7 @@ import classnames from 'classnames'
 import Message from '@ttn-lw/lib/components/message'
 
 import PropTypes from '@ttn-lw/lib/prop-types'
+import stringToHash from '@ttn-lw/lib/string-to-hash'
 
 import { RadioGroupContext } from './group'
 
@@ -107,12 +108,14 @@ class RadioButton extends React.PureComponent {
       radioProps.name = this.context.name
       radioProps.disabled = disabled || this.context.disabled
       radioProps.checked = value === this.context.value
+      radioProps.id = `${this.context.name}-${stringToHash(value)}`
       groupCls = this.context.className
     } else {
       radioProps.name = name
       radioProps.disabled = disabled
       radioProps.checked = checked
       radioProps.value = value
+      radioProps.id = `${name}-${stringToHash(value)}`
     }
 
     const cls = classnames(className, style.wrapper, groupCls, {
@@ -120,7 +123,7 @@ class RadioButton extends React.PureComponent {
     })
 
     return (
-      <label className={cls}>
+      <label className={cls} htmlFor={radioProps.id}>
         <span className={style.radio}>
           <input
             type="radio"

--- a/pkg/webui/console/components/rights-group/index.js
+++ b/pkg/webui/console/components/rights-group/index.js
@@ -122,6 +122,8 @@ class RightsGroup extends React.Component {
     intl: PropTypes.shape({
       formatMessage: PropTypes.func.isRequired,
     }).isRequired,
+    /** The name attribute passed down to the rights group. */
+    name: PropTypes.isRequired,
     /** The Blur event hook. */
     onBlur: PropTypes.func,
     /** The Change event hook. */
@@ -208,6 +210,7 @@ class RightsGroup extends React.Component {
       grantType,
       derivedPseudoRight,
       derivedRights,
+      name,
     } = this.props
     const { individualRightValue } = this.state
 


### PR DESCRIPTION
#### Summary
This quickfix PR will introduce various improvements to the field labels in our forms.

Closes #1383

#### Changes
- Use  the `::after` selector to render the "required dot"
  - This will keep the inner HTML of the label clean and enable easier selection via `cy.findByLabelText()`
- Fix a display problem that made the required dot rendered too high (in horizontal layout)
- Use proper `id` attribute for the `<input />`'s and corresponding `for` attribute for labels
- Make sure checkbox/radio group are using and passing down the `name` attribute


#### Testing

Checked in storybook

##### Regressions

Might cause log errors for invalid IDs and/or `for` attributes

#### Notes for Reviewers
This is mostly for #2764 with some other small things added while being at it.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
