### PR TITLE
Fix RTT handling for LBS gateways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - Simulated uplinks visibility in webhook messages.
 - Retransmission handling.
+- RTT recording for LBS gateways. The maximum round trip delay for RTT calculation is configurable via `--gs.basic-station.max-valid-round-trip-delay`.
 
 ### Security
 

--- a/cmd/internal/shared/gatewayserver/config.go
+++ b/cmd/internal/shared/gatewayserver/config.go
@@ -51,9 +51,10 @@ var DefaultGatewayServerConfig = gatewayserver.Config{
 		PublicTLSAddress: fmt.Sprintf("%s:8882", shared.DefaultPublicHost),
 	},
 	BasicStation: gatewayserver.BasicStationConfig{
-		Config:    ws.DefaultConfig,
-		Listen:    ":1887",
-		ListenTLS: ":8887",
+		Config:                 ws.DefaultConfig,
+		MaxValidRoundTripDelay: 10 * time.Second,
+		Listen:                 ":1887",
+		ListenTLS:              ":8887",
 	},
 	UpdateConnectionStatsDebounceTime: 3 * time.Second,
 }

--- a/pkg/gatewayserver/config.go
+++ b/pkg/gatewayserver/config.go
@@ -32,9 +32,10 @@ type UDPConfig struct {
 // BasicStationConfig defines the LoRa Basics Station configuration of the Gateway Server.
 type BasicStationConfig struct {
 	ws.Config               `name:",squash"`
-	FallbackFrequencyPlanID string `name:"fallback-frequency-plan-id" description:"Fallback frequency plan ID for non-registered gateways"`
-	Listen                  string `name:"listen" description:"Address for the Basic Station frontend to listen on"`
-	ListenTLS               string `name:"listen-tls" description:"Address for the Basic Station frontend to listen on (with TLS)"`
+	MaxValidRoundTripDelay  time.Duration `name:"max-valid-round-trip-delay" description:"Maximum valid round trip delay to qualify for RTT calculations"`
+	FallbackFrequencyPlanID string        `name:"fallback-frequency-plan-id" description:"Fallback frequency plan ID for non-registered gateways"`
+	Listen                  string        `name:"listen" description:"Address for the Basic Station frontend to listen on"`
+	ListenTLS               string        `name:"listen-tls" description:"Address for the Basic Station frontend to listen on (with TLS)"`
 }
 
 // Config represents the Gateway Server configuration.

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -271,7 +271,7 @@ func New(c *component.Component, conf *Config, opts ...Option) (gs *GatewayServe
 	}{
 		{
 			Name:      "basicstation",
-			Formatter: lbslns.NewFormatter(),
+			Formatter: lbslns.NewFormatter(conf.BasicStation.MaxValidRoundTripDelay),
 			listenerConfig: listenerConfig{
 				fallbackFreqPlanID: conf.BasicStation.FallbackFrequencyPlanID,
 				listen:             conf.BasicStation.Listen,

--- a/pkg/gatewayserver/io/ws/lbslns/format.go
+++ b/pkg/gatewayserver/io/ws/lbslns/format.go
@@ -16,6 +16,7 @@ package lbslns
 
 import (
 	"fmt"
+	"time"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io"
@@ -33,12 +34,15 @@ type State struct {
 }
 
 type lbsLNS struct {
-	tokens io.DownlinkTokens
+	maxRoundTripDelay time.Duration
+	tokens            io.DownlinkTokens
 }
 
 // NewFormatter returns a new LoRa Basic Station LNS formatter.
-func NewFormatter() ws.Formatter {
-	return &lbsLNS{}
+func NewFormatter(maxRoundTripDelay time.Duration) ws.Formatter {
+	return &lbsLNS{
+		maxRoundTripDelay: maxRoundTripDelay,
+	}
 }
 
 func (f *lbsLNS) Endpoints() ws.Endpoints {

--- a/pkg/gatewayserver/io/ws/lbslns/upstream.go
+++ b/pkg/gatewayserver/io/ws/lbslns/upstream.go
@@ -433,11 +433,7 @@ func (f *lbsLNS) HandleUp(ctx context.Context, raw []byte, ids ttnpb.GatewayIden
 
 	recordTime := func(recordRTT bool, refTime float64, xTime int64, server time.Time) {
 		if recordRTT {
-			sec, nsec := math.Modf(refTime)
-			if sec != 0 {
-				ref := time.Unix(int64(sec), int64(nsec*1e9))
-				conn.RecordRTT(server.Sub(ref), server)
-			}
+			conn.RecordRTT(server.Sub(getTimeFromFloat64(refTime)), server)
 		}
 		conn.SyncWithGatewayConcentrator(
 			// The concentrator timestamp is the 32 LSB.
@@ -446,11 +442,6 @@ func (f *lbsLNS) HandleUp(ctx context.Context, raw []byte, ids ttnpb.GatewayIden
 			// The Basic Station epoch is the 48 LSB.
 			scheduling.ConcentratorTime(time.Duration(xTime&0xFFFFFFFFFF)*time.Microsecond),
 		)
-	}
-
-	getTimeFromFloat64 := func(timeInFloat float64) time.Time {
-		sec, nsec := math.Modf(timeInFloat)
-		return time.Unix(int64(sec), int64(nsec*1e9))
 	}
 
 	switch typ {
@@ -557,4 +548,9 @@ func (f *lbsLNS) HandleUp(ctx context.Context, raw []byte, ids ttnpb.GatewayIden
 
 	}
 	return nil, nil
+}
+
+func getTimeFromFloat64(timeInFloat float64) time.Time {
+	sec, nsec := math.Modf(timeInFloat)
+	return time.Unix(int64(sec), int64(nsec*1e9))
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #3515 

Moved `timesync` message support to #3546 

#### Changes
<!-- What are the changes made in this pull request? -->

- Measure RTT only for valid TxAcks.
- Add sanity check for round trip time
- Update tests

#### Testing

<!-- How did you verify that this change works? -->

UT (testing on gateway ongoing)

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Traffic test on physical gateways should cover regressions.


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
