### PR TITLE
Add key vault caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI support for setting and unsetting end device location (see `--location.latitude`, `--location.longitude`, `--location.altitude` and `--location.accuracy` options).
 - Functionality to allow admin users to list all applications and gateways in the Console.
 - Ursalink UG8X gateway documentation.
+- Intercom, Google Analytics, and Emojicom feedback in documentation.
+- LORIX One gateway documentation.
+- Display own user name instead of ID in Console if possible.
+- Option to hide rarely used fields in the Join Settings step (end device wizard) in the Console.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Service data messages published by integrations. Can be consumed using the bundled MQTT server, Webhooks or Pub/Sub integrations.
 - Application package application-wide associations support.
 - LoRaCloud DAS application package server URL overrides support.
+- Key vault caching mechanism (see `--key-vault.cache.size` and `--key-vault.cache.ttl` options).
 
 ### Changed
 
@@ -41,10 +42,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI support for setting and unsetting end device location (see `--location.latitude`, `--location.longitude`, `--location.altitude` and `--location.accuracy` options).
 - Functionality to allow admin users to list all applications and gateways in the Console.
 - Ursalink UG8X gateway documentation.
-- Intercom, Google Analytics, and Emojicom feedback in documentation.
-- LORIX One gateway documentation.
-- Display own user name instead of ID in Console if possible.
-- Option to hide rarely used fields in the Join Settings step (end device wizard) in the Console.
 
 ### Changed
 

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/TheThingsNetwork/go-cayenne-lib v1.0.0
 	github.com/aws/aws-sdk-go v1.31.1
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/bluele/gcache v0.0.0-20190518031135-bc40bd653833
 	github.com/chrj/smtpd v0.1.2
 	github.com/disintegration/imaging v1.6.2
 	github.com/eclipse/paho.mqtt.golang v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/bluele/gcache v0.0.0-20190518031135-bc40bd653833 h1:yCfXxYaelOyqnia8F/Yng47qhmfC9nKTRIbYRrRueq4=
+github.com/bluele/gcache v0.0.0-20190518031135-bc40bd653833/go.mod h1:8c4/i2VlovMO2gBnHGQPN5EJw+H0lx1u/5p+cgsXtCk=
 github.com/bradfitz/gomemcache v0.0.0-20170208213004-1952afaa557d/go.mod h1:PmM6Mmwb0LSuEubjR8N7PtNe1KxZLtOUHtbeikc5h60=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.2.1 h1:glEXhBS5PSLLv4IXzLA5yPRVX4bilULVyxxbrfOtDAk=

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -133,8 +133,8 @@ type Rights struct {
 
 // KeyVaultCache represents the configuration for key vault caching.
 type KeyVaultCache struct {
-	Size int           `name:"size" description:"Cache size"`
-	TTL  time.Duration `name:"ttl" description:"Cache elements time to live"`
+	Size int           `name:"size" description:"Cache size. Caching is disabled if size is 0"`
+	TTL  time.Duration `name:"ttl" description:"Cache elements time to live. No expiration mechanism is used if TTL is 0"`
 }
 
 // KeyVault represents configuration for key vaults.

--- a/pkg/crypto/cryptoutil/keyvault_cache.go
+++ b/pkg/crypto/cryptoutil/keyvault_cache.go
@@ -1,0 +1,103 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cryptoutil
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/bluele/gcache"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.thethings.network/lorawan-stack/v3/pkg/crypto"
+	"go.thethings.network/lorawan-stack/v3/pkg/metrics"
+)
+
+type cryptoMetrics struct {
+	cacheHit  *metrics.ContextualCounterVec
+	cacheMiss *metrics.ContextualCounterVec
+}
+
+func (m cryptoMetrics) Describe(ch chan<- *prometheus.Desc) {
+	m.cacheHit.Describe(ch)
+	m.cacheMiss.Describe(ch)
+}
+
+func (m cryptoMetrics) Collect(ch chan<- prometheus.Metric) {
+	m.cacheHit.Collect(ch)
+	m.cacheMiss.Collect(ch)
+}
+
+const (
+	subsystem = "cryptoutil"
+)
+
+var cMetrics = &cryptoMetrics{
+	cacheHit: metrics.NewContextualCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "cache_hit",
+			Help:      "Number of cache hits",
+		},
+		[]string{"cache"},
+	),
+	cacheMiss: metrics.NewContextualCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "cache_miss",
+			Help:      "Number of cache misses",
+		},
+		[]string{"cache"},
+	),
+}
+
+func init() {
+	metrics.MustRegister(cMetrics)
+}
+
+type unwrapEntry struct {
+	value []byte
+	err   error
+}
+
+type cachedVault struct {
+	crypto.KeyVault
+	unwrapCache gcache.Cache
+}
+
+func NewCacheKeyVault(main crypto.KeyVault, ttl time.Duration, size int) crypto.KeyVault {
+	return &cachedVault{
+		KeyVault:    main,
+		unwrapCache: gcache.New(size).Expiration(ttl).ARC().Build(),
+	}
+}
+
+func unwrapCacheKey(ciphertext []byte, kekLabel string) string {
+	return fmt.Sprintf("%v:%v", kekLabel, ciphertext)
+}
+
+func (c *cachedVault) Unwrap(ctx context.Context, ciphertext []byte, kekLabel string) ([]byte, error) {
+	id := unwrapCacheKey(ciphertext, kekLabel)
+	if val, err := c.unwrapCache.Get(id); err == nil {
+		cMetrics.cacheHit.WithLabelValues(ctx, "unwrap").Inc()
+		v := val.(*unwrapEntry)
+		return v.value, v.err
+	}
+	v := &unwrapEntry{}
+	c.unwrapCache.Set(id, v)
+	cMetrics.cacheMiss.WithLabelValues(ctx, "unwrap").Inc()
+	v.value, v.err = c.KeyVault.Unwrap(ctx, ciphertext, kekLabel)
+	return v.value, v.err
+}

--- a/pkg/crypto/cryptoutil/keyvault_cache_test.go
+++ b/pkg/crypto/cryptoutil/keyvault_cache_test.go
@@ -1,0 +1,124 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cryptoutil_test
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"testing"
+
+	"github.com/smartystreets/assertions"
+	. "go.thethings.network/lorawan-stack/v3/pkg/crypto/cryptoutil"
+	"go.thethings.network/lorawan-stack/v3/pkg/types"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+)
+
+type mockKeyVault struct {
+	params struct {
+		ctx        context.Context
+		ciphertext []byte
+		kekLabel   string
+	}
+	results struct {
+		key []byte
+		err error
+	}
+	calls struct {
+		count int
+	}
+}
+
+func (*mockKeyVault) NsKEKLabel(ctx context.Context, netID *types.NetID, addr string) string {
+	return ""
+}
+
+func (*mockKeyVault) AsKEKLabel(ctx context.Context, addr string) string {
+	return ""
+}
+
+func (*mockKeyVault) Wrap(ctx context.Context, plaintext []byte, kekLabel string) ([]byte, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockKeyVault) Unwrap(ctx context.Context, ciphertext []byte, kekLabel string) ([]byte, error) {
+	m.params.ctx, m.params.ciphertext, m.params.kekLabel = ctx, ciphertext, kekLabel
+	m.calls.count++
+	return m.results.key, m.results.err
+}
+
+func (*mockKeyVault) GetCertificate(ctx context.Context, id string) (*x509.Certificate, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (*mockKeyVault) ExportCertificate(ctx context.Context, id string) (*tls.Certificate, error) {
+	return nil, errors.New("not implemented")
+}
+
+func TestCacheUsed(t *testing.T) {
+	a := assertions.New(t)
+	m := &mockKeyVault{}
+
+	ctx := test.Context()
+	ck := NewCacheKeyVault(m, test.Delay, 1)
+
+	// Cache is empty, expect a miss
+	m.results.key = []byte{0x01, 0x02, 0x03}
+	m.results.err = nil
+
+	key, err := ck.Unwrap(ctx, []byte{0x02, 0x03, 0x04}, "foo")
+	a.So(key, should.Resemble, m.results.key)
+	a.So(err, should.Equal, m.results.err)
+	a.So(m.params.ctx, should.HaveParentContextOrEqual, ctx)
+	a.So(m.params.ciphertext, should.Resemble, []byte{0x02, 0x03, 0x04})
+	a.So(m.params.kekLabel, should.Equal, "foo")
+	a.So(m.calls.count, should.Equal, 1)
+
+	// Expect to be served from cache
+	key, err = ck.Unwrap(ctx, []byte{0x02, 0x03, 0x04}, "foo")
+	a.So(key, should.Resemble, m.results.key)
+	a.So(err, should.Equal, m.results.err)
+	a.So(m.calls.count, should.Equal, 1)
+
+	// Expect the old element to be evicted, and a cache miss to occur
+	m.results.key = []byte{0x05, 0x06, 0x07}
+	m.results.err = nil
+	m.calls.count = 0
+
+	key, err = ck.Unwrap(ctx, []byte{0x03, 0x04, 0x05}, "bar")
+	a.So(key, should.Resemble, m.results.key)
+	a.So(err, should.Equal, m.results.err)
+	a.So(m.params.ctx, should.HaveParentContextOrEqual, ctx)
+	a.So(m.params.ciphertext, should.Resemble, []byte{0x03, 0x04, 0x05})
+	a.So(m.params.kekLabel, should.Equal, "bar")
+	a.So(m.calls.count, should.Equal, 1)
+
+	// Expect the cache miss
+	m.results.key = []byte{0x01, 0x02, 0x03}
+	m.results.err = nil
+	m.calls.count = 0
+
+	key, err = ck.Unwrap(ctx, []byte{0x02, 0x03, 0x04}, "foo")
+	a.So(key, should.Resemble, m.results.key)
+	a.So(err, should.Equal, m.results.err)
+	a.So(m.params.ctx, should.HaveParentContextOrEqual, ctx)
+	a.So(m.params.ciphertext, should.Resemble, []byte{0x02, 0x03, 0x04})
+	a.So(m.params.kekLabel, should.Equal, "foo")
+	a.So(m.calls.count, should.Equal, 1)
+
+	// Delay based evictions are left out since they may lead to flakyness.
+}

--- a/pkg/crypto/observability.go
+++ b/pkg/crypto/observability.go
@@ -1,0 +1,74 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crypto
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.thethings.network/lorawan-stack/v3/pkg/metrics"
+)
+
+type cryptoMetrics struct {
+	cacheHit  *metrics.ContextualCounterVec
+	cacheMiss *metrics.ContextualCounterVec
+}
+
+func (m cryptoMetrics) Describe(ch chan<- *prometheus.Desc) {
+	m.cacheHit.Describe(ch)
+	m.cacheMiss.Describe(ch)
+}
+
+func (m cryptoMetrics) Collect(ch chan<- prometheus.Metric) {
+	m.cacheHit.Collect(ch)
+	m.cacheMiss.Collect(ch)
+}
+
+const (
+	subsystem = "crypto"
+)
+
+var cMetrics = &cryptoMetrics{
+	cacheHit: metrics.NewContextualCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "cache_hit",
+			Help:      "Number of cache hits",
+		},
+		[]string{"cache"},
+	),
+	cacheMiss: metrics.NewContextualCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "cache_miss",
+			Help:      "Number of cache misses",
+		},
+		[]string{"cache"},
+	),
+}
+
+func init() {
+	metrics.MustRegister(cMetrics)
+}
+
+// RegisterCacheHit registers a cache hit for the provided cache.
+func RegisterCacheHit(ctx context.Context, cache string) {
+	cMetrics.cacheHit.WithLabelValues(ctx, cache).Inc()
+}
+
+// RegisterCacheMiss registers a cache miss for the provided cache.
+func RegisterCacheMiss(ctx context.Context, cache string) {
+	cMetrics.cacheMiss.WithLabelValues(ctx, cache).Inc()
+}

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -178,6 +178,8 @@ github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb h1:m935MPodAbYS46DG4
 github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb/go.mod h1:PkYb9DJNAwrSvRx5DYA+gUcOIgTGVMNkfSCbZM8cWpI=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/bluele/gcache v0.0.0-20190518031135-bc40bd653833 h1:yCfXxYaelOyqnia8F/Yng47qhmfC9nKTRIbYRrRueq4=
+github.com/bluele/gcache v0.0.0-20190518031135-bc40bd653833/go.mod h1:8c4/i2VlovMO2gBnHGQPN5EJw+H0lx1u/5p+cgsXtCk=
 github.com/bombsimon/wsl/v3 v3.0.0 h1:w9f49xQatuaeTJFaNP4SpiWSR5vfT6IstPtM62JjcqA=
 github.com/bombsimon/wsl/v3 v3.0.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
 github.com/bradfitz/gomemcache v0.0.0-20170208213004-1952afaa557d/go.mod h1:PmM6Mmwb0LSuEubjR8N7PtNe1KxZLtOUHtbeikc5h60=


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #36 

#### Changes
<!-- What are the changes made in this pull request? -->

- Added a cached `KeyVault` wrapper. It currently caches only the unwrapping process, based on the KEK label and the ciphertext.
- Added the cached wrapper as part of the configuration.
- Added cache metrics to `pkg/crypto`.

#### Testing

<!-- How did you verify that this change works? -->

Unit testing with a mock key vault.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Enabling the caching may affect only the unwrapping process. However, I haven't seen any changed behavior during testing.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I haven't included a default configuration for this - any thoughts on what 'sane defaults' we should add ? I'd propose 5 minutes TTL with a cache size of ~1000.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
