### PR TITLE
Fix `Use credentials` option being always checked in Pub/Sub edit form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RSSI metadata for MQTT gateways connected with The Things Network Stack V2 protocol.
 - Gateway ID usage in upstream connection.
 - Last seen counter for applications, end devices and gateways in the Console.
+- `Use credentials` option being always checked in Pub/Sub edit form in the Console.
 
 ### Security
 
@@ -49,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Display the full event object when expanded in the Console (used to be `event.data` only).
 
 ### Fixed
+
 - Performance issues of event views in the Console (freezing after some time).
 - Gateway Server panic on upstream message handling.
 - Incorrect redirects for restricted routes in the Console.

--- a/pkg/webui/console/components/pubsub-form/mapping.js
+++ b/pkg/webui/console/components/pubsub-form/mapping.js
@@ -57,8 +57,10 @@ export const mapNatsFormValues = function(nats) {
   }
 }
 
-export const mapMqttFormValues = function(mqtt) {
-  return merge({ _use_credentials: Boolean(mqtt.username || mqtt.password) }, mqttBlankValues, mqtt)
+export const mapMqttFormValues = mqtt => {
+  return merge({}, mqttBlankValues, mqtt, {
+    _use_credentials: Boolean(mqtt.username || mqtt.password),
+  })
 }
 
 const mapPubsubMessageTypeToFormValue = messageType =>

--- a/pkg/webui/console/components/pubsub-form/mapping.js
+++ b/pkg/webui/console/components/pubsub-form/mapping.js
@@ -41,7 +41,7 @@ const mqttBlankValues = {
   _use_credentials: true,
 }
 
-export const mapNatsFormValues = function(nats) {
+export const mapNatsFormValues = nats => {
   try {
     const res = nats.server_url.match(natsUrlRegexp)
     return {
@@ -66,7 +66,7 @@ export const mapMqttFormValues = mqtt => {
 const mapPubsubMessageTypeToFormValue = messageType =>
   (messageType && { enabled: true, value: messageType.topic }) || { enabled: false, value: '' }
 
-export const mapPubsubToFormValues = function(pubsub) {
+export const mapPubsubToFormValues = pubsub => {
   const isNats = 'nats' in pubsub
   const isMqtt = 'mqtt' in pubsub
   let provider = blankValues._provider
@@ -98,23 +98,22 @@ export const mapPubsubToFormValues = function(pubsub) {
   return result
 }
 
-const mapNatsConfigFormValueToNatsServerUrl = function({
+const mapNatsConfigFormValueToNatsServerUrl = ({
   username,
   password,
   address,
   port,
   secure,
   _use_credentials,
-}) {
-  return `${secure ? 'tls' : 'nats'}://${
+}) =>
+  `${secure ? 'tls' : 'nats'}://${
     _use_credentials ? `${username}:${password}@` : ''
   }${address}:${port}`
-}
 
 const mapMessageTypeFormValueToPubsubMessageType = formValue =>
   (formValue.enabled && { topic: formValue.value }) || null
 
-export const mapFormValuesToPubsub = function(values, appId) {
+export const mapFormValuesToPubsub = (values, appId) => {
   const result = {
     ids: {
       application_ids: {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsIndustries/lorawan-stack-support/issues/155

#### Changes
<!-- What are the changes made in this pull request? -->

- Adjust how `initialValues` are merged such that `_use_credentials` is not overwritten

#### Testing

<!-- How did you verify that this change works? -->

1. Create pub-sub without credentials.
2. Open the edit form for this pub-sub.
3. See `Use credentials` is not checked.
_
1. Create pub-sub with credentials.
2. Open the edit form for this pub-sub.
3. See `Use credentials` is checked.


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
