### PR TITLE
Add eslint rules for arrow functions

### DIFF
--- a/config/eslintrc.yaml
+++ b/config/eslintrc.yaml
@@ -14,6 +14,7 @@ plugins:
   - prettier
   - import
   - cypress
+  - prefer-arrow
 
 settings:
   import/ignore:
@@ -160,6 +161,13 @@ rules:
   jsdoc/require-hyphen-before-param-description: warn
   jsdoc/check-indentation: warn
   jsdoc/require-description-complete-sentence: warn
+
+  prefer-arrow/prefer-arrow-functions:
+    - warn
+    - disallowPrototype: true
+      singleReturnOnly: false
+      classPropertiesAllowed: false
+      allowStandaloneDeclarations: false
 
 # Overwrite jest's expect rules for cypress test files, which uses a different
 # assertion syntax.

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-jest": "^21.17.0",
     "eslint-plugin-jsdoc": "^24.0.0",
+    "eslint-plugin-prefer-arrow": "^1.2.2",
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.4.0",
     "file-loader": "^1.1.11",

--- a/pkg/webui/lib/yup.js
+++ b/pkg/webui/lib/yup.js
@@ -27,6 +27,7 @@ class NullableStringSchemaType extends StringSchema {
 
     const self = this
 
+    /* eslint-disable prefer-arrow/prefer-arrow-functions */
     self.withMutation(function() {
       self
         .transform(function(value) {
@@ -38,6 +39,7 @@ class NullableStringSchemaType extends StringSchema {
         })
         .nullable(true)
     })
+    /* eslint-enable prefer-arrow/prefer-arrow-functions */
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6585,6 +6585,11 @@ eslint-plugin-jsdoc@^24.0.0:
     semver "^6.3.0"
     spdx-expression-parse "^3.0.0"
 
+eslint-plugin-prefer-arrow@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prefer-arrow/-/eslint-plugin-prefer-arrow-1.2.2.tgz#0c6d25a6b94cb3e0110a23d129760af5860edb6e"
+  integrity sha512-C8YMhL+r8RMeMdYAw/rQtE6xNdMulj+zGWud/qIGnlmomiPRaLDGLMeskZ3alN6uMBojmooRimtdrXebLN4svQ==
+
 eslint-plugin-prettier@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.0.tgz#8695188f95daa93b0dc54b249347ca3b79c4686d"
@@ -14545,7 +14550,7 @@ tslib@^2.0.1:
   integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
 
 "ttn-lw@file:sdk/js":
-  version "3.10.0-rc2"
+  version "3.10.0"
   dependencies:
     arraybuffer-to-string "^1.0.2"
     axios "^0.19.0"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

As requested in https://github.com/TheThingsNetwork/lorawan-stack/pull/3452#discussion_r521227652

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `eslint-plugin-prefer-arrow`
- Disable rule for `yup` extenstions where `function` must be used


#### Testing

<!-- How did you verify that this change works? -->

`mage js:lint`

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Set this rule to `warn` to avoid failing CI and refactor plain functions to arrow functions incrementally.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
