### PR TITLE
Update CODEOWNERS for cypress tests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,6 +15,7 @@
 /Makefile @htdvisser @rvolosatovs @johanstokking
 /tools @htdvisser @rvolosatovs @johanstokking
 /.github/workflows @htdvisser @rvolosatovs @johanstokking
+/cypress @bafonins @kschiffer
 
 # API, configuration, CLI and storage compatibility
 /api @johanstokking @htdvisser @rvolosatovs


### PR DESCRIPTION
#### Summary
Add @bafonins and me as codeowners for `/cypress`

#### Changes
- Add @bafonins and me as codeowners for `/cypress`
