### PR TITLE
Display user name instead of ID if possible in Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI support for setting and unsetting end device location (see `--location.latitude`, `--location.longitude`, `--location.altitude` and `--location.accuracy` options).
 - Functionality to allow admin users to list all applications and gateways in the Console.
 - Ursalink UG8X gateway documentation.
+<<<<<<< HEAD
 - Intercom, Google Analytics, and Emojicom feedback in documentation.
+=======
+- Display own user name instead of ID in Console if possible.
+>>>>>>> doc: Update changelog
 
 ### Changed
 

--- a/pkg/webui/components/header/index.js
+++ b/pkg/webui/components/header/index.js
@@ -69,7 +69,10 @@ const Header = function({
         {!isGuest && (
           <div className={style.right}>
             {searchable && <Input icon="search" onEnter={onSearchRequest} />}
-            <ProfileDropdown className={style.profileDropdown} userId={user.ids.user_id}>
+            <ProfileDropdown
+              className={style.profileDropdown}
+              userName={user.name || user.ids.user_id}
+            >
               {dropdownItems}
             </ProfileDropdown>
             <button onClick={handleMobileMenuClick} className={style.mobileMenu}>

--- a/pkg/webui/components/profile-dropdown/index.js
+++ b/pkg/webui/components/profile-dropdown/index.js
@@ -64,7 +64,7 @@ export default class ProfileDropdown extends React.PureComponent {
   }
 
   render() {
-    const { userId, className, children, ...rest } = this.props
+    const { userName, className, children, ...rest } = this.props
 
     return (
       <div
@@ -76,7 +76,7 @@ export default class ProfileDropdown extends React.PureComponent {
         role="button"
         {...rest}
       >
-        <span className={styles.id}>{userId}</span>
+        <span className={styles.id}>{userName}</span>
         <Icon icon="arrow_drop_down" />
         {this.state.expanded && <Dropdown className={styles.dropdown}>{children}</Dropdown>}
       </div>
@@ -91,8 +91,8 @@ ProfileDropdown.propTypes = {
    */
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
-  /** The id of the current user. */
-  userId: PropTypes.string.isRequired,
+  /** The name/id of the current user. */
+  userName: PropTypes.string.isRequired,
 }
 
 ProfileDropdown.defaultProps = {

--- a/pkg/webui/components/profile-dropdown/index_test.js
+++ b/pkg/webui/components/profile-dropdown/index_test.js
@@ -18,7 +18,7 @@ import Dropdown from '../dropdown'
 
 import getProfileDropdownDriver from './index_driver'
 
-const userId = 'kschiffer'
+const userName = 'kschiffer'
 const nullAction = function() {
   return null
 }
@@ -38,7 +38,7 @@ describe('Profile Dropdown', function() {
 
   describe('is in initial state', function() {
     beforeEach(function() {
-      driver.when.created({ userId, children })
+      driver.when.created({ userName, children })
     })
     it('should match snapshot', function() {
       expect(driver.component).toMatchSnapshot()

--- a/pkg/webui/console/store/middleware/logics/user.js
+++ b/pkg/webui/console/store/middleware/logics/user.js
@@ -41,7 +41,7 @@ export default [
         if (isUnauthenticatedError(err)) {
           // If there was an Unauthenticated Error, it either means that the
           // console client or the OAuth app session is no longer valid.
-          // In this situation, it's best try to initializing the OAuth
+          // In this situation, it's best to try initializing the OAuth
           // roundtrip again. This might provide a new console session cookie
           // with which the propagated logout can be retried. If not, it can
           // be assumed that both console and OAuth app sessions are already

--- a/pkg/webui/console/store/selectors/user.js
+++ b/pkg/webui/console/store/selectors/user.js
@@ -33,6 +33,18 @@ export const selectUserId = function(state) {
   return user.ids.user_id
 }
 
+export const selectUserName = state => {
+  const user = selectUser(state)
+
+  return user ? user.name : undefined
+}
+
+export const selectUserNameOrId = state => {
+  const user = selectUser(state)
+
+  return user ? user.name || user.ids.user_id : undefined
+}
+
 export const selectUserIsAdmin = function(state) {
   const user = selectUser(state)
 

--- a/pkg/webui/console/views/overview/index.js
+++ b/pkg/webui/console/views/overview/index.js
@@ -49,7 +49,7 @@ import { getGatewaysList, GET_GTWS_LIST_BASE } from '@console/store/actions/gate
 import { selectApplicationsTotalCount } from '@console/store/selectors/applications'
 import { selectGatewaysTotalCount } from '@console/store/selectors/gateways'
 import { createFetchingSelector } from '@console/store/selectors/fetching'
-import { selectUserId, selectUserRights } from '@console/store/selectors/user'
+import { selectUserNameOrId, selectUserRights } from '@console/store/selectors/user'
 
 import style from './overview.styl'
 
@@ -59,7 +59,7 @@ const m = defineMessages({
   gotoApplications: 'Go to applications',
   gotoGateways: 'Go to gateways',
   welcome: 'Welcome to the Console!',
-  welcomeBack: 'Welcome back, {userId}! 👋',
+  welcomeBack: 'Welcome back, {userName}! 👋',
   getStarted: 'Get started right away by creating an application or registering a gateway',
   continueWorking: 'Walk right through to your applications and/or gateways',
   componentStatus: 'Component status',
@@ -84,7 +84,7 @@ const overviewFetchingSelector = createFetchingSelector([GET_APPS_LIST_BASE, GET
       applicationCount: selectApplicationsTotalCount(state),
       gatewayCount: selectGatewaysTotalCount(state),
       fetching: overviewFetchingSelector(state),
-      userId: selectUserId(state),
+      userName: selectUserNameOrId(state),
       mayCreateApplications: mayCreateApplications.check(rights),
       mayViewApplications: mayViewApplications.check(rights),
       mayViewGateways: mayViewGateways.check(rights),
@@ -113,7 +113,7 @@ export default class Overview extends React.Component {
     mayCreateGateways: PropTypes.bool.isRequired,
     mayViewApplications: PropTypes.bool.isRequired,
     mayViewGateways: PropTypes.bool.isRequired,
-    userId: PropTypes.string.isRequired,
+    userName: PropTypes.string.isRequired,
   }
 
   static defaultProps = {
@@ -210,7 +210,7 @@ export default class Overview extends React.Component {
       fetching,
       applicationCount,
       gatewayCount,
-      userId,
+      userName,
       mayCreateApplications,
       mayCreateGateways,
       mayViewApplications,
@@ -237,7 +237,7 @@ export default class Overview extends React.Component {
               <Message
                 className={style.welcome}
                 content={hasEntities ? m.welcomeBack : m.welcome}
-                values={{ userId }}
+                values={{ userName }}
                 component="h1"
               />
               {!mayNotViewEntities && (

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -339,7 +339,7 @@
   "console.views.overview.index.gotoApplications": "Go to applications",
   "console.views.overview.index.gotoGateways": "Go to gateways",
   "console.views.overview.index.welcome": "Welcome to the Console!",
-  "console.views.overview.index.welcomeBack": "Welcome back, {userId}! 👋",
+  "console.views.overview.index.welcomeBack": "Welcome back, {userName}! 👋",
   "console.views.overview.index.getStarted": "Get started right away by creating an application or registering a gateway",
   "console.views.overview.index.continueWorking": "Walk right through to your applications and/or gateways",
   "console.views.overview.index.componentStatus": "Component status",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -339,7 +339,7 @@
   "console.views.overview.index.gotoApplications": "Xx xx xxxxxxxxxxxx",
   "console.views.overview.index.gotoGateways": "Xx xx xxxxxxxx",
   "console.views.overview.index.welcome": "Xxxxxxx xx xxx Xxxxxxx!",
-  "console.views.overview.index.welcomeBack": "Xxxxxxx xxxx, {userId}! xx",
+  "console.views.overview.index.welcomeBack": "Xxxxxxx xxxx, {userName}! xx",
   "console.views.overview.index.getStarted": "Xxx xxxxxxx xxxxx xxxx xx xxxxxxxx xx xxxxxxxxxxx xx xxxxxxxxxxx x xxxxxxx",
   "console.views.overview.index.continueWorking": "Xxxx xxxxx xxxxxxx xx xxxx xxxxxxxxxxxx xxx/xx xxxxxxxx",
   "console.views.overview.index.componentStatus": "Xxxxxxxxx xxxxxx",


### PR DESCRIPTION
#### Summary
This quickfix PR displays the user name in the overview greeting as well as header (with fallback to user id)

![image](https://user-images.githubusercontent.com/5710611/85982059-24f55880-ba20-11ea-8ffa-4e713bdd85da.png)

References #1622

#### Changes
- Add a selector for user name
- Add a selector for user name or id
- User user name in overview greeting
- Use user name in profile dropdown


#### Testing
Check correct display with and without set user name

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
