### PR TITLE
Fix handling of fragmented event stream chunks in JS SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Decoding of uplinks with frame counters exceeding 16 bits in Application Server.
 - Validation of keys for gateway metrics and version fields.
 - Read only access for the gateway overview page in the Console.
+- Fix an issue that frequently caused event data views crashing in the Console.
 
 ### Security
 

--- a/sdk/js/src/api/stream/stream-node.js
+++ b/sdk/js/src/api/stream/stream-node.js
@@ -34,9 +34,9 @@ import { notify, EVENTS } from './shared'
  *
  *    // Add listeners to the stream.
  *    stream
- *      .on('start', () => console.log('conn opened'));
- *      .on('chunk', chunk => console.log('received chunk', chunk));
- *      .on('error', error => console.log(error));
+ *      .on('start', () => console.log('conn opened'))
+ *      .on('chunk', chunk => console.log('received chunk', chunk))
+ *      .on('error', error => console.log(error))
  *      .on('close', () => console.log('conn closed'))
  *
  *    // Close the stream after 20 s.
@@ -58,6 +58,7 @@ export default async function(payload, url) {
   }
 
   let reader = null
+  let buffer = ''
   axios({
     url,
     data: JSON.stringify(payload),
@@ -65,6 +66,7 @@ export default async function(payload, url) {
     responseType: 'stream',
     headers: {
       Authorization,
+      Accept: 'text/event-stream',
     },
   })
     .then(response => response.data)
@@ -74,10 +76,11 @@ export default async function(payload, url) {
 
       stream.on('data', function(data) {
         const parsed = data.toString('utf8')
-
-        for (const line of parsed.trim().split('\n')) {
-          const result = JSON.parse(line).result
-          notify(listeners[EVENTS.CHUNK], result)
+        buffer += parsed
+        const lines = buffer.split(/\n\n/)
+        buffer = lines.pop()
+        for (const line of lines) {
+          notify(listeners[EVENTS.CHUNK], JSON.parse(line).result)
         }
       })
       stream.on('end', function() {

--- a/sdk/js/src/api/stream/stream.js
+++ b/sdk/js/src/api/stream/stream.js
@@ -35,9 +35,9 @@ import 'web-streams-polyfill/dist/polyfill'
  *
  *    // Add listeners to the stream.
  *    stream
- *      .on('start', () => console.log('conn opened'));
- *      .on('chunk', chunk => console.log('received chunk', chunk));
- *      .on('error', error => console.log(error));
+ *      .on('start', () => console.log('conn opened'))
+ *      .on('chunk', chunk => console.log('received chunk', chunk))
+ *      .on('error', error => console.log(error))
  *      .on('close', () => console.log('conn closed'))
  *
  *    // Close the stream after 20 s.
@@ -65,6 +65,7 @@ export default async function(payload, url) {
     signal: abortController.signal,
     headers: {
       Authorization,
+      Accept: 'text/event-stream',
     },
   })
 
@@ -74,6 +75,7 @@ export default async function(payload, url) {
     throw 'error' in err ? err.error : err
   }
 
+  let buffer = ''
   const reader = response.body.getReader()
   reader
     .read()
@@ -90,10 +92,11 @@ export default async function(payload, url) {
       }
 
       const parsed = ArrayBufferToString(value)
-
-      for (const line of parsed.trim().split('\n')) {
-        const result = JSON.parse(line).result
-        notify(listeners[EVENTS.CHUNK], result)
+      buffer += parsed
+      const lines = buffer.split(/\n\n/)
+      buffer = lines.pop()
+      for (const line of lines) {
+        notify(listeners[EVENTS.CHUNK], JSON.parse(line).result)
       }
 
       return reader.read().then(onChunk)


### PR DESCRIPTION
#### Summary
Closes #2826

This PR fixes an issue where incomplete event stream chunks will cause crashes in the console data views.

#### Changes
- Buffer stream chunks so that parsing can be retried when concatenated with the consequent chunks
- Refactor error logic to prevent that the stream is terminated when it does not have to be

#### Testing

Manual testing on the staging environment

##### Regressions

This could introduce errors in streaming endpoints handled by the SDK

#### Notes for Reviewers
I'm also working on some improvement on how event errors are handled in the console. We currently throw and stop the event stream on any error, when for some errors related to the `onChunk` handler, the event stream can very well be continued after that.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
