### PR TITLE
Fix spamming of error-notification logs

### DIFF
--- a/pkg/webui/components/error-notification/index.js
+++ b/pkg/webui/components/error-notification/index.js
@@ -20,7 +20,7 @@ import { isBackend, toMessageProps } from '@ttn-lw/lib/errors/utils'
 import { error } from '@ttn-lw/lib/log'
 import PropTypes from '@ttn-lw/lib/prop-types'
 
-const ErrorNotification = function({ content, ...rest }) {
+const ErrorNotification = ({ content, ...rest }) => {
   const message = toMessageProps(content)
   let details = undefined
 


### PR DESCRIPTION
#### Summary
This is a quickfix for a functionality that was recently added, which logs the content of error notifications to the console. This logging needs to be put into an effect hook to prevent the logs from being issued on ever render.

#### Changes
- Put log into `useEffect(…, [])`


#### Testing

Manual.

##### Regressions

None.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
