### PR TITLE
Various small NS downlink flow fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Scheduling failure events are now emitted on unsuccessful scheduling attempts.
+
 ### Deprecated
 
 ### Removed

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -986,7 +986,6 @@ func recordDataDownlink(dev *ttnpb.EndDevice, genDown *generatedDownlink, genSta
 		dev.MACState.PendingApplicationDownlink = genState.ApplicationDownlink
 		dev.Session.LastConfFCntDown = genDown.FCnt
 	}
-	dev.MACState.QueuedResponses = nil
 	dev.MACState.RxWindowsAvailable = false
 	dev.MACState.RecentDownlinks = appendRecentDownlink(dev.MACState.RecentDownlinks, down.Message, recentDownlinkCount)
 	dev.RecentDownlinks = appendRecentDownlink(dev.RecentDownlinks, down.Message, recentDownlinkCount)

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -1344,6 +1344,7 @@ func (ns *NetworkServer) attemptNetworkInitiatedDataDownlink(ctx context.Context
 								},
 							},
 						}),
+						QueuedEvents: queuedEvents,
 					}
 				}
 				if len(genState.ApplicationDownlink.GetClassBC().GetGateways()) > 0 &&
@@ -1361,6 +1362,7 @@ func (ns *NetworkServer) attemptNetworkInitiatedDataDownlink(ctx context.Context
 								},
 							},
 						}),
+						QueuedEvents: queuedEvents,
 					}
 				}
 			}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Various small NS downlink flow fixes for issues discovered while working on #3052 

#### Changes
<!-- What are the changes made in this pull request? -->

- Do not reset `QueuedResponses` on each successful downlink (requirement for #3103 to work correctly, in 3.9 it does not change anything)
- Publish unsuccessful scheduling events


#### Testing

<!-- How did you verify that this change works? -->

Unit tests

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Unlikely

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Technically https://github.com/TheThingsNetwork/lorawan-stack/commit/6f426621caedfc28d65a39734c1d22a9a39a8f58 belongs in 3.10, but for convenience I'm merging it here - it does not affect behavior in 3.9

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
