### PR TITLE
Fix changelog reference in release notes

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -67,9 +67,9 @@ jobs:
       with:
         result-encoding: string
         script: |
-          const tag = context.ref.slice('refs/rev/'.length);
+          const tag = context.ref.slice('refs/rev/v'.length);
           const tagParts = tag.split('.');
-          require('fs').writeFileSync('/tmp/release-notes.md', `[Release notes](https://github.com/TheThingsNetwork/lorawan-stack/blob/${tag}/CHANGELOG.md#${tagParts[0]}${tagParts[1]}${tagParts[2]}---${{ steps.date.outputs.result }})`);
+          require('fs').writeFileSync('/tmp/release-notes.md', `[Release notes](https://github.com/TheThingsNetwork/lorawan-stack/blob/${tag}/CHANGELOG.md#${tagParts[0]}${tagParts[1]}${tagParts[2]}---${{ steps.date.outputs.value }})`);
     - name: Determine Goreleaser version
       id: goreleaser_version
       run: echo "::set-output name=value::$(cat tools/go.mod | grep 'github.com/goreleaser/goreleaser v' | cut -d ' ' -f 2)"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Quickfix PR for the Changelog reference link in the release notes.

#### Changes
<!-- What are the changes made in this pull request? -->

- Use the correct output value from the `date` step.
- Drop the `v` prefix from the tag.

Example: For the 3.9.4 release notes, https://github.com/TheThingsNetwork/lorawan-stack/releases/tag/v3.9.4, the `Release notes` at the bottom redirects to https://github.com/TheThingsNetwork/lorawan-stack/blob//v3.9.4/CHANGELOG.md#/v394---, but that should be https://github.com/TheThingsNetwork/lorawan-stack/blob//v3.9.4/CHANGELOG.md#/394---2020-09-23 instead (which correctly anchors to the proper section of the changelog.

#### Testing

<!-- How did you verify that this change works? -->

Test the URL, and also test as part of https://github.com/TheThingsNetwork/lorawan-stack-migrate/pull/5

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

I do not think this breaks anything. Given that it is a very minor change, no need to merge before we get a new release out.
