### PR TITLE
Drop toa computation error message to debug level

### DIFF
--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -1330,7 +1330,7 @@ func (ns *NetworkServer) HandleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 	ctx = log.NewContext(ctx, logger)
 
 	if t, err := toa.Compute(len(up.RawPayload), up.Settings); err != nil {
-		log.FromContext(ctx).WithError(err).Warn("Failed to compute time-on-air")
+		log.FromContext(ctx).WithError(err).Debug("Failed to compute time-on-air")
 	} else {
 		up.ConsumedAirtime = &t
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Quickfix PR, followup for #3298. Reduce error message to debug level when Time On Air cannot be computed.
