### PR TITLE
Use correct TLS server name in cluster connections

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -249,7 +249,8 @@ func (c *cluster) Join() (err error) {
 			if c.tlsConfig != nil {
 				tlsConfig = c.tlsConfig.Clone()
 			}
-			tlsConfig.ServerName = c.tlsServerName
+			tlsConfig.ServerName = peer.tlsServerName
+			logger = logger.WithField("tls_server_name", peer.tlsServerName)
 			options = append(options, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 		} else {
 			options = append(options, grpc.WithInsecure())


### PR DESCRIPTION
and improve debugging

<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quick fix for the cluster package, which didn't use the the TLS server name from the peer, but from the cluster. While at it, I added a label to the debug logs.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This doesn't actually change behavior, because the current configuration only allows you to configure a single TLS server name for the entire cluster. It hopefully does prevent future confusion if we do implement custom TLS server names per cluster peer type.