### PR TITLE
Hide event start/stop messages in the Console

### DIFF
--- a/pkg/webui/console/store/reducers/events.js
+++ b/pkg/webui/console/store/reducers/events.js
@@ -27,6 +27,11 @@ import {
 import CONNECTION_STATUS from '../../constants/connection-status'
 
 const addEvent = (state, event) => {
+  // See https://github.com/TheThingsNetwork/lorawan-stack/pull/2989
+  if (event.name === 'events.stream.start' || event.name === 'events.stream.stop') {
+    return state
+  }
+
   const currentEvents = state.events
   const eventTime = new Date(event.time).getTime()
 


### PR DESCRIPTION
#### Summary
Quickfix to ignore start/stop events in the Console.

#### Changes
- Add check to events reducer to swallow start/stop events

#### Testing

Manual.

##### Regressions

Might break event streams in the Console.

#### Notes for Reviewers
See the reviewers notes for https://github.com/TheThingsNetwork/lorawan-stack/pull/2989 and https://github.com/TheThingsNetwork/lorawan-stack/issues/2950#issuecomment-666222378
So we might need to remove this once @rvolosatovs found a better solution.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
