### PR TITLE
Fix default values reset in payload formatters form

### DIFF
--- a/pkg/webui/console/components/payload-formatters-form/index.js
+++ b/pkg/webui/console/components/payload-formatters-form/index.js
@@ -109,6 +109,10 @@ class PayloadFormattersForm extends React.Component {
         resetValues[FIELD_NAMES.JAVASCRIPT] = getDefaultJavascriptFormatter(uplink)
         resetValues[FIELD_NAMES.GRPC] = grpcParameter
         break
+      default:
+        resetValues[FIELD_NAMES.GRPC] = getDefaultGrpcServiceFormatter(uplink)
+        resetValues[FIELD_NAMES.JAVASCRIPT] = getDefaultJavascriptFormatter(uplink)
+        break
     }
 
     try {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2804 

#### Changes
<!-- What are the changes made in this pull request? -->

- Set default JS and GRPC formatter values when a formatter with no parameter is selected

#### Testing

<!-- How did you verify that this change works? -->

1. Set a formatter with no parameter in the payload formatter form (`None` or `CayeneLPP`)
2. Switch to JS payload formatter
3. Observe the default formatter is there

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
