### PR TITLE
Clean up device general settings

### DIFF
--- a/pkg/webui/console/views/device-general-settings/device-general-settings.js
+++ b/pkg/webui/console/views/device-general-settings/device-general-settings.js
@@ -210,6 +210,8 @@ export default class DeviceGeneralSettings extends React.Component {
                 onDeleteSuccess={this.handleDeleteSuccess}
                 onDeleteFailure={this.handleDeleteFailure}
                 jsConfig={jsConfig}
+                nsConfig={nsConfig}
+                asConfig={asConfig}
                 mayReadKeys={mayReadKeys}
               />
             </Collapse>

--- a/pkg/webui/console/views/device-general-settings/device-general-settings.js
+++ b/pkg/webui/console/views/device-general-settings/device-general-settings.js
@@ -212,7 +212,6 @@ export default class DeviceGeneralSettings extends React.Component {
                 jsConfig={jsConfig}
                 nsConfig={nsConfig}
                 asConfig={asConfig}
-                mayReadKeys={mayReadKeys}
               />
             </Collapse>
             <Collapse title={m.nsTitle} description={nsDescription} disabled={nsDisabled}>

--- a/pkg/webui/console/views/device-general-settings/identity-server-form/index.js
+++ b/pkg/webui/console/views/device-general-settings/identity-server-form/index.js
@@ -49,7 +49,6 @@ const IdentityServerForm = React.memo(props => {
     onDelete,
     onDeleteSuccess,
     onDeleteFailure,
-    mayReadKeys,
     jsConfig,
     nsConfig,
     asConfig,
@@ -68,7 +67,7 @@ const IdentityServerForm = React.memo(props => {
   )
 
   const [error, setError] = React.useState('')
-  const [externalJs, setExternaljs] = React.useState(hasExternalJs(device) && mayReadKeys)
+  const [externalJs, setExternaljs] = React.useState(hasExternalJs(device))
 
   const validationContext = React.useMemo(
     () => ({
@@ -81,12 +80,12 @@ const IdentityServerForm = React.memo(props => {
   const initialValues = React.useMemo(() => {
     const initialValues = {
       ...device,
-      _external_js: hasExternalJs(device) && mayReadKeys,
+      _external_js: hasExternalJs(device),
       attributes: mapAttributesToFormValue(device.attributes),
     }
 
     return validationSchema.cast(initialValues, { context: validationContext })
-  }, [device, mayReadKeys, validationContext])
+  }, [device, validationContext])
 
   const handleExternalJsChange = React.useCallback(
     evt => {
@@ -293,7 +292,6 @@ IdentityServerForm.propTypes = {
   asConfig: PropTypes.stackComponent.isRequired,
   device: PropTypes.device.isRequired,
   jsConfig: PropTypes.stackComponent.isRequired,
-  mayReadKeys: PropTypes.bool.isRequired,
   nsConfig: PropTypes.stackComponent.isRequired,
   onDelete: PropTypes.func.isRequired,
   onDeleteFailure: PropTypes.func.isRequired,

--- a/pkg/webui/console/views/device-general-settings/identity-server-form/index.js
+++ b/pkg/webui/console/views/device-general-settings/identity-server-form/index.js
@@ -26,7 +26,6 @@ import KeyValueMap from '@ttn-lw/components/key-value-map'
 import diff from '@ttn-lw/lib/diff'
 import PropTypes from '@ttn-lw/lib/prop-types'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
-import { selectAsConfig, selectJsConfig, selectNsConfig } from '@ttn-lw/lib/selectors/env'
 
 import { mapFormValueToAttributes, mapAttributesToFormValue } from '@console/lib/attributes'
 import { parseLorawanMacVersion } from '@console/lib/device-utils'
@@ -50,6 +49,9 @@ const IdentityServerForm = React.memo(props => {
     onDeleteSuccess,
     onDeleteFailure,
     mayReadKeys,
+    jsConfig,
+    nsConfig,
+    asConfig,
   } = props
   const { name, ids } = device
 
@@ -114,9 +116,9 @@ const IdentityServerForm = React.memo(props => {
     }
   }, [onDelete, onDeleteFailure, onDeleteSuccess])
 
-  const { enabled: jsEnabled } = selectJsConfig()
-  const { enabled: asEnabled } = selectAsConfig()
-  const { enabled: nsEnabled } = selectNsConfig()
+  const { enabled: jsEnabled } = jsConfig
+  const { enabled: asEnabled } = asConfig
+  const { enabled: nsEnabled } = nsConfig
 
   const lorawanVersion = parseLorawanMacVersion(device.lorawan_version)
   const isOTAA = isDeviceOTAA(device)
@@ -263,8 +265,11 @@ const IdentityServerForm = React.memo(props => {
 })
 
 IdentityServerForm.propTypes = {
+  asConfig: PropTypes.stackComponent.isRequired,
   device: PropTypes.device.isRequired,
+  jsConfig: PropTypes.stackComponent.isRequired,
   mayReadKeys: PropTypes.bool.isRequired,
+  nsConfig: PropTypes.stackComponent.isRequired,
   onDelete: PropTypes.func.isRequired,
   onDeleteFailure: PropTypes.func.isRequired,
   onDeleteSuccess: PropTypes.func.isRequired,

--- a/pkg/webui/console/views/device-general-settings/identity-server-form/index.js
+++ b/pkg/webui/console/views/device-general-settings/identity-server-form/index.js
@@ -23,6 +23,7 @@ import Checkbox from '@ttn-lw/components/checkbox'
 import ModalButton from '@ttn-lw/components/button/modal-button'
 import KeyValueMap from '@ttn-lw/components/key-value-map'
 
+import getHostnameFromUrl from '@ttn-lw/lib/host-from-url'
 import diff from '@ttn-lw/lib/diff'
 import PropTypes from '@ttn-lw/lib/prop-types'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
@@ -56,8 +57,17 @@ const IdentityServerForm = React.memo(props => {
   const { name, ids } = device
 
   const formRef = React.useRef(null)
-  const [error, setError] = React.useState('')
+  // Store default join server address that is used to fill the `join_server_address` field when
+  // `_external_js` checkbox is unchecked.
+  const jsAddressRef = React.useRef(
+    device.join_server_address
+      ? device.join_server_address
+      : jsConfig.enabled
+      ? getHostnameFromUrl(jsConfig.base_url)
+      : '',
+  )
 
+  const [error, setError] = React.useState('')
   const [externalJs, setExternaljs] = React.useState(hasExternalJs(device) && mayReadKeys)
 
   const validationContext = React.useMemo(
@@ -84,10 +94,13 @@ const IdentityServerForm = React.memo(props => {
       const { setValues, values } = formRef.current
 
       setExternaljs(externalJsChecked)
-
       setValues(
         validationSchema.cast(
-          { ...values, _external_js: externalJsChecked },
+          {
+            ...values,
+            _external_js: externalJsChecked,
+            join_server_address: externalJsChecked ? undefined : jsAddressRef.current,
+          },
           { context: validationContext },
         ),
       )

--- a/pkg/webui/console/views/device-general-settings/identity-server-form/validation-schema.js
+++ b/pkg/webui/console/views/device-general-settings/identity-server-form/validation-schema.js
@@ -47,10 +47,8 @@ const validationSchema = Yup.object()
       sharedMessages.validateAddressFormat,
     ),
     _external_js: Yup.boolean(),
-    _supports_join: Yup.boolean(),
-    _lorawan_version: Yup.string(),
     join_server_address: Yup.string().when(
-      ['_supports_join', ' _external_js'],
+      ['$supportsJoin', ' _external_js'],
       (supportsJoin, externalJs, schema) => {
         if (!supportsJoin) {
           return schema.strip()
@@ -67,7 +65,7 @@ const validationSchema = Yup.object()
       },
     ),
     resets_join_nonces: Yup.bool().when(
-      ['_supports_join', '_lorawan_version', '_external_js'],
+      ['$supportsJoin', 'lorawanVersion', '_external_js'],
       (supportsJoin, lorawanVersion, externalJs, schema) => {
         if (!supportsJoin || parseLorawanMacVersion(lorawanVersion) < 110) {
           return schema.strip()
@@ -81,7 +79,7 @@ const validationSchema = Yup.object()
       },
     ),
     root_keys: Yup.object().when(
-      ['_external_js', '_lorawan_version'],
+      ['_external_js', '$lorawanVersion'],
       (externalJs, version, schema) => {
         const strippedSchema = Yup.object().strip()
         const keySchema = Yup.lazy(() => {

--- a/pkg/webui/console/views/device-general-settings/identity-server-form/validation-schema.js
+++ b/pkg/webui/console/views/device-general-settings/identity-server-form/validation-schema.js
@@ -15,13 +15,10 @@
 import * as Yup from 'yup'
 
 import sharedMessages from '@ttn-lw/lib/shared-messages'
-import { selectJsConfig } from '@ttn-lw/lib/selectors/env'
 
 import { attributeValidCheck, attributeTooShortCheck } from '@console/lib/attributes'
 import { id as deviceIdRegexp, address as addressRegexp } from '@console/lib/regexp'
 import { parseLorawanMacVersion, generate16BytesKey } from '@console/lib/device-utils'
-
-const jsConfig = selectJsConfig()
 
 const toUndefined = value => (!Boolean(value) ? undefined : value)
 
@@ -47,25 +44,15 @@ const validationSchema = Yup.object()
       sharedMessages.validateAddressFormat,
     ),
     _external_js: Yup.boolean(),
-    join_server_address: Yup.string().when(
-      ['$supportsJoin', ' _external_js'],
-      (supportsJoin, externalJs, schema) => {
-        if (!supportsJoin) {
-          return schema.strip()
-        }
+    join_server_address: Yup.string().when(['$supportsJoin'], (supportsJoin, schema) => {
+      if (!supportsJoin) {
+        return schema.strip()
+      }
 
-        if (externalJs) {
-          return schema.transform(() => '')
-        }
-
-        return schema
-          .matches(addressRegexp, sharedMessages.validateAddressFormat)
-          .transform(toUndefined)
-          .default(new URL(jsConfig.base_url).hostname)
-      },
-    ),
+      return schema.matches(addressRegexp, sharedMessages.validateAddressFormat).default('')
+    }),
     resets_join_nonces: Yup.bool().when(
-      ['$supportsJoin', 'lorawanVersion', '_external_js'],
+      ['$supportsJoin', '$lorawanVersion', '_external_js'],
       (supportsJoin, lorawanVersion, externalJs, schema) => {
         if (!supportsJoin || parseLorawanMacVersion(lorawanVersion) < 110) {
           return schema.strip()
@@ -79,9 +66,12 @@ const validationSchema = Yup.object()
       },
     ),
     root_keys: Yup.object().when(
-      ['_external_js', '$lorawanVersion'],
-      (externalJs, version, schema) => {
-        const strippedSchema = Yup.object().strip()
+      ['_external_js', '$lorawanVersion', '$supportsJoin'],
+      (externalJs, version, supportsJoin, schema) => {
+        if (!supportsJoin) {
+          return schema.strip()
+        }
+
         const keySchema = Yup.lazy(() => {
           return !externalJs
             ? Yup.object().shape({
@@ -95,14 +85,14 @@ const validationSchema = Yup.object()
 
         if (externalJs) {
           return schema.shape({
-            nwk_key: strippedSchema,
-            app_key: strippedSchema,
+            nwk_key: Yup.object().strip(),
+            app_key: Yup.object().strip(),
           })
         }
 
         if (parseLorawanMacVersion(version) < 110) {
           return schema.shape({
-            nwk_key: strippedSchema,
+            nwk_key: Yup.object().strip(),
             app_key: keySchema,
           })
         }

--- a/pkg/webui/console/views/device-general-settings/join-server-form/index.js
+++ b/pkg/webui/console/views/device-general-settings/join-server-form/index.js
@@ -47,7 +47,7 @@ const JoinServerForm = React.memo(props => {
 
   // Fallback to 1.1.0 in case NS is not available and lorawan version is not set present.
   const isNewLorawanVersion = parseLorawanMacVersion(device.lorawan_version || '1.1.0') >= 110
-  const externalJs = hasExternalJs(device) && mayReadKeys
+  const externalJs = hasExternalJs(device)
 
   const formRef = React.useRef(null)
   const [error, setError] = React.useState('')

--- a/pkg/webui/console/views/device-general-settings/join-server-form/index.js
+++ b/pkg/webui/console/views/device-general-settings/join-server-form/index.js
@@ -45,8 +45,7 @@ const isAppKeyHidden = ({ root_keys }) =>
 const JoinServerForm = React.memo(props => {
   const { device, onSubmit, onSubmitSuccess, mayReadKeys, mayEditKeys } = props
 
-  // Fallback to 1.1.0 in case NS is not available and lorawan version is not
-  // set present.
+  // Fallback to 1.1.0 in case NS is not available and lorawan version is not set present.
   const isNewLorawanVersion = parseLorawanMacVersion(device.lorawan_version || '1.1.0') >= 110
   const externalJs = hasExternalJs(device) && mayReadKeys
 
@@ -54,21 +53,23 @@ const JoinServerForm = React.memo(props => {
   const [error, setError] = React.useState('')
   const [resetsJoinNonces, setResetsJoinNonces] = React.useState(device.resets_join_nonces)
 
+  const validationContext = React.useMemo(
+    () => ({
+      lorawanVersion: device.lorawanVersion,
+      mayEditKeys,
+      mayReadKeys,
+      externalJs,
+    }),
+    [device.lorawanVersion, externalJs, mayEditKeys, mayReadKeys],
+  )
+
   // Setup and memoize initial form state.
-  const initialValues = React.useMemo(() => {
-    const values = {
-      ...device,
-      _external_js: hasExternalJs(device) && mayReadKeys,
-      _lorawan_version: device.lorawan_version,
-      _may_edit_keys: mayEditKeys,
-      _may_read_keys: mayReadKeys,
-    }
+  const initialValues = React.useMemo(
+    () => validationSchema.cast(device, { context: validationContext }),
+    [device, validationContext],
+  )
 
-    return validationSchema.cast(values)
-  }, [device, mayEditKeys, mayReadKeys])
-
-  // Setup and memoize callbacks for changes to `resets_join_nonces` for
-  // displaying the field warning.
+  // Setup and memoize callbacks for changes to `resets_join_nonces` for displaying the field warning.
   const handleResetsJoinNoncesChange = React.useCallback(
     evt => {
       setResetsJoinNonces(evt.target.checked)
@@ -78,13 +79,8 @@ const JoinServerForm = React.memo(props => {
 
   const onFormSubmit = React.useCallback(
     async (values, { setSubmitting, resetForm }) => {
-      const castedValues = validationSchema.cast(values)
-      const updatedValues = diff(initialValues, castedValues, [
-        '_external_js',
-        '_lorawan_version',
-        '_may_edit_keys',
-        '_may_read_keys',
-      ])
+      const castedValues = validationSchema.cast(values, { context: validationContext })
+      const updatedValues = diff(initialValues, castedValues)
 
       setError('')
       try {
@@ -96,7 +92,7 @@ const JoinServerForm = React.memo(props => {
         setError(err)
       }
     },
-    [initialValues, onSubmit, onSubmitSuccess],
+    [initialValues, onSubmit, onSubmitSuccess, validationContext],
   )
 
   const nwkKeyHidden = isNwkKeyHidden(device)
@@ -116,13 +112,14 @@ const JoinServerForm = React.memo(props => {
     nwkKeyPlaceholder = sharedMessages.unexposed
   }
 
-  // Notify the user that the root keys might be there, but since there are no
-  // rights to read the keys we cannot display them.
+  // Notify the user that the root keys might be there, but since there are no rights to read
+  // the keys we cannot display them.
   const showResetNotification = !mayReadKeys && mayEditKeys && !Boolean(device.root_keys)
 
   return (
     <Form
       validationSchema={validationSchema}
+      validationContext={validationContext}
       initialValues={initialValues}
       onSubmit={onFormSubmit}
       formikRef={formRef}

--- a/pkg/webui/console/views/device-general-settings/join-server-form/validation-schema.js
+++ b/pkg/webui/console/views/device-general-settings/join-server-form/validation-schema.js
@@ -24,8 +24,8 @@ const validationSchema = Yup.object()
       .emptyOrLength(3 * 2, Yup.passValues(sharedMessages.validateLength)) // 3 Byte hex.
       .default(''),
     root_keys: Yup.object().when(
-      ['_external_js', '_lorawan_version', '_may_edit_keys', '_may_read_keys'],
-      (externalJs, version, mayEditKeys, mayReadKeys, schema) => {
+      ['$externalJs', '$lorawanVersion', '$mayEditKeys', '$mayEditkeys'],
+      (externalJs, lorawanVersion, mayEditKeys, mayReadKeys, schema) => {
         const strippedSchema = Yup.object().strip()
         const keySchema = Yup.lazy(value => {
           return !externalJs && Boolean(value) && Boolean(value.key)
@@ -49,7 +49,7 @@ const validationSchema = Yup.object()
           })
         }
 
-        if (parseLorawanMacVersion(version) < 110) {
+        if (parseLorawanMacVersion(lorawanVersion) < 110) {
           return schema.shape({
             nwk_key: strippedSchema,
             app_key: keySchema,
@@ -62,7 +62,7 @@ const validationSchema = Yup.object()
         })
       },
     ),
-    resets_join_nonces: Yup.boolean().when('_lorawan_version', {
+    resets_join_nonces: Yup.boolean().when('$lorawanVersion', {
       // Verify if lorawan version is 1.1.0 or higher.
       is: version => parseLorawanMacVersion(version) >= 110,
       then: schema => schema,
@@ -77,10 +77,6 @@ const validationSchema = Yup.object()
     network_server_kek_label: Yup.string()
       .max(2048, Yup.passValues(sharedMessages.validateTooLong))
       .default(''),
-    _external_js: Yup.boolean().default(false),
-    _lorawan_version: Yup.string().default('1.1.0'),
-    _may_edit_keys: Yup.boolean().default(false),
-    _may_read_keys: Yup.boolean().default(false),
   })
   .noUnknown()
 

--- a/pkg/webui/console/views/device-general-settings/network-server-form/index.js
+++ b/pkg/webui/console/views/device-general-settings/network-server-form/index.js
@@ -66,6 +66,16 @@ const NetworkServerForm = React.memo(props => {
     parseLorawanMacVersion(device.lorawan_version),
   )
 
+  const validationContext = React.useMemo(
+    () => ({
+      mayEditKeys,
+      mayReadKeys,
+      isJoined: isDeviceOTAA(device) && isDeviceJoined(device),
+      externalJs: hasExternalJs(device) && mayReadKeys,
+    }),
+    [device, mayEditKeys, mayReadKeys],
+  )
+
   const initialValues = React.useMemo(() => {
     const { multicast = false, supports_join = false } = device
 
@@ -79,25 +89,15 @@ const NetworkServerForm = React.memo(props => {
     const values = {
       ...device,
       _activation_mode,
-      _external_js: hasExternalJs(device) && mayReadKeys,
-      _joined: isDeviceOTAA(device) && isDeviceJoined(device),
-      _may_edit_keys: mayEditKeys,
-      _may_read_keys: mayReadKeys,
     }
 
-    return validationSchema.cast(values)
-  }, [device, mayEditKeys, mayReadKeys])
+    return validationSchema.cast(values, { context: validationContext })
+  }, [device, validationContext])
 
   const onFormSubmit = React.useCallback(
     async (values, { resetForm, setSubmitting }) => {
-      const castedValues = validationSchema.cast(values)
-      const updatedValues = diff(initialValues, castedValues, [
-        '_activation_mode',
-        '_external_js',
-        '_joined',
-        '_may_edit_keys',
-        '_may_read_keys',
-      ])
+      const castedValues = validationSchema.cast(values, { context: validationContext })
+      const updatedValues = diff(initialValues, castedValues, ['_activation_mode'])
 
       setError('')
       try {
@@ -109,7 +109,7 @@ const NetworkServerForm = React.memo(props => {
         setError(err)
       }
     },
-    [initialValues, onSubmit, onSubmitSuccess],
+    [initialValues, onSubmit, onSubmitSuccess, validationContext],
   )
 
   const handleResetsFCntChange = React.useCallback(evt => {
@@ -169,6 +169,7 @@ const NetworkServerForm = React.memo(props => {
   return (
     <Form
       validationSchema={validationSchema}
+      validationContext={validationContext}
       initialValues={initialValues}
       onSubmit={onFormSubmit}
       error={error}

--- a/pkg/webui/console/views/device-general-settings/network-server-form/index.js
+++ b/pkg/webui/console/views/device-general-settings/network-server-form/index.js
@@ -71,7 +71,7 @@ const NetworkServerForm = React.memo(props => {
       mayEditKeys,
       mayReadKeys,
       isJoined: isDeviceOTAA(device) && isDeviceJoined(device),
-      externalJs: hasExternalJs(device) && mayReadKeys,
+      externalJs: hasExternalJs(device),
     }),
     [device, mayEditKeys, mayReadKeys],
   )

--- a/pkg/webui/console/views/device-general-settings/network-server-form/validation-schema.js
+++ b/pkg/webui/console/views/device-general-settings/network-server-form/validation-schema.js
@@ -20,19 +20,15 @@ import { parseLorawanMacVersion, ACTIVATION_MODES } from '@console/lib/device-ut
 
 const validationSchema = Yup.object()
   .shape({
-    _external_js: Yup.boolean(),
     _activation_mode: Yup.mixed()
       .oneOf([ACTIVATION_MODES.ABP, ACTIVATION_MODES.OTAA, ACTIVATION_MODES.MULTICAST])
       .required(sharedMessages.validateRequired),
-    _may_edit_keys: Yup.boolean().default(false),
-    _may_read_keys: Yup.boolean().default(false),
-    _joined: Yup.boolean().default(false),
     lorawan_version: Yup.string().required(sharedMessages.validateRequired),
     lorawan_phy_version: Yup.string().required(sharedMessages.validateRequired),
     frequency_plan_id: Yup.string().required(sharedMessages.validateRequired),
     supports_class_c: Yup.boolean().default(false),
     session: Yup.object().when(
-      ['_activation_mode', 'lorawan_version', '_joined', '_may_edit_keys', '_may_read_keys'],
+      ['_activation_mode', 'lorawan_version', '$isJoined', '$mayEditKeys', '$mayReadKeys'],
       (mode, version, isJoined, mayEditKeys, mayReadKeys, schema) => {
         if (mode === ACTIVATION_MODES.ABP || mode === ACTIVATION_MODES.MULTICAST || isJoined) {
           const isNewVersion = parseLorawanMacVersion(version) >= 110


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/2832

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix handling abp/multicast devices in the identity server form when form submission results in setting an empty `root_keys` object.
- Move dependecies required in the validation schema to the validation context
- Remove redundant check for `RIGHT_APPLICATION_DEVICES_READ_KEYS` when checking if the device is registered on an external JS. 
- Adjust handling of `join_server_address` in the identity server form. We didnt check if JS is enabled before setting the default address to point to the local cluster JS.
- Remove direct imports of config selectors in the general settings forms.


#### Testing

<!-- How did you verify that this change works? -->

Updated abp/multicast/otaa devices with various stack configurations (no NS/JS/AS) as well as for the users without `RIGHT_APPLICATION_DEVICES_{READ|WRITE}_KEYS` rights.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Device general settings page


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
