### PR TITLE
Set gateway connection stats atomically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The CLI snap version uses the `$SNAP_USER_COMMON` directory for config by default, so that it is preserved between revisions.
 - Defer events subscriptions until there is actual interest for events.
 - End device creation form with wizard in the Console.
+- Gateway connection stats are now stored in a single key.
 
 ### Deprecated
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -3788,24 +3788,6 @@
       "file": "io.go"
     }
   },
-  "error:pkg/gatewayserver/redis:invalid_stats": {
-    "translations": {
-      "en": "invalid `{type}` stats in store"
-    },
-    "description": {
-      "package": "pkg/gatewayserver/redis",
-      "file": "registry.go"
-    }
-  },
-  "error:pkg/gatewayserver/redis:stats_not_found": {
-    "translations": {
-      "en": "gateway stats not found"
-    },
-    "description": {
-      "package": "pkg/gatewayserver/redis",
-      "file": "registry.go"
-    }
-  },
   "error:pkg/gatewayserver/scheduling:conflict": {
     "translations": {
       "en": "scheduling conflict"

--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -1109,7 +1109,7 @@ func TestGatewayServer(t *testing.T) {
 							a.So(ok, should.BeTrue)
 							a.So(conn.Stats(), should.NotBeNil)
 							if config.Stats != nil {
-								a.So(gs.UpdateConnectionStats(conn, true, true, true), should.BeNil)
+								a.So(gs.UpdateConnectionStats(conn), should.BeNil)
 							}
 
 							stats, err := statsClient.GetGatewayConnectionStats(statsCtx, &ids)
@@ -1380,7 +1380,7 @@ func TestGatewayServer(t *testing.T) {
 							a.So(ok, should.BeTrue)
 							a.So(conn.Stats(), should.NotBeNil)
 							if config.Stats != nil {
-								a.So(gs.UpdateConnectionStats(conn, true, true, true), should.BeNil)
+								a.So(gs.UpdateConnectionStats(conn), should.BeNil)
 							}
 
 							stats, err := statsClient.GetGatewayConnectionStats(statsCtx, &ids)

--- a/pkg/gatewayserver/redis/registry.go
+++ b/pkg/gatewayserver/redis/registry.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"runtime/trace"
 
-	"github.com/go-redis/redis/v7"
-	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	ttnredis "go.thethings.network/lorawan-stack/v3/pkg/redis"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/unique"
@@ -30,78 +28,22 @@ type GatewayConnectionStatsRegistry struct {
 	Redis *ttnredis.Client
 }
 
-const (
-	downKey   = "down"
-	upKey     = "up"
-	statusKey = "status"
-)
-
-var (
-	errNotFound     = errors.DefineNotFound("stats_not_found", "gateway stats not found")
-	errInvalidStats = errors.DefineCorruption("invalid_stats", "invalid `{type}` stats in store")
-)
-
-func (r *GatewayConnectionStatsRegistry) key(which string, uid string) string {
-	return r.Redis.Key(which, "uid", uid)
+func (r *GatewayConnectionStatsRegistry) key(uid string) string {
+	return r.Redis.Key("uid", uid)
 }
 
 // Set sets or clears the connection stats for a gateway.
-func (r *GatewayConnectionStatsRegistry) Set(ctx context.Context, ids ttnpb.GatewayIdentifiers, stats *ttnpb.GatewayConnectionStats, updateUp bool, updateDown bool, updateStatus bool) error {
+func (r *GatewayConnectionStatsRegistry) Set(ctx context.Context, ids ttnpb.GatewayIdentifiers, stats *ttnpb.GatewayConnectionStats) error {
 	uid := unique.ID(ctx, ids)
 
 	defer trace.StartRegion(ctx, "set gateway connection stats").End()
 
-	_, err := r.Redis.Pipelined(func(p redis.Pipeliner) error {
-		for _, part := range []struct {
-			key    string
-			update bool
-			fields func() *ttnpb.GatewayConnectionStats
-		}{
-			{
-				key:    r.key(upKey, uid),
-				update: updateUp,
-				fields: func() *ttnpb.GatewayConnectionStats {
-					return &ttnpb.GatewayConnectionStats{
-						LastUplinkReceivedAt: stats.LastUplinkReceivedAt,
-						UplinkCount:          stats.UplinkCount,
-					}
-				},
-			},
-			{
-				key:    r.key(downKey, uid),
-				update: updateDown,
-				fields: func() *ttnpb.GatewayConnectionStats {
-					return &ttnpb.GatewayConnectionStats{
-						LastDownlinkReceivedAt: stats.LastDownlinkReceivedAt,
-						DownlinkCount:          stats.DownlinkCount,
-						RoundTripTimes:         stats.RoundTripTimes,
-					}
-				},
-			},
-			{
-				key:    r.key(statusKey, uid),
-				update: updateStatus,
-				fields: func() *ttnpb.GatewayConnectionStats {
-					return &ttnpb.GatewayConnectionStats{
-						ConnectedAt:          stats.ConnectedAt,
-						Protocol:             stats.Protocol,
-						LastStatus:           stats.LastStatus,
-						LastStatusReceivedAt: stats.LastStatusReceivedAt,
-					}
-				},
-			},
-		} {
-			if !part.update {
-				continue
-			}
-			if stats == nil {
-				p.Del(part.key)
-			} else {
-				ttnredis.SetProto(p, part.key, part.fields(), 0)
-			}
-		}
-		return nil
-	})
+	var err error
+	if stats == nil {
+		err = r.Redis.Del(r.key(uid)).Err()
+	} else {
+		_, err = ttnredis.SetProto(r.Redis, r.key(uid), stats, 0)
+	}
 
 	if err != nil {
 		return ttnredis.ConvertError(err)
@@ -113,46 +55,8 @@ func (r *GatewayConnectionStatsRegistry) Set(ctx context.Context, ids ttnpb.Gate
 func (r *GatewayConnectionStatsRegistry) Get(ctx context.Context, ids ttnpb.GatewayIdentifiers) (*ttnpb.GatewayConnectionStats, error) {
 	uid := unique.ID(ctx, ids)
 	result := &ttnpb.GatewayConnectionStats{}
-	stats := &ttnpb.GatewayConnectionStats{}
-
-	retrieved, err := r.Redis.MGet(r.key(upKey, uid), r.key(downKey, uid), r.key(statusKey, uid)).Result()
-	if err != nil {
+	if err := ttnredis.GetProto(r.Redis, r.key(uid)).ScanProto(result); err != nil {
 		return nil, ttnredis.ConvertError(err)
 	}
-
-	if retrieved[0] == nil && retrieved[1] == nil && retrieved[2] == nil {
-		return nil, errNotFound
-	}
-
-	// Retrieve uplink stats.
-	if retrieved[0] != nil {
-		if err = ttnredis.UnmarshalProto(retrieved[0].(string), stats); err != nil {
-			return nil, errInvalidStats.WithAttributes("type", "uplink").WithCause(err)
-		}
-		result.LastUplinkReceivedAt = stats.LastUplinkReceivedAt
-		result.UplinkCount = stats.UplinkCount
-	}
-
-	// Retrieve downlink stats.
-	if retrieved[1] != nil {
-		if err = ttnredis.UnmarshalProto(retrieved[1].(string), stats); err != nil {
-			return nil, errInvalidStats.WithAttributes("type", "downlink").WithCause(err)
-		}
-		result.LastDownlinkReceivedAt = stats.LastDownlinkReceivedAt
-		result.DownlinkCount = stats.DownlinkCount
-		result.RoundTripTimes = stats.RoundTripTimes
-	}
-
-	// Retrieve gateway status.
-	if retrieved[2] != nil {
-		if err = ttnredis.UnmarshalProto(retrieved[2].(string), stats); err != nil {
-			return nil, errInvalidStats.WithAttributes("type", "status").WithCause(err)
-		}
-		result.ConnectedAt = stats.ConnectedAt
-		result.Protocol = stats.Protocol
-		result.LastStatus = stats.LastStatus
-		result.LastStatusReceivedAt = stats.LastStatusReceivedAt
-	}
-
 	return result, nil
 }

--- a/pkg/gatewayserver/registry.go
+++ b/pkg/gatewayserver/registry.go
@@ -25,5 +25,5 @@ type GatewayConnectionStatsRegistry interface {
 	// Get returns connection stats for a gateway.
 	Get(ctx context.Context, ids ttnpb.GatewayIdentifiers) (*ttnpb.GatewayConnectionStats, error)
 	// Set sets or clears the connection stats for a gateway.
-	Set(ctx context.Context, ids ttnpb.GatewayIdentifiers, stats *ttnpb.GatewayConnectionStats, up, down, status bool) error
+	Set(ctx context.Context, ids ttnpb.GatewayIdentifiers, stats *ttnpb.GatewayConnectionStats) error
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Reverts parts of #2108

#### Changes
<!-- What are the changes made in this pull request? -->

- Store gateway connection stats atomically under a single key.

#### Testing

<!-- How did you verify that this change works? -->

Unit tests, simulate gateway connection, send a few dummy messages and verify stats

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

- 

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [X] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
