### PR TITLE
Remove title assertions from e2e tests

### DIFF
--- a/cypress/integration/console/applications/create.spec.js
+++ b/cypress/integration/console/applications/create.spec.js
@@ -62,9 +62,6 @@ describe('Application create', () => {
       .should('contain', 'Leave empty to link to the Network Server in the same cluster')
       .and('be.visible')
     cy.findByRole('button', { name: 'Create application' }).should('be.visible')
-    cy.title().then(({ title, config }) => {
-      expect(title).to.eq(`Add application - ${config.siteTitle} - ${config.siteName}`)
-    })
   })
 
   it('validates before submitting an empty form', () => {
@@ -122,9 +119,6 @@ describe('Application create', () => {
       cy.findByLabelText('Linking').should('not.exist')
       cy.findByLabelText('Network Server address').should('not.exist')
       cy.findByRole('button', { name: 'Create application' }).should('be.visible')
-      cy.title().then(({ title, config }) => {
-        expect(title).to.eq(`Add application - ${config.siteTitle} - ${config.siteName}`)
-      })
     })
   })
 })

--- a/cypress/integration/oauth/change-password.spec.js
+++ b/cypress/integration/oauth/change-password.spec.js
@@ -34,10 +34,6 @@ describe('OAuth change password', () => {
       .and('be.visible')
     cy.findByRole('button', { name: 'Change password' }).should('be.visible')
     cy.findByRole('button', { name: 'Cancel' }).should('be.visible')
-
-    cy.title().then(({ title, config }) => {
-      expect(title).to.eq(`Change password - ${config.siteName}`)
-    })
   })
 
   it('validates before submitting an empty form', () => {

--- a/cypress/integration/oauth/login.spec.js
+++ b/cypress/integration/oauth/login.spec.js
@@ -32,9 +32,6 @@ describe('OAuth login', () => {
     cy.findByRole('button', { name: 'Forgot password?' }).should('be.visible')
     cy.findByLabelText('User ID').should('be.visible')
     cy.findByLabelText('Password').should('be.visible')
-    cy.title().then(({ title, config }) => {
-      expect(title).to.eq(`Login - ${config.siteName}`)
-    })
   })
 
   it('validates before submitting an empty form', () => {

--- a/cypress/integration/oauth/user-registration.spec.js
+++ b/cypress/integration/oauth/user-registration.spec.js
@@ -27,9 +27,6 @@ describe('OAuth user registration', () => {
     cy.findByLabelText('Confirm password').should('be.visible')
     cy.findByRole('button', { name: 'Register' }).should('be.visible')
     cy.findByRole('button', { name: 'Cancel' }).should('be.visible')
-    cy.title().then(({ title, config }) => {
-      expect(title).to.eq(`Register - ${config.siteName}`)
-    })
   })
 
   it('validates before submitting an empty form', () => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import stringToHash from '../../pkg/webui/lib/string-to-hash'
-import { getSiteName, getSiteTitle } from './utils'
 
 // Helper function to quickly login to the oauth app programmatically.
 Cypress.Commands.add('loginOAuth', credentials => {
@@ -172,22 +171,4 @@ Cypress.Commands.add('findWarningByLabelText', label => {
 // Helper function to select field description.
 Cypress.Commands.add('findDescriptionByLabelText', label => {
   return getFieldDescriptorByLabel(label)
-})
-
-// Helper function to get stack configuration object.
-Cypress.Commands.add('stackConfiguration', () => {
-  return cy.window().its('__ttn_config__')
-})
-
-// Change default behavior of `cy.title` to include title related entries from the stack configuration.
-Cypress.Commands.overwrite('title', original => {
-  return cy.stackConfiguration().then(config => {
-    return original().then(title => ({
-      title: title,
-      config: {
-        siteName: getSiteName(config),
-        siteTitle: getSiteTitle(config),
-      },
-    }))
-  })
 })

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -67,32 +67,10 @@ const disableGatewayServer = config => {
   })
 }
 
-/**
- * Returns the site title.
- *
- * @param {object} config - The stack configuration object.
- * @returns {string} - The site title.
- */
-const getSiteTitle = config => {
-  return config.SITE_TITLE
-}
-
-/**
- * Returns the site name.
- *
- * @param {object} config - The stack configuration object.
- * @returns {string} - The site name.
- */
-const getSiteName = config => {
-  return config.SITE_NAME
-}
-
 export {
   disableIdentityServer,
   disableNetworkServer,
   disableApplicationServer,
   disableJoinServer,
   disableGatewayServer,
-  getSiteName,
-  getSiteTitle,
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Currently, title assertions result in unexpected test fails. 

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove title assertions


#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I tried:
1. Increasing timeouts
2. Using native `cy.title`
3. Hardcoding title values without using the stack configuration

All 3 suffer from unexpected failures when asserting the page title. Most probably it is related to `react-helmet` or the way we use it via `IntlHelmet`. I will look into how this can be fixed, but for now I suggest to remove title assertions altogether.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
