### PR TITLE
Add JS dependencies timeout in CI

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -52,6 +52,7 @@ jobs:
       continue-on-error: true
     - name: Install JS dependencies
       run: tools/bin/mage js:deps
+      timeout-minutes: 5
     - name: Check headers
       run: tools/bin/mage headers:check
     - name: Fix common spelling mistakes

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -62,6 +62,7 @@ jobs:
       run: tools/bin/mage jsSDK:clean jsSDK:build
     - name: Install JS dependencies
       run: tools/bin/mage js:deps
+      timeout-minutes: 5
     - name: Generate JS translations
       run: tools/bin/mage js:translations js:backendTranslations
     - name: Lint JS SDK code
@@ -109,6 +110,7 @@ jobs:
       run: tools/bin/mage jsSDK:clean jsSDK:build
     - name: Install JS dependencies
       run: tools/bin/mage js:deps
+      timeout-minutes: 5
     - name: Build frontend
       run: tools/bin/mage js:clean js:build
     - name: Test JS SDK code

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -73,6 +73,7 @@ jobs:
       run: tools/bin/mage jsSDK:clean jsSDK:build
     - name: Install JS dependencies
       run: tools/bin/mage js:deps
+      timeout-minutes: 5
     - name: Build frontend
       run: tools/bin/mage js:clean js:build
     - name: File versioning

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -51,6 +51,7 @@ jobs:
       run: tools/bin/mage jsSDK:clean jsSDK:build
     - name: Install JS dependencies
       run: tools/bin/mage js:deps
+      timeout-minutes: 5
     - name: Build frontend
       run: tools/bin/mage js:clean js:build
     - name: File versioning


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This quickfix adds a 5 minute timeout to the `mage js:deps` target in CI. We've seen this target hang for up to 30 minutes in the past, without any kind of progress, but finish in less than 3 minutes if working.
