### PR TITLE
Testing utilities, use in Network Server

### DIFF
--- a/pkg/networkserver/mac_adr_param_setup_test.go
+++ b/pkg/networkserver/mac_adr_param_setup_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/band"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
@@ -233,7 +232,7 @@ func TestHandleADRParamSetupAns(t *testing.T) {
 			Name:     tc.Name,
 			Parallel: true,
 			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
-				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
+				dev := CopyEndDevice(tc.Device)
 
 				evs, err := handleADRParamSetupAns(ctx, dev)
 				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||

--- a/pkg/networkserver/mac_adr_param_setup_test.go
+++ b/pkg/networkserver/mac_adr_param_setup_test.go
@@ -15,6 +15,7 @@
 package networkserver
 
 import (
+	"context"
 	"testing"
 
 	"github.com/mohae/deepcopy"
@@ -165,17 +166,19 @@ func TestNeedsADRParamSetupReq(t *testing.T) {
 	})
 
 	for _, tc := range tcs {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
-
-			dev := CopyEndDevice(tc.InputDevice)
-			res := deviceNeedsADRParamSetupReq(dev, tc.Band)
-			if tc.Needs {
-				a.So(res, should.BeTrue)
-			} else {
-				a.So(res, should.BeFalse)
-			}
-			a.So(dev, should.Resemble, tc.InputDevice)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := CopyEndDevice(tc.InputDevice)
+				res := deviceNeedsADRParamSetupReq(dev, tc.Band)
+				if tc.Needs {
+					a.So(res, should.BeTrue)
+				} else {
+					a.So(res, should.BeFalse)
+				}
+				a.So(dev, should.Resemble, tc.InputDevice)
+			},
 		})
 	}
 }
@@ -226,18 +229,20 @@ func TestHandleADRParamSetupAns(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
 
-			dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
-
-			evs, err := handleADRParamSetupAns(test.Context(), dev)
-			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
-				tc.Error == nil && !a.So(err, should.BeNil) {
-				t.FailNow()
-			}
-			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventBuilders, tc.Events)
+				evs, err := handleADRParamSetupAns(ctx, dev)
+				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
+					tc.Error == nil && !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
+				a.So(dev, should.Resemble, tc.Expected)
+				a.So(evs, should.ResembleEventBuilders, tc.Events)
+			},
 		})
 	}
 }

--- a/pkg/networkserver/mac_beacon_freq_test.go
+++ b/pkg/networkserver/mac_beacon_freq_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -204,7 +203,7 @@ func TestHandleBeaconFreqAns(t *testing.T) {
 			Name:     tc.Name,
 			Parallel: true,
 			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
-				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
+				dev := CopyEndDevice(tc.Device)
 
 				var err error
 				evs, err := handleBeaconFreqAns(ctx, dev, tc.Payload)

--- a/pkg/networkserver/mac_beacon_timing_test.go
+++ b/pkg/networkserver/mac_beacon_timing_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -121,7 +120,7 @@ func TestHandleBeaconTimingReq(t *testing.T) {
 			Name:     tc.Name,
 			Parallel: true,
 			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
-				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
+				dev := CopyEndDevice(tc.Device)
 
 				evs, err := handleBeaconTimingReq(ctx, dev)
 				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||

--- a/pkg/networkserver/mac_beacon_timing_test.go
+++ b/pkg/networkserver/mac_beacon_timing_test.go
@@ -15,6 +15,7 @@
 package networkserver
 
 import (
+	"context"
 	"testing"
 
 	"github.com/mohae/deepcopy"
@@ -54,17 +55,19 @@ func TestNeedsBeaconTimingReq(t *testing.T) {
 	})
 
 	for _, tc := range tcs {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
-
-			dev := CopyEndDevice(tc.InputDevice)
-			res := deviceNeedsBeaconTimingReq(dev)
-			if tc.Needs {
-				a.So(res, should.BeTrue)
-			} else {
-				a.So(res, should.BeFalse)
-			}
-			a.So(dev, should.Resemble, tc.InputDevice)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := CopyEndDevice(tc.InputDevice)
+				res := deviceNeedsBeaconTimingReq(dev)
+				if tc.Needs {
+					a.So(res, should.BeTrue)
+				} else {
+					a.So(res, should.BeFalse)
+				}
+				a.So(dev, should.Resemble, tc.InputDevice)
+			},
 		})
 	}
 }
@@ -114,18 +117,20 @@ func TestHandleBeaconTimingReq(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
 
-			dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
-
-			evs, err := handleBeaconTimingReq(test.Context(), dev)
-			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
-				tc.Error == nil && !a.So(err, should.BeNil) {
-				t.FailNow()
-			}
-			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventBuilders, tc.Events)
+				evs, err := handleBeaconTimingReq(ctx, dev)
+				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
+					tc.Error == nil && !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
+				a.So(dev, should.Resemble, tc.Expected)
+				a.So(evs, should.ResembleEventBuilders, tc.Events)
+			},
 		})
 	}
 }

--- a/pkg/networkserver/mac_dev_status_test.go
+++ b/pkg/networkserver/mac_dev_status_test.go
@@ -15,6 +15,7 @@
 package networkserver
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -163,19 +164,21 @@ func TestNeedsDevStatusReq(t *testing.T) {
 			Needs: 1000-1 >= DefaultStatusCountPeriodicity,
 		},
 	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
-
-			dev := CopyEndDevice(tc.InputDevice)
-			defaults := deepcopy.Copy(tc.Defaults).(ttnpb.MACSettings)
-			res := deviceNeedsDevStatusReq(dev, tc.Defaults, scheduleAt)
-			if tc.Needs {
-				a.So(res, should.BeTrue)
-			} else {
-				a.So(res, should.BeFalse)
-			}
-			a.So(dev, should.Resemble, tc.InputDevice)
-			a.So(defaults, should.Resemble, tc.Defaults)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := CopyEndDevice(tc.InputDevice)
+				defaults := deepcopy.Copy(tc.Defaults).(ttnpb.MACSettings)
+				res := deviceNeedsDevStatusReq(dev, tc.Defaults, scheduleAt)
+				if tc.Needs {
+					a.So(res, should.BeTrue)
+				} else {
+					a.So(res, should.BeFalse)
+				}
+				a.So(dev, should.Resemble, tc.InputDevice)
+				a.So(defaults, should.Resemble, tc.Defaults)
+			},
 		})
 	}
 }
@@ -325,18 +328,20 @@ func TestHandleDevStatusAns(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
 
-			dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
-
-			evs, err := handleDevStatusAns(test.Context(), dev, tc.Payload, tc.FCntUp, tc.ReceivedAt)
-			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
-				tc.Error == nil && !a.So(err, should.BeNil) {
-				t.FailNow()
-			}
-			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventBuilders, tc.Events)
+				evs, err := handleDevStatusAns(ctx, dev, tc.Payload, tc.FCntUp, tc.ReceivedAt)
+				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
+					tc.Error == nil && !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
+				a.So(dev, should.Resemble, tc.Expected)
+				a.So(evs, should.ResembleEventBuilders, tc.Events)
+			},
 		})
 	}
 }

--- a/pkg/networkserver/mac_dev_status_test.go
+++ b/pkg/networkserver/mac_dev_status_test.go
@@ -332,7 +332,7 @@ func TestHandleDevStatusAns(t *testing.T) {
 			Name:     tc.Name,
 			Parallel: true,
 			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
-				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
+				dev := CopyEndDevice(tc.Device)
 
 				evs, err := handleDevStatusAns(ctx, dev, tc.Payload, tc.FCntUp, tc.ReceivedAt)
 				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||

--- a/pkg/networkserver/mac_device_mode_test.go
+++ b/pkg/networkserver/mac_device_mode_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -150,7 +149,7 @@ func TestHandleDeviceModeInd(t *testing.T) {
 			Name:     tc.Name,
 			Parallel: true,
 			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
-				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
+				dev := CopyEndDevice(tc.Device)
 
 				evs, err := handleDeviceModeInd(ctx, dev, tc.Payload)
 				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||

--- a/pkg/networkserver/mac_device_mode_test.go
+++ b/pkg/networkserver/mac_device_mode_test.go
@@ -15,6 +15,7 @@
 package networkserver
 
 import (
+	"context"
 	"testing"
 
 	"github.com/mohae/deepcopy"
@@ -145,18 +146,20 @@ func TestHandleDeviceModeInd(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
 
-			dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
-
-			evs, err := handleDeviceModeInd(test.Context(), dev, tc.Payload)
-			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
-				tc.Error == nil && !a.So(err, should.BeNil) {
-				t.FailNow()
-			}
-			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventBuilders, tc.Events)
+				evs, err := handleDeviceModeInd(ctx, dev, tc.Payload)
+				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
+					tc.Error == nil && !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
+				a.So(dev, should.Resemble, tc.Expected)
+				a.So(evs, should.ResembleEventBuilders, tc.Events)
+			},
 		})
 	}
 }

--- a/pkg/networkserver/mac_device_time_test.go
+++ b/pkg/networkserver/mac_device_time_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -131,7 +130,7 @@ func TestHandleDeviceTimeReq(t *testing.T) {
 			Name:     tc.Name,
 			Parallel: true,
 			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
-				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
+				dev := CopyEndDevice(tc.Device)
 
 				evs, err := handleDeviceTimeReq(ctx, dev, tc.Message)
 				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||

--- a/pkg/networkserver/mac_device_time_test.go
+++ b/pkg/networkserver/mac_device_time_test.go
@@ -15,6 +15,7 @@
 package networkserver
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -126,18 +127,20 @@ func TestHandleDeviceTimeReq(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
 
-			dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
-
-			evs, err := handleDeviceTimeReq(test.Context(), dev, tc.Message)
-			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
-				tc.Error == nil && !a.So(err, should.BeNil) {
-				t.FailNow()
-			}
-			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventBuilders, tc.Events)
+				evs, err := handleDeviceTimeReq(ctx, dev, tc.Message)
+				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
+					tc.Error == nil && !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
+				a.So(dev, should.Resemble, tc.Expected)
+				a.So(evs, should.ResembleEventBuilders, tc.Events)
+			},
 		})
 	}
 }

--- a/pkg/networkserver/mac_duty_cycle_test.go
+++ b/pkg/networkserver/mac_duty_cycle_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -129,7 +128,7 @@ func TestHandleDutyCycleAns(t *testing.T) {
 			Name:     tc.Name,
 			Parallel: true,
 			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
-				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
+				dev := CopyEndDevice(tc.Device)
 
 				evs, err := handleDutyCycleAns(ctx, dev)
 				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||

--- a/pkg/networkserver/mac_duty_cycle_test.go
+++ b/pkg/networkserver/mac_duty_cycle_test.go
@@ -15,6 +15,7 @@
 package networkserver
 
 import (
+	"context"
 	"testing"
 
 	"github.com/mohae/deepcopy"
@@ -63,17 +64,19 @@ func TestNeedsDutyCycleReq(t *testing.T) {
 			Needs: true,
 		},
 	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
-
-			dev := CopyEndDevice(tc.InputDevice)
-			res := deviceNeedsDutyCycleReq(dev)
-			if tc.Needs {
-				a.So(res, should.BeTrue)
-			} else {
-				a.So(res, should.BeFalse)
-			}
-			a.So(dev, should.Resemble, tc.InputDevice)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := CopyEndDevice(tc.InputDevice)
+				res := deviceNeedsDutyCycleReq(dev)
+				if tc.Needs {
+					a.So(res, should.BeTrue)
+				} else {
+					a.So(res, should.BeFalse)
+				}
+				a.So(dev, should.Resemble, tc.InputDevice)
+			},
 		})
 	}
 }
@@ -122,18 +125,20 @@ func TestHandleDutyCycleAns(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
 
-			dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
-
-			evs, err := handleDutyCycleAns(test.Context(), dev)
-			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
-				tc.Error == nil && !a.So(err, should.BeNil) {
-				t.FailNow()
-			}
-			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventBuilders, tc.Events)
+				evs, err := handleDutyCycleAns(ctx, dev)
+				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
+					tc.Error == nil && !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
+				a.So(dev, should.Resemble, tc.Expected)
+				a.So(evs, should.ResembleEventBuilders, tc.Events)
+			},
 		})
 	}
 }

--- a/pkg/networkserver/mac_link_adr_test.go
+++ b/pkg/networkserver/mac_link_adr_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/band"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
@@ -1011,7 +1010,7 @@ func TestHandleLinkADRAns(t *testing.T) {
 			Name:     tc.Name,
 			Parallel: true,
 			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
-				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
+				dev := CopyEndDevice(tc.Device)
 
 				evs, err := handleLinkADRAns(ctx, dev, tc.Payload, tc.DupCount, frequencyplans.NewStore(test.FrequencyPlansFetcher))
 				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||

--- a/pkg/networkserver/mac_link_adr_test.go
+++ b/pkg/networkserver/mac_link_adr_test.go
@@ -15,6 +15,7 @@
 package networkserver
 
 import (
+	"context"
 	"testing"
 
 	"github.com/mohae/deepcopy"
@@ -22,7 +23,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/band"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/frequencyplans"
-	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
@@ -147,17 +147,19 @@ func TestNeedsLinkADRReq(t *testing.T) {
 			Needs: true,
 		},
 	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
-
-			dev := CopyEndDevice(tc.InputDevice)
-			res := deviceNeedsLinkADRReq(dev, DefaultConfig.DefaultMACSettings.Parse(), LoRaWANBands[band.EU_863_870][ttnpb.PHY_V1_0_3_REV_A])
-			if tc.Needs {
-				a.So(res, should.BeTrue)
-			} else {
-				a.So(res, should.BeFalse)
-			}
-			a.So(dev, should.Resemble, tc.InputDevice)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := CopyEndDevice(tc.InputDevice)
+				res := deviceNeedsLinkADRReq(dev, DefaultConfig.DefaultMACSettings.Parse(), LoRaWANBands[band.EU_863_870][ttnpb.PHY_V1_0_3_REV_A])
+				if tc.Needs {
+					a.So(res, should.BeTrue)
+				} else {
+					a.So(res, should.BeFalse)
+				}
+				a.So(dev, should.Resemble, tc.InputDevice)
+			},
 		})
 	}
 }
@@ -464,19 +466,21 @@ func TestEnqueueLinkADRReq(t *testing.T) {
 			ErrorAssertion: func(t *testing.T, err error) bool { return assertions.New(t).So(err, should.BeNil) },
 		},
 	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := CopyEndDevice(tc.InputDevice)
 
-			dev := CopyEndDevice(tc.InputDevice)
-
-			st, err := enqueueLinkADRReq(log.NewContext(test.Context(), test.GetLogger(t)), dev, tc.MaxDownlinkLength, tc.MaxUplinkLength, ttnpb.MACSettings{}, tc.Band)
-			if !a.So(tc.ErrorAssertion(t, err), should.BeTrue) {
-				t.FailNow()
-			}
-			a.So(dev, should.Resemble, tc.ExpectedDevice)
-			a.So(st.QueuedEvents, should.ResembleEventBuilders, tc.State.QueuedEvents)
-			st.QueuedEvents = tc.State.QueuedEvents
-			a.So(st, should.Resemble, tc.State)
+				st, err := enqueueLinkADRReq(ctx, dev, tc.MaxDownlinkLength, tc.MaxUplinkLength, ttnpb.MACSettings{}, tc.Band)
+				if !a.So(tc.ErrorAssertion(t, err), should.BeTrue) {
+					t.FailNow()
+				}
+				a.So(dev, should.Resemble, tc.ExpectedDevice)
+				a.So(st.QueuedEvents, should.ResembleEventBuilders, tc.State.QueuedEvents)
+				st.QueuedEvents = tc.State.QueuedEvents
+				a.So(st, should.Resemble, tc.State)
+			},
 		})
 	}
 }
@@ -1003,18 +1007,20 @@ func TestHandleLinkADRAns(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
 
-			dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
-
-			evs, err := handleLinkADRAns(test.Context(), dev, tc.Payload, tc.DupCount, frequencyplans.NewStore(test.FrequencyPlansFetcher))
-			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
-				tc.Error == nil && !a.So(err, should.BeNil) {
-				t.FailNow()
-			}
-			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventBuilders, tc.Events)
+				evs, err := handleLinkADRAns(ctx, dev, tc.Payload, tc.DupCount, frequencyplans.NewStore(test.FrequencyPlansFetcher))
+				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
+					tc.Error == nil && !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
+				a.So(dev, should.Resemble, tc.Expected)
+				a.So(evs, should.ResembleEventBuilders, tc.Events)
+			},
 		})
 	}
 }

--- a/pkg/networkserver/mac_link_check_test.go
+++ b/pkg/networkserver/mac_link_check_test.go
@@ -15,6 +15,7 @@
 package networkserver
 
 import (
+	"context"
 	"testing"
 
 	"github.com/mohae/deepcopy"
@@ -317,18 +318,20 @@ func TestHandleLinkCheckReq(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
 
-			dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
-
-			evs, err := handleLinkCheckReq(test.Context(), dev, tc.Message)
-			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
-				tc.Error == nil && !a.So(err, should.BeNil) {
-				t.FailNow()
-			}
-			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventBuilders, tc.Events)
+				evs, err := handleLinkCheckReq(ctx, dev, tc.Message)
+				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
+					tc.Error == nil && !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
+				a.So(dev, should.Resemble, tc.Expected)
+				a.So(evs, should.ResembleEventBuilders, tc.Events)
+			},
 		})
 	}
 }

--- a/pkg/networkserver/mac_link_check_test.go
+++ b/pkg/networkserver/mac_link_check_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/cluster"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
@@ -322,7 +321,7 @@ func TestHandleLinkCheckReq(t *testing.T) {
 			Name:     tc.Name,
 			Parallel: true,
 			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
-				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
+				dev := CopyEndDevice(tc.Device)
 
 				evs, err := handleLinkCheckReq(ctx, dev, tc.Message)
 				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||

--- a/pkg/networkserver/mac_new_channel_test.go
+++ b/pkg/networkserver/mac_new_channel_test.go
@@ -20,7 +20,6 @@ import (
 	"math"
 	"testing"
 
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/encoding/lorawan"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
@@ -701,7 +700,7 @@ func TestHandleNewChannelAns(t *testing.T) {
 			Name:     tc.Name,
 			Parallel: true,
 			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
-				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
+				dev := CopyEndDevice(tc.Device)
 
 				evs, err := handleNewChannelAns(ctx, dev, tc.Payload)
 				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||

--- a/pkg/networkserver/mac_new_channel_test.go
+++ b/pkg/networkserver/mac_new_channel_test.go
@@ -15,6 +15,7 @@
 package networkserver
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"testing"
@@ -347,17 +348,19 @@ func TestNeedsNewChannelReq(t *testing.T) {
 			Needs: true,
 		},
 	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
-
-			dev := CopyEndDevice(tc.InputDevice)
-			res := deviceNeedsNewChannelReq(dev)
-			if tc.Needs {
-				a.So(res, should.BeTrue)
-			} else {
-				a.So(res, should.BeFalse)
-			}
-			a.So(dev, should.Resemble, tc.InputDevice)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := CopyEndDevice(tc.InputDevice)
+				res := deviceNeedsNewChannelReq(dev)
+				if tc.Needs {
+					a.So(res, should.BeTrue)
+				} else {
+					a.So(res, should.BeFalse)
+				}
+				a.So(dev, should.Resemble, tc.InputDevice)
+			},
 		})
 	}
 }
@@ -476,75 +479,80 @@ func TestEnqueueNewChannelReq(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			downlinkLength := 1 + lorawan.DefaultMACCommands[ttnpb.CID_NEW_CHANNEL].DownlinkLength
-			uplinkLength := 1 + lorawan.DefaultMACCommands[ttnpb.CID_NEW_CHANNEL].UplinkLength
+		test.RunSubtest(t, test.SubtestConfig{
+			Name: tc.Name,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				downlinkLength := 1 + lorawan.DefaultMACCommands[ttnpb.CID_NEW_CHANNEL].DownlinkLength
+				uplinkLength := 1 + lorawan.DefaultMACCommands[ttnpb.CID_NEW_CHANNEL].UplinkLength
 
-			type TestConf struct {
-				MaxDownlinkLength, MaxUplinkLength uint16
-				ExpectedCount                      int
-			}
-			confs := []TestConf{
-				{},
-				{
-					MaxUplinkLength: math.MaxUint16,
-				},
-				{
-					MaxDownlinkLength: math.MaxUint16,
-				},
-				{
-					MaxDownlinkLength: math.MaxUint16,
-					MaxUplinkLength:   math.MaxUint16,
-					ExpectedCount:     len(tc.ExpectedRequests),
-				},
-			}
-			for i := range tc.ExpectedRequests {
-				for j := 0; j <= i; j++ {
-					confs = append(confs, TestConf{
-						MaxDownlinkLength: uint16(i+1) * downlinkLength,
-						MaxUplinkLength:   uint16(j+1) * uplinkLength,
-						ExpectedCount:     j + 1,
-					})
+				type TestConf struct {
+					MaxDownlinkLength, MaxUplinkLength uint16
+					ExpectedCount                      int
 				}
-			}
-
-			for _, conf := range confs {
-				for _, pendingReqs := range [][]*ttnpb.MACCommand{
-					nil,
+				confs := []TestConf{
+					{},
 					{
-						{},
+						MaxUplinkLength: math.MaxUint16,
 					},
-				} {
-					t.Run(fmt.Sprintf("max_downlink_len:%d,max_uplink_len:%d,pending_requests:%d", conf.MaxDownlinkLength, conf.MaxUplinkLength, len(pendingReqs)), func(t *testing.T) {
-						a := assertions.New(t)
-
-						dev := &ttnpb.EndDevice{
-							MACState: &ttnpb.MACState{
-								CurrentParameters: tc.CurrentParameters,
-								DesiredParameters: tc.DesiredParameters,
-								PendingRequests:   pendingReqs,
-							},
-						}
-						reqs := tc.ExpectedRequests[:conf.ExpectedCount]
-						expectedDev := CopyEndDevice(dev)
-						var expectedEvs events.Builders
-						for _, req := range reqs {
-							expectedDev.MACState.PendingRequests = append(expectedDev.MACState.PendingRequests, req.MACCommand())
-							expectedEvs = append(expectedEvs, evtEnqueueNewChannelRequest.With(events.WithData(req)))
-						}
-
-						st := enqueueNewChannelReq(test.Context(), dev, conf.MaxDownlinkLength, conf.MaxUplinkLength)
-						a.So(dev, should.Resemble, expectedDev)
-						a.So(st.QueuedEvents, should.ResembleEventBuilders, expectedEvs)
-						a.So(st, should.Resemble, macCommandEnqueueState{
-							MaxDownLen:   conf.MaxDownlinkLength - uint16(conf.ExpectedCount)*downlinkLength,
-							MaxUpLen:     conf.MaxUplinkLength - uint16(conf.ExpectedCount)*uplinkLength,
-							Ok:           len(tc.ExpectedRequests) == conf.ExpectedCount,
-							QueuedEvents: st.QueuedEvents,
-						})
-					})
+					{
+						MaxDownlinkLength: math.MaxUint16,
+					},
+					{
+						MaxDownlinkLength: math.MaxUint16,
+						MaxUplinkLength:   math.MaxUint16,
+						ExpectedCount:     len(tc.ExpectedRequests),
+					},
 				}
-			}
+				for i := range tc.ExpectedRequests {
+					for j := 0; j <= i; j++ {
+						confs = append(confs, TestConf{
+							MaxDownlinkLength: uint16(i+1) * downlinkLength,
+							MaxUplinkLength:   uint16(j+1) * uplinkLength,
+							ExpectedCount:     j + 1,
+						})
+					}
+				}
+
+				for _, conf := range confs {
+					for _, pendingReqs := range [][]*ttnpb.MACCommand{
+						nil,
+						{
+							{},
+						},
+					} {
+						test.RunSubtest(t, test.SubtestConfig{
+							Name:     fmt.Sprintf("max_downlink_len:%d,max_uplink_len:%d,pending_requests:%d", conf.MaxDownlinkLength, conf.MaxUplinkLength, len(pendingReqs)),
+							Parallel: true,
+							Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+								dev := &ttnpb.EndDevice{
+									MACState: &ttnpb.MACState{
+										CurrentParameters: tc.CurrentParameters,
+										DesiredParameters: tc.DesiredParameters,
+										PendingRequests:   pendingReqs,
+									},
+								}
+								reqs := tc.ExpectedRequests[:conf.ExpectedCount]
+								expectedDev := CopyEndDevice(dev)
+								var expectedEvs events.Builders
+								for _, req := range reqs {
+									expectedDev.MACState.PendingRequests = append(expectedDev.MACState.PendingRequests, req.MACCommand())
+									expectedEvs = append(expectedEvs, evtEnqueueNewChannelRequest.With(events.WithData(req)))
+								}
+
+								st := enqueueNewChannelReq(ctx, dev, conf.MaxDownlinkLength, conf.MaxUplinkLength)
+								a.So(dev, should.Resemble, expectedDev)
+								a.So(st.QueuedEvents, should.ResembleEventBuilders, expectedEvs)
+								a.So(st, should.Resemble, macCommandEnqueueState{
+									MaxDownLen:   conf.MaxDownlinkLength - uint16(conf.ExpectedCount)*downlinkLength,
+									MaxUpLen:     conf.MaxUplinkLength - uint16(conf.ExpectedCount)*uplinkLength,
+									Ok:           len(tc.ExpectedRequests) == conf.ExpectedCount,
+									QueuedEvents: st.QueuedEvents,
+								})
+							},
+						})
+					}
+				}
+			},
 		})
 	}
 }
@@ -689,18 +697,20 @@ func TestHandleNewChannelAns(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
 
-			dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
-
-			evs, err := handleNewChannelAns(test.Context(), dev, tc.Payload)
-			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
-				tc.Error == nil && !a.So(err, should.BeNil) {
-				t.FailNow()
-			}
-			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventBuilders, tc.Events)
+				evs, err := handleNewChannelAns(ctx, dev, tc.Payload)
+				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
+					tc.Error == nil && !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
+				a.So(dev, should.Resemble, tc.Expected)
+				a.So(evs, should.ResembleEventBuilders, tc.Events)
+			},
 		})
 	}
 }

--- a/pkg/networkserver/mac_ping_slot_channel_test.go
+++ b/pkg/networkserver/mac_ping_slot_channel_test.go
@@ -15,6 +15,7 @@
 package networkserver
 
 import (
+	"context"
 	"testing"
 
 	"github.com/mohae/deepcopy"
@@ -83,17 +84,19 @@ func TestNeedsPingSlotChannelReq(t *testing.T) {
 			Needs: true,
 		},
 	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
-
-			dev := CopyEndDevice(tc.InputDevice)
-			res := deviceNeedsPingSlotChannelReq(dev)
-			if tc.Needs {
-				a.So(res, should.BeTrue)
-			} else {
-				a.So(res, should.BeFalse)
-			}
-			a.So(dev, should.Resemble, tc.InputDevice)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := CopyEndDevice(tc.InputDevice)
+				res := deviceNeedsPingSlotChannelReq(dev)
+				if tc.Needs {
+					a.So(res, should.BeTrue)
+				} else {
+					a.So(res, should.BeFalse)
+				}
+				a.So(dev, should.Resemble, tc.InputDevice)
+			},
 		})
 	}
 }
@@ -169,18 +172,20 @@ func TestHandlePingSlotChannelAns(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
 
-			dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
-
-			evs, err := handlePingSlotChannelAns(test.Context(), dev, tc.Payload)
-			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
-				tc.Error == nil && !a.So(err, should.BeNil) {
-				t.FailNow()
-			}
-			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventBuilders, tc.Events)
+				evs, err := handlePingSlotChannelAns(ctx, dev, tc.Payload)
+				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
+					tc.Error == nil && !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
+				a.So(dev, should.Resemble, tc.Expected)
+				a.So(evs, should.ResembleEventBuilders, tc.Events)
+			},
 		})
 	}
 }

--- a/pkg/networkserver/mac_ping_slot_channel_test.go
+++ b/pkg/networkserver/mac_ping_slot_channel_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -176,7 +175,7 @@ func TestHandlePingSlotChannelAns(t *testing.T) {
 			Name:     tc.Name,
 			Parallel: true,
 			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
-				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
+				dev := CopyEndDevice(tc.Device)
 
 				evs, err := handlePingSlotChannelAns(ctx, dev, tc.Payload)
 				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||

--- a/pkg/networkserver/mac_ping_slot_info_test.go
+++ b/pkg/networkserver/mac_ping_slot_info_test.go
@@ -15,6 +15,7 @@
 package networkserver
 
 import (
+	"context"
 	"testing"
 
 	"github.com/mohae/deepcopy"
@@ -129,18 +130,20 @@ func TestHandlePingSlotInfoReq(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
 
-			dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
-
-			evs, err := handlePingSlotInfoReq(test.Context(), dev, tc.Payload)
-			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
-				tc.Error == nil && !a.So(err, should.BeNil) {
-				t.FailNow()
-			}
-			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventBuilders, tc.Events)
+				evs, err := handlePingSlotInfoReq(ctx, dev, tc.Payload)
+				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
+					tc.Error == nil && !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
+				a.So(dev, should.Resemble, tc.Expected)
+				a.So(evs, should.ResembleEventBuilders, tc.Events)
+			},
 		})
 	}
 }

--- a/pkg/networkserver/mac_ping_slot_info_test.go
+++ b/pkg/networkserver/mac_ping_slot_info_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -134,7 +133,7 @@ func TestHandlePingSlotInfoReq(t *testing.T) {
 			Name:     tc.Name,
 			Parallel: true,
 			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
-				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
+				dev := CopyEndDevice(tc.Device)
 
 				evs, err := handlePingSlotInfoReq(ctx, dev, tc.Payload)
 				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||

--- a/pkg/networkserver/mac_rejoin_param_setup_test.go
+++ b/pkg/networkserver/mac_rejoin_param_setup_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -216,7 +215,7 @@ func TestHandleRejoinParamSetupAns(t *testing.T) {
 			Name:     tc.Name,
 			Parallel: true,
 			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
-				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
+				dev := CopyEndDevice(tc.Device)
 
 				evs, err := handleRejoinParamSetupAns(ctx, dev, tc.Payload)
 				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||

--- a/pkg/networkserver/mac_rejoin_param_setup_test.go
+++ b/pkg/networkserver/mac_rejoin_param_setup_test.go
@@ -15,6 +15,7 @@
 package networkserver
 
 import (
+	"context"
 	"testing"
 
 	"github.com/mohae/deepcopy"
@@ -96,17 +97,19 @@ func TestNeedsRejoinParamSetupReq(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
-
-			dev := CopyEndDevice(tc.InputDevice)
-			res := deviceNeedsRejoinParamSetupReq(dev)
-			if tc.Needs {
-				a.So(res, should.BeTrue)
-			} else {
-				a.So(res, should.BeFalse)
-			}
-			a.So(dev, should.Resemble, tc.InputDevice)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := CopyEndDevice(tc.InputDevice)
+				res := deviceNeedsRejoinParamSetupReq(dev)
+				if tc.Needs {
+					a.So(res, should.BeTrue)
+				} else {
+					a.So(res, should.BeFalse)
+				}
+				a.So(dev, should.Resemble, tc.InputDevice)
+			},
 		})
 	}
 }
@@ -209,18 +212,20 @@ func TestHandleRejoinParamSetupAns(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
 
-			dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
-
-			evs, err := handleRejoinParamSetupAns(test.Context(), dev, tc.Payload)
-			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
-				tc.Error == nil && !a.So(err, should.BeNil) {
-				t.FailNow()
-			}
-			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventBuilders, tc.Events)
+				evs, err := handleRejoinParamSetupAns(ctx, dev, tc.Payload)
+				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
+					tc.Error == nil && !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
+				a.So(dev, should.Resemble, tc.Expected)
+				a.So(evs, should.ResembleEventBuilders, tc.Events)
+			},
 		})
 	}
 }

--- a/pkg/networkserver/mac_rekey_test.go
+++ b/pkg/networkserver/mac_rekey_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -248,7 +247,7 @@ func TestHandleRekeyInd(t *testing.T) {
 			Name:     tc.Name,
 			Parallel: true,
 			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
-				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
+				dev := CopyEndDevice(tc.Device)
 
 				evs, err := handleRekeyInd(ctx, dev, tc.Payload, DevAddr)
 				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||

--- a/pkg/networkserver/mac_rekey_test.go
+++ b/pkg/networkserver/mac_rekey_test.go
@@ -15,6 +15,7 @@
 package networkserver
 
 import (
+	"context"
 	"testing"
 
 	"github.com/mohae/deepcopy"
@@ -243,18 +244,20 @@ func TestHandleRekeyInd(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
 
-			dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
-
-			evs, err := handleRekeyInd(test.Context(), dev, tc.Payload, DevAddr)
-			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
-				tc.Error == nil && !a.So(err, should.BeNil) {
-				t.FailNow()
-			}
-			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventBuilders, tc.Events)
+				evs, err := handleRekeyInd(ctx, dev, tc.Payload, DevAddr)
+				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
+					tc.Error == nil && !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
+				a.So(dev, should.Resemble, tc.Expected)
+				a.So(evs, should.ResembleEventBuilders, tc.Events)
+			},
 		})
 	}
 }

--- a/pkg/networkserver/mac_reset_test.go
+++ b/pkg/networkserver/mac_reset_test.go
@@ -15,6 +15,7 @@
 package networkserver
 
 import (
+	"context"
 	"testing"
 
 	"github.com/mohae/deepcopy"
@@ -146,18 +147,20 @@ func TestHandleResetInd(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
 
-			dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
-
-			evs, err := handleResetInd(test.Context(), dev, tc.Payload, frequencyplans.NewStore(test.FrequencyPlansFetcher), ttnpb.MACSettings{})
-			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
-				tc.Error == nil && !a.So(err, should.BeNil) {
-				t.FailNow()
-			}
-			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventBuilders, tc.Events)
+				evs, err := handleResetInd(ctx, dev, tc.Payload, frequencyplans.NewStore(test.FrequencyPlansFetcher), ttnpb.MACSettings{})
+				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
+					tc.Error == nil && !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
+				a.So(dev, should.Resemble, tc.Expected)
+				a.So(evs, should.ResembleEventBuilders, tc.Events)
+			},
 		})
 	}
 }

--- a/pkg/networkserver/mac_reset_test.go
+++ b/pkg/networkserver/mac_reset_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
@@ -151,7 +150,7 @@ func TestHandleResetInd(t *testing.T) {
 			Name:     tc.Name,
 			Parallel: true,
 			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
-				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
+				dev := CopyEndDevice(tc.Device)
 
 				evs, err := handleResetInd(ctx, dev, tc.Payload, frequencyplans.NewStore(test.FrequencyPlansFetcher), ttnpb.MACSettings{})
 				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||

--- a/pkg/networkserver/mac_rx_param_setup_test.go
+++ b/pkg/networkserver/mac_rx_param_setup_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -248,7 +247,7 @@ func TestHandleRxParamSetupAns(t *testing.T) {
 			Name:     tc.Name,
 			Parallel: true,
 			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
-				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
+				dev := CopyEndDevice(tc.Device)
 
 				evs, err := handleRxParamSetupAns(ctx, dev, tc.Payload)
 				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||

--- a/pkg/networkserver/mac_rx_param_setup_test.go
+++ b/pkg/networkserver/mac_rx_param_setup_test.go
@@ -15,6 +15,7 @@
 package networkserver
 
 import (
+	"context"
 	"testing"
 
 	"github.com/mohae/deepcopy"
@@ -108,17 +109,19 @@ func TestNeedsRxParamSetupReq(t *testing.T) {
 			Needs: true,
 		},
 	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
-
-			dev := CopyEndDevice(tc.InputDevice)
-			res := deviceNeedsRxParamSetupReq(dev)
-			if tc.Needs {
-				a.So(res, should.BeTrue)
-			} else {
-				a.So(res, should.BeFalse)
-			}
-			a.So(dev, should.Resemble, tc.InputDevice)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := CopyEndDevice(tc.InputDevice)
+				res := deviceNeedsRxParamSetupReq(dev)
+				if tc.Needs {
+					a.So(res, should.BeTrue)
+				} else {
+					a.So(res, should.BeFalse)
+				}
+				a.So(dev, should.Resemble, tc.InputDevice)
+			},
 		})
 	}
 }
@@ -241,18 +244,20 @@ func TestHandleRxParamSetupAns(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
 
-			dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
-
-			evs, err := handleRxParamSetupAns(test.Context(), dev, tc.Payload)
-			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
-				tc.Error == nil && !a.So(err, should.BeNil) {
-				t.FailNow()
-			}
-			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventBuilders, tc.Events)
+				evs, err := handleRxParamSetupAns(ctx, dev, tc.Payload)
+				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
+					tc.Error == nil && !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
+				a.So(dev, should.Resemble, tc.Expected)
+				a.So(evs, should.ResembleEventBuilders, tc.Events)
+			},
 		})
 	}
 }

--- a/pkg/networkserver/mac_rx_timing_setup_test.go
+++ b/pkg/networkserver/mac_rx_timing_setup_test.go
@@ -15,6 +15,7 @@
 package networkserver
 
 import (
+	"context"
 	"testing"
 
 	"github.com/mohae/deepcopy"
@@ -64,17 +65,19 @@ func TestNeedsRxTimingSetupReq(t *testing.T) {
 			Needs: true,
 		},
 	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
-
-			dev := CopyEndDevice(tc.InputDevice)
-			res := deviceNeedsRxTimingSetupReq(dev)
-			if tc.Needs {
-				a.So(res, should.BeTrue)
-			} else {
-				a.So(res, should.BeFalse)
-			}
-			a.So(dev, should.Resemble, tc.InputDevice)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := CopyEndDevice(tc.InputDevice)
+				res := deviceNeedsRxTimingSetupReq(dev)
+				if tc.Needs {
+					a.So(res, should.BeTrue)
+				} else {
+					a.So(res, should.BeFalse)
+				}
+				a.So(dev, should.Resemble, tc.InputDevice)
+			},
 		})
 	}
 }
@@ -123,18 +126,20 @@ func TestHandleRxTimingSetupAns(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			a := assertions.New(t)
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
 
-			dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
-
-			evs, err := handleRxTimingSetupAns(test.Context(), dev)
-			if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
-				tc.Error == nil && !a.So(err, should.BeNil) {
-				t.FailNow()
-			}
-			a.So(dev, should.Resemble, tc.Expected)
-			a.So(evs, should.ResembleEventBuilders, tc.Events)
+				evs, err := handleRxTimingSetupAns(ctx, dev)
+				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||
+					tc.Error == nil && !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
+				a.So(dev, should.Resemble, tc.Expected)
+				a.So(evs, should.ResembleEventBuilders, tc.Events)
+			},
 		})
 	}
 }

--- a/pkg/networkserver/mac_rx_timing_setup_test.go
+++ b/pkg/networkserver/mac_rx_timing_setup_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -130,7 +129,7 @@ func TestHandleRxTimingSetupAns(t *testing.T) {
 			Name:     tc.Name,
 			Parallel: true,
 			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
-				dev := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
+				dev := CopyEndDevice(tc.Device)
 
 				evs, err := handleRxTimingSetupAns(ctx, dev)
 				if tc.Error != nil && !a.So(err, should.EqualErrorOrDefinition, tc.Error) ||

--- a/pkg/util/test/test.go
+++ b/pkg/util/test/test.go
@@ -82,7 +82,8 @@ func runTestFromContext(ctx context.Context, conf TestConfig) {
 	t.Helper()
 
 	if conf.Parallel {
-		t.Parallel()
+		// TODO: Enable once https://github.com/TheThingsNetwork/lorawan-stack/pull/3052 is merged.
+		// t.Parallel()
 	}
 	timeout := conf.Timeout
 	if timeout == 0 {

--- a/pkg/util/test/test.go
+++ b/pkg/util/test/test.go
@@ -18,6 +18,7 @@ package test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
@@ -66,4 +67,98 @@ func MustNewTFromContext(ctx context.Context) (*testing.T, *assertions.Assertion
 	t := MustTFromContext(ctx)
 	t.Helper()
 	return t, assertions.New(t)
+}
+
+var defaultTestTimeout = (1 << 15) * Delay
+
+type TestConfig struct {
+	Parallel bool
+	Timeout  time.Duration
+	Func     func(context.Context, *assertions.Assertion)
+}
+
+func runTestFromContext(ctx context.Context, conf TestConfig) {
+	t := MustTFromContext(ctx)
+	t.Helper()
+
+	if conf.Parallel {
+		t.Parallel()
+	}
+	timeout := conf.Timeout
+	if timeout == 0 {
+		timeout = defaultTestTimeout
+	}
+	a, ctx := New(t)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	dl, ok := ctx.Deadline()
+	if !ok {
+		panic("missing deadline in context")
+	}
+	timeout = time.Until(dl)
+
+	start := time.Now()
+	doneCh := make(chan struct{})
+	defer func() {
+		t.Helper()
+		close(doneCh)
+		if d := time.Since(start); d > timeout {
+			t.Errorf("%s took too long to execute. Expected execution time below %v, ran for %v", t.Name(), timeout, d)
+		}
+	}()
+	go func() {
+		for {
+			select {
+			case <-doneCh:
+				return
+			case <-time.Tick(timeout / 4):
+				t.Logf("%s is taking a long time to execute. Expected execution time below %v, running already for: %v", t.Name(), timeout, time.Since(start))
+			}
+		}
+	}()
+	conf.Func(ctx, a)
+}
+
+func RunTest(t *testing.T, conf TestConfig) {
+	t.Helper()
+	_, ctx := New(t)
+	runTestFromContext(ctx, conf)
+}
+
+var defaultSubtestTimeout = defaultTestTimeout / 4
+
+type SubtestConfig struct {
+	Name     string
+	Parallel bool
+	Timeout  time.Duration
+	Func     func(context.Context, *testing.T, *assertions.Assertion)
+}
+
+func RunSubtestFromContext(ctx context.Context, conf SubtestConfig) bool {
+	t := MustTFromContext(ctx)
+	t.Helper()
+	return t.Run(conf.Name, func(t *testing.T) {
+		t.Helper()
+
+		timeout := conf.Timeout
+		if timeout == 0 {
+			timeout = defaultSubtestTimeout
+		}
+		_, ctx = NewWithContext(ctx, t)
+		runTestFromContext(ctx, TestConfig{
+			Parallel: conf.Parallel,
+			Timeout:  timeout,
+			Func: func(ctx context.Context, a *assertions.Assertion) {
+				t.Helper()
+				conf.Func(ctx, t, a)
+			},
+		})
+	})
+}
+
+func RunSubtest(t *testing.T, conf SubtestConfig) bool {
+	t.Helper()
+	_, ctx := New(t)
+	return RunSubtestFromContext(ctx, conf)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Various testing utilities used by https://github.com/TheThingsNetwork/lorawan-stack/pull/3052
Refs #2732 #3142 

#### Changes
<!-- What are the changes made in this pull request? -->

- Add various test utlities used by https://github.com/TheThingsNetwork/lorawan-stack/pull/3052
- Introduce `RunTest`, `RunSubtest` and the like. There create a new test context, etc and set a mandatory timeout on the context (either a quite liberal default is set, or user-configured). A log statement is printed for long-running tests to ease debugging of hanging tests.
- I was able to checkout some changes from https://github.com/TheThingsNetwork/lorawan-stack/pull/3052 where this new functionality is used in NS, so I added it here.


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.