### PR TITLE
Configure Application Activation Settings with the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Added
 
+- Configure application activation settings from the CLI (see `ttn-lw-cli application activation-settings` commands).
+
 ### Changed
 
 ### Deprecated

--- a/cmd/ttn-lw-cli/commands/applications_activation_settings.go
+++ b/cmd/ttn-lw-cli/commands/applications_activation_settings.go
@@ -1,0 +1,139 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"os"
+	"strings"
+
+	"github.com/gogo/protobuf/types"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
+	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/io"
+	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/util"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+)
+
+var (
+	selectApplicationActivationSettingsFlags = util.FieldMaskFlags(&ttnpb.ApplicationActivationSettings{})
+	setApplicationActivationSettingsFlags    = util.FieldFlags(&ttnpb.ApplicationActivationSettings{})
+
+	selectAllApplicationActivationSettingsFlags = util.SelectAllFlagSet("application activation settings")
+)
+
+var (
+	applicationActivationSettingsCommand = &cobra.Command{
+		Use:   "activation-settings",
+		Short: "Application activation settings commands",
+	}
+	applicationActivationSettingsGetCommand = &cobra.Command{
+		Use:   "get [application-id]",
+		Short: "Get application activation settings",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			appID := getApplicationID(cmd.Flags(), args)
+			if appID == nil {
+				return errNoApplicationID
+			}
+			paths := util.SelectFieldMask(cmd.Flags(), selectApplicationActivationSettingsFlags)
+			if len(paths) == 0 {
+				logger.Warn("No fields selected, will select everything")
+				selectApplicationActivationSettingsFlags.VisitAll(func(flag *pflag.Flag) {
+					paths = append(paths, strings.Replace(flag.Name, "-", "_", -1))
+				})
+			}
+			paths = ttnpb.AllowedFields(paths, ttnpb.AllowedFieldMaskPathsForRPC["/ttn.lorawan.v3.ApplicationActivationSettingRegistry/Get"])
+
+			js, err := api.Dial(ctx, config.JoinServerGRPCAddress)
+			if err != nil {
+				return err
+			}
+			res, err := ttnpb.NewApplicationActivationSettingRegistryClient(js).Get(ctx, &ttnpb.GetApplicationActivationSettingsRequest{
+				ApplicationIdentifiers: *appID,
+				FieldMask:              types.FieldMask{Paths: paths},
+			})
+			if err != nil {
+				return err
+			}
+
+			return io.Write(os.Stdout, config.OutputFormat, res)
+		},
+	}
+	applicationActivationSettingsSetCommand = &cobra.Command{
+		Use:     "set [application-id]",
+		Aliases: []string{"update"},
+		Short:   "Set application activation settings",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			appID := getApplicationID(cmd.Flags(), args)
+			if appID == nil {
+				return errNoApplicationID
+			}
+			paths := util.UpdateFieldMask(cmd.Flags(), setApplicationActivationSettingsFlags)
+
+			var aas ttnpb.ApplicationActivationSettings
+			if err := util.SetFields(&aas, setApplicationActivationSettingsFlags); err != nil {
+				return err
+			}
+
+			js, err := api.Dial(ctx, config.JoinServerGRPCAddress)
+			if err != nil {
+				return err
+			}
+			res, err := ttnpb.NewApplicationActivationSettingRegistryClient(js).Set(ctx, &ttnpb.SetApplicationActivationSettingsRequest{
+				ApplicationIdentifiers:        *appID,
+				ApplicationActivationSettings: aas,
+				FieldMask:                     types.FieldMask{Paths: paths},
+			})
+			if err != nil {
+				return err
+			}
+
+			return io.Write(os.Stdout, config.OutputFormat, res)
+		},
+	}
+	applicationActivationSettingsDeleteCommand = &cobra.Command{
+		Use:     "delete [application-id]",
+		Aliases: []string{"del", "remove", "rm"},
+		Short:   "Delete application activation settings",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			appID := getApplicationID(cmd.Flags(), args)
+			if appID == nil {
+				return errNoApplicationID
+			}
+
+			as, err := api.Dial(ctx, config.ApplicationServerGRPCAddress)
+			if err != nil {
+				return err
+			}
+			_, err = ttnpb.NewApplicationActivationSettingRegistryClient(as).Delete(ctx, &ttnpb.DeleteApplicationActivationSettingsRequest{
+				ApplicationIdentifiers: *appID,
+			})
+			return err
+		},
+	}
+)
+
+func init() {
+	applicationActivationSettingsGetCommand.Flags().AddFlagSet(applicationIDFlags())
+	applicationActivationSettingsGetCommand.Flags().AddFlagSet(selectApplicationActivationSettingsFlags)
+	applicationActivationSettingsGetCommand.Flags().AddFlagSet(selectAllApplicationActivationSettingsFlags)
+	applicationActivationSettingsCommand.AddCommand(applicationActivationSettingsGetCommand)
+	applicationActivationSettingsSetCommand.Flags().AddFlagSet(applicationIDFlags())
+	applicationActivationSettingsSetCommand.Flags().AddFlagSet(setApplicationActivationSettingsFlags)
+	applicationActivationSettingsCommand.AddCommand(applicationActivationSettingsSetCommand)
+	applicationActivationSettingsDeleteCommand.Flags().AddFlagSet(applicationIDFlags())
+	applicationActivationSettingsCommand.AddCommand(applicationActivationSettingsDeleteCommand)
+	applicationsCommand.AddCommand(applicationActivationSettingsCommand)
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #3401 

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `ttn-lw-cli application activation-settings get/set/delete` commands

#### Testing

<!-- How did you verify that this change works? -->

Set, update, and then delete application activation settings with the CLI.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Is there anything extra needed for field validations? Relying on message validation only.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
