### PR TITLE
Change rights for managing application links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ For details about compatibility between different releases, see the **Commitment
 - Improve MQTT Pub/Sub task restart conditions and error propagation.
 - Pausing event streams is not saving up arriving events during the pause anymore.
 - Gateway server can now update the gateway location only if the gateway is authenticated.
+- Right to manage links on Application Server is now `RIGHT_APPLICATION_SETTINGS_BASIC`.
 
 ### Deprecated
 

--- a/pkg/applicationserver/grpc.go
+++ b/pkg/applicationserver/grpc.go
@@ -26,7 +26,7 @@ import (
 
 // GetLink implements ttnpb.AsServer.
 func (as *ApplicationServer) GetLink(ctx context.Context, req *ttnpb.GetApplicationLinkRequest) (*ttnpb.ApplicationLink, error) {
-	if err := rights.RequireApplication(ctx, req.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_LINK); err != nil {
+	if err := rights.RequireApplication(ctx, req.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_SETTINGS_BASIC); err != nil {
 		return nil, err
 	}
 	return as.linkRegistry.Get(ctx, req.ApplicationIdentifiers, req.FieldMask.Paths)
@@ -34,7 +34,7 @@ func (as *ApplicationServer) GetLink(ctx context.Context, req *ttnpb.GetApplicat
 
 // SetLink implements ttnpb.AsServer.
 func (as *ApplicationServer) SetLink(ctx context.Context, req *ttnpb.SetApplicationLinkRequest) (*ttnpb.ApplicationLink, error) {
-	if err := rights.RequireApplication(ctx, req.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_LINK); err != nil {
+	if err := rights.RequireApplication(ctx, req.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_SETTINGS_BASIC); err != nil {
 		return nil, err
 	}
 	// Get all the fields here for starting the link task.
@@ -60,7 +60,7 @@ func (as *ApplicationServer) SetLink(ctx context.Context, req *ttnpb.SetApplicat
 
 // DeleteLink implements ttnpb.AsServer.
 func (as *ApplicationServer) DeleteLink(ctx context.Context, ids *ttnpb.ApplicationIdentifiers) (*types.Empty, error) {
-	if err := rights.RequireApplication(ctx, *ids, ttnpb.RIGHT_APPLICATION_LINK); err != nil {
+	if err := rights.RequireApplication(ctx, *ids, ttnpb.RIGHT_APPLICATION_SETTINGS_BASIC); err != nil {
 		return nil, err
 	}
 	if err := as.cancelLink(ctx, *ids); err != nil && !errors.IsNotFound(err) {
@@ -75,7 +75,7 @@ func (as *ApplicationServer) DeleteLink(ctx context.Context, ids *ttnpb.Applicat
 
 // GetLinkStats implements ttnpb.AsServer.
 func (as *ApplicationServer) GetLinkStats(ctx context.Context, ids *ttnpb.ApplicationIdentifiers) (*ttnpb.ApplicationLinkStats, error) {
-	if err := rights.RequireApplication(ctx, *ids, ttnpb.RIGHT_APPLICATION_LINK); err != nil {
+	if err := rights.RequireApplication(ctx, *ids, ttnpb.RIGHT_APPLICATION_SETTINGS_BASIC); err != nil {
 		return nil, err
 	}
 

--- a/pkg/applicationserver/linking_test.go
+++ b/pkg/applicationserver/linking_test.go
@@ -115,7 +115,7 @@ func TestLink(t *testing.T) {
 				ctx := rights.NewContext(ctx, rights.Rights{
 					ApplicationRights: map[string]*ttnpb.Rights{
 						unique.ID(ctx, app2): {
-							Rights: []ttnpb.Right{ttnpb.RIGHT_APPLICATION_LINK},
+							Rights: []ttnpb.Right{ttnpb.RIGHT_APPLICATION_SETTINGS_BASIC},
 						},
 					},
 				})
@@ -217,7 +217,7 @@ func TestLink(t *testing.T) {
 				ctx := rights.NewContext(ctx, rights.Rights{
 					ApplicationRights: map[string]*ttnpb.Rights{
 						unique.ID(ctx, app3): {
-							Rights: []ttnpb.Right{ttnpb.RIGHT_APPLICATION_LINK},
+							Rights: []ttnpb.Right{ttnpb.RIGHT_APPLICATION_SETTINGS_BASIC},
 						},
 					},
 				})


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Change the right to manage AS links.

#### Changes
<!-- What are the changes made in this pull request? -->

From `LINK` to `SETTINGS_BASIC`.

#### Testing

<!-- How did you verify that this change works? -->

Unit testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This breaks clients that depend on the `LINK` right to manage links. I believe this is buggy behavior: the `LINK` right is intended for the linking from AS to NS, not to manage the links, per documentation.

In practice, these links are managed by a user that created the application, who is admin already.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
