### PR TITLE
Return registry error cause code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validation of keys for gateway metrics and version fields.
 - Read only access for the gateway overview page in the Console.
 - Fix an issue that frequently caused event data views crashing in the Console.
+- Application Server contacting Join Server via interop for fetching the AppSKey.
 
 ### Security
 

--- a/pkg/errors/comparison.go
+++ b/pkg/errors/comparison.go
@@ -14,7 +14,7 @@
 
 package errors
 
-// Resemble returns true iff the given errors resemble, meaning that the Code,
+// Resemble returns true iff the given errors resemble, meaning that the
 // Namespace and Name of the errors are equal. A nil error only resembles nil.
 // Invalid errors or definitions (including typed nil) never resemble anything.
 func Resemble(a, b error) bool {
@@ -29,7 +29,6 @@ func Resemble(a, b error) bool {
 	if !ok {
 		return false
 	}
-	return ttnA.Code() == ttnB.Code() &&
-		ttnA.Namespace() == ttnB.Namespace() &&
+	return ttnA.Namespace() == ttnB.Namespace() &&
 		ttnA.Name() == ttnB.Name()
 }

--- a/pkg/errors/comparison_test.go
+++ b/pkg/errors/comparison_test.go
@@ -54,4 +54,8 @@ func TestResembles(t *testing.T) {
 
 	a.So(errors.Resemble(defInvalidArgument, defPermissionDenied), should.BeFalse)
 
+	defWrapper := errors.Define("wrapper", "something went wrong")
+
+	a.So(errors.Resemble(defWrapper.WithCause(defPermissionDenied), defWrapper), should.BeTrue)
+	a.So(errors.Resemble(defWrapper.WithCause(defPermissionDenied), defWrapper.WithCause(defInvalidArgument)), should.BeTrue)
 }

--- a/pkg/joinserver/errors.go
+++ b/pkg/joinserver/errors.go
@@ -54,7 +54,7 @@ var (
 	errProvisionerDecode              = errors.Define("provisioner_decode", "failed to decode provisioning data")
 	errProvisionerNotFound            = errors.DefineNotFound("provisioner_not_found", "provisioner `{id}` not found")
 	errProvisioning                   = errors.DefineAborted("provisioning", "provisioning failed")
-	errRegistryOperation              = errors.DefineInternal("registry_operation", "registry operation failed")
+	errRegistryOperation              = errors.Define("registry_operation", "registry operation failed")
 	errReuseDevNonce                  = errors.DefineInvalidArgument("reuse_dev_nonce", "DevNonce has already been used")
 	errUnauthenticated                = errors.DefineUnauthenticated("unauthenticated", "unauthenticated")
 	errUnknownJoinEUI                 = errors.Define("unknown_join_eui", "JoinEUI specified is not known")

--- a/pkg/joinserver/joinserver_test.go
+++ b/pkg/joinserver/joinserver_test.go
@@ -1985,7 +1985,7 @@ func TestGetNwkSKeys(t *testing.T) {
 				if !a.So(err, should.EqualErrorOrDefinition, ErrRegistryOperation.WithCause(errTest)) {
 					t.FailNow()
 				}
-				return a.So(errors.IsInternal(err), should.BeTrue)
+				return a.So(errors.IsUnknown(err), should.BeTrue)
 			},
 		},
 		{
@@ -2152,7 +2152,7 @@ func TestGetNwkSKeys(t *testing.T) {
 func TestGetAppSKey(t *testing.T) {
 	ctx := test.Context()
 
-	errTest := errors.New("test")
+	errNotFound := errors.DefineNotFound("test_not_found", "not found")
 
 	for _, tc := range []struct {
 		Name        string
@@ -2176,7 +2176,7 @@ func TestGetAppSKey(t *testing.T) {
 				a.So(paths, should.HaveSameElementsDeep, []string{
 					"app_s_key",
 				})
-				return nil, errTest.New()
+				return nil, errNotFound.New()
 			},
 			KeyRequest: &ttnpb.SessionKeyRequest{
 				JoinEUI:      types.EUI64{0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
@@ -2186,10 +2186,10 @@ func TestGetAppSKey(t *testing.T) {
 			KeyResponse: nil,
 			ErrorAssertion: func(t *testing.T, err error) bool {
 				a := assertions.New(t)
-				if !a.So(err, should.EqualErrorOrDefinition, ErrRegistryOperation.WithCause(errTest)) {
+				if !a.So(err, should.EqualErrorOrDefinition, ErrRegistryOperation.WithCause(errNotFound)) {
 					t.FailNow()
 				}
-				return a.So(errors.IsInternal(err), should.BeTrue)
+				return a.So(errors.IsNotFound(err), should.BeTrue)
 			},
 		},
 		{
@@ -2464,7 +2464,7 @@ func TestGetHomeNetID(t *testing.T) {
 				if !a.So(err, should.EqualErrorOrDefinition, ErrRegistryOperation.WithCause(errTest)) {
 					t.FailNow()
 				}
-				return a.So(errors.IsInternal(err), should.BeTrue)
+				return a.So(errors.IsUnknown(err), should.BeTrue)
 			},
 		},
 		{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2940

#### Changes
<!-- What are the changes made in this pull request? -->

- JS now returns the registry error cause's code instead of `Internal` (13). This is useful for clients to act on whether the entity exists in the registry, for example
- AS contacts interop JS when the cluster-local JS reported not found (no functional change, but now it works)
- Error comparison now doesn't take code into account if any is `Unknown`

#### Testing

<!-- How did you verify that this change works? -->

Unit tests

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Clients relying on `Internal` code from JS device registry operations break.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@htdvisser please check `pkg/errors`

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
