### PR TITLE
Update gateway antenna location only when auth is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ For details about compatibility between different releases, see the **Commitment
 - CUPS Server only accepts The Things Stack API Key for token auth.
 - Improve MQTT Pub/Sub task restart conditions and error propagation.
 - Pausing event streams is not saving up arriving events during the pause anymore.
+- Gateway server can now update the gateway location only if the gateway is authenticated.
 
 ### Deprecated
 

--- a/api/api.md
+++ b/api/api.md
@@ -2797,7 +2797,7 @@ Gateway is the message that defines a gateway on the network.
 | `enforce_duty_cycle` | [`bool`](#bool) |  | Enforcing gateway duty cycle is recommended for all gateways to respect spectrum regulations. Disable enforcing the duty cycle only in controlled research and development environments. |
 | `downlink_path_constraint` | [`DownlinkPathConstraint`](#ttn.lorawan.v3.DownlinkPathConstraint) |  |  |
 | `schedule_anytime_delay` | [`google.protobuf.Duration`](#google.protobuf.Duration) |  | Adjust the time that GS schedules class C messages in advance. This is useful for gateways that have a known high latency backhaul, like 3G and satellite. |
-| `update_location_from_status` | [`bool`](#bool) |  | update the location of this gateway from status messages |
+| `update_location_from_status` | [`bool`](#bool) |  | Update the location of this gateway from status messages. This only works for gateways connecting with authentication; gateways connected over UDP are not supported. |
 | `lbs_lns_secret` | [`Secret`](#ttn.lorawan.v3.Secret) |  | The LoRa Basics Station LNS secret. This is either an auth token (such as an API Key) or a TLS private certificate. Requires the RIGHT_GATEWAY_READ_SECRETS for reading and RIGHT_GATEWAY_WRITE_SECRETS for updating this value.
 
 next: 23 |

--- a/api/api.swagger.json
+++ b/api/api.swagger.json
@@ -11145,7 +11145,7 @@
         "update_location_from_status": {
           "type": "boolean",
           "format": "boolean",
-          "title": "update the location of this gateway from status messages"
+          "description": "Update the location of this gateway from status messages. This only works for gateways connecting with authentication; gateways connected over UDP are not supported."
         },
         "lbs_lns_secret": {
           "$ref": "#/definitions/v3Secret",

--- a/api/gateway.proto
+++ b/api/gateway.proto
@@ -130,7 +130,7 @@ message Gateway {
   DownlinkPathConstraint downlink_path_constraint = 18 [(validate.rules).enum.defined_only = true];
   // Adjust the time that GS schedules class C messages in advance. This is useful for gateways that have a known high latency backhaul, like 3G and satellite.
   google.protobuf.Duration schedule_anytime_delay = 19 [(gogoproto.stdduration) = true, (gogoproto.nullable) = true];
-  // update the location of this gateway from status messages
+  // Update the location of this gateway from status messages. This only works for gateways connecting with authentication; gateways connected over UDP are not supported.
   bool update_location_from_status = 21;
   // The LoRa Basics Station LNS secret.
   // This is either an auth token (such as an API Key) or a TLS private certificate.

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -804,9 +804,7 @@ func (gs *GatewayServer) handleLocationUpdates(conn connectionEntry) {
 	var err error
 	var callOpt grpc.CallOption
 	callOpt, err = rpcmetadata.WithForwardedAuth(ctx, gs.AllowInsecureForCredentials())
-	if errors.IsUnauthenticated(err) {
-		callOpt = gs.WithClusterAuth()
-	} else if err != nil {
+	if err != nil {
 		return
 	}
 	registry, err := gs.getRegistry(ctx, &conn.Gateway().GatewayIdentifiers)

--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -154,12 +154,14 @@ func TestGatewayServer(t *testing.T) {
 		DetectsInvalidMessages bool
 		DetectsDisconnect      bool
 		TimeoutOnInvalidAuth   bool
+		HasAuth                bool
 		ValidAuth              func(ctx context.Context, ids ttnpb.GatewayIdentifiers, key string) bool
 		Link                   func(ctx context.Context, t *testing.T, ids ttnpb.GatewayIdentifiers, key string, upCh <-chan *ttnpb.GatewayUp, downCh chan<- *ttnpb.GatewayDown) error
 	}{
 		{
 			Protocol:          "grpc",
 			SupportsStatus:    true,
+			HasAuth:           true,
 			DetectsDisconnect: true,
 			ValidAuth: func(ctx context.Context, ids ttnpb.GatewayIdentifiers, key string) bool {
 				return ids.GatewayID == registeredGatewayID && key == registeredGatewayKey
@@ -218,6 +220,7 @@ func TestGatewayServer(t *testing.T) {
 		{
 			Protocol:             "mqtt",
 			SupportsStatus:       true,
+			HasAuth:              true,
 			DetectsDisconnect:    true,
 			TimeoutOnInvalidAuth: true, // The MQTT client keeps reconnecting on invalid auth.
 			ValidAuth: func(ctx context.Context, ids ttnpb.GatewayIdentifiers, key string) bool {
@@ -434,6 +437,7 @@ func TestGatewayServer(t *testing.T) {
 			SupportsStatus:         false,
 			DetectsDisconnect:      true,
 			DetectsInvalidMessages: true,
+			HasAuth:                true,
 			ValidAuth: func(ctx context.Context, ids ttnpb.GatewayIdentifiers, key string) bool {
 				return ids.EUI != nil
 			},
@@ -694,7 +698,7 @@ func TestGatewayServer(t *testing.T) {
 				}
 			})
 
-			if ptc.SupportsStatus {
+			if ptc.SupportsStatus && ptc.HasAuth {
 				t.Run("UpdateLocation", func(t *testing.T) {
 					for _, tc := range []struct {
 						Name           string

--- a/pkg/ttnpb/gateway.pb.go
+++ b/pkg/ttnpb/gateway.pb.go
@@ -482,7 +482,7 @@ type Gateway struct {
 	DownlinkPathConstraint DownlinkPathConstraint `protobuf:"varint,18,opt,name=downlink_path_constraint,json=downlinkPathConstraint,proto3,enum=ttn.lorawan.v3.DownlinkPathConstraint" json:"downlink_path_constraint,omitempty"`
 	// Adjust the time that GS schedules class C messages in advance. This is useful for gateways that have a known high latency backhaul, like 3G and satellite.
 	ScheduleAnytimeDelay *time.Duration `protobuf:"bytes,19,opt,name=schedule_anytime_delay,json=scheduleAnytimeDelay,proto3,stdduration" json:"schedule_anytime_delay,omitempty"`
-	// update the location of this gateway from status messages
+	// Update the location of this gateway from status messages. This only works for gateways connecting with authentication; gateways connected over UDP are not supported.
 	UpdateLocationFromStatus bool `protobuf:"varint,21,opt,name=update_location_from_status,json=updateLocationFromStatus,proto3" json:"update_location_from_status,omitempty"`
 	// The LoRa Basics Station LNS secret.
 	// This is either an auth token (such as an API Key) or a TLS private certificate.

--- a/sdk/js/generated/api.json
+++ b/sdk/js/generated/api.json
@@ -11235,7 +11235,7 @@
             },
             {
               "name": "update_location_from_status",
-              "description": "update the location of this gateway from status messages",
+              "description": "Update the location of this gateway from status messages. This only works for gateways connecting with authentication; gateways connected over UDP are not supported.",
               "label": "",
               "type": "bool",
               "longType": "bool",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #3138

#### Changes
<!-- What are the changes made in this pull request? -->

- Accept RIGHT_GATEWAY_LINK in GatewayRegistry.Update if only locations path is passed
- Do not use clusterauth for location updates from GS.
- Update Console messages to reflect this change.

#### Testing

<!-- How did you verify that this change works? -->

Unit tests, pending tests with an actual gateway

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [X] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
