### PR TITLE
Always account for LinkADR index rejections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Decoded downlink payloads are stored now by Network Server.
 - Raw downlink PHY payloads are not stored anymore by Network Server.
 - Move documentation to [lorawan-stack-docs](https://github.com/TheThingsIndustries/lorawan-stack-docs).
+- Improve LinkADRReq scheduling condition computation and, as a consequence, downlink task efficiency.
 
 ### Deprecated
 
@@ -39,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Gateway ID usage in upstream connection.
 - Last seen counter for applications, end devices and gateways in the Console.
 - `Use credentials` option being always checked in Pub/Sub edit form in the Console.
+- FPending being set on downlinks, when LinkADRReq is required, but all available TxPower and data rate index combinations are rejected by the device.
 
 ### Security
 

--- a/pkg/band/band.go
+++ b/pkg/band/band.go
@@ -453,7 +453,7 @@ func generateChMask16(currentChs, desiredChs []bool) ([]ChMaskCntlPair, error) {
 	}, nil
 }
 
-func equalChMasks(a, b []bool) bool {
+func EqualChMasks(a, b []bool) bool {
 	if len(a) != len(b) {
 		return false
 	}
@@ -499,7 +499,7 @@ func generateChMask72Generic(currentChs, desiredChs []bool) ([]ChMaskCntlPair, e
 	if len(currentChs) != 72 || len(desiredChs) != 72 {
 		return nil, errInvalidChannelCount.New()
 	}
-	if equalChMasks(currentChs, desiredChs) {
+	if EqualChMasks(currentChs, desiredChs) {
 		return []ChMaskCntlPair{
 			{
 				Mask: boolsTo16BoolArray(desiredChs[0:16]...),
@@ -653,7 +653,7 @@ func generateChMask96(currentChs, desiredChs []bool) ([]ChMaskCntlPair, error) {
 	if len(currentChs) != 96 || len(desiredChs) != 96 {
 		return nil, errInvalidChannelCount.New()
 	}
-	if equalChMasks(currentChs, desiredChs) {
+	if EqualChMasks(currentChs, desiredChs) {
 		return []ChMaskCntlPair{
 			{
 				Mask: boolsTo16BoolArray(desiredChs[0:16]...),

--- a/pkg/encoding/lorawan/mac.go
+++ b/pkg/encoding/lorawan/mac.go
@@ -108,7 +108,6 @@ var DefaultMACCommands = MACCommandSpec{
 	ttnpb.CID_LINK_CHECK: &MACCommandDescriptor{
 		InitiatedByDevice: true,
 
-		UplinkLength: 0,
 		AppendUplink: func(phy band.Band, b []byte, _ ttnpb.MACCommand) ([]byte, error) {
 			return b, nil
 		},
@@ -215,7 +214,6 @@ var DefaultMACCommands = MACCommandSpec{
 	ttnpb.CID_DUTY_CYCLE: &MACCommandDescriptor{
 		InitiatedByDevice: false,
 
-		UplinkLength: 0,
 		AppendUplink: func(phy band.Band, b []byte, _ ttnpb.MACCommand) ([]byte, error) {
 			return b, nil
 		},
@@ -332,7 +330,6 @@ var DefaultMACCommands = MACCommandSpec{
 			return nil
 		}),
 
-		DownlinkLength: 0,
 		AppendDownlink: func(phy band.Band, b []byte, _ ttnpb.MACCommand) ([]byte, error) {
 			return b, nil
 		},
@@ -406,7 +403,6 @@ var DefaultMACCommands = MACCommandSpec{
 	ttnpb.CID_RX_TIMING_SETUP: &MACCommandDescriptor{
 		InitiatedByDevice: false,
 
-		UplinkLength: 0,
 		AppendUplink: func(phy band.Band, b []byte, _ ttnpb.MACCommand) ([]byte, error) {
 			return b, nil
 		},
@@ -434,7 +430,6 @@ var DefaultMACCommands = MACCommandSpec{
 	ttnpb.CID_TX_PARAM_SETUP: &MACCommandDescriptor{
 		InitiatedByDevice: false,
 
-		UplinkLength: 0,
 		AppendUplink: func(phy band.Band, b []byte, _ ttnpb.MACCommand) ([]byte, error) {
 			return b, nil
 		},
@@ -560,7 +555,6 @@ var DefaultMACCommands = MACCommandSpec{
 	ttnpb.CID_ADR_PARAM_SETUP: &MACCommandDescriptor{
 		InitiatedByDevice: false,
 
-		UplinkLength: 0,
 		AppendUplink: func(phy band.Band, b []byte, _ ttnpb.MACCommand) ([]byte, error) {
 			return b, nil
 		},
@@ -596,7 +590,6 @@ var DefaultMACCommands = MACCommandSpec{
 	ttnpb.CID_DEVICE_TIME: &MACCommandDescriptor{
 		InitiatedByDevice: true,
 
-		UplinkLength: 0,
 		AppendUplink: func(phy band.Band, b []byte, _ ttnpb.MACCommand) ([]byte, error) {
 			return b, nil
 		},
@@ -742,7 +735,6 @@ var DefaultMACCommands = MACCommandSpec{
 			return nil
 		}),
 
-		DownlinkLength: 0,
 		AppendDownlink: func(phy band.Band, b []byte, _ ttnpb.MACCommand) ([]byte, error) {
 			return b, nil
 		},
@@ -805,7 +797,6 @@ var DefaultMACCommands = MACCommandSpec{
 	ttnpb.CID_BEACON_TIMING: &MACCommandDescriptor{
 		InitiatedByDevice: true,
 
-		UplinkLength: 0,
 		AppendUplink: func(phy band.Band, b []byte, _ ttnpb.MACCommand) ([]byte, error) {
 			return b, nil
 		},

--- a/pkg/networkserver/internal/test/shared/shared.go
+++ b/pkg/networkserver/internal/test/shared/shared.go
@@ -15,6 +15,12 @@
 // Package test contains testing utilities usable by all subpackages of networkserver excluding itself.
 package test
 
-import "go.thethings.network/lorawan-stack/v3/pkg/util/test"
+import (
+	. "go.thethings.network/lorawan-stack/v3/pkg/networkserver"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
+)
 
-var CacheTTL = (1 << 5) * test.Delay
+var (
+	CacheTTL           = (1 << 5) * test.Delay
+	DefaultMACSettings = DefaultConfig.DefaultMACSettings.Parse()
+)

--- a/pkg/networkserver/mac/adr.go
+++ b/pkg/networkserver/mac/adr.go
@@ -144,37 +144,6 @@ func txPowerStep(phy *band.Band, from, to uint8) float32 {
 	return phy.TxOffset[from] - phy.TxOffset[to]
 }
 
-func channelDataRateRange(chs ...*ttnpb.MACParameters_Channel) (min, max ttnpb.DataRateIndex, ok bool) {
-	i := 0
-	for {
-		if i >= len(chs) {
-			return 0, 0, false
-		}
-		if chs[i].EnableUplink {
-			break
-		}
-		i++
-	}
-
-	min = chs[i].MinDataRateIndex
-	max = chs[i].MaxDataRateIndex
-	for _, ch := range chs[i+1:] {
-		if !ch.EnableUplink {
-			continue
-		}
-		if ch.MaxDataRateIndex > max {
-			max = ch.MaxDataRateIndex
-		}
-		if ch.MinDataRateIndex < min {
-			min = ch.MinDataRateIndex
-		}
-	}
-	if min > max {
-		return 0, 0, false
-	}
-	return min, max, true
-}
-
 func AdaptDataRate(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band, defaults ttnpb.MACSettings) error {
 	if len(dev.RecentADRUplinks) == 0 {
 		return nil

--- a/pkg/networkserver/mac/beacon_timing_test.go
+++ b/pkg/networkserver/mac/beacon_timing_test.go
@@ -43,7 +43,6 @@ func TestNeedsBeaconTimingReq(t *testing.T) {
 		},
 	)
 	ForEachClass(t, func(makeClassName func(parts ...string) string, class ttnpb.Class) {
-		// TODO: Support Class B (https://github.com/TheThingsNetwork/lorawan-stack/issues/19)
 		tcs = append(tcs,
 			TestCase{
 				Name: makeClassName("empty parameters"),
@@ -92,7 +91,7 @@ func TestHandleBeaconTimingReq(t *testing.T) {
 			Expected: &ttnpb.EndDevice{
 				MACState: &ttnpb.MACState{
 					QueuedResponses: []*ttnpb.MACCommand{
-						// TODO: Support Class B (https://github.com/TheThingsNetwork/lorawan-stack/issues/19)
+						// TODO: Support BeaconTimingReq. (https://github.com/TheThingsNetwork/lorawan-stack/issues/2431)
 					},
 				},
 			},
@@ -114,7 +113,7 @@ func TestHandleBeaconTimingReq(t *testing.T) {
 						{},
 						{},
 						{},
-						// TODO: Support Class B (https://github.com/TheThingsNetwork/lorawan-stack/issues/19)
+						// TODO: Support BeaconTimingReq. (https://github.com/TheThingsNetwork/lorawan-stack/issues/2431)
 					},
 				},
 			},

--- a/pkg/networkserver/mac/link_adr.go
+++ b/pkg/networkserver/mac/link_adr.go
@@ -51,6 +51,9 @@ func generateLinkADRReq(ctx context.Context, dev *ttnpb.EndDevice, defaults ttnp
 	if dev.GetMulticast() || dev.GetMACState() == nil {
 		return linkADRReqParameters{}, false, nil
 	}
+	if len(dev.MACState.DesiredParameters.Channels) > int(phy.MaxUplinkChannels) {
+		return linkADRReqParameters{}, false, ErrCorruptedMACState.New()
+	}
 	var needsChMask bool
 	for i := 0; !needsChMask && i < len(dev.MACState.CurrentParameters.Channels); i++ {
 		isEnabled := dev.MACState.CurrentParameters.Channels[i].GetEnableUplink()
@@ -121,7 +124,6 @@ func generateLinkADRReq(ctx context.Context, dev *ttnpb.EndDevice, defaults ttnp
 	} else {
 		minDataRateIndex, maxDataRateIndex, ok := channelDataRateRange(dev.MACState.DesiredParameters.Channels...)
 		if !ok ||
-			len(dev.MACState.DesiredParameters.Channels) > int(phy.MaxUplinkChannels) ||
 			dev.MACState.DesiredParameters.ADRTxPowerIndex > uint32(phy.MaxTxPowerIndex()) ||
 			dev.MACState.DesiredParameters.ADRDataRateIndex > phy.MaxADRDataRateIndex {
 			return linkADRReqParameters{}, false, ErrCorruptedMACState.New()

--- a/pkg/networkserver/mac/link_adr_test.go
+++ b/pkg/networkserver/mac/link_adr_test.go
@@ -293,8 +293,9 @@ func TestLinkADRReq(t *testing.T) {
 			CurrentADRNbTrans:       1,
 			CurrentADRDataRateIndex: ttnpb.DATA_RATE_1,
 			DesiredChannels:         MakeDefaultUS915FSB2DesiredChannels(),
-			DesiredADRNbTrans:       1,
+			DesiredADRNbTrans:       2,
 			DesiredADRDataRateIndex: ttnpb.DATA_RATE_2,
+			DesiredADRTxPowerIndex:  3,
 			NoADRCommands: []*ttnpb.MACCommand_LinkADRReq{
 				{
 					ChannelMask: []bool{
@@ -322,7 +323,8 @@ func TestLinkADRReq(t *testing.T) {
 					},
 					ChannelMaskControl: 7,
 					DataRateIndex:      ttnpb.DATA_RATE_2,
-					NbTrans:            1,
+					TxPowerIndex:       3,
+					NbTrans:            2,
 				},
 				{
 					ChannelMask: []bool{
@@ -330,7 +332,8 @@ func TestLinkADRReq(t *testing.T) {
 						true, true, true, true, true, true, true, true,
 					},
 					DataRateIndex: ttnpb.DATA_RATE_2,
-					NbTrans:       1,
+					TxPowerIndex:  3,
+					NbTrans:       2,
 				},
 			},
 		},

--- a/pkg/networkserver/mac/utils.go
+++ b/pkg/networkserver/mac/utils.go
@@ -31,6 +31,37 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 )
 
+func channelDataRateRange(chs ...*ttnpb.MACParameters_Channel) (min, max ttnpb.DataRateIndex, ok bool) {
+	i := 0
+	for {
+		if i >= len(chs) {
+			return 0, 0, false
+		}
+		if chs[i].EnableUplink {
+			break
+		}
+		i++
+	}
+
+	min = chs[i].MinDataRateIndex
+	max = chs[i].MaxDataRateIndex
+	for _, ch := range chs[i+1:] {
+		if !ch.EnableUplink {
+			continue
+		}
+		if ch.MaxDataRateIndex > max {
+			max = ch.MaxDataRateIndex
+		}
+		if ch.MinDataRateIndex < min {
+			min = ch.MinDataRateIndex
+		}
+	}
+	if min > max {
+		return 0, 0, false
+	}
+	return min, max, true
+}
+
 // DefaultClassBTimeout is the default time-out for the device to respond to class B downlink messages.
 // When waiting for a response times out, the downlink message is considered lost, and the downlink task triggers again.
 const DefaultClassBTimeout = 10 * time.Minute

--- a/pkg/networkserver/networkserver_util_internal_test.go
+++ b/pkg/networkserver/networkserver_util_internal_test.go
@@ -15,6 +15,7 @@
 package networkserver
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"sort"
@@ -28,6 +29,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/cluster"
 	"go.thethings.network/lorawan-stack/v3/pkg/component"
 	componenttest "go.thethings.network/lorawan-stack/v3/pkg/component/test"
+	"go.thethings.network/lorawan-stack/v3/pkg/encoding/lorawan"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/frequencyplans"
@@ -979,6 +981,13 @@ func (env TestEnvironment) AssertScheduleDownlink(ctx context.Context, conf Down
 							CorrelationIDs: req.Message.CorrelationIDs,
 						}),
 					) {
+						if !bytes.Equal(req.Message.RawPayload, conf.Payload) {
+							actual := &ttnpb.Message{}
+							expected := &ttnpb.Message{}
+							a.So(lorawan.UnmarshalMessage(req.Message.RawPayload, actual), should.BeNil)
+							a.So(lorawan.UnmarshalMessage(conf.Payload, expected), should.BeNil)
+							a.So(actual, should.Resemble, expected)
+						}
 						t.Errorf("NsGs.ScheduleDownlink request assertion failed for schedule attempt number %d", i)
 						return
 					}

--- a/pkg/networkserver/utils.go
+++ b/pkg/networkserver/utils.go
@@ -265,7 +265,7 @@ func nextDataDownlinkSlot(ctx context.Context, dev *ttnpb.EndDevice, phy *band.B
 		case mac.DeviceNeedsDutyCycleReq(dev):
 			logger.Debug("Device needs DutyCycleReq, choose class A downlink slot")
 			return classA, true
-		case mac.DeviceNeedsLinkADRReq(dev, defaults, phy):
+		case mac.DeviceNeedsLinkADRReq(ctx, dev, defaults, phy):
 			logger.Debug("Device needs LinkADRReq, choose class A downlink slot")
 			return classA, true
 		case mac.DeviceNeedsNewChannelReq(dev):


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Always account for LinkADR index rejections
References #2192 https://github.com/TheThingsIndustries/lorawan-stack-support/issues/134#issuecomment-702328256

#### Changes
<!-- What are the changes made in this pull request? -->

- Always account for LinkADR index rejections (i.e. also when scheduling
  downlink tasks, for example)
- Fix BeaconTimingReq comments
- Avoid sending desired ADR values when only ChMasks necessary and ADR is disabled
- Fix/improve testing of LinkADR (this structure will be used for other
  tests in the subpackage as well)


#### Testing

<!-- How did you verify that this change works? -->

Unit testing should suffice given the new structure, integration testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This should fix the occasional downlink weirdness (https://github.com/TheThingsIndustries/lorawan-stack-support/issues/134#issuecomment-702328256) and should also
drastically lower the amount of ERROR logs, such that we can enable Sentry again. cc @htdvisser (NOTE, there's another PR coming to fully address this as part of #2192 )

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.