### PR TITLE
Fix initialization of stopped counters on start

### DIFF
--- a/pkg/applicationserver/observability.go
+++ b/pkg/applicationserver/observability.go
@@ -244,6 +244,7 @@ func (m messageMetrics) Collect(ch chan<- prometheus.Metric) {
 func registerLinkStart(ctx context.Context, link *link) {
 	events.Publish(evtLinkStart(ctx, link.ApplicationIdentifiers, nil))
 	asMetrics.linksStarted.WithLabelValues(ctx, link.NetworkServerAddress).Inc()
+	asMetrics.linksStopped.WithLabelValues(ctx, link.NetworkServerAddress) // Initialize the "stopped" counter.
 }
 
 func registerLinkStop(ctx context.Context, link *link) {
@@ -263,6 +264,7 @@ func registerSubscribe(ctx context.Context, sub *io.Subscription) {
 	}
 	events.Publish(evtApplicationSubscribe(ctx, ids, nil))
 	asMetrics.subscriptionsStarted.WithLabelValues(ctx, sub.Protocol()).Inc()
+	asMetrics.subscriptionsStopped.WithLabelValues(ctx, sub.Protocol()) // Initialize the "stopped" counter.
 }
 
 func registerUnsubscribe(ctx context.Context, sub *io.Subscription) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This quickfix fixes the lack of telemetry for active links and subscriptions in the Application Server by initializing the "stopped" counters so that we can subtract them.