### PR TITLE
Fix matching of 16-bit FCnt devices resetting FCnt

### DIFF
--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -753,9 +753,17 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 				"pending_session", isPending,
 			))
 
-			matchType := currentSessionMatch
-			if isPending {
+			var matchType sessionMatchType
+			switch {
+			case isPending:
 				matchType = pendingSessionMatch
+			case fCnt < match.LastFCnt():
+				if pld.FCnt != fCnt {
+					panic("invalid FCnt")
+				}
+				matchType = fCntResetMatch
+			default:
+				matchType = currentSessionMatch
 			}
 			var cmacF [4]byte
 			cmacF, ok = matchCmacF(ctx, fNwkSIntKey, macVersion, fCnt, up)

--- a/pkg/networkserver/internal/utils.go
+++ b/pkg/networkserver/internal/utils.go
@@ -135,10 +135,10 @@ func FullFCnt(fCnt uint16, lastFCnt uint32, supports32BitFCnt bool) uint32 {
 		return 0
 	case !supports32BitFCnt:
 		return uint32(fCnt)
-	case uint32(fCnt) > lastFCnt&0xffff:
-		return uint32(fCnt) | lastFCnt&^0xffff
+	case uint32(fCnt) >= lastFCnt&0xffff:
+		return lastFCnt&^0xffff | uint32(fCnt)
 	case lastFCnt < 0xffff0000:
-		return uint32(fCnt) | (lastFCnt+0x10000)&^0xffff
+		return (lastFCnt+0x10000)&^0xffff | uint32(fCnt)
 	default:
 		return uint32(fCnt)
 	}

--- a/pkg/networkserver/redis/lua/deviceMatch.lua
+++ b/pkg/networkserver/redis/lua/deviceMatch.lua
@@ -28,11 +28,11 @@
 -- KEYS[8] 	- sorted list of uids of devices matching using 32-bit frame counters with no rollover
 -- KEYS[9] 	- sorted list of uids of devices matching using 32-bit frame counters with no rollover being processed
 --
--- KEYS[10]	- sorted list of uids of devices matching using 32-bit frame counters with rollover
--- KEYS[11] - sorted list of uids of devices matching using 32-bit frame counters with rollover being processed
+-- KEYS[10] - list of uids of devices matching pending session DevAddr
+-- KEYS[11] - list of uids of devices matching pending session DevAddr being processed
 --
--- KEYS[12] - list of uids of devices matching pending session DevAddr
--- KEYS[13] - list of uids of devices matching pending session DevAddr being processed
+-- KEYS[12]	- sorted list of uids of devices matching using 32-bit frame counters with rollover
+-- KEYS[13] - sorted list of uids of devices matching using 32-bit frame counters with rollover being processed
 --
 -- KEYS[14] - sorted list of uids of devices matching using 16-bit frame counters with a reset
 -- KEYS[15] - sorted list of uids of devices matching using 16-bit frame counters with a reset being processed
@@ -67,12 +67,12 @@ if redis.call('sort', KEYS[3], 'by', 'nosort', 'limit', 0, longCount, 'store', K
   table.insert(toScan, 8)
 end
 
-if redis.call('sort', KEYS[3], 'by', 'nosort', 'limit', longCount, -1, 'store', KEYS[10]) > 0 then
+if redis.call('sort', KEYS[4], 'by', 'nosort', 'store', KEYS[10]) > 0 then
   redis.call('pexpire', KEYS[10], ARGV[2])
   table.insert(toScan, 10)
 end
 
-if redis.call('sort', KEYS[4], 'by', 'nosort', 'store', KEYS[12]) > 0 then
+if redis.call('sort', KEYS[3], 'by', 'nosort', 'limit', longCount, -1, 'store', KEYS[12]) > 0 then
   redis.call('pexpire', KEYS[12], ARGV[2])
   table.insert(toScan, 12)
 end

--- a/pkg/networkserver/redis/lua/deviceMatch.lua
+++ b/pkg/networkserver/redis/lua/deviceMatch.lua
@@ -22,20 +22,23 @@
 -- KEYS[4] 	- set of uids of devices matching pending session DevAddr
 -- KEYS[5]  - set of uids of devices matching either current or pending session DevAddr (legacy)
 --
--- KEYS[6] 	- sorted list of uid, LastFCntUp, FNwkSIntKey, MACVersion of matching devices using 16-bit frame counters
--- KEYS[7] 	- sorted list of uid, LastFCntUp, FNwkSIntKey, MACVersion of matching devices using 16-bit frame counters being processed
+-- KEYS[6] 	- sorted list of uids of devices matching using 16-bit frame counters
+-- KEYS[7] 	- sorted list of uids of devices matching using 16-bit frame counters being processed
 --
--- KEYS[8] 	- sorted list of uid, LastFCntUp, FNwkSIntKey, MACVersion of matching devices using 32-bit frame counters with no rollover
--- KEYS[9] 	- sorted list of uid, LastFCntUp, FNwkSIntKey, MACVersion of matching devices using 32-bit frame counters with no rollover being processed
+-- KEYS[8] 	- sorted list of uids of devices matching using 32-bit frame counters with no rollover
+-- KEYS[9] 	- sorted list of uids of devices matching using 32-bit frame counters with no rollover being processed
 --
--- KEYS[10]	- sorted list of uid, LastFCntUp, FNwkSIntKey, MACVersion of matching devices using 32-bit frame counters with rollover
--- KEYS[11] - sorted list of uid, LastFCntUp, FNwkSIntKey, MACVersion of matching devices using 32-bit frame counters with rollover being processed
+-- KEYS[10]	- sorted list of uids of devices matching using 32-bit frame counters with rollover
+-- KEYS[11] - sorted list of uids of devices matching using 32-bit frame counters with rollover being processed
 --
 -- KEYS[12] - list of uids of devices matching pending session DevAddr
 -- KEYS[13] - list of uids of devices matching pending session DevAddr being processed
 --
--- KEYS[14] - list of uids of devices matching either current or pending session DevAddr not present in either KEYS[2], KEYS[3], nor KEYS[4]
--- KEYS[15] - list of uids of devices matching either current or pending session DevAddr not present in either KEYS[2], KEYS[3], nor KEYS[4] being processed
+-- KEYS[14] - sorted list of uids of devices matching using 16-bit frame counters with a reset
+-- KEYS[15] - sorted list of uids of devices matching using 16-bit frame counters with a reset being processed
+--
+-- KEYS[16] - list of uids of devices matching either current or pending session DevAddr not present in either KEYS[2], KEYS[3], nor KEYS[4]
+-- KEYS[17] - list of uids of devices matching either current or pending session DevAddr not present in either KEYS[2], KEYS[3], nor KEYS[4] being processed
 -- NOTE: The script is optimized for the assumption that count of devices using 16-bit frame counters << count of devices using 32-bit frame counters.
 if redis.call('pexpire', KEYS[1], ARGV[2]) > 0 then
   return redis.call('get', KEYS[1])
@@ -74,9 +77,14 @@ if redis.call('sort', KEYS[4], 'by', 'nosort', 'store', KEYS[12]) > 0 then
   table.insert(toScan, 12)
 end
 
-if redis.call('sort', KEYS[5], 'by', 'nosort', 'store', KEYS[14]) > 0 then
+if redis.call('sort', KEYS[2], 'by', 'nosort', 'limit', shortCount, -1, 'store', KEYS[14]) > 0 then
   redis.call('pexpire', KEYS[14], ARGV[2])
   table.insert(toScan, 14)
+end
+
+if redis.call('sort', KEYS[5], 'by', 'nosort', 'store', KEYS[16]) > 0 then
+  redis.call('pexpire', KEYS[16], ARGV[2])
+  table.insert(toScan, 16)
 end
 
 if #toScan > 0 then

--- a/pkg/networkserver/redis/registry.go
+++ b/pkg/networkserver/redis/registry.go
@@ -413,7 +413,7 @@ func getUplinkMatch(ctx context.Context, r redis.Cmdable, inputKeys, processingK
 			}
 		} else {
 			switch fields[i] {
-			case "mac_settings.resets_f_cnt.value":
+			case "mac_settings.resets_f_cnt":
 				v, err := decodeBool(v)
 				if err != nil {
 					return nil, errDatabaseCorruption.WithCause(err)

--- a/pkg/networkserver/redis/registry.go
+++ b/pkg/networkserver/redis/registry.go
@@ -193,8 +193,8 @@ func (m uplinkMatch) IsPending() bool {
 type matchKeySet struct {
 	ShortFCntLE string
 	LongFCntLE  string
-	LongFCntGT  string
 	Pending     string
+	LongFCntGT  string
 	ShortFCntGT string
 	Legacy      string
 }
@@ -509,8 +509,8 @@ func (r *DeviceRegistry) RangeByUplinkMatches(ctx context.Context, up *ttnpb.Upl
 		Input: matchKeySet{
 			ShortFCntLE: ttnredis.Key(addrKeys.ShortFCnt, payloadHash, "le"),
 			LongFCntLE:  ttnredis.Key(addrKeys.LongFCnt, payloadHash, "le"),
-			LongFCntGT:  ttnredis.Key(addrKeys.LongFCnt, payloadHash, "gt"),
 			Pending:     ttnredis.Key(addrKeys.Pending, payloadHash),
+			LongFCntGT:  ttnredis.Key(addrKeys.LongFCnt, payloadHash, "gt"),
 			ShortFCntGT: ttnredis.Key(addrKeys.ShortFCnt, payloadHash, "gt"),
 			Legacy:      ttnredis.Key(addrKeys.Legacy, payloadHash),
 		},
@@ -518,8 +518,8 @@ func (r *DeviceRegistry) RangeByUplinkMatches(ctx context.Context, up *ttnpb.Upl
 	matchKeys.Processing = matchKeySet{
 		ShortFCntLE: ttnredis.Key(matchKeys.Input.ShortFCntLE, "processing"),
 		LongFCntLE:  ttnredis.Key(matchKeys.Input.LongFCntLE, "processing"),
-		LongFCntGT:  ttnredis.Key(matchKeys.Input.LongFCntGT, "processing"),
 		Pending:     ttnredis.Key(matchKeys.Input.Pending, "processing"),
+		LongFCntGT:  ttnredis.Key(matchKeys.Input.LongFCntGT, "processing"),
 		ShortFCntGT: ttnredis.Key(matchKeys.Input.ShortFCntGT, "processing"),
 		Legacy:      ttnredis.Key(matchKeys.Input.Legacy, "processing"),
 	}
@@ -543,11 +543,11 @@ func (r *DeviceRegistry) RangeByUplinkMatches(ctx context.Context, up *ttnpb.Upl
 		matchKeys.Input.LongFCntLE,
 		matchKeys.Processing.LongFCntLE,
 
-		matchKeys.Input.LongFCntGT,
-		matchKeys.Processing.LongFCntGT,
-
 		matchKeys.Input.Pending,
 		matchKeys.Processing.Pending,
+
+		matchKeys.Input.LongFCntGT,
+		matchKeys.Processing.LongFCntGT,
 
 		matchKeys.Input.ShortFCntGT,
 		matchKeys.Processing.ShortFCntGT,
@@ -592,14 +592,14 @@ func (r *DeviceRegistry) RangeByUplinkMatches(ctx context.Context, up *ttnpb.Upl
 				scanKeys = append(scanKeys, matchKeys.Processing.LongFCntLE)
 				continue
 			case 10:
-				scanKeys = append(scanKeys, matchKeys.Input.LongFCntGT, matchKeys.Processing.LongFCntGT)
+				scanKeys = append(scanKeys, matchKeys.Input.Pending, matchKeys.Processing.Pending)
 			case 11:
-				scanKeys = append(scanKeys, matchKeys.Processing.LongFCntGT)
+				scanKeys = append(scanKeys, matchKeys.Processing.Pending)
 				continue
 			case 12:
-				scanKeys = append(scanKeys, matchKeys.Input.Pending, matchKeys.Processing.Pending)
+				scanKeys = append(scanKeys, matchKeys.Input.LongFCntGT, matchKeys.Processing.LongFCntGT)
 			case 13:
-				scanKeys = append(scanKeys, matchKeys.Processing.Pending)
+				scanKeys = append(scanKeys, matchKeys.Processing.LongFCntGT)
 				continue
 			case 14:
 				scanKeys = append(scanKeys, matchKeys.Input.ShortFCntGT, matchKeys.Processing.ShortFCntGT)
@@ -705,8 +705,8 @@ func (r *DeviceRegistry) RangeByUplinkMatches(ctx context.Context, up *ttnpb.Upl
 				switch scanKeys[0] {
 				case matchKeys.Processing.ShortFCntLE,
 					matchKeys.Processing.LongFCntLE,
-					matchKeys.Processing.LongFCntGT,
 					matchKeys.Processing.Pending,
+					matchKeys.Processing.LongFCntGT,
 					matchKeys.Processing.ShortFCntGT,
 					matchKeys.Processing.Legacy:
 					// If the UID is from processing set, we don't need to remove it

--- a/pkg/networkserver/redis/scripts.go
+++ b/pkg/networkserver/redis/scripts.go
@@ -15,20 +15,23 @@ var (
 	// KEYS[4] 	- set of uids of devices matching pending session DevAddr
 	// KEYS[5]  - set of uids of devices matching either current or pending session DevAddr (legacy)
 	//
-	// KEYS[6] 	- sorted list of uid, LastFCntUp, FNwkSIntKey, MACVersion of matching devices using 16-bit frame counters
-	// KEYS[7] 	- sorted list of uid, LastFCntUp, FNwkSIntKey, MACVersion of matching devices using 16-bit frame counters being processed
+	// KEYS[6] 	- sorted list of uids of devices matching using 16-bit frame counters
+	// KEYS[7] 	- sorted list of uids of devices matching using 16-bit frame counters being processed
 	//
-	// KEYS[8] 	- sorted list of uid, LastFCntUp, FNwkSIntKey, MACVersion of matching devices using 32-bit frame counters with no rollover
-	// KEYS[9] 	- sorted list of uid, LastFCntUp, FNwkSIntKey, MACVersion of matching devices using 32-bit frame counters with no rollover being processed
+	// KEYS[8] 	- sorted list of uids of devices matching using 32-bit frame counters with no rollover
+	// KEYS[9] 	- sorted list of uids of devices matching using 32-bit frame counters with no rollover being processed
 	//
-	// KEYS[10]	- sorted list of uid, LastFCntUp, FNwkSIntKey, MACVersion of matching devices using 32-bit frame counters with rollover
-	// KEYS[11] - sorted list of uid, LastFCntUp, FNwkSIntKey, MACVersion of matching devices using 32-bit frame counters with rollover being processed
+	// KEYS[10]	- sorted list of uids of devices matching using 32-bit frame counters with rollover
+	// KEYS[11] - sorted list of uids of devices matching using 32-bit frame counters with rollover being processed
 	//
 	// KEYS[12] - list of uids of devices matching pending session DevAddr
 	// KEYS[13] - list of uids of devices matching pending session DevAddr being processed
 	//
-	// KEYS[14] - list of uids of devices matching either current or pending session DevAddr not present in either KEYS[2], KEYS[3], nor KEYS[4]
-	// KEYS[15] - list of uids of devices matching either current or pending session DevAddr not present in either KEYS[2], KEYS[3], nor KEYS[4] being processed
+	// KEYS[14] - sorted list of uids of devices matching using 16-bit frame counters with a reset
+	// KEYS[15] - sorted list of uids of devices matching using 16-bit frame counters with a reset being processed
+	//
+	// KEYS[16] - list of uids of devices matching either current or pending session DevAddr not present in either KEYS[2], KEYS[3], nor KEYS[4]
+	// KEYS[17] - list of uids of devices matching either current or pending session DevAddr not present in either KEYS[2], KEYS[3], nor KEYS[4] being processed
 	// NOTE: The script is optimized for the assumption that count of devices using 16-bit frame counters << count of devices using 32-bit frame counters.
 	deviceMatchScript = redis.NewScript(`if redis.call('pexpire', KEYS[1], ARGV[2]) > 0 then
   return redis.call('get', KEYS[1])
@@ -60,9 +63,13 @@ if redis.call('sort', KEYS[4], 'by', 'nosort', 'store', KEYS[12]) > 0 then
   redis.call('pexpire', KEYS[12], ARGV[2])
   table.insert(toScan, 12)
 end
-if redis.call('sort', KEYS[5], 'by', 'nosort', 'store', KEYS[14]) > 0 then
+if redis.call('sort', KEYS[2], 'by', 'nosort', 'limit', shortCount, -1, 'store', KEYS[14]) > 0 then
   redis.call('pexpire', KEYS[14], ARGV[2])
   table.insert(toScan, 14)
+end
+if redis.call('sort', KEYS[5], 'by', 'nosort', 'store', KEYS[16]) > 0 then
+  redis.call('pexpire', KEYS[16], ARGV[2])
+  table.insert(toScan, 16)
 end
 if #toScan > 0 then
     return toScan

--- a/pkg/networkserver/redis/scripts.go
+++ b/pkg/networkserver/redis/scripts.go
@@ -21,11 +21,11 @@ var (
 	// KEYS[8] 	- sorted list of uids of devices matching using 32-bit frame counters with no rollover
 	// KEYS[9] 	- sorted list of uids of devices matching using 32-bit frame counters with no rollover being processed
 	//
-	// KEYS[10]	- sorted list of uids of devices matching using 32-bit frame counters with rollover
-	// KEYS[11] - sorted list of uids of devices matching using 32-bit frame counters with rollover being processed
+	// KEYS[10] - list of uids of devices matching pending session DevAddr
+	// KEYS[11] - list of uids of devices matching pending session DevAddr being processed
 	//
-	// KEYS[12] - list of uids of devices matching pending session DevAddr
-	// KEYS[13] - list of uids of devices matching pending session DevAddr being processed
+	// KEYS[12]	- sorted list of uids of devices matching using 32-bit frame counters with rollover
+	// KEYS[13] - sorted list of uids of devices matching using 32-bit frame counters with rollover being processed
 	//
 	// KEYS[14] - sorted list of uids of devices matching using 16-bit frame counters with a reset
 	// KEYS[15] - sorted list of uids of devices matching using 16-bit frame counters with a reset being processed
@@ -55,11 +55,11 @@ if redis.call('sort', KEYS[3], 'by', 'nosort', 'limit', 0, longCount, 'store', K
   redis.call('pexpire', KEYS[8], ARGV[2])
   table.insert(toScan, 8)
 end
-if redis.call('sort', KEYS[3], 'by', 'nosort', 'limit', longCount, -1, 'store', KEYS[10]) > 0 then
+if redis.call('sort', KEYS[4], 'by', 'nosort', 'store', KEYS[10]) > 0 then
   redis.call('pexpire', KEYS[10], ARGV[2])
   table.insert(toScan, 10)
 end
-if redis.call('sort', KEYS[4], 'by', 'nosort', 'store', KEYS[12]) > 0 then
+if redis.call('sort', KEYS[3], 'by', 'nosort', 'limit', longCount, -1, 'store', KEYS[12]) > 0 then
   redis.call('pexpire', KEYS[12], ARGV[2])
   table.insert(toScan, 12)
 end


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fix matching of 16-bit FCnt devices resetting FCnt
Follow-up of #2837

#### Changes
<!-- What are the changes made in this pull request? -->

- Match pending session before 32-bit rollover/reset
- Support reset of 16-bit FCnts
- Support retransmissions in FullFCnt
- Fix invalid field name causing errors


#### Testing

<!-- How did you verify that this change works? -->

Locally

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.