### PR TITLE
Extend dial backoff configuration for application frontends in the AS

### DIFF
--- a/pkg/applicationserver/io/backoff.go
+++ b/pkg/applicationserver/io/backoff.go
@@ -25,7 +25,7 @@ import (
 var (
 	// TaskExtendedBackoffIntervals extends the default backoff intervals with longer periods for
 	// higher invocation counts.
-	TaskExtendedBackoffIntervals = append(component.DefaultTaskBackoffIntervals[:],
+	TaskExtendedBackoffIntervals = append(component.DialTaskBackoffIntervals[:],
 		time.Minute,
 		5*time.Minute,
 		15*time.Minute,
@@ -43,7 +43,8 @@ var (
 				errors.IsPermissionDenied(err),
 				errors.IsInvalidArgument(err),
 				errors.IsAlreadyExists(err),
-				errors.IsCanceled(err):
+				errors.IsCanceled(err),
+				errors.IsNotFound(err):
 				intervals = TaskExtendedBackoffIntervals
 			}
 			switch {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR changes the base task backoff durations used by linking and Pub/Sub connections to use the dial backoff, instead of the normal task backoff durations. 

This is required since `network_server_not_found` errors (caused by `GetLink`) are of type `NotFound`. Since this error code wasn't considered worthy of an extended backoff, the normal backoff is used. But, this maximum normal backoff is actually of 1 second instead of 10 seconds (the maximum dial backoff). This results in the AS attempting to reconnect the link and Pub/Subs every second instead of every 10 seconds (which is too little anyway).

#### Changes
<!-- What are the changes made in this pull request? -->

- Extend the dial backoffs instead of the normal backoff durations
- Add `NotFound` errors to the extended backoff lists


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This extends the backoff periods but has no side effects (as the backoffs are considered normal).

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Normally I would just say that we're getting rid of links anyway in 3.10 so this is just a quickfix but the reality is that due to the memory issues observed in CH, re-linking occurs quite often and the message spam which happens every second is not ideal. 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
