### PR TITLE
Remove sentry logging from event error boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Broken link to setting device location in the device map widget.
+- Error events causing Console becoming unresponsive and crashing.
 
 ### Security
 

--- a/pkg/webui/console/components/events/error-boundary.js
+++ b/pkg/webui/console/components/events/error-boundary.js
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import React from 'react'
-import * as Sentry from '@sentry/browser'
 
 import Icon from '@ttn-lw/components/icon'
 
@@ -28,9 +27,8 @@ import style from './events.styl'
 class EventErrorBoundary extends React.Component {
   state = { hasErrored: false, error: undefined, expanded: false }
 
-  static getDerivedStateFromError(error) {
-    Sentry.captureException(error)
-    return { hasErrored: true, error }
+  static getDerivedStateFromError() {
+    return { hasErrored: true }
   }
 
   render() {


### PR DESCRIPTION
#### Summary
Quickfix PR to remove error logging inside the error boundary of single events.

#### Changes
- Remove sentry error logging in the `<ErrorBoundary />` component


#### Testing

Manual.

##### Regressions

None.

#### Notes for Reviewers
With the old implementation, errors would be sent repeatedly on every render which spams Sentry and eventually crashes the Console. It's possible to use `componentDidCatch()` instead which is only called initially but it would still resend the error whenever navigating away and back to the event views. I guess to properly implement this, we'd need to keep track of event ids for errors that have already been sent. Until figuring that out, it's best to just remove the logging entirely.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
