### PR TITLE
Accept well known LoRaWAN and Regional Parameters versions

### DIFF
--- a/pkg/ttnpb/lorawan.go
+++ b/pkg/ttnpb/lorawan.go
@@ -686,6 +686,8 @@ func init() {
 	for i := range MACVersion_name {
 		MACVersion_value[MACVersion(i).String()] = i
 	}
+	MACVersion_value["1.0"] = int32(MAC_V1_0) // 1.0 is the official version number
+	MACVersion_value["1.1"] = int32(MAC_V1_1) // 1.1 is the official version number
 }
 
 // Compare compares MACVersions v to o:
@@ -797,6 +799,10 @@ func init() {
 	for i := range PHYVersion_name {
 		PHYVersion_value[PHYVersion(i).String()] = i
 	}
+	PHYVersion_value["1.0"] = int32(PHY_V1_0)           // 1.0 is the official version number
+	PHYVersion_value["1.0.2"] = int32(PHY_V1_0_2_REV_A) // Revisions were added from 1.0.2-b
+	PHYVersion_value["1.1-a"] = int32(PHY_V1_1_REV_A)   // 1.1 is the official version number
+	PHYVersion_value["1.1-b"] = int32(PHY_V1_1_REV_B)   // 1.1 is the official version number
 }
 
 // String implements fmt.Stringer.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Accept well known LoRaWAN and Regional Parameters versions

References https://github.com/TheThingsNetwork/lorawan-stack/issues/2784

#### Changes
<!-- What are the changes made in this pull request? -->

MAC versions `1.0` and `1.1` are now accepted; in the target branch only `1.0.0` and `1.1.0` are accepted respectively. For the PHY versions, now `1.0`, `1.0.2` * and `1.1-a` and `1.1-b` are accepted.

\* revisions were added from 1.0.2-b onwards, so we have LoRaWAN Regional Parameters 1.0.2 and 1.0.2-b, technically.

#### Testing

<!-- How did you verify that this change works? -->

Parse JSON encoded string with field types `ttnpb.MACVersion` and `ttnpb.PHYVersion`

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Not expected

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
