### PR TITLE
Improve cluster logging

### DIFF
--- a/pkg/component/cluster.go
+++ b/pkg/component/cluster.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/cluster"
+	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"google.golang.org/grpc"
 )
@@ -30,7 +31,8 @@ func (c *Component) initCluster() (err error) {
 	if tlsConfig, err := c.GetTLSClientConfig(c.Context()); err == nil {
 		clusterOpts = append(clusterOpts, cluster.WithTLSConfig(tlsConfig))
 	}
-	c.cluster, err = c.clusterNew(c.ctx, &c.config.ServiceBase.Cluster, clusterOpts...)
+	ctx := log.NewContextWithField(c.ctx, "namespace", "cluster")
+	c.cluster, err = c.clusterNew(ctx, &c.config.ServiceBase.Cluster, clusterOpts...)
 	if err != nil {
 		return err
 	}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -56,7 +56,7 @@ func (e Error) Error() string { return e.String() }
 func (e Error) Fields() map[string]interface{} {
 	res := make(map[string]interface{})
 	pref := "error_cause"
-	for cause := Cause(e); cause != nil && !IsInternal(cause); cause = Cause(cause) {
+	for cause := Cause(e); cause != nil; cause = Cause(cause) {
 		res[pref] = cause.Error()
 		pref += "_cause"
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a small PR that improves logging in the cluster package.

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove the filter of internal errors in log package. We even send internal errors over gRPC, so no need to keep those out of logs.
- Set a namespace on cluster logs.