### PR TITLE
Fix cookies removal potentially leaving cookies active for the current path

### DIFF
--- a/pkg/web/cookie/cookie.go
+++ b/pkg/web/cookie/cookie.go
@@ -131,4 +131,15 @@ func (d *Cookie) Remove(c echo.Context) {
 		Expires:  time.Unix(1, 0),
 		MaxAge:   0,
 	})
+
+	// Additionally, explicitly remove the cookie also from the current path.
+	// This can be necessary to also remove old cookies when the cookie paths
+	// have been changed.
+	http.SetCookie(c.Response().Writer, &http.Cookie{
+		Name:     d.Name,
+		HttpOnly: d.HTTPOnly,
+		Value:    tombstone,
+		Expires:  time.Unix(1, 0),
+		MaxAge:   0,
+	})
 }


### PR DESCRIPTION
#### Summary
This quickfix PR will make sure that when removing cookies, they're not only removed from their defined path but additionally also from the current path of the request. This can be necessary if cookie paths have changed between releases.

#### Changes
- Add cookie removal for current path of the request, additionally to the removal from the initially configured cookie path

#### Testing

Manual testing

##### Regressions
This might affect cookie removal in general, e.g. during logout, which I tested manually.

#### Notes for Reviewers
This PR will make sure that there will be no login problems in the next releases when we change the path of the `_session` cookie. Without this change, old `_session` cookies would not get deleted, which breaks the login.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
