### PR TITLE
Fix RTT usage in downlink delta calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Console webhook templates empty headers error.
 - Console MQTT URL validation.
 - AFCntDown from the application-layer is respected when skipping application payload crypto.
+- RTT usage for calculating downlink delta.
 
 ### Security
 

--- a/pkg/gatewayserver/scheduling/scheduler.go
+++ b/pkg/gatewayserver/scheduling/scheduler.go
@@ -276,7 +276,7 @@ type Options struct {
 }
 
 // ScheduleAt attempts to schedule the given Tx settings with the given priority.
-// If there are round-trip times available, the maximum value will be used instead of ScheduleTimeShort.
+// If there are round-trip times available, the nth percentile (n = scheduleLateRTTPercentile) value will be used instead of ScheduleTimeShort.
 func (s *Scheduler) ScheduleAt(ctx context.Context, opts Options) (Emission, error) {
 	defer trace.StartRegion(ctx, "schedule transmission").End()
 
@@ -292,7 +292,7 @@ func (s *Scheduler) ScheduleAt(ctx context.Context, opts Options) (Emission, err
 	var medianRTT *time.Duration
 	if opts.RTTs != nil {
 		if _, _, median, np, n := opts.RTTs.Stats(scheduleLateRTTPercentile, s.timeSource.Now()); n >= scheduleMinRTTCount {
-			minScheduleTime = np + QueueDelay
+			minScheduleTime = np/2 + QueueDelay
 			medianRTT = &median
 		}
 	}

--- a/pkg/gatewayserver/scheduling/scheduler_test.go
+++ b/pkg/gatewayserver/scheduling/scheduler_test.go
@@ -118,7 +118,7 @@ func TestScheduleAtWithBandDutyCycle(t *testing.T) {
 				Timestamp:  300000,
 			},
 			Priority:       ttnpb.TxSchedulePriority_NORMAL,
-			NPercentileRTT: durationPtr(100 * time.Millisecond),
+			NPercentileRTT: durationPtr(550 * time.Millisecond),
 			ExpectedToa:    41216 * time.Microsecond,
 			// Too late for transmission with RTT.
 			ExpectedError: &scheduling.ErrTooLate,

--- a/pkg/gatewayserver/scheduling/scheduler_test.go
+++ b/pkg/gatewayserver/scheduling/scheduler_test.go
@@ -118,7 +118,7 @@ func TestScheduleAtWithBandDutyCycle(t *testing.T) {
 				Timestamp:  300000,
 			},
 			Priority:       ttnpb.TxSchedulePriority_NORMAL,
-			NPercentileRTT: durationPtr(500 * time.Millisecond),
+			NPercentileRTT: durationPtr(100 * time.Millisecond),
 			ExpectedToa:    41216 * time.Microsecond,
 			// Too late for transmission with RTT.
 			ExpectedError: &scheduling.ErrTooLate,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #3014 

#### Changes
<!-- What are the changes made in this pull request? -->

- Use `np/2` instead of `np` for `minScheduleTime`.
- Update tests and doc


#### Testing

<!-- How did you verify that this change works? -->

UT

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This is quite tricky to physically test (simulate an observable RTT). Suggestions @johanstokking? Maybe connect a gateway to `nam1` to check?

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
