### PR TITLE
Fix offline-status display on error view in the Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ For details about compatibility between different releases, see the **Commitment
 - Navigation to the user edit page after creation in the Console.
 - The port number of the `--http.redirect-to-host` option was ignored when `--http.redirect-to-tls` was used. This could lead to situations where the HTTPS server would always redirect to port 443, even if a different one was specified.
   - If the HTTPS server is available on `https://thethings.example.com:8443`, the following config is required: `--http.redirect-to-tls --http.redirect-to-host=thethings.example.com:8443`.
+- Status display on the error view in the Console.
 
 ### Security
 

--- a/pkg/webui/console/views/error/connect.js
+++ b/pkg/webui/console/views/error/connect.js
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { FullViewError, FullViewErrorInner } from './error'
-import connect from './connect'
+import { connect } from 'react-redux'
 
-const ConnectedFullErrorView = connect(FullViewError)
+import { selectConnectionStatus } from '@console/store/selectors/status'
 
-export { ConnectedFullErrorView as default, FullViewError, FullViewErrorInner }
+export default ErrorView =>
+  connect(state => ({
+    isOnline: selectConnectionStatus(state),
+  }))(ErrorView)

--- a/pkg/webui/console/views/error/error.js
+++ b/pkg/webui/console/views/error/error.js
@@ -1,0 +1,121 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+import { Container, Row, Col } from 'react-grid-system'
+
+import Link from '@ttn-lw/components/link'
+import Footer from '@ttn-lw/components/footer'
+
+import Message from '@ttn-lw/lib/components/message'
+import ErrorMessage from '@ttn-lw/lib/components/error-message'
+import { withEnv } from '@ttn-lw/lib/components/env'
+import IntlHelmet from '@ttn-lw/lib/components/intl-helmet'
+
+import Header from '@console/containers/header'
+
+import errorMessages from '@ttn-lw/lib/errors/error-messages'
+import sharedMessages from '@ttn-lw/lib/shared-messages'
+import {
+  httpStatusCode,
+  isUnknown as isUnknownError,
+  isNotFoundError,
+  isFrontend as isFrontendError,
+} from '@ttn-lw/lib/errors/utils'
+import statusCodeMessages from '@ttn-lw/lib/errors/status-code-messages'
+import PropTypes from '@ttn-lw/lib/prop-types'
+
+import style from './error.styl'
+
+const FullViewErrorInner = ({ error, env }) => {
+  const isUnknown = isUnknownError(error)
+  const statusCode = httpStatusCode(error)
+  const isNotFound = isNotFoundError(error)
+  const isFrontend = isFrontendError(error)
+
+  let errorTitleMessage = errorMessages.unknownErrorTitle
+  let errorMessageMessage = errorMessages.contactAdministrator
+  if (!isUnknown) {
+    errorMessageMessage = error
+  } else if (isNotFound) {
+    errorMessageMessage = errorMessages.genericNotFound
+  }
+  if (statusCode) {
+    errorTitleMessage = statusCodeMessages[statusCode]
+  }
+  if (isFrontend) {
+    errorMessageMessage = error.errorMessage
+    if (Boolean(error.errorTitle)) {
+      errorTitleMessage = error.errorTitle
+    }
+  }
+
+  let action = undefined
+  if (isNotFound) {
+    action = (
+      <Link.Anchor icon="keyboard_arrow_left" href={env.appRoot} primary>
+        <Message content={sharedMessages.backToOverview} />
+      </Link.Anchor>
+    )
+  }
+
+  return (
+    <div className={style.fullViewError} data-test-id="full-error-view">
+      <Container>
+        <Row>
+          <Col md={6} sm={12}>
+            <IntlHelmet title={errorMessages.error} />
+            <Message
+              className={style.fullViewErrorHeader}
+              component="h2"
+              content={errorTitleMessage}
+            />
+            <ErrorMessage className={style.fullViewErrorSub} content={errorMessageMessage} />
+            {action}
+          </Col>
+        </Row>
+      </Container>
+    </div>
+  )
+}
+
+const FullViewErrorInnerWithEnv = withEnv(FullViewErrorInner)
+
+const FullViewError = ({ error, isOnline }) => {
+  return (
+    <div className={style.wrapper}>
+      <Header className={style.header} anchored />
+      <div className={style.flexWrapper}>
+        <FullViewErrorInnerWithEnv error={error} />
+      </div>
+      <Footer isOnline={isOnline} />
+    </div>
+  )
+}
+
+FullViewErrorInner.propTypes = {
+  env: PropTypes.env,
+  error: PropTypes.error.isRequired,
+}
+
+FullViewError.propTypes = {
+  error: PropTypes.error.isRequired,
+  isOnline: PropTypes.bool.isRequired,
+}
+
+FullViewErrorInner.defaultProps = {
+  env: undefined,
+}
+
+export { FullViewError, FullViewErrorInnerWithEnv as FullViewErrorInner }

--- a/pkg/webui/console/views/error/error.styl
+++ b/pkg/webui/console/views/error/error.styl
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/webui/console/views/error/index.js
+++ b/pkg/webui/console/views/error/index.js
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ import PropTypes from '@ttn-lw/lib/prop-types'
 
 import style from './error.styl'
 
-const FullViewErrorInner = function({ error, env }) {
+const FullViewErrorInner = ({ error, env }) => {
   const isUnknown = isUnknownError(error)
   const statusCode = httpStatusCode(error)
   const isNotFound = isNotFoundError(error)
@@ -92,7 +92,7 @@ const FullViewErrorInner = function({ error, env }) {
 
 const FullViewErrorInnerWithEnv = withEnv(FullViewErrorInner)
 
-const FullViewError = function({ error }) {
+const FullViewError = ({ error }) => {
   return (
     <div className={style.wrapper}>
       <Header className={style.header} anchored />

--- a/pkg/webui/console/views/error/sub-view.js
+++ b/pkg/webui/console/views/error/sub-view.js
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import statusCodeMessages from '@ttn-lw/lib/errors/status-code-messages'
 
 import style from './sub-view.styl'
 
-const SubViewError = function({ error }) {
+const SubViewError = ({ error }) => {
   const isNotFound = isNotFoundError(error)
   const statusCode = httpStatusCode(error)
   let errorExplanation = errorMessages.subviewErrorExplanation

--- a/pkg/webui/console/views/error/sub-view.styl
+++ b/pkg/webui/console/views/error/sub-view.styl
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Currently, `<Footer />` always shows the offline indicator on error view. With this PR it will depend on the `isOnline` prop and display the offline indicator only if there is no internet connection.

<details>
<summary>Screenshots</summary>
<img width="688" alt="Screenshot 2020-11-10 at 15 43 18" src="https://user-images.githubusercontent.com/16374166/98681969-014a0380-236c-11eb-8603-567a60e6d4e5.png">
<img width="688" alt="Screenshot 2020-11-10 at 15 43 11" src="https://user-images.githubusercontent.com/16374166/98681981-04dd8a80-236c-11eb-88fb-e8ede5e2f394.png">

</details>

#### Changes
<!-- What are the changes made in this pull request? -->

- Pass `isOnline` to full error view


#### Testing

<!-- How did you verify that this change works? -->

Manual

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
