### PR TITLE
Do not assume supports_join when importing devices with the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Authentication metadata missing from published events.
+- Under some circumstances, CLI would mistakenly import ABP devices as OTAA.
 
 ### Security
 

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -362,12 +362,10 @@ var (
 				}
 				paths = append(paths, ttnpb.FlattenPaths(decodedPaths, endDeviceFlattenPaths)...)
 
-				if ttnpb.ContainsField("supports_join", paths) {
-					if abp && device.SupportsJoin {
-						return errActivationMode.New()
-					}
-					abp = !device.SupportsJoin
+				if abp && device.SupportsJoin {
+					logger.Warn("Reading from standard input, ignoring --abp and --multicast flags")
 				}
+				abp = !device.SupportsJoin
 			}
 
 			setDefaults, _ := cmd.Flags().GetBool("defaults")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Quickfix PR that stops assuming `supports_join` is true when importing devices with the `ttn-lw-cli end-devices create < devices.json` command.

#### Testing

<!-- How did you verify that this change works? -->

Test locally

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This breaks OTAA devices being imported if the `supports_join` field is unset, but this should count as a bug rather than expected behaviour.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

For context, https://github.com/TheThingsIndustries/lorawan-stack-migrate/pull/1#discussion_r467604230

> @johanstokking: I see. So the problem is that if you don't pass supports_join, we assume supports_join. I think that is wrong. So the problem is in the create command. Let's not work around that by explicitly setting supports_join to false. It feels like the best solution is to take the values from the input decoder literally, and don't assume defaults in that case.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
