### PR TITLE
Use same CSRF cookie for OAuth app and API

### DIFF
--- a/pkg/oauth/server.go
+++ b/pkg/oauth/server.go
@@ -220,7 +220,7 @@ func (s *server) RegisterRoutes(server *web.Server) {
 		}),
 	)
 
-	csrfMiddleware := middleware.CSRF("_csrf", s.config.Mount, s.config.CSRFAuthKey)
+	csrfMiddleware := middleware.CSRF("_csrf", "/", s.config.CSRFAuthKey)
 
 	api := root.Group("/api", csrfMiddleware)
 	api.POST("/auth/login", s.Login)

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -226,7 +226,7 @@ func New(ctx context.Context, opts ...Option) (*Server, error) {
 	apiRouter.Use(
 		mux.MiddlewareFunc(webmiddleware.CookieAuth("_session")),
 		mux.MiddlewareFunc(webmiddleware.Conditional(
-			webmiddleware.CSRF(hashKey, csrf.CookieName("_csrf"), csrf.Path("/api"), csrf.SameSite(csrf.SameSiteStrictMode)),
+			webmiddleware.CSRF(hashKey, csrf.CookieName("_csrf"), csrf.Path("/"), csrf.SameSite(csrf.SameSiteStrictMode)),
 			csrfSkip,
 		)),
 		mux.MiddlewareFunc(

--- a/pkg/webui/oauth/api/index.js
+++ b/pkg/webui/oauth/api/index.js
@@ -32,16 +32,16 @@ const instance = axios.create({
 export default {
   users: {
     async register(userData) {
-      return axios.post(`${isBaseUrl}/users`, userData)
+      return instance.post(`${isBaseUrl}/users`, userData)
     },
     async resetPassword(user_id) {
-      return axios.post(`${isBaseUrl}/users/${user_id}/temporary_password`)
+      return instance.post(`${isBaseUrl}/users/${user_id}/temporary_password`)
     },
     async updatePassword(user_id, passwordData) {
-      return axios.put(`${isBaseUrl}/users/${user_id}/password`, passwordData)
+      return instance.put(`${isBaseUrl}/users/${user_id}/password`, passwordData)
     },
     async validate(validationData) {
-      return axios.patch(`${isBaseUrl}/contact_info/validation`, validationData)
+      return instance.patch(`${isBaseUrl}/contact_info/validation`, validationData)
     },
   },
   oauth: {


### PR DESCRIPTION
#### Summary
Closes #2951 

#### Changes
- Use common parent path `/` in the CSRF configuration of OAuth app and API
- Set `X-CSRF-Token` header for API requests in the OAuth app (was only used for `/oauth/api` routes before)

#### Testing

Manual.

##### Regressions

This could break CSRF validation in the OAuth app. I tried to test different scenarios but it's always quite hard to anticipate what various already set cookies might cause in trouble. So this needs to be especially verified in the staging environment.

#### Notes for Reviewers
The issue was that we used two different cookie paths `/api` and `/oauth` respectively, resulting in two separate CSRF cookies. Since want to use both for the same CSRF protection (the CSRF tokens exposed on `/oauth` need to be valid in `/api` as well), the cookie setup was wrong and needed to be changed so that both use the same parent path `/` as `path` prop of the cookie. That way, the same cookie can be used for both paths.

Additionally, we also weren't passing the `X-CSRF-Header` to the API requests.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
