### PR TITLE
Fix lora cloud documenation link in Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - CLI login issues when OAuth Server Address explicitly includes the `:443` HTTPS port.
+- Documentation link for LoRa Cloud Device & Application Services in the Lora Cloud integration view in the Console.
 
 ### Security
 

--- a/pkg/webui/console/views/application-integrations-lora-cloud/index.js
+++ b/pkg/webui/console/views/application-integrations-lora-cloud/index.js
@@ -42,7 +42,6 @@ import { selectSelectedApplicationId } from '@console/store/selectors/applicatio
 import style from './application-integrations-lora-cloud.styl'
 
 const m = defineMessages({
-  loRaCloudDeviceManagement: 'LoRa Cloud Device Management',
   officialLoRaCloudDocumentation: 'Official LoRa Cloud documentation',
   loRaCloudInfoText: `With the LoRa Cloud Device & Application Services protocol, you can manage common device functionality at the application layer for LoRaWAN®-enabled devices. This protocol consists of a set of messages that are exchanged on a predefined device management LoRaWAN port (199 by default). The purpose of these messages is three-fold:
 <ol><li>Periodically communicate info messages</li><li>Trigger client-initiated management commands</li><li>Run advanced, application-layer protocols which solve common LoRaWAN use cases</li></ol>`,
@@ -59,7 +58,7 @@ const LoRaCloud = () => {
     >
       <ErrorView ErrorComponent={SubViewError}>
         <Container>
-          <PageTitle title="LoRa Cloud™ Device & Application Services" />
+          <PageTitle title="LoRa Cloud Device & Application Services" />
           <Row>
             <Col lg={8} md={12}>
               <img className={style.logo} src={LoRaCloudImage} alt="LoRa Cloud" />
@@ -78,10 +77,10 @@ const LoRaCloud = () => {
                   className={style.furtherResources}
                 />
                 <Link.DocLink
-                  path="/integrations/application-packages/lora-cloud-device-management/"
+                  path="/integrations/application-packages/lora-cloud-device-and-application-services/"
                   secondary
                 >
-                  <Message content={m.loRaCloudDeviceManagement} />
+                  LoRa Cloud Device & Application Services
                 </Link.DocLink>
                 {' | '}
                 <Link.Anchor

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -228,7 +228,6 @@
   "console.views.application-general-settings.index.deleteApp": "Delete application",
   "console.views.application-general-settings.index.modalWarning": "Are you sure you want to delete \"{appName}\"? This action cannot be undone and it will not be possible to reuse the application ID.",
   "console.views.application-general-settings.index.updateSuccess": "Application updated",
-  "console.views.application-integrations-lora-cloud.index.loRaCloudDeviceManagement": "LoRa Cloud Device Management",
   "console.views.application-integrations-lora-cloud.index.officialLoRaCloudDocumentation": "Official LoRa Cloud documentation",
   "console.views.application-integrations-lora-cloud.index.loRaCloudInfoText": "With the LoRa Cloud Device & Application Services protocol, you can manage common device functionality at the application layer for LoRaWAN®-enabled devices. This protocol consists of a set of messages that are exchanged on a predefined device management LoRaWAN port (199 by default). The purpose of these messages is three-fold:\n<ol><li>Periodically communicate info messages</li><li>Trigger client-initiated management commands</li><li>Run advanced, application-layer protocols which solve common LoRaWAN use cases</li></ol>",
   "console.views.application-integrations-lora-cloud.index.furtherResources": "Further resources",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -228,7 +228,6 @@
   "console.views.application-general-settings.index.deleteApp": "Xxxxxx xxxxxxxxxxx",
   "console.views.application-general-settings.index.modalWarning": "Xxx xxx xxxx xxx xxxx xx xxxxxx \"{appName}\"? Xxxx xxxxxx xxxxxx xx xxxxxx xxx xx xxxx xxx xx xxxxxxxx xx xxxxx xxx xxxxxxxxxxx XX.",
   "console.views.application-general-settings.index.updateSuccess": "Xxxxxxxxxxx xxxxxxx",
-  "console.views.application-integrations-lora-cloud.index.loRaCloudDeviceManagement": "XxXx Xxxxx Xxxxxx Xxxxxxxxxx",
   "console.views.application-integrations-lora-cloud.index.officialLoRaCloudDocumentation": "Xxxxxxxx XxXx Xxxxx xxxxxxxxxxxxx",
   "console.views.application-integrations-lora-cloud.index.loRaCloudInfoText": "Xxxx xxx XxXx Xxxxx Xxxxxx x Xxxxxxxxxxx Xxxxxxxx xxxxxxxx, xxx xxx xxxxxx xxxxxx xxxxxx xxxxxxxxxxxxx xx xxx xxxxxxxxxxx xxxxx xxx XxXxXXXx-xxxxxxx xxxxxxx. Xxxx xxxxxxxx xxxxxxxx xx x xxx xx xxxxxxxx xxxx xxx xxxxxxxxx xx x xxxxxxxxxx xxxxxx xxxxxxxxxx XxXxXXX xxxx (xxx xx xxxxxxx). Xxx xxxxxxx xx xxxxx xxxxxxxx xx xxxxx-xxxx:\nxxxxxxxxXxxxxxxxxxxx xxxxxxxxxxx xxxx xxxxxxxxx/xxxxxxxXxxxxxx xxxxxx-xxxxxxxxx xxxxxxxxxx xxxxxxxxx/xxxxxxxXxx xxxxxxxx, xxxxxxxxxxx-xxxxx xxxxxxxxx xxxxx xxxxx xxxxxx XxXxXXX xxx xxxxxx/xxxx/xxx",
   "console.views.application-integrations-lora-cloud.index.furtherResources": "Xxxxxxx xxxxxxxxx",


### PR DESCRIPTION
#### Summary
This quickfix PR fixes the `LoRa Cloud Device & Application Services` documentation link in the console which appears to have changed since I added it. It also removes an unnecessary i18n message.

#### Changes
- Fix the documentation link for `LoRa Cloud Device & Application Services`
- Remove the message for `LoRa Cloud Device & Application Services` since this is a brand name that is not to be translated

#### Testing

Manual. I will look into building an e2e test for this view later.

##### Regressions

None.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
