### PR TITLE
Use correct coding rates in LoRa 2.4 GHz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Last seen counter for applications, end devices and gateways in the Console.
 - `Use credentials` option being always checked in Pub/Sub edit form in the Console.
 - FPending being set on downlinks, when LinkADRReq is required, but all available TxPower and data rate index combinations are rejected by the device.
+- Coding rate for LoRa 2.4 GHz: it's now `4/8LI`.
 
 ### Security
 

--- a/pkg/band/ism_2400.go
+++ b/pkg/band/ism_2400.go
@@ -120,7 +120,7 @@ func init() {
 		GenerateChMasks: generateChMask16,
 		ParseChMask:     parseChMask16,
 
-		LoRaCodingRate: "4/8",
+		LoRaCodingRate: "4/8LI",
 
 		FreqMultiplier:   200,
 		ImplementsCFList: true,
@@ -130,7 +130,7 @@ func init() {
 
 		Beacon: Beacon{
 			DataRateIndex:    ttnpb.DATA_RATE_3,
-			CodingRate:       "4/8",
+			CodingRate:       "4/8LI",
 			ComputeFrequency: func(_ float64) uint64 { return beaconFrequency },
 		},
 		PingSlotFrequency: uint64Ptr(beaconFrequency),

--- a/pkg/toa/toa.go
+++ b/pkg/toa/toa.go
@@ -81,7 +81,7 @@ func computeLoRa(payloadSize int, frequency uint64, spreadingFactor uint8, bandw
 		return time.Duration(timeOnAir), nil
 
 	case frequency >= 2400000000 && frequency < 2500000000:
-		// See https://www.semtech.com/uploads/documents/DS_SX1280-1_V2.2.pdf, 7.4.4.2
+		// See Semtech SX1280/SX1281/SX1282 Data Sheet Rev 3.0, 7.4.4
 		nBitCRC := 0.0
 		if crc {
 			nBitCRC = 16.0
@@ -90,14 +90,14 @@ func computeLoRa(payloadSize int, frequency uint64, spreadingFactor uint8, bandw
 		bw := float64(bandwidth) / 1000
 		var cr float64
 		switch codingRate {
-		case "4/5":
+		case "4/5LI":
 			cr = 5
-		case "4/6":
+		case "4/6LI":
 			cr = 6
-		case "4/8":
+		case "4/7LI", "4/8LI": // 4/7LI is wrongly defined; it is in fact 4/8LI.
 			cr = 8
 		default:
-			return 0, errCodingRate
+			return 0, errCodingRate.New()
 		}
 		var nBitHeaderSpace float64
 		var denominator float64

--- a/pkg/toa/toa_test.go
+++ b/pkg/toa/toa_test.go
@@ -201,7 +201,7 @@ func TestInvalidLoRa2400(t *testing.T) {
 					Bandwidth:       812000,
 				},
 			},
-		}, "1/9")
+		}, "1/9LI")
 		_, err = Compute(len(downlink.RawPayload), *downlink.GetScheduled())
 		a.So(err, should.NotBeNil)
 	}
@@ -215,7 +215,7 @@ func TestInvalidLoRa2400(t *testing.T) {
 					Bandwidth:       812000,
 				},
 			},
-		}, "4/5")
+		}, "4/5LI")
 		_, err = Compute(len(downlink.RawPayload), *downlink.GetScheduled())
 		a.So(err, should.NotBeNil)
 	}
@@ -229,7 +229,7 @@ func TestInvalidLoRa2400(t *testing.T) {
 					Bandwidth:       0,
 				},
 			},
-		}, "4/5")
+		}, "4/5LI")
 		_, err = Compute(len(downlink.RawPayload), *downlink.GetScheduled())
 		a.So(err, should.NotBeNil)
 	}
@@ -248,7 +248,7 @@ func TestDifferentLoRa2400SFs(t *testing.T) {
 		{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{SpreadingFactor: 12, Bandwidth: 812000}}}: 142502500,
 	}
 	for dr, ns := range sfTests {
-		dl, err := buildLoRaDownlinkFromParameters(10, 2422000000, dr, "4/5")
+		dl, err := buildLoRaDownlinkFromParameters(10, 2422000000, dr, "4/5LI")
 		toa, err := Compute(len(dl.RawPayload), *dl.GetScheduled())
 		a.So(err, should.BeNil)
 		a.So(toa, should.AlmostEqual, time.Duration(ns), 50)
@@ -264,7 +264,7 @@ func TestDifferentLoRa2400BWs(t *testing.T) {
 		{Modulation: &ttnpb.DataRate_LoRa{LoRa: &ttnpb.LoRaDataRate{SpreadingFactor: 7, Bandwidth: 1625000}}}: 2776600,
 	}
 	for dr, ns := range bwTests {
-		dl, err := buildLoRaDownlinkFromParameters(10, 2422000000, dr, "4/5")
+		dl, err := buildLoRaDownlinkFromParameters(10, 2422000000, dr, "4/5LI")
 		toa, err := Compute(len(dl.RawPayload), *dl.GetScheduled())
 		a.So(err, should.BeNil)
 		a.So(toa, should.AlmostEqual, ns, 50)
@@ -274,9 +274,10 @@ func TestDifferentLoRa2400BWs(t *testing.T) {
 func TestDifferentLoRa2400CRs(t *testing.T) {
 	a := assertions.New(t)
 	crTests := map[string]time.Duration{
-		"4/5": 5556700,
-		"4/6": 6029600,
-		"4/8": 6817700,
+		"4/5LI": 5556700,
+		"4/6LI": 6029600,
+		"4/7LI": 6817700,
+		"4/8LI": 6817700,
 	}
 	for cr, ns := range crTests {
 		dl, err := buildLoRaDownlinkFromParameters(10, 2422000000, ttnpb.DataRate{
@@ -311,7 +312,7 @@ func TestDifferentLoRa2400PayloadSizes(t *testing.T) {
 					Bandwidth:       812000,
 				},
 			},
-		}, "4/5")
+		}, "4/5LI")
 		toa, err := Compute(len(dl.RawPayload), *dl.GetScheduled())
 		a.So(err, should.BeNil)
 		a.So(toa, should.AlmostEqual, ns, 50)
@@ -332,7 +333,7 @@ func TestDifferentLoRa2400CRCs(t *testing.T) {
 					Bandwidth:       812000,
 				},
 			},
-		}, "4/5")
+		}, "4/5LI")
 		dl.GetScheduled().EnableCRC = crc
 		toa, err := Compute(len(dl.RawPayload), *dl.GetScheduled())
 		a.So(err, should.BeNil)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Use correct coding rates

#### Changes
<!-- What are the changes made in this pull request? -->

LoRa 2.4 GHz uses coding rate 4/8LI. The time-on-air calculation was already for long interleaving (LI) so this only fixes the identifier.

#### Testing

<!-- How did you verify that this change works? -->

Unit testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This may break downlink on gateways that depend on the wrong behavior. I expect that gateways already overwrite this to 4/8LI. If not, and the gateway respects the field from GS, the right coding rate is now used.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
