### PR TITLE
Omit default HTTP ports from generated oauth server address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Gateway connection stats are now stored in a single key.
 - The example configuration for deployments with custom certificates now also uses a CA certificate.
 - Increase Network Server application uplink buffer queue size.
+- `ttn-lw-cli use` command no longer adds default HTTP ports (80/443) to the OAuth Server address.
 
 ### Deprecated
 

--- a/pkg/rpcmiddleware/discover/discover.go
+++ b/pkg/rpcmiddleware/discover/discover.go
@@ -108,9 +108,12 @@ var HTTPScheme = map[bool]string{
 
 // DefaultURL appends protocol and port if target does not already have one.
 func DefaultURL(target string, port int, tls bool) (string, error) {
-	target, err := DefaultPort(target, port)
-	if err != nil {
-		return "", nil
+	if port != DefaultHTTPPorts[tls] {
+		var err error
+		target, err = DefaultPort(target, port)
+		if err != nil {
+			return "", nil
+		}
 	}
 	return fmt.Sprintf("%s://%s", HTTPScheme[tls], target), nil
 }

--- a/pkg/rpcmiddleware/discover/discover_internal_test.go
+++ b/pkg/rpcmiddleware/discover/discover_internal_test.go
@@ -58,7 +58,13 @@ func TestDefaultURL(t *testing.T) {
 			target:   "localhost",
 			port:     80,
 			tls:      false,
-			expected: "http://localhost:80",
+			expected: "http://localhost",
+		},
+		{
+			target:   "localhost",
+			port:     8080,
+			tls:      false,
+			expected: "http://localhost:8080",
 		},
 		{
 			target:   "host.with.port:http",
@@ -71,6 +77,12 @@ func TestDefaultURL(t *testing.T) {
 			port:     4000,
 			tls:      true,
 			expected: "https://hostname:433",
+		},
+		{
+			target:   "hostname",
+			port:     443,
+			tls:      true,
+			expected: "https://hostname",
 		},
 		{
 			target:   "hostname",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Changes
<!-- What are the changes made in this pull request? -->

This quickfix PR removes default HTTP ports from the OAuth server address generated when creating configuration with the `ttn-lw-cli use` command.

#### Testing

<!-- How did you verify that this change works? -->

Added unit tests for default ports. Test locally (also with `--insecure`) as well as `eu1.cloud.thethings.industries`.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

There should not be any, we are only omitting the default HTTP ports here.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
