### PR TITLE
Fix Basic Station Authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Options to allow/deny non-admin users to create applications, gateways, etc. (the the `is.user-rights.*` options).
 - Admins now receive emails about requested user accounts that need approval.
 - Support for synchronizing gateway clocks via uplink tokens. UDP gateways may not connect to the same Gateway Server instance.
+- Option to allow unauthenticated Basic Station connections. Unset `gs.basic-station.allow-authenticated` to enforce auth check for production clusters.
 
 ### Changed
 
@@ -50,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Read only access for the gateway overview page in the Console.
 - Fix an issue that frequently caused event data views crashing in the Console.
 - Application Server contacting Join Server via interop for fetching the AppSKey.
+- Basic Station always allows unauthenticated connections when API Key is defined.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Options to allow/deny non-admin users to create applications, gateways, etc. (the the `is.user-rights.*` options).
 - Admins now receive emails about requested user accounts that need approval.
 - Support for synchronizing gateway clocks via uplink tokens. UDP gateways may not connect to the same Gateway Server instance.
-- Option to allow unauthenticated Basic Station connections. Unset `gs.basic-station.allow-authenticated` to enforce auth check for production clusters.
+- Option to allow unauthenticated Basic Station connections. Unset `gs.basic-station.allow-unauthenticated` to enforce auth check for production clusters. Please note that unauthenticated connections in existing connections will not be allowed unless this is set.
 
 ### Changed
 
@@ -51,7 +51,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Read only access for the gateway overview page in the Console.
 - Fix an issue that frequently caused event data views crashing in the Console.
 - Application Server contacting Join Server via interop for fetching the AppSKey.
-- Basic Station always allows unauthenticated connections when API Key is defined.
 
 ### Security
 

--- a/cmd/internal/shared/gatewayserver/config.go
+++ b/cmd/internal/shared/gatewayserver/config.go
@@ -51,8 +51,9 @@ var DefaultGatewayServerConfig = gatewayserver.Config{
 	},
 	UpdateConnectionStatsDebounceTime: 3 * time.Second,
 	BasicStation: gatewayserver.BasicStationConfig{
-		Listen:         ":1887",
-		ListenTLS:      ":8887",
-		WSPingInterval: 30 * time.Second,
+		Listen:               ":1887",
+		ListenTLS:            ":8887",
+		WSPingInterval:       30 * time.Second,
+		AllowUnauthenticated: true,
 	},
 }

--- a/cmd/internal/shared/gatewayserver/config.go
+++ b/cmd/internal/shared/gatewayserver/config.go
@@ -21,6 +21,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/shared"
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver"
+	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/basicstationlns"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/udp"
 )
 
@@ -51,9 +52,8 @@ var DefaultGatewayServerConfig = gatewayserver.Config{
 	},
 	UpdateConnectionStatsDebounceTime: 3 * time.Second,
 	BasicStation: gatewayserver.BasicStationConfig{
-		Listen:               ":1887",
-		ListenTLS:            ":8887",
-		WSPingInterval:       30 * time.Second,
-		AllowUnauthenticated: true,
+		Config:    basicstationlns.DefaultConfig,
+		Listen:    ":1887",
+		ListenTLS: ":8887",
 	},
 }

--- a/config/messages.json
+++ b/config/messages.json
@@ -3482,6 +3482,15 @@
       "file": "upstream.go"
     }
   },
+  "error:pkg/gatewayserver/io/basicstationlns:auth_not_provided": {
+    "translations": {
+      "en": "no auth provided for gateway id `{id}`"
+    },
+    "description": {
+      "package": "pkg/gatewayserver/io/basicstationlns",
+      "file": "basicstationlns.go"
+    }
+  },
   "error:pkg/gatewayserver/io/basicstationlns:empty_gateway_eui": {
     "translations": {
       "en": "empty gateway EUI"

--- a/doc/content/reference/configuration/gateway-server.md
+++ b/doc/content/reference/configuration/gateway-server.md
@@ -27,6 +27,7 @@ The Gateway Server can be configured to update the location of gateway antennas 
 ## Security Options
 
 - `gs.require-registered-gateways`: Require the gateways to be registered in the Identity Server
+- `gs.basic-station.allow-unauthenticated`: Allow unauthenticated Basic Station connections. This is set to `true` by default.  Unset to enforce auth check for production clusters.
 
 ## Basic Station Options
 

--- a/pkg/gatewayserver/config.go
+++ b/pkg/gatewayserver/config.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
+	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/basicstationlns"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/udp"
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
 )
@@ -30,12 +31,10 @@ type UDPConfig struct {
 
 // BasicStationConfig defines the Basic Station configuration of the Gateway Server.
 type BasicStationConfig struct {
-	FallbackFrequencyPlanID string        `name:"fallback-frequency-plan-id" description:"Fallback frequency plan ID for non-registered gateways"`
-	Listen                  string        `name:"listen" description:"Address for the Basic Station frontend to listen on"`
-	ListenTLS               string        `name:"listen-tls" description:"Address for the Basic Station frontend to listen on (with TLS)"`
-	UseTrafficTLSAddress    bool          `name:"use-traffic-tls-address" description:"Use WSS for the traffic address regardless of the TLS setting"`
-	WSPingInterval          time.Duration `name:"ws-ping-interval" description:"Interval to send WS ping messages"`
-	AllowUnauthenticated    bool          `name:"allow-unauthenticated" description:"Allow unauthenticated connections"`
+	basicstationlns.Config  `name:",squash"`
+	FallbackFrequencyPlanID string `name:"fallback-frequency-plan-id" description:"Fallback frequency plan ID for non-registered gateways"`
+	Listen                  string `name:"listen" description:"Address for the Basic Station frontend to listen on"`
+	ListenTLS               string `name:"listen-tls" description:"Address for the Basic Station frontend to listen on (with TLS)"`
 }
 
 // Config represents the Gateway Server configuration.

--- a/pkg/gatewayserver/config.go
+++ b/pkg/gatewayserver/config.go
@@ -35,6 +35,7 @@ type BasicStationConfig struct {
 	ListenTLS               string        `name:"listen-tls" description:"Address for the Basic Station frontend to listen on (with TLS)"`
 	UseTrafficTLSAddress    bool          `name:"use-traffic-tls-address" description:"Use WSS for the traffic address regardless of the TLS setting"`
 	WSPingInterval          time.Duration `name:"ws-ping-interval" description:"Interval to send WS ping messages"`
+	AllowUnauthenticated    bool          `name:"allow-unauthenticated" description:"Allow unauthenticated connections"`
 }
 
 // Config represents the Gateway Server configuration.

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -246,7 +246,11 @@ func New(c *component.Component, conf *Config, opts ...Option) (gs *GatewayServe
 	if conf.BasicStation.FallbackFrequencyPlanID != "" {
 		bsCtx = frequencyplans.WithFallbackID(bsCtx, conf.BasicStation.FallbackFrequencyPlanID)
 	}
-	bsWebServer := basicstationlns.New(bsCtx, gs, conf.BasicStation.UseTrafficTLSAddress, conf.BasicStation.WSPingInterval)
+	bsWebServer := basicstationlns.New(bsCtx, gs, basicstationlns.Options{
+		UseTrafficTLSAddress: conf.BasicStation.UseTrafficTLSAddress,
+		WSPingInterval:       conf.BasicStation.WSPingInterval,
+		AllowUnauthenticated: conf.BasicStation.AllowUnauthenticated,
+	})
 	for _, endpoint := range []component.Endpoint{
 		component.NewTCPEndpoint(conf.BasicStation.Listen, "Basic Station"),
 		component.NewTLSEndpoint(conf.BasicStation.ListenTLS, "Basic Station", component.WithNextProtos("h2", "http/1.1")),

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -246,7 +246,7 @@ func New(c *component.Component, conf *Config, opts ...Option) (gs *GatewayServe
 	if conf.BasicStation.FallbackFrequencyPlanID != "" {
 		bsCtx = frequencyplans.WithFallbackID(bsCtx, conf.BasicStation.FallbackFrequencyPlanID)
 	}
-	bsWebServer := basicstationlns.New(bsCtx, gs, basicstationlns.Options{
+	bsWebServer := basicstationlns.New(bsCtx, gs, basicstationlns.Config{
 		UseTrafficTLSAddress: conf.BasicStation.UseTrafficTLSAddress,
 		WSPingInterval:       conf.BasicStation.WSPingInterval,
 		AllowUnauthenticated: conf.BasicStation.AllowUnauthenticated,

--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -108,8 +108,9 @@ func TestGatewayServer(t *testing.T) {
 			},
 		},
 		BasicStation: gatewayserver.BasicStationConfig{
-			Listen:         ":1887",
-			WSPingInterval: wsPingInterval,
+			Listen:               ":1887",
+			WSPingInterval:       wsPingInterval,
+			AllowUnauthenticated: true,
 		},
 		UpdateConnectionStatsDebounceTime: 0,
 	}

--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -39,6 +39,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/frequencyplans"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io"
+	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/basicstationlns"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/basicstationlns/messages"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/udp"
 	gsredis "go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/redis"
@@ -108,9 +109,11 @@ func TestGatewayServer(t *testing.T) {
 			},
 		},
 		BasicStation: gatewayserver.BasicStationConfig{
-			Listen:               ":1887",
-			WSPingInterval:       wsPingInterval,
-			AllowUnauthenticated: true,
+			Listen: ":1887",
+			Config: basicstationlns.Config{
+				WSPingInterval:       wsPingInterval,
+				AllowUnauthenticated: true,
+			},
 		},
 		UpdateConnectionStatsDebounceTime: 0,
 	}

--- a/pkg/gatewayserver/io/basicstationlns/basicstationlns.go
+++ b/pkg/gatewayserver/io/basicstationlns/basicstationlns.go
@@ -54,8 +54,8 @@ var (
 		"listener",
 		"failed to serve Basic Station frontend listener",
 	)
-	errGatewayID       = errors.DefineInvalidArgument("invalid_gateway_id", "invalid gateway id `{id}`")
-	errAuthNotProvided = errors.DefineNotFound("auth_not_provided", "no auth provided for gateway id `{id}`")
+	errGatewayID      = errors.DefineInvalidArgument("invalid_gateway_id", "invalid gateway id `{id}`")
+	errNoAuthProvided = errors.DefineUnauthenticated("no_auth_provided", "no auth provided for gateway id `{id}`")
 )
 
 type srv struct {
@@ -228,7 +228,7 @@ func (s *srv) handleTraffic(c echo.Context) (err error) {
 	}
 
 	if auth == "" {
-		// If the server allows unauthenticated connections (for local testing), we provide the link rights ourselves as in the udp frontend.
+		// If the server allows unauthenticated connections (for local testing), we provide the link rights ourselves.
 		if s.cfg.AllowUnauthenticated {
 			ctx = rights.NewContext(ctx, rights.Rights{
 				GatewayRights: map[string]*ttnpb.Rights{
@@ -239,7 +239,7 @@ func (s *srv) handleTraffic(c echo.Context) (err error) {
 			})
 		} else {
 			// We error here directly as there is no need make an RPC call to the IS to get a failed rights check due to no Auth.
-			return errAuthNotProvided
+			return errNoAuthProvided
 		}
 	}
 

--- a/pkg/gatewayserver/io/basicstationlns/basicstationlns_test.go
+++ b/pkg/gatewayserver/io/basicstationlns/basicstationlns_test.go
@@ -58,8 +58,8 @@ var (
 
 	testTrafficEndPoint = "/traffic/eui-0101010101010101"
 
-	timeout        = (1 << 5) * test.Delay
-	defaultOptions = Options{
+	timeout       = (1 << 5) * test.Delay
+	defaultConfig = Config{
 		WSPingInterval:       (1 << 3) * test.Delay,
 		AllowUnauthenticated: true,
 		UseTrafficTLSAddress: false,
@@ -107,9 +107,9 @@ func TestClientTokenAuth(t *testing.T) {
 			AllowUnauthenticated: false,
 		},
 	} {
-		opts := defaultOptions
-		opts.AllowUnauthenticated = ttc.AllowUnauthenticated
-		bsWebServer := New(ctx, gs, opts)
+		cfg := defaultConfig
+		cfg.AllowUnauthenticated = ttc.AllowUnauthenticated
+		bsWebServer := New(ctx, gs, cfg)
 		lis, err := net.Listen("tcp", serverAddress)
 		if !a.So(err, should.BeNil) {
 			t.FailNow()
@@ -225,7 +225,7 @@ func TestDiscover(t *testing.T) {
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 	gs := mock.NewServer(c)
 
-	bsWebServer := New(ctx, gs, defaultOptions)
+	bsWebServer := New(ctx, gs, defaultConfig)
 	lis, err := net.Listen("tcp", serverAddress)
 	if !a.So(err, should.BeNil) {
 		t.FailNow()
@@ -463,7 +463,7 @@ func TestVersion(t *testing.T) {
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 	gs := mock.NewServer(c)
 
-	bsWebServer := New(ctx, gs, defaultOptions)
+	bsWebServer := New(ctx, gs, defaultConfig)
 	lis, err := net.Listen("tcp", serverAddress)
 	if !a.So(err, should.BeNil) {
 		t.FailNow()
@@ -726,7 +726,7 @@ func TestTraffic(t *testing.T) {
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 	gs := mock.NewServer(c)
 
-	bsWebServer := New(ctx, gs, defaultOptions)
+	bsWebServer := New(ctx, gs, defaultConfig)
 	lis, err := net.Listen("tcp", serverAddress)
 	if !a.So(err, should.BeNil) {
 		t.FailNow()
@@ -1062,7 +1062,7 @@ func TestRTT(t *testing.T) {
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 	gs := mock.NewServer(c)
 
-	bsWebServer := New(ctx, gs, defaultOptions)
+	bsWebServer := New(ctx, gs, defaultConfig)
 	lis, err := net.Listen("tcp", serverAddress)
 	if !a.So(err, should.BeNil) {
 		t.FailNow()
@@ -1343,7 +1343,7 @@ func TestPingPong(t *testing.T) {
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 	gs := mock.NewServer(c)
 
-	bsWebServer := New(ctx, gs, defaultOptions)
+	bsWebServer := New(ctx, gs, defaultConfig)
 	lis, err := net.Listen("tcp", serverAddress)
 	if !a.So(err, should.BeNil) {
 		t.FailNow()

--- a/pkg/gatewayserver/io/basicstationlns/basicstationlns_test.go
+++ b/pkg/gatewayserver/io/basicstationlns/basicstationlns_test.go
@@ -58,8 +58,12 @@ var (
 
 	testTrafficEndPoint = "/traffic/eui-0101010101010101"
 
-	timeout               = (1 << 5) * test.Delay
-	defaultWSPingInterval = (1 << 3) * test.Delay
+	timeout        = (1 << 5) * test.Delay
+	defaultOptions = Options{
+		WSPingInterval:       (1 << 3) * test.Delay,
+		AllowUnauthenticated: true,
+		UseTrafficTLSAddress: false,
+	}
 )
 
 func eui64Ptr(eui types.EUI64) *types.EUI64 { return &eui }
@@ -90,77 +94,104 @@ func TestClientTokenAuth(t *testing.T) {
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 	gs := mock.NewServer(c)
 
-	bsWebServer := New(ctx, gs, false, defaultWSPingInterval)
-	lis, err := net.Listen("tcp", serverAddress)
-	if !a.So(err, should.BeNil) {
-		t.FailNow()
-	}
-	defer lis.Close()
-	go func() error {
-		return http.Serve(lis, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			bsWebServer.ServeHTTP(w, r)
-		}))
-	}()
-	servAddr := fmt.Sprintf("ws://%s", lis.Addr().String())
-
-	for _, tc := range []struct {
-		Name           string
-		GatewayID      string
-		AuthToken      string
-		TokenPrefix    string
-		ErrorAssertion func(err error) bool
+	for _, ttc := range []struct {
+		Name                 string
+		AllowUnauthenticated bool
 	}{
 		{
-			Name:           "RegisteredGatewayAndValidKey",
-			GatewayID:      registeredGatewayID.GatewayID,
-			AuthToken:      registeredGatewayToken,
-			ErrorAssertion: nil,
+			Name:                 "ServerAllowUnauthenticated",
+			AllowUnauthenticated: true,
 		},
 		{
-			Name:           "RegisteredGatewayAndValidKey",
-			GatewayID:      registeredGatewayID.GatewayID,
-			AuthToken:      registeredGatewayToken,
-			TokenPrefix:    "Bearer ",
-			ErrorAssertion: nil,
-		},
-		{
-			Name:      "RegisteredGatewayAndInValidKey",
-			GatewayID: registeredGatewayID.GatewayID,
-			AuthToken: "invalidToken",
-			ErrorAssertion: func(err error) bool {
-				return err == websocket.ErrBadHandshake
-			},
-		},
-		{
-			Name:           "RegisteredGatewayAndNoKey",
-			GatewayID:      registeredGatewayID.GatewayID,
-			ErrorAssertion: nil,
-		},
-		{
-			Name:      "UnregisteredGateway",
-			GatewayID: "eui-1122334455667788",
-			AuthToken: registeredGatewayToken,
-			ErrorAssertion: func(err error) bool {
-				return err == websocket.ErrBadHandshake
-			},
+			Name:                 "ServerDontAllowUnauthenticated",
+			AllowUnauthenticated: false,
 		},
 	} {
-		t.Run(fmt.Sprintf("%s", tc.Name), func(t *testing.T) {
-			a := assertions.New(t)
-			h := http.Header{}
-			h.Set("Authorization", fmt.Sprintf("%s%s", tc.TokenPrefix, tc.AuthToken))
-			conn, _, err := websocket.DefaultDialer.Dial(servAddr+connectionRootEndPoint+tc.GatewayID, h)
-			if err != nil {
-				if tc.ErrorAssertion == nil || !a.So(tc.ErrorAssertion(err), should.BeTrue) {
-					t.Fatalf("Unexpected error: %v", err)
+		opts := defaultOptions
+		opts.AllowUnauthenticated = ttc.AllowUnauthenticated
+		bsWebServer := New(ctx, gs, opts)
+		lis, err := net.Listen("tcp", serverAddress)
+		if !a.So(err, should.BeNil) {
+			t.FailNow()
+		}
+		defer lis.Close()
+		go func() error {
+			return http.Serve(lis, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				bsWebServer.ServeHTTP(w, r)
+			}))
+		}()
+		servAddr := fmt.Sprintf("ws://%s", lis.Addr().String())
+
+		for _, tc := range []struct {
+			Name           string
+			GatewayID      string
+			AuthToken      string
+			TokenPrefix    string
+			ErrorAssertion func(err error) bool
+		}{
+			{
+				Name:           "RegisteredGatewayAndValidKey",
+				GatewayID:      registeredGatewayID.GatewayID,
+				AuthToken:      registeredGatewayToken,
+				ErrorAssertion: nil,
+			},
+			{
+				Name:           "RegisteredGatewayAndValidKey",
+				GatewayID:      registeredGatewayID.GatewayID,
+				AuthToken:      registeredGatewayToken,
+				TokenPrefix:    "Bearer ",
+				ErrorAssertion: nil,
+			},
+			{
+				Name:      "RegisteredGatewayAndInValidKey",
+				GatewayID: registeredGatewayID.GatewayID,
+				AuthToken: "invalidToken",
+				ErrorAssertion: func(err error) bool {
+					if err == nil {
+						return false
+					}
+					return err == websocket.ErrBadHandshake
+				},
+			},
+			{
+				Name:      "RegisteredGatewayAndNoKey",
+				GatewayID: registeredGatewayID.GatewayID,
+				ErrorAssertion: func(err error) bool {
+					if ttc.AllowUnauthenticated && err == nil {
+						return true
+					}
+					return err == websocket.ErrBadHandshake
+				},
+			},
+			{
+				Name:      "UnregisteredGateway",
+				GatewayID: "eui-1122334455667788",
+				AuthToken: registeredGatewayToken,
+				ErrorAssertion: func(err error) bool {
+					if err == nil {
+						return false
+					}
+					return err == websocket.ErrBadHandshake
+				},
+			},
+		} {
+			t.Run(fmt.Sprintf("%s/%s", ttc.Name, tc.Name), func(t *testing.T) {
+				a := assertions.New(t)
+				h := http.Header{}
+				h.Set("Authorization", fmt.Sprintf("%s%s", tc.TokenPrefix, tc.AuthToken))
+				conn, _, err := websocket.DefaultDialer.Dial(servAddr+connectionRootEndPoint+tc.GatewayID, h)
+				if err != nil {
+					if tc.ErrorAssertion == nil || !a.So(tc.ErrorAssertion(err), should.BeTrue) {
+						t.Fatalf("Unexpected error: %v", err)
+					}
+				} else if tc.ErrorAssertion != nil {
+					a.So(tc.ErrorAssertion(err), should.BeTrue)
 				}
-			} else if tc.ErrorAssertion != nil {
-				t.Fatalf("Expected error")
-			}
-			if conn != nil {
-				conn.Close()
-			}
-		})
+				if conn != nil {
+					conn.Close()
+				}
+			})
+		}
 	}
 }
 
@@ -194,7 +225,7 @@ func TestDiscover(t *testing.T) {
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 	gs := mock.NewServer(c)
 
-	bsWebServer := New(ctx, gs, false, defaultWSPingInterval)
+	bsWebServer := New(ctx, gs, defaultOptions)
 	lis, err := net.Listen("tcp", serverAddress)
 	if !a.So(err, should.BeNil) {
 		t.FailNow()
@@ -432,7 +463,7 @@ func TestVersion(t *testing.T) {
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 	gs := mock.NewServer(c)
 
-	bsWebServer := New(ctx, gs, false, defaultWSPingInterval)
+	bsWebServer := New(ctx, gs, defaultOptions)
 	lis, err := net.Listen("tcp", serverAddress)
 	if !a.So(err, should.BeNil) {
 		t.FailNow()
@@ -695,7 +726,7 @@ func TestTraffic(t *testing.T) {
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 	gs := mock.NewServer(c)
 
-	bsWebServer := New(ctx, gs, false, defaultWSPingInterval)
+	bsWebServer := New(ctx, gs, defaultOptions)
 	lis, err := net.Listen("tcp", serverAddress)
 	if !a.So(err, should.BeNil) {
 		t.FailNow()
@@ -1031,7 +1062,7 @@ func TestRTT(t *testing.T) {
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 	gs := mock.NewServer(c)
 
-	bsWebServer := New(ctx, gs, false, defaultWSPingInterval)
+	bsWebServer := New(ctx, gs, defaultOptions)
 	lis, err := net.Listen("tcp", serverAddress)
 	if !a.So(err, should.BeNil) {
 		t.FailNow()
@@ -1312,7 +1343,7 @@ func TestPingPong(t *testing.T) {
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 	gs := mock.NewServer(c)
 
-	bsWebServer := New(ctx, gs, false, defaultWSPingInterval)
+	bsWebServer := New(ctx, gs, defaultOptions)
 	lis, err := net.Listen("tcp", serverAddress)
 	if !a.So(err, should.BeNil) {
 		t.FailNow()

--- a/pkg/gatewayserver/io/basicstationlns/config.go
+++ b/pkg/gatewayserver/io/basicstationlns/config.go
@@ -27,5 +27,5 @@ type Config struct {
 var DefaultConfig = Config{
 	UseTrafficTLSAddress: false,
 	WSPingInterval:       30 * time.Second,
-	AllowUnauthenticated: true,
+	AllowUnauthenticated: false,
 }

--- a/pkg/gatewayserver/io/basicstationlns/config.go
+++ b/pkg/gatewayserver/io/basicstationlns/config.go
@@ -1,0 +1,31 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package basicstationlns
+
+import "time"
+
+// Config defines the Basic Station configuration of the Gateway Server.
+type Config struct {
+	UseTrafficTLSAddress bool          `name:"use-traffic-tls-address" description:"Use WSS for the traffic address regardless of the TLS setting"`
+	WSPingInterval       time.Duration `name:"ws-ping-interval" description:"Interval to send WS ping messages"`
+	AllowUnauthenticated bool          `name:"allow-unauthenticated" description:"Allow unauthenticated connections"`
+}
+
+// DefaultConfig contains the default configuration.
+var DefaultConfig = Config{
+	UseTrafficTLSAddress: false,
+	WSPingInterval:       30 * time.Second,
+	AllowUnauthenticated: true,
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2882 

#### Changes
<!-- What are the changes made in this pull request? -->

- Add new `allow-unauthenticated` flag (default is `true` to make it compatible with existing deployments.
- Integrate functions
- Test

#### Testing

<!-- How did you verify that this change works? -->

Unit Tests

|`allow-unauthenticated` flag (down)/Header in Auth(right)|Yes|No|
|---|----|---|
|True|Check auth and allow connection|Assume rights and allow connection|
|False|Check auth and allow connection|Don't allow|

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Covered by UTs

Also checked that there's no regression in the config due to the refactoring

This PR
```
gs:
  basic-station:
    allow-unauthenticated: true
    fallback-frequency-plan-id: ""
    listen: :1887
    listen-tls: :8887
    use-traffic-tls-address: false
    ws-ping-interval: 30s
```

On `master`
```
gs:
  basic-station:
    fallback-frequency-plan-id: ""
    listen: :1887
    listen-tls: :8887
    use-traffic-tls-address: false
    ws-ping-interval: 30s
```

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Requires a small PR in `lorawan-stack-aws`. Will add that.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
