### PR TITLE
Improve frontend color contrasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Read only access for the gateway overview page in the Console.
 - Fix an issue that frequently caused event data views crashing in the Console.
 - Application Server contacting Join Server via interop for fetching the AppSKey.
+- Low color contrast situations in the Console.
 
 ### Security
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -119,13 +119,19 @@ The Things Stack for LoRaWAN employs a set of design tokens that ensure a stream
 
 We use a sober and subtle color scheme that revolves around our brand colors as well as some grayscale tones to ensure proper contrast. We want to keep the console as clean as possible to also facilitate custom branding and alternative color schemes (like a dark mode) in the future. Our non-grayscale colors are used sparingly to focus attention.
 
+#### Brand colors
+
 For gradients, brand related colors and arbitrary coloring according to our brand, you can use our brand color scheme:
+
 ![Brand Colors](https://user-images.githubusercontent.com/26456318/78355503-14168180-75ae-11ea-982d-368c022e96d3.png)
 
-In our Web UIs, we use the following colors:
-![WebUI Colors](https://user-images.githubusercontent.com/5710611/79414964-02d66780-7fe7-11ea-97ee-525bbd8e92ba.png)
+#### Web UI Colors
 
-#### Shading
+In our Web UIs, we use the following colors:
+
+![Web UI Colors](https://user-images.githubusercontent.com/5710611/88513232-dd63eb80-d022-11ea-958d-e04c9df6f3ad.png)
+
+##### Shading
 
 All fill colors may be shaded in both directions two times in discrete steps. This should only be done to improve an otherwise poor contrast situation or to produce `:hover` and `:active` color values
 

--- a/pkg/webui/components/button/button.styl
+++ b/pkg/webui/components/button/button.styl
@@ -19,7 +19,6 @@ $button($color)
   justify-content: center
   align-items: center
   text-align: center
-  background: $color
   border-radius: $br.s
   padding: 0 $cs.s
   height: 2.3rem
@@ -42,6 +41,8 @@ $button($color)
     margin-right: $cs.s
 
   &:not(.naked)
+    background: $color
+
     &:hover
       background-color: hoverize($color)
 
@@ -65,7 +66,8 @@ $button($color)
     color: $c-icon-fill
 
   &.naked
-    background: transparent
+    transition: background-color $ad.s
+    background-color: transparent
     font-weight: $fw.normal
     border: 1px solid transparent
 
@@ -74,10 +76,9 @@ $button($color)
 
     &:not(.busy):not(:active):not(:disabled)
       &:hover
-        color: darken($color, 15)
+        background-color: $c-backdrop
       +focus-visible()
-        color: darken($color, 15)
-        border: 1px solid $color
+        background-color: $c-backdrop
 
   &.busy:not(.naked),
   &.busy:disabled
@@ -108,10 +109,16 @@ $button($color)
     $button($c-error)
 
   &.warning
-    $button($c-warning)
+    &:not(.naked)
+      $button($c-warning)
+    &.naked
+      $button($tc-warning)
 
   &.secondary
-    $button($c-subtle-fill)
+    &:not(.naked)
+      $button($c-subtle-fill)
+    &.naked
+      $button($tc-subtle-gray)
 
   &.raw
     $button(white)

--- a/pkg/webui/components/form/field/field.styl
+++ b/pkg/webui/components/form/field/field.styl
@@ -110,7 +110,7 @@
   color: $c-error
 
 .warn
-  color: $c-warning
+  color: $tc-warning
 
 .disabled .info-area
     opacity: .4

--- a/pkg/webui/components/notification/notification.styl
+++ b/pkg/webui/components/notification/notification.styl
@@ -49,7 +49,7 @@ left-border($color)
 
   &.warning
     left-border($c-warning)
-    color: darker($c-warning, 4)
+    color: $tc-warning
 
   &.info
     left-border($c-active-blue)

--- a/pkg/webui/components/table/table/table.styl
+++ b/pkg/webui/components/table/table/table.styl
@@ -22,6 +22,7 @@
     text-align: center
     margin-top: $ls.xs
     color: $tc-subtle-gray
+    font-weight: normal
 
     &-row
       border-bottom: none

--- a/pkg/webui/components/tabs/tab/tab.styl
+++ b/pkg/webui/components/tabs/tab/tab.styl
@@ -27,11 +27,7 @@
   position: relative
   cursor: pointer
   user-select: none
-  color: $tc-subtle-gray
   transition: color $ad.xs
-
-  &:not(.tab-item-active):hover
-    color: $tc-deep-gray
 
   &-narrow
     padding: $cs.s $cs.m
@@ -45,4 +41,4 @@
 
   &-active
     pseudo-border(3px, $c-active-blue)
-    color: $c-active-blue
+    color: $tc-active

--- a/pkg/webui/styles/variables/brand.styl
+++ b/pkg/webui/styles/variables/brand.styl
@@ -27,6 +27,6 @@ $c-backdrop-lighter = #FAFAFA
 
 // ## Text
 
-$tc-active = $c-active-blue
+$tc-active = #006CFF
 $tc-active-hover = $c-active-blue-hover
 $tc-error = #EA0000

--- a/pkg/webui/styles/variables/generic.styl
+++ b/pkg/webui/styles/variables/generic.styl
@@ -28,6 +28,7 @@ $c-input-border = #DFDFDF
 $c-success = #24C833
 $c-error = #FF5C5C
 $c-warning = #FFC464
+$tc-warning = #D18100
 $c-info = $c-active-blue
 
 
@@ -35,7 +36,7 @@ $c-info = $c-active-blue
 
 $tc-black = #000
 $tc-deep-gray = #363636
-$tc-subtle-gray = #AAA
+$tc-subtle-gray = #868686
 
 
 


### PR DESCRIPTION
#### Summary
This quickfix PR fixes some poor contrast situations in the console. Most notably, it changes the color value for `$tc-subtle-gray` to a darker `#868686`

#### Changes
- Improve `$tc-subtle-gray` variable for better contrast
- Introduce `$tc-warning` value, to avoid usage of `$c-warning` for text (contrast too low)
  - Replace with `$tc-warning` where applicable
- Change hover state styles for tabs
- Change hover state styles for naked buttons
- Update `DESIGN.md` design guidelines to reflect these changes

#### Testing

Manual.

##### Regressions

None.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
