### PR TITLE
Remove usage of default HTTP client and transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ For details about compatibility between different releases, see the **Commitment
 
 - Changed the pub/sub channels that the Redis backend of the Events system uses.
 - Changed the encoding of events transported by the Redis backend of the Events system.
+- All external HTTP calls are now using TLS client configuration. This fixes issues where HTTP calls would fail if custom (e.g. self-signed) CAs were used.
+- All external HTTP calls are now using a default timeout. This fixes issues where HTTP calls would stall for a long time.
 
 ### Deprecated
 

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -190,6 +190,17 @@ var startCommand = &cobra.Command{
 
 		redisConsumerID := redis.Key(host, strconv.Itoa(os.Getpid()))
 
+		transport, err := c.HTTPTransport(ctx)
+		if err != nil {
+			return err
+		}
+		if conf := config.ServiceBase.FrequencyPlans; conf.Transport == nil {
+			conf.Transport = transport
+		}
+		if conf := config.ServiceBase.Interop.SenderClientCA; conf.Transport == nil {
+			conf.Transport = transport
+		}
+
 		if start.IdentityServer {
 			logger.Info("Setting up Identity Server")
 			if config.IS.OAuth.UI.TemplateData.SentryDSN == "" {

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -97,6 +97,10 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 
 	baseConf := c.GetBaseConfig(ctx)
 
+	transport, err := c.HTTPTransport(ctx)
+	if err != nil {
+		return nil, err
+	}
 	var interopCl InteropClient
 	if !conf.Interop.IsZero() {
 		interopConf := conf.Interop.InteropClient
@@ -104,6 +108,9 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 			return c.GetTLSClientConfig(ctx)
 		}
 		interopConf.BlobConfig = baseConf.Blob
+		if interopConf.Transport == nil {
+			interopConf.Transport = transport
+		}
 
 		interopCl, err = interop.NewClient(ctx, interopConf)
 		if err != nil {
@@ -199,6 +206,9 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 		c.RegisterWeb(webhooks)
 	}
 
+	if conf.Webhooks.Templates.Transport == nil {
+		conf.Webhooks.Templates.Transport = transport
+	}
 	if as.webhookTemplates, err = conf.Webhooks.Templates.NewTemplateStore(); err != nil {
 		return nil, err
 	}

--- a/pkg/applicationserver/config.go
+++ b/pkg/applicationserver/config.go
@@ -150,10 +150,13 @@ func (c WebhooksConfig) NewWebhooks(ctx context.Context, server io.Server) (web.
 	case "":
 		return nil, nil
 	case "direct":
+		client, err := server.HTTPClient(ctx)
+		if err != nil {
+			return nil, err
+		}
+		client.Timeout = c.Timeout
 		target = &web.HTTPClientSink{
-			Client: &http.Client{
-				Timeout: c.Timeout,
-			},
+			Client: client,
 		}
 	default:
 		return nil, errWebhooksTarget.WithAttributes("target", c.Target)

--- a/pkg/applicationserver/io/io.go
+++ b/pkg/applicationserver/io/io.go
@@ -16,6 +16,7 @@ package io
 
 import (
 	"context"
+	"net/http"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/component"
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
@@ -46,6 +47,8 @@ type Server interface {
 	DownlinkQueueReplace(context.Context, ttnpb.EndDeviceIdentifiers, []*ttnpb.ApplicationDownlink) error
 	// DownlinkQueueList lists the application downlink queue of the given end device.
 	DownlinkQueueList(context.Context, ttnpb.EndDeviceIdentifiers) ([]*ttnpb.ApplicationDownlink, error)
+	// HTTPClient returns a configured *http.Client.
+	HTTPClient(context.Context) (*http.Client, error)
 }
 
 // ContextualApplicationUp represents an ttnpb.ApplicationUp with its context.

--- a/pkg/applicationserver/io/web/config.go
+++ b/pkg/applicationserver/io/web/config.go
@@ -16,6 +16,7 @@ package web
 
 import (
 	"context"
+	"net/http"
 	"net/url"
 	"os"
 
@@ -29,6 +30,8 @@ type TemplatesConfig struct {
 	Directory   string            `name:"directory" description:"Retrieve the webhook templates from the filesystem"`
 	URL         string            `name:"url" description:"Retrieve the webhook templates from a web server"`
 	LogoBaseURL string            `name:"logo-base-url" description:"The base URL for the logo storage"`
+
+	Transport http.RoundTripper `name:"-"`
 }
 
 // TemplateStore contains the webhook templates.
@@ -53,7 +56,7 @@ func (c TemplatesConfig) NewTemplateStore() (TemplateStore, error) {
 		fallthrough
 	case c.URL != "":
 		var err error
-		fetcher, err = fetch.FromHTTP(c.URL, true)
+		fetcher, err = fetch.FromHTTP(c.Transport, c.URL, true)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/applicationserver/io/web/grpc_webhooks_test.go
+++ b/pkg/applicationserver/io/web/grpc_webhooks_test.go
@@ -16,6 +16,7 @@ package web_test
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/gogo/protobuf/types"
@@ -228,7 +229,8 @@ description: Bar`),
 			a := assertions.New(t)
 
 			config := web.TemplatesConfig{
-				Static: tc.contents,
+				Static:    tc.contents,
+				Transport: http.DefaultTransport,
 			}
 			store, err := config.NewTemplateStore()
 			a.So(err, should.BeNil)

--- a/pkg/component/http.go
+++ b/pkg/component/http.go
@@ -1,0 +1,47 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package component
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// defaultHTTPClientTimeout is the default timeout for the HTTP client.
+const defaultHTTPClientTimeout = 10 * time.Second
+
+// HTTPClient returns a new *http.Client with a default timeout and a configured transport.
+func (c *Component) HTTPClient(ctx context.Context) (*http.Client, error) {
+	tr, err := c.HTTPTransport(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &http.Client{
+		Timeout:   defaultHTTPClientTimeout,
+		Transport: tr,
+	}, nil
+}
+
+// HTTPTransport returns a new http.RoundTripper with TLS client configuration.
+func (c *Component) HTTPTransport(ctx context.Context) (http.RoundTripper, error) {
+	tlsConfig, err := c.GetTLSClientConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.TLSClientConfig = tlsConfig
+	return tr, nil
+}

--- a/pkg/fetch/fetch_test.go
+++ b/pkg/fetch/fetch_test.go
@@ -16,12 +16,13 @@ package fetch_test
 
 import (
 	"fmt"
+	"net/http"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/fetch"
 )
 
 func Example() {
-	fetcher, err := fetch.FromHTTP("http://webserver.thethings.network/repository", true)
+	fetcher, err := fetch.FromHTTP(http.DefaultTransport, "http://webserver.thethings.network/repository", true)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/fetch/http.go
+++ b/pkg/fetch/http.go
@@ -64,10 +64,16 @@ func (f httpFetcher) File(pathElements ...string) ([]byte, error) {
 }
 
 // FromHTTP returns an object to fetch files from a webserver.
-func FromHTTP(rootURL string, cache bool) (Interface, error) {
-	transport := http.DefaultTransport
+func FromHTTP(transport http.RoundTripper, rootURL string, cache bool) (Interface, error) {
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
 	if cache {
-		transport = httpcache.NewMemoryCacheTransport()
+		transport = &httpcache.Transport{
+			Transport:           transport,
+			Cache:               httpcache.NewMemoryCache(),
+			MarkCachedResponses: true,
+		}
 	}
 	var root *url.URL
 	if rootURL != "" {

--- a/pkg/fetch/http_test.go
+++ b/pkg/fetch/http_test.go
@@ -32,13 +32,13 @@ func TestHTTP(t *testing.T) {
 
 	// Invalid path
 	{
-		fetcher, err := fetch.FromHTTP("", false)
+		fetcher, err := fetch.FromHTTP(http.DefaultTransport, "", false)
 		if a.So(err, should.BeNil) && a.So(fetcher, should.NotBeNil) {
 			_, err = fetcher.File("test")
 			a.So(err, should.BeError)
 		}
 
-		fetcher, err = fetch.FromHTTP("/asd", false)
+		fetcher, err = fetch.FromHTTP(http.DefaultTransport, "/asd", false)
 		if a.So(err, should.NotBeNil) {
 			a.So(fetcher, should.BeNil)
 		}
@@ -53,7 +53,7 @@ func TestHTTP(t *testing.T) {
 	httpmock.RegisterResponder("GET", fmt.Sprintf("%s/success", serverHost), httpmock.NewStringResponder(200, content))
 	httpmock.RegisterResponder("GET", fmt.Sprintf("%s/fail", serverHost), httpmock.NewStringResponder(500, ""))
 
-	fetcher, err := fetch.FromHTTP(serverHost, false)
+	fetcher, err := fetch.FromHTTP(http.DefaultTransport, serverHost, false)
 	if !a.So(err, should.BeNil) {
 		t.Fatalf("Failed to construct HTTP fetcher: %v", err)
 	}
@@ -100,7 +100,7 @@ func TestHTTPCache(t *testing.T) {
 
 	time.Sleep(10 * test.Delay)
 
-	fetcher, err := fetch.FromHTTP(fmt.Sprintf("http://%s", s.Addr), true)
+	fetcher, err := fetch.FromHTTP(http.DefaultTransport, fmt.Sprintf("http://%s", s.Addr), true)
 	if !a.So(err, should.BeNil) {
 		t.Fatalf("Failed to construct HTTP fetcher: %v", err)
 	}

--- a/pkg/frequencyplans/frequencyplans_test.go
+++ b/pkg/frequencyplans/frequencyplans_test.go
@@ -16,6 +16,7 @@ package frequencyplans_test
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
@@ -34,7 +35,7 @@ func boolPtr(v bool) *bool                       { return &v }
 func durationPtr(v time.Duration) *time.Duration { return &v }
 
 func Example() {
-	fetcher, err := fetch.FromHTTP("https://raw.githubusercontent.com/TheThingsNetwork/lorawan-frequency-plans", true)
+	fetcher, err := fetch.FromHTTP(http.DefaultTransport, "https://raw.githubusercontent.com/TheThingsNetwork/lorawan-frequency-plans", true)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/identityserver/config.go
+++ b/pkg/identityserver/config.go
@@ -16,6 +16,7 @@ package identityserver
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"time"
 
@@ -99,6 +100,8 @@ type emailTemplatesConfig struct {
 	Blob      config.BlobPathConfig `name:"blob"`
 
 	Includes []string `name:"includes" description:"The email templates that will be preloaded on startup"`
+
+	Transport http.RoundTripper `name:"-"`
 }
 
 // Fetcher returns a fetch.Interface based on the configuration.
@@ -127,7 +130,7 @@ func (c emailTemplatesConfig) Fetcher(ctx context.Context, blobConf config.BlobC
 	case "directory":
 		return fetch.FromFilesystem(c.Directory), nil
 	case "url":
-		return fetch.FromHTTP(c.URL, true)
+		return fetch.FromHTTP(c.Transport, c.URL, true)
 	case "blob":
 		b, err := blobConf.Bucket(ctx, c.Blob.Bucket)
 		if err != nil {

--- a/pkg/identityserver/email.go
+++ b/pkg/identityserver/email.go
@@ -30,6 +30,13 @@ import (
 
 func (is *IdentityServer) initEmailTemplates(ctx context.Context) (*email.TemplateRegistry, error) {
 	config := is.configFromContext(ctx).Email.Templates
+	if config.Transport == nil {
+		transport, err := is.HTTPTransport(ctx)
+		if err != nil {
+			return nil, err
+		}
+		config.Transport = transport
+	}
 	fetcher, err := config.Fetcher(ctx, is.Component.GetBaseConfig(ctx).Blob)
 	if err != nil {
 		return nil, err

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -191,6 +191,13 @@ func New(c *component.Component, conf *Config, opts ...Option) (*NetworkServer, 
 			return c.GetTLSClientConfig(ctx)
 		}
 		interopConf.BlobConfig = c.GetBaseConfig(ctx).Blob
+		if interopConf.Transport == nil {
+			tr, err := c.HTTPTransport(ctx)
+			if err != nil {
+				return nil, err
+			}
+			interopConf.Transport = tr
+		}
 
 		interopCl, err = interop.NewClient(ctx, interopConf)
 		if err != nil {

--- a/pkg/pfconfig/semtechudp/semtechudp_test.go
+++ b/pkg/pfconfig/semtechudp/semtechudp_test.go
@@ -16,6 +16,7 @@ package semtechudp
 
 import (
 	"encoding/json"
+	"net/http"
 	"os"
 	"strings"
 	"testing"
@@ -35,7 +36,7 @@ func TestBuild(t *testing.T) {
 		fetcher = fetch.FromFilesystem(localPath)
 	} else {
 		var err error
-		fetcher, err = fetch.FromHTTP("https://raw.githubusercontent.com/TheThingsNetwork/lorawan-frequency-plans/master", true)
+		fetcher, err = fetch.FromHTTP(http.DefaultTransport, "https://raw.githubusercontent.com/TheThingsNetwork/lorawan-frequency-plans/master", true)
 		if err != nil {
 			t.Fatalf("Failed to construct HTTP fetcher: %v", err)
 		}
@@ -48,7 +49,7 @@ func TestBuild(t *testing.T) {
 		referenceFetcher = fetch.FromFilesystem(referenceLocalPath)
 	} else {
 		var err error
-		referenceFetcher, err = fetch.FromHTTP("https://raw.githubusercontent.com/TheThingsNetwork/gateway-conf/master", true)
+		referenceFetcher, err = fetch.FromHTTP(http.DefaultTransport, "https://raw.githubusercontent.com/TheThingsNetwork/gateway-conf/master", true)
 		if err != nil {
 			t.Fatalf("Failed to construct HTTP fetcher: %v", err)
 		}

--- a/pkg/web/oauthclient/callback.go
+++ b/pkg/web/oauthclient/callback.go
@@ -78,7 +78,7 @@ func (oc *OAuthClient) HandleCallback(c echo.Context) error {
 	}
 
 	// Exchange token.
-	ctx, err := oc.withTLSClientConfig(c.Request().Context())
+	ctx, err := oc.withHTTPClient(c.Request().Context())
 	if err != nil {
 		return err
 	}

--- a/pkg/web/oauthclient/oauthclient.go
+++ b/pkg/web/oauthclient/oauthclient.go
@@ -17,7 +17,6 @@ package oauthclient
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"net/url"
 	"strings"
 
@@ -56,16 +55,12 @@ func (oc *OAuthClient) getMountPath() string {
 	return path
 }
 
-func (oc *OAuthClient) withTLSClientConfig(ctx context.Context) (context.Context, error) {
-	config, err := oc.component.GetTLSClientConfig(ctx)
+func (oc *OAuthClient) withHTTPClient(ctx context.Context) (context.Context, error) {
+	client, err := oc.component.HTTPClient(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return context.WithValue(ctx, oauth2.HTTPClient, &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: config,
-		},
-	}), nil
+	return context.WithValue(ctx, oauth2.HTTPClient, client), nil
 }
 
 // New returns a new OAuth client instance.

--- a/pkg/web/oauthclient/token.go
+++ b/pkg/web/oauthclient/token.go
@@ -39,7 +39,7 @@ func (oc *OAuthClient) freshToken(c echo.Context) (*oauth2.Token, error) {
 		Expiry:       time.Now(),
 	}
 
-	ctx, err := oc.withTLSClientConfig(c.Request().Context())
+	ctx, err := oc.withHTTPClient(c.Request().Context())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2533

#### Changes
<!-- What are the changes made in this pull request? -->

- Adds `component.HTTPClient(context.Context) (*http.Client, error)` and `component.HTTPTransport(context.Context) (http.RoundTripper, error)`
- Extend `fetcher.FromHTTP` to accept a custom transport.
- Add new configuration `Transport http.RoundTripper` for all fetchers.
- (as) Extend `io.Server` with `HTTPClient()` method and use it for webhooks and the LoRaCloud package.
- (oauthclient) Use the component HTTPClient.

#### Testing

<!-- How did you verify that this change works? -->

Unit tests, test locally.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Possible, since different parts of the codebase dealt with HTTP clients and transports in all sorts of ways.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Please make sure your code-owned files look OK.

@johanstokking `pkg/interop` client intentionally not changed, since it would require quite some refactoring which I would prefer to do in a separate PR.
@kschiffer specifically, what is a scenario to verify that `oauthclient` works as expected?

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
