### PR TITLE
Fix mage dev:DBRestore target

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -61,6 +61,6 @@ jobs:
       - name: Initialize stack environment
         run: tools/bin/mage init
       - name: Run test preparations
-        run: tools/bin/mage dev:dbStop dev:dbErase dev:dbStart dev:initStack dev:dbDump js:Build
+        run: tools/bin/mage dev:dbStop dev:dbErase dev:dbStart dev:initStack dev:sqlDump js:Build
       - name: Run frontend end-to-end tests
         run: tools/bin/mage dev:startDevStack & tools/bin/mage -v js:cypressHeadless

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -106,7 +106,7 @@ Cypress.Commands.add('createUser', user => {
 // Helper function to quickly seed the database to a fresh state using a
 // previously generated sql dump.
 Cypress.Commands.add('dropAndSeedDatabase', () => {
-  cy.exec('tools/bin/mage dev:DBrestore')
+  cy.exec('tools/bin/mage dev:sqlRestore dev:redisFlush')
     .its('code')
     .should('eq', 0)
 })

--- a/tools/mage/dev.go
+++ b/tools/mage/dev.go
@@ -136,13 +136,13 @@ func (Dev) DBRestore(ctx context.Context) error {
 	}
 	db, err := store.Open(ctx, databaseURI)
 	if err != nil {
-		return nil
+		return err
 	}
 	defer db.Close()
 
 	b, err := ioutil.ReadFile(filepath.Join(".cache", "sqldump.sql"))
 	if err != nil {
-		return nil
+		return err
 	}
 	return db.Exec(fmt.Sprintf(`DROP DATABASE %s;
 		CREATE DATABASE %s;

--- a/tools/mage/dev.go
+++ b/tools/mage/dev.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
@@ -114,10 +115,10 @@ func (d Dev) SQLRestoreSnapshot() error {
 	return d.SQLStart()
 }
 
-// DBDump performs an SQL database dump of the dev database to the .cache folder.
-func (Dev) DBDump() error {
+// SQLDump performs an SQL database dump of the dev database to the .cache folder.
+func (Dev) SQLDump() error {
 	if mg.Verbose() {
-		fmt.Println("Saving database dump")
+		fmt.Println("Saving sql database dump")
 	}
 	if err := os.MkdirAll(".cache", 0755); err != nil {
 		return err
@@ -129,8 +130,8 @@ func (Dev) DBDump() error {
 	return ioutil.WriteFile(filepath.Join(".cache", "sqldump.sql"), []byte(output), 0644)
 }
 
-// DBRestore restores the dev database using a previously generated dump.
-func (Dev) DBRestore(ctx context.Context) error {
+// SQLRestore restores the dev database using a previously generated dump.
+func (Dev) SQLRestore(ctx context.Context) error {
 	if mg.Verbose() {
 		fmt.Println("Restoring database from dump")
 	}
@@ -149,6 +150,25 @@ func (Dev) DBRestore(ctx context.Context) error {
 		%s`,
 		devDatabaseName, devDatabaseName, string(b)),
 	).Error
+}
+
+// RedisFlush deletes all keys from redis.
+func (Dev) RedisFlush() error {
+	if mg.Verbose() {
+		fmt.Println("Deleting all keys from redis")
+	}
+
+	keys, err := sh.Output("docker-compose", dockerComposeFlags("exec", "-T", "redis", "redis-cli", "keys", "ttn:v3:*")...)
+	if err != nil {
+		return err
+	}
+	ks := strings.Split(keys, "\n")
+	if len(ks) == 0 {
+		return nil
+	}
+	flags := dockerComposeFlags(append([]string{"exec", "-T", "redis", "redis-cli", "del"}, ks...)...)
+	_, err = sh.Exec(nil, nil, os.Stderr, "docker-compose", flags...)
+	return err
 }
 
 // DBStart starts the databases of the development environment.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/2605


#### Changes
<!-- What are the changes made in this pull request? -->

- Flush redis when running `dev:DBRestore`
- Fix error handling in `dev:DBRestore`

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Currently, we restore only the sql database between tests which causes problems when adding tests for devices since entities are partially stored in redis. We have to reset redis together with the sql database.

~Not sure how this should be implemented exactly. I picked the easiest option to just flush the database via `redis-cli`. It is worth mentioning that it is also possible to dump and restore redis state from `rdb` and `aol` files.~

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
