### PR TITLE
doc: Use canonical CLI command names in documentation pages

### DIFF
--- a/doc/content/devices/class-c-multicast/_index.md
+++ b/doc/content/devices/class-c-multicast/_index.md
@@ -16,7 +16,7 @@ In order to send Class C downlink messages to a single device, enable Class C su
 For example, when enabling Class C for an existing device:
 
 ```bash
-$ ttn-lw-cli end-devices update app1 dev1 --supports-class-c
+$ ttn-lw-cli end-devices set app1 dev1 --supports-class-c
 ```
 
 This will enable the Class C downlink scheduling of the device. That's it! Downlink messages are now scheduled as soon as possible.

--- a/doc/content/devices/end-device-templates/assigning-euis.md
+++ b/doc/content/devices/end-device-templates/assigning-euis.md
@@ -24,7 +24,7 @@ This example illustrates creating a device profile template, assigning 5 `DevEUI
 First, create a mapping file with a device profile in `profile.json`:
 
 ```bash
-$ ttn-lw-cli end-device template extend \
+$ ttn-lw-cli end-devices template extend \
   --frequency-plan-id EU_863_870 \
   --lorawan-version 1.0.3 \
   --lorawan-phy-version 1.0.3-a \
@@ -35,7 +35,7 @@ Second, assign the EUIs. The first argument is the `JoinEUI`, the second argumen
 
 ```bash
 $ cat profile.json \
-  | ttn-lw-cli end-device template assign-euis 70b3d57ed0000000 70b3d57ed0000001 --count 5 > devices.json
+  | ttn-lw-cli end-devices template assign-euis 70b3d57ed0000000 70b3d57ed0000001 --count 5 > devices.json
 ```
 
 <details><summary>Show output</summary>
@@ -203,6 +203,6 @@ Finally, you can create these devices in your {{% tts %}} application `test-app`
 
 ```bash
 $ cat devices.json \
-  | ttn-lw-cli end-device template execute \
-  | ttn-lw-cli device create --application-id test-app
+  | ttn-lw-cli end-devices template execute \
+  | ttn-lw-cli end-devices create --application-id test-app
 ```

--- a/doc/content/devices/end-device-templates/converting.md
+++ b/doc/content/devices/end-device-templates/converting.md
@@ -11,7 +11,7 @@ You can convert data in various formats to device templates using formats suppor
 Start with listing the supported formats:
 
 ```bash
-$ ttn-lw-cli end-device template list-formats
+$ ttn-lw-cli end-devices template list-formats
 ```
 
 This gives the supported formats. For example:
@@ -34,7 +34,7 @@ Given input data, you can use the `end-device template from-data` command to get
 >This example uses a **Microchip ATECC608A-MAHTN-T Manifest File**. This file contains provisioning data for The Things Industries Join Server. You can [download the example file](../microchip-atecc608a-mahtn-t-example.json).
 
 ```bash
-$ ttn-lw-cli end-device template from-data microchip-atecc608a-mahtn-t --local-file example.json
+$ ttn-lw-cli end-devices template from-data microchip-atecc608a-mahtn-t --local-file example.json
 ```
 
 Output:

--- a/doc/content/devices/end-device-templates/creating.md
+++ b/doc/content/devices/end-device-templates/creating.md
@@ -55,7 +55,7 @@ Use the `end-device template extend` command to extend a template:
 
 ```bash
 $ cat template.json \
-  | ttn-lw-cli end-device template extend \
+  | ttn-lw-cli end-devices template extend \
   --frequency-plan-id EU_863_870
 ```
 
@@ -87,7 +87,7 @@ Output:
 }
 ```
 
-See `$ ttn-lw-cli end-device template extend --help` for all the fields that can be set.
+See `$ ttn-lw-cli end-devices template extend --help` for all the fields that can be set.
 
 ## Create from scratch
 
@@ -96,7 +96,7 @@ The `end-device template extend` can also be used to create a new template from 
 For example, create a new template from scratch:
 
 ```bash
-$ ttn-lw-cli end-device template extend \
+$ ttn-lw-cli end-devices template extend \
   --lorawan-version 1.0.3 \
   --lorawan-phy-version 1.0.3-a \
   --frequency-plan-id EU_863_870

--- a/doc/content/devices/end-device-templates/executing.md
+++ b/doc/content/devices/end-device-templates/executing.md
@@ -10,7 +10,7 @@ Once you created or converted a template, you can execute the template with the 
 
 ```bash
 # The examples use a template that has been created as follows:
-$ ttn-lw-cli end-device template extend \
+$ ttn-lw-cli end-devices template extend \
   --lorawan-version 1.0.3 \
   --lorawan-phy-version 1.0.3-a \
   --frequency-plan-id US_902_928 > example.json
@@ -19,7 +19,7 @@ $ ttn-lw-cli end-device template extend \
 You can execute an end device as follows:
 
 ```bash
-$ cat example.json | ttn-lw-cli end-device template execute
+$ cat example.json | ttn-lw-cli end-devices template execute
 ```
 
 Output:
@@ -43,9 +43,9 @@ The `end-device template execute` command **does not create** the end device. Yo
 
 ```bash
 $ cat example.json \
-  | ttn-lw-cli end-device template assign-euis 70b3d57ed0000000 70b3d57ed0000001 \
-  | ttn-lw-cli end-device template execute \
-  | ttn-lw-cli device create --application-id test-app
+  | ttn-lw-cli end-devices template assign-euis 70b3d57ed0000000 70b3d57ed0000001 \
+  | ttn-lw-cli end-devices template execute \
+  | ttn-lw-cli end-devices create --application-id test-app
 ```
 
 Output:

--- a/doc/content/devices/end-device-templates/mapping.md
+++ b/doc/content/devices/end-device-templates/mapping.md
@@ -22,7 +22,7 @@ This example shows creating a generic device profile that is mapped with provisi
 First, create a mapping file with a device profile:
 
 ```bash
-$ ttn-lw-cli end-device template extend \
+$ ttn-lw-cli end-devices template extend \
   --frequency-plan-id EU_863_870 \
   --lorawan-version 1.0.3 \
   --lorawan-phy-version 1.0.3-a \
@@ -75,14 +75,14 @@ Second, convert the provisioning data to a device templates file to `provisionin
 >This example uses a **Microchip ATECC608A-MAHTN-T Manifest File**. This file contains provisioning data for The Things Industries Join Server. You can [download the example file](../microchip-atecc608a-mahtn-t-example.json).
 
 ```bash
-$ ttn-lw-cli end-device template from-data microchip-atecc608a-mahtn-t --local-file example.json > provisioningdata.json
+$ ttn-lw-cli end-devices template from-data microchip-atecc608a-mahtn-t --local-file example.json > provisioningdata.json
 ```
 
 Third, map the two files to `templates.json`:
 
 ```bash
 $ cat provisioningdata.json \
-  | ttn-lw-cli end-device template map --mapping-local-file profile.json > templates.json
+  | ttn-lw-cli end-devices template map --mapping-local-file profile.json > templates.json
 ```
 
 This returns the device templates with provisioning data and device profile combined.
@@ -203,7 +203,7 @@ Fourth, you can personalize these devices by assigning the `JoinEUI` and `DevEUI
 
 ```bash
 $ cat templates.json \
-  | ttn-lw-cli end-device template assign-euis 70b3d57ed0000000 70b3d57ed0000001 > devices.json
+  | ttn-lw-cli end-devices template assign-euis 70b3d57ed0000000 70b3d57ed0000001 > devices.json
 ```
 
 <details><summary>Show output</summary>
@@ -334,6 +334,6 @@ Finally, you can create these devices in your {{% tts %}} application `test-app`
 
 ```bash
 $ cat devices.json \
-  | ttn-lw-cli end-device template execute \
-  | ttn-lw-cli device create --application-id test-app
+  | ttn-lw-cli end-devices template execute \
+  | ttn-lw-cli end-devices create --application-id test-app
 ```

--- a/doc/content/getting-started/events/_index.md
+++ b/doc/content/getting-started/events/_index.md
@@ -22,7 +22,7 @@ $ ttn-lw-cli events subscribe --gateway-id gtw1 --application-id app1
 You can get streaming events with `curl`. For this, you need an API key for the entities you want to watch, for example:
 
 ```bash
-$ ttn-lw-cli user api-key create \
+$ ttn-lw-cli users api-key create \
   --user-id admin \
   --right-application-all \
   --right-gateway-all

--- a/doc/content/getting-started/migrating-from-v2/configure-mac-settings.md
+++ b/doc/content/getting-started/migrating-from-v2/configure-mac-settings.md
@@ -14,7 +14,7 @@ MAC settings on {{% tts %}} are configurable per end device. They can be configu
 The RX1 delay of end devices is set to 1 second by default. For some end devices, this may lead to downlink messages not being scheduled in time. Therefore, it is recommended that the RX1 delay be increased to 5 seconds:
 
 ```bash
-$ ttn-lw-cli end-devices update "app-id" "device-id" --mac-settings.rx1-delay RX_DELAY_5
+$ ttn-lw-cli end-devices set "app-id" "device-id" --mac-settings.rx1-delay RX_DELAY_5
 ```
 
 ### Unsetting MAC settings
@@ -22,7 +22,7 @@ $ ttn-lw-cli end-devices update "app-id" "device-id" --mac-settings.rx1-delay RX
 The CLI can also be used to unset MAC settings (so that the default ones are used):
 
 ```bash
-$ ttn-lw-cli end-devices update "app-id" "device-id" --unset mac-settings.rx1-delay
+$ ttn-lw-cli end-devices set "app-id" "device-id" --unset mac-settings.rx1-delay
 ```
 
 ### Available MAC settings
@@ -30,7 +30,7 @@ $ ttn-lw-cli end-devices update "app-id" "device-id" --unset mac-settings.rx1-de
 Run the following command to get a list of all available MAC settings:
 
 ```bash
-$ ttn-lw-cli end-devices update --help
+$ ttn-lw-cli end-devices set --help
 ```
 
 You can also refer to the [API Reference page]({{< ref "reference/api/end_device#message:MACSettings" >}}) for documentation on the available MAC settings and MAC state parameters.

--- a/doc/content/getting-started/user-management/cli/_index.md
+++ b/doc/content/getting-started/user-management/cli/_index.md
@@ -133,7 +133,7 @@ $ ttn-lw-cli users invitations delete colleague@thethings.network
 To update users with the CLI, use the `users update` command. The following command updates the state of user `new-user` to "approved" and makes them admin of the network:
 
 ```bash
-$ ttn-lw-cli users update new-user --state APPROVED --admin true
+$ ttn-lw-cli users set new-user --state APPROVED --admin true
 ```
 
 Output:

--- a/doc/content/integrations/payload-formatters/cli.md
+++ b/doc/content/integrations/payload-formatters/cli.md
@@ -50,7 +50,7 @@ To create a [CayenneLPP]({{< relref "cayenne" >}}) or [Device Repository]({{< re
 To change the payload formatter for an existing device, use the `end-devices update` command:
 
 ```bash
-$ ttn-lw-cli end-devices update app1 dev1-with-formatter \
+$ ttn-lw-cli end-devices set app1 dev1-with-formatter \
   --formatters.down-formatter FORMATTER_JAVASCRIPT \
   --formatters.down-formatter-parameter-local-file "encoder.js" \
   --formatters.up-formatter FORMATTER_JAVASCRIPT \
@@ -60,13 +60,13 @@ $ ttn-lw-cli end-devices update app1 dev1-with-formatter \
 To unset the payload formatters, use the `--unset` flag. The command below will unset all device specific payload formatters:
 
 ```bash
-$ ttn-lw-cli end-devices update app1 dev1-with-formatter \
+$ ttn-lw-cli end-devices set app1 dev1-with-formatter \
   --unset "formatters"
 ```
 
 It is also possible to unset the uplink or downlink formatters separately:
 
 ```bash
-$ ttn-lw-cli end-devices update app1 dev1-with-formatter \
+$ ttn-lw-cli end-devices set app1 dev1-with-formatter \
   --unset "formatters.up-formatter,formatters.up-formatter-parameter"
 ```


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Quickfix PR that updates CLI commands in the documentation with their canonical names.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [X] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
