### PR TITLE
Only schedule MAC commands in class A downlink slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- MAC commands (both requests and responses) are now only scheduled in class A downlink slots in accordance to latest revisions to LoRaWAN specification.
+
 ### Deprecated
 
 ### Removed

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -2910,22 +2910,10 @@ func TestProcessDownlinkTask(t *testing.T) {
 							/*** DevAddr ***/
 							devAddr[3], devAddr[2], devAddr[1], devAddr[0],
 							/*** FCtrl ***/
-							0b1_0_0_1_0001,
+							0b1_0_0_1_0000,
 							/*** FCnt ***/
 							0x42, 0x00,
 						}
-
-						/** FOpts **/
-						b = append(b, test.Must(crypto.EncryptDownlink(
-							nwkSEncKey,
-							devAddr,
-							0x24,
-							[]byte{
-								/* DevStatusReq */
-								0x06,
-							},
-							true,
-						)).([]byte)...)
 
 						/** FPort **/
 						b = append(b, 0x1)
@@ -2947,7 +2935,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 						return &ttnpb.TxRequest{
 							Class:            ttnpb.CLASS_B,
 							DownlinkPaths:    paths,
-							Priority:         ttnpb.TxSchedulePriority_HIGH,
+							Priority:         ttnpb.TxSchedulePriority_NORMAL,
 							Rx2DataRateIndex: ttnpb.DATA_RATE_3,
 							Rx2Frequency:     869525000,
 							AbsoluteTime:     TimePtr(pingAt.UTC()),
@@ -2978,11 +2966,6 @@ func TestProcessDownlinkTask(t *testing.T) {
 				setDevice.MACState.LastDownlinkAt = &downAt
 				setDevice.MACState.LastNetworkInitiatedDownlinkAt = &downAt
 				setDevice.MACState.PendingApplicationDownlink = setDevice.Session.QueuedApplicationDownlinks[0]
-				setDevice.MACState.PendingRequests = []*ttnpb.MACCommand{
-					{
-						CID: ttnpb.CID_DEV_STATUS,
-					},
-				}
 				setDevice.MACState.RecentDownlinks = append(setDevice.MACState.RecentDownlinks, lastDown)
 				setDevice.RecentDownlinks = append(setDevice.RecentDownlinks, lastDown)
 				setDevice.Session.QueuedApplicationDownlinks = []*ttnpb.ApplicationDownlink{
@@ -3024,10 +3007,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 
 				clock.Add(time.Second)
 
-				if timeout, interval := *setDevice.MACSettings.ClassBTimeout, networkInitiatedDownlinkInterval; timeout < interval {
-					panic(fmt.Sprintf("class B timeout less than networkInitiatedDownlinkInterval (%v < %v)", timeout, interval))
-				}
-				nextPingSlot, ok := nextPingSlotAt(ctx, setDevice, downAt.Add(*setDevice.MACSettings.ClassBTimeout))
+				nextPingSlot, ok := nextPingSlotAt(ctx, setDevice, downAt.Add(networkInitiatedDownlinkInterval))
 				if !a.So(ok, should.BeTrue) {
 					t.Error("Failed to compute next ping slot")
 				}
@@ -3536,22 +3516,10 @@ func TestProcessDownlinkTask(t *testing.T) {
 							/*** DevAddr ***/
 							devAddr[3], devAddr[2], devAddr[1], devAddr[0],
 							/*** FCtrl ***/
-							0b1_0_0_0_0001,
+							0b1_0_0_0_0000,
 							/*** FCnt ***/
 							0x42, 0x00,
 						}
-
-						/** FOpts **/
-						b = append(b, test.Must(crypto.EncryptDownlink(
-							nwkSEncKey,
-							devAddr,
-							0x24,
-							[]byte{
-								/* DevStatusReq */
-								0x06,
-							},
-							true,
-						)).([]byte)...)
 
 						/** FPort **/
 						b = append(b, 0x1)
@@ -3573,7 +3541,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 						return &ttnpb.TxRequest{
 							Class:            ttnpb.CLASS_C,
 							DownlinkPaths:    paths,
-							Priority:         ttnpb.TxSchedulePriority_HIGH,
+							Priority:         ttnpb.TxSchedulePriority_NORMAL,
 							Rx2DataRateIndex: getDevice.MACState.CurrentParameters.Rx2DataRateIndex,
 							Rx2Frequency:     getDevice.MACState.CurrentParameters.Rx2Frequency,
 							FrequencyPlanID:  test.EUFrequencyPlanID,
@@ -3603,14 +3571,8 @@ func TestProcessDownlinkTask(t *testing.T) {
 				}
 
 				setDevice := CopyEndDevice(getDevice)
-				setDevice.MACState.LastConfirmedDownlinkAt = &downAt
 				setDevice.MACState.LastDownlinkAt = &downAt
 				setDevice.MACState.LastNetworkInitiatedDownlinkAt = &downAt
-				setDevice.MACState.PendingRequests = []*ttnpb.MACCommand{
-					{
-						CID: ttnpb.CID_DEV_STATUS,
-					},
-				}
 				setDevice.MACState.QueuedResponses = nil
 				setDevice.MACState.RecentDownlinks = append(setDevice.MACState.RecentDownlinks, lastDown)
 				setDevice.MACState.RxWindowsAvailable = false
@@ -4077,22 +4039,10 @@ func TestProcessDownlinkTask(t *testing.T) {
 							/*** DevAddr ***/
 							devAddr[3], devAddr[2], devAddr[1], devAddr[0],
 							/*** FCtrl ***/
-							0b1_0_0_0_0001,
+							0b1_0_0_0_0000,
 							/*** FCnt ***/
 							0x42, 0x00,
 						}
-
-						/** FOpts **/
-						b = append(b, test.Must(crypto.EncryptDownlink(
-							nwkSEncKey,
-							devAddr,
-							0x24,
-							[]byte{
-								/* DevStatusReq */
-								0x06,
-							},
-							true,
-						)).([]byte)...)
 
 						/** FPort **/
 						b = append(b, 0x1)
@@ -4114,7 +4064,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 						return &ttnpb.TxRequest{
 							Class:            ttnpb.CLASS_C,
 							DownlinkPaths:    paths,
-							Priority:         ttnpb.TxSchedulePriority_HIGH,
+							Priority:         ttnpb.TxSchedulePriority_NORMAL,
 							AbsoluteTime:     &absTime,
 							Rx2DataRateIndex: getDevice.MACState.CurrentParameters.Rx2DataRateIndex,
 							Rx2Frequency:     getDevice.MACState.CurrentParameters.Rx2Frequency,
@@ -4369,22 +4319,10 @@ func TestProcessDownlinkTask(t *testing.T) {
 							/*** DevAddr ***/
 							devAddr[3], devAddr[2], devAddr[1], devAddr[0],
 							/*** FCtrl ***/
-							0b1_0_0_0_0001,
+							0b1_0_0_0_0000,
 							/*** FCnt ***/
 							0x42, 0x00,
 						}
-
-						/** FOpts **/
-						b = append(b, test.Must(crypto.EncryptDownlink(
-							nwkSEncKey,
-							devAddr,
-							0x24,
-							[]byte{
-								/* DevStatusReq */
-								0x06,
-							},
-							true,
-						)).([]byte)...)
 
 						/** FPort **/
 						b = append(b, 0x1)
@@ -4406,7 +4344,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 						return &ttnpb.TxRequest{
 							Class:            ttnpb.CLASS_C,
 							DownlinkPaths:    paths,
-							Priority:         ttnpb.TxSchedulePriority_HIGH,
+							Priority:         ttnpb.TxSchedulePriority_NORMAL,
 							Rx2DataRateIndex: getDevice.MACState.CurrentParameters.Rx2DataRateIndex,
 							Rx2Frequency:     getDevice.MACState.CurrentParameters.Rx2Frequency,
 							FrequencyPlanID:  test.EUFrequencyPlanID,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #2909 https://github.com/TheThingsNetwork/lorawan-stack/issues/2774

Incidentally, this makes proceeding with #3052 easier.

cc @ama9910

#### Changes
<!-- What are the changes made in this pull request? -->

- Only schedule MAC commands in class A downlink slots
- In case something goes wrong with MAC queue and either responses don't fit or an unknown command is present, this is only logged and does not prevent new MAC requests from being scheduled anymore.

#### Testing

<!-- How did you verify that this change works? -->

integration testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This can affect MAC command scheduling for all classes, regressions not expected.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Actual support for flag from #2909 will be added later.
Perhaps we should implement it as part of the next release to allow users to fallback to the legacy behavior? To be honest, it seems that scheduling MAC in classes B/C causes more trouble than benefits for us and our customers.
In the past we have encountered numerous issues with this and many users were confused about this behavior and consequences it brings to downlink scheduling and priorities. Perhaps we could move #2909 to Backlog instead and only implement if customers explicitly ask for it? Again, as I see it now, I don't think anyone today is going to miss this feature and users are more likely to be happy for this change, however it does change behavior. Thoughts @johanstokking ?

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
