### PR TITLE
Fix webhook template handling when headers are empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Application Server contacting Join Server via interop for fetching the AppSKey.
 - Low color contrast situations in the Console.
 - Application Server pub/sub integrations race condition during shutdown.
+- Console webhook templates empty headers error.
+- Console MQTT URL validation.
 
 ### Security
 

--- a/pkg/webui/console/components/webhook-template-form/index.js
+++ b/pkg/webui/console/components/webhook-template-form/index.js
@@ -61,7 +61,7 @@ export default class WebhookTemplateForm extends Component {
     const { webhookTemplate: template, appId } = this.props
     const { webhook_id, ...fields } = values
 
-    const headers = Object.keys(template.headers).reduce((acc, key) => {
+    const headers = Object.keys(template.headers || {}).reduce((acc, key) => {
       const val = template.headers[key]
       acc[key] = val.replace(/{([a-z0-9_-]+)}/i, (_, field) => values[field])
       return acc

--- a/pkg/webui/console/lib/regexp.js
+++ b/pkg/webui/console/lib/regexp.js
@@ -19,7 +19,7 @@ export const address = new RegExp(
   '^(?:(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*(?:[A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])(?::[0-9]{1,5})?$|^$',
 )
 export const natsUrl = /^((\w+):)?(\/\/(([a-zA-z-0-9]+)?(:([a-zA-z-0-9]+))?@)?([^/?:]+)(:(\d+))?)?(\/?([^/?#][^?#]*)?)?(\?([^#]+))?(#(\w*))?/
-export const mqttUrl = new RegExp('^(mqtts?)://[^\\s/$.?#].[^\\s]*$')
+export const mqttUrl = new RegExp('^(mqtt|mqtts|tcp|ssl|tls|tcps|ws|wss)://[^\\s/$.?#].[^\\s]*$')
 export const mqttPassword = /^(?![\s\S])|.{2,100}/
 export const latitude = /^[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?)$/
 export const longitude = /^\s*[-+]?(180(\.0+)?|((1[0-7]\d)|([1-9]?\d))(\.\d+)?)$/


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Changes
<!-- What are the changes made in this pull request? -->

- If a retrieved webhook template does not contain headers, coalesce the `undefined` object with `{}` in order to avoid throwing on `Object.keys`.
- Synchronize the accepted URL schemas for the MQTT pub/sub provider.

#### Testing

<!-- How did you verify that this change works? -->

I took a webhook template and set the headers to empty (so `headers: {}` in the `template.yml` file), then checked if I could actually save a webhook based on the said template in the Console. 

For the MQTT URL change, I just tried to save pub/sub integrations with the newly supported schemas.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Only the accepted MQTT URLs have changed and this is a relaxation based on schemas that we know that are valid.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The schemas that our MQTT driver actually supports are based on the following to sources:
- A small adapter that ensures that we allow `mqtt` and `mqtts`:
https://github.com/TheThingsNetwork/lorawan-stack/blob/1ee582607b7219eb8195c46defc494de2d3ebf92/pkg/applicationserver/io/pubsub/provider/mqtt/provider.go#L170-L182 
- The actual parser in Paho (the MQTT library that we use behind the scenes):
https://github.com/eclipse/paho.mqtt.golang/blob/adca289fdcf8c883800aafa545bc263452290bae/net.go#L41-L119

The `headers` of an webhook template can be `undefined` if they are actually empty on the backend side, since `gogoproto` does not include empty values.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
