### PR TITLE
Add option to override server name in cluster TLS handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - LoRaCloud DAS integration page in the Console.
 - User Agent metadata on published events (when available).
+- Option to override server name used in TLS handshake with cluster peers (`cluster.tls-server-name`).
 
 ### Changed
 

--- a/doc/content/reference/configuration/the-things-stack.md
+++ b/doc/content/reference/configuration/the-things-stack.md
@@ -226,9 +226,10 @@ The cluster keys are 128 bit, hex-encoded keys that cluster components use to au
 
 - `cluster.keys`: Keys used to communicate between components of the cluster. The first one will be used by the cluster to identify itself
 
-It is possible to configure the cluster to use TLS or not. We recommend to enable TLS for production deployments.
+It is possible to configure the cluster to use TLS or not. We recommend to enable TLS for production deployments. The server name used in the TLS handshake between cluster peers can be overridden so that {{% tts %}} can connect to cluster peers using private (IP) addresses, while using a (public) TLS certificate that doesn't include those private addresses.
 
 - `cluster.tls`: Do cluster gRPC over TLS
+- `cluster.tls-server-name`: Server name to use in TLS handshake to cluster peers
 
 ## Cache Options
 

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -26,5 +26,6 @@ type Config struct {
 	JoinServer        string   `name:"join-server" description:"Address for the Join Server"`
 	CryptoServer      string   `name:"crypto-server" description:"Address for the Crypto Server"`
 	TLS               bool     `name:"tls" description:"Do cluster gRPC over TLS"`
+	TLSServerName     string   `name:"tls-server-name" description:"Server name to use in TLS handshake to cluster peers"`
 	Keys              []string `name:"keys" description:"Keys used to communicate between components of the cluster. The first one will be used by the cluster to identify itself"`
 }

--- a/pkg/cluster/peer.go
+++ b/pkg/cluster/peer.go
@@ -40,7 +40,8 @@ type peer struct {
 	roles []ttnpb.ClusterRole
 	tags  map[string]string
 
-	target string
+	target        string
+	tlsServerName string
 
 	ctx     context.Context
 	cancel  context.CancelFunc


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR adds an option to override the server name that is used in the TLS handshake between peers in a clustered deployment.

#### Changes
<!-- What are the changes made in this pull request? -->

- Added option
- Use option if set, otherwise keep using original peer address

#### Testing

<!-- How did you verify that this change works? -->

- Start the IS: `ttn-lw-stack start is --interop.listen-tls=""`
- Start the Console without the option: `go run ./cmd/ttn-lw-stack start console --interop.listen-tls="" --grpc.listen=:1894 --grpc.listen-tls=:8894 --http.listen=:1895 --http.listen-tls=:8895 --cluster.identity-server=127.0.0.1:8884 --cluster.tls`
	- This errors with `transport: authentication handshake failed: x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs`
- Start the Console with the option: same as previous, but with `--cluster.tls-server-name=localhost`
	- Successful connection.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->



#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
