### PR TITLE
Avoid updating dowlink task on queue deletion

### DIFF
--- a/pkg/networkserver/grpc_asns.go
+++ b/pkg/networkserver/grpc_asns.go
@@ -311,8 +311,10 @@ func (ns *NetworkServer) DownlinkQueueReplace(ctx context.Context, req *ttnpb.Do
 	))
 	log.FromContext(ctx).Debug("Replaced application downlink queue")
 
-	if err := ns.updateDataDownlinkTask(ctx, dev, time.Time{}); err != nil {
-		log.FromContext(ctx).WithError(err).Error("Failed to update downlink task queue after downlink queue replace")
+	if len(req.Downlinks) > 0 {
+		if err := ns.updateDataDownlinkTask(ctx, dev, time.Time{}); err != nil {
+			log.FromContext(ctx).WithError(err).Error("Failed to update downlink task queue after downlink queue replace")
+		}
 	}
 	return ttnpb.Empty, nil
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Avoid updating dowlink task on queue deletion

#### Changes
<!-- What are the changes made in this pull request? -->

- Avoid updating dowlink task on queue deletion


#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

We don't GET the frequency plan of the device on queue deletion, so we
can't update the tasks. This removes the annoying WARN log every time
queue is flushed.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.