### PR TITLE
Fix handling error in JS SDK for non-object errors

### DIFF
--- a/sdk/js/src/api/http.js
+++ b/sdk/js/src/api/http.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import axios from 'axios'
-import { cloneDeep, get } from 'lodash'
+import { cloneDeep, get, isObject } from 'lodash'
 
 import { URI_PREFIX_STACK_COMPONENT_MAP, STACK_COMPONENTS_MAP } from '../util/constants'
 import EventHandler from '../util/events'
@@ -117,10 +117,12 @@ class Http {
         // Augment the default error with config entries as well as the stack component
         // abbreviation that threw an error.
         // TODO: Consider changing this, see https://github.com/TheThingsNetwork/lorawan-stack/issues/3424.
-        error.request_details = {
-          url: get(err, 'response.config.url'),
-          method: get(err, 'response.config.method'),
-          stack_component: parsedComponent,
+        if (isObject(error)) {
+          error.request_details = {
+            url: get(err, 'response.config.url'),
+            method: get(err, 'response.config.method'),
+            stack_component: parsedComponent,
+          }
         }
 
         throw error


### PR DESCRIPTION
Do not augment the error with request details if it is not of type object

<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fixes https://sentry.io/organizations/the-things-industries/issues/2022726623/?project=2682566

#### Changes
<!-- What are the changes made in this pull request? -->

- Check whether error response is an object


#### Testing

<!-- How did you verify that this change works? -->

Manual

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
