### PR TITLE
gcs: Use gateway auth for registry operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Decoded downlink payloads are stored now by Network Server.
 - Raw downlink PHY payloads are not stored anymore by Network Server.
 - Move documentation to [lorawan-stack-docs](https://github.com/TheThingsIndustries/lorawan-stack-docs).
+- CUPS Server only accepts The Things Stack API Key for token auth.
 
 ### Deprecated
 

--- a/pkg/basicstation/cups/server_test.go
+++ b/pkg/basicstation/cups/server_test.go
@@ -162,7 +162,7 @@ var (
 	mockRightsFetcher = rights.FetcherFunc(func(ctx context.Context, ids ttnpb.Identifiers) (*ttnpb.Rights, error) {
 		md := rpcmetadata.FromIncomingContext(ctx)
 		if md.AuthType == "Bearer" {
-			return ttnpb.RightsFrom(ttnpb.RIGHT_GATEWAY_INFO, ttnpb.RIGHT_GATEWAY_SETTINGS_BASIC), nil
+			return ttnpb.RightsFrom(ttnpb.RIGHT_GATEWAY_INFO, ttnpb.RIGHT_GATEWAY_SETTINGS_BASIC, ttnpb.RIGHT_GATEWAY_READ_SECRETS), nil
 		}
 		return nil, rights.ErrNoGatewayRights
 	})
@@ -256,6 +256,7 @@ func TestServer(t *testing.T) {
 					ID:  "KEYID",
 					Key: "KEYCONTENTS",
 				}
+				c.res.Get = c.res.Create
 			},
 			Options: []Option{
 				WithRegisterUnknown(&ttnpb.OrganizationOrUserIdentifiers{}, mockAuthFunc),
@@ -399,8 +400,8 @@ func TestServer(t *testing.T) {
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
 			err := s.UpdateInfo(c)
-			if tt.AssertError != nil {
-				a.So(tt.AssertError(err), should.BeTrue)
+			if tt.AssertError != nil && !a.So(tt.AssertError(err), should.BeTrue) {
+				t.Fatalf("Unexpected error :%v", err)
 			}
 			if tt.AssertResponse != nil {
 				tt.AssertResponse(a, rec)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes the use of Gateway Auth in CUPS. Needed for testing #3288 

#### Changes
<!-- What are the changes made in this pull request? -->

- Always use gateway auth for Gateway Registry calls (except the initial `GetIdentifiersForEUI`)
- Remove `cups-auth-header` support to allow only CUPS API Keys

#### Testing

<!-- How did you verify that this change works? -->

UT

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Will be tested as part of #3288 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
