### PR TITLE
CLI set payload formatters from file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Payload formatter documentation.
+- CLI support for setting message payload formatters from a local file. (see `--formatters.down-formatter-parameter-local-file` and `--formatters.up-formatter-parameter-local-file` options).
+
 ### Changed
 
 ### Deprecated
@@ -34,7 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - LORIX One gateway documentation.
 - Display own user name instead of ID in Console if possible.
 - Option to hide rarely used fields in the Join Settings step (end device wizard) in the Console.
-- Payload formatter documentation.
 
 ### Changed
 

--- a/cmd/ttn-lw-cli/commands/applications_link.go
+++ b/cmd/ttn-lw-cli/commands/applications_link.go
@@ -93,7 +93,11 @@ var (
 			if link.APIKey == "" {
 				return errNoApplicationLinkAPIKey
 			}
-
+			newPaths, err := parsePayloadFormatterParameterFlags("default-formatters", link.DefaultFormatters, cmd.Flags())
+			if err != nil {
+				return err
+			}
+			paths = append(paths, newPaths...)
 			as, err := api.Dial(ctx, config.ApplicationServerGRPCAddress)
 			if err != nil {
 				return err
@@ -140,6 +144,7 @@ func init() {
 	applicationsLinkCommand.AddCommand(applicationsLinkGetCommand)
 	applicationsLinkSetCommand.Flags().AddFlagSet(applicationIDFlags())
 	applicationsLinkSetCommand.Flags().AddFlagSet(setApplicationLinkFlags)
+	applicationsLinkSetCommand.Flags().AddFlagSet(payloadFormatterParameterFlags("default-formatters"))
 	applicationsLinkCommand.AddCommand(applicationsLinkSetCommand)
 	applicationsLinkDeleteCommand.Flags().AddFlagSet(applicationIDFlags())
 	applicationsLinkCommand.AddCommand(applicationsLinkDeleteCommand)

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -497,6 +497,11 @@ var (
 					device.DevEUI = devID.DevEUI
 				}
 			}
+			newPaths, err := parsePayloadFormatterParameterFlags("formatters", device.Formatters, cmd.Flags())
+			if err != nil {
+				return err
+			}
+			paths = append(paths, newPaths...)
 
 			if device.ApplicationID == "" {
 				return errNoApplicationID
@@ -582,6 +587,11 @@ var (
 			if err = util.SetFields(&device, setEndDeviceFlags); err != nil {
 				return err
 			}
+			newPaths, err := parsePayloadFormatterParameterFlags("formatters", device.Formatters, cmd.Flags())
+			if err != nil {
+				return err
+			}
+			paths = append(paths, newPaths...)
 			device.Attributes = mergeAttributes(device.Attributes, cmd.Flags())
 			device.EndDeviceIdentifiers = *devID
 
@@ -1160,6 +1170,7 @@ func init() {
 	endDevicesCreateCommand.Flags().AddFlagSet(endDeviceIDFlags())
 	endDevicesCreateCommand.Flags().AddFlagSet(setEndDeviceFlags)
 	endDevicesCreateCommand.Flags().AddFlagSet(attributesFlags())
+	endDevicesCreateCommand.Flags().AddFlagSet(payloadFormatterParameterFlags("formatters"))
 	endDevicesCreateCommand.Flags().Bool("defaults", true, "configure end device with defaults")
 	endDevicesCreateCommand.Flags().Bool("with-root-keys", false, "generate OTAA root keys")
 	endDevicesCreateCommand.Flags().Bool("abp", false, "configure end device as ABP")
@@ -1171,6 +1182,7 @@ func init() {
 	endDevicesUpdateCommand.Flags().AddFlagSet(endDeviceIDFlags())
 	endDevicesUpdateCommand.Flags().AddFlagSet(setEndDeviceFlags)
 	endDevicesUpdateCommand.Flags().AddFlagSet(attributesFlags())
+	endDevicesUpdateCommand.Flags().AddFlagSet(payloadFormatterParameterFlags("formatters"))
 	endDevicesUpdateCommand.Flags().Bool("touch", false, "set in all registries even if no fields are specified")
 	endDevicesUpdateCommand.Flags().AddFlagSet(endDevicePictureFlags)
 	endDevicesUpdateCommand.Flags().AddFlagSet(endDeviceLocationFlags)

--- a/doc/content/integrations/payload-formatters/cli.md
+++ b/doc/content/integrations/payload-formatters/cli.md
@@ -44,3 +44,29 @@ $ ttn-lw-cli end-devices create app1 dev1-with-formatter \
 ```
 
 To create a [CayenneLPP]({{< relref "cayenne" >}}) or [Device Repository]({{< relref "device-repo" >}}) device payload formatter, use the `FORMATTER_CAYENNELPP` or `FORMATTER_DEVICEREPO` constants. No `formatter-parameter-local-file` parameter is needed.
+
+## Edit a Device Specific Payload Formatter
+
+To change the payload formatter for an existing device, use the `end-devices update` command:
+
+```bash
+$ ttn-lw-cli end-devices update app1 dev1-with-formatter \
+  --formatters.down-formatter FORMATTER_JAVASCRIPT \
+  --formatters.down-formatter-parameter-local-file "encoder.js" \
+  --formatters.up-formatter FORMATTER_JAVASCRIPT \
+  --formatters.up-formatter-parameter-local-file "decoder.js"
+```
+
+To unset the payload formatters, use the `--unset` flag. The command below will unset all device specific payload formatters:
+
+```bash
+$ ttn-lw-cli end-devices update app1 dev1-with-formatter \
+  --unset "formatters"
+```
+
+It is also possible to unset the uplink or downlink formatters separately:
+
+```bash
+$ ttn-lw-cli end-devices update app1 dev1-with-formatter \
+  --unset "formatters.up-formatter,formatters.up-formatter-parameter"
+```


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2819

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `formatters.up/down-formatter-parameter-local-file` parameters.

#### Testing

<!-- How did you verify that this change works? -->

- Test setting formatters from the CLI, per device (device create + update) and per application link (link set).
- Test using the commands without the new flags, so that existing behaviour does not break in some way.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

There should not be any.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
