### PR TITLE
Skip downlink queue invalidation in a later stage

### DIFF
--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -1530,6 +1530,25 @@ hardware_versions:
 						},
 					},
 					{
+						Name: "RegisteredDevice/DownlinkQueueInvalidated/KnownSession/NoDownlinks",
+						IDs:  registeredDevice.EndDeviceIdentifiers,
+						Message: &ttnpb.ApplicationUp{
+							EndDeviceIdentifiers: withDevAddr(registeredDevice.EndDeviceIdentifiers, types.DevAddr{0x44, 0x44, 0x44, 0x44}),
+							Up: &ttnpb.ApplicationUp_DownlinkQueueInvalidated{
+								DownlinkQueueInvalidated: &ttnpb.ApplicationInvalidatedDownlinks{
+									Downlinks:    nil,
+									LastFCntDown: 46,
+								},
+							},
+						},
+						ResetQueue: make([]*ttnpb.ApplicationDownlink, 0),
+						AssertDevice: func(t *testing.T, dev *ttnpb.EndDevice, queue []*ttnpb.ApplicationDownlink) {
+							a := assertions.New(t)
+							a.So(dev.Session.LastAFCntDown, should.Equal, 46)
+							a.So(queue, should.Resemble, []*ttnpb.ApplicationDownlink(nil))
+						},
+					},
+					{
 						Name: "RegisteredDevice/DownlinkQueueInvalidated/UnknownSession",
 						IDs:  registeredDevice.EndDeviceIdentifiers,
 						Message: &ttnpb.ApplicationUp{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Downlink queue invalidation skip introduced by https://github.com/TheThingsNetwork/lorawan-stack/commit/530615db025c080fa8c970a8ea5d3f48bf455d55 should not be done there, as it would stop the `AFCntDown` from incrementing/updating when the queue is empty. 

#### Changes
<!-- What are the changes made in this pull request? -->

- Skip the downlink queue replacement if there were no downlinks to be replaced in the first place.

#### Testing

<!-- How did you verify that this change works? -->

Tested with a device which had de-synchronized sessions between NS and AS. After the fix they stay in sync.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Downlink queue operations and invalidations - tested with a previously de-synced environment.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
