### PR TITLE
Implement device template converter for The Things Stack v3 JSON end device format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - LoRaCloud DAS integration page in the Console.
 - User Agent metadata on published events (when available).
 - Option to override server name used in TLS handshake with cluster peers (`cluster.tls-server-name`).
+- Add `the-things-stack` device template converter, enabled by default. Effectively, this allows importing end devices from the Console.
 
 ### Changed
 

--- a/cmd/internal/shared/devicetemplateconverter/config.go
+++ b/cmd/internal/shared/devicetemplateconverter/config.go
@@ -19,4 +19,6 @@ import (
 )
 
 // DefaultDeviceTemplateConverterConfig is the default configuration for the Device Template Converter.
-var DefaultDeviceTemplateConverterConfig = devicetemplateconverter.Config{}
+var DefaultDeviceTemplateConverterConfig = devicetemplateconverter.Config{
+	Enabled: []string{"the-things-stack"},
+}

--- a/cmd/internal/shared/devicetemplateconverter/config.go
+++ b/cmd/internal/shared/devicetemplateconverter/config.go
@@ -19,6 +19,4 @@ import (
 )
 
 // DefaultDeviceTemplateConverterConfig is the default configuration for the Device Template Converter.
-var DefaultDeviceTemplateConverterConfig = devicetemplateconverter.Config{
-	Enabled: []string{"the-things-stack"},
-}
+var DefaultDeviceTemplateConverterConfig = devicetemplateconverter.Config{}

--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -29,11 +29,12 @@ import (
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/shared/version"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
-	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/io"
+	cmdio "go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/util"
 	conf "go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/io"
 	"golang.org/x/oauth2"
 )
 
@@ -83,7 +84,7 @@ func preRun(tasks ...func() error) func(cmd *cobra.Command, args []string) error
 		}
 
 		// create input decoder on Stdin
-		if rd, ok := io.BufferedPipe(os.Stdin); ok {
+		if rd, ok := cmdio.BufferedPipe(os.Stdin); ok {
 			inputDecoder, err = getInputDecoder(rd)
 			if err != nil {
 				return err

--- a/cmd/ttn-lw-cli/commands/utils.go
+++ b/cmd/ttn-lw-cli/commands/utils.go
@@ -23,10 +23,10 @@ import (
 	"strings"
 
 	"github.com/spf13/pflag"
-	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/util"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/io"
 )
 
 func getHost(address string) string {

--- a/pkg/devicetemplateconverter/devicetemplateconverter.go
+++ b/pkg/devicetemplateconverter/devicetemplateconverter.go
@@ -45,6 +45,9 @@ var errNotFound = errors.DefineNotFound("converter", "converter `{id}` not found
 
 // New returns a new *DeviceTemplateConverter.
 func New(c *component.Component, conf *Config) (*DeviceTemplateConverter, error) {
+	// Always enable the TTS device template converter
+	conf.Enabled = append(conf.Enabled, devicetemplates.TTS)
+
 	converters := make(map[string]devicetemplates.Converter, len(conf.Enabled))
 	for _, id := range conf.Enabled {
 		converter := devicetemplates.GetConverter(id)

--- a/pkg/devicetemplateconverter/grpc_test.go
+++ b/pkg/devicetemplateconverter/grpc_test.go
@@ -85,6 +85,7 @@ func TestConvertEndDeviceTemplate(t *testing.T) {
 			Name:        "Test",
 			Description: "Test",
 		},
+		devicetemplates.TTS: devicetemplates.GetConverter(devicetemplates.TTS).Format(),
 	})
 
 	stream, err := client.Convert(ctx, &ttnpb.ConvertEndDeviceTemplateRequest{

--- a/pkg/devicetemplates/tts.go
+++ b/pkg/devicetemplates/tts.go
@@ -1,0 +1,70 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package devicetemplates
+
+import (
+	"context"
+	"io"
+
+	pbtypes "github.com/gogo/protobuf/types"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	ttnio "go.thethings.network/lorawan-stack/v3/pkg/util/io"
+)
+
+type tts struct{}
+
+// Format implements the devicetemplates.Converter interface.
+func (t *tts) Format() *ttnpb.EndDeviceTemplateFormat {
+	return &ttnpb.EndDeviceTemplateFormat{
+		Name:           "The Things Stack JSON",
+		Description:    "JSON file containing end devices exported in the v3 JSON format.",
+		FileExtensions: []string{".json"},
+	}
+}
+
+// Convert implements the devicetemplates.Converter interface.
+func (t *tts) Convert(ctx context.Context, r io.Reader, ch chan<- *ttnpb.EndDeviceTemplate) error {
+	defer close(ch)
+
+	dec := ttnio.NewJSONDecoder(r)
+
+	for {
+		dev := ttnpb.EndDevice{}
+		paths, err := dec.Decode(&dev)
+		if err != nil {
+			if err != io.EOF {
+				return err
+			}
+			return nil
+		}
+		paths = append(paths, "supports_join")
+
+		tmpl := &ttnpb.EndDeviceTemplate{
+			EndDevice: dev,
+			FieldMask: pbtypes.FieldMask{
+				Paths: paths,
+			},
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ch <- tmpl:
+		}
+	}
+}
+
+func init() {
+	RegisterConverter("the-things-stack", &tts{})
+}

--- a/pkg/devicetemplates/tts.go
+++ b/pkg/devicetemplates/tts.go
@@ -23,6 +23,9 @@ import (
 	ttnio "go.thethings.network/lorawan-stack/v3/pkg/util/io"
 )
 
+// TTS is the device template converter id.
+const TTS = "the-things-stack"
+
 type tts struct{}
 
 // Format implements the devicetemplates.Converter interface.
@@ -39,7 +42,6 @@ func (t *tts) Convert(ctx context.Context, r io.Reader, ch chan<- *ttnpb.EndDevi
 	defer close(ch)
 
 	dec := ttnio.NewJSONDecoder(r)
-
 	for {
 		dev := ttnpb.EndDevice{}
 		paths, err := dec.Decode(&dev)
@@ -66,5 +68,5 @@ func (t *tts) Convert(ctx context.Context, r io.Reader, ch chan<- *ttnpb.EndDevi
 }
 
 func init() {
-	RegisterConverter("the-things-stack", &tts{})
+	RegisterConverter(TTS, &tts{})
 }

--- a/pkg/devicetemplates/tts.go
+++ b/pkg/devicetemplates/tts.go
@@ -29,7 +29,7 @@ type tts struct{}
 func (t *tts) Format() *ttnpb.EndDeviceTemplateFormat {
 	return &ttnpb.EndDeviceTemplateFormat{
 		Name:           "The Things Stack JSON",
-		Description:    "JSON file containing end devices exported in the v3 JSON format.",
+		Description:    "File containing end devices in The Things Stack JSON format.",
 		FileExtensions: []string{".json"},
 	}
 }

--- a/pkg/devicetemplates/tts.go
+++ b/pkg/devicetemplates/tts.go
@@ -53,6 +53,22 @@ func (t *tts) Convert(ctx context.Context, r io.Reader, ch chan<- *ttnpb.EndDevi
 		}
 		paths = append(paths, "supports_join")
 
+		// dev_addr must be set as `session.dev_addr`.
+		dev.DevAddr = nil
+		for idx, path := range paths {
+			if path == "dev_addr" {
+				switch idx {
+				case 0:
+					paths = paths[1:]
+				case len(paths) - 1:
+					paths = paths[:len(paths)-1]
+				default:
+					paths = append(paths[:idx], paths[idx+1:]...)
+				}
+				break
+			}
+		}
+
 		tmpl := &ttnpb.EndDeviceTemplate{
 			EndDevice: dev,
 			FieldMask: pbtypes.FieldMask{

--- a/pkg/devicetemplates/tts_test.go
+++ b/pkg/devicetemplates/tts_test.go
@@ -1,0 +1,209 @@
+// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package devicetemplates_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/smartystreets/assertions"
+	. "go.thethings.network/lorawan-stack/v3/pkg/devicetemplates"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+)
+
+const (
+	otaaDevice = `{
+		"ids": {
+			"device_id": "otaa-device",
+			"application_ids": {
+				"application_id": "test-app"
+			},
+			"dev_eui": "0102030405060708",
+			"join_eui": "0807060504030201"
+		},
+		"frequency_plan_id": "EU_863_870",
+		"lorawan_version": "1.0.2",
+		"lorawan_phy_version": "1.0.2-b",
+		"root_keys": {
+			"app_key": {
+				"key": "01020304010203040102030401020304"
+			}
+		},
+		"supports_join": true
+	}`
+
+	abpDevice = `{
+		"ids": {
+			"device_id": "abp-device",
+			"application_ids": {
+				"application_id": "test-app"
+			},
+			"dev_eui": "0102030405060708",
+			"join_eui": "0807060504030201"
+		},
+		"frequency_plan_id": "US_902_928_FSB_2",
+		"lorawan_version": "1.0.2",
+		"lorawan_phy_version": "1.0.2-b",
+		"mac_settings": {
+			"rx1_delay": null
+		},
+		"supports_join": false,
+		"session": {
+			"dev_addr": "01010101"
+		}
+	}`
+
+	abpDeviceWithoutSession = `{
+		"ids": {
+			"device_id": "abp-device-error",
+			"application_ids": {
+				"application_id": "test-app"
+			},
+			"dev_eui": "0102030405060708",
+			"join_eui": "0807060504030201"
+		},
+		"frequency_plan_id": "US_902_928_FSB_2",
+		"lorawan_version": "1.0.2",
+		"lorawan_phy_version": "1.0.2-b",
+		"mac_settings": {
+			"rx1_delay": null
+		},
+		"supports_join": false
+	}
+	`
+)
+
+func validateTemplate(t *testing.T, tmpl *ttnpb.EndDeviceTemplate) {
+	a := assertions.New(t)
+	if !a.So(tmpl, should.NotBeNil) {
+		t.FailNow()
+	}
+
+	var dev ttnpb.EndDevice
+	a.So(dev.SetFields(&tmpl.EndDevice, tmpl.FieldMask.Paths...), should.BeNil)
+	a.So(dev, should.Resemble, tmpl.EndDevice)
+}
+
+func validateTemplates(t *testing.T, templates []*ttnpb.EndDeviceTemplate, count int) {
+	a := assertions.New(t)
+
+	if !a.So(len(templates), should.Equal, count) {
+		t.FailNow()
+	}
+
+	for _, template := range templates {
+		validateTemplate(t, template)
+	}
+}
+
+func TestTTSConverter(t *testing.T) {
+	tts := GetConverter("the-things-stack")
+	a := assertions.New(t)
+	if !a.So(tts, should.NotBeNil) {
+		t.FailNow()
+	}
+
+	for _, tc := range []struct {
+		name              string
+		reader            io.Reader
+		validateError     func(t *testing.T, err error)
+		validateResult    func(t *testing.T, templates []*ttnpb.EndDeviceTemplate, count int)
+		nExpect           int
+		expectedTemplates []*ttnpb.EndDeviceTemplate
+	}{
+		{
+			name:   "InvalidJSON",
+			reader: bytes.NewBufferString("invalid json"),
+			validateError: func(t *testing.T, err error) {
+				_, ok := err.(*json.SyntaxError)
+				assertions.New(t).So(ok, should.BeTrue)
+			},
+		},
+		{
+			name:   "OneDevice",
+			reader: bytes.NewBufferString(otaaDevice),
+			validateError: func(t *testing.T, err error) {
+				assertions.New(t).So(err, should.BeNil)
+			},
+			nExpect:        1,
+			validateResult: validateTemplates,
+		},
+		{
+			name:   "OneABPOneOTAA",
+			reader: bytes.NewBufferString(abpDevice + "\n\n" + otaaDevice),
+			validateError: func(t *testing.T, err error) {
+				assertions.New(t).So(err, should.BeNil)
+			},
+			validateResult: validateTemplates,
+			nExpect:        2,
+		},
+		{
+			name:   "OneOKOneError",
+			reader: bytes.NewBufferString(abpDevice + "\n\n" + "invalid json"),
+			validateError: func(t *testing.T, err error) {
+				_, ok := err.(*json.SyntaxError)
+				assertions.New(t).So(ok, should.BeTrue)
+			},
+			validateResult: validateTemplates,
+			nExpect:        1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := test.Context()
+			ch := make(chan *ttnpb.EndDeviceTemplate)
+
+			wg := sync.WaitGroup{}
+			wg.Add(2)
+			var err error
+			templates := []*ttnpb.EndDeviceTemplate{}
+			go func() {
+				err = tts.Convert(ctx, tc.reader, ch)
+				wg.Done()
+			}()
+			go func() {
+				for i := 0; i < tc.nExpect; i++ {
+					templates = append(templates, <-ch)
+				}
+				wg.Done()
+			}()
+
+			complete := make(chan struct{})
+			go func() {
+				defer func() {
+					complete <- struct{}{}
+				}()
+				wg.Wait()
+			}()
+
+			select {
+			case <-complete:
+			case <-time.After(time.Second):
+				t.Error("Timed out waiting for converter")
+				t.FailNow()
+			}
+
+			tc.validateError(t, err)
+			if tc.validateResult != nil {
+				tc.validateResult(t, templates, tc.nExpect)
+			}
+		})
+	}
+}

--- a/pkg/devicetemplates/tts_test.go
+++ b/pkg/devicetemplates/tts_test.go
@@ -87,8 +87,30 @@ const (
 			"rx1_delay": null
 		},
 		"supports_join": false
-	}
-	`
+	}`
+
+	otaaWithSession = `{"ids":{"device_id":"industrial-tracker","application_ids":{"application_id":"ttn-tabs"},"dev_eui":"E8E1E100010146B1","join_eui":"E8E1E1000101363E"},"name":"industrial-tracker","lorawan_version":"MAC_V1_0_2","lorawan_phy_version":"PHY_V1_0_2_REV_B","frequency_plan_id":"EU_863_870","supports_join":true,"root_keys":{"app_key":{"key":"00112233445566778899AABBCCDDEEFF"}},"mac_settings":{"rx1_delay":{"value":"RX_DELAY_1"},"supports_32_bit_f_cnt":true,"resets_f_cnt":false},"session":{"dev_addr":"260125FD","keys":{"app_s_key":{"key":"00112233445566778899AABBCCDDEEFF"},"f_nwk_s_int_key":{"key":"00112233445566778899AABBCCDDEEFF"}},"last_f_cnt_up":0,"last_n_f_cnt_down":0}}`
+
+	devWithDevAddr = `{
+		"ids": {
+			"device_id": "otaa-device",
+			"application_ids": {
+				"application_id": "test-app"
+			},
+			"dev_eui": "0102030405060708",
+			"join_eui": "0807060504030201"
+		},
+		"dev_addr": "01010101",
+		"frequency_plan_id": "EU_863_870",
+		"lorawan_version": "1.0.2",
+		"lorawan_phy_version": "1.0.2-b",
+		"root_keys": {
+			"app_key": {
+				"key": "01020304010203040102030401020304"
+			}
+		},
+		"supports_join": true
+	}`
 )
 
 func validateTemplate(t *testing.T, tmpl *ttnpb.EndDeviceTemplate) {
@@ -164,6 +186,36 @@ func TestTTSConverter(t *testing.T) {
 			},
 			validateResult: validateTemplates,
 			nExpect:        1,
+		},
+		{
+			name:   "OneWithSession",
+			reader: bytes.NewBufferString(otaaWithSession),
+			validateError: func(t *testing.T, err error) {
+				assertions.New(t).So(err, should.BeNil)
+			},
+			validateResult: validateTemplates,
+			nExpect:        1,
+		},
+		{
+			name:   "RemovesDevAddrFromRoot",
+			reader: bytes.NewBufferString(devWithDevAddr),
+			validateError: func(t *testing.T, err error) {
+				assertions.New(t).So(err, should.BeNil)
+			},
+			validateResult: func(t *testing.T, templates []*ttnpb.EndDeviceTemplate, count int) {
+				a := assertions.New(t)
+				if !a.So(len(templates), should.Equal, count) {
+					t.FailNow()
+				}
+				tmpl := templates[0]
+				if !a.So(tmpl, should.NotBeNil) {
+					t.FailNow()
+				}
+
+				a.So(tmpl.EndDevice.DevAddr, should.BeNil)
+				a.So(tmpl.FieldMask.Paths, should.NotContain, "dev_addr")
+			},
+			nExpect: 1,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/util/io/io.go
+++ b/pkg/util/io/io.go
@@ -1,0 +1,84 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/jsonpb"
+)
+
+// Decoder is the interface for the functionality that reads and decodes entities
+// from an io.Reader, typically os.Stdin.
+type Decoder interface {
+	Decode(data interface{}) (paths []string, err error)
+}
+
+type jsonDecoder struct {
+	rd  *bufio.Reader
+	dec *json.Decoder
+}
+
+// NewJSONDecoder returns a new Decoder on top of r, and that uses the common JSON
+// format used in The Things Stack.
+func NewJSONDecoder(r io.Reader) Decoder {
+	rd := bufio.NewReader(r)
+	return &jsonDecoder{
+		rd:  rd,
+		dec: json.NewDecoder(rd),
+	}
+}
+
+func (r *jsonDecoder) Decode(data interface{}) (paths []string, err error) {
+	t, err := r.rd.ReadByte()
+	if err != nil {
+		return nil, err
+	}
+	if t == '{' {
+		if err := r.rd.UnreadByte(); err != nil {
+			return nil, err
+		}
+	}
+	var obj json.RawMessage
+	if err = r.dec.Decode(&obj); err != nil {
+		return nil, err
+	}
+	var m map[string]interface{}
+	if err = json.Unmarshal(obj, &m); err != nil {
+		return nil, err
+	}
+	paths = fieldPaths(m, "")
+	b := bytes.NewBuffer(obj)
+	if err = jsonpb.TTN().NewDecoder(b).Decode(data); err != nil {
+		return nil, err
+	}
+	r.rd = bufio.NewReader(io.MultiReader(r.dec.Buffered(), r.rd))
+	r.dec = json.NewDecoder(r.rd)
+	return paths, nil
+}
+
+func fieldPaths(m map[string]interface{}, prefix string) (paths []string) {
+	for path, sub := range m {
+		if m, ok := sub.(map[string]interface{}); ok {
+			paths = append(paths, fieldPaths(m, prefix+path+".")...)
+		} else {
+			paths = append(paths, prefix+path)
+		}
+	}
+	return paths
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #3002 

#### Changes
<!-- What are the changes made in this pull request? -->

- Extract the `jsonDecoder` used in our CLI so that it can be reused.
- Implement `the-things-stack` device template converter.
- Enable converter by default.


#### Testing

<!-- How did you verify that this change works? -->

Tested locally, successfully imported multiple devices from the Console "Import End Devices" page. I also want to add some simple unit tests for the converter.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
