### PR TITLE
Fix stepper styling on small screens

### DIFF
--- a/pkg/webui/components/stepper/step/step.styl
+++ b/pkg/webui/components/stepper/step/step.styl
@@ -130,6 +130,7 @@
 
   .title
     nudge('down', 2.5px)
+    white-space: nowrap
     color: $tc-deep-gray
     padding-right: $cs.l
 

--- a/pkg/webui/components/stepper/step/step.styl
+++ b/pkg/webui/components/stepper/step/step.styl
@@ -152,7 +152,7 @@
     margin-top: 0
     max-width: $ls.xxl
 
-+media-query($bp.xxs)
++media-query($bp.xs)
   .step
     position: relative
 

--- a/pkg/webui/components/stepper/stepper.styl
+++ b/pkg/webui/components/stepper/stepper.styl
@@ -28,6 +28,6 @@
     &:last-child
       flex: none
 
-+media-query($bp.xxs)
++media-query($bp.xs)
   .stepper
     display: block

--- a/pkg/webui/console/views/device-add/messages.js
+++ b/pkg/webui/console/views/device-add/messages.js
@@ -16,7 +16,7 @@ import { defineMessages } from 'react-intl'
 
 const messages = defineMessages({
   basicTitle: 'Basic settings',
-  basicDescription: "General settings of the end device. End device ID's, Name and Description",
+  basicDescription: "End device ID's, Name and Description",
   basicDetails: 'Defines general settings of an end device',
   networkTitle: 'Network layer settings',
   networkDescription: 'Frequency plan, regional parameters, end device class and session keys.',

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -269,7 +269,7 @@
   "console.views.device-add.configuration-form.index.preparation": "Preparation",
   "console.views.device-add.index.title": "Add new end device",
   "console.views.device-add.messages.basicTitle": "Basic settings",
-  "console.views.device-add.messages.basicDescription": "General settings of the end device. End device ID's, Name and Description",
+  "console.views.device-add.messages.basicDescription": "End device ID's, Name and Description",
   "console.views.device-add.messages.basicDetails": "Defines general settings of an end device",
   "console.views.device-add.messages.networkTitle": "Network layer settings",
   "console.views.device-add.messages.networkDescription": "Frequency plan, regional parameters, end device class and session keys.",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -269,7 +269,7 @@
   "console.views.device-add.configuration-form.index.preparation": "Xxxxxxxxxxx",
   "console.views.device-add.index.title": "Xxx xxx xxx xxxxxx",
   "console.views.device-add.messages.basicTitle": "Xxxxx xxxxxxxx",
-  "console.views.device-add.messages.basicDescription": "Xxxxxxx xxxxxxxx xx xxx xxx xxxxxx. Xxx xxxxxx XX'x, Xxxx xxx Xxxxxxxxxxx",
+  "console.views.device-add.messages.basicDescription": "Xxx xxxxxx XX'x, Xxxx xxx Xxxxxxxxxxx",
   "console.views.device-add.messages.basicDetails": "Xxxxxxx xxxxxxx xxxxxxxx xx xx xxx xxxxxx",
   "console.views.device-add.messages.networkTitle": "Xxxxxxx xxxxx xxxxxxxx",
   "console.views.device-add.messages.networkDescription": "Xxxxxxxxx xxxx, xxxxxxxx xxxxxxxxxx, xxx xxxxxx xxxxx xxx xxxxxxx xxxx.",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fix `<Stepper />` styles on smaller screens;
<img width="843" alt="Screenshot 2020-07-09 at 16 45 58" src="https://user-images.githubusercontent.com/16374166/87050786-6a2b3e80-c207-11ea-950f-b60e8f242720.png">
<img width="841" alt="Screenshot 2020-07-09 at 16 46 38" src="https://user-images.githubusercontent.com/16374166/87050790-6b5c6b80-c207-11ea-8af5-bf8d279cc613.png">


#### Changes
<!-- What are the changes made in this pull request? -->

- Fix styles
- Change basic settings step description. To be consistent with other steps.


#### Testing

<!-- How did you verify that this change works? -->

Storybook, device wizard on small screen sizes


#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Just noticed that the basic settings step description is not consistent with other steps. Most probably lost the change when rebasing https://github.com/TheThingsNetwork/lorawan-stack/pull/2644

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
