### PR TITLE
Fix gateway concentrator clock roll over

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Troubleshooting guide.
 - API to get configuration from the Identity Server (including user registration options and password requirements).
 - Synchronize gateway time by uplink token on downstream in case the Gateway Server instance is not handling the upstream gateway connection.
+- Work-around for Basic Station gateways sending uplink frames with no `xtime`.
 
 ### Changed
 
@@ -84,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Console MQTT URL validation.
 - AFCntDown from the application-layer is respected when skipping application payload crypto.
 - RTT usage for calculating downlink delta.
+- Synchronize concentrator timestamp when uplink messages arrive out-of-order.
 
 ## [3.8.6] - 2020-07-10
 

--- a/pkg/gatewayserver/io/basicstationlns/basicstationlns.go
+++ b/pkg/gatewayserver/io/basicstationlns/basicstationlns.go
@@ -431,6 +431,11 @@ func (s *srv) handleTraffic(c echo.Context) (err error) {
 				logger.WithError(err).Debug("Failed to parse join-request message")
 				return err
 			}
+			// TODO: Remove (https://github.com/lorabasics/basicstation/issues/74)
+			if jreq.UpInfo.XTime == 0 {
+				logger.Warn("Received join-request without xtime, drop message")
+				break
+			}
 			recordXTime(jreq.UpInfo.XTime, up.ReceivedAt)
 			if err := conn.HandleUp(up); err != nil {
 				logger.WithError(err).Warn("Failed to handle uplink message")
@@ -447,6 +452,11 @@ func (s *srv) handleTraffic(c echo.Context) (err error) {
 			if err != nil {
 				logger.WithError(err).Debug("Failed to parse uplink data frame")
 				return err
+			}
+			// TODO: Remove (https://github.com/lorabasics/basicstation/issues/74)
+			if updf.UpInfo.XTime == 0 {
+				logger.Warn("Received uplink data frame without xtime, drop message")
+				break
 			}
 			recordXTime(updf.UpInfo.XTime, up.ReceivedAt)
 			if err := conn.HandleUp(up); err != nil {

--- a/pkg/gatewayserver/io/basicstationlns/basicstationlns.go
+++ b/pkg/gatewayserver/io/basicstationlns/basicstationlns.go
@@ -334,20 +334,16 @@ func (s *srv) handleTraffic(c echo.Context) (err error) {
 		}
 	}()
 
-	var syncedConcentratorTime bool
 	recordXTime := func(timestamp int64, server time.Time) {
 		// The session is the 16 MSB.
 		atomic.StoreInt32(&sessionID, int32(timestamp>>48))
-		if !syncedConcentratorTime {
-			conn.SyncWithGatewayConcentrator(
-				// The concentrator timestamp is the 32 LSB.
-				uint32(timestamp&0xFFFFFFFF),
-				server,
-				// The Basic Station epoch is the 48 LSB.
-				scheduling.ConcentratorTime(time.Duration(timestamp&0xFFFFFFFFFF)*time.Microsecond),
-			)
-			syncedConcentratorTime = true
-		}
+		conn.SyncWithGatewayConcentrator(
+			// The concentrator timestamp is the 32 LSB.
+			uint32(timestamp&0xFFFFFFFF),
+			server,
+			// The Basic Station epoch is the 48 LSB.
+			scheduling.ConcentratorTime(time.Duration(timestamp&0xFFFFFFFFFF)*time.Microsecond),
+		)
 	}
 
 	for {

--- a/pkg/gatewayserver/scheduling/clock.go
+++ b/pkg/gatewayserver/scheduling/clock.go
@@ -59,10 +59,13 @@ func (c *RolloverClock) SyncTime() (time.Time, bool) {
 // Sync synchronizes the clock with the given concentrator timestamp and the server time.
 func (c *RolloverClock) Sync(timestamp uint32, server time.Time) ConcentratorTime {
 	rollovers := int64(c.absolute/ConcentratorTime(time.Microsecond)) >> 32
-	if passed := int64(timestamp) - int64(c.relative); passed < 0 {
+	// If the new timestamp is lower, it is considered a roll over if it advanced more than 25%.
+	// Otherwise, this is considered an out-of-order arrival.
+	if passed := int64(timestamp) - int64(c.relative); passed < -0x40000000 {
 		rollovers++
 	}
-	if c.server != nil {
+	// If there are full roll over windows between the last and the current server time, take these into account.
+	if c.server != nil && server.After(*c.server) {
 		rollovers += int64(server.Sub(*c.server)/time.Microsecond) >> 32
 	}
 	c.absolute = (ConcentratorTime(rollovers<<32) + ConcentratorTime(timestamp)) * ConcentratorTime(time.Microsecond)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2581
References #1707

#### Changes
<!-- What are the changes made in this pull request? -->

- Synchronize concentrator timestamp when uplink messages arrive out-of-order
- Work-around for Basic Station gateways sending uplink frames with no `xtime` (https://github.com/lorabasics/basicstation/issues/74)


#### Testing

<!-- How did you verify that this change works? -->

Unit testing, see test case for #2581

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Not expected

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
