### PR TITLE
Remove context from events metrics

### DIFF
--- a/pkg/events/handler.go
+++ b/pkg/events/handler.go
@@ -46,7 +46,7 @@ func (ch Channel) Notify(evt Event) {
 	select {
 	case ch <- evt:
 	default:
-		channelDropped.WithLabelValues(evt.Context(), evt.Name())
+		channelDropped.WithLabelValues(evt.Name())
 	}
 }
 

--- a/pkg/events/observability.go
+++ b/pkg/events/observability.go
@@ -15,15 +15,13 @@
 package events
 
 import (
-	"context"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"go.thethings.network/lorawan-stack/v3/pkg/metrics"
 )
 
 const subsystem = "events"
 
-var publishes = metrics.NewContextualCounterVec(
+var publishes = metrics.NewCounterVec(
 	prometheus.CounterOpts{
 		Subsystem: subsystem,
 		Name:      "publishes_total",
@@ -41,7 +39,7 @@ var subscriptions = metrics.NewGaugeVec(
 	[]string{"name"},
 )
 
-var channelDropped = metrics.NewContextualCounterVec(
+var channelDropped = metrics.NewCounterVec(
 	prometheus.CounterOpts{
 		Subsystem: subsystem,
 		Name:      "channel_dropped_total",
@@ -51,10 +49,9 @@ var channelDropped = metrics.NewContextualCounterVec(
 )
 
 func initMetrics(name string) {
-	ctx := context.Background()
-	publishes.WithLabelValues(ctx, name).Add(0)
+	publishes.WithLabelValues(name).Add(0)
 	subscriptions.WithLabelValues(name).Add(0)
-	channelDropped.WithLabelValues(ctx, name).Add(0)
+	channelDropped.WithLabelValues(name).Add(0)
 }
 
 func init() {

--- a/pkg/events/pubsub.go
+++ b/pkg/events/pubsub.go
@@ -123,7 +123,7 @@ func (e *pubsub) Unsubscribe(name string, hdl Handler) {
 
 func (e *pubsub) Publish(evt Event) {
 	localEvent := local(evt)
-	publishes.WithLabelValues(evt.Context(), evt.Name()).Inc()
+	publishes.WithLabelValues(evt.Name()).Inc()
 	e.events <- tracedEvent{
 		event: localEvent.withCaller(),
 		trace: trace.StartRegion(evt.Context(), "publish event"),


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This quickfix removes the context from events metrics.