### PR TITLE
Optimize band queries, record LoRaWAN version pairs

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -5876,6 +5876,15 @@
       "file": "errors.go"
     }
   },
+  "error:pkg/networkserver:no_band_version": {
+    "translations": {
+      "en": "specified version `{ver}` of band `{id}` does not exist"
+    },
+    "description": {
+      "package": "pkg/networkserver",
+      "file": "utils.go"
+    }
+  },
   "error:pkg/networkserver:no_dev_eui": {
     "translations": {
       "en": "no DevEUI specified"

--- a/pkg/networkserver/adr.go
+++ b/pkg/networkserver/adr.go
@@ -158,7 +158,7 @@ func uplinkMetadata(ups ...*ttnpb.UplinkMessage) []*ttnpb.RxMetadata {
 	return mds
 }
 
-func txPowerStep(phy band.Band, from, to uint8) float32 {
+func txPowerStep(phy *band.Band, from, to uint8) float32 {
 	max := phy.MaxTxPowerIndex()
 	if from > max {
 		from = max
@@ -200,7 +200,7 @@ func channelDataRateRange(chs ...*ttnpb.MACParameters_Channel) (min, max ttnpb.D
 	return min, max, true
 }
 
-func adaptDataRate(ctx context.Context, dev *ttnpb.EndDevice, phy band.Band, defaults ttnpb.MACSettings) error {
+func adaptDataRate(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band, defaults ttnpb.MACSettings) error {
 	if len(dev.RecentADRUplinks) == 0 {
 		return nil
 	}

--- a/pkg/networkserver/adr_internal_test.go
+++ b/pkg/networkserver/adr_internal_test.go
@@ -473,7 +473,8 @@ func TestAdaptDataRate(t *testing.T) {
 			err := adaptDataRate(
 				log.NewContext(test.ContextWithTB(test.Context(), t), test.GetLogger(t)),
 				dev,
-				Band(fp.BandID, dev.LoRaWANPHYVersion), ttnpb.MACSettings{},
+				LoRaWANBands[fp.BandID][dev.LoRaWANPHYVersion],
+				ttnpb.MACSettings{},
 			)
 			if !a.So(err, should.Equal, tc.Error) {
 				t.Fatalf("ADR failed with: %s", err)

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -110,7 +110,7 @@ func (ns *NetworkServer) updateDataDownlinkTask(ctx context.Context, dev *ttnpb.
 		earliestAt = t
 	}
 	var taskAt time.Time
-	_, phy, err := deviceFrequencyPlanAndBand(dev, ns.FrequencyPlans)
+	phy, err := deviceBand(dev, ns.FrequencyPlans)
 	if err != nil {
 		logger.WithError(err).Warn("Failed to determine device band")
 	} else {

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -110,7 +110,7 @@ func (ns *NetworkServer) updateDataDownlinkTask(ctx context.Context, dev *ttnpb.
 		earliestAt = t
 	}
 	var taskAt time.Time
-	_, phy, err := getDeviceBandVersion(dev, ns.FrequencyPlans)
+	_, phy, err := deviceFrequencyPlanAndBand(dev, ns.FrequencyPlans)
 	if err != nil {
 		logger.WithError(err).Warn("Failed to determine device band")
 	} else {
@@ -148,7 +148,7 @@ func (ns *NetworkServer) updateDataDownlinkTask(ctx context.Context, dev *ttnpb.
 // device operating in a region where a fixed channel plan is defined in case
 // dev.MACState.CurrentParameters.Channels is not equal to dev.MACState.DesiredParameters.Channels.
 // Note, that generateDataDownlink assumes transmitAt is the earliest possible time a downlink can be transmitted to the device.
-func (ns *NetworkServer) generateDataDownlink(ctx context.Context, dev *ttnpb.EndDevice, phy band.Band, class ttnpb.Class, transmitAt time.Time, maxDownLen, maxUpLen uint16) (*generatedDownlink, generateDownlinkState, error) {
+func (ns *NetworkServer) generateDataDownlink(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band, class ttnpb.Class, transmitAt time.Time, maxDownLen, maxUpLen uint16) (*generatedDownlink, generateDownlinkState, error) {
 	if dev.MACState == nil {
 		return nil, generateDownlinkState{}, errUnknownMACState.New()
 	}
@@ -270,7 +270,7 @@ func (ns *NetworkServer) generateDataDownlink(ctx context.Context, dev *ttnpb.En
 			logger := logger.WithField("cid", cmd.CID)
 			logger.Debug("Add MAC command to buffer")
 			var err error
-			cmdBuf, err = spec.AppendDownlink(phy, cmdBuf, *cmd)
+			cmdBuf, err = spec.AppendDownlink(*phy, cmdBuf, *cmd)
 			if err != nil {
 				return nil, generateDownlinkState{}, errEncodeMAC.WithCause(err)
 			}
@@ -921,7 +921,7 @@ func appendRecentDownlink(recent []*ttnpb.DownlinkMessage, down *ttnpb.DownlinkM
 	return recent
 }
 
-func rx1Parameters(phy band.Band, macState *ttnpb.MACState, up *ttnpb.UplinkMessage) (uint64, ttnpb.DataRateIndex, error) {
+func rx1Parameters(phy *band.Band, macState *ttnpb.MACState, up *ttnpb.UplinkMessage) (uint64, ttnpb.DataRateIndex, error) {
 	if up.DeviceChannelIndex > math.MaxUint8 {
 		return 0, 0, errInvalidChannelIndex.New()
 	}
@@ -945,7 +945,7 @@ func rx1Parameters(phy band.Band, macState *ttnpb.MACState, up *ttnpb.UplinkMess
 }
 
 // maximumUplinkLength returns the maximum length of the next uplink after ups.
-func maximumUplinkLength(fp *frequencyplans.FrequencyPlan, phy band.Band, ups ...*ttnpb.UplinkMessage) (uint16, error) {
+func maximumUplinkLength(fp *frequencyplans.FrequencyPlan, phy *band.Band, ups ...*ttnpb.UplinkMessage) (uint16, error) {
 	// NOTE: If no data uplink is found, we assume ADR is off on the device and, hence, data rate index 0 is used in computation.
 	maxUpDRIdx := ttnpb.DATA_RATE_0
 loop:
@@ -1006,7 +1006,7 @@ type downlinkAttemptResult struct {
 	DownlinkTaskUpdateStrategy downlinkTaskUpdateStrategy
 }
 
-func (ns *NetworkServer) attemptClassADataDownlink(ctx context.Context, dev *ttnpb.EndDevice, phy band.Band, fp *frequencyplans.FrequencyPlan, slot *classADownlinkSlot, maxUpLength uint16) downlinkAttemptResult {
+func (ns *NetworkServer) attemptClassADataDownlink(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band, fp *frequencyplans.FrequencyPlan, slot *classADownlinkSlot, maxUpLength uint16) downlinkAttemptResult {
 	ctx = events.ContextWithCorrelationID(ctx, slot.Uplink.CorrelationIDs...)
 	if !dev.MACState.RxWindowsAvailable {
 		log.FromContext(ctx).Error("RX windows not available, skip class A downlink slot")
@@ -1203,7 +1203,7 @@ func (ns *NetworkServer) attemptClassADataDownlink(ctx context.Context, dev *ttn
 	}
 }
 
-func (ns *NetworkServer) attemptNetworkInitiatedDataDownlink(ctx context.Context, dev *ttnpb.EndDevice, phy band.Band, fp *frequencyplans.FrequencyPlan, slot *networkInitiatedDownlinkSlot, maxUpLength uint16) downlinkAttemptResult {
+func (ns *NetworkServer) attemptNetworkInitiatedDataDownlink(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band, fp *frequencyplans.FrequencyPlan, slot *networkInitiatedDownlinkSlot, maxUpLength uint16) downlinkAttemptResult {
 	var drIdx ttnpb.DataRateIndex
 	var freq uint64
 	switch slot.Class {
@@ -1441,7 +1441,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context) error {
 					return nil, nil, nil
 				}
 
-				fp, phy, err := getDeviceBandVersion(dev, ns.FrequencyPlans)
+				fp, phy, err := deviceFrequencyPlanAndBand(dev, ns.FrequencyPlans)
 				if err != nil {
 					taskUpdateStrategy = retryDownlinkTask
 					logger.WithError(err).Error("Failed to get frequency plan of the device, retry downlink slot")

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -5138,8 +5138,6 @@ func TestProcessDownlinkTask(t *testing.T) {
 }
 
 func TestGenerateDownlink(t *testing.T) {
-	phy := test.Must(test.Must(band.GetByID(band.EU_863_870)).(band.Band).Version(ttnpb.PHY_V1_1_REV_B)).(band.Band)
-
 	const appIDString = "process-downlink-test-app-id"
 	appID := ttnpb.ApplicationIdentifiers{ApplicationID: appIDString}
 	const devID = "process-downlink-test-dev-id"
@@ -5198,9 +5196,9 @@ func TestGenerateDownlink(t *testing.T) {
 		return append(b, mic[:]...)
 	}
 
-	encodeMAC := func(phy band.Band, cmds ...*ttnpb.MACCommand) (b []byte) {
+	encodeMAC := func(phy *band.Band, cmds ...*ttnpb.MACCommand) (b []byte) {
 		for _, cmd := range cmds {
-			b = test.Must(lorawan.DefaultMACCommands.AppendDownlink(phy, b, *cmd)).([]byte)
+			b = test.Must(lorawan.DefaultMACCommands.AppendDownlink(*phy, b, *cmd)).([]byte)
 		}
 		return
 	}
@@ -5908,7 +5906,7 @@ func TestGenerateDownlink(t *testing.T) {
 							},
 							FCnt: 42,
 							FOpts: encodeMAC(
-								phy,
+								LoRaWANBands[band.EU_863_870][ttnpb.PHY_V1_1_REV_B],
 								ttnpb.CID_DEV_STATUS.MACCommand(),
 							),
 						},
@@ -6014,7 +6012,7 @@ func TestGenerateDownlink(t *testing.T) {
 							},
 							FCnt: 42,
 							FOpts: encodeMAC(
-								phy,
+								LoRaWANBands[band.EU_863_870][ttnpb.PHY_V1_1_REV_B],
 								ttnpb.CID_DEV_STATUS.MACCommand(),
 							),
 						},
@@ -6100,7 +6098,7 @@ func TestGenerateDownlink(t *testing.T) {
 			}
 
 			dev := CopyEndDevice(tc.Device)
-			_, phy, err := getDeviceBandVersion(dev, ns.FrequencyPlans)
+			_, phy, err := deviceFrequencyPlanAndBand(dev, ns.FrequencyPlans)
 			if !a.So(err, should.BeNil) {
 				t.Fail()
 				return

--- a/pkg/networkserver/downlink_internal_test.go
+++ b/pkg/networkserver/downlink_internal_test.go
@@ -6098,7 +6098,7 @@ func TestGenerateDownlink(t *testing.T) {
 			}
 
 			dev := CopyEndDevice(tc.Device)
-			_, phy, err := deviceFrequencyPlanAndBand(dev, ns.FrequencyPlans)
+			phy, err := deviceBand(dev, ns.FrequencyPlans)
 			if !a.So(err, should.BeNil) {
 				t.Fail()
 				return

--- a/pkg/networkserver/grpc_asns.go
+++ b/pkg/networkserver/grpc_asns.go
@@ -214,7 +214,7 @@ func matchQueuedApplicationDownlinks(ctx context.Context, dev *ttnpb.EndDevice, 
 		return nil
 	}
 
-	fp, phy, err := getDeviceBandVersion(dev, fps)
+	fp, phy, err := deviceFrequencyPlanAndBand(dev, fps)
 	if err != nil {
 		return err
 	}

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -398,7 +398,7 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 				if !ttnpb.HasAnyField(sets, "lorawan_phy_version") {
 					req.EndDevice.LoRaWANPHYVersion = dev.LoRaWANPHYVersion
 				}
-				_, phy, err := getDeviceBandVersion(&req.EndDevice, ns.FrequencyPlans)
+				_, phy, err := deviceFrequencyPlanAndBand(&req.EndDevice, ns.FrequencyPlans)
 				if err != nil {
 					return nil, nil, err
 				}
@@ -420,7 +420,7 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 			return nil, nil, errInvalidFieldMask.WithCause(err)
 		}
 
-		_, phy, err := getDeviceBandVersion(&req.EndDevice, ns.FrequencyPlans)
+		_, phy, err := deviceFrequencyPlanAndBand(&req.EndDevice, ns.FrequencyPlans)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -398,7 +398,7 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 				if !ttnpb.HasAnyField(sets, "lorawan_phy_version") {
 					req.EndDevice.LoRaWANPHYVersion = dev.LoRaWANPHYVersion
 				}
-				_, phy, err := deviceFrequencyPlanAndBand(&req.EndDevice, ns.FrequencyPlans)
+				phy, err := deviceBand(&req.EndDevice, ns.FrequencyPlans)
 				if err != nil {
 					return nil, nil, err
 				}
@@ -420,7 +420,7 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 			return nil, nil, errInvalidFieldMask.WithCause(err)
 		}
 
-		_, phy, err := deviceFrequencyPlanAndBand(&req.EndDevice, ns.FrequencyPlans)
+		phy, err := deviceBand(&req.EndDevice, ns.FrequencyPlans)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -196,7 +196,7 @@ func (ns *NetworkServer) matchAndHandleDataUplink(up *ttnpb.UplinkMessage, dedup
 		logger := log.FromContext(ctx).WithField("device_uid", unique.ID(ctx, dev.EndDeviceIdentifiers))
 		ctx = log.NewContext(ctx, logger)
 
-		_, phy, err := deviceFrequencyPlanAndBand(dev.EndDevice, ns.FrequencyPlans)
+		phy, err := deviceBand(dev.EndDevice, ns.FrequencyPlans)
 		if err != nil {
 			logger.WithError(err).Warn("Failed to get device's versioned band, skip")
 			continue

--- a/pkg/networkserver/grpc_gsns_internal_test.go
+++ b/pkg/networkserver/grpc_gsns_internal_test.go
@@ -23,10 +23,8 @@ import (
 
 	pbtypes "github.com/gogo/protobuf/types"
 	"github.com/smartystreets/assertions"
-	"go.thethings.network/lorawan-stack/v3/pkg/band"
 	"go.thethings.network/lorawan-stack/v3/pkg/component"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
-	"go.thethings.network/lorawan-stack/v3/pkg/frequencyplans"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
@@ -105,8 +103,8 @@ func TestMatchAndHandleUplink(t *testing.T) {
 
 	fpID := test.EUFrequencyPlanID
 	phyVersion := ttnpb.PHY_V1_1_REV_B
-	fp := test.Must(frequencyplans.NewStore(test.FrequencyPlansFetcher).GetByID(fpID)).(*frequencyplans.FrequencyPlan)
-	phy := test.Must(test.Must(band.GetByID(fp.BandID)).(band.Band).Version(phyVersion)).(band.Band)
+	fp := FrequencyPlan(fpID)
+	phy := LoRaWANBands[fp.BandID][phyVersion]
 	chIdx := uint8(len(phy.UplinkChannels) - 1)
 	ch := phy.UplinkChannels[chIdx]
 	drIdx := ch.MaxDataRate
@@ -1093,8 +1091,8 @@ func TestMatchAndHandleUplink(t *testing.T) {
 						), should.BeTrue) {
 							return false
 						}
-						matched.Context = nil     // Comparing context with should.Resemble results in infinite recursion.
-						matched.phy = band.Band{} // band.Band cannot be compared with neither should.Resemble, nor should.Equal.
+						matched.Context = nil // Comparing context with should.Resemble results in infinite recursion.
+						matched.phy = nil     // band.Band cannot be compared with neither should.Resemble, nor should.Equal.
 						if !a.So(test.AllTrue(
 							a.So(matched.SetPaths, should.HaveSameElementsDeep, devConf.SetPaths),
 							a.So(matched.QueuedEventBuilders, should.ResembleEventBuilders, devConf.MakeQueuedEvents(deduplicated)),

--- a/pkg/networkserver/grpc_gsns_test.go
+++ b/pkg/networkserver/grpc_gsns_test.go
@@ -588,7 +588,7 @@ func TestHandleUplink(t *testing.T) {
 		makeMDName := func(parts ...string) string {
 			return MakeTestCaseName(append(parts, fmt.Sprintf("Metadata length:%d", len(uplinkMDs)))...)
 		}
-		ForEachBand(t, func(makeLoopName func(...string) string, phy band.Band, phyVersion ttnpb.PHYVersion) {
+		ForEachBand(t, func(makeLoopName func(...string) string, phy *band.Band, phyVersion ttnpb.PHYVersion) {
 			switch phyVersion {
 			case ttnpb.PHY_V1_0_3_REV_A:
 			case ttnpb.PHY_V1_1_REV_B, ttnpb.PHY_V1_0_2_REV_B:
@@ -666,7 +666,7 @@ func TestHandleUplink(t *testing.T) {
 			)
 		})
 
-		ForEachFrequencyPlanBandMACVersion(t, func(makeLoopName func(...string) string, fpID string, fp *frequencyplans.FrequencyPlan, phy band.Band, phyVersion ttnpb.PHYVersion, macVersion ttnpb.MACVersion) {
+		ForEachFrequencyPlanLoRaWANVersionPair(t, func(makeLoopName func(...string) string, fpID string, fp *frequencyplans.FrequencyPlan, phy *band.Band, phyVersion ttnpb.PHYVersion, macVersion ttnpb.MACVersion) {
 			switch fpID {
 			case test.EUFrequencyPlanID, test.USFrequencyPlanID:
 			default:
@@ -1289,8 +1289,8 @@ func TestHandleUplink(t *testing.T) {
 
 			fpID := test.EUFrequencyPlanID
 			phyVersion := ttnpb.PHY_V1_1_REV_B
-			fp := test.Must(frequencyplans.NewStore(test.FrequencyPlansFetcher).GetByID(fpID)).(*frequencyplans.FrequencyPlan)
-			phy := test.Must(test.Must(band.GetByID(fp.BandID)).(band.Band).Version(phyVersion)).(band.Band)
+			fp := FrequencyPlan(fpID)
+			phy := LoRaWANBands[fp.BandID][phyVersion]
 			chIdx := uint8(len(phy.UplinkChannels) - 1)
 			ch := phy.UplinkChannels[chIdx]
 			drIdx := ch.MaxDataRate

--- a/pkg/networkserver/grpc_gsns_test.go
+++ b/pkg/networkserver/grpc_gsns_test.go
@@ -589,16 +589,6 @@ func TestHandleUplink(t *testing.T) {
 			return MakeTestCaseName(append(parts, fmt.Sprintf("Metadata length:%d", len(uplinkMDs)))...)
 		}
 		ForEachBand(t, func(makeLoopName func(...string) string, phy *band.Band, phyVersion ttnpb.PHYVersion) {
-			switch phyVersion {
-			case ttnpb.PHY_V1_0_3_REV_A:
-			case ttnpb.PHY_V1_1_REV_B, ttnpb.PHY_V1_0_2_REV_B:
-				if testing.Short() {
-					return
-				}
-			default:
-				return
-			}
-
 			chIdx := uint8(len(phy.UplinkChannels) - 1)
 			ch := phy.UplinkChannels[chIdx]
 			drIdx := ch.MaxDataRate
@@ -666,31 +656,7 @@ func TestHandleUplink(t *testing.T) {
 			)
 		})
 
-		ForEachFrequencyPlanLoRaWANVersionPair(t, func(makeLoopName func(...string) string, fpID string, fp *frequencyplans.FrequencyPlan, phy *band.Band, phyVersion ttnpb.PHYVersion, macVersion ttnpb.MACVersion) {
-			switch fpID {
-			case test.EUFrequencyPlanID, test.USFrequencyPlanID:
-			default:
-				return
-			}
-			switch phyVersion {
-			case ttnpb.PHY_V1_0_3_REV_A:
-			case ttnpb.PHY_V1_1_REV_B, ttnpb.PHY_V1_0_2_REV_B:
-				if testing.Short() {
-					return
-				}
-			default:
-				return
-			}
-			switch macVersion {
-			case ttnpb.MAC_V1_0_4:
-			case ttnpb.MAC_V1_1, ttnpb.MAC_V1_0_3:
-				if testing.Short() {
-					return
-				}
-			default:
-				return
-			}
-
+		ForEachFrequencyPlanLoRaWANVersionPair(t, func(makeLoopName func(...string) string, fpID string, fp *frequencyplans.FrequencyPlan, phy *band.Band, macVersion ttnpb.MACVersion, phyVersion ttnpb.PHYVersion) {
 			makeJoinResponse := func(withAppSKey bool) *ttnpb.JoinResponse {
 				return &ttnpb.JoinResponse{
 					RawPayload:  bytes.Repeat([]byte{0x42}, 17),
@@ -1276,19 +1242,8 @@ func TestHandleUplink(t *testing.T) {
 			}
 		})
 
-		ForEachMACVersion(func(makeLoopName func(...string) string, macVersion ttnpb.MACVersion) {
-			switch macVersion {
-			case ttnpb.MAC_V1_0_4:
-			case ttnpb.MAC_V1_1, ttnpb.MAC_V1_0_3:
-				if testing.Short() {
-					return
-				}
-			default:
-				return
-			}
-
+		ForEachLoRaWANVersionPair(t, func(makeLoopName func(...string) string, macVersion ttnpb.MACVersion, phyVersion ttnpb.PHYVersion) {
 			fpID := test.EUFrequencyPlanID
-			phyVersion := ttnpb.PHY_V1_1_REV_B
 			fp := FrequencyPlan(fpID)
 			phy := LoRaWANBands[fp.BandID][phyVersion]
 			chIdx := uint8(len(phy.UplinkChannels) - 1)

--- a/pkg/networkserver/mac_adr_param_setup.go
+++ b/pkg/networkserver/mac_adr_param_setup.go
@@ -33,21 +33,21 @@ var (
 	)()
 )
 
-func deviceADRAckLimit(dev *ttnpb.EndDevice, phy band.Band) ttnpb.ADRAckLimitExponent {
+func deviceADRAckLimit(dev *ttnpb.EndDevice, phy *band.Band) ttnpb.ADRAckLimitExponent {
 	if dev.MACState.CurrentParameters.ADRAckLimitExponent != nil {
 		return dev.MACState.CurrentParameters.ADRAckLimitExponent.Value
 	}
 	return phy.ADRAckLimit
 }
 
-func deviceADRAckDelay(dev *ttnpb.EndDevice, phy band.Band) ttnpb.ADRAckDelayExponent {
+func deviceADRAckDelay(dev *ttnpb.EndDevice, phy *band.Band) ttnpb.ADRAckDelayExponent {
 	if dev.MACState.CurrentParameters.ADRAckDelayExponent != nil {
 		return dev.MACState.CurrentParameters.ADRAckDelayExponent.Value
 	}
 	return phy.ADRAckDelay
 }
 
-func deviceNeedsADRParamSetupReq(dev *ttnpb.EndDevice, phy band.Band) bool {
+func deviceNeedsADRParamSetupReq(dev *ttnpb.EndDevice, phy *band.Band) bool {
 	if dev.GetMulticast() ||
 		dev.GetMACState() == nil ||
 		dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 {
@@ -59,7 +59,7 @@ func deviceNeedsADRParamSetupReq(dev *ttnpb.EndDevice, phy band.Band) bool {
 			deviceADRAckDelay(dev, phy) != dev.MACState.DesiredParameters.ADRAckDelayExponent.Value
 }
 
-func enqueueADRParamSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16, phy band.Band) macCommandEnqueueState {
+func enqueueADRParamSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16, phy *band.Band) macCommandEnqueueState {
 	if !deviceNeedsADRParamSetupReq(dev, phy) {
 		return macCommandEnqueueState{
 			MaxDownLen: maxDownLen,

--- a/pkg/networkserver/mac_adr_param_setup_test.go
+++ b/pkg/networkserver/mac_adr_param_setup_test.go
@@ -30,12 +30,12 @@ func TestNeedsADRParamSetupReq(t *testing.T) {
 	type TestCase struct {
 		Name        string
 		InputDevice *ttnpb.EndDevice
-		Band        band.Band
+		Band        *band.Band
 		Needs       bool
 	}
 	var tcs []TestCase
 
-	ForEachBand(t, func(makeBandName func(parts ...string) string, phy band.Band, _ ttnpb.PHYVersion) {
+	ForEachBand(t, func(makeBandName func(parts ...string) string, phy *band.Band, _ ttnpb.PHYVersion) {
 		tcs = append(tcs,
 			TestCase{
 				Name:        makeBandName("no MAC state"),

--- a/pkg/networkserver/mac_adr_param_setup_test.go
+++ b/pkg/networkserver/mac_adr_param_setup_test.go
@@ -145,7 +145,7 @@ func TestNeedsADRParamSetupReq(t *testing.T) {
 				Needs: true,
 			},
 		} {
-			ForEachMACVersion(func(makeMACName func(parts ...string) string, macVersion ttnpb.MACVersion) {
+			ForEachMACVersion(t, func(makeMACName func(parts ...string) string, macVersion ttnpb.MACVersion) {
 				tcs = append(tcs,
 					TestCase{
 						Name: makeBandName(makeMACName(conf.Suffix)),

--- a/pkg/networkserver/mac_beacon_freq_test.go
+++ b/pkg/networkserver/mac_beacon_freq_test.go
@@ -39,7 +39,7 @@ func TestNeedsBeaconFreqReq(t *testing.T) {
 			InputDevice: &ttnpb.EndDevice{},
 		},
 	)
-	ForEachClass(func(makeClassName func(parts ...string) string, class ttnpb.Class) {
+	ForEachClass(t, func(makeClassName func(parts ...string) string, class ttnpb.Class) {
 		for _, conf := range []struct {
 			Suffix                               string
 			CurrentParameters, DesiredParameters ttnpb.MACParameters

--- a/pkg/networkserver/mac_beacon_timing_test.go
+++ b/pkg/networkserver/mac_beacon_timing_test.go
@@ -39,7 +39,7 @@ func TestNeedsBeaconTimingReq(t *testing.T) {
 			InputDevice: &ttnpb.EndDevice{},
 		},
 	)
-	ForEachClass(func(makeClassName func(parts ...string) string, class ttnpb.Class) {
+	ForEachClass(t, func(makeClassName func(parts ...string) string, class ttnpb.Class) {
 		// TODO: Support Class B (https://github.com/TheThingsNetwork/lorawan-stack/issues/19)
 		tcs = append(tcs,
 			TestCase{

--- a/pkg/networkserver/mac_dl_channel_test.go
+++ b/pkg/networkserver/mac_dl_channel_test.go
@@ -101,7 +101,7 @@ func TestNeedsDLChannelReq(t *testing.T) {
 			Needs: true,
 		},
 	} {
-		ForEachMACVersion(func(makeMACName func(parts ...string) string, macVersion ttnpb.MACVersion) {
+		ForEachMACVersion(t, func(makeMACName func(parts ...string) string, macVersion ttnpb.MACVersion) {
 			tcs = append(tcs,
 				TestCase{
 					Name: makeMACName(conf.Suffix),

--- a/pkg/networkserver/mac_link_adr.go
+++ b/pkg/networkserver/mac_link_adr.go
@@ -40,7 +40,7 @@ var (
 	)()
 )
 
-func deviceNeedsLinkADRReq(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings, phy band.Band) bool {
+func deviceNeedsLinkADRReq(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings, phy *band.Band) bool {
 	if dev.GetMulticast() || dev.GetMACState() == nil {
 		return false
 	}
@@ -70,7 +70,7 @@ const (
 	noChangeTXPowerIndex  = 15
 )
 
-func enqueueLinkADRReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16, defaults ttnpb.MACSettings, phy band.Band) (macCommandEnqueueState, error) {
+func enqueueLinkADRReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16, defaults ttnpb.MACSettings, phy *band.Band) (macCommandEnqueueState, error) {
 	if !deviceNeedsLinkADRReq(dev, defaults, phy) {
 		return macCommandEnqueueState{
 			MaxDownLen: maxDownLen,
@@ -239,7 +239,7 @@ func handleLinkADRAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACC
 	}
 	evs := events.Builders{evt.With(events.WithData(pld))}
 
-	_, phy, err := getDeviceBandVersion(dev, fps)
+	_, phy, err := deviceFrequencyPlanAndBand(dev, fps)
 	if err != nil {
 		return evs, err
 	}

--- a/pkg/networkserver/mac_link_adr.go
+++ b/pkg/networkserver/mac_link_adr.go
@@ -239,7 +239,7 @@ func handleLinkADRAns(ctx context.Context, dev *ttnpb.EndDevice, pld *ttnpb.MACC
 	}
 	evs := events.Builders{evt.With(events.WithData(pld))}
 
-	_, phy, err := deviceFrequencyPlanAndBand(dev, fps)
+	phy, err := deviceBand(dev, fps)
 	if err != nil {
 		return evs, err
 	}

--- a/pkg/networkserver/mac_link_adr_test.go
+++ b/pkg/networkserver/mac_link_adr_test.go
@@ -151,7 +151,7 @@ func TestNeedsLinkADRReq(t *testing.T) {
 			a := assertions.New(t)
 
 			dev := CopyEndDevice(tc.InputDevice)
-			res := deviceNeedsLinkADRReq(dev, DefaultConfig.DefaultMACSettings.Parse(), Band(band.EU_863_870, ttnpb.PHY_V1_0_3_REV_A))
+			res := deviceNeedsLinkADRReq(dev, DefaultConfig.DefaultMACSettings.Parse(), LoRaWANBands[band.EU_863_870][ttnpb.PHY_V1_0_3_REV_A])
 			if tc.Needs {
 				a.So(res, should.BeTrue)
 			} else {
@@ -165,7 +165,7 @@ func TestNeedsLinkADRReq(t *testing.T) {
 func TestEnqueueLinkADRReq(t *testing.T) {
 	for _, tc := range []struct {
 		Name                        string
-		Band                        band.Band
+		Band                        *band.Band
 		InputDevice, ExpectedDevice *ttnpb.EndDevice
 		MaxDownlinkLength           uint16
 		MaxUplinkLength             uint16
@@ -174,7 +174,7 @@ func TestEnqueueLinkADRReq(t *testing.T) {
 	}{
 		{
 			Name: "payload fits/US915 FSB2/MAC:1.0.3,PHY:1.0.3a",
-			Band: test.Must(test.Must(band.GetByID(band.US_902_928)).(band.Band).Version(ttnpb.PHY_V1_0_3_REV_A)).(band.Band),
+			Band: LoRaWANBands[band.US_902_928][ttnpb.PHY_V1_0_3_REV_A],
 			InputDevice: &ttnpb.EndDevice{
 				FrequencyPlanID: test.USFrequencyPlanID,
 				MACState:        MakeDefaultUS915FSB2MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_3, ttnpb.PHY_V1_0_3_REV_A),
@@ -231,7 +231,7 @@ func TestEnqueueLinkADRReq(t *testing.T) {
 		},
 		{
 			Name: "payload fits/US915 FSB2/MAC:1.0.3,PHY:1.0.3a/ADR/rejected desired data rate and TX power",
-			Band: test.Must(test.Must(band.GetByID(band.US_902_928)).(band.Band).Version(ttnpb.PHY_V1_0_3_REV_A)).(band.Band),
+			Band: LoRaWANBands[band.US_902_928][ttnpb.PHY_V1_0_3_REV_A],
 			InputDevice: &ttnpb.EndDevice{
 				FrequencyPlanID: test.USFrequencyPlanID,
 				MACState: func() *ttnpb.MACState {
@@ -317,7 +317,7 @@ func TestEnqueueLinkADRReq(t *testing.T) {
 		},
 		{
 			Name: "payload fits/EU868/MAC:1.0.1,PHY:1.0.1/ADR/rejected all possible data rates",
-			Band: test.Must(test.Must(band.GetByID(band.EU_863_870)).(band.Band).Version(ttnpb.PHY_V1_0_1)).(band.Band),
+			Band: LoRaWANBands[band.EU_863_870][ttnpb.PHY_V1_0_1],
 			InputDevice: &ttnpb.EndDevice{
 				FrequencyPlanID: test.USFrequencyPlanID,
 				MACState: func() *ttnpb.MACState {
@@ -362,7 +362,7 @@ func TestEnqueueLinkADRReq(t *testing.T) {
 		},
 		{
 			Name: "payload fits/US915 FSB2/MAC:1.0.4,PHY:1.0.3a/no data rate change",
-			Band: test.Must(test.Must(band.GetByID(band.US_902_928)).(band.Band).Version(ttnpb.PHY_V1_0_3_REV_A)).(band.Band),
+			Band: LoRaWANBands[band.US_902_928][ttnpb.PHY_V1_0_3_REV_A],
 			InputDevice: &ttnpb.EndDevice{
 				FrequencyPlanID: test.USFrequencyPlanID,
 				MACState:        MakeDefaultUS915FSB2MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_4, ttnpb.PHY_V1_0_3_REV_A),
@@ -427,7 +427,7 @@ func TestEnqueueLinkADRReq(t *testing.T) {
 		},
 		{
 			Name: "downlink does not fit/US915 FSB2/MAC:1.0.3,PHY:1.0.3a",
-			Band: test.Must(test.Must(band.GetByID(band.US_902_928)).(band.Band).Version(ttnpb.PHY_V1_0_3_REV_A)).(band.Band),
+			Band: LoRaWANBands[band.US_902_928][ttnpb.PHY_V1_0_3_REV_A],
 			InputDevice: &ttnpb.EndDevice{
 				FrequencyPlanID: test.USFrequencyPlanID,
 				MACState:        MakeDefaultUS915FSB2MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_0_3, ttnpb.PHY_V1_0_3_REV_A),
@@ -446,7 +446,7 @@ func TestEnqueueLinkADRReq(t *testing.T) {
 		},
 		{
 			Name: "uplink does not fit/US915 FSB2/MAC:1.1,PHY:1.1b",
-			Band: test.Must(test.Must(band.GetByID(band.US_902_928)).(band.Band).Version(ttnpb.PHY_V1_1_REV_B)).(band.Band),
+			Band: LoRaWANBands[band.US_902_928][ttnpb.PHY_V1_1_REV_B],
 			InputDevice: &ttnpb.EndDevice{
 				FrequencyPlanID: test.USFrequencyPlanID,
 				MACState:        MakeDefaultUS915FSB2MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1, ttnpb.PHY_V1_1_REV_B),

--- a/pkg/networkserver/mac_rejoin_param_setup_test.go
+++ b/pkg/networkserver/mac_rejoin_param_setup_test.go
@@ -31,14 +31,12 @@ func TestNeedsRejoinParamSetupReq(t *testing.T) {
 		InputDevice *ttnpb.EndDevice
 		Needs       bool
 	}
-	var tcs []TestCase
-
-	tcs = append(tcs,
-		TestCase{
+	tcs := []TestCase{
+		{
 			Name:        "no MAC state",
 			InputDevice: &ttnpb.EndDevice{},
 		},
-	)
+	}
 	for _, conf := range []struct {
 		Suffix                               string
 		CurrentParameters, DesiredParameters ttnpb.MACParameters
@@ -80,7 +78,7 @@ func TestNeedsRejoinParamSetupReq(t *testing.T) {
 			Needs: true,
 		},
 	} {
-		ForEachMACVersion(func(makeMACName func(parts ...string) string, macVersion ttnpb.MACVersion) {
+		ForEachMACVersion(t, func(makeMACName func(parts ...string) string, macVersion ttnpb.MACVersion) {
 			tcs = append(tcs,
 				TestCase{
 					Name: makeMACName(conf.Suffix),

--- a/pkg/networkserver/mac_tx_param_setup.go
+++ b/pkg/networkserver/mac_tx_param_setup.go
@@ -35,7 +35,7 @@ var (
 	)()
 )
 
-func deviceNeedsTxParamSetupReq(dev *ttnpb.EndDevice, phy band.Band) bool {
+func deviceNeedsTxParamSetupReq(dev *ttnpb.EndDevice, phy *band.Band) bool {
 	if !phy.TxParamSetupReqSupport ||
 		dev.GetMulticast() ||
 		dev.GetMACState() == nil ||
@@ -58,7 +58,7 @@ func deviceNeedsTxParamSetupReq(dev *ttnpb.EndDevice, phy band.Band) bool {
 	return false
 }
 
-func enqueueTxParamSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16, phy band.Band) macCommandEnqueueState {
+func enqueueTxParamSetupReq(ctx context.Context, dev *ttnpb.EndDevice, maxDownLen, maxUpLen uint16, phy *band.Band) macCommandEnqueueState {
 	if !deviceNeedsTxParamSetupReq(dev, phy) {
 		return macCommandEnqueueState{
 			MaxDownLen: maxDownLen,

--- a/pkg/networkserver/mac_tx_param_setup_test.go
+++ b/pkg/networkserver/mac_tx_param_setup_test.go
@@ -33,111 +33,109 @@ func TestNeedsTxParamSetupReq(t *testing.T) {
 		Band        *band.Band
 		Needs       bool
 	}
-	var tcs []TestCase
-
-	ForEachBand(t, func(makeBandName func(parts ...string) string, phy *band.Band, _ ttnpb.PHYVersion) {
-		tcs = append(tcs,
-			TestCase{
-				Name:        makeBandName("no MAC state"),
-				InputDevice: &ttnpb.EndDevice{},
-				Band:        phy,
+	tcs := []TestCase{
+		{
+			Name:        "no MAC state",
+			InputDevice: &ttnpb.EndDevice{},
+			Band:        LoRaWANBands[band.EU_863_870][ttnpb.PHY_V1_1_REV_B],
+		},
+	}
+	for _, conf := range []struct {
+		Suffix                               string
+		CurrentParameters, DesiredParameters ttnpb.MACParameters
+		Needs                                bool
+	}{
+		{
+			Suffix: "current(EIRP:26,downlink:nil,uplink:nil),desired(EIRP:26,downlink:nil,uplink:nil)",
+			CurrentParameters: ttnpb.MACParameters{
+				MaxEIRP: 26,
 			},
-		)
-		for _, conf := range []struct {
-			Suffix                               string
-			CurrentParameters, DesiredParameters ttnpb.MACParameters
-			Needs                                bool
-		}{
-			{
-				Suffix: "current(EIRP:26,downlink:nil,uplink:nil),desired(EIRP:26,downlink:nil,uplink:nil)",
-				CurrentParameters: ttnpb.MACParameters{
-					MaxEIRP: 26,
-				},
-				DesiredParameters: ttnpb.MACParameters{
-					MaxEIRP: 26,
-				},
+			DesiredParameters: ttnpb.MACParameters{
+				MaxEIRP: 26,
 			},
-			{
-				Suffix: "current(EIRP:26,downlink:true,uplink:false),desired(EIRP:26,downlink:nil,uplink:nil)",
-				CurrentParameters: ttnpb.MACParameters{
-					MaxEIRP:           26,
-					DownlinkDwellTime: &pbtypes.BoolValue{Value: true},
-					UplinkDwellTime:   &pbtypes.BoolValue{Value: false},
-				},
-				DesiredParameters: ttnpb.MACParameters{
-					MaxEIRP: 26,
-				},
+		},
+		{
+			Suffix: "current(EIRP:26,downlink:true,uplink:false),desired(EIRP:26,downlink:nil,uplink:nil)",
+			CurrentParameters: ttnpb.MACParameters{
+				MaxEIRP:           26,
+				DownlinkDwellTime: &pbtypes.BoolValue{Value: true},
+				UplinkDwellTime:   &pbtypes.BoolValue{Value: false},
 			},
-			{
-				Suffix: "current(EIRP:26,downlink:nil,uplink:nil),desired(EIRP:26,downlink:true,uplink:true)",
-				CurrentParameters: ttnpb.MACParameters{
-					MaxEIRP: 26,
-				},
-				DesiredParameters: ttnpb.MACParameters{
-					MaxEIRP:           26,
-					DownlinkDwellTime: &pbtypes.BoolValue{Value: true},
-					UplinkDwellTime:   &pbtypes.BoolValue{Value: true},
-				},
-				Needs: true,
+			DesiredParameters: ttnpb.MACParameters{
+				MaxEIRP: 26,
 			},
-			{
-				Suffix: "current(EIRP:26,downlink:nil,uplink:nil),desired(EIRP:26,downlink:false,uplink:false)",
-				CurrentParameters: ttnpb.MACParameters{
-					MaxEIRP: 26,
-				},
-				DesiredParameters: ttnpb.MACParameters{
-					MaxEIRP:           26,
-					DownlinkDwellTime: &pbtypes.BoolValue{Value: false},
-					UplinkDwellTime:   &pbtypes.BoolValue{Value: false},
-				},
-				Needs: true,
+		},
+		{
+			Suffix: "current(EIRP:26,downlink:nil,uplink:nil),desired(EIRP:26,downlink:true,uplink:true)",
+			CurrentParameters: ttnpb.MACParameters{
+				MaxEIRP: 26,
 			},
-			{
-				Suffix: "current(EIRP:26,downlink:true,uplink:nil),desired(EIRP:26,downlink:false,uplink:false)",
-				CurrentParameters: ttnpb.MACParameters{
-					MaxEIRP:           26,
-					DownlinkDwellTime: &pbtypes.BoolValue{Value: true},
-				},
-				DesiredParameters: ttnpb.MACParameters{
-					MaxEIRP:           26,
-					DownlinkDwellTime: &pbtypes.BoolValue{Value: false},
-					UplinkDwellTime:   &pbtypes.BoolValue{Value: false},
-				},
-				Needs: true,
+			DesiredParameters: ttnpb.MACParameters{
+				MaxEIRP:           26,
+				DownlinkDwellTime: &pbtypes.BoolValue{Value: true},
+				UplinkDwellTime:   &pbtypes.BoolValue{Value: true},
 			},
-			{
-				Suffix: "current(EIRP:24,downlink:true,uplink:false),desired(EIRP:26,downlink:true,uplink:false)",
-				CurrentParameters: ttnpb.MACParameters{
-					MaxEIRP:           24,
-					DownlinkDwellTime: &pbtypes.BoolValue{Value: true},
-					UplinkDwellTime:   &pbtypes.BoolValue{Value: false},
-				},
-				DesiredParameters: ttnpb.MACParameters{
-					MaxEIRP:           26,
-					DownlinkDwellTime: &pbtypes.BoolValue{Value: true},
-					UplinkDwellTime:   &pbtypes.BoolValue{Value: false},
-				},
-				Needs: true,
+			Needs: true,
+		},
+		{
+			Suffix: "current(EIRP:26,downlink:nil,uplink:nil),desired(EIRP:26,downlink:false,uplink:false)",
+			CurrentParameters: ttnpb.MACParameters{
+				MaxEIRP: 26,
 			},
-		} {
-			ForEachMACVersion(func(makeMACName func(parts ...string) string, macVersion ttnpb.MACVersion) {
-				tcs = append(tcs,
-					TestCase{
-						Name: makeBandName(makeMACName(conf.Suffix)),
-						InputDevice: &ttnpb.EndDevice{
-							MACState: &ttnpb.MACState{
-								LoRaWANVersion:    macVersion,
-								CurrentParameters: conf.CurrentParameters,
-								DesiredParameters: conf.DesiredParameters,
-							},
+			DesiredParameters: ttnpb.MACParameters{
+				MaxEIRP:           26,
+				DownlinkDwellTime: &pbtypes.BoolValue{Value: false},
+				UplinkDwellTime:   &pbtypes.BoolValue{Value: false},
+			},
+			Needs: true,
+		},
+		{
+			Suffix: "current(EIRP:26,downlink:true,uplink:nil),desired(EIRP:26,downlink:false,uplink:false)",
+			CurrentParameters: ttnpb.MACParameters{
+				MaxEIRP:           26,
+				DownlinkDwellTime: &pbtypes.BoolValue{Value: true},
+			},
+			DesiredParameters: ttnpb.MACParameters{
+				MaxEIRP:           26,
+				DownlinkDwellTime: &pbtypes.BoolValue{Value: false},
+				UplinkDwellTime:   &pbtypes.BoolValue{Value: false},
+			},
+			Needs: true,
+		},
+		{
+			Suffix: "current(EIRP:24,downlink:true,uplink:false),desired(EIRP:26,downlink:true,uplink:false)",
+			CurrentParameters: ttnpb.MACParameters{
+				MaxEIRP:           24,
+				DownlinkDwellTime: &pbtypes.BoolValue{Value: true},
+				UplinkDwellTime:   &pbtypes.BoolValue{Value: false},
+			},
+			DesiredParameters: ttnpb.MACParameters{
+				MaxEIRP:           26,
+				DownlinkDwellTime: &pbtypes.BoolValue{Value: true},
+				UplinkDwellTime:   &pbtypes.BoolValue{Value: false},
+			},
+			Needs: true,
+		},
+	} {
+		ForEachBandMACVersion(t, func(makeName func(parts ...string) string, phy *band.Band, phyVersion ttnpb.PHYVersion, macVersion ttnpb.MACVersion) {
+			tcs = append(tcs,
+				TestCase{
+					Name: makeName(conf.Suffix),
+					InputDevice: &ttnpb.EndDevice{
+						LoRaWANVersion:    macVersion,
+						LoRaWANPHYVersion: phyVersion,
+						MACState: &ttnpb.MACState{
+							LoRaWANVersion:    macVersion,
+							CurrentParameters: conf.CurrentParameters,
+							DesiredParameters: conf.DesiredParameters,
 						},
-						Band:  phy,
-						Needs: phy.TxParamSetupReqSupport && conf.Needs && macVersion.Compare(ttnpb.MAC_V1_0_2) >= 0,
 					},
-				)
-			})
-		}
-	})
+					Band:  phy,
+					Needs: phy.TxParamSetupReqSupport && conf.Needs && macVersion.Compare(ttnpb.MAC_V1_0_2) >= 0,
+				},
+			)
+		})
+	}
 
 	for _, tc := range tcs {
 		t.Run(tc.Name, func(t *testing.T) {

--- a/pkg/networkserver/mac_tx_param_setup_test.go
+++ b/pkg/networkserver/mac_tx_param_setup_test.go
@@ -30,12 +30,12 @@ func TestNeedsTxParamSetupReq(t *testing.T) {
 	type TestCase struct {
 		Name        string
 		InputDevice *ttnpb.EndDevice
-		Band        band.Band
+		Band        *band.Band
 		Needs       bool
 	}
 	var tcs []TestCase
 
-	ForEachBand(t, func(makeBandName func(parts ...string) string, phy band.Band, _ ttnpb.PHYVersion) {
+	ForEachBand(t, func(makeBandName func(parts ...string) string, phy *band.Band, _ ttnpb.PHYVersion) {
 		tcs = append(tcs,
 			TestCase{
 				Name:        makeBandName("no MAC state"),
@@ -319,7 +319,7 @@ func TestEnqueueTxParamSetupReq(t *testing.T) {
 
 			dev := CopyEndDevice(tc.InputDevice)
 
-			st := enqueueTxParamSetupReq(test.Context(), dev, tc.MaxDownlinkLength, tc.MaxUplinkLength, test.Must(test.Must(band.GetByID(band.AS_923)).(band.Band).Version(ttnpb.PHY_V1_1_REV_B)).(band.Band))
+			st := enqueueTxParamSetupReq(test.Context(), dev, tc.MaxDownlinkLength, tc.MaxUplinkLength, LoRaWANBands[band.AS_923][ttnpb.PHY_V1_1_REV_B])
 			a.So(dev, should.Resemble, tc.ExpectedDevice)
 			a.So(st.QueuedEvents, should.ResembleEventBuilders, tc.State.QueuedEvents)
 			st.QueuedEvents = tc.State.QueuedEvents

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -18,10 +18,12 @@ package networkserver
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"go.thethings.network/lorawan-stack/v3/pkg/band"
 	"go.thethings.network/lorawan-stack/v3/pkg/cluster"
 	"go.thethings.network/lorawan-stack/v3/pkg/component"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -56,6 +56,43 @@ const (
 	networkInitiatedDownlinkInterval = time.Second
 )
 
+var lorawanVersionPairs = map[ttnpb.MACVersion]map[ttnpb.PHYVersion]struct{}{
+	ttnpb.MAC_V1_0: {
+		ttnpb.PHY_V1_0: struct{}{},
+	},
+	ttnpb.MAC_V1_0_1: {
+		ttnpb.PHY_V1_0_1: struct{}{},
+	},
+	ttnpb.MAC_V1_0_2: {
+		ttnpb.PHY_V1_0_2_REV_A: struct{}{},
+		ttnpb.PHY_V1_0_2_REV_B: struct{}{},
+	},
+	ttnpb.MAC_V1_0_3: {
+		ttnpb.PHY_V1_0_3_REV_A: struct{}{},
+	},
+	ttnpb.MAC_V1_1: {
+		ttnpb.PHY_V1_1_REV_A: struct{}{},
+		ttnpb.PHY_V1_1_REV_B: struct{}{},
+	},
+}
+
+var lorawanBands = func() map[string]map[ttnpb.PHYVersion]*band.Band {
+	bands := make(map[string]map[ttnpb.PHYVersion]*band.Band, len(band.All))
+	for _, b := range band.All {
+		vers := b.Versions()
+		m := make(map[ttnpb.PHYVersion]*band.Band, len(vers))
+		for _, ver := range vers {
+			b, err := b.Version(ver)
+			if err != nil {
+				panic(fmt.Errorf("failed to obtain %s band of version %s", b.ID, ver))
+			}
+			m[ver] = &b
+		}
+		bands[b.ID] = m
+	}
+	return bands
+}()
+
 // windowDurationFunc is a function, which is used by Network Server to determine the duration of deduplication and cooldown windows.
 type windowDurationFunc func(ctx context.Context) time.Duration
 

--- a/pkg/networkserver/networkserver_flow_test.go
+++ b/pkg/networkserver/networkserver_flow_test.go
@@ -316,7 +316,7 @@ func (env FlowTestEnvironment) AssertJoin(ctx context.Context, link ttnpb.AsNs_L
 	t := test.MustTFromContext(ctx)
 
 	fp := FrequencyPlan(fpID)
-	phy := Band(fp.BandID, phyVersion)
+	phy := LoRaWANBands[fp.BandID][phyVersion]
 	upCh := phy.UplinkChannels[upChIdx]
 	upDR := phy.DataRates[upDRIdx].Rate
 
@@ -726,7 +726,7 @@ func makeClassCOTAAFlowTest(macVersion ttnpb.MACVersion, phyVersion ttnpb.PHYVer
 
 		ids = *MakeOTAAIdentifiers(&joinReq.DevAddr)
 		fp := FrequencyPlan(fpID)
-		phy := Band(fp.BandID, phyVersion)
+		phy := LoRaWANBands[fp.BandID][phyVersion]
 
 		upChs := FrequencyPlanChannels(phy, fp.UplinkChannels, fp.DownlinkChannels...)
 		upChIdx := uint8(2)

--- a/pkg/networkserver/networkserver_util_test.go
+++ b/pkg/networkserver/networkserver_util_test.go
@@ -61,6 +61,8 @@ var (
 	FrequencyPlanChannels               = frequencyPlanChannels
 	HandleLinkCheckReq                  = handleLinkCheckReq
 	JoinResponseWithoutKeys             = joinResponseWithoutKeys
+	LoRaWANBands                        = lorawanBands
+	LoRaWANVersionPairs                 = lorawanVersionPairs
 	NewMACState                         = newMACState
 	TimePtr                             = timePtr
 
@@ -187,10 +189,6 @@ func AES128KeyPtr(key types.AES128Key) *types.AES128Key {
 
 func FrequencyPlan(id string) *frequencyplans.FrequencyPlan {
 	return test.Must(frequencyplans.NewStore(test.FrequencyPlansFetcher).GetByID(id)).(*frequencyplans.FrequencyPlan)
-}
-
-func Band(id string, phyVersion ttnpb.PHYVersion) band.Band {
-	return test.Must(test.Must(band.GetByID(id)).(band.Band).Version(phyVersion)).(band.Band)
 }
 
 func MakeDefaultEU868CurrentChannels() []*ttnpb.MACParameters_Channel {
@@ -582,18 +580,18 @@ func AppendMACCommanders(queue []*ttnpb.MACCommand, cmds ...MACCommander) []*ttn
 	return queue
 }
 
-func MakeUplinkMACBuffer(phy band.Band, cmds ...MACCommander) []byte {
+func MakeUplinkMACBuffer(phy *band.Band, cmds ...MACCommander) []byte {
 	var b []byte
 	for _, cmd := range cmds {
-		b = test.Must(lorawan.DefaultMACCommands.AppendUplink(phy, b, *cmd.MACCommand())).([]byte)
+		b = test.Must(lorawan.DefaultMACCommands.AppendUplink(*phy, b, *cmd.MACCommand())).([]byte)
 	}
 	return b
 }
 
-func MakeDownlinkMACBuffer(phy band.Band, cmds ...MACCommander) []byte {
+func MakeDownlinkMACBuffer(phy *band.Band, cmds ...MACCommander) []byte {
 	var b []byte
 	for _, cmd := range cmds {
-		b = test.Must(lorawan.DefaultMACCommands.AppendDownlink(phy, b, *cmd.MACCommand())).([]byte)
+		b = test.Must(lorawan.DefaultMACCommands.AppendDownlink(*phy, b, *cmd.MACCommand())).([]byte)
 	}
 	return b
 }
@@ -1907,29 +1905,13 @@ func MakeTestCaseName(parts ...string) string {
 	return strings.Join(parts, "/")
 }
 
-func ForEachBand(t *testing.T, f func(func(...string) string, band.Band, ttnpb.PHYVersion)) {
-	for phyID, phy := range band.All {
-		for _, phyVersion := range phy.Versions() {
+func ForEachBand(t *testing.T, f func(func(...string) string, *band.Band, ttnpb.PHYVersion)) {
+	for phyID, phyVersions := range LoRaWANBands {
+		for phyVersion, b := range phyVersions {
 			f(func(parts ...string) string {
-				return MakeTestCaseName(append(parts, fmt.Sprintf("%s/PHY:%s", phyID, phyVersion.String()))...)
-			}, Band(phyID, phyVersion), phyVersion)
+				return MakeTestCaseName(append(parts, phyID, fmt.Sprintf("PHY:%s", phyVersion.String()))...)
+			}, b, phyVersion)
 		}
-	}
-}
-
-func ForEachPHYVersion(f func(func(...string) string, ttnpb.PHYVersion)) {
-	for _, phyVersion := range []ttnpb.PHYVersion{
-		ttnpb.PHY_V1_0,
-		ttnpb.PHY_V1_0_1,
-		ttnpb.PHY_V1_0_2_REV_A,
-		ttnpb.PHY_V1_0_2_REV_B,
-		ttnpb.PHY_V1_0_3_REV_A,
-		ttnpb.PHY_V1_1_REV_A,
-		ttnpb.PHY_V1_1_REV_B,
-	} {
-		f(func(parts ...string) string {
-			return MakeTestCaseName(append(parts, fmt.Sprintf("PHY:%s", phyVersion.String()))...)
-		}, phyVersion)
 	}
 }
 
@@ -1973,21 +1955,21 @@ func ForEachFrequencyPlan(t *testing.T, f func(func(...string) string, string, *
 	}
 }
 
-func ForEachPHYMACVersion(f func(func(...string) string, ttnpb.PHYVersion, ttnpb.MACVersion)) {
-	ForEachPHYVersion(func(makePHYName func(...string) string, phyVersion ttnpb.PHYVersion) {
-		ForEachMACVersion(func(makeMACName func(...string) string, macVersion ttnpb.MACVersion) {
+func ForEachLoRaWANVersionPair(f func(func(...string) string, ttnpb.PHYVersion, ttnpb.MACVersion)) {
+	for macVersion, phyVersions := range LoRaWANVersionPairs {
+		for phyVersion := range phyVersions {
 			f(func(parts ...string) string {
-				return makePHYName(makeMACName(parts...))
+				return MakeTestCaseName(append(parts, fmt.Sprintf("MAC:%s", macVersion.String()), fmt.Sprintf("PHY:%s", phyVersion.String()))...)
 			}, phyVersion, macVersion)
-		})
-	})
+		}
+	}
 }
 
-func ForEachClassPHYMACVersion(f func(func(...string) string, ttnpb.Class, ttnpb.PHYVersion, ttnpb.MACVersion)) {
+func ForEachClassLoRaWANVersionPair(f func(func(...string) string, ttnpb.Class, ttnpb.PHYVersion, ttnpb.MACVersion)) {
 	ForEachClass(func(makeClassName func(...string) string, class ttnpb.Class) {
-		ForEachPHYMACVersion(func(makePHYMACName func(parts ...string) string, phyVersion ttnpb.PHYVersion, macVersion ttnpb.MACVersion) {
+		ForEachLoRaWANVersionPair(func(makeLoRaWANName func(parts ...string) string, phyVersion ttnpb.PHYVersion, macVersion ttnpb.MACVersion) {
 			f(func(parts ...string) string {
-				return makeClassName(makePHYMACName(parts...))
+				return makeClassName(makeLoRaWANName(parts...))
 			}, class, phyVersion, macVersion)
 		})
 	})
@@ -2003,26 +1985,26 @@ func ForEachClassMACVersion(f func(func(...string) string, ttnpb.Class, ttnpb.MA
 	})
 }
 
-func ForEachFrequencyPlanBandMACVersion(t *testing.T, f func(func(...string) string, string, *frequencyplans.FrequencyPlan, band.Band, ttnpb.PHYVersion, ttnpb.MACVersion)) {
+func ForEachFrequencyPlanLoRaWANVersionPair(t *testing.T, f func(func(...string) string, string, *frequencyplans.FrequencyPlan, *band.Band, ttnpb.PHYVersion, ttnpb.MACVersion)) {
 	ForEachFrequencyPlan(t, func(makeFPName func(...string) string, fpID string, fp *frequencyplans.FrequencyPlan) {
-		phy, err := band.GetByID(fp.BandID)
-		if err != nil {
-			t.Errorf("failed to get PHY by id `%s` associated with frequency plan `%s`: %s", fp.BandID, fpID, err)
-			return
-		}
-		for _, phyVersion := range phy.Versions() {
-			ForEachMACVersion(func(makeMACName func(parts ...string) string, macVersion ttnpb.MACVersion) {
-				f(func(parts ...string) string {
-					return makeFPName(makeMACName(append(parts, fmt.Sprintf("PHY:%s", phyVersion))...))
-				}, fpID, fp, Band(fp.BandID, phyVersion), phyVersion, macVersion)
-			})
-		}
+		ForEachLoRaWANVersionPair(func(makeLoRaWANName func(parts ...string) string, phyVersion ttnpb.PHYVersion, macVersion ttnpb.MACVersion) {
+			b, ok := LoRaWANBands[fp.BandID][phyVersion]
+			if !ok || b == nil {
+				return
+			}
+			f(func(parts ...string) string {
+				return makeFPName(makeLoRaWANName(parts...))
+			}, fpID, fp, b, phyVersion, macVersion)
+		})
 	})
 }
 
-func ForEachBandMACVersion(t *testing.T, f func(func(...string) string, band.Band, ttnpb.PHYVersion, ttnpb.MACVersion)) {
-	ForEachBand(t, func(makeBandName func(...string) string, phy band.Band, phyVersion ttnpb.PHYVersion) {
+func ForEachBandMACVersion(t *testing.T, f func(func(...string) string, *band.Band, ttnpb.PHYVersion, ttnpb.MACVersion)) {
+	ForEachBand(t, func(makeBandName func(...string) string, phy *band.Band, phyVersion ttnpb.PHYVersion) {
 		ForEachMACVersion(func(makeMACName func(...string) string, macVersion ttnpb.MACVersion) {
+			if _, ok := LoRaWANVersionPairs[macVersion][phyVersion]; !ok {
+				return
+			}
 			f(func(parts ...string) string {
 				return makeBandName(makeMACName(parts...))
 			}, phy, phyVersion, macVersion)

--- a/pkg/networkserver/networkserver_util_test.go
+++ b/pkg/networkserver/networkserver_util_test.go
@@ -2002,8 +2002,8 @@ func ForEachFrequencyPlan(tb testing.TB, f func(func(...string) string, string, 
 func ForEachLoRaWANVersionPair(tb testing.TB, f func(func(...string) string, ttnpb.MACVersion, ttnpb.PHYVersion)) {
 	for macVersion, phyVersions := range LoRaWANVersionPairs {
 		switch macVersion {
-		case ttnpb.MAC_V1_0_4, ttnpb.MAC_V1_1:
-		case ttnpb.MAC_V1_0_3:
+		case ttnpb.MAC_V1_0_3, ttnpb.MAC_V1_1:
+		case ttnpb.MAC_V1_0_2:
 			if !testing.Short() {
 				break
 			}

--- a/pkg/networkserver/utils.go
+++ b/pkg/networkserver/utils.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mohae/deepcopy"
 	"go.thethings.network/lorawan-stack/v3/pkg/band"
 	"go.thethings.network/lorawan-stack/v3/pkg/crypto"
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/frequencyplans"
 	"go.thethings.network/lorawan-stack/v3/pkg/gpstime"
@@ -62,7 +63,7 @@ func timePtr(t time.Time) *time.Time {
 	return &t
 }
 
-func deviceUseADR(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings, phy band.Band) bool {
+func deviceUseADR(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings, phy *band.Band) bool {
 	if !phy.EnableADR {
 		return false
 	}
@@ -103,18 +104,19 @@ func deviceClassCTimeout(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings) time.
 	return DefaultClassCTimeout
 }
 
-func getDeviceBandVersion(dev *ttnpb.EndDevice, fps *frequencyplans.Store) (*frequencyplans.FrequencyPlan, band.Band, error) {
+var errNoBandVersion = errors.DefineInvalidArgument("no_band_version", "specified version `{ver}` of band `{id}` does not exist")
+
+func deviceFrequencyPlanAndBand(dev *ttnpb.EndDevice, fps *frequencyplans.Store) (*frequencyplans.FrequencyPlan, *band.Band, error) {
 	fp, err := fps.GetByID(dev.FrequencyPlanID)
 	if err != nil {
-		return nil, band.Band{}, err
+		return nil, nil, err
 	}
-	b, err := band.GetByID(fp.BandID)
-	if err != nil {
-		return nil, band.Band{}, err
-	}
-	b, err = b.Version(dev.LoRaWANPHYVersion)
-	if err != nil {
-		return nil, band.Band{}, err
+	b, ok := lorawanBands[fp.BandID][dev.LoRaWANPHYVersion]
+	if !ok || b == nil {
+		return nil, nil, errNoBandVersion.WithAttributes(
+			"ver", dev.LoRaWANPHYVersion,
+			"id", fp.BandID,
+		)
 	}
 	return fp, b, nil
 }
@@ -155,7 +157,7 @@ func deviceRejectedFrequency(dev *ttnpb.EndDevice, freq uint64) bool {
 	return i < len(dev.MACState.RejectedFrequencies) && dev.MACState.RejectedFrequencies[i] == freq
 }
 
-func deviceNeedsMACRequestsAt(ctx context.Context, dev *ttnpb.EndDevice, earliestAt time.Time, phy band.Band, defaults ttnpb.MACSettings) bool {
+func deviceNeedsMACRequestsAt(ctx context.Context, dev *ttnpb.EndDevice, earliestAt time.Time, phy *band.Band, defaults ttnpb.MACSettings) bool {
 	if dev.GetMulticast() {
 		return false
 	}
@@ -232,7 +234,7 @@ func (s networkInitiatedDownlinkSlot) IsContinuous() bool {
 
 // lastClassADataDownlinkSlot returns the latest class A downlink slot in current session
 // if such exists and true, otherwise it returns nil and false.
-func lastClassADataDownlinkSlot(dev *ttnpb.EndDevice, phy band.Band) (*classADownlinkSlot, bool) {
+func lastClassADataDownlinkSlot(dev *ttnpb.EndDevice, phy *band.Band) (*classADownlinkSlot, bool) {
 	if dev.GetMACState() == nil || len(dev.MACState.RecentUplinks) == 0 || dev.Multicast {
 		return nil, false
 	}
@@ -257,7 +259,7 @@ func lastClassADataDownlinkSlot(dev *ttnpb.EndDevice, phy band.Band) (*classADow
 // nextUnconfirmedNetworkInitiatedDownlinkAt returns the earliest possible time instant when next unconfirmed
 // network-initiated data downlink can be transmitted to the device given the data known by Network Server and true,
 // if such time instant exists, otherwise it returns time.Time{} and false.
-func nextUnconfirmedNetworkInitiatedDownlinkAt(ctx context.Context, dev *ttnpb.EndDevice, phy band.Band) (time.Time, bool) {
+func nextUnconfirmedNetworkInitiatedDownlinkAt(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band) (time.Time, bool) {
 	switch {
 	case dev.GetMACState() == nil:
 		log.FromContext(ctx).Warn("Insufficient data to compute next network-initiated unconfirmed downlink slot")
@@ -293,7 +295,7 @@ func nextUnconfirmedNetworkInitiatedDownlinkAt(ctx context.Context, dev *ttnpb.E
 // nextConfirmedNetworkInitiatedDownlinkAt returns the earliest possible time instant when a confirmed
 // network-initiated data downlink can be transmitted to the device given the data known by Network Server and true,
 // if such time instant exists, otherwise it returns time.Time{} and false.
-func nextConfirmedNetworkInitiatedDownlinkAt(ctx context.Context, dev *ttnpb.EndDevice, phy band.Band, defaults ttnpb.MACSettings) (time.Time, bool) {
+func nextConfirmedNetworkInitiatedDownlinkAt(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band, defaults ttnpb.MACSettings) (time.Time, bool) {
 	if dev.GetMACState() == nil {
 		log.FromContext(ctx).Warn("Insufficient data to compute next network-initiated confirmed downlink slot")
 		return time.Time{}, false
@@ -412,7 +414,7 @@ func deviceHasPathForDownlink(ctx context.Context, dev *ttnpb.EndDevice, down *t
 
 // nextDataDownlinkSlot returns the next downlinkSlot before or at earliestAt when next data downlink can be transmitted to the device
 // given the data known by Network Server and true, if such downlinkSlot and downlink exist, otherwise it returns nil and false.
-func nextDataDownlinkSlot(ctx context.Context, dev *ttnpb.EndDevice, phy band.Band, defaults ttnpb.MACSettings, earliestAt time.Time) (downlinkSlot, bool) {
+func nextDataDownlinkSlot(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band, defaults ttnpb.MACSettings, earliestAt time.Time) (downlinkSlot, bool) {
 	if dev.GetMACState() == nil {
 		return nil, false
 	}
@@ -532,7 +534,7 @@ func nextDataDownlinkSlot(ctx context.Context, dev *ttnpb.EndDevice, phy band.Ba
 	return nil, false
 }
 
-func frequencyPlanChannels(phy band.Band, fpUpChs []frequencyplans.Channel, fpDownChs ...frequencyplans.Channel) []*ttnpb.MACParameters_Channel {
+func frequencyPlanChannels(phy *band.Band, fpUpChs []frequencyplans.Channel, fpDownChs ...frequencyplans.Channel) []*ttnpb.MACParameters_Channel {
 	chs := make([]*ttnpb.MACParameters_Channel, 0, len(phy.UplinkChannels)+len(fpUpChs))
 	for i, phyUpCh := range phy.UplinkChannels {
 		chs = append(chs, &ttnpb.MACParameters_Channel{
@@ -570,7 +572,7 @@ outerUp:
 }
 
 func newMACState(dev *ttnpb.EndDevice, fps *frequencyplans.Store, defaults ttnpb.MACSettings) (*ttnpb.MACState, error) {
-	fp, phy, err := getDeviceBandVersion(dev, fps)
+	fp, phy, err := deviceFrequencyPlanAndBand(dev, fps)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/networkserver/utils.go
+++ b/pkg/networkserver/utils.go
@@ -121,6 +121,11 @@ func deviceFrequencyPlanAndBand(dev *ttnpb.EndDevice, fps *frequencyplans.Store)
 	return fp, b, nil
 }
 
+func deviceBand(dev *ttnpb.EndDevice, fps *frequencyplans.Store) (*band.Band, error) {
+	_, phy, err := deviceFrequencyPlanAndBand(dev, fps)
+	return phy, err
+}
+
 func searchUplinkChannel(freq uint64, macState *ttnpb.MACState) (uint8, error) {
 	for i, ch := range macState.CurrentParameters.Channels {
 		if ch.UplinkFrequency == freq {

--- a/pkg/networkserver/utils_internal_test.go
+++ b/pkg/networkserver/utils_internal_test.go
@@ -994,7 +994,7 @@ func TestNextDataDownlinkSlot(t *testing.T) {
 			a := assertions.New(t)
 
 			ctx := log.NewContext(ctx, test.GetLogger(t))
-			ret, ok := nextDataDownlinkSlot(ctx, tc.Device, test.Must(band.GetByID(band.EU_863_870)).(band.Band), ttnpb.MACSettings{}, tc.EarliestAt)
+			ret, ok := nextDataDownlinkSlot(ctx, tc.Device, LoRaWANBands[band.EU_863_870][ttnpb.PHY_V1_1_REV_B], ttnpb.MACSettings{}, tc.EarliestAt)
 			if a.So(ok, should.Equal, tc.ExpectedOk) {
 				a.So(ret, should.Resemble, tc.ExpectedSlot)
 			}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Requirement for #3026 
Refs #3052 
Refs https://github.com/TheThingsNetwork/lorawan-stack/issues/2732

#### Changes
<!-- What are the changes made in this pull request? -->

- Query and construct a data structure with all available bands on initialization
- Use pointers to bands
- Record possible LoRaWAN version pairs
- Only consider possible LoRaWAN version pairs when testing


#### Testing

<!-- How did you verify that this change works? -->

unit tests

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This should also speed up tests by lowering the amount of LoRaWAN version pairs tested

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
