### PR TITLE
Use Gateway IDs retrieved from IS for upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Incorrect event detail panel open/close behavior for some events in the Console.
 - Improved error resilience and stability of the event views in the Console.
 - RSSI metadata for MQTT gateways connected with The Things Network Stack V2 protocol.
+- Gateway ID usage in upstream connection.
 
 ### Security
 

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -493,6 +493,8 @@ func (gs *GatewayServer) Connect(ctx context.Context, frontend io.Frontend, ids 
 		return nil, err
 	}
 
+	ids = gtw.GatewayIdentifiers
+
 	conn, err := io.NewConnection(ctx, frontend, gtw, gs.FrequencyPlans, gtw.EnforceDutyCycle, gtw.ScheduleAnytimeDelay)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Use Gateway IDs retrieved from IS for upstream

#### Changes
<!-- What are the changes made in this pull request? -->

- Use Gateway IDs retrieved from IS for upstream instead of passing the IDs from the frontend

#### Testing

<!-- How did you verify that this change works? -->

UT

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Not relevant for single instance clusters, will be tested in `staging1` after merge.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
