### PR TITLE
Fix mobile navigation menu overflow

### DIFF
--- a/pkg/webui/components/dropdown/dropdown.styl
+++ b/pkg/webui/components/dropdown/dropdown.styl
@@ -40,15 +40,14 @@ ul.dropdown
       reset-button()
 
     & > a, & > button
+      box-sizing: border-box
       line-height: 1
       display: block
-      color: $tc-deep-gray
       text-decoration: none
       padding: $cs.m
       width: 100%
-
-      span:last-child
-        nudge('down')
+      &:not(.active)
+        color: $tc-deep-gray
 
     .icon
       margin-right: $cs.xs
@@ -67,6 +66,4 @@ ul.dropdown
 
 .active
   border-left: $c-active-blue 5px solid
-  box-sizing: border-box
-  span
-    color: $c-active-blue
+  color: $c-active-blue


### PR DESCRIPTION
#### Summary
This quickfix PR fixes an issue in the mobile navigation, which unnecessarily shows a horizontal scrollbar.
https://user-images.githubusercontent.com/5710611/88354408-c495d480-cd9b-11ea-8413-21a52acc1cf5.png
https://user-images.githubusercontent.com/5710611/88354456-eabb7480-cd9b-11ea-8954-c3aa8183d6d8.png


#### Changes
<!-- What are the changes made in this pull request? -->

- Fix styles of the dropdown component

#### Testing

Manual.

##### Regressions

None.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
