### PR TITLE
Add options to restrict create rights for non-admin users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Option to ignore log messages for selected gRPC method on success (see `grpc.log-ignore-methods` option).
 - CLI auto-completion support (see `ttn-lw-cli complete` command).
 - Options to disable profile picture and end device picture uploads (`is.profile-picture.disable-upload` and `is.end-device-picture.disable-upload`).
+- Options to allow/deny non-admin users to create applications, gateways, etc. (the the `is.user-rights.*` options).
 
 ### Changed
 

--- a/cmd/internal/shared/identityserver/config.go
+++ b/cmd/internal/shared/identityserver/config.go
@@ -62,4 +62,8 @@ func init() {
 	DefaultIdentityServerConfig.ProfilePicture.UseGravatar = true
 	DefaultIdentityServerConfig.EndDevicePicture.Bucket = "end_device_pictures"
 	DefaultIdentityServerConfig.EndDevicePicture.BucketURL = path.Join(shared.DefaultAssetsBaseURL, "blob", "end_device_pictures")
+	DefaultIdentityServerConfig.UserRights.CreateApplications = true
+	DefaultIdentityServerConfig.UserRights.CreateClients = true
+	DefaultIdentityServerConfig.UserRights.CreateGateways = true
+	DefaultIdentityServerConfig.UserRights.CreateOrganizations = true
 }

--- a/config/messages.json
+++ b/config/messages.json
@@ -4391,6 +4391,42 @@
       "file": "oauth_registry.go"
     }
   },
+  "error:pkg/identityserver:admins_create_applications": {
+    "translations": {
+      "en": "applications may only be created by admins, or in organizations"
+    },
+    "description": {
+      "package": "pkg/identityserver",
+      "file": "application_registry.go"
+    }
+  },
+  "error:pkg/identityserver:admins_create_clients": {
+    "translations": {
+      "en": "OAuth clients may only be created by admins, or in organizations"
+    },
+    "description": {
+      "package": "pkg/identityserver",
+      "file": "client_registry.go"
+    }
+  },
+  "error:pkg/identityserver:admins_create_gateways": {
+    "translations": {
+      "en": "gateways may only be created by admins, or in organizations"
+    },
+    "description": {
+      "package": "pkg/identityserver",
+      "file": "gateway_registry.go"
+    }
+  },
+  "error:pkg/identityserver:admins_create_organizations": {
+    "translations": {
+      "en": "organizations may only be created by admins"
+    },
+    "description": {
+      "package": "pkg/identityserver",
+      "file": "organization_registry.go"
+    }
+  },
   "error:pkg/identityserver:api_key_not_found": {
     "translations": {
       "en": "API key not found"

--- a/doc/content/reference/configuration/identity-server.md
+++ b/doc/content/reference/configuration/identity-server.md
@@ -123,3 +123,12 @@ There are several options to customize the requirements for user passwords.
 - `is.user-registration.password-requirements.min-length`: Minimum password length
 - `is.user-registration.password-requirements.min-special`: Minimum number of special characters
 - `is.user-registration.password-requirements.min-uppercase`: Minimum number of uppercase letters
+
+## User Rights Options
+
+By default users can create applications, gateways, organizations and OAuth clients. With the following configuration options it is possible to restrict this, in which case only admin users are allowed to create these entities. By adding users to organizations, and assigning the appropriate rights, they can still create these entities in the organization.
+
+- `is.user-rights.create-applications`: Allow non-admin users to create applications in their user account
+- `is.user-rights.create-clients`: Allow non-admin users to create OAuth clients in their user account
+- `is.user-rights.create-gateways`: Allow non-admin users to create gateways in their user account
+- `is.user-rights.create-organizations`: Allow non-admin users to create organizations in their user account

--- a/pkg/identityserver/application_registry_test.go
+++ b/pkg/identityserver/application_registry_test.go
@@ -126,6 +126,22 @@ func TestApplicationsCRUD(t *testing.T) {
 		userID, creds := population.Users[defaultUserIdx].UserIdentifiers, userCreds(defaultUserIdx)
 		credsWithoutRights := userCreds(defaultUserIdx, "key without rights")
 
+		is.config.UserRights.CreateApplications = false
+
+		_, err := reg.Create(ctx, &ttnpb.CreateApplicationRequest{
+			Application: ttnpb.Application{
+				ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "foo"},
+				Name:                   "Foo Application",
+			},
+			Collaborator: *userID.OrganizationOrUserIdentifiers(),
+		}, creds)
+
+		if a.So(err, should.NotBeNil) {
+			a.So(errors.IsPermissionDenied(err), should.BeTrue)
+		}
+
+		is.config.UserRights.CreateApplications = true
+
 		created, err := reg.Create(ctx, &ttnpb.CreateApplicationRequest{
 			Application: ttnpb.Application{
 				ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "foo"},

--- a/pkg/identityserver/client_registry_test.go
+++ b/pkg/identityserver/client_registry_test.go
@@ -126,6 +126,22 @@ func TestClientsCRUD(t *testing.T) {
 		userID, creds := population.Users[defaultUserIdx].UserIdentifiers, userCreds(defaultUserIdx)
 		credsWithoutRights := userCreds(defaultUserIdx, "key without rights")
 
+		is.config.UserRights.CreateClients = false
+
+		_, err := reg.Create(ctx, &ttnpb.CreateClientRequest{
+			Client: ttnpb.Client{
+				ClientIdentifiers: ttnpb.ClientIdentifiers{ClientID: "foo"},
+				Name:              "Foo Client",
+			},
+			Collaborator: *userID.OrganizationOrUserIdentifiers(),
+		}, creds)
+
+		if a.So(err, should.NotBeNil) {
+			a.So(errors.IsPermissionDenied(err), should.BeTrue)
+		}
+
+		is.config.UserRights.CreateClients = true
+
 		created, err := reg.Create(ctx, &ttnpb.CreateClientRequest{
 			Client: ttnpb.Client{
 				ClientIdentifiers: ttnpb.ClientIdentifiers{ClientID: "foo"},

--- a/pkg/identityserver/config.go
+++ b/pkg/identityserver/config.go
@@ -63,6 +63,12 @@ type Config struct {
 		Bucket        string `name:"bucket" description:"Bucket used for storing end device pictures"`
 		BucketURL     string `name:"bucket-url" description:"Base URL for public bucket access"`
 	} `name:"end-device-picture"`
+	UserRights struct {
+		CreateApplications  bool `name:"create-applications" description:"Allow non-admin users to create applications in their user account"`
+		CreateClients       bool `name:"create-clients" description:"Allow non-admin users to create OAuth clients in their user account"`
+		CreateGateways      bool `name:"create-gateways" description:"Allow non-admin users to create gateways in their user account"`
+		CreateOrganizations bool `name:"create-organizations" description:"Allow non-admin users to create organizations in their user account"`
+	} `name:"user-rights"`
 	Email struct {
 		email.Config `name:",squash"`
 		SendGrid     sendgrid.Config      `name:"sendgrid"`

--- a/pkg/identityserver/gateway_registry_test.go
+++ b/pkg/identityserver/gateway_registry_test.go
@@ -129,6 +129,21 @@ func TestGatewaysCRUD(t *testing.T) {
 
 		eui := types.EUI64{1, 2, 3, 4, 5, 6, 7, 8}
 
+		is.config.UserRights.CreateGateways = false
+
+		_, err := reg.Create(ctx, &ttnpb.CreateGatewayRequest{
+			Gateway: ttnpb.Gateway{
+				GatewayIdentifiers: ttnpb.GatewayIdentifiers{
+					GatewayID: "foo",
+					EUI:       &eui,
+				},
+				Name: "Foo Gateway",
+			},
+			Collaborator: *userID.OrganizationOrUserIdentifiers(),
+		}, creds)
+
+		is.config.UserRights.CreateGateways = true
+
 		created, err := reg.Create(ctx, &ttnpb.CreateGatewayRequest{
 			Gateway: ttnpb.Gateway{
 				GatewayIdentifiers: ttnpb.GatewayIdentifiers{

--- a/pkg/identityserver/identityserver_test.go
+++ b/pkg/identityserver/identityserver_test.go
@@ -316,6 +316,10 @@ func getIdentityServer(t *testing.T) (*IdentityServer, *grpc.ClientConn) {
 		"overridden.html":        []byte("Overridden HTML {{.User.Name}} {{.User.Email}}"),
 		"overridden.txt":         []byte("Overridden text {{.User.Name}} {{.User.Email}}"),
 	}
+	conf.UserRights.CreateApplications = true
+	conf.UserRights.CreateClients = true
+	conf.UserRights.CreateGateways = true
+	conf.UserRights.CreateOrganizations = true
 	is, err := New(c, conf)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/identityserver/organization_registry_test.go
+++ b/pkg/identityserver/organization_registry_test.go
@@ -161,6 +161,18 @@ func TestOrganizationsCRUD(t *testing.T) {
 		userID, creds := population.Users[defaultUserIdx].UserIdentifiers, userCreds(defaultUserIdx)
 		credsWithoutRights := userCreds(defaultUserIdx, "key without rights")
 
+		is.config.UserRights.CreateOrganizations = false
+
+		_, err := reg.Create(ctx, &ttnpb.CreateOrganizationRequest{
+			Organization: ttnpb.Organization{
+				OrganizationIdentifiers: ttnpb.OrganizationIdentifiers{OrganizationID: "foo"},
+				Name:                    "Foo Organization",
+			},
+			Collaborator: *userID.OrganizationOrUserIdentifiers(),
+		}, creds)
+
+		is.config.UserRights.CreateOrganizations = true
+
 		created, err := reg.Create(ctx, &ttnpb.CreateOrganizationRequest{
 			Organization: ttnpb.Organization{
 				OrganizationIdentifiers: ttnpb.OrganizationIdentifiers{OrganizationID: "foo"},


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Add options for restricting rights of non-admin users to create entities.

Closes #1890

#### Testing

<!-- How did you verify that this change works? -->

Unit tests

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
