### PR TITLE
Event backends resilience improvements

### DIFF
--- a/cmd/internal/shared/events.go
+++ b/cmd/internal/shared/events.go
@@ -28,15 +28,15 @@ import (
 )
 
 // InitializeEvents initializes the event system.
-func InitializeEvents(ctx context.Context, c *component.Component, conf config.ServiceBase) error {
+func InitializeEvents(ctx context.Context, taskStarter component.TaskStarter, conf config.ServiceBase) error {
 	switch conf.Events.Backend {
 	case "internal":
 		return nil // this is the default.
 	case "redis":
-		events.SetDefaultPubSub(redis.NewPubSub(c, conf.Events.Redis))
+		events.SetDefaultPubSub(redis.NewPubSub(ctx, taskStarter, conf.Events.Redis))
 		return nil
 	case "cloud":
-		ps, err := cloud.NewPubSub(c, conf.Events.Cloud.PublishURL, conf.Events.Cloud.SubscribeURL)
+		ps, err := cloud.NewPubSub(ctx, taskStarter, conf.Events.Cloud.PublishURL, conf.Events.Cloud.SubscribeURL)
 		if err != nil {
 			return err
 		}

--- a/cmd/internal/shared/events.go
+++ b/cmd/internal/shared/events.go
@@ -28,21 +28,21 @@ import (
 )
 
 // InitializeEvents initializes the event system.
-func InitializeEvents(ctx context.Context, c *component.Component, config config.ServiceBase) error {
-	switch config.Events.Backend {
+func InitializeEvents(ctx context.Context, c *component.Component, conf config.ServiceBase) error {
+	switch conf.Events.Backend {
 	case "internal":
 		return nil // this is the default.
 	case "redis":
-		events.SetDefaultPubSub(redis.NewPubSub(c, config.Events.Redis))
+		events.SetDefaultPubSub(redis.NewPubSub(c, conf.Events.Redis))
 		return nil
 	case "cloud":
-		ps, err := cloud.NewPubSub(c, config.Events.Cloud.PublishURL, config.Events.Cloud.SubscribeURL)
+		ps, err := cloud.NewPubSub(c, conf.Events.Cloud.PublishURL, conf.Events.Cloud.SubscribeURL)
 		if err != nil {
 			return err
 		}
 		events.SetDefaultPubSub(ps)
 		return nil
 	default:
-		return fmt.Errorf("unknown events backend: %s", config.Events.Backend)
+		return fmt.Errorf("unknown events backend: %s", conf.Events.Backend)
 	}
 }

--- a/cmd/internal/shared/events.go
+++ b/cmd/internal/shared/events.go
@@ -36,7 +36,7 @@ func InitializeEvents(ctx context.Context, c *component.Component, config config
 		events.SetDefaultPubSub(redis.NewPubSub(c, config.Events.Redis))
 		return nil
 	case "cloud":
-		ps, err := cloud.NewPubSub(ctx, config.Events.Cloud.PublishURL, config.Events.Cloud.SubscribeURL)
+		ps, err := cloud.NewPubSub(c, config.Events.Cloud.PublishURL, config.Events.Cloud.SubscribeURL)
 		if err != nil {
 			return err
 		}

--- a/cmd/internal/shared/events.go
+++ b/cmd/internal/shared/events.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"go.thethings.network/lorawan-stack/v3/pkg/component"
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/events/cloud"
@@ -27,12 +28,12 @@ import (
 )
 
 // InitializeEvents initializes the event system.
-func InitializeEvents(ctx context.Context, config config.ServiceBase) (err error) {
+func InitializeEvents(ctx context.Context, c *component.Component, config config.ServiceBase) error {
 	switch config.Events.Backend {
 	case "internal":
 		return nil // this is the default.
 	case "redis":
-		events.SetDefaultPubSub(redis.NewPubSub(config.Events.Redis))
+		events.SetDefaultPubSub(redis.NewPubSub(c, config.Events.Redis))
 		return nil
 	case "cloud":
 		ps, err := cloud.NewPubSub(ctx, config.Events.Cloud.PublishURL, config.Events.Cloud.SubscribeURL)

--- a/cmd/internal/shared/init.go
+++ b/cmd/internal/shared/init.go
@@ -19,14 +19,14 @@ import (
 )
 
 // Initialize configuration fallbacks.
-func InitializeFallbacks(config *config.ServiceBase) error {
+func InitializeFallbacks(conf *config.ServiceBase) error {
 	// Fallback to the default Redis configuration for the cache system
-	if config.Cache.Redis.IsZero() {
-		config.Cache.Redis = config.Redis
+	if conf.Cache.Redis.IsZero() {
+		conf.Cache.Redis = conf.Redis
 	}
 	// Fallback to the default Redis configuration for the events system
-	if config.Events.Redis.IsZero() {
-		config.Events.Redis = config.Redis
+	if conf.Events.Redis.IsZero() {
+		conf.Events.Redis = conf.Redis
 	}
 	return nil
 }

--- a/cmd/internal/shared/init.go
+++ b/cmd/internal/shared/init.go
@@ -15,13 +15,11 @@
 package shared
 
 import (
-	"context"
-
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
 )
 
-// Initialize global packages.
-func Initialize(ctx context.Context, config *config.ServiceBase) error {
+// Initialize configuration fallbacks.
+func InitializeFallbacks(config *config.ServiceBase) error {
 	// Fallback to the default Redis configuration for the cache system
 	if config.Cache.Redis.IsZero() {
 		config.Cache.Redis = config.Redis
@@ -29,10 +27,6 @@ func Initialize(ctx context.Context, config *config.ServiceBase) error {
 	// Fallback to the default Redis configuration for the events system
 	if config.Events.Redis.IsZero() {
 		config.Events.Redis = config.Redis
-	}
-
-	if err := InitializeEvents(ctx, *config); err != nil {
-		return err
 	}
 	return nil
 }

--- a/cmd/ttn-lw-stack/commands/root.go
+++ b/cmd/ttn-lw-stack/commands/root.go
@@ -61,6 +61,11 @@ var (
 				return err
 			}
 
+			// initialize configuration fallbacks
+			if err := shared.InitializeFallbacks(&config.ServiceBase); err != nil {
+				return err
+			}
+
 			// create logger
 			logger = log.NewLogger(
 				log.WithLevel(config.Base.Log.Level),
@@ -86,12 +91,7 @@ var (
 
 			ctx = log.NewContext(ctx, logger)
 
-			// initialize shared packages
-			if err := shared.Initialize(ctx, &config.ServiceBase); err != nil {
-				return err
-			}
-
-			return err
+			return nil
 		},
 	}
 )

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -140,6 +140,10 @@ var startCommand = &cobra.Command{
 			return shared.ErrInitializeBaseComponent.WithCause(err)
 		}
 
+		if err := shared.InitializeEvents(ctx, c, config.ServiceBase); err != nil {
+			return err
+		}
+
 		c.RegisterGRPC(events_grpc.NewEventsServer(c.Context(), events.DefaultPubSub()))
 		c.RegisterGRPC(component.NewConfigurationServer(c))
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -3230,6 +3230,15 @@
       "file": "grpc.go"
     }
   },
+  "error:pkg/events/redis:channel_closed": {
+    "translations": {
+      "en": "channel closed"
+    },
+    "description": {
+      "package": "pkg/events/redis",
+      "file": "redis.go"
+    }
+  },
   "error:pkg/fetch:fetch_file": {
     "translations": {
       "en": "could not fetch file `{filename}`"

--- a/pkg/events/cloud/cloud.go
+++ b/pkg/events/cloud/cloud.go
@@ -35,7 +35,7 @@ func WrapPubSub(wrapped events.PubSub, c *component.Component, pubURL, subURL st
 	ctx, cancel := context.WithCancel(ctx)
 	ps = &PubSub{
 		PubSub:      wrapped,
-		c:           c,
+		component:   c,
 		ctx:         ctx,
 		cancel:      cancel,
 		contentType: "application/protobuf",
@@ -58,7 +58,7 @@ func NewPubSub(c *component.Component, pubURL, subURL string) (*PubSub, error) {
 type PubSub struct {
 	events.PubSub
 
-	c           *component.Component
+	component   *component.Component
 	ctx         context.Context
 	cancel      context.CancelFunc
 	contentType string
@@ -133,7 +133,7 @@ func (ps *PubSub) subscribeTask(ctx context.Context) error {
 // Subscribe to events from Go Cloud.
 func (ps *PubSub) Subscribe(name string, hdl events.Handler) error {
 	ps.subOnce.Do(func() {
-		ps.c.StartTask(&component.TaskConfig{
+		ps.component.StartTask(&component.TaskConfig{
 			Context: ps.ctx,
 			ID:      "events_cloud_subscribe",
 			Func:    ps.subscribeTask,

--- a/pkg/events/cloud/cloud.go
+++ b/pkg/events/cloud/cloud.go
@@ -19,81 +19,129 @@ import (
 	"context"
 	"encoding/json"
 	"strings"
+	"sync"
 
+	"go.thethings.network/lorawan-stack/v3/pkg/component"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
+	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"gocloud.dev/pubsub"
 )
 
 // WrapPubSub wraps an existing PubSub and publishes all events received from Go Cloud to that PubSub.
 // If the subURL is an empty string, this PubSub will only publish to Go Cloud.
-func WrapPubSub(ctx context.Context, wrapped events.PubSub, pubURL, subURL string) (ps *PubSub, err error) {
+func WrapPubSub(wrapped events.PubSub, c *component.Component, pubURL, subURL string) (ps *PubSub, err error) {
+	ctx := log.NewContextWithField(c.Context(), "namespace", "events/cloud")
+	ctx, cancel := context.WithCancel(ctx)
 	ps = &PubSub{
 		PubSub:      wrapped,
+		c:           c,
 		ctx:         ctx,
+		cancel:      cancel,
 		contentType: "application/protobuf",
+		subURL:      subURL,
 	}
 	ps.topic, err = pubsub.OpenTopic(ctx, pubURL)
 	if err != nil {
 		return nil, err
-	}
-	if subURL != "" {
-		ps.subscription, err = pubsub.OpenSubscription(ctx, subURL)
-		if err != nil {
-			return nil, err
-		}
-		go func() {
-			for ctx.Err() == nil {
-				msg, err := ps.subscription.Receive(ctx)
-				if err != nil {
-					return
-				}
-				switch msg.Metadata["content-type"] {
-				case "application/protobuf":
-					var evtpb ttnpb.Event
-					if err = evtpb.Unmarshal(msg.Body); err == nil {
-						if evt, err := events.FromProto(&evtpb); err == nil {
-							ps.PubSub.Publish(evt)
-						}
-					}
-				case "application/json":
-					if evt, err := events.UnmarshalJSON(msg.Body); err == nil {
-						ps.PubSub.Publish(evt)
-					}
-				}
-				msg.Ack()
-			}
-		}()
 	}
 	return ps, nil
 }
 
 // NewPubSub creates a new PubSub that publishes and subscribes to Go Cloud.
 // If the subURL is an empty string, this PubSub will only publish to Go Cloud.
-func NewPubSub(ctx context.Context, pubURL, subURL string) (*PubSub, error) {
-	return WrapPubSub(ctx, events.NewPubSub(events.DefaultBufferSize), pubURL, subURL)
+func NewPubSub(c *component.Component, pubURL, subURL string) (*PubSub, error) {
+	return WrapPubSub(events.NewPubSub(events.DefaultBufferSize), c, pubURL, subURL)
 }
 
 // PubSub with Go Cloud backend.
 type PubSub struct {
 	events.PubSub
 
-	ctx          context.Context
-	contentType  string
-	topic        *pubsub.Topic
-	subscription *pubsub.Subscription
+	c           *component.Component
+	ctx         context.Context
+	cancel      context.CancelFunc
+	contentType string
+	subURL      string
+	topic       *pubsub.Topic
+	subOnce     sync.Once
 }
 
 // Close the Go Cloud publisher.
-func (ps *PubSub) Close() (err error) {
-	if ps.subscription != nil {
-		err = ps.subscription.Shutdown(ps.ctx)
+func (ps *PubSub) Close(ctx context.Context) error {
+	if err := ps.topic.Shutdown(ps.ctx); err != nil {
+		return err
 	}
-	pubShutdownErr := ps.topic.Shutdown(ps.ctx)
-	if err == nil {
-		err = pubShutdownErr
+	ps.cancel()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-ps.ctx.Done():
+		return ps.ctx.Err()
 	}
-	return err
+}
+
+func (ps *PubSub) subscribeTask(ctx context.Context) error {
+	if ps.subURL == "" {
+		return nil
+	}
+	logger := log.FromContext(ctx)
+	subscription, err := pubsub.OpenSubscription(ctx, ps.subURL)
+	if err != nil {
+		return err
+	}
+	logger.Info("Subscribed")
+	defer func() {
+		if err := subscription.Shutdown(ctx); err != nil {
+			logger.WithError(err).Warn("Failed to close Go Cloud subscription")
+		} else {
+			logger.Info("Unsubscribed")
+		}
+	}()
+	for {
+		msg, err := subscription.Receive(ctx)
+		if err != nil {
+			return err
+		}
+		msg.Ack()
+		m := msg.Metadata["content-type"]
+		var evt events.Event
+		switch m {
+		case "application/protobuf":
+			var e ttnpb.Event
+			if err = e.Unmarshal(msg.Body); err != nil {
+				logger.WithError(err).Warn("Failed to unmarshal event from binary")
+				continue
+			}
+			if evt, err = events.FromProto(&e); err != nil {
+				logger.WithError(err).Warn("Failed to unmarshal event from protobuf")
+				continue
+			}
+		case "application/json":
+			if evt, err = events.UnmarshalJSON(msg.Body); err != nil {
+				logger.WithError(err).Warn("Failed to unmarshal event from JSON")
+				continue
+			}
+		default:
+			logger.WithField("content_type", m).Warn("Received event with unknown content type")
+			continue
+		}
+		ps.PubSub.Publish(evt)
+	}
+}
+
+// Subscribe to events from Go Cloud.
+func (ps *PubSub) Subscribe(name string, hdl events.Handler) error {
+	ps.subOnce.Do(func() {
+		ps.c.StartTask(&component.TaskConfig{
+			Context: ps.ctx,
+			ID:      "events_cloud_subscribe",
+			Func:    ps.subscribeTask,
+			Restart: component.TaskRestartOnFailure,
+			Backoff: component.DefaultTaskBackoffConfig,
+		})
+	})
+	return ps.PubSub.Subscribe(name, hdl)
 }
 
 func (ps *PubSub) getMetadata(evt events.Event) map[string]string {
@@ -129,21 +177,25 @@ func (ps *PubSub) getMetadata(evt events.Event) map[string]string {
 
 // Publish an event to Go Cloud.
 func (ps *PubSub) Publish(evt events.Event) {
+	logger := log.FromContext(ps.ctx)
 	var body []byte
 	switch ps.contentType {
 	case "application/protobuf":
 		evtpb, err := events.Proto(evt)
 		if err != nil {
+			logger.WithError(err).Warn("Failed to marshal event to protobuf")
 			return
 		}
 		body, err = evtpb.Marshal()
 		if err != nil {
+			logger.WithError(err).Warn("Failed to marshal event to binary")
 			return
 		}
 	case "application/json":
 		var err error
 		body, err = json.Marshal(evt)
 		if err != nil {
+			logger.WithError(err).Warn("Failed to marshal event to JSON")
 			return
 		}
 	}

--- a/pkg/events/redis/redis.go
+++ b/pkg/events/redis/redis.go
@@ -39,7 +39,7 @@ func WrapPubSub(wrapped events.PubSub, c *component.Component, conf ttnredis.Con
 	ctx, cancel := context.WithCancel(ctx)
 	return &PubSub{
 		PubSub:       wrapped,
-		c:            c,
+		component:    c,
 		ctx:          ctx,
 		cancel:       cancel,
 		client:       ttnRedisClient.Client,
@@ -56,7 +56,7 @@ func NewPubSub(c *component.Component, conf ttnredis.Config) *PubSub {
 type PubSub struct {
 	events.PubSub
 
-	c            *component.Component
+	component    *component.Component
 	ctx          context.Context
 	cancel       context.CancelFunc
 	eventChannel string
@@ -99,7 +99,7 @@ func (ps *PubSub) subscribeTask(ctx context.Context) error {
 // Subscribe implements the events.Subscriber interface.
 func (ps *PubSub) Subscribe(name string, hdl events.Handler) error {
 	ps.subOnce.Do(func() {
-		ps.c.StartTask(&component.TaskConfig{
+		ps.component.StartTask(&component.TaskConfig{
 			Context: ps.ctx,
 			ID:      "events_redis_subscribe",
 			Func:    ps.subscribeTask,

--- a/pkg/events/redis/redis.go
+++ b/pkg/events/redis/redis.go
@@ -21,80 +21,118 @@ import (
 	"sync"
 
 	"github.com/go-redis/redis/v7"
+	"go.thethings.network/lorawan-stack/v3/pkg/component"
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
+	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	ttnredis "go.thethings.network/lorawan-stack/v3/pkg/redis"
 )
 
 // WrapPubSub wraps an existing PubSub and publishes all events received from Redis to that PubSub.
-func WrapPubSub(wrapped events.PubSub, conf ttnredis.Config) (ps *PubSub) {
+func WrapPubSub(wrapped events.PubSub, c *component.Component, conf ttnredis.Config) *PubSub {
 	ttnRedisClient := ttnredis.New(&conf)
-	ps = &PubSub{
+	eventChannel := ttnRedisClient.Key("events")
+	ctx := log.NewContextWithFields(c.Context(), log.Fields(
+		"namespace", "events/redis",
+		"channel", eventChannel,
+	))
+	ctx, cancel := context.WithCancel(ctx)
+	return &PubSub{
 		PubSub:       wrapped,
+		c:            c,
+		ctx:          ctx,
+		cancel:       cancel,
 		client:       ttnRedisClient.Client,
-		eventChannel: ttnRedisClient.Key("events"),
-		closeWait:    make(chan struct{}),
+		eventChannel: eventChannel,
 	}
-	return
 }
 
 // NewPubSub creates a new PubSub that publishes and subscribes to Redis.
-func NewPubSub(conf ttnredis.Config) *PubSub {
-	return WrapPubSub(events.NewPubSub(events.DefaultBufferSize), conf)
+func NewPubSub(c *component.Component, conf ttnredis.Config) *PubSub {
+	return WrapPubSub(events.NewPubSub(events.DefaultBufferSize), c, conf)
 }
 
 // PubSub with Redis backend.
 type PubSub struct {
 	events.PubSub
 
+	c            *component.Component
+	ctx          context.Context
+	cancel       context.CancelFunc
 	eventChannel string
 	client       *redis.Client
 	subOnce      sync.Once
-	sub          *redis.PubSub
-	closeWait    chan struct{}
+}
+
+var errChannelClosed = errors.DefineAborted("channel_closed", "channel closed")
+
+func (ps *PubSub) subscribeTask(ctx context.Context) error {
+	logger := log.FromContext(ctx)
+	sub := ps.client.Subscribe(ps.eventChannel)
+	logger.Info("Subscribed")
+	defer func() {
+		if err := sub.Close(); err != nil {
+			logger.WithError(err).Warn("Failed to close Redis subscription")
+		} else {
+			logger.Info("Unsubscribed")
+		}
+	}()
+	ch := sub.Channel()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case msg, ok := <-ch:
+			if !ok {
+				return errChannelClosed.New()
+			}
+			evt, err := events.UnmarshalJSON([]byte(msg.Payload))
+			if err != nil {
+				logger.WithError(err).Warn("Failed to unmarshal event from JSON")
+				continue
+			}
+			ps.PubSub.Publish(evt)
+		}
+	}
 }
 
 // Subscribe implements the events.Subscriber interface.
 func (ps *PubSub) Subscribe(name string, hdl events.Handler) error {
 	ps.subOnce.Do(func() {
-		ps.sub = ps.client.Subscribe(ps.eventChannel)
-		go func() {
-			defer close(ps.closeWait)
-			for {
-				msg, err := ps.sub.ReceiveMessage()
-				if err != nil {
-					return
-				}
-				if evt, err := events.UnmarshalJSON([]byte(msg.Payload)); err == nil {
-					ps.PubSub.Publish(evt)
-				}
-			}
-		}()
+		ps.c.StartTask(&component.TaskConfig{
+			Context: ps.ctx,
+			ID:      "events_redis_subscribe",
+			Func:    ps.subscribeTask,
+			Restart: component.TaskRestartOnFailure,
+			Backoff: component.DefaultTaskBackoffConfig,
+		})
 	})
 	return ps.PubSub.Subscribe(name, hdl)
 }
 
 // Close the Redis publisher.
 func (ps *PubSub) Close(ctx context.Context) error {
-	var unsubErr error
-	if ps.sub != nil {
-		unsubErr = ps.sub.Unsubscribe(ps.eventChannel)
-	}
-	closeErr := ps.client.Close()
+	ps.cancel()
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-ps.closeWait:
+	case <-ps.ctx.Done():
+		if err := ps.client.Close(); err != nil {
+			return err
+		}
+		return ps.ctx.Err()
 	}
-	if unsubErr != nil {
-		return unsubErr
-	}
-	return closeErr
 }
 
 // Publish an event to Redis.
 func (ps *PubSub) Publish(evt events.Event) {
-	json, err := json.Marshal(evt)
-	if err == nil {
-		ps.client.Publish(ps.eventChannel, string(json))
+	logger := log.FromContext(ps.ctx)
+	b, err := json.Marshal(evt)
+	if err != nil {
+		logger.WithError(err).Warn("Failed to marshal event to JSON")
+		return
+	}
+	if err := ps.client.Publish(ps.eventChannel, b).Err(); err != nil {
+		logger.WithError(err).Warn("Failed to publish event")
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #3191 

#### Changes
<!-- What are the changes made in this pull request? -->

- Backends are now initialized after a component has been created
- Backends now have their own context and always log their errors, instead of relying on `err == nil`
- Backends now subscribe inside a component task
- The Go Cloud backend now also subscribes on the first `Subscribe`, similar to the behavior of the Redis backend

#### Testing

<!-- How did you verify that this change works? -->

1 . Started two stacks with the following extra configuration:
```yaml
events:
  backend: redis
  redis:
    address: localhost:6379
    database: 0
    namespace:
    - ttn
    - v3
```
2. Killed my Redis container, waited for a bit, started it again.
3. Checked that published events are still visible (I've updated an application and checked for the event, but anything would do).

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This changes how the Redis events pub/sub subscribes to events and improves logging capabilities. Already existing unit tests should cover this.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
