### PR TITLE
Unclaim gateway identifiers on connection context done

### DIFF
--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -374,7 +374,6 @@ func (s *srv) handleDown(ctx context.Context, state *state) error {
 			lastSeenPull := time.Unix(0, atomic.LoadInt64(&state.lastSeenPull))
 			if time.Since(lastSeenPull) > s.config.DownlinkPathExpires {
 				logger.Debug("Downlink path expired")
-				s.server.UnclaimDownlink(ctx, state.io.Gateway().GatewayIdentifiers)
 				state.lastDownlinkPath.Store(downlinkPath{})
 				state.startHandleDownMu.Lock()
 				state.startHandleDown = &sync.Once{}

--- a/pkg/gatewayserver/upstream/ns/ns.go
+++ b/pkg/gatewayserver/upstream/ns/ns.go
@@ -66,13 +66,9 @@ func (h *Handler) ConnectGateway(ctx context.Context, ids ttnpb.GatewayIdentifie
 		return nil
 	}
 	h.cluster.ClaimIDs(ctx, ids)
-	select {
-	case <-ctx.Done():
-		h.cluster.UnclaimIDs(ctx, ids)
-		return ctx.Err()
-	default:
-		return nil
-	}
+	defer h.cluster.UnclaimIDs(ctx, ids)
+	<-ctx.Done()
+	return ctx.Err()
 }
 
 var errNetworkServerNotFound = errors.DefineNotFound("network_server_not_found", "Network Server not found")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This quickfix should address the issue with GS instances not unclaiming the gateway identifiers once the connection is done.

#### Changes
<!-- What are the changes made in this pull request? -->

- Gateway Identifiers are now unclaimed once the connection context is `Done`.
- In the UDP frontend, avoid unclaiming twice the gateway identifiers if the health check fails.

#### Testing

<!-- How did you verify that this change works? -->

Unit tests.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This change now makes the GS (correctly) unclaim IDs for frontends that do not support downlink claiming, hopefully fixing stale claims.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
