### PR TITLE
Improve prop structure for portalled modal

### DIFF
--- a/pkg/webui/components/button/modal-button/index.js
+++ b/pkg/webui/components/button/modal-button/index.js
@@ -74,7 +74,7 @@ class ModalButton extends React.Component {
 
     return (
       <React.Fragment>
-        <PortalledModal visible={this.state.modalVisible} modal={modalComposedData} />
+        <PortalledModal visible={this.state.modalVisible} {...modalComposedData} />
         <Button onClick={this.handleClick} message={message} {...rest} />
       </React.Fragment>
     )

--- a/pkg/webui/components/modal/portalled/index.js
+++ b/pkg/webui/components/modal/portalled/index.js
@@ -28,27 +28,18 @@ import Modal from '..'
  *
  * @returns {object} - The modal rendered into a portal.
  */
-const PortalledModal = function({ modal, visible, ...rest }) {
-  if (!modal) {
-    return null
-  }
-
-  const props = { ...rest, ...modal }
-
-  return DOM.createPortal(
-    visible && <Modal {...props} />,
-    document.getElementById('modal-container'),
-  )
-}
+const PortalledModal = ({ visible, ...modalProps }) =>
+  DOM.createPortal(visible && <Modal {...modalProps} />, document.getElementById('modal-container'))
 
 PortalledModal.Modal = Modal
 
 PortalledModal.propTypes = {
-  modal: PropTypes.shape({ ...Modal.propTypes }),
+  ...Modal.propTypes,
   visible: PropTypes.bool,
 }
 
 PortalledModal.defaultProps = {
+  ...Modal.defaultProps,
   visible: false,
 }
 

--- a/pkg/webui/components/prompt/index.js
+++ b/pkg/webui/components/prompt/index.js
@@ -74,7 +74,7 @@ const Prompt = props => {
   return (
     <>
       <RouterPrompt when={when} message={handlePromptTrigger} />
-      <PortalledModal visible={showModal} approval onComplete={handleModalComplete} modal={modal}>
+      <PortalledModal visible={showModal} {...modal} approval onComplete={handleModalComplete}>
         {children}
       </PortalledModal>
     </>

--- a/pkg/webui/console/components/api-key-modal/index.js
+++ b/pkg/webui/console/components/api-key-modal/index.js
@@ -46,13 +46,11 @@ const ApiKeyModal = function(props) {
   return (
     <PortalledModal
       visible={visible}
-      modal={{
-        ...rest,
-        title: m.title,
-        subtitle: m.subtitle,
-        approval: false,
-        buttonMessage: m.buttonMessage,
-      }}
+      {...rest}
+      title={m.title}
+      subtitle={m.subtitle}
+      approval={false}
+      buttonMessage={m.buttonMessage}
     >
       <div className={style.left}>
         <Message component="h4" content={m.grantedRights} />


### PR DESCRIPTION
#### Summary
This quickfix PR improves the prop structure of the `<PortalledModal />`-component.

#### Changes
- Spread the modal props over to the `<Modal />`-component
- Refactor places where `<PortalledModal />` is used


#### Testing
Manual.

##### Regressions

This could break
- API Key Modal
- Modal Button component
- Route change prompt

#### Notes for Reviewers
Extracted this refactor from my branch for #2649 and #2658 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
