### PR TITLE
Give more information about conflicting EUIs on create

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -4211,6 +4211,15 @@
       "file": "store.go"
     }
   },
+  "error:pkg/identityserver/store:eui_taken": {
+    "translations": {
+      "en": "EUI already taken"
+    },
+    "description": {
+      "package": "pkg/identityserver/store",
+      "file": "store.go"
+    }
+  },
   "error:pkg/identityserver/store:gateway_not_found": {
     "translations": {
       "en": "gateway `{gateway_id}` not found"
@@ -4380,6 +4389,24 @@
     "description": {
       "package": "pkg/identityserver",
       "file": "identityserver.go"
+    }
+  },
+  "error:pkg/identityserver:end_device_euis_taken": {
+    "translations": {
+      "en": "an end device with JoinEUI `{join_eui}` and DevEUI `{dev_eui}` is already registered as `{device_id}` in application `{application_id}`"
+    },
+    "description": {
+      "package": "pkg/identityserver",
+      "file": "end_device_registry.go"
+    }
+  },
+  "error:pkg/identityserver:gateway_eui_taken": {
+    "translations": {
+      "en": "a gateway with EUI `{gateway_eui}` is already registered as `{gateway_id}`"
+    },
+    "description": {
+      "package": "pkg/identityserver",
+      "file": "gateway_registry.go"
     }
   },
   "error:pkg/identityserver:invalid_authorization": {

--- a/pkg/identityserver/end_device_registry_test.go
+++ b/pkg/identityserver/end_device_registry_test.go
@@ -20,11 +20,11 @@ import (
 
 	pbtypes "github.com/gogo/protobuf/types"
 	"github.com/smartystreets/assertions"
-	"github.com/smartystreets/assertions/should"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
 	"google.golang.org/grpc"
 )
 
@@ -172,6 +172,22 @@ func TestEndDevicesCRUD(t *testing.T) {
 		a.So(err, should.BeNil)
 		if a.So(ids, should.NotBeNil) {
 			a.So(*ids, should.Resemble, created.EndDeviceIdentifiers)
+		}
+
+		_, err = reg.Create(ctx, &ttnpb.CreateEndDeviceRequest{
+			EndDevice: ttnpb.EndDevice{
+				EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
+					DeviceID:               "other-test-device-id",
+					ApplicationIdentifiers: app.ApplicationIdentifiers,
+					JoinEUI:                &joinEUI,
+					DevEUI:                 &devEUI,
+				},
+				Name: "test-device-name",
+			},
+		}, creds)
+
+		if a.So(err, should.NotBeNil) {
+			a.So(err, should.HaveSameErrorDefinitionAs, errEndDeviceEUIsTaken)
 		}
 
 		list, err := reg.List(ctx, &ttnpb.ListEndDevicesRequest{

--- a/pkg/identityserver/gateway_registry_test.go
+++ b/pkg/identityserver/gateway_registry_test.go
@@ -19,11 +19,11 @@ import (
 
 	ptypes "github.com/gogo/protobuf/types"
 	"github.com/smartystreets/assertions"
-	"github.com/smartystreets/assertions/should"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
 	"google.golang.org/grpc"
 )
 
@@ -165,6 +165,21 @@ func TestGatewaysCRUD(t *testing.T) {
 		a.So(err, should.BeNil)
 		if a.So(ids, should.NotBeNil) {
 			a.So(ids.GatewayID, should.Equal, created.GatewayID)
+		}
+
+		_, err = reg.Create(ctx, &ttnpb.CreateGatewayRequest{
+			Gateway: ttnpb.Gateway{
+				GatewayIdentifiers: ttnpb.GatewayIdentifiers{
+					GatewayID: "bar",
+					EUI:       &eui,
+				},
+				Name: "Bar Gateway",
+			},
+			Collaborator: *userID.OrganizationOrUserIdentifiers(),
+		}, creds)
+
+		if a.So(err, should.NotBeNil) {
+			a.So(err, should.HaveSameErrorDefinitionAs, errGatewayEUITaken)
 		}
 
 		got, err = reg.Get(ctx, &ttnpb.GetGatewayRequest{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR adds more information to errors indicating that an entity with the same EUI already exists.

Refs https://github.com/TheThingsIndustries/lorawan-stack/issues/2130

#### Changes
<!-- What are the changes made in this pull request? -->

- Update IS store to improve matching of constraint violation errors (currently of ID and EUI indices)
- Update IS to return more useful errors when such a violation occurs

#### Testing

<!-- How did you verify that this change works? -->

Added unit tests, manual testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

The error chain is slightly different, so even though the HTTP and gRPC response codes are the same, applications may get confused if they only look at the error namespace/name.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
