### PR TITLE
Recognize request errors and x509 errors

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -3239,6 +3239,15 @@
       "file": "attributes.go"
     }
   },
+  "error:pkg/errors:request": {
+    "translations": {
+      "en": "request to `{url}` failed"
+    },
+    "description": {
+      "package": "pkg/errors",
+      "file": "conversion.go"
+    }
+  },
   "error:pkg/errors:validation": {
     "translations": {
       "en": "invalid `{field}`: {reason}"
@@ -3246,6 +3255,15 @@
     "description": {
       "package": "pkg/errors",
       "file": "validation.go"
+    }
+  },
+  "error:pkg/errors:x509_unknown_authority": {
+    "translations": {
+      "en": "unknown certificate authority"
+    },
+    "description": {
+      "package": "pkg/errors",
+      "file": "conversion.go"
     }
   },
   "error:pkg/events/grpc:no_identifiers": {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This adds `*url.Error` and `x509.UnknownAuthorityError` to the list of "common" errors, so that they are returned to users.

#### Testing

<!-- How did you verify that this change works? -->

🐒 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
