### PR TITLE
cli: Fix login issues with explicit :443 port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- CLI login issues when OAuth Server Address explicitly includes the `:443` HTTPS port.
+
 ### Security
 
 ## [3.9.1] - 2020-08-19

--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -131,6 +132,14 @@ func preRun(tasks ...func() error) func(cmd *cobra.Command, args []string) error
 			if err = api.AddCA(pemBytes); err != nil {
 				return err
 			}
+		}
+
+		// Drop default HTTP port numbers from OAuth server address if present.
+		// Causes issues with `--http.redirect-to-tls` stack option.
+		u, err := url.Parse(config.OAuthServerAddress)
+		if u.Port() == "443" && u.Scheme == "https" || u.Port() == "80" && u.Scheme == "http" {
+			u.Host = u.Hostname()
+			config.OAuthServerAddress = u.String()
 		}
 
 		// OAuth


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #2965

#### Changes
<!-- What are the changes made in this pull request? -->

Drop the explicit `:443` port number from the oauth server address if present.

#### Testing

<!-- How did you verify that this change works? -->

Test locally, with `http.redirect-to-tls` enabled and disabled. Login works as expected.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

There should not be any, 443 is the default HTTPS port

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This does not fix the issue on the server side, it only makes sure that the CLI does not suffer from it.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [X] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
