### PR TITLE
Ensure sufficient data before adjusting NbTrans

### DIFF
--- a/pkg/networkserver/adr.go
+++ b/pkg/networkserver/adr.go
@@ -299,7 +299,7 @@ func adaptDataRate(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band, de
 	if dev.MACState.DesiredParameters.ADRNbTrans > maxNbTrans {
 		dev.MACState.DesiredParameters.ADRNbTrans = maxNbTrans
 	}
-	if len(dev.RecentADRUplinks) >= 2 {
+	if len(dev.RecentADRUplinks) >= optimalADRUplinkCount/2 {
 		switch r := lossRate(dev.RecentADRUplinks...); {
 		case r < 0.05:
 			dev.MACState.DesiredParameters.ADRNbTrans = 1 + dev.MACState.DesiredParameters.ADRNbTrans/3


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Refs https://github.com/TheThingsIndustries/lorawan-stack-support/issues/132

#### Changes
<!-- What are the changes made in this pull request? -->

- Only adjust `NbTrans` after half of "optimal" count uplinks are collected - otherwise NS ends up continuously adjusting `NbTrans` back and forth - see https://github.com/TheThingsIndustries/lorawan-stack-support/issues/132


#### Testing

<!-- How did you verify that this change works? -->

Trivial change, unnecessary

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
