### PR TITLE
Fix redirects for Echo groups without trailing slashes

### DIFF
--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -156,6 +156,9 @@ var startCommand = &cobra.Command{
 				is.SetRedisCache(redis.New(config.Cache.Redis.WithNamespace("is", "cache")))
 			}
 			if oauthMount := config.IS.OAuth.UI.MountPath(); oauthMount != "/" {
+				if !strings.HasSuffix(oauthMount, "/") {
+					oauthMount += "/"
+				}
 				rootRedirect = web.Redirect("/", http.StatusFound, oauthMount)
 			}
 		}
@@ -264,6 +267,9 @@ var startCommand = &cobra.Command{
 			}
 			_ = console
 			if consoleMount := config.Console.UI.MountPath(); consoleMount != "/" {
+				if !strings.HasSuffix(consoleMount, "/") {
+					consoleMount += "/"
+				}
 				rootRedirect = web.Redirect("/", http.StatusFound, consoleMount)
 			}
 		}

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -322,7 +322,7 @@ func (s *Server) Group(prefix string, middleware ...echo.MiddlewareFunc) *echo.G
 	pathWithSlash := path + "/"
 	router := s.getRouter(pathWithSlash)
 	router.PathPrefix(replaceEchoVars(pathWithSlash)).Handler(s.echo)
-	if path != "/" {
+	if !strings.HasSuffix(path, "/") {
 		router.Handle(replaceEchoVars(path), http.RedirectHandler(pathWithSlash, http.StatusPermanentRedirect))
 	}
 	return s.echo.Group(path, middleware...)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This quickfix fixes the way we redirect Echo groups without trailing slashes, such as the `/console` and `/oauth` groups. This should save at least one redirect when accessing `/`.