### PR TITLE
Add support for standard library error wrapping

### DIFF
--- a/pkg/errors/std.go
+++ b/pkg/errors/std.go
@@ -1,0 +1,46 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	stderrors "errors"
+)
+
+// Alias standard library error functions.
+var (
+	As     = stderrors.As
+	Is     = stderrors.Is
+	Unwrap = stderrors.Unwrap
+)
+
+// Unwrap makes the Error implement error unwrapping.
+func (e Error) Unwrap() error {
+	return e.cause
+}
+
+// Is makes the Error implement error comparison.
+func (e Error) Is(target error) bool {
+	return Resemble(e, target)
+}
+
+// Unwrap makes the Definition implement error unwrapping.
+func (Definition) Unwrap() error {
+	return nil
+}
+
+// Is makes the Definition implement error comparison.
+func (d Definition) Is(target error) bool {
+	return Resemble(d, target)
+}

--- a/pkg/errors/std_test.go
+++ b/pkg/errors/std_test.go
@@ -1,0 +1,45 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+)
+
+func TestStandardLibrarayErrors(t *testing.T) {
+	a := assertions.New(t)
+
+	var (
+		d1 = errors.Define("test_std_1", "definition 1")
+		d2 = errors.Define("test_std_2", "definition 2")
+		d3 = errors.Define("test_std_3", "definition 3")
+	)
+
+	a.So(errors.Is(d1, d1), should.BeTrue)
+	a.So(errors.Is(d1, d2), should.BeFalse)
+
+	e := d1.WithCause(d2.WithCause(io.EOF))
+
+	a.So(errors.Is(e, d3), should.BeFalse)
+
+	a.So(errors.Is(e, d1), should.BeTrue)
+	a.So(errors.Is(e, d2), should.BeTrue)
+	a.So(errors.Is(e, io.EOF), should.BeTrue)
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a small PR that adds support for standard library error unwrapping, and error comparison (`errors.Is`) to our `pkg/errors` package.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- This intentionally does not add conversion (`errors.As`) support to our error types

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
