### PR TITLE
Refactor task backoff intervals, enable NS downlink task backoff on failure

### DIFF
--- a/pkg/applicationserver/io/pubsub/integrate_internal_test.go
+++ b/pkg/applicationserver/io/pubsub/integrate_internal_test.go
@@ -15,11 +15,10 @@
 package pubsub
 
 import (
-	"time"
-
+	"go.thethings.network/lorawan-stack/v3/pkg/component"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
 )
 
 func init() {
-	startBackoffConfig.Intervals = []time.Duration{(1 << 5) * test.Delay}
+	startBackoffConfig.IntervalFunc = component.MakeTaskBackoffIntervalFunc(false, component.DefaultTaskBackoffResetDuration, (1<<5)*test.Delay)
 }

--- a/pkg/applicationserver/io/pubsub/pubsub.go
+++ b/pkg/applicationserver/io/pubsub/pubsub.go
@@ -74,12 +74,12 @@ func (ps *PubSub) startAll(ctx context.Context) error {
 }
 
 var startBackoffConfig = &component.TaskBackoffConfig{
-	Jitter: component.DefaultBackoffJitter,
-	Intervals: []time.Duration{
-		100 * time.Millisecond,
+	Jitter: component.DefaultTaskBackoffJitter,
+	IntervalFunc: component.MakeTaskBackoffIntervalFunc(false, component.DefaultTaskBackoffResetDuration,
+		100*time.Millisecond,
 		time.Second,
-		10 * time.Second,
-	},
+		10*time.Second,
+	),
 }
 
 func (ps *PubSub) startTask(ctx context.Context, ids ttnpb.ApplicationPubSubIdentifiers) {

--- a/pkg/applicationserver/linking_internal_test.go
+++ b/pkg/applicationserver/linking_internal_test.go
@@ -15,12 +15,10 @@
 package applicationserver
 
 import (
-	"time"
-
+	"go.thethings.network/lorawan-stack/v3/pkg/component"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
 )
 
 func init() {
-	linkBackoffConfig.DynamicInterval = nil
-	linkBackoffConfig.Intervals = []time.Duration{(1 << 5) * test.Delay}
+	linkBackoffConfig.IntervalFunc = component.MakeTaskBackoffIntervalFunc(false, component.DefaultTaskBackoffResetDuration, (1<<5)*test.Delay)
 }

--- a/pkg/component/tasks.go
+++ b/pkg/component/tasks.go
@@ -37,40 +37,67 @@ const (
 	TaskRestartOnFailure
 )
 
-var backoffResetTime = time.Minute
+const (
+	DefaultTaskBackoffResetDuration = time.Minute
+	DefaultTaskBackoffJitter        = 0.1
+)
 
-// DynamicIntervalFunc is a function that decides the backoff interval based on the attempt history.
-type DynamicIntervalFunc func(ctx context.Context, executionTime time.Duration, invocation int, err error) time.Duration
+// TaskBackoffIntervalFunc is a function that decides the backoff interval based on the attempt history.
+// invocation is a counter, which starts at 1 and is incremented after each task function invocation.
+type TaskBackoffIntervalFunc func(ctx context.Context, executionDuration time.Duration, invocation uint, err error) time.Duration
 
+// TaskBackoffConfig represents task backoff configuration.
 type TaskBackoffConfig struct {
-	Jitter          float64
-	Intervals       []time.Duration
-	DynamicInterval DynamicIntervalFunc
-	OnFailure       bool
+	Jitter       float64
+	IntervalFunc TaskBackoffIntervalFunc
 }
 
-const DefaultBackoffJitter = 0.1
+// MakeTaskBackoffIntervalFunc returns a new TaskBackoffIntervalFunc.
+func MakeTaskBackoffIntervalFunc(onFailure bool, resetDuration time.Duration, intervals ...time.Duration) TaskBackoffIntervalFunc {
+	return func(ctx context.Context, executionDuration time.Duration, invocation uint, err error) time.Duration {
+		switch {
+		case onFailure && err == nil:
+			return 0
+		case executionDuration > resetDuration:
+			return intervals[0]
+		case invocation >= uint(len(intervals)):
+			return intervals[len(intervals)-1]
+		default:
+			return intervals[invocation-1]
+		}
+	}
+}
 
-// DefaultTaskBackoffConfig is a default task backoff config to use.
-var DefaultTaskBackoffConfig = &TaskBackoffConfig{
-	Jitter: DefaultBackoffJitter,
-	Intervals: []time.Duration{
+var (
+	// DefaultTaskBackoffIntervals are the default task backoff intervals.
+	DefaultTaskBackoffIntervals = [...]time.Duration{
 		10 * time.Millisecond,
 		50 * time.Millisecond,
 		100 * time.Millisecond,
 		time.Second,
-	},
-}
+	}
+	// DefaultTaskBackoffIntervalFunc is the default TaskBackoffIntervalFunc.
+	DefaultTaskBackoffIntervalFunc = MakeTaskBackoffIntervalFunc(false, DefaultTaskBackoffResetDuration, DefaultTaskBackoffIntervals[:]...)
+	// DefaultTaskBackoffConfig is the default task backoff config.
+	DefaultTaskBackoffConfig = &TaskBackoffConfig{
+		Jitter:       DefaultTaskBackoffJitter,
+		IntervalFunc: DefaultTaskBackoffIntervalFunc,
+	}
 
-// DialTaskBackoffConfig is a default task backoff config to use.
-var DialTaskBackoffConfig = &TaskBackoffConfig{
-	Jitter: DefaultBackoffJitter,
-	Intervals: []time.Duration{
+	// DialTaskBackoffIntervals are the default task backoff intervals for tasks using Dial.
+	DialTaskBackoffIntervals = [...]time.Duration{
 		100 * time.Millisecond,
 		time.Second,
 		10 * time.Second,
-	},
-}
+	}
+	// DialTaskBackoffIntervalFunc is the default TaskBackoffIntervalFunc for tasks using Dial.
+	DialTaskBackoffIntervalFunc = MakeTaskBackoffIntervalFunc(false, DefaultTaskBackoffResetDuration, DialTaskBackoffIntervals[:]...)
+	// DialTaskBackoffConfig is the default task backoff config for tasks using Dial.
+	DialTaskBackoffConfig = &TaskBackoffConfig{
+		Jitter:       DefaultTaskBackoffJitter,
+		IntervalFunc: DialTaskBackoffIntervalFunc,
+	}
+)
 
 type TaskConfig struct {
 	Context context.Context
@@ -99,12 +126,15 @@ func (f StartTaskFunc) StartTask(conf *TaskConfig) {
 func DefaultStartTask(conf *TaskConfig) {
 	logger := log.FromContext(conf.Context).WithField("task_id", conf.ID)
 	go func() {
-		invocation := 0
+		invocation := uint(1)
 		for {
-			invocation++
+			if invocation == 0 {
+				logger.Warn("Invocation count rollover detected")
+				invocation = 1
+			}
 			startTime := time.Now()
 			err := conf.Func(conf.Context)
-			executionTime := time.Since(startTime)
+			executionDuration := time.Since(startTime)
 			if err != nil && err != context.Canceled {
 				logger.WithField("invocation", invocation).WithError(err).Warn("Task failed")
 			}
@@ -124,21 +154,12 @@ func DefaultStartTask(conf *TaskConfig) {
 				return
 			default:
 			}
-			var s time.Duration
-			switch {
-			case conf.Backoff == nil, conf.Backoff.OnFailure && err == nil:
+			if conf.Backoff == nil {
 				continue
-			case conf.Backoff.DynamicInterval != nil:
-				s = conf.Backoff.DynamicInterval(conf.Context, executionTime, invocation, err)
-			default:
-				bi := invocation - 1
-				if bi >= len(conf.Backoff.Intervals) {
-					bi = len(conf.Backoff.Intervals) - 1
-				}
-				if executionTime > backoffResetTime {
-					bi = 0
-				}
-				s = conf.Backoff.Intervals[bi]
+			}
+			s := conf.Backoff.IntervalFunc(conf.Context, executionDuration, invocation, err)
+			if s == 0 {
+				continue
 			}
 			if conf.Backoff.Jitter != 0 {
 				s = random.Jitter(s, conf.Backoff.Jitter)
@@ -148,6 +169,7 @@ func DefaultStartTask(conf *TaskConfig) {
 				return
 			case <-time.After(s):
 			}
+			invocation++
 		}
 	}()
 }

--- a/pkg/component/tasks.go
+++ b/pkg/component/tasks.go
@@ -46,6 +46,7 @@ type TaskBackoffConfig struct {
 	Jitter          float64
 	Intervals       []time.Duration
 	DynamicInterval DynamicIntervalFunc
+	OnFailure       bool
 }
 
 const DefaultBackoffJitter = 0.1
@@ -125,7 +126,7 @@ func DefaultStartTask(conf *TaskConfig) {
 			}
 			var s time.Duration
 			switch {
-			case conf.Backoff == nil:
+			case conf.Backoff == nil, conf.Backoff.OnFailure && err == nil:
 				continue
 			case conf.Backoff.DynamicInterval != nil:
 				s = conf.Backoff.DynamicInterval(conf.Context, executionTime, invocation, err)

--- a/pkg/component/tasks_internal_test.go
+++ b/pkg/component/tasks_internal_test.go
@@ -27,17 +27,13 @@ import (
 )
 
 var TestTaskBackoffConfig = &TaskBackoffConfig{
-	Jitter: DefaultBackoffJitter,
-	Intervals: []time.Duration{
+	Jitter: DefaultTaskBackoffJitter,
+	IntervalFunc: MakeTaskBackoffIntervalFunc(false, 2*test.Delay,
 		test.Delay,
-		2 * test.Delay,
-		3 * test.Delay,
-		4 * test.Delay,
-	},
-}
-
-func init() {
-	backoffResetTime = 2 * test.Delay
+		2*test.Delay,
+		3*test.Delay,
+		4*test.Delay,
+	),
 }
 
 func TestTaskBackoffReset(t *testing.T) {

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -219,6 +219,10 @@ func New(c *component.Component, conf *Config, opts ...Option) (*NetworkServer, 
 		ID:      downlinkProcessTaskName,
 		Func:    ns.processDownlinkTask,
 		Restart: component.TaskRestartAlways,
+		Backoff: &component.TaskBackoffConfig{
+			Jitter:       component.DefaultTaskBackoffConfig.Jitter,
+			IntervalFunc: component.MakeTaskBackoffIntervalFunc(true, component.DefaultTaskBackoffResetDuration, component.DefaultTaskBackoffIntervals[:]...),
+		},
 	})
 	c.RegisterGRPC(ns)
 	return ns, nil


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Refactor task backoff intervals, enable NS downlink task backoff on failure.
Discovered while working on #3052. Currently NS infinitely retries with no backoff if e.g. Redis in unavailable.

#### Changes
<!-- What are the changes made in this pull request? -->

- Instead of having two mutually exclusive fields - `Intervals` and `DynamicInterval`, just have one, more powerful `IntervalFunc` with same signature as original `DynamicInterval`
- Enable backoff for downlink tasks on failure

#### Testing

<!-- How did you verify that this change works? -->

Unit tests

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Unlikely

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
