### PR TITLE
Fix join settings validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - End device events stream restart in the Console.
 - CLI was unable to read input from pipes.
 - Timezones issue in claim authentication code form, causing time to reverse on submission.
+- Errors during submit of the join settings for end devices in the Console.
 
 ## [3.8.4] - 2020-06-12
 

--- a/pkg/webui/components/form/field/index.js
+++ b/pkg/webui/components/form/field/index.js
@@ -66,8 +66,10 @@ class FormField extends React.Component {
         render: PropTypes.func.isRequired,
       }),
     ]).isRequired,
+    decode: PropTypes.func,
     description: PropTypes.message,
     disabled: PropTypes.bool,
+    encode: PropTypes.func,
     name: PropTypes.string.isRequired,
     onChange: PropTypes.func,
     readOnly: PropTypes.bool,
@@ -79,6 +81,8 @@ class FormField extends React.Component {
   static defaultProps = {
     className: undefined,
     disabled: false,
+    encode: value => value,
+    decode: value => value,
     onChange: () => null,
     warning: '',
     description: '',
@@ -114,7 +118,7 @@ class FormField extends React.Component {
 
   @bind
   async handleChange(value, enforceValidation = false) {
-    const { name, onChange } = this.props
+    const { name, onChange, encode } = this.props
     const { setFieldValue, setFieldTouched } = this.context
 
     // Check if the value is react's synthetic event.
@@ -132,7 +136,7 @@ class FormField extends React.Component {
       setFieldTouched(name)
     }
 
-    onChange(value)
+    onChange(encode(value))
   }
 
   @bind
@@ -149,6 +153,7 @@ class FormField extends React.Component {
   render() {
     const {
       className,
+      decode,
       name,
       title,
       warning,
@@ -160,7 +165,7 @@ class FormField extends React.Component {
     } = this.props
     const { horizontal, disabled: formDisabled } = this.context
 
-    const fieldValue = getIn(this.context.values, name)
+    const fieldValue = decode(getIn(this.context.values, name))
     const fieldError = getIn(this.context.errors, name)
     const fieldTouched = getIn(this.context.touched, name)
     const fieldDisabled = disabled || formDisabled

--- a/pkg/webui/console/views/device-add/wizard/join-settings-form/index.js
+++ b/pkg/webui/console/views/device-add/wizard/join-settings-form/index.js
@@ -30,12 +30,16 @@ import validationSchema from './validation-schema'
 
 const defaultInitialValues = {
   root_keys: {},
-  net_id: undefined,
+  net_id: null,
   resets_join_nonces: false,
   application_server_id: undefined,
   application_server_kek_label: undefined,
   network_server_kek_label: undefined,
 }
+
+// The `net_id` value can be null as empty value, which needs to be
+// transformed to an empty string for the byte input to accept it.
+const netIdDecoder = value => (value === null ? '' : value)
 
 const JoinSettingsForm = React.memo(props => {
   const { lorawanVersion, mayEditKeys, error } = props
@@ -125,6 +129,7 @@ const JoinSettingsForm = React.memo(props => {
           min={3}
           max={3}
           component={Input}
+          decode={netIdDecoder}
         />
         <Form.Field
           title={sharedMessages.asServerID}

--- a/pkg/webui/console/views/device-general-settings/join-server-form/index.js
+++ b/pkg/webui/console/views/device-general-settings/join-server-form/index.js
@@ -42,6 +42,10 @@ const isNwkKeyHidden = ({ root_keys }) =>
 const isAppKeyHidden = ({ root_keys }) =>
   Boolean(root_keys) && Boolean(root_keys.app_key) && !Boolean(root_keys.app_key.key)
 
+// The `net_id` value can be null as empty value, which needs to be
+// transformed to an empty string for the byte input to accept it.
+const netIdDecoder = value => (value === null ? '' : value)
+
 const JoinServerForm = React.memo(props => {
   const { device, onSubmit, onSubmitSuccess, mayReadKeys, mayEditKeys } = props
 
@@ -134,6 +138,7 @@ const JoinServerForm = React.memo(props => {
         min={3}
         max={3}
         component={Input}
+        decode={netIdDecoder}
       />
       <Form.Field
         title={sharedMessages.asServerID}

--- a/pkg/webui/console/views/device-general-settings/join-server-form/validation-schema.js
+++ b/pkg/webui/console/views/device-general-settings/join-server-form/validation-schema.js
@@ -22,7 +22,7 @@ const validationSchema = Yup.object()
   .shape({
     net_id: Yup.nullableString()
       .emptyOrLength(3 * 2, Yup.passValues(sharedMessages.validateLength)) // 3 Byte hex.
-      .default(''),
+      .default(null),
     root_keys: Yup.object().when(
       ['$externalJs', '$lorawanVersion', '$mayEditKeys', '$mayEditkeys'],
       (externalJs, lorawanVersion, mayEditKeys, mayReadKeys, schema) => {


### PR DESCRIPTION
#### Summary
This quickfix PR fixes an issue of the validation of the `Home net ID` field in the join settings forms.

#### Changes
- Make `net_id` default to an empty string

#### Testing

Manual testing.

##### Regressions

This might break setting the `net_id` prop of end devices.

#### Notes for Reviewers
Noticed this via https://sentry.io/organizations/the-things-industries/issues/1757151966/?project=2682566

Without this patch, the byte input field will receive null after submitting, which is an invalid value. Since you initially set the validation to `nullableString()`, I'm not sure whether this patch introduces any side effects. I did not notice any when testing this though.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
