### PR TITLE
Improve error reporting when trying to change password with CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Network Server now only publishes payload-related downlink events if scheduling succeeds.
 - Moved remote IP event metadata outside authentication.
+- Admins can now set the expiration time of temporary passwords of users.
 
 ### Deprecated
 

--- a/cmd/ttn-lw-cli/commands/users.go
+++ b/cmd/ttn-lw-cli/commands/users.go
@@ -271,6 +271,13 @@ var (
 				logger.Warn("No fields selected, won't update anything")
 				return nil
 			}
+			if ttnpb.ContainsField("password", paths) {
+				logger.Warn("Most servers do not allow changing the password of a user like this.")
+				logger.Warnf("Use \"%s [user-id]\" to change your password.", usersUpdatePasswordCommand.CommandPath())
+				logger.Warnf("Use \"%s [user-id]\" if you forgot your password and want to request a temporary password.", usersForgotPasswordCommand.CommandPath())
+				logger.Warnf("Alternatively, admins may use \"%s [user-id] --temporary-password [pass]\" to set a temporary password for a user.", cmd.CommandPath())
+				logger.Warn("The user can then use this temporary password when changing their password.")
+			}
 			var user ttnpb.User
 			if err := util.SetFields(&user, setUserFlags); err != nil {
 				return err

--- a/cmd/ttn-lw-cli/internal/util/flags.go
+++ b/cmd/ttn-lw-cli/internal/util/flags.go
@@ -174,8 +174,7 @@ func isSelectableField(name string) bool {
 
 func isSettableField(name string) bool {
 	switch name {
-	case "attributes", "contact_info", "password_updated_at", "temporary_password_created_at",
-		"temporary_password_expires_at", "antennas", "profile_picture":
+	case "attributes", "contact_info", "password_updated_at", "temporary_password_created_at", "antennas", "profile_picture":
 		return false
 	}
 	return true


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This improves error reporting in the CLI when trying to update the password of a user using the wrong command. Updating the password of a user is only allowed with the `update-password` command. It is however allowed for admins to set a temporary password on users, as well as an expiration time.

Closes #1147

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This wasn't documented, so didn't add or update documentation.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
