### PR TITLE
Fix AFCntDown when skipping application payload crypto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Application Server pub/sub integrations race condition during shutdown.
 - Console webhook templates empty headers error.
 - Console MQTT URL validation.
+- AFCntDown from the application-layer is respected when skipping application payload crypto.
 
 ### Security
 

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -345,10 +345,14 @@ func (as *ApplicationServer) downlinkQueueOp(ctx context.Context, ids ttnpb.EndD
 			var encryptedItems []*ttnpb.ApplicationDownlink
 			for _, session := range sessions {
 				for _, item := range items {
+					fCnt := session.LastAFCntDown + 1
+					if skipPayloadCrypto(link, dev) {
+						fCnt = item.FCnt
+					}
 					encryptedItem := &ttnpb.ApplicationDownlink{
 						SessionKeyID:   session.SessionKeyID,
 						FPort:          item.FPort,
-						FCnt:           session.LastAFCntDown + 1,
+						FCnt:           fCnt,
 						FRMPayload:     item.FRMPayload,
 						DecodedPayload: item.DecodedPayload,
 						Confirmed:      item.Confirmed,

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -516,30 +516,30 @@ func (as *ApplicationServer) fetchAppSKey(ctx context.Context, ids ttnpb.EndDevi
 	return ttnpb.KeyEnvelope{}, errJSUnavailable.WithAttributes("join_eui", *ids.JoinEUI)
 }
 
-func (as *ApplicationServer) handleUp(ctx context.Context, up *ttnpb.ApplicationUp, link *link) error {
+func (as *ApplicationServer) handleUp(ctx context.Context, up *ttnpb.ApplicationUp, link *link) (pass bool, err error) {
 	ctx = log.NewContextWithField(ctx, "device_uid", unique.ID(ctx, up.EndDeviceIdentifiers))
 	if up.Simulated {
-		return as.handleSimulatedUp(ctx, up, link)
+		return true, as.handleSimulatedUp(ctx, up, link)
 	}
 	switch p := up.Up.(type) {
 	case *ttnpb.ApplicationUp_JoinAccept:
-		return as.handleJoinAccept(ctx, up.EndDeviceIdentifiers, p.JoinAccept, link)
+		return true, as.handleJoinAccept(ctx, up.EndDeviceIdentifiers, p.JoinAccept, link)
 	case *ttnpb.ApplicationUp_UplinkMessage:
-		return as.handleUplink(ctx, up.EndDeviceIdentifiers, p.UplinkMessage, link)
+		return true, as.handleUplink(ctx, up.EndDeviceIdentifiers, p.UplinkMessage, link)
 	case *ttnpb.ApplicationUp_DownlinkQueueInvalidated:
 		return as.handleDownlinkQueueInvalidated(ctx, up.EndDeviceIdentifiers, p.DownlinkQueueInvalidated, link)
 	case *ttnpb.ApplicationUp_DownlinkQueued:
-		return as.decryptDownlinkMessage(ctx, up.EndDeviceIdentifiers, p.DownlinkQueued, link)
+		return true, as.decryptDownlinkMessage(ctx, up.EndDeviceIdentifiers, p.DownlinkQueued, link)
 	case *ttnpb.ApplicationUp_DownlinkSent:
-		return as.decryptDownlinkMessage(ctx, up.EndDeviceIdentifiers, p.DownlinkSent, link)
+		return true, as.decryptDownlinkMessage(ctx, up.EndDeviceIdentifiers, p.DownlinkSent, link)
 	case *ttnpb.ApplicationUp_DownlinkFailed:
-		return as.decryptDownlinkMessage(ctx, up.EndDeviceIdentifiers, &p.DownlinkFailed.ApplicationDownlink, link)
+		return true, as.decryptDownlinkMessage(ctx, up.EndDeviceIdentifiers, &p.DownlinkFailed.ApplicationDownlink, link)
 	case *ttnpb.ApplicationUp_DownlinkAck:
-		return as.decryptDownlinkMessage(ctx, up.EndDeviceIdentifiers, p.DownlinkAck, link)
+		return true, as.decryptDownlinkMessage(ctx, up.EndDeviceIdentifiers, p.DownlinkAck, link)
 	case *ttnpb.ApplicationUp_DownlinkNack:
-		return as.handleDownlinkNack(ctx, up.EndDeviceIdentifiers, p.DownlinkNack, link)
+		return true, as.handleDownlinkNack(ctx, up.EndDeviceIdentifiers, p.DownlinkNack, link)
 	default:
-		return nil
+		return false, nil
 	}
 }
 
@@ -933,8 +933,8 @@ func (as *ApplicationServer) handleSimulatedUplink(ctx context.Context, ids ttnp
 	return as.decode(ctx, dev, uplink, link.DefaultFormatters)
 }
 
-func (as *ApplicationServer) handleDownlinkQueueInvalidated(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, invalid *ttnpb.ApplicationInvalidatedDownlinks, link *link) error {
-	_, err := as.deviceRegistry.Set(ctx, ids,
+func (as *ApplicationServer) handleDownlinkQueueInvalidated(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, invalid *ttnpb.ApplicationInvalidatedDownlinks, link *link) (pass bool, err error) {
+	_, err = as.deviceRegistry.Set(ctx, ids,
 		[]string{
 			"session",
 			"skip_payload_crypto_override",
@@ -946,16 +946,19 @@ func (as *ApplicationServer) handleDownlinkQueueInvalidated(ctx context.Context,
 			if dev.Session == nil {
 				return nil, nil, errNoDeviceSession.WithAttributes("device_uid", unique.ID(ctx, ids))
 			}
+			if skipPayloadCrypto(link, dev) {
+				// When skipping application payload crypto, the upstream application is responsible for recalculating the
+				// downlink queue. No error is returned here to pass the downlink queue invalidation message upstream.
+				pass = true
+				return dev, nil, nil
+			}
 			if err := as.recalculateDownlinkQueue(ctx, dev, link, dev.Session, invalid.Downlinks, invalid.LastFCntDown+1, true); err != nil {
 				return nil, nil, err
 			}
 			return dev, []string{"session"}, nil
 		},
 	)
-	if err != nil {
-		return err
-	}
-	return nil
+	return
 }
 
 func (as *ApplicationServer) handleDownlinkNack(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, msg *ttnpb.ApplicationDownlink, link *link) error {
@@ -998,22 +1001,35 @@ func (as *ApplicationServer) handleDownlinkNack(ctx context.Context, ids ttnpb.E
 	return nil
 }
 
+// decryptDownlinkMessage decrypts the downlink message.
+// If application payload crypto is skipped, this method returns nil.
 func (as *ApplicationServer) decryptDownlinkMessage(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, msg *ttnpb.ApplicationDownlink, link *link) error {
-	dev, err := as.deviceRegistry.Get(ctx, ids, []string{"session", "skip_payload_crypto"})
+	dev, err := as.deviceRegistry.Get(ctx, ids, []string{
+		"pending_session",
+		"session",
+		"skip_payload_crypto_override",
+	})
 	if err != nil {
 		return err
 	}
 	if skipPayloadCrypto(link, dev) {
 		return nil
 	}
-	if dev.Session == nil || !bytes.Equal(dev.Session.SessionKeyID, msg.SessionKeyID) || dev.Session.AppSKey == nil {
+	var session *ttnpb.Session
+	switch {
+	case dev.Session != nil && bytes.Equal(dev.Session.SessionKeyID, msg.SessionKeyID):
+		session = dev.Session
+	case dev.PendingSession != nil && bytes.Equal(dev.PendingSession.SessionKeyID, msg.SessionKeyID):
+		session = dev.PendingSession
+	}
+	if session.GetAppSKey() == nil {
 		return errNoAppSKey.New()
 	}
-	appSKey, err := cryptoutil.UnwrapAES128Key(ctx, *dev.Session.AppSKey, as.KeyVault)
+	appSKey, err := cryptoutil.UnwrapAES128Key(ctx, *session.AppSKey, as.KeyVault)
 	if err != nil {
 		return err
 	}
-	msg.FRMPayload, err = crypto.DecryptDownlink(appSKey, dev.Session.DevAddr, msg.FCnt, msg.FRMPayload, false)
+	msg.FRMPayload, err = crypto.DecryptDownlink(appSKey, session.DevAddr, msg.FCnt, msg.FRMPayload, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -2333,10 +2333,12 @@ func TestSkipPayloadCrypto(t *testing.T) {
 						{
 							{
 								FPort:      11,
+								FCnt:       1,
 								FRMPayload: []byte{0x1, 0x1, 0x1},
 							},
 							{
 								FPort:      22,
+								FCnt:       2,
 								FRMPayload: []byte{0x2, 0x2, 0x2},
 							},
 						},

--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -2232,6 +2232,48 @@ func TestSkipPayloadCrypto(t *testing.T) {
 							}
 						},
 					},
+					{
+						Name: "DownlinkQueueInvalidation",
+						Message: &ttnpb.ApplicationUp{
+							EndDeviceIdentifiers: withDevAddr(registeredDevice.EndDeviceIdentifiers, types.DevAddr{0x22, 0x22, 0x22, 0x22}),
+							Up: &ttnpb.ApplicationUp_DownlinkQueueInvalidated{
+								DownlinkQueueInvalidated: &ttnpb.ApplicationInvalidatedDownlinks{
+									Downlinks: []*ttnpb.ApplicationDownlink{
+										{
+											SessionKeyID: []byte{0x22},
+											FPort:        22,
+											FCnt:         22,
+											FRMPayload:   []byte{0x01},
+										},
+									},
+								},
+							},
+						},
+						AssertUp: func(t *testing.T, up *ttnpb.ApplicationUp) {
+							a := assertions.New(t)
+							if effectiveSkip {
+								a.So(up, should.Resemble, &ttnpb.ApplicationUp{
+									EndDeviceIdentifiers: withDevAddr(registeredDevice.EndDeviceIdentifiers, types.DevAddr{0x22, 0x22, 0x22, 0x22}),
+									Up: &ttnpb.ApplicationUp_DownlinkQueueInvalidated{
+										DownlinkQueueInvalidated: &ttnpb.ApplicationInvalidatedDownlinks{
+											Downlinks: []*ttnpb.ApplicationDownlink{
+												{
+													SessionKeyID: []byte{0x22},
+													FPort:        22,
+													FCnt:         22,
+													FRMPayload:   []byte{0x01},
+												},
+											},
+										},
+									},
+									CorrelationIDs: up.CorrelationIDs,
+									ReceivedAt:     up.ReceivedAt,
+								})
+							} else {
+								a.So(up, should.BeNil)
+							}
+						},
+					},
 				} {
 					stepok := t.Run(step.Name, func(t *testing.T) {
 						ns.upCh <- step.Message
@@ -2243,7 +2285,11 @@ func TestSkipPayloadCrypto(t *testing.T) {
 								t.Fatalf("Expected no upstream message but got %v", msg)
 							}
 						case <-time.After(Timeout):
-							t.Fatal("Expected upstream timeout")
+							if step.AssertUp != nil {
+								step.AssertUp(t, nil)
+							} else {
+								t.Fatal("Expected upstream timeout")
+							}
 						}
 						if step.AssertDevice != nil {
 							dev, err := deviceRegistry.Get(ctx, step.Message.EndDeviceIdentifiers, []string{"session", "pending_session"})

--- a/pkg/applicationserver/io/grpc/grpc_test.go
+++ b/pkg/applicationserver/io/grpc/grpc_test.go
@@ -258,7 +258,6 @@ func TestTraffic(t *testing.T) {
 					{
 						SessionKeyID:   []byte{0x11, 0x22, 0x33, 0x44}, // This gets discarded.
 						FPort:          1,
-						FCnt:           100, // This gets discarded.
 						FRMPayload:     []byte{0x01, 0x01, 0x01},
 						Confirmed:      true,
 						CorrelationIDs: []string{"test"},
@@ -326,7 +325,6 @@ func TestTraffic(t *testing.T) {
 				Downlinks: []*ttnpb.ApplicationDownlink{
 					{
 						FPort:      4,
-						FCnt:       100, // This gets discarded.
 						FRMPayload: []byte{0x04, 0x04, 0x04},
 						Confirmed:  true,
 					},

--- a/pkg/applicationserver/io/io.go
+++ b/pkg/applicationserver/io/io.go
@@ -117,6 +117,7 @@ func CleanDownlinks(items []*ttnpb.ApplicationDownlink) []*ttnpb.ApplicationDown
 	for _, item := range items {
 		res = append(res, &ttnpb.ApplicationDownlink{
 			FPort:          item.FPort,
+			FCnt:           item.FCnt, // FCnt must be set when skipping application payload crypto.
 			FRMPayload:     item.FRMPayload,
 			DecodedPayload: item.DecodedPayload,
 			ClassBC:        item.ClassBC,

--- a/pkg/applicationserver/io/mock/server.go
+++ b/pkg/applicationserver/io/mock/server.go
@@ -111,9 +111,8 @@ func (s *server) DownlinkQueueReplace(ctx context.Context, ids ttnpb.EndDeviceId
 // DownlinkQueueList implements io.Server.
 func (s *server) DownlinkQueueList(ctx context.Context, ids ttnpb.EndDeviceIdentifiers) ([]*ttnpb.ApplicationDownlink, error) {
 	s.downlinkQueueMu.RLock()
-	queue := s.downlinkQueue[unique.ID(ctx, ids)]
-	s.downlinkQueueMu.RUnlock()
-	return queue, nil
+	defer s.downlinkQueueMu.RUnlock()
+	return s.downlinkQueue[unique.ID(ctx, ids)], nil
 }
 
 func (s *server) SetSubscribeError(err error) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

AFCntDown from the application-layer is respected when skipping application payload crypto.

#### Changes
<!-- What are the changes made in this pull request? -->

- AFCntDown can be passed from the application-layer and is left in-tact when skipping application layer crypto. This is required because the AFCntDown is part of the FRMPayload encryption key stream
- For applications to re-encrypt the downlink queue when skipping application payload crypto, the downlink queue invalidation message is passed upstream
- Downlink message events now work for the pending session too

#### Testing

<!-- How did you verify that this change works? -->

Unit testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Not expected

#### Notes for Reviewers

@adriansmares is the main reviewer

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
