### PR TITLE
Fix byte input value change

### DIFF
--- a/pkg/webui/components/input/byte.js
+++ b/pkg/webui/components/input/byte.js
@@ -147,10 +147,28 @@ export default class ByteInput extends React.Component {
 
   @bind
   onChange(evt) {
+    const { max, showPerChar } = this.props
+    const { data } = evt.nativeEvent
+
+    let value = clean(event.target.value)
+    const normalizedMax = showPerChar ? Math.ceil(max / 2) : max
+
+    // Check if the value already has length equal to `max`.
+    const isValueMaxLength = value.length === normalizedMax * 2
+    // Check if the cursor is placed after the last placeholder chararcter.
+    const isCursorAfterMask = evt.target.selectionStart === normalizedMax * 3 - 1
+
+    if (!isValueMaxLength && isCursorAfterMask && data !== null) {
+      const hexMatch = data.match(hex)
+      if (hexMatch !== null) {
+        value += hexMatch[0]
+      }
+    }
+
     this.props.onChange({
       target: {
         name: evt.target.name,
-        value: clean(evt.target.value),
+        value,
       },
     })
   }

--- a/pkg/webui/console/containers/dev-addr-input/dev-addr-input.js
+++ b/pkg/webui/console/containers/dev-addr-input/dev-addr-input.js
@@ -26,6 +26,7 @@ const m = defineMessages({
 const DevAddrInput = props => {
   const {
     className,
+    id,
     name,
     onFocus,
     onChange,
@@ -65,6 +66,7 @@ const DevAddrInput = props => {
   return (
     <Input
       type="byte"
+      id={id}
       min={4}
       max={4}
       action={action}
@@ -91,6 +93,7 @@ DevAddrInput.propTypes = {
   generatedError: PropTypes.bool.isRequired,
   generatedLoading: PropTypes.bool.isRequired,
   generatedValue: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired,
   loading: PropTypes.bool,
   name: PropTypes.string.isRequired,
   onBlur: PropTypes.func.isRequired,

--- a/pkg/webui/console/containers/join-eui-prefixes-input/join-eui-prefixes-input.js
+++ b/pkg/webui/console/containers/join-eui-prefixes-input/join-eui-prefixes-input.js
@@ -141,6 +141,7 @@ class JoinEUIPrefixesInput extends React.PureComponent {
   render() {
     const {
       className,
+      id,
       name,
       description,
       disabled,
@@ -184,6 +185,7 @@ class JoinEUIPrefixesInput extends React.PureComponent {
         {selectComponent}
         <Input
           showPerChar
+          id={id}
           ref={this.inputRef}
           className={style.byte}
           value={inputValue}
@@ -218,6 +220,7 @@ JoinEUIPrefixesInput.propTypes = {
   disabled: PropTypes.bool,
   error: PropTypes.bool,
   fetching: PropTypes.bool,
+  id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   onBlur: PropTypes.func,
   onChange: PropTypes.func.isRequired,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/2605
Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/1336

#### Changes
<!-- What are the changes made in this pull request? -->

- Check for cursor position and explicitly process input character when cursor position is outside of the input mask.
- Add `id` prop to `<JoinEuiPrefixesInput />` component.
- Add `id` prop to `<DevAddrInput />` component.


#### Testing

<!-- How did you verify that this change works? -->

Tested byte input with various values for `min`, `max` and `showPerChar` props.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Byte input value handling

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

As mentioned in https://github.com/TheThingsNetwork/lorawan-stack/issues/1336 ignoring inputs when cursor is outside of the input mask is expected behavior of `react-text-mask`. However, this is blocking issue for using cypress `type()`.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
