### PR TITLE
Use rxDelay correctly for BS xTime calculation

### DIFF
--- a/pkg/gatewayserver/io/ws/lbslns/downstream.go
+++ b/pkg/gatewayserver/io/ws/lbslns/downstream.go
@@ -68,6 +68,10 @@ func (f *lbsLNS) FromDownlink(ctx context.Context, uid string, down ttnpb.Downli
 	dnmsg.RCtx = int64(settings.Downlink.AntennaIndex)
 	dnmsg.Diid = int64(f.tokens.Next(down.CorrelationIDs, dlTime))
 
+	// Chosen fixed values.
+	dnmsg.Priority = 25
+	dnmsg.RxDelay = 1
+
 	// The first 16 bits of XTime gets the session ID from the upstream latestXTime and the other 48 bits are concentrator timestamp accounted for rollover.
 	var (
 		state State
@@ -86,10 +90,6 @@ func (f *lbsLNS) FromDownlink(ctx context.Context, uid string, down ttnpb.Downli
 
 	// This field is not used but needs to be defined for the station to parse the json.
 	dnmsg.DevEUI = "00-00-00-00-00-00-00-00"
-
-	// Chosen fixed values.
-	dnmsg.Priority = 25
-	dnmsg.RxDelay = 1
 
 	// Fix the Tx Parameters since we don't use the gateway scheduler.
 	dnmsg.Rx1DR = int(settings.DataRateIndex)

--- a/pkg/gatewayserver/io/ws/ws_test.go
+++ b/pkg/gatewayserver/io/ws/ws_test.go
@@ -912,7 +912,7 @@ func TestTraffic(t *testing.T) {
 				RxDelay:     1,
 				Rx1Freq:     868100000,
 				Rx1DR:       5,
-				XTime:       1553759666,
+				XTime:       12666375505739186,
 				Priority:    25,
 				MuxTime:     1554300787.123456,
 			},
@@ -1019,7 +1019,6 @@ func TestTraffic(t *testing.T) {
 						if err := json.Unmarshal(res, &msg); err != nil {
 							t.Fatalf("Failed to unmarshal response `%s`: %v", string(res), err)
 						}
-						msg.XTime = tc.ExpectedBSDownstream.(lbslns.DownlinkMessage).XTime
 						msg.MuxTime = tc.ExpectedBSDownstream.(lbslns.DownlinkMessage).MuxTime
 						if !a.So(msg, should.Resemble, tc.ExpectedBSDownstream.(lbslns.DownlinkMessage)) {
 							t.Fatalf("Incorrect Downlink received: %s", string(res))


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Use rxDelay correctly for BS xTime calculation

#### Changes
<!-- What are the changes made in this pull request? -->

- `dnmsg.RxDelay` should be set to 1 before using that to offset the xTime.
- Update tests so that this can be caught in the future.


#### Testing

<!-- How did you verify that this change works? -->

UT, with a desk TTIGs.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

will test in staging.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
