### PR TITLE
Remove unnecessary error notifications for event streams

### DIFF
--- a/pkg/webui/console/containers/application-events/index.js
+++ b/pkg/webui/console/containers/application-events/index.js
@@ -23,10 +23,7 @@ import PropTypes from '@ttn-lw/lib/prop-types'
 
 import { mayViewApplicationEvents } from '@console/lib/feature-checks'
 
-import {
-  clearApplicationEventsStream,
-  startApplicationEventsStream,
-} from '@console/store/actions/applications'
+import { clearApplicationEventsStream } from '@console/store/actions/applications'
 
 import { selectApplicationEvents } from '@console/store/selectors/applications'
 
@@ -65,7 +62,6 @@ export default withFeatureRequirement(mayViewApplicationEvents)(
     },
     (dispatch, ownProps) => ({
       onClear: () => dispatch(clearApplicationEventsStream(ownProps.appId)),
-      onRestart: () => dispatch(startApplicationEventsStream(ownProps.appId)),
     }),
   )(ApplicationEvents),
 )

--- a/pkg/webui/console/containers/device-events/index.js
+++ b/pkg/webui/console/containers/device-events/index.js
@@ -15,33 +15,17 @@
 import React from 'react'
 import { connect } from 'react-redux'
 
-import ErrorNotification from '@ttn-lw/components/error-notification'
-
 import Events from '@console/components/events'
 
 import { getApplicationId, getDeviceId, combineDeviceIds } from '@ttn-lw/lib/selectors/id'
-import sharedMessages from '@ttn-lw/lib/shared-messages'
 import PropTypes from '@ttn-lw/lib/prop-types'
 
-import { clearDeviceEventsStream, startDeviceEventsStream } from '@console/store/actions/devices'
+import { clearDeviceEventsStream } from '@console/store/actions/devices'
 
-import { selectDeviceEvents, selectDeviceEventsError } from '@console/store/selectors/devices'
+import { selectDeviceEvents } from '@console/store/selectors/devices'
 
 const DeviceEvents = props => {
-  const { appId, devId, events, error, onRestart, widget, onClear } = props
-
-  if (error) {
-    return (
-      <ErrorNotification
-        small
-        title={sharedMessages.eventsCannotShow}
-        content={error}
-        action={onRestart}
-        actionMessage={sharedMessages.restartStream}
-        buttonIcon="refresh"
-      />
-    )
-  }
+  const { appId, devId, events, widget, onClear } = props
 
   if (widget) {
     return (
@@ -66,17 +50,14 @@ DeviceEvents.propTypes = {
       application_id: PropTypes.string,
     }),
   }).isRequired,
-  error: PropTypes.error,
   events: PropTypes.events,
   onClear: PropTypes.func.isRequired,
-  onRestart: PropTypes.func.isRequired,
   widget: PropTypes.bool,
 }
 
 DeviceEvents.defaultProps = {
   widget: false,
   events: [],
-  error: undefined,
 }
 
 export default connect(
@@ -91,7 +72,6 @@ export default connect(
       devId,
       appId,
       events: selectDeviceEvents(state, combinedId),
-      error: selectDeviceEventsError(state, combinedId),
     }
   },
   (dispatch, ownProps) => {
@@ -99,7 +79,6 @@ export default connect(
 
     return {
       onClear: () => dispatch(clearDeviceEventsStream(devIds)),
-      onRestart: () => dispatch(startDeviceEventsStream(devIds)),
     }
   },
 )(DeviceEvents)

--- a/pkg/webui/console/containers/gateway-events/index.js
+++ b/pkg/webui/console/containers/gateway-events/index.js
@@ -15,36 +15,20 @@
 import React from 'react'
 import { connect } from 'react-redux'
 
-import ErrorNotification from '@ttn-lw/components/error-notification'
-
 import Events from '@console/components/events'
 
 import withFeatureRequirement from '@console/lib/components/with-feature-requirement'
 
-import sharedMessages from '@ttn-lw/lib/shared-messages'
 import PropTypes from '@ttn-lw/lib/prop-types'
 
 import { mayViewGatewayEvents } from '@console/lib/feature-checks'
 
-import { clearGatewayEventsStream, startGatewayEventsStream } from '@console/store/actions/gateways'
+import { clearGatewayEventsStream } from '@console/store/actions/gateways'
 
-import { selectGatewayEvents, selectGatewayEventsError } from '@console/store/selectors/gateways'
+import { selectGatewayEvents } from '@console/store/selectors/gateways'
 
 const GatewayEvents = props => {
-  const { gtwId, events, error, onRestart, widget, onClear } = props
-
-  if (error) {
-    return (
-      <ErrorNotification
-        small
-        title={sharedMessages.eventsCannotShow}
-        content={error}
-        action={onRestart}
-        actionMessage={sharedMessages.restartStream}
-        buttonIcon="refresh"
-      />
-    )
-  }
+  const { gtwId, events, widget, onClear } = props
 
   if (widget) {
     return (
@@ -56,18 +40,15 @@ const GatewayEvents = props => {
 }
 
 GatewayEvents.propTypes = {
-  error: PropTypes.error,
   events: PropTypes.events,
   gtwId: PropTypes.string.isRequired,
   onClear: PropTypes.func.isRequired,
-  onRestart: PropTypes.func.isRequired,
   widget: PropTypes.bool,
 }
 
 GatewayEvents.defaultProps = {
   widget: false,
   events: [],
-  error: undefined,
 }
 
 export default withFeatureRequirement(mayViewGatewayEvents)(
@@ -77,12 +58,10 @@ export default withFeatureRequirement(mayViewGatewayEvents)(
 
       return {
         events: selectGatewayEvents(state, gtwId),
-        error: selectGatewayEventsError(state, gtwId),
       }
     },
     (dispatch, ownProps) => ({
       onClear: () => dispatch(clearGatewayEventsStream(ownProps.gtwId)),
-      onRestart: () => dispatch(startGatewayEventsStream(ownProps.gtwId)),
     }),
   )(GatewayEvents),
 )

--- a/pkg/webui/console/containers/organization-events/connect.js
+++ b/pkg/webui/console/containers/organization-events/connect.js
@@ -14,27 +14,19 @@
 
 import { connect } from 'react-redux'
 
-import {
-  clearOrganizationEventsStream,
-  startOrganizationEventsStream,
-} from '@console/store/actions/organizations'
+import { clearOrganizationEventsStream } from '@console/store/actions/organizations'
 
-import {
-  selectOrganizationEvents,
-  selectOrganizationEventsError,
-} from '@console/store/selectors/organizations'
+import { selectOrganizationEvents } from '@console/store/selectors/organizations'
 
 const mapStateToProps = (state, props) => {
   const { orgId } = props
 
   return {
     events: selectOrganizationEvents(state, orgId),
-    error: selectOrganizationEventsError(state, orgId),
   }
 }
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-  onRestart: () => dispatch(startOrganizationEventsStream(ownProps.orgId)),
   onClear: () => dispatch(clearOrganizationEventsStream(ownProps.orgId)),
 })
 

--- a/pkg/webui/console/containers/organization-events/organization-events.js
+++ b/pkg/webui/console/containers/organization-events/organization-events.js
@@ -14,28 +14,12 @@
 
 import React from 'react'
 
-import ErrorNotification from '@ttn-lw/components/error-notification'
-
 import Events from '@console/components/events'
 
-import sharedMessages from '@ttn-lw/lib/shared-messages'
 import PropTypes from '@ttn-lw/lib/prop-types'
 
 const OrganizationEvents = props => {
-  const { orgId, events, error, onRestart, widget, onClear } = props
-
-  if (error) {
-    return (
-      <ErrorNotification
-        small
-        title={sharedMessages.eventsCannotShow}
-        content={error}
-        action={onRestart}
-        actionMessage={sharedMessages.restartStream}
-        buttonIcon="refresh"
-      />
-    )
-  }
+  const { orgId, events, widget, onClear } = props
 
   if (widget) {
     return (
@@ -52,10 +36,8 @@ const OrganizationEvents = props => {
 }
 
 OrganizationEvents.propTypes = {
-  error: PropTypes.error,
   events: PropTypes.events,
   onClear: PropTypes.func.isRequired,
-  onRestart: PropTypes.func.isRequired,
   orgId: PropTypes.string.isRequired,
   widget: PropTypes.bool,
 }
@@ -63,7 +45,6 @@ OrganizationEvents.propTypes = {
 OrganizationEvents.defaultProps = {
   widget: false,
   events: [],
-  error: undefined,
 }
 
 export default OrganizationEvents


### PR DESCRIPTION
#### Summary
This quickfix PR removes now superfluous error notifications that are shown instead of the event containers, when the event store has an error. This is not necessary anymore since the event view itself will communicate errors via synthetic events.

#### Changes
- Remove unnecessary error notifications and corresponding store logic for event containers

#### Testing

Manual.

#### Notes for Reviewers
This was originally part of #3330 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
