### PR TITLE
Gateway Server downlink path claiming fixes

### DIFF
--- a/pkg/component/tasks.go
+++ b/pkg/component/tasks.go
@@ -121,6 +121,7 @@ type TaskConfig struct {
 	Context context.Context
 	ID      string
 	Func    TaskFunc
+	Done    func()
 	Restart TaskRestart
 	Backoff *TaskBackoffConfig
 }
@@ -146,6 +147,12 @@ var errTaskRecovered = errors.Define("task_recovered", "task recovered")
 func DefaultStartTask(conf *TaskConfig) {
 	logger := log.FromContext(conf.Context).WithField("task_id", conf.ID)
 	go func() {
+		defer func() {
+			if conf.Done == nil {
+				return
+			}
+			conf.Done()
+		}()
 		invocation := uint(1)
 		for {
 			if invocation == 0 {

--- a/pkg/component/tasks.go
+++ b/pkg/component/tasks.go
@@ -148,10 +148,9 @@ func DefaultStartTask(conf *TaskConfig) {
 	logger := log.FromContext(conf.Context).WithField("task_id", conf.ID)
 	go func() {
 		defer func() {
-			if conf.Done == nil {
-				return
+			if done := conf.Done; done != nil {
+				done()
 			}
-			conf.Done()
 		}()
 		invocation := uint(1)
 		for {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR adds additional logic in order to ensure that gateway identifier claiming sequences such as the following no longer occur:
- Connect `gtw1`
- Claim `gtw1` (in task1)
- Disconnect `gtw1`
- Connect `gtw1`
- Claim `gtw1` (in task2)
- Unclaim `gtw1` (in task1)


#### Changes
<!-- What are the changes made in this pull request? -->

- Add task `Done` callback that occurs when the task is completely finished (no matter the error)
- Ensure that the tasks of the old connection are awaited before starting the ones of the new connection - general, targeted at the NS handler (which claims / unclaims on `Connect`)
- Ensure that the downlink handler of the old connection is closed before deleting the connection in the UDP frontend


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This PR only ensures that old connections are completely 'finished' before allowing new ones, so semantics are not expected to change.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This race has been on my mind for a long time and I want to rule it out once and for all.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
