### PR TITLE
Use public folder cache to js,e2e CI workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,10 +34,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Initialize public folder cache
+        id: public-cache
         uses: actions/cache@v2
         with:
           path: public
-          key: ${{ runner.os }}-public-cache-${{ hashFiles('pkg/webui/**') }}-${{ hashFiles('sdk/js/**/*.js') }}-${{ hashFiles('config/webpack.config.babel.js') }}-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('pkg/ttnpb/field_mask_validation.go') }}
+          key: public-cache-${{ hashFiles('pkg/webui/**') }}-${{ hashFiles('sdk/js/**/*.js', 'sdk/js/generated/*.json') }}-${{ hashFiles('config/webpack.config.babel.js') }}-${{ hashFiles('yarn.lock', 'sdk/js/yarn.lock')}}
       - name: Set up Go 1.14
         uses: actions/setup-go@v2
         with:
@@ -63,7 +64,10 @@ jobs:
       - name: Initialize stack environment
         run: tools/bin/mage init
       - name: Run test preparations
-        run: tools/bin/mage dev:dbStop dev:dbErase dev:dbStart dev:initStack dev:sqlDump js:Build
+        run: tools/bin/mage dev:dbStop dev:dbErase dev:dbStart dev:initStack dev:sqlDump
+      - name: Build frontend
+        if: steps.public-cache.outputs.cache-hit != 'true'
+        run: tools/bin/mage js:build
       - name: Run frontend end-to-end tests
         run: tools/bin/mage dev:startDevStack & tools/bin/mage -v js:cypressHeadless
       - name: Upload logs

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -88,6 +88,12 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: '~1.15'
+    - name: Initialize public folder cache
+      id: public-cache
+      uses: actions/cache@v2
+      with:
+        path: public
+        key: public-cache-${{ hashFiles('pkg/webui/**') }}-${{ hashFiles('sdk/js/**/*.js', 'sdk/js/generated/*.json') }}-${{ hashFiles('config/webpack.config.babel.js') }}-${{ hashFiles('yarn.lock', 'sdk/js/yarn.lock')}}
     - name: Initialize Go module cache
       uses: actions/cache@v2
       with:
@@ -114,7 +120,8 @@ jobs:
       run: tools/bin/mage js:deps
       timeout-minutes: 5
     - name: Build frontend
-      run: tools/bin/mage js:clean js:build
+      if: steps.public-cache.outputs.cache-hit != 'true'
+      run: tools/bin/mage js:build
     - name: Test JS SDK code
       run: tools/bin/mage jsSDK:test
     - name: Test frontend code

--- a/pkg/webui/console/views/application-payload-formatters/index.js
+++ b/pkg/webui/console/views/application-payload-formatters/index.js
@@ -50,7 +50,7 @@ const m = defineMessages({
 })
 
 @connect(
-  function(state) {
+  state => {
     const link = selectApplicationLink(state)
     const fetching = selectApplicationLinkFetching(state)
 
@@ -64,7 +64,7 @@ const m = defineMessages({
     getLink: (id, selector) => dispatch(getApplicationLink(id, selector)),
   }),
 )
-@withBreadcrumb('apps.single.payload-formatters', function(props) {
+@withBreadcrumb('apps.single.payload-formatters', props => {
   const { appId } = props
 
   return (

--- a/pkg/webui/console/views/organization/organization.js
+++ b/pkg/webui/console/views/organization/organization.js
@@ -41,7 +41,7 @@ import {
 } from '@console/lib/feature-checks'
 
 @withEnv
-@withBreadcrumb('orgs.single', function(props) {
+@withBreadcrumb('orgs.single', props => {
   const {
     orgId,
     organization: { name },


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/3480
This PR adds caching for the `public` folder to avoid running `js:build` when it is not required to save time on js and e2e workflows.

#### Changes
<!-- What are the changes made in this pull request? -->

- Check for cache hit before running `js:build`.


#### Testing

<!-- How did you verify that this change works? -->

See CI


#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

tba

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
