### PR TITLE
Fix navigation to user edit view after creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Fixed
 
 - Next button title in the end device wizard in the Console.
+- Navigation to the user edit page after creation in the Console.
 
 ### Security
 

--- a/pkg/webui/console/views/admin-user-management-add/index.js
+++ b/pkg/webui/console/views/admin-user-management-add/index.js
@@ -45,7 +45,7 @@ import {
   }),
   {
     createUser: attachPromise(createUser),
-    navigateToList: () => push(`/admin/user-management/`),
+    navigateToList: () => push(`/admin/user-management`),
     getConfiguration: () => getIsConfiguration(),
   },
 )


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes navigation to the user edit page right after creation.

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove `/`


#### Testing

<!-- How did you verify that this change works? -->

Manual testing

1. Go to the user management page
2. Create a new user
3. Navigate to the recently created user via the users table

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Without this PR the user is navigated to `/console/admin/user-management//test-user` which results in 404 error view.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
