### PR TITLE
Application Server link setup fixes

### DIFF
--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -262,7 +262,7 @@ func (as *ApplicationServer) Subscribe(ctx context.Context, protocol string, ids
 
 // Publish processes the given upstream message and then publishes it to the application frontends.
 func (as *ApplicationServer) Publish(ctx context.Context, up *ttnpb.ApplicationUp) error {
-	link, err := as.linkRegistry.Get(ctx, up.ApplicationIdentifiers, []string{
+	link, err := as.getLink(ctx, up.ApplicationIdentifiers, []string{
 		"default_formatters",
 		"skip_payload_crypto",
 	})
@@ -336,7 +336,7 @@ func (as *ApplicationServer) downlinkQueueOp(ctx context.Context, ids ttnpb.EndD
 	if err != nil {
 		return err
 	}
-	link, err := as.linkRegistry.Get(ctx, ids.ApplicationIdentifiers, []string{
+	link, err := as.getLink(ctx, ids.ApplicationIdentifiers, []string{
 		"default_formatters",
 		"skip_payload_crypto",
 	})
@@ -473,7 +473,7 @@ func (as *ApplicationServer) DownlinkQueueList(ctx context.Context, ids ttnpb.En
 	if err != nil {
 		return nil, err
 	}
-	link, err := as.linkRegistry.Get(ctx, ids.ApplicationIdentifiers, []string{
+	link, err := as.getLink(ctx, ids.ApplicationIdentifiers, []string{
 		"default_formatters",
 		"skip_payload_crypto",
 	})

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -119,8 +119,8 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 			ttnpb.PayloadFormatter_FORMATTER_JAVASCRIPT: javascript.New(),
 			ttnpb.PayloadFormatter_FORMATTER_CAYENNELPP: cayennelpp.New(),
 		}),
-		clusterDistributor: distribution.NewPubSubDistributor(ctx, conf.Distribution.Timeout, conf.Distribution.PubSub),
-		localDistributor:   distribution.NewLocalDistributor(ctx, conf.Distribution.Timeout),
+		clusterDistributor: distribution.NewPubSubDistributor(ctx, c, conf.Distribution.Timeout, conf.Distribution.PubSub),
+		localDistributor:   distribution.NewLocalDistributor(ctx, c, conf.Distribution.Timeout),
 		interopClient:      interopCl,
 		interopID:          conf.Interop.ID,
 		endDeviceFetcher:   conf.EndDeviceFetcher.Fetcher,
@@ -417,7 +417,7 @@ func (as *ApplicationServer) downlinkQueueOp(ctx context.Context, ids ttnpb.EndD
 			errorDetails = *ttnpb.ErrorDetailsToProto(ttnErr)
 		}
 		for _, item := range items {
-			if err := as.publishUp(as.FromRequestContext(ctx), &ttnpb.ApplicationUp{
+			if err := as.publishUp(ctx, &ttnpb.ApplicationUp{
 				EndDeviceIdentifiers: ids,
 				CorrelationIDs:       item.CorrelationIDs,
 				Up: &ttnpb.ApplicationUp_DownlinkFailed{
@@ -434,7 +434,7 @@ func (as *ApplicationServer) downlinkQueueOp(ctx context.Context, ids ttnpb.EndD
 		return err
 	}
 	for _, item := range items {
-		if err := as.publishUp(as.FromRequestContext(ctx), &ttnpb.ApplicationUp{
+		if err := as.publishUp(ctx, &ttnpb.ApplicationUp{
 			EndDeviceIdentifiers: ids,
 			CorrelationIDs:       item.CorrelationIDs,
 			Up: &ttnpb.ApplicationUp_DownlinkQueued{

--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -211,7 +211,7 @@ func TestApplicationServer(t *testing.T) {
 	defer pubsubRedisClient.Close()
 	pubsubRegistry := iopubsubredis.PubSubRegistry{Redis: pubsubRedisClient}
 
-	distribRedisClient, distribFlush := test.NewRedis(t, "applicationserver_test", "traffic")
+	distribRedisClient, distribFlush := test.NewRedis(ctx, "applicationserver_test", "traffic")
 	defer distribFlush()
 	defer distribRedisClient.Close()
 	distribPubSub := distribredis.PubSub{Redis: distribRedisClient}
@@ -2284,7 +2284,7 @@ func TestSkipPayloadCrypto(t *testing.T) {
 		t.Fatalf("Failed to set link in registry: %s", err)
 	}
 
-	distribRedisClient, distribFlush := test.NewRedis(t, "applicationserver_test", "traffic")
+	distribRedisClient, distribFlush := test.NewRedis(ctx, "applicationserver_test", "traffic")
 	defer distribFlush()
 	defer distribRedisClient.Close()
 	distribPubSub := distribredis.PubSub{Redis: distribRedisClient}

--- a/pkg/applicationserver/distribution/distribution.go
+++ b/pkg/applicationserver/distribution/distribution.go
@@ -36,3 +36,9 @@ type Distributor interface {
 	// Subscribe to the traffic of a specific application.
 	Subscribe(context.Context, string, *ttnpb.ApplicationIdentifiers) (*io.Subscription, error)
 }
+
+// RequestDecoupler decouples the security information found in a context
+// from the lifetime of the context.
+type RequestDecoupler interface {
+	FromRequestContext(ctx context.Context) context.Context
+}

--- a/pkg/applicationserver/distribution/local_distributor.go
+++ b/pkg/applicationserver/distribution/local_distributor.go
@@ -26,10 +26,10 @@ import (
 // NewLocalDistributor creates a Distributor that routes the traffic locally.
 // The underlying subscription sets can timeout if there are no active subscribers.
 // A timeout of 0 means the underlying subscriptions never timeout.
-func NewLocalDistributor(ctx context.Context, timeout time.Duration) Distributor {
+func NewLocalDistributor(ctx context.Context, rd RequestDecoupler, timeout time.Duration) Distributor {
 	return &localDistributor{
-		broadcast:     newSubscriptionSet(ctx, 0),
-		subscriptions: newSubscriptionMap(ctx, timeout, noSetup),
+		broadcast:     newSubscriptionSet(ctx, rd, 0),
+		subscriptions: newSubscriptionMap(ctx, rd, timeout, noSetup),
 	}
 }
 

--- a/pkg/applicationserver/distribution/pubsub_distributor.go
+++ b/pkg/applicationserver/distribution/pubsub_distributor.go
@@ -27,10 +27,10 @@ import (
 // NewPubSubDistributor creates a Distributor on top of the provided PubSub.
 // The underlying subscription sets can timeout if there are no active subscribers.
 // A timeout of 0 means the underlying subscription sets never timeout.
-func NewPubSubDistributor(ctx context.Context, timeout time.Duration, pubsub PubSub) Distributor {
+func NewPubSubDistributor(ctx context.Context, rd RequestDecoupler, timeout time.Duration, pubsub PubSub) Distributor {
 	return &pubSubDistributor{
 		pubsub:        pubsub,
-		subscriptions: newSubscriptionMap(ctx, timeout, subscribeSetToPubSub(pubsub)),
+		subscriptions: newSubscriptionMap(ctx, rd, timeout, subscribeSetToPubSub(pubsub)),
 	}
 }
 

--- a/pkg/applicationserver/distribution/redis/redis.go
+++ b/pkg/applicationserver/distribution/redis/redis.go
@@ -40,7 +40,7 @@ func (ps PubSub) Publish(ctx context.Context, up *ttnpb.ApplicationUp) error {
 	}
 	uid := unique.ID(ctx, up.ApplicationIdentifiers)
 	ch := ps.uidUplinkKey(uid)
-	if err = ps.Redis.Publish(ch, s).Err(); err != nil {
+	if err = ps.Redis.Publish(ctx, ch, s).Err(); err != nil {
 		return ttnredis.ConvertError(err)
 	}
 	return nil
@@ -53,7 +53,7 @@ func (ps PubSub) Subscribe(ctx context.Context, ids ttnpb.ApplicationIdentifiers
 	uid := unique.ID(ctx, ids)
 	ch := ps.uidUplinkKey(uid)
 
-	sub := ps.Redis.Subscribe(ch)
+	sub := ps.Redis.Subscribe(ctx, ch)
 	defer sub.Close()
 	msgs := sub.Channel()
 

--- a/pkg/applicationserver/grpc.go
+++ b/pkg/applicationserver/grpc.go
@@ -38,13 +38,8 @@ func (as *ApplicationServer) SetLink(ctx context.Context, req *ttnpb.SetApplicat
 		return nil, err
 	}
 	return as.linkRegistry.Set(ctx, req.ApplicationIdentifiers, ttnpb.ApplicationLinkFieldPathsTopLevel,
-		func(link *ttnpb.ApplicationLink) (*ttnpb.ApplicationLink, []string, error) {
-			if link != nil {
-				return &req.ApplicationLink, req.FieldMask.Paths, nil
-			}
-			return &req.ApplicationLink, append(req.FieldMask.Paths,
-				"application_ids",
-			), nil
+		func(*ttnpb.ApplicationLink) (*ttnpb.ApplicationLink, []string, error) {
+			return &req.ApplicationLink, req.FieldMask.Paths, nil
 		},
 	)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/3263

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix the `SetLink` gRPC endpoint - it was adding a non existing field mask field on link creation
- Use an empty link internally, when the link does not exist. This is for convenience - it ensures that link setup is not required in order to receive or send traffic. The sematics of `GetLink` have not been affected by this.
- Fix AS tests based on the https://github.com/TheThingsNetwork/lorawan-stack/pull/3415 `redis-go` update.

#### Testing

<!-- How did you verify that this change works? -->

Local testing of downlink operations (based on @rvolosatovs report [here](https://github.com/TheThingsNetwork/lorawan-stack/pull/3398#issuecomment-717526781))

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This changes the link retrieval logic, but shouldn't cause malfunctioning.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
