### PR TITLE
Use dynamic backoff for pub/sub

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -1907,15 +1907,6 @@
       "file": "registry.go"
     }
   },
-  "error:pkg/applicationserver/io/pubsub:already_configured": {
-    "translations": {
-      "en": "already configured to `{application_uid}` `{pub_sub_id}`"
-    },
-    "description": {
-      "package": "pkg/applicationserver/io/pubsub",
-      "file": "pubsub.go"
-    }
-  },
   "error:pkg/applicationserver/io/pubsub:format_not_found": {
     "translations": {
       "en": "format `{format}` not found"

--- a/config/messages.json
+++ b/config/messages.json
@@ -2069,15 +2069,6 @@
       "file": "registry.go"
     }
   },
-  "error:pkg/applicationserver:already_linked": {
-    "translations": {
-      "en": "already linked to `{application_uid}`"
-    },
-    "description": {
-      "package": "pkg/applicationserver",
-      "file": "linking.go"
-    }
-  },
   "error:pkg/applicationserver:app_s_key": {
     "translations": {
       "en": "failed to get AppSKey"

--- a/pkg/applicationserver/io/backoff.go
+++ b/pkg/applicationserver/io/backoff.go
@@ -1,0 +1,64 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io
+
+import (
+	"context"
+	"time"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/component"
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+)
+
+// TaskHealthyDuration is the duration after which a task is considered to be in steady state.
+const TaskHealthyDuration = 1 * time.Minute
+
+// TaskBackoffConfig derives the component.DefaultTaskBackoffConfig and dynamically determines the backoff duration
+// based on recent error codes.
+var TaskBackoffConfig = &component.TaskBackoffConfig{
+	Jitter: component.DefaultTaskBackoffConfig.Jitter,
+	DynamicInterval: func(ctx context.Context, executionTime time.Duration, invocation int, err error) time.Duration {
+		defaultIntervals := component.DefaultTaskBackoffConfig.Intervals
+		extendedIntervals := append(defaultIntervals,
+			1*time.Minute,
+			5*time.Minute,
+			15*time.Minute,
+			30*time.Minute,
+		)
+
+		var intervals []time.Duration
+		switch {
+		case errors.IsFailedPrecondition(err),
+			errors.IsUnauthenticated(err),
+			errors.IsPermissionDenied(err),
+			errors.IsInvalidArgument(err),
+			errors.IsAlreadyExists(err),
+			errors.IsCanceled(err):
+			intervals = extendedIntervals
+		default:
+			intervals = defaultIntervals
+		}
+
+		bi := invocation - 1
+		if bi >= len(intervals) {
+			bi = len(intervals) - 1
+		}
+		if executionTime > TaskHealthyDuration {
+			bi = 0
+		}
+
+		return intervals[bi]
+	},
+}

--- a/pkg/applicationserver/io/pubsub/integrate_internal_test.go
+++ b/pkg/applicationserver/io/pubsub/integrate_internal_test.go
@@ -15,10 +15,11 @@
 package pubsub
 
 import (
+	"go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io"
 	"go.thethings.network/lorawan-stack/v3/pkg/component"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
 )
 
 func init() {
-	startBackoffConfig.IntervalFunc = component.MakeTaskBackoffIntervalFunc(false, component.DefaultTaskBackoffResetDuration, (1<<5)*test.Delay)
+	io.TaskBackoffConfig.IntervalFunc = component.MakeTaskBackoffIntervalFunc(false, component.DefaultTaskBackoffResetDuration, (1<<5)*test.Delay)
 }

--- a/pkg/applicationserver/linking.go
+++ b/pkg/applicationserver/linking.go
@@ -100,7 +100,7 @@ func (as *ApplicationServer) startLinkTask(ctx context.Context, ids ttnpb.Applic
 			return as.link(ctx, ids, target)
 		},
 		Restart: component.TaskRestartOnFailure,
-		Backoff: linkBackoffConfig,
+		Backoff: io.TaskBackoffConfig,
 	})
 }
 

--- a/pkg/applicationserver/linking_internal_test.go
+++ b/pkg/applicationserver/linking_internal_test.go
@@ -15,10 +15,11 @@
 package applicationserver
 
 import (
+	"go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io"
 	"go.thethings.network/lorawan-stack/v3/pkg/component"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
 )
 
 func init() {
-	linkBackoffConfig.IntervalFunc = component.MakeTaskBackoffIntervalFunc(false, component.DefaultTaskBackoffResetDuration, (1<<5)*test.Delay)
+	io.TaskBackoffConfig.IntervalFunc = component.MakeTaskBackoffIntervalFunc(false, component.DefaultTaskBackoffResetDuration, (1<<5)*test.Delay)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsIndustries/lorawan-stack/issues/2266
References https://github.com/TheThingsNetwork/lorawan-stack/pull/3117

#### Changes
<!-- What are the changes made in this pull request? -->

- Promote the dynamic backoff configuration to the `io` package
- Use this configuration in the pub/sub 'links'
- Pub/sub `stop` events/metrics are now registered only after a `start` event. This ensures that we can count the active pub/subs using `started - stopped`. cc @htdvisser 


#### Testing

<!-- How did you verify that this change works? -->

Already existing unit tests.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Unit tests should cover this already, and no regressions are intended. We're more lenient now than we were before.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
