### PR TITLE
Do not redirect to port 443 if a different port is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ For details about compatibility between different releases, see the **Commitment
 
 - Next button title in the end device wizard in the Console.
 - Navigation to the user edit page after creation in the Console.
+- The port number of the `--http.redirect-to-host` option was ignored when `--http.redirect-to-tls` was used. This could lead to situations where the HTTPS server would always redirect to port 443, even if a different one was specified.
+  - If the HTTPS server is available on `https://thethings.example.com:8443`, the following config is required: `--http.redirect-to-tls --http.redirect-to-host=thethings.example.com:8443`.
 
 ### Security
 

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -194,8 +194,11 @@ func New(ctx context.Context, opts ...Option) (*Server, error) {
 	}
 	if options.redirectToHTTPS != nil {
 		redirectConfig.Scheme = func(string) string { return "https" }
-		redirectConfig.Port = func(current uint) uint {
-			return uint(options.redirectToHTTPS[int(current)])
+		// Only redirect to HTTPS port if no port redirection has been configured
+		if redirectConfig.Port == nil {
+			redirectConfig.Port = func(current uint) uint {
+				return uint(options.redirectToHTTPS[int(current)])
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #3118 

#### Changes
<!-- What are the changes made in this pull request? -->

- When `--http.redirect-to-tls` is set, only configure `redirectConfig.Port` if it is not set already.

#### Testing

<!-- How did you verify that this change works? -->

- Test locally with `curl`, test with built Docker image.
- Test with `--http.redirect-to-tls` --> redirects to port 443, preserving existing behaviour
- Test with `--http.redirect-to-tls --http.redirect-to-host=my.host` --> redirects to `https://my.host`, preserving existing behaviour
- Test with `--http.redirect-to-tls --http.redirect-to-host=my.host:8885` --> redirects to `https://my.host:8885` (without this PR, the stack redirects to `https://my.host`)

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

There should not be any. The fixed bug would only occur when the HTTPS server was accessed at a port other than 443 with `redirect-to-tls` enabled. The comment on the CHANGELOG should be enough to clear out any confusion.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This seems to be the least "breaking" way to deal with the bug discussed in the issue.

It would be best if we could get this in `3.10.0` (or wait for `3.11.0`). I do not think it's good to introduce this change on a patchlevel release.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [X] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
