### PR TITLE
Fix application uplinks queue memory usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Webhooks and Pub/Subs forms in the Console will now let users choose whether they want to overwrite an existing record when the ID already exists (as opposed to overwriting by default).
 - Pub/Sub integrations not backing off on internal connection failures.
 - Network Server ping slot-related field validation.
+- Memory usage of Network Server application uplink queues.
 
 ### Security
 

--- a/pkg/networkserver/redis/application_uplink_queue.go
+++ b/pkg/networkserver/redis/application_uplink_queue.go
@@ -46,8 +46,16 @@ func NewApplicationUplinkQueue(cl *ttnredis.Client, maxLen int64, group, id stri
 	}
 }
 
-func (q *ApplicationUplinkQueue) uidUplinkKey(uid string) string {
+func (q *ApplicationUplinkQueue) uidGenericUplinkKey(uid string) string {
 	return q.redis.Key("uid", uid, "uplinks")
+}
+
+func (q *ApplicationUplinkQueue) uidInvalidationKey(uid string) string {
+	return q.redis.Key(q.uidGenericUplinkKey(uid), "invalidation")
+}
+
+func (q *ApplicationUplinkQueue) uidJoinAcceptKey(uid string) string {
+	return q.redis.Key(q.uidGenericUplinkKey(uid), "join-accept")
 }
 
 const payloadKey = "payload"
@@ -61,9 +69,26 @@ func (q *ApplicationUplinkQueue) Add(ctx context.Context, ups ...*ttnpb.Applicat
 			return err
 		}
 
+		var (
+			streamID             string
+			maxLen, maxLenApprox int64
+		)
+		switch up.Up.(type) {
+		case *ttnpb.ApplicationUp_JoinAccept:
+			streamID = q.uidJoinAcceptKey(uid)
+			maxLenApprox = q.maxLen
+		case *ttnpb.ApplicationUp_DownlinkQueueInvalidated:
+			streamID = q.uidInvalidationKey(uid)
+			maxLen = 1
+		default:
+			streamID = q.uidGenericUplinkKey(uid)
+			maxLenApprox = q.maxLen
+		}
+
 		if err = q.redis.XAdd(&redis.XAddArgs{
-			Stream:       q.uidUplinkKey(uid),
-			MaxLenApprox: q.maxLen,
+			Stream:       streamID,
+			MaxLen:       maxLen,
+			MaxLenApprox: maxLenApprox,
 			Values: map[string]interface{}{
 				payloadKey: s,
 			},
@@ -87,15 +112,41 @@ var (
 	errMissingPayload = errors.DefineDataLoss("missing_payload", "missing payload")
 )
 
-// Subscribe ranges over q.uidUplinkKey(unique.ID(ctx, appID)) using f until ctx is done.
+func (q *ApplicationUplinkQueue) initConsumer(ctx context.Context, streamID string) (func(), error) {
+	_, err := q.redis.XGroupCreateMkStream(streamID, q.group, "0").Result()
+	if err != nil && !ttnredis.IsConsumerGroupExistsErr(err) {
+		return nil, ttnredis.ConvertError(err)
+	}
+	return func() {
+		if err := q.redis.XGroupDelConsumer(streamID, q.group, q.id).Err(); err != nil {
+			log.FromContext(ctx).WithError(err).WithFields(log.Fields(
+				"consumer", q.id,
+				"group", q.group,
+				"stream", streamID,
+			)).Error("Failed to delete application uplink queue redis consumer")
+		}
+	}, nil
+}
+
+// Subscribe ranges over uplink keys using f until ctx is done.
 // Subscribe assumes that there's at most 1 active consumer in q.group per stream at all times.
 func (q *ApplicationUplinkQueue) Subscribe(ctx context.Context, appID ttnpb.ApplicationIdentifiers, f func(context.Context, *ttnpb.ApplicationUp) error) error {
 	uid := unique.ID(ctx, appID)
-	upStream := q.uidUplinkKey(uid)
 
-	_, err := q.redis.XGroupCreateMkStream(upStream, q.group, "0").Result()
-	if err != nil && !ttnredis.IsConsumerGroupExistsErr(err) {
-		return ttnredis.ConvertError(err)
+	genericUpStream := q.uidGenericUplinkKey(uid)
+	invalidationUpStream := q.uidInvalidationKey(uid)
+	joinAcceptUpStream := q.uidJoinAcceptKey(uid)
+
+	for _, streamID := range [...]string{
+		genericUpStream,
+		invalidationUpStream,
+		joinAcceptUpStream,
+	} {
+		delConsumer, err := q.initConsumer(ctx, streamID)
+		if err != nil {
+			return err
+		}
+		defer delConsumer()
 	}
 
 	upCh := make(chan *ttnpb.ApplicationUp, 1)
@@ -104,30 +155,17 @@ func (q *ApplicationUplinkQueue) Subscribe(ctx context.Context, appID ttnpb.Appl
 		panic(fmt.Sprintf("duplicate subscription for application %s", uid))
 	}
 	defer q.subscriptions.Delete(uid)
-	defer func() {
-		if err := q.redis.XGroupDelConsumer(upStream, q.group, q.id).Err(); err != nil {
-			log.FromContext(ctx).WithError(err).WithFields(log.Fields(
-				"consumer", q.id,
-				"group", q.group,
-				"stream", upStream,
-			)).Error("Failed to delete application uplink queue redis consumer")
-		}
-	}()
-
 	for {
 		rets, err := q.redis.XReadGroup(&redis.XReadGroupArgs{
 			Group:    q.group,
 			Consumer: q.id,
-			Streams:  []string{upStream, upStream, "0", ">"},
+			Streams:  []string{joinAcceptUpStream, joinAcceptUpStream, invalidationUpStream, invalidationUpStream, genericUpStream, genericUpStream, "0", ">", "0", ">", "0", ">"},
+			Count:    1,
 		}).Result()
 		if err != nil && err != redis.Nil {
 			return ttnredis.ConvertError(err)
 		}
 		for _, ret := range rets {
-			if ret.Stream != upStream {
-				panic(fmt.Sprintf("unknown stream read %s", ret.Stream))
-			}
-
 			for _, msg := range ret.Messages {
 				v, ok := msg.Values[payloadKey]
 				if !ok {
@@ -145,8 +183,8 @@ func (q *ApplicationUplinkQueue) Subscribe(ctx context.Context, appID ttnpb.Appl
 					return err
 				}
 				_, err := q.redis.Pipelined(func(p redis.Pipeliner) error {
-					p.XAck(upStream, q.group, msg.ID)
-					p.XDel(upStream, msg.ID)
+					p.XAck(ret.Stream, q.group, msg.ID)
+					p.XDel(ret.Stream, msg.ID)
 					return nil
 				})
 				if err != nil {

--- a/pkg/networkserver/redis/redis.go
+++ b/pkg/networkserver/redis/redis.go
@@ -14,3 +14,13 @@
 
 // Package redis provides Redis implementations of interfaces used by networkserver.
 package redis
+
+import ttnredis "go.thethings.network/lorawan-stack/v3/pkg/redis"
+
+func deviceUIDKey(cl *ttnredis.Client, uid string) string {
+	return cl.Key("uid", uid)
+}
+
+func deviceUIDLastInvalidationKey(cl *ttnredis.Client, uid string) string {
+	return ttnredis.Key(deviceUIDKey(cl, uid), "last-invalidation")
+}

--- a/pkg/networkserver/redis/registry.go
+++ b/pkg/networkserver/redis/registry.go
@@ -58,7 +58,7 @@ func (r *DeviceRegistry) Init() error {
 }
 
 func (r *DeviceRegistry) uidKey(uid string) string {
-	return r.Redis.Key("uid", uid)
+	return deviceUIDKey(r.Redis, uid)
 }
 
 func (r *DeviceRegistry) addrKey(addr types.DevAddr) string {
@@ -224,6 +224,7 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIde
 		if pb == nil && len(sets) == 0 {
 			pipelined = func(p redis.Pipeliner) error {
 				p.Del(uk)
+				p.Del(deviceUIDLastInvalidationKey(r.Redis, uid))
 				if stored.JoinEUI != nil && stored.DevEUI != nil {
 					p.Del(r.euiKey(*stored.JoinEUI, *stored.DevEUI))
 				}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2908

#### Changes
<!-- What are the changes made in this pull request? -->

- Delete processed application uplinks from queues
- Categorize application uplink streams, store at most 1 invalidation and store join-accepts separately. Thanks @adrian for the suggestion.
- ~Read at most 1 uplink from queue - this ensures maximum fail-safety and minimizes allocations in NS.~ Store the last invalidation FCnt per-device UID and avoid sending invalidations with FCnt lower than that value

#### Testing

<!-- How did you verify that this change works? -->

Unit testing, test with a class c device

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

From https://redis.io/commands/xdel:
> Eventually if all the entries in a macro-node are marked as deleted, the whole node is destroyed and the memory reclaimed. This means that if you delete a large amount of entries from a stream, for instance more than 50% of the entries appended to the stream, the memory usage per entry may increment, since what happens is that the stream will start to be fragmented. However the stream performances will remain the same.

The memory usage may slightly increase for a while, but I believe it will fix our issues after that

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.