### PR TITLE
Improve `Last seen` time display in the Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved error resilience and stability of the event views in the Console.
 - RSSI metadata for MQTT gateways connected with The Things Network Stack V2 protocol.
 - Gateway ID usage in upstream connection.
+- Last seen counter for applications, end devices and gateways in the Console.
 
 ### Security
 

--- a/pkg/webui/console/components/entity-title-section/content/last-seen/index.js
+++ b/pkg/webui/console/components/entity-title-section/content/last-seen/index.js
@@ -1,0 +1,59 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import classnames from 'classnames'
+
+import DateTime from '@ttn-lw/lib/components/date-time'
+import Message from '@ttn-lw/lib/components/message'
+
+import PropTypes from '@ttn-lw/lib/prop-types'
+import sharedMessages from '@ttn-lw/lib/shared-messages'
+
+import style from './last-seen.styl'
+
+const computeDeltaInSeconds = (from, to) => {
+  // Avoid situations when server clock is ahead of the browser clock.
+  if (from > to) {
+    return 0
+  }
+
+  return Math.floor((from - to) / 1000)
+}
+
+const LastSeen = props => {
+  const { className, lastSeen } = props
+
+  return (
+    <div className={classnames(className, style.container)}>
+      <Message className={style.message} content={sharedMessages.lastSeen} />
+      <DateTime.Relative value={lastSeen} computeDelta={computeDeltaInSeconds} />
+    </div>
+  )
+}
+
+LastSeen.propTypes = {
+  className: PropTypes.string,
+  lastSeen: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number, // Support timestamps.
+    PropTypes.instanceOf(Date),
+  ]).isRequired,
+}
+
+LastSeen.defaultProps = {
+  className: undefined,
+}
+
+export default LastSeen

--- a/pkg/webui/console/components/entity-title-section/content/last-seen/last-seen.styl
+++ b/pkg/webui/console/components/entity-title-section/content/last-seen/last-seen.styl
@@ -12,13 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import EntityTitleSectionContent from './content'
-import EntityCount from './entity-count'
-import MessagesCount from './messages-count'
-import LastSeen from './last-seen'
+.container
+  display: inline-block
 
-EntityTitleSectionContent.EntityCount = EntityCount
-EntityTitleSectionContent.MessagesCount = MessagesCount
-EntityTitleSectionContent.LastSeen = LastSeen
-
-export default EntityTitleSectionContent
+.message
+  margin-right: $cs.xxs

--- a/pkg/webui/console/containers/application-title-section/status/index.js
+++ b/pkg/webui/console/containers/application-title-section/status/index.js
@@ -16,13 +16,14 @@ import React from 'react'
 
 import Status from '@ttn-lw/components/status'
 
-import DateTime from '@ttn-lw/lib/components/date-time'
-import Message from '@ttn-lw/lib/components/message'
+import EntityTitleSection from '@console/components/entity-title-section'
 
 import PropTypes from '@ttn-lw/lib/prop-types'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 
 import style from './status.styl'
+
+const { Content } = EntityTitleSection
 
 const ApplicationStatus = React.memo(props => {
   const { linked, lastSeen } = props
@@ -30,20 +31,15 @@ const ApplicationStatus = React.memo(props => {
   const linkStatus = linked ? 'good' : 'bad'
   const linkLabel = linked ? sharedMessages.linked : sharedMessages.notLinked
 
-  let linkElement
   if (linked && lastSeen) {
-    linkElement = (
+    return (
       <Status className={style.status} status={linkStatus} flipped>
-        <Message content={sharedMessages.lastSeen} /> <DateTime.Relative value={lastSeen} />
+        <Content.lastSeen lastSeen={lastSeen} />
       </Status>
     )
   }
 
-  if (!linkElement) {
-    linkElement = <Status className={style.status} label={linkLabel} status={linkStatus} flipped />
-  }
-
-  return linkElement
+  return <Status className={style.status} label={linkLabel} status={linkStatus} flipped />
 })
 
 ApplicationStatus.propTypes = {

--- a/pkg/webui/console/containers/device-title-section/device-title-section.js
+++ b/pkg/webui/console/containers/device-title-section/device-title-section.js
@@ -20,13 +20,14 @@ import deviceIcon from '@assets/misc/end-device.svg'
 import Status from '@ttn-lw/components/status'
 import Spinner from '@ttn-lw/components/spinner'
 
-import DateTime from '@ttn-lw/lib/components/date-time'
 import Message from '@ttn-lw/lib/components/message'
 
 import EntityTitleSection from '@console/components/entity-title-section'
 
 import PropTypes from '@ttn-lw/lib/prop-types'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
+
+import LastSeen from '../../components/entity-title-section/content/last-seen'
 
 import style from './device-title-section.styl'
 
@@ -58,7 +59,7 @@ const DeviceTitleSection = props => {
           <>
             {showLastSeen ? (
               <Status status="good" flipped>
-                <Message content={sharedMessages.lastSeen} /> <DateTime.Relative value={lastSeen} />
+                <LastSeen lastSeen={lastSeen} />
               </Status>
             ) : (
               <Status status="mediocre" label={m.lastSeenUnavailable} flipped />

--- a/pkg/webui/console/containers/gateway-connection/gateway-connection.js
+++ b/pkg/webui/console/containers/gateway-connection/gateway-connection.js
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,14 +20,17 @@ import Status from '@ttn-lw/components/status'
 import Icon from '@ttn-lw/components/icon'
 import Button from '@ttn-lw/components/button'
 
-import DateTime from '@ttn-lw/lib/components/date-time'
 import Message from '@ttn-lw/lib/components/message'
+
+import EntityTitleSection from '@console/components/entity-title-section'
 
 import PropTypes from '@ttn-lw/lib/prop-types'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 import { isNotFoundError, isTranslated } from '@ttn-lw/lib/errors/utils'
 
 import style from './gateway-connection.styl'
+
+const { Content } = EntityTitleSection
 
 class GatewayConnection extends React.PureComponent {
   static propTypes = {
@@ -82,7 +85,7 @@ class GatewayConnection extends React.PureComponent {
       statusIndicator = 'unknown'
       message = error.message
     } else if (hasStatistics) {
-      message = hasLastSeen ? sharedMessages.lastSeen : sharedMessages.connected
+      message = sharedMessages.connected
       statusIndicator = 'good'
     } else {
       message = sharedMessages.unknown
@@ -91,9 +94,10 @@ class GatewayConnection extends React.PureComponent {
 
     return (
       <Status className={style.status} status={statusIndicator} flipped>
-        <Message className={style.lastSeen} content={message} />
-        {statusIndicator === 'good' && lastSeen && (
-          <DateTime.Relative className={style.dateTime} value={lastSeen} />
+        {statusIndicator === 'good' && hasLastSeen ? (
+          <Content.LastSeen lastSeen={lastSeen} />
+        ) : (
+          <Message content={message} />
         )}
       </Status>
     )

--- a/pkg/webui/lib/components/date-time/relative.js
+++ b/pkg/webui/lib/components/date-time/relative.js
@@ -19,11 +19,9 @@ import PropTypes from '@ttn-lw/lib/prop-types'
 
 import DateTime from '.'
 
-function formatInSeconds(from, to) {
-  return Math.floor((from - to) / 1000)
-}
+const formatInSeconds = (from, to) => Math.floor((from - to) / 1000)
 
-const RelativeTime = function(props) {
+const RelativeTime = props => {
   const { className, value, unit, computeDelta, updateIntervalInSeconds, children } = props
 
   return (
@@ -53,16 +51,13 @@ const RelativeTime = function(props) {
 RelativeTime.propTypes = {
   children: PropTypes.func,
   className: PropTypes.string,
-  /** The time to be displayed. */
+  /** A function to compute relative delta in specified time units in the `unit` prop. */
   computeDelta: PropTypes.func,
-  /** The interval that the component will re-render in seconds. */
-  unit: PropTypes.oneOf(['second', 'minute', 'hour', 'day', 'week', 'month', 'year']),
   /** The unit to calculate relative date time. */
+  unit: PropTypes.oneOf(['second', 'minute', 'hour', 'day', 'week', 'month', 'year']),
+  /** The interval that the component will re-render in seconds. */
   updateIntervalInSeconds: PropTypes.number,
-  /**
-   * A function to compute relative delta in specified time units in the `unit`
-   * prop.
-   */
+  /** The time to be displayed. */
   value: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number, // Support timestamps.
@@ -72,7 +67,7 @@ RelativeTime.propTypes = {
 
 RelativeTime.defaultProps = {
   children: dateTime => dateTime,
-  className: '',
+  className: undefined,
   updateIntervalInSeconds: 1,
   unit: 'second',
   computeDelta: formatInSeconds,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/2740

In certain cases (e.g. when server clock is ahead of the browsers clock) entity title sections with `Last seen` info can display relative time in future. While this is technically correct, thats not what we really want to show to the users.

Issue:
![last-seen](https://user-images.githubusercontent.com/16374166/95066887-b0f7da00-070b-11eb-84aa-c798187b2efa.gif)


#### Changes
<!-- What are the changes made in this pull request? -->

- Add `<LastSeen />` component for `<EntityTitleSection />`
- Only display time as `now` or `... ago`


#### Testing

<!-- How did you verify that this change works? -->

Tested on applications, devices and gateways on staing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

`Last seen` time display for application, device and gateway title sections.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
