### PR TITLE
Remove mage version:files from non-release builds

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -57,7 +57,5 @@ jobs:
       run: tools/bin/mage headers:check
     - name: Fix common spelling mistakes
       run: tools/bin/mage dev:misspell
-    - name: File versioning
-      run: tools/bin/mage version:files
     - name: Check for diff
       run: tools/bin/mage git:diff

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -76,8 +76,6 @@ jobs:
       timeout-minutes: 5
     - name: Build frontend
       run: tools/bin/mage js:clean js:build
-    - name: File versioning
-      run: tools/bin/mage version:files
     - name: Check for diff
       run: tools/bin/mage git:diff
     - name: Determine Goreleaser version

--- a/api/api.md
+++ b/api/api.md
@@ -865,8 +865,8 @@ The AsEndDeviceRegistry service allows clients to manage their end devices on th
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| `application_ids` | [`ApplicationIdentifiers`](#ttn.lorawan.v3.ApplicationIdentifiers) |  | Query upstream messages from all end devices of an application. Cannot be used in conjuction with EndDeviceIdentifiers. |
-| `end_device_ids` | [`EndDeviceIdentifiers`](#ttn.lorawan.v3.EndDeviceIdentifiers) |  | Query upstream messages from a single end device. Cannot be used in conjuction with ApplicationIdentifiers. |
+| `application_ids` | [`ApplicationIdentifiers`](#ttn.lorawan.v3.ApplicationIdentifiers) |  | Query upstream messages from all end devices of an application. Cannot be used in conjunction with EndDeviceIdentifiers. |
+| `end_device_ids` | [`EndDeviceIdentifiers`](#ttn.lorawan.v3.EndDeviceIdentifiers) |  | Query upstream messages from a single end device. Cannot be used in conjunction with ApplicationIdentifiers. |
 | `type` | [`string`](#string) |  | Query upstream messages of a specific type. If not set, then all upstream messages are returned. |
 | `limit` | [`google.protobuf.UInt32Value`](#google.protobuf.UInt32Value) |  | Limit number of results. |
 | `after` | [`google.protobuf.Timestamp`](#google.protobuf.Timestamp) |  | Query upstream messages after this timestamp only. |

--- a/api/applicationserver_integrations_storage.proto
+++ b/api/applicationserver_integrations_storage.proto
@@ -27,9 +27,9 @@ package ttn.lorawan.v3;
 option go_package = "go.thethings.network/lorawan-stack/v3/pkg/ttnpb";
 
 message GetStoredApplicationUpRequest {
-  // Query upstream messages from all end devices of an application. Cannot be used in conjuction with EndDeviceIdentifiers.
+  // Query upstream messages from all end devices of an application. Cannot be used in conjunction with EndDeviceIdentifiers.
   ApplicationIdentifiers application_ids = 1 [(gogoproto.nullable) = true, (gogoproto.customname) = "ApplicationIDs"];
-  // Query upstream messages from a single end device. Cannot be used in conjuction with ApplicationIdentifiers.
+  // Query upstream messages from a single end device. Cannot be used in conjunction with ApplicationIdentifiers.
   EndDeviceIdentifiers end_device_ids = 2 [(gogoproto.nullable) = true, (gogoproto.customname) = "EndDeviceIDs"];
 
   // Query upstream messages of a specific type. If not set, then all upstream messages are returned.

--- a/pkg/ttnpb/applicationserver_integrations_storage.pb.go
+++ b/pkg/ttnpb/applicationserver_integrations_storage.pb.go
@@ -39,9 +39,9 @@ var _ = time.Kitchen
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type GetStoredApplicationUpRequest struct {
-	// Query upstream messages from all end devices of an application. Cannot be used in conjuction with EndDeviceIdentifiers.
+	// Query upstream messages from all end devices of an application. Cannot be used in conjunction with EndDeviceIdentifiers.
 	ApplicationIDs *ApplicationIdentifiers `protobuf:"bytes,1,opt,name=application_ids,json=applicationIds,proto3" json:"application_ids,omitempty"`
-	// Query upstream messages from a single end device. Cannot be used in conjuction with ApplicationIdentifiers.
+	// Query upstream messages from a single end device. Cannot be used in conjunction with ApplicationIdentifiers.
 	EndDeviceIDs *EndDeviceIdentifiers `protobuf:"bytes,2,opt,name=end_device_ids,json=endDeviceIds,proto3" json:"end_device_ids,omitempty"`
 	// Query upstream messages of a specific type. If not set, then all upstream messages are returned.
 	Type string `protobuf:"bytes,3,opt,name=type,proto3" json:"type,omitempty"`

--- a/sdk/js/generated/api.json
+++ b/sdk/js/generated/api.json
@@ -1706,7 +1706,7 @@
           "fields": [
             {
               "name": "application_ids",
-              "description": "Query upstream messages from all end devices of an application. Cannot be used in conjuction with EndDeviceIdentifiers.",
+              "description": "Query upstream messages from all end devices of an application. Cannot be used in conjunction with EndDeviceIdentifiers.",
               "label": "",
               "type": "ApplicationIdentifiers",
               "longType": "ApplicationIdentifiers",
@@ -1716,7 +1716,7 @@
             },
             {
               "name": "end_device_ids",
-              "description": "Query upstream messages from a single end device. Cannot be used in conjuction with ApplicationIdentifiers.",
+              "description": "Query upstream messages from a single end device. Cannot be used in conjunction with ApplicationIdentifiers.",
               "label": "",
               "type": "EndDeviceIdentifiers",
               "longType": "EndDeviceIdentifiers",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This removes `mage version:files` step from non-release builds.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

We only need to make sure the version files are in sync on releases. In normal PRs, and even snapshot builds, it doesn't really matter if the version files are not in sync with the latest git tag.