### PR TITLE
Run root class hook only on initial render

### DIFF
--- a/pkg/webui/lib/hooks/use-root-class.js
+++ b/pkg/webui/lib/hooks/use-root-class.js
@@ -26,5 +26,9 @@ export default (className, id = 'app') => {
         containerClasses.remove(cls)
       }
     }
-  })
+    // Disabling deps check because in this case we want the effect hook to
+    // run only once on component mount. See also:
+    // https://github.com/facebook/create-react-app/issues/6880
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 }


### PR DESCRIPTION
#### Summary
Small quickfix to avoid running the `useRootClass()` effect hook on every update, but only on initial render.

#### Changes
- Run root class hook only on initial render


#### Testing

Manual.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
