### PR TITLE
Fix release actions again

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -31,8 +31,6 @@ jobs:
         go mod download
     - name: Make Mage
       run: make tools/bin/mage
-    - name: Auto-completion scripts
-      run: tools/bin/mage cli:autocomplete
     - name: Install JS SDK dependencies
       run: tools/bin/mage jsSDK:deps
     - name: Build JS SDK
@@ -97,6 +95,8 @@ jobs:
         go mod download
     - name: Make Mage
       run: make tools/bin/mage
+    - name: Auto-completion scripts
+      run: tools/bin/mage cli:autocomplete
     - name: Install JS SDK dependencies
       run: tools/bin/mage jsSDK:deps
     - name: Build JS SDK


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is another fix for the release actions, this time moving the "generate autocomplete" from the GitHub Pages job to the Release job.