### PR TITLE
Use select when writing or reading from a channel

### DIFF
--- a/cmd/ttn-lw-cli/commands/events.go
+++ b/cmd/ttn-lw-cli/commands/events.go
@@ -77,7 +77,11 @@ var eventsCommand = &cobra.Command{
 						}
 						break
 					}
-					events <- event
+					select {
+					case <-ctx.Done():
+						return
+					case events <- event:
+					}
 				}
 				wg.Done()
 			}()

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -275,7 +275,11 @@ func (as *ApplicationServer) Subscribe(ctx context.Context, protocol string, ids
 		return nil, err
 	}
 	sub := io.NewSubscription(ctx, protocol, &ids)
-	link.subscribeCh <- sub
+	select {
+	case <-link.ctx.Done():
+		return nil, link.ctx.Err()
+	case link.subscribeCh <- sub:
+	}
 	go func() {
 		select {
 		case <-link.ctx.Done():
@@ -285,7 +289,11 @@ func (as *ApplicationServer) Subscribe(ctx context.Context, protocol string, ids
 			return
 		case <-sub.Context().Done():
 		}
-		link.unsubscribeCh <- sub
+		select {
+		case <-link.ctx.Done():
+			return
+		case link.unsubscribeCh <- sub:
+		}
 	}()
 	return sub, nil
 }
@@ -389,7 +397,7 @@ func (as *ApplicationServer) downlinkQueueOp(ctx context.Context, ids ttnpb.EndD
 			errorDetails = *ttnpb.ErrorDetailsToProto(ttnErr)
 		}
 		for _, item := range items {
-			link.upCh <- &io.ContextualApplicationUp{
+			ctxUp := &io.ContextualApplicationUp{
 				Context: ctx,
 				ApplicationUp: &ttnpb.ApplicationUp{
 					EndDeviceIdentifiers: ids,
@@ -402,6 +410,11 @@ func (as *ApplicationServer) downlinkQueueOp(ctx context.Context, ids ttnpb.EndD
 					},
 				},
 			}
+			select {
+			case <-link.ctx.Done():
+				return link.ctx.Err()
+			case link.upCh <- ctxUp:
+			}
 			registerDropDownlink(ctx, ids, item, err)
 		}
 		return err
@@ -409,7 +422,7 @@ func (as *ApplicationServer) downlinkQueueOp(ctx context.Context, ids ttnpb.EndD
 	atomic.AddUint64(&link.downlinks, uint64(len(items)))
 	atomic.StoreInt64(&link.lastDownlinkTime, time.Now().UnixNano())
 	for _, item := range items {
-		link.upCh <- &io.ContextualApplicationUp{
+		ctxUp := &io.ContextualApplicationUp{
 			Context: ctx,
 			ApplicationUp: &ttnpb.ApplicationUp{
 				EndDeviceIdentifiers: ids,
@@ -418,6 +431,11 @@ func (as *ApplicationServer) downlinkQueueOp(ctx context.Context, ids ttnpb.EndD
 					DownlinkQueued: item,
 				},
 			},
+		}
+		select {
+		case <-link.ctx.Done():
+			return link.ctx.Err()
+		case link.upCh <- ctxUp:
 		}
 		registerForwardDownlink(ctx, ids, item, link.connName)
 	}

--- a/pkg/applicationserver/io/io.go
+++ b/pkg/applicationserver/io/io.go
@@ -93,13 +93,14 @@ var errBufferFull = errors.DefineResourceExhausted("buffer_full", "buffer is ful
 // SendUp sends an upstream message.
 // This method returns immediately, returning nil if the message is buffered, or with an error when the buffer is full.
 func (s *Subscription) SendUp(ctx context.Context, up *ttnpb.ApplicationUp) error {
+	ctxUp := &ContextualApplicationUp{
+		Context:       ctx,
+		ApplicationUp: up,
+	}
 	select {
 	case <-s.ctx.Done():
 		return s.ctx.Err()
-	case s.upCh <- &ContextualApplicationUp{
-		Context:       ctx,
-		ApplicationUp: up,
-	}:
+	case s.upCh <- ctxUp:
 	default:
 		return errBufferFull.New()
 	}

--- a/pkg/applicationserver/io/mqtt/mqtt.go
+++ b/pkg/applicationserver/io/mqtt/mqtt.go
@@ -120,7 +120,7 @@ func (c *connection) setup(ctx context.Context) error {
 			if pkt != nil {
 				logger.Debugf("Schedule %s packet", packet.Name[pkt.PacketType()])
 				select {
-				case <ctx.Done():
+				case <-ctx.Done():
 					return
 				case controlCh <- pkt:
 				}

--- a/pkg/applicationserver/io/mqtt/mqtt.go
+++ b/pkg/applicationserver/io/mqtt/mqtt.go
@@ -119,7 +119,11 @@ func (c *connection) setup(ctx context.Context) error {
 			}
 			if pkt != nil {
 				logger.Debugf("Schedule %s packet", packet.Name[pkt.PacketType()])
-				controlCh <- pkt
+				select {
+				case <ctx.Done():
+					return
+				case controlCh <- pkt:
+				}
 			}
 		}
 	}()

--- a/pkg/applicationserver/io/packages/packages.go
+++ b/pkg/applicationserver/io/packages/packages.go
@@ -142,7 +142,7 @@ func (s *server) NewSubscription() *io.Subscription {
 	go func() {
 		for {
 			select {
-			case <-s.ctx.Done():
+			case <-sub.Context().Done():
 				return
 			case up := <-sub.Up():
 				if err := s.handleUp(up.Context, up.ApplicationUp); err != nil {

--- a/pkg/applicationserver/io/pubsub/provider/mqtt/driver_internal_test.go
+++ b/pkg/applicationserver/io/pubsub/provider/mqtt/driver_internal_test.go
@@ -46,7 +46,7 @@ func (h *harness) MakeNonexistentTopic(ctx context.Context) (driver.Topic, error
 }
 
 func (h *harness) CreateSubscription(ctx context.Context, t driver.Topic, testName string) (ds driver.Subscription, cleanup func(), err error) {
-	dt, err := openDriverSubscription(h.client, fmt.Sprintf("test/%s", testName), timeout, 1)
+	dt, err := openDriverSubscription(ctx, h.client, fmt.Sprintf("test/%s", testName), timeout, 1)
 	if err != nil {
 		return nil, func() {}, err
 	}

--- a/pkg/applicationserver/io/pubsub/provider/mqtt/provider.go
+++ b/pkg/applicationserver/io/pubsub/provider/mqtt/provider.go
@@ -155,6 +155,7 @@ func OpenConnection(ctx context.Context, settings *ttnpb.ApplicationPubSub_MQTT,
 			continue
 		}
 		if *s.subscription, err = OpenSubscription(
+			ctx,
 			client,
 			mqtt_topic.Join(append(mqtt_topic.Split(topics.GetBaseTopic()), mqtt_topic.Split(s.message.GetTopic())...)),
 			timeout,

--- a/pkg/applicationserver/linking.go
+++ b/pkg/applicationserver/linking.go
@@ -229,7 +229,11 @@ func (as *ApplicationServer) link(ctx context.Context, ids ttnpb.ApplicationIden
 	go l.run()
 	for _, sub := range as.defaultSubscribers {
 		sub := sub
-		l.subscribeCh <- sub
+		select {
+		case <-l.ctx.Done():
+			return
+		case l.subscribeCh <- sub:
+		}
 		go func() {
 			select {
 			case <-l.ctx.Done():
@@ -239,7 +243,11 @@ func (as *ApplicationServer) link(ctx context.Context, ids ttnpb.ApplicationIden
 				return
 			case <-sub.Context().Done():
 			}
-			l.unsubscribeCh <- sub
+			select {
+			case <-l.ctx.Done():
+				return
+			case l.unsubscribeCh <- sub:
+			}
 		}()
 	}
 	for {
@@ -273,7 +281,11 @@ func (as *ApplicationServer) cancelLink(ctx context.Context, ids ttnpb.Applicati
 		l := val.(*link)
 		log.FromContext(ctx).WithField("application_uid", uid).Debug("Unlink")
 		l.cancel(context.Canceled)
-		<-l.closed
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-l.closed:
+		}
 	} else {
 		as.linkErrors.Delete(uid)
 	}
@@ -371,10 +383,14 @@ func (l *link) sendUp(ctx context.Context, up *ttnpb.ApplicationUp, ack func() e
 		registerDropUp(ctx, up, handleUpErr)
 		return nil
 	}
-
-	l.upCh <- &io.ContextualApplicationUp{
+	ctxUp := &io.ContextualApplicationUp{
 		Context:       ctx,
 		ApplicationUp: up,
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case l.upCh <- ctxUp:
 	}
 	registerForwardUp(ctx, up)
 	return nil

--- a/pkg/auth/rights/cache.go
+++ b/pkg/auth/rights/cache.go
@@ -73,8 +73,13 @@ func (c *cachedRes) set(rights *ttnpb.Rights, err error) {
 	close(c.waitChan)
 }
 
-func (c *cachedRes) wait() {
-	<-c.waitChan
+func (c *cachedRes) wait(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.waitChan:
+		return nil
+	}
 }
 
 // NewInMemoryCache returns a new in-memory cache on top of the given fetcher.
@@ -156,7 +161,9 @@ func (f *inMemoryCache) ApplicationRights(ctx context.Context, appID ttnpb.Appli
 	}
 	f.maybeCleanup()
 	f.mu.Unlock()
-	res.wait()
+	if err := res.wait(ctx); err != nil {
+		return nil, err
+	}
 	return res.rights, res.err
 }
 
@@ -172,7 +179,9 @@ func (f *inMemoryCache) ClientRights(ctx context.Context, clientID ttnpb.ClientI
 	}
 	f.maybeCleanup()
 	f.mu.Unlock()
-	res.wait()
+	if err := res.wait(ctx); err != nil {
+		return nil, err
+	}
 	return res.rights, res.err
 }
 
@@ -188,7 +197,9 @@ func (f *inMemoryCache) GatewayRights(ctx context.Context, gtwID ttnpb.GatewayId
 	}
 	f.maybeCleanup()
 	f.mu.Unlock()
-	res.wait()
+	if err := res.wait(ctx); err != nil {
+		return nil, err
+	}
 	return res.rights, res.err
 }
 
@@ -204,7 +215,9 @@ func (f *inMemoryCache) OrganizationRights(ctx context.Context, orgID ttnpb.Orga
 	}
 	f.maybeCleanup()
 	f.mu.Unlock()
-	res.wait()
+	if err := res.wait(ctx); err != nil {
+		return nil, err
+	}
 	return res.rights, res.err
 }
 
@@ -220,6 +233,8 @@ func (f *inMemoryCache) UserRights(ctx context.Context, userID ttnpb.UserIdentif
 	}
 	f.maybeCleanup()
 	f.mu.Unlock()
-	res.wait()
+	if err := res.wait(ctx); err != nil {
+		return nil, err
+	}
 	return res.rights, res.err
 }

--- a/pkg/devicetemplates/microchip.go
+++ b/pkg/devicetemplates/microchip.go
@@ -187,7 +187,7 @@ func (m *microchipATECC608AMAHTNT) Convert(ctx context.Context, r io.Reader, ch 
 			return errMicrochipData.WithCause(err)
 		}
 		sn := s.Fields["uniqueId"].GetStringValue()
-		ch <- &ttnpb.EndDeviceTemplate{
+		tmpl := &ttnpb.EndDeviceTemplate{
 			EndDevice: ttnpb.EndDevice{
 				EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
 					JoinEUI: &joinEUI,
@@ -209,6 +209,11 @@ func (m *microchipATECC608AMAHTNT) Convert(ctx context.Context, r io.Reader, ch 
 				},
 			},
 			MappingKey: sn,
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ch <- tmpl:
 		}
 	}
 	return nil
@@ -343,7 +348,7 @@ func (m *microchipATECC608TNGLORA) Convert(ctx context.Context, r io.Reader, ch 
 			return errMicrochipData.WithCause(err)
 		}
 		sn := s.Fields["uniqueId"].GetStringValue()
-		ch <- &ttnpb.EndDeviceTemplate{
+		tmpl := &ttnpb.EndDeviceTemplate{
 			EndDevice: ttnpb.EndDevice{
 				EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
 					DeviceID: strings.ToLower(fmt.Sprintf("eui-%s", devEUI)),
@@ -369,6 +374,11 @@ func (m *microchipATECC608TNGLORA) Convert(ctx context.Context, r io.Reader, ch 
 				},
 			},
 			MappingKey: sn,
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ch <- tmpl:
 		}
 	}
 	return nil

--- a/pkg/events/redis/redis_test.go
+++ b/pkg/events/redis/redis_test.go
@@ -74,12 +74,12 @@ func TestRedisPubSub(t *testing.T) {
 		eventCh <- e
 	})
 
+	ctx := events.ContextWithCorrelationID(test.Context(), t.Name())
+
 	pubsub := redis.NewPubSub(redisConfig())
-	defer pubsub.Close()
+	defer pubsub.Close(ctx)
 
 	pubsub.Subscribe("redis.**", handler)
-
-	ctx := events.ContextWithCorrelationID(test.Context(), t.Name())
 
 	appID := &ttnpb.ApplicationIdentifiers{ApplicationID: "test-app"}
 

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -653,7 +653,7 @@ func (gs *GatewayServer) handleUpstream(conn connectionEntry) {
 			host := host
 			select {
 			case <-ctx.Done():
-				return ctx.Err()
+				return
 			case host.handleCh <- item:
 			default:
 				if atomic.LoadInt32(&host.handlers) < maxUpstreamHandlers {
@@ -669,7 +669,7 @@ func (gs *GatewayServer) handleUpstream(conn connectionEntry) {
 					go func() {
 						select {
 						case <-ctx.Done():
-							return ctx.Err()
+							return
 						case host.handleCh <- item:
 						}
 					}()

--- a/pkg/gatewayserver/io/mqtt/mqtt.go
+++ b/pkg/gatewayserver/io/mqtt/mqtt.go
@@ -28,6 +28,7 @@ import (
 	"github.com/TheThingsIndustries/mystique/pkg/packet"
 	"github.com/TheThingsIndustries/mystique/pkg/session"
 	"github.com/TheThingsIndustries/mystique/pkg/topic"
+	"go.thethings.network/lorawan-stack/v3/pkg/errorcontext"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
@@ -99,6 +100,7 @@ func (*connection) SupportsDownlinkClaim() bool { return false }
 
 func (c *connection) setup(ctx context.Context) (err error) {
 	ctx = auth.NewContextWithInterface(ctx, c)
+	ctx, cancel := errorcontext.New(ctx)
 	defer func() {
 		retrievedErr := recoverMQTTFrontend(ctx)
 		if retrievedErr != nil {
@@ -107,12 +109,12 @@ func (c *connection) setup(ctx context.Context) (err error) {
 	}()
 	c.session = session.New(ctx, c.mqtt, c.deliver)
 	if err := c.session.ReadConnect(); err != nil {
+		cancel(err)
 		return err
 	}
 	ctx = c.io.Context()
 
 	logger := log.FromContext(ctx)
-	errCh := make(chan error)
 	controlCh := make(chan packet.ControlPacket)
 
 	// Read control packets
@@ -124,11 +126,7 @@ func (c *connection) setup(ctx context.Context) (err error) {
 				if err != stdio.EOF {
 					logger.WithError(err).Warn("Error when reading packet")
 				}
-				select {
-				case <-ctx.Done():
-					return
-				case errCh <- err:
-				}
+				cancel(err)
 				return
 			}
 			if pkt != nil {
@@ -148,9 +146,9 @@ func (c *connection) setup(ctx context.Context) (err error) {
 		for {
 			select {
 			case <-c.io.Context().Done():
-				logger.WithError(c.io.Context().Err()).Debug("Done sending downlink")
-				c.session.Close()
-				c.mqtt.Close()
+				err := c.io.Context().Err()
+				cancel(err)
+				logger.WithError(err).Debug("Done sending downlink")
 				return
 			case down := <-c.io.Down():
 				buf, err := c.format.FromDownlink(down, c.io.Gateway().GatewayIdentifiers)
@@ -176,7 +174,8 @@ func (c *connection) setup(ctx context.Context) (err error) {
 		for {
 			var err error
 			select {
-			case err = <-errCh:
+			case <-ctx.Done():
+				return
 			case pkt, ok := <-controlCh:
 				if !ok {
 					controlCh = nil
@@ -196,11 +195,18 @@ func (c *connection) setup(ctx context.Context) (err error) {
 				} else {
 					logger.Info("Disconnected")
 				}
-				c.io.Disconnect(err)
-				c.session.Close()
-				c.mqtt.Close()
+				cancel(err)
 				return
 			}
+		}
+	}()
+
+	// Close connection on context closure
+	go func() {
+		select {
+		case <-ctx.Done():
+			c.session.Close()
+			c.mqtt.Close()
 		}
 	}()
 

--- a/pkg/gatewayserver/io/mqtt/mqtt.go
+++ b/pkg/gatewayserver/io/mqtt/mqtt.go
@@ -129,7 +129,11 @@ func (c *connection) setup(ctx context.Context) (err error) {
 			}
 			if pkt != nil {
 				logger.Debugf("Schedule %s packet", packet.Name[pkt.PacketType()])
-				controlCh <- pkt
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case controlCh <- pkt:
+				}
 			}
 		}
 	}()

--- a/pkg/gatewayserver/io/mqtt/mqtt.go
+++ b/pkg/gatewayserver/io/mqtt/mqtt.go
@@ -124,14 +124,18 @@ func (c *connection) setup(ctx context.Context) (err error) {
 				if err != stdio.EOF {
 					logger.WithError(err).Warn("Error when reading packet")
 				}
-				errCh <- err
+				select {
+				case <-ctx.Done():
+					return
+				case errCh <- err:
+				}
 				return
 			}
 			if pkt != nil {
 				logger.Debugf("Schedule %s packet", packet.Name[pkt.PacketType()])
 				select {
 				case <-ctx.Done():
-					return ctx.Err()
+					return
 				case controlCh <- pkt:
 				}
 			}

--- a/pkg/packetbrokeragent/mock/pbdataplane.go
+++ b/pkg/packetbrokeragent/mock/pbdataplane.go
@@ -93,11 +93,16 @@ type routerHomeNetworkServer struct {
 }
 
 func (s *routerHomeNetworkServer) Publish(ctx context.Context, req *packetbroker.PublishDownlinkMessageRequest) (*packetbroker.PublishDownlinkMessageResponse, error) {
-	s.downCh <- &packetbroker.RoutedDownlinkMessage{
+	down := &packetbroker.RoutedDownlinkMessage{
 		ForwarderNetId:    req.ForwarderNetId,
 		ForwarderId:       req.ForwarderId,
 		ForwarderTenantId: req.ForwarderTenantId,
 		Message:           req.Message,
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case s.downCh <- down:
 	}
 	return &packetbroker.PublishDownlinkMessageResponse{
 		Id: "test",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR is a follow up of our [Discuss](https://discuss.thethingsindustries.com/t/eu-pcn-optimizations-and-changes/255/3?u=adriansmares) topic on concurrency optimizations and correctness. After the PB [router](https://github.com/packetbroker/router/commit/39366f3b2ca7aa0ebfd110416a0bc038388184d4) bug and the leak I found this morning in the GS bridges I've searched through all of usages of `<-` and tried to make them context aware.

#### Changes
<!-- What are the changes made in this pull request? -->

- Read or write from channels with `select`, binding to the context.

#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Shouldn't be the case.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

`pkg/util/test` didn't seem to require this type of behavior, but we can update that one as well.

GS leak source:
![image](https://user-images.githubusercontent.com/36161392/89909372-a9c6bb00-dbf7-11ea-9d6f-b6acacdb56ed.png)

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
