### PR TITLE
Fix gateway form in the Console

### DIFF
--- a/pkg/webui/components/form/field/index.js
+++ b/pkg/webui/components/form/field/index.js
@@ -167,7 +167,7 @@ class FormField extends React.Component {
 
     const fieldValue = decode(getIn(this.context.values, name))
     const fieldError = getIn(this.context.errors, name)
-    const fieldTouched = getIn(this.context.touched, name)
+    const fieldTouched = getIn(this.context.touched, name) || false
     const fieldDisabled = disabled || formDisabled
 
     const hasError = Boolean(fieldError)

--- a/pkg/webui/components/form/field/story.js
+++ b/pkg/webui/components/form/field/story.js
@@ -28,22 +28,11 @@ import UnitInput from '@ttn-lw/components/unit-input'
 
 import Yup from '@ttn-lw/lib/yup'
 
-import { unit as unitRegexp } from '@console/lib/regexp'
-
 import Form from '..'
 
 const handleSubmit = function(data, { resetForm }) {
   action('Submit')(data)
   setTimeout(() => resetForm({ values: data }), 1000)
-}
-
-const decode = function(value) {
-  const duration = value.split(unitRegexp)[0]
-  const unit = value.split(duration)[1]
-  return {
-    duration: duration ? Number(duration) : undefined,
-    unit,
-  }
 }
 
 const info = {
@@ -904,7 +893,6 @@ storiesOf('Fields/UnitInput', module)
       <Form.Field
         name="default"
         title="Default"
-        decode={decode}
         units={[
           { label: 'miliseconds', value: 'ms' },
           { label: 'seconds', value: 's' },
@@ -916,7 +904,6 @@ storiesOf('Fields/UnitInput', module)
       <Form.Field
         name="description"
         title="Description"
-        decode={decode}
         units={[
           { label: 'miliseconds', value: 'ms' },
           { label: 'seconds', value: 's' },
@@ -929,7 +916,6 @@ storiesOf('Fields/UnitInput', module)
       <Form.Field
         name="warning"
         title="Warning"
-        decode={decode}
         units={[
           { label: 'miliseconds', value: 'ms' },
           { label: 'seconds', value: 's' },
@@ -942,7 +928,6 @@ storiesOf('Fields/UnitInput', module)
       <Form.Field
         name="error"
         title="Error"
-        decode={decode}
         units={[
           { label: 'miliseconds', value: 'ms' },
           { label: 'seconds', value: 's' },
@@ -968,7 +953,6 @@ storiesOf('Fields/UnitInput', module)
       <Form.Field
         name="default"
         title="Default"
-        decode={decode}
         units={[
           { label: 'miliseconds', value: 'ms' },
           { label: 'seconds', value: 's' },
@@ -980,7 +964,6 @@ storiesOf('Fields/UnitInput', module)
       <Form.Field
         name="description"
         title="Description"
-        decode={decode}
         units={[
           { label: 'miliseconds', value: 'ms' },
           { label: 'seconds', value: 's' },
@@ -993,7 +976,6 @@ storiesOf('Fields/UnitInput', module)
       <Form.Field
         name="warning"
         title="Warning"
-        decode={decode}
         units={[
           { label: 'miliseconds', value: 'ms' },
           { label: 'seconds', value: 's' },
@@ -1006,7 +988,6 @@ storiesOf('Fields/UnitInput', module)
       <Form.Field
         name="error"
         title="Error"
-        decode={decode}
         units={[
           { label: 'miliseconds', value: 'ms' },
           { label: 'seconds', value: 's' },

--- a/pkg/webui/components/form/field/story.js
+++ b/pkg/webui/components/form/field/story.js
@@ -830,12 +830,7 @@ storiesOf('Fields/FileInput', module)
         component={FileInput}
       />
       <Form.Field name="withValue" title="With initially attached file" component={FileInput} />
-      <Form.Field
-        name="error"
-        title="With error"
-        component={FileInput}
-        error="There was an error."
-      />
+      <Form.Field name="error" title="With error" component={FileInput} />
       <Form.Field
         name="warning"
         title="With warning"
@@ -862,12 +857,7 @@ storiesOf('Fields/FileInput', module)
         component={FileInput}
       />
       <Form.Field name="withValue" title="With initially attached file" component={FileInput} />
-      <Form.Field
-        name="error"
-        title="With error"
-        component={FileInput}
-        error="There was an error."
-      />
+      <Form.Field name="error" title="With error" component={FileInput} />
       <Form.Field
         name="warning"
         title="With warning"
@@ -935,7 +925,6 @@ storiesOf('Fields/UnitInput', module)
           { label: 'hours', value: 'h' },
         ]}
         component={UnitInput}
-        error="There was an error"
       />
     </FieldsWrapperExample>
   ))
@@ -995,7 +984,6 @@ storiesOf('Fields/UnitInput', module)
           { label: 'hours', value: 'h' },
         ]}
         component={UnitInput}
-        error="There was an error"
       />
     </FieldsWrapperExample>
   ))

--- a/pkg/webui/components/unit-input/index.js
+++ b/pkg/webui/components/unit-input/index.js
@@ -27,15 +27,9 @@ import PropTypes from '@ttn-lw/lib/prop-types'
 
 import style from './unit-input.styl'
 
-@withComputedProps(props => ({
-  ...props,
-  value: props.decode(props.value),
-}))
 class UnitInput extends React.PureComponent {
   static propTypes = {
     className: PropTypes.string,
-    // eslint-disable-next-line react/no-unused-prop-types
-    decode: PropTypes.func,
     disabled: PropTypes.bool,
     encode: PropTypes.func,
     error: PropTypes.bool,
@@ -58,14 +52,6 @@ class UnitInput extends React.PureComponent {
   static defaultProps = {
     className: undefined,
     encode: (duration, unit) => (duration ? `${duration}${unit}` : unit),
-    decode: value => {
-      const duration = value.split(unitRegexp)[0]
-      const unit = value.split(duration)[1]
-      return {
-        duration: duration ? Number(duration) : undefined,
-        unit,
-      }
-    },
     disabled: false,
     required: false,
     value: undefined,
@@ -130,4 +116,24 @@ class UnitInput extends React.PureComponent {
   }
 }
 
-export default UnitInput
+const WrappedUnitInput = withComputedProps(props => ({
+  ...props,
+  value: props.decode(props.value),
+}))(UnitInput)
+
+WrappedUnitInput.propTypes = {
+  decode: PropTypes.func,
+}
+
+WrappedUnitInput.defaultProps = {
+  decode: value => {
+    const duration = value.split(unitRegexp)[0]
+    const unit = value.split(duration)[1]
+    return {
+      duration: duration ? Number(duration) : undefined,
+      unit,
+    }
+  },
+}
+
+export default WrappedUnitInput

--- a/pkg/webui/console/components/gateway-data-form/index.js
+++ b/pkg/webui/console/components/gateway-data-form/index.js
@@ -61,8 +61,6 @@ const m = defineMessages({
   scheduleAnyTimeDelay: 'Schedule any time delay',
   scheduleAnyTimeDescription:
     'Configure gateway delay (minimum: {minimumValue}ms, default: {defaultValue}ms)',
-  miliseconds: 'miliseconds',
-  seconds: 'seconds',
   delayWarning:
     'Delay too short. The lower bound ({minimumValue}ms) will be used by the Gateway Server.',
 })
@@ -269,7 +267,7 @@ class GatewayDataForm extends React.Component {
             },
           }}
           units={[
-            { label: sharedMessages.miliseconds, value: 'ms' },
+            { label: sharedMessages.milliseconds, value: 'ms' },
             { label: sharedMessages.seconds, value: 's' },
             { label: sharedMessages.minutes, value: 'm' },
             { label: sharedMessages.hours, value: 'h' },

--- a/pkg/webui/console/components/gateway-data-form/index.js
+++ b/pkg/webui/console/components/gateway-data-form/index.js
@@ -275,7 +275,6 @@ class GatewayDataForm extends React.Component {
             { label: sharedMessages.hours, value: 'h' },
           ]}
           onChange={this.onScheduleAnytimeDelayChange}
-          decode={this.decodeDelayValue}
           warning={
             shouldDisplayWarning
               ? {

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -84,8 +84,6 @@
   "console.components.gateway-data-form.index.enforceDutyCycleDescription": "Recommended for all gateways in order to respect spectrum regulations",
   "console.components.gateway-data-form.index.scheduleAnyTimeDelay": "Schedule any time delay",
   "console.components.gateway-data-form.index.scheduleAnyTimeDescription": "Configure gateway delay (minimum: {minimumValue}ms, default: {defaultValue}ms)",
-  "console.components.gateway-data-form.index.miliseconds": "miliseconds",
-  "console.components.gateway-data-form.index.seconds": "seconds",
   "console.components.gateway-data-form.index.delayWarning": "Delay too short. The lower bound ({minimumValue}ms) will be used by the Gateway Server.",
   "console.components.location-form.index.deleteWarning": "Are you sure you want to delete this location entry?",
   "console.components.location-form.index.deleteLocation": "Remove location entry",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -84,8 +84,6 @@
   "console.components.gateway-data-form.index.enforceDutyCycleDescription": "Xxxxxxxxxxx xxx xxx xxxxxxxx xx xxxxx xx xxxxxxx xxxxxxxx xxxxxxxxxxx",
   "console.components.gateway-data-form.index.scheduleAnyTimeDelay": "Xxxxxxxx xxx xxxx xxxxx",
   "console.components.gateway-data-form.index.scheduleAnyTimeDescription": "Xxxxxxxxx xxxxxxx xxxxx (xxxxxxx: {minimumValue}xx, xxxxxxx: {defaultValue}xx)",
-  "console.components.gateway-data-form.index.miliseconds": "xxxxxxxxxxx",
-  "console.components.gateway-data-form.index.seconds": "xxxxxxx",
   "console.components.gateway-data-form.index.delayWarning": "Xxxxx xxx xxxxx. Xxx xxxxx xxxxx ({minimumValue}xx) xxxx xx xxxx xx xxx Xxxxxxx Xxxxxx.",
   "console.components.location-form.index.deleteWarning": "Xxx xxx xxxx xxx xxxx xx xxxxxx xxxx xxxxxxxx xxxxx?",
   "console.components.location-form.index.deleteLocation": "Xxxxxx xxxxxxxx xxxxx",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes regressions introduced in https://github.com/TheThingsNetwork/lorawan-stack/pull/2844 and https://github.com/TheThingsNetwork/lorawan-stack/pull/2823 

#### Changes
<!-- What are the changes made in this pull request? -->

- Avoid decoding the value for `<UnitInput />` twice.
- Fix missing `ms` display in the select
- Fix prop-types issues with `warning` and `error` props.


#### Testing

<!-- How did you verify that this change works? -->

The gateway create should show be accessible and no warnings regarding prop-types in `<UnitInput />`

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

`UnitInput` storybook, gateway form 


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
