### PR TITLE
Fix font weight inconsistencies

### DIFF
--- a/pkg/webui/components/button/button.styl
+++ b/pkg/webui/components/button/button.styl
@@ -24,7 +24,7 @@ $button($color)
   padding: 0 $cs.s
   height: 2.3rem
   outline: 0
-  font-weight: 600
+  font-weight: $fw.bold
   cursor: pointer
   color: white
 
@@ -66,7 +66,7 @@ $button($color)
 
   &.naked
     background: transparent
-    font-weight: 400
+    font-weight: $fw.normal
     border: 1px solid transparent
 
     &:not(.busy)

--- a/pkg/webui/components/data-sheet/data-sheet.styl
+++ b/pkg/webui/components/data-sheet/data-sheet.styl
@@ -21,7 +21,7 @@
 
   th
     text-align: left
-    font-weight: normal
+    font-weight: $fw.normal
     color: $tc-subtle-gray
     min-width: 6rem
     padding-right: $cs.xs
@@ -37,7 +37,7 @@ tr.group-heading
     height: 3.5rem
   th
     color: $tc-deep-gray
-    font-weight: 600
+    font-weight: $fw.bold
     width: 33%
     white-space: nowrap
     +media-query($bp.s)

--- a/pkg/webui/components/events-list/header/column.styl
+++ b/pkg/webui/components/events-list/header/column.styl
@@ -21,5 +21,5 @@
     flex-grow: 1
 
 .content
-  font-weight: 600
+  font-weight: $fw.bold
   white-space: nowrap

--- a/pkg/webui/components/events-list/widget/widget.styl
+++ b/pkg/webui/components/events-list/widget/widget.styl
@@ -20,7 +20,7 @@
   padding-right: 0
 
 .header-title
-  font-weight: 600
+  font-weight: $fw.bold
 
 .see-all-link
   text-decoration: none

--- a/pkg/webui/components/form/field/field.styl
+++ b/pkg/webui/components/form/field/field.styl
@@ -19,7 +19,7 @@
     flex-wrap: nowrap
 
     .title
-      font-weight: normal
+      font-weight: $fw.normal
       padding-top: 0
 
     .component-area
@@ -31,7 +31,7 @@
     .label
       display: flex
       width: 14rem
-      font-weight: normal
+      font-weight: $fw.normal
 
 .field
   margin-bottom: $cs.l
@@ -40,7 +40,7 @@
   width: 100%
 
   .label
-    font-weight: 600
+    font-weight: $fw.bold
 
     &::after
       display: none
@@ -64,7 +64,7 @@
   user-select: none
 
 .description
-  font-weight: normal
+  font-weight: $fw.normal
   color: $tc-subtle-gray
 
 .component-area
@@ -92,7 +92,7 @@
     display: inline-block
 
   .name
-    font-weight: bold
+    font-weight: $fw.bold
 
   &.show
     height: auto

--- a/pkg/webui/components/input/input.styl
+++ b/pkg/webui/components/input/input.styl
@@ -64,7 +64,7 @@
 
 ::placeholder
   font-family: $font-family
-  font-weight: normal
+  font-weight: $fw.normal
   color: $tc-subtle-gray
   letter-spacing: initial
   font-variant: normal
@@ -113,7 +113,7 @@
   font-family: 'IBM Plex Mono', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace
 
 .byte
-  font-weight: 600
+  font-weight: $fw.bold
   letter-spacing: .05rem
 
 .code

--- a/pkg/webui/components/map/widget/widget.styl
+++ b/pkg/webui/components/map/widget/widget.styl
@@ -22,7 +22,7 @@
   margin-bottom: $cs.xs
 
 .title-message
-  font-weight: 600
+  font-weight: $fw.bold
   margin-right: $cs.xs
 
 .change-location

--- a/pkg/webui/components/modal/story.styl
+++ b/pkg/webui/components/modal/story.styl
@@ -54,7 +54,7 @@
       one-liner()
       nudge('up', 2px)
       font-size: $fs.s
-      font-weight: 600
+      font-weight: $fw.bold
       text-transform: uppercase
       color: $c-active-blue
       border: 1px solid $c-active-blue

--- a/pkg/webui/components/navigation/side/side.styl
+++ b/pkg/webui/components/navigation/side/side.styl
@@ -54,7 +54,7 @@
   display: flex
   align-items: center
   padding: $cs.xl $cs.l
-  font-weight: 600
+  font-weight: $fw.bold
 
   +media-query-min($bp.s)
     &-minimized

--- a/pkg/webui/components/notification/notification.styl
+++ b/pkg/webui/components/notification/notification.styl
@@ -62,7 +62,7 @@ left-border($color)
   .title
     one-liner()
     margin: 0 0 $cs.s
-    font-weight: bold
+    font-weight: $fw.bold
 
   .content
     display: inline-block

--- a/pkg/webui/components/pagination/pagination.styl
+++ b/pkg/webui/components/pagination/pagination.styl
@@ -22,7 +22,7 @@
 .item
   display: inline-block
   color: $c-active-blue
-  font-weight: 600
+  font-weight: $fw.bold
   user-select: none
 
   .link:hover

--- a/pkg/webui/components/stepper/step/step.styl
+++ b/pkg/webui/components/stepper/step/step.styl
@@ -57,7 +57,7 @@
 .active
   .status,
   .content > .title
-    font-weight: 600
+    font-weight: $fw.bold
 
 .current
   .status

--- a/pkg/webui/components/table/cell/cell.styl
+++ b/pkg/webui/components/table/cell/cell.styl
@@ -22,6 +22,9 @@
   &:first-child, &:last-child
     padding-right: $cs.s
 
+  &:first-child
+    font-weight: 600
+
   &:last-child:not(&-centered)
     text-align: right
 

--- a/pkg/webui/components/table/cell/cell.styl
+++ b/pkg/webui/components/table/cell/cell.styl
@@ -23,7 +23,7 @@
     padding-right: $cs.s
 
   &:first-child
-    font-weight: 600
+    font-weight: $fw.bold
 
   &:last-child:not(&-centered)
     text-align: right

--- a/pkg/webui/console/components/entity-title-section/entity-title-section.styl
+++ b/pkg/webui/console/components/entity-title-section/entity-title-section.styl
@@ -23,7 +23,7 @@
 .title
   text-margin-top($ls.m)
   text-margin-bottom($cs.m)
-  font-weight: bold
+  font-weight: $fwh.bolder
 
 .below-title
   one-liner()

--- a/pkg/webui/console/components/key-value-tag/key-value-tag.styl
+++ b/pkg/webui/console/components/key-value-tag/key-value-tag.styl
@@ -27,7 +27,7 @@
   margin-right: $cs.xs
 
 .value
-  font-weight: bold
+  font-weight: $fw.bold
   margin-right: $cs.xxs
 
 .message

--- a/pkg/webui/console/views/application-integrations-webhook-add-choose/application-integrations-webhook-add-choose.styl
+++ b/pkg/webui/console/views/application-integrations-webhook-add-choose/application-integrations-webhook-add-choose.styl
@@ -47,7 +47,7 @@
   .name
     display: block
     font-size: $fs.l
-    font-weight: bold
+    font-weight: $fw.bold
     line-height: 1.2
     margin-bottom: $cs.xs
     +media-query($bp.s)

--- a/pkg/webui/console/views/device-overview/device-overview.styl
+++ b/pkg/webui/console/views/device-overview/device-overview.styl
@@ -33,7 +33,7 @@
 
   .key
     flex-basis: 50%
-    font-weight: bold
+    font-weight: $fw.bold
 
   .value
     flex-basis:50%

--- a/pkg/webui/console/views/device/device.styl
+++ b/pkg/webui/console/views/device/device.styl
@@ -28,7 +28,7 @@
   height: 1rem
   white-space: no-break
   margin: 0
-  font-weight: 600
+  font-weight: $fw.bold
   display: inline-block
 
 .rule

--- a/pkg/webui/console/views/overview/overview.styl
+++ b/pkg/webui/console/views/overview/overview.styl
@@ -28,7 +28,7 @@
 
 .get-started
   font-size: $fs.l
-  font-weight: normal
+  font-weight: $fwh.normal
 
 .chooser
   padding: 2.5rem 1rem
@@ -112,4 +112,4 @@
 
 .version-value
   font-size: $fs.xl4
-  font-weight: bold
+  font-weight: $fwh.bolder

--- a/pkg/webui/oauth/views/forgot-password/forgot-password.styl
+++ b/pkg/webui/oauth/views/forgot-password/forgot-password.styl
@@ -24,6 +24,6 @@
 
 .description
   h4()
-  font-weight: lighter
+  font-weight: $fwh.normal
   color: $tc-subtle-gray
   margin-bottom: $ls.xs

--- a/pkg/webui/styles/main.styl
+++ b/pkg/webui/styles/main.styl
@@ -50,6 +50,9 @@ h2
 h3
   h3()
 
+h4
+  h4()
+
 ul li
   &:not(:last-child)
     margin-bottom: $cs.s

--- a/pkg/webui/styles/mixins.styl
+++ b/pkg/webui/styles/mixins.styl
@@ -145,17 +145,22 @@ full-screen($padding = 0)
 h1()
   font-size: $fs.xxl
   line-height: $lh.xxl
-  font-weight: 600
+  font-weight: $fwh.bold
 
 h2()
   font-size: $fs.xl
   line-height: $lh.xl
-  font-weight: bold
+  font-weight: $fwh.bolder
 
 h3()
   font-size: $fs.l
   line-height: $lh.l
-  font-weight: 400
+  font-weight: $fwh.bold
+
+h4()
+  font-size: $fs.m
+  line-height: $lh.m
+  font-weight: $fwh.bold
 
 // One liner, sets line-height to 1, makes components spacing a lot easier.
 // Only suitable for texts that will not wrap at all. Otherwise use

--- a/pkg/webui/styles/variables/generic.styl
+++ b/pkg/webui/styles/variables/generic.styl
@@ -106,6 +106,20 @@ $lh = {
   'xxl': 1.2
 }
 
+// Font weights for body copy
+$fw = {
+  'normal': 500,
+  'bold': 600, // Prefer this over `bolder`.
+  'bolder': 800,
+}
+
+// Font weights for headings
+$fwh = {
+  'normal': 400,
+  'bold': 600,
+  'bolder': 800,
+}
+
 
 // ## Radius
 


### PR DESCRIPTION
#### Summary
This quickfix PR fixes inconsistencies in our `font-weight` usage, by defining stylus variables that will be used throughout. It also changes the content of the first cell of a table row to be bold.

#### Changes
- Introduce font weight stylus variables
- Refactor `font-weight` usage in the codebase to replace hardcoded values with variables (where applicable)
- Add definitions and mixins for `h4`
- Make content of first cell of a table row bold


#### Testing

Manual testing

##### Regressions

This is only affects font-weights, so no major regressions to be expected here.

#### Notes for Reviewers
Splitting this up from a larger branch I'm working on that introduces a variety of styling fixes.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
