### PR TITLE
OAuth contextual configuration

### DIFF
--- a/pkg/identityserver/identityserver.go
+++ b/pkg/identityserver/identityserver.go
@@ -100,7 +100,7 @@ func New(c *component.Component, config *Config) (is *IdentityServer, err error)
 	}
 
 	is.config.OAuth.CSRFAuthKey = is.GetBaseConfig(is.Context()).HTTP.Cookie.HashKey
-	is.oauth = oauth.NewServer(is.Context(), struct {
+	is.oauth, err = oauth.NewServer(c, struct {
 		store.UserStore
 		store.UserSessionStore
 		store.ClientStore
@@ -110,7 +110,10 @@ func New(c *component.Component, config *Config) (is *IdentityServer, err error)
 		UserSessionStore: store.GetUserSessionStore(is.db),
 		ClientStore:      store.GetClientStore(is.db),
 		OAuthStore:       store.GetOAuthStore(is.db),
-	}, is.config.OAuth)
+	}, oauth.StaticConfigProvider(is.config.OAuth))
+	if err != nil {
+		return nil, err
+	}
 
 	c.AddContextFiller(func(ctx context.Context) context.Context {
 		ctx = is.withRequestAccessCache(ctx)

--- a/pkg/oauth/config.go
+++ b/pkg/oauth/config.go
@@ -14,7 +14,11 @@
 
 package oauth
 
-import "go.thethings.network/lorawan-stack/v3/pkg/webui"
+import (
+	"context"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/webui"
+)
 
 // UIConfig is the combined configuration for the OAuth UI.
 type UIConfig struct {
@@ -38,4 +42,14 @@ type Config struct {
 	Mount       string   `name:"mount" description:"Path on the server where the OAuth server will be served"`
 	UI          UIConfig `name:"ui"`
 	CSRFAuthKey []byte   `name:"-"`
+}
+
+// ConfigProvider returns the server configuration based on the context.
+type ConfigProvider func(context.Context) Config
+
+// StaticConfigProvider is a provider that always returns the same config.
+func StaticConfigProvider(conf Config) ConfigProvider {
+	return func(context.Context) Config {
+		return conf
+	}
 }

--- a/pkg/oauth/middleware.go
+++ b/pkg/oauth/middleware.go
@@ -42,9 +42,10 @@ func (s *server) redirectToLogin(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		_, err := s.getSession(c)
 		if err != nil {
+			config := s.configFromEchoContext(c)
 			values := make(url.Values)
 			values.Set(nextKey, fmt.Sprintf("%s?%s", c.Request().URL.Path, c.QueryParams().Encode()))
-			return c.Redirect(http.StatusFound, fmt.Sprintf("%s?%s", path.Join(s.config.UI.MountPath(), "login"), values.Encode()))
+			return c.Redirect(http.StatusFound, fmt.Sprintf("%s?%s", path.Join(config.UI.MountPath(), "login"), values.Encode()))
 		}
 		return next(c)
 	}
@@ -56,7 +57,8 @@ func (s *server) redirectToNext(next echo.HandlerFunc) echo.HandlerFunc {
 		if err == nil {
 			next := c.QueryParam(nextKey)
 			if next == "" {
-				next = s.config.UI.MountPath()
+				config := s.configFromEchoContext(c)
+				next = config.UI.MountPath()
 			}
 			url, err := url.Parse(next)
 			if err != nil {

--- a/pkg/oauth/server_test.go
+++ b/pkg/oauth/server_test.go
@@ -96,7 +96,6 @@ func init() {
 }
 
 func TestOAuthFlow(t *testing.T) {
-	ctx := test.Context()
 	store := &mockStore{}
 	jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
 	if err != nil {
@@ -112,7 +111,7 @@ func TestOAuthFlow(t *testing.T) {
 			},
 		},
 	})
-	s := oauth.NewServer(ctx, store, oauth.Config{
+	s, err := oauth.NewServer(c, store, oauth.StaticConfigProvider(oauth.Config{
 		Mount:       "/oauth",
 		CSRFAuthKey: []byte("12345678123456781234567812345678"),
 		UI: oauth.UIConfig{
@@ -122,7 +121,10 @@ func TestOAuthFlow(t *testing.T) {
 				CanonicalURL: "https://example.com/oauth",
 			},
 		},
-	})
+	}))
+	if err != nil {
+		panic(err)
+	}
 	c.RegisterWeb(s)
 	componenttest.StartComponent(t, c)
 
@@ -587,7 +589,6 @@ func TestOAuthFlow(t *testing.T) {
 }
 
 func TestTokenExchange(t *testing.T) {
-	ctx := test.Context()
 	store := &mockStore{}
 	c := componenttest.NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
@@ -599,7 +600,7 @@ func TestTokenExchange(t *testing.T) {
 			},
 		},
 	})
-	s := oauth.NewServer(ctx, store, oauth.Config{
+	s, err := oauth.NewServer(c, store, oauth.StaticConfigProvider(oauth.Config{
 		Mount: "/oauth",
 		UI: oauth.UIConfig{
 			TemplateData: webui.TemplateData{
@@ -607,7 +608,10 @@ func TestTokenExchange(t *testing.T) {
 				Title:    "OAuth",
 			},
 		},
-	})
+	}))
+	if err != nil {
+		panic(err)
+	}
 	c.RegisterWeb(s)
 	componenttest.StartComponent(t, c)
 

--- a/pkg/oauth/token_generators.go
+++ b/pkg/oauth/token_generators.go
@@ -20,23 +20,24 @@ import (
 )
 
 func (s *server) GenerateAuthorizeToken(_ *osin.AuthorizeData) (string, error) {
-	return auth.AuthorizationCode.Generate(s.ctx, "")
+	return auth.AuthorizationCode.Generate(s.c.Context(), "")
 }
 
 func (s *server) GenerateAccessToken(_ *osin.AccessData, generateRefresh bool) (accessToken string, refreshToken string, err error) {
+	ctx := s.c.Context()
 	var id string
 	if generateRefresh {
-		id, err = auth.GenerateID(s.ctx)
+		id, err = auth.GenerateID(ctx)
 		if err != nil {
 			return
 		}
 	}
-	accessToken, err = auth.AccessToken.Generate(s.ctx, id)
+	accessToken, err = auth.AccessToken.Generate(ctx, id)
 	if err != nil {
 		return
 	}
 	if generateRefresh {
-		refreshToken, err = auth.RefreshToken.Generate(s.ctx, id)
+		refreshToken, err = auth.RefreshToken.Generate(ctx, id)
 		if err != nil {
 			return
 		}

--- a/pkg/web/oauthclient/callback.go
+++ b/pkg/web/oauthclient/callback.go
@@ -86,6 +86,10 @@ func (oc *OAuthClient) HandleCallback(c echo.Context) error {
 		return err
 	}
 
+	return oc.callback(c, token, stateCookie.Next)
+}
+
+func (oc *OAuthClient) defaultCallback(c echo.Context, _ *oauth2.Token, next string) error {
 	config := oc.configFromContext(c.Request().Context())
-	return c.Redirect(http.StatusFound, config.RootURL+stateCookie.Next)
+	return c.Redirect(http.StatusFound, config.RootURL+next)
 }

--- a/pkg/web/oauthclient/config.go
+++ b/pkg/web/oauthclient/config.go
@@ -26,4 +26,6 @@ type Config struct {
 
 	StateCookieName string `name:"-"`
 	AuthCookieName  string `name:"-"`
+
+	customProvider bool
 }

--- a/pkg/web/oauthclient/login.go
+++ b/pkg/web/oauthclient/login.go
@@ -24,7 +24,7 @@ import (
 // HandleLogin is the handler for redirecting the user to the authorization
 // endpoint.
 func (oc *OAuthClient) HandleLogin(c echo.Context) error {
-	next := c.QueryParam("next")
+	next := c.QueryParam(oc.nextKey)
 
 	// Only allow relative paths.
 	if !strings.HasPrefix(next, "/") && !strings.HasPrefix(next, "#") && !strings.HasPrefix(next, "?") {

--- a/pkg/web/oauthclient/options.go
+++ b/pkg/web/oauthclient/options.go
@@ -1,0 +1,52 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauthclient
+
+import (
+	echo "github.com/labstack/echo/v4"
+	"golang.org/x/oauth2"
+)
+
+// Option is an OAuth2Client configuration option.
+type Option func(*OAuthClient)
+
+// OAuth2ConfigProvider provides an OAuth2 client config based on the context.
+type OAuth2ConfigProvider func(echo.Context) *oauth2.Config
+
+// WithOAuth2ConfigProvider overrides the default OAuth2 configuration provider.
+func WithOAuth2ConfigProvider(provider OAuth2ConfigProvider) Option {
+	return func(o *OAuthClient) {
+		o.config.customProvider = true
+		o.oauth = provider
+	}
+}
+
+// WithNextKey overrides the default query parameter used for callback return.
+func WithNextKey(key string) Option {
+	return func(o *OAuthClient) {
+		o.nextKey = key
+	}
+}
+
+// Callback occurs after the OAuth2 token exchange has been performed successfully.
+type Callback func(echo.Context, *oauth2.Token, string) error
+
+// WithCallback adds a callback to be executed at the end of the OAuth2
+// token exchange.
+func WithCallback(cb Callback) Option {
+	return func(o *OAuthClient) {
+		o.callback = cb
+	}
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/issues/1659

#### Changes
<!-- What are the changes made in this pull request? -->

- OAuth server configuration is no longer static and now is provided by a `ConfigProvider` which returns the configuration based on the context. A static provider has been added for ease of use and backwards compatibility.
- OAuth server constructor now requires a `Component` and a `ConfigProvider` instead of `context.Context` and `Config`. The component is needed in order to allow the OAuth server to use `pkg/web/oauthclient`.
- OAuth client configuration (`*oauth2.Config`) can now be overridden contextually. The original design of `pkg/web/oauthclient` is tailored towards our own OAuth server (or rather, to the normal addressing schema). The changes proposed by this PR allows the component that constructs the client to provide it's own `*oauth2.Config` at runtime using the `WithOAuth2ConfigProvider` option.
- OAuth client token callback end may now be overwritten in order to allow additional steps to be performed after the token exchange. 

#### Testing

<!-- How did you verify that this change works? -->

Tested as a whole as part of closed-source [changeset](https://github.com/TheThingsIndustries/lorawan-stack/tree/feature/1659-fed-auth-db ). Changes are backwards compatible, as the default behavior (i.e. without any `Option`s) is just the one that was available before.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

The already existing uses of the two packages are virtually unchanged, and this has been tested as described above.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

See [this federated provider](https://github.com/TheThingsIndustries/lorawan-stack/tree/feature/1659-fed-auth-db/pkg/oauth/oidc) in order to see how the changes are used. Feel free to suggest changes or alternative approaches. I've tried to reuse and integrate our already existing building blocks as best as possible.

@htdvisser and @kschiffer main reviewers.
@rvolosatovs, @bafonins, @johanstokking no need to review (I cannot manually remove the requests, sorry).

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
