### PR TITLE
Send emails to admins when they need to approve a new user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI auto-completion support (see `ttn-lw-cli complete` command).
 - Options to disable profile picture and end device picture uploads (`is.profile-picture.disable-upload` and `is.end-device-picture.disable-upload`).
 - Options to allow/deny non-admin users to create applications, gateways, etc. (the the `is.user-rights.*` options).
+- Admins now receive emails about requested user accounts that need approval.
 
 ### Changed
 

--- a/pkg/identityserver/emails/user_requested.go
+++ b/pkg/identityserver/emails/user_requested.go
@@ -1,0 +1,40 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package emails
+
+// UserRequested is the email that is sent to admins when a user requests to join the network.
+type UserRequested struct {
+	Data
+}
+
+// TemplateName returns the name of the template to use for this email.
+func (UserRequested) TemplateName() string { return "user_requested" }
+
+const userRequestedSubject = `User {{ .Entity.ID }} is waiting for approval`
+
+const userRequestedText = `Dear {{ .User.Name }},
+
+User "{{ .Entity.ID }}" wants to join {{ .Network.Name }}.
+
+You can approve or reject them in the Console or using the Command-line interface.
+
+You can read how exactly to do this in the user management guide:
+https://thethingsstack.io/latest/getting-started/user-management/
+`
+
+// DefaultTemplates returns the default templates for this email.
+func (UserRequested) DefaultTemplates() (subject, html, text string) {
+	return userRequestedSubject, "", userRequestedText
+}

--- a/pkg/identityserver/store/store_interfaces.go
+++ b/pkg/identityserver/store/store_interfaces.go
@@ -90,6 +90,7 @@ type OrganizationStore interface {
 type UserStore interface {
 	CreateUser(ctx context.Context, usr *ttnpb.User) (*ttnpb.User, error)
 	FindUsers(ctx context.Context, ids []*ttnpb.UserIdentifiers, fieldMask *types.FieldMask) ([]*ttnpb.User, error)
+	ListAdmins(ctx context.Context, fieldMask *types.FieldMask) ([]*ttnpb.User, error)
 	GetUser(ctx context.Context, id *ttnpb.UserIdentifiers, fieldMask *types.FieldMask) (*ttnpb.User, error)
 	UpdateUser(ctx context.Context, usr *ttnpb.User, fieldMask *types.FieldMask) (*ttnpb.User, error)
 	DeleteUser(ctx context.Context, id *ttnpb.UserIdentifiers) error

--- a/pkg/identityserver/store/user_store_test.go
+++ b/pkg/identityserver/store/user_store_test.go
@@ -35,6 +35,11 @@ func TestUserStore(t *testing.T) {
 		prepareTest(db, &Account{}, &User{}, &Attribute{}, &Picture{})
 		store := GetUserStore(db)
 
+		list, err := store.ListAdmins(ctx, &types.FieldMask{Paths: []string{"name"}})
+
+		a.So(err, should.BeNil)
+		a.So(list, should.BeEmpty)
+
 		created, err := store.CreateUser(ctx, &ttnpb.User{
 			UserIdentifiers: ttnpb.UserIdentifiers{UserID: "foo"},
 			Name:            "Foo User",
@@ -97,7 +102,8 @@ func TestUserStore(t *testing.T) {
 			ProfilePicture: &ttnpb.Picture{
 				Sizes: map[uint32]string{0: "https://example.com/profile_picture.jpg"},
 			},
-		}, &types.FieldMask{Paths: []string{"description", "attributes", "profile_picture"}})
+			Admin: true,
+		}, &types.FieldMask{Paths: []string{"description", "attributes", "profile_picture", "admin"}})
 
 		a.So(err, should.BeNil)
 		if a.So(updated, should.NotBeNil) {
@@ -122,7 +128,14 @@ func TestUserStore(t *testing.T) {
 			a.So(got.UpdatedAt, should.Equal, updated.UpdatedAt)
 		}
 
-		list, err := store.FindUsers(ctx, nil, &types.FieldMask{Paths: []string{"name"}})
+		list, err = store.FindUsers(ctx, nil, &types.FieldMask{Paths: []string{"name"}})
+
+		a.So(err, should.BeNil)
+		if a.So(list, should.HaveLength, 1) {
+			a.So(list[0].Name, should.EndWith, got.Name)
+		}
+
+		list, err = store.ListAdmins(ctx, &types.FieldMask{Paths: []string{"name"}})
 
 		a.So(err, should.BeNil)
 		if a.So(list, should.HaveLength, 1) {

--- a/pkg/identityserver/user_registry.go
+++ b/pkg/identityserver/user_registry.go
@@ -200,6 +200,18 @@ func (is *IdentityServer) createUser(ctx context.Context, req *ttnpb.CreateUserR
 		return nil, err
 	}
 
+	if usr.State == ttnpb.STATE_REQUESTED {
+		err = is.SendAdminsEmail(ctx, func(data emails.Data) email.MessageData {
+			data.Entity.Type, data.Entity.ID = "user", usr.UserID
+			return &emails.UserRequested{
+				Data: data,
+			}
+		})
+		if err != nil {
+			log.FromContext(ctx).WithError(err).Error("Could not send user requested email")
+		}
+	}
+
 	// TODO: Send welcome email (https://github.com/TheThingsNetwork/lorawan-stack/issues/72).
 
 	if _, err := is.requestContactInfoValidation(ctx, req.UserIdentifiers.EntityIdentifiers()); err != nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR adds support for sending emails to admins. Initially this is only for informing them about new users that need to be approved. In the future we could do the same for requested OAuth clients, or other situations that may require admin attention.

Closes #1735

#### Changes
<!-- What are the changes made in this pull request? -->

- Store support for listing admins
- IS support for sending emails to all admins
- The "user requested" email

#### Testing

<!-- How did you verify that this change works? -->

We can't unit-test sending emails, so tested manually (emails are printed to logs).

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
