### PR TITLE
Set ChannelRSSI to RSSI in MQTT V2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - Support for sending end device uplinks in the Console.
 - PHY version filtering based on LoRaWAN MAC in the Console.
 - Meta information and status events in the event views in the Console.
@@ -32,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Incorrect entity count in title sections in the Console.
 - Incorrect event detail panel open/close behavior for some events in the Console.
 - Improved error resilience and stability of the event views in the Console.
+- RSSI metadata for MQTT gateways connected with The Things Network Stack V2 protocol.
 
 ### Security
 

--- a/pkg/gatewayserver/io/mqtt/format_protobufv2.go
+++ b/pkg/gatewayserver/io/mqtt/format_protobufv2.go
@@ -167,12 +167,16 @@ func (protobufv2) ToUplink(message []byte, ids ttnpb.GatewayIdentifiers) (*ttnpb
 	mdTime := time.Unix(0, gwMetadata.Time)
 	if antennas := gwMetadata.Antennas; len(antennas) > 0 {
 		for _, antenna := range antennas {
+			rssi := antenna.ChannelRssi
+			if rssi == 0 {
+				rssi = antenna.Rssi
+			}
 			uplink.RxMetadata = append(uplink.RxMetadata, &ttnpb.RxMetadata{
 				GatewayIdentifiers:    ids,
 				AntennaIndex:          antenna.Antenna,
-				ChannelRSSI:           antenna.ChannelRssi,
+				ChannelRSSI:           rssi,
 				FrequencyOffset:       antenna.FrequencyOffset,
-				RSSI:                  antenna.Rssi,
+				RSSI:                  rssi,
 				RSSIStandardDeviation: antenna.RssiStandardDeviation,
 				SNR:                   antenna.Snr,
 				Time:                  &mdTime,
@@ -183,6 +187,7 @@ func (protobufv2) ToUplink(message []byte, ids ttnpb.GatewayIdentifiers) (*ttnpb
 		uplink.RxMetadata = append(uplink.RxMetadata, &ttnpb.RxMetadata{
 			GatewayIdentifiers: ids,
 			AntennaIndex:       0,
+			ChannelRSSI:        gwMetadata.Rssi,
 			RSSI:               gwMetadata.Rssi,
 			SNR:                gwMetadata.Snr,
 			Time:               &mdTime,

--- a/pkg/gatewayserver/io/mqtt/format_protobufv2_test.go
+++ b/pkg/gatewayserver/io/mqtt/format_protobufv2_test.go
@@ -137,6 +137,7 @@ func TestProtobufV2Uplinks(t *testing.T) {
 	validV3Metadata := []*ttnpb.RxMetadata{
 		{
 			GatewayIdentifiers: ids,
+			ChannelRSSI:        -2,
 			RSSI:               -2,
 			SNR:                -75,
 			Time:               &nilTime,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Harmonize `ChannelRSSI` and `RSSI` in MQTT V2 frontend.

#### Changes
<!-- What are the changes made in this pull request? -->

Apparently the channel RSSI reported by gateways is, or can be, empty.

Our API spec prescribes that `ChannelRSSI` equals `RSSI`, so we have to set the value to the same source. The V2's `channel_rssi` field now takes precedence over `rssi`.

#### Testing

<!-- How did you verify that this change works? -->

Unit testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
