### PR TITLE
Revert `formik` update

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "connected-react-router": "^6.5.2",
     "deep-diff": "^1.0.2",
     "focus-visible": "^4.1.4",
-    "formik": "^2.2.1",
+    "formik": "^2.1.3",
     "history": "^4.9.0",
     "intl": "^1.2.5",
     "intl-pluralrules": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7352,10 +7352,10 @@ format@^0.2.0:
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
   integrity sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=
 
-formik@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/formik/-/formik-2.2.1.tgz#e09747569e44ffc17263541d2e732cc6568208dc"
-  integrity sha512-N/8Q1yGlXHibyrM5CyKtC85V8U+mxY04zSfakpyR1e6KpaIC4+A4yo30NBARRprkFoxoT1EV+yK8bo5tjXxfyg==
+formik@^2.1.3:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/formik/-/formik-2.1.4.tgz#8deef07ec845ea98f75e03da4aad7aab4ac46570"
+  integrity sha512-oKz8S+yQBzuQVSEoxkqqJrKQS5XJASWGVn6mrs+oTWrBoHgByVwwI1qHiVc9GKDpZBU9vAxXYAKz2BvujlwunA==
   dependencies:
     deepmerge "^2.1.1"
     hoist-non-react-statics "^3.3.0"


### PR DESCRIPTION
This reverts commit b4924771074fc4b8a27b62acae1b7bb376ba6dbc.

<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fixup for https://github.com/TheThingsNetwork/lorawan-stack/pull/3412. Looks like `formik` update from `2.1.3` to `2.2.1` causes field validation to flicker on blur even when the field has valid value:
![ezgif com-video-to-gif(2)](https://user-images.githubusercontent.com/16374166/97976625-99c40f00-1dd3-11eb-9260-99837eaaf457.gif)





#### Changes
<!-- What are the changes made in this pull request? -->

- Revert formik update

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
