### PR TITLE
Fix NACK handling in Network Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ For details about compatibility between different releases, see the **Commitment
 - Status display on the error view in the Console.
 - Event views in the Console freezing after receiving thousands of events.
 - Wrong FPort value displayed for downlink attempt events in the Console.
+- Network Server sending duplicate application downlink NACKs.
+- Network Server now sends downlink NACK when it assumes confirmed downlink is lost.
 
 ### Security
 

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -525,6 +525,7 @@ func (ns *NetworkServer) generateDataDownlink(ctx context.Context, dev *ttnpb.En
 					DownlinkNack: dev.MACState.PendingApplicationDownlink,
 				},
 			})
+			dev.MACState.PendingApplicationDownlink = nil
 		}
 	}
 

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -505,16 +505,26 @@ func (ns *NetworkServer) generateDataDownlink(ctx context.Context, dev *ttnpb.En
 	logger = logger.WithField("f_pending", pld.FHDR.FCtrl.FPending)
 	ctx = log.NewContext(ctx, logger)
 
-	confirmed := mType == ttnpb.MType_CONFIRMED_DOWN
-	if confirmed && class != ttnpb.CLASS_A {
-		confirmedAt, ok := nextConfirmedNetworkInitiatedDownlinkAt(ctx, dev, phy, ns.defaultMACSettings)
-		if !ok {
-			return nil, genState, errCorruptedMACState.New()
+	if mType == ttnpb.MType_CONFIRMED_DOWN {
+		if class != ttnpb.CLASS_A {
+			confirmedAt, ok := nextConfirmedNetworkInitiatedDownlinkAt(ctx, dev, phy, ns.defaultMACSettings)
+			if !ok {
+				return nil, genState, errCorruptedMACState.New()
+			}
+			if confirmedAt.After(transmitAt) {
+				// Caller must have checked this already.
+				logger.WithField("confirmed_at", confirmedAt).Error("Confirmed class B/C downlink attempt performed too soon")
+				return nil, genState, errConfirmedDownlinkTooSoon.New()
+			}
 		}
-		if confirmedAt.After(transmitAt) {
-			// Caller must have checked this already.
-			logger.WithField("confirmed_at", confirmedAt).Error("Confirmed class B/C downlink attempt performed too soon")
-			return nil, genState, errConfirmedDownlinkTooSoon.New()
+		if dev.MACState.PendingApplicationDownlink != nil {
+			genState.ifScheduledApplicationUps = append(genState.ifScheduledApplicationUps, &ttnpb.ApplicationUp{
+				EndDeviceIdentifiers: dev.EndDeviceIdentifiers,
+				CorrelationIDs:       events.CorrelationIDsFromContext(ctx),
+				Up: &ttnpb.ApplicationUp_DownlinkNack{
+					DownlinkNack: dev.MACState.PendingApplicationDownlink,
+				},
+			})
 		}
 	}
 

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -310,6 +310,7 @@ func (ns *NetworkServer) matchAndHandleDataUplink(ctx context.Context, dev *ttnp
 				}
 			}
 			queuedApplicationUplinks = []*ttnpb.ApplicationUp{asUp}
+			dev.MACState.PendingApplicationDownlink = nil
 		}
 
 		fCntGap = cmacFMatchResult.FullFCnt - dev.Session.LastFCntUp
@@ -348,6 +349,7 @@ func (ns *NetworkServer) matchAndHandleDataUplink(ctx context.Context, dev *ttnp
 					CorrelationIDs: append(dev.MACState.PendingApplicationDownlink.CorrelationIDs, up.CorrelationIDs...),
 				},
 			}
+			dev.MACState.PendingApplicationDownlink = nil
 		}
 		dev.MACState = dev.PendingMACState
 		dev.PendingSession.StartedAt = up.ReceivedAt
@@ -378,6 +380,7 @@ func (ns *NetworkServer) matchAndHandleDataUplink(ctx context.Context, dev *ttnp
 					CorrelationIDs: append(dev.MACState.PendingApplicationDownlink.CorrelationIDs, up.CorrelationIDs...),
 				},
 			}
+			dev.MACState.PendingApplicationDownlink = nil
 		}
 		dev.MACState = macState
 		dev.Session.StartedAt = up.ReceivedAt


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Refs https://github.com/TheThingsNetwork/lorawan-stack/issues/3498

#### Changes
<!-- What are the changes made in this pull request? -->

- Avoid sending duplicate NACKs
- Send NACK, when NS assumes confirmed downlink to be lost and goes to next one


#### Testing

<!-- How did you verify that this change works? -->

Unit tests

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Extremely unlikely, this is a bugfix

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

No unit tests, because we apparently need this ASAP cc @adriansmares

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.