### PR TITLE
Add panic recovery to tasks

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -2654,6 +2654,15 @@
       "file": "listeners.go"
     }
   },
+  "error:pkg/component:task_recovered": {
+    "translations": {
+      "en": "task recovered"
+    },
+    "description": {
+      "package": "pkg/component",
+      "file": "tasks.go"
+    }
+  },
   "error:pkg/config/tlsconfig:acme_already_initialized": {
     "translations": {
       "en": "ACME already initialized"

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -271,7 +271,6 @@ func New(c *component.Component, conf *Config, opts ...Option) (*NetworkServer, 
 			Jitter:       component.DefaultTaskBackoffConfig.Jitter,
 			IntervalFunc: component.MakeTaskBackoffIntervalFunc(true, component.DefaultTaskBackoffResetDuration, component.DefaultTaskBackoffIntervals[:]...),
 		},
-		RecoverPanics: true,
 	})
 	c.RegisterGRPC(ns)
 	return ns, nil

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -271,6 +271,7 @@ func New(c *component.Component, conf *Config, opts ...Option) (*NetworkServer, 
 			Jitter:       component.DefaultTaskBackoffConfig.Jitter,
 			IntervalFunc: component.MakeTaskBackoffIntervalFunc(true, component.DefaultTaskBackoffResetDuration, component.DefaultTaskBackoffIntervals[:]...),
 		},
+		RecoverPanics: true,
 	})
 	c.RegisterGRPC(ns)
 	return ns, nil


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Add panic recovery to tasks. Refs https://github.com/TheThingsNetwork/lorawan-stack/pull/3262#issuecomment-696648760

#### Changes
<!-- What are the changes made in this pull request? -->

- Add panic recovery to tasks
- Recover Network Server downlink tasks


#### Testing

<!-- How did you verify that this change works? -->

Ran the stack

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Unlikely

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Looks like this:
```
 ERROR Task panicked with:
goroutine 231 [running]:
runtime/debug.Stack(0xc000a0be40, 0x24189e7, 0x5)
	/nix/store/jn02sd9pvby91w31di0kjzj0303694vl-go-1.15.1/share/go/src/runtime/debug/stack.go:24 +0x9f
go.thethings.network/lorawan-stack/v3/pkg/component.runTask.func1(0x2813100, 0xc000a0be40, 0xc000360c00, 0xc001719fd0)
	/home/rvolosatovs/src/go.thethings.network/lorawan-stack/pkg/component/tasks.go:140 +0xbb
panic(0x2002be0, 0x275a6b0)
	/nix/store/jn02sd9pvby91w31di0kjzj0303694vl-go-1.15.1/share/go/src/runtime/panic.go:969 +0x175
go.thethings.network/lorawan-stack/v3/pkg/networkserver.(*NetworkServer).processDownlinkTask.func1(0x27ed5a0, 0xc00285b200, 0xc0028eec2a, 0xa, 0xc0028eec20, 0x9, 0x0, 0x0, 0x0, 0x0, ...)
	/home/rvolosatovs/src/go.thethings.network/lorawan-stack/pkg/networkserver/downlink.go:1462 +0x42e
go.thethings.network/lorawan-stack/v3/pkg/networkserver/redis.(*DownlinkTaskQueue).Pop.func1(0xc0028eec20, 0x14, 0x26d8171c, 0xed6fbd425, 0x0, 0xc001714360, 0xc0007fe320)
	/home/rvolosatovs/src/go.thethings.network/lorawan-stack/pkg/networkserver/redis/downlink_task_queue.go:63 +0x173
go.thethings.network/lorawan-stack/v3/pkg/redis.(*TaskQueue).Pop.func1(0xc000d44200, 0x18, 0xc0028eec20, 0x14, 0x26d8171c, 0xed6fbd425, 0x0, 0x2, 0x0)
	/home/rvolosatovs/src/go.thethings.network/lorawan-stack/pkg/redis/redis.go:724 +0x57
go.thethings.network/lorawan-stack/v3/pkg/redis.PopTask(0x282e2a0, 0xc000b46120, 0x2415ebc, 0x2, 0xc000c7f920, 0xc, 0x0, 0xc001719d88, 0xc001719d78, 0x1, ...)
	/home/rvolosatovs/src/go.thethings.network/lorawan-stack/pkg/redis/redis.go:637 +0x6d7
go.thethings.network/lorawan-stack/v3/pkg/redis.(*TaskQueue).Pop(0xc0002200a0, 0x27ed5a0, 0xc0018c42d0, 0xc0016c15d8, 0xc0016c15f8, 0x40e458)
	/home/rvolosatovs/src/go.thethings.network/lorawan-stack/pkg/redis/redis.go:723 +0x14e
go.thethings.network/lorawan-stack/v3/pkg/networkserver/redis.(*DownlinkTaskQueue).Pop(0xc0001a8498, 0x27ed5a0, 0xc0018c42d0, 0xc000b46700, 0x0, 0x0)
	/home/rvolosatovs/src/go.thethings.network/lorawan-stack/pkg/networkserver/redis/downlink_task_queue.go:54 +0x7d
go.thethings.network/lorawan-stack/v3/pkg/networkserver.(*NetworkServer).processDownlinkTask(0xc000266a80, 0x27ed5a0, 0xc0018c42d0, 0xc02d5f58b8, 0x23dea96d710b)
	/home/rvolosatovs/src/go.thethings.network/lorawan-stack/pkg/networkserver/downlink.go:1454 +0xcc
go.thethings.network/lorawan-stack/v3/pkg/component.runTask(0x1, 0xc000360c00)
	/home/rvolosatovs/src/go.thethings.network/lorawan-stack/pkg/component/tasks.go:160 +0x1c9
created by go.thethings.network/lorawan-stack/v3/pkg/component.DefaultStartTask
	/home/rvolosatovs/src/go.thethings.network/lorawan-stack/pkg/component/tasks.go:201 +0x48
 error=WTF namespace=networkserver task_id=process_downlink
 DEBUG Synchronized server absolute time only   gateway_eui=647FDAFFFE007B3F gateway_uid=eui-647fdafffe007b3f namespace=gatewayserver/io/udp protocol=udp server_time=2020-09-22 13:16:58.302330627 +0200 CEST m=+15.983315218 timestamp=3537609068
 DEBUG Crypto Server connection is not available cluster_role=CRYPTO SERVER dev_eui=DEADBEEF01020304 error=error:pkg/cluster:peer_unavailable (CRYPTO SERVER cluster peer unavailable) grpc_method=HandleJoin grpc_service=ttn.lorawan.v3.NsJs join_eui=01020304DEADBEEF namespace=joinserver request_id=01EJTRFVA07Y8GWKTVFSC1DW9Y
  INFO Finished unary call                      duration=1.464638ms grpc_method=HandleJoin grpc_service=ttn.lorawan.v3.NsJs namespace=grpc request_id=01EJTRFVA07Y8GWKTVFSC1DW9Y
 DEBUG Finished unary call                      duration=1.900416ms grpc_method=HandleJoin grpc_service=ttn.lorawan.v3.NsJs namespace=grpc request_id=01EJTRFV9YBF3V8JXCD2013K4H
 DEBUG Join-request accepted by cluster-local Join Server bandwidth=125000 data_rate_index=4 dev_addr=01AF0C54 dev_eui=DEADBEEF01020304 device_channel_index=4 device_uid=test-app2.test-dev-c frequency=868500000 grpc_method=HandleUplink grpc_service=ttn.lorawan.v3.GsNs join_eui=01020304DEADBEEF m_type=JOIN_REQUEST major=LORAWAN_R1 namespace=networkserver phy_payload_len=23 received_at=2020-09-22 11:16:58.303037844 +0000 UTC request_id=01EJTRFV9YBF3V8JXCD2013K4H spreading_factor=8
 DEBUG Publish events                           bandwidth=125000 data_rate_index=4 dev_addr=01AF0C54 dev_eui=DEADBEEF01020304 device_channel_index=4 device_uid=test-app2.test-dev-c event_count=3 frequency=868500000 grpc_method=HandleUplink grpc_service=ttn.lorawan.v3.GsNs join_eui=01020304DEADBEEF m_type=JOIN_REQUEST major=LORAWAN_R1 namespace=networkserver phy_payload_len=23 received_at=2020-09-22 11:16:58.303037844 +0000 UTC request_id=01EJTRFV9YBF3V8JXCD2013K4H spreading_factor=8
 DEBUG Merged metadata                          bandwidth=125000 data_rate_index=4 dev_addr=01AF0C54 dev_eui=DEADBEEF01020304 device_channel_index=4 device_uid=test-app2.test-dev-c frequency=868500000 grpc_method=HandleUplink grpc_service=ttn.lorawan.v3.GsNs join_eui=01020304DEADBEEF m_type=JOIN_REQUEST major=LORAWAN_R1 metadata_count=1 namespace=networkserver phy_payload_len=23 received_at=2020-09-22 11:16:58.303037844 +0000 UTC request_id=01EJTRFV9YBF3V8JXCD2013K4H spreading_factor=8
 DEBUG Add downlink task                        bandwidth=125000 data_rate_index=4 dev_addr=01AF0C54 dev_eui=DEADBEEF01020304 device_channel_index=4 device_uid=test-app2.test-dev-c frequency=868500000 grpc_method=HandleUplink grpc_service=ttn.lorawan.v3.GsNs join_eui=01020304DEADBEEF m_type=JOIN_REQUEST major=LORAWAN_R1 namespace=networkserver phy_payload_len=23 received_at=2020-09-22 11:16:58.303037844 +0000 UTC request_id=01EJTRFV9YBF3V8JXCD2013K4H spreading_factor=8 start_at=2020-09-22 11:17:00.103037844 +0000 UTC
 DEBUG Enqueue application uplinks for sending to Application Server bandwidth=125000 data_rate_index=4 dev_addr=01AF0C54 dev_eui=DEADBEEF01020304 device_channel_index=4 device_uid=test-app2.test-dev-c frequency=868500000 grpc_method=HandleUplink grpc_service=ttn.lorawan.v3.GsNs join_eui=01020304DEADBEEF m_type=JOIN_REQUEST major=LORAWAN_R1 namespace=networkserver phy_payload_len=23 received_at=2020-09-22 11:16:58.303037844 +0000 UTC request_id=01EJTRFV9YBF3V8JXCD2013K4H spreading_factor=8 uplink_count=1
 DEBUG Publish events                           bandwidth=125000 data_rate_index=4 dev_addr=01AF0C54 dev_eui=DEADBEEF01020304 device_channel_index=4 device_uid=test-app2.test-dev-c event_count=1 frequency=868500000 grpc_method=HandleUplink grpc_service=ttn.lorawan.v3.GsNs join_eui=01020304DEADBEEF m_type=JOIN_REQUEST major=LORAWAN_R1 namespace=networkserver phy_payload_len=23 received_at=2020-09-22 11:16:58.303037844 +0000 UTC request_id=01EJTRFV9YBF3V8JXCD2013K4H spreading_factor=8
  INFO Finished unary call                      duration=204.037672ms grpc_method=HandleUplink grpc_service=ttn.lorawan.v3.GsNs namespace=grpc request_id=01EJTRFV9YBF3V8JXCD2013K4H
 DEBUG Finished unary call                      duration=204.448883ms grpc_method=HandleUplink grpc_service=ttn.lorawan.v3.GsNs namespace=grpc
 DEBUG Received AppSKey from Network Server     application_uid=test-app2 dev_eui=DEADBEEF01020304 device_uid=test-app2.test-dev-c join_eui=01020304DEADBEEF namespace=applicationserver network_server=cobalt session_key_id=0174B587ED41DB48B80D82FAE2C026A6
 DEBUG Process downlink task                    device_uid=test-app2.test-dev-c namespace=networkserver start_at=2020-09-22 11:17:00.103038 +0000 UTC started_at=2020-09-22 11:17:00.169988141 +0000 UTC
 ERROR Task panicked with:
goroutine 223 [running]:
runtime/debug.Stack(0xc00294d2c0, 0x24189e7, 0x5)
	/nix/store/jn02sd9pvby91w31di0kjzj0303694vl-go-1.15.1/share/go/src/runtime/debug/stack.go:24 +0x9f
go.thethings.network/lorawan-stack/v3/pkg/component.runTask.func1(0x2813100, 0xc00294d2c0, 0xc000360c00, 0xc001719fd0)
	/home/rvolosatovs/src/go.thethings.network/lorawan-stack/pkg/component/tasks.go:140 +0xbb
panic(0x2002be0, 0x275a6b0)
	/nix/store/jn02sd9pvby91w31di0kjzj0303694vl-go-1.15.1/share/go/src/runtime/panic.go:969 +0x175
go.thethings.network/lorawan-stack/v3/pkg/networkserver.(*NetworkServer).processDownlinkTask.func1(0x27ed5a0, 0xc0009b39e0, 0xc000b3612a, 0xa, 0xc000b36120, 0x9, 0x0, 0x0, 0x0, 0x0, ...)
	/home/rvolosatovs/src/go.thethings.network/lorawan-stack/pkg/networkserver/downlink.go:1462 +0x42e
go.thethings.network/lorawan-stack/v3/pkg/networkserver/redis.(*DownlinkTaskQueue).Pop.func1(0xc000b36120, 0x14, 0x6243c30, 0xed6fbd42c, 0x0, 0xc000eff8c0, 0xc00283b360)
	/home/rvolosatovs/src/go.thethings.network/lorawan-stack/pkg/networkserver/redis/downlink_task_queue.go:63 +0x173
go.thethings.network/lorawan-stack/v3/pkg/redis.(*TaskQueue).Pop.func1(0xc000d44200, 0x18, 0xc000b36120, 0x14, 0x6243c30, 0xed6fbd42c, 0x0, 0x2, 0x441e6a)
	/home/rvolosatovs/src/go.thethings.network/lorawan-stack/pkg/redis/redis.go:724 +0x57
go.thethings.network/lorawan-stack/v3/pkg/redis.PopTask(0x282e2a0, 0xc000b46120, 0x2415ebc, 0x2, 0xc000c7f920, 0xc, 0x0, 0xc001719d88, 0xc001719d78, 0x1, ...)
	/home/rvolosatovs/src/go.thethings.network/lorawan-stack/pkg/redis/redis.go:637 +0x6d7
go.thethings.network/lorawan-stack/v3/pkg/redis.(*TaskQueue).Pop(0xc0002200a0, 0x27ed5a0, 0xc0018c42d0, 0xc000b565d8, 0xc000b565f8, 0x40e458)
	/home/rvolosatovs/src/go.thethings.network/lorawan-stack/pkg/redis/redis.go:723 +0x14e
go.thethings.network/lorawan-stack/v3/pkg/networkserver/redis.(*DownlinkTaskQueue).Pop(0xc0001a8498, 0x27ed5a0, 0xc0018c42d0, 0xc0017170e0, 0x0, 0x0)
	/home/rvolosatovs/src/go.thethings.network/lorawan-stack/pkg/networkserver/redis/downlink_task_queue.go:54 +0x7d
go.thethings.network/lorawan-stack/v3/pkg/networkserver.(*NetworkServer).processDownlinkTask(0xc000266a80, 0x27ed5a0, 0xc0018c42d0, 0xc02cdc2f1b, 0x23e13890f44c)
	/home/rvolosatovs/src/go.thethings.network/lorawan-stack/pkg/networkserver/downlink.go:1454 +0xcc
go.thethings.network/lorawan-stack/v3/pkg/component.runTask(0x1, 0xc000360c00)
	/home/rvolosatovs/src/go.thethings.network/lorawan-stack/pkg/component/tasks.go:160 +0x1c9
created by go.thethings.network/lorawan-stack/v3/pkg/component.runTask.func1
	/home/rvolosatovs/src/go.thethings.network/lorawan-stack/pkg/component/tasks.go:146 +0x1bf
 error=WTF namespace=networkserver task_id=process_downlink
```

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.