### PR TITLE
Reset downlink handler on error

### DIFF
--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -317,7 +317,14 @@ func (s *srv) handleDown(ctx context.Context, state *state) error {
 		logger.WithError(err).Error("Failed to claim downlink")
 		return errClaimDownlinkFailed.WithCause(err)
 	}
-	defer s.server.UnclaimDownlink(ctx, state.io.Gateway().GatewayIdentifiers)
+	logger.Info("Downlink path claimed")
+	defer func() {
+		if err := s.server.UnclaimDownlink(ctx, state.io.Gateway().GatewayIdentifiers); err != nil {
+			logger.WithError(err).Error("Failed to unclaim downlink")
+			return
+		}
+		logger.Info("Downlink path unclaimed")
+	}()
 	healthCheck := time.NewTicker(s.config.DownlinkPathExpires / 2)
 	defer healthCheck.Stop()
 	for {

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -162,7 +162,7 @@ func (s *srv) handlePackets() {
 			}
 
 			if err := s.handleUp(cs.io.Context(), cs, packet); err != nil {
-				logger.WithError(err).Warn("Failed to handle packet")
+				logger.WithError(err).Warn("Failed to handle upstream packet")
 			}
 		}
 	}
@@ -239,7 +239,7 @@ func (s *srv) handleUp(ctx context.Context, state *state, packet encoding.Packet
 		state.startHandleDown.Do(func() {
 			go func() {
 				if err := s.handleDown(ctx, state); err != nil {
-					logger.WithError(err).Warn("Downlink handler failed")
+					logger.WithError(err).Warn("Failed to handle downstream packet")
 				}
 			}()
 		})
@@ -326,13 +326,13 @@ func (s *srv) handleDown(ctx context.Context, state *state) error {
 	}()
 	logger := log.FromContext(ctx)
 	if err := s.server.ClaimDownlink(ctx, state.io.Gateway().GatewayIdentifiers); err != nil {
-		logger.WithError(err).Error("Failed to claim downlink")
+		logger.WithError(err).Error("Failed to claim downlink path")
 		return errClaimDownlinkFailed.WithCause(err)
 	}
 	logger.Info("Downlink path claimed")
 	defer func() {
 		if err := s.server.UnclaimDownlink(ctx, state.io.Gateway().GatewayIdentifiers); err != nil {
-			logger.WithError(err).Error("Failed to unclaim downlink")
+			logger.WithError(err).Error("Failed to unclaim downlink path")
 			return
 		}
 		logger.Info("Downlink path unclaimed")

--- a/pkg/gatewayserver/upstream/ns/ns.go
+++ b/pkg/gatewayserver/upstream/ns/ns.go
@@ -68,16 +68,16 @@ func (h *Handler) ConnectGateway(ctx context.Context, ids ttnpb.GatewayIdentifie
 	}
 	logger := log.FromContext(ctx)
 	if err := h.cluster.ClaimIDs(ctx, ids); err != nil {
-		logger.WithError(err).Error("Failed to claim gateway")
+		logger.WithError(err).Error("Failed to claim downlink path")
 		return err
 	}
-	logger.Info("Gateway claimed")
+	logger.Info("Downlink path claimed")
 	defer func() {
 		if err := h.cluster.UnclaimIDs(ctx, ids); err != nil {
-			logger.WithError(err).Error("Failed to unclaim gateway")
+			logger.WithError(err).Error("Failed to unclaim downlink path")
 			return
 		}
-		logger.Info("Gateway unclaimed")
+		logger.Info("Downlink path unclaimed")
 	}()
 	<-ctx.Done()
 	return ctx.Err()

--- a/pkg/gatewayserver/upstream/ns/ns.go
+++ b/pkg/gatewayserver/upstream/ns/ns.go
@@ -20,6 +20,7 @@ import (
 
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io"
+	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
 	"google.golang.org/grpc"
@@ -65,8 +66,19 @@ func (h *Handler) ConnectGateway(ctx context.Context, ids ttnpb.GatewayIdentifie
 	if conn.Frontend().SupportsDownlinkClaim() {
 		return nil
 	}
-	h.cluster.ClaimIDs(ctx, ids)
-	defer h.cluster.UnclaimIDs(ctx, ids)
+	logger := log.FromContext(ctx)
+	if err := h.cluster.ClaimIDs(ctx, ids); err != nil {
+		logger.WithError(err).Error("Failed to claim gateway")
+		return err
+	}
+	logger.Info("Gateway claimed")
+	defer func() {
+		if err := h.cluster.UnclaimIDs(ctx, ids); err != nil {
+			logger.WithError(err).Error("Failed to unclaim gateway")
+			return
+		}
+		logger.Info("Gateway unclaimed")
+	}()
 	<-ctx.Done()
 	return ctx.Err()
 }


### PR DESCRIPTION
 <!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR changes `handleDown` to always reset the associated `sync.Once` on shutdown. This ensures that the downlink handler (`handleDown`) can actually be restarted, in case an error occured (like an error on `Claim`). Logging has also been significantly improved for `Claim` and `Unclaim`.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
