### PR TITLE
Fix Application Server pub/sub disconnect race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix an issue that frequently caused event data views crashing in the Console.
 - Application Server contacting Join Server via interop for fetching the AppSKey.
 - Low color contrast situations in the Console.
+- Application Server pub/sub integrations race condition during shutdown.
 
 ### Security
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -1853,9 +1853,9 @@
       "file": "provider.go"
     }
   },
-  "error:pkg/applicationserver/io/pubsub/provider:shutdown_failed": {
+  "error:pkg/applicationserver/io/pubsub/provider:shutdown": {
     "translations": {
-      "en": "failed to shutdown"
+      "en": "shutdown"
     },
     "description": {
       "package": "pkg/applicationserver/io/pubsub/provider",

--- a/config/messages.json
+++ b/config/messages.json
@@ -1853,6 +1853,15 @@
       "file": "provider.go"
     }
   },
+  "error:pkg/applicationserver/io/pubsub/provider:shutdown_failed": {
+    "translations": {
+      "en": "failed to shutdown"
+    },
+    "description": {
+      "package": "pkg/applicationserver/io/pubsub/provider",
+      "file": "connection.go"
+    }
+  },
   "error:pkg/applicationserver/io/pubsub/redis:application_uid": {
     "translations": {
       "en": "invalid application UID `{application_uid}`"

--- a/pkg/applicationserver/io/pubsub/grpc_pubsub.go
+++ b/pkg/applicationserver/io/pubsub/grpc_pubsub.go
@@ -96,7 +96,7 @@ func (ps *PubSub) Set(ctx context.Context, req *ttnpb.SetApplicationPubSubReques
 		log.FromContext(ctx).WithFields(log.Fields(
 			"application_uid", unique.ID(ctx, req.ApplicationIdentifiers),
 			"pub_sub_id", req.PubSubID,
-		)).WithError(err).Warn("Failed to cancel integration")
+		)).WithError(err).Warn("Failed to cancel pub/sub")
 	}
 	ps.startTask(ps.ctx, req.ApplicationPubSubIdentifiers)
 	events.Publish(evtSetPubSub(ctx, req.ApplicationIdentifiers, req.ApplicationPubSubIdentifiers))
@@ -116,7 +116,7 @@ func (ps *PubSub) Delete(ctx context.Context, ids *ttnpb.ApplicationPubSubIdenti
 		log.FromContext(ctx).WithFields(log.Fields(
 			"application_uid", unique.ID(ctx, ids.ApplicationIdentifiers),
 			"pub_sub_id", ids.PubSubID,
-		)).WithError(err).Warn("Failed to cancel integration")
+		)).WithError(err).Warn("Failed to cancel pub/sub")
 	}
 	_, err := ps.registry.Set(ctx, *ids, nil,
 		func(pubsub *ttnpb.ApplicationPubSub) (*ttnpb.ApplicationPubSub, []string, error) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/96

#### Changes
<!-- What are the changes made in this pull request? -->

- Renamed `integration` to `pub/sub` for clarity in logs.
- Refactored pub/sub provider connection `Shutdown` methods to no longer fail early.
- Now the pub/sub `closed` channel, which signals that the integration has been _completely_ shutdown, is closed when we are sure that the connection has been killed (or at least a full attempt to `Shutdown` has been made).
- Always attempt to `Shutdown` the connection, even in cases in which the error is not `cancelled`.

#### Testing

<!-- How did you verify that this change works? -->

This is a non deterministic bug so I've tried to fix the race condition from a correctness point of view, but I've been unable to observe it in my development environment. Already existing unit tests cover the remaining correctness from a CRUD / piping point of view.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Pub/Sub startup / closure mechanism has been altered, but the unit tests cover this already.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The comments in the PR should explain the race condition in more depth.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
