### PR TITLE
Use yarn cache in CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,16 +23,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
-      - name: Get Yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(npx yarn cache dir)"
-      - name: Initialize Yarn module cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
       - name: Initialize public folder cache
         id: public-cache
         uses: actions/cache@v2

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -17,6 +17,7 @@ jobs:
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(npx yarn cache dir)"
     - name: Initialize Yarn module cache
+      id: yarn-cache
       uses: actions/cache@v2
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -51,6 +52,7 @@ jobs:
       # https://github.com/TheThingsNetwork/lorawan-stack/issues/2723
       continue-on-error: true
     - name: Install JS dependencies
+      if: steps.yarn-cache.outputs.cache-hit != 'true'
       run: tools/bin/mage js:deps
       timeout-minutes: 5
     - name: Check headers

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -28,6 +28,7 @@ jobs:
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(npx yarn cache dir)"
     - name: Initialize Yarn module cache
+      id: yarn-cache
       uses: actions/cache@v2
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -63,6 +64,7 @@ jobs:
     - name: Build JS SDK
       run: tools/bin/mage jsSDK:clean jsSDK:build
     - name: Install JS dependencies
+      if: steps.yarn-cache.outputs.cache-hit != 'true'
       run: tools/bin/mage js:deps
       timeout-minutes: 5
     - name: Generate JS translations
@@ -84,6 +86,17 @@ jobs:
       uses: actions/setup-node@v2-beta
       with:
         node-version: '14'
+    - name: Get Yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(npx yarn cache dir)"
+    - name: Initialize Yarn module cache
+      id: yarn-cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
@@ -117,6 +130,7 @@ jobs:
     - name: Build JS SDK
       run: tools/bin/mage jsSDK:clean jsSDK:build
     - name: Install JS dependencies
+      if: steps.yarn-cache.outputs.cache-hit != 'true'
       run: tools/bin/mage js:deps
       timeout-minutes: 5
     - name: Build frontend

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -35,6 +35,7 @@ jobs:
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(npx yarn cache dir)"
     - name: Initialize Yarn module cache
+      id: yarn-cache
       uses: actions/cache@v2
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -72,6 +73,7 @@ jobs:
     - name: Build JS SDK
       run: tools/bin/mage jsSDK:clean jsSDK:build
     - name: Install JS dependencies
+      if: steps.yarn-cache.outputs.cache-hit != 'true'
       run: tools/bin/mage js:deps
       timeout-minutes: 5
     - name: Build frontend

--- a/pkg/webui/console/views/application/index.js
+++ b/pkg/webui/console/views/application/index.js
@@ -70,7 +70,7 @@ import {
 } from '@console/store/selectors/applications'
 
 @connect(
-  function(state, props) {
+  (state, props) => {
     return {
       appId: props.match.params.appId,
       fetching: selectApplicationFetching(state) || selectApplicationRightsFetching(state),

--- a/pkg/webui/console/views/applications/index.js
+++ b/pkg/webui/console/views/applications/index.js
@@ -30,7 +30,7 @@ import sharedMessages from '@ttn-lw/lib/shared-messages'
 import { mayViewApplications } from '@console/lib/feature-checks'
 
 @withFeatureRequirement(mayViewApplications, { redirect: '/' })
-@withBreadcrumb('apps', function(props) {
+@withBreadcrumb('apps', () => {
   return <Breadcrumb path="/applications" content={sharedMessages.applications} />
 })
 export default class Applications extends React.Component {

--- a/pkg/webui/console/views/gateway-add/index.js
+++ b/pkg/webui/console/views/gateway-add/index.js
@@ -45,7 +45,7 @@ const m = defineMessages({
 
 @withEnv
 @connect(
-  function(state) {
+  state => {
     const userId = selectUserId(state)
 
     return { userId }

--- a/pkg/webui/console/views/gateway-api-key-add/index.js
+++ b/pkg/webui/console/views/gateway-api-key-add/index.js
@@ -42,7 +42,7 @@ import {
 } from '@console/store/selectors/gateways'
 
 @connect(
-  (state, props) => ({
+  state => ({
     gtwId: selectSelectedGatewayId(state),
     fetching: selectGatewayRightsFetching(state),
     error: selectGatewayRightsError(state),

--- a/pkg/webui/console/views/gateway-api-key-edit/index.js
+++ b/pkg/webui/console/views/gateway-api-key-edit/index.js
@@ -47,7 +47,7 @@ import {
 } from '@console/store/selectors/api-keys'
 
 @connect(
-  function(state, props) {
+  (state, props) => {
     const apiKeyId = props.match.params.apiKeyId
     const keyFetching = selectApiKeyFetching(state)
     const rightsFetching = selectGatewayRightsFetching(state)

--- a/pkg/webui/console/views/gateway-collaborator-add/index.js
+++ b/pkg/webui/console/views/gateway-collaborator-add/index.js
@@ -49,7 +49,7 @@ import { selectSelectedCollaborator } from '@console/store/selectors/collaborato
     rights: selectGatewayRights(state),
     pseudoRights: selectGatewayPseudoRights(state),
   }),
-  (dispatch, ownProps) => ({
+  dispatch => ({
     getGatewaysRightsList: gtwId => dispatch(getGatewaysRightsList(gtwId)),
     redirectToList: gtwId => dispatch(push(`/gateways/${gtwId}/collaborators`)),
   }),
@@ -61,7 +61,7 @@ import { selectSelectedCollaborator } from '@console/store/selectors/collaborato
     redirectToList: () => dispatchProps.redirectToList(stateProps.gtwId),
   }),
 )
-@withBreadcrumb('gtws.single.collaborators.add', function(props) {
+@withBreadcrumb('gtws.single.collaborators.add', props => {
   const gtwId = props.gtwId
   return <Breadcrumb path={`/gateways/${gtwId}/collaborators/add`} content={sharedMessages.add} />
 })

--- a/pkg/webui/console/views/gateway-collaborator-edit/index.js
+++ b/pkg/webui/console/views/gateway-collaborator-edit/index.js
@@ -49,7 +49,7 @@ import {
 } from '@console/store/selectors/collaborators'
 
 @connect(
-  function(state, props) {
+  (state, props) => {
     const gtwId = selectSelectedGatewayId(state, props)
 
     const { collaboratorId, collaboratorType } = props.match.params

--- a/pkg/webui/console/views/gateway-collaborator-edit/index.js
+++ b/pkg/webui/console/views/gateway-collaborator-edit/index.js
@@ -73,7 +73,7 @@ import {
       error,
     }
   },
-  (dispatch, ownProps) => ({
+  dispatch => ({
     getCollaborator(gtwId, collaboratorId, isUser) {
       dispatch(getCollaborator('gateway', gtwId, collaboratorId, isUser))
     },
@@ -98,7 +98,7 @@ import {
   ({ getGatewayCollaborator }) => getGatewayCollaborator(),
   ({ fetching, collaborator }) => fetching || !Boolean(collaborator),
 )
-@withBreadcrumb('gtws.single.collaborators.edit', function(props) {
+@withBreadcrumb('gtws.single.collaborators.edit', props => {
   const { gtwId, collaboratorId, collaboratorType } = props
 
   return (

--- a/pkg/webui/console/views/gateway-location/index.js
+++ b/pkg/webui/console/views/gateway-location/index.js
@@ -40,7 +40,7 @@ const GatewayLocation = () => {
   )
 }
 
-export default withBreadcrumb('gateway.single.data', function(props) {
+export default withBreadcrumb('gateway.single.data', props => {
   const { gtwId } = props
   return <Breadcrumb path={`/gateways/${gtwId}/location`} content={sharedMessages.location} />
 })(

--- a/pkg/webui/console/views/gateway-overview/connect.js
+++ b/pkg/webui/console/views/gateway-overview/connect.js
@@ -16,13 +16,9 @@ import { connect } from 'react-redux'
 
 import { selectSelectedGateway, selectSelectedGatewayId } from '@console/store/selectors/gateways'
 
-const mapStateToProps = state => {
-  const gtwId = selectSelectedGatewayId(state)
-
-  return {
-    gtwId,
-    gateway: selectSelectedGateway(state),
-  }
-}
+const mapStateToProps = state => ({
+  gtwId: selectSelectedGatewayId(state),
+  gateway: selectSelectedGateway(state),
+})
 
 export default GatewayOverview => connect(mapStateToProps)(GatewayOverview)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

`yarn` cache was added to the js workflow in [this commit](https://github.com/TheThingsNetwork/lorawan-stack/commit/980c8e1719adf462ffebc042fc67509e3b5ab96a#diff-9992b6f0e329a6dc49913c62f6efe2102f7a64f55d4bdab3d47df86292db5e87), however there is no check for cache hits. this PR adds exactly this.

#### Changes
<!-- What are the changes made in this pull request? -->

- Check for cache hit before installing dependencies. 
- Some clean up for gateway and application views to trigger js related jobs.

#### Testing

<!-- How did you verify that this change works? -->

see CI

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Im not exactly sure whether `resore-keys` entry is needed in this case, but all examples both in the `cache` action repo and in discussions `restore-keys` is present. This might cause issues.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
