### PR TITLE
Refactor testing delays in pub/sub tests

### DIFF
--- a/pkg/applicationserver/io/pubsub/provider/mqtt/provider_test.go
+++ b/pkg/applicationserver/io/pubsub/provider/mqtt/provider_test.go
@@ -178,20 +178,20 @@ func TestOpenConnection(t *testing.T) {
 			},
 		},
 	} {
-		client := utc.createClient(t, a)
-		defer client.Disconnect(uint(timeout / time.Millisecond))
-
-		unsubscribe := func(t *testing.T, topic string) {
-			token := client.Unsubscribe(topic)
-			if !token.WaitTimeout(timeout) {
-				t.Fatal("Unsubscribe timeout")
-			}
-			if !a.So(token.Error(), should.BeNil) {
-				t.FailNow()
-			}
-		}
-
 		t.Run(utc.name, func(t *testing.T) {
+			client := utc.createClient(t, a)
+			defer client.Disconnect(uint(timeout / time.Millisecond))
+
+			unsubscribe := func(t *testing.T, topic string) {
+				token := client.Unsubscribe(topic)
+				if !token.WaitTimeout(timeout) {
+					t.Fatal("Unsubscribe timeout")
+				}
+				if !a.So(token.Error(), should.BeNil) {
+					t.FailNow()
+				}
+			}
+
 			pb.Provider = utc.provider
 
 			conn, err := impl.OpenConnection(ctx, pb)

--- a/pkg/applicationserver/io/pubsub/provider/mqtt/provider_test.go
+++ b/pkg/applicationserver/io/pubsub/provider/mqtt/provider_test.go
@@ -178,6 +178,19 @@ func TestOpenConnection(t *testing.T) {
 			},
 		},
 	} {
+		client := utc.createClient(t, a)
+		defer client.Disconnect(uint(timeout / time.Millisecond))
+
+		unsubscribe := func(t *testing.T, topic string) {
+			token := client.Unsubscribe(topic)
+			if !token.WaitTimeout(timeout) {
+				t.Fatal("Unsubscribe timeout")
+			}
+			if !a.So(token.Error(), should.BeNil) {
+				t.FailNow()
+			}
+		}
+
 		t.Run(utc.name, func(t *testing.T) {
 			pb.Provider = utc.provider
 
@@ -222,11 +235,6 @@ func TestOpenConnection(t *testing.T) {
 				} {
 					t.Run(tc.name, func(t *testing.T) {
 						a := assertions.New(t)
-						ctx, cancel := context.WithTimeout(ctx, timeout)
-						defer cancel()
-
-						client := utc.createClient(t, a)
-						defer client.Disconnect(uint(timeout / time.Millisecond))
 
 						token := client.Publish(tc.topicName, 2, false, "foobar")
 						if !token.WaitTimeout(timeout) {
@@ -236,12 +244,16 @@ func TestOpenConnection(t *testing.T) {
 							t.FailNow()
 						}
 
+						ctx, cancel := context.WithTimeout(ctx, timeout)
+						defer cancel()
+
 						msg, err := tc.subscription.Receive(ctx)
 						if tc.expectMessage {
 							a.So(err, should.BeNil)
-							a.So(msg, should.NotBeNil)
 
-							a.So(msg.Body, should.Resemble, []byte("foobar"))
+							if a.So(msg, should.NotBeNil) {
+								a.So(msg.Body, should.Resemble, []byte("foobar"))
+							}
 						} else if err == nil {
 							t.Fatal("Unexpected message received")
 						}
@@ -301,9 +313,6 @@ func TestOpenConnection(t *testing.T) {
 					t.Run(tc.name, func(t *testing.T) {
 						a := assertions.New(t)
 
-						client := utc.createClient(t, a)
-						defer client.Disconnect(uint(timeout / time.Millisecond))
-
 						upCh := make(chan paho_mqtt.Message, 10)
 						defer close(upCh)
 						token := client.Subscribe(tc.topicName, 2, func(_ paho_mqtt.Client, msg paho_mqtt.Message) {
@@ -315,6 +324,10 @@ func TestOpenConnection(t *testing.T) {
 						if !a.So(token.Error(), should.BeNil) {
 							t.FailNow()
 						}
+						defer unsubscribe(t, tc.topicName)
+
+						ctx, cancel := context.WithTimeout(ctx, timeout)
+						defer cancel()
 
 						err = tc.topic.Send(ctx, &pubsub.Message{
 							Body: []byte("foobar"),
@@ -325,8 +338,9 @@ func TestOpenConnection(t *testing.T) {
 						case <-time.After(timeout):
 							t.Fatal("Expected message never arrived")
 						case msg := <-upCh:
-							a.So(msg, should.NotBeNil)
-							a.So(msg.Payload(), should.Resemble, []byte("foobar"))
+							if a.So(msg, should.NotBeNil) {
+								a.So(msg.Payload(), should.Resemble, []byte("foobar"))
+							}
 						}
 					})
 				}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2847 

#### Changes
<!-- What are the changes made in this pull request? -->

- Pub/Sub clients (both NATS/MQTT) are no longer initialized/connected per test case, but rather shared between tests. This should lower test runtime and no longer eat into the `timeout` quanta of each test.
- `context.WithTimeout` is now initialized before actual context usage, in order to avoid losing part of the `timeout` to operations that don't need it.
- Assertions on message bodies are now done only the message is not `nil`.

#### Testing

<!-- How did you verify that this change works? -->

Ran the tests locally.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This affects only the tests.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The same fix was 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
