### PR TITLE
Make CLI command aliases consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Options to allow/deny non-admin users to create applications, gateways, etc. (the the `is.user-rights.*` options).
 - Admins now receive emails about requested user accounts that need approval.
 - Support for synchronizing gateway clocks via uplink tokens. UDP gateways may not connect to the same Gateway Server instance.
+- Consistent command aliases for CLI commands.
 
 ### Changed
 

--- a/cmd/ttn-lw-cli/commands/applications.go
+++ b/cmd/ttn-lw-cli/commands/applications.go
@@ -186,9 +186,9 @@ var (
 		}),
 	}
 	applicationsUpdateCommand = &cobra.Command{
-		Use:     "update [application-id]",
-		Aliases: []string{"set"},
-		Short:   "Update an application",
+		Use:     "set [application-id]",
+		Aliases: []string{"update"},
+		Short:   "Set properties of an application",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			appID := getApplicationID(cmd.Flags(), args)
 			if appID == nil {
@@ -223,8 +223,9 @@ var (
 		},
 	}
 	applicationsDeleteCommand = &cobra.Command{
-		Use:   "delete [application-id]",
-		Short: "Delete an application",
+		Use:     "delete [application-id]",
+		Aliases: []string{"del", "remove", "rm"},
+		Short:   "Delete an application",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			appID := getApplicationID(cmd.Flags(), args)
 			if appID == nil {

--- a/cmd/ttn-lw-cli/commands/applications.go
+++ b/cmd/ttn-lw-cli/commands/applications.go
@@ -185,7 +185,7 @@ var (
 			return io.Write(os.Stdout, config.OutputFormat, res)
 		}),
 	}
-	applicationsUpdateCommand = &cobra.Command{
+	applicationsSetCommand = &cobra.Command{
 		Use:     "set [application-id]",
 		Aliases: []string{"update"},
 		Short:   "Set properties of an application",
@@ -273,10 +273,10 @@ func init() {
 	applicationsCreateCommand.Flags().AddFlagSet(setApplicationFlags)
 	applicationsCreateCommand.Flags().AddFlagSet(attributesFlags())
 	applicationsCommand.AddCommand(applicationsCreateCommand)
-	applicationsUpdateCommand.Flags().AddFlagSet(applicationIDFlags())
-	applicationsUpdateCommand.Flags().AddFlagSet(setApplicationFlags)
-	applicationsUpdateCommand.Flags().AddFlagSet(attributesFlags())
-	applicationsCommand.AddCommand(applicationsUpdateCommand)
+	applicationsSetCommand.Flags().AddFlagSet(applicationIDFlags())
+	applicationsSetCommand.Flags().AddFlagSet(setApplicationFlags)
+	applicationsSetCommand.Flags().AddFlagSet(attributesFlags())
+	applicationsCommand.AddCommand(applicationsSetCommand)
 	applicationsDeleteCommand.Flags().AddFlagSet(applicationIDFlags())
 	applicationsCommand.AddCommand(applicationsDeleteCommand)
 	applicationsContactInfoCommand.PersistentFlags().AddFlagSet(applicationIDFlags())

--- a/cmd/ttn-lw-cli/commands/applications_access.go
+++ b/cmd/ttn-lw-cli/commands/applications_access.go
@@ -91,8 +91,9 @@ var (
 		},
 	}
 	applicationCollaboratorsSet = &cobra.Command{
-		Use:   "set",
-		Short: "Set an application collaborator",
+		Use:     "set",
+		Aliases: []string{"update"},
+		Short:   "Set properties of an application collaborator",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			appID := getApplicationID(cmd.Flags(), nil)
 			if appID == nil {
@@ -127,7 +128,7 @@ var (
 	}
 	applicationCollaboratorsDelete = &cobra.Command{
 		Use:     "delete",
-		Aliases: []string{"remove"},
+		Aliases: []string{"del", "remove", "rm"},
 		Short:   "Delete an application collaborator",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			appID := getApplicationID(cmd.Flags(), nil)
@@ -190,7 +191,7 @@ var (
 	}
 	applicationAPIKeysCreate = &cobra.Command{
 		Use:     "create [application-id]",
-		Aliases: []string{"add", "generate"},
+		Aliases: []string{"add", "register", "generate"},
 		Short:   "Create an application API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			appID := getApplicationID(cmd.Flags(), args)
@@ -218,9 +219,9 @@ var (
 		},
 	}
 	applicationAPIKeysUpdate = &cobra.Command{
-		Use:     "update [application-id] [api-key-id]",
-		Aliases: []string{"set"},
-		Short:   "Update an application API key",
+		Use:     "set [application-id] [api-key-id]",
+		Aliases: []string{"update"},
+		Short:   "Set properties of an application API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			appID := getApplicationID(cmd.Flags(), firstArgs(1, args...))
 			if appID == nil {
@@ -258,7 +259,7 @@ var (
 	}
 	applicationAPIKeysDelete = &cobra.Command{
 		Use:     "delete [application-id] [api-key-id]",
-		Aliases: []string{"remove"},
+		Aliases: []string{"del", "remove", "rm"},
 		Short:   "Delete an application API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			appID := getApplicationID(cmd.Flags(), firstArgs(1, args...))

--- a/cmd/ttn-lw-cli/commands/applications_link.go
+++ b/cmd/ttn-lw-cli/commands/applications_link.go
@@ -115,8 +115,9 @@ var (
 		},
 	}
 	applicationsLinkDeleteCommand = &cobra.Command{
-		Use:   "delete [application-id]",
-		Short: "Delete an application link",
+		Use:     "delete [application-id]",
+		Aliases: []string{"del", "remove", "rm"},
+		Short:   "Delete an application link",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			appID := getApplicationID(cmd.Flags(), args)
 			if appID == nil {

--- a/cmd/ttn-lw-cli/commands/applications_packages.go
+++ b/cmd/ttn-lw-cli/commands/applications_packages.go
@@ -287,7 +287,7 @@ var (
 	}
 	applicationsPackageAssociationDeleteCommand = &cobra.Command{
 		Use:     "delete [application-id] [device-id] [f-port]",
-		Aliases: []string{"delete"},
+		Aliases: []string{"del", "remove", "rm"},
 		Short:   "Delete an application package association",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			assocID, err := getApplicationPackageAssociationID(cmd.Flags(), args)
@@ -430,7 +430,7 @@ var (
 	}
 	applicationsPackageDefaultAssociationDeleteCommand = &cobra.Command{
 		Use:     "delete [application-id] [f-port]",
-		Aliases: []string{"delete"},
+		Aliases: []string{"del", "remove", "rm"},
 		Short:   "Delete an application package default association",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			assocID, err := getApplicationPackageDefaultAssociationID(cmd.Flags(), args)

--- a/cmd/ttn-lw-cli/commands/applications_pubsub.go
+++ b/cmd/ttn-lw-cli/commands/applications_pubsub.go
@@ -104,7 +104,7 @@ var (
 	}
 	applicationsPubSubsGetFormatsCommand = &cobra.Command{
 		Use:     "get-formats",
-		Aliases: []string{"formats"},
+		Aliases: []string{"formats", "list-formats"},
 		Short:   "Get the available formats for application pubsubs",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			as, err := api.Dial(ctx, config.ApplicationServerGRPCAddress)
@@ -278,8 +278,9 @@ var (
 		},
 	}
 	applicationsPubSubsDeleteCommand = &cobra.Command{
-		Use:   "delete [application-id] [pubsub-id]",
-		Short: "Delete an application pub/sub",
+		Use:     "delete [application-id] [pubsub-id]",
+		Aliases: []string{"del", "remove", "rm"},
+		Short:   "Delete an application pub/sub",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			pubsubID, err := getApplicationPubSubID(cmd.Flags(), args)
 			if err != nil {

--- a/cmd/ttn-lw-cli/commands/applications_webhooks.go
+++ b/cmd/ttn-lw-cli/commands/applications_webhooks.go
@@ -85,7 +85,7 @@ var (
 	}
 	applicationsWebhooksGetFormatsCommand = &cobra.Command{
 		Use:     "get-formats",
-		Aliases: []string{"formats"},
+		Aliases: []string{"formats", "list-formats"},
 		Short:   "Get the available formats for application webhooks",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			as, err := api.Dial(ctx, config.ApplicationServerGRPCAddress)
@@ -201,8 +201,9 @@ var (
 		},
 	}
 	applicationsWebhooksDeleteCommand = &cobra.Command{
-		Use:   "delete [application-id] [webhook-id]",
-		Short: "Delete an application webhook",
+		Use:     "delete [application-id] [webhook-id]",
+		Aliases: []string{"del", "remove", "rm"},
+		Short:   "Delete an application webhook",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			webhookID, err := getApplicationWebhookID(cmd.Flags(), args)
 			if err != nil {

--- a/cmd/ttn-lw-cli/commands/clients.go
+++ b/cmd/ttn-lw-cli/commands/clients.go
@@ -194,9 +194,9 @@ var (
 		}),
 	}
 	clientsUpdateCommand = &cobra.Command{
-		Use:     "update [client-id]",
-		Aliases: []string{"set"},
-		Short:   "Update a client",
+		Use:     "set [client-id]",
+		Aliases: []string{"update"},
+		Short:   "Set properties of a client",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliID := getClientID(cmd.Flags(), args)
 			if cliID == nil {
@@ -231,8 +231,9 @@ var (
 		},
 	}
 	clientsDeleteCommand = &cobra.Command{
-		Use:   "delete [client-id]",
-		Short: "Delete a client",
+		Use:     "delete [client-id]",
+		Aliases: []string{"del", "remove", "rm"},
+		Short:   "Delete a client",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliID := getClientID(cmd.Flags(), args)
 			if cliID == nil {

--- a/cmd/ttn-lw-cli/commands/clients.go
+++ b/cmd/ttn-lw-cli/commands/clients.go
@@ -193,7 +193,7 @@ var (
 			return io.Write(os.Stdout, config.OutputFormat, res)
 		}),
 	}
-	clientsUpdateCommand = &cobra.Command{
+	clientsSetCommand = &cobra.Command{
 		Use:     "set [client-id]",
 		Aliases: []string{"update"},
 		Short:   "Set properties of a client",
@@ -283,10 +283,10 @@ func init() {
 	clientsCreateCommand.Flags().Lookup("state").DefValue = ttnpb.STATE_APPROVED.String()
 	clientsCreateCommand.Flags().Lookup("grants").DefValue = ttnpb.GRANT_AUTHORIZATION_CODE.String()
 	clientsCommand.AddCommand(clientsCreateCommand)
-	clientsUpdateCommand.Flags().AddFlagSet(clientIDFlags())
-	clientsUpdateCommand.Flags().AddFlagSet(setClientFlags)
-	clientsUpdateCommand.Flags().AddFlagSet(attributesFlags())
-	clientsCommand.AddCommand(clientsUpdateCommand)
+	clientsSetCommand.Flags().AddFlagSet(clientIDFlags())
+	clientsSetCommand.Flags().AddFlagSet(setClientFlags)
+	clientsSetCommand.Flags().AddFlagSet(attributesFlags())
+	clientsCommand.AddCommand(clientsSetCommand)
 	clientsDeleteCommand.Flags().AddFlagSet(clientIDFlags())
 	clientsCommand.AddCommand(clientsDeleteCommand)
 	clientsContactInfoCommand.PersistentFlags().AddFlagSet(clientIDFlags())

--- a/cmd/ttn-lw-cli/commands/clients_access.go
+++ b/cmd/ttn-lw-cli/commands/clients_access.go
@@ -78,8 +78,9 @@ var (
 		},
 	}
 	clientCollaboratorsSet = &cobra.Command{
-		Use:   "set",
-		Short: "Set a client collaborator",
+		Use:     "set",
+		Aliases: []string{"update"},
+		Short:   "Set a client collaborator",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliID := getClientID(cmd.Flags(), nil)
 			if cliID == nil {
@@ -114,7 +115,7 @@ var (
 	}
 	clientCollaboratorsDelete = &cobra.Command{
 		Use:     "delete",
-		Aliases: []string{"remove"},
+		Aliases: []string{"del", "remove", "rm"},
 		Short:   "Delete a client collaborator",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliID := getClientID(cmd.Flags(), nil)

--- a/cmd/ttn-lw-cli/commands/contact_info.go
+++ b/cmd/ttn-lw-cli/commands/contact_info.go
@@ -161,7 +161,8 @@ func contactInfoCommands(entity string, getID func(cmd *cobra.Command, args []st
 		},
 	}
 	add := &cobra.Command{
-		Use: fmt.Sprintf("add [%s-id]", entity),
+		Use:     fmt.Sprintf("create [%s-id]", entity),
+		Aliases: []string{"add", "register"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := getID(cmd, args)
 			if err != nil {
@@ -186,7 +187,8 @@ func contactInfoCommands(entity string, getID func(cmd *cobra.Command, args []st
 		},
 	}
 	remove := &cobra.Command{
-		Use: fmt.Sprintf("remove [%s-id]", entity),
+		Use:     fmt.Sprintf("delete [%s-id]", entity),
+		Aliases: []string{"del", "remove", "rm"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := getID(cmd, args)
 			if err != nil {

--- a/cmd/ttn-lw-cli/commands/end_device_templates.go
+++ b/cmd/ttn-lw-cli/commands/end_device_templates.go
@@ -101,8 +101,9 @@ var (
 		}),
 	}
 	endDeviceTemplatesCreateCommand = &cobra.Command{
-		Use:   "create [flags]",
-		Short: "Create an end device template from an existing device (EXPERIMENTAL)",
+		Use:     "create [flags]",
+		Aliases: []string{"add", "register"},
+		Short:   "Create an end device template from an existing device (EXPERIMENTAL)",
 		Long: `Create an end device template from an existing device (EXPERIMENTAL)
 
 By default, this command strips the device's application ID, device ID, JoinEUI,

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -554,7 +554,7 @@ var (
 			return io.Write(os.Stdout, config.OutputFormat, &device)
 		}),
 	}
-	endDevicesUpdateCommand = &cobra.Command{
+	endDevicesSetCommand = &cobra.Command{
 		Use:     "set [application-id] [device-id]",
 		Aliases: []string{"update"},
 		Short:   "Set properties of an end device",
@@ -1181,15 +1181,15 @@ func init() {
 	endDevicesCreateCommand.Flags().AddFlagSet(endDevicePictureFlags)
 	endDevicesCreateCommand.Flags().AddFlagSet(endDeviceLocationFlags)
 	endDevicesCommand.AddCommand(endDevicesCreateCommand)
-	endDevicesUpdateCommand.Flags().AddFlagSet(endDeviceIDFlags())
-	endDevicesUpdateCommand.Flags().AddFlagSet(setEndDeviceFlags)
-	endDevicesUpdateCommand.Flags().AddFlagSet(attributesFlags())
-	endDevicesUpdateCommand.Flags().AddFlagSet(payloadFormatterParameterFlags("formatters"))
-	endDevicesUpdateCommand.Flags().Bool("touch", false, "set in all registries even if no fields are specified")
-	endDevicesUpdateCommand.Flags().AddFlagSet(endDevicePictureFlags)
-	endDevicesUpdateCommand.Flags().AddFlagSet(endDeviceLocationFlags)
-	endDevicesUpdateCommand.Flags().AddFlagSet(util.UnsetFlagSet())
-	endDevicesCommand.AddCommand(endDevicesUpdateCommand)
+	endDevicesSetCommand.Flags().AddFlagSet(endDeviceIDFlags())
+	endDevicesSetCommand.Flags().AddFlagSet(setEndDeviceFlags)
+	endDevicesSetCommand.Flags().AddFlagSet(attributesFlags())
+	endDevicesSetCommand.Flags().AddFlagSet(payloadFormatterParameterFlags("formatters"))
+	endDevicesSetCommand.Flags().Bool("touch", false, "set in all registries even if no fields are specified")
+	endDevicesSetCommand.Flags().AddFlagSet(endDevicePictureFlags)
+	endDevicesSetCommand.Flags().AddFlagSet(endDeviceLocationFlags)
+	endDevicesSetCommand.Flags().AddFlagSet(util.UnsetFlagSet())
+	endDevicesCommand.AddCommand(endDevicesSetCommand)
 	endDevicesProvisionCommand.Flags().AddFlagSet(applicationIDFlags())
 	endDevicesProvisionCommand.Flags().AddFlagSet(dataFlags("", ""))
 	endDevicesProvisionCommand.Flags().String("provisioner-id", "", "provisioner service")

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -179,6 +179,7 @@ var (
 	}
 	endDevicesListFrequencyPlans = &cobra.Command{
 		Use:               "list-frequency-plans",
+		Aliases:           []string{"get-frequency-plans", "frequency-plans", "fps"},
 		Short:             "List available frequency plans for end devices",
 		PersistentPreRunE: preRun(),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -554,9 +555,9 @@ var (
 		}),
 	}
 	endDevicesUpdateCommand = &cobra.Command{
-		Use:     "update [application-id] [device-id]",
-		Aliases: []string{"set"},
-		Short:   "Update an end device",
+		Use:     "set [application-id] [device-id]",
+		Aliases: []string{"update"},
+		Short:   "Set properties of an end device",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			forwardDeprecatedDeviceFlags(cmd.Flags())
 
@@ -769,8 +770,9 @@ var (
 		},
 	}
 	endDevicesDeleteCommand = &cobra.Command{
-		Use:   "delete [application-id] [device-id]",
-		Short: "Delete an end device",
+		Use:     "delete [application-id] [device-id]",
+		Aliases: []string{"del", "remove", "rm"},
+		Short:   "Delete an end device",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			devID, err := getEndDeviceID(cmd.Flags(), args, true)
 			if err != nil {
@@ -923,7 +925,7 @@ values will be stored in the Join Server.`,
 	}
 	endDevicesListQRCodeFormatsCommand = &cobra.Command{
 		Use:     "list-qr-formats",
-		Aliases: []string{"ls-qr-formats", "listqrformats", "lsqrformats", "lsqrfmts", "lsqrfmt"},
+		Aliases: []string{"ls-qr-formats", "listqrformats", "lsqrformats", "lsqrfmts", "lsqrfmt", "qr-formats"},
 		Short:   "List QR code formats (EXPERIMENTAL)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			qrg, err := api.Dial(ctx, config.QRCodeGeneratorGRPCAddress)

--- a/cmd/ttn-lw-cli/commands/gateways.go
+++ b/cmd/ttn-lw-cli/commands/gateways.go
@@ -83,6 +83,7 @@ var (
 	}
 	gatewaysListFrequencyPlans = &cobra.Command{
 		Use:               "list-frequency-plans",
+		Aliases:           []string{"get-frequency-plans", "frequency-plans", "fps"},
 		Short:             "List available frequency plans for gateways",
 		PersistentPreRunE: preRun(),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -269,9 +270,9 @@ var (
 	}
 	errAntennaIndex       = errors.DefineInvalidArgument("antenna_index", "index of antenna to update out of bounds")
 	gatewaysUpdateCommand = &cobra.Command{
-		Use:     "update [gateway-id]",
-		Aliases: []string{"set"},
-		Short:   "Update a gateway",
+		Use:     "set [gateway-id]",
+		Aliases: []string{"update"},
+		Short:   "Set properties of a gateway",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			gtwID, err := getGatewayID(cmd.Flags(), args, true)
 			if err != nil {
@@ -340,8 +341,9 @@ var (
 		},
 	}
 	gatewaysDeleteCommand = &cobra.Command{
-		Use:   "delete [gateway-id]",
-		Short: "Delete a gateway",
+		Use:     "delete [gateway-id]",
+		Aliases: []string{"del", "remove", "rm"},
+		Short:   "Delete a gateway",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			gtwID, err := getGatewayID(cmd.Flags(), args, true)
 			if err != nil {
@@ -361,8 +363,9 @@ var (
 		},
 	}
 	gatewaysConnectionStats = &cobra.Command{
-		Use:   "connection-stats [gateway-id]",
-		Short: "Get connection stats for a gateway",
+		Use:     "get-connection-stats [gateway-id]",
+		Aliases: []string{"connection-stats", "cnx-stats", "stats"},
+		Short:   "Get connection stats for a gateway",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			gtwID, err := getGatewayID(cmd.Flags(), args, true)
 			if err != nil {

--- a/cmd/ttn-lw-cli/commands/gateways.go
+++ b/cmd/ttn-lw-cli/commands/gateways.go
@@ -268,8 +268,8 @@ var (
 			return io.Write(os.Stdout, config.OutputFormat, res)
 		}),
 	}
-	errAntennaIndex       = errors.DefineInvalidArgument("antenna_index", "index of antenna to update out of bounds")
-	gatewaysUpdateCommand = &cobra.Command{
+	errAntennaIndex    = errors.DefineInvalidArgument("antenna_index", "index of antenna to update out of bounds")
+	gatewaysSetCommand = &cobra.Command{
 		Use:     "set [gateway-id]",
 		Aliases: []string{"update"},
 		Short:   "Set properties of a gateway",
@@ -435,14 +435,14 @@ func init() {
 	gatewaysCreateCommand.Flags().AddFlagSet(attributesFlags())
 	gatewaysCreateCommand.Flags().Bool("defaults", true, "configure gateway with defaults")
 	gatewaysCommand.AddCommand(gatewaysCreateCommand)
-	gatewaysUpdateCommand.Flags().AddFlagSet(gatewayIDFlags())
-	gatewaysUpdateCommand.Flags().AddFlagSet(setGatewayFlags)
-	gatewaysUpdateCommand.Flags().Int("antenna.index", 0, "index of the antenna to update or remove")
-	gatewaysUpdateCommand.Flags().Bool("antenna.add", false, "add an extra antenna")
-	gatewaysUpdateCommand.Flags().Bool("antenna.remove", false, "remove an antenna")
-	gatewaysUpdateCommand.Flags().AddFlagSet(setGatewayAntennaFlags)
-	gatewaysUpdateCommand.Flags().AddFlagSet(attributesFlags())
-	gatewaysCommand.AddCommand(gatewaysUpdateCommand)
+	gatewaysSetCommand.Flags().AddFlagSet(gatewayIDFlags())
+	gatewaysSetCommand.Flags().AddFlagSet(setGatewayFlags)
+	gatewaysSetCommand.Flags().Int("antenna.index", 0, "index of the antenna to update or remove")
+	gatewaysSetCommand.Flags().Bool("antenna.add", false, "add an extra antenna")
+	gatewaysSetCommand.Flags().Bool("antenna.remove", false, "remove an antenna")
+	gatewaysSetCommand.Flags().AddFlagSet(setGatewayAntennaFlags)
+	gatewaysSetCommand.Flags().AddFlagSet(attributesFlags())
+	gatewaysCommand.AddCommand(gatewaysSetCommand)
 	gatewaysDeleteCommand.Flags().AddFlagSet(gatewayIDFlags())
 	gatewaysCommand.AddCommand(gatewaysDeleteCommand)
 	gatewaysConnectionStats.Flags().AddFlagSet(gatewayIDFlags())

--- a/cmd/ttn-lw-cli/commands/gateways_access.go
+++ b/cmd/ttn-lw-cli/commands/gateways_access.go
@@ -78,8 +78,9 @@ var (
 		},
 	}
 	gatewayCollaboratorsSet = &cobra.Command{
-		Use:   "set",
-		Short: "Set a gateway collaborator",
+		Use:     "set",
+		Aliases: []string{"update"},
+		Short:   "Set a gateway collaborator",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			gtwID, err := getGatewayID(cmd.Flags(), nil, true)
 			if err != nil {
@@ -114,7 +115,7 @@ var (
 	}
 	gatewayCollaboratorsDelete = &cobra.Command{
 		Use:     "delete",
-		Aliases: []string{"remove"},
+		Aliases: []string{"del", "remove", "rm"},
 		Short:   "Delete a gateway collaborator",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			gtwID, err := getGatewayID(cmd.Flags(), nil, true)
@@ -177,7 +178,7 @@ var (
 	}
 	gatewayAPIKeysCreate = &cobra.Command{
 		Use:     "create [gateway-id]",
-		Aliases: []string{"add", "generate"},
+		Aliases: []string{"add", "register", "generate"},
 		Short:   "Create a gateway API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			gtwID, err := getGatewayID(cmd.Flags(), args, true)
@@ -213,9 +214,9 @@ var (
 		},
 	}
 	gatewayAPIKeysUpdate = &cobra.Command{
-		Use:     "update [gateway-id] [api-key-id]",
-		Aliases: []string{"set"},
-		Short:   "Update a gateway API key",
+		Use:     "set [gateway-id] [api-key-id]",
+		Aliases: []string{"update"},
+		Short:   "Set properties of a gateway API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			gtwID, err := getGatewayID(cmd.Flags(), firstArgs(1, args...), true)
 			if err != nil {
@@ -253,7 +254,7 @@ var (
 	}
 	gatewayAPIKeysDelete = &cobra.Command{
 		Use:     "delete [gateway-id] [api-key-id]",
-		Aliases: []string{"remove"},
+		Aliases: []string{"del", "remove", "rm"},
 		Short:   "Delete a gateway API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			gtwID, err := getGatewayID(cmd.Flags(), firstArgs(1, args...), true)

--- a/cmd/ttn-lw-cli/commands/organizations.go
+++ b/cmd/ttn-lw-cli/commands/organizations.go
@@ -186,9 +186,9 @@ var (
 		}),
 	}
 	organizationsUpdateCommand = &cobra.Command{
-		Use:     "update [organization-id]",
+		Use:     "set [organization-id]",
 		Aliases: []string{"set"},
-		Short:   "Update an organization",
+		Short:   "Set properties of an organization",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			orgID := getOrganizationID(cmd.Flags(), args)
 			if orgID == nil {
@@ -223,8 +223,9 @@ var (
 		},
 	}
 	organizationsDeleteCommand = &cobra.Command{
-		Use:   "delete [organization-id]",
-		Short: "Delete an organization",
+		Use:     "delete [organization-id]",
+		Aliases: []string{"del", "remove", "rm"},
+		Short:   "Delete an organization",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			orgID := getOrganizationID(cmd.Flags(), args)
 			if orgID == nil {

--- a/cmd/ttn-lw-cli/commands/organizations.go
+++ b/cmd/ttn-lw-cli/commands/organizations.go
@@ -185,7 +185,7 @@ var (
 			return io.Write(os.Stdout, config.OutputFormat, res)
 		}),
 	}
-	organizationsUpdateCommand = &cobra.Command{
+	organizationsSetCommand = &cobra.Command{
 		Use:     "set [organization-id]",
 		Aliases: []string{"set"},
 		Short:   "Set properties of an organization",
@@ -273,10 +273,10 @@ func init() {
 	organizationsCreateCommand.Flags().AddFlagSet(setOrganizationFlags)
 	organizationsCreateCommand.Flags().AddFlagSet(attributesFlags())
 	organizationsCommand.AddCommand(organizationsCreateCommand)
-	organizationsUpdateCommand.Flags().AddFlagSet(organizationIDFlags())
-	organizationsUpdateCommand.Flags().AddFlagSet(setOrganizationFlags)
-	organizationsUpdateCommand.Flags().AddFlagSet(attributesFlags())
-	organizationsCommand.AddCommand(organizationsUpdateCommand)
+	organizationsSetCommand.Flags().AddFlagSet(organizationIDFlags())
+	organizationsSetCommand.Flags().AddFlagSet(setOrganizationFlags)
+	organizationsSetCommand.Flags().AddFlagSet(attributesFlags())
+	organizationsCommand.AddCommand(organizationsSetCommand)
 	organizationsDeleteCommand.Flags().AddFlagSet(organizationIDFlags())
 	organizationsCommand.AddCommand(organizationsDeleteCommand)
 	organizationsContactInfoCommand.PersistentFlags().AddFlagSet(organizationIDFlags())

--- a/cmd/ttn-lw-cli/commands/organizations_access.go
+++ b/cmd/ttn-lw-cli/commands/organizations_access.go
@@ -78,8 +78,9 @@ var (
 		},
 	}
 	organizationCollaboratorsSet = &cobra.Command{
-		Use:   "set",
-		Short: "Set an organization collaborator",
+		Use:     "set",
+		Aliases: []string{"update"},
+		Short:   "Set an organization collaborator",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			orgID := getOrganizationID(cmd.Flags(), nil)
 			if orgID == nil {
@@ -114,7 +115,7 @@ var (
 	}
 	organizationCollaboratorsDelete = &cobra.Command{
 		Use:     "delete",
-		Aliases: []string{"remove"},
+		Aliases: []string{"del", "remove", "rm"},
 		Short:   "Delete an organization collaborator",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			orgID := getOrganizationID(cmd.Flags(), nil)

--- a/cmd/ttn-lw-cli/commands/use.go
+++ b/cmd/ttn-lw-cli/commands/use.go
@@ -40,6 +40,7 @@ var (
 	errFailWrite  = errors.DefinePermissionDenied("fail_write", "failed to write `{file}`")
 	useCommand    = &cobra.Command{
 		Use:               "use [host]",
+		Aliases:           []string{"generate-configuration", "generate-cfg"},
 		Short:             "Use",
 		PersistentPreRunE: preRun(),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/ttn-lw-cli/commands/users.go
+++ b/cmd/ttn-lw-cli/commands/users.go
@@ -210,7 +210,7 @@ var (
 			return io.Write(os.Stdout, config.OutputFormat, res)
 		}),
 	}
-	usersUpdateCommand = &cobra.Command{
+	usersSetCommand = &cobra.Command{
 		Use:     "set [user-id]",
 		Aliases: []string{"update"},
 		Short:   "Set properties of a user",
@@ -381,11 +381,11 @@ func init() {
 	usersCreateCommand.Flags().Lookup("state").DefValue = ttnpb.STATE_APPROVED.String()
 	usersCreateCommand.Flags().String("invitation-token", "", "")
 	usersCommand.AddCommand(usersCreateCommand)
-	usersUpdateCommand.Flags().AddFlagSet(userIDFlags())
-	usersUpdateCommand.Flags().AddFlagSet(setUserFlags)
-	usersUpdateCommand.Flags().AddFlagSet(attributesFlags())
-	usersUpdateCommand.Flags().AddFlagSet(profilePictureFlags)
-	usersCommand.AddCommand(usersUpdateCommand)
+	usersSetCommand.Flags().AddFlagSet(userIDFlags())
+	usersSetCommand.Flags().AddFlagSet(setUserFlags)
+	usersSetCommand.Flags().AddFlagSet(attributesFlags())
+	usersSetCommand.Flags().AddFlagSet(profilePictureFlags)
+	usersCommand.AddCommand(usersSetCommand)
 	usersForgotPasswordCommand.Flags().AddFlagSet(userIDFlags())
 	usersForgotPasswordCommand.Flags().String("email", "", "")
 	usersCommand.AddCommand(usersForgotPasswordCommand)

--- a/cmd/ttn-lw-cli/commands/users.go
+++ b/cmd/ttn-lw-cli/commands/users.go
@@ -211,9 +211,9 @@ var (
 		}),
 	}
 	usersUpdateCommand = &cobra.Command{
-		Use:     "update [user-id]",
-		Aliases: []string{"set"},
-		Short:   "Update a user",
+		Use:     "set [user-id]",
+		Aliases: []string{"update"},
+		Short:   "Set properties of a user",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			usrID := getUserID(cmd.Flags(), args)
 			if usrID == nil {
@@ -328,8 +328,9 @@ var (
 		},
 	}
 	usersDeleteCommand = &cobra.Command{
-		Use:   "delete [user-id]",
-		Short: "Delete a user",
+		Use:     "delete [user-id]",
+		Aliases: []string{"del", "remove", "rm"},
+		Short:   "Delete a user",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			usrID := getUserID(cmd.Flags(), args)
 			if usrID == nil {

--- a/cmd/ttn-lw-cli/commands/users_access.go
+++ b/cmd/ttn-lw-cli/commands/users_access.go
@@ -79,7 +79,7 @@ var (
 	}
 	userAPIKeysCreate = &cobra.Command{
 		Use:     "create [user-id]",
-		Aliases: []string{"add", "generate"},
+		Aliases: []string{"add", "generate", "register"},
 		Short:   "Create a user API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			usrID := getUserID(cmd.Flags(), args)
@@ -115,9 +115,9 @@ var (
 		},
 	}
 	userAPIKeysUpdate = &cobra.Command{
-		Use:     "update [user-id] [api-key-id]",
-		Aliases: []string{"set"},
-		Short:   "Update a user API key",
+		Use:     "set [user-id] [api-key-id]",
+		Aliases: []string{"update"},
+		Short:   "Set properties of a user API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			usrID := getUserID(cmd.Flags(), firstArgs(1, args...))
 			if usrID == nil {
@@ -155,7 +155,7 @@ var (
 	}
 	userAPIKeysDelete = &cobra.Command{
 		Use:     "delete [user-id] [api-key-id]",
-		Aliases: []string{"remove"},
+		Aliases: []string{"del", "remove", "rm"},
 		Short:   "Delete a user API key",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			usrID := getUserID(cmd.Flags(), firstArgs(1, args...))

--- a/cmd/ttn-lw-cli/commands/users_invitations.go
+++ b/cmd/ttn-lw-cli/commands/users_invitations.go
@@ -69,8 +69,9 @@ var (
 		},
 	}
 	userInvitationsCreate = &cobra.Command{
-		Use:   "create [email]",
-		Short: "Create a user invitation",
+		Use:     "create [email]",
+		Aliases: []string{"add", "register"},
+		Short:   "Create a user invitation",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			email := getEmail(cmd.Flags(), args)
 			if email == "" {
@@ -90,8 +91,9 @@ var (
 		},
 	}
 	userInvitationsDelete = &cobra.Command{
-		Use:   "delete [email]",
-		Short: "Delete a user invitation",
+		Use:     "delete [email]",
+		Aliases: []string{"del", "remove", "rm"},
+		Short:   "Delete a user invitation",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			email := getEmail(cmd.Flags(), args)
 			if email == "" {

--- a/cmd/ttn-lw-cli/commands/users_oauth.go
+++ b/cmd/ttn-lw-cli/commands/users_oauth.go
@@ -89,8 +89,9 @@ var (
 		},
 	}
 	oauthAuthorizationsDeleteCommand = &cobra.Command{
-		Use:   "delete [user-id] [client-id]",
-		Short: "Delete an OAuth authorization and all access tokens",
+		Use:     "delete [user-id] [client-id]",
+		Aliases: []string{"del", "remove", "rm"},
+		Short:   "Delete an OAuth authorization and all access tokens",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			usrID, cliID := getUserAndClientID(cmd.Flags(), args)
 			if usrID == nil {
@@ -167,8 +168,9 @@ var (
 		},
 	}
 	oauthAccessTokensDeleteCommand = &cobra.Command{
-		Use:   "delete [user-id] [client-id]",
-		Short: "Delete an OAuth access token",
+		Use:     "delete [user-id] [client-id]",
+		Aliases: []string{"del", "remove", "rm"},
+		Short:   "Delete an OAuth access token",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			usrID, cliID := getUserAndClientID(cmd.Flags(), args)
 			if usrID == nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2546 

#### Changes
<!-- What are the changes made in this pull request? -->

- Update command aliases, as proposed in the linked issue.

#### Testing

<!-- How did you verify that this change works? -->

Verify create/update/delete works locally with existing commands and new aliases

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

For some commands, changed `update` to be an alias to `set`. This should not break anything, `update` still works.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Not updating documentation, will follow up with a separate PR.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md`. The target branch is set to `master` if the changes are fully compatible with existing API, database, configuration and CLI.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
