### PR TITLE
Fix logout redirect loops for clients without logout redirect URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - End device import in the Console crashing in Firefox.
 - Creation of multicast end devices in the Console.
 - Overwriting values in the end device wizard in the Console.
+- Redirect loops when logging out of the Console if the Console OAuth client had no logout redirect URI(s) set.
 
 ### Security
 

--- a/pkg/oauth/server_test.go
+++ b/pkg/oauth/server_test.go
@@ -511,6 +511,26 @@ func TestOAuthFlow(t *testing.T) {
 			},
 		},
 		{
+			Name: "client-initiated without logout redirect URI set in the client",
+			StoreSetup: func(s *mockStore) {
+				s.res.session = mockSession
+				s.res.client = mockClient
+				s.res.client.LogoutRedirectURIs = []string{}
+				s.res.accessToken = mockAccessToken
+			},
+			Method:           "GET",
+			Path:             "/oauth/logout?access_token_id=access-token-id&post_logout_redirect_uri=http://uri/logout-callback",
+			ExpectedCode:     http.StatusFound,
+			ExpectedRedirect: "/oauth",
+			StoreCheck: func(t *testing.T, s *mockStore) {
+				a := assertions.New(t)
+				a.So(s.calls, should.Contain, "DeleteSession")
+				a.So(s.calls, should.Contain, "DeleteAccessToken")
+				a.So(s.calls, should.Contain, "GetAccessToken")
+				a.So(s.calls, should.Contain, "GetClient")
+			},
+		},
+		{
 			Name: "client-initiated logout without access token",
 			StoreSetup: func(s *mockStore) {
 				s.res.session = mockSession

--- a/pkg/oauth/user.go
+++ b/pkg/oauth/user.go
@@ -231,7 +231,7 @@ var (
 func (s *server) ClientLogout(c echo.Context) error {
 	ctx := c.Request().Context()
 	accessTokenID := c.QueryParam("access_token_id")
-	var redirectURI string
+	redirectURI := s.config.UI.MountPath()
 	if accessTokenID == "" {
 		return errMissingAccessTokenIDParam
 	}
@@ -256,8 +256,6 @@ func (s *server) ClientLogout(c echo.Context) error {
 		if redirectParam == "" {
 			if len(client.LogoutRedirectURIs) != 0 {
 				redirectURI = client.LogoutRedirectURIs[0]
-			} else {
-				redirectURI = s.config.UI.MountPath()
 			}
 		} else {
 			for _, uri := range client.LogoutRedirectURIs {


### PR DESCRIPTION
#### Summary
Closes #3371

#### Changes
- Use the OAuth mount path as default redirect URI

#### Testing

Manual and unit tests.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
