### PR TITLE
Prevent header navigation line-breaks

### DIFF
--- a/pkg/webui/components/header/header.styl
+++ b/pkg/webui/components/header/header.styl
@@ -104,6 +104,7 @@ mobile-styles($breakpoint)
   flex-grow: 2
   height: 100%
   max-width: 36rem
+  flex-shrink: 0
 
 .profile-dropdown
   margin-right: -2rem


### PR DESCRIPTION
#### Summary
One line fix to prevent line-breaks in the header navigation (for navigation entries with more than one word).

#### Changes
- Set `flex-shrink` to `0`

#### Testing
Manual.

##### Regressions

None.

#### Notes for Reviewers
The issue did not affect the console (visibly) but it would do, once we'd add a header entry with more than one word. This will become more relevant for the header navigation of the account app, but still good to merge already.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
