### PR TITLE
Fix dial task backoff extension

### DIFF
--- a/pkg/applicationserver/io/backoff.go
+++ b/pkg/applicationserver/io/backoff.go
@@ -23,20 +23,20 @@ import (
 )
 
 var (
-	// TaskExtendedBackoffIntervals extends the default backoff intervals with longer periods for
-	// higher invocation counts.
-	TaskExtendedBackoffIntervals = append(component.DialTaskBackoffIntervals[:],
+	dialTaskBackoffIntervals = append(component.DialTaskBackoffIntervals[:],
 		time.Minute,
+	)
+	dialTaskExtendedBackoffIntervals = append(dialTaskBackoffIntervals[:],
 		5*time.Minute,
 		15*time.Minute,
 		30*time.Minute,
 	)
-	// TaskBackoffConfig derives the component.DefaultTaskBackoffConfig and dynamically determines the backoff duration
+	// DialTaskBackoffConfig derives the component.DialTaskBackoffConfig and dynamically determines the backoff duration
 	// based on recent error codes.
-	TaskBackoffConfig = &component.TaskBackoffConfig{
+	DialTaskBackoffConfig = &component.TaskBackoffConfig{
 		Jitter: component.DefaultTaskBackoffJitter,
 		IntervalFunc: func(ctx context.Context, executionDuration time.Duration, invocation uint, err error) time.Duration {
-			intervals := component.DefaultTaskBackoffIntervals[:]
+			intervals := dialTaskBackoffIntervals
 			switch {
 			case errors.IsFailedPrecondition(err),
 				errors.IsUnauthenticated(err),
@@ -45,7 +45,7 @@ var (
 				errors.IsAlreadyExists(err),
 				errors.IsCanceled(err),
 				errors.IsNotFound(err):
-				intervals = TaskExtendedBackoffIntervals
+				intervals = dialTaskExtendedBackoffIntervals
 			}
 			switch {
 			case executionDuration > component.DefaultTaskBackoffResetDuration:

--- a/pkg/applicationserver/io/pubsub/integrate_internal_test.go
+++ b/pkg/applicationserver/io/pubsub/integrate_internal_test.go
@@ -21,5 +21,5 @@ import (
 )
 
 func init() {
-	io.TaskBackoffConfig.IntervalFunc = component.MakeTaskBackoffIntervalFunc(false, component.DefaultTaskBackoffResetDuration, (1<<5)*test.Delay)
+	io.DialTaskBackoffConfig.IntervalFunc = component.MakeTaskBackoffIntervalFunc(false, component.DefaultTaskBackoffResetDuration, (1<<5)*test.Delay)
 }

--- a/pkg/applicationserver/io/pubsub/pubsub.go
+++ b/pkg/applicationserver/io/pubsub/pubsub.go
@@ -92,7 +92,7 @@ func (ps *PubSub) startTask(ctx context.Context, ids ttnpb.ApplicationPubSubIden
 			return ps.start(ctx, target)
 		},
 		Restart: component.TaskRestartOnFailure,
-		Backoff: io.TaskBackoffConfig,
+		Backoff: io.DialTaskBackoffConfig,
 	})
 }
 

--- a/pkg/applicationserver/linking.go
+++ b/pkg/applicationserver/linking.go
@@ -66,7 +66,7 @@ func (as *ApplicationServer) startLinkTask(ctx context.Context, ids ttnpb.Applic
 			return as.link(ctx, ids, target)
 		},
 		Restart: component.TaskRestartOnFailure,
-		Backoff: io.TaskBackoffConfig,
+		Backoff: io.DialTaskBackoffConfig,
 	})
 }
 

--- a/pkg/applicationserver/linking_internal_test.go
+++ b/pkg/applicationserver/linking_internal_test.go
@@ -21,5 +21,5 @@ import (
 )
 
 func init() {
-	io.TaskBackoffConfig.IntervalFunc = component.MakeTaskBackoffIntervalFunc(false, component.DefaultTaskBackoffResetDuration, (1<<5)*test.Delay)
+	io.DialTaskBackoffConfig.IntervalFunc = component.MakeTaskBackoffIntervalFunc(false, component.DefaultTaskBackoffResetDuration, (1<<5)*test.Delay)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/3337

#### Changes
<!-- What are the changes made in this pull request? -->

- Make base backoff intervals derive `DialTaskBackoffIntervals` (which go up to 10 seconds) instead of `DefaultTaskBackoffIntervals` (which goes up to 1 second) - this should've been in #3337 but I've missed it.
- Add a 1 minute duration to the base backoff intervals. The reasoning behind this being that even after the derivation fix, a 10 second max backoff is still too small for some errors whose error code shouldn't necessarily go up to 30 minutes.


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Not expected. Should lower AS task scheduling pressure however.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
