### PR TITLE
Fix Redis matching key check

### DIFF
--- a/pkg/networkserver/redis/lua/deviceMatchScan.lua
+++ b/pkg/networkserver/redis/lua/deviceMatchScan.lua
@@ -19,7 +19,7 @@ end
 
 for i = 1, #KEYS, 2 do
   local uid
-  if KEYS[i]:sub(-7) == "pending" then
+  if KEYS[i]:sub(-10) == "processing" then
 	  uid = redis.call('rpop', KEYS[i])
   else
 	  uid = redis.call('rpoplpush', KEYS[i], KEYS[i+1])

--- a/pkg/networkserver/redis/scripts.go
+++ b/pkg/networkserver/redis/scripts.go
@@ -74,7 +74,7 @@ return nil`)
 end
 for i = 1, #KEYS, 2 do
   local uid
-  if KEYS[i]:sub(-7) == "pending" then
+  if KEYS[i]:sub(-10) == "processing" then
 	  uid = redis.call('rpop', KEYS[i])
   else
 	  uid = redis.call('rpoplpush', KEYS[i], KEYS[i+1])


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fix Redis matching key check. Fixup #2837 
Fixes the `ERR Error running script (call to f_e5e0ee12ef8a9dbc3b6dbd986f74b65b5326936a): @user_script:9: @user_script: 9: Lua redis() command arguments must be strings or integers` we see on staging all the time.

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix Redis matching key check

#### Testing

<!-- How did you verify that this change works? -->

Integration testing with physical devices

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I am extremely embarrassed by how long it took me to figure out what's wrong here. I tried literally everything - except checking the actual word used :man_facepalming: 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
