### PR TITLE
Allow setting custom id to select components

### DIFF
--- a/pkg/webui/components/select/index.js
+++ b/pkg/webui/components/select/index.js
@@ -31,6 +31,7 @@ class Select extends React.PureComponent {
     className: PropTypes.string,
     disabled: PropTypes.bool,
     error: PropTypes.bool,
+    id: PropTypes.string,
     intl: PropTypes.shape({
       formatMessage: PropTypes.func,
     }).isRequired,
@@ -58,6 +59,7 @@ class Select extends React.PureComponent {
     error: false,
     warning: false,
     value: undefined,
+    id: undefined,
   }
 
   constructor(props) {
@@ -124,6 +126,7 @@ class Select extends React.PureComponent {
       error,
       warning,
       name,
+      id,
       ...rest
     } = this.props
 
@@ -144,6 +147,7 @@ class Select extends React.PureComponent {
     return (
       <ReactSelect
         className={cls}
+        inputId={id}
         classNamePrefix="select"
         value={getValue(translatedOptions, value)}
         options={translatedOptions}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/2605
Required for e2e tests in https://github.com/TheThingsNetwork/lorawan-stack/pull/3065

#### Changes
<!-- What are the changes made in this pull request? -->

- Add the `id` to the `<Select />` component


#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

By default `rect-select` sets its input `id` to `react-select-{n}-input`. In order to utilize the  `findByLabelText` function it should match the `for` attribute on the `label` element. This PR does exactly this. 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
