### PR TITLE
Make sure RxMetadata location is nil if gateway location is not public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Authentication metadata missing from published events.
 - Under some circumstances, CLI would mistakenly import ABP devices as OTAA.
+- Gateway Server could include the gateway antenna location on messages forwarded to the Network Server even if the gateway location was not public.
 
 ### Security
 

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -215,6 +215,8 @@ func (c *Connection) HandleUp(up *ttnpb.UplinkMessage) error {
 			if location.Source != ttnpb.SOURCE_UNKNOWN {
 				md.Location = &location
 			}
+		} else if !c.gateway.LocationPublic {
+			md.Location = nil
 		}
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Quickfix PR, make sure that `RxMetadata.Location` is nil when gateway location is not public. This came up while refactoring the GS tests.

#### Testing

<!-- How did you verify that this change works? -->

Unit tests

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

`RxMetadata.Location` is injected by the GS and the NS does not depend on it, so no regressions here.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
