### PR TITLE
doc: Improve webhook template instantiation doc

### DIFF
--- a/doc/content/integrations/webhooks/webhook-templates/instantiation.md
+++ b/doc/content/integrations/webhooks/webhook-templates/instantiation.md
@@ -25,6 +25,19 @@ headers:
 
 If the user has filled in the value of `token` with `Zpdc7jWMvYzVTeNQ`, then the resulting webhook will contain a header named `Authorization` with the value `Bearer Zpdc7jWMvYzVTeNQ`.
 
+Keep in mind that if you need to use a field directly as header value, you should wrap it with hyphens as follows:
+
+```yaml
+headers:
+- Authorization: "{token}"
+```
+
+If the webhook template is to be defined without header entries, define the `headers` field as follows:
+
+```yaml
+headers: {}
+```
+
 ## Instantiation of URLs and Paths
 
 The fields are replaced inside the URLs and the paths according to the [RFC6570](https://tools.ietf.org/html/rfc6570) format. Consider the following fragment of a webhook template, describing the available template fields and the paths of the endpoint.


### PR DESCRIPTION
#### Summary
Adding the instruction for using just token value as a header value.

#### Testing
Tested on a webhook template with TTS running locally.

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
