### PR TITLE
Limit event views in the Console to 2000 events per stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
+- Limitation of displayed and stored events in the Console to 2000.
+
 ### Deprecated
 
 ### Removed
@@ -26,6 +28,7 @@ For details about compatibility between different releases, see the **Commitment
 - The port number of the `--http.redirect-to-host` option was ignored when `--http.redirect-to-tls` was used. This could lead to situations where the HTTPS server would always redirect to port 443, even if a different one was specified.
   - If the HTTPS server is available on `https://thethings.example.com:8443`, the following config is required: `--http.redirect-to-tls --http.redirect-to-host=thethings.example.com:8443`.
 - Status display on the error view in the Console.
+- Event views in the Console freezing after receiving thousands of events.
 
 ### Security
 

--- a/pkg/webui/console/components/events/details/index.js
+++ b/pkg/webui/console/components/events/details/index.js
@@ -29,6 +29,14 @@ import style from './details.styl'
 const EventDetails = ({ className, children, event }) => {
   const hasChildren = Boolean(children)
 
+  if (!Boolean(event)) {
+    return (
+      <div className={classnames(className, style.details)}>
+        <Notification content={messages.eventUnavailable} warning small />
+      </div>
+    )
+  }
+
   return (
     <div className={classnames(className, style.details)}>
       {event.isSynthetic && <Notification content={messages.syntheticEvent} info small />}
@@ -44,12 +52,13 @@ const EventDetails = ({ className, children, event }) => {
 EventDetails.propTypes = {
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
   className: PropTypes.string,
-  event: PropTypes.event.isRequired,
+  event: PropTypes.event,
 }
 
 EventDetails.defaultProps = {
   children: null,
   className: undefined,
+  event: undefined,
 }
 
 export default EventDetails

--- a/pkg/webui/console/components/events/events.styl
+++ b/pkg/webui/console/components/events/events.styl
@@ -95,6 +95,18 @@ $event-container-height = 40px
     margin: 0
     list-style: none
 
+.truncated
+  border-normal(top)
+  display: flex
+  align-items: center
+  justify-content: center
+  font-size: $fs.s
+  color: $tc-warning
+  padding: $cs.xxs 0
+
+  span
+    margin-right: $cs.xxs
+
 .event
   height: $event-container-height
   background-color: transparent

--- a/pkg/webui/console/components/events/index.js
+++ b/pkg/webui/console/components/events/index.js
@@ -15,9 +15,11 @@
 import React, { useState, useCallback } from 'react'
 import classnames from 'classnames'
 
+import EVENT_STORE_LIMIT from '@console/constants/event-store-limit'
 import hamburgerMenuClose from '@assets/misc/hamburger-menu-close.svg'
 
 import Button from '@ttn-lw/components/button'
+import Icon from '@ttn-lw/components/icon'
 
 import Message from '@ttn-lw/lib/components/message'
 
@@ -32,81 +34,91 @@ import { getEventId } from './utils'
 
 import style from './events.styl'
 
-const Events = React.memo(({ events, scoped, paused, onClear, onPauseToggle, entityId }) => {
-  const [focus, setFocus] = useState({ eventId: undefined, visible: false })
-  const onPause = useCallback(() => onPauseToggle(paused), [onPauseToggle, paused])
-  const handleRowClick = useCallback(
-    eventId => {
-      if (eventId !== focus.eventId) {
-        setFocus({ eventId, visible: eventId })
-      } else {
-        setFocus({ eventId: undefined, visible: false })
-      }
-    },
-    [focus],
-  )
+const Events = React.memo(
+  ({ events, scoped, paused, onClear, onPauseToggle, entityId, truncated }) => {
+    const [focus, setFocus] = useState({ eventId: undefined, visible: false })
+    const onPause = useCallback(() => onPauseToggle(paused), [onPauseToggle, paused])
+    const handleRowClick = useCallback(
+      eventId => {
+        if (eventId !== focus.eventId) {
+          setFocus({ eventId, visible: eventId })
+        } else {
+          setFocus({ eventId: undefined, visible: false })
+        }
+      },
+      [focus],
+    )
 
-  const handleEventInfoCloseClick = useCallback(() => {
-    setFocus({ entityId: undefined, visible: false })
-  }, [])
+    const handleEventInfoCloseClick = useCallback(() => {
+      setFocus({ eventId: undefined, visible: false })
+    }, [])
 
-  return (
-    <div className={style.container}>
-      <section className={style.header}>
-        <div className={style.headerCells}>
-          <Message content={sharedMessages.time} className={style.cellTime} component="div" />
-          {!scoped && (
-            <Message content={sharedMessages.entityId} className={style.cellId} component="div" />
-          )}
-          <Message content={sharedMessages.type} className={style.cellType} component="div" />
-          <Message content={m.dataPreview} className={style.cellData} component="div" />
-          <div className={style.stickyContainer}>
-            <div className={style.actions}>
-              <Button
-                onClick={onPause}
-                message={paused ? sharedMessages.resume : sharedMessages.pause}
-                naked
-                secondary={!paused}
-                warning={paused}
-                icon={paused ? 'play_arrow' : 'pause'}
-              />
-              <Button
-                onClick={onClear}
-                message={sharedMessages.clear}
-                naked
-                secondary
-                icon="delete"
-              />
+    return (
+      <div className={style.container}>
+        <section className={style.header}>
+          <div className={style.headerCells}>
+            <Message content={sharedMessages.time} className={style.cellTime} component="div" />
+            {!scoped && (
+              <Message content={sharedMessages.entityId} className={style.cellId} component="div" />
+            )}
+            <Message content={sharedMessages.type} className={style.cellType} component="div" />
+            <Message content={m.dataPreview} className={style.cellData} component="div" />
+            <div className={style.stickyContainer}>
+              <div className={style.actions}>
+                <Button
+                  onClick={onPause}
+                  message={paused ? sharedMessages.resume : sharedMessages.pause}
+                  naked
+                  secondary={!paused}
+                  warning={paused}
+                  icon={paused ? 'play_arrow' : 'pause'}
+                />
+                <Button
+                  onClick={onClear}
+                  message={sharedMessages.clear}
+                  naked
+                  secondary
+                  icon="delete"
+                />
+              </div>
             </div>
           </div>
-        </div>
-      </section>
-      <section className={style.body}>
-        <EventsList
-          events={events}
-          paused={paused}
-          scoped={scoped}
-          entityId={entityId}
-          onRowClick={handleRowClick}
-          activeId={focus.eventId}
-        />
-      </section>
-      <section className={classnames(style.sidebarContainer, { [style.expanded]: focus.visible })}>
-        <div className={style.sidebarHeader}>
-          <Message content={m.eventDetails} className={style.sidebarTitle} />
-          <button className={style.sidebarCloseButton} onClick={handleEventInfoCloseClick}>
-            <img src={hamburgerMenuClose} alt="Close event info" />
-          </button>
-        </div>
-        <div className={style.sidebarContent}>
-          {Boolean(focus.eventId) && (
-            <EventDetails event={events.find(event => getEventId(event) === focus.eventId)} />
-          )}
-        </div>
-      </section>
-    </div>
-  )
-})
+        </section>
+        <section className={style.body}>
+          <EventsList
+            events={events}
+            paused={paused}
+            scoped={scoped}
+            entityId={entityId}
+            onRowClick={handleRowClick}
+            activeId={focus.eventId}
+          />
+        </section>
+        {truncated && (
+          <div className={style.truncated}>
+            <Icon icon="info" />
+            <Message content={m.eventsTruncated} values={{ limit: EVENT_STORE_LIMIT }} />
+          </div>
+        )}
+        <section
+          className={classnames(style.sidebarContainer, { [style.expanded]: focus.visible })}
+        >
+          <div className={style.sidebarHeader}>
+            <Message content={m.eventDetails} className={style.sidebarTitle} />
+            <button className={style.sidebarCloseButton} onClick={handleEventInfoCloseClick}>
+              <img src={hamburgerMenuClose} alt="Close event info" />
+            </button>
+          </div>
+          <div className={style.sidebarContent}>
+            {Boolean(focus.eventId) && (
+              <EventDetails event={events.find(event => getEventId(event) === focus.eventId)} />
+            )}
+          </div>
+        </section>
+      </div>
+    )
+  },
+)
 
 Events.propTypes = {
   entityId: PropTypes.string.isRequired,
@@ -115,6 +127,7 @@ Events.propTypes = {
   onPauseToggle: PropTypes.func,
   paused: PropTypes.bool.isRequired,
   scoped: PropTypes.bool,
+  truncated: PropTypes.bool.isRequired,
 }
 
 Events.defaultProps = {

--- a/pkg/webui/console/components/events/messages.js
+++ b/pkg/webui/console/components/events/messages.js
@@ -35,6 +35,9 @@ const messages = defineMessages({
   dataPreview: 'Data preview',
   seeAllActivity: 'See all activity',
   syntheticEvent: 'Note: This meta event did not originate from the event stream',
+  eventsTruncated:
+    'Old events have been truncated to save memory. The current event limit per stream is {limit}.',
+  eventUnavailable: 'This event is not available anymore. It was likely truncated to save memory.',
 })
 
 export default messages

--- a/pkg/webui/console/constants/event-store-limit.js
+++ b/pkg/webui/console/constants/event-store-limit.js
@@ -1,0 +1,15 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export default 2000

--- a/pkg/webui/console/containers/application-events/index.js
+++ b/pkg/webui/console/containers/application-events/index.js
@@ -32,10 +32,11 @@ import {
 import {
   selectApplicationEvents,
   selectApplicationEventsPaused,
+  selectApplicationEventsTruncated,
 } from '@console/store/selectors/applications'
 
 const ApplicationEvents = props => {
-  const { appId, events, widget, paused, onClear, onPauseToggle } = props
+  const { appId, events, widget, paused, onClear, onPauseToggle, truncated } = props
 
   if (widget) {
     return (
@@ -49,6 +50,7 @@ const ApplicationEvents = props => {
       events={events}
       paused={paused}
       onClear={onClear}
+      truncated={truncated}
       onPauseToggle={onPauseToggle}
     />
   )
@@ -60,6 +62,7 @@ ApplicationEvents.propTypes = {
   onClear: PropTypes.func.isRequired,
   onPauseToggle: PropTypes.func.isRequired,
   paused: PropTypes.bool.isRequired,
+  truncated: PropTypes.bool.isRequired,
   widget: PropTypes.bool,
 }
 
@@ -76,6 +79,7 @@ export default withFeatureRequirement(mayViewApplicationEvents)(
       return {
         events: selectApplicationEvents(state, appId),
         paused: selectApplicationEventsPaused(state, appId),
+        truncated: selectApplicationEventsTruncated(state, appId),
       }
     },
     (dispatch, ownProps) => ({

--- a/pkg/webui/console/containers/device-events/index.js
+++ b/pkg/webui/console/containers/device-events/index.js
@@ -26,10 +26,14 @@ import {
   resumeDeviceEventsStream,
 } from '@console/store/actions/devices'
 
-import { selectDeviceEvents, selectDeviceEventsPaused } from '@console/store/selectors/devices'
+import {
+  selectDeviceEvents,
+  selectDeviceEventsPaused,
+  selectDeviceEventsTruncated,
+} from '@console/store/selectors/devices'
 
 const DeviceEvents = props => {
-  const { appId, devId, events, widget, paused, onClear, onPauseToggle } = props
+  const { appId, devId, events, widget, paused, onClear, onPauseToggle, truncated } = props
 
   if (widget) {
     return (
@@ -49,6 +53,7 @@ const DeviceEvents = props => {
       paused={paused}
       onClear={onClear}
       onPauseToggle={onPauseToggle}
+      truncated={truncated}
       scoped
       widget
     />
@@ -68,6 +73,7 @@ DeviceEvents.propTypes = {
   onClear: PropTypes.func.isRequired,
   onPauseToggle: PropTypes.func.isRequired,
   paused: PropTypes.bool.isRequired,
+  truncated: PropTypes.bool.isRequired,
   widget: PropTypes.bool,
 }
 
@@ -89,6 +95,7 @@ export default connect(
       appId,
       events: selectDeviceEvents(state, combinedId),
       paused: selectDeviceEventsPaused(state, combinedId),
+      truncated: selectDeviceEventsTruncated(state, combinedId),
     }
   },
   (dispatch, ownProps) => {

--- a/pkg/webui/console/containers/gateway-events/index.js
+++ b/pkg/webui/console/containers/gateway-events/index.js
@@ -29,10 +29,14 @@ import {
   resumeGatewayEventsStream,
 } from '@console/store/actions/gateways'
 
-import { selectGatewayEvents, selectGatewayEventsPaused } from '@console/store/selectors/gateways'
+import {
+  selectGatewayEvents,
+  selectGatewayEventsPaused,
+  selectGatewayEventsTruncated,
+} from '@console/store/selectors/gateways'
 
 const GatewayEvents = props => {
-  const { gtwId, events, widget, paused, onPauseToggle, onClear } = props
+  const { gtwId, events, widget, paused, onPauseToggle, onClear, truncated } = props
 
   if (widget) {
     return (
@@ -47,6 +51,7 @@ const GatewayEvents = props => {
       paused={paused}
       onClear={onClear}
       onPauseToggle={onPauseToggle}
+      truncated={truncated}
       scoped
     />
   )
@@ -58,6 +63,7 @@ GatewayEvents.propTypes = {
   onClear: PropTypes.func.isRequired,
   onPauseToggle: PropTypes.func.isRequired,
   paused: PropTypes.bool.isRequired,
+  truncated: PropTypes.bool.isRequired,
   widget: PropTypes.bool,
 }
 
@@ -74,6 +80,7 @@ export default withFeatureRequirement(mayViewGatewayEvents)(
       return {
         events: selectGatewayEvents(state, gtwId),
         paused: selectGatewayEventsPaused(state, gtwId),
+        truncated: selectGatewayEventsTruncated(state, gtwId),
       }
     },
     (dispatch, ownProps) => ({

--- a/pkg/webui/console/containers/organization-events/connect.js
+++ b/pkg/webui/console/containers/organization-events/connect.js
@@ -23,6 +23,7 @@ import {
 import {
   selectOrganizationEvents,
   selectOrganizationEventsPaused,
+  selectOrganizationEventsTruncated,
 } from '@console/store/selectors/organizations'
 
 const mapStateToProps = (state, props) => {
@@ -31,6 +32,7 @@ const mapStateToProps = (state, props) => {
   return {
     events: selectOrganizationEvents(state, orgId),
     paused: selectOrganizationEventsPaused(state, orgId),
+    truncated: selectOrganizationEventsTruncated(state, orgId),
   }
 }
 

--- a/pkg/webui/console/containers/organization-events/organization-events.js
+++ b/pkg/webui/console/containers/organization-events/organization-events.js
@@ -19,7 +19,7 @@ import Events from '@console/components/events'
 import PropTypes from '@ttn-lw/lib/prop-types'
 
 const OrganizationEvents = props => {
-  const { orgId, events, widget, paused, onPauseToggle, onClear } = props
+  const { orgId, events, widget, paused, onPauseToggle, onClear, truncated } = props
 
   if (widget) {
     return (
@@ -38,6 +38,7 @@ const OrganizationEvents = props => {
       paused={paused}
       onClear={onClear}
       onPauseToggle={onPauseToggle}
+      truncated={truncated}
       entityId={orgId}
     />
   )
@@ -49,6 +50,7 @@ OrganizationEvents.propTypes = {
   onPauseToggle: PropTypes.func.isRequired,
   orgId: PropTypes.string.isRequired,
   paused: PropTypes.bool.isRequired,
+  truncated: PropTypes.bool.isRequired,
   widget: PropTypes.bool,
 }
 

--- a/pkg/webui/console/store/selectors/applications.js
+++ b/pkg/webui/console/store/selectors/applications.js
@@ -32,6 +32,7 @@ import {
   createEventsStatusSelector,
   createEventsInterruptedSelector,
   createEventsPausedSelector,
+  createEventsTruncatedSelector,
 } from './events'
 import { createRightsSelector, createPseudoRightsSelector } from './rights'
 import { createFetchingSelector } from './fetching'
@@ -72,6 +73,7 @@ export const selectApplicationEventsError = createEventsErrorSelector(ENTITY)
 export const selectApplicationEventsStatus = createEventsStatusSelector(ENTITY)
 export const selectApplicationEventsInterrupted = createEventsInterruptedSelector(ENTITY)
 export const selectApplicationEventsPaused = createEventsPausedSelector(ENTITY)
+export const selectApplicationEventsTruncated = createEventsTruncatedSelector(ENTITY)
 
 // Rights.
 export const selectApplicationRights = createRightsSelector(ENTITY)

--- a/pkg/webui/console/store/selectors/devices.js
+++ b/pkg/webui/console/store/selectors/devices.js
@@ -22,6 +22,7 @@ import {
   createEventsStatusSelector,
   createEventsInterruptedSelector,
   createEventsPausedSelector,
+  createEventsTruncatedSelector,
 } from './events'
 import {
   createPaginationIdsSelectorByEntity,
@@ -86,3 +87,4 @@ export const selectDeviceEventsError = createEventsErrorSelector(ENTITY)
 export const selectDeviceEventsStatus = createEventsStatusSelector(ENTITY)
 export const selectDeviceEventsInterruptted = createEventsInterruptedSelector(ENTITY)
 export const selectDeviceEventsPaused = createEventsPausedSelector(ENTITY)
+export const selectDeviceEventsTruncated = createEventsTruncatedSelector(ENTITY)

--- a/pkg/webui/console/store/selectors/events.js
+++ b/pkg/webui/console/store/selectors/events.js
@@ -49,6 +49,13 @@ export const createEventsErrorSelector = entity =>
     return store ? store.error : undefined
   }
 
+export const createEventsTruncatedSelector = entity =>
+  function(state, entityId) {
+    const store = selectEventsStore(state.events[entity], entityId)
+
+    return Boolean(store.truncated)
+  }
+
 export const createLatestEventSelector = function(entity) {
   const eventsSelector = createEventsSelector(entity)
 

--- a/pkg/webui/console/store/selectors/gateways.js
+++ b/pkg/webui/console/store/selectors/gateways.js
@@ -26,6 +26,7 @@ import {
   createEventsStatusSelector,
   createEventsInterruptedSelector,
   createEventsPausedSelector,
+  createEventsTruncatedSelector,
   createLatestEventSelector,
 } from './events'
 import { createRightsSelector, createPseudoRightsSelector } from './rights'
@@ -67,6 +68,7 @@ export const selectGatewayEventsError = createEventsErrorSelector(ENTITY)
 export const selectGatewayEventsStatus = createEventsStatusSelector(ENTITY)
 export const selectGatewayEventsInterrupted = createEventsInterruptedSelector(ENTITY)
 export const selectGatewayEventsPaused = createEventsPausedSelector(ENTITY)
+export const selectGatewayEventsTruncated = createEventsTruncatedSelector(ENTITY)
 export const selectLatestGatewayEvent = createLatestEventSelector(ENTITY)
 
 // Rights.

--- a/pkg/webui/console/store/selectors/organizations.js
+++ b/pkg/webui/console/store/selectors/organizations.js
@@ -28,6 +28,7 @@ import {
   createEventsStatusSelector,
   createEventsInterruptedSelector,
   createEventsPausedSelector,
+  createEventsTruncatedSelector,
 } from './events'
 import { createFetchingSelector } from './fetching'
 import { createErrorSelector } from './error'
@@ -70,3 +71,4 @@ export const selectOrganizationEventsError = createEventsErrorSelector(ENTITY)
 export const selectOrganizationEventsStatus = createEventsStatusSelector(ENTITY)
 export const selectOrganizationEventsInterrupted = createEventsInterruptedSelector(ENTITY)
 export const selectOrganizationEventsPaused = createEventsPausedSelector(ENTITY)
+export const selectOrganizationEventsTruncated = createEventsTruncatedSelector(ENTITY)

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -78,6 +78,8 @@
   "console.components.events.messages.dataPreview": "Data preview",
   "console.components.events.messages.seeAllActivity": "See all activity",
   "console.components.events.messages.syntheticEvent": "Note: This meta event did not originate from the event stream",
+  "console.components.events.messages.eventsTruncated": "Old events have been truncated to save memory. The current event limit per stream is {limit}.",
+  "console.components.events.messages.eventUnavailable": "This event is not available anymore. It was likely truncated to save memory.",
   "console.components.events.previews.shared.json-payload.index.invalid": "Invalid JSON",
   "console.components.join-eui-prefixes-input.index.empty": "No prefix",
   "console.components.join-eui-prefixes-input.index.zeroInput": "Fill with zeros",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -78,6 +78,8 @@
   "console.components.events.messages.dataPreview": "Xxxx xxxxxxx",
   "console.components.events.messages.seeAllActivity": "Xxx xxx xxxxxxxx",
   "console.components.events.messages.syntheticEvent": "Xxxx: Xxxx xxxx xxxxx xxx xxx xxxxxxxxx xxxx xxx xxxxx xxxxxx",
+  "console.components.events.messages.eventsTruncated": "Xxx xxxxxx xxxx xxxx xxxxxxxxx xx xxxx xxxxxx. Xxx xxxxxxx xxxxx xxxxx xxx xxxxxx xx {limit}.",
+  "console.components.events.messages.eventUnavailable": "Xxxx xxxxx xx xxx xxxxxxxxx xxxxxxx. Xx xxx xxxxxx xxxxxxxxx xx xxxx xxxxxx.",
   "console.components.events.previews.shared.json-payload.index.invalid": "Xxxxxxx XXXX",
   "console.components.join-eui-prefixes-input.index.empty": "Xx xxxxxx",
   "console.components.join-eui-prefixes-input.index.zeroInput": "Xxxx xxxx xxxxx",


### PR DESCRIPTION
#### Summary
This PR is a forgotten followup from #3330. It limits the number of events per stream to 2000 in the Console, to prevent memory and performance issues in the event views.

![image](https://user-images.githubusercontent.com/5710611/98935521-f1edc600-24e3-11eb-9b43-df9493730943.png)

Closes #2887 

#### Changes
- Set a hard limit for events to 2000, after that old limits will be truncated
- Add some logic and styles to communicate truncated events

#### Testing

Manual testing on the staging environment

##### Regressions

This touches store logic for events, so it could introduce arbitrary issues with event ingestion and display in the Console.

#### Notes for Reviewers
> Regarding 2000 event limit: this seemed like a sane limitation to me for now, at which the console still runs smoothly. We might want to fine-tune this value later when we have more feedback and metrics. Generally, it's important to establish for the user that the Console event view is not the correct place to source long-term event data.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
