### PR TITLE
Fix app container style

### DIFF
--- a/pkg/webui/styles/main.styl
+++ b/pkg/webui/styles/main.styl
@@ -28,6 +28,9 @@ body
   -moz-osx-font-smoothing: grayscale
   background: white
 
+:global(#app)
+  height: 100%
+
 ::-webkit-scrollbar
   width: .5rem
   height: .5rem


### PR DESCRIPTION
#### Summary
This quickfix PR fixes a bug introduced via #3183, resulting in the OAuth login view being styled wrong.

#### Changes
- Select outermost container via `#app` and apply `height: 100%`

#### Testing

Manual.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
