### PR TITLE
Fix oauth logout redirect URI composition

### DIFF
--- a/pkg/oauth/user.go
+++ b/pkg/oauth/user.go
@@ -17,7 +17,6 @@ package oauth
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/url"
 	"runtime/trace"
@@ -288,7 +287,7 @@ func (s *server) ClientLogout(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	return c.Redirect(http.StatusFound, fmt.Sprintf("%s?%s", url.Path, url.RawQuery))
+	return c.Redirect(http.StatusFound, url.String())
 }
 
 func (s *server) Logout(c echo.Context) error {


### PR DESCRIPTION
#### Summary
This quickfix fixes the way that the logout redirect URI is composed.

#### Changes
- Use the whole URI, not just the path


#### Testing

Manual

##### Regressions

This could break the logout redirect for client-initiated logouts.

#### Notes for reviewers
Would be good if you could checkout and do some manual testing as well before we merge this, to be sure.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
