### PR TITLE
Improve join eui prefix styling

### DIFF
--- a/pkg/webui/components/input/index.js
+++ b/pkg/webui/components/input/index.js
@@ -206,7 +206,7 @@ class Input extends React.Component {
         </div>
         {hasAction && (
           <div className={style.actions}>
-            <Button className={style.button} {...action} />
+            <Button className={style.button} disabled={disabled} {...action} />
           </div>
         )}
       </div>

--- a/pkg/webui/console/containers/join-eui-prefixes-input/join-eui-prefixes-input.js
+++ b/pkg/webui/console/containers/join-eui-prefixes-input/join-eui-prefixes-input.js
@@ -46,7 +46,10 @@ const getOptions = prefixes => {
       const hasDuplicate = Boolean(result.find(pr => pr.value === computedPrefix))
       if (!hasDuplicate) {
         result.push({
-          label: computedPrefix.toUpperCase(),
+          label: computedPrefix
+            .toUpperCase()
+            .match(/.{1,2}/g)
+            .join(' '),
           value: computedPrefix,
         })
       }
@@ -181,7 +184,7 @@ class JoinEUIPrefixesInput extends React.PureComponent {
     }
 
     return (
-      <div className={classnames(className, style.container)}>
+      <div className={classnames(className, style.container, { [style.noPrefix]: prefix === '' })}>
         {selectComponent}
         <Input
           showPerChar

--- a/pkg/webui/console/containers/join-eui-prefixes-input/join-eui-prefixes-input.styl
+++ b/pkg/webui/console/containers/join-eui-prefixes-input/join-eui-prefixes-input.styl
@@ -16,9 +16,20 @@
   display: flex
   flex-wrap: wrap
 
+  &:not(.no-prefix)
+    :global(.select__value-container)
+      font-family: $font-family-mono
+      font-weight: $fw.bold
+      font-size: $fs.s
+
   .select
     flex-basis: 100%
     margin-bottom: $cs.xs
+
+    :global(.select__option):not(:first-child)
+      font-family: $font-family-mono
+      font-weight: $fw.bold
+      font-size: $fs.s
 
   .byte
     flex-basis: 100%


### PR DESCRIPTION
#### Summary
Quickfix to improve the styling of the join eui prefix select.

#### Changes
- Improve styling of join eui prefix (style byte values consistently)
- Disabled action buttons of input components by default if the input is disabled itself

#### Testing

Manual.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
