### PR TITLE
Add user session access method to rights and id lookup

### DIFF
--- a/pkg/ttnpb/identityserver.go
+++ b/pkg/ttnpb/identityserver.go
@@ -24,6 +24,8 @@ func (m *AuthInfoResponse) GetEntityIdentifiers() *EntityIdentifiers {
 		return &accessMethod.APIKey.EntityIDs
 	case *AuthInfoResponse_OAuthAccessToken:
 		return accessMethod.OAuthAccessToken.UserIDs.EntityIdentifiers()
+	case *AuthInfoResponse_UserSession:
+		return accessMethod.UserSession.UserIdentifiers.EntityIdentifiers()
 	}
 	return nil
 }
@@ -38,6 +40,8 @@ func (m *AuthInfoResponse) GetRights() []Right {
 		return accessMethod.APIKey.Rights
 	case *AuthInfoResponse_OAuthAccessToken:
 		return accessMethod.OAuthAccessToken.Rights
+	case *AuthInfoResponse_UserSession:
+		return RightsFrom(RIGHT_ALL).Implied().GetRights()
 	}
 	return nil
 }


### PR DESCRIPTION
#### Summary
This quickfix PR adds the `UserSession` access method to the lookups for rights and entity ID lookups. Without this, non-admin users won't have any rights when using the session token authorization.

#### Changes
- Add user session access method to rights and id lookup


#### Testing

Manual testing in oauth and console.

##### Regressions

It should not have any effect on other access methods.


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
