### PR TITLE
Fix end device import crashes in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Use credentials` option being always checked in Pub/Sub edit form in the Console.
 - FPending being set on downlinks, when LinkADRReq is required, but all available TxPower and data rate index combinations are rejected by the device.
 - Coding rate for LoRa 2.4 GHz: it's now `4/8LI`.
+- End device import in the Console crashing in Firefox.
 
 ### Security
 

--- a/pkg/webui/components/progress-bar/index.js
+++ b/pkg/webui/components/progress-bar/index.js
@@ -92,9 +92,9 @@ export default class ProgressBar extends PureComponent {
     let displayEstimation = null
 
     if (showEstimation && percentage < 100) {
-      const now = new Date(Date.now() + 1000)
+      const now = Date.now()
       let eta = new Date(startTime + estimatedDuration)
-      if (eta < now) {
+      if (eta <= now) {
         // Avoid estimations in the past.
         eta = new Date(now + 1000)
       }

--- a/pkg/webui/lib/components/date-time/index.js
+++ b/pkg/webui/lib/components/date-time/index.js
@@ -15,7 +15,11 @@
 import React from 'react'
 import { FormattedDate, FormattedTime } from 'react-intl'
 
+import Message from '@ttn-lw/lib/components/message'
+
 import PropTypes from '@ttn-lw/lib/prop-types'
+import sharedMessages from '@ttn-lw/lib/shared-messages'
+import { warn } from '@ttn-lw/lib/log'
 
 import RelativeTime from './relative'
 
@@ -34,6 +38,15 @@ class DateTime extends React.PureComponent {
       }
 
       result += formattedTime
+    }
+
+    if (isNaN(dateValue)) {
+      warn('Invalid date passed to DateTime component')
+      return (
+        <time className={className}>
+          <Message content={sharedMessages.unknown} firstToLower />
+        </time>
+      )
     }
 
     return (


### PR DESCRIPTION
#### Summary
Closes #3345 

#### Changes
- Use timestamp instead of `Date` object for date arithmetic
- Make `DateTime` component handle invalid dates gracefully

#### Testing

Manual.

##### Regressions

None.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
