### PR TITLE
Add CLI command for simulating end device uplinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
-- Renamed expiremental command `ttn-lw-cli simulate uplink` to `ttn-lw-cli simulate gateway-uplink`.
+- Renamed experimental command `ttn-lw-cli simulate uplink` to `ttn-lw-cli simulate gateway-uplink`.
+- Renamed experimental command `ttn-lw-cli simulate join-request` to `ttn-lw-cli simulate gateway-join-request`.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Added
 
+- Support for sending end device uplinks using the CLI (see `ttn-lw-cli simulate application-uplink` command).
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
+- Renamed expiremental command `ttn-lw-cli simulate uplink` to `ttn-lw-cli simulate gateway-uplink`.
+
 ### Deprecated
 
 ### Removed

--- a/cmd/ttn-lw-cli/commands/simulate.go
+++ b/cmd/ttn-lw-cli/commands/simulate.go
@@ -675,6 +675,9 @@ var (
 			if err != nil {
 				return err
 			}
+			if uplinkMessage.ReceivedAt.IsZero() {
+				uplinkMessage.ReceivedAt = time.Now()
+			}
 			_, err = ttnpb.NewAppAsClient(cc).SimulateUplink(ctx, up)
 			return err
 		},

--- a/cmd/ttn-lw-cli/commands/simulate.go
+++ b/cmd/ttn-lw-cli/commands/simulate.go
@@ -422,12 +422,12 @@ var (
 	simulateCommand = &cobra.Command{
 		Use:     "simulate",
 		Aliases: []string{"sim"},
-		Short:   "Simulation commands (EXPERIMENTAL)",
-		Hidden:  true,
+		Short:   "Simulation commands",
 	}
 	simulateJoinRequestCommand = &cobra.Command{
-		Use:   "join-request",
-		Short: "Simulate a join request (EXPERIMENTAL)",
+		Use:    "join-request",
+		Short:  "Simulate a join request (EXPERIMENTAL)",
+		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var uplinkParams simulateMetadataParams
 			if err := util.SetFields(&uplinkParams, simulateUplinkFlags); err != nil {
@@ -507,8 +507,9 @@ var (
 	}
 
 	simulateDataUplinkCommand = &cobra.Command{
-		Use:   "gateway-uplink",
-		Short: "Simulate a gateway uplink message (EXPERIMENTAL)",
+		Use:    "gateway-uplink",
+		Short:  "Simulate a gateway uplink message (EXPERIMENTAL)",
+		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var uplinkParams simulateMetadataParams
 			if err := util.SetFields(&uplinkParams, simulateUplinkFlags); err != nil {

--- a/cmd/ttn-lw-cli/commands/simulate.go
+++ b/cmd/ttn-lw-cli/commands/simulate.go
@@ -432,8 +432,8 @@ var (
 		Short:   "Simulation commands",
 	}
 	simulateJoinRequestCommand = &cobra.Command{
-		Use:    "join-request",
-		Short:  "Simulate a join request (EXPERIMENTAL)",
+		Use:    "gateway-join-request",
+		Short:  "Simulates a join request from an end device, sent through a simulated gateway connection (EXPERIMENTAL)",
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var uplinkParams simulateMetadataParams
@@ -515,7 +515,7 @@ var (
 
 	simulateDataUplinkCommand = &cobra.Command{
 		Use:    "gateway-uplink",
-		Short:  "Simulate a gateway uplink message (EXPERIMENTAL)",
+		Short:  "Simulate an uplink message from an end device, sent through a simulated gateway connection (EXPERIMENTAL)",
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var uplinkParams simulateMetadataParams
@@ -652,7 +652,7 @@ var (
 	}
 	simulateApplicationUplinkCommand = &cobra.Command{
 		Use:   "application-uplink [application-id] [device-id]",
-		Short: "Simulate application uplink message from an end device",
+		Short: "Simulate an application-layer uplink message from an end device, sent directly to the Application Server",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			devID, err := getEndDeviceID(cmd.Flags(), args, true)
 			if err != nil {

--- a/cmd/ttn-lw-cli/commands/simulate.go
+++ b/cmd/ttn-lw-cli/commands/simulate.go
@@ -507,8 +507,8 @@ var (
 	}
 
 	simulateDataUplinkCommand = &cobra.Command{
-		Use:   "uplink",
-		Short: "Simulate a data uplink (EXPERIMENTAL)",
+		Use:   "gateway-uplink",
+		Short: "Simulate a gateway uplink message (EXPERIMENTAL)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var uplinkParams simulateMetadataParams
 			if err := util.SetFields(&uplinkParams, simulateUplinkFlags); err != nil {

--- a/cmd/ttn-lw-cli/commands/simulate.go
+++ b/cmd/ttn-lw-cli/commands/simulate.go
@@ -142,6 +142,13 @@ var (
 	errApplicationServerDisabled = errors.DefineFailedPrecondition("application_server_disabled", "Application Server is disabled")
 )
 
+func simulateFlags() *pflag.FlagSet {
+	flagSet := &pflag.FlagSet{}
+	flagSet.String("gateway-api-key", "", "API key used for linking the gateway (optional when using user authentication)")
+	flagSet.Bool("dry-run", false, "print the message instead of sending it")
+	return flagSet
+}
+
 func simulateDownlinkFlags() *pflag.FlagSet {
 	flagSet := &pflag.FlagSet{}
 	flagSet.Duration("timeout", 20*time.Second, "how long to wait for downlinks")
@@ -679,6 +686,7 @@ func init() {
 	simulateJoinRequestCommand.Flags().AddFlagSet(simulateUplinkFlags)
 	simulateJoinRequestCommand.Flags().AddFlagSet(simulateDownlinkFlags())
 	simulateJoinRequestCommand.Flags().AddFlagSet(simulateJoinRequestFlags)
+	simulateJoinRequestCommand.Flags().AddFlagSet(simulateFlags())
 
 	simulateCommand.AddCommand(simulateJoinRequestCommand)
 
@@ -687,6 +695,7 @@ func init() {
 	simulateDataUplinkCommand.Flags().AddFlagSet(simulateDownlinkFlags())
 	simulateDataUplinkCommand.Flags().AddFlagSet(simulateDataUplinkFlags)
 	simulateDataUplinkCommand.Flags().AddFlagSet(simulateDataDownlinkFlags())
+	simulateDataUplinkCommand.Flags().AddFlagSet(simulateFlags())
 
 	simulateCommand.AddCommand(simulateDataUplinkCommand)
 
@@ -695,7 +704,5 @@ func init() {
 
 	simulateCommand.AddCommand(simulateApplicationUplinkCommand)
 
-	simulateCommand.PersistentFlags().String("gateway-api-key", "", "API key used for linking the gateway (optional when using user authentication)")
-	simulateCommand.PersistentFlags().Bool("dry-run", false, "print the message instead of sending it")
 	Root.AddCommand(simulateCommand)
 }

--- a/config/messages.json
+++ b/config/messages.json
@@ -1214,6 +1214,15 @@
       "file": "gateways.go"
     }
   },
+  "error:cmd/ttn-lw-cli/commands:application_server_disabled": {
+    "translations": {
+      "en": "Application Server is disabled"
+    },
+    "description": {
+      "package": "cmd/ttn-lw-cli/commands",
+      "file": "simulate.go"
+    }
+  },
   "error:cmd/ttn-lw-cli/commands:conflicting_paths": {
     "translations": {
       "en": "conflicting set and unset field mask paths"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #3144 

#### Changes
<!-- What are the changes made in this pull request? -->

- Add a new `ttn-lw-cli end-devices simulate-uplink` command, accepting arguments for the uplink message.

#### Testing

<!-- How did you verify that this change works? -->

- `ttn-lw-cli login`
- `ttn-lw-cli end-devices simulate-uplink app-id dev-id --uplink-message.f-port 13 --uplink-message.frm-payload 01010202`
- Uplink message is received from the Application Server, events are sent, integrations are working as they should.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

There should not be any.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
