### PR TITLE
Fix regexp validation error messages

### DIFF
--- a/pkg/webui/console/components/collaborator-form/index.js
+++ b/pkg/webui/console/components/collaborator-form/index.js
@@ -36,7 +36,7 @@ import { id as collaboratorIdRegexp } from '@console/lib/regexp'
 
 const validationSchema = Yup.object().shape({
   collaborator_id: Yup.string()
-    .matches(collaboratorIdRegexp, sharedMessages.validateIdFormat)
+    .matches(collaboratorIdRegexp, Yup.passValues(sharedMessages.validateIdFormat))
     .required(sharedMessages.validateRequired),
   collaborator_type: Yup.string().required(sharedMessages.validateRequired),
   rights: Yup.array().min(1, sharedMessages.validateRights),

--- a/pkg/webui/console/components/gateway-data-form/index.js
+++ b/pkg/webui/console/components/gateway-data-form/index.js
@@ -69,7 +69,7 @@ const validationSchema = Yup.object().shape({
   owner_id: Yup.string(),
   ids: Yup.object().shape({
     gateway_id: Yup.string()
-      .matches(gatewayIdRegexp, sharedMessages.validateIdFormat)
+      .matches(gatewayIdRegexp, Yup.passValues(sharedMessages.validateIdFormat))
       .min(2, Yup.passValues(sharedMessages.validateTooShort))
       .max(36, Yup.passValues(sharedMessages.validateTooLong))
       .required(sharedMessages.validateRequired),
@@ -83,13 +83,19 @@ const validationSchema = Yup.object().shape({
     .max(50, Yup.passValues(sharedMessages.validateTooLong)),
   description: Yup.string().max(2000, Yup.passValues(sharedMessages.validateTooLong)),
   frequency_plan_id: Yup.string(),
-  gateway_server_address: Yup.string().matches(addressRegexp, sharedMessages.validateAddressFormat),
+  gateway_server_address: Yup.string().matches(
+    addressRegexp,
+    Yup.passValues(sharedMessages.validateAddressFormat),
+  ),
   location_public: Yup.boolean().default(false),
   status_public: Yup.boolean().default(false),
   schedule_downlink_late: Yup.boolean().default(false),
   update_location_from_status: Yup.boolean().default(false),
   auto_update: Yup.boolean().default(false),
-  schedule_anytime_delay: Yup.string().matches(delayRegexp, sharedMessages.validateDelayFormat),
+  schedule_anytime_delay: Yup.string().matches(
+    delayRegexp,
+    Yup.passValues(sharedMessages.validateDelayFormat),
+  ),
   attributes: Yup.array()
     .test(
       'has no empty string values',

--- a/pkg/webui/console/components/organization-form/index.js
+++ b/pkg/webui/console/components/organization-form/index.js
@@ -28,7 +28,7 @@ import { id as organizationIdRegexp } from '@console/lib/regexp'
 const validationSchema = Yup.object().shape({
   ids: Yup.object().shape({
     organization_id: Yup.string()
-      .matches(organizationIdRegexp, sharedMessages.validateIdFormat)
+      .matches(organizationIdRegexp, Yup.passValues(sharedMessages.validateIdFormat))
       .min(2, Yup.passValues(sharedMessages.validateTooShort))
       .max(25, Yup.passValues(sharedMessages.validateTooLong))
       .required(sharedMessages.validateRequired),

--- a/pkg/webui/console/components/payload-formatters-form/index.js
+++ b/pkg/webui/console/components/payload-formatters-form/index.js
@@ -59,7 +59,7 @@ const validationSchema = Yup.object().shape({
     then: Yup.string().required(sharedMessages.validateRequired),
   }),
   [FIELD_NAMES.GRPC]: Yup.string()
-    .matches(addressRegexp, sharedMessages.validateAddressFormat)
+    .matches(addressRegexp, Yup.passValues(sharedMessages.validateAddressFormat))
     .when(FIELD_NAMES.RADIO, {
       is: TYPES.GRPC,
       then: Yup.string().required(sharedMessages.validateRequired),

--- a/pkg/webui/console/components/user-data-form/index.js
+++ b/pkg/webui/console/components/user-data-form/index.js
@@ -43,7 +43,7 @@ const approvalStates = [
 const validationSchema = Yup.object().shape({
   ids: Yup.object().shape({
     user_id: Yup.string()
-      .matches(userIdRegexp, sharedMessages.validateIdFormat)
+      .matches(userIdRegexp, Yup.passValues(sharedMessages.validateIdFormat))
       .min(2, Yup.passValues(sharedMessages.validateTooShort))
       .max(25, Yup.passValues(sharedMessages.validateTooLong))
       .required(sharedMessages.validateRequired),

--- a/pkg/webui/console/components/webhook-form/index.js
+++ b/pkg/webui/console/components/webhook-form/index.js
@@ -65,7 +65,7 @@ const headerCheck = headers =>
 
 const validationSchema = Yup.object().shape({
   webhook_id: Yup.string()
-    .matches(webhookIdRegexp, sharedMessages.validateIdFormat)
+    .matches(webhookIdRegexp, Yup.passValues(sharedMessages.validateIdFormat))
     .min(2, Yup.passValues(sharedMessages.validateTooShort))
     .max(25, Yup.passValues(sharedMessages.validateTooLong))
     .required(sharedMessages.validateRequired),
@@ -80,9 +80,12 @@ const validationSchema = Yup.object().shape({
     .test('has no empty string values', m.headersValidateRequired, headerCheck)
     .default([]),
   base_url: Yup.string()
-    .matches(urlRegexp, sharedMessages.validateUrl)
+    .matches(urlRegexp, Yup.passValues(sharedMessages.validateUrl))
     .required(sharedMessages.validateRequired),
-  downlink_api_key: Yup.string().matches(webhookAPIKeyRegexp, sharedMessages.validateApiKey),
+  downlink_api_key: Yup.string().matches(
+    webhookAPIKeyRegexp,
+    Yup.passValues(sharedMessages.validateApiKey),
+  ),
 })
 
 export default class WebhookForm extends Component {

--- a/pkg/webui/console/components/webhook-template-form/index.js
+++ b/pkg/webui/console/components/webhook-template-form/index.js
@@ -155,7 +155,7 @@ export default class WebhookTemplateForm extends Component {
         }),
         {
           webhook_id: Yup.string()
-            .matches(webhookIdRegexp, sharedMessages.validateIdFormat)
+            .matches(webhookIdRegexp, Yup.passValues(sharedMessages.validateIdFormat))
             .min(2, Yup.passValues(sharedMessages.validateTooShort))
             .max(25, Yup.passValues(sharedMessages.validateTooLong))
             .required(sharedMessages.validateRequired),

--- a/pkg/webui/console/views/application-add/index.js
+++ b/pkg/webui/console/views/application-add/index.js
@@ -60,7 +60,7 @@ const m = defineMessages({
 const validationSchema = Yup.object().shape({
   owner_id: Yup.string().required(sharedMessages.validateRequired),
   application_id: Yup.string()
-    .matches(applicationIdRegexp, sharedMessages.validateIdFormat)
+    .matches(applicationIdRegexp, Yup.passValues(sharedMessages.validateIdFormat))
     .min(2, Yup.passValues(sharedMessages.validateTooShort))
     .max(25, Yup.passValues(sharedMessages.validateTooLong))
     .required(sharedMessages.validateRequired),
@@ -71,7 +71,7 @@ const validationSchema = Yup.object().shape({
   description: Yup.string(),
   network_server_address: Yup.string().when('link', {
     is: true,
-    then: schema => schema.matches(address, sharedMessages.validateAddressFormat),
+    then: schema => schema.matches(address, Yup.passValues(sharedMessages.validateAddressFormat)),
   }),
 })
 

--- a/pkg/webui/console/views/application-link/index.js
+++ b/pkg/webui/console/views/application-link/index.js
@@ -82,9 +82,12 @@ const m = defineMessages({
 
 const validationSchema = Yup.object().shape({
   api_key: Yup.string()
-    .matches(apiKey, sharedMessages.validateApiKey)
+    .matches(apiKey, Yup.passValues(sharedMessages.validateApiKey))
     .required(sharedMessages.validateRequired),
-  network_server_address: Yup.string().matches(address, sharedMessages.validateAddressFormat),
+  network_server_address: Yup.string().matches(
+    address,
+    Yup.passValues(sharedMessages.validateAddressFormat),
+  ),
   tls: Yup.bool(),
 })
 

--- a/pkg/webui/console/views/device-add/configuration-form/validation-schema.js
+++ b/pkg/webui/console/views/device-add/configuration-form/validation-schema.js
@@ -31,11 +31,11 @@ const validationSchema = Yup.object()
         }
 
         if (!asEnabled) {
-          return schema.matches(addressRegexp, sharedMessages.validateAddressFormat)
+          return schema.matches(addressRegexp, Yup.passValues(sharedMessages.validateAddressFormat))
         }
 
         return schema
-          .matches(addressRegexp, sharedMessages.validateAddressFormat)
+          .matches(addressRegexp, Yup.passValues(sharedMessages.validateAddressFormat))
           .default(getHostFromUrl(asUrl))
       },
     ),
@@ -47,21 +47,21 @@ const validationSchema = Yup.object()
         }
 
         if (!nsEnabled) {
-          return schema.matches(addressRegexp, sharedMessages.validateAddressFormat)
+          return schema.matches(addressRegexp, Yup.passValues(sharedMessages.validateAddressFormat))
         }
 
         if (!mayEditKeys) {
           if (activationMode === ACTIVATION_MODES.OTAA) {
             return schema
-              .matches(addressRegexp, sharedMessages.validateAddressFormat)
+              .matches(addressRegexp, Yup.passValues(sharedMessages.validateAddressFormat))
               .default(getHostFromUrl(nsUrl))
           }
 
-          return schema.matches(addressRegexp, sharedMessages.validateAddressFormat)
+          return schema.matches(addressRegexp, Yup.passValues(sharedMessages.validateAddressFormat))
         }
 
         return schema
-          .matches(addressRegexp, sharedMessages.validateAddressFormat)
+          .matches(addressRegexp, Yup.passValues(sharedMessages.validateAddressFormat))
           .default(getHostFromUrl(nsUrl))
       },
     ),
@@ -73,7 +73,7 @@ const validationSchema = Yup.object()
         }
 
         return schema
-          .matches(addressRegexp, sharedMessages.validateAddressFormat)
+          .matches(addressRegexp, Yup.passValues(sharedMessages.validateAddressFormat))
           .transform(toUndefined)
           .default(getHostFromUrl(jsUrl))
       },

--- a/pkg/webui/console/views/device-add/wizard/basic-settings-form/validation-schema.js
+++ b/pkg/webui/console/views/device-add/wizard/basic-settings-form/validation-schema.js
@@ -19,7 +19,7 @@ import { id as deviceIdRegexp } from '@ttn-lw/lib/regexp'
 import { ACTIVATION_MODES, parseLorawanMacVersion } from '@console/lib/device-utils'
 
 const deviceIdSchema = Yup.string()
-  .matches(deviceIdRegexp, sharedMessages.validateIdFormat)
+  .matches(deviceIdRegexp, Yup.passValues(sharedMessages.validateIdFormat))
   .min(2, Yup.passValues(sharedMessages.validateTooShort))
   .max(36, Yup.passValues(sharedMessages.validateTooLong))
   .required(sharedMessages.validateRequired)

--- a/pkg/webui/console/views/device-claim-authentication-code/index.js
+++ b/pkg/webui/console/views/device-claim-authentication-code/index.js
@@ -52,7 +52,7 @@ const m = defineMessages({
 const validationSchema = Yup.object({
   claim_authentication_code: Yup.object({
     value: Yup.string()
-      .matches(/^[A-Z0-9]{1,32}$/, m.validateCode)
+      .matches(/^[A-Z0-9]{1,32}$/, Yup.passValues(m.validateCode))
       .required(sharedMessages.validateRequired),
     valid_from: Yup.date(),
     valid_to: Yup.date().when('valid_from', (validFrom, schema) => {

--- a/pkg/webui/console/views/device-general-settings/identity-server-form/validation-schema.js
+++ b/pkg/webui/console/views/device-general-settings/identity-server-form/validation-schema.js
@@ -36,11 +36,11 @@ const validationSchema = Yup.object()
     description: Yup.string().max(2000, Yup.passValues(sharedMessages.validateTooLong)),
     network_server_address: Yup.string().matches(
       addressRegexp,
-      sharedMessages.validateAddressFormat,
+      Yup.passValues(sharedMessages.validateAddressFormat),
     ),
     application_server_address: Yup.string().matches(
       addressRegexp,
-      sharedMessages.validateAddressFormat,
+      Yup.passValues(sharedMessages.validateAddressFormat),
     ),
     _external_js: Yup.boolean(),
     join_server_address: Yup.string().when(['$supportsJoin'], (supportsJoin, schema) => {
@@ -48,7 +48,9 @@ const validationSchema = Yup.object()
         return schema.strip()
       }
 
-      return schema.matches(addressRegexp, sharedMessages.validateAddressFormat).default('')
+      return schema
+        .matches(addressRegexp, Yup.passValues(sharedMessages.validateAddressFormat))
+        .default('')
     }),
     resets_join_nonces: Yup.bool().when(
       ['$supportsJoin', '$lorawanVersion', '_external_js'],

--- a/pkg/webui/oauth/views/create-account/index.js
+++ b/pkg/webui/oauth/views/create-account/index.js
@@ -52,7 +52,7 @@ const validationSchema = Yup.object().shape({
   user_id: Yup.string()
     .min(3, Yup.passValues(sharedMessages.validateTooShort))
     .max(36, Yup.passValues(sharedMessages.validateTooLong))
-    .matches(userRegexp, sharedMessages.validateIdFormat)
+    .matches(userRegexp, Yup.passValues(sharedMessages.validateIdFormat))
     .required(sharedMessages.validateRequired),
   name: Yup.string()
     .min(3, Yup.passValues(sharedMessages.validateTooShort))

--- a/pkg/webui/oauth/views/forgot-password/index.js
+++ b/pkg/webui/oauth/views/forgot-password/index.js
@@ -51,7 +51,7 @@ const validationSchema = Yup.object().shape({
   user_id: Yup.string()
     .min(3, Yup.passValues(sharedMessages.validateTooShort))
     .max(36, Yup.passValues(sharedMessages.validateTooLong))
-    .matches(userRegexp, sharedMessages.validateIdFormat)
+    .matches(userRegexp, Yup.passValues(sharedMessages.validateIdFormat))
     .required(sharedMessages.validateRequired),
 })
 

--- a/pkg/webui/oauth/views/login/index.js
+++ b/pkg/webui/oauth/views/login/index.js
@@ -50,7 +50,7 @@ const validationSchema = Yup.object().shape({
   user_id: Yup.string()
     .min(3, Yup.passValues(sharedMessages.validateTooShort))
     .max(36, Yup.passValues(sharedMessages.validateTooLong))
-    .matches(userRegexp, sharedMessages.validateIdFormat)
+    .matches(userRegexp, Yup.passValues(sharedMessages.validateIdFormat))
     .required(sharedMessages.validateRequired),
   password: Yup.string().required(sharedMessages.validateRequired),
 })


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Before:

<img width="851" alt="Screenshot 2020-10-02 at 16 13 42" src="https://user-images.githubusercontent.com/16374166/94926979-4c9a0800-04ca-11eb-9687-2e5006bce7f1.png">

With this PR:

<img width="851" alt="Screenshot 2020-10-02 at 16 13 18" src="https://user-images.githubusercontent.com/16374166/94926974-4c017180-04ca-11eb-9506-ee8b6b5292a4.png">


#### Changes
<!-- What are the changes made in this pull request? -->

- Use `Yup.passValues` when using `matches`.


#### Testing

<!-- How did you verify that this change works? -->

I tested every form I made changes to.


#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

`Yup.passValues` is not really a proper solution for this, but we already had places that used `passValues` to make sure regexp validation yields a proper message. Please see [this comment](https://github.com/TheThingsNetwork/lorawan-stack/issues/2953#issuecomment-662912596) for why this works.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
