### PR TITLE
Clear GS connection stats registry on graceful exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Option to allow unauthenticated Basic Station connections. Unset `gs.basic-station.allow-unauthenticated` to enforce auth check for production clusters. Please note that unauthenticated connections in existing connections will not be allowed unless this is set.
 - Option to require TLS on connections to Redis servers (see `redis.tls.require` and related options).
 - Documentation for `cache` options.
+- Clear the connection stats registry when (gracefully) terminating the Gateway Server. This should prevent gateways from appearing as connected after restarting the Gateway Server when in fact they are not.
 
 ### Changed
 

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -290,6 +290,12 @@ func New(c *component.Component, conf *Config, opts ...Option) (gs *GatewayServe
 			}, component.TaskRestartOnFailure)
 	}
 
+	if gs.statsRegistry != nil {
+		go func() {
+			<-gs.Context().Done()
+			gs.statsRegistry.ClearAll()
+		}()
+	}
 	return gs, nil
 }
 

--- a/pkg/gatewayserver/redis/registry_test.go
+++ b/pkg/gatewayserver/redis/registry_test.go
@@ -137,4 +137,21 @@ func TestRegistry(t *testing.T) {
 		a.So(err, should.BeNil)
 		a.So(retrieved, should.Resemble, stats)
 	})
+
+	t.Run("TestDeleteMany", func(t *testing.T) {
+		a.So(registry.Set(ctx, ids, initialStats), should.BeNil)
+		a.So(registry.Set(ctx, ids2, initialStats), should.BeNil)
+
+		_, err := registry.Get(ctx, ids)
+		a.So(err, should.BeNil)
+		_, err = registry.Get(ctx, ids2)
+		a.So(err, should.BeNil)
+
+		a.So(registry.ClearAll(), should.BeNil)
+
+		_, err = registry.Get(ctx, ids)
+		a.So(errors.IsNotFound(err), should.BeTrue)
+		_, err = registry.Get(ctx, ids2)
+		a.So(errors.IsNotFound(err), should.BeTrue)
+	})
 }

--- a/pkg/gatewayserver/registry.go
+++ b/pkg/gatewayserver/registry.go
@@ -26,4 +26,6 @@ type GatewayConnectionStatsRegistry interface {
 	Get(ctx context.Context, ids ttnpb.GatewayIdentifiers) (*ttnpb.GatewayConnectionStats, error)
 	// Set sets or clears the connection stats for a gateway.
 	Set(ctx context.Context, ids ttnpb.GatewayIdentifiers, stats *ttnpb.GatewayConnectionStats) error
+	// ClearAll clears the connection stats of all gateways set by this instance.
+	ClearAll() error
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2906

#### Changes
<!-- What are the changes made in this pull request? -->

- Keep track of the Redis keys we set
- Clear all keys when Gateway Server is gracefully shutting down

#### Testing

<!-- How did you verify that this change works? -->

- Added unit test for new `ClearAll` registry interface function.
- Tested locally with simulated gateways. I want to test a bit more.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This should not affect the normal operation, this is only running a clean action after GS context expires.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

As noted in the linked issue, trying to terminate a large number connections in the short time window where the GS is shutting down might not work very well. This PR simply clears the connection stats instead.

Storing the keys internally in the registry for two main reasons:

- No need to compute N Redis keys when shutting down.
- Not really a fan of using the `gs.connections` map for ranging over the GS active connections while the server is shutting down.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
