### PR TITLE
Remove generated gateway secret key ID from populated test gateways

### DIFF
--- a/pkg/identityserver/store/populate.go
+++ b/pkg/identityserver/store/populate.go
@@ -52,6 +52,11 @@ func NewPopulator(size int, seed int64) *Populator {
 		gateway := ttnpb.NewPopulatedGateway(randy, false)
 		gateway.Description = fmt.Sprintf("Random Gateway %d", i+1)
 		gatewayID := gateway.EntityIdentifiers()
+
+		// This is to prevent the IS trying to use the randomly generated key ID to decrypt the secret.
+		if gateway.LBSLNSSecret != nil {
+			gateway.LBSLNSSecret.KeyID = ""
+		}
 		p.Gateways = append(p.Gateways, gateway)
 		p.APIKeys[gatewayID] = append(
 			p.APIKeys[gatewayID],


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Remove generated gateway secret key ID from populated test gateways. This is one of those wtf ones.

When the [IS test generates gateways](https://github.com/TheThingsNetwork/lorawan-stack/blob/843230b552e156457088f885e3cec5ee5c68accb/pkg/identityserver/store/populate.go#L52), it also pre-fills the `KeyID` of the `LBSLNSSecret`. This should normally fail the `ListGateways` test case since the IS should ideally fail trying to decrypt the message using a non-existent randomly generated  key ID.

But, all current tests pass. 🤷 

I noticed this issue only when implementing https://github.com/TheThingsNetwork/lorawan-stack/pull/3571.

```
 INFO Finished unary call                      duration=46.984916ms error=error:pkg/crypto/cryptoutil:key_not_found (key with ID `cgd1sIVlybew9YZ2j7ZsXlLxPbk16MBFHen6dIBpRs0YhBFElVUfvk87DLyttQBIxTrzNsK7aAmVJNkLELA7C2dJvRlCChbd` not found) error_correlation_id=e25f6b3af6414b49b03f7d3cd3ae7d2a error_name=key_not_found error_namespace=pkg/crypto/cryptoutil grpc_code=NotFound grpc_method=List grpc_service=ttn.lorawan.v3.GatewayRegistry id=cgd1sIVlybew9YZ2j7ZsXlLxPbk16MBFHen6dIBpRs0YhBFElVUfvk87DLyttQBIxTrzNsK7aAmVJNkLELA7C2dJvRlCChbd namespace=grpc request_id=01ES11E12WZKAWA1HD5RWEYW47 test_name=TestGatewaysSecrets
 DEBUG Finished unary call                      duration=47.312849ms error=rpc error: code = NotFound desc = error:pkg/crypto/cryptoutil:key_not_found (key with ID `cgd1sIVlybew9YZ2j7ZsXlLxPbk16MBFHen6dIBpRs0YhBFElVUfvk87DLyttQBIxTrzNsK7aAmVJNkLELA7C2dJvRlCChbd` not found) error_correlation_id=e25f6b3af6414b49b03f7d3cd3ae7d2a error_name=key_not_found error_namespace=pkg/crypto/cryptoutil grpc_code=NotFound grpc_method=List grpc_service=ttn.lorawan.v3.GatewayRegistry namespace=grpc test_name=TestGatewaysSecrets
    doc.go:66:
        /Users/krishnaiyereaswaran/go/src/go.thethings.network/lorawan-stack/pkg/identityserver/gateway_registry_test.go:533
        Expected: nil
        Actual:   'error:pkg/crypto/cryptoutil:key_not_found (key with ID `cgd1sIVlybew9YZ2j7ZsXlLxPbk16MBFHen6dIBpRs0YhBFElVUfvk87DLyttQBIxTrzNsK7aAmVJNkLELA7C2dJvRlCChbd` not found)'
    doc.go:66:
        /Users/krishnaiyereaswaran/go/src/go.thethings.network/lorawan-stack/pkg/identityserver/gateway_registry_test.go:534
        Expected 'nil' to NOT be nil (but it was)!
```
 
For some strange reason, in `v3.10`, the test case only fetches a random gateway with empty LBS LNS key.
```
gateway_id |    description    |   lbs_lns_secret|
|---|---|---|
 qlg3ptcxupy-5-qjohfk            | Random Gateway 12 | \x51695a44767a534f42726c3259736b426f50715172694671737557444a696b4b326e6f4649413657647a6f747136684342327170736b646657696a463063624a79647178374f7932506d3a28fdafb24271f5812099189a89294c2616d9781c8989066fad1b4968c4a1d1b2f3aae5ea8418e246693c4ba8804ba57030c3
 equ-nms1                        | Random Gateway 7  | \x
 ae-pgvjpd6oxd-7ebu              | Random Gateway 2  | \x49456478763a0237422cc8f2724e4180a525e56bcfad95dcc4aaa5e2f6b490996507ededcba6cf73d36a
 j5wr-uozymq9m                   | Random Gateway 5  | \x
 foo-with-secret                 |                   | \x69732d746573743ad244efa9bf08bbc2c8d9dc7928cd9a3b879e984dc50e4d30bd630629d80f629d4528cc64bc977533db0b35658fb850
 f-0k67tahw48a9vfab-sj           | Random Gateway 13 | \x4139784c7a4d65436e4849334446786b63385033586b716e75414f476f42376e51526e64797054757378536447534467574246576a646843705941614e434f76387249316d4f724b6e36733ae752f38a32af0b1100096c
 g6p82l0x6n0-m759gc7-l           | Random Gateway 10 | \x536e647935496946535956535039337246397933364169436c394e4a6d434469477650645069687a614f7a6d346a443134484f496f5564476e48744a784c4a477948723868637671654868476931363a79f54e0a41bcbdabef766f1798524883c96bc5198ee8478d6b21d591535248e619eea5007ddc224086675068cd4ceb5db0c290ef2e17fffeb360858cde4cbe9dcb6077c864aa1495e33481305630c0221d8a764ef40a60fac9858ddee54a4de8362a5c
 79-li3k-jw6n793k1               | Random Gateway 1  | \x
 fj1-xbozochg8                   | Random Gateway 11 | \x4d34765a397a38726b577871444b44556f373477667076676a4d3866316c4977764f473ab64b3460af2614aeed0d9ca2e424d26463a1a531c1a508755b8b781f1a9d3d778a50c9cf5d723bb47ef791642298179494721c03f9546a555f794c41ef8f
 pddic7av-feuq2                  | Random Gateway 15 | \x7834703143724d51396374794c613465464a697870676451684f62755a6147616b70546f49756f4c4b6d444c6459766f566c4872504b7a633553415430454a796a4235355264626259766e7a6c6543436f6466714c7576554f6f7a476e31763a41f087babe2133cc23c8c9f4a4c389a0bc7a70e9ffe5a02fc4049eb49ba2e6414bbb11
 n-zskel8p1d7kg6v-sqxsci-k       | Random Gateway 6  | \x6d44614d4d4f4f38583a147ba5de526f352d4ee3fb156895a84a2f1854a125a7d5a5ddd0c424daad7675
 oevo                            | Random Gateway 3  | \x4d4b75304f52706f3162613553394d3171614b6438415158434e4a566c5638537533586d4d3553306a3a44b7b6a45c4173912a0b04ef25ba9ebfac5e07172f4dbfd311e0a86db044bbcfc717ca9939
 yixqdfg296cle5-7ljrbf-3j7h      | Random Gateway 8  | \x
 foo-without-encryption-key      |                   | \x3a6d792076657279207365637265742076616c7565
 6kpmlwy8oes9u-vetcxq-eemvvw-bv8 | Random Gateway 9  | \x6974377a4b6b307666497575676e477a78503974726258727a4b396759784d37746764304f416d7631455158464c7855774d634e574b4344396338584f395a5933736b42306a784b53317265626467384c6356794a447768713a2e086bd34e4b1c4b1c53c5076de0c6a3523d5b92dd9af92722f616770096edc5d5bcd65bd6b6adbc5066bb1812ab273dd89abbaa43c1ee7e1facb44caa711c0ea12d80
 2dwsv-4m10l1k7                  | Random Gateway 14 | \x7843586776547974796b4a6444696c51516f4a356d534c756a52396c74543935746871505638543a189e8b013fa22f3f4665156b
 hqldozd-tm4a9dxcz-o50r          | Random Gateway 4  | \x70643afc327f83d0c64e35bf3a74feb2ed300c37d764ef283f2caca088c8f08352
```

In https://github.com/TheThingsNetwork/lorawan-stack/pull/3571;
```
 gateway_id  |    description    |   lbs_lns_secret|
 |---|---|---|
 9jsgqdh57c-erw-0lhv-rdg0        | Random Gateway 15 | \x3ad26eb7e1e09176b03d1e9aeb34bffa347c06f93ba370005bec4d866e9a24e69967ae25aaf612ccb749ded2147c80276ec3c870620b42
 z4lj-4217jgij3q                 | Random Gateway 9  | \x3aa758b0e7fc070d4a878287aeb71c8a6074cb312595412fe42938774d569c5a08d810aa191376265efcb50f094cdc8d2584864cace428
 fz1cq129-gc2bz-k3vaikeba16g     | Random Gateway 2  | \x3a577d
 t6-8wnulh2orx-ln-36395b5q7n     | Random Gateway 10 | \x3ae84e5926fefea759197b4544fc1acfc6de113d88398d2cf3032e0d33bb63e1f23cd3d822ee94d78418b5d616354855a15b86117b010378a6b90c87852e67934588be3f1382f44cee9255697b16c453f1fedeb622fb23d645
 foo-with-secrets                |                   | \x69732d746573743a72927920944e697d882f8fc7965160e8454dd3e7b87767f03c8dd9dc9bd91be53819932c94e00535ad7caf2bc8350a
 14-2ereravqjord7lxt-93          | Random Gateway 13 | \x3ac1e12dd7b9a89b1c47692fe533e5ff05d8369a8125a619a85bd25f52d8c64bf44fd131426b9dbc2dc67dcd7726712e1e7f5eb41ecccfa8f910574834ac23cf
 3hzrii3wjjvdza2w-8twz5g         | Random Gateway 6  | \x
 xi-xz1fnm                       | Random Gateway 12 | \x3aebb457b8c4e3eba56628b228352526dd8d1abf178fc0048f2c2137a839c584b42b6f73945bda912521febacb9fa4f3e3f26f75
 2y2ogr8vyp-tv                   | Random Gateway 11 | \x3aa32b0bcd91f5faea965d30eb3e91e5bba6fd6a43d69c0e1287dac55688bce684
 d0wscib3t-5mgvi2-r              | Random Gateway 4  | \x
 79-li3k-jw6n793k1               | Random Gateway 1  | \x
 qme-r31p-cqj5cc7pd9s4301uhmaex5 | Random Gateway 3  | \x3a16e2c49f9a171f06f191013f5e78b0ad74c780d7311b64a7afcac2e66838dfbea7ed4e9bb5c7b8d2d5c3a1c9716ebc
 g-5ru06up2bty-d5q               | Random Gateway 7  | \x3af3260e680f43ec95c430a93df2c299f0c7581510593d9d57e767b60f1a73144f
 8f8l-mdcgy0pnr91yyg6d-mb2-jn    | Random Gateway 5  | \x3a6bdbfbe7bff270d07b94bcf2343c2493e4abab2c1aec1420df4b49752d13e8ebafb43f06b535ea2b7c73336f85d2c6d20bb4748211c8efc510bc333412ebe374bbacbf924e8ff20053087ab6c35d53552f602f93295d8fb3d18c966e5593245bab2d88
 foo-without-encryption-key      |                   | \x3a6d792076657279207365637265742076616c7565
 y-39lpsjo3n2                    | Random Gateway 14 | \x3abd93acd50aead1554881c45e900713953377e15b3194
 trdg-cs-wqxpynslclaw-wn789f     | Random Gateway 8  | \x3a7c70cfc4a6a78a
```

So I'm not sure yet what is the source of this flake. Perhaps adding a new `Secret` field to the gateway alters the way the [random test gateways are populated](https://github.com/TheThingsNetwork/lorawan-stack/blob/694b1ea761a769e7ea81fe3a77a69b77fb0d317e/pkg/ttnpb/gateway.pb.go#L4756-L4758).

#### Changes
<!-- What are the changes made in this pull request? -->

- Unset `gateway.LBSLNSSecret.KeyID` in the populated gateway.


#### Testing

<!-- How did you verify that this change works? -->

Verified as a part of https://github.com/TheThingsNetwork/lorawan-stack/pull/3571

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Handled in https://github.com/TheThingsNetwork/lorawan-stack/pull/3571

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- Once merged to `v3.11`, repeat for `gateway.ClaimAuthenticationCode.KeyID`.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
