### PR TITLE
Improve e2e documentation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -724,7 +724,7 @@ We use [Cypress](https://cypress.io) for running frontend-based end-to-end tests
 
 #### Running frontend end-to-end tests locally
 
-Make sure to build the frontend assets and run the stack before executing end-to-end tests.
+Make sure to [build the frontend assets](#building-the-frontend), [start The Things Stack](#starting-the-things-stack) and run `tools/bin/mage dev:sqlDump` to save database dump before executing end-to-end tests.
 
 `Cypress` provides two modes for running tests: headless and interactive.
 - Headless mode - will not display any browser GUI and output test progress into your terminal instead. This is helpful when one just needs see the results of the tests.


### PR DESCRIPTION
Reference sections for building assets and starting the stack. Add a note for 'dev:sqlDump'.

<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Just noticed that we do not mention `dev:sqlDump` anywhere in the docs while this is required for running `cypress` tests locally. This happened to @asmulko when running the tests for the first time. I think it can be useful for other new hires as well.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add a note to execute `dev:sqlDump` before running the e2e tests.
- Add references to building js and starting the stack.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
