### PR TITLE
Add WidgetContainer component

### DIFF
--- a/pkg/webui/components/button/index.js
+++ b/pkg/webui/components/button/index.js
@@ -248,12 +248,12 @@ buttonChildren.defaultProps = {
 }
 
 Button.propTypes = {
+  onBlur: PropTypes.func,
   /**
    * A click listener to be called when the button is pressed.
    * Not called if the button is in the `busy` or `disabled` state.
    */
   onClick: PropTypes.func,
-  onBlur: PropTypes.func,
   ...commonPropTypes,
 }
 

--- a/pkg/webui/components/events-list/widget/index.js
+++ b/pkg/webui/components/events-list/widget/index.js
@@ -15,8 +15,8 @@
 import React from 'react'
 import { defineMessages } from 'react-intl'
 
-import Link from '@ttn-lw/components/link'
 import Status from '@ttn-lw/components/status'
+import WidgetContainer from '@ttn-lw/components/widget-container'
 
 import Message from '@ttn-lw/lib/components/message'
 
@@ -39,20 +39,23 @@ const EventsWidget = props => {
     truncatedEvents = events.slice(0, limit)
   }
 
+  const title = (
+    <Status flipped status="good">
+      <Message content={sharedMessges.liveData} className={style.headerTitle} />
+    </Status>
+  )
+
   return (
-    <aside className={className}>
+    <WidgetContainer
+      title={title}
+      toAllUrl={toAllUrl}
+      linkMessage={m.seeAllActivity}
+      className={className}
+    >
       <Events events={truncatedEvents} renderEvent={renderEvent} entityId={entityId} widget>
-        <Events.Header className={style.header}>
-          <Status flipped status="good">
-            <Message content={sharedMessges.liveData} className={style.headerTitle} />
-          </Status>
-          <Link className={style.seeAllLink} secondary to={toAllUrl}>
-            <Message content={m.seeAllActivity} /> →
-          </Link>
-        </Events.Header>
         <Events.List />
       </Events>
-    </aside>
+    </WidgetContainer>
   )
 }
 

--- a/pkg/webui/components/events-list/widget/widget.styl
+++ b/pkg/webui/components/events-list/widget/widget.styl
@@ -12,15 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-.header
-  display: flex
-  align-items: center
-  justify-content: space-between
-  padding-left: 0
-  padding-right: 0
-
 .header-title
   font-weight: $fw.bold
-
-.see-all-link
-  text-decoration: none

--- a/pkg/webui/components/map/widget/index.js
+++ b/pkg/webui/components/map/widget/index.js
@@ -15,8 +15,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import Link from '@ttn-lw/components/link'
 import LocationMap from '@ttn-lw/components/map'
+import WidgetContainer from '@ttn-lw/components/widget-container'
 
 import Message from '@ttn-lw/lib/components/message'
 
@@ -72,15 +72,13 @@ export default class MapWidget extends React.Component {
     const { path } = this.props
 
     return (
-      <aside className={style.wrapper}>
-        <div className={style.header}>
-          <Message className={style.titleMessage} content={sharedMessages.location} />
-          <Link className={style.changeLocation} secondary to={path}>
-            <Message content={sharedMessages.changeLocation} /> →
-          </Link>
-        </div>
+      <WidgetContainer
+        title={sharedMessages.location}
+        toAllUrl={path}
+        linkMessage={sharedMessages.changeLocation}
+      >
         {this.Map}
-      </aside>
+      </WidgetContainer>
     )
   }
 }

--- a/pkg/webui/components/widget-container/index.js
+++ b/pkg/webui/components/widget-container/index.js
@@ -1,0 +1,60 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import classnames from 'classnames'
+
+import Link from '@ttn-lw/components/link'
+
+import Message from '@ttn-lw/lib/components/message'
+
+import PropTypes from '@ttn-lw/lib/prop-types'
+
+import style from './widget-container.styl'
+
+const WidgetContainer = ({ children, title, toAllUrl, linkMessage, className }) => {
+  return (
+    <aside className={classnames(style.container, className)}>
+      <div className={style.header}>
+        {typeof title === 'object' && 'id' in title ? (
+          <Message content={title} className={style.headerTitle} />
+        ) : (
+          title
+        )}
+        <Link className={style.seeAllLink} secondary to={toAllUrl}>
+          <Message content={linkMessage} /> →
+        </Link>
+      </div>
+      <div className={style.body}>
+        <Link className={style.bodyLink} to={toAllUrl}>
+          {children}
+        </Link>
+      </div>
+    </aside>
+  )
+}
+
+WidgetContainer.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  linkMessage: PropTypes.message.isRequired,
+  title: PropTypes.oneOfType([PropTypes.message.isRequired, PropTypes.message.node]).isRequired,
+  toAllUrl: PropTypes.string.isRequired,
+}
+
+WidgetContainer.defaultProps = {
+  className: undefined,
+}
+
+export default WidgetContainer

--- a/pkg/webui/components/widget-container/story.js
+++ b/pkg/webui/components/widget-container/story.js
@@ -1,0 +1,38 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import WidgetContainer from '.'
+
+storiesOf('WidgetContainer', module).add('Default', () => (
+  <div style={{ width: '500px' }}>
+    <WidgetContainer title="Location" toAllUrl="#" linkMessage="Change location">
+      <div
+        style={{
+          height: '300px',
+          border: '1px solid gray',
+          backgroundColor: '#eee',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: 'gray',
+        }}
+      >
+        Map placeholder as example
+      </div>
+    </WidgetContainer>
+  </div>
+))

--- a/pkg/webui/components/widget-container/widget-container.styl
+++ b/pkg/webui/components/widget-container/widget-container.styl
@@ -1,0 +1,35 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+.container
+  &:not(:last-child)
+    margin-bottom: $ls.m
+
+.header
+  margin-bottom: $cs.xxs
+  display: flex
+  align-items: center
+  justify-content: space-between
+  padding-left: 0
+  padding-right: 0
+
+
+.header-title
+  font-weight: $fw.bold
+
+.see-all-link
+  text-decoration: none
+
+.body-link
+  color: inherit


### PR DESCRIPTION
#### Summary
This quickfix PR adds a `WidgetContainer` component that will wrap the common container styling for widgets to reduce code duplication.
#### Changes
- Add `<WidgetContainer />` component
- Use new container for map widget
- Use new container for event widget
- Fix eslint warning

#### Testing

Manual via storybook and live.

##### Regressions

None.

#### Notes for Reviewers

Outsourced from my work on events.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
