### PR TITLE
Show missing data warning message when applicable only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Removed misleading warning message for missing package data when setting up the storage integration package association.
+
 ### Security
 
 ## [3.10.4] - 2020-12-08

--- a/cmd/ttn-lw-cli/commands/applications_packages.go
+++ b/cmd/ttn-lw-cli/commands/applications_packages.go
@@ -38,6 +38,10 @@ var (
 
 	selectAllApplicationPackageAssociationsFlags        = util.SelectAllFlagSet("application package association")
 	selectAllApplicationPackageDefaultAssociationsFlags = util.SelectAllFlagSet("application package default association")
+
+	packageNeedsData = map[string]struct{}{
+		"lora-cloud-device-management-v1": {},
+	}
 )
 
 func applicationPackageAssociationIDFlags() *pflag.FlagSet {
@@ -258,7 +262,9 @@ var (
 
 			reader, err := getDataReader("data", cmd.Flags())
 			if err != nil {
-				logger.WithError(err).Warn("Package data not available")
+				if _, needsData := packageNeedsData[association.PackageName]; needsData {
+					logger.WithError(err).Warn("Package data not available")
+				}
 			} else {
 				var st types.Struct
 				err := jsonpb.TTN().NewDecoder(reader).Decode(&st)
@@ -401,7 +407,9 @@ var (
 
 			reader, err := getDataReader("data", cmd.Flags())
 			if err != nil {
-				logger.WithError(err).Warn("Package data not available")
+				if _, needsData := packageNeedsData[association.PackageName]; needsData {
+					logger.WithError(err).Warn("Package data not available")
+				}
 			} else {
 				var st types.Struct
 				err := jsonpb.TTN().NewDecoder(reader).Decode(&st)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #3584

#### Changes
<!-- What are the changes made in this pull request? -->

- Print warning when the application package for packages where that makes sense. For now, this is `lora-cloud-device-management-v1` only.

#### Testing

<!-- How did you verify that this change works? -->

- `cli app pkg association set --package-name storage-integration-v1 ...` does not print a warning message
- `cli app pkg association set --package-name lora-cloud-device-management-v1 ...` does

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

...

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [X] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
