### PR TITLE
Add simple markdown to backend error messages

### DIFF
--- a/cypress/integration/console/shared/collaborators/add.spec.js
+++ b/cypress/integration/console/shared/collaborators/add.spec.js
@@ -96,7 +96,7 @@ describe('Collaborators', () => {
 
       cy.findByTestId('error-notification')
         .should('be.visible')
-        .findByText(`user \`${userNotExist}\` not found`)
+        .findByText(userNotExist)
         .should('be.visible')
       cy.visit(
         `${Cypress.config('consoleRootPath')}/applications/${applicationId}/collaborators/add`,
@@ -124,7 +124,7 @@ describe('Collaborators', () => {
 
       cy.findByTestId('error-notification')
         .should('be.visible')
-        .findByText(`organization \`${orgNotExist}\` not found`)
+        .findByText(orgNotExist)
         .should('be.visible')
       cy.visit(
         `${Cypress.config('consoleRootPath')}/applications/${applicationId}/collaborators/add`,
@@ -169,7 +169,7 @@ describe('Collaborators', () => {
 
       cy.findByTestId('error-notification')
         .should('be.visible')
-        .findByText(`user \`${userNotExist}\` not found`)
+        .findByText(userNotExist)
         .should('be.visible')
       cy.visit(`${Cypress.config('consoleRootPath')}/gateways/${gatewayId}/collaborators/add`)
     })
@@ -195,7 +195,7 @@ describe('Collaborators', () => {
 
       cy.findByTestId('error-notification')
         .should('be.visible')
-        .findByText(`organization \`${orgNotExist}\` not found`)
+        .findByText(orgNotExist)
         .should('be.visible')
       cy.visit(`${Cypress.config('consoleRootPath')}/gateways/${gatewayId}/collaborators/add`)
     })
@@ -240,7 +240,7 @@ describe('Collaborators', () => {
 
       cy.findByTestId('error-notification')
         .should('be.visible')
-        .findByText(`user \`${userNotExist}\` not found`)
+        .findByText(userNotExist)
         .should('be.visible')
       cy.visit(`${Cypress.config('consoleRootPath')}/organizations/${testOrgId}/collaborators/add`)
     })
@@ -253,7 +253,7 @@ describe('Collaborators', () => {
 
       cy.findByTestId('error-notification')
         .should('be.visible')
-        .findByText('account of type `organization` can not collaborate on `organization`')
+        .findByText(/can not collaborate/i)
         .should('be.visible')
       cy.visit(`${Cypress.config('consoleRootPath')}/organizations/${testOrgId}/collaborators/add`)
     })
@@ -266,7 +266,7 @@ describe('Collaborators', () => {
 
       cy.findByTestId('error-notification')
         .should('be.visible')
-        .findByText(`organization \`${orgNotExist}\` not found`)
+        .findByText(orgNotExist)
         .should('be.visible')
       cy.visit(`${Cypress.config('consoleRootPath')}/organizations/${testOrgId}/collaborators/add`)
     })

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "react-redux": "^7.1.0",
     "react-router-dom": "^5.1.2",
     "react-select": "^3.1.0",
+    "react-string-replace": "^0.4.4",
     "react-text-mask": "^5.4.3",
     "react-toastify": "^6.0.9",
     "react-virtualized-auto-sizer": "^1.0.2",

--- a/pkg/webui/components/error-notification/story.js
+++ b/pkg/webui/components/error-notification/story.js
@@ -42,11 +42,28 @@ const exampleError = {
   ],
 }
 
+const testErrorWithMarkup = {
+  code: 2,
+  message: 'error:pkg/assets:http (HTTP error: `` is not a valid ID.',
+  details: [
+    {
+      '@type': 'type.googleapis.com/ttn.lorawan.v3.ErrorDetails',
+      namespace: 'pkg/assets',
+      name: 'http',
+      message_format: 'HTTP error: {message}',
+      attributes: {
+        message: '`12345` is not a valid ID.',
+      },
+    },
+  ],
+}
+
 storiesOf('Notification/ErrorNotification', module).add('Error', () => (
   <div>
     <ErrorNotification title="example message title" content={m.problem} />
     <ErrorNotification content={m.problem} />
     <ErrorNotification title={m.lengthyProblem} content={exampleError} small />
     <ErrorNotification content={exampleError} small />
+    <ErrorNotification title="example of error with markup" content={testErrorWithMarkup} />
   </div>
 ))

--- a/pkg/webui/components/notification/index.js
+++ b/pkg/webui/components/notification/index.js
@@ -26,7 +26,7 @@ import Details from './details'
 
 import style from './notification.styl'
 
-const Notification = function({
+const Notification = ({
   content,
   className,
   title,
@@ -41,7 +41,7 @@ const Notification = function({
   actionMessage,
   buttonIcon,
   'data-test-id': dataTestId,
-}) {
+}) => {
   const classname = classnames(style.notification, className, {
     [style.error]: error,
     [style.warning]: warning,
@@ -65,7 +65,7 @@ const Notification = function({
         <div className={style.content}>
           {title && <Message className={style.title} content={title} component="h4" />}
           <div>
-            <Message content={content} values={messageValues} />
+            <Message content={content} values={messageValues} convertBackticks={Boolean(error)} />
             {action && (
               <Button
                 secondary

--- a/pkg/webui/lib/components/error-message/index.js
+++ b/pkg/webui/lib/components/error-message/index.js
@@ -17,12 +17,18 @@ import React from 'react'
 import Message from '@ttn-lw/lib/components/message'
 
 import PropTypes from '@ttn-lw/lib/prop-types'
-import { hasCauses, getBackendErrorRootCause, toMessageProps } from '@ttn-lw/lib/errors/utils'
+import {
+  hasCauses,
+  getBackendErrorRootCause,
+  toMessageProps,
+  isBackend,
+} from '@ttn-lw/lib/errors/utils'
 
-const ErrorMessage = function({ content, withRootCause, className, ...rest }) {
+const ErrorMessage = ({ content, withRootCause, className, ...rest }) => {
   const baseProps = {
     className,
     firstToUpper: true,
+    convertBackticks: Boolean(isBackend(content)),
     ...rest,
   }
 

--- a/pkg/webui/lib/components/message/index.js
+++ b/pkg/webui/lib/components/message/index.js
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 import React from 'react'
-import { FormattedMessage } from 'react-intl'
+import { FormattedMessage, useIntl } from 'react-intl'
 import classnames from 'classnames'
+import reactStringReplace from 'react-string-replace'
 
 import PropTypes from '@ttn-lw/lib/prop-types'
 
@@ -37,7 +38,7 @@ const renderContent = (content, component, props) => {
   return content
 }
 
-const Message = function({
+const Message = ({
   content,
   values = {},
   component,
@@ -47,8 +48,9 @@ const Message = function({
   firstToLower,
   capitalize,
   className,
+  convertBackticks,
   ...rest
-}) {
+}) => {
   const cls = classnames(className, {
     [style.lowercase]: lowercase,
     [style.uppercase]: uppercase,
@@ -56,6 +58,8 @@ const Message = function({
     [style.firstToLower]: firstToLower,
     [style.capitalize]: capitalize,
   })
+
+  const { formatMessage } = useIntl()
 
   if (cls) {
     rest.className = cls
@@ -68,6 +72,17 @@ const Message = function({
 
   if (typeof content === 'string' || typeof content === 'number') {
     return renderContent(content, component, rest)
+  }
+
+  if (convertBackticks) {
+    const contentWithMarkdown = formatMessage(content, vals)
+    return renderContent(
+      reactStringReplace(contentWithMarkdown, /`([^`[]+)`/g, (match, i) => (
+        <code key={i}>{match}</code>
+      )),
+      component,
+      rest,
+    )
   }
 
   return (
@@ -95,6 +110,10 @@ Message.propTypes = {
    * passed through without any modifications.
    */
   content: PropTypes.message.isRequired,
+  /**
+   * Flag specifying whether the the backticks should be converted to `<code/>` tag.
+   */
+  convertBackticks: PropTypes.bool,
   /** Flag specifying whether the first letter of the message should be
    * transformed to lowercase.
    */
@@ -122,6 +141,7 @@ Message.defaultProps = {
   capitalize: false,
   className: undefined,
   component: undefined,
+  convertBackticks: false,
   firstToLower: false,
   firstToUpper: false,
   lowercase: false,

--- a/pkg/webui/lib/errors/utils.js
+++ b/pkg/webui/lib/errors/utils.js
@@ -275,7 +275,7 @@ export const getBackendErrorMessageAttributes = error => error.details[0].attrib
  * @param {object} error - The backend error object.
  * @returns {object} Message props of the error object, or generic error object.
  */
-export const toMessageProps = function(error) {
+export const toMessageProps = error => {
   let props
   // Check if it is a error message and transform it to a intl message.
   if (isBackend(error)) {

--- a/pkg/webui/styles/main.styl
+++ b/pkg/webui/styles/main.styl
@@ -67,6 +67,13 @@ hr
   border: 0
   height: 1px
 
+code
+  font-family: $font-family-mono
+  font-size: $fs.s
+  background-color: $c-text-backdrop
+  padding: 0.1rem $cs.xxs
+  color: $tc-black
+
 // Remove focus from elements when targeted by a mouse.
 // The `focus-visible` class is added on focusable elements
 // automatically when in focus.

--- a/pkg/webui/styles/variables/brand.styl
+++ b/pkg/webui/styles/variables/brand.styl
@@ -24,6 +24,7 @@ $c-icon-fill = #686868
 $c-subtle-fill = #AAA
 $c-backdrop = #F3F3F3
 $c-backdrop-lighter = #FAFAFA
+$c-text-backdrop = #ECECEC
 
 // ## Text
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10075,7 +10075,7 @@ lodash@4.17.19, lodash@^4.17.10, lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
-lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.15:
+lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.4:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -12444,6 +12444,13 @@ react-sizeme@^2.6.7:
     invariant "^2.2.4"
     shallowequal "^1.1.0"
     throttle-debounce "^2.1.0"
+
+react-string-replace@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/react-string-replace/-/react-string-replace-0.4.4.tgz#24006fbe0db573d5be583133df38b1a735cb4225"
+  integrity sha512-FAMkhxmDpCsGTwTZg7p/2v+/GTmxAp73so3fbSvlAcBBX36ujiGRNEaM/1u+jiYQrArhns+7eE92g2pi5E5FUA==
+  dependencies:
+    lodash "^4.17.4"
 
 react-syntax-highlighter@^11.0.2:
   version "11.0.2"


### PR DESCRIPTION
#### Summary

Closes #3581

#### Changes
- Added simple parser that replaces backend error message `back quotes` with `<pre></pre>` tag
- Added simple unit tests for the parser
- Added [dompurify](https://www.npmjs.com/package/dompurify) dependency
- Added example in storybook
![errorWithMarkup](https://user-images.githubusercontent.com/72162194/102238153-1d5a3b00-3efe-11eb-82a3-3b40a2ac2419.jpg)


#### Testing

- Unit tests
- Manually tested in storybook

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
