### PR TITLE
cli: Add --dry-run flag for simulation

### DIFF
--- a/cmd/ttn-lw-cli/commands/simulate.go
+++ b/cmd/ttn-lw-cli/commands/simulate.go
@@ -194,6 +194,13 @@ func simulate(cmd *cobra.Command, forUp func(*ttnpb.UplinkMessage) error, forDow
 		return err
 	}
 
+	if dryRun, _ := cmd.Flags().GetBool("dry-run"); dryRun {
+		if err = io.Write(os.Stdout, config.OutputFormat, upMsg); err != nil {
+			return err
+		}
+		return nil
+	}
+
 	gs, err := api.Dial(ctx, config.GatewayServerGRPCAddress)
 	if err != nil {
 		return err
@@ -649,5 +656,6 @@ func init() {
 	simulateCommand.AddCommand(simulateDataUplinkCommand)
 
 	simulateCommand.PersistentFlags().String("gateway-api-key", "", "API key used for linking the gateway (optional when using user authentication)")
+	simulateCommand.PersistentFlags().Bool("dry-run", false, "print the message instead of sending it")
 	Root.AddCommand(simulateCommand)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Allow users to see raw frame as it gets sent to the Gateway Server. This is useful to generate LoRaWAN frames.

#### Changes
<!-- What are the changes made in this pull request? -->

Add `--dry-run` flag for simulation

#### Testing

<!-- How did you verify that this change works? -->

Local

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
