### PR TITLE
Improve performance and load resilience of event store logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI support for Storage Integration (see `ttn-lw-cli end-devices storage` and `ttn-lw-cli applications storage` commands).
 - Network Server does not retry rejected `NewChannelReq` data rate ranges or rejected `DLChannelReq` frequencies anymore.
 - Functionality to allow admin users to list all organizations in the Console.
+- Limitation of displayed and stored events in the Console to 2000.
 
 ### Changed
 

--- a/pkg/webui/console/components/events/events.styl
+++ b/pkg/webui/console/components/events/events.styl
@@ -95,6 +95,18 @@ $event-container-height = 40px
     margin: 0
     list-style: none
 
+.truncated
+  border-normal(top)
+  display: flex
+  align-items: center
+  justify-content: center
+  font-size: $fs.s
+  color: $tc-warning
+  padding: $cs.xxs 0
+
+  span
+    margin-right: $cs.xxs
+
 .event
   height: $event-container-height
   background-color: transparent

--- a/pkg/webui/console/components/events/index.js
+++ b/pkg/webui/console/components/events/index.js
@@ -18,6 +18,7 @@ import classnames from 'classnames'
 import hamburgerMenuClose from '@assets/misc/hamburger-menu-close.svg'
 
 import Button from '@ttn-lw/components/button'
+import Icon from '@ttn-lw/components/icon'
 
 import Message from '@ttn-lw/lib/components/message'
 
@@ -32,7 +33,7 @@ import { getEventId } from './utils'
 
 import style from './events.styl'
 
-const Events = React.memo(({ events, scoped, onClear, entityId }) => {
+const Events = React.memo(({ events, scoped, onClear, entityId, truncated }) => {
   const [paused, setPause] = useState(false)
   const [focus, setFocus] = useState({ eventId: undefined, visible: false })
   const onPause = useCallback(() => setPause(paused => !paused), [])
@@ -91,6 +92,12 @@ const Events = React.memo(({ events, scoped, onClear, entityId }) => {
           activeId={focus.eventId}
         />
       </section>
+      {truncated && (
+        <div className={style.truncated}>
+          <Icon icon="info" />
+          <Message content={m.eventsTruncated} />
+        </div>
+      )}
       <section className={classnames(style.sidebarContainer, { [style.expanded]: focus.visible })}>
         <div className={style.sidebarHeader}>
           <Message content={m.eventDetails} className={style.sidebarTitle} />
@@ -113,6 +120,7 @@ Events.propTypes = {
   events: PropTypes.events.isRequired,
   onClear: PropTypes.func,
   scoped: PropTypes.bool,
+  truncated: PropTypes.bool.isRequired,
 }
 
 Events.defaultProps = {

--- a/pkg/webui/console/components/events/messages.js
+++ b/pkg/webui/console/components/events/messages.js
@@ -35,6 +35,7 @@ const messages = defineMessages({
   dataPreview: 'Data preview',
   seeAllActivity: 'See all activity',
   syntheticEvent: 'Note: This meta event did not originate from the event stream',
+  eventsTruncated: 'Old events have been truncated to save memory',
 })
 
 export default messages

--- a/pkg/webui/console/constants/event-store-limit.js
+++ b/pkg/webui/console/constants/event-store-limit.js
@@ -1,0 +1,15 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export default 2000

--- a/pkg/webui/console/containers/application-events/index.js
+++ b/pkg/webui/console/containers/application-events/index.js
@@ -23,15 +23,15 @@ import PropTypes from '@ttn-lw/lib/prop-types'
 
 import { mayViewApplicationEvents } from '@console/lib/feature-checks'
 
-import {
-  clearApplicationEventsStream,
-  startApplicationEventsStream,
-} from '@console/store/actions/applications'
+import { clearApplicationEventsStream } from '@console/store/actions/applications'
 
-import { selectApplicationEvents } from '@console/store/selectors/applications'
+import {
+  selectApplicationEvents,
+  selectApplicationEventsTruncated,
+} from '@console/store/selectors/applications'
 
 const ApplicationEvents = props => {
-  const { appId, events, widget, onClear } = props
+  const { appId, events, widget, onClear, truncated } = props
 
   if (widget) {
     return (
@@ -39,13 +39,14 @@ const ApplicationEvents = props => {
     )
   }
 
-  return <Events entityId={appId} events={events} onClear={onClear} />
+  return <Events entityId={appId} events={events} onClear={onClear} truncated={truncated} />
 }
 
 ApplicationEvents.propTypes = {
   appId: PropTypes.string.isRequired,
   events: PropTypes.events,
   onClear: PropTypes.func.isRequired,
+  truncated: PropTypes.bool.isRequired,
   widget: PropTypes.bool,
 }
 
@@ -61,11 +62,11 @@ export default withFeatureRequirement(mayViewApplicationEvents)(
 
       return {
         events: selectApplicationEvents(state, appId),
+        truncated: selectApplicationEventsTruncated(state, appId),
       }
     },
     (dispatch, ownProps) => ({
       onClear: () => dispatch(clearApplicationEventsStream(ownProps.appId)),
-      onRestart: () => dispatch(startApplicationEventsStream(ownProps.appId)),
     }),
   )(ApplicationEvents),
 )

--- a/pkg/webui/console/containers/device-events/index.js
+++ b/pkg/webui/console/containers/device-events/index.js
@@ -15,33 +15,17 @@
 import React from 'react'
 import { connect } from 'react-redux'
 
-import ErrorNotification from '@ttn-lw/components/error-notification'
-
 import Events from '@console/components/events'
 
 import { getApplicationId, getDeviceId, combineDeviceIds } from '@ttn-lw/lib/selectors/id'
-import sharedMessages from '@ttn-lw/lib/shared-messages'
 import PropTypes from '@ttn-lw/lib/prop-types'
 
-import { clearDeviceEventsStream, startDeviceEventsStream } from '@console/store/actions/devices'
+import { clearDeviceEventsStream } from '@console/store/actions/devices'
 
-import { selectDeviceEvents, selectDeviceEventsError } from '@console/store/selectors/devices'
+import { selectDeviceEvents, selectDeviceEventsTruncated } from '@console/store/selectors/devices'
 
 const DeviceEvents = props => {
-  const { appId, devId, events, error, onRestart, widget, onClear } = props
-
-  if (error) {
-    return (
-      <ErrorNotification
-        small
-        title={sharedMessages.eventsCannotShow}
-        content={error}
-        action={onRestart}
-        actionMessage={sharedMessages.restartStream}
-        buttonIcon="refresh"
-      />
-    )
-  }
+  const { appId, devId, events, widget, onClear, truncated } = props
 
   if (widget) {
     return (
@@ -54,7 +38,16 @@ const DeviceEvents = props => {
     )
   }
 
-  return <Events events={events} entityId={devId} onClear={onClear} scoped widget />
+  return (
+    <Events
+      events={events}
+      entityId={devId}
+      onClear={onClear}
+      truncated={truncated}
+      scoped
+      widget
+    />
+  )
 }
 
 DeviceEvents.propTypes = {
@@ -66,17 +59,15 @@ DeviceEvents.propTypes = {
       application_id: PropTypes.string,
     }),
   }).isRequired,
-  error: PropTypes.error,
   events: PropTypes.events,
   onClear: PropTypes.func.isRequired,
-  onRestart: PropTypes.func.isRequired,
+  truncated: PropTypes.bool.isRequired,
   widget: PropTypes.bool,
 }
 
 DeviceEvents.defaultProps = {
   widget: false,
   events: [],
-  error: undefined,
 }
 
 export default connect(
@@ -91,7 +82,7 @@ export default connect(
       devId,
       appId,
       events: selectDeviceEvents(state, combinedId),
-      error: selectDeviceEventsError(state, combinedId),
+      truncated: selectDeviceEventsTruncated(state, combinedId),
     }
   },
   (dispatch, ownProps) => {
@@ -99,7 +90,6 @@ export default connect(
 
     return {
       onClear: () => dispatch(clearDeviceEventsStream(devIds)),
-      onRestart: () => dispatch(startDeviceEventsStream(devIds)),
     }
   },
 )(DeviceEvents)

--- a/pkg/webui/console/containers/gateway-events/index.js
+++ b/pkg/webui/console/containers/gateway-events/index.js
@@ -15,36 +15,23 @@
 import React from 'react'
 import { connect } from 'react-redux'
 
-import ErrorNotification from '@ttn-lw/components/error-notification'
-
 import Events from '@console/components/events'
 
 import withFeatureRequirement from '@console/lib/components/with-feature-requirement'
 
-import sharedMessages from '@ttn-lw/lib/shared-messages'
 import PropTypes from '@ttn-lw/lib/prop-types'
 
 import { mayViewGatewayEvents } from '@console/lib/feature-checks'
 
-import { clearGatewayEventsStream, startGatewayEventsStream } from '@console/store/actions/gateways'
+import { clearGatewayEventsStream } from '@console/store/actions/gateways'
 
-import { selectGatewayEvents, selectGatewayEventsError } from '@console/store/selectors/gateways'
+import {
+  selectGatewayEvents,
+  selectGatewayEventsTruncated,
+} from '@console/store/selectors/gateways'
 
 const GatewayEvents = props => {
-  const { gtwId, events, error, onRestart, widget, onClear } = props
-
-  if (error) {
-    return (
-      <ErrorNotification
-        small
-        title={sharedMessages.eventsCannotShow}
-        content={error}
-        action={onRestart}
-        actionMessage={sharedMessages.restartStream}
-        buttonIcon="refresh"
-      />
-    )
-  }
+  const { gtwId, events, widget, onClear, truncated } = props
 
   if (widget) {
     return (
@@ -52,22 +39,20 @@ const GatewayEvents = props => {
     )
   }
 
-  return <Events events={events} entityId={gtwId} onClear={onClear} scoped />
+  return <Events events={events} entityId={gtwId} onClear={onClear} truncated={truncated} scoped />
 }
 
 GatewayEvents.propTypes = {
-  error: PropTypes.error,
   events: PropTypes.events,
   gtwId: PropTypes.string.isRequired,
   onClear: PropTypes.func.isRequired,
-  onRestart: PropTypes.func.isRequired,
+  truncated: PropTypes.bool.isRequired,
   widget: PropTypes.bool,
 }
 
 GatewayEvents.defaultProps = {
   widget: false,
   events: [],
-  error: undefined,
 }
 
 export default withFeatureRequirement(mayViewGatewayEvents)(
@@ -77,12 +62,11 @@ export default withFeatureRequirement(mayViewGatewayEvents)(
 
       return {
         events: selectGatewayEvents(state, gtwId),
-        error: selectGatewayEventsError(state, gtwId),
+        truncated: selectGatewayEventsTruncated(state, gtwId),
       }
     },
     (dispatch, ownProps) => ({
       onClear: () => dispatch(clearGatewayEventsStream(ownProps.gtwId)),
-      onRestart: () => dispatch(startGatewayEventsStream(ownProps.gtwId)),
     }),
   )(GatewayEvents),
 )

--- a/pkg/webui/console/containers/organization-events/connect.js
+++ b/pkg/webui/console/containers/organization-events/connect.js
@@ -14,14 +14,11 @@
 
 import { connect } from 'react-redux'
 
-import {
-  clearOrganizationEventsStream,
-  startOrganizationEventsStream,
-} from '@console/store/actions/organizations'
+import { clearOrganizationEventsStream } from '@console/store/actions/organizations'
 
 import {
   selectOrganizationEvents,
-  selectOrganizationEventsError,
+  selectOrganizationEventsTruncated,
 } from '@console/store/selectors/organizations'
 
 const mapStateToProps = (state, props) => {
@@ -29,12 +26,11 @@ const mapStateToProps = (state, props) => {
 
   return {
     events: selectOrganizationEvents(state, orgId),
-    error: selectOrganizationEventsError(state, orgId),
+    truncated: selectOrganizationEventsTruncated(state, orgId),
   }
 }
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-  onRestart: () => dispatch(startOrganizationEventsStream(ownProps.orgId)),
   onClear: () => dispatch(clearOrganizationEventsStream(ownProps.orgId)),
 })
 

--- a/pkg/webui/console/containers/organization-events/organization-events.js
+++ b/pkg/webui/console/containers/organization-events/organization-events.js
@@ -14,28 +14,12 @@
 
 import React from 'react'
 
-import ErrorNotification from '@ttn-lw/components/error-notification'
-
 import Events from '@console/components/events'
 
-import sharedMessages from '@ttn-lw/lib/shared-messages'
 import PropTypes from '@ttn-lw/lib/prop-types'
 
 const OrganizationEvents = props => {
-  const { orgId, events, error, onRestart, widget, onClear } = props
-
-  if (error) {
-    return (
-      <ErrorNotification
-        small
-        title={sharedMessages.eventsCannotShow}
-        content={error}
-        action={onRestart}
-        actionMessage={sharedMessages.restartStream}
-        buttonIcon="refresh"
-      />
-    )
-  }
+  const { orgId, events, widget, onClear, truncated } = props
 
   if (widget) {
     return (
@@ -48,22 +32,20 @@ const OrganizationEvents = props => {
     )
   }
 
-  return <Events events={events} onClear={onClear} entityId={orgId} />
+  return <Events events={events} onClear={onClear} entityId={orgId} truncated={truncated} />
 }
 
 OrganizationEvents.propTypes = {
-  error: PropTypes.error,
   events: PropTypes.events,
   onClear: PropTypes.func.isRequired,
-  onRestart: PropTypes.func.isRequired,
   orgId: PropTypes.string.isRequired,
+  truncated: PropTypes.bool.isRequired,
   widget: PropTypes.bool,
 }
 
 OrganizationEvents.defaultProps = {
   widget: false,
   events: [],
-  error: undefined,
 }
 
 export default OrganizationEvents

--- a/pkg/webui/console/store/selectors/applications.js
+++ b/pkg/webui/console/store/selectors/applications.js
@@ -31,6 +31,7 @@ import {
   createEventsErrorSelector,
   createEventsStatusSelector,
   createEventsInterruptedSelector,
+  createEventsTruncatedSelector,
 } from './events'
 import { createRightsSelector, createPseudoRightsSelector } from './rights'
 import { createFetchingSelector } from './fetching'
@@ -70,6 +71,7 @@ export const selectApplicationEvents = createEventsSelector(ENTITY)
 export const selectApplicationEventsError = createEventsErrorSelector(ENTITY)
 export const selectApplicationEventsStatus = createEventsStatusSelector(ENTITY)
 export const selectApplicationEventsInterrupted = createEventsInterruptedSelector(ENTITY)
+export const selectApplicationEventsTruncated = createEventsTruncatedSelector(ENTITY)
 
 // Rights.
 export const selectApplicationRights = createRightsSelector(ENTITY)

--- a/pkg/webui/console/store/selectors/devices.js
+++ b/pkg/webui/console/store/selectors/devices.js
@@ -21,6 +21,7 @@ import {
   createEventsErrorSelector,
   createEventsStatusSelector,
   createEventsInterruptedSelector,
+  createEventsTruncatedSelector,
 } from './events'
 import {
   createPaginationIdsSelectorByEntity,
@@ -78,3 +79,4 @@ export const selectDeviceEvents = createEventsSelector(ENTITY)
 export const selectDeviceEventsError = createEventsErrorSelector(ENTITY)
 export const selectDeviceEventsStatus = createEventsStatusSelector(ENTITY)
 export const selectDeviceEventsInterruptted = createEventsInterruptedSelector(ENTITY)
+export const selectDeviceEventsTruncated = createEventsTruncatedSelector(ENTITY)

--- a/pkg/webui/console/store/selectors/events.js
+++ b/pkg/webui/console/store/selectors/events.js
@@ -32,7 +32,7 @@ export const createEventsInterruptedSelector = entity =>
   function(state, entityId) {
     const store = selectEventsStore(state.events[entity], entityId)
 
-    return store ? store.interrupted : false
+    return Boolean(store.interrupted)
   }
 
 export const createEventsErrorSelector = entity =>
@@ -40,6 +40,13 @@ export const createEventsErrorSelector = entity =>
     const store = selectEventsStore(state.events[entity], entityId)
 
     return store ? store.error : undefined
+  }
+
+export const createEventsTruncatedSelector = entity =>
+  function(state, entityId) {
+    const store = selectEventsStore(state.events[entity], entityId)
+
+    return Boolean(store.truncated)
   }
 
 export const createLatestEventSelector = function(entity) {

--- a/pkg/webui/console/store/selectors/gateways.js
+++ b/pkg/webui/console/store/selectors/gateways.js
@@ -25,6 +25,7 @@ import {
   createEventsErrorSelector,
   createEventsStatusSelector,
   createEventsInterruptedSelector,
+  createEventsTruncatedSelector,
   createLatestEventSelector,
 } from './events'
 import { createRightsSelector, createPseudoRightsSelector } from './rights'
@@ -65,6 +66,7 @@ export const selectGatewayEvents = createEventsSelector(ENTITY)
 export const selectGatewayEventsError = createEventsErrorSelector(ENTITY)
 export const selectGatewayEventsStatus = createEventsStatusSelector(ENTITY)
 export const selectGatewayEventsInterrupted = createEventsInterruptedSelector(ENTITY)
+export const selectGatewayEventsTruncated = createEventsTruncatedSelector(ENTITY)
 export const selectLatestGatewayEvent = createLatestEventSelector(ENTITY)
 
 // Rights.

--- a/pkg/webui/console/store/selectors/organizations.js
+++ b/pkg/webui/console/store/selectors/organizations.js
@@ -27,6 +27,7 @@ import {
   createEventsErrorSelector,
   createEventsStatusSelector,
   createEventsInterruptedSelector,
+  createEventsTruncatedSelector,
 } from './events'
 import { createFetchingSelector } from './fetching'
 import { createErrorSelector } from './error'
@@ -68,3 +69,4 @@ export const selectOrganizationEvents = createEventsSelector(ENTITY)
 export const selectOrganizationEventsError = createEventsErrorSelector(ENTITY)
 export const selectOrganizationEventsStatus = createEventsStatusSelector(ENTITY)
 export const selectOrganizationEventsInterrupted = createEventsInterruptedSelector(ENTITY)
+export const selectOrganizationEventsTruncated = createEventsTruncatedSelector(ENTITY)

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -76,6 +76,7 @@
   "console.components.events.messages.dataPreview": "Data preview",
   "console.components.events.messages.seeAllActivity": "See all activity",
   "console.components.events.messages.syntheticEvent": "Note: This meta event did not originate from the event stream",
+  "console.components.events.messages.eventsTruncated": "Old events have been truncated to save memory",
   "console.components.events.previews.shared.json-payload.index.invalid": "Invalid JSON",
   "console.components.gateway-data-form.index.enforced": "Enforced",
   "console.components.gateway-data-form.index.dutyCycle": "Duty cycle",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -76,6 +76,7 @@
   "console.components.events.messages.dataPreview": "Xxxx xxxxxxx",
   "console.components.events.messages.seeAllActivity": "Xxx xxx xxxxxxxx",
   "console.components.events.messages.syntheticEvent": "Xxxx: Xxxx xxxx xxxxx xxx xxx xxxxxxxxx xxxx xxx xxxxx xxxxxx",
+  "console.components.events.messages.eventsTruncated": "Xxx xxxxxx xxxx xxxx xxxxxxxxx xx xxxx xxxxxx",
   "console.components.events.previews.shared.json-payload.index.invalid": "Xxxxxxx XXXX",
   "console.components.gateway-data-form.index.enforced": "Xxxxxxxx",
   "console.components.gateway-data-form.index.dutyCycle": "Xxxx xxxxx",


### PR DESCRIPTION
#### Summary
This PR fixes lags, freezes and improves the performance of the event views by introducing optimizations to the event store logic.

References #3329 
Closes #2887 

#### Changes

- Improve performance of store logic
  - Introduce an event limit to avoid memory issues (currently set to 2000 events, ~3MB)
  - Introduce a buffered dispatch to the event store, to debounce expensive processing and store update operations, which caused significant lag in very active event streams (especially when scrolling the list)
    - Refactor affected store logic to handle multiple events per dispatch
- Other tweaks
  - Remove superfluous top-level error checks for end devices, gateways and organization (missed doing that in #3229)

#### Testing

Manual testing in staging environment and injected redux state.
##### Regressions

This might introduce issues regarding event list integrity.

#### Notes for Reviewers
Regarding 2000 event limit: this seemed like a sane limitation to me for now, at which the console still runs smoothly. We might want to fine-tune this value later when we have more feedback and metrics. Generally, it's important to establish for the user that the Console event view is not the correct place to source long-term event data.

See also #3329 and #3301 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
