### PR TITLE
AS End Device Fetcher

### DIFF
--- a/cmd/internal/shared/applicationserver/config.go
+++ b/cmd/internal/shared/applicationserver/config.go
@@ -46,4 +46,10 @@ var DefaultApplicationServerConfig = applicationserver.Config{
 		Workers:   16,
 		Downlinks: web.DownlinksConfig{PublicAddress: shared.DefaultPublicURL + "/api/v3"},
 	},
+	EndDeviceFetcher: applicationserver.EndDeviceFetcherConfig{
+		Cache: applicationserver.EndDeviceFetcherCacheConfig{
+			Enable: true,
+			TTL:    5 * time.Minute,
+		},
+	},
 }

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -269,6 +269,11 @@ var startCommand = &cobra.Command{
 					Redis: redis.New(config.Redis.WithNamespace("as", "io", "webhooks")),
 				}
 			}
+			fetcher, err := config.AS.EndDeviceFetcher.NewFetcher(c)
+			if err != nil {
+				return shared.ErrInitializeApplicationServer.WithCause(err)
+			}
+			config.AS.EndDeviceFetcher.Fetcher = fetcher
 			as, err := applicationserver.New(c, &config.AS)
 			if err != nil {
 				return shared.ErrInitializeApplicationServer.WithCause(err)

--- a/config/messages.json
+++ b/config/messages.json
@@ -2132,6 +2132,15 @@
       "file": "payload.go"
     }
   },
+  "error:pkg/applicationserver:invalid_ttl": {
+    "translations": {
+      "en": "Invalid TTL `{ttl}`"
+    },
+    "description": {
+      "package": "pkg/applicationserver",
+      "file": "config.go"
+    }
+  },
   "error:pkg/applicationserver:join_server_unavailable": {
     "translations": {
       "en": "Join Server unavailable for JoinEUI `{join_eui}`"

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -935,10 +935,6 @@ func (as *ApplicationServer) handleUplink(ctx context.Context, ids ttnpb.EndDevi
 		uplink.LastAFCntDown = dev.Session.LastAFCntDown
 	}
 
-	if isDev, err := as.endDeviceFetcher.Get(ctx, dev.EndDeviceIdentifiers, "locations"); err == nil {
-		fmt.Println("\n\n++", isDev.Locations)
-	}
-
 	// TODO: Run uplink messages through location solvers async (https://github.com/TheThingsNetwork/lorawan-stack/issues/37)
 	return nil
 }

--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -277,6 +277,9 @@ func TestApplicationServer(t *testing.T) {
 		PubSub: applicationserver.PubSubConfig{
 			Registry: pubsubRegistry,
 		},
+		EndDeviceFetcher: applicationserver.EndDeviceFetcherConfig{
+			Fetcher: &noopEndDeviceFetcher{},
+		},
 	}
 	as, err := applicationserver.New(c, config)
 	if !a.So(err, should.BeNil) {

--- a/pkg/applicationserver/applicationserver_util_test.go
+++ b/pkg/applicationserver/applicationserver_util_test.go
@@ -47,3 +47,11 @@ func (r MockDeviceRegistry) Set(ctx context.Context, ids ttnpb.EndDeviceIdentifi
 	}
 	return r.SetFunc(ctx, ids, paths, f)
 }
+
+// noopEndDeviceFetcher is a no-op.
+type noopEndDeviceFetcher struct{}
+
+// Get implements the EndDeviceFetcher interface.
+func (noopEndDeviceFetcher) Get(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, fieldMaskPaths ...string) (*ttnpb.EndDevice, error) {
+	return nil, errNotFound.New()
+}

--- a/pkg/applicationserver/config.go
+++ b/pkg/applicationserver/config.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/bluele/gcache"
 	"go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io"
 	"go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io/packages"
 	loraclouddevicemanagementv1 "go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io/packages/loradms/v1"
@@ -52,17 +53,31 @@ type InteropConfig struct {
 	ID                   string `name:"id" description:"AS-ID used for interoperability"`
 }
 
+// EndDeviceFetcherConfig represents configuration for the end device fetcher in Application Server.
+type EndDeviceFetcherConfig struct {
+	Fetcher EndDeviceFetcher            `name:"-"`
+	Cache   EndDeviceFetcherCacheConfig `name:"cache" description:"Cache configuration options for the end device fetcher"`
+}
+
+// EndDeviceFetcherCacheConfig represents configuration for device information caching in Application Server.
+type EndDeviceFetcherCacheConfig struct {
+	Enable bool          `name:"enable" description:"Cache fetched end devices"`
+	TTL    time.Duration `name:"ttl" description:"TTL for cached end devices"`
+	Size   int           `name:"size" description:"Cache size"`
+}
+
 // Config represents the ApplicationServer configuration.
 type Config struct {
-	LinkMode       string                    `name:"link-mode" description:"Mode to link applications to their Network Server (all, explicit)"`
-	Devices        DeviceRegistry            `name:"-"`
-	Links          LinkRegistry              `name:"-"`
-	MQTT           config.MQTT               `name:"mqtt" description:"MQTT configuration"`
-	Webhooks       WebhooksConfig            `name:"webhooks" description:"Webhooks configuration"`
-	PubSub         PubSubConfig              `name:"pubsub" description:"Pub/sub messaging configuration"`
-	Packages       ApplicationPackagesConfig `name:"packages" description:"Application packages configuration"`
-	Interop        InteropConfig             `name:"interop" description:"Interop client configuration"`
-	DeviceKEKLabel string                    `name:"device-kek-label" description:"Label of KEK used to encrypt device keys at rest"`
+	LinkMode         string                    `name:"link-mode" description:"Mode to link applications to their Network Server (all, explicit)"`
+	Devices          DeviceRegistry            `name:"-"`
+	Links            LinkRegistry              `name:"-"`
+	EndDeviceFetcher EndDeviceFetcherConfig    `name:"fetcher" description:"End Device fetcher configuration"`
+	MQTT             config.MQTT               `name:"mqtt" description:"MQTT configuration"`
+	Webhooks         WebhooksConfig            `name:"webhooks" description:"Webhooks configuration"`
+	PubSub           PubSubConfig              `name:"pubsub" description:"Pub/sub messaging configuration"`
+	Packages         ApplicationPackagesConfig `name:"packages" description:"Application packages configuration"`
+	Interop          InteropConfig             `name:"interop" description:"Interop client configuration"`
+	DeviceKEKLabel   string                    `name:"device-kek-label" description:"Label of KEK used to encrypt device keys at rest"`
 }
 
 var errLinkMode = errors.DefineInvalidArgument("link_mode", "invalid link mode `{value}`")
@@ -164,4 +179,28 @@ func (c ApplicationPackagesConfig) NewApplicationPackages(ctx context.Context, s
 	handlers[loradmsHandler.Package().Name] = loradmsHandler
 
 	return packages.New(ctx, server, c.Registry, handlers)
+}
+
+var (
+	errInvalidTTL = errors.DefineInvalidArgument("invalid_ttl", "Invalid TTL `{ttl}`")
+)
+
+// NewFetcher creates an EndDeviceFetcher from config.
+func (c EndDeviceFetcherConfig) NewFetcher(comp *component.Component) (EndDeviceFetcher, error) {
+	fetcher := NewRegistryEndDeviceFetcher(comp)
+	if c.Cache.Enable {
+		if c.Cache.TTL <= 0 {
+			return nil, errInvalidTTL.WithAttributes("ttl", c.Cache.TTL)
+		}
+		var builder *gcache.CacheBuilder
+		if c.Cache.Size > 0 {
+			builder = gcache.New(c.Cache.Size).LFU()
+		} else {
+			builder = gcache.New(-1)
+		}
+		builder = builder.Expiration(c.Cache.TTL)
+		fetcher = NewCachedEndDeviceFetcher(fetcher, builder.Build())
+	}
+
+	return fetcher, nil
 }

--- a/pkg/applicationserver/device_fetcher.go
+++ b/pkg/applicationserver/device_fetcher.go
@@ -1,0 +1,82 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package applicationserver
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/bluele/gcache"
+	pbtypes "github.com/gogo/protobuf/types"
+	"go.thethings.network/lorawan-stack/v3/pkg/component"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/unique"
+)
+
+// EndDeviceFetcher fetches end device protos.
+type EndDeviceFetcher interface {
+	Get(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, fieldMaskPaths ...string) (*ttnpb.EndDevice, error)
+}
+
+// endDeviceFetcher fetches end devices
+type endDeviceFetcher struct {
+	c *component.Component
+}
+
+// NewRegistryEndDeviceFetcher returns a new endDeviceFetcher.
+func NewRegistryEndDeviceFetcher(c *component.Component) EndDeviceFetcher {
+	return &endDeviceFetcher{c}
+}
+
+// Get implements the EndDeviceFetcher interface.
+func (f *endDeviceFetcher) Get(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, fieldMaskPaths ...string) (*ttnpb.EndDevice, error) {
+	cc, err := f.c.GetPeerConn(ctx, ttnpb.ClusterRole_ENTITY_REGISTRY, ids)
+	if err != nil {
+		return nil, err
+	}
+
+	return ttnpb.NewEndDeviceRegistryClient(cc).Get(ctx, &ttnpb.GetEndDeviceRequest{
+		EndDeviceIdentifiers: ids,
+		FieldMask: pbtypes.FieldMask{
+			Paths: fieldMaskPaths,
+		},
+	}, f.c.WithClusterAuth())
+}
+
+type cachedEndDeviceFetcher struct {
+	fetcher EndDeviceFetcher
+	cache   gcache.Cache
+}
+
+// NewCachedEndDeviceFetcher wraps an EndDeviceFetcher with a local cache.
+func NewCachedEndDeviceFetcher(fetcher EndDeviceFetcher, cache gcache.Cache) EndDeviceFetcher {
+	return &cachedEndDeviceFetcher{fetcher, cache}
+}
+
+// Get implements the EndDeviceFetcher interface.
+func (f *cachedEndDeviceFetcher) Get(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, fieldMaskPaths ...string) (*ttnpb.EndDevice, error) {
+	uid := unique.ID(ctx, ids)
+	key := fmt.Sprintf("%s:%s", uid, strings.Join(fieldMaskPaths, ","))
+	dev, err := f.cache.Get(key)
+	if err != nil {
+		dev, err := f.fetcher.Get(ctx, ids, fieldMaskPaths...)
+		if err == nil {
+			f.cache.Set(key, dev)
+		}
+		return dev, err
+	}
+	return dev.(*ttnpb.EndDevice), err
+}

--- a/pkg/applicationserver/device_fetcher_test.go
+++ b/pkg/applicationserver/device_fetcher_test.go
@@ -1,0 +1,99 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package applicationserver_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bluele/gcache"
+	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/v3/pkg/applicationserver"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+)
+
+type mockFetcher struct {
+	numCalls int
+}
+
+func (f *mockFetcher) Get(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, fieldMaskPaths ...string) (*ttnpb.EndDevice, error) {
+	f.numCalls++
+	return nil, nil
+}
+
+func TestEndDeviceFetcher(t *testing.T) {
+	t.Run("Cache", func(t *testing.T) {
+		a := assertions.New(t)
+		f := &mockFetcher{}
+
+		_, err := f.Get(test.Context(), ttnpb.EndDeviceIdentifiers{}, "locations")
+		a.So(err, should.BeNil)
+		a.So(f.numCalls, should.Equal, 1)
+
+		fakeClock := gcache.NewFakeClock()
+		cache := gcache.New(-1).Clock(fakeClock).Expiration(time.Second).Build()
+
+		dev1 := ttnpb.EndDeviceIdentifiers{
+			DeviceID: "dev1",
+			ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{
+				ApplicationID: "app1",
+			},
+		}
+		dev2 := ttnpb.EndDeviceIdentifiers{
+			DeviceID: "dev2",
+			ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{
+				ApplicationID: "app2",
+			},
+		}
+
+		cf := applicationserver.NewCachedEndDeviceFetcher(f, cache)
+
+		t.Run("Cold", func(t *testing.T) {
+			a := assertions.New(t)
+			cf.Get(test.Context(), dev1, "locations")
+			a.So(f.numCalls, should.Equal, 2)
+			cf.Get(test.Context(), dev1, "locations")
+			a.So(f.numCalls, should.Equal, 2)
+		})
+
+		t.Run("Expire", func(t *testing.T) {
+			a := assertions.New(t)
+			fakeClock.Advance(2 * time.Second)
+			cf.Get(test.Context(), dev1, "locations")
+			a.So(f.numCalls, should.Equal, 3)
+			cf.Get(test.Context(), dev1, "locations")
+			a.So(f.numCalls, should.Equal, 3)
+		})
+
+		t.Run("OtherDevice", func(t *testing.T) {
+			a := assertions.New(t)
+			cf.Get(test.Context(), dev1, "locations")
+			a.So(f.numCalls, should.Equal, 3)
+			cf.Get(test.Context(), dev2, "locations")
+			a.So(f.numCalls, should.Equal, 4)
+		})
+
+		t.Run("OtherFieldMask", func(t *testing.T) {
+			a := assertions.New(t)
+			cf.Get(test.Context(), dev1, "attributes")
+			a.So(f.numCalls, should.Equal, 5)
+			cf.Get(test.Context(), dev1, "attributes")
+			a.So(f.numCalls, should.Equal, 5)
+		})
+	})
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #2669

#### Changes
<!-- What are the changes made in this pull request? -->

- Add an AS cache for retrieving device information from other registries, for use as metadata. Kept separately from the AS device registry.
- Currently, only retrieve location information, as needed for #2669

#### Testing

<!-- How did you verify that this change works? -->

- Test locally
- Unit tests

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

- Increases memory usage in AS, can be leveraged by using a Redis cache instead

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This is groundwork for #2669, extracted as a separate PR.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [X] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
