### PR TITLE
Allow suppressing logs for selected gRPC methods on success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Payload formatter documentation.
 - CLI support for setting message payload formatters from a local file. (see `--formatters.down-formatter-parameter-local-file` and `--formatters.up-formatter-parameter-local-file` options).
 - Generic encryption/decryption to KeyVault.
+- Option to ignore log messages for selected gRPC method on success (see `grpc.log-ignore-methods` option).
 
 ### Changed
 

--- a/doc/content/reference/configuration/the-things-stack.md
+++ b/doc/content/reference/configuration/the-things-stack.md
@@ -49,6 +49,12 @@ When running a cluster in a trusted network, you can allow sending credentials o
 
 - `grpc.allow-insecure-for-credentials`: Allow transmission of credentials over insecure transport
 
+You can suppress log messages for successful gRPC method calls (e.g. to reduce the noise caused by the health checks in a production environment).
+
+- `grpc.log-ignore-methods`: List of gRPC methods for which to suppress logs of successful requests.
+
+> NOTE: If you are seeing a lot of logs with `grpc_service=/ttn.v3.lorawan.ServiceName` and `grpc_method=MethodName`, use `/ttn.v3.lorawan.ServiceName/MethodName` for this option.
+
 ## HTTP Options
 
 The `http` options configure how {{% tts %}} listens for HTTP connections. The format is `host:port`. When listening on TLS ports, it uses the global [TLS configuration]({{< ref "#tls-options" >}}).

--- a/pkg/component/grpc.go
+++ b/pkg/component/grpc.go
@@ -34,6 +34,7 @@ func (c *Component) initGRPC() {
 	c.grpc = rpcserver.New(
 		c.ctx,
 		rpcserver.WithContextFiller(c.FillContext),
+		rpcserver.WithLogIgnoreMethods(c.config.GRPC.LogIgnoreMethods),
 	)
 }
 

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -55,6 +55,8 @@ type GRPC struct {
 
 	Listen    string `name:"listen" description:"Address for the TCP gRPC server to listen on"`
 	ListenTLS string `name:"listen-tls" description:"Address for the TLS gRPC server to listen on"`
+
+	LogIgnoreMethods []string `name:"log-ignore-methods" description:"List of paths for which successful requests will not be logged"`
 }
 
 // Cookie represents cookie configuration.

--- a/pkg/rpcmiddleware/rpclog/options.go
+++ b/pkg/rpcmiddleware/rpclog/options.go
@@ -15,21 +15,23 @@
 package rpclog
 
 import (
-	"github.com/grpc-ecosystem/go-grpc-middleware/logging"
+	grpc_logging "github.com/grpc-ecosystem/go-grpc-middleware/logging"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"google.golang.org/grpc/codes"
 )
 
 var (
 	defaultOptions = &options{
-		levelFunc: DefaultCodeToLevel,
-		codeFunc:  grpc_logging.DefaultErrorToCode,
+		levelFunc:     DefaultCodeToLevel,
+		codeFunc:      grpc_logging.DefaultErrorToCode,
+		ignoreMethods: make(map[string]struct{}),
 	}
 )
 
 type options struct {
-	levelFunc CodeToLevel
-	codeFunc  grpc_logging.ErrorToCode
+	levelFunc     CodeToLevel
+	codeFunc      grpc_logging.ErrorToCode
+	ignoreMethods map[string]struct{}
 }
 
 func evaluateServerOpt(opts []Option) *options {
@@ -69,6 +71,15 @@ func WithLevels(f CodeToLevel) Option {
 func WithCodes(f grpc_logging.ErrorToCode) Option {
 	return func(o *options) {
 		o.codeFunc = f
+	}
+}
+
+// WithIgnoreMethods sets a list of methods for which no log messages are printed on success.
+func WithIgnoreMethods(methods []string) Option {
+	return func(o *options) {
+		for _, m := range methods {
+			o.ignoreMethods[m] = struct{}{}
+		}
 	}
 }
 

--- a/pkg/rpcmiddleware/rpclog/server_interceptors.go
+++ b/pkg/rpcmiddleware/rpclog/server_interceptors.go
@@ -31,6 +31,11 @@ func UnaryServerInterceptor(ctx context.Context, opts ...Option) grpc.UnaryServe
 		newCtx := newLoggerForCall(ctx, logger, info.FullMethod)
 		startTime := time.Now()
 		resp, err := handler(newCtx, req)
+		if err == nil {
+			if _, ok := o.ignoreMethods[info.FullMethod]; ok {
+				return resp, err
+			}
+		}
 		logFields := []interface{}{
 			"duration", time.Since(startTime),
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #2655

#### Changes
<!-- What are the changes made in this pull request? -->

- Add a new `--grpc.log-ignore-methods` option
- Pass that to the log middleware of the gRPC server
- If the method call succeeds, do not log anything.

This is useful for methods like `GetGatewayConnectionStats`, which is used frequently when the Console is open or for health checks for the gateways.

#### Testing

<!-- How did you verify that this change works? -->

Test locally

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

There should not be any

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [X] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
