### PR TITLE
Fix errored entity count display in the Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Broken link to setting device location in the device map widget.
 - Error events causing Console becoming unresponsive and crashing.
+- Incorrect entity count in title sections in the Console.
 
 ### Security
 

--- a/pkg/webui/console/components/entity-title-section/content/entity-count/index.js
+++ b/pkg/webui/console/components/entity-title-section/content/entity-count/index.js
@@ -34,6 +34,7 @@ const EntityCount = props => {
         [style.error]: errored,
       })}
       to={toAllUrl}
+      disabled={errored}
     >
       <Icon className={style.icon} icon={icon} nudgeUp />
       {!errored && <span className={style.value}>{value} </span>}

--- a/pkg/webui/console/components/entity-title-section/content/entity-count/index.js
+++ b/pkg/webui/console/components/entity-title-section/content/entity-count/index.js
@@ -36,7 +36,7 @@ const EntityCount = props => {
       to={toAllUrl}
     >
       <Icon className={style.icon} icon={icon} nudgeUp />
-      <span className={style.value}>{value} </span>
+      {!errored && <span className={style.value}>{value} </span>}
       <Message
         className={style.message}
         content={errored ? sharedMessages.notAvailable : keyMessage}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fix entity count for errored sub-entity requests:
<img width="384" alt="Screenshot 2020-09-25 at 16 44 10" src="https://user-images.githubusercontent.com/16374166/94274502-74c7bb00-ff4e-11ea-86b1-1b94329905f1.png">



#### Changes
<!-- What are the changes made in this pull request? -->

- Hide entity count value
- Disable errored link

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
