### PR TITLE
Fix usage of incorrect uplink FCnt in the Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Incorrect uplink FCnt display in end device title section.
+
 ### Security
 
 ## [3.9.2] - 2020-09-11

--- a/pkg/webui/console/store/reducers/devices.js
+++ b/pkg/webui/console/store/reducers/devices.js
@@ -71,7 +71,7 @@ const devices = function(state = defaultState, { type, payload, event }) {
       }
 
       // Update derived last seen value if possible.
-      const { recent_uplinks, session } = payload
+      const { recent_uplinks } = payload
       const derived = {}
       if (recent_uplinks) {
         const last_uplink = Boolean(recent_uplinks)
@@ -80,11 +80,6 @@ const devices = function(state = defaultState, { type, payload, event }) {
         if (last_uplink) {
           derived.lastSeen = last_uplink.received_at
         }
-      }
-
-      // Update uplink frame counts if possible.
-      if (session) {
-        derived.uplinkFrameCount = session.last_f_cnt_up
       }
 
       return mergeDerived(updatedState, id, derived)
@@ -127,7 +122,7 @@ const devices = function(state = defaultState, { type, payload, event }) {
       else if (event.name === uplinkFrameCountEvent) {
         const id = getCombinedDeviceId(event.identifiers[0].device_ids)
         return mergeDerived(state, id, {
-          uplinkFrameCount: getByPath(event, 'data.payload.mac_payload.f_hdr.f_cnt'),
+          uplinkFrameCount: getByPath(event, 'data.payload.mac_payload.full_f_cnt'),
         })
       }
       return state


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/3230

#### Changes
<!-- What are the changes made in this pull request? -->

- Use `full_f_cnt`

#### Testing

<!-- How did you verify that this change works? -->

None

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Uplink display in device title section

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
