### PR TITLE
Change AS linking retry logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Network Server now only publishes payload-related downlink events if scheduling succeeds.
 - Moved remote IP event metadata outside authentication.
 - Admins can now set the expiration time of temporary passwords of users.
+- Application Server links are no longer canceled prematurely for special error codes. Longer back off times are used instead.
 
 ### Deprecated
 

--- a/pkg/applicationserver/linking.go
+++ b/pkg/applicationserver/linking.go
@@ -44,6 +44,45 @@ func (as *ApplicationServer) linkAll(ctx context.Context) error {
 	)
 }
 
+var (
+	linkHealthyDuration = 1 * time.Minute
+	linkBackoffConfig   = &component.TaskBackoffConfig{
+		Jitter: component.DefaultTaskBackoffConfig.Jitter,
+		DynamicInterval: func(ctx context.Context, executionTime time.Duration, invocation int, err error) time.Duration {
+			defaultIntervals := component.DefaultTaskBackoffConfig.Intervals
+			extendedIntervals := append(defaultIntervals,
+				1*time.Minute,
+				5*time.Minute,
+				15*time.Minute,
+				30*time.Minute,
+			)
+
+			var intervals []time.Duration
+			switch {
+			case errors.IsFailedPrecondition(err),
+				errors.IsUnauthenticated(err),
+				errors.IsPermissionDenied(err),
+				errors.IsInvalidArgument(err),
+				errors.IsAlreadyExists(err),
+				errors.IsCanceled(err):
+				intervals = extendedIntervals
+			default:
+				intervals = defaultIntervals
+			}
+
+			bi := invocation - 1
+			if bi >= len(intervals) {
+				bi = len(intervals) - 1
+			}
+			if executionTime > linkHealthyDuration {
+				bi = 0
+			}
+
+			return intervals[bi]
+		},
+	}
+)
+
 func (as *ApplicationServer) startLinkTask(ctx context.Context, ids ttnpb.ApplicationIdentifiers) {
 	ctx = log.NewContextWithField(ctx, "application_uid", unique.ID(ctx, ids))
 	as.StartTask(&component.TaskConfig{
@@ -63,23 +102,10 @@ func (as *ApplicationServer) startLinkTask(ctx context.Context, ids ttnpb.Applic
 				return nil
 			}
 
-			err = as.link(ctx, ids, target)
-			switch {
-			case errors.IsFailedPrecondition(err),
-				errors.IsUnauthenticated(err),
-				errors.IsPermissionDenied(err),
-				errors.IsInvalidArgument(err):
-				log.FromContext(ctx).WithError(err).Warn("Failed to link")
-				return nil
-			case errors.IsCanceled(err),
-				errors.IsAlreadyExists(err):
-				return nil
-			default:
-				return err
-			}
+			return as.link(ctx, ids, target)
 		},
 		Restart: component.TaskRestartOnFailure,
-		Backoff: component.DialTaskBackoffConfig,
+		Backoff: linkBackoffConfig,
 	})
 }
 
@@ -198,7 +224,7 @@ func (as *ApplicationServer) link(ctx context.Context, ids ttnpb.ApplicationIden
 	}
 	if _, loaded := as.links.LoadOrStore(uid, l); loaded {
 		log.FromContext(ctx).Warn("Link already started")
-		return errAlreadyLinked.WithAttributes("application_uid", uid)
+		return nil
 	}
 	go func() {
 		<-ctx.Done()
@@ -227,7 +253,7 @@ func (as *ApplicationServer) link(ctx context.Context, ids ttnpb.ApplicationIden
 	go func() {
 		<-ctx.Done()
 		if err := ctx.Err(); errors.IsCanceled(err) {
-			logger.Info("Unlinked")
+			logger.WithError(err).Info("Unlinked")
 			registerLinkStop(ctx, l)
 		}
 	}()
@@ -286,7 +312,7 @@ func (as *ApplicationServer) cancelLink(ctx context.Context, ids ttnpb.Applicati
 	if val, ok := as.links.Load(uid); ok {
 		l := val.(*link)
 		log.FromContext(ctx).WithField("application_uid", uid).Debug("Unlink")
-		l.cancel(context.Canceled)
+		l.cancel(nil)
 		select {
 		case <-ctx.Done():
 			return ctx.Err()

--- a/pkg/applicationserver/linking.go
+++ b/pkg/applicationserver/linking.go
@@ -230,7 +230,7 @@ func (as *ApplicationServer) link(ctx context.Context, ids ttnpb.ApplicationIden
 		<-ctx.Done()
 		as.linkErrors.Store(uid, ctx.Err())
 		as.links.Delete(uid)
-		if err := ctx.Err(); err != nil && !errors.IsCanceled(err) {
+		if err := ctx.Err(); err != nil {
 			log.FromContext(ctx).WithError(err).Warn("Link failed")
 			registerLinkFail(ctx, l, err)
 		}
@@ -252,10 +252,8 @@ func (as *ApplicationServer) link(ctx context.Context, ids ttnpb.ApplicationIden
 	registerLinkStart(ctx, l)
 	go func() {
 		<-ctx.Done()
-		if err := ctx.Err(); errors.IsCanceled(err) {
-			logger.WithError(err).Info("Unlinked")
-			registerLinkStop(ctx, l)
-		}
+		logger.WithError(ctx.Err()).Info("Unlinked")
+		registerLinkStop(ctx, l)
 	}()
 
 	go l.run()

--- a/pkg/applicationserver/linking_internal_test.go
+++ b/pkg/applicationserver/linking_internal_test.go
@@ -17,10 +17,10 @@ package applicationserver
 import (
 	"time"
 
-	"go.thethings.network/lorawan-stack/v3/pkg/component"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
 )
 
 func init() {
-	component.DialTaskBackoffConfig.Intervals = []time.Duration{(1 << 5) * test.Delay}
+	linkBackoffConfig.DynamicInterval = nil
+	linkBackoffConfig.Intervals = []time.Duration{(1 << 5) * test.Delay}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsIndustries/lorawan-stack/issues/2313
Closes https://github.com/TheThingsIndustries/lorawan-stack/issues/2265

#### Changes
<!-- What are the changes made in this pull request? -->

- Add dynamic backoff duration support to component tasks
- Use dynamic backoff duration depending on last error code that occurred during linking. Problematic error codes can go to up to 30 minutes of backoff
- Link tasks no longer stop unless explicitly stopped by a `Set` or `Delete` call, no matter the error code
- Count link failures for any non-`nil` error
- Always count link stops

#### Testing

<!-- How did you verify that this change works? -->

Already existing tests cover this. The fixes presented here deal with issues that exist only at scale.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This changes link behavior in order to allow links to live longer lifetimes and no longer get cancelled too early.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
