### PR TITLE
Fix handling of FCnt resets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Removed
 
 ### Fixed
+- Uplink frame counter reset handling.
 
 ### Security
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fix handling of FCnt resets. Closes https://github.com/TheThingsIndustries/lorawan-stack-support/issues/221

#### Changes
<!-- What are the changes made in this pull request? -->

- Assume the uplink FCnt is the FCntGap on resets


#### Testing

<!-- How did you verify that this change works? -->

Simulated a reset of an ABP device from CLI

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.