### PR TITLE
Fix target dependency of install yarn target

### DIFF
--- a/tools/mage/js.go
+++ b/tools/mage/js.go
@@ -42,7 +42,6 @@ func yarnWorkingDirectoryArg(elem ...string) string {
 func installYarn() error {
 	ok, err := target.Path(
 		filepath.Join("node_modules", "yarn"),
-		"package.json",
 	)
 	if err != nil {
 		return targetError(err)


### PR DESCRIPTION
#### Summary
This quickfix PR fixes the dependency of the `installYarn` target of our mage tooling. Before this fix, `yarn` would be reinstalled whenever the `package.json` changed, which is not necessary and resulted in fragmented builds and the necessity to load and rebuild all JS dependencies from scratch which has cost me a lot of time already.

#### Changes
- Run `installYarn` only when the yarn folder is missing in `node_modules`

#### Testing

Manual testing.

#### Notes for Reviewers
Technically we could compare the versions of the yarn installation and the version value in `package.json` but I believe this is unnecessary overengineering given that the yarn version doesn't change frequently.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
