### PR TITLE
Various Network Server utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Scheduling failure events are now emitted on unsuccessful scheduling attempts.
 - Default Javascript function signatures to `encodeDownlink()`, `decodeUplink()` and `decodeDownlink()`.
+- Default Class B timeout is increased from 1 minute to 10 minutes as was originally intended.
 
 ### Deprecated
 

--- a/pkg/networkserver/config.go
+++ b/pkg/networkserver/config.go
@@ -143,7 +143,7 @@ var DefaultConfig = Config{
 	DefaultMACSettings: MACSettingConfig{
 		ADRMargin:              func(v float32) *float32 { return &v }(DefaultADRMargin),
 		DesiredRx1Delay:        func(v ttnpb.RxDelay) *ttnpb.RxDelay { return &v }(ttnpb.RX_DELAY_5),
-		ClassBTimeout:          func(v time.Duration) *time.Duration { return &v }(time.Minute),
+		ClassBTimeout:          func(v time.Duration) *time.Duration { return &v }(DefaultClassBTimeout),
 		ClassCTimeout:          func(v time.Duration) *time.Duration { return &v }(DefaultClassCTimeout),
 		StatusTimePeriodicity:  func(v time.Duration) *time.Duration { return &v }(DefaultStatusTimePeriodicity),
 		StatusCountPeriodicity: func(v uint32) *uint32 { return &v }(DefaultStatusCountPeriodicity),

--- a/pkg/networkserver/observability.go
+++ b/pkg/networkserver/observability.go
@@ -274,7 +274,15 @@ var nsMetrics = &messageMetrics{
 			Help:      "Number of gateways that forwarded the uplink (within the deduplication window)",
 			Buckets:   []float64{1, 2, 3, 4, 5, 10, 20, 30, 40, 50},
 		},
-		[]string{},
+		nil,
+	),
+	micMismatches: metrics.NewContextualCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "mic_mismatch_total",
+			Help:      "Total number of MIC mismatches",
+		},
+		nil,
 	),
 
 	downlinkAttempted: metrics.NewContextualCounterVec(
@@ -306,6 +314,7 @@ type messageMetrics struct {
 	uplinkForwarded  *metrics.ContextualCounterVec
 	uplinkDropped    *metrics.ContextualCounterVec
 	uplinkGateways   *metrics.ContextualHistogramVec
+	micMismatches    *metrics.ContextualCounterVec
 
 	downlinkAttempted *metrics.ContextualCounterVec
 	downlinkForwarded *metrics.ContextualCounterVec
@@ -318,6 +327,7 @@ func (m messageMetrics) Describe(ch chan<- *prometheus.Desc) {
 	m.uplinkForwarded.Describe(ch)
 	m.uplinkDropped.Describe(ch)
 	m.uplinkGateways.Describe(ch)
+	m.micMismatches.Describe(ch)
 
 	m.downlinkAttempted.Describe(ch)
 	m.downlinkForwarded.Describe(ch)
@@ -330,6 +340,7 @@ func (m messageMetrics) Collect(ch chan<- prometheus.Metric) {
 	m.uplinkForwarded.Collect(ch)
 	m.uplinkDropped.Collect(ch)
 	m.uplinkGateways.Collect(ch)
+	m.micMismatches.Collect(ch)
 
 	m.downlinkAttempted.Collect(ch)
 	m.downlinkForwarded.Collect(ch)
@@ -374,6 +385,10 @@ func registerDropUplink(ctx context.Context, msg *ttnpb.UplinkMessage, err error
 func registerMergeMetadata(ctx context.Context, msg *ttnpb.UplinkMessage) {
 	gtwCount, _ := rxMetadataStats(ctx, msg.RxMetadata)
 	nsMetrics.uplinkGateways.WithLabelValues(ctx).Observe(float64(gtwCount))
+}
+
+func registerMICMismatch(ctx context.Context) {
+	nsMetrics.micMismatches.WithLabelValues(ctx).Inc()
 }
 
 var (

--- a/pkg/networkserver/observability.go
+++ b/pkg/networkserver/observability.go
@@ -276,6 +276,14 @@ var nsMetrics = &messageMetrics{
 		},
 		nil,
 	),
+	micComputations: metrics.NewContextualCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "mic_compute_total",
+			Help:      "Total number of MIC computations",
+		},
+		nil,
+	),
 	micMismatches: metrics.NewContextualCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: subsystem,
@@ -314,6 +322,7 @@ type messageMetrics struct {
 	uplinkForwarded  *metrics.ContextualCounterVec
 	uplinkDropped    *metrics.ContextualCounterVec
 	uplinkGateways   *metrics.ContextualHistogramVec
+	micComputations  *metrics.ContextualCounterVec
 	micMismatches    *metrics.ContextualCounterVec
 
 	downlinkAttempted *metrics.ContextualCounterVec
@@ -327,6 +336,7 @@ func (m messageMetrics) Describe(ch chan<- *prometheus.Desc) {
 	m.uplinkForwarded.Describe(ch)
 	m.uplinkDropped.Describe(ch)
 	m.uplinkGateways.Describe(ch)
+	m.micComputations.Describe(ch)
 	m.micMismatches.Describe(ch)
 
 	m.downlinkAttempted.Describe(ch)
@@ -340,6 +350,7 @@ func (m messageMetrics) Collect(ch chan<- prometheus.Metric) {
 	m.uplinkForwarded.Collect(ch)
 	m.uplinkDropped.Collect(ch)
 	m.uplinkGateways.Collect(ch)
+	m.micComputations.Collect(ch)
 	m.micMismatches.Collect(ch)
 
 	m.downlinkAttempted.Collect(ch)
@@ -385,6 +396,10 @@ func registerDropUplink(ctx context.Context, msg *ttnpb.UplinkMessage, err error
 func registerMergeMetadata(ctx context.Context, msg *ttnpb.UplinkMessage) {
 	gtwCount, _ := rxMetadataStats(ctx, msg.RxMetadata)
 	nsMetrics.uplinkGateways.WithLabelValues(ctx).Observe(float64(gtwCount))
+}
+
+func registerMICComputation(ctx context.Context) {
+	nsMetrics.micComputations.WithLabelValues(ctx).Inc()
 }
 
 func registerMICMismatch(ctx context.Context) {

--- a/pkg/ttnpb/end_device.go
+++ b/pkg/ttnpb/end_device.go
@@ -75,3 +75,10 @@ func (m *SetEndDeviceRequest) ValidateContext(context.Context) error {
 		"end_device.ids.device_id",
 	)...)
 }
+
+func (s *Session) GetSessionKeys() *SessionKeys {
+	if s == nil {
+		return nil
+	}
+	return &s.SessionKeys
+}

--- a/pkg/ttnpb/lorawan.go
+++ b/pkg/ttnpb/lorawan.go
@@ -15,6 +15,7 @@
 package ttnpb
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -79,9 +80,26 @@ func (v *Major) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// MarshalBinary implements encoding.BinaryMarshaler interface.
+func (v MACVersion) MarshalBinary() ([]byte, error) {
+	if v > 255 {
+		panic(fmt.Errorf("MACVersion enum exceeds 255"))
+	}
+	return []byte{byte(v)}, nil
+}
+
 // MarshalText implements encoding.TextMarshaler interface.
 func (v MACVersion) MarshalText() ([]byte, error) {
 	return []byte(v.String()), nil
+}
+
+// UnmarshalBinary implements encoding.BinaryMarshaler interface.
+func (v *MACVersion) UnmarshalBinary(b []byte) error {
+	if len(b) != 1 {
+		return errCouldNotParse("MACVersion")(string(b))
+	}
+	*v = MACVersion(b[0])
+	return nil
 }
 
 // UnmarshalText implements encoding.TextUnmarshaler interface.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Various Network Server utilities
References #2837

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix default class B timeout
- Add Session.GetSessionKeys()
- Implement binary marshaling for MACVersion
- Observe MIC mismatches (not called, done in #2837)
- Allow computing 1.1 MIC from cmacf

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.