### PR TITLE
console: Add hover menu to sidebar in collapsed state

### DIFF
--- a/pkg/webui/components/dropdown/dropdown.styl
+++ b/pkg/webui/components/dropdown/dropdown.styl
@@ -32,6 +32,17 @@ ul.dropdown
     margin-top: 0
     height: .4rem
 
+  li.dropdown-header-item
+    border-normal('bottom')
+    display: block
+    margin-bottom: 0
+    font-weight: $fw.bold
+
+    span
+      line-height: 1
+      display: block
+      padding: $cs.m
+
   li.dropdown-item
     display: block
     margin-bottom: 0

--- a/pkg/webui/components/dropdown/index.js
+++ b/pkg/webui/components/dropdown/index.js
@@ -46,15 +46,18 @@ Dropdown.defaultProps = {
   onItemsClick: () => null,
 }
 
-const DropdownItem = function({ icon, title, path, action, exact }) {
+const DropdownItem = ({ icon, title, path, action, exact, showActive, tabIndex }) => {
   const iconElement = icon && <Icon className={style.icon} icon={icon} nudgeUp />
+  const activeClassName = classnames({
+    [style.active]: showActive,
+  })
   const ItemElement = action ? (
-    <button onClick={action} onKeyPress={action} role="tab" tabIndex="0">
+    <button onClick={action} onKeyPress={action} role="tab" tabIndex={tabIndex}>
       {iconElement}
       <Message content={title} />
     </button>
   ) : (
-    <NavLink activeClassName={style.active} to={path} exact={exact}>
+    <NavLink activeClassName={activeClassName} to={path} exact={exact} tabIndex={tabIndex}>
       {iconElement}
       <Message content={title} />
     </NavLink>
@@ -71,6 +74,8 @@ DropdownItem.propTypes = {
   exact: PropTypes.bool,
   icon: PropTypes.string.isRequired,
   path: PropTypes.string,
+  showActive: PropTypes.bool,
+  tabIndex: PropTypes.string,
   title: PropTypes.message.isRequired,
 }
 
@@ -78,8 +83,23 @@ DropdownItem.defaultProps = {
   action: undefined,
   exact: false,
   path: undefined,
+  showActive: true,
+  tabIndex: '0',
+}
+
+const DropdownHeaderItem = ({ title }) => (
+  <li className={style.dropdownHeaderItem}>
+    <span>
+      <Message content={title} />
+    </span>
+  </li>
+)
+
+DropdownHeaderItem.propTypes = {
+  title: PropTypes.message.isRequired,
 }
 
 Dropdown.Item = DropdownItem
+Dropdown.HeaderItem = DropdownHeaderItem
 
 export default Dropdown

--- a/pkg/webui/components/navigation/side/item/item.styl
+++ b/pkg/webui/components/navigation/side/item/item.styl
@@ -15,8 +15,10 @@
 .item
   +media-query-min($bp.s)
     &-minimized
+      position: relative
       .message,
       .expand-icon
+      .sub-items
         display: none
 
       .icon
@@ -28,6 +30,11 @@
         padding: $cs.m 0
         height: auto
         justify-content: space-evenly
+
+      &:focus-within,
+      &:hover
+        .fly-out-list
+          display: block
 
 .button
   reset-button()
@@ -118,3 +125,17 @@
 
   &-open
     transform: translateY(-50%) rotate(180deg)
+
+.fly-out-list
+  display: none
+  left: 3rem
+  top: 0
+
+  &::before
+    content: ''
+    position: absolute
+    top: -30px
+    bottom: -30px
+    left: -10px
+    right: -30px
+    z-index: -1

--- a/pkg/webui/components/navigation/side/side.styl
+++ b/pkg/webui/components/navigation/side/side.styl
@@ -78,6 +78,7 @@ $minimize-button-height = 5rem
     width: 100%
 
   &-minimized
+    overflow: visible
     display: flex
     flex-direction: column
     justify-content: space-between
@@ -97,6 +98,12 @@ $minimize-button-height = 5rem
 
         .icon
           margin-right: 0
+
+      .navigation-list
+        overflow: visible
+
+      .drawer
+        overflow: visible
 
 .header
   border-normal(bottom)


### PR DESCRIPTION
#### Summary
Closes #1157

#### Changes

- Added hover menu to sidebar menu in collapsed (minimized) state.
- Updated side menu parent button to highlight if one of the children is active.

Before:
![before1](https://user-images.githubusercontent.com/72162194/100224436-7e0cde00-2f25-11eb-9701-100af67bf6c2.png)
![before2](https://user-images.githubusercontent.com/72162194/100224443-8107ce80-2f25-11eb-81b8-fe8bad2a6b8b.png)

Now:
![after_1](https://user-images.githubusercontent.com/72162194/100597108-b0438480-3305-11eb-908a-d79b4b153746.png)
![after2](https://user-images.githubusercontent.com/72162194/100224467-89f8a000-2f25-11eb-8b2e-c587822a4a8d.png)

#### Testing

Manually tested

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
