### PR TITLE
Send event stream start events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Event stream start and stop events are not published anymore.
 - Remove version from hosted documentation paths.
 - Gateway connection stats are now stored in a single key.
 - The example configuration for deployments with custom certificates now also uses a CA certificate.

--- a/pkg/events/grpc/grpc.go
+++ b/pkg/events/grpc/grpc.go
@@ -18,8 +18,10 @@ package grpc
 
 import (
 	"context"
+	"os"
 	"runtime"
 	"sync"
+	"time"
 
 	grpc_runtime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"go.thethings.network/lorawan-stack/v3/pkg/auth/rights"
@@ -117,6 +119,20 @@ func (srv *EventsServer) Stream(req *ttnpb.StreamEventsRequest, stream ttnpb.Eve
 	}
 
 	if err := stream.SendHeader(metadata.MD{}); err != nil {
+		return err
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		return err
+	}
+	if err := stream.Send(&ttnpb.Event{
+		Name:           "events.stream.start",
+		Time:           time.Now().UTC(),
+		Identifiers:    req.Identifiers,
+		Origin:         hostname,
+		CorrelationIDs: events.CorrelationIDsFromContext(ctx),
+	}); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #2950 

#### Changes
<!-- What are the changes made in this pull request? -->

- Reintroduce `events.stream.start`

#### Testing

<!-- How did you verify that this change works? -->

Ran console

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Console-related

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Please DO NOT depend on `events.stream.start` - console must completely ignore this event, the only purpose of it is to ensure that headers are sent.
As part of #2950 I will later investigate how we could fix this without relying on such workarounds. ( hence, also, the issue is not closed, but merely referenced)
Assigning @johanstokking since I'm almost done for today and off tomorrow

@kschiffer these entries should not be present:
![2020-07-28-15:53:05-screenshot](https://user-images.githubusercontent.com/12877905/88674767-81649a00-d0ea-11ea-9abd-1c1b1bd2024a.png)

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
