### PR TITLE
Cancel pub/sub integration on send and receive failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI login issues when OAuth Server Address explicitly includes the `:443` HTTPS port.
 - Documentation link for LoRa Cloud Device & Application Services in the Lora Cloud integration view in the Console.
 - Webhooks and Pub/Subs forms in the Console will now let users choose whether they want to overwrite an existing record when the ID already exists (as opposed to overwriting by default).
+- Pub/Sub integrations not backing off on internal connection failures.
 
 ### Security
 

--- a/pkg/applicationserver/io/pubsub/pubsub.go
+++ b/pkg/applicationserver/io/pubsub/pubsub.go
@@ -151,7 +151,8 @@ func (i *integration) handleUp(ctx context.Context) {
 			})
 			if err != nil {
 				logger.WithError(err).Warn("Failed to publish upstream message")
-				continue
+				i.cancel(err)
+				return
 			}
 			logger.Debug("Publish upstream message")
 		}
@@ -164,7 +165,8 @@ func (i *integration) handleDown(ctx context.Context, op func(io.Server, context
 		msg, err := subscription.Receive(ctx)
 		if err != nil {
 			logger.WithError(err).Warn("Failed to receive downlink queue operation")
-			continue
+			i.cancel(err)
+			return
 		}
 		msg.Ack()
 		operation, err := i.format.ToDownlinkQueueRequest(msg.Body)

--- a/pkg/applicationserver/io/pubsub/pubsub.go
+++ b/pkg/applicationserver/io/pubsub/pubsub.go
@@ -161,7 +161,12 @@ func (i *integration) handleUp(ctx context.Context) {
 
 func (i *integration) handleDown(ctx context.Context, op func(io.Server, context.Context, ttnpb.EndDeviceIdentifiers, []*ttnpb.ApplicationDownlink) error, subscription *pubsub.Subscription) {
 	logger := log.FromContext(ctx)
-	for ctx.Err() == nil {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
 		msg, err := subscription.Receive(ctx)
 		if err != nil {
 			logger.WithError(err).Warn("Failed to receive downlink queue operation")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This quickfix ensures that pub/sub integration tasks are cancelled when sending or receiving messages from pub/sub fails.

#### Changes
<!-- What are the changes made in this pull request? -->

- Cancel pub/sub task on `topic.Send` failures
- Cancel pub/sub task on `subscription.Receive` failures

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
