### PR TITLE
Fix ping slot-related field validation in NS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documentation link for LoRa Cloud Device & Application Services in the Lora Cloud integration view in the Console.
 - Webhooks and Pub/Subs forms in the Console will now let users choose whether they want to overwrite an existing record when the ID already exists (as opposed to overwriting by default).
 - Pub/Sub integrations not backing off on internal connection failures.
+- Network Server ping slot-related field validation.
 
 ### Security
 

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -436,12 +436,18 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 				); err != nil {
 					return nil, nil, errInvalidFieldMask.WithCause(err)
 				}
+				if dev.GetMACSettings().GetPingSlotFrequency() == nil {
+					return nil, nil, errInvalidFieldValue.WithAttributes("field", "mac_settings.ping_slot_frequency")
+				}
 			}
 			if ns.defaultMACSettings.PingSlotPeriodicity == nil && ttnpb.HasAnyField(req.FieldMask.Paths, "multicast") && req.EndDevice.Multicast {
 				if err := ttnpb.RequireFields(sets,
 					"mac_settings.ping_slot_periodicity.value",
 				); err != nil {
 					return nil, nil, errInvalidFieldMask.WithCause(err)
+				}
+				if dev.GetMACSettings().GetPingSlotPeriodicity() == nil {
+					return nil, nil, errInvalidFieldValue.WithAttributes("field", "mac_settings.ping_slot_periodicity")
 				}
 			}
 		}

--- a/pkg/networkserver/grpc_deviceregistry_test.go
+++ b/pkg/networkserver/grpc_deviceregistry_test.go
@@ -529,6 +529,109 @@ func TestDeviceRegistrySet(t *testing.T) {
 			},
 		},
 
+		// Based on https://github.com/TheThingsNetwork/lorawan-stack/issues/3198.
+		{
+			Name: "Create multicast class B device without ping slot periodicity",
+			ContextFunc: func(ctx context.Context) context.Context {
+				return rights.NewContext(ctx, rights.Rights{
+					ApplicationRights: map[string]*ttnpb.Rights{
+						unique.ID(test.Context(), ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"}): {
+							Rights: []ttnpb.Right{
+								ttnpb.RIGHT_APPLICATION_DEVICES_WRITE,
+								ttnpb.RIGHT_APPLICATION_DEVICES_WRITE_KEYS,
+							},
+						},
+					},
+				})
+			},
+			AddFunc: func(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, at time.Time, replace bool) error {
+				err := errors.New("AddFunc must not be called")
+				test.MustTFromContext(ctx).Error(err)
+				return err
+			},
+			SetByIDFunc: func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
+				a := assertions.New(test.MustTFromContext(ctx))
+				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"})
+				a.So(devID, should.Equal, "test-dev-id")
+				a.So(gets, should.HaveSameElementsDeep, []string{
+					"frequency_plan_id",
+					"ids.dev_eui",
+					"ids.device_id",
+					"ids.join_eui",
+					"last_dev_status_received_at",
+					"lorawan_phy_version",
+					"lorawan_version",
+					"mac_settings",
+					"mac_state",
+					"multicast",
+					"queued_application_downlinks",
+					"recent_uplinks",
+					"session.dev_addr",
+					"session.keys.f_nwk_s_int_key.key",
+					"session.last_conf_f_cnt_down",
+					"session.last_f_cnt_up",
+					"session.last_n_f_cnt_down",
+					"session.queued_application_downlinks",
+					"supports_class_b",
+					"supports_class_c",
+					"supports_join",
+				})
+
+				dev, sets, err := f(ctx, nil)
+				if !a.So(err, should.NotBeNil) {
+					return nil, ctx, errors.New("test failed")
+				}
+				a.So(dev, should.BeNil)
+				a.So(sets, should.BeNil)
+				a.So(errors.IsInvalidArgument(err), should.BeTrue)
+				return nil, ctx, err
+			},
+			Request: &ttnpb.SetEndDeviceRequest{
+				EndDevice: ttnpb.EndDevice{
+					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
+						DeviceID:               "test-dev-id",
+						ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app-id"},
+						JoinEUI:                &types.EUI64{0x42, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+						DevEUI:                 &types.EUI64{0x42, 0x42, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+					},
+					FrequencyPlanID:   test.EUFrequencyPlanID,
+					LoRaWANPHYVersion: ttnpb.PHY_V1_0,
+					LoRaWANVersion:    ttnpb.MAC_V1_0,
+					Multicast:         true,
+					Session: &ttnpb.Session{
+						SessionKeys: ttnpb.SessionKeys{
+							FNwkSIntKey: &ttnpb.KeyEnvelope{
+								Key: &FNwkSIntKey,
+							},
+						},
+						DevAddr: DevAddr,
+					},
+					SupportsClassB: true,
+				},
+				FieldMask: pbtypes.FieldMask{
+					Paths: []string{
+						"frequency_plan_id",
+						"ids.dev_eui",
+						"ids.device_id",
+						"ids.join_eui",
+						"lorawan_phy_version",
+						"lorawan_version",
+						"mac_settings",
+						"multicast",
+						"session.dev_addr",
+						"session.keys.f_nwk_s_int_key.key",
+						"supports_class_b",
+						"supports_class_c",
+						"supports_join",
+					},
+				},
+			},
+			SetByIDCalls: 1,
+			ErrorAssertion: func(t *testing.T, err error) bool {
+				return assertions.New(t).So(errors.IsInvalidArgument(err), should.BeTrue)
+			},
+		},
+
 		{
 			Name: "Create OTAA device with invalid frequency plan",
 			ContextFunc: func(ctx context.Context) context.Context {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/3198

#### Changes
<!-- What are the changes made in this pull request? -->

- Disallow empty MAC settings when ping slot parameters unknown.


#### Testing

<!-- How did you verify that this change works? -->

Unit tests. cc @bafonins for testing in console.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.