### PR TITLE
Improve stability and status communication of event views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-
 - Support for sending end device uplinks in the Console.
 - PHY version filtering based on LoRaWAN MAC in the Console.
+- Meta information and status events in the event views in the Console.
 
 ### Changed
 
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Error events causing Console becoming unresponsive and crashing.
 - Incorrect entity count in title sections in the Console.
 - Incorrect event detail panel open/close behavior for some events in the Console.
+- Improved error resilience and stability of the event views in the Console.
 
 ### Security
 
@@ -41,7 +42,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Display the full event object when expanded in the Console (used to be `event.data` only).
 
 ### Fixed
-
 - Performance issues of event views in the Console (freezing after some time).
 - Gateway Server panic on upstream message handling.
 - Incorrect redirects for restricted routes in the Console.

--- a/pkg/webui/console/lib/events/utils.js
+++ b/pkg/webui/console/lib/events/utils.js
@@ -19,6 +19,7 @@ export const defineSyntheticEvent = name => data => ({
   name: `synthetic.${name}`,
   isError: name.startsWith('error'),
   isSynthetic: true,
+  unique_id: `synthetic.${Date.now()}`,
   data,
 })
 

--- a/pkg/webui/console/store/actions/events.js
+++ b/pkg/webui/console/store/actions/events.js
@@ -20,6 +20,8 @@ export const createStartEventsStreamFailureActionType = name => `START_${name}_E
 
 export const createStopEventsStreamActionType = name => `STOP_${name}_EVENT_STREAM`
 
+export const createEventStreamClosedActionType = name => `${name}_EVENT_STREAM_CLOSED`
+
 export const createGetEventMessageSuccessActionType = name => `GET_${name}_EVENT_MESSAGE_SUCCESS`
 
 export const createGetEventMessageFailureActionType = name => `GET_${name}_EVENT_MESSAGE_FAILURE`
@@ -43,6 +45,11 @@ export const startEventsStreamFailure = name => (id, error) => ({
 })
 
 export const stopEventsStream = name => id => ({ type: createStopEventsStreamActionType(name), id })
+
+export const eventStreamClosed = name => id => ({
+  type: createEventStreamClosedActionType(name),
+  id,
+})
 
 export const getEventMessageSuccess = name => (id, event) => ({
   type: createGetEventMessageSuccessActionType(name),

--- a/pkg/webui/console/store/middleware/logics/events.js
+++ b/pkg/webui/console/store/middleware/logics/events.js
@@ -19,19 +19,29 @@ import CONNECTION_STATUS from '@console/constants/connection-status'
 import { getCombinedDeviceId } from '@ttn-lw/lib/selectors/id'
 import { isUnauthenticatedError } from '@ttn-lw/lib/errors/utils'
 
-import { createEventsStatusSelector } from '@console/store/selectors/events'
+import {
+  createEventsStatusSelector,
+  createEventsInterruptedSelector,
+  createInterruptedStreamsSelector,
+} from '@console/store/selectors/events'
+import { selectConnectionStatus } from '@console/store/selectors/status'
 
 import {
   createStartEventsStreamActionType,
   createStopEventsStreamActionType,
   createStartEventsStreamFailureActionType,
+  createStartEventsStreamSuccessActionType,
+  createEventStreamClosedActionType,
   createGetEventMessageFailureActionType,
+  createGetEventMessageSuccessActionType,
   getEventMessageSuccess,
   getEventMessageFailure,
   startEventsStreamFailure,
   startEventsStreamSuccess,
-  stopEventsStream,
+  eventStreamClosed,
+  startEventsStream,
 } from '../../actions/events'
+import { SET_CONNECTION_STATUS } from '../../actions/status'
 
 /**
  * Creates `redux-logic` logic from processing entity events.
@@ -44,22 +54,28 @@ import {
  */
 const createEventsConnectLogics = function(reducerName, entityName, onEventsStart) {
   const START_EVENTS = createStartEventsStreamActionType(reducerName)
+  const START_EVENTS_SUCCESS = createStartEventsStreamSuccessActionType(reducerName)
   const START_EVENTS_FAILURE = createStartEventsStreamFailureActionType(reducerName)
   const STOP_EVENTS = createStopEventsStreamActionType(reducerName)
+  const EVENT_STREAM_CLOSED = createEventStreamClosedActionType(reducerName)
   const GET_EVENT_MESSAGE_FAILURE = createGetEventMessageFailureActionType(reducerName)
+  const GET_EVENT_MESSAGE_SUCCESS = createGetEventMessageSuccessActionType(reducerName)
   const startEventsSuccess = startEventsStreamSuccess(reducerName)
   const startEventsFailure = startEventsStreamFailure(reducerName)
-  const stopEvents = stopEventsStream(reducerName)
+  const closeEvents = eventStreamClosed(reducerName)
+  const startEvents = startEventsStream(reducerName)
   const getEventSuccess = getEventMessageSuccess(reducerName)
   const getEventFailure = getEventMessageFailure(reducerName)
   const selectEntityEventsStatus = createEventsStatusSelector(entityName)
+  const selectEntityEventsInterrupted = createEventsInterruptedSelector(entityName)
+  const selectInterruptedStreams = createInterruptedStreamsSelector(entityName)
 
   let channel = null
 
   return [
     createLogic({
       type: START_EVENTS,
-      cancelType: [STOP_EVENTS, START_EVENTS_FAILURE, GET_EVENT_MESSAGE_FAILURE],
+      cancelType: [STOP_EVENTS, START_EVENTS_FAILURE],
       warnTimeout: 0,
       processOptions: {
         dispatchMultiple: true,
@@ -72,11 +88,13 @@ const createEventsConnectLogics = function(reducerName, entityName, onEventsStar
 
         const id = typeof action.id === 'object' ? getCombinedDeviceId(action.id) : action.id
 
-        // Only proceed if not already connected.
-        const status = selectEntityEventsStatus(getState(), id)
+        // Only proceed if not already connected and online.
+        const state = getState()
+        const isOnline = selectConnectionStatus(state)
+        const status = selectEntityEventsStatus(state, id)
         const connected = status === CONNECTION_STATUS.CONNECTED
         const connecting = status === CONNECTION_STATUS.CONNECTING
-        if (connected || connecting) {
+        if (connected || connecting || !isOnline) {
           reject()
           return
         }
@@ -92,11 +110,11 @@ const createEventsConnectLogics = function(reducerName, entityName, onEventsStar
           channel.on('start', () => dispatch(startEventsSuccess(id)))
           channel.on('chunk', message => dispatch(getEventSuccess(id, message)))
           channel.on('error', error => dispatch(getEventFailure(id, error)))
-          channel.on('close', () => dispatch(stopEvents(id)))
+          channel.on('close', () => dispatch(closeEvents(id)))
         } catch (error) {
           if (isUnauthenticatedError(error)) {
             // The user is no longer authenticated; reinitiate the auth flow
-            // by refreshing the page
+            // by refreshing the page.
             window.location.reload()
           } else {
             dispatch(startEventsFailure(id, error))
@@ -105,7 +123,7 @@ const createEventsConnectLogics = function(reducerName, entityName, onEventsStar
       },
     }),
     createLogic({
-      type: [STOP_EVENTS, START_EVENTS_FAILURE, GET_EVENT_MESSAGE_FAILURE],
+      type: [STOP_EVENTS, START_EVENTS_FAILURE],
       validate({ getState, action = {} }, allow, reject) {
         if (!action.id) {
           reject()
@@ -129,6 +147,75 @@ const createEventsConnectLogics = function(reducerName, entityName, onEventsStar
         if (channel) {
           channel.close()
         }
+        done()
+      },
+    }),
+    createLogic({
+      type: [GET_EVENT_MESSAGE_FAILURE, EVENT_STREAM_CLOSED],
+      cancelType: [START_EVENTS_SUCCESS, GET_EVENT_MESSAGE_SUCCESS, STOP_EVENTS],
+      warnTimeout: 0,
+      validate({ getState, action = {} }, allow, reject) {
+        if (!action.id) {
+          reject()
+          return
+        }
+
+        const id = typeof action.id === 'object' ? getCombinedDeviceId(action.id) : action.id
+
+        // Only proceed if connected and not interrupted.
+        const status = selectEntityEventsStatus(getState(), id)
+        const connected = status === CONNECTION_STATUS.CONNECTED
+        const interrupted = selectEntityEventsInterrupted(getState(), id)
+        if (!connected && interrupted) {
+          reject()
+        }
+
+        allow(action)
+      },
+      process({ getState, action }, dispatch, done) {
+        const isOnline = selectConnectionStatus(getState())
+
+        // If the app is not offline, try to reconnect periodically.
+        if (isOnline) {
+          const reconnector = setInterval(() => {
+            // Only proceed if still disconnected, interrupted and online.
+            const state = getState()
+            const id = typeof action.id === 'object' ? getCombinedDeviceId(action.id) : action.id
+            const status = selectEntityEventsStatus(state, id)
+            const disconnected = status === CONNECTION_STATUS.DISCONNECTED
+            const interrupted = selectEntityEventsInterrupted(state, id)
+            const isOnline = selectConnectionStatus(state)
+            if (disconnected && interrupted && isOnline) {
+              dispatch(startEvents(id))
+            } else {
+              clearInterval(reconnector)
+              done()
+            }
+          }, 5000)
+        } else {
+          done()
+        }
+      },
+    }),
+    createLogic({
+      type: SET_CONNECTION_STATUS,
+      process({ getState, action }, dispatch, done) {
+        const isOnline = action.payload.isOnline
+
+        if (isOnline) {
+          const state = getState()
+          for (const id in selectInterruptedStreams(state)) {
+            const status = selectEntityEventsStatus(state, id)
+            const disconnected = status === CONNECTION_STATUS.DISCONNECTED
+
+            // If the app reconnected to the internet and there is a pending
+            // interrupted stream connection, try to reconnect.
+            if (disconnected) {
+              dispatch(dispatch(startEvents(id)))
+            }
+          }
+        }
+
         done()
       },
     }),

--- a/pkg/webui/console/store/selectors/applications.js
+++ b/pkg/webui/console/store/selectors/applications.js
@@ -30,6 +30,7 @@ import {
   createEventsSelector,
   createEventsErrorSelector,
   createEventsStatusSelector,
+  createEventsInterruptedSelector,
 } from './events'
 import { createRightsSelector, createPseudoRightsSelector } from './rights'
 import { createFetchingSelector } from './fetching'
@@ -68,6 +69,7 @@ export const selectApplicationsError = state => selectAppsError(state)
 export const selectApplicationEvents = createEventsSelector(ENTITY)
 export const selectApplicationEventsError = createEventsErrorSelector(ENTITY)
 export const selectApplicationEventsStatus = createEventsStatusSelector(ENTITY)
+export const selectApplicationEventsInterrupted = createEventsInterruptedSelector(ENTITY)
 
 // Rights.
 export const selectApplicationRights = createRightsSelector(ENTITY)

--- a/pkg/webui/console/store/selectors/devices.js
+++ b/pkg/webui/console/store/selectors/devices.js
@@ -20,6 +20,7 @@ import {
   createEventsSelector,
   createEventsErrorSelector,
   createEventsStatusSelector,
+  createEventsInterruptedSelector,
 } from './events'
 import {
   createPaginationIdsSelectorByEntity,
@@ -76,3 +77,4 @@ export const selectDevicesError = state => selectDevsError(state)
 export const selectDeviceEvents = createEventsSelector(ENTITY)
 export const selectDeviceEventsError = createEventsErrorSelector(ENTITY)
 export const selectDeviceEventsStatus = createEventsStatusSelector(ENTITY)
+export const selectDeviceEventsInterruptted = createEventsInterruptedSelector(ENTITY)

--- a/pkg/webui/console/store/selectors/events.js
+++ b/pkg/webui/console/store/selectors/events.js
@@ -28,6 +28,13 @@ export const createEventsStatusSelector = entity =>
     return store ? store.status : 'unknown'
   }
 
+export const createEventsInterruptedSelector = entity =>
+  function(state, entityId) {
+    const store = selectEventsStore(state.events[entity], entityId)
+
+    return store ? store.interrupted : false
+  }
+
 export const createEventsErrorSelector = entity =>
   function(state, entityId) {
     const store = selectEventsStore(state.events[entity], entityId)
@@ -43,4 +50,16 @@ export const createLatestEventSelector = function(entity) {
 
     return events[0]
   }
+}
+
+export const createInterruptedStreamsSelector = entity => state => {
+  const eventsStore = state.events[entity]
+
+  return Object.keys(eventsStore).reduce((acc, id) => {
+    if (eventsStore[id].interrupted) {
+      acc[id] = eventsStore[id]
+    }
+
+    return acc
+  }, {})
 }

--- a/pkg/webui/console/store/selectors/gateways.js
+++ b/pkg/webui/console/store/selectors/gateways.js
@@ -24,6 +24,7 @@ import {
   createEventsSelector,
   createEventsErrorSelector,
   createEventsStatusSelector,
+  createEventsInterruptedSelector,
   createLatestEventSelector,
 } from './events'
 import { createRightsSelector, createPseudoRightsSelector } from './rights'
@@ -63,6 +64,7 @@ export const selectGatewaysError = state => selectGtwsError(state)
 export const selectGatewayEvents = createEventsSelector(ENTITY)
 export const selectGatewayEventsError = createEventsErrorSelector(ENTITY)
 export const selectGatewayEventsStatus = createEventsStatusSelector(ENTITY)
+export const selectGatewayEventsInterrupted = createEventsInterruptedSelector(ENTITY)
 export const selectLatestGatewayEvent = createLatestEventSelector(ENTITY)
 
 // Rights.

--- a/pkg/webui/console/store/selectors/organizations.js
+++ b/pkg/webui/console/store/selectors/organizations.js
@@ -26,6 +26,7 @@ import {
   createEventsSelector,
   createEventsErrorSelector,
   createEventsStatusSelector,
+  createEventsInterruptedSelector,
 } from './events'
 import { createFetchingSelector } from './fetching'
 import { createErrorSelector } from './error'
@@ -66,3 +67,4 @@ export const selectOrganizationRightsFetching = createFetchingSelector(GET_ORGS_
 export const selectOrganizationEvents = createEventsSelector(ENTITY)
 export const selectOrganizationEventsError = createEventsErrorSelector(ENTITY)
 export const selectOrganizationEventsStatus = createEventsStatusSelector(ENTITY)
+export const selectOrganizationEventsInterrupted = createEventsInterruptedSelector(ENTITY)


### PR DESCRIPTION
#### Summary
This PR improves the stability and error resilience of event related views and components in the Console. It will issue automatic reconnection events when the streams have been interrupted either periodically if a connection to the internet persists or triggered by the `online` event when the browser detected the system going offline. It also issues "synthetic" 
status and info events that add situational awareness for the user.

Closes #2884 

<details><summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/5710611/93879718-27d8b000-fcd4-11ea-8ebd-2e28ccb20e17.png)

</details>

#### Changes
- Update store logic to
  - Prevent crashing the whole view on any error
  - Perform automatic reconnects
    - either periodically (5s) if the browser is still online
    - or once when the internet connection is reestablished 
  - Distinguish between planned, client initiated stream closings and unexpected stream disconnects from the remote side
  - Issue synthetic events for various situations (disconnect and reconnects, errors, event clearing)
  - Resolve a precision issue in the time comparison of events for sorting them chronologically

#### Testing

Manual testing.

##### Regressions

This PR might introduce issues related to
- Correct display of events
- Establishing or maintaining the stream connection

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
