### PR TITLE
Fix CLI segfault when listing default package associations without appID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Inconsistent error message responses when retrieving connection stats from GS if the gateway is not connected.
 - Empty form validation in the Console.
+- CLI crash when listing application package default associations without providing an application ID.
 
 ### Security
 

--- a/cmd/ttn-lw-cli/commands/applications_packages.go
+++ b/cmd/ttn-lw-cli/commands/applications_packages.go
@@ -351,6 +351,9 @@ var (
 		Short:   "List application package default associations",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			appID := getApplicationID(cmd.Flags(), args)
+			if appID == nil {
+				return errNoApplicationID
+			}
 			paths := util.SelectFieldMask(cmd.Flags(), selectApplicationPackageDefaultAssociationsFlags)
 			if len(paths) == 0 {
 				logger.Warn("No fields selected, will select everything")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Quickfix PR fixes a crash caused by using a `nil` appID.
