### PR TITLE
Device Repository Message Processor

### DIFF
--- a/pkg/messageprocessors/devicerepository/devicerepository.go
+++ b/pkg/messageprocessors/devicerepository/devicerepository.go
@@ -1,0 +1,160 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package devicerepository
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/bluele/gcache"
+	"go.thethings.network/lorawan-stack/v3/pkg/log"
+	"go.thethings.network/lorawan-stack/v3/pkg/messageprocessors"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"golang.org/x/sync/singleflight"
+	"google.golang.org/grpc"
+)
+
+type codecType string
+
+const (
+	downlinkEncoder = codecType("downlinkEncoder")
+	downlinkDecoder = codecType("downlinkDecoder")
+	uplinkDecoder   = codecType("uplinkDecoder")
+
+	// cacheTTL is the TTL for cached payload formatters.
+	cacheTTL = time.Hour
+	// cacheErrorTTL is the TTL for cached payload formatters, when there was an error retrieving them.
+	cacheErrorTTL = 5 * time.Minute
+	// cacheSize is the cache size.
+	cacheSize = 500
+)
+
+type getCodecFunc func(ctx context.Context, req *ttnpb.GetPayloadFormatterRequest, opts ...grpc.CallOption) (*ttnpb.MessagePayloadFormatter, error)
+
+func (c codecType) codecFunc(client ttnpb.DeviceRepositoryClient) getCodecFunc {
+	switch c {
+	case downlinkDecoder:
+		return client.GetDownlinkDecoder
+	case downlinkEncoder:
+		return client.GetDownlinkEncoder
+	case uplinkDecoder:
+		return client.GetUplinkDecoder
+	default:
+		panic(fmt.Sprintf("Invalid codec type: %v", c))
+	}
+}
+
+// Cluster represents the interface the cluster.
+type Cluster interface {
+	GetPeerConn(ctx context.Context, role ttnpb.ClusterRole, ids ttnpb.Identifiers) (*grpc.ClientConn, error)
+	WithClusterAuth() grpc.CallOption
+}
+
+// cacheItem stores the payload formatter as well as the error response.
+type cacheItem struct {
+	formatter *ttnpb.MessagePayloadFormatter
+	err       error
+}
+
+type host struct {
+	ctx context.Context
+
+	cluster   Cluster
+	processor messageprocessors.PayloadProcessor
+
+	singleflight singleflight.Group
+	cache        gcache.Cache
+}
+
+// New creates a new PayloadEncodeDecoder that retrieves codecs from the Device Repository
+// and uses an underlying PayloadEncodeDecoder to execute them.
+func New(processor messageprocessors.PayloadProcessor, cluster Cluster) messageprocessors.PayloadEncodeDecoder {
+	return &host{
+		cluster:   cluster,
+		processor: processor,
+
+		cache: gcache.New(cacheSize).LFU().Build(),
+	}
+}
+
+func cacheKey(codec codecType, version *ttnpb.EndDeviceVersionIdentifiers) string {
+	return fmt.Sprintf("%s:%s:%s:%s:%v", version.BrandID, version.ModelID, version.FirmwareVersion, version.BandID, codec)
+}
+
+func (h *host) retrieve(ctx context.Context, codec codecType, ids ttnpb.ApplicationIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers) (*ttnpb.MessagePayloadFormatter, error) {
+	key := cacheKey(codec, version)
+	if cachedInterface, err := h.cache.Get(key); err == nil {
+		cached := cachedInterface.(cacheItem)
+		return cached.formatter, cached.err
+	}
+	cc, err := h.cluster.GetPeerConn(ctx, ttnpb.ClusterRole_DEVICE_REPOSITORY, nil)
+	if err != nil {
+		return nil, err
+	}
+	result, err, _ := h.singleflight.Do(key, func() (interface{}, error) {
+		f := codec.codecFunc(ttnpb.NewDeviceRepositoryClient(cc))
+		formatter, err := f(ctx, &ttnpb.GetPayloadFormatterRequest{
+			ApplicationIDs: ids,
+			VersionIDs:     version,
+		}, h.cluster.WithClusterAuth())
+
+		expire := cacheTTL
+		if err != nil {
+			expire = cacheErrorTTL
+		}
+		if err := h.cache.SetWithExpire(key, cacheItem{formatter, err}, expire); err != nil {
+			log.FromContext(h.ctx).WithError(err).Error("Failed to cache payload formatter")
+		}
+		return formatter, err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*ttnpb.MessagePayloadFormatter), nil
+}
+
+// EncodeDownlink encodes a downlink message.
+func (h *host) EncodeDownlink(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationDownlink, parameter string) error {
+	res, err := h.retrieve(ctx, downlinkEncoder, ids.ApplicationIdentifiers, version)
+	if err != nil {
+		return err
+	}
+	return h.processor.EncodeDownlink(ctx, ids, version, message, res.Formatter, res.FormatterParameter)
+}
+
+// DecodeUplink decodes an uplink message.
+func (h *host) DecodeUplink(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationUplink, parameter string) error {
+	res, err := h.retrieve(ctx, uplinkDecoder, ids.ApplicationIdentifiers, version)
+	if err != nil {
+		return err
+	}
+	if err != nil {
+		return err
+	}
+	return h.processor.DecodeUplink(ctx, ids, version, message, res.Formatter, res.FormatterParameter)
+}
+
+// DecodeDownlink decodes a downlink message.
+func (h *host) DecodeDownlink(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationDownlink, parameter string) error {
+	res, err := h.retrieve(ctx, downlinkDecoder, ids.ApplicationIdentifiers, version)
+	if err != nil {
+		return err
+	}
+	if err != nil {
+		return err
+	}
+	return h.processor.DecodeDownlink(ctx, ids, version, message, res.Formatter, res.FormatterParameter)
+}

--- a/pkg/messageprocessors/devicerepository/devicerepository_test.go
+++ b/pkg/messageprocessors/devicerepository/devicerepository_test.go
@@ -1,0 +1,286 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package devicerepository_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/v3/pkg/cluster"
+	"go.thethings.network/lorawan-stack/v3/pkg/component"
+	componenttest "go.thethings.network/lorawan-stack/v3/pkg/component/test"
+	"go.thethings.network/lorawan-stack/v3/pkg/config"
+	dr_processor "go.thethings.network/lorawan-stack/v3/pkg/messageprocessors/devicerepository"
+	"go.thethings.network/lorawan-stack/v3/pkg/rpcserver"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+)
+
+// mockProcessor is a mock messageprocessors.PayloadEncodeDecoder
+type mockProcessor struct {
+	ch  chan *ttnpb.MessagePayloadFormatter
+	err error
+}
+
+func (p *mockProcessor) handle(formatter ttnpb.PayloadFormatter, parameter string) error {
+	if p.err == nil {
+		p.ch <- &ttnpb.MessagePayloadFormatter{
+			Formatter:          formatter,
+			FormatterParameter: parameter,
+		}
+	}
+	return p.err
+}
+
+func (p *mockProcessor) EncodeDownlink(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationDownlink, formatter ttnpb.PayloadFormatter, parameter string) error {
+	return p.handle(formatter, parameter)
+}
+
+func (p *mockProcessor) DecodeUplink(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationUplink, formatter ttnpb.PayloadFormatter, parameter string) error {
+	return p.handle(formatter, parameter)
+}
+
+func (p *mockProcessor) DecodeDownlink(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationDownlink, formatter ttnpb.PayloadFormatter, parameter string) error {
+	return p.handle(formatter, parameter)
+}
+
+type mockDR struct {
+	uplinkDecoders,
+	downlinkDecoders,
+	downlinkEncoders map[string]*ttnpb.MessagePayloadFormatter
+}
+
+func (dr *mockDR) ListBrands(_ context.Context, _ *ttnpb.ListEndDeviceBrandsRequest) (*ttnpb.ListEndDeviceBrandsResponse, error) {
+	panic("not implemented")
+}
+
+func (dr *mockDR) GetBrand(_ context.Context, _ *ttnpb.GetEndDeviceBrandRequest) (*ttnpb.EndDeviceBrand, error) {
+	panic("not implemented")
+}
+
+func (dr *mockDR) ListModels(_ context.Context, _ *ttnpb.ListEndDeviceModelsRequest) (*ttnpb.ListEndDeviceModelsResponse, error) {
+	panic("not implemented")
+}
+
+func (dr *mockDR) GetModel(_ context.Context, _ *ttnpb.GetEndDeviceModelRequest) (*ttnpb.EndDeviceModel, error) {
+	panic("not implemented")
+}
+
+func (dr *mockDR) GetTemplate(_ context.Context, _ *ttnpb.GetTemplateRequest) (*ttnpb.EndDeviceTemplate, error) {
+	panic("not implemented")
+}
+
+func (dr *mockDR) key(ids *ttnpb.EndDeviceVersionIdentifiers) string {
+	return fmt.Sprintf("%s:%s:%s:%s", ids.BrandID, ids.ModelID, ids.FirmwareVersion, ids.BandID)
+}
+
+var (
+	mockError = fmt.Errorf("mock_error")
+)
+
+func (dr *mockDR) GetUplinkDecoder(_ context.Context, req *ttnpb.GetPayloadFormatterRequest) (*ttnpb.MessagePayloadFormatter, error) {
+	f, ok := dr.uplinkDecoders[dr.key(req.VersionIDs)]
+	if !ok {
+		return nil, mockError
+	}
+	return f, nil
+}
+
+func (dr *mockDR) GetDownlinkDecoder(_ context.Context, req *ttnpb.GetPayloadFormatterRequest) (*ttnpb.MessagePayloadFormatter, error) {
+	f, ok := dr.downlinkDecoders[dr.key(req.VersionIDs)]
+	if !ok {
+		return nil, mockError
+	}
+	return f, nil
+}
+
+func (dr *mockDR) GetDownlinkEncoder(_ context.Context, req *ttnpb.GetPayloadFormatterRequest) (*ttnpb.MessagePayloadFormatter, error) {
+	f, ok := dr.downlinkEncoders[dr.key(req.VersionIDs)]
+	if !ok {
+		return nil, mockError
+	}
+	return f, nil
+}
+
+// start mock device repository and return listen address.
+func (dr *mockDR) start(ctx context.Context) string {
+	srv := rpcserver.New(ctx)
+	ttnpb.RegisterDeviceRepositoryServer(srv.Server, dr)
+	lis, err := net.Listen("tcp", ":0")
+	if err != nil {
+		panic(err)
+	}
+	go srv.Serve(lis)
+	return lis.Addr().String()
+}
+
+func mustHavePeer(ctx context.Context, c *component.Component, role ttnpb.ClusterRole) {
+	for i := 0; i < 20; i++ {
+		time.Sleep(20 * time.Millisecond)
+		if _, err := c.GetPeer(ctx, role, nil); err == nil {
+			return
+		}
+	}
+	panic("could not connect to peer")
+}
+
+func TestDeviceRepository(t *testing.T) {
+	ids := &ttnpb.EndDeviceVersionIdentifiers{
+		BrandID:         "brand",
+		ModelID:         "model",
+		FirmwareVersion: "1.0",
+		HardwareVersion: "1.1",
+		BandID:          "band",
+	}
+	idsNotFound := &ttnpb.EndDeviceVersionIdentifiers{
+		BrandID:         "brand2",
+		ModelID:         "model1",
+		FirmwareVersion: "1.0",
+		HardwareVersion: "1.1",
+		BandID:          "band",
+	}
+	devID := ttnpb.EndDeviceIdentifiers{
+		DeviceID: "dev1",
+		ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{
+			ApplicationID: "app1",
+		},
+	}
+
+	dr := &mockDR{
+		uplinkDecoders:   make(map[string]*ttnpb.MessagePayloadFormatter),
+		downlinkDecoders: make(map[string]*ttnpb.MessagePayloadFormatter),
+		downlinkEncoders: make(map[string]*ttnpb.MessagePayloadFormatter),
+	}
+	dr.uplinkDecoders[dr.key(ids)] = &ttnpb.MessagePayloadFormatter{
+		Formatter:          ttnpb.PayloadFormatter_FORMATTER_JAVASCRIPT,
+		FormatterParameter: "uplink decoder",
+	}
+	dr.downlinkDecoders[dr.key(ids)] = &ttnpb.MessagePayloadFormatter{
+		Formatter:          ttnpb.PayloadFormatter_FORMATTER_JAVASCRIPT,
+		FormatterParameter: "downlink decoder",
+	}
+	dr.downlinkEncoders[dr.key(ids)] = &ttnpb.MessagePayloadFormatter{
+		Formatter:          ttnpb.PayloadFormatter_FORMATTER_JAVASCRIPT,
+		FormatterParameter: "downlink encoder",
+	}
+	drAddr := dr.start(test.Context())
+
+	ctx := test.Context()
+	mockProcessor := &mockProcessor{
+		ch:  make(chan *ttnpb.MessagePayloadFormatter, 1),
+		err: nil,
+	}
+
+	// start mock device repository
+	c := componenttest.NewComponent(t, &component.Config{
+		ServiceBase: config.ServiceBase{
+			GRPC: config.GRPC{
+				Listen:                      ":0",
+				AllowInsecureForCredentials: true,
+			},
+			Cluster: cluster.Config{
+				DeviceRepository: drAddr,
+			},
+		},
+	})
+	componenttest.StartComponent(t, c)
+	defer c.Close()
+
+	mustHavePeer(ctx, c, ttnpb.ClusterRole_DEVICE_REPOSITORY)
+
+	p := dr_processor.New(mockProcessor, c)
+
+	t.Run("DeviceNotFound", func(t *testing.T) {
+		err := p.DecodeDownlink(test.Context(), devID, idsNotFound, nil, "")
+		a := assertions.New(t)
+		a.So(err.Error(), should.ContainSubstring, mockError.Error())
+
+		select {
+		case <-mockProcessor.ch:
+			t.Error("Expected timeout but processor was called instead")
+			t.FailNow()
+		case <-time.After(30 * time.Millisecond):
+		}
+	})
+
+	t.Run("UplinkDecoder", func(t *testing.T) {
+		err := p.DecodeUplink(test.Context(), devID, ids, nil, "")
+		a := assertions.New(t)
+		a.So(err, should.BeNil)
+
+		select {
+		case f := <-mockProcessor.ch:
+			a.So(f, should.Resemble, &ttnpb.MessagePayloadFormatter{
+				Formatter:          ttnpb.PayloadFormatter_FORMATTER_JAVASCRIPT,
+				FormatterParameter: "uplink decoder",
+			})
+		case <-time.After(time.Second):
+			t.Error("Timed out waiting for message processor")
+			t.FailNow()
+		}
+	})
+
+	t.Run("DownlinkDecoder", func(t *testing.T) {
+		err := p.DecodeDownlink(test.Context(), devID, ids, nil, "")
+		a := assertions.New(t)
+		a.So(err, should.BeNil)
+
+		select {
+		case f := <-mockProcessor.ch:
+			a.So(f, should.Resemble, &ttnpb.MessagePayloadFormatter{
+				Formatter:          ttnpb.PayloadFormatter_FORMATTER_JAVASCRIPT,
+				FormatterParameter: "downlink decoder",
+			})
+		case <-time.After(time.Second):
+			t.Error("Timed out waiting for message processor")
+			t.FailNow()
+		}
+	})
+	t.Run("DownlinkEncoder", func(t *testing.T) {
+		err := p.EncodeDownlink(test.Context(), devID, ids, nil, "")
+		a := assertions.New(t)
+		a.So(err, should.BeNil)
+
+		select {
+		case f := <-mockProcessor.ch:
+			a.So(f, should.Resemble, &ttnpb.MessagePayloadFormatter{
+				Formatter:          ttnpb.PayloadFormatter_FORMATTER_JAVASCRIPT,
+				FormatterParameter: "downlink encoder",
+			})
+		case <-time.After(time.Second):
+			t.Error("Timed out waiting for message processor")
+			t.FailNow()
+		}
+	})
+
+	t.Run("ProcessorError", func(t *testing.T) {
+		mockProcessor.err = mockError
+		a := assertions.New(t)
+
+		err := p.DecodeDownlink(test.Context(), devID, ids, nil, "")
+		a.So(err.Error(), should.ContainSubstring, mockError.Error())
+		err = p.DecodeUplink(test.Context(), devID, ids, nil, "")
+		a.So(err.Error(), should.ContainSubstring, mockError.Error())
+		err = p.EncodeDownlink(test.Context(), devID, ids, nil, "")
+		a.So(err.Error(), should.ContainSubstring, mockError.Error())
+
+		mockProcessor.err = nil
+	})
+}

--- a/pkg/messageprocessors/payload.go
+++ b/pkg/messageprocessors/payload.go
@@ -26,3 +26,10 @@ type PayloadEncodeDecoder interface {
 	DecodeUplink(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationUplink, parameter string) error
 	DecodeDownlink(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationDownlink, parameter string) error
 }
+
+// PayloadProcessor provides an interface to processing payloads of multiple formats.
+type PayloadProcessor interface {
+	EncodeDownlink(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationDownlink, formatter ttnpb.PayloadFormatter, parameter string) error
+	DecodeUplink(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationUplink, formatter ttnpb.PayloadFormatter, parameter string) error
+	DecodeDownlink(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationDownlink, formatter ttnpb.PayloadFormatter, parameter string) error
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #3433

#### Changes
<!-- What are the changes made in this pull request? -->

- Create a new message processor that handles `PayloadFormatter_DEVICE_REPOSITORY`.
- Connects with a client to the Device Repository peer, retrieves the codes and executes the proper message processor.
- Some of the logic is similar to the existing behaviour in AS (choose message processor from a map of supported processors based on formatter type). We could probably refactor this to extract the logic from AS and re-use it, but I want to avoid creating a very large diff, and focus on DR stuff instead.

#### Testing

<!-- How did you verify that this change works? -->

Unit testing with mock device repo + mock message processors

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

No regressions for existing behaviour

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- Using the cluster peer with role DEVICE_REPOSITORY, with cluster auth. The message processor is agnostic to the AS, it accepts functions to retrieve the `*grpc.ClientConn` and the necessary `grpc.CallOption`s
- Using a `singleflight.Group` for fetching codecs, to avoid unnecessary duplicate calls.
- The code does not take into account the validity of the `*ttnpb.EndDeviceVersionIdentifiers`. We could do something simple here, like checking for empty values and fail early (and avoid unnecessary round-trips to the device repository).

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
