### PR TITLE
Use `start-single-node` command for CockroachDB

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,6 +14,7 @@ on:
       - 'sdk/js/**'
       - 'yarn.lock'
       - 'cypress/**'
+      - 'docker-compose.yml'
 
 jobs:
   end-to-end:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   # If using CockroachDB:
   cockroach:
     image: cockroachdb/cockroach
-    command: start --http-port 26256 --insecure
+    command: start-single-node --http-port 26256 --insecure
     restart: unless-stopped
     volumes:
       - ${DEV_DATA_DIR:-.env/data}/cockroach:/cockroach/cockroach-data


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #3465 

#### Changes
<!-- What are the changes made in this pull request? -->

- Use `start-single-node` instead of `start`
- Run the end-to-end tests GitHub workflow when `docker-compose.yml` file changes, which also helps with making sure this change fixes the end-to-end tests issues we have experienced.

#### Testing

<!-- How did you verify that this change works? -->

`docker-compose up -d` works, end-to-end tests work.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

I would assume that this would break very old cockroachdb versions that lack the `start-single-node` command. I could not find a changelog for the version or date where `start-single-node` was introduced, but I highly doubt there are any deployments that would use such an old version.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@htdvisser @benolayinka In some capacity, I think we should add a note in the changelog for this, even though the TTS version is irrelevant. Please suggest how that could look like.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [X] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
