### PR TITLE
Add downlink count for end devices in the Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI support for Storage Integration (see `ttn-lw-cli end-devices storage` and `ttn-lw-cli applications storage` commands).
 - Network Server does not retry rejected `NewChannelReq` data rate ranges or rejected `DLChannelReq` frequencies anymore.
 - Functionality to allow admin users to list all organizations in the Console.
+- Downlink count for end devices in the Console.
 
 ### Changed
 

--- a/pkg/webui/console/components/entity-title-section/content/messages-count/messages-count.styl
+++ b/pkg/webui/console/components/entity-title-section/content/messages-count/messages-count.styl
@@ -14,3 +14,6 @@
 
 .container
   margin-left: $ls.s
+
+  &:not(:first-of-type)
+    margin-left: $ls.xxs

--- a/pkg/webui/console/containers/device-title-section/connect.js
+++ b/pkg/webui/console/containers/device-title-section/connect.js
@@ -17,6 +17,7 @@ import { connect } from 'react-redux'
 import {
   selectDeviceByIds,
   selectDeviceUplinkFrameCount,
+  selectDeviceDownlinkFrameCount,
   selectDeviceLastSeen,
 } from '@console/store/selectors/devices'
 
@@ -28,6 +29,7 @@ const mapStateToProps = (state, props) => {
     appId,
     device: selectDeviceByIds(state, appId, devId),
     uplinkFrameCount: selectDeviceUplinkFrameCount(state, appId, devId),
+    downlinkFrameCount: selectDeviceDownlinkFrameCount(state, appId, devId),
     lastSeen: selectDeviceLastSeen(state, appId, devId),
   }
 }

--- a/pkg/webui/console/containers/device-title-section/device-title-section.js
+++ b/pkg/webui/console/containers/device-title-section/device-title-section.js
@@ -36,10 +36,19 @@ const m = defineMessages({
 const { Content } = EntityTitleSection
 
 const DeviceTitleSection = props => {
-  const { devId, fetching, device, uplinkFrameCount, lastSeen, children } = props
+  const {
+    devId,
+    fetching,
+    device,
+    uplinkFrameCount,
+    downlinkFrameCount,
+    lastSeen,
+    children,
+  } = props
 
   const showLastSeen = Boolean(lastSeen)
   const showUplinkCount = typeof uplinkFrameCount === 'number'
+  const showDownlinkCount = typeof downlinkFrameCount === 'number'
 
   return (
     <EntityTitleSection
@@ -70,6 +79,14 @@ const DeviceTitleSection = props => {
                 iconClassName={style.messageIcon}
               />
             )}
+            {showDownlinkCount && (
+              <Content.MessagesCount
+                icon="downlink"
+                value={downlinkFrameCount}
+                tooltipMessage={sharedMessages.downlinkFrameCount}
+                iconClassName={style.messageIcon}
+              />
+            )}
           </>
         )}
       </Content>
@@ -82,6 +99,7 @@ DeviceTitleSection.propTypes = {
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
   devId: PropTypes.string.isRequired,
   device: PropTypes.device.isRequired,
+  downlinkFrameCount: PropTypes.number,
   fetching: PropTypes.bool,
   lastSeen: PropTypes.string,
   uplinkFrameCount: PropTypes.number,
@@ -92,6 +110,7 @@ DeviceTitleSection.defaultProps = {
   lastSeen: undefined,
   children: null,
   fetching: false,
+  downlinkFrameCount: undefined,
 }
 
 export default DeviceTitleSection

--- a/pkg/webui/console/store/selectors/devices.js
+++ b/pkg/webui/console/store/selectors/devices.js
@@ -55,6 +55,12 @@ export const selectDeviceUplinkFrameCount = function(state, appId, devId) {
 
   return derived.uplinkFrameCount
 }
+export const selectDeviceDownlinkFrameCount = function(state, appId, devId) {
+  const derived = selectDeviceDerivedById(state, combineDeviceIds(appId, devId))
+  if (!Boolean(derived)) return undefined
+
+  return derived.downlinkFrameCount
+}
 export const selectDeviceLastSeen = function(state, appId, devId) {
   const derived = selectDeviceDerivedById(state, combineDeviceIds(appId, devId))
   if (!Boolean(derived)) return undefined


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/2740

<details>
<summary>Screenshots</summary>
<img width="599" alt="Screenshot 2020-09-28 at 15 31 04" src="https://user-images.githubusercontent.com/16374166/94435000-40990800-01a3-11eb-86c3-eab76fc37d60.png">
<img width="318" alt="Screenshot 2020-09-28 at 15 31 40" src="https://user-images.githubusercontent.com/16374166/94435002-4262cb80-01a3-11eb-8c17-20baaef91a5f.png">


</details>

#### Changes
<!-- What are the changes made in this pull request? -->

- Extract downlink frame count from the `ns.down.data.schedule.attempt` event.
- Adjust styles for `<MessagesCount />`


#### Testing

<!-- How did you verify that this change works? -->

Tested with actual devices on ch staging



#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@rvolosatovs Please confirm that the `ns.down.data.schedule.attempt` event is the one to check for downlink count. Also, can we use this (or any other) event to bump `last seen` timer for an end device in the console related to downlinks? Currently, we do this only for uplinks (`ns.up.data.receive`, `ns.up.join.receive`, `ns.up.rejoin.receive`)

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
