### PR TITLE
Add loading and formatting of i18n MessageDescriptors

### DIFF
--- a/pkg/i18n/i18n_test.go
+++ b/pkg/i18n/i18n_test.go
@@ -1,0 +1,76 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package i18n_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/smartystreets/assertions"
+	"github.com/smartystreets/assertions/should"
+	"go.thethings.network/lorawan-stack/v3/pkg/i18n"
+)
+
+func TestI18N(t *testing.T) {
+	a := assertions.New(t)
+	fileName := filepath.Join(os.TempDir(), fmt.Sprintf("TestI18N_%d", time.Now().Unix()))
+
+	m1 := make(i18n.MessageDescriptorMap)
+	m1.Define("not_used", "not used")
+
+	def := m1.Define("hello_world", "hello, world")
+	a.So(def.Description.Package, should.Equal, "pkg/i18n")
+	a.So(def.Description.File, should.Equal, "i18n_test.go")
+	def.Translations["nl"] = "hallo, wereld"
+	def.Translations["ja"] = "こんにちは世界"
+
+	a.So(def.Load(), should.BeNil)
+
+	def.Translations["unknown"] = "hello, world"
+
+	for lang, translation := range def.Translations {
+		actual := def.Format(lang, nil)
+		a.So(actual, should.Equal, translation)
+	}
+
+	err := m1.WriteFile(fileName)
+	a.So(err, should.BeNil)
+
+	m2, err := i18n.ReadFile(fileName)
+	a.So(err, should.BeNil)
+	a.So(m2["hello_world"].Translations, should.Resemble, def.Translations)
+	a.So(m2["hello_world"].Description, should.Resemble, def.Description)
+
+	m3 := make(i18n.MessageDescriptorMap)
+	m3.Define("hello_world", "hello, beautiful world")
+	m3.Define("hello_you", "hello, you")
+
+	m3.Merge(m2)
+
+	a.So(m3.Cleanup(), should.Contain, "not_used")
+	a.So(m3.Updated(), should.Contain, "hello_world")
+}
+
+func Example() {
+	i18n.Define("welcome_message", "Welcome, {name}!")
+
+	fmt.Println(i18n.Format("welcome_message", "en", map[string]interface{}{"name": "Alice"}))
+
+	// Output:
+	// Welcome, Alice!
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

As the title says, this PR adds loading of MessageDescriptors (including parsing the messages) and formatting messages to different languages.

Closes #1629.

#### Testing

<!-- How did you verify that this change works? -->

Added unit tests.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None, it's not used anywhere yet.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

No documentation or changelog, since this doesn't impact users.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
