### PR TITLE
Refactor Go API of pkg/events

### DIFF
--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -633,9 +633,9 @@ func (as *ApplicationServer) resetInvalidDownlinkQueue(ctx context.Context, ids 
 	_, err := client.DownlinkQueueReplace(ctx, req, link.callOpts...)
 	if err != nil {
 		logger.WithError(err).Warn("Failed to clear the downlink queue; any queued items in the Network Server are invalid")
-		events.Publish(evtInvalidQueueDataDown(ctx, ids, err))
+		events.Publish(evtInvalidQueueDataDown.NewWithIdentifiersAndData(ctx, ids, err))
 	} else {
-		events.Publish(evtLostQueueDataDown(ctx, ids, err))
+		events.Publish(evtLostQueueDataDown.NewWithIdentifiersAndData(ctx, ids, err))
 	}
 	return err
 }

--- a/pkg/applicationserver/io/pubsub/grpc_pubsub.go
+++ b/pkg/applicationserver/io/pubsub/grpc_pubsub.go
@@ -99,7 +99,7 @@ func (ps *PubSub) Set(ctx context.Context, req *ttnpb.SetApplicationPubSubReques
 		)).WithError(err).Warn("Failed to cancel pub/sub")
 	}
 	ps.startTask(ps.ctx, req.ApplicationPubSubIdentifiers)
-	events.Publish(evtSetPubSub(ctx, req.ApplicationIdentifiers, req.ApplicationPubSubIdentifiers))
+	events.Publish(evtSetPubSub.NewWithIdentifiersAndData(ctx, req.ApplicationIdentifiers, req.ApplicationPubSubIdentifiers))
 	return pubsub, nil
 }
 
@@ -126,6 +126,6 @@ func (ps *PubSub) Delete(ctx context.Context, ids *ttnpb.ApplicationPubSubIdenti
 	if err != nil {
 		return nil, err
 	}
-	events.Publish(evtDeletePubSub(ctx, ids.ApplicationIdentifiers, *ids))
+	events.Publish(evtDeletePubSub.NewWithIdentifiersAndData(ctx, ids.ApplicationIdentifiers, *ids))
 	return ttnpb.Empty, nil
 }

--- a/pkg/applicationserver/io/pubsub/observability.go
+++ b/pkg/applicationserver/io/pubsub/observability.go
@@ -30,29 +30,35 @@ import (
 var (
 	evtSetPubSub = events.Define(
 		"as.pubsub.set", "set pub/sub",
-		ttnpb.RIGHT_APPLICATION_SETTINGS_BASIC,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_SETTINGS_BASIC),
 	)
 	evtDeletePubSub = events.Define(
 		"as.pubsub.delete", "delete pub/sub",
-		ttnpb.RIGHT_APPLICATION_SETTINGS_BASIC,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_SETTINGS_BASIC),
 	)
 	evtPubSubStart = events.Define(
 		"as.pubsub.start", "start pub/sub",
-		ttnpb.RIGHT_APPLICATION_SETTINGS_BASIC,
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_DOWN_WRITE,
+		events.WithVisibility(
+			ttnpb.RIGHT_APPLICATION_SETTINGS_BASIC,
+			ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+			ttnpb.RIGHT_APPLICATION_TRAFFIC_DOWN_WRITE,
+		),
 	)
 	evtPubSubStop = events.Define(
 		"as.pubsub.stop", "stop pub/sub",
-		ttnpb.RIGHT_APPLICATION_SETTINGS_BASIC,
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_DOWN_WRITE,
+		events.WithVisibility(
+			ttnpb.RIGHT_APPLICATION_SETTINGS_BASIC,
+			ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+			ttnpb.RIGHT_APPLICATION_TRAFFIC_DOWN_WRITE,
+		),
 	)
 	evtPubSubFail = events.Define(
 		"as.pubsub.fail", "fail pub/sub",
-		ttnpb.RIGHT_APPLICATION_SETTINGS_BASIC,
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_DOWN_WRITE,
+		events.WithVisibility(
+			ttnpb.RIGHT_APPLICATION_SETTINGS_BASIC,
+			ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+			ttnpb.RIGHT_APPLICATION_TRAFFIC_DOWN_WRITE,
+		),
 	)
 )
 
@@ -118,14 +124,14 @@ func providerLabelValue(i *integration) string {
 }
 
 func registerIntegrationStart(ctx context.Context, i *integration) {
-	events.Publish(evtPubSubStart(ctx, i.ApplicationIdentifiers, i.ApplicationPubSubIdentifiers))
+	events.Publish(evtPubSubStart.NewWithIdentifiersAndData(ctx, i.ApplicationIdentifiers, i.ApplicationPubSubIdentifiers))
 	labelValue := providerLabelValue(i)
 	pubsubMetrics.integrationsStarted.WithLabelValues(ctx, labelValue).Inc()
 	pubsubMetrics.integrationsStopped.WithLabelValues(ctx, labelValue) // Initialize the "stopped" counter.
 }
 
 func registerIntegrationStop(ctx context.Context, i *integration) {
-	events.Publish(evtPubSubStop(ctx, i.ApplicationIdentifiers, i.ApplicationPubSubIdentifiers))
+	events.Publish(evtPubSubStop.NewWithIdentifiersAndData(ctx, i.ApplicationIdentifiers, i.ApplicationPubSubIdentifiers))
 	pubsubMetrics.integrationsStopped.WithLabelValues(ctx, providerLabelValue(i)).Inc()
 }
 
@@ -138,6 +144,6 @@ func registerIntegrationFail(ctx context.Context, i *integration, err error) {
 			"pub_sub_id", i.PubSubID,
 		).
 		WithCause(err)
-	events.Publish(evtPubSubFail(ctx, i.ApplicationIdentifiers, err))
+	events.Publish(evtPubSubFail.NewWithIdentifiersAndData(ctx, i.ApplicationIdentifiers, err))
 	pubsubMetrics.integrationsFailed.WithLabelValues(ctx, providerLabelValue(i)).Inc()
 }

--- a/pkg/applicationserver/observability.go
+++ b/pkg/applicationserver/observability.go
@@ -28,71 +28,71 @@ import (
 var (
 	evtLinkStart = events.Define(
 		"as.link.start", "start link",
-		ttnpb.RIGHT_APPLICATION_LINK,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_LINK),
 	)
 	evtLinkStop = events.Define(
 		"as.link.stop", "stop link",
-		ttnpb.RIGHT_APPLICATION_LINK,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_LINK),
 	)
 	evtLinkFail = events.Define(
 		"as.link.fail", "fail link",
-		ttnpb.RIGHT_APPLICATION_LINK,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_LINK),
 	)
 	evtApplicationSubscribe = events.Define(
 		"as.application.subscribe", "subscribe application",
-		ttnpb.RIGHT_APPLICATION_LINK,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_LINK),
 	)
 	evtApplicationUnsubscribe = events.Define(
 		"as.application.unsubscribe", "unsubscribe application",
-		ttnpb.RIGHT_APPLICATION_LINK,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_LINK),
 	)
 	evtReceiveDataUp = events.Define(
 		"as.up.data.receive", "receive uplink data message",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtDropDataUp = events.Define(
 		"as.up.data.drop", "drop uplink data message",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtForwardDataUp = events.Define(
 		"as.up.data.forward", "forward uplink data message",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtDecodeFailDataUp = events.Define(
 		"as.up.data.decode.fail", "decode uplink data message failure",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtReceiveJoinAccept = events.Define(
 		"as.up.join.receive", "receive join-accept message",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtDropJoinAccept = events.Define(
 		"as.up.join.drop", "drop join-accept message",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtForwardJoinAccept = events.Define(
 		"as.up.join.forward", "forward join-accept message",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtReceiveDataDown = events.Define(
 		"as.down.data.receive", "receive downlink data message",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtDropDataDown = events.Define(
 		"as.down.data.drop", "drop downlink data message",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtForwardDataDown = events.Define(
 		"as.down.data.forward", "forward downlink data message",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtLostQueueDataDown = events.Define(
 		"as.down.data.queue.lost", "lose downlink data queue",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtInvalidQueueDataDown = events.Define(
 		"as.down.data.queue.invalid", "invalid downlink data queue",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 )
 
@@ -242,17 +242,17 @@ func (m messageMetrics) Collect(ch chan<- prometheus.Metric) {
 }
 
 func registerLinkStart(ctx context.Context, link *link) {
-	events.Publish(evtLinkStart(ctx, link.ApplicationIdentifiers, nil))
+	events.Publish(evtLinkStart.NewWithIdentifiersAndData(ctx, link.ApplicationIdentifiers, nil))
 	asMetrics.linksStarted.WithLabelValues(ctx, link.NetworkServerAddress).Inc()
 }
 
 func registerLinkStop(ctx context.Context, link *link) {
-	events.Publish(evtLinkStop(ctx, link.ApplicationIdentifiers, nil))
+	events.Publish(evtLinkStop.NewWithIdentifiersAndData(ctx, link.ApplicationIdentifiers, nil))
 	asMetrics.linksStopped.WithLabelValues(ctx, link.NetworkServerAddress).Inc()
 }
 
 func registerLinkFail(ctx context.Context, link *link, err error) {
-	events.Publish(evtLinkFail(ctx, link.ApplicationIdentifiers, err))
+	events.Publish(evtLinkFail.NewWithIdentifiersAndData(ctx, link.ApplicationIdentifiers, err))
 	asMetrics.linksFailed.WithLabelValues(ctx, link.NetworkServerAddress).Inc()
 }
 
@@ -261,7 +261,7 @@ func registerSubscribe(ctx context.Context, sub *io.Subscription) {
 	if appIDs := sub.ApplicationIDs(); appIDs != nil {
 		ids = appIDs
 	}
-	events.Publish(evtApplicationSubscribe(ctx, ids, nil))
+	events.Publish(evtApplicationSubscribe.NewWithIdentifiersAndData(ctx, ids, nil))
 	asMetrics.subscriptionsStarted.WithLabelValues(ctx, sub.Protocol()).Inc()
 }
 
@@ -270,16 +270,16 @@ func registerUnsubscribe(ctx context.Context, sub *io.Subscription) {
 	if appIDs := sub.ApplicationIDs(); appIDs != nil {
 		ids = appIDs
 	}
-	events.Publish(evtApplicationUnsubscribe(ctx, ids, nil))
+	events.Publish(evtApplicationUnsubscribe.NewWithIdentifiersAndData(ctx, ids, nil))
 	asMetrics.subscriptionsStopped.WithLabelValues(ctx, sub.Protocol()).Inc()
 }
 
 func registerReceiveUp(ctx context.Context, msg *ttnpb.ApplicationUp, ns string) {
 	switch msg.Up.(type) {
 	case *ttnpb.ApplicationUp_JoinAccept:
-		events.Publish(evtReceiveJoinAccept(ctx, msg.EndDeviceIdentifiers, nil))
+		events.Publish(evtReceiveJoinAccept.NewWithIdentifiersAndData(ctx, msg.EndDeviceIdentifiers, nil))
 	case *ttnpb.ApplicationUp_UplinkMessage:
-		events.Publish(evtReceiveDataUp(ctx, msg.EndDeviceIdentifiers, nil))
+		events.Publish(evtReceiveDataUp.NewWithIdentifiersAndData(ctx, msg.EndDeviceIdentifiers, nil))
 	default:
 		return
 	}
@@ -289,9 +289,9 @@ func registerReceiveUp(ctx context.Context, msg *ttnpb.ApplicationUp, ns string)
 func registerForwardUp(ctx context.Context, msg *ttnpb.ApplicationUp) {
 	switch msg.Up.(type) {
 	case *ttnpb.ApplicationUp_JoinAccept:
-		events.Publish(evtForwardJoinAccept(ctx, msg.EndDeviceIdentifiers, msg))
+		events.Publish(evtForwardJoinAccept.NewWithIdentifiersAndData(ctx, msg.EndDeviceIdentifiers, msg))
 	case *ttnpb.ApplicationUp_UplinkMessage:
-		events.Publish(evtForwardDataUp(ctx, msg.EndDeviceIdentifiers, msg))
+		events.Publish(evtForwardDataUp.NewWithIdentifiersAndData(ctx, msg.EndDeviceIdentifiers, msg))
 	default:
 		return
 	}
@@ -301,9 +301,9 @@ func registerForwardUp(ctx context.Context, msg *ttnpb.ApplicationUp) {
 func registerDropUp(ctx context.Context, msg *ttnpb.ApplicationUp, err error) {
 	switch msg.Up.(type) {
 	case *ttnpb.ApplicationUp_JoinAccept:
-		events.Publish(evtDropJoinAccept(ctx, msg.EndDeviceIdentifiers, err))
+		events.Publish(evtDropJoinAccept.NewWithIdentifiersAndData(ctx, msg.EndDeviceIdentifiers, err))
 	case *ttnpb.ApplicationUp_UplinkMessage:
-		events.Publish(evtDropDataUp(ctx, msg.EndDeviceIdentifiers, err))
+		events.Publish(evtDropDataUp.NewWithIdentifiersAndData(ctx, msg.EndDeviceIdentifiers, err))
 	default:
 		return
 	}
@@ -315,17 +315,17 @@ func registerDropUp(ctx context.Context, msg *ttnpb.ApplicationUp, err error) {
 }
 
 func registerReceiveDownlink(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, msg *ttnpb.ApplicationDownlink) {
-	events.Publish(evtReceiveDataDown(ctx, ids, msg))
+	events.Publish(evtReceiveDataDown.NewWithIdentifiersAndData(ctx, ids, msg))
 	asMetrics.downlinkReceived.WithLabelValues(ctx, ids.ApplicationID).Inc()
 }
 
 func registerForwardDownlink(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, msg *ttnpb.ApplicationDownlink, ns string) {
-	events.Publish(evtForwardDataDown(ctx, ids, msg))
+	events.Publish(evtForwardDataDown.NewWithIdentifiersAndData(ctx, ids, msg))
 	asMetrics.downlinkForwarded.WithLabelValues(ctx, ns).Inc()
 }
 
 func registerDropDownlink(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, msg *ttnpb.ApplicationDownlink, err error) {
-	events.Publish(evtDropDataDown(ctx, ids, err))
+	events.Publish(evtDropDataDown.NewWithIdentifiersAndData(ctx, ids, err))
 	if ttnErr, ok := errors.From(err); ok {
 		asMetrics.downlinkDropped.WithLabelValues(ctx, ttnErr.FullName()).Inc()
 	} else {

--- a/pkg/applicationserver/payload.go
+++ b/pkg/applicationserver/payload.go
@@ -96,7 +96,7 @@ func (as *ApplicationServer) decode(ctx context.Context, dev *ttnpb.EndDevice, u
 	if formatter != ttnpb.PayloadFormatter_FORMATTER_NONE {
 		if err := as.formatter.Decode(ctx, dev.EndDeviceIdentifiers, dev.VersionIDs, uplink, formatter, parameter); err != nil {
 			log.FromContext(ctx).WithError(err).Warn("Payload decoding failed")
-			events.Publish(evtDecodeFailDataUp(ctx, dev.EndDeviceIdentifiers, err))
+			events.Publish(evtDecodeFailDataUp.NewWithIdentifiersAndData(ctx, dev.EndDeviceIdentifiers, err))
 		}
 	}
 	return nil

--- a/pkg/events/builder.go
+++ b/pkg/events/builder.go
@@ -1,0 +1,93 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"context"
+	"time"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+)
+
+type builder struct {
+	definition *definition
+	options    []Option
+}
+
+func (b *builder) With(options ...Option) Builder {
+	extended := &builder{
+		definition: b.definition,
+	}
+	extended.options = append(extended.options, b.options...)
+	extended.options = append(extended.options, options...)
+	return extended
+}
+
+func (b *builder) New(ctx context.Context, opts ...Option) Event {
+	evt := &event{
+		ctx: ctx,
+		innerEvent: ttnpb.Event{
+			Name:           b.definition.name,
+			Time:           time.Now().UTC(),
+			Origin:         hostname,
+			CorrelationIDs: CorrelationIDsFromContext(ctx),
+		},
+	}
+	for _, opt := range b.options {
+		opt.applyTo(evt)
+	}
+	for _, opt := range opts {
+		opt.applyTo(evt)
+	}
+	return evt
+}
+
+func (b *builder) NewWithIdentifiersAndData(ctx context.Context, ids CombinedIdentifiers, data interface{}) Event {
+	e := local(b.New(ctx))
+	if ids != nil {
+		e.innerEvent.Identifiers = ids.CombinedIdentifiers().GetEntityIdentifiers()
+	}
+	if data != nil {
+		e.data = data
+	}
+	return e
+}
+
+func (b *builder) BindData(data interface{}) Builder {
+	return b.With(WithData(data))
+}
+
+// Builder is the interface for building events from definitions.
+type Builder interface {
+	With(opts ...Option) Builder
+	New(ctx context.Context, opts ...Option) Event
+
+	// Convenience function for legacy code. Same as New(ctx, WithIdentifiers(ids), WithData(data)).
+	NewWithIdentifiersAndData(ctx context.Context, ids CombinedIdentifiers, data interface{}) Event
+	// Convenience function for legacy code. Same as With(WithData(data)).
+	BindData(data interface{}) Builder
+}
+
+// Builders makes it easier to create multiple events at once.
+type Builders []Builder
+
+// New returns new events for each builder in the list.
+func (bs Builders) New(ctx context.Context, opts ...Option) []Event {
+	events := make([]Event, len(bs))
+	for i, b := range bs {
+		events[i] = b.New(ctx, opts...)
+	}
+	return events
+}

--- a/pkg/events/cloud/cloud_test.go
+++ b/pkg/events/cloud/cloud_test.go
@@ -84,7 +84,7 @@ func TestCloudPubSub(t *testing.T) {
 
 	cloud.SetContentType(pubsub, "application/json")
 
-	pubsub.Publish(events.New(ctx, "cloud.test.evt0", &appID, nil))
+	pubsub.Publish(events.New(ctx, "cloud.test.evt0", "cloud test event 0", events.WithIdentifiers(appID)))
 	select {
 	case e := <-eventCh:
 		a.So(e.Name(), should.Equal, "cloud.test.evt0")
@@ -98,7 +98,7 @@ func TestCloudPubSub(t *testing.T) {
 
 	cloud.SetContentType(pubsub, "application/protobuf")
 
-	pubsub.Publish(events.New(ctx, "cloud.test.evt1", ttnpb.CombineIdentifiers(&devID, &gtwID), nil))
+	pubsub.Publish(events.New(ctx, "cloud.test.evt1", "cloud test event 1", events.WithIdentifiers(&devID, &gtwID)))
 	select {
 	case e := <-eventCh:
 		a.So(e.Name(), should.Equal, "cloud.test.evt1")

--- a/pkg/events/context_test.go
+++ b/pkg/events/context_test.go
@@ -45,7 +45,7 @@ func TestContextMarshaler(t *testing.T) {
 
 	ctx := context.WithValue(context.Background(), "ctx-test", "foo")
 
-	evt := events.New(ctx, "test", nil, nil)
+	evt := events.New(ctx, "test", "test")
 
 	b, err := json.Marshal(evt)
 	a.So(err, should.BeNil)

--- a/pkg/events/default.go
+++ b/pkg/events/default.go
@@ -14,12 +14,6 @@
 
 package events
 
-import (
-	"context"
-
-	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
-)
-
 var defaultPubSub = NewPubSub(DefaultBufferSize)
 
 // SetDefaultPubSub sets pubsub used by the package to ps.
@@ -49,13 +43,4 @@ func Publish(evts ...Event) {
 	for _, evt := range evts {
 		defaultPubSub.Publish(local(evt).withCaller())
 	}
-}
-
-// PublishEvent creates an event and emits it on the default event pubsub.
-// Event names are dot-separated for namespacing.
-// Event identifiers identify the entities that are related to the event.
-// System events have nil identifiers.
-// Event data will in most cases be marshaled to JSON, but ideally is a proto message.
-func PublishEvent(ctx context.Context, name string, identifiers CombinedIdentifiers, data interface{}, visibility ...ttnpb.Right) {
-	defaultPubSub.Publish(local(New(ctx, name, identifiers, data, visibility...)).withCaller())
 }

--- a/pkg/events/definitions_test.go
+++ b/pkg/events/definitions_test.go
@@ -26,8 +26,8 @@ import (
 
 func TestDefinitions(t *testing.T) {
 	a := assertions.New(t)
-	testEvent := events.Define("test", "Test Event", ttnpb.RIGHT_ALL)
-	evt := testEvent(test.Context(), nil, "err")
+	testEvent := events.Define("test", "Test Event", events.WithVisibility(ttnpb.RIGHT_ALL))
+	evt := testEvent.New(test.Context())
 	a.So(evt.Name(), should.Equal, "test")
 	a.So(evt.Visibility().Rights, should.Contain, ttnpb.RIGHT_ALL)
 }

--- a/pkg/events/fs/fs.go
+++ b/pkg/events/fs/fs.go
@@ -95,19 +95,19 @@ func NewWatcher(pubsub events.PubSub) (Watcher, error) {
 					return
 				}
 				if event.Op&fsnotify.Create == fsnotify.Create {
-					pubsub.Publish(events.New(context.Background(), "fs.create", nil, event.Name))
+					pubsub.Publish(events.New(context.Background(), "fs.create", "create file", events.WithData(event.Name)))
 				}
 				if event.Op&fsnotify.Write == fsnotify.Write {
-					pubsub.Publish(events.New(context.Background(), "fs.write", nil, event.Name))
+					pubsub.Publish(events.New(context.Background(), "fs.write", "write file", events.WithData(event.Name)))
 				}
 				if event.Op&fsnotify.Remove == fsnotify.Remove {
-					pubsub.Publish(events.New(context.Background(), "fs.remove", nil, event.Name))
+					pubsub.Publish(events.New(context.Background(), "fs.remove", "remove file", events.WithData(event.Name)))
 				}
 				if event.Op&fsnotify.Rename == fsnotify.Rename {
-					pubsub.Publish(events.New(context.Background(), "fs.rename", nil, event.Name))
+					pubsub.Publish(events.New(context.Background(), "fs.rename", "rename file", events.WithData(event.Name)))
 				}
 				if event.Op&fsnotify.Chmod == fsnotify.Chmod {
-					pubsub.Publish(events.New(context.Background(), "fs.chmod", nil, event.Name))
+					pubsub.Publish(events.New(context.Background(), "fs.chmod", "chmod file", events.WithData(event.Name)))
 				}
 			case err := <-w.Errors:
 				log.WithError(err).Warn("Error in file watcher")

--- a/pkg/events/handler_test.go
+++ b/pkg/events/handler_test.go
@@ -66,9 +66,9 @@ func TestChannelReceive(t *testing.T) {
 	a := assertions.New(t)
 
 	eventChan := make(events.Channel, 2)
-	eventChan.Notify(events.New(test.Context(), "evt", nil, nil))
-	eventChan.Notify(events.New(test.Context(), "evt", nil, nil))
-	eventChan.Notify(events.New(test.Context(), "overflow", nil, nil))
+	eventChan.Notify(events.New(test.Context(), "evt", "event"))
+	eventChan.Notify(events.New(test.Context(), "evt", "event"))
+	eventChan.Notify(events.New(test.Context(), "overflow", "this overflows the channel"))
 
 	runtime.Gosched()
 

--- a/pkg/events/identifiers_test.go
+++ b/pkg/events/identifiers_test.go
@@ -32,29 +32,29 @@ func TestIdentifierFilter(t *testing.T) {
 
 	filter := events.NewIdentifierFilter()
 
-	evtAppFoo := events.New(test.Context(), "test", ttnpb.ApplicationIdentifiers{ApplicationID: "foo"}, "hello foo")
-	evtAppBar := events.New(test.Context(), "test", ttnpb.ApplicationIdentifiers{ApplicationID: "bar"}, "hello bar")
+	evtAppFoo := events.New(test.Context(), "test", "test", events.WithIdentifiers(ttnpb.ApplicationIdentifiers{ApplicationID: "foo"}))
+	evtAppBar := events.New(test.Context(), "test", "test", events.WithIdentifiers(ttnpb.ApplicationIdentifiers{ApplicationID: "bar"}))
 
-	evtCliFoo := events.New(test.Context(), "test", ttnpb.ClientIdentifiers{ClientID: "foo"}, "hello foo")
-	evtCliBar := events.New(test.Context(), "test", ttnpb.ClientIdentifiers{ClientID: "bar"}, "hello bar")
+	evtCliFoo := events.New(test.Context(), "test", "test", events.WithIdentifiers(ttnpb.ClientIdentifiers{ClientID: "foo"}))
+	evtCliBar := events.New(test.Context(), "test", "test", events.WithIdentifiers(ttnpb.ClientIdentifiers{ClientID: "bar"}))
 
-	evtDevFoo := events.New(test.Context(), "test", ttnpb.EndDeviceIdentifiers{
+	evtDevFoo := events.New(test.Context(), "test", "test", events.WithIdentifiers(ttnpb.EndDeviceIdentifiers{
 		DeviceID:               "foo",
 		ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "foo"},
-	}, "hello foo")
-	evtDevBar := events.New(test.Context(), "test", ttnpb.EndDeviceIdentifiers{
+	}))
+	evtDevBar := events.New(test.Context(), "test", "test", events.WithIdentifiers(ttnpb.EndDeviceIdentifiers{
 		DeviceID:               "bar",
 		ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "bar"},
-	}, "hello bar")
+	}))
 
-	evtGtwFoo := events.New(test.Context(), "test", ttnpb.GatewayIdentifiers{GatewayID: "foo"}, "hello foo")
-	evtGtwBar := events.New(test.Context(), "test", ttnpb.GatewayIdentifiers{GatewayID: "bar"}, "hello bar")
+	evtGtwFoo := events.New(test.Context(), "test", "test", events.WithIdentifiers(ttnpb.GatewayIdentifiers{GatewayID: "foo"}))
+	evtGtwBar := events.New(test.Context(), "test", "test", events.WithIdentifiers(ttnpb.GatewayIdentifiers{GatewayID: "bar"}))
 
-	evtOrgFoo := events.New(test.Context(), "test", ttnpb.OrganizationIdentifiers{OrganizationID: "foo"}, "hello foo")
-	evtOrgBar := events.New(test.Context(), "test", ttnpb.OrganizationIdentifiers{OrganizationID: "bar"}, "hello bar")
+	evtOrgFoo := events.New(test.Context(), "test", "test", events.WithIdentifiers(ttnpb.OrganizationIdentifiers{OrganizationID: "foo"}))
+	evtOrgBar := events.New(test.Context(), "test", "test", events.WithIdentifiers(ttnpb.OrganizationIdentifiers{OrganizationID: "bar"}))
 
-	evtUsrFoo := events.New(test.Context(), "test", ttnpb.UserIdentifiers{UserID: "foo"}, "hello foo")
-	evtUsrBar := events.New(test.Context(), "test", ttnpb.UserIdentifiers{UserID: "bar"}, "hello bar")
+	evtUsrFoo := events.New(test.Context(), "test", "test", events.WithIdentifiers(ttnpb.UserIdentifiers{UserID: "foo"}))
+	evtUsrBar := events.New(test.Context(), "test", "test", events.WithIdentifiers(ttnpb.UserIdentifiers{UserID: "bar"}))
 
 	fooIDs := &ttnpb.CombinedIdentifiers{
 		EntityIdentifiers: []*ttnpb.EntityIdentifiers{

--- a/pkg/events/options.go
+++ b/pkg/events/options.go
@@ -1,0 +1,95 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"net"
+	"sort"
+	"strings"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/auth"
+	"go.thethings.network/lorawan-stack/v3/pkg/rpcmetadata"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"google.golang.org/grpc/peer"
+)
+
+// Option is an option that is used to build events.
+type Option interface {
+	applyTo(*event)
+}
+
+type optionFunc func(e *event)
+
+func (f optionFunc) applyTo(e *event) { f(e) }
+
+// WithIdentifiers returns an option that sets the identifiers of the event.
+func WithIdentifiers(identifiers ...ttnpb.Identifiers) Option {
+	return optionFunc(func(e *event) {
+		for _, ids := range identifiers {
+			e.innerEvent.Identifiers = append(e.innerEvent.Identifiers, ids.EntityIdentifiers())
+		}
+	})
+}
+
+// WithData returns an option that sets the data of the event.
+func WithData(data interface{}) Option {
+	return optionFunc(func(e *event) {
+		e.data = data
+		if data, ok := data.(interface{ GetCorrelationIDs() []string }); ok {
+			if cids := data.GetCorrelationIDs(); len(cids) > 0 {
+				cids = append(cids[:0:0], cids...)
+				sort.Strings(cids)
+				e.innerEvent.CorrelationIDs = mergeStrings(e.innerEvent.CorrelationIDs, cids)
+			}
+		}
+	})
+}
+
+// WithVisibility returns an option that sets the visibility of the event.
+func WithVisibility(rights ...ttnpb.Right) Option {
+	return optionFunc(func(e *event) {
+		e.innerEvent.Visibility = ttnpb.RightsFrom(rights...)
+	})
+}
+
+// WithAuthFromContext returns an option that extracts auth information from the context when the event is created.
+func WithAuthFromContext() Option {
+	return optionFunc(func(e *event) {
+		authentication := &ttnpb.Event_Authentication{}
+		if p, ok := peer.FromContext(e.ctx); ok && p.Addr != nil && p.Addr.String() != "pipe" {
+			if host, _, err := net.SplitHostPort(p.Addr.String()); err == nil {
+				authentication.RemoteIP = host
+			}
+		}
+		md := rpcmetadata.FromIncomingContext(e.ctx)
+		if md.AuthType != "" {
+			authentication.Type = md.AuthType
+		}
+		if md.AuthValue != "" {
+			if tokenType, tokenID, _, err := auth.SplitToken(md.AuthValue); err == nil {
+				authentication.TokenType = tokenType.String()
+				authentication.TokenID = tokenID
+			}
+		}
+		if md.XForwardedFor != "" {
+			xff := strings.Split(md.XForwardedFor, ",")
+			authentication.RemoteIP = strings.Trim(xff[0], " ")
+		}
+		if authentication.RemoteIP != "" || authentication.TokenID != "" ||
+			authentication.TokenType != "" || authentication.Type != "" {
+			e.innerEvent.Authentication = authentication
+		}
+	})
+}

--- a/pkg/events/redis/redis_test.go
+++ b/pkg/events/redis/redis_test.go
@@ -83,7 +83,7 @@ func TestRedisPubSub(t *testing.T) {
 
 	appID := &ttnpb.ApplicationIdentifiers{ApplicationID: "test-app"}
 
-	pubsub.Publish(events.New(ctx, "redis.test.evt0", appID, nil))
+	pubsub.Publish(events.New(ctx, "redis.test.evt0", "redis test event 0", events.WithIdentifiers(appID)))
 	select {
 	case e := <-eventCh:
 		a.So(e.Name(), should.Equal, "redis.test.evt0")

--- a/pkg/gatewayserver/observability.go
+++ b/pkg/gatewayserver/observability.go
@@ -27,57 +27,61 @@ import (
 var (
 	evtGatewayConnect = events.Define(
 		"gs.gateway.connect", "connect gateway",
-		ttnpb.RIGHT_GATEWAY_LINK,
-		ttnpb.RIGHT_GATEWAY_STATUS_READ,
+		events.WithVisibility(
+			ttnpb.RIGHT_GATEWAY_LINK,
+			ttnpb.RIGHT_GATEWAY_STATUS_READ,
+		),
 	)
 	evtGatewayDisconnect = events.Define(
 		"gs.gateway.disconnect", "disconnect gateway",
-		ttnpb.RIGHT_GATEWAY_LINK,
-		ttnpb.RIGHT_GATEWAY_STATUS_READ,
+		events.WithVisibility(
+			ttnpb.RIGHT_GATEWAY_LINK,
+			ttnpb.RIGHT_GATEWAY_STATUS_READ,
+		),
 	)
 	evtReceiveStatus = events.Define(
 		"gs.status.receive", "receive gateway status",
-		ttnpb.RIGHT_GATEWAY_STATUS_READ,
+		events.WithVisibility(ttnpb.RIGHT_GATEWAY_STATUS_READ),
 	)
 	evtForwardStatus = events.Define(
 		"gs.status.forward", "forward gateway status",
-		ttnpb.RIGHT_GATEWAY_STATUS_READ,
+		events.WithVisibility(ttnpb.RIGHT_GATEWAY_STATUS_READ),
 	)
 	evtDropStatus = events.Define(
 		"gs.status.drop", "drop gateway status",
-		ttnpb.RIGHT_GATEWAY_STATUS_READ,
+		events.WithVisibility(ttnpb.RIGHT_GATEWAY_STATUS_READ),
 	)
 	evtFailStatus = events.Define(
 		"gs.status.fail", "fail to handle gateway status",
-		ttnpb.RIGHT_GATEWAY_STATUS_READ,
+		events.WithVisibility(ttnpb.RIGHT_GATEWAY_STATUS_READ),
 	)
 	evtReceiveUp = events.Define(
 		"gs.up.receive", "receive uplink message",
-		ttnpb.RIGHT_GATEWAY_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_GATEWAY_TRAFFIC_READ),
 	)
 	evtDropUp = events.Define(
 		"gs.up.drop", "drop uplink message",
-		ttnpb.RIGHT_GATEWAY_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_GATEWAY_TRAFFIC_READ),
 	)
 	evtForwardUp = events.Define(
 		"gs.up.forward", "forward uplink message",
-		ttnpb.RIGHT_GATEWAY_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_GATEWAY_TRAFFIC_READ),
 	)
 	evtFailUp = events.Define(
 		"gs.up.fail", "fail to handle uplink message",
-		ttnpb.RIGHT_GATEWAY_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_GATEWAY_TRAFFIC_READ),
 	)
 	evtSendDown = events.Define(
 		"gs.down.send", "send downlink message",
-		ttnpb.RIGHT_GATEWAY_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_GATEWAY_TRAFFIC_READ),
 	)
 	evtTxSuccessDown = events.Define(
 		"gs.down.tx.success", "transmit downlink message successful",
-		ttnpb.RIGHT_GATEWAY_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_GATEWAY_TRAFFIC_READ),
 	)
 	evtTxFailureDown = events.Define(
 		"gs.down.tx.fail", "transmit downlink message failure",
-		ttnpb.RIGHT_GATEWAY_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_GATEWAY_TRAFFIC_READ),
 	)
 )
 
@@ -249,12 +253,12 @@ func (m messageMetrics) Collect(ch chan<- prometheus.Metric) {
 }
 
 func registerGatewayConnect(ctx context.Context, ids ttnpb.GatewayIdentifiers, protocol string) {
-	events.Publish(evtGatewayConnect(ctx, ids, nil))
+	events.Publish(evtGatewayConnect.NewWithIdentifiersAndData(ctx, ids, nil))
 	gsMetrics.gatewaysConnected.WithLabelValues(ctx, protocol).Inc()
 }
 
 func registerGatewayDisconnect(ctx context.Context, ids ttnpb.GatewayIdentifiers, protocol string) {
-	events.Publish(evtGatewayDisconnect(ctx, ids, nil))
+	events.Publish(evtGatewayDisconnect.NewWithIdentifiersAndData(ctx, ids, nil))
 	gsMetrics.gatewaysConnected.WithLabelValues(ctx, protocol).Dec()
 }
 
@@ -267,17 +271,17 @@ func registerUpstreamHandlerStop(ctx context.Context, host string) {
 }
 
 func registerReceiveStatus(ctx context.Context, gtw *ttnpb.Gateway, status *ttnpb.GatewayStatus, protocol string) {
-	events.Publish(evtReceiveStatus(ctx, gtw, status))
+	events.Publish(evtReceiveStatus.NewWithIdentifiersAndData(ctx, gtw, status))
 	gsMetrics.statusReceived.WithLabelValues(ctx, protocol).Inc()
 }
 
 func registerForwardStatus(ctx context.Context, gtw *ttnpb.Gateway, status *ttnpb.GatewayStatus, host string) {
-	events.Publish(evtForwardStatus(ctx, gtw, status))
+	events.Publish(evtForwardStatus.NewWithIdentifiersAndData(ctx, gtw, status))
 	gsMetrics.statusForwarded.WithLabelValues(ctx, host).Inc()
 }
 
 func registerDropStatus(ctx context.Context, gtw *ttnpb.Gateway, status *ttnpb.GatewayStatus, host string, err error) {
-	events.Publish(evtDropStatus(ctx, gtw, err))
+	events.Publish(evtDropStatus.NewWithIdentifiersAndData(ctx, gtw, err))
 	if ttnErr, ok := errors.From(err); ok {
 		gsMetrics.statusDropped.WithLabelValues(ctx, host, ttnErr.FullName()).Inc()
 	} else {
@@ -286,22 +290,22 @@ func registerDropStatus(ctx context.Context, gtw *ttnpb.Gateway, status *ttnpb.G
 }
 
 func registerFailStatus(ctx context.Context, gtw *ttnpb.Gateway, status *ttnpb.GatewayStatus, host string) {
-	events.Publish(evtFailStatus(ctx, gtw, status))
+	events.Publish(evtFailStatus.NewWithIdentifiersAndData(ctx, gtw, status))
 	gsMetrics.statusFailed.WithLabelValues(ctx, host).Inc()
 }
 
 func registerReceiveUplink(ctx context.Context, gtw *ttnpb.Gateway, msg *ttnpb.UplinkMessage, protocol string) {
-	events.Publish(evtReceiveUp(ctx, gtw, msg))
+	events.Publish(evtReceiveUp.NewWithIdentifiersAndData(ctx, gtw, msg))
 	gsMetrics.uplinkReceived.WithLabelValues(ctx, protocol).Inc()
 }
 
 func registerForwardUplink(ctx context.Context, gtw *ttnpb.Gateway, msg *ttnpb.UplinkMessage, host string) {
-	events.Publish(evtForwardUp(ctx, gtw, nil))
+	events.Publish(evtForwardUp.NewWithIdentifiersAndData(ctx, gtw, nil))
 	gsMetrics.uplinkForwarded.WithLabelValues(ctx, host).Inc()
 }
 
 func registerDropUplink(ctx context.Context, gtw *ttnpb.Gateway, msg *ttnpb.UplinkMessage, host string, err error) {
-	events.Publish(evtDropUp(ctx, gtw, err))
+	events.Publish(evtDropUp.NewWithIdentifiersAndData(ctx, gtw, err))
 	if ttnErr, ok := errors.From(err); ok {
 		gsMetrics.uplinkDropped.WithLabelValues(ctx, host, ttnErr.FullName()).Inc()
 	} else {
@@ -310,21 +314,21 @@ func registerDropUplink(ctx context.Context, gtw *ttnpb.Gateway, msg *ttnpb.Upli
 }
 
 func registerFailUplink(ctx context.Context, gtw *ttnpb.Gateway, msg *ttnpb.UplinkMessage, host string) {
-	events.Publish(evtFailUp(ctx, gtw, nil))
+	events.Publish(evtFailUp.NewWithIdentifiersAndData(ctx, gtw, nil))
 	gsMetrics.uplinkFailed.WithLabelValues(ctx, host).Inc()
 }
 
 func registerSendDownlink(ctx context.Context, gtw *ttnpb.Gateway, msg *ttnpb.DownlinkMessage, protocol string) {
-	events.Publish(evtSendDown(ctx, gtw, msg))
+	events.Publish(evtSendDown.NewWithIdentifiersAndData(ctx, gtw, msg))
 	gsMetrics.downlinkSent.WithLabelValues(ctx, protocol).Inc()
 }
 
 func registerSuccessDownlink(ctx context.Context, gtw *ttnpb.Gateway, protocol string) {
-	events.Publish(evtTxSuccessDown(ctx, gtw, nil))
+	events.Publish(evtTxSuccessDown.NewWithIdentifiersAndData(ctx, gtw, nil))
 	gsMetrics.downlinkSent.WithLabelValues(ctx, protocol).Inc()
 }
 
 func registerFailDownlink(ctx context.Context, gtw *ttnpb.Gateway, ack *ttnpb.TxAcknowledgment, protocol string) {
-	events.Publish(evtTxFailureDown(ctx, gtw, ack.Result))
+	events.Publish(evtTxFailureDown.NewWithIdentifiersAndData(ctx, gtw, ack.Result))
 	gsMetrics.downlinkTxFailed.WithLabelValues(ctx, protocol).Inc()
 }

--- a/pkg/identityserver/application_registry.go
+++ b/pkg/identityserver/application_registry.go
@@ -30,15 +30,15 @@ import (
 var (
 	evtCreateApplication = events.Define(
 		"application.create", "create application",
-		ttnpb.RIGHT_APPLICATION_INFO,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_INFO),
 	)
 	evtUpdateApplication = events.Define(
 		"application.update", "update application",
-		ttnpb.RIGHT_APPLICATION_INFO,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_INFO),
 	)
 	evtDeleteApplication = events.Define(
 		"application.delete", "delete application",
-		ttnpb.RIGHT_APPLICATION_INFO,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_INFO),
 	)
 )
 
@@ -88,7 +88,7 @@ func (is *IdentityServer) createApplication(ctx context.Context, req *ttnpb.Crea
 	if err != nil {
 		return nil, err
 	}
-	events.Publish(evtCreateApplication(ctx, req.ApplicationIdentifiers, nil))
+	events.Publish(evtCreateApplication.NewWithIdentifiersAndData(ctx, req.ApplicationIdentifiers, nil))
 	return app, nil
 }
 
@@ -219,7 +219,7 @@ func (is *IdentityServer) updateApplication(ctx context.Context, req *ttnpb.Upda
 	if err != nil {
 		return nil, err
 	}
-	events.Publish(evtUpdateApplication(ctx, req.ApplicationIdentifiers, req.FieldMask.Paths))
+	events.Publish(evtUpdateApplication.NewWithIdentifiersAndData(ctx, req.ApplicationIdentifiers, req.FieldMask.Paths))
 	return app, nil
 }
 
@@ -242,7 +242,7 @@ func (is *IdentityServer) deleteApplication(ctx context.Context, ids *ttnpb.Appl
 	if err != nil {
 		return nil, err
 	}
-	events.Publish(evtDeleteApplication(ctx, ids, nil))
+	events.Publish(evtDeleteApplication.NewWithIdentifiersAndData(ctx, ids, nil))
 	return ttnpb.Empty, nil
 }
 

--- a/pkg/identityserver/client_access.go
+++ b/pkg/identityserver/client_access.go
@@ -32,13 +32,17 @@ import (
 var (
 	evtUpdateClientCollaborator = events.Define(
 		"client.collaborator.update", "update client collaborator",
-		ttnpb.RIGHT_CLIENT_ALL,
-		ttnpb.RIGHT_USER_CLIENTS_LIST,
+		events.WithVisibility(
+			ttnpb.RIGHT_CLIENT_ALL,
+			ttnpb.RIGHT_USER_CLIENTS_LIST,
+		),
 	)
 	evtDeleteClientCollaborator = events.Define(
 		"client.collaborator.delete", "delete client collaborator",
-		ttnpb.RIGHT_CLIENT_ALL,
-		ttnpb.RIGHT_USER_CLIENTS_LIST,
+		events.WithVisibility(
+			ttnpb.RIGHT_CLIENT_ALL,
+			ttnpb.RIGHT_USER_CLIENTS_LIST,
+		),
 	)
 )
 
@@ -116,7 +120,7 @@ func (is *IdentityServer) setClientCollaborator(ctx context.Context, req *ttnpb.
 		return nil, err
 	}
 	if len(req.Collaborator.Rights) > 0 {
-		events.Publish(evtUpdateClientCollaborator(ctx, ttnpb.CombineIdentifiers(req.ClientIdentifiers, req.Collaborator), nil))
+		events.Publish(evtUpdateClientCollaborator.NewWithIdentifiersAndData(ctx, ttnpb.CombineIdentifiers(req.ClientIdentifiers, req.Collaborator), nil))
 		err = is.SendContactsEmail(ctx, req.EntityIdentifiers(), func(data emails.Data) email.MessageData {
 			data.SetEntity(req.EntityIdentifiers())
 			return &emails.CollaboratorChanged{Data: data, Collaborator: req.Collaborator}
@@ -125,7 +129,7 @@ func (is *IdentityServer) setClientCollaborator(ctx context.Context, req *ttnpb.
 			log.FromContext(ctx).WithError(err).Error("Could not send collaborator updated notification email")
 		}
 	} else {
-		events.Publish(evtDeleteClientCollaborator(ctx, ttnpb.CombineIdentifiers(req.ClientIdentifiers, req.Collaborator), nil))
+		events.Publish(evtDeleteClientCollaborator.NewWithIdentifiersAndData(ctx, ttnpb.CombineIdentifiers(req.ClientIdentifiers, req.Collaborator), nil))
 	}
 	return ttnpb.Empty, nil
 }

--- a/pkg/identityserver/client_registry.go
+++ b/pkg/identityserver/client_registry.go
@@ -35,15 +35,15 @@ import (
 var (
 	evtCreateClient = events.Define(
 		"client.create", "create OAuth client",
-		ttnpb.RIGHT_CLIENT_ALL,
+		events.WithVisibility(ttnpb.RIGHT_CLIENT_ALL),
 	)
 	evtUpdateClient = events.Define(
 		"client.update", "update OAuth client",
-		ttnpb.RIGHT_CLIENT_ALL,
+		events.WithVisibility(ttnpb.RIGHT_CLIENT_ALL),
 	)
 	evtDeleteClient = events.Define(
 		"client.delete", "delete OAuth client",
-		ttnpb.RIGHT_CLIENT_ALL,
+		events.WithVisibility(ttnpb.RIGHT_CLIENT_ALL),
 	)
 )
 
@@ -118,7 +118,7 @@ func (is *IdentityServer) createClient(ctx context.Context, req *ttnpb.CreateCli
 
 	cli.Secret = secret // Return the unhashed secret, in case it was generated.
 
-	events.Publish(evtCreateClient(ctx, req.ClientIdentifiers, nil))
+	events.Publish(evtCreateClient.NewWithIdentifiersAndData(ctx, req.ClientIdentifiers, nil))
 	return cli, nil
 }
 
@@ -262,7 +262,7 @@ func (is *IdentityServer) updateClient(ctx context.Context, req *ttnpb.UpdateCli
 	if err != nil {
 		return nil, err
 	}
-	events.Publish(evtUpdateClient(ctx, req.ClientIdentifiers, req.FieldMask.Paths))
+	events.Publish(evtUpdateClient.NewWithIdentifiersAndData(ctx, req.ClientIdentifiers, req.FieldMask.Paths))
 	if ttnpb.HasAnyField(req.FieldMask.Paths, "state") {
 		err = is.SendContactsEmail(ctx, req.EntityIdentifiers(), func(data emails.Data) email.MessageData {
 			data.SetEntity(req.EntityIdentifiers())
@@ -285,7 +285,7 @@ func (is *IdentityServer) deleteClient(ctx context.Context, ids *ttnpb.ClientIde
 	if err != nil {
 		return nil, err
 	}
-	events.Publish(evtDeleteClient(ctx, ids, nil))
+	events.Publish(evtDeleteClient.NewWithIdentifiersAndData(ctx, ids, nil))
 	return ttnpb.Empty, nil
 }
 

--- a/pkg/identityserver/end_device_registry.go
+++ b/pkg/identityserver/end_device_registry.go
@@ -31,15 +31,15 @@ import (
 var (
 	evtCreateEndDevice = events.Define(
 		"end_device.create", "create end device",
-		ttnpb.RIGHT_APPLICATION_DEVICES_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_DEVICES_READ),
 	)
 	evtUpdateEndDevice = events.Define(
 		"end_device.update", "update end device",
-		ttnpb.RIGHT_APPLICATION_DEVICES_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_DEVICES_READ),
 	)
 	evtDeleteEndDevice = events.Define(
 		"end_device.delete", "delete end device",
-		ttnpb.RIGHT_APPLICATION_DEVICES_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_DEVICES_READ),
 	)
 )
 
@@ -86,7 +86,7 @@ func (is *IdentityServer) createEndDevice(ctx context.Context, req *ttnpb.Create
 		}
 		return nil, err
 	}
-	events.Publish(evtCreateEndDevice(ctx, req.EndDeviceIdentifiers, nil))
+	events.Publish(evtCreateEndDevice.NewWithIdentifiersAndData(ctx, req.EndDeviceIdentifiers, nil))
 	return dev, nil
 }
 
@@ -201,7 +201,7 @@ func (is *IdentityServer) updateEndDevice(ctx context.Context, req *ttnpb.Update
 	if err != nil {
 		return nil, err
 	}
-	events.Publish(evtUpdateEndDevice(ctx, req.EndDeviceIdentifiers, req.FieldMask.Paths))
+	events.Publish(evtUpdateEndDevice.NewWithIdentifiersAndData(ctx, req.EndDeviceIdentifiers, req.FieldMask.Paths))
 	return dev, nil
 }
 
@@ -215,7 +215,7 @@ func (is *IdentityServer) deleteEndDevice(ctx context.Context, ids *ttnpb.EndDev
 	if err != nil {
 		return nil, err
 	}
-	events.Publish(evtDeleteEndDevice(ctx, ids, nil))
+	events.Publish(evtDeleteEndDevice.NewWithIdentifiersAndData(ctx, ids, nil))
 	return ttnpb.Empty, nil
 }
 

--- a/pkg/identityserver/gateway_registry.go
+++ b/pkg/identityserver/gateway_registry.go
@@ -30,15 +30,15 @@ import (
 var (
 	evtCreateGateway = events.Define(
 		"gateway.create", "create gateway",
-		ttnpb.RIGHT_GATEWAY_INFO,
+		events.WithVisibility(ttnpb.RIGHT_GATEWAY_INFO),
 	)
 	evtUpdateGateway = events.Define(
 		"gateway.update", "update gateway",
-		ttnpb.RIGHT_GATEWAY_INFO,
+		events.WithVisibility(ttnpb.RIGHT_GATEWAY_INFO),
 	)
 	evtDeleteGateway = events.Define(
 		"gateway.delete", "delete gateway",
-		ttnpb.RIGHT_GATEWAY_INFO,
+		events.WithVisibility(ttnpb.RIGHT_GATEWAY_INFO),
 	)
 )
 
@@ -105,7 +105,7 @@ func (is *IdentityServer) createGateway(ctx context.Context, req *ttnpb.CreateGa
 		}
 		return nil, err
 	}
-	events.Publish(evtCreateGateway(ctx, req.GatewayIdentifiers, nil))
+	events.Publish(evtCreateGateway.NewWithIdentifiersAndData(ctx, req.GatewayIdentifiers, nil))
 	return gtw, nil
 }
 
@@ -293,7 +293,7 @@ func (is *IdentityServer) updateGateway(ctx context.Context, req *ttnpb.UpdateGa
 	if err != nil {
 		return nil, err
 	}
-	events.Publish(evtUpdateGateway(ctx, req.GatewayIdentifiers, req.FieldMask.Paths))
+	events.Publish(evtUpdateGateway.NewWithIdentifiersAndData(ctx, req.GatewayIdentifiers, req.FieldMask.Paths))
 	return gtw, nil
 }
 
@@ -307,7 +307,7 @@ func (is *IdentityServer) deleteGateway(ctx context.Context, ids *ttnpb.GatewayI
 	if err != nil {
 		return nil, err
 	}
-	events.Publish(evtDeleteGateway(ctx, ids, nil))
+	events.Publish(evtDeleteGateway.NewWithIdentifiersAndData(ctx, ids, nil))
 	return ttnpb.Empty, nil
 }
 

--- a/pkg/identityserver/invitation_registry.go
+++ b/pkg/identityserver/invitation_registry.go
@@ -61,7 +61,7 @@ func (is *IdentityServer) sendInvitation(ctx context.Context, in *ttnpb.SendInvi
 	if err != nil {
 		return nil, err
 	}
-	events.Publish(evtCreateInvitation(ctx, nil, invitation))
+	events.Publish(evtCreateInvitation.NewWithIdentifiersAndData(ctx, nil, invitation))
 	err = is.SendEmail(ctx, func(data emails.Data) email.MessageData {
 		data.User.Email = in.Email
 		return &emails.Invitation{

--- a/pkg/identityserver/organization_registry.go
+++ b/pkg/identityserver/organization_registry.go
@@ -30,15 +30,15 @@ import (
 var (
 	evtCreateOrganization = events.Define(
 		"organization.create", "create organization",
-		ttnpb.RIGHT_ORGANIZATION_INFO,
+		events.WithVisibility(ttnpb.RIGHT_ORGANIZATION_INFO),
 	)
 	evtUpdateOrganization = events.Define(
 		"organization.update", "update organization",
-		ttnpb.RIGHT_ORGANIZATION_INFO,
+		events.WithVisibility(ttnpb.RIGHT_ORGANIZATION_INFO),
 	)
 	evtDeleteOrganization = events.Define(
 		"organization.delete", "delete organization",
-		ttnpb.RIGHT_ORGANIZATION_INFO,
+		events.WithVisibility(ttnpb.RIGHT_ORGANIZATION_INFO),
 	)
 )
 
@@ -89,7 +89,7 @@ func (is *IdentityServer) createOrganization(ctx context.Context, req *ttnpb.Cre
 	if err != nil {
 		return nil, err
 	}
-	events.Publish(evtCreateOrganization(ctx, req.OrganizationIdentifiers, nil))
+	events.Publish(evtCreateOrganization.NewWithIdentifiersAndData(ctx, req.OrganizationIdentifiers, nil))
 	return org, nil
 }
 
@@ -218,7 +218,7 @@ func (is *IdentityServer) updateOrganization(ctx context.Context, req *ttnpb.Upd
 	if err != nil {
 		return nil, err
 	}
-	events.Publish(evtUpdateOrganization(ctx, req.OrganizationIdentifiers, req.FieldMask.Paths))
+	events.Publish(evtUpdateOrganization.NewWithIdentifiersAndData(ctx, req.OrganizationIdentifiers, req.FieldMask.Paths))
 	return org, nil
 }
 
@@ -232,7 +232,7 @@ func (is *IdentityServer) deleteOrganization(ctx context.Context, ids *ttnpb.Org
 	if err != nil {
 		return nil, err
 	}
-	events.Publish(evtDeleteOrganization(ctx, ids, nil))
+	events.Publish(evtDeleteOrganization.NewWithIdentifiersAndData(ctx, ids, nil))
 	return ttnpb.Empty, nil
 }
 

--- a/pkg/joinserver/grpc_deviceregistry.go
+++ b/pkg/joinserver/grpc_deviceregistry.go
@@ -30,15 +30,15 @@ import (
 var (
 	evtCreateEndDevice = events.Define(
 		"js.end_device.create", "create end device",
-		ttnpb.RIGHT_APPLICATION_DEVICES_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_DEVICES_READ),
 	)
 	evtUpdateEndDevice = events.Define(
 		"js.end_device.update", "update end device",
-		ttnpb.RIGHT_APPLICATION_DEVICES_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_DEVICES_READ),
 	)
 	evtDeleteEndDevice = events.Define(
 		"js.end_device.delete", "delete end device",
-		ttnpb.RIGHT_APPLICATION_DEVICES_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_DEVICES_READ),
 	)
 )
 
@@ -237,7 +237,7 @@ func (srv jsEndDeviceRegistryServer) Set(ctx context.Context, req *ttnpb.SetEndD
 	var evt events.Event
 	dev, err = srv.JS.devices.SetByID(ctx, req.EndDevice.ApplicationIdentifiers, req.EndDevice.DeviceID, req.FieldMask.Paths, func(dev *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
 		if dev != nil {
-			evt = evtUpdateEndDevice(ctx, req.EndDevice.EndDeviceIdentifiers, req.FieldMask.Paths)
+			evt = evtUpdateEndDevice.NewWithIdentifiersAndData(ctx, req.EndDevice.EndDeviceIdentifiers, req.FieldMask.Paths)
 			if err := ttnpb.ProhibitFields(sets,
 				"ids.dev_addr",
 			); err != nil {
@@ -246,7 +246,7 @@ func (srv jsEndDeviceRegistryServer) Set(ctx context.Context, req *ttnpb.SetEndD
 			return &req.EndDevice, sets, nil
 		}
 
-		evt = evtCreateEndDevice(ctx, req.EndDevice.EndDeviceIdentifiers, nil)
+		evt = evtCreateEndDevice.NewWithIdentifiersAndData(ctx, req.EndDevice.EndDeviceIdentifiers, nil)
 		if req.EndDevice.DevAddr != nil && !req.EndDevice.DevAddr.IsZero() {
 			return nil, nil, errInvalidFieldValue.WithAttributes("field", "ids.dev_addr")
 		}
@@ -285,7 +285,7 @@ func (srv jsEndDeviceRegistryServer) Delete(ctx context.Context, ids *ttnpb.EndD
 		if dev == nil {
 			return nil, nil, errDeviceNotFound.New()
 		}
-		evt = evtDeleteEndDevice(ctx, ids, nil)
+		evt = evtDeleteEndDevice.NewWithIdentifiersAndData(ctx, ids, nil)
 		return nil, nil, nil
 	})
 	if err != nil {

--- a/pkg/joinserver/observability.go
+++ b/pkg/joinserver/observability.go
@@ -27,11 +27,11 @@ import (
 var (
 	evtRejectJoin = events.Define(
 		"js.join.reject", "reject join-request",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtAcceptJoin = events.Define(
 		"js.join.accept", "accept join-request",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 )
 
@@ -79,12 +79,12 @@ func (m messageMetrics) Collect(ch chan<- prometheus.Metric) {
 }
 
 func registerAcceptJoin(ctx context.Context, dev *ttnpb.EndDevice, msg *ttnpb.JoinRequest) {
-	events.Publish(evtAcceptJoin(ctx, dev.EndDeviceIdentifiers, nil))
+	events.Publish(evtAcceptJoin.NewWithIdentifiersAndData(ctx, dev.EndDeviceIdentifiers, nil))
 	jsMetrics.joinAccepted.WithLabelValues(ctx, msg.NetID.String()).Inc()
 }
 
 func registerRejectJoin(ctx context.Context, req *ttnpb.JoinRequest, err error) {
-	events.Publish(evtRejectJoin(ctx, nil, err))
+	events.Publish(evtRejectJoin.NewWithIdentifiersAndData(ctx, nil, err))
 	if ttnErr, ok := errors.From(err); ok {
 		jsMetrics.joinRejected.WithLabelValues(ctx, ttnErr.FullName()).Inc()
 	} else {

--- a/pkg/networkserver/grpc_asns.go
+++ b/pkg/networkserver/grpc_asns.go
@@ -103,7 +103,7 @@ func (ns *NetworkServer) LinkApplication(link ttnpb.AsNs_LinkApplicationServer) 
 	defer ns.applicationServers.Delete(uid)
 
 	logger.Debug("Linked application")
-	events.Publish(evtBeginApplicationLink(ctx, ids, nil))
+	events.Publish(evtBeginApplicationLink.NewWithIdentifiersAndData(ctx, ids, nil))
 	err := ns.applicationUplinks.Subscribe(ctx, ids, func(ctx context.Context, up *ttnpb.ApplicationUp) error {
 		if err := link.Send(up); err != nil {
 			return err
@@ -114,9 +114,9 @@ func (ns *NetworkServer) LinkApplication(link ttnpb.AsNs_LinkApplicationServer) 
 		switch pld := up.Up.(type) {
 		case *ttnpb.ApplicationUp_UplinkMessage:
 			registerForwardDataUplink(ctx, pld.UplinkMessage)
-			events.Publish(evtForwardDataUplink(ctx, up.EndDeviceIdentifiers, up))
+			events.Publish(evtForwardDataUplink.NewWithIdentifiersAndData(ctx, up.EndDeviceIdentifiers, up))
 		case *ttnpb.ApplicationUp_JoinAccept:
-			events.Publish(evtForwardJoinAccept(ctx, up.EndDeviceIdentifiers, &ttnpb.ApplicationUp{
+			events.Publish(evtForwardJoinAccept.NewWithIdentifiersAndData(ctx, up.EndDeviceIdentifiers, &ttnpb.ApplicationUp{
 				EndDeviceIdentifiers: up.EndDeviceIdentifiers,
 				CorrelationIDs:       up.CorrelationIDs,
 				Up: &ttnpb.ApplicationUp_JoinAccept{
@@ -127,7 +127,7 @@ func (ns *NetworkServer) LinkApplication(link ttnpb.AsNs_LinkApplicationServer) 
 		return nil
 	})
 	logger.WithError(err).Debug("Close application link")
-	events.Publish(evtEndApplicationLink(ctx, ids, err))
+	events.Publish(evtEndApplicationLink.NewWithIdentifiersAndData(ctx, ids, err))
 	return err
 }
 

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -29,15 +29,15 @@ import (
 var (
 	evtCreateEndDevice = events.Define(
 		"ns.end_device.create", "create end device",
-		ttnpb.RIGHT_APPLICATION_DEVICES_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_DEVICES_READ),
 	)
 	evtUpdateEndDevice = events.Define(
 		"ns.end_device.update", "update end device",
-		ttnpb.RIGHT_APPLICATION_DEVICES_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_DEVICES_READ),
 	)
 	evtDeleteEndDevice = events.Define(
 		"ns.end_device.delete", "delete end device",
-		ttnpb.RIGHT_APPLICATION_DEVICES_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_DEVICES_READ),
 	)
 )
 
@@ -366,7 +366,7 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 		}
 
 		if dev != nil {
-			evt = evtUpdateEndDevice(ctx, req.EndDevice.EndDeviceIdentifiers, req.FieldMask.Paths)
+			evt = evtUpdateEndDevice.NewWithIdentifiersAndData(ctx, req.EndDevice.EndDeviceIdentifiers, req.FieldMask.Paths)
 			if err := ttnpb.ProhibitFields(sets,
 				"ids.dev_addr",
 				"multicast",
@@ -403,7 +403,7 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 			return &req.EndDevice, sets, nil
 		}
 
-		evt = evtCreateEndDevice(ctx, req.EndDevice.EndDeviceIdentifiers, nil)
+		evt = evtCreateEndDevice.NewWithIdentifiersAndData(ctx, req.EndDevice.EndDeviceIdentifiers, nil)
 		if err := ttnpb.RequireFields(sets,
 			"frequency_plan_id",
 			"lorawan_phy_version",
@@ -555,7 +555,7 @@ func (ns *NetworkServer) Delete(ctx context.Context, req *ttnpb.EndDeviceIdentif
 		if dev == nil {
 			return nil, nil, errDeviceNotFound.New()
 		}
-		evt = evtDeleteEndDevice(ctx, req, nil)
+		evt = evtDeleteEndDevice.NewWithIdentifiersAndData(ctx, req, nil)
 		return nil, nil, nil
 	})
 	if err != nil {

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -127,11 +127,11 @@ func fCntResetGap(last, recv uint32) uint32 {
 	}
 }
 
-type macHandler func(context.Context, *ttnpb.EndDevice, *ttnpb.UplinkMessage) ([]events.DefinitionDataClosure, error)
+type macHandler func(context.Context, *ttnpb.EndDevice, *ttnpb.UplinkMessage) (events.Builders, error)
 
 func makeDeferredMACHandler(dev *ttnpb.EndDevice, f macHandler) macHandler {
 	queuedLength := len(dev.MACState.QueuedResponses)
-	return func(ctx context.Context, dev *ttnpb.EndDevice, up *ttnpb.UplinkMessage) ([]events.DefinitionDataClosure, error) {
+	return func(ctx context.Context, dev *ttnpb.EndDevice, up *ttnpb.UplinkMessage) (events.Builders, error) {
 		switch n := len(dev.MACState.QueuedResponses); {
 		case n < queuedLength:
 			return nil, errCorruptedMACState.New()
@@ -160,7 +160,7 @@ type matchedDevice struct {
 	NbTrans                  uint32
 	Pending                  bool
 	QueuedApplicationUplinks []*ttnpb.ApplicationUp
-	QueuedEventClosures      []events.DefinitionDataClosure
+	QueuedEventBuilders      events.Builders
 	SetPaths                 []string
 }
 
@@ -583,15 +583,15 @@ matchLoop:
 
 			case match.Device.MACState.DeviceClass != ttnpb.CLASS_B:
 				logger.WithField("previous_class", match.Device.MACState.DeviceClass).Debug("Switch device class to class B")
-				match.QueuedEventClosures = append(match.QueuedEventClosures, evtClassBSwitch.BindData(match.Device.MACState.DeviceClass))
+				match.QueuedEventBuilders = append(match.QueuedEventBuilders, evtClassBSwitch.BindData(match.Device.MACState.DeviceClass))
 				match.Device.MACState.DeviceClass = ttnpb.CLASS_B
 			}
 		} else if match.Device.MACState.DeviceClass == ttnpb.CLASS_B {
 			if match.Device.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 && match.Device.SupportsClassC {
-				match.QueuedEventClosures = append(match.QueuedEventClosures, evtClassCSwitch.BindData(ttnpb.CLASS_B))
+				match.QueuedEventBuilders = append(match.QueuedEventBuilders, evtClassCSwitch.BindData(ttnpb.CLASS_B))
 				match.Device.MACState.DeviceClass = ttnpb.CLASS_C
 			} else {
-				match.QueuedEventClosures = append(match.QueuedEventClosures, evtClassASwitch.BindData(ttnpb.CLASS_B))
+				match.QueuedEventBuilders = append(match.QueuedEventBuilders, evtClassASwitch.BindData(ttnpb.CLASS_B))
 				match.Device.MACState.DeviceClass = ttnpb.CLASS_A
 			}
 		}
@@ -606,7 +606,7 @@ matchLoop:
 
 			logger.Debug("Handle MAC command")
 
-			var evs []events.DefinitionDataClosure
+			var evs events.Builders
 			var err error
 			switch cmd.CID {
 			case ttnpb.CID_RESET:
@@ -685,7 +685,7 @@ matchLoop:
 				logger.WithError(err).Debug("Failed to process MAC command")
 				break macLoop
 			}
-			match.QueuedEventClosures = append(match.QueuedEventClosures, evs...)
+			match.QueuedEventBuilders = append(match.QueuedEventBuilders, evs...)
 		}
 		if n := len(match.Device.MACState.PendingRequests); n > 0 {
 			logger.WithField("unanswered_request_count", n).Warn("MAC command buffer not fully answered")
@@ -889,11 +889,11 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 	))
 
 	queuedEvents := []events.Event{
-		evtReceiveDataUplink(ctx, matched.Device.EndDeviceIdentifiers, up),
+		evtReceiveDataUplink.NewWithIdentifiersAndData(ctx, matched.Device.EndDeviceIdentifiers, up),
 	}
 	defer func() {
 		if err != nil {
-			queuedEvents = append(queuedEvents, evtDropDataUplink(ctx, matched.Device.EndDeviceIdentifiers, err))
+			queuedEvents = append(queuedEvents, evtDropDataUplink.NewWithIdentifiersAndData(ctx, matched.Device.EndDeviceIdentifiers, err))
 		}
 		publishEvents(ctx, queuedEvents...)
 	}()
@@ -903,7 +903,7 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 		return err
 	}
 	if !ok {
-		queuedEvents = append(queuedEvents, evtDropDataUplink(ctx, matched.Device.EndDeviceIdentifiers, errDuplicate))
+		queuedEvents = append(queuedEvents, evtDropDataUplink.NewWithIdentifiersAndData(ctx, matched.Device.EndDeviceIdentifiers, errDuplicate))
 		registerReceiveDuplicateUplink(ctx, up)
 		return nil
 	}
@@ -926,7 +926,7 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 			logger.WithError(err).Warn("Failed to process MAC command after deduplication")
 			break
 		}
-		matched.QueuedEventClosures = append(matched.QueuedEventClosures, evs...)
+		matched.QueuedEventBuilders = append(matched.QueuedEventBuilders, evs...)
 	}
 
 	var queuedApplicationUplinks []*ttnpb.ApplicationUp
@@ -960,7 +960,7 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 			}
 
 			queuedApplicationUplinks = append(queuedApplicationUplinks, matched.QueuedApplicationUplinks...)
-			queuedEvents = append(queuedEvents, events.ApplyDefinitionDataClosures(ctx, matched.Device.EndDeviceIdentifiers, matched.QueuedEventClosures...)...)
+			queuedEvents = append(queuedEvents, matched.QueuedEventBuilders.New(ctx, events.WithIdentifiers(matched.Device.EndDeviceIdentifiers))...)
 
 			stored = matched.Device
 			paths := ttnpb.AddFields(matched.SetPaths,
@@ -1023,7 +1023,7 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 			},
 		})
 	}
-	queuedEvents = append(queuedEvents, evtProcessDataUplink(ctx, matched.Device.EndDeviceIdentifiers, up))
+	queuedEvents = append(queuedEvents, evtProcessDataUplink.NewWithIdentifiersAndData(ctx, matched.Device.EndDeviceIdentifiers, up))
 	registerProcessUplink(ctx, up)
 	return nil
 }
@@ -1050,29 +1050,29 @@ func (ns *NetworkServer) sendJoinRequest(ctx context.Context, ids ttnpb.EndDevic
 			logger.WithError(err).Error("Join Server peer connection lookup failed")
 		}
 	} else {
-		queuedEvents = append(queuedEvents, evtClusterJoinAttempt(ctx, ids, req))
+		queuedEvents = append(queuedEvents, evtClusterJoinAttempt.NewWithIdentifiersAndData(ctx, ids, req))
 		resp, err := ttnpb.NewNsJsClient(cc).HandleJoin(ctx, req, ns.WithClusterAuth())
 		if err == nil {
 			logger.Debug("Join-request accepted by cluster-local Join Server")
-			queuedEvents = append(queuedEvents, evtClusterJoinSuccess(ctx, ids, joinResponseWithoutKeys(resp)))
+			queuedEvents = append(queuedEvents, evtClusterJoinSuccess.NewWithIdentifiersAndData(ctx, ids, joinResponseWithoutKeys(resp)))
 			return resp, queuedEvents, nil
 		}
 		logger.WithError(err).Info("Cluster-local Join Server did not accept join-request")
-		queuedEvents = append(queuedEvents, evtClusterJoinFail(ctx, ids, err))
+		queuedEvents = append(queuedEvents, evtClusterJoinFail.NewWithIdentifiersAndData(ctx, ids, err))
 		if !errors.IsNotFound(err) {
 			return nil, queuedEvents, err
 		}
 	}
 	if ns.interopClient != nil {
-		queuedEvents = append(queuedEvents, evtInteropJoinAttempt(ctx, ids, req))
+		queuedEvents = append(queuedEvents, evtInteropJoinAttempt.NewWithIdentifiersAndData(ctx, ids, req))
 		resp, err := ns.interopClient.HandleJoinRequest(ctx, ns.netID, req)
 		if err == nil {
 			logger.Debug("Join-request accepted by interop Join Server")
-			queuedEvents = append(queuedEvents, evtInteropJoinSuccess(ctx, ids, joinResponseWithoutKeys(resp)))
+			queuedEvents = append(queuedEvents, evtInteropJoinSuccess.NewWithIdentifiersAndData(ctx, ids, joinResponseWithoutKeys(resp)))
 			return resp, queuedEvents, nil
 		}
 		logger.WithError(err).Warn("Interop Join Server did not accept join-request")
-		queuedEvents = append(queuedEvents, evtInteropJoinFail(ctx, ids, err))
+		queuedEvents = append(queuedEvents, evtInteropJoinFail.NewWithIdentifiersAndData(ctx, ids, err))
 		if !errors.IsNotFound(err) {
 			return nil, queuedEvents, err
 		}
@@ -1111,18 +1111,18 @@ func (ns *NetworkServer) handleJoinRequest(ctx context.Context, up *ttnpb.Uplink
 	ctx = log.NewContextWithField(ctx, "device_uid", unique.ID(ctx, matched.EndDeviceIdentifiers))
 
 	queuedEvents := []events.Event{
-		evtReceiveJoinRequest(ctx, matched.EndDeviceIdentifiers, up),
+		evtReceiveJoinRequest.NewWithIdentifiersAndData(ctx, matched.EndDeviceIdentifiers, up),
 	}
 	defer func() {
 		if err != nil {
-			queuedEvents = append(queuedEvents, evtDropJoinRequest(ctx, matched.EndDeviceIdentifiers, err))
+			queuedEvents = append(queuedEvents, evtDropJoinRequest.NewWithIdentifiersAndData(ctx, matched.EndDeviceIdentifiers, err))
 		}
 		publishEvents(ctx, queuedEvents...)
 	}()
 
 	if !matched.SupportsJoin {
 		log.FromContext(ctx).Warn("ABP device sent a join-request, drop")
-		queuedEvents = append(queuedEvents, evtDropJoinRequest(ctx, matched.EndDeviceIdentifiers, errABPJoinRequest))
+		queuedEvents = append(queuedEvents, evtDropJoinRequest.NewWithIdentifiersAndData(ctx, matched.EndDeviceIdentifiers, errABPJoinRequest))
 		return nil
 	}
 
@@ -1159,7 +1159,7 @@ func (ns *NetworkServer) handleJoinRequest(ctx context.Context, up *ttnpb.Uplink
 		return err
 	}
 	if !ok {
-		queuedEvents = append(queuedEvents, evtDropJoinRequest(ctx, matched.EndDeviceIdentifiers, errDuplicate))
+		queuedEvents = append(queuedEvents, evtDropJoinRequest.NewWithIdentifiersAndData(ctx, matched.EndDeviceIdentifiers, errDuplicate))
 		registerReceiveDuplicateUplink(ctx, up)
 		return nil
 	}
@@ -1281,7 +1281,7 @@ func (ns *NetworkServer) handleJoinRequest(ctx context.Context, up *ttnpb.Uplink
 			},
 		},
 	})
-	queuedEvents = append(queuedEvents, evtProcessJoinRequest(ctx, matched.EndDeviceIdentifiers, up))
+	queuedEvents = append(queuedEvents, evtProcessJoinRequest.NewWithIdentifiersAndData(ctx, matched.EndDeviceIdentifiers, up))
 	registerProcessUplink(ctx, up)
 	return nil
 }

--- a/pkg/networkserver/grpc_gsns_internal_test.go
+++ b/pkg/networkserver/grpc_gsns_internal_test.go
@@ -164,7 +164,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 			}
 		}
 		makeIdentifiers := func() ttnpb.EndDeviceIdentifiers { return *MakeABPIdentifiers(macVersion.RequireDevEUIForABP()) }
-		makeNilEvents := func(bool) []events.DefinitionDataClosure { return nil }
+		makeNilEvents := func(bool) events.Builders { return nil }
 
 		type devConfig struct {
 			Name   string
@@ -176,7 +176,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 			NbTrans                  uint32
 			Pending                  bool
 			ApplyDeviceDiff          func(deduplicated bool, dev *ttnpb.EndDevice) *ttnpb.EndDevice
-			MakeQueuedEvents         func(deduplicated bool) []events.DefinitionDataClosure
+			MakeQueuedEvents         func(deduplicated bool) events.Builders
 			QueuedApplicationUplinks []*ttnpb.ApplicationUp
 			SetPaths                 []string
 		}
@@ -467,9 +467,9 @@ func TestMatchAndHandleUplink(t *testing.T) {
 						dev.MACState.RxWindowsAvailable = true
 						return dev
 					},
-					MakeQueuedEvents: func(deduplicated bool) []events.DefinitionDataClosure {
+					MakeQueuedEvents: func(deduplicated bool) events.Builders {
 						if deduplicated {
-							return []events.DefinitionDataClosure{
+							return events.Builders{
 								evtReceiveLinkCheckRequest.BindData(nil),
 								evtReceivePingSlotInfoRequest.BindData(pingSlotInfoReq),
 								evtEnqueuePingSlotInfoAnswer.BindData(nil),
@@ -477,7 +477,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 								evtEnqueueDeviceTimeAnswer.BindData(deviceTimeAns),
 							}
 						}
-						return []events.DefinitionDataClosure{
+						return events.Builders{
 							evtReceivePingSlotInfoRequest.BindData(pingSlotInfoReq),
 							evtEnqueuePingSlotInfoAnswer.BindData(nil),
 							evtReceiveDeviceTimeRequest.BindData(nil),
@@ -527,9 +527,9 @@ func TestMatchAndHandleUplink(t *testing.T) {
 						dev.Session.StartedAt = upRecvAt
 						return dev
 					},
-					MakeQueuedEvents: func(deduplicated bool) []events.DefinitionDataClosure {
+					MakeQueuedEvents: func(deduplicated bool) events.Builders {
 						if deduplicated {
-							return []events.DefinitionDataClosure{
+							return events.Builders{
 								evtReceiveLinkCheckRequest.BindData(nil),
 								evtReceivePingSlotInfoRequest.BindData(pingSlotInfoReq),
 								evtEnqueuePingSlotInfoAnswer.BindData(nil),
@@ -537,7 +537,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 								evtEnqueueDeviceTimeAnswer.BindData(deviceTimeAns),
 							}
 						}
-						return []events.DefinitionDataClosure{
+						return events.Builders{
 							evtReceivePingSlotInfoRequest.BindData(pingSlotInfoReq),
 							evtEnqueuePingSlotInfoAnswer.BindData(nil),
 							evtReceiveDeviceTimeRequest.BindData(nil),
@@ -588,9 +588,9 @@ func TestMatchAndHandleUplink(t *testing.T) {
 						dev.Session.StartedAt = upRecvAt
 						return dev
 					},
-					MakeQueuedEvents: func(deduplicated bool) []events.DefinitionDataClosure {
+					MakeQueuedEvents: func(deduplicated bool) events.Builders {
 						if deduplicated {
-							return []events.DefinitionDataClosure{
+							return events.Builders{
 								evtReceiveLinkCheckRequest.BindData(nil),
 								evtReceivePingSlotInfoRequest.BindData(pingSlotInfoReq),
 								evtEnqueuePingSlotInfoAnswer.BindData(nil),
@@ -598,7 +598,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 								evtEnqueueDeviceTimeAnswer.BindData(deviceTimeAns),
 							}
 						}
-						return []events.DefinitionDataClosure{
+						return events.Builders{
 							evtReceivePingSlotInfoRequest.BindData(pingSlotInfoReq),
 							evtEnqueuePingSlotInfoAnswer.BindData(nil),
 							evtReceiveDeviceTimeRequest.BindData(nil),
@@ -666,8 +666,8 @@ func TestMatchAndHandleUplink(t *testing.T) {
 						dev.MACState.RxWindowsAvailable = true
 						return dev
 					},
-					MakeQueuedEvents: func(bool) []events.DefinitionDataClosure {
-						return []events.DefinitionDataClosure{
+					MakeQueuedEvents: func(bool) events.Builders {
+						return events.Builders{
 							evtReceivePingSlotInfoRequest.BindData(pingSlotInfoReq),
 							evtEnqueuePingSlotInfoAnswer.BindData(nil),
 						}
@@ -717,8 +717,8 @@ func TestMatchAndHandleUplink(t *testing.T) {
 							},
 						},
 					},
-					MakeQueuedEvents: func(bool) []events.DefinitionDataClosure {
-						return []events.DefinitionDataClosure{
+					MakeQueuedEvents: func(bool) events.Builders {
+						return events.Builders{
 							evtReceivePingSlotInfoRequest.BindData(pingSlotInfoReq),
 							evtEnqueuePingSlotInfoAnswer.BindData(nil),
 						}
@@ -835,8 +835,8 @@ func TestMatchAndHandleUplink(t *testing.T) {
 						dev.MACState.RxWindowsAvailable = true
 						return dev
 					},
-					MakeQueuedEvents: func(bool) []events.DefinitionDataClosure {
-						return []events.DefinitionDataClosure{
+					MakeQueuedEvents: func(bool) events.Builders {
+						return events.Builders{
 							evtClassBSwitch.BindData(ttnpb.CLASS_A),
 						}
 					},
@@ -1097,7 +1097,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 						matched.phy = band.Band{} // band.Band cannot be compared with neither should.Resemble, nor should.Equal.
 						if !a.So(test.AllTrue(
 							a.So(matched.SetPaths, should.HaveSameElementsDeep, devConf.SetPaths),
-							a.So(matched.QueuedEventClosures, should.ResembleEventDefinitionDataClosures, devConf.MakeQueuedEvents(deduplicated)),
+							a.So(matched.QueuedEventBuilders, should.ResembleEventBuilders, devConf.MakeQueuedEvents(deduplicated)),
 							a.So(matched, should.Resemble, &matchedDevice{
 								ChannelIndex:             chIdx,
 								DataRateIndex:            drIdx,
@@ -1108,7 +1108,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 								NbTrans:                  devConf.NbTrans,
 								Pending:                  devConf.Pending,
 								QueuedApplicationUplinks: devConf.QueuedApplicationUplinks,
-								QueuedEventClosures:      matched.QueuedEventClosures,
+								QueuedEventBuilders:      matched.QueuedEventBuilders,
 								SetPaths:                 matched.SetPaths,
 							}),
 						), should.BeTrue) {
@@ -1118,7 +1118,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 						if deduplicated || len(matched.DeferredMACHandlers) == 0 {
 							return true
 						}
-						queuedEvents := matched.QueuedEventClosures
+						queuedEvents := matched.QueuedEventBuilders
 						for _, f := range matched.DeferredMACHandlers {
 							evs, err := f(matched.Context, matched.Device, CopyUplinkMessage(up))
 							if !a.So(err, should.BeNil) {
@@ -1127,7 +1127,7 @@ func TestMatchAndHandleUplink(t *testing.T) {
 							queuedEvents = append(queuedEvents, evs...)
 						}
 						return test.AllTrue(
-							a.So(queuedEvents, should.HaveSameElementsFunc, test.EventDefinitionDataClosureEqual, devConf.MakeQueuedEvents(true)),
+							a.So(queuedEvents, should.HaveSameElementsFunc, test.EventBuilderEqual, devConf.MakeQueuedEvents(true)),
 							a.So(matched.Device, should.Resemble, devConf.ApplyDeviceDiff(true, CopyEndDevice(devConf.Device))),
 						)
 					}

--- a/pkg/networkserver/grpc_gsns_test.go
+++ b/pkg/networkserver/grpc_gsns_test.go
@@ -764,8 +764,8 @@ func TestHandleUplink(t *testing.T) {
 							return a.So(test.AllTrue(
 								ok,
 								a.So(env.Events, should.ReceiveEventsResembling,
-									EvtReceiveJoinRequest(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
-									EvtDropJoinRequest(getCtx, getDevice.EndDeviceIdentifiers, ErrABPJoinRequest),
+									EvtReceiveJoinRequest.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
+									EvtDropJoinRequest.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, ErrABPJoinRequest),
 								),
 							), should.BeTrue)
 						}, nil), should.BeTrue)
@@ -784,8 +784,8 @@ func TestHandleUplink(t *testing.T) {
 							return a.So(test.AllTrue(
 								ok,
 								a.So(env.Events, should.ReceiveEventsResembling,
-									EvtReceiveJoinRequest(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
-									EvtDropJoinRequest(getCtx, getDevice.EndDeviceIdentifiers, ErrTestInternal),
+									EvtReceiveJoinRequest.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
+									EvtDropJoinRequest.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, ErrTestInternal),
 								),
 							), should.BeTrue)
 						}, ErrTestInternal), should.BeTrue)
@@ -804,8 +804,8 @@ func TestHandleUplink(t *testing.T) {
 							return a.So(test.AllTrue(
 								ok,
 								a.So(env.Events, should.ReceiveEventsResembling,
-									EvtReceiveJoinRequest(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
-									EvtDropJoinRequest(getCtx, getDevice.EndDeviceIdentifiers, ErrDuplicate),
+									EvtReceiveJoinRequest.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
+									EvtDropJoinRequest.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, ErrDuplicate),
 								),
 							), should.BeTrue)
 						}, nil), should.BeTrue)
@@ -825,12 +825,12 @@ func TestHandleUplink(t *testing.T) {
 							return a.So(test.AllTrue(
 								ok,
 								a.So(env.Events, should.ReceiveEventsResembling,
-									EvtReceiveJoinRequest(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
-									EvtClusterJoinAttempt(getCtx, getDevice.EndDeviceIdentifiers, joinReq),
+									EvtReceiveJoinRequest.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
+									EvtClusterJoinAttempt.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, joinReq),
 								),
 								a.So(env.Events, should.ReceiveEventsFunc, eventRPCErrorEqual,
-									EvtClusterJoinFail(getCtx, getDevice.EndDeviceIdentifiers, ErrTestInternal),
-									EvtDropJoinRequest(getCtx, getDevice.EndDeviceIdentifiers, ErrTestInternal),
+									EvtClusterJoinFail.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, ErrTestInternal),
+									EvtDropJoinRequest.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, ErrTestInternal),
 								),
 							), should.BeTrue)
 						}, ErrTestInternal), should.BeTrue)
@@ -850,12 +850,12 @@ func TestHandleUplink(t *testing.T) {
 							return a.So(test.AllTrue(
 								ok,
 								a.So(env.Events, should.ReceiveEventsResembling,
-									EvtReceiveJoinRequest(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
-									EvtInteropJoinAttempt(getCtx, getDevice.EndDeviceIdentifiers, joinReq),
+									EvtReceiveJoinRequest.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
+									EvtInteropJoinAttempt.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, joinReq),
 								),
 								a.So(env.Events, should.ReceiveEventsFunc, eventRPCErrorEqual,
-									EvtInteropJoinFail(getCtx, getDevice.EndDeviceIdentifiers, ErrTestInternal),
-									EvtDropJoinRequest(getCtx, getDevice.EndDeviceIdentifiers, ErrTestInternal),
+									EvtInteropJoinFail.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, ErrTestInternal),
+									EvtDropJoinRequest.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, ErrTestInternal),
 								),
 							), should.BeTrue)
 						}, ErrTestInternal), should.BeTrue)
@@ -883,13 +883,13 @@ func TestHandleUplink(t *testing.T) {
 							return a.So(test.AllTrue(
 								ok,
 								a.So(env.Events, should.ReceiveEventsResembling,
-									EvtReceiveJoinRequest(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
-									EvtClusterJoinAttempt(getCtx, getDevice.EndDeviceIdentifiers, joinReq),
+									EvtReceiveJoinRequest.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
+									EvtClusterJoinAttempt.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, joinReq),
 								),
-								a.So(env.Events, should.ReceiveEventFunc, eventRPCErrorEqual, EvtClusterJoinFail(getCtx, getDevice.EndDeviceIdentifiers, ErrTestNotFound)),
+								a.So(env.Events, should.ReceiveEventFunc, eventRPCErrorEqual, EvtClusterJoinFail.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, ErrTestNotFound)),
 								a.So(env.Events, should.ReceiveEventsResembling,
-									EvtInteropJoinAttempt(getCtx, getDevice.EndDeviceIdentifiers, joinReq),
-									EvtInteropJoinSuccess(getCtx, getDevice.EndDeviceIdentifiers, JoinResponseWithoutKeys(joinResp)),
+									EvtInteropJoinAttempt.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, joinReq),
+									EvtInteropJoinSuccess.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, JoinResponseWithoutKeys(joinResp)),
 								),
 								assertAccumulatedMetadata(ctx, env, getCtx, decodedMsg, nil, ErrTestInternal),
 								AssertDeviceRegistrySetByID(ctx, env.DeviceRegistry.SetByID, func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) bool {
@@ -905,7 +905,7 @@ func TestHandleUplink(t *testing.T) {
 									}
 								}),
 								a.So(env.Events, should.ReceiveEventResembling,
-									EvtDropJoinRequest(getCtx, getDevice.EndDeviceIdentifiers, ErrTestInternal),
+									EvtDropJoinRequest.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, ErrTestInternal),
 								),
 							), should.BeTrue)
 						}, ErrTestInternal), should.BeTrue)
@@ -935,13 +935,13 @@ func TestHandleUplink(t *testing.T) {
 							if !a.So(test.AllTrue(
 								ok,
 								a.So(env.Events, should.ReceiveEventsResembling,
-									EvtReceiveJoinRequest(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
-									EvtClusterJoinAttempt(getCtx, getDevice.EndDeviceIdentifiers, joinReq),
+									EvtReceiveJoinRequest.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
+									EvtClusterJoinAttempt.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, joinReq),
 								),
-								a.So(env.Events, should.ReceiveEventFunc, eventRPCErrorEqual, EvtClusterJoinFail(getCtx, getDevice.EndDeviceIdentifiers, ErrTestNotFound)),
+								a.So(env.Events, should.ReceiveEventFunc, eventRPCErrorEqual, EvtClusterJoinFail.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, ErrTestNotFound)),
 								a.So(env.Events, should.ReceiveEventsResembling,
-									EvtInteropJoinAttempt(getCtx, getDevice.EndDeviceIdentifiers, joinReq),
-									EvtInteropJoinSuccess(getCtx, getDevice.EndDeviceIdentifiers, JoinResponseWithoutKeys(joinResp)),
+									EvtInteropJoinAttempt.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, joinReq),
+									EvtInteropJoinSuccess.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, JoinResponseWithoutKeys(joinResp)),
 								),
 								assertAccumulatedMetadata(ctx, env, getCtx, decodedMsg, nil, ErrTestInternal),
 							), should.BeTrue) {
@@ -951,7 +951,7 @@ func TestHandleUplink(t *testing.T) {
 							return a.So(test.AllTrue(
 								ok,
 								a.So(env.Events, should.ReceiveEventResembling,
-									EvtDropJoinRequest(getCtx, getDevice.EndDeviceIdentifiers, registryErr),
+									EvtDropJoinRequest.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, registryErr),
 								),
 							), should.BeTrue)
 						}, registryErr), should.BeTrue)
@@ -979,13 +979,13 @@ func TestHandleUplink(t *testing.T) {
 							if !a.So(test.AllTrue(
 								ok,
 								a.So(env.Events, should.ReceiveEventsResembling,
-									EvtReceiveJoinRequest(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
-									EvtClusterJoinAttempt(getCtx, getDevice.EndDeviceIdentifiers, joinReq),
+									EvtReceiveJoinRequest.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
+									EvtClusterJoinAttempt.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, joinReq),
 								),
-								a.So(env.Events, should.ReceiveEventFunc, eventRPCErrorEqual, EvtClusterJoinFail(getCtx, getDevice.EndDeviceIdentifiers, ErrTestNotFound)),
+								a.So(env.Events, should.ReceiveEventFunc, eventRPCErrorEqual, EvtClusterJoinFail.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, ErrTestNotFound)),
 								a.So(env.Events, should.ReceiveEventsResembling,
-									EvtInteropJoinAttempt(getCtx, getDevice.EndDeviceIdentifiers, joinReq),
-									EvtInteropJoinSuccess(getCtx, getDevice.EndDeviceIdentifiers, JoinResponseWithoutKeys(joinResp)),
+									EvtInteropJoinAttempt.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, joinReq),
+									EvtInteropJoinSuccess.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, JoinResponseWithoutKeys(joinResp)),
 								),
 								assertAccumulatedMetadata(ctx, env, getCtx, decodedMsg, nil, ErrTestInternal),
 							), should.BeTrue) {
@@ -995,7 +995,7 @@ func TestHandleUplink(t *testing.T) {
 							return a.So(test.AllTrue(
 								ok,
 								a.So(env.Events, should.ReceiveEventResembling,
-									EvtDropJoinRequest(getCtx, getDevice.EndDeviceIdentifiers, ErrTestInternal),
+									EvtDropJoinRequest.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, ErrTestInternal),
 								),
 							), should.BeTrue)
 						}, ErrTestInternal), should.BeTrue)
@@ -1023,13 +1023,13 @@ func TestHandleUplink(t *testing.T) {
 							if !a.So(test.AllTrue(
 								ok,
 								a.So(env.Events, should.ReceiveEventsResembling,
-									EvtReceiveJoinRequest(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
-									EvtClusterJoinAttempt(getCtx, getDevice.EndDeviceIdentifiers, joinReq),
+									EvtReceiveJoinRequest.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
+									EvtClusterJoinAttempt.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, joinReq),
 								),
-								a.So(env.Events, should.ReceiveEventFunc, eventRPCErrorEqual, EvtClusterJoinFail(getCtx, getDevice.EndDeviceIdentifiers, ErrTestNotFound)),
+								a.So(env.Events, should.ReceiveEventFunc, eventRPCErrorEqual, EvtClusterJoinFail.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, ErrTestNotFound)),
 								a.So(env.Events, should.ReceiveEventsResembling,
-									EvtInteropJoinAttempt(getCtx, getDevice.EndDeviceIdentifiers, joinReq),
-									EvtInteropJoinSuccess(getCtx, getDevice.EndDeviceIdentifiers, JoinResponseWithoutKeys(joinResp)),
+									EvtInteropJoinAttempt.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, joinReq),
+									EvtInteropJoinSuccess.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, JoinResponseWithoutKeys(joinResp)),
 								),
 								assertAccumulatedMetadata(ctx, env, getCtx, decodedMsg, nil, ErrTestInternal),
 							), should.BeTrue) {
@@ -1044,7 +1044,7 @@ func TestHandleUplink(t *testing.T) {
 								assertDownlinkTaskAdd(ctx, env, setCtx, setDevice.EndDeviceIdentifiers, decodedMsg.ReceivedAt.Add(-InfrastructureDelay/2+phy.JoinAcceptDelay1-joinReq.RxDelay.Duration()/2-NSScheduleWindow()), true, nil),
 								assertJoinApplicationUp(ctx, env, setCtx, setDevice, joinResp, joinRespRecvAt, nil),
 								a.So(env.Events, should.ReceiveEventResembling,
-									EvtProcessJoinRequest(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
+									EvtProcessJoinRequest.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
 								),
 							)
 						}, nil), should.BeTrue)
@@ -1071,9 +1071,9 @@ func TestHandleUplink(t *testing.T) {
 							if !a.So(test.AllTrue(
 								ok,
 								a.So(env.Events, should.ReceiveEventsResembling,
-									EvtReceiveJoinRequest(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
-									EvtClusterJoinAttempt(getCtx, getDevice.EndDeviceIdentifiers, joinReq),
-									EvtClusterJoinSuccess(getCtx, getDevice.EndDeviceIdentifiers, JoinResponseWithoutKeys(joinResp)),
+									EvtReceiveJoinRequest.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
+									EvtClusterJoinAttempt.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, joinReq),
+									EvtClusterJoinSuccess.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, JoinResponseWithoutKeys(joinResp)),
 								),
 								assertAccumulatedMetadata(ctx, env, getCtx, decodedMsg, RxMetadata[:], nil),
 							), should.BeTrue) {
@@ -1089,7 +1089,7 @@ func TestHandleUplink(t *testing.T) {
 								assertDownlinkTaskAdd(ctx, env, setCtx, setDevice.EndDeviceIdentifiers, decodedMsg.ReceivedAt.Add(-InfrastructureDelay/2+phy.JoinAcceptDelay1-joinReq.RxDelay.Duration()/2-NSScheduleWindow()), true, ErrTestInternal),
 								assertJoinApplicationUp(ctx, env, setCtx, setDevice, joinResp, joinRespRecvAt, ErrTestInternal),
 								a.So(env.Events, should.ReceiveEventResembling,
-									EvtProcessJoinRequest(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
+									EvtProcessJoinRequest.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
 								),
 							), should.BeTrue)
 						}, nil), should.BeTrue)
@@ -1125,9 +1125,9 @@ func TestHandleUplink(t *testing.T) {
 							if !a.So(test.AllTrue(
 								ok,
 								a.So(env.Events, should.ReceiveEventsResembling,
-									EvtReceiveJoinRequest(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
-									EvtClusterJoinAttempt(getCtx, getDevice.EndDeviceIdentifiers, joinReq),
-									EvtClusterJoinSuccess(getCtx, getDevice.EndDeviceIdentifiers, JoinResponseWithoutKeys(joinResp)),
+									EvtReceiveJoinRequest.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
+									EvtClusterJoinAttempt.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, joinReq),
+									EvtClusterJoinSuccess.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, JoinResponseWithoutKeys(joinResp)),
 								),
 								assertAccumulatedMetadata(ctx, env, getCtx, decodedMsg, RxMetadata[:], nil),
 							), should.BeTrue) {
@@ -1143,7 +1143,7 @@ func TestHandleUplink(t *testing.T) {
 								assertDownlinkTaskAdd(ctx, env, setCtx, setDevice.EndDeviceIdentifiers, decodedMsg.ReceivedAt.Add(-InfrastructureDelay/2+phy.JoinAcceptDelay1-joinReq.RxDelay.Duration()/2-NSScheduleWindow()), true, nil),
 								assertJoinApplicationUp(ctx, env, setCtx, setDevice, joinResp, joinRespRecvAt, ErrTestInternal),
 								a.So(env.Events, should.ReceiveEventResembling,
-									EvtProcessJoinRequest(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
+									EvtProcessJoinRequest.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
 								),
 							), should.BeTrue)
 						}, nil), should.BeTrue)
@@ -1164,9 +1164,9 @@ func TestHandleUplink(t *testing.T) {
 							if !a.So(test.AllTrue(
 								ok,
 								a.So(env.Events, should.ReceiveEventsResembling,
-									EvtReceiveJoinRequest(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
-									EvtClusterJoinAttempt(getCtx, getDevice.EndDeviceIdentifiers, joinReq),
-									EvtClusterJoinSuccess(getCtx, getDevice.EndDeviceIdentifiers, JoinResponseWithoutKeys(joinResp)),
+									EvtReceiveJoinRequest.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, decodedMsg),
+									EvtClusterJoinAttempt.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, joinReq),
+									EvtClusterJoinSuccess.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, JoinResponseWithoutKeys(joinResp)),
 								),
 								assertAccumulatedMetadata(ctx, env, getCtx, decodedMsg, RxMetadata[:], nil),
 							), should.BeTrue) {
@@ -1178,7 +1178,7 @@ func TestHandleUplink(t *testing.T) {
 							return a.So(test.AllTrue(
 								ok,
 								a.So(env.Events, should.ReceiveEventResembling,
-									EvtDropJoinRequest(getCtx, getDevice.EndDeviceIdentifiers, ErrTestInternal),
+									EvtDropJoinRequest.NewWithIdentifiersAndData(getCtx, getDevice.EndDeviceIdentifiers, ErrTestInternal),
 								),
 							), should.BeTrue)
 						}, ErrTestInternal), should.BeTrue)
@@ -1365,10 +1365,10 @@ func TestHandleUplink(t *testing.T) {
 					"recent_uplinks",
 					"session",
 				}
-				makeDataSetDevice := func(ctx context.Context, getDevice *ttnpb.EndDevice, decodedMsg *ttnpb.UplinkMessage) (*ttnpb.EndDevice, []events.DefinitionDataClosure) {
+				makeDataSetDevice := func(ctx context.Context, getDevice *ttnpb.EndDevice, decodedMsg *ttnpb.UplinkMessage) (*ttnpb.EndDevice, events.Builders) {
 					setDevice := CopyEndDevice(getDevice)
 					setDevice.MACState.QueuedResponses = nil
-					evs := test.Must(HandleLinkCheckReq(test.Context(), setDevice, decodedMsg)).([]events.DefinitionDataClosure)
+					evs := test.Must(HandleLinkCheckReq(test.Context(), setDevice, decodedMsg)).(events.Builders)
 					setDevice.MACState.RecentUplinks = AppendRecentUplink(setDevice.MACState.RecentUplinks, WithMatchedUplinkSettings(decodedMsg, chIdx, drIdx), RecentUplinkCount)
 					setDevice.MACState.RxWindowsAvailable = true
 					setDevice.RecentUplinks = AppendRecentUplink(setDevice.RecentUplinks, WithMatchedUplinkSettings(decodedMsg, chIdx, drIdx), RecentUplinkCount)
@@ -1491,8 +1491,8 @@ func TestHandleUplink(t *testing.T) {
 									return a.So(test.AllTrue(
 										ok,
 										a.So(env.Events, should.ReceiveEventsResembling,
-											EvtReceiveDataUplink(rangeCtx, rangeDevices[matchIdx].EndDeviceIdentifiers, decodedMsg),
-											EvtDropDataUplink(rangeCtx, rangeDevices[matchIdx].EndDeviceIdentifiers, ErrTestInternal),
+											EvtReceiveDataUplink.NewWithIdentifiersAndData(rangeCtx, rangeDevices[matchIdx].EndDeviceIdentifiers, decodedMsg),
+											EvtDropDataUplink.NewWithIdentifiersAndData(rangeCtx, rangeDevices[matchIdx].EndDeviceIdentifiers, ErrTestInternal),
 										),
 									), should.BeTrue)
 								}, ErrTestInternal), should.BeTrue)
@@ -1511,8 +1511,8 @@ func TestHandleUplink(t *testing.T) {
 									return a.So(test.AllTrue(
 										ok,
 										a.So(env.Events, should.ReceiveEventsResembling,
-											EvtReceiveDataUplink(rangeCtx, rangeDevices[matchIdx].EndDeviceIdentifiers, decodedMsg),
-											EvtDropDataUplink(rangeCtx, rangeDevices[matchIdx].EndDeviceIdentifiers, ErrDuplicate),
+											EvtReceiveDataUplink.NewWithIdentifiersAndData(rangeCtx, rangeDevices[matchIdx].EndDeviceIdentifiers, decodedMsg),
+											EvtDropDataUplink.NewWithIdentifiersAndData(rangeCtx, rangeDevices[matchIdx].EndDeviceIdentifiers, ErrDuplicate),
 										),
 									), should.BeTrue)
 								}, nil), should.BeTrue)
@@ -1531,7 +1531,7 @@ func TestHandleUplink(t *testing.T) {
 									return a.So(test.AllTrue(
 										ok,
 										a.So(env.Events, should.ReceiveEventResembling,
-											EvtReceiveDataUplink(rangeCtx, rangeDevices[matchIdx].EndDeviceIdentifiers, decodedMsg),
+											EvtReceiveDataUplink.NewWithIdentifiersAndData(rangeCtx, rangeDevices[matchIdx].EndDeviceIdentifiers, decodedMsg),
 										),
 										assertAccumulatedMetadata(ctx, env, rangeCtx, decodedMsg, nil, ErrTestInternal),
 										AssertDeviceRegistrySetByID(ctx, env.DeviceRegistry.SetByID, func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) bool {
@@ -1547,7 +1547,7 @@ func TestHandleUplink(t *testing.T) {
 											}
 										}),
 										a.So(env.Events, should.ReceiveEventResembling,
-											EvtDropDataUplink(rangeCtx, rangeDevices[matchIdx].EndDeviceIdentifiers, ErrTestInternal),
+											EvtDropDataUplink.NewWithIdentifiersAndData(rangeCtx, rangeDevices[matchIdx].EndDeviceIdentifiers, ErrTestInternal),
 										),
 									), should.BeTrue)
 								}, ErrTestInternal), should.BeTrue)
@@ -1568,7 +1568,7 @@ func TestHandleUplink(t *testing.T) {
 									if !a.So(test.AllTrue(
 										ok,
 										a.So(env.Events, should.ReceiveEventResembling,
-											EvtReceiveDataUplink(rangeCtx, rangeDevices[matchIdx].EndDeviceIdentifiers, decodedMsg),
+											EvtReceiveDataUplink.NewWithIdentifiersAndData(rangeCtx, rangeDevices[matchIdx].EndDeviceIdentifiers, decodedMsg),
 										),
 										assertAccumulatedMetadata(ctx, env, rangeCtx, decodedMsg, RxMetadata[:], nil),
 									), should.BeTrue) {
@@ -1579,7 +1579,7 @@ func TestHandleUplink(t *testing.T) {
 									return a.So(test.AllTrue(
 										ok,
 										a.So(env.Events, should.ReceiveEventResembling,
-											EvtDropDataUplink(rangeCtx, rangeDevices[matchIdx].EndDeviceIdentifiers, registryErr),
+											EvtDropDataUplink.NewWithIdentifiersAndData(rangeCtx, rangeDevices[matchIdx].EndDeviceIdentifiers, registryErr),
 										),
 									), should.BeTrue)
 								}, registryErr), should.BeTrue)
@@ -1600,7 +1600,7 @@ func TestHandleUplink(t *testing.T) {
 									if !a.So(test.AllTrue(
 										ok,
 										a.So(env.Events, should.ReceiveEventResembling,
-											EvtReceiveDataUplink(rangeCtx, rangeDevices[matchIdx].EndDeviceIdentifiers, decodedMsg),
+											EvtReceiveDataUplink.NewWithIdentifiersAndData(rangeCtx, rangeDevices[matchIdx].EndDeviceIdentifiers, decodedMsg),
 										),
 										assertAccumulatedMetadata(ctx, env, rangeCtx, decodedMsg, RxMetadata[:], nil),
 									), should.BeTrue) {
@@ -1615,7 +1615,7 @@ func TestHandleUplink(t *testing.T) {
 									return a.So(test.AllTrue(
 										ok,
 										a.So(env.Events, should.ReceiveEventResembling,
-											EvtDropDataUplink(rangeCtx, rangeDevices[matchIdx].EndDeviceIdentifiers, registryErr),
+											EvtDropDataUplink.NewWithIdentifiersAndData(rangeCtx, rangeDevices[matchIdx].EndDeviceIdentifiers, registryErr),
 										),
 									), should.BeTrue)
 								}, registryErr), should.BeTrue)
@@ -1634,7 +1634,7 @@ func TestHandleUplink(t *testing.T) {
 									if !a.So(test.AllTrue(
 										ok,
 										a.So(env.Events, should.ReceiveEventResembling,
-											EvtReceiveDataUplink(rangeCtx, rangeDevices[matchIdx].EndDeviceIdentifiers, decodedMsg),
+											EvtReceiveDataUplink.NewWithIdentifiersAndData(rangeCtx, rangeDevices[matchIdx].EndDeviceIdentifiers, decodedMsg),
 										),
 										assertAccumulatedMetadata(ctx, env, rangeCtx, decodedMsg, nil, ErrTestInternal),
 									), should.BeTrue) {
@@ -1654,8 +1654,8 @@ func TestHandleUplink(t *testing.T) {
 										}(),
 										assertDataApplicationUp(ctx, env, setCtx, setDevice, decodedMsg, ErrTestInternal),
 										a.So(env.Events, should.ReceiveEventsResembling,
-											events.ApplyDefinitionDataClosures(setCtx, setDevice.EndDeviceIdentifiers, macEvs...),
-											EvtProcessDataUplink(setCtx, setDevice.EndDeviceIdentifiers, decodedMsg),
+											macEvs.New(setCtx, events.WithIdentifiers(setDevice.EndDeviceIdentifiers)),
+											EvtProcessDataUplink.NewWithIdentifiersAndData(setCtx, setDevice.EndDeviceIdentifiers, decodedMsg),
 										),
 									), should.BeTrue)
 								}, nil), should.BeTrue)
@@ -1674,7 +1674,7 @@ func TestHandleUplink(t *testing.T) {
 									if !a.So(test.AllTrue(
 										ok,
 										a.So(env.Events, should.ReceiveEventResembling,
-											EvtReceiveDataUplink(rangeCtx, rangeDevices[matchIdx].EndDeviceIdentifiers, decodedMsg),
+											EvtReceiveDataUplink.NewWithIdentifiersAndData(rangeCtx, rangeDevices[matchIdx].EndDeviceIdentifiers, decodedMsg),
 										),
 										assertAccumulatedMetadata(ctx, env, rangeCtx, decodedMsg, RxMetadata[:], nil),
 									), should.BeTrue) {
@@ -1690,8 +1690,8 @@ func TestHandleUplink(t *testing.T) {
 										assertDownlinkTaskAdd(ctx, env, setCtx, setDevice.EndDeviceIdentifiers, clock.Now().Add(NSScheduleWindow()), true, nil),
 										assertDataApplicationUp(ctx, env, setCtx, setDevice, WithMatchedUplinkSettings(decodedMsg, chIdx, drIdx), nil),
 										a.So(env.Events, should.ReceiveEventsResembling,
-											events.ApplyDefinitionDataClosures(setCtx, setDevice.EndDeviceIdentifiers, macEvs...),
-											EvtProcessDataUplink(setCtx, setDevice.EndDeviceIdentifiers, decodedMsg),
+											macEvs.New(setCtx, events.WithIdentifiers(setDevice.EndDeviceIdentifiers)),
+											EvtProcessDataUplink.NewWithIdentifiersAndData(setCtx, setDevice.EndDeviceIdentifiers, decodedMsg),
 										),
 									), should.BeTrue)
 								}, nil), should.BeTrue)
@@ -1714,7 +1714,7 @@ func TestHandleUplink(t *testing.T) {
 									if !a.So(test.AllTrue(
 										ok,
 										a.So(env.Events, should.ReceiveEventResembling,
-											EvtReceiveDataUplink(rangeCtx, rangeDevices[matchIdx].EndDeviceIdentifiers, decodedMsg),
+											EvtReceiveDataUplink.NewWithIdentifiersAndData(rangeCtx, rangeDevices[matchIdx].EndDeviceIdentifiers, decodedMsg),
 										),
 										assertAccumulatedMetadata(ctx, env, rangeCtx, decodedMsg, RxMetadata[:], nil),
 									), should.BeTrue) {
@@ -1727,8 +1727,8 @@ func TestHandleUplink(t *testing.T) {
 										ok,
 										assertDownlinkTaskAdd(ctx, env, setCtx, setDevice.EndDeviceIdentifiers, clock.Now().Add(NSScheduleWindow()), true, ErrTestInternal),
 										a.So(env.Events, should.ReceiveEventsResembling,
-											events.ApplyDefinitionDataClosures(setCtx, setDevice.EndDeviceIdentifiers, macEvs...),
-											EvtProcessDataUplink(setCtx, setDevice.EndDeviceIdentifiers, decodedMsg),
+											macEvs.New(setCtx, events.WithIdentifiers(setDevice.EndDeviceIdentifiers)),
+											EvtProcessDataUplink.NewWithIdentifiersAndData(setCtx, setDevice.EndDeviceIdentifiers, decodedMsg),
 										),
 									), should.BeTrue)
 								}, nil), should.BeTrue)

--- a/pkg/networkserver/mac.go
+++ b/pkg/networkserver/mac.go
@@ -22,7 +22,7 @@ import (
 
 type macCommandEnqueueState struct {
 	MaxDownLen, MaxUpLen uint16
-	QueuedEvents         []events.DefinitionDataClosure
+	QueuedEvents         events.Builders
 	Ok                   bool
 }
 
@@ -30,7 +30,7 @@ type macCommandEnqueueState struct {
 // Arguments to f represent the amount of downlink and uplink messages respectively with CID cid which fit in byte limits maxDownLen and maxUpLen.
 // f returns a slice downlink commands to append to cmds, amount of uplinks to expect and bool indicating whether all commands fit.
 // enqueueMACCommand returns the resulting downlink MAC command slice, new value for maxDownLen, maxUpLen and bool indicating whether all commands fit.
-func enqueueMACCommand(cid ttnpb.MACCommandIdentifier, maxDownLen, maxUpLen uint16, f func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, []events.DefinitionDataClosure, bool), cmds ...*ttnpb.MACCommand) ([]*ttnpb.MACCommand, macCommandEnqueueState) {
+func enqueueMACCommand(cid ttnpb.MACCommandIdentifier, maxDownLen, maxUpLen uint16, f func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, events.Builders, bool), cmds ...*ttnpb.MACCommand) ([]*ttnpb.MACCommand, macCommandEnqueueState) {
 	desc := lorawan.DefaultMACCommands[cid]
 	maxDown := maxDownLen / (1 + desc.DownlinkLength)
 	maxUp := maxUpLen / (1 + desc.UplinkLength)

--- a/pkg/networkserver/mac_adr_param_setup.go
+++ b/pkg/networkserver/mac_adr_param_setup.go
@@ -78,7 +78,7 @@ func enqueueADRParamSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownL
 	}
 
 	var st macCommandEnqueueState
-	dev.MACState.PendingRequests, st = enqueueMACCommand(ttnpb.CID_ADR_PARAM_SETUP, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, []events.DefinitionDataClosure, bool) {
+	dev.MACState.PendingRequests, st = enqueueMACCommand(ttnpb.CID_ADR_PARAM_SETUP, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, events.Builders, bool) {
 		if nDown < 1 || nUp < 1 {
 			return nil, 0, nil, false
 		}
@@ -95,15 +95,15 @@ func enqueueADRParamSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownL
 				req.MACCommand(),
 			},
 			1,
-			[]events.DefinitionDataClosure{
-				evtEnqueueADRParamSetupRequest.BindData(req),
+			events.Builders{
+				evtEnqueueADRParamSetupRequest.With(events.WithData(req)),
 			},
 			true
 	}, dev.MACState.PendingRequests...)
 	return st
 }
 
-func handleADRParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice) ([]events.DefinitionDataClosure, error) {
+func handleADRParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice) (events.Builders, error) {
 	var err error
 	dev.MACState.PendingRequests, err = handleMACResponse(ttnpb.CID_ADR_PARAM_SETUP, func(cmd *ttnpb.MACCommand) error {
 		req := cmd.GetADRParamSetupReq()
@@ -113,7 +113,7 @@ func handleADRParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice) ([]events
 
 		return nil
 	}, dev.MACState.PendingRequests...)
-	return []events.DefinitionDataClosure{
-		evtReceiveADRParamSetupAnswer.BindData(nil),
+	return events.Builders{
+		evtReceiveADRParamSetupAnswer,
 	}, err
 }

--- a/pkg/networkserver/mac_adr_param_setup_test.go
+++ b/pkg/networkserver/mac_adr_param_setup_test.go
@@ -184,7 +184,7 @@ func TestHandleADRParamSetupAns(t *testing.T) {
 	for _, tc := range []struct {
 		Name             string
 		Device, Expected *ttnpb.EndDevice
-		Events           []events.DefinitionDataClosure
+		Events           events.Builders
 		Error            error
 	}{
 		{
@@ -195,8 +195,8 @@ func TestHandleADRParamSetupAns(t *testing.T) {
 			Expected: &ttnpb.EndDevice{
 				MACState: &ttnpb.MACState{},
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveADRParamSetupAnswer.BindData(nil),
+			Events: events.Builders{
+				evtReceiveADRParamSetupAnswer,
 			},
 			Error: errMACRequestNotFound,
 		},
@@ -221,8 +221,8 @@ func TestHandleADRParamSetupAns(t *testing.T) {
 					PendingRequests: []*ttnpb.MACCommand{},
 				},
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveADRParamSetupAnswer.BindData(nil),
+			Events: events.Builders{
+				evtReceiveADRParamSetupAnswer,
 			},
 		},
 	} {
@@ -237,7 +237,7 @@ func TestHandleADRParamSetupAns(t *testing.T) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
+			a.So(evs, should.ResembleEventBuilders, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/mac_beacon_freq.go
+++ b/pkg/networkserver/mac_beacon_freq.go
@@ -44,7 +44,7 @@ func enqueueBeaconFreqReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen,
 	}
 
 	var st macCommandEnqueueState
-	dev.MACState.PendingRequests, st = enqueueMACCommand(ttnpb.CID_BEACON_FREQ, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, []events.DefinitionDataClosure, bool) {
+	dev.MACState.PendingRequests, st = enqueueMACCommand(ttnpb.CID_BEACON_FREQ, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, events.Builders, bool) {
 		if nDown < 1 || nUp < 1 {
 			return nil, 0, nil, false
 		}
@@ -59,15 +59,15 @@ func enqueueBeaconFreqReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen,
 				req.MACCommand(),
 			},
 			1,
-			[]events.DefinitionDataClosure{
-				evtEnqueueBeaconFreqRequest.BindData(req),
+			events.Builders{
+				evtEnqueueBeaconFreqRequest.With(events.WithData(req)),
 			},
 			true
 	}, dev.MACState.PendingRequests...)
 	return st
 }
 
-func handleBeaconFreqAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_BeaconFreqAns) ([]events.DefinitionDataClosure, error) {
+func handleBeaconFreqAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_BeaconFreqAns) (events.Builders, error) {
 	if pld == nil {
 		return nil, errNoPayload.New()
 	}
@@ -87,7 +87,7 @@ func handleBeaconFreqAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.M
 		dev.MACState.CurrentParameters.BeaconFrequency = req.Frequency
 		return nil
 	}, dev.MACState.PendingRequests...)
-	return []events.DefinitionDataClosure{
-		evt.BindData(pld),
+	return events.Builders{
+		evt.With(events.WithData(pld)),
 	}, err
 }

--- a/pkg/networkserver/mac_beacon_freq_test.go
+++ b/pkg/networkserver/mac_beacon_freq_test.go
@@ -102,7 +102,7 @@ func TestHandleBeaconFreqAns(t *testing.T) {
 		Name             string
 		Device, Expected *ttnpb.EndDevice
 		Payload          *ttnpb.MACCommand_BeaconFreqAns
-		Events           []events.DefinitionDataClosure
+		Events           events.Builders
 		Error            error
 	}{
 		{
@@ -126,10 +126,10 @@ func TestHandleBeaconFreqAns(t *testing.T) {
 			Payload: &ttnpb.MACCommand_BeaconFreqAns{
 				FrequencyAck: true,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveBeaconFreqAccept.BindData(&ttnpb.MACCommand_BeaconFreqAns{
+			Events: events.Builders{
+				evtReceiveBeaconFreqAccept.With(events.WithData(&ttnpb.MACCommand_BeaconFreqAns{
 					FrequencyAck: true,
-				}),
+				})),
 			},
 			Error: errMACRequestNotFound,
 		},
@@ -142,8 +142,8 @@ func TestHandleBeaconFreqAns(t *testing.T) {
 				MACState: &ttnpb.MACState{},
 			},
 			Payload: &ttnpb.MACCommand_BeaconFreqAns{},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveBeaconFreqReject.BindData(&ttnpb.MACCommand_BeaconFreqAns{}),
+			Events: events.Builders{
+				evtReceiveBeaconFreqReject.With(events.WithData(&ttnpb.MACCommand_BeaconFreqAns{})),
 			},
 			Error: errMACRequestNotFound,
 		},
@@ -169,10 +169,10 @@ func TestHandleBeaconFreqAns(t *testing.T) {
 			Payload: &ttnpb.MACCommand_BeaconFreqAns{
 				FrequencyAck: true,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveBeaconFreqAccept.BindData(&ttnpb.MACCommand_BeaconFreqAns{
+			Events: events.Builders{
+				evtReceiveBeaconFreqAccept.With(events.WithData(&ttnpb.MACCommand_BeaconFreqAns{
 					FrequencyAck: true,
-				}),
+				})),
 			},
 		},
 		{
@@ -192,8 +192,8 @@ func TestHandleBeaconFreqAns(t *testing.T) {
 				},
 			},
 			Payload: &ttnpb.MACCommand_BeaconFreqAns{},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveBeaconFreqReject.BindData(&ttnpb.MACCommand_BeaconFreqAns{}),
+			Events: events.Builders{
+				evtReceiveBeaconFreqReject.With(events.WithData(&ttnpb.MACCommand_BeaconFreqAns{})),
 			},
 		},
 	} {
@@ -209,7 +209,7 @@ func TestHandleBeaconFreqAns(t *testing.T) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
+			a.So(evs, should.ResembleEventBuilders, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/mac_beacon_timing.go
+++ b/pkg/networkserver/mac_beacon_timing.go
@@ -28,7 +28,7 @@ func deviceNeedsBeaconTimingReq(dev *ttnpb.EndDevice) bool {
 	return !dev.GetMulticast() && dev.GetMACState().GetDeviceClass() == ttnpb.CLASS_B && false
 }
 
-func handleBeaconTimingReq(ctx context.Context, dev *ttnpb.EndDevice) ([]events.DefinitionDataClosure, error) {
+func handleBeaconTimingReq(ctx context.Context, dev *ttnpb.EndDevice) (events.Builders, error) {
 	_ = deviceNeedsBeaconTimingReq(dev)
 	// TODO: Support BeaconTimingReq. (https://github.com/TheThingsNetwork/lorawan-stack/issues/2431)
 	return nil, nil

--- a/pkg/networkserver/mac_beacon_timing_test.go
+++ b/pkg/networkserver/mac_beacon_timing_test.go
@@ -73,7 +73,7 @@ func TestHandleBeaconTimingReq(t *testing.T) {
 	for _, tc := range []struct {
 		Name             string
 		Device, Expected *ttnpb.EndDevice
-		Events           []events.DefinitionDataClosure
+		Events           events.Builders
 		Error            error
 	}{
 		{
@@ -125,7 +125,7 @@ func TestHandleBeaconTimingReq(t *testing.T) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
+			a.So(evs, should.ResembleEventBuilders, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/mac_dev_status_test.go
+++ b/pkg/networkserver/mac_dev_status_test.go
@@ -187,7 +187,7 @@ func TestHandleDevStatusAns(t *testing.T) {
 		Payload          *ttnpb.MACCommand_DevStatusAns
 		FCntUp           uint32
 		ReceivedAt       time.Time
-		Events           []events.DefinitionDataClosure
+		Events           events.Builders
 		Error            error
 	}{
 		{
@@ -214,11 +214,11 @@ func TestHandleDevStatusAns(t *testing.T) {
 				Margin:  4,
 			},
 			ReceivedAt: time.Unix(42, 0),
-			Events: []events.DefinitionDataClosure{
-				evtReceiveDevStatusAnswer.BindData(&ttnpb.MACCommand_DevStatusAns{
+			Events: events.Builders{
+				evtReceiveDevStatusAnswer.With(events.WithData(&ttnpb.MACCommand_DevStatusAns{
 					Battery: 42,
 					Margin:  4,
-				}),
+				})),
 			},
 			Error: errMACRequestNotFound,
 		},
@@ -250,11 +250,11 @@ func TestHandleDevStatusAns(t *testing.T) {
 			},
 			FCntUp:     43,
 			ReceivedAt: time.Unix(42, 0),
-			Events: []events.DefinitionDataClosure{
-				evtReceiveDevStatusAnswer.BindData(&ttnpb.MACCommand_DevStatusAns{
+			Events: events.Builders{
+				evtReceiveDevStatusAnswer.With(events.WithData(&ttnpb.MACCommand_DevStatusAns{
 					Battery: 42,
 					Margin:  4,
-				}),
+				})),
 			},
 		},
 		{
@@ -284,10 +284,10 @@ func TestHandleDevStatusAns(t *testing.T) {
 			},
 			FCntUp:     43,
 			ReceivedAt: time.Unix(42, 0),
-			Events: []events.DefinitionDataClosure{
-				evtReceiveDevStatusAnswer.BindData(&ttnpb.MACCommand_DevStatusAns{
+			Events: events.Builders{
+				evtReceiveDevStatusAnswer.With(events.WithData(&ttnpb.MACCommand_DevStatusAns{
 					Margin: 20,
-				}),
+				})),
 			},
 		},
 		{
@@ -317,11 +317,11 @@ func TestHandleDevStatusAns(t *testing.T) {
 			},
 			FCntUp:     43,
 			ReceivedAt: time.Unix(42, 0),
-			Events: []events.DefinitionDataClosure{
-				evtReceiveDevStatusAnswer.BindData(&ttnpb.MACCommand_DevStatusAns{
+			Events: events.Builders{
+				evtReceiveDevStatusAnswer.With(events.WithData(&ttnpb.MACCommand_DevStatusAns{
 					Battery: 255,
 					Margin:  -5,
-				}),
+				})),
 			},
 		},
 	} {
@@ -336,7 +336,7 @@ func TestHandleDevStatusAns(t *testing.T) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
+			a.So(evs, should.ResembleEventBuilders, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/mac_device_mode_test.go
+++ b/pkg/networkserver/mac_device_mode_test.go
@@ -30,7 +30,7 @@ func TestHandleDeviceModeInd(t *testing.T) {
 		Name             string
 		Device, Expected *ttnpb.EndDevice
 		Payload          *ttnpb.MACCommand_DeviceModeInd
-		Events           []events.DefinitionDataClosure
+		Events           events.Builders
 		Error            error
 	}{
 		{
@@ -63,13 +63,13 @@ func TestHandleDeviceModeInd(t *testing.T) {
 			Payload: &ttnpb.MACCommand_DeviceModeInd{
 				Class: ttnpb.CLASS_C,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveDeviceModeIndication.BindData(&ttnpb.MACCommand_DeviceModeInd{
+			Events: events.Builders{
+				evtReceiveDeviceModeIndication.With(events.WithData(&ttnpb.MACCommand_DeviceModeInd{
 					Class: ttnpb.CLASS_C,
-				}),
-				evtEnqueueDeviceModeConfirmation.BindData(&ttnpb.MACCommand_DeviceModeConf{
+				})),
+				evtEnqueueDeviceModeConfirmation.With(events.WithData(&ttnpb.MACCommand_DeviceModeConf{
 					Class: ttnpb.CLASS_A,
-				}),
+				})),
 			},
 		},
 		{
@@ -94,14 +94,14 @@ func TestHandleDeviceModeInd(t *testing.T) {
 			Payload: &ttnpb.MACCommand_DeviceModeInd{
 				Class: ttnpb.CLASS_C,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveDeviceModeIndication.BindData(&ttnpb.MACCommand_DeviceModeInd{
+			Events: events.Builders{
+				evtReceiveDeviceModeIndication.With(events.WithData(&ttnpb.MACCommand_DeviceModeInd{
 					Class: ttnpb.CLASS_C,
-				}),
-				evtClassCSwitch.BindData(ttnpb.CLASS_A),
-				evtEnqueueDeviceModeConfirmation.BindData(&ttnpb.MACCommand_DeviceModeConf{
+				})),
+				evtClassCSwitch.With(events.WithData(ttnpb.CLASS_A)),
+				evtEnqueueDeviceModeConfirmation.With(events.WithData(&ttnpb.MACCommand_DeviceModeConf{
 					Class: ttnpb.CLASS_C,
-				}),
+				})),
 			},
 		},
 		{
@@ -134,14 +134,14 @@ func TestHandleDeviceModeInd(t *testing.T) {
 			Payload: &ttnpb.MACCommand_DeviceModeInd{
 				Class: ttnpb.CLASS_A,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveDeviceModeIndication.BindData(&ttnpb.MACCommand_DeviceModeInd{
+			Events: events.Builders{
+				evtReceiveDeviceModeIndication.With(events.WithData(&ttnpb.MACCommand_DeviceModeInd{
 					Class: ttnpb.CLASS_A,
-				}),
-				evtClassASwitch.BindData(ttnpb.CLASS_C),
-				evtEnqueueDeviceModeConfirmation.BindData(&ttnpb.MACCommand_DeviceModeConf{
+				})),
+				evtClassASwitch.With(events.WithData(ttnpb.CLASS_C)),
+				evtEnqueueDeviceModeConfirmation.With(events.WithData(&ttnpb.MACCommand_DeviceModeConf{
 					Class: ttnpb.CLASS_A,
-				}),
+				})),
 			},
 		},
 	} {
@@ -156,7 +156,7 @@ func TestHandleDeviceModeInd(t *testing.T) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
+			a.So(evs, should.ResembleEventBuilders, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/mac_device_time.go
+++ b/pkg/networkserver/mac_device_time.go
@@ -26,13 +26,13 @@ var (
 	evtEnqueueDeviceTimeAnswer  = defineEnqueueMACAnswerEvent("device_time", "device time")()
 )
 
-func handleDeviceTimeReq(ctx context.Context, dev *ttnpb.EndDevice, msg *ttnpb.UplinkMessage) ([]events.DefinitionDataClosure, error) {
+func handleDeviceTimeReq(ctx context.Context, dev *ttnpb.EndDevice, msg *ttnpb.UplinkMessage) (events.Builders, error) {
 	ans := &ttnpb.MACCommand_DeviceTimeAns{
 		Time: msg.ReceivedAt,
 	}
 	dev.MACState.QueuedResponses = append(dev.MACState.QueuedResponses, ans.MACCommand())
-	return []events.DefinitionDataClosure{
-		evtReceiveDeviceTimeRequest.BindData(nil),
-		evtEnqueueDeviceTimeAnswer.BindData(ans),
+	return events.Builders{
+		evtReceiveDeviceTimeRequest,
+		evtEnqueueDeviceTimeAnswer.With(events.WithData(ans)),
 	}, nil
 }

--- a/pkg/networkserver/mac_device_time_test.go
+++ b/pkg/networkserver/mac_device_time_test.go
@@ -32,7 +32,7 @@ func TestHandleDeviceTimeReq(t *testing.T) {
 		Name             string
 		Device, Expected *ttnpb.EndDevice
 		Message          *ttnpb.UplinkMessage
-		Events           []events.DefinitionDataClosure
+		Events           events.Builders
 		Error            error
 	}{
 		{
@@ -52,11 +52,11 @@ func TestHandleDeviceTimeReq(t *testing.T) {
 			Message: &ttnpb.UplinkMessage{
 				ReceivedAt: recvAt,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveDeviceTimeRequest.BindData(nil),
-				evtEnqueueDeviceTimeAnswer.BindData(&ttnpb.MACCommand_DeviceTimeAns{
+			Events: events.Builders{
+				evtReceiveDeviceTimeRequest,
+				evtEnqueueDeviceTimeAnswer.With(events.WithData(&ttnpb.MACCommand_DeviceTimeAns{
 					Time: recvAt,
-				}),
+				})),
 			},
 		},
 		{
@@ -85,11 +85,11 @@ func TestHandleDeviceTimeReq(t *testing.T) {
 			Message: &ttnpb.UplinkMessage{
 				ReceivedAt: recvAt,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveDeviceTimeRequest.BindData(nil),
-				evtEnqueueDeviceTimeAnswer.BindData(&ttnpb.MACCommand_DeviceTimeAns{
+			Events: events.Builders{
+				evtReceiveDeviceTimeRequest,
+				evtEnqueueDeviceTimeAnswer.With(events.WithData(&ttnpb.MACCommand_DeviceTimeAns{
 					Time: recvAt,
-				}),
+				})),
 			},
 		},
 		{
@@ -118,11 +118,11 @@ func TestHandleDeviceTimeReq(t *testing.T) {
 			Message: &ttnpb.UplinkMessage{
 				ReceivedAt: recvAt,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveDeviceTimeRequest.BindData(nil),
-				evtEnqueueDeviceTimeAnswer.BindData(&ttnpb.MACCommand_DeviceTimeAns{
+			Events: events.Builders{
+				evtReceiveDeviceTimeRequest,
+				evtEnqueueDeviceTimeAnswer.With(events.WithData(&ttnpb.MACCommand_DeviceTimeAns{
 					Time: recvAt,
-				}),
+				})),
 			},
 		},
 	} {
@@ -137,7 +137,7 @@ func TestHandleDeviceTimeReq(t *testing.T) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
+			a.So(evs, should.ResembleEventBuilders, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/mac_dl_channel_test.go
+++ b/pkg/networkserver/mac_dl_channel_test.go
@@ -336,15 +336,15 @@ func TestEnqueueDLChannelReq(t *testing.T) {
 						}
 						reqs := tc.ExpectedRequests[:conf.ExpectedCount]
 						expectedDev := CopyEndDevice(dev)
-						var expectedEvs []events.DefinitionDataClosure
+						var expectedEvs events.Builders
 						for _, req := range reqs {
 							expectedDev.MACState.PendingRequests = append(expectedDev.MACState.PendingRequests, req.MACCommand())
-							expectedEvs = append(expectedEvs, evtEnqueueDLChannelRequest.BindData(req))
+							expectedEvs = append(expectedEvs, evtEnqueueDLChannelRequest.With(events.WithData(req)))
 						}
 
 						st := enqueueDLChannelReq(test.ContextWithTB(log.NewContext(test.Context(), test.GetLogger(t)), t), dev, conf.MaxDownlinkLength, conf.MaxUplinkLength)
 						a.So(dev, should.Resemble, expectedDev)
-						a.So(st.QueuedEvents, should.ResembleEventDefinitionDataClosures, expectedEvs)
+						a.So(st.QueuedEvents, should.ResembleEventBuilders, expectedEvs)
 						a.So(st, should.Resemble, macCommandEnqueueState{
 							MaxDownLen:   conf.MaxDownlinkLength - uint16(conf.ExpectedCount)*downlinkLength,
 							MaxUpLen:     conf.MaxUplinkLength - uint16(conf.ExpectedCount)*uplinkLength,
@@ -364,7 +364,7 @@ func TestHandleDLChannelAns(t *testing.T) {
 		InputDevice, ExpectedDevice *ttnpb.EndDevice
 		Payload                     *ttnpb.MACCommand_DLChannelAns
 		Error                       error
-		Events                      []events.DefinitionDataClosure
+		Events                      events.Builders
 	}{
 		{
 			Name: "nil payload",
@@ -388,11 +388,11 @@ func TestHandleDLChannelAns(t *testing.T) {
 				FrequencyAck:    true,
 				ChannelIndexAck: true,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveDLChannelAccept.BindData(&ttnpb.MACCommand_DLChannelAns{
+			Events: events.Builders{
+				evtReceiveDLChannelAccept.With(events.WithData(&ttnpb.MACCommand_DLChannelAns{
 					FrequencyAck:    true,
 					ChannelIndexAck: true,
-				}),
+				})),
 			},
 			Error: errMACRequestNotFound,
 		},
@@ -407,10 +407,10 @@ func TestHandleDLChannelAns(t *testing.T) {
 			Payload: &ttnpb.MACCommand_DLChannelAns{
 				ChannelIndexAck: true,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveDLChannelReject.BindData(&ttnpb.MACCommand_DLChannelAns{
+			Events: events.Builders{
+				evtReceiveDLChannelReject.With(events.WithData(&ttnpb.MACCommand_DLChannelAns{
 					ChannelIndexAck: true,
-				}),
+				})),
 			},
 			Error: errMACRequestNotFound,
 		},
@@ -457,8 +457,8 @@ func TestHandleDLChannelAns(t *testing.T) {
 				},
 			},
 			Payload: &ttnpb.MACCommand_DLChannelAns{},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveDLChannelReject.BindData(&ttnpb.MACCommand_DLChannelAns{}),
+			Events: events.Builders{
+				evtReceiveDLChannelReject.With(events.WithData(&ttnpb.MACCommand_DLChannelAns{})),
 			},
 		},
 		{
@@ -507,10 +507,10 @@ func TestHandleDLChannelAns(t *testing.T) {
 			Payload: &ttnpb.MACCommand_DLChannelAns{
 				ChannelIndexAck: true,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveDLChannelReject.BindData(&ttnpb.MACCommand_DLChannelAns{
+			Events: events.Builders{
+				evtReceiveDLChannelReject.With(events.WithData(&ttnpb.MACCommand_DLChannelAns{
 					ChannelIndexAck: true,
-				}),
+				})),
 			},
 		},
 		{
@@ -539,11 +539,11 @@ func TestHandleDLChannelAns(t *testing.T) {
 				FrequencyAck:    true,
 				ChannelIndexAck: true,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveDLChannelAccept.BindData(&ttnpb.MACCommand_DLChannelAns{
+			Events: events.Builders{
+				evtReceiveDLChannelAccept.With(events.WithData(&ttnpb.MACCommand_DLChannelAns{
 					FrequencyAck:    true,
 					ChannelIndexAck: true,
-				}),
+				})),
 			},
 			Error: errCorruptedMACState.WithCause(errUnknownChannel),
 		},
@@ -592,11 +592,11 @@ func TestHandleDLChannelAns(t *testing.T) {
 				FrequencyAck:    true,
 				ChannelIndexAck: true,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveDLChannelAccept.BindData(&ttnpb.MACCommand_DLChannelAns{
+			Events: events.Builders{
+				evtReceiveDLChannelAccept.With(events.WithData(&ttnpb.MACCommand_DLChannelAns{
 					FrequencyAck:    true,
 					ChannelIndexAck: true,
-				}),
+				})),
 			},
 		},
 	} {
@@ -611,7 +611,7 @@ func TestHandleDLChannelAns(t *testing.T) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.ExpectedDevice)
-			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
+			a.So(evs, should.ResembleEventBuilders, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/mac_duty_cycle.go
+++ b/pkg/networkserver/mac_duty_cycle.go
@@ -43,7 +43,7 @@ func enqueueDutyCycleReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, 
 	}
 
 	var st macCommandEnqueueState
-	dev.MACState.PendingRequests, st = enqueueMACCommand(ttnpb.CID_DUTY_CYCLE, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, []events.DefinitionDataClosure, bool) {
+	dev.MACState.PendingRequests, st = enqueueMACCommand(ttnpb.CID_DUTY_CYCLE, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, events.Builders, bool) {
 		if nDown < 1 || nUp < 1 {
 			return nil, 0, nil, false
 		}
@@ -57,15 +57,15 @@ func enqueueDutyCycleReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, 
 				req.MACCommand(),
 			},
 			1,
-			[]events.DefinitionDataClosure{
-				evtEnqueueDutyCycleRequest.BindData(req),
+			events.Builders{
+				evtEnqueueDutyCycleRequest.With(events.WithData(req)),
 			},
 			true
 	}, dev.MACState.PendingRequests...)
 	return st
 }
 
-func handleDutyCycleAns(ctx context.Context, dev *ttnpb.EndDevice) ([]events.DefinitionDataClosure, error) {
+func handleDutyCycleAns(ctx context.Context, dev *ttnpb.EndDevice) (events.Builders, error) {
 	var err error
 	dev.MACState.PendingRequests, err = handleMACResponse(ttnpb.CID_DUTY_CYCLE, func(cmd *ttnpb.MACCommand) error {
 		req := cmd.GetDutyCycleReq()
@@ -73,7 +73,7 @@ func handleDutyCycleAns(ctx context.Context, dev *ttnpb.EndDevice) ([]events.Def
 		dev.MACState.CurrentParameters.MaxDutyCycle = req.MaxDutyCycle
 		return nil
 	}, dev.MACState.PendingRequests...)
-	return []events.DefinitionDataClosure{
-		evtReceiveDutyCycleAnswer.BindData(nil),
+	return events.Builders{
+		evtReceiveDutyCycleAnswer,
 	}, err
 }

--- a/pkg/networkserver/mac_duty_cycle_test.go
+++ b/pkg/networkserver/mac_duty_cycle_test.go
@@ -82,7 +82,7 @@ func TestHandleDutyCycleAns(t *testing.T) {
 	for _, tc := range []struct {
 		Name             string
 		Device, Expected *ttnpb.EndDevice
-		Events           []events.DefinitionDataClosure
+		Events           events.Builders
 		Error            error
 	}{
 		{
@@ -93,8 +93,8 @@ func TestHandleDutyCycleAns(t *testing.T) {
 			Expected: &ttnpb.EndDevice{
 				MACState: &ttnpb.MACState{},
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveDutyCycleAnswer.BindData(nil),
+			Events: events.Builders{
+				evtReceiveDutyCycleAnswer,
 			},
 			Error: errMACRequestNotFound,
 		},
@@ -117,8 +117,8 @@ func TestHandleDutyCycleAns(t *testing.T) {
 					},
 				},
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveDutyCycleAnswer.BindData(nil),
+			Events: events.Builders{
+				evtReceiveDutyCycleAnswer,
 			},
 		},
 	} {
@@ -133,7 +133,7 @@ func TestHandleDutyCycleAns(t *testing.T) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
+			a.So(evs, should.ResembleEventBuilders, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/mac_link_adr_test.go
+++ b/pkg/networkserver/mac_link_adr_test.go
@@ -209,22 +209,22 @@ func TestEnqueueLinkADRReq(t *testing.T) {
 				MaxDownLen: 32,
 				MaxUpLen:   20,
 				Ok:         true,
-				QueuedEvents: []events.DefinitionDataClosure{
-					evtEnqueueLinkADRRequest.BindData(&ttnpb.MACCommand_LinkADRReq{
+				QueuedEvents: events.Builders{
+					evtEnqueueLinkADRRequest.With(events.WithData(&ttnpb.MACCommand_LinkADRReq{
 						ChannelMask: []bool{
 							false, false, false, false, false, false, false, false,
 							false, false, false, false, false, false, false, false,
 						},
 						ChannelMaskControl: 7,
 						NbTrans:            1,
-					}),
-					evtEnqueueLinkADRRequest.BindData(&ttnpb.MACCommand_LinkADRReq{
+					})),
+					evtEnqueueLinkADRRequest.With(events.WithData(&ttnpb.MACCommand_LinkADRReq{
 						ChannelMask: []bool{
 							false, false, false, false, false, false, false, false,
 							true, true, true, true, true, true, true, true,
 						},
 						NbTrans: 1,
-					}),
+					})),
 				},
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool { return assertions.New(t).So(err, should.BeNil) },
@@ -291,8 +291,8 @@ func TestEnqueueLinkADRReq(t *testing.T) {
 				MaxDownLen: 32,
 				MaxUpLen:   20,
 				Ok:         true,
-				QueuedEvents: []events.DefinitionDataClosure{
-					evtEnqueueLinkADRRequest.BindData(&ttnpb.MACCommand_LinkADRReq{
+				QueuedEvents: events.Builders{
+					evtEnqueueLinkADRRequest.With(events.WithData(&ttnpb.MACCommand_LinkADRReq{
 						ChannelMask: []bool{
 							false, false, false, false, false, false, false, false,
 							false, false, false, false, false, false, false, false,
@@ -301,8 +301,8 @@ func TestEnqueueLinkADRReq(t *testing.T) {
 						NbTrans:            1,
 						DataRateIndex:      ttnpb.DATA_RATE_1,
 						TxPowerIndex:       15,
-					}),
-					evtEnqueueLinkADRRequest.BindData(&ttnpb.MACCommand_LinkADRReq{
+					})),
+					evtEnqueueLinkADRRequest.With(events.WithData(&ttnpb.MACCommand_LinkADRReq{
 						ChannelMask: []bool{
 							false, false, false, false, false, false, false, false,
 							true, true, true, true, true, true, true, true,
@@ -310,7 +310,7 @@ func TestEnqueueLinkADRReq(t *testing.T) {
 						NbTrans:       1,
 						DataRateIndex: ttnpb.DATA_RATE_1,
 						TxPowerIndex:  15,
-					}),
+					})),
 				},
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool { return assertions.New(t).So(err, should.BeNil) },
@@ -401,8 +401,8 @@ func TestEnqueueLinkADRReq(t *testing.T) {
 				MaxDownLen: 32,
 				MaxUpLen:   20,
 				Ok:         true,
-				QueuedEvents: []events.DefinitionDataClosure{
-					evtEnqueueLinkADRRequest.BindData(&ttnpb.MACCommand_LinkADRReq{
+				QueuedEvents: events.Builders{
+					evtEnqueueLinkADRRequest.With(events.WithData(&ttnpb.MACCommand_LinkADRReq{
 						ChannelMask: []bool{
 							false, false, false, false, false, false, false, false,
 							false, false, false, false, false, false, false, false,
@@ -411,8 +411,8 @@ func TestEnqueueLinkADRReq(t *testing.T) {
 						NbTrans:            1,
 						DataRateIndex:      ttnpb.DATA_RATE_15,
 						TxPowerIndex:       15,
-					}),
-					evtEnqueueLinkADRRequest.BindData(&ttnpb.MACCommand_LinkADRReq{
+					})),
+					evtEnqueueLinkADRRequest.With(events.WithData(&ttnpb.MACCommand_LinkADRReq{
 						ChannelMask: []bool{
 							false, false, false, false, false, false, false, false,
 							true, true, true, true, true, true, true, true,
@@ -420,7 +420,7 @@ func TestEnqueueLinkADRReq(t *testing.T) {
 						NbTrans:       1,
 						DataRateIndex: ttnpb.DATA_RATE_15,
 						TxPowerIndex:  15,
-					}),
+					})),
 				},
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool { return assertions.New(t).So(err, should.BeNil) },
@@ -474,7 +474,7 @@ func TestEnqueueLinkADRReq(t *testing.T) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.ExpectedDevice)
-			a.So(st.QueuedEvents, should.ResembleEventDefinitionDataClosures, tc.State.QueuedEvents)
+			a.So(st.QueuedEvents, should.ResembleEventBuilders, tc.State.QueuedEvents)
 			st.QueuedEvents = tc.State.QueuedEvents
 			a.So(st, should.Resemble, tc.State)
 		})
@@ -524,7 +524,7 @@ func TestHandleLinkADRAns(t *testing.T) {
 		Device, Expected *ttnpb.EndDevice
 		Payload          *ttnpb.MACCommand_LinkADRAns
 		DupCount         uint
-		Events           []events.DefinitionDataClosure
+		Events           events.Builders
 		Error            error
 	}{
 		{
@@ -570,12 +570,12 @@ func TestHandleLinkADRAns(t *testing.T) {
 				DataRateIndexAck: true,
 				TxPowerIndexAck:  true,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveLinkADRAccept.BindData(&ttnpb.MACCommand_LinkADRAns{
+			Events: events.Builders{
+				evtReceiveLinkADRAccept.With(events.WithData(&ttnpb.MACCommand_LinkADRAns{
 					ChannelMaskAck:   true,
 					DataRateIndexAck: true,
 					TxPowerIndexAck:  true,
-				}),
+				})),
 			},
 			Error: errMACRequestNotFound,
 		},
@@ -638,12 +638,12 @@ func TestHandleLinkADRAns(t *testing.T) {
 				DataRateIndexAck: true,
 				TxPowerIndexAck:  true,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveLinkADRAccept.BindData(&ttnpb.MACCommand_LinkADRAns{
+			Events: events.Builders{
+				evtReceiveLinkADRAccept.With(events.WithData(&ttnpb.MACCommand_LinkADRAns{
 					ChannelMaskAck:   true,
 					DataRateIndexAck: true,
 					TxPowerIndexAck:  true,
-				}),
+				})),
 			},
 		},
 		{
@@ -731,12 +731,12 @@ func TestHandleLinkADRAns(t *testing.T) {
 				DataRateIndexAck: true,
 				TxPowerIndexAck:  true,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveLinkADRAccept.BindData(&ttnpb.MACCommand_LinkADRAns{
+			Events: events.Builders{
+				evtReceiveLinkADRAccept.With(events.WithData(&ttnpb.MACCommand_LinkADRAns{
 					ChannelMaskAck:   true,
 					DataRateIndexAck: true,
 					TxPowerIndexAck:  true,
-				}),
+				})),
 			},
 		},
 		{
@@ -825,12 +825,12 @@ func TestHandleLinkADRAns(t *testing.T) {
 				DataRateIndexAck: true,
 				TxPowerIndexAck:  true,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveLinkADRAccept.BindData(&ttnpb.MACCommand_LinkADRAns{
+			Events: events.Builders{
+				evtReceiveLinkADRAccept.With(events.WithData(&ttnpb.MACCommand_LinkADRAns{
 					ChannelMaskAck:   true,
 					DataRateIndexAck: true,
 					TxPowerIndexAck:  true,
-				}),
+				})),
 			},
 		},
 		{
@@ -929,12 +929,12 @@ func TestHandleLinkADRAns(t *testing.T) {
 				DataRateIndexAck: true,
 				TxPowerIndexAck:  true,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveLinkADRAccept.BindData(&ttnpb.MACCommand_LinkADRAns{
+			Events: events.Builders{
+				evtReceiveLinkADRAccept.With(events.WithData(&ttnpb.MACCommand_LinkADRAns{
 					ChannelMaskAck:   true,
 					DataRateIndexAck: true,
 					TxPowerIndexAck:  true,
-				}),
+				})),
 			},
 		},
 		{
@@ -994,12 +994,12 @@ func TestHandleLinkADRAns(t *testing.T) {
 				DataRateIndexAck: true,
 				TxPowerIndexAck:  true,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveLinkADRAccept.BindData(&ttnpb.MACCommand_LinkADRAns{
+			Events: events.Builders{
+				evtReceiveLinkADRAccept.With(events.WithData(&ttnpb.MACCommand_LinkADRAns{
 					ChannelMaskAck:   true,
 					DataRateIndexAck: true,
 					TxPowerIndexAck:  true,
-				}),
+				})),
 			},
 		},
 	} {
@@ -1014,7 +1014,7 @@ func TestHandleLinkADRAns(t *testing.T) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
+			a.So(evs, should.ResembleEventBuilders, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/mac_link_check.go
+++ b/pkg/networkserver/mac_link_check.go
@@ -26,9 +26,9 @@ var (
 	evtEnqueueLinkCheckAnswer  = defineEnqueueMACAnswerEvent("link_check", "link check")()
 )
 
-func handleLinkCheckReq(ctx context.Context, dev *ttnpb.EndDevice, msg *ttnpb.UplinkMessage) ([]events.DefinitionDataClosure, error) {
-	evs := []events.DefinitionDataClosure{
-		evtReceiveLinkCheckRequest.BindData(nil),
+func handleLinkCheckReq(ctx context.Context, dev *ttnpb.EndDevice, msg *ttnpb.UplinkMessage) (events.Builders, error) {
+	evs := events.Builders{
+		evtReceiveLinkCheckRequest,
 	}
 
 	var floor float32
@@ -49,6 +49,6 @@ func handleLinkCheckReq(ctx context.Context, dev *ttnpb.EndDevice, msg *ttnpb.Up
 	}
 	dev.MACState.QueuedResponses = append(dev.MACState.QueuedResponses, ans.MACCommand())
 	return append(evs,
-		evtEnqueueLinkCheckAnswer.BindData(ans),
+		evtEnqueueLinkCheckAnswer.With(events.WithData(ans)),
 	), nil
 }

--- a/pkg/networkserver/mac_link_check_test.go
+++ b/pkg/networkserver/mac_link_check_test.go
@@ -32,7 +32,7 @@ func TestHandleLinkCheckReq(t *testing.T) {
 		Name             string
 		Device, Expected *ttnpb.EndDevice
 		Message          *ttnpb.UplinkMessage
-		Events           []events.DefinitionDataClosure
+		Events           events.Builders
 		Error            error
 	}{
 		{
@@ -55,8 +55,8 @@ func TestHandleLinkCheckReq(t *testing.T) {
 					},
 				},
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveLinkCheckRequest.BindData(nil),
+			Events: events.Builders{
+				evtReceiveLinkCheckRequest,
 			},
 			Error: errInvalidDataRate,
 		},
@@ -80,8 +80,8 @@ func TestHandleLinkCheckReq(t *testing.T) {
 					},
 				},
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveLinkCheckRequest.BindData(nil),
+			Events: events.Builders{
+				evtReceiveLinkCheckRequest,
 			},
 		},
 		{
@@ -119,12 +119,12 @@ func TestHandleLinkCheckReq(t *testing.T) {
 					},
 				},
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveLinkCheckRequest.BindData(nil),
-				evtEnqueueLinkCheckAnswer.BindData(&ttnpb.MACCommand_LinkCheckAns{
+			Events: events.Builders{
+				evtReceiveLinkCheckRequest,
+				evtEnqueueLinkCheckAnswer.With(events.WithData(&ttnpb.MACCommand_LinkCheckAns{
 					Margin:       42,
 					GatewayCount: 1,
-				}),
+				})),
 			},
 		},
 		{
@@ -171,12 +171,12 @@ func TestHandleLinkCheckReq(t *testing.T) {
 					},
 				},
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveLinkCheckRequest.BindData(nil),
-				evtEnqueueLinkCheckAnswer.BindData(&ttnpb.MACCommand_LinkCheckAns{
+			Events: events.Builders{
+				evtReceiveLinkCheckRequest,
+				evtEnqueueLinkCheckAnswer.With(events.WithData(&ttnpb.MACCommand_LinkCheckAns{
 					Margin:       42,
 					GatewayCount: 1,
-				}),
+				})),
 			},
 		},
 		{
@@ -235,12 +235,12 @@ func TestHandleLinkCheckReq(t *testing.T) {
 					},
 				},
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveLinkCheckRequest.BindData(nil),
-				evtEnqueueLinkCheckAnswer.BindData(&ttnpb.MACCommand_LinkCheckAns{
+			Events: events.Builders{
+				evtReceiveLinkCheckRequest,
+				evtEnqueueLinkCheckAnswer.With(events.WithData(&ttnpb.MACCommand_LinkCheckAns{
 					Margin:       42,
 					GatewayCount: 3,
-				}),
+				})),
 			},
 		},
 		{
@@ -308,12 +308,12 @@ func TestHandleLinkCheckReq(t *testing.T) {
 					},
 				},
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveLinkCheckRequest.BindData(nil),
-				evtEnqueueLinkCheckAnswer.BindData(&ttnpb.MACCommand_LinkCheckAns{
+			Events: events.Builders{
+				evtReceiveLinkCheckRequest,
+				evtEnqueueLinkCheckAnswer.With(events.WithData(&ttnpb.MACCommand_LinkCheckAns{
 					Margin:       43,
 					GatewayCount: 4,
-				}),
+				})),
 			},
 		},
 	} {
@@ -328,7 +328,7 @@ func TestHandleLinkCheckReq(t *testing.T) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
+			a.So(evs, should.ResembleEventBuilders, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/mac_new_channel_test.go
+++ b/pkg/networkserver/mac_new_channel_test.go
@@ -527,15 +527,15 @@ func TestEnqueueNewChannelReq(t *testing.T) {
 						}
 						reqs := tc.ExpectedRequests[:conf.ExpectedCount]
 						expectedDev := CopyEndDevice(dev)
-						var expectedEvs []events.DefinitionDataClosure
+						var expectedEvs events.Builders
 						for _, req := range reqs {
 							expectedDev.MACState.PendingRequests = append(expectedDev.MACState.PendingRequests, req.MACCommand())
-							expectedEvs = append(expectedEvs, evtEnqueueNewChannelRequest.BindData(req))
+							expectedEvs = append(expectedEvs, evtEnqueueNewChannelRequest.With(events.WithData(req)))
 						}
 
 						st := enqueueNewChannelReq(test.Context(), dev, conf.MaxDownlinkLength, conf.MaxUplinkLength)
 						a.So(dev, should.Resemble, expectedDev)
-						a.So(st.QueuedEvents, should.ResembleEventDefinitionDataClosures, expectedEvs)
+						a.So(st.QueuedEvents, should.ResembleEventBuilders, expectedEvs)
 						a.So(st, should.Resemble, macCommandEnqueueState{
 							MaxDownLen:   conf.MaxDownlinkLength - uint16(conf.ExpectedCount)*downlinkLength,
 							MaxUpLen:     conf.MaxUplinkLength - uint16(conf.ExpectedCount)*uplinkLength,
@@ -554,7 +554,7 @@ func TestHandleNewChannelAns(t *testing.T) {
 		Name             string
 		Device, Expected *ttnpb.EndDevice
 		Payload          *ttnpb.MACCommand_NewChannelAns
-		Events           []events.DefinitionDataClosure
+		Events           events.Builders
 		Error            error
 	}{
 		{
@@ -580,11 +580,11 @@ func TestHandleNewChannelAns(t *testing.T) {
 				FrequencyAck: true,
 				DataRateAck:  true,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveNewChannelAccept.BindData(&ttnpb.MACCommand_NewChannelAns{
+			Events: events.Builders{
+				evtReceiveNewChannelAccept.With(events.WithData(&ttnpb.MACCommand_NewChannelAns{
 					FrequencyAck: true,
 					DataRateAck:  true,
-				}),
+				})),
 			},
 			Error: errMACRequestNotFound,
 		},
@@ -611,10 +611,10 @@ func TestHandleNewChannelAns(t *testing.T) {
 			Payload: &ttnpb.MACCommand_NewChannelAns{
 				DataRateAck: true,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveNewChannelReject.BindData(&ttnpb.MACCommand_NewChannelAns{
+			Events: events.Builders{
+				evtReceiveNewChannelReject.With(events.WithData(&ttnpb.MACCommand_NewChannelAns{
 					DataRateAck: true,
-				}),
+				})),
 			},
 		},
 		{
@@ -639,8 +639,8 @@ func TestHandleNewChannelAns(t *testing.T) {
 				},
 			},
 			Payload: &ttnpb.MACCommand_NewChannelAns{},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveNewChannelReject.BindData(&ttnpb.MACCommand_NewChannelAns{}),
+			Events: events.Builders{
+				evtReceiveNewChannelReject.With(events.WithData(&ttnpb.MACCommand_NewChannelAns{})),
 			},
 		},
 		{
@@ -681,11 +681,11 @@ func TestHandleNewChannelAns(t *testing.T) {
 				FrequencyAck: true,
 				DataRateAck:  true,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveNewChannelAccept.BindData(&ttnpb.MACCommand_NewChannelAns{
+			Events: events.Builders{
+				evtReceiveNewChannelAccept.With(events.WithData(&ttnpb.MACCommand_NewChannelAns{
 					FrequencyAck: true,
 					DataRateAck:  true,
-				}),
+				})),
 			},
 		},
 	} {
@@ -700,7 +700,7 @@ func TestHandleNewChannelAns(t *testing.T) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
+			a.So(evs, should.ResembleEventBuilders, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/mac_ping_slot_channel.go
+++ b/pkg/networkserver/mac_ping_slot_channel.go
@@ -53,7 +53,7 @@ func enqueuePingSlotChannelReq(ctx context.Context, dev *ttnpb.EndDevice, maxDow
 	}
 
 	var st macCommandEnqueueState
-	dev.MACState.PendingRequests, st = enqueueMACCommand(ttnpb.CID_PING_SLOT_CHANNEL, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, []events.DefinitionDataClosure, bool) {
+	dev.MACState.PendingRequests, st = enqueueMACCommand(ttnpb.CID_PING_SLOT_CHANNEL, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, events.Builders, bool) {
 		if nDown < 1 || nUp < 1 {
 			return nil, 0, nil, false
 		}
@@ -69,15 +69,15 @@ func enqueuePingSlotChannelReq(ctx context.Context, dev *ttnpb.EndDevice, maxDow
 				req.MACCommand(),
 			},
 			1,
-			[]events.DefinitionDataClosure{
-				evtEnqueuePingSlotChannelRequest.BindData(req),
+			events.Builders{
+				evtEnqueuePingSlotChannelRequest.With(events.WithData(req)),
 			},
 			true
 	}, dev.MACState.PendingRequests...)
 	return st
 }
 
-func handlePingSlotChannelAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_PingSlotChannelAns) ([]events.DefinitionDataClosure, error) {
+func handlePingSlotChannelAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_PingSlotChannelAns) (events.Builders, error) {
 	if pld == nil {
 		return nil, errNoPayload.New()
 	}
@@ -90,7 +90,7 @@ func handlePingSlotChannelAns(ctx context.Context, dev *ttnpb.EndDevice, pld *tt
 		dev.MACState.CurrentParameters.PingSlotDataRateIndexValue = &ttnpb.DataRateIndexValue{Value: req.DataRateIndex}
 		return nil
 	}, dev.MACState.PendingRequests...)
-	return []events.DefinitionDataClosure{
-		evtReceivePingSlotChannelAnswer.BindData(pld),
+	return events.Builders{
+		evtReceivePingSlotChannelAnswer.With(events.WithData(pld)),
 	}, err
 }

--- a/pkg/networkserver/mac_ping_slot_channel_test.go
+++ b/pkg/networkserver/mac_ping_slot_channel_test.go
@@ -103,7 +103,7 @@ func TestHandlePingSlotChannelAns(t *testing.T) {
 		Name             string
 		Device, Expected *ttnpb.EndDevice
 		Payload          *ttnpb.MACCommand_PingSlotChannelAns
-		Events           []events.DefinitionDataClosure
+		Events           events.Builders
 		Error            error
 	}{
 		{
@@ -128,11 +128,11 @@ func TestHandlePingSlotChannelAns(t *testing.T) {
 				FrequencyAck:     true,
 				DataRateIndexAck: true,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceivePingSlotChannelAnswer.BindData(&ttnpb.MACCommand_PingSlotChannelAns{
+			Events: events.Builders{
+				evtReceivePingSlotChannelAnswer.With(events.WithData(&ttnpb.MACCommand_PingSlotChannelAns{
 					FrequencyAck:     true,
 					DataRateIndexAck: true,
-				}),
+				})),
 			},
 			Error: errMACRequestNotFound,
 		},
@@ -161,11 +161,11 @@ func TestHandlePingSlotChannelAns(t *testing.T) {
 				FrequencyAck:     true,
 				DataRateIndexAck: true,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceivePingSlotChannelAnswer.BindData(&ttnpb.MACCommand_PingSlotChannelAns{
+			Events: events.Builders{
+				evtReceivePingSlotChannelAnswer.With(events.WithData(&ttnpb.MACCommand_PingSlotChannelAns{
 					FrequencyAck:     true,
 					DataRateIndexAck: true,
-				}),
+				})),
 			},
 		},
 	} {
@@ -180,7 +180,7 @@ func TestHandlePingSlotChannelAns(t *testing.T) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
+			a.So(evs, should.ResembleEventBuilders, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/mac_ping_slot_info.go
+++ b/pkg/networkserver/mac_ping_slot_info.go
@@ -27,13 +27,13 @@ var (
 	evtReceivePingSlotInfoRequest = defineReceiveMACRequestEvent("ping_slot_info", "ping slot info")()
 )
 
-func handlePingSlotInfoReq(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_PingSlotInfoReq) ([]events.DefinitionDataClosure, error) {
+func handlePingSlotInfoReq(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_PingSlotInfoReq) (events.Builders, error) {
 	if pld == nil {
 		return nil, errNoPayload.New()
 	}
 
-	evs := []events.DefinitionDataClosure{
-		evtReceivePingSlotInfoRequest.BindData(pld),
+	evs := events.Builders{
+		evtReceivePingSlotInfoRequest.With(events.WithData(pld)),
 	}
 	if dev.MACState.DeviceClass != ttnpb.CLASS_A {
 		log.FromContext(ctx).Debug("Ignore PingSlotInfoReq from device not in class A mode")
@@ -43,6 +43,6 @@ func handlePingSlotInfoReq(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb
 	dev.MACState.PingSlotPeriodicity = &ttnpb.PingSlotPeriodValue{Value: pld.Period}
 	dev.MACState.QueuedResponses = append(dev.MACState.QueuedResponses, ttnpb.CID_PING_SLOT_INFO.MACCommand())
 	return append(evs,
-		evtEnqueuePingSlotInfoAnswer.BindData(nil),
+		evtEnqueuePingSlotInfoAnswer,
 	), nil
 }

--- a/pkg/networkserver/mac_ping_slot_info_test.go
+++ b/pkg/networkserver/mac_ping_slot_info_test.go
@@ -30,7 +30,7 @@ func TestHandlePingSlotInfoReq(t *testing.T) {
 		Name             string
 		Device, Expected *ttnpb.EndDevice
 		Payload          *ttnpb.MACCommand_PingSlotInfoReq
-		Events           []events.DefinitionDataClosure
+		Events           events.Builders
 		Error            error
 	}{
 		{
@@ -62,10 +62,10 @@ func TestHandlePingSlotInfoReq(t *testing.T) {
 			Payload: &ttnpb.MACCommand_PingSlotInfoReq{
 				Period: 42,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceivePingSlotInfoRequest.BindData(&ttnpb.MACCommand_PingSlotInfoReq{
+			Events: events.Builders{
+				evtReceivePingSlotInfoRequest.With(events.WithData(&ttnpb.MACCommand_PingSlotInfoReq{
 					Period: 42,
-				}),
+				})),
 			},
 		},
 		{
@@ -87,11 +87,11 @@ func TestHandlePingSlotInfoReq(t *testing.T) {
 			Payload: &ttnpb.MACCommand_PingSlotInfoReq{
 				Period: 42,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceivePingSlotInfoRequest.BindData(&ttnpb.MACCommand_PingSlotInfoReq{
+			Events: events.Builders{
+				evtReceivePingSlotInfoRequest.With(events.WithData(&ttnpb.MACCommand_PingSlotInfoReq{
 					Period: 42,
-				}),
-				evtEnqueuePingSlotInfoAnswer.BindData(nil),
+				})),
+				evtEnqueuePingSlotInfoAnswer,
 			},
 		},
 		{
@@ -121,11 +121,11 @@ func TestHandlePingSlotInfoReq(t *testing.T) {
 			Payload: &ttnpb.MACCommand_PingSlotInfoReq{
 				Period: 42,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceivePingSlotInfoRequest.BindData(&ttnpb.MACCommand_PingSlotInfoReq{
+			Events: events.Builders{
+				evtReceivePingSlotInfoRequest.With(events.WithData(&ttnpb.MACCommand_PingSlotInfoReq{
 					Period: 42,
-				}),
-				evtEnqueuePingSlotInfoAnswer.BindData(nil),
+				})),
+				evtEnqueuePingSlotInfoAnswer,
 			},
 		},
 	} {
@@ -140,7 +140,7 @@ func TestHandlePingSlotInfoReq(t *testing.T) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
+			a.So(evs, should.ResembleEventBuilders, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/mac_rejoin_param_setup.go
+++ b/pkg/networkserver/mac_rejoin_param_setup.go
@@ -45,7 +45,7 @@ func enqueueRejoinParamSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDo
 	}
 
 	var st macCommandEnqueueState
-	dev.MACState.PendingRequests, st = enqueueMACCommand(ttnpb.CID_REJOIN_PARAM_SETUP, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, []events.DefinitionDataClosure, bool) {
+	dev.MACState.PendingRequests, st = enqueueMACCommand(ttnpb.CID_REJOIN_PARAM_SETUP, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, events.Builders, bool) {
 		if nDown < 1 || nUp < 1 {
 			return nil, 0, nil, false
 		}
@@ -62,15 +62,15 @@ func enqueueRejoinParamSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDo
 				req.MACCommand(),
 			},
 			1,
-			[]events.DefinitionDataClosure{
-				evtEnqueueRejoinParamSetupRequest.BindData(req),
+			events.Builders{
+				evtEnqueueRejoinParamSetupRequest.With(events.WithData(req)),
 			},
 			true
 	}, dev.MACState.PendingRequests...)
 	return st
 }
 
-func handleRejoinParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_RejoinParamSetupAns) ([]events.DefinitionDataClosure, error) {
+func handleRejoinParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_RejoinParamSetupAns) (events.Builders, error) {
 	if pld == nil {
 		return nil, errNoPayload.New()
 	}
@@ -85,7 +85,7 @@ func handleRejoinParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice, pld *t
 		}
 		return nil
 	}, dev.MACState.PendingRequests...)
-	return []events.DefinitionDataClosure{
-		evtReceiveRejoinParamSetupAnswer.BindData(pld),
+	return events.Builders{
+		evtReceiveRejoinParamSetupAnswer.With(events.WithData(pld)),
 	}, err
 }

--- a/pkg/networkserver/mac_rejoin_param_setup_test.go
+++ b/pkg/networkserver/mac_rejoin_param_setup_test.go
@@ -118,7 +118,7 @@ func TestHandleRejoinParamSetupAns(t *testing.T) {
 		Name             string
 		Device, Expected *ttnpb.EndDevice
 		Payload          *ttnpb.MACCommand_RejoinParamSetupAns
-		Events           []events.DefinitionDataClosure
+		Events           events.Builders
 		Error            error
 	}{
 		{
@@ -142,10 +142,10 @@ func TestHandleRejoinParamSetupAns(t *testing.T) {
 			Payload: &ttnpb.MACCommand_RejoinParamSetupAns{
 				MaxTimeExponentAck: true,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveRejoinParamSetupAnswer.BindData(&ttnpb.MACCommand_RejoinParamSetupAns{
+			Events: events.Builders{
+				evtReceiveRejoinParamSetupAnswer.With(events.WithData(&ttnpb.MACCommand_RejoinParamSetupAns{
 					MaxTimeExponentAck: true,
-				}),
+				})),
 			},
 			Error: errMACRequestNotFound,
 		},
@@ -173,10 +173,10 @@ func TestHandleRejoinParamSetupAns(t *testing.T) {
 			Payload: &ttnpb.MACCommand_RejoinParamSetupAns{
 				MaxTimeExponentAck: true,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveRejoinParamSetupAnswer.BindData(&ttnpb.MACCommand_RejoinParamSetupAns{
+			Events: events.Builders{
+				evtReceiveRejoinParamSetupAnswer.With(events.WithData(&ttnpb.MACCommand_RejoinParamSetupAns{
 					MaxTimeExponentAck: true,
-				}),
+				})),
 			},
 		},
 		{
@@ -206,8 +206,8 @@ func TestHandleRejoinParamSetupAns(t *testing.T) {
 			Payload: &ttnpb.MACCommand_RejoinParamSetupAns{
 				MaxTimeExponentAck: false,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveRejoinParamSetupAnswer.BindData(&ttnpb.MACCommand_RejoinParamSetupAns{}),
+			Events: events.Builders{
+				evtReceiveRejoinParamSetupAnswer.With(events.WithData(&ttnpb.MACCommand_RejoinParamSetupAns{})),
 			},
 		},
 	} {
@@ -222,7 +222,7 @@ func TestHandleRejoinParamSetupAns(t *testing.T) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
+			a.So(evs, should.ResembleEventBuilders, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/mac_rekey.go
+++ b/pkg/networkserver/mac_rekey.go
@@ -27,13 +27,13 @@ var (
 	evtEnqueueRekeyConfirmation = defineEnqueueMACConfirmationEvent("rekey", "device rekey")()
 )
 
-func handleRekeyInd(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_RekeyInd, devAddr types.DevAddr) ([]events.DefinitionDataClosure, error) {
+func handleRekeyInd(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_RekeyInd, devAddr types.DevAddr) (events.Builders, error) {
 	if pld == nil {
 		return nil, errNoPayload.New()
 	}
 
-	evs := []events.DefinitionDataClosure{
-		evtReceiveRekeyIndication.BindData(pld),
+	evs := events.Builders{
+		evtReceiveRekeyIndication.With(events.WithData(pld)),
 	}
 	if !dev.SupportsJoin {
 		return evs, nil
@@ -52,6 +52,6 @@ func handleRekeyInd(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCom
 	}
 	dev.MACState.QueuedResponses = append(dev.MACState.QueuedResponses, conf.MACCommand())
 	return append(evs,
-		evtEnqueueRekeyConfirmation.BindData(conf),
+		evtEnqueueRekeyConfirmation.With(events.WithData(conf)),
 	), nil
 }

--- a/pkg/networkserver/mac_rekey_test.go
+++ b/pkg/networkserver/mac_rekey_test.go
@@ -31,7 +31,7 @@ func TestHandleRekeyInd(t *testing.T) {
 		Name             string
 		Device, Expected *ttnpb.EndDevice
 		Payload          *ttnpb.MACCommand_RekeyInd
-		Events           []events.DefinitionDataClosure
+		Events           events.Builders
 		Error            error
 	}{
 		{
@@ -81,13 +81,13 @@ func TestHandleRekeyInd(t *testing.T) {
 			Payload: &ttnpb.MACCommand_RekeyInd{
 				MinorVersion: 1,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveRekeyIndication.BindData(&ttnpb.MACCommand_RekeyInd{
+			Events: events.Builders{
+				evtReceiveRekeyIndication.With(events.WithData(&ttnpb.MACCommand_RekeyInd{
 					MinorVersion: 1,
-				}),
-				evtEnqueueRekeyConfirmation.BindData(&ttnpb.MACCommand_RekeyConf{
+				})),
+				evtEnqueueRekeyConfirmation.With(events.WithData(&ttnpb.MACCommand_RekeyConf{
 					MinorVersion: 1,
-				}),
+				})),
 			},
 		},
 		{
@@ -135,13 +135,13 @@ func TestHandleRekeyInd(t *testing.T) {
 			Payload: &ttnpb.MACCommand_RekeyInd{
 				MinorVersion: 1,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveRekeyIndication.BindData(&ttnpb.MACCommand_RekeyInd{
+			Events: events.Builders{
+				evtReceiveRekeyIndication.With(events.WithData(&ttnpb.MACCommand_RekeyInd{
 					MinorVersion: 1,
-				}),
-				evtEnqueueRekeyConfirmation.BindData(&ttnpb.MACCommand_RekeyConf{
+				})),
+				evtEnqueueRekeyConfirmation.With(events.WithData(&ttnpb.MACCommand_RekeyConf{
 					MinorVersion: 1,
-				}),
+				})),
 			},
 		},
 		{
@@ -180,13 +180,13 @@ func TestHandleRekeyInd(t *testing.T) {
 			Payload: &ttnpb.MACCommand_RekeyInd{
 				MinorVersion: 1,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveRekeyIndication.BindData(&ttnpb.MACCommand_RekeyInd{
+			Events: events.Builders{
+				evtReceiveRekeyIndication.With(events.WithData(&ttnpb.MACCommand_RekeyInd{
 					MinorVersion: 1,
-				}),
-				evtEnqueueRekeyConfirmation.BindData(&ttnpb.MACCommand_RekeyConf{
+				})),
+				evtEnqueueRekeyConfirmation.With(events.WithData(&ttnpb.MACCommand_RekeyConf{
 					MinorVersion: 1,
-				}),
+				})),
 			},
 		},
 		{
@@ -233,13 +233,13 @@ func TestHandleRekeyInd(t *testing.T) {
 			Payload: &ttnpb.MACCommand_RekeyInd{
 				MinorVersion: 1,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveRekeyIndication.BindData(&ttnpb.MACCommand_RekeyInd{
+			Events: events.Builders{
+				evtReceiveRekeyIndication.With(events.WithData(&ttnpb.MACCommand_RekeyInd{
 					MinorVersion: 1,
-				}),
-				evtEnqueueRekeyConfirmation.BindData(&ttnpb.MACCommand_RekeyConf{
+				})),
+				evtEnqueueRekeyConfirmation.With(events.WithData(&ttnpb.MACCommand_RekeyConf{
 					MinorVersion: 1,
-				}),
+				})),
 			},
 		},
 	} {
@@ -254,7 +254,7 @@ func TestHandleRekeyInd(t *testing.T) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
+			a.So(evs, should.ResembleEventBuilders, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/mac_reset.go
+++ b/pkg/networkserver/mac_reset.go
@@ -27,13 +27,13 @@ var (
 	evtEnqueueResetConfirmation = defineEnqueueMACConfirmationEvent("reset", "device reset")()
 )
 
-func handleResetInd(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_ResetInd, fps *frequencyplans.Store, defaults ttnpb.MACSettings) ([]events.DefinitionDataClosure, error) {
+func handleResetInd(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_ResetInd, fps *frequencyplans.Store, defaults ttnpb.MACSettings) (events.Builders, error) {
 	if pld == nil {
 		return nil, errNoPayload.New()
 	}
 
-	evs := []events.DefinitionDataClosure{
-		evtReceiveResetIndication.BindData(pld),
+	evs := events.Builders{
+		evtReceiveResetIndication.With(events.WithData(pld)),
 	}
 	if dev.SupportsJoin {
 		return evs, nil
@@ -51,6 +51,6 @@ func handleResetInd(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCom
 	}
 	dev.MACState.QueuedResponses = append(dev.MACState.QueuedResponses, conf.MACCommand())
 	return append(evs,
-		evtEnqueueResetConfirmation.BindData(conf),
+		evtEnqueueResetConfirmation.With(events.WithData(conf)),
 	), nil
 }

--- a/pkg/networkserver/mac_reset_test.go
+++ b/pkg/networkserver/mac_reset_test.go
@@ -32,7 +32,7 @@ func TestHandleResetInd(t *testing.T) {
 		Name             string
 		Device, Expected *ttnpb.EndDevice
 		Payload          *ttnpb.MACCommand_ResetInd
-		Events           []events.DefinitionDataClosure
+		Events           events.Builders
 		Error            error
 	}{
 		{
@@ -87,13 +87,13 @@ func TestHandleResetInd(t *testing.T) {
 			Payload: &ttnpb.MACCommand_ResetInd{
 				MinorVersion: 1,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveResetIndication.BindData(&ttnpb.MACCommand_ResetInd{
+			Events: events.Builders{
+				evtReceiveResetIndication.With(events.WithData(&ttnpb.MACCommand_ResetInd{
 					MinorVersion: 1,
-				}),
-				evtEnqueueResetConfirmation.BindData(&ttnpb.MACCommand_ResetConf{
+				})),
+				evtEnqueueResetConfirmation.With(events.WithData(&ttnpb.MACCommand_ResetConf{
 					MinorVersion: 1,
-				}),
+				})),
 			},
 		},
 		{
@@ -136,13 +136,13 @@ func TestHandleResetInd(t *testing.T) {
 			Payload: &ttnpb.MACCommand_ResetInd{
 				MinorVersion: 1,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveResetIndication.BindData(&ttnpb.MACCommand_ResetInd{
+			Events: events.Builders{
+				evtReceiveResetIndication.With(events.WithData(&ttnpb.MACCommand_ResetInd{
 					MinorVersion: 1,
-				}),
-				evtEnqueueResetConfirmation.BindData(&ttnpb.MACCommand_ResetConf{
+				})),
+				evtEnqueueResetConfirmation.With(events.WithData(&ttnpb.MACCommand_ResetConf{
 					MinorVersion: 1,
-				}),
+				})),
 			},
 		},
 	} {
@@ -157,7 +157,7 @@ func TestHandleResetInd(t *testing.T) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
+			a.So(evs, should.ResembleEventBuilders, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/mac_rx_param_setup.go
+++ b/pkg/networkserver/mac_rx_param_setup.go
@@ -46,7 +46,7 @@ func enqueueRxParamSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLe
 	}
 
 	var st macCommandEnqueueState
-	dev.MACState.PendingRequests, st = enqueueMACCommand(ttnpb.CID_RX_PARAM_SETUP, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, []events.DefinitionDataClosure, bool) {
+	dev.MACState.PendingRequests, st = enqueueMACCommand(ttnpb.CID_RX_PARAM_SETUP, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, events.Builders, bool) {
 		if nDown < 1 || nUp < 1 {
 			return nil, 0, nil, false
 		}
@@ -64,15 +64,15 @@ func enqueueRxParamSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLe
 				req.MACCommand(),
 			},
 			1,
-			[]events.DefinitionDataClosure{
-				evtEnqueueRxParamSetupRequest.BindData(req),
+			events.Builders{
+				evtEnqueueRxParamSetupRequest.With(events.WithData(req)),
 			},
 			true
 	}, dev.MACState.PendingRequests...)
 	return st
 }
 
-func handleRxParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_RxParamSetupAns) ([]events.DefinitionDataClosure, error) {
+func handleRxParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACCommand_RxParamSetupAns) (events.Builders, error) {
 	if pld == nil {
 		return nil, errNoPayload.New()
 	}
@@ -94,7 +94,7 @@ func handleRxParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb
 	if !pld.Rx1DataRateOffsetAck || !pld.Rx2DataRateIndexAck || !pld.Rx2FrequencyAck {
 		evt = evtReceiveRxParamSetupReject
 	}
-	return []events.DefinitionDataClosure{
-		evt.BindData(pld),
+	return events.Builders{
+		evt.With(events.WithData(pld)),
 	}, err
 }

--- a/pkg/networkserver/mac_rx_param_setup_test.go
+++ b/pkg/networkserver/mac_rx_param_setup_test.go
@@ -128,7 +128,7 @@ func TestHandleRxParamSetupAns(t *testing.T) {
 		Name             string
 		Device, Expected *ttnpb.EndDevice
 		Payload          *ttnpb.MACCommand_RxParamSetupAns
-		Events           []events.DefinitionDataClosure
+		Events           events.Builders
 		Error            error
 	}{
 		{
@@ -154,12 +154,12 @@ func TestHandleRxParamSetupAns(t *testing.T) {
 				Rx2DataRateIndexAck:  true,
 				Rx2FrequencyAck:      true,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveRxParamSetupAccept.BindData(&ttnpb.MACCommand_RxParamSetupAns{
+			Events: events.Builders{
+				evtReceiveRxParamSetupAccept.With(events.WithData(&ttnpb.MACCommand_RxParamSetupAns{
 					Rx1DataRateOffsetAck: true,
 					Rx2DataRateIndexAck:  true,
 					Rx2FrequencyAck:      true,
-				}),
+				})),
 			},
 			Error: errMACRequestNotFound,
 		},
@@ -195,12 +195,12 @@ func TestHandleRxParamSetupAns(t *testing.T) {
 				Rx2DataRateIndexAck:  true,
 				Rx2FrequencyAck:      true,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveRxParamSetupAccept.BindData(&ttnpb.MACCommand_RxParamSetupAns{
+			Events: events.Builders{
+				evtReceiveRxParamSetupAccept.With(events.WithData(&ttnpb.MACCommand_RxParamSetupAns{
 					Rx1DataRateOffsetAck: true,
 					Rx2DataRateIndexAck:  true,
 					Rx2FrequencyAck:      true,
-				}),
+				})),
 			},
 		},
 		{
@@ -233,11 +233,11 @@ func TestHandleRxParamSetupAns(t *testing.T) {
 				Rx1DataRateOffsetAck: true,
 				Rx2DataRateIndexAck:  true,
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveRxParamSetupReject.BindData(&ttnpb.MACCommand_RxParamSetupAns{
+			Events: events.Builders{
+				evtReceiveRxParamSetupReject.With(events.WithData(&ttnpb.MACCommand_RxParamSetupAns{
 					Rx1DataRateOffsetAck: true,
 					Rx2DataRateIndexAck:  true,
-				}),
+				})),
 			},
 		},
 	} {
@@ -252,7 +252,7 @@ func TestHandleRxParamSetupAns(t *testing.T) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
+			a.So(evs, should.ResembleEventBuilders, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/mac_rx_timing_setup.go
+++ b/pkg/networkserver/mac_rx_timing_setup.go
@@ -43,7 +43,7 @@ func enqueueRxTimingSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownL
 	}
 
 	var st macCommandEnqueueState
-	dev.MACState.PendingRequests, st = enqueueMACCommand(ttnpb.CID_RX_TIMING_SETUP, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, []events.DefinitionDataClosure, bool) {
+	dev.MACState.PendingRequests, st = enqueueMACCommand(ttnpb.CID_RX_TIMING_SETUP, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, events.Builders, bool) {
 		if nDown < 1 || nUp < 1 {
 			return nil, 0, nil, false
 		}
@@ -57,15 +57,15 @@ func enqueueRxTimingSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownL
 				req.MACCommand(),
 			},
 			1,
-			[]events.DefinitionDataClosure{
-				evtEnqueueRxTimingSetupRequest.BindData(req),
+			events.Builders{
+				evtEnqueueRxTimingSetupRequest.With(events.WithData(req)),
 			},
 			true
 	}, dev.MACState.PendingRequests...)
 	return st
 }
 
-func handleRxTimingSetupAns(ctx context.Context, dev *ttnpb.EndDevice) ([]events.DefinitionDataClosure, error) {
+func handleRxTimingSetupAns(ctx context.Context, dev *ttnpb.EndDevice) (events.Builders, error) {
 	var err error
 	dev.MACState.PendingRequests, err = handleMACResponse(ttnpb.CID_RX_TIMING_SETUP, func(cmd *ttnpb.MACCommand) error {
 		req := cmd.GetRxTimingSetupReq()
@@ -73,7 +73,7 @@ func handleRxTimingSetupAns(ctx context.Context, dev *ttnpb.EndDevice) ([]events
 		dev.MACState.CurrentParameters.Rx1Delay = req.Delay
 		return nil
 	}, dev.MACState.PendingRequests...)
-	return []events.DefinitionDataClosure{
-		evtReceiveRxTimingSetupAnswer.BindData(nil),
+	return events.Builders{
+		evtReceiveRxTimingSetupAnswer,
 	}, err
 }

--- a/pkg/networkserver/mac_rx_timing_setup_test.go
+++ b/pkg/networkserver/mac_rx_timing_setup_test.go
@@ -83,7 +83,7 @@ func TestHandleRxTimingSetupAns(t *testing.T) {
 	for _, tc := range []struct {
 		Name             string
 		Device, Expected *ttnpb.EndDevice
-		Events           []events.DefinitionDataClosure
+		Events           events.Builders
 		Error            error
 	}{
 		{
@@ -94,8 +94,8 @@ func TestHandleRxTimingSetupAns(t *testing.T) {
 			Expected: &ttnpb.EndDevice{
 				MACState: &ttnpb.MACState{},
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveRxTimingSetupAnswer.BindData(nil),
+			Events: events.Builders{
+				evtReceiveRxTimingSetupAnswer,
 			},
 			Error: errMACRequestNotFound,
 		},
@@ -118,8 +118,8 @@ func TestHandleRxTimingSetupAns(t *testing.T) {
 					PendingRequests: []*ttnpb.MACCommand{},
 				},
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveRxTimingSetupAnswer.BindData(nil),
+			Events: events.Builders{
+				evtReceiveRxTimingSetupAnswer,
 			},
 		},
 	} {
@@ -134,7 +134,7 @@ func TestHandleRxTimingSetupAns(t *testing.T) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
+			a.So(evs, should.ResembleEventBuilders, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/mac_tx_param_setup.go
+++ b/pkg/networkserver/mac_tx_param_setup.go
@@ -63,7 +63,7 @@ func enqueueTxParamSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLe
 	}
 
 	var st macCommandEnqueueState
-	dev.MACState.PendingRequests, st = enqueueMACCommand(ttnpb.CID_TX_PARAM_SETUP, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, []events.DefinitionDataClosure, bool) {
+	dev.MACState.PendingRequests, st = enqueueMACCommand(ttnpb.CID_TX_PARAM_SETUP, maxDownLen, maxUpLen, func(nDown, nUp uint16) ([]*ttnpb.MACCommand, uint16, events.Builders, bool) {
 		if nDown < 1 || nUp < 1 {
 			return nil, 0, nil, false
 		}
@@ -81,15 +81,15 @@ func enqueueTxParamSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLe
 				req.MACCommand(),
 			},
 			1,
-			[]events.DefinitionDataClosure{
-				evtEnqueueTxParamSetupRequest.BindData(req),
+			events.Builders{
+				evtEnqueueTxParamSetupRequest.With(events.WithData(req)),
 			},
 			true
 	}, dev.MACState.PendingRequests...)
 	return st
 }
 
-func handleTxParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice) ([]events.DefinitionDataClosure, error) {
+func handleTxParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice) (events.Builders, error) {
 	var err error
 	dev.MACState.PendingRequests, err = handleMACResponse(ttnpb.CID_TX_PARAM_SETUP, func(cmd *ttnpb.MACCommand) error {
 		req := cmd.GetTxParamSetupReq()
@@ -103,7 +103,7 @@ func handleTxParamSetupAns(ctx context.Context, dev *ttnpb.EndDevice) ([]events.
 		}
 		return nil
 	}, dev.MACState.PendingRequests...)
-	return []events.DefinitionDataClosure{
-		evtReceiveTxParamSetupAnswer.BindData(nil),
+	return events.Builders{
+		evtReceiveTxParamSetupAnswer,
 	}, err
 }

--- a/pkg/networkserver/mac_tx_param_setup_test.go
+++ b/pkg/networkserver/mac_tx_param_setup_test.go
@@ -204,12 +204,12 @@ func TestEnqueueTxParamSetupReq(t *testing.T) {
 				MaxDownLen: 40,
 				MaxUpLen:   23,
 				Ok:         true,
-				QueuedEvents: []events.DefinitionDataClosure{
-					evtEnqueueTxParamSetupRequest.BindData(&ttnpb.MACCommand_TxParamSetupReq{
+				QueuedEvents: events.Builders{
+					evtEnqueueTxParamSetupRequest.With(events.WithData(&ttnpb.MACCommand_TxParamSetupReq{
 						MaxEIRPIndex:      ttnpb.DEVICE_EIRP_26,
 						DownlinkDwellTime: true,
 						UplinkDwellTime:   true,
-					}),
+					})),
 				},
 			},
 		},
@@ -321,7 +321,7 @@ func TestEnqueueTxParamSetupReq(t *testing.T) {
 
 			st := enqueueTxParamSetupReq(test.Context(), dev, tc.MaxDownlinkLength, tc.MaxUplinkLength, test.Must(test.Must(band.GetByID(band.AS_923)).(band.Band).Version(ttnpb.PHY_V1_1_REV_B)).(band.Band))
 			a.So(dev, should.Resemble, tc.ExpectedDevice)
-			a.So(st.QueuedEvents, should.ResembleEventDefinitionDataClosures, tc.State.QueuedEvents)
+			a.So(st.QueuedEvents, should.ResembleEventBuilders, tc.State.QueuedEvents)
 			st.QueuedEvents = tc.State.QueuedEvents
 			a.So(st, should.Resemble, tc.State)
 		})
@@ -332,7 +332,7 @@ func TestHandleTxParamSetupAns(t *testing.T) {
 	for _, tc := range []struct {
 		Name                        string
 		InputDevice, ExpectedDevice *ttnpb.EndDevice
-		Events                      []events.DefinitionDataClosure
+		Events                      events.Builders
 		Error                       error
 	}{
 		{
@@ -343,8 +343,8 @@ func TestHandleTxParamSetupAns(t *testing.T) {
 			ExpectedDevice: &ttnpb.EndDevice{
 				MACState: &ttnpb.MACState{},
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveTxParamSetupAnswer.BindData(nil),
+			Events: events.Builders{
+				evtReceiveTxParamSetupAnswer,
 			},
 			Error: errMACRequestNotFound,
 		},
@@ -371,8 +371,8 @@ func TestHandleTxParamSetupAns(t *testing.T) {
 					PendingRequests: []*ttnpb.MACCommand{},
 				},
 			},
-			Events: []events.DefinitionDataClosure{
-				evtReceiveTxParamSetupAnswer.BindData(nil),
+			Events: events.Builders{
+				evtReceiveTxParamSetupAnswer,
 			},
 		},
 	} {
@@ -387,7 +387,7 @@ func TestHandleTxParamSetupAns(t *testing.T) {
 				t.FailNow()
 			}
 			a.So(dev, should.Resemble, tc.ExpectedDevice)
-			a.So(evs, should.ResembleEventDefinitionDataClosures, tc.Events)
+			a.So(evs, should.ResembleEventBuilders, tc.Events)
 		})
 	}
 }

--- a/pkg/networkserver/networkserver_util_test.go
+++ b/pkg/networkserver/networkserver_util_test.go
@@ -1583,7 +1583,7 @@ func AssertLinkApplication(ctx context.Context, conn *grpc.ClientConn, getPeerCh
 
 	if !a.So(test.AssertEventPubSubPublishRequests(ctx, eventsPublishCh, 1+len(replaceEvents), func(evs ...events.Event) bool {
 		return a.So(evs, should.HaveSameElementsEvent, append(
-			[]events.Event{EvtBeginApplicationLink(events.ContextWithCorrelationID(test.Context(), reqCIDs...), appID, nil)},
+			[]events.Event{EvtBeginApplicationLink.NewWithIdentifiersAndData(events.ContextWithCorrelationID(test.Context(), reqCIDs...), appID, nil)},
 			replaceEvents...,
 		))
 	}), should.BeTrue) {
@@ -1596,7 +1596,7 @@ func AssertLinkApplication(ctx context.Context, conn *grpc.ClientConn, getPeerCh
 		return nil, nil, false
 	}
 	return link, func(err error) events.Event {
-		return EvtEndApplicationLink(events.ContextWithCorrelationID(test.Context(), reqCIDs...), appID, err)
+		return EvtEndApplicationLink.NewWithIdentifiersAndData(events.ContextWithCorrelationID(test.Context(), reqCIDs...), appID, err)
 	}, a.So(err, should.BeNil)
 }
 

--- a/pkg/networkserver/observability.go
+++ b/pkg/networkserver/observability.go
@@ -27,163 +27,163 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 )
 
-func defineReceiveMACAcceptEvent(name, desc string) func() events.Definition {
+func defineReceiveMACAcceptEvent(name, desc string) func() events.Builder {
 	return events.DefineFunc(
 		fmt.Sprintf("ns.mac.%s.answer.accept", name), fmt.Sprintf("%s accept received", desc),
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 }
 
-func defineReceiveMACAnswerEvent(name, desc string) func() events.Definition {
+func defineReceiveMACAnswerEvent(name, desc string) func() events.Builder {
 	return events.DefineFunc(
 		fmt.Sprintf("ns.mac.%s.answer", name), fmt.Sprintf("%s answer received", desc),
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 }
 
-func defineReceiveMACIndicationEvent(name, desc string) func() events.Definition {
+func defineReceiveMACIndicationEvent(name, desc string) func() events.Builder {
 	return events.DefineFunc(
 		fmt.Sprintf("ns.mac.%s.indication", name), fmt.Sprintf("%s indication received", desc),
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 }
 
-func defineReceiveMACRejectEvent(name, desc string) func() events.Definition {
+func defineReceiveMACRejectEvent(name, desc string) func() events.Builder {
 	return events.DefineFunc(
 		fmt.Sprintf("ns.mac.%s.answer.reject", name), fmt.Sprintf("%s rejection received", desc),
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 }
 
-func defineReceiveMACRequestEvent(name, desc string) func() events.Definition {
+func defineReceiveMACRequestEvent(name, desc string) func() events.Builder {
 	return events.DefineFunc(
 		fmt.Sprintf("ns.mac.%s.request", name), fmt.Sprintf("%s request received", desc),
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 }
 
-func defineEnqueueMACAnswerEvent(name, desc string) func() events.Definition {
+func defineEnqueueMACAnswerEvent(name, desc string) func() events.Builder {
 	return events.DefineFunc(
 		fmt.Sprintf("ns.mac.%s.answer", name), fmt.Sprintf("%s answer enqueued", desc),
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 }
 
-func defineEnqueueMACConfirmationEvent(name, desc string) func() events.Definition {
+func defineEnqueueMACConfirmationEvent(name, desc string) func() events.Builder {
 	return events.DefineFunc(
 		fmt.Sprintf("ns.mac.%s.confirmation", name), fmt.Sprintf("%s confirmation enqueued", desc),
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 }
 
-func defineEnqueueMACRequestEvent(name, desc string) func() events.Definition {
+func defineEnqueueMACRequestEvent(name, desc string) func() events.Builder {
 	return events.DefineFunc(
 		fmt.Sprintf("ns.mac.%s.request", name), fmt.Sprintf("%s request enqueued", desc),
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 }
 
-func defineClassSwitchEvent(class rune) func() events.Definition {
+func defineClassSwitchEvent(class rune) func() events.Builder {
 	return events.DefineFunc(
 		fmt.Sprintf("ns.class.switch.%c", class), fmt.Sprintf("switched to class %c", unicode.ToUpper(class)),
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 }
 
 var (
 	evtBeginApplicationLink = events.Define(
 		"ns.application.link.begin", "begin application link",
-		ttnpb.RIGHT_APPLICATION_LINK,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_LINK),
 	)
 	evtEndApplicationLink = events.Define(
 		"ns.application.link.end", "end application link",
-		ttnpb.RIGHT_APPLICATION_LINK,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_LINK),
 	)
 	evtReceiveDataUplink = events.Define(
 		"ns.up.data.receive", "receive data message",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtDropDataUplink = events.Define(
 		"ns.up.data.drop", "drop data message",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtProcessDataUplink = events.Define(
 		"ns.up.data.process", "successfully processed data message",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtForwardDataUplink = events.Define(
 		"ns.up.data.forward", "forward data message to Application Server",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtScheduleDataDownlinkAttempt = events.Define(
 		"ns.down.data.schedule.attempt", "schedule data downlink for transmission on Gateway Server",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtScheduleDataDownlinkSuccess = events.Define(
 		"ns.down.data.schedule.success", "successfully scheduled data downlink for transmission on Gateway Server",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtScheduleDataDownlinkFail = events.Define(
 		"ns.down.data.schedule.fail", "failed to schedule data downlink for transmission on Gateway Server",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtReceiveJoinRequest = events.Define(
 		"ns.up.join.receive", "receive join-request",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtDropJoinRequest = events.Define(
 		"ns.up.join.drop", "drop join-request",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtProcessJoinRequest = events.Define(
 		"ns.up.join.process", "successfully processed join-request",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtClusterJoinAttempt = events.Define(
 		"ns.up.join.cluster.attempt", "send join-request to cluster-local Join Server",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtClusterJoinSuccess = events.Define(
 		"ns.up.join.cluster.success", "join-request to cluster-local Join Server succeeded",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtClusterJoinFail = events.Define(
 		"ns.up.join.cluster.fail", "join-request to cluster-local Join Server failed",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtInteropJoinAttempt = events.Define(
 		"ns.up.join.interop.attempt", "forward join-request to interoperability Join Server",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtInteropJoinSuccess = events.Define(
 		"ns.up.join.interop.success", "join-request to interoperability Join Server succeeded",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtInteropJoinFail = events.Define(
 		"ns.up.join.interop.fail", "join-request to interoperability Join Server failed",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtForwardJoinAccept = events.Define(
 		"ns.up.join.accept.forward", "forward join-accept to Application Server",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtScheduleJoinAcceptAttempt = events.Define(
 		"ns.down.join.schedule.attempt", "schedule join-accept for transmission on Gateway Server",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtScheduleJoinAcceptSuccess = events.Define(
 		"ns.down.join.schedule.success", "successfully scheduled join-accept for transmission on Gateway Server",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtScheduleJoinAcceptFail = events.Define(
 		"ns.down.join.schedule.fail", "failed to schedule join-accept for transmission on Gateway Server",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 	evtEnqueueProprietaryMACAnswer  = defineEnqueueMACAnswerEvent("proprietary", "proprietary MAC command")
 	evtEnqueueProprietaryMACRequest = defineEnqueueMACRequestEvent("proprietary", "proprietary MAC command")
 	evtReceiveProprietaryMAC        = events.Define(
 		"ns.mac.proprietary.receive", "receive proprietary MAC command",
-		ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
+		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 	)
 
 	evtClassASwitch = defineClassSwitchEvent('a')()

--- a/pkg/oauth/oauth.go
+++ b/pkg/oauth/oauth.go
@@ -145,7 +145,7 @@ func (s *server) Authorize(authorizePage echo.HandlerFunc) echo.HandlerFunc {
 			}
 		}
 		if ar.Authorized {
-			events.Publish(evtAuthorize(req.Context(), ttnpb.CombineIdentifiers(session.UserIdentifiers, client.ClientIdentifiers), nil))
+			events.Publish(evtAuthorize.NewWithIdentifiersAndData(req.Context(), ttnpb.CombineIdentifiers(session.UserIdentifiers, client.ClientIdentifiers), nil))
 		}
 		oauth2.FinishAuthorizeRequest(resp, req, ar)
 		return s.output(c, resp)
@@ -216,7 +216,7 @@ func (s *server) Token(c echo.Context) error {
 		}
 	}
 	if ar.Authorized {
-		events.Publish(evtTokenExchange(req.Context(), ttnpb.CombineIdentifiers(userIDs, client.ClientIdentifiers), nil))
+		events.Publish(evtTokenExchange.NewWithIdentifiersAndData(req.Context(), ttnpb.CombineIdentifiers(userIDs, client.ClientIdentifiers), nil))
 	}
 	oauth2.FinishAccessRequest(resp, req, ar)
 	delete(resp.Output, "scope")

--- a/pkg/oauth/observability.go
+++ b/pkg/oauth/observability.go
@@ -22,22 +22,22 @@ import (
 var (
 	evtUserLogin = events.Define(
 		"oauth.user.login", "login user successful",
-		ttnpb.RIGHT_USER_ALL,
+		events.WithVisibility(ttnpb.RIGHT_USER_ALL),
 	)
 	evtUserLoginFailed = events.Define(
 		"oauth.user.login_failed", "login user failure",
-		ttnpb.RIGHT_USER_ALL,
+		events.WithVisibility(ttnpb.RIGHT_USER_ALL),
 	)
 	evtUserLogout = events.Define(
 		"oauth.user.logout", "logout user",
-		ttnpb.RIGHT_USER_ALL,
+		events.WithVisibility(ttnpb.RIGHT_USER_ALL),
 	)
 	evtAuthorize = events.Define(
 		"oauth.authorize", "authorize OAuth client",
-		ttnpb.RIGHT_USER_AUTHORIZED_CLIENTS,
+		events.WithVisibility(ttnpb.RIGHT_USER_AUTHORIZED_CLIENTS),
 	)
 	evtTokenExchange = events.Define(
 		"oauth.token.exchange", "exchange OAuth access token",
-		ttnpb.RIGHT_USER_AUTHORIZED_CLIENTS,
+		events.WithVisibility(ttnpb.RIGHT_USER_AUTHORIZED_CLIENTS),
 	)
 )

--- a/pkg/oauth/user.go
+++ b/pkg/oauth/user.go
@@ -171,7 +171,7 @@ func (s *server) doLogin(ctx context.Context, userID, password string) error {
 	ok, err := auth.Validate(user.Password, password)
 	region.End()
 	if err != nil || !ok {
-		events.Publish(evtUserLoginFailed(ctx, user.UserIdentifiers, nil))
+		events.Publish(evtUserLoginFailed.NewWithIdentifiersAndData(ctx, user.UserIdentifiers, nil))
 		return errIncorrectPasswordOrUserID.New()
 	}
 	return nil
@@ -202,7 +202,7 @@ func (s *server) Login(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	events.Publish(evtUserLogin(ctx, userIDs, nil))
+	events.Publish(evtUserLogin.NewWithIdentifiersAndData(ctx, userIDs, nil))
 	err = s.updateAuthCookie(c, func(cookie *auth.CookieShape) error {
 		cookie.UserID = session.UserIdentifiers.UserID
 		cookie.SessionID = session.SessionID
@@ -245,7 +245,7 @@ func (s *server) ClientLogout(c echo.Context) error {
 		if err = s.store.DeleteAccessToken(ctx, accessTokenID); err != nil {
 			return err
 		}
-		events.Publish(evtUserLogout(ctx, at.UserIDs, nil))
+		events.Publish(evtUserLogout.NewWithIdentifiersAndData(ctx, at.UserIDs, nil))
 		err = s.store.DeleteSession(ctx, &at.UserIDs, at.UserSessionID)
 		if err != nil && !errors.IsNotFound(err) {
 			return err
@@ -271,7 +271,7 @@ func (s *server) ClientLogout(c echo.Context) error {
 		return err
 	}
 	if session != nil {
-		events.Publish(evtUserLogout(ctx, session.UserIdentifiers, nil))
+		events.Publish(evtUserLogout.NewWithIdentifiersAndData(ctx, session.UserIdentifiers, nil))
 		if err = s.store.DeleteSession(ctx, &session.UserIdentifiers, session.SessionID); err != nil {
 			return err
 		}
@@ -290,7 +290,7 @@ func (s *server) Logout(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	events.Publish(evtUserLogout(ctx, session.UserIdentifiers, nil))
+	events.Publish(evtUserLogout.NewWithIdentifiersAndData(ctx, session.UserIdentifiers, nil))
 	if err = s.store.DeleteSession(ctx, &session.UserIdentifiers, session.SessionID); err != nil {
 		return err
 	}

--- a/pkg/util/test/assertions/should/should.go
+++ b/pkg/util/test/assertions/should/should.go
@@ -188,10 +188,10 @@ var (
 
 	// ResembleEvent receives exactly two events.Event and does a resemblance check.
 	ResembleEvent = testassertions.ShouldResembleEvent
-	// ResembleEventDefinitionDataClosure receives exactly two events.DefinitionDataClosure and does a resemblance check.
-	ResembleEventDefinitionDataClosure = testassertions.ShouldResembleEventDefinitionDataClosure
-	// ResembleEventDefinitionDataClosures receives exactly two []events.DefinitionDataClosure and does a resemblance check.
-	ResembleEventDefinitionDataClosures = testassertions.ShouldResembleEventDefinitionDataClosures
+	// ResembleEventBuilder receives exactly two events.Builder and does a resemblance check.
+	ResembleEventBuilder = testassertions.ShouldResembleEventBuilder
+	// ResembleEventBuilders receives exactly two events.Builders and does a resemblance check.
+	ResembleEventBuilders = testassertions.ShouldResembleEventBuilders
 
 	// ResembleFields receives at least two SetFielder parameters and optional variadic field paths and does a deep equal check (see reflect.DeepEqual) on selected fields. If field paths are empty, it checks all fields similar to Resemble.
 	ResembleFields = testassertions.ShouldResembleFields

--- a/pkg/util/test/events.go
+++ b/pkg/util/test/events.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
-	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 )
 
 type MockEventPubSub struct {
@@ -130,15 +129,9 @@ func EventEqual(a, b events.Event) bool {
 	return reflect.DeepEqual(ap, bp)
 }
 
-func EventDefinitionDataClosureEqual(a, b events.DefinitionDataClosure) bool {
+func EventBuilderEqual(a, b events.Builder) bool {
 	ctx := Context()
-	ids := &ttnpb.EndDeviceIdentifiers{
-		DeviceID: "test-dev",
-		ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{
-			ApplicationID: "test-app",
-		},
-	}
-	return EventEqual(a(ctx, ids), b(ctx, ids))
+	return EventEqual(a.New(ctx), b.New(ctx))
 }
 
 var (

--- a/pkg/util/test/events_test.go
+++ b/pkg/util/test/events_test.go
@@ -33,8 +33,12 @@ func TestSetDefaultEventPubSub(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, (1<<5)*Delay)
 	defer cancel()
 
-	testEvent1 := events.Define("test-set-default-event-pub-sub-1", "test-event-1")(ctx, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app"}, nil)
-	testEvent2 := events.Define("test-set-default-event-pub-sub-2", "test-event-2")(ctx, ttnpb.GatewayIdentifiers{GatewayID: "test-gtw"}, nil)
+	testEvent1 := events.New(ctx, "test-set-default-event-pub-sub-1", "test-event-1",
+		events.WithIdentifiers(ttnpb.ApplicationIdentifiers{ApplicationID: "test-app"}),
+	)
+	testEvent2 := events.New(ctx, "test-set-default-event-pub-sub-2", "test-event-2",
+		events.WithIdentifiers(ttnpb.GatewayIdentifiers{GatewayID: "test-gtw"}),
+	)
 
 	events.Publish(testEvent1)
 	events.Publish(testEvent2)
@@ -71,8 +75,12 @@ func TestSetDefaultEventPubSub(t *testing.T) {
 
 func TestCollectEvents(t *testing.T) {
 	ctx := Context()
-	testEvent1 := events.Define("test-collect-events-1", "test-event-1")(ctx, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app"}, nil)
-	testEvent2 := events.Define("test-collect-events-2", "test-event-2")(ctx, ttnpb.GatewayIdentifiers{GatewayID: "test-gtw"}, nil)
+	testEvent1 := events.New(ctx, "test-collect-events-1", "test-event-1",
+		events.WithIdentifiers(ttnpb.ApplicationIdentifiers{ApplicationID: "test-app"}),
+	)
+	testEvent2 := events.New(ctx, "test-collect-events-2", "test-event-2",
+		events.WithIdentifiers(ttnpb.GatewayIdentifiers{GatewayID: "test-gtw"}),
+	)
 	assertions.New(t).So(CollectEvents(func() {
 		events.Publish(testEvent1)
 		events.Publish(testEvent1)
@@ -86,8 +94,12 @@ func TestCollectEvents(t *testing.T) {
 
 func TestRedirectEvents(t *testing.T) {
 	ctx := Context()
-	testEvent1 := events.Define("test-redirect-events-1", "test-event-1")(ctx, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app"}, nil)
-	testEvent2 := events.Define("test-redirect-events-2", "test-event-2")(ctx, ttnpb.GatewayIdentifiers{GatewayID: "test-gtw"}, nil)
+	testEvent1 := events.New(ctx, "test-redirect-events-1", "test-event-1",
+		events.WithIdentifiers(ttnpb.ApplicationIdentifiers{ApplicationID: "test-app"}),
+	)
+	testEvent2 := events.New(ctx, "test-redirect-events-2", "test-event-2",
+		events.WithIdentifiers(ttnpb.GatewayIdentifiers{GatewayID: "test-gtw"}),
+	)
 	ch := make(chan events.Event, 2)
 	defer RedirectEvents(ch)()
 	events.Publish(testEvent1)
@@ -108,7 +120,9 @@ func TestRedirectEvents(t *testing.T) {
 func TestWaitEvent(t *testing.T) {
 	ctx := Context()
 	ch := make(chan events.Event, 1)
-	ch <- events.Define("test-wait-event-1", "test-event-1")(ctx, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app"}, nil)
+	ch <- events.New(ctx, "test-wait-event-1", "test-event-1",
+		events.WithIdentifiers(ttnpb.ApplicationIdentifiers{ApplicationID: "test-app"}),
+	)
 	defer close(ch)
 	assertions.New(t).So(
 		WaitEvent(ctx, ch, "test-wait-event-1"),


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR refactors the Go API of `pkg/events` in preparation for #2632.

#### Changes
<!-- What are the changes made in this pull request? -->

- `events.Define` now takes variadic options (instead of visibility rights) and returns an `events.Builder` interface (instead of a function).
- Updated all places that define events to move visibility into option.
- Updated all places that call events (which are now structs, not funcs) to use a convenience function `NewWithIdentifiersAndData` which has the same signature as the old event functions.
- Changes in the Network Server to work with the new Builders instead of closures.

#### Testing

<!-- How did you verify that this change works? -->

Existing unit tests should still pass.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Can't think of anything that could break at runtime, unless I made some stupid mistake in my regex find/replace

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This makes a lot of small changes in many places, so let's try to get this merged ASAP to avoid conflicts.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
	- ⚠️ No, this is only preparation, but I think it's acceptable to do this separately.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
	- Apparently the events documentation wasn't updated for `visibility` so it's correct again.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
