### PR TITLE
Fix unsetting AAS KEKs and validation

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -5426,6 +5426,15 @@
       "file": "errors.go"
     }
   },
+  "error:pkg/joinserver:no_kek_label": {
+    "translations": {
+      "en": "no KEK label specified"
+    },
+    "description": {
+      "package": "pkg/joinserver",
+      "file": "grpc_application_activation_settings_registry.go"
+    }
+  },
   "error:pkg/joinserver:no_net_id": {
     "translations": {
       "en": "no NetID specified"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Quickfix for unsetting KEKs. This is an optional field so blanking them must work.

#### Changes
<!-- What are the changes made in this pull request? -->

- Allow unsetting the KEK
- Require a KEK label when a KEK is specified
- Add test cases

#### Testing

<!-- How did you verify that this change works? -->

Unit testing and local testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

API clients depending on setting a KEK with a blank label will break. This is a bugfix.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
