### PR TITLE
Fix context used in lbslns tests

### DIFF
--- a/pkg/gatewayserver/io/ws/lbslns/downstream_test.go
+++ b/pkg/gatewayserver/io/ws/lbslns/downstream_test.go
@@ -21,8 +21,10 @@ import (
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/ws"
+	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/unique"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
 )
 
@@ -30,7 +32,7 @@ func timePtr(time time.Time) *time.Time { return &time }
 
 func TestFromDownlinkMessage(t *testing.T) {
 	var lbsLNS lbsLNS
-	ctx := context.Background()
+	ctx := log.NewContext(test.Context(), test.GetLogger(t))
 	uid := unique.ID(ctx, ttnpb.GatewayIdentifiers{GatewayID: "test-gateway"})
 	var session ws.Session
 	session.Data = State{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quickfix for the context used in `lbslns` tests.

#### Changes
<!-- What are the changes made in this pull request? -->

- Use `test.context()` as in other tests instead of `context.Background()`


#### Testing

<!-- How did you verify that this change works? -->

UT

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

NA

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
