### PR TITLE
Revert OAuth dynamic configuration changes

### DIFF
--- a/pkg/identityserver/identityserver.go
+++ b/pkg/identityserver/identityserver.go
@@ -110,7 +110,7 @@ func New(c *component.Component, config *Config) (is *IdentityServer, err error)
 		UserSessionStore: store.GetUserSessionStore(is.db),
 		ClientStore:      store.GetClientStore(is.db),
 		OAuthStore:       store.GetOAuthStore(is.db),
-	}, oauth.StaticConfigProvider(is.config.OAuth))
+	}, is.config.OAuth)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oauth/config.go
+++ b/pkg/oauth/config.go
@@ -15,8 +15,6 @@
 package oauth
 
 import (
-	"context"
-
 	"go.thethings.network/lorawan-stack/v3/pkg/webui"
 )
 
@@ -42,14 +40,4 @@ type Config struct {
 	Mount       string   `name:"mount" description:"Path on the server where the OAuth server will be served"`
 	UI          UIConfig `name:"ui"`
 	CSRFAuthKey []byte   `name:"-"`
-}
-
-// ConfigProvider returns the server configuration based on the context.
-type ConfigProvider func(context.Context) Config
-
-// StaticConfigProvider is a provider that always returns the same config.
-func StaticConfigProvider(conf Config) ConfigProvider {
-	return func(context.Context) Config {
-		return conf
-	}
 }

--- a/pkg/oauth/middleware.go
+++ b/pkg/oauth/middleware.go
@@ -42,10 +42,9 @@ func (s *server) redirectToLogin(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		_, err := s.getSession(c)
 		if err != nil {
-			config := s.configFromEchoContext(c)
 			values := make(url.Values)
 			values.Set(nextKey, fmt.Sprintf("%s?%s", c.Request().URL.Path, c.QueryParams().Encode()))
-			return c.Redirect(http.StatusFound, fmt.Sprintf("%s?%s", path.Join(config.UI.MountPath(), "login"), values.Encode()))
+			return c.Redirect(http.StatusFound, fmt.Sprintf("%s?%s", path.Join(s.config.UI.MountPath(), "login"), values.Encode()))
 		}
 		return next(c)
 	}
@@ -57,8 +56,7 @@ func (s *server) redirectToNext(next echo.HandlerFunc) echo.HandlerFunc {
 		if err == nil {
 			next := c.QueryParam(nextKey)
 			if next == "" {
-				config := s.configFromEchoContext(c)
-				next = config.UI.MountPath()
+				next = s.config.UI.MountPath()
 			}
 			url, err := url.Parse(next)
 			if err != nil {

--- a/pkg/oauth/server_test.go
+++ b/pkg/oauth/server_test.go
@@ -111,7 +111,7 @@ func TestOAuthFlow(t *testing.T) {
 			},
 		},
 	})
-	s, err := oauth.NewServer(c, store, oauth.StaticConfigProvider(oauth.Config{
+	s, err := oauth.NewServer(c, store, oauth.Config{
 		Mount:       "/oauth",
 		CSRFAuthKey: []byte("12345678123456781234567812345678"),
 		UI: oauth.UIConfig{
@@ -121,7 +121,7 @@ func TestOAuthFlow(t *testing.T) {
 				CanonicalURL: "https://example.com/oauth",
 			},
 		},
-	}))
+	})
 	if err != nil {
 		panic(err)
 	}
@@ -619,7 +619,7 @@ func TestTokenExchange(t *testing.T) {
 			},
 		},
 	})
-	s, err := oauth.NewServer(c, store, oauth.StaticConfigProvider(oauth.Config{
+	s, err := oauth.NewServer(c, store, oauth.Config{
 		Mount: "/oauth",
 		UI: oauth.UIConfig{
 			TemplateData: webui.TemplateData{
@@ -627,7 +627,7 @@ func TestTokenExchange(t *testing.T) {
 				Title:    "OAuth",
 			},
 		},
-	}))
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/oauth/user.go
+++ b/pkg/oauth/user.go
@@ -257,8 +257,7 @@ func (s *server) ClientLogout(c echo.Context) error {
 			if len(client.LogoutRedirectURIs) != 0 {
 				redirectURI = client.LogoutRedirectURIs[0]
 			} else {
-				config := s.configFromContext(ctx)
-				redirectURI = config.UI.MountPath()
+				redirectURI = s.config.UI.MountPath()
 			}
 		} else {
 			for _, uri := range client.LogoutRedirectURIs {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/3093

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove the `ConfigProvider` concept and go back to static `Config`

#### Testing

<!-- How did you verify that this change works? -->

Ran a fresh stack instance.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Shouldn't be the case, but I've tested a fresh stack installation nonetheless.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This reverts the `ConfigProvider` introduction to the OAuth server since dynamic configuration is no longer needed for the providers, as a database store is used instead.

@kschiffer, @bafonins no need to review.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
