### PR TITLE
as: Make webhook templates repo part of default AS config

### DIFF
--- a/cmd/internal/shared/applicationserver/config.go
+++ b/cmd/internal/shared/applicationserver/config.go
@@ -24,6 +24,11 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
 )
 
+// DefaultWebhookTemplatesConfig is the default configuration for the Webhook templates.
+var DefaultWebhookTemplatesConfig = web.TemplatesConfig{
+	URL: "https://raw.githubusercontent.com/TheThingsNetwork/lorawan-webhook-templates/master",
+}
+
 // DefaultApplicationServerConfig is the default configuration for the Application Server.
 var DefaultApplicationServerConfig = applicationserver.Config{
 	LinkMode: "all",
@@ -34,6 +39,7 @@ var DefaultApplicationServerConfig = applicationserver.Config{
 		PublicTLSAddress: fmt.Sprintf("%s:8883", shared.DefaultPublicHost),
 	},
 	Webhooks: applicationserver.WebhooksConfig{
+		Templates: DefaultWebhookTemplatesConfig,
 		Target:    "direct",
 		Timeout:   5 * time.Second,
 		QueueSize: 16,


### PR DESCRIPTION
#### Summary
References #2946 

#### Changes
Making webhook templates repository part of default Application Server configuration.

#### Testing
Tested creating, editing and deleting webhook templates on local TTS deployment.

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
