### PR TITLE
Remove faulty prop types from env HOC

### DIFF
--- a/pkg/webui/lib/components/env.js
+++ b/pkg/webui/lib/components/env.js
@@ -25,8 +25,6 @@ export const withEnv = function(Component) {
   class WithEnv extends Base {
     static displayName = `WithEnv(${displayName(Component)})`
 
-    static propTypes = Component.propTypes
-
     static contextTypes = {
       env: PropTypes.env,
     }


### PR DESCRIPTION
#### Summary
Quickfix to remove an unnecessary prop type definition from the `withEnv` HOC.

#### Changes
- Remove prop types definition from `withEnv` HOC


#### Testing

Manual.

##### Regressions

None.

#### Notes for Reviewers
The definition was unnecessary and would sometimes result in proptype warnings.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
