### PR TITLE
Rework Network Server matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ For details about compatibility between different releases, see the **Commitment
 
 - Network Server does not store `recent_uplinks`, `recent_adr_uplinks` and `recent_downlinks` anymore.
 - Improved Network Server downlink task performance.
+- Improved Network Server matching performance.
+- Network Server matching mapping in the database.
+  - This requires a database migration (`ttn-lw-stack ns-db migrate`).
 
 ### Deprecated
 
@@ -30,6 +33,7 @@ For details about compatibility between different releases, see the **Commitment
   - While not backwards compatible, the decision to remove linking was heavily motivated by scalability concerns - the previous linking model scales poorly when taking high availability and load balancing concerns into account.
 
 ### Fixed
+
 - Network Server DevStatusReq scheduling conditions in relation to frame counter value.
 
 ### Security

--- a/cmd/ttn-lw-stack/commands/ns_db.go
+++ b/cmd/ttn-lw-stack/commands/ns_db.go
@@ -1,0 +1,320 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"regexp"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+	"github.com/spf13/cobra"
+	nsredis "go.thethings.network/lorawan-stack/v3/pkg/networkserver/redis"
+	ttnredis "go.thethings.network/lorawan-stack/v3/pkg/redis"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/types"
+)
+
+var (
+	nsDBCommand = &cobra.Command{
+		Use:   "ns-db",
+		Short: "Manage Network Server database",
+	}
+	nsDBPruneCommand = &cobra.Command{
+		Use:   "prune",
+		Short: "Remove unused Network Server data",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if config.Redis.IsZero() {
+				panic("Only Redis is supported by this command")
+			}
+
+			logger.Info("Connecting to Redis database...")
+			cl := NewNetworkServerApplicationUplinkQueueRedis(*config)
+			var deleted uint64
+			defer func() { logger.Debugf("%d processed stream entries deleted", deleted) }()
+			return rangeRedisKeys(ctx, cl, nsredis.ApplicationUplinkQueueUIDGenericUplinkKey(cl, "*"), 1, func(k string) (bool, error) {
+				gs, err := cl.XInfoGroups(ctx, k).Result()
+				if err != nil {
+					logger.WithError(err).Errorf("Failed to query groups of stream %q", k)
+					return true, nil
+				}
+				for _, g := range gs {
+					if g.Name != "ns" {
+						logger.Errorf("Unexpected consumer group with name %q found for stream %q", g.Name, k)
+						continue
+					}
+					last := "-"
+					for {
+						msgs, err := cl.XRangeN(ctx, k, last, g.LastDeliveredID, 1).Result()
+						if err != nil {
+							logger.WithError(err).Errorf("Failed to XRANGE over stream %q", k)
+							return true, nil
+						}
+						if len(msgs) == 0 {
+							return true, nil
+						}
+						var ids []string
+						for _, msg := range msgs {
+							ids = append(ids, msg.ID)
+							last = msg.ID
+						}
+						_, err = cl.XDel(ctx, k, ids...).Result()
+						if err != nil {
+							logger.WithError(err).Errorf("Failed to XDEL from stream %q, continue to next stream", k)
+							return true, nil
+						}
+						deleted += uint64(len(ids))
+					}
+				}
+				return true, nil
+			})
+		},
+	}
+	nsDBMigrateCommand = &cobra.Command{
+		Use:   "migrate",
+		Short: "Migrate Network Server data",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if config.Redis.IsZero() {
+				panic("Only Redis is supported by this command")
+			}
+
+			logger.Info("Connecting to Redis database...")
+			cl := NewNetworkServerDeviceRegistryRedis(*config)
+			var migrated uint64
+			defer func() { logger.Debugf("%d keys migrated", migrated) }()
+
+			const (
+				idRegexpStr      = `([a-z0-9](?:[-]?[a-z0-9]){2,}){1,36}?`
+				uidRegexpStr     = idRegexpStr + `\.` + idRegexpStr
+				euiRegexpStr     = "[[:xdigit:]]{16}"
+				devAddrRegexpStr = "[[:xdigit:]]{8}"
+			)
+
+			uidRegexp := regexp.MustCompile(cl.Key("uid", uidRegexpStr+"$"))
+			uidRegexp3_10_Fields := regexp.MustCompile(cl.Key("uid", uidRegexpStr, "fields$"))
+
+			euiRegexp := regexp.MustCompile(cl.Key("eui", euiRegexpStr, euiRegexpStr+"$"))
+
+			addrRegexpLegacy := regexp.MustCompile(cl.Key("addr", devAddrRegexpStr+"$"))
+			addrRegexp3_10_16Bit := regexp.MustCompile(cl.Key("addr", devAddrRegexpStr, "16bit$"))
+			addrRegexp3_10_32Bit := regexp.MustCompile(cl.Key("addr", devAddrRegexpStr, "32bit$"))
+			addrRegexp3_10_Pending := regexp.MustCompile(cl.Key("addr", devAddrRegexpStr, "pending$"))
+			addrRegexp3_11_Current := regexp.MustCompile(cl.Key("addr", devAddrRegexpStr, "current$"))
+			addrRegexp3_11_CurrentFields := regexp.MustCompile(cl.Key("addr", devAddrRegexpStr, "current", "fields$"))
+			addrRegexp3_11_PendingFields := regexp.MustCompile(cl.Key("addr", devAddrRegexpStr, "pending", "fields$"))
+			return rangeRedisKeys(ctx, cl, cl.Key("*"), 1, func(k string) (bool, error) {
+				logger := logger.WithField("key", k)
+				switch {
+				case uidRegexp3_10_Fields.MatchString(k):
+					if err := cl.Del(ctx, k).Err(); err != nil {
+						logger.WithError(err).Error("Failed to delete key")
+						return true, nil
+					}
+				case addrRegexpLegacy.MatchString(k):
+					var devAddr types.DevAddr
+					if err := devAddr.UnmarshalText([]byte(k[len(k)-8:])); err != nil {
+						logger.WithError(err).Error("Failed to parse DevAddr from legacy DevAddr key")
+						return true, nil
+					}
+					currentKey := nsredis.CurrentAddrKey(k)
+					currentFieldKey := nsredis.FieldKey(currentKey)
+					pendingKey := nsredis.PendingAddrKey(k)
+					pendingFieldKey := nsredis.FieldKey(pendingKey)
+					pendingScore := float64(time.Now().UnixNano())
+					if err := rangeRedisSet(ctx, cl, k, "*", 1, func(uid string) (bool, error) {
+						logger := logger.WithField("uid", uid)
+						uk := nsredis.UIDKey(cl, uid)
+						if err := cl.Watch(ctx, func(tx *redis.Tx) error {
+							dev := &ttnpb.EndDevice{}
+							if err := ttnredis.GetProto(ctx, tx, uk).ScanProto(dev); err != nil {
+								logger.WithError(err).Error("Failed to get device proto")
+								return err
+							}
+							p := tx.TxPipeline()
+							if dev.Session != nil && dev.Session.DevAddr.Equal(devAddr) {
+								if dev.MACState == nil {
+									logger.Error("Device is missing MAC state, skip migrating current session")
+								} else {
+									b, err := nsredis.MarshalDeviceCurrentSession(dev)
+									if err != nil {
+										return err
+									}
+									p.ZAdd(ctx, currentKey, &redis.Z{
+										Score:  float64(dev.Session.LastFCntUp & 0xffff),
+										Member: uid,
+									})
+									p.HSet(ctx, currentFieldKey, uid, b)
+								}
+							}
+							if dev.PendingSession != nil && dev.PendingSession.DevAddr.Equal(devAddr) {
+								if dev.PendingMACState == nil {
+									logger.Error("Device is missing MAC state, skip migrating pending session")
+								} else {
+									b, err := nsredis.MarshalDevicePendingSession(dev)
+									if err != nil {
+										return err
+									}
+									p.ZAdd(ctx, pendingKey, &redis.Z{
+										Score:  pendingScore,
+										Member: uid,
+									})
+									p.HSet(ctx, pendingFieldKey, uid, b)
+								}
+							}
+							p.SRem(ctx, k, uid)
+							_, err := p.Exec(ctx)
+							if err != nil {
+								logger.WithError(err).Error("Pipeline failed")
+								return err
+							}
+							return nil
+						}, k, uk); err != nil {
+							logger.WithError(err).Error("Transaction failed")
+						}
+						return true, nil
+					}); err != nil {
+						logger.WithError(err).Error("Failed to scan legacy DevAddr key")
+						return true, nil
+					}
+				case addrRegexp3_10_16Bit.MatchString(k), addrRegexp3_10_32Bit.MatchString(k):
+					currentKey := nsredis.CurrentAddrKey(k[:len(k)-6])
+					fieldKey := nsredis.FieldKey(currentKey)
+					if err := rangeRedisZSet(ctx, cl, k, "*", 1, func(uid string, v float64) (bool, error) {
+						logger := logger.WithField("uid", uid)
+						uk := nsredis.UIDKey(cl, uid)
+						if err := cl.Watch(ctx, func(tx *redis.Tx) error {
+							dev := &ttnpb.EndDevice{}
+							if err := ttnredis.GetProto(ctx, tx, uk).ScanProto(dev); err != nil {
+								logger.WithError(err).Error("Failed to get device proto")
+								return err
+							}
+							if dev.Session == nil || dev.MACState == nil {
+								logger.Error("Device is missing session or MAC state, skip")
+								return nil
+							}
+							b, err := nsredis.MarshalDeviceCurrentSession(dev)
+							if err != nil {
+								return err
+							}
+							_, err = tx.TxPipelined(ctx, func(p redis.Pipeliner) error {
+								p.ZAdd(ctx, currentKey, &redis.Z{
+									Score:  float64(uint32(v) & 0xffff),
+									Member: uid,
+								})
+								p.HSet(ctx, fieldKey, uid, b)
+								p.ZRem(ctx, k, uid)
+								return nil
+							})
+							if err != nil {
+								logger.WithError(err).Error("Pipeline failed")
+								return err
+							}
+							return nil
+						}, k, uk); err != nil {
+							logger.WithError(err).Error("Transaction failed")
+						}
+						return true, nil
+					}); err != nil {
+						logger.WithError(err).Error("Failed to scan 3.10 current DevAddr key")
+						return true, nil
+					}
+				case addrRegexp3_10_Pending.MatchString(k):
+					typ, err := cl.Type(ctx, k).Result()
+					if err != nil {
+						logger.WithError(err).Error("Failed to determine type of value stored under key")
+						return true, nil
+					}
+					if typ == "zset" {
+						return true, nil
+					}
+					fieldKey := nsredis.FieldKey(k)
+					tmpKey := cl.Key(k, "migrate")
+					score := float64(time.Now().UnixNano())
+					if err := cl.Watch(ctx, func(tx *redis.Tx) error {
+						p := tx.TxPipeline()
+						if err := rangeRedisSet(ctx, tx, k, "*", 1, func(uid string) (bool, error) {
+							logger := logger.WithField("uid", uid)
+							uk := nsredis.UIDKey(cl, uid)
+							if err := tx.Watch(ctx, uk).Err(); err != nil {
+								logger.WithField("key", uk).WithError(err).Error("Failed to watch UID key")
+								return false, err
+							}
+							dev := &ttnpb.EndDevice{}
+							if err := ttnredis.GetProto(ctx, tx, uk).ScanProto(dev); err != nil {
+								logger.WithError(err).Error("Failed to get device proto")
+								return false, err
+							}
+							if dev.PendingSession == nil || dev.PendingMACState == nil {
+								logger.Error("Device is missing pending session or MAC state, skip")
+								return true, nil
+							}
+							b, err := nsredis.MarshalDevicePendingSession(dev)
+							if err != nil {
+								return false, err
+							}
+							p.ZAdd(ctx, tmpKey, &redis.Z{
+								Score:  score,
+								Member: uid,
+							})
+							p.HSet(ctx, fieldKey, uid, b)
+							p.SRem(ctx, k, uid)
+							return true, nil
+						}); err != nil {
+							logger.WithError(err).Error("Failed to scan 3.10 pending DevAddr key")
+							return err
+						}
+						p.RenameNX(ctx, tmpKey, k)
+						_, err := p.Exec(ctx)
+						if err != nil {
+							logger.WithError(err).Error("Pipeline failed")
+							return err
+						}
+						return nil
+					}, k, tmpKey); err != nil {
+						logger.WithError(err).Error("Transaction failed")
+						return true, nil
+					}
+				case uidRegexp.MatchString(k),
+					euiRegexp.MatchString(k),
+					addrRegexp3_11_Current.MatchString(k),
+					addrRegexp3_11_CurrentFields.MatchString(k),
+					addrRegexp3_11_PendingFields.MatchString(k):
+					logger.Debug("Skip valid key")
+					return true, nil
+				default:
+					d, err := cl.TTL(ctx, k).Result()
+					if err != nil {
+						logger.WithError(err).Error("Failed to determine TTL of unmatched key")
+						return true, nil
+					}
+					if d < 0 {
+						logger.Error("Skip unmatched key with no TTL")
+						return true, nil
+					}
+					logger.Debug("Skip unmatched key with a TTL")
+					return true, nil
+				}
+				logger.Debug("Migrated key to 3.11 format")
+				migrated++
+				return true, nil
+			})
+		},
+	}
+)
+
+func init() {
+	Root.AddCommand(nsDBCommand)
+	nsDBCommand.AddCommand(nsDBPruneCommand)
+	nsDBCommand.AddCommand(nsDBMigrateCommand)
+}

--- a/config/messages.json
+++ b/config/messages.json
@@ -5804,18 +5804,18 @@
       "file": "registry.go"
     }
   },
-  "error:pkg/networkserver/redis:invalid_fieldmask": {
+  "error:pkg/networkserver/redis:invalid_device": {
     "translations": {
-      "en": "invalid fieldmask"
+      "en": "device is invalid"
     },
     "description": {
       "package": "pkg/networkserver/redis",
       "file": "registry.go"
     }
   },
-  "error:pkg/networkserver/redis:invalid_format": {
+  "error:pkg/networkserver/redis:invalid_fieldmask": {
     "translations": {
-      "en": "invalid value format"
+      "en": "invalid fieldmask"
     },
     "description": {
       "package": "pkg/networkserver/redis",
@@ -5838,15 +5838,6 @@
     "description": {
       "package": "pkg/networkserver/redis",
       "file": "application_uplink_queue.go"
-    }
-  },
-  "error:pkg/networkserver/redis:missing_field_value": {
-    "translations": {
-      "en": "missing field `{field}` value"
-    },
-    "description": {
-      "package": "pkg/networkserver/redis",
-      "file": "registry.go"
     }
   },
   "error:pkg/networkserver/redis:missing_payload": {

--- a/pkg/networkserver/downlink_test.go
+++ b/pkg/networkserver/downlink_test.go
@@ -362,17 +362,11 @@ func TestProcessDownlinkTask(t *testing.T) {
 					},
 					FrequencyPlanID:   test.EUFrequencyPlanID,
 					LoRaWANPHYVersion: ttnpb.PHY_V1_1_REV_B,
-					Session: &ttnpb.Session{
-						DevAddr:       devAddr,
-						LastNFCntDown: 0x24,
-						SessionKeys:   *sessionKeys,
-					},
 				},
 				Paths: []string{
 					"frequency_plan_id",
 					"ids",
 					"lorawan_phy_version",
-					"session",
 				},
 			},
 		},
@@ -2561,7 +2555,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 		},
 
 		{
-			Name: "join-accept/windows open/RX1,RX2 available/no active MAC state/EU868",
+			Name: "join-accept/windows open/RX1,RX2 available/active session/EU868",
 			CreateDevice: SetDeviceRequest{
 				EndDevice: &ttnpb.EndDevice{
 					EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
@@ -2621,12 +2615,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 							},
 						},
 					},
+					MACState:     MakeDefaultEU868MACState(ttnpb.CLASS_A, ttnpb.MAC_V1_1, ttnpb.PHY_V1_1_REV_B),
 					SupportsJoin: true,
 				},
 				Paths: []string{
 					"frequency_plan_id",
 					"ids",
 					"lorawan_phy_version",
+					"mac_state",
 					"pending_mac_state",
 					"session",
 					"supports_join",

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -93,7 +93,7 @@ func matchCmacF(ctx context.Context, fNwkSIntKey types.AES128Key, macVersion ttn
 		return [4]byte{}, false
 	}
 	var micMatch bool
-	if macVersion.Compare(ttnpb.MAC_V1_1) < 0 {
+	if macVersion.UseLegacyMIC() {
 		micMatch = bytes.Equal(up.Payload.MIC, cmacF[:])
 	} else {
 		micMatch = bytes.Equal(up.Payload.MIC[2:], cmacF[:2])
@@ -105,18 +105,13 @@ func matchCmacF(ctx context.Context, fNwkSIntKey types.AES128Key, macVersion ttn
 	return cmacF, true
 }
 
-type sessionMatchType uint8
-
-const (
-	currentSessionMatch sessionMatchType = iota
-	pendingSessionMatch
-	fCntResetMatch
-)
-
 type cmacFMatchingResult struct {
-	MatchType sessionMatchType
-	FullFCnt  uint32
-	CmacF     [4]byte
+	LastFCnt       uint32
+	IsPending      bool
+	FNwkSIntKey    types.AES128Key
+	LoRaWANVersion ttnpb.MACVersion
+	FullFCnt       uint32
+	CmacF          [4]byte
 }
 
 type macHandler func(context.Context, *ttnpb.EndDevice, *ttnpb.UplinkMessage) (events.Builders, error)
@@ -209,179 +204,180 @@ func (ns *NetworkServer) matchAndHandleDataUplink(ctx context.Context, dev *ttnp
 	}
 	drIdx, dr, ok := phy.FindUplinkDataRate(up.Settings.DataRate)
 	if !ok {
-		log.FromContext(ctx).Debug("Data rate not found in PHY, skip")
+		log.FromContext(ctx).Debug("Data rate not found in PHY")
 		return nil, false, nil
 	}
+	ctx = log.NewContextWithFields(ctx, log.Fields(
+		"band_id", phy.ID,
+		"data_rate_index", up.Settings.DataRateIndex,
+	))
 
 	pld := up.Payload.GetMACPayload()
+	pendingAppDown := dev.MACState.GetPendingApplicationDownlink()
 
-	var isRetransmission bool
-	var fCntGap uint32
-	var session *ttnpb.Session
-	var queuedApplicationUplinks []*ttnpb.ApplicationUp
-	switch cmacFMatchResult.MatchType {
-	case currentSessionMatch:
-		ctx = log.NewContextWithField(ctx, "last_f_cnt_up", dev.Session.LastFCntUp)
-		if pld.Ack && len(dev.MACState.RecentDownlinks) == 0 {
-			log.FromContext(ctx).Debug("Uplink contains ACK, but no downlink was sent to device, skip")
-			return nil, false, nil
-		}
-
-		maxNbTrans := maxTransmissionNumber(dev.MACState.LoRaWANVersion, up.Payload.MType == ttnpb.MType_CONFIRMED_UP, dev.MACState.CurrentParameters.ADRNbTrans)
-		ctx = log.NewContextWithField(ctx, "max_transmissions", maxNbTrans)
-
-		nbTrans := uint32(1)
-		var (
-			lastAt             time.Time
-			recentUpPHYPayload []byte
-		)
-		for i := len(dev.MACState.RecentUplinks) - 1; i >= 0; i-- {
-			recentUp := dev.MACState.RecentUplinks[i]
-			recentUpPHYPayload, err = lorawan.AppendMessage(recentUpPHYPayload[:0], *recentUp.Payload)
-			if err != nil {
-				log.FromContext(ctx).WithError(err).Error("Failed to marshal recent uplink payload, skip")
-				return nil, false, nil
-			}
-			if len(recentUpPHYPayload) < 4 {
-				log.FromContext(ctx).Error("Length of marshaled recent uplink payload is too short, skip")
-				return nil, false, nil
-			}
-			if !bytes.Equal(up.RawPayload[:len(up.RawPayload)-4], recentUpPHYPayload[:len(recentUpPHYPayload)-4]) {
-				break
-			}
-			nbTrans++
-			if recentUp.ReceivedAt.After(lastAt) {
-				lastAt = recentUp.ReceivedAt
-			}
-		}
-		ctx = log.NewContextWithField(ctx, "transmission", nbTrans)
-		if nbTrans >= 2 && lastAt.IsZero() {
-			log.FromContext(ctx).Error("Unknown transmission delay, skip")
-			return nil, false, nil
-		}
-
-		isRetransmission = nbTrans > 1
-		if isRetransmission {
-			delay := up.ReceivedAt.Sub(lastAt)
-			maxDelay := maxRetransmissionDelay(dev.MACState.CurrentParameters.Rx1Delay)
-
-			ctx = log.NewContextWithFields(ctx, log.Fields(
-				"last_transmission_at", lastAt,
-				"max_retransmission_delay", maxDelay,
-				"retransmission_delay", delay,
-			))
-			if delay > maxDelay {
-				log.FromContext(ctx).Warn("Retransmission delay exceeds maximum, skip")
-				return nil, true, errRetransmissionDelayExceeded
-			}
-			if nbTrans > maxNbTrans {
-				log.FromContext(ctx).Warn("Transmission number exceeds maximum, skip")
-				return nil, true, errTransmissionNumberExceeded
-			}
-		} else if dev.MACState.PendingApplicationDownlink != nil {
-			asUp := &ttnpb.ApplicationUp{
-				EndDeviceIdentifiers: dev.EndDeviceIdentifiers,
-				Up: &ttnpb.ApplicationUp_DownlinkNack{
-					DownlinkNack: dev.MACState.PendingApplicationDownlink,
-				},
-				CorrelationIDs: append(dev.MACState.PendingApplicationDownlink.CorrelationIDs, up.CorrelationIDs...),
-			}
-			if pld.Ack {
-				asUp.Up = &ttnpb.ApplicationUp_DownlinkAck{
-					DownlinkAck: dev.MACState.PendingApplicationDownlink,
-				}
-			} else {
-				asUp.Up = &ttnpb.ApplicationUp_DownlinkNack{
-					DownlinkNack: dev.MACState.PendingApplicationDownlink,
-				}
-			}
-			queuedApplicationUplinks = []*ttnpb.ApplicationUp{asUp}
-			dev.MACState.PendingApplicationDownlink = nil
-		}
-
-		fCntGap = cmacFMatchResult.FullFCnt - dev.Session.LastFCntUp
-		session = dev.Session
-
-	case pendingSessionMatch:
-		if pld.Ack {
-			log.FromContext(ctx).Debug("ACK bit set in uplink matching pending session, skip")
-			return nil, false, nil
-		}
-		if dev.PendingMACState.PendingJoinRequest == nil {
-			log.FromContext(ctx).Warn("Pending join-request missing")
-			return nil, false, nil
-		}
-		dev.PendingMACState.CurrentParameters.Rx1Delay = dev.PendingMACState.PendingJoinRequest.RxDelay
-		dev.PendingMACState.CurrentParameters.Rx1DataRateOffset = dev.PendingMACState.PendingJoinRequest.DownlinkSettings.Rx1DROffset
-		dev.PendingMACState.CurrentParameters.Rx2DataRateIndex = dev.PendingMACState.PendingJoinRequest.DownlinkSettings.Rx2DR
-		if dev.PendingMACState.PendingJoinRequest.DownlinkSettings.OptNeg && dev.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) >= 0 {
-			// The version will be further negotiated via RekeyInd/RekeyConf
-			dev.PendingMACState.LoRaWANVersion = ttnpb.MAC_V1_1
-		}
-		chs, ok := applyCFList(dev.PendingMACState.PendingJoinRequest.CFList, phy, dev.PendingMACState.CurrentParameters.Channels...)
-		if !ok {
-			log.FromContext(ctx).Debug("Failed to apply CFList, skip")
-			return nil, false, nil
-		}
-		dev.PendingMACState.CurrentParameters.Channels = chs
-
-		if dev.MACState.GetPendingApplicationDownlink() != nil {
-			queuedApplicationUplinks = []*ttnpb.ApplicationUp{
-				{
-					EndDeviceIdentifiers: dev.EndDeviceIdentifiers,
-					Up: &ttnpb.ApplicationUp_DownlinkNack{
-						DownlinkNack: dev.MACState.PendingApplicationDownlink,
-					},
-					CorrelationIDs: append(dev.MACState.PendingApplicationDownlink.CorrelationIDs, up.CorrelationIDs...),
-				},
-			}
-			dev.MACState.PendingApplicationDownlink = nil
-		}
-		dev.MACState = dev.PendingMACState
-		dev.PendingSession.StartedAt = up.ReceivedAt
-
-		fCntGap = cmacFMatchResult.FullFCnt
-		session = dev.PendingSession
-
-	case fCntResetMatch:
-		ctx = log.NewContextWithField(ctx, "last_f_cnt_up", dev.Session.LastFCntUp)
-		if pld.Ack {
-			log.FromContext(ctx).Debug("ACK bit set in uplink after FCnt reset, skip")
-			return nil, false, nil
-		}
-		var err error
-		macState, err := mac.NewState(dev, ns.FrequencyPlans, ns.defaultMACSettings)
+	type sessionMatchType uint8
+	const (
+		currentOriginalMatch sessionMatchType = iota
+		currentRetransmissionMatch
+		currentResetMatch
+		pendingMatch
+	)
+	var matchType sessionMatchType
+	switch {
+	case !pld.Ack &&
+		cmacFMatchResult.IsPending &&
+		dev.PendingSession != nil &&
+		dev.PendingMACState != nil &&
+		pld.DevAddr.Equal(dev.PendingSession.DevAddr) &&
+		cmacFMatchResult.LoRaWANVersion.UseLegacyMIC() == dev.PendingMACState.LoRaWANVersion.UseLegacyMIC():
+		fNwkSIntKey, err := cryptoutil.UnwrapAES128Key(ctx, dev.PendingSession.FNwkSIntKey, ns.KeyVault)
 		if err != nil {
-			log.FromContext(ctx).WithError(err).Warn("Failed to generate new MAC state")
+			log.FromContext(ctx).WithError(err).WithField("kek_label", dev.PendingSession.FNwkSIntKey.KEKLabel).Warn("Failed to unwrap FNwkSIntKey")
 			return nil, false, nil
 		}
-
-		if dev.MACState.GetPendingApplicationDownlink() != nil {
-			queuedApplicationUplinks = []*ttnpb.ApplicationUp{
-				{
-					EndDeviceIdentifiers: dev.EndDeviceIdentifiers,
-					Up: &ttnpb.ApplicationUp_DownlinkNack{
-						DownlinkNack: dev.MACState.PendingApplicationDownlink,
-					},
-					CorrelationIDs: append(dev.MACState.PendingApplicationDownlink.CorrelationIDs, up.CorrelationIDs...),
-				},
+		if cmacFMatchResult.FNwkSIntKey.Equal(fNwkSIntKey) {
+			ctx = log.NewContextWithField(ctx, "mac_version", dev.PendingMACState.LoRaWANVersion)
+			if dev.PendingMACState.PendingJoinRequest == nil {
+				log.FromContext(ctx).Warn("Pending join-request missing")
+				return nil, false, nil
 			}
-			dev.MACState.PendingApplicationDownlink = nil
-		}
-		dev.MACState = macState
-		dev.Session.StartedAt = up.ReceivedAt
+			dev.PendingMACState.CurrentParameters.Rx1Delay = dev.PendingMACState.PendingJoinRequest.RxDelay
+			dev.PendingMACState.CurrentParameters.Rx1DataRateOffset = dev.PendingMACState.PendingJoinRequest.DownlinkSettings.Rx1DROffset
+			dev.PendingMACState.CurrentParameters.Rx2DataRateIndex = dev.PendingMACState.PendingJoinRequest.DownlinkSettings.Rx2DR
+			if dev.PendingMACState.PendingJoinRequest.DownlinkSettings.OptNeg && dev.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) >= 0 {
+				// The version will be further negotiated via RekeyInd/RekeyConf
+				dev.PendingMACState.LoRaWANVersion = ttnpb.MAC_V1_1
+			}
+			chs, ok := applyCFList(dev.PendingMACState.PendingJoinRequest.CFList, phy, dev.PendingMACState.CurrentParameters.Channels...)
+			if !ok {
+				log.FromContext(ctx).Debug("Failed to apply CFList")
+				return nil, false, nil
+			}
+			dev.PendingMACState.CurrentParameters.Channels = chs
 
-		fCntGap = cmacFMatchResult.FullFCnt
-		session = dev.Session
+			dev.MACState = dev.PendingMACState
+			dev.PendingSession.StartedAt = up.ReceivedAt
+
+			matchType = pendingMatch
+			break
+		}
+		fallthrough
+
+	case dev.Session != nil &&
+		dev.MACState != nil &&
+		pld.DevAddr.Equal(dev.Session.DevAddr) &&
+		cmacFMatchResult.LoRaWANVersion.UseLegacyMIC() == dev.MACState.LoRaWANVersion.UseLegacyMIC() &&
+		cmacFMatchResult.FullFCnt == FullFCnt(uint16(pld.FCnt), dev.Session.LastFCntUp, mac.DeviceSupports32BitFCnt(dev, ns.defaultMACSettings)):
+		fNwkSIntKey, err := cryptoutil.UnwrapAES128Key(ctx, dev.Session.FNwkSIntKey, ns.KeyVault)
+		if err != nil {
+			log.FromContext(ctx).WithError(err).WithField("kek_label", dev.Session.FNwkSIntKey.KEKLabel).Warn("Failed to unwrap FNwkSIntKey")
+			return nil, false, nil
+		}
+		if cmacFMatchResult.FNwkSIntKey.Equal(fNwkSIntKey) {
+			ctx = log.NewContextWithFields(ctx, log.Fields(
+				"last_f_cnt_up", dev.Session.LastFCntUp,
+				"mac_version", dev.MACState.LoRaWANVersion,
+				"pending_session", false,
+			))
+			switch {
+			case cmacFMatchResult.FullFCnt < dev.Session.LastFCntUp:
+				if pld.Ack || dev.Session.LastFCntUp != cmacFMatchResult.LastFCnt || !mac.DeviceResetsFCnt(dev, ns.defaultMACSettings) {
+					return nil, false, nil
+				}
+				ctx = log.NewContextWithField(ctx, "f_cnt_reset", true)
+
+				macState, err := mac.NewState(dev, ns.FrequencyPlans, ns.defaultMACSettings)
+				if err != nil {
+					log.FromContext(ctx).WithError(err).Warn("Failed to generate new MAC state")
+					return nil, false, nil
+				}
+
+				dev.MACState = macState
+				dev.Session.StartedAt = up.ReceivedAt
+
+				matchType = currentResetMatch
+
+			case cmacFMatchResult.FullFCnt > dev.Session.LastFCntUp:
+				ctx = log.NewContextWithField(ctx, "f_cnt_reset", false)
+
+				fCntGap := cmacFMatchResult.FullFCnt - dev.Session.LastFCntUp
+				if dev.MACState.LoRaWANVersion.HasMaxFCntGap() && uint(fCntGap) > phy.MaxFCntGap {
+					log.FromContext(ctx).WithFields(log.Fields(
+						"f_cnt_gap", fCntGap,
+						"max_f_cnt_gap", phy.MaxFCntGap,
+					)).Debug("FCnt gap exceeds maximum after reset")
+					return nil, false, nil
+				}
+
+				matchType = currentOriginalMatch
+
+			case dev.Session.LastFCntUp == 0 && dev.SupportsJoin && len(dev.MACState.RecentUplinks) == 1,
+				dev.Session.LastFCntUp == 0 && !dev.SupportsJoin && len(dev.MACState.RecentUplinks) == 0:
+
+				ctx = log.NewContextWithField(ctx, "f_cnt_reset", false)
+				matchType = currentOriginalMatch
+
+			default: // cmacFMatchResult.FullFCnt == dev.Session.LastFCntUp
+				ctx = log.NewContextWithField(ctx, "f_cnt_reset", false)
+
+				maxNbTrans := maxTransmissionNumber(dev.MACState.LoRaWANVersion, up.Payload.MType == ttnpb.MType_CONFIRMED_UP, dev.MACState.CurrentParameters.ADRNbTrans)
+				if maxNbTrans < 1 {
+					panic(fmt.Sprintf("invalid maximum transmission number %d", maxNbTrans))
+				}
+				ctx = log.NewContextWithField(ctx, "max_transmissions", maxNbTrans)
+
+				nbTrans := uint32(1)
+				var (
+					lastAt             time.Time
+					recentUpPHYPayload []byte
+				)
+				for i := len(dev.MACState.RecentUplinks) - 1; i >= 0; i-- {
+					recentUp := dev.MACState.RecentUplinks[i]
+					recentUpPHYPayload, err = lorawan.AppendMessage(recentUpPHYPayload[:0], *recentUp.Payload)
+					if err != nil {
+						log.FromContext(ctx).WithError(err).Error("Failed to marshal recent uplink payload")
+						return nil, false, nil
+					}
+					if len(recentUpPHYPayload) < 4 {
+						log.FromContext(ctx).Error("Length of marshaled recent uplink payload is too short")
+						return nil, false, nil
+					}
+					if !bytes.Equal(up.RawPayload[:len(up.RawPayload)-4], recentUpPHYPayload[:len(recentUpPHYPayload)-4]) {
+						break
+					}
+					if nbTrans >= maxNbTrans {
+						log.FromContext(ctx).Warn("Transmission number exceeds maximum")
+						return nil, false, nil
+					}
+					nbTrans++
+					if recentUp.ReceivedAt.After(lastAt) {
+						lastAt = recentUp.ReceivedAt
+					}
+				}
+				if nbTrans < 2 || lastAt.IsZero() {
+					log.FromContext(ctx).Debug("Repeated FCnt value, but frame is not a retransmission, skip")
+					return nil, false, nil
+				}
+				maxDelay := maxRetransmissionDelay(dev.MACState.CurrentParameters.Rx1Delay)
+				delay := up.ReceivedAt.Sub(lastAt)
+				ctx = log.NewContextWithFields(ctx, log.Fields(
+					"last_transmission_at", lastAt,
+					"max_retransmission_delay", maxDelay,
+					"retransmission_delay", delay,
+					"retransmission_number", nbTrans,
+				))
+				if delay > maxDelay {
+					log.FromContext(ctx).Warn("Retransmission delay exceeds maximum, skip")
+					return nil, false, nil
+				}
+
+				matchType = currentRetransmissionMatch
+			}
+			break
+		}
+		fallthrough
 
 	default:
-		panic(fmt.Sprintf("invalid data uplink match type '%v'", cmacFMatchResult.MatchType))
-	}
-	if dev.MACState.LoRaWANVersion.HasMaxFCntGap() && uint(fCntGap) > phy.MaxFCntGap {
-		log.FromContext(ctx).WithFields(log.Fields(
-			"f_cnt_gap", fCntGap,
-			"max_f_cnt_gap", phy.MaxFCntGap,
-		)).Debug("FCnt gap exceeds maximum after reset, skip")
 		return nil, false, nil
 	}
 
@@ -396,6 +392,10 @@ func (ns *NetworkServer) matchAndHandleDataUplink(ctx context.Context, dev *ttnp
 		cmdBuf = pld.FRMPayload
 	}
 	if len(cmdBuf) > 0 && (len(pld.FOpts) == 0 || dev.MACState.LoRaWANVersion.EncryptFOpts()) {
+		session := dev.Session
+		if matchType == pendingMatch {
+			session = dev.PendingSession
+		}
 		if session.NwkSEncKey == nil || len(session.NwkSEncKey.Key) == 0 {
 			log.FromContext(ctx).Warn("Device missing NwkSEncKey in registry, skip")
 			return nil, false, nil
@@ -413,7 +413,7 @@ func (ns *NetworkServer) matchAndHandleDataUplink(ctx context.Context, dev *ttnp
 	}
 
 	logger := log.FromContext(ctx)
-	if isRetransmission {
+	if matchType == currentRetransmissionMatch {
 		dev.MACState.PendingRequests = nil
 	}
 	var cmds []*ttnpb.MACCommand
@@ -429,13 +429,16 @@ func (ns *NetworkServer) matchAndHandleDataUplink(ctx context.Context, dev *ttnp
 		logger := logger.WithField("command", cmd)
 		logger.Debug("Read MAC command")
 		def, ok := lorawan.DefaultMACCommands[cmd.CID]
-		switch {
-		case ok && !def.InitiatedByDevice && (cmacFMatchResult.MatchType == pendingSessionMatch || cmacFMatchResult.MatchType == fCntResetMatch):
-			logger.Debug("Received MAC command answer after MAC state reset, skip")
-			return nil, false, nil
-		case ok && isRetransmission && !lorawan.DefaultMACCommands[cmd.CID].InitiatedByDevice:
-			logger.Debug("Skip processing of MAC command not initiated by the device in a retransmission")
-			continue
+		if ok && !def.InitiatedByDevice {
+			switch matchType {
+			case currentResetMatch, pendingMatch:
+				logger.Debug("Received MAC command answer after MAC state reset, skip")
+				return nil, false, nil
+
+			case currentRetransmissionMatch:
+				logger.Debug("Skip processing of MAC command not initiated by the device in a retransmission")
+				continue
+			}
 		}
 		cmds = append(cmds, cmd)
 	}
@@ -572,7 +575,7 @@ macLoop:
 		dev.MACState.PendingRequests = dev.MACState.PendingRequests[:0]
 	}
 
-	if cmacFMatchResult.MatchType == pendingSessionMatch {
+	if cmacFMatchResult.IsPending {
 		if dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) < 0 {
 			dev.EndDeviceIdentifiers.DevAddr = &pld.DevAddr
 			dev.Session = dev.PendingSession
@@ -593,20 +596,14 @@ macLoop:
 		logger.WithError(err).Debug("Failed to determine channel index of uplink, skip")
 		return nil, false, nil
 	}
-	logger = logger.WithField("channel_index", chIdx)
+	logger = logger.WithField("device_channel_index", chIdx)
 	ctx = log.NewContext(ctx, logger)
 
-	// NOTE: MIC check for pre-1.1 devices is already performed.
-	if dev.MACState.LoRaWANVersion.Compare(ttnpb.MAC_V1_1) >= 0 {
-		if dev.Session.SNwkSIntKey == nil || len(dev.Session.SNwkSIntKey.Key) == 0 {
-			logger.Warn("Device missing SNwkSIntKey in registry, skip")
-			return nil, false, nil
-		}
-
-		var sNwkSIntKey types.AES128Key
-		sNwkSIntKey, err = cryptoutil.UnwrapAES128Key(ctx, dev.Session.SNwkSIntKey, ns.KeyVault)
+	// NOTE: Legacy MIC check is already performed.
+	if !dev.MACState.LoRaWANVersion.UseLegacyMIC() {
+		sNwkSIntKey, err := cryptoutil.UnwrapAES128Key(ctx, dev.Session.SNwkSIntKey, ns.KeyVault)
 		if err != nil {
-			logger.WithField("kek_label", dev.Session.SNwkSIntKey.KEKLabel).WithError(err).Warn("Failed to unwrap SNwkSIntKey, skip")
+			logger.WithField("kek_label", dev.Session.SNwkSIntKey.GetKEKLabel()).WithError(err).Warn("Failed to unwrap SNwkSIntKey, skip")
 			return nil, false, nil
 		}
 
@@ -637,6 +634,32 @@ macLoop:
 	}
 	dev.MACState.RxWindowsAvailable = true
 	dev.Session.LastFCntUp = cmacFMatchResult.FullFCnt
+
+	var queuedApplicationUplinks []*ttnpb.ApplicationUp
+	if pendingAppDown != nil {
+		if pld.Ack {
+			queuedApplicationUplinks = []*ttnpb.ApplicationUp{
+				{
+					EndDeviceIdentifiers: dev.EndDeviceIdentifiers,
+					Up: &ttnpb.ApplicationUp_DownlinkAck{
+						DownlinkAck: dev.MACState.PendingApplicationDownlink,
+					},
+					CorrelationIDs: append(dev.MACState.PendingApplicationDownlink.CorrelationIDs, up.CorrelationIDs...),
+				},
+			}
+		} else {
+			queuedApplicationUplinks = []*ttnpb.ApplicationUp{
+				{
+					EndDeviceIdentifiers: dev.EndDeviceIdentifiers,
+					Up: &ttnpb.ApplicationUp_DownlinkNack{
+						DownlinkNack: dev.MACState.PendingApplicationDownlink,
+					},
+					CorrelationIDs: append(dev.MACState.PendingApplicationDownlink.CorrelationIDs, up.CorrelationIDs...),
+				},
+			}
+		}
+		dev.MACState.PendingApplicationDownlink = nil
+	}
 	return &matchResult{
 		cmacFMatchingResult:      cmacFMatchResult,
 		phy:                      phy,
@@ -645,7 +668,7 @@ macLoop:
 		ChannelIndex:             chIdx,
 		DataRateIndex:            drIdx,
 		DeferredMACHandlers:      deferredMACHandlers,
-		IsRetransmission:         isRetransmission,
+		IsRetransmission:         matchType == currentRetransmissionMatch,
 		QueuedApplicationUplinks: queuedApplicationUplinks,
 		QueuedEventBuilders:      queuedEventBuilders,
 		SetPaths: append(setPaths,
@@ -713,80 +736,63 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 	))
 
 	var (
-		fNwkSIntKey         types.AES128Key
-		fNwkSIntKeyEnvelope *ttnpb.KeyEnvelope
-		matched             *matchResult
-		ok                  bool
+		matched *matchResult
+		ok      bool
 	)
 	const matchTTL = time.Minute
 	if err := ns.devices.RangeByUplinkMatches(ctx, up, matchTTL,
 		func(ctx context.Context, match *UplinkMatch) (bool, error) {
-			fNwkSIntKeyEnvelope = match.FNwkSIntKey
-			var err error
-			fNwkSIntKey, err = cryptoutil.UnwrapAES128Key(ctx, fNwkSIntKeyEnvelope, ns.KeyVault)
-			if err != nil {
-				log.FromContext(ctx).WithError(err).WithField("kek_label", fNwkSIntKeyEnvelope.KEKLabel).Warn("Failed to unwrap FNwkSIntKey, skip")
-				return false, nil
-			}
-			isPending := match.IsPending
-			macVersion := match.LoRaWANVersion
 			ctx = log.NewContextWithFields(ctx, log.Fields(
-				"mac_version", macVersion,
-				"pending_session", isPending,
+				"mac_version", match.LoRaWANVersion,
+				"pending_session", match.IsPending,
 			))
 
+			fNwkSIntKey, err := cryptoutil.UnwrapAES128Key(ctx, match.FNwkSIntKey, ns.KeyVault)
+			if err != nil {
+				log.FromContext(ctx).WithError(err).WithField("kek_label", match.FNwkSIntKey.KEKLabel).Warn("Failed to unwrap FNwkSIntKey, skip")
+				return false, nil
+			}
 			fCnt := FullFCnt(uint16(pld.FCnt), match.LastFCnt, mac.DeviceSupports32BitFCnt(&ttnpb.EndDevice{
 				MACSettings: &ttnpb.MACSettings{
 					Supports32BitFCnt: match.Supports32BitFCnt,
 				},
 			}, ns.defaultMACSettings))
-			var matchType sessionMatchType
-			switch {
-			case isPending:
-				matchType = pendingSessionMatch
-			case fCnt < match.LastFCnt:
-				if pld.FCnt != fCnt {
-					panic("invalid FCnt")
-				}
-				matchType = fCntResetMatch
-			default:
-				matchType = currentSessionMatch
-			}
-			var cmacF [4]byte
-			cmacF, ok = matchCmacF(ctx, fNwkSIntKey, macVersion, fCnt, up)
-			if !ok {
-				if pld.FCnt == fCnt || pld.Ack || isPending || !mac.DeviceResetsFCnt(&ttnpb.EndDevice{
-					MACSettings: &ttnpb.MACSettings{
-						ResetsFCnt: match.ResetsFCnt,
-					},
-				}, ns.defaultMACSettings) {
-					return false, nil
-				}
 
+			var cmacF [4]byte
+			cmacF, ok = matchCmacF(ctx, fNwkSIntKey, match.LoRaWANVersion, fCnt, up)
+			if !ok && fCnt != pld.FCnt && !pld.Ack && !match.IsPending && mac.DeviceResetsFCnt(&ttnpb.EndDevice{
+				MACSettings: &ttnpb.MACSettings{
+					ResetsFCnt: match.ResetsFCnt,
+				},
+			}, ns.defaultMACSettings) {
 				// FCnt reset
 				fCnt = pld.FCnt
-				cmacF, ok = matchCmacF(ctx, fNwkSIntKey, macVersion, fCnt, up)
-				if !ok {
-					return false, nil
-				}
-				matchType = fCntResetMatch
+				cmacF, ok = matchCmacF(ctx, fNwkSIntKey, match.LoRaWANVersion, fCnt, up)
 			}
-			ctx = log.NewContextWithFields(ctx, log.Fields(
-				"f_cnt_reset", matchType == fCntResetMatch,
-				"full_f_cnt_up", fCnt,
-			))
+			if !ok {
+				return false, nil
+			}
+
+			ctx = log.NewContextWithField(ctx, "full_f_cnt_up", fCnt)
 			dev, ctx, err := ns.devices.GetByID(ctx, match.ApplicationIdentifiers, match.DeviceID, handleDataUplinkGetPaths[:])
 			if err != nil {
 				log.FromContext(ctx).WithError(err).Warn("Failed to get device after cmacF matching")
-				return false, nil
+				return match.LoRaWANVersion.UseLegacyMIC(), nil
 			}
 			matched, ok, err = ns.matchAndHandleDataUplink(ctx, dev, up, false, cmacFMatchingResult{
-				MatchType: matchType,
-				FullFCnt:  fCnt,
-				CmacF:     cmacF,
+				LastFCnt:       match.LastFCnt,
+				IsPending:      match.IsPending,
+				FNwkSIntKey:    fNwkSIntKey,
+				LoRaWANVersion: match.LoRaWANVersion,
+				FullFCnt:       fCnt,
+				CmacF:          cmacF,
 			})
-			return ok, err
-		}); err != nil {
+			if err != nil {
+				return false, err
+			}
+			return ok || match.LoRaWANVersion.UseLegacyMIC(), nil
+		},
+	); err != nil {
 		logRegistryRPCError(ctx, err, "Failed to find devices in registry by DevAddr")
 		return errDeviceNotFound.WithCause(err)
 	}
@@ -798,10 +804,6 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 	up.DeviceChannelIndex = uint32(matched.ChannelIndex)
 	up.Settings.DataRateIndex = matched.DataRateIndex
 	ctx = matched.Context
-	ctx = log.NewContextWithFields(ctx, log.Fields(
-		"data_rate_index", up.Settings.DataRateIndex,
-		"device_channel_index", up.DeviceChannelIndex,
-	))
 
 	queuedEvents := []events.Event{
 		evtReceiveDataUplink.NewWithIdentifiersAndData(ctx, matched.Device.EndDeviceIdentifiers, up),
@@ -852,81 +854,10 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 				return nil, nil, errOutdatedData.New()
 			}
 
-			if ok = stored.CreatedAt.Equal(matched.Device.CreatedAt) && stored.UpdatedAt.Equal(matched.Device.UpdatedAt); !ok {
-				matched, ok, err = func() (*matchResult, bool, error) {
-					if matched.MatchType == pendingSessionMatch && stored.PendingSession != nil && stored.PendingSession.DevAddr == pld.DevAddr {
-						if stored.PendingSession.FNwkSIntKey == nil {
-							return nil, false, errUnknownFNwkSIntKey
-						}
-						if !fNwkSIntKeyEnvelope.Equal(stored.PendingSession.FNwkSIntKey) {
-							var err error
-							fNwkSIntKey, err = cryptoutil.UnwrapAES128Key(ctx, stored.PendingSession.FNwkSIntKey, ns.KeyVault)
-							if err != nil {
-								log.FromContext(ctx).WithError(err).WithField("kek_label", fNwkSIntKeyEnvelope.KEKLabel).Warn("Failed to unwrap FNwkSIntKey, skip")
-								return nil, false, err
-							}
-						}
-						var cmacF [4]byte
-						cmacF, ok = matchCmacF(ctx, fNwkSIntKey, stored.PendingMACState.LoRaWANVersion, pld.FCnt, up)
-						if ok {
-							stored := stored
-							if stored.Session != nil && stored.Session.DevAddr == pld.DevAddr {
-								stored = CopyEndDevice(stored)
-							}
-							matched, ok, err = ns.matchAndHandleDataUplink(ctx, stored, up, true, cmacFMatchingResult{
-								MatchType: pendingSessionMatch,
-								FullFCnt:  pld.FCnt,
-								CmacF:     cmacF,
-							})
-							if err != nil {
-								return nil, false, err
-							}
-							if ok {
-								return matched, true, nil
-							}
-						}
-					}
-
-					if stored.Session == nil || stored.Session.DevAddr != pld.DevAddr {
-						return nil, false, nil
-					}
-					if stored.Session.FNwkSIntKey == nil {
-						return nil, false, errUnknownFNwkSIntKey
-					}
-					if !fNwkSIntKeyEnvelope.Equal(stored.Session.FNwkSIntKey) {
-						var err error
-						fNwkSIntKey, err = cryptoutil.UnwrapAES128Key(ctx, stored.Session.FNwkSIntKey, ns.KeyVault)
-						if err != nil {
-							log.FromContext(ctx).WithError(err).WithField("kek_label", fNwkSIntKeyEnvelope.KEKLabel).Warn("Failed to unwrap FNwkSIntKey, skip")
-							return nil, false, err
-						}
-					}
-
-					fCnt := pld.FCnt
-					matchType := matched.MatchType
-					var cmacF [4]byte
-					if matched.MatchType == fCntResetMatch && mac.DeviceResetsFCnt(stored, ns.defaultMACSettings) {
-						cmacF, ok = matchCmacF(ctx, fNwkSIntKey, stored.MACState.LoRaWANVersion, pld.FCnt, up)
-					}
-					if matched.MatchType == currentSessionMatch || !ok {
-						fCnt = FullFCnt(uint16(pld.FCnt&0xffff), stored.Session.LastFCntUp, mac.DeviceSupports32BitFCnt(stored, ns.defaultMACSettings))
-						if matched.MatchType == fCntResetMatch && fCnt == pld.FCnt {
-							// NOTE: This was already attempted above and did not succeed.
-							return nil, false, nil
-						}
-						cmacF, ok = matchCmacF(ctx, fNwkSIntKey, stored.MACState.LoRaWANVersion, fCnt, up)
-					}
-					if ok {
-						return ns.matchAndHandleDataUplink(ctx, stored, up, true, cmacFMatchingResult{
-							MatchType: matchType,
-							FullFCnt:  fCnt,
-							CmacF:     cmacF,
-						})
-					}
-					return nil, false, nil
-				}()
+			if !matched.Device.CreatedAt.Equal(stored.CreatedAt) || !matched.Device.UpdatedAt.Equal(stored.UpdatedAt) {
+				matched, ok, err = ns.matchAndHandleDataUplink(ctx, stored, up, true, matched.cmacFMatchingResult)
 				if err != nil {
-					return nil, nil, errOutdatedData.WithCause(err)
+					return nil, nil, err
 				}
 				if !ok {
 					return nil, nil, errOutdatedData.New()
@@ -934,14 +865,6 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 				pld.FullFCnt = matched.FullFCnt
 				up.DeviceChannelIndex = uint32(matched.ChannelIndex)
 				up.Settings.DataRateIndex = matched.DataRateIndex
-				matched.Context = log.NewContextWithFields(matched.Context, log.Fields(
-					"data_rate_index", up.Settings.DataRateIndex,
-					"device_channel_index", up.DeviceChannelIndex,
-					"f_cnt_reset", matched.MatchType == fCntResetMatch,
-					"full_f_cnt_up", matched.FullFCnt,
-					"mac_version", matched.Device.MACState.LoRaWANVersion,
-					"pending_session", matched.MatchType == pendingSessionMatch,
-				))
 				ctx = matched.Context
 			}
 

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -215,6 +215,9 @@ func (ns *NetworkServer) matchAndHandleDataUplink(ctx context.Context, dev *ttnp
 	pld := up.Payload.GetMACPayload()
 	pendingAppDown := dev.MACState.GetPendingApplicationDownlink()
 
+	// NOTE: Device might have changed session since the CMACF match.
+	// E.g. We could have matched pending session by CMACF and device might
+	// have activated it meanwhile and made that matched session current.
 	type sessionMatchType uint8
 	const (
 		currentOriginalMatch sessionMatchType = iota
@@ -262,6 +265,7 @@ func (ns *NetworkServer) matchAndHandleDataUplink(ctx context.Context, dev *ttnp
 			matchType = pendingMatch
 			break
 		}
+		// Key mismatch, attempt to match current session.
 		fallthrough
 
 	// Current session match
@@ -373,7 +377,8 @@ func (ns *NetworkServer) matchAndHandleDataUplink(ctx context.Context, dev *ttnp
 			}
 			break
 		}
-		fallthrough
+		// Key mismatch
+		return nil, false, nil
 
 	default:
 		return nil, false, nil

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -721,13 +721,6 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 	const matchTTL = time.Minute
 	if err := ns.devices.RangeByUplinkMatches(ctx, up, matchTTL,
 		func(ctx context.Context, match *UplinkMatch) (bool, error) {
-			if pld.Ack && match.IsPending {
-				// TODO: Perform this optimization in the storage backend.
-				// (https://github.com/TheThingsNetwork/lorawan-stack/issues/3254)
-				log.FromContext(ctx).Debug("Uplink carrying ACK for pending session, skip")
-				return false, nil
-			}
-
 			fNwkSIntKeyEnvelope = match.FNwkSIntKey
 			var err error
 			fNwkSIntKey, err = cryptoutil.UnwrapAES128Key(ctx, fNwkSIntKeyEnvelope, ns.KeyVault)

--- a/pkg/networkserver/internal/test/shared/shared.go
+++ b/pkg/networkserver/internal/test/shared/shared.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	CacheTTL           = (1 << 5) * test.Delay
+	CacheTTL           = (1 << 6) * test.Delay
 	DefaultMACSettings = DefaultConfig.DefaultMACSettings.Parse()
 )
 

--- a/pkg/networkserver/networkserver_util_internal_test.go
+++ b/pkg/networkserver/networkserver_util_internal_test.go
@@ -2080,6 +2080,6 @@ func (m MockDeviceRegistry) SetByID(ctx context.Context, appID ttnpb.Application
 }
 
 // RangeByUplinkMatches panics.
-func (m MockDeviceRegistry) RangeByUplinkMatches(context.Context, *ttnpb.UplinkMessage, time.Duration, func(context.Context, UplinkMatch) (bool, error)) error {
+func (m MockDeviceRegistry) RangeByUplinkMatches(context.Context, *ttnpb.UplinkMessage, time.Duration, func(context.Context, *UplinkMatch) (bool, error)) error {
 	panic("RangeByUplinkMatches must not be called")
 }

--- a/pkg/networkserver/redis/application_uplink_queue.go
+++ b/pkg/networkserver/redis/application_uplink_queue.go
@@ -37,7 +37,6 @@ type ApplicationUplinkQueue struct {
 }
 
 const (
-	uidKey     = "uid"
 	payloadKey = "payload"
 )
 
@@ -60,7 +59,7 @@ func NewApplicationUplinkQueue(cl *ttnredis.Client, maxLen int64, group, id stri
 }
 
 func ApplicationUplinkQueueUIDGenericUplinkKey(r keyer, uid string) string {
-	return r.Key(uidKey, uid, "uplinks")
+	return ttnredis.Key(UIDKey(r, uid), "uplinks")
 }
 
 func (q *ApplicationUplinkQueue) uidGenericUplinkKey(uid string) string {
@@ -106,7 +105,7 @@ func (q *ApplicationUplinkQueue) Add(ctx context.Context, ups ...*ttnpb.Applicat
 				uidStreamID = q.uidJoinAcceptKey(uid)
 			case *ttnpb.ApplicationUp_DownlinkQueueInvalidated:
 				uidStreamID = q.uidInvalidationKey(uid)
-				p.Set(ctx, deviceUIDLastInvalidationKey(q.redis, unique.ID(ctx, up.EndDeviceIdentifiers)), pld.DownlinkQueueInvalidated.LastFCntDown, 0)
+				p.Set(ctx, uidLastInvalidationKey(q.redis, unique.ID(ctx, up.EndDeviceIdentifiers)), pld.DownlinkQueueInvalidated.LastFCntDown, 0)
 			default:
 				uidStreamID = q.uidGenericUplinkKey(uid)
 			}
@@ -237,7 +236,7 @@ func (q *ApplicationUplinkQueue) Pop(ctx context.Context, f func(context.Context
 						devUID := unique.ID(ctx, up.EndDeviceIdentifiers)
 						lastFCnt, ok := invalidationFCnts[devUID]
 						if !ok {
-							lastFCnt, err = q.redis.Get(ctx, deviceUIDLastInvalidationKey(q.redis, devUID)).Uint64()
+							lastFCnt, err = q.redis.Get(ctx, uidLastInvalidationKey(q.redis, devUID)).Uint64()
 							if err != nil {
 								return false, ttnredis.ConvertError(err)
 							}

--- a/pkg/networkserver/redis/lua/deviceMatch.lua
+++ b/pkg/networkserver/redis/lua/deviceMatch.lua
@@ -59,13 +59,19 @@ if gt > 0 then
   table.insert(to_scan, 7)
 end
 if pivot > 0 or gt > 0 then
-  redis.call('copy', KEYS[3], KEYS[9])
+  -- TODO: Use COPY once Redis is updated to 6.2.0 (https://github.com/TheThingsNetwork/lorawan-stack/issues/3592)
+  -- redis.call('copy', KEYS[3], KEYS[9])
+  -- redis.call('pexpire', KEYS[9], ARGV[2])
+  redis.call('restore', KEYS[9], 0, ARGV[2], redis.call('dump', KEYS[3]))
 end
 
 if redis.call('sort', KEYS[4], 'by', 'nosort', 'store', KEYS[8]) > 0 then
   redis.call('pexpire', KEYS[9], ARGV[2])
   table.insert(to_scan, 9)
-  redis.call('copy', KEYS[5], KEYS[10])
+  -- TODO: Use COPY once Redis is updated to 6.2.0 (https://github.com/TheThingsNetwork/lorawan-stack/issues/3592)
+  -- redis.call('copy', KEYS[5], KEYS[10])
+  -- redis.call('pexpire', KEYS[10], ARGV[2])
+  redis.call('restore', KEYS[10], 0, ARGV[2], redis.call('dump', KEYS[5]))
 end
 
 if #to_scan > 1 then

--- a/pkg/networkserver/redis/lua/deviceMatch.lua
+++ b/pkg/networkserver/redis/lua/deviceMatch.lua
@@ -62,16 +62,16 @@ if pivot > 0 or gt > 0 then
   -- TODO: Use COPY once Redis is updated to 6.2.0 (https://github.com/TheThingsNetwork/lorawan-stack/issues/3592)
   -- redis.call('copy', KEYS[3], KEYS[9])
   -- redis.call('pexpire', KEYS[9], ARGV[2])
-  redis.call('restore', KEYS[9], 0, ARGV[2], redis.call('dump', KEYS[3]))
+  redis.call('restore', KEYS[9], ARGV[2], redis.call('dump', KEYS[3]))
 end
 
 if redis.call('sort', KEYS[4], 'by', 'nosort', 'store', KEYS[8]) > 0 then
-  redis.call('pexpire', KEYS[9], ARGV[2])
-  table.insert(to_scan, 9)
+  redis.call('pexpire', KEYS[8], ARGV[2])
+  table.insert(to_scan, 8)
   -- TODO: Use COPY once Redis is updated to 6.2.0 (https://github.com/TheThingsNetwork/lorawan-stack/issues/3592)
   -- redis.call('copy', KEYS[5], KEYS[10])
   -- redis.call('pexpire', KEYS[10], ARGV[2])
-  redis.call('restore', KEYS[10], 0, ARGV[2], redis.call('dump', KEYS[5]))
+  redis.call('restore', KEYS[10], ARGV[2], redis.call('dump', KEYS[5]))
 end
 
 if #to_scan > 1 then

--- a/pkg/networkserver/redis/lua/deviceMatch.lua
+++ b/pkg/networkserver/redis/lua/deviceMatch.lua
@@ -17,77 +17,58 @@
 --
 -- KEYS[1] 	- previous matching result key
 --
--- KEYS[2] 	- sorted set of uids of devices matching current session DevAddr using 16-bit frame counters sorted by LastFCntUp
--- KEYS[3] 	- sorted set of uids of devices matching current session DevAddr using 32-bit frame counters sorted by 2 LSB of LastFCntUp
--- KEYS[4] 	- set of uids of devices matching pending session DevAddr
--- KEYS[5]  - set of uids of devices matching either current or pending session DevAddr (legacy)
+-- KEYS[2] 	- sorted set of uids of devices matching current session DevAddr sorted ascending by LSB of LastFCntUp
+-- KEYS[3] 	- hash containing msgpack-encoded sessions for devices matching current session DevAddr keyed by uid
 --
--- KEYS[6] 	- sorted list of uids of devices matching using 16-bit frame counters
--- KEYS[7] 	- sorted list of uids of devices matching using 16-bit frame counters being processed
+-- KEYS[4] 	- sorted set of uids of devices matching pending session DevAddr sorted ascending by creation time
+-- KEYS[5] 	- hash containing msgpack-encoded sessions for devices matching pending session DevAddr keyed by uid
 --
--- KEYS[8] 	- sorted list of uids of devices matching using 32-bit frame counters with no rollover
--- KEYS[9] 	- sorted list of uids of devices matching using 32-bit frame counters with no rollover being processed
+-- KEYS[6] 	- sorted list of uids of devices matching with current session LastFCntUp LSB being lower than or equalt to current
+-- KEYS[7] 	- sorted list of uids of devices matching with current session LastFCntUp LSB being greater than current
+-- KEYS[8]  - sorted list of uids of devices matching pending session DevAddr
 --
--- KEYS[10] - list of uids of devices matching pending session DevAddr
--- KEYS[11] - list of uids of devices matching pending session DevAddr being processed
---
--- KEYS[12]	- sorted list of uids of devices matching using 32-bit frame counters with rollover
--- KEYS[13] - sorted list of uids of devices matching using 32-bit frame counters with rollover being processed
---
--- KEYS[14] - sorted list of uids of devices matching using 16-bit frame counters with a reset
--- KEYS[15] - sorted list of uids of devices matching using 16-bit frame counters with a reset being processed
---
--- KEYS[16] - list of uids of devices matching either current or pending session DevAddr not present in either KEYS[2], KEYS[3], nor KEYS[4]
--- KEYS[17] - list of uids of devices matching either current or pending session DevAddr not present in either KEYS[2], KEYS[3], nor KEYS[4] being processed
--- NOTE: The script is optimized for the assumption that count of devices using 16-bit frame counters << count of devices using 32-bit frame counters.
-if redis.call('pexpire', KEYS[1], ARGV[2]) > 0 then
-  return redis.call('get', KEYS[1])
+-- KEYS[9] - copy of KEYS[3]
+-- KEYS[10] - copy of KEYS[5]
+if redis.call('pexpire', KEYS[1], ARGV[2]) == 1 then
+  return { 'result', redis.call('get', KEYS[1]) }
 end
 
 -- Update expiration of all match keys - if any exist - return.
-local toScan = {}
-for i=6,17 do
+local to_scan = { 'scan' }
+for i=6,8 do
   if redis.call('pexpire', KEYS[i], ARGV[2]) == 1 then
-    table.insert(toScan, i)
+    table.insert(to_scan, i)
   end
 end
-if #toScan > 0 then
-    return toScan
+if #to_scan > 1 then
+  for i=9,10 do
+    redis.call('pexpire', KEYS[i], ARGV[2])
+  end
+  return to_scan
 end
 
-local shortCount = redis.call('zcount', KEYS[2], '-inf', ARGV[1])
-if redis.call('sort', KEYS[2], 'by', 'nosort', 'limit', 0, shortCount, 'store', KEYS[6]) > 0 then
+local pivot = redis.call('zcount', KEYS[2], '-inf', ARGV[1])
+if pivot > 0 then
+  redis.call('sort', KEYS[2], 'by', 'nosort', 'limit', 0, pivot, 'store', KEYS[6])
   redis.call('pexpire', KEYS[6], ARGV[2])
-  table.insert(toScan, 6)
+  table.insert(to_scan, 6)
+end
+local gt = redis.call('sort', KEYS[2], 'by', 'nosort', 'limit', pivot, -1, 'store', KEYS[7])
+if gt > 0 then
+  redis.call('pexpire', KEYS[7], ARGV[2])
+  table.insert(to_scan, 7)
+end
+if pivot > 0 or gt > 0 then
+  redis.call('copy', KEYS[3], KEYS[9])
 end
 
-local longCount = redis.call('zcount', KEYS[3], '-inf', ARGV[1])
-if redis.call('sort', KEYS[3], 'by', 'nosort', 'limit', 0, longCount, 'store', KEYS[8]) > 0 then
-  redis.call('pexpire', KEYS[8], ARGV[2])
-  table.insert(toScan, 8)
+if redis.call('sort', KEYS[4], 'by', 'nosort', 'store', KEYS[8]) > 0 then
+  redis.call('pexpire', KEYS[9], ARGV[2])
+  table.insert(to_scan, 9)
+  redis.call('copy', KEYS[5], KEYS[10])
 end
 
-if redis.call('sort', KEYS[4], 'by', 'nosort', 'store', KEYS[10]) > 0 then
-  redis.call('pexpire', KEYS[10], ARGV[2])
-  table.insert(toScan, 10)
-end
-
-if redis.call('sort', KEYS[3], 'by', 'nosort', 'limit', longCount, -1, 'store', KEYS[12]) > 0 then
-  redis.call('pexpire', KEYS[12], ARGV[2])
-  table.insert(toScan, 12)
-end
-
-if redis.call('sort', KEYS[2], 'by', 'nosort', 'limit', shortCount, -1, 'store', KEYS[14]) > 0 then
-  redis.call('pexpire', KEYS[14], ARGV[2])
-  table.insert(toScan, 14)
-end
-
-if redis.call('sort', KEYS[5], 'by', 'nosort', 'store', KEYS[16]) > 0 then
-  redis.call('pexpire', KEYS[16], ARGV[2])
-  table.insert(toScan, 16)
-end
-
-if #toScan > 0 then
-    return toScan
+if #to_scan > 1 then
+    return to_scan
 end
 return nil

--- a/pkg/networkserver/redis/lua/deviceMatchScan.lua
+++ b/pkg/networkserver/redis/lua/deviceMatchScan.lua
@@ -12,7 +12,12 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-if redis.call('lindex', KEYS[1], 0) == ARGV[1] then
+for old_uid in ARGV do
+  local uid = redis.call('lindex', KEYS[1], 0)
+  if uid ~= old_uid then
+    return uid
+  end
   redis.call('ltrim', KEYS[1], 1, -1)
   redis.call('hdel', KEYS[2], ARGV[1])
 end
+return redis.call('lindex', KEYS[1], 0)

--- a/pkg/networkserver/redis/lua/deviceMatchScan.lua
+++ b/pkg/networkserver/redis/lua/deviceMatchScan.lua
@@ -12,12 +12,12 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-for old_uid in ARGV do
-  local uid = redis.call('lindex', KEYS[1], 0)
+for _, old_uid in ipairs(ARGV) do
+  local uid = redis.call('lindex', KEYS[1], -1)
   if uid ~= old_uid then
     return uid
   end
-  redis.call('ltrim', KEYS[1], 1, -1)
-  redis.call('hdel', KEYS[2], ARGV[1])
+  redis.call('ltrim', KEYS[1], 0, -2)
+  redis.call('hdel', KEYS[2], old_uid)
 end
-return redis.call('lindex', KEYS[1], 0)
+return redis.call('lindex', KEYS[1], -1)

--- a/pkg/networkserver/redis/lua/deviceMatchScan.lua
+++ b/pkg/networkserver/redis/lua/deviceMatchScan.lua
@@ -12,23 +12,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-if #ARGV == 2 then
-	redis.call("lrem", KEYS[2], 1, ARGV[2])
+if redis.call('lindex', KEYS[1], 0) == ARGV[1] then
+  redis.call('ltrim', KEYS[1], 1, -1)
+  redis.call('hdel', KEYS[2], ARGV[1])
 end
-
-
-for i = 1, #KEYS do
-  local uid
-  if KEYS[i]:sub(-10) == "processing" then
-	  uid = redis.call('rpop', KEYS[i])
-  else
-	  uid = redis.call('rpoplpush', KEYS[i], KEYS[i+1])
-  end
-	if uid then
-	  for j = i, #KEYS, 1 do
-	  	redis.call('pexpire', KEYS[j], ARGV[1])
-	  end
-	  return {i,uid}
-	end
-end
-return nil

--- a/pkg/networkserver/redis/lua/deviceMatchScanGT.lua
+++ b/pkg/networkserver/redis/lua/deviceMatchScanGT.lua
@@ -1,0 +1,28 @@
+-- Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+for _, old_uid in ipairs(ARGV) do
+  local uid = redis.call('lindex', KEYS[1], -1)
+  if uid ~= old_uid then
+    return uid
+  end
+  redis.call('ltrim', KEYS[1], 0, -2)
+  redis.call('hdel', KEYS[2], old_uid)
+end
+
+local uid = redis.call('lindex', KEYS[1], -1)
+if uid then
+  return { uid, redis.call('hget', KEYS[2], uid) }
+end
+return nil

--- a/pkg/networkserver/redis/lua/deviceMatchScanGT.lua
+++ b/pkg/networkserver/redis/lua/deviceMatchScanGT.lua
@@ -15,14 +15,27 @@
 for _, old_uid in ipairs(ARGV) do
   local uid = redis.call('lindex', KEYS[1], -1)
   if uid ~= old_uid then
-    return uid
+    local s = redis.call('hget', KEYS[2], uid)
+    local m = cmsgpack.unpack(s)
+    if not m.Supports32BitFCnt or m.Supports32BitFCnt.value
+      or m.ResetsFCnt and m.ResetsFCnt.value then
+      return { uid, s }
+    end
   end
   redis.call('ltrim', KEYS[1], 0, -2)
-  redis.call('hdel', KEYS[2], old_uid)
+  redis.call('hdel', KEYS[2], uid)
 end
 
 local uid = redis.call('lindex', KEYS[1], -1)
-if uid then
-  return { uid, redis.call('hget', KEYS[2], uid) }
+while uid do
+  local s = redis.call('hget', KEYS[2], uid)
+  local m = cmsgpack.unpack(s)
+  if not m.Supports32BitFCnt or m.Supports32BitFCnt.value
+    or m.ResetsFCnt and m.ResetsFCnt.value then
+    return { uid, s }
+  end
+  redis.call('ltrim', KEYS[1], 0, -2)
+  redis.call('hdel', KEYS[2], uid)
+  uid = redis.call('lindex', KEYS[1], -1)
 end
 return nil

--- a/pkg/networkserver/redis/lua/deviceMatchScanGT.lua
+++ b/pkg/networkserver/redis/lua/deviceMatchScanGT.lua
@@ -12,13 +12,15 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+local ack = ARGV[1]
+table.remove(ARGV, 1)
 for _, old_uid in ipairs(ARGV) do
   local uid = redis.call('lindex', KEYS[1], -1)
   if uid ~= old_uid then
     local s = redis.call('hget', KEYS[2], uid)
     local m = cmsgpack.unpack(s)
     if not m.Supports32BitFCnt or m.Supports32BitFCnt.value
-      or m.ResetsFCnt and m.ResetsFCnt.value then
+      or ack == 0 and m.ResetsFCnt and m.ResetsFCnt.value then
       return { uid, s }
     end
   end
@@ -31,7 +33,7 @@ while uid do
   local s = redis.call('hget', KEYS[2], uid)
   local m = cmsgpack.unpack(s)
   if not m.Supports32BitFCnt or m.Supports32BitFCnt.value
-    or m.ResetsFCnt and m.ResetsFCnt.value then
+    or ack == 0 and m.ResetsFCnt and m.ResetsFCnt.value then
     return { uid, s }
   end
   redis.call('ltrim', KEYS[1], 0, -2)

--- a/pkg/networkserver/redis/redis.go
+++ b/pkg/networkserver/redis/redis.go
@@ -29,12 +29,12 @@ type keyer interface {
 	Key(ks ...string) string
 }
 
-func deviceUIDKey(r keyer, uid string) string {
+func UIDKey(r keyer, uid string) string {
 	return r.Key("uid", uid)
 }
 
-func deviceUIDLastInvalidationKey(r keyer, uid string) string {
-	return ttnredis.Key(deviceUIDKey(r, uid), "last-invalidation")
+func uidLastInvalidationKey(r keyer, uid string) string {
+	return ttnredis.Key(UIDKey(r, uid), "last-invalidation")
 }
 
 var keyEncoding = base64.RawStdEncoding

--- a/pkg/networkserver/redis/registry.go
+++ b/pkg/networkserver/redis/registry.go
@@ -673,13 +673,14 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIde
 						return false, true, true
 					case !updated.Session.DevAddr.Equal(storedSession.DevAddr):
 						return true, true, true
+					case updated.Session.LastFCntUp != storedSession.LastFCntUp:
+						return false, true, true
 					}
 					storedMACState := stored.GetMACState()
 					storedMACSettings := stored.GetMACSettings()
 					return false, false, storedMACState == nil ||
 						updated.MACState.LoRaWANVersion != storedMACState.LoRaWANVersion ||
 						!updated.Session.FNwkSIntKey.Equal(storedSession.FNwkSIntKey) ||
-						updated.Session.LastFCntUp != storedSession.LastFCntUp ||
 						!updated.MACSettings.GetResetsFCnt().Equal(storedMACSettings.GetResetsFCnt()) ||
 						!updated.MACSettings.GetSupports32BitFCnt().Equal(storedMACSettings.GetSupports32BitFCnt())
 				}()

--- a/pkg/networkserver/redis/registry.go
+++ b/pkg/networkserver/redis/registry.go
@@ -454,6 +454,8 @@ func MarshalDevicePendingSession(dev *ttnpb.EndDevice) ([]byte, error) {
 	})
 }
 
+var errInvalidDevice = errors.DefineInvalidArgument("invalid_device", "device is invalid")
+
 // SetByID sets device by appID, devID.
 func (r *DeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, gets []string, f func(ctx context.Context, pb *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error) {
 	ids := ttnpb.EndDeviceIdentifiers{
@@ -596,8 +598,7 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIde
 
 			if updated.Session != nil && updated.MACState == nil ||
 				updated.PendingSession != nil && updated.PendingMACState == nil {
-				// TODO error
-				panic("TODO")
+				return errInvalidDevice.New()
 			}
 
 			storedPendingSession := stored.GetPendingSession()

--- a/pkg/networkserver/redis/registry.go
+++ b/pkg/networkserver/redis/registry.go
@@ -17,12 +17,10 @@ package redis
 import (
 	"bytes"
 	"context"
-	"encoding"
 	"fmt"
 	"io"
 	"math/rand"
 	"runtime/trace"
-	"strconv"
 	"sync"
 	"time"
 
@@ -34,7 +32,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/networkserver"
-	. "go.thethings.network/lorawan-stack/v3/pkg/networkserver/internal"
 	ttnredis "go.thethings.network/lorawan-stack/v3/pkg/redis"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
@@ -46,14 +43,6 @@ var (
 	errInvalidIdentifiers   = errors.DefineInvalidArgument("invalid_identifiers", "invalid identifiers")
 	errDuplicateIdentifiers = errors.DefineAlreadyExists("duplicate_identifiers", "duplicate identifiers")
 	errReadOnlyField        = errors.DefineInvalidArgument("read_only_field", "read-only field `{field}`")
-)
-
-const (
-	fieldKey = "fields"
-
-	shortFCntKey = "16bit"
-	longFCntKey  = "32bit"
-	pendingKey   = "pending"
 )
 
 // DeviceRegistry is an implementation of networkserver.DeviceRegistry.
@@ -76,8 +65,42 @@ func (r *DeviceRegistry) Init(ctx context.Context) error {
 	return nil
 }
 
+// marshalMsgpack is adaptation of msgpack.Marshal (https://github.com/vmihailenco/msgpack/blob/8b121f7d2c8eac21ab98ef6443d272f355b88999/encode.go#L58-L74).
+func marshalMsgpack(v interface{}) ([]byte, error) {
+	enc := msgpack.GetEncoder()
+
+	var buf bytes.Buffer
+	enc.Reset(&buf)
+	enc.UseCompactFloats(true)
+	enc.UseCompactInts(true)
+	enc.UseCustomStructTag("json")
+
+	err := enc.Encode(v)
+	b := buf.Bytes()
+
+	msgpack.PutEncoder(enc)
+
+	if err != nil {
+		return nil, err
+	}
+	return b, err
+}
+
+// unmarshalMsgpack is adaptation of msgpack.Unmarshal (https://github.com/vmihailenco/msgpack/blob/8b121f7d2c8eac21ab98ef6443d272f355b88999/decode.go#L54-L63).
+func unmarshalMsgpack(b []byte, v interface{}) error {
+	dec := msgpack.GetDecoder()
+
+	dec.ResetBytes(b)
+	dec.UseCustomStructTag("json")
+	err := dec.Decode(v)
+
+	msgpack.PutDecoder(dec)
+
+	return err
+}
+
 func (r *DeviceRegistry) uidKey(uid string) string {
-	return deviceUIDKey(r.Redis, uid)
+	return UIDKey(r.Redis, uid)
 }
 
 func (r *DeviceRegistry) addrKey(addr types.DevAddr) string {
@@ -86,13 +109,6 @@ func (r *DeviceRegistry) addrKey(addr types.DevAddr) string {
 
 func (r *DeviceRegistry) euiKey(joinEUI, devEUI types.EUI64) string {
 	return r.Redis.Key("eui", joinEUI.String(), devEUI.String())
-}
-
-func deviceSupports32BitFCnt(pb *ttnpb.EndDevice) bool {
-	if pb.GetMACSettings().GetSupports32BitFCnt() != nil {
-		return pb.MACSettings.Supports32BitFCnt.Value
-	}
-	return true
 }
 
 // GetByID gets device by appID, devID.
@@ -135,425 +151,80 @@ func (r *DeviceRegistry) GetByEUI(ctx context.Context, joinEUI, devEUI types.EUI
 	return pb, ctx, nil
 }
 
-type uplinkMatch struct {
-	appID                   ttnpb.ApplicationIdentifiers
-	devID                   string
-	loRaWANVersion          ttnpb.MACVersion
-	fNwkSIntKeyKey          *types.AES128Key
-	fNwkSIntKeyKEKLabel     string
-	fNwkSIntKeyEncryptedKey []byte
-	resetsFCnt              *bool
-
-	fCnt      uint32
-	lastFCnt  uint32
-	isPending bool
+type uplinkMatchSession struct {
+	LoRaWANVersion    ttnpb.MACVersion
+	FNwkSIntKey       *ttnpb.KeyEnvelope
+	LastFCnt          uint32             `json:",omitempty"`
+	ResetsFCnt        *pbtypes.BoolValue `json:",omitempty"`
+	Supports32BitFCnt *pbtypes.BoolValue `json:",omitempty"`
 }
 
-func (m uplinkMatch) ApplicationIdentifiers() ttnpb.ApplicationIdentifiers {
-	return m.appID
+type uplinkMatchPendingSession struct {
+	LoRaWANVersion ttnpb.MACVersion
+	FNwkSIntKey    *ttnpb.KeyEnvelope
 }
 
-func (m uplinkMatch) DeviceID() string {
-	return m.devID
+type uplinkMatchResult struct {
+	UID               string
+	LoRaWANVersion    ttnpb.MACVersion
+	FNwkSIntKey       *ttnpb.KeyEnvelope
+	LastFCnt          uint32             `json:",omitempty"`
+	IsPending         bool               `json:",omitempty"`
+	ResetsFCnt        *pbtypes.BoolValue `json:",omitempty"`
+	Supports32BitFCnt *pbtypes.BoolValue `json:",omitempty"`
 }
 
-func (m uplinkMatch) LoRaWANVersion() ttnpb.MACVersion {
-	return m.loRaWANVersion
+func CurrentAddrKey(addrKey string) string {
+	return ttnredis.Key(addrKey, "current")
 }
 
-func (m uplinkMatch) FNwkSIntKey() *ttnpb.KeyEnvelope {
-	return &ttnpb.KeyEnvelope{
-		Key:          m.fNwkSIntKeyKey,
-		KEKLabel:     m.fNwkSIntKeyKEKLabel,
-		EncryptedKey: m.fNwkSIntKeyEncryptedKey,
-	}
+func PendingAddrKey(addrKey string) string {
+	return ttnredis.Key(addrKey, "pending")
 }
 
-func (m uplinkMatch) FCnt() uint32 {
-	return m.fCnt
-}
-
-func (m uplinkMatch) LastFCnt() uint32 {
-	return m.lastFCnt
-}
-
-func (m uplinkMatch) ResetsFCnt() *pbtypes.BoolValue {
-	if m.resetsFCnt == nil {
-		return nil
-	}
-	return &pbtypes.BoolValue{
-		Value: *m.resetsFCnt,
-	}
-}
-
-func (m uplinkMatch) IsPending() bool {
-	return m.isPending
-}
-
-type matchKeySet struct {
-	ShortFCntLE string
-	LongFCntLE  string
-	Pending     string
-	LongFCntGT  string
-	ShortFCntGT string
-	Legacy      string
-}
-
-func boolPtr(v bool) *bool {
-	return &v
-}
-
-func encodeBool(v bool) uint8 {
-	if v {
-		return 1
-	}
-	return 0
-}
-
-var errInvalidFormat = errors.DefineInvalidArgument("invalid_format", "invalid value format")
-
-func decodeString(v interface{}) (string, error) {
-	s, ok := v.(string)
-	if !ok {
-		return "", errInvalidFormat.New()
-	}
-	return s, nil
-}
-
-func decodeBool(v interface{}) (bool, error) {
-	s, err := decodeString(v)
-	if err != nil {
-		return false, err
-	}
-	switch s {
-	case "0":
-		return false, nil
-	case "1":
-		return true, nil
-	default:
-		return false, errInvalidFormat.New()
-	}
-}
-
-func decodeBytes(v interface{}) ([]byte, error) {
-	s, err := decodeString(v)
-	if err != nil {
-		return nil, err
-	}
-	return []byte(s), nil
-}
-
-func decodeBinary(src interface{}, dst encoding.BinaryUnmarshaler) error {
-	b, err := decodeBytes(src)
-	if err != nil {
-		return err
-	}
-	if err = dst.UnmarshalBinary(b); err != nil {
-		return err
-	}
-	return nil
-}
-
-func decodeMACVersion(v interface{}) (ttnpb.MACVersion, error) {
-	var ver ttnpb.MACVersion
-	if err := decodeBinary(v, &ver); err != nil {
-		return -1, err
-	}
-	if err := ver.Validate(); err != nil {
-		return -1, err
-	}
-	return ver, nil
-}
-
-func decodeAES128Key(v interface{}) (*types.AES128Key, error) {
-	key := &types.AES128Key{}
-	if err := decodeBinary(v, key); err != nil {
-		return nil, err
-	}
-	return key, nil
-}
-
-var errMissingField = errors.DefineCorruption("missing_field_value", "missing field `{field}` value")
-
-func getUplinkMatch(ctx context.Context, r redis.Cmdable, inputKeys, processingKeys matchKeySet, appID ttnpb.ApplicationIdentifiers, devID string, devAddr types.DevAddr, lsb uint16, matchKey, uidKey string) ([]*uplinkMatch, error) {
-	var isPending bool
-	switch matchKey {
-	case inputKeys.ShortFCntLE, processingKeys.ShortFCntLE,
-		inputKeys.ShortFCntGT, processingKeys.ShortFCntGT,
-		inputKeys.LongFCntLE, processingKeys.LongFCntLE,
-		inputKeys.LongFCntGT, processingKeys.LongFCntGT:
-	case inputKeys.Pending, processingKeys.Pending:
-		// NOTE: While the legacy key may point to a pending session, we can safely ignore that
-		// and let device rejoin and perform migration to new format.
-		isPending = true
-	case inputKeys.Legacy, processingKeys.Legacy:
-		pb := &ttnpb.EndDevice{}
-		if err := ttnredis.GetProto(ctx, r, uidKey).ScanProto(pb); err != nil {
-			return nil, err
-		}
-		ms := make([]*uplinkMatch, 0, 2)
-		if pb.GetMACState() != nil &&
-			pb.GetSession() != nil &&
-			pb.Session.DevAddr.Equal(devAddr) &&
-			pb.Session.FNwkSIntKey != nil {
-			var resetsFCnt *bool
-			if pb.GetMACSettings().GetResetsFCnt() != nil {
-				resetsFCnt = &pb.MACSettings.ResetsFCnt.Value
-			}
-			if pb.ApplicationIdentifiers != appID || pb.DeviceID != devID {
-				return nil, errDatabaseCorruption.WithCause(errInvalidIdentifiers.New())
-			}
-			if err := pb.MACState.LoRaWANVersion.Validate(); err != nil {
-				return nil, errDatabaseCorruption.WithCause(err)
-			}
-			ms = append(ms, &uplinkMatch{
-				appID:                   appID,
-				devID:                   devID,
-				loRaWANVersion:          pb.MACState.LoRaWANVersion,
-				fNwkSIntKeyKey:          pb.Session.FNwkSIntKey.Key,
-				fNwkSIntKeyKEKLabel:     pb.Session.FNwkSIntKey.KEKLabel,
-				fNwkSIntKeyEncryptedKey: pb.Session.FNwkSIntKey.EncryptedKey,
-				resetsFCnt:              resetsFCnt,
-				fCnt:                    FullFCnt(lsb, pb.Session.LastFCntUp, deviceSupports32BitFCnt(pb)),
-				lastFCnt:                pb.Session.LastFCntUp,
-			})
-		}
-		if pb.GetPendingMACState() != nil &&
-			pb.GetPendingSession() != nil &&
-			pb.PendingSession.DevAddr.Equal(devAddr) &&
-			pb.PendingSession.FNwkSIntKey != nil {
-			if err := pb.PendingMACState.LoRaWANVersion.Validate(); err != nil {
-				return nil, errDatabaseCorruption.WithCause(err)
-			}
-			ms = append(ms, &uplinkMatch{
-				appID:                   appID,
-				devID:                   devID,
-				loRaWANVersion:          pb.PendingMACState.LoRaWANVersion,
-				fNwkSIntKeyKey:          pb.PendingSession.FNwkSIntKey.Key,
-				fNwkSIntKeyKEKLabel:     pb.PendingSession.FNwkSIntKey.KEKLabel,
-				fNwkSIntKeyEncryptedKey: pb.PendingSession.FNwkSIntKey.EncryptedKey,
-				fCnt:                    uint32(lsb),
-				isPending:               true,
-			})
-		}
-		return ms, nil
-	default:
-		panic(fmt.Sprintf("invalid match key specified `%s`", matchKey))
-	}
-
-	var fields []string
-	if isPending {
-		fields = []string{
-			"pending_mac_state.lorawan_version",
-			"pending_session.keys.f_nwk_s_int_key.encrypted_key",
-			"pending_session.keys.f_nwk_s_int_key.kek_label",
-			"pending_session.keys.f_nwk_s_int_key.key",
-		}
-	} else {
-		fields = []string{
-			"mac_settings.resets_f_cnt",
-			"mac_state.lorawan_version",
-			"session.keys.f_nwk_s_int_key.encrypted_key",
-			"session.keys.f_nwk_s_int_key.kek_label",
-			"session.keys.f_nwk_s_int_key.key",
-			"session.last_f_cnt_up",
-		}
-	}
-
-	vs, err := r.HMGet(ctx, ttnredis.Key(uidKey, fieldKey), fields...).Result()
-	if err != nil {
-		return nil, ttnredis.ConvertError(err)
-	}
-	if len(vs) != len(fields) {
-		panic("invalid Redis answer field count")
-	}
-	m := &uplinkMatch{
-		appID:     appID,
-		devID:     devID,
-		fCnt:      uint32(lsb),
-		isPending: isPending,
-	}
-	for i, v := range vs {
-		if v == nil {
-			switch name := fields[i]; name {
-			case "pending_mac_state.lorawan_version", "mac_state.lorawan_version":
-				log.FromContext(ctx).WithField("field", name).Error("Device is missing required field")
-				return nil, errDatabaseCorruption.WithCause(errMissingField.WithAttributes("field", name).New())
-			}
-			continue
-		}
-		if isPending {
-			switch fields[i] {
-			case "pending_mac_state.lorawan_version":
-				v, err := decodeMACVersion(v)
-				if err != nil {
-					return nil, errDatabaseCorruption.WithCause(err)
-				}
-				m.loRaWANVersion = v
-			case "pending_session.keys.f_nwk_s_int_key.encrypted_key":
-				v, err := decodeBytes(v)
-				if err != nil {
-					return nil, errDatabaseCorruption.WithCause(err)
-				}
-				m.fNwkSIntKeyEncryptedKey = v
-			case "pending_session.keys.f_nwk_s_int_key.kek_label":
-				v, err := decodeString(v)
-				if err != nil {
-					return nil, errDatabaseCorruption.WithCause(err)
-				}
-				m.fNwkSIntKeyKEKLabel = v
-			case "pending_session.keys.f_nwk_s_int_key.key":
-				v, err := decodeAES128Key(v)
-				if err != nil {
-					return nil, errDatabaseCorruption.WithCause(err)
-				}
-				m.fNwkSIntKeyKey = v
-			default:
-				panic(fmt.Sprintf("unknown field received from Redis: `%s`", fields[i]))
-			}
-		} else {
-			switch fields[i] {
-			case "mac_settings.resets_f_cnt":
-				v, err := decodeBool(v)
-				if err != nil {
-					return nil, errDatabaseCorruption.WithCause(err)
-				}
-				m.resetsFCnt = &v
-			case "mac_state.lorawan_version":
-				v, err := decodeMACVersion(v)
-				if err != nil {
-					return nil, errDatabaseCorruption.WithCause(err)
-				}
-				m.loRaWANVersion = v
-			case "session.keys.f_nwk_s_int_key.encrypted_key":
-				v, err := decodeBytes(v)
-				if err != nil {
-					return nil, errDatabaseCorruption.WithCause(err)
-				}
-				m.fNwkSIntKeyEncryptedKey = v
-			case "session.keys.f_nwk_s_int_key.kek_label":
-				v, err := decodeString(v)
-				if err != nil {
-					return nil, errDatabaseCorruption.WithCause(err)
-				}
-				m.fNwkSIntKeyKEKLabel = v
-			case "session.keys.f_nwk_s_int_key.key":
-				v, err := decodeAES128Key(v)
-				if err != nil {
-					return nil, errDatabaseCorruption.WithCause(err)
-				}
-				m.fNwkSIntKeyKey = v
-			case "session.last_f_cnt_up":
-				s, err := decodeString(v)
-				if err != nil {
-					return nil, errDatabaseCorruption.WithCause(err)
-				}
-				n, err := strconv.ParseUint(s, 10, 32)
-				if err != nil {
-					return nil, errDatabaseCorruption.WithCause(errInvalidFormat.WithCause(err))
-				}
-				m.lastFCnt = uint32(n)
-				m.fCnt = FullFCnt(lsb, m.lastFCnt, func() bool {
-					switch matchKey {
-					case inputKeys.ShortFCntLE, processingKeys.ShortFCntLE,
-						inputKeys.ShortFCntGT, processingKeys.ShortFCntGT:
-						return false
-					case inputKeys.LongFCntLE, processingKeys.LongFCntLE,
-						inputKeys.LongFCntGT, processingKeys.LongFCntGT:
-						return true
-					default:
-						panic(fmt.Sprintf("invalid match key specified: `%s`", matchKey))
-					}
-				}())
-
-			default:
-				panic(fmt.Sprintf("unknown field received from Redis: `%s`", fields[i]))
-			}
-		}
-	}
-	return []*uplinkMatch{m}, nil
+func FieldKey(addrKey string) string {
+	return ttnredis.Key(addrKey, "fields")
 }
 
 var errNoUplinkMatch = errors.DefineNotFound("no_uplink_match", "no device matches uplink")
 
 // RangeByUplinkMatches ranges over devices matching the uplink.
-func (r *DeviceRegistry) RangeByUplinkMatches(ctx context.Context, up *ttnpb.UplinkMessage, cacheTTL time.Duration, f func(context.Context, networkserver.UplinkMatch) (bool, error)) error {
+func (r *DeviceRegistry) RangeByUplinkMatches(ctx context.Context, up *ttnpb.UplinkMessage, cacheTTL time.Duration, f func(context.Context, *networkserver.UplinkMatch) (bool, error)) error {
 	defer trace.StartRegion(ctx, "range end devices by dev_addr").End()
-	if cacheTTL < time.Millisecond {
-		// TODO: Remove once https://github.com/TheThingsNetwork/lorawan-stack/issues/2698 is closed.
-		cacheTTL = time.Millisecond
-	}
-	pld := up.Payload.GetMACPayload()
-	addrKey := r.addrKey(pld.DevAddr)
 
-	addrKeys := struct {
-		ShortFCnt string
-		LongFCnt  string
-		Pending   string
-		Legacy    string
-	}{
-		ShortFCnt: ttnredis.Key(addrKey, shortFCntKey),
-		LongFCnt:  ttnredis.Key(addrKey, longFCntKey),
-		Pending:   ttnredis.Key(addrKey, pendingKey),
-		Legacy:    addrKey,
-	}
+	pld := up.Payload.GetMACPayload()
+	lsb := uint16(pld.FCnt)
+
+	addrKey := r.addrKey(pld.DevAddr)
+	addrKeyCurrent := CurrentAddrKey(addrKey)
+	addrKeyPending := PendingAddrKey(addrKey)
+	fieldKeyCurrent := FieldKey(addrKeyCurrent)
+	fieldKeyPending := FieldKey(addrKeyPending)
 
 	payloadHash := uplinkPayloadHash(up.RawPayload)
 
-	matchKeys := struct {
-		Match      string
-		Input      matchKeySet
-		Processing matchKeySet
-	}{
-		Match: ttnredis.Key(addrKey, "match", payloadHash),
-		Input: matchKeySet{
-			ShortFCntLE: ttnredis.Key(addrKeys.ShortFCnt, payloadHash, "le"),
-			LongFCntLE:  ttnredis.Key(addrKeys.LongFCnt, payloadHash, "le"),
-			Pending:     ttnredis.Key(addrKeys.Pending, payloadHash),
-			LongFCntGT:  ttnredis.Key(addrKeys.LongFCnt, payloadHash, "gt"),
-			ShortFCntGT: ttnredis.Key(addrKeys.ShortFCnt, payloadHash, "gt"),
-			Legacy:      ttnredis.Key(addrKeys.Legacy, payloadHash),
-		},
-	}
-	matchKeys.Processing = matchKeySet{
-		ShortFCntLE: ttnredis.Key(matchKeys.Input.ShortFCntLE, "processing"),
-		LongFCntLE:  ttnredis.Key(matchKeys.Input.LongFCntLE, "processing"),
-		Pending:     ttnredis.Key(matchKeys.Input.Pending, "processing"),
-		LongFCntGT:  ttnredis.Key(matchKeys.Input.LongFCntGT, "processing"),
-		ShortFCntGT: ttnredis.Key(matchKeys.Input.ShortFCntGT, "processing"),
-		Legacy:      ttnredis.Key(matchKeys.Input.Legacy, "processing"),
-	}
+	matchResultKey := ttnredis.Key(addrKey, "up", payloadHash, "result")
+	matchUIDKeyCurrentLE := ttnredis.Key(addrKeyCurrent, "up", payloadHash, "le")
+	matchUIDKeyCurrentGT := ttnredis.Key(addrKeyCurrent, "up", payloadHash, "gt")
+	matchUIDKeyPending := ttnredis.Key(addrKeyPending, "up", payloadHash)
+	matchFieldKeyCurrent := ttnredis.Key(fieldKeyCurrent, "up", payloadHash)
+	matchFieldKeyPending := ttnredis.Key(fieldKeyPending, "up", payloadHash)
 
-	type MatchResult struct {
-		Key string
-		UID string
-	}
-	lsb := uint16(pld.FCnt)
-	v, err := deviceMatchScript.Run(ctx, r.Redis, []string{
-		matchKeys.Match,
+	ret, err := deviceMatchScript.Run(ctx, r.Redis, []string{
+		matchResultKey,
 
-		addrKeys.ShortFCnt,
-		addrKeys.LongFCnt,
-		addrKeys.Pending,
-		addrKeys.Legacy,
+		addrKeyCurrent,
+		fieldKeyCurrent,
 
-		matchKeys.Input.ShortFCntLE,
-		matchKeys.Processing.ShortFCntLE,
+		addrKeyPending,
+		fieldKeyPending,
 
-		matchKeys.Input.LongFCntLE,
-		matchKeys.Processing.LongFCntLE,
+		matchUIDKeyCurrentLE,
+		matchUIDKeyCurrentGT,
+		matchUIDKeyPending,
 
-		matchKeys.Input.Pending,
-		matchKeys.Processing.Pending,
-
-		matchKeys.Input.LongFCntGT,
-		matchKeys.Processing.LongFCntGT,
-
-		matchKeys.Input.ShortFCntGT,
-		matchKeys.Processing.ShortFCntGT,
-
-		matchKeys.Input.Legacy,
-		matchKeys.Processing.Legacy,
+		matchFieldKeyCurrent,
+		matchFieldKeyPending,
 	}, lsb, cacheTTL.Milliseconds()).Result()
 	if err != nil {
 		if err == redis.Nil {
@@ -561,210 +232,182 @@ func (r *DeviceRegistry) RangeByUplinkMatches(ctx context.Context, up *ttnpb.Upl
 		}
 		return ttnredis.ConvertError(err)
 	}
-	// NOTE(1): Indexes must be consistent with lua/deviceMatch.lua.
-	// NOTE(2): Lua indexing starts from 1.
-	var scanKeys []string
-	switch v := v.(type) {
-	case []interface{}:
-		keyIndexes := make([]uint8, 0, len(v))
-		for _, iface := range v {
-			idx, ok := iface.(int64)
-			if !ok {
-				panic(fmt.Sprintf("failed to process match script return value '%v' as index", iface))
-			}
-			keyIndexes = append(keyIndexes, uint8(idx))
+
+	vs, ok := ret.([]interface{})
+	if !ok {
+		panic(fmt.Sprintf("expected match script return value to be []interface{}, got %T", ret))
+	}
+	if len(vs) < 1 {
+		panic("empty match script return value")
+	}
+	matchType, ok := vs[0].(string)
+	if !ok {
+		panic(fmt.Sprintf("expected first match script return value element to be a string, got %T", vs[0]))
+	}
+	if matchType == "result" {
+		if len(vs) != 2 {
+			panic(fmt.Sprintf("expected match script return value of `result` type to contain 2 elements, got %d", len(vs)))
 		}
-		scanKeys = make([]string, 0, 12)
-		for i := 0; i < len(keyIndexes); i++ {
-			switch keyIndexes[i] {
-			case 6:
-				scanKeys = append(scanKeys, matchKeys.Input.ShortFCntLE, matchKeys.Processing.ShortFCntLE)
-			case 7:
-				scanKeys = append(scanKeys, matchKeys.Processing.ShortFCntLE)
-				continue
-
-			case 8:
-				scanKeys = append(scanKeys, matchKeys.Input.LongFCntLE, matchKeys.Processing.LongFCntLE)
-			case 9:
-				scanKeys = append(scanKeys, matchKeys.Processing.LongFCntLE)
-				continue
-
-			case 10:
-				scanKeys = append(scanKeys, matchKeys.Input.Pending, matchKeys.Processing.Pending)
-			case 11:
-				scanKeys = append(scanKeys, matchKeys.Processing.Pending)
-				continue
-
-			case 12:
-				scanKeys = append(scanKeys, matchKeys.Input.LongFCntGT, matchKeys.Processing.LongFCntGT)
-			case 13:
-				scanKeys = append(scanKeys, matchKeys.Processing.LongFCntGT)
-				continue
-
-			case 14:
-				scanKeys = append(scanKeys, matchKeys.Input.ShortFCntGT, matchKeys.Processing.ShortFCntGT)
-			case 15:
-				scanKeys = append(scanKeys, matchKeys.Processing.ShortFCntGT)
-				continue
-
-			case 16:
-				scanKeys = append(scanKeys, matchKeys.Input.Legacy, matchKeys.Processing.Legacy)
-			case 17:
-				scanKeys = append(scanKeys, matchKeys.Processing.Legacy)
-				continue
-
-			default:
-				panic(fmt.Sprintf("invalid index returned by match script: %d", keyIndexes[i]))
-			}
-			if len(keyIndexes) > i+1 && keyIndexes[i+1] == keyIndexes[i]+1 {
-				// Next key is "processing" key, which is already added above - skip
-				i++
-			}
+		s, ok := vs[1].(string)
+		if !ok {
+			panic(fmt.Sprintf("expected second element of match script return value of `result` type to be a string, got %T", vs[1]))
 		}
-
-	case string:
-		res := &MatchResult{}
-		if err := msgpack.Unmarshal([]byte(v), res); err != nil {
-			return err
-		}
-
-		ids, err := unique.ToDeviceID(res.UID)
-		if err != nil {
-			log.FromContext(ctx).WithError(err).Error("Failed to parse match uid value recorded")
+		ctx := log.NewContextWithField(ctx, "match_key", matchResultKey)
+		res := &uplinkMatchResult{}
+		if err := unmarshalMsgpack([]byte(s), res); err != nil {
+			log.FromContext(ctx).WithError(err).Error("Failed to unmarshal match result")
 			return errDatabaseCorruption.WithCause(err)
 		}
-		ctx := log.NewContextWithField(ctx, "device_uid", res.UID)
-		ms, err := getUplinkMatch(ctx, r.Redis, matchKeys.Input, matchKeys.Processing, ids.ApplicationIdentifiers, ids.DeviceID, pld.DevAddr, lsb, res.Key, r.uidKey(res.UID))
+		ctx = log.NewContextWithField(ctx, "device_uid", res.UID)
+		ids, err := unique.ToDeviceID(res.UID)
 		if err != nil {
-			return err
+			log.FromContext(ctx).WithError(err).Error("Failed to parse match result UID as device identifiers")
+			return errDatabaseCorruption.WithCause(err)
 		}
-		for _, m := range ms {
+		ok, err = f(ctx, &networkserver.UplinkMatch{
+			ApplicationIdentifiers: ids.ApplicationIdentifiers,
+			DeviceID:               ids.DeviceID,
+			LoRaWANVersion:         res.LoRaWANVersion,
+			FNwkSIntKey:            res.FNwkSIntKey,
+			LastFCnt:               res.LastFCnt,
+			IsPending:              res.IsPending,
+			ResetsFCnt:             res.ResetsFCnt,
+			Supports32BitFCnt:      res.Supports32BitFCnt,
+		})
+		if err != nil {
+			return errNoUplinkMatch.WithCause(err)
+		}
+		if !ok {
+			return errNoUplinkMatch
+		}
+		if err = r.Redis.Set(ctx, matchResultKey, s, cacheTTL).Err(); err != nil {
+			return ttnredis.ConvertError(err)
+		}
+		return nil
+	}
+
+	for _, v := range vs[1:] {
+		// NOTE(1): Indexes must be consistent with lua/deviceMatch.lua.
+		// NOTE(2): Lua indexing starts from 1.
+		idx, ok := v.(int64)
+		if !ok {
+			panic(fmt.Sprintf("expected match script `continue` type return value to be int64, got '%v'(%T)", v, v))
+		}
+		var (
+			matchUIDKey   string
+			matchFieldKey string
+			isPending     bool
+		)
+		switch idx {
+		case 6:
+			matchUIDKey = matchUIDKeyCurrentLE
+			matchFieldKey = matchFieldKeyCurrent
+		case 7:
+			matchUIDKey = matchUIDKeyCurrentGT
+			matchFieldKey = matchFieldKeyCurrent
+		case 8:
+			matchUIDKey = matchUIDKeyPending
+			matchFieldKey = matchFieldKeyPending
+			isPending = true
+		default:
+			panic(fmt.Sprintf("invalid index returned by match script with `continue` type: %d", idx))
+		}
+		for {
+			uid, err := r.Redis.LIndex(ctx, matchUIDKey, 0).Result()
+			if err != nil {
+				if err == redis.Nil {
+					break
+				}
+				log.FromContext(ctx).WithField("key", matchUIDKey).WithError(err).Error("Failed to scan UID")
+				return ttnredis.ConvertError(err)
+			}
+			ctx := log.NewContextWithFields(ctx, log.Fields(
+				"device_uid", uid,
+				"match_key", matchUIDKey,
+			))
+			ids, err := unique.ToDeviceID(uid)
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Error("Failed to parse UID as device identifiers")
+				return errDatabaseCorruption.WithCause(err)
+			}
+
+			s, err := r.Redis.HGet(ctx, matchFieldKey, uid).Result()
+			if err != nil {
+				if err == redis.Nil {
+					// Another client already processed this entry
+					continue
+				}
+				log.FromContext(ctx).WithField("key", matchFieldKey).WithError(err).Error("Failed to get device session")
+				return ttnredis.ConvertError(err)
+			}
+			var m *networkserver.UplinkMatch
+			if isPending {
+				ses := &uplinkMatchPendingSession{}
+				err = unmarshalMsgpack([]byte(s), ses)
+				if err == nil {
+					m = &networkserver.UplinkMatch{
+						ApplicationIdentifiers: ids.ApplicationIdentifiers,
+						DeviceID:               ids.DeviceID,
+						LoRaWANVersion:         ses.LoRaWANVersion,
+						FNwkSIntKey:            ses.FNwkSIntKey,
+						IsPending:              true,
+					}
+				}
+			} else {
+				ses := &uplinkMatchSession{}
+				err = unmarshalMsgpack([]byte(s), ses)
+				if err == nil {
+					m = &networkserver.UplinkMatch{
+						ApplicationIdentifiers: ids.ApplicationIdentifiers,
+						DeviceID:               ids.DeviceID,
+						LoRaWANVersion:         ses.LoRaWANVersion,
+						FNwkSIntKey:            ses.FNwkSIntKey,
+						LastFCnt:               ses.LastFCnt,
+						ResetsFCnt:             ses.ResetsFCnt,
+						Supports32BitFCnt:      ses.Supports32BitFCnt,
+					}
+				}
+			}
+			if err != nil {
+				log.FromContext(ctx).WithError(err).Error("Failed to unmarshal device session")
+				return err
+			}
 			ok, err := f(ctx, m)
 			if err != nil {
 				return errNoUplinkMatch.WithCause(err)
 			}
-			if ok {
+			if !ok {
+				if err := deviceMatchScanScript.Run(ctx, r.Redis, []string{matchUIDKey, matchFieldKey}, uid).Err(); err != nil {
+					return ttnredis.ConvertError(err)
+				}
+				continue
+			}
+			b, err := marshalMsgpack(uplinkMatchResult{
+				UID:               uid,
+				LoRaWANVersion:    m.LoRaWANVersion,
+				FNwkSIntKey:       m.FNwkSIntKey,
+				LastFCnt:          m.LastFCnt,
+				ResetsFCnt:        m.ResetsFCnt,
+				Supports32BitFCnt: m.Supports32BitFCnt,
+				IsPending:         m.IsPending,
+			})
+			if err != nil {
+				return err
+			}
+			_, err = r.Redis.Pipelined(ctx, func(p redis.Pipeliner) error {
+				p.Set(ctx, matchResultKey, b, cacheTTL)
+				p.Del(ctx,
+					matchUIDKeyCurrentLE,
+					matchUIDKeyCurrentGT,
+					matchUIDKeyPending,
+					matchFieldKeyCurrent,
+					matchFieldKeyPending,
+				)
 				return nil
-			}
-		}
-		return errNoUplinkMatch.New()
-
-	default:
-		log.FromContext(ctx).WithField("value", v).WithError(err).Error("Failed to process matching result")
-		return errDatabaseCorruption.New()
-	}
-
-	args := make([]interface{}, 1, 2)
-	args[0] = cacheTTL.Milliseconds()
-	for len(scanKeys) > 0 {
-		v, err := deviceMatchScanScript.Run(ctx, r.Redis, scanKeys, args...).Result()
-		if err != nil && err != redis.Nil {
-			log.FromContext(ctx).WithFields(log.Fields(
-				"scan_keys", scanKeys,
-				"args", args,
-			)).WithError(err).Error("Failed to run device match scan script")
-			return ttnredis.ConvertError(err)
-		}
-		if err == redis.Nil {
-			return errNoUplinkMatch.New()
-		}
-		vs, ok := v.([]interface{})
-		if !ok || len(vs) != 2 || vs[0] == nil {
-			log.FromContext(ctx).WithField("value", v).Error("Invalid value returned by device match scan script")
-			return errDatabaseCorruption.New()
-		}
-		i, ok := vs[0].(int64)
-		switch {
-		case !ok:
-			log.FromContext(ctx).WithField("index", vs[0]).Error("Invalid index returned by device match scan script")
-			return errDatabaseCorruption.New()
-		case i < 1, int64(len(scanKeys)) < i:
-			log.FromContext(ctx).WithFields(log.Fields(
-				"index", i,
-				"scan_key_count", len(scanKeys),
-			)).Error("Invalid index returned by device match scan script")
-			return errDatabaseCorruption.New()
-		case i > 1:
-			scanKeys = scanKeys[i-1:]
-		}
-
-		vsUID := vs[1]
-		if vsUID == nil {
-			return errDatabaseCorruption.New()
-		}
-		uid, err := decodeString(vsUID)
-		if err != nil {
-			log.FromContext(ctx).WithError(err).
-				Error("Failed to parse UID returned by device match scan script as a string")
-			return errDatabaseCorruption.WithCause(err)
-		}
-		ctx := log.NewContextWithField(ctx, "device_uid", uid)
-		ok, err = func() (ok bool, err error) {
-			defer func() {
-				if err != nil || ok {
-					return
-				}
-				switch scanKeys[0] {
-				case matchKeys.Processing.ShortFCntLE,
-					matchKeys.Processing.LongFCntLE,
-					matchKeys.Processing.Pending,
-					matchKeys.Processing.LongFCntGT,
-					matchKeys.Processing.ShortFCntGT,
-					matchKeys.Processing.Legacy:
-					// If the UID is from processing set, we don't need to remove it
-					args = args[:1]
-				default:
-					if len(args) > 1 {
-						args[1] = uid
-					} else {
-						args = append(args, uid)
-					}
-				}
-			}()
-
-			ids, err := unique.ToDeviceID(uid)
+			})
 			if err != nil {
-				log.FromContext(ctx).WithError(err).
-					Error("Failed to parse UID returned by device match scan script as device identifiers")
-				return false, errDatabaseCorruption.WithCause(err)
+				return ttnredis.ConvertError(err)
 			}
-			ms, err := getUplinkMatch(ctx, r.Redis, matchKeys.Input, matchKeys.Processing, ids.ApplicationIdentifiers, ids.DeviceID, pld.DevAddr, lsb, scanKeys[0], r.uidKey(uid))
-			if err != nil {
-				log.FromContext(ctx).WithError(err).
-					Error("Failed to get uplink matches")
-				return false, err
-			}
-			for _, m := range ms {
-				ok, err := f(ctx, m)
-				if err != nil {
-					return false, errNoUplinkMatch.WithCause(err)
-				}
-				if ok {
-					b, err := msgpack.Marshal(MatchResult{
-						Key: scanKeys[0],
-						UID: uid,
-					})
-					if err != nil {
-						return false, err
-					}
-					_, err = r.Redis.Pipelined(ctx, func(p redis.Pipeliner) error {
-						p.Set(ctx, matchKeys.Match, string(b), cacheTTL)
-						p.Del(ctx, scanKeys...)
-						return nil
-					})
-					if err != nil {
-						return false, ttnredis.ConvertError(err)
-					}
-					return true, nil
-				}
-			}
-			return false, nil
-		}()
-		if err != nil {
-			return err
-		}
-		if ok {
-			return nil
 		}
 	}
 	return errNoUplinkMatch.New()
@@ -777,20 +420,25 @@ func equalEUI64(x, y *types.EUI64) bool {
 	return x.Equal(*y)
 }
 
-func removeLegacyDevAddrMapping(ctx context.Context, r redis.Cmdable, addrKey, uid string) {
-	r.SRem(ctx, addrKey, uid)
+func removeAddrMapping(ctx context.Context, r redis.Cmdable, addrKey, uid string) (*redis.IntCmd, *redis.IntCmd) {
+	return r.ZRem(ctx, addrKey, uid), r.HDel(ctx, FieldKey(addrKey), uid)
 }
 
-func removeCurrentDevAddrMapping(ctx context.Context, r redis.Cmdable, addrKey, uid string, supports32Bit bool) {
-	if !supports32Bit {
-		r.ZRem(ctx, ttnredis.Key(addrKey, shortFCntKey), uid)
-	} else {
-		r.ZRem(ctx, ttnredis.Key(addrKey, longFCntKey), uid)
-	}
+func MarshalDeviceCurrentSession(dev *ttnpb.EndDevice) ([]byte, error) {
+	return marshalMsgpack(uplinkMatchSession{
+		LoRaWANVersion:    dev.GetMACState().GetLoRaWANVersion(),
+		FNwkSIntKey:       dev.GetSession().GetFNwkSIntKey(),
+		LastFCnt:          dev.GetSession().GetLastFCntUp(),
+		ResetsFCnt:        dev.GetMACSettings().GetResetsFCnt(),
+		Supports32BitFCnt: dev.GetMACSettings().GetSupports32BitFCnt(),
+	})
 }
 
-func removePendingDevAddrMapping(ctx context.Context, r redis.Cmdable, addrKey, uid string) {
-	r.SRem(ctx, ttnredis.Key(addrKey, pendingKey), uid)
+func MarshalDevicePendingSession(dev *ttnpb.EndDevice) ([]byte, error) {
+	return marshalMsgpack(uplinkMatchSession{
+		LoRaWANVersion: dev.GetPendingMACState().GetLoRaWANVersion(),
+		FNwkSIntKey:    dev.GetPendingSession().GetFNwkSIntKey(),
+	})
 }
 
 // SetByID sets device by appID, devID.
@@ -858,17 +506,15 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIde
 		_, err = tx.TxPipelined(ctx, func(p redis.Pipeliner) error {
 			if pb == nil && len(sets) == 0 {
 				p.Del(ctx, uk)
-				p.Del(ctx, deviceUIDLastInvalidationKey(r.Redis, uid))
+				p.Del(ctx, uidLastInvalidationKey(r.Redis, uid))
 				if stored.JoinEUI != nil && stored.DevEUI != nil {
 					p.Del(ctx, r.euiKey(*stored.JoinEUI, *stored.DevEUI))
 				}
 				if stored.PendingSession != nil {
-					removeLegacyDevAddrMapping(ctx, p, r.addrKey(stored.PendingSession.DevAddr), uid)
-					removePendingDevAddrMapping(ctx, p, r.addrKey(stored.PendingSession.DevAddr), uid)
+					removeAddrMapping(ctx, p, PendingAddrKey(r.addrKey(stored.PendingSession.DevAddr)), uid)
 				}
 				if stored.Session != nil {
-					removeLegacyDevAddrMapping(ctx, p, r.addrKey(stored.Session.DevAddr), uid)
-					removeCurrentDevAddrMapping(ctx, p, r.addrKey(stored.Session.DevAddr), uid, deviceSupports32BitFCnt(stored))
+					removeAddrMapping(ctx, p, CurrentAddrKey(r.addrKey(stored.Session.DevAddr)), uid)
 				}
 				return nil
 			}
@@ -935,123 +581,81 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIde
 				updated.CreatedAt = updated.UpdatedAt
 			}
 
-			var delFields []string
-			var setFields []interface{}
-			forceFieldWrite := r.CompatibilityVersion.Compare(semver.Version{Major: 3, Minor: 10}) < 0
-
-			// NOTE: The following sequence of switches use concept of "container" - a container is the pointer type "containing" the field value we're interested in.
-
-			switch storedCont, updatedCont := stored.GetMACSettings().GetResetsFCnt(), updated.MACSettings.GetResetsFCnt(); {
-			case storedCont == nil && updatedCont == nil:
-			case updatedCont == nil:
-				delFields = append(delFields, "mac_settings.resets_f_cnt")
-			case storedCont == nil, storedCont.Value != updatedCont.Value, forceFieldWrite:
-				setFields = append(setFields, "mac_settings.resets_f_cnt", encodeBool(updatedCont.Value))
+			if updated.Session != nil && updated.MACState == nil ||
+				updated.PendingSession != nil && updated.PendingMACState == nil {
+				// TODO error
+				panic("TODO")
 			}
 
-			switch storedCont, updatedCont := stored.GetMACState(), updated.MACState; {
-			case storedCont == nil && updatedCont == nil:
-			case updatedCont == nil:
-				delFields = append(delFields, "mac_state.lorawan_version")
-			case storedCont == nil, storedCont.LoRaWANVersion != updatedCont.LoRaWANVersion, forceFieldWrite:
-				setFields = append(setFields, "mac_state.lorawan_version", updatedCont.LoRaWANVersion)
-			}
-
-			switch storedCont, updatedCont := stored.GetPendingMACState(), updated.PendingMACState; {
-			case storedCont == nil && updatedCont == nil:
-			case updatedCont == nil:
-				delFields = append(delFields, "pending_mac_state.lorawan_version")
-			case storedCont == nil, storedCont.LoRaWANVersion != updatedCont.LoRaWANVersion, forceFieldWrite:
-				setFields = append(setFields, "pending_mac_state.lorawan_version", updatedCont.LoRaWANVersion)
-			}
-
-			switch storedCont, updatedCont := stored.GetPendingSession().GetSessionKeys().GetFNwkSIntKey(), updated.GetPendingSession().GetSessionKeys().GetFNwkSIntKey(); {
-			case storedCont == nil && updatedCont == nil:
-			case updatedCont == nil:
-				delFields = append(delFields, "pending_session.keys.f_nwk_s_int_key.kek_label")
-				delFields = append(delFields, "pending_session.keys.f_nwk_s_int_key.encrypted_key")
-			case storedCont == nil, !bytes.Equal(storedCont.EncryptedKey, updatedCont.EncryptedKey), forceFieldWrite:
-				setFields = append(setFields, "pending_session.keys.f_nwk_s_int_key.encrypted_key", updatedCont.EncryptedKey)
-				fallthrough
-			case storedCont == nil, storedCont.KEKLabel != updatedCont.KEKLabel, forceFieldWrite:
-				setFields = append(setFields, "pending_session.keys.f_nwk_s_int_key.kek_label", updatedCont.KEKLabel)
-			}
-			switch storedCont, updatedCont := stored.GetPendingSession().GetSessionKeys().GetFNwkSIntKey().GetKey(), updated.GetPendingSession().GetSessionKeys().GetFNwkSIntKey().GetKey(); {
-			case storedCont == nil && updatedCont == nil:
-			case updatedCont == nil:
-				delFields = append(delFields, "pending_session.keys.f_nwk_s_int_key.key")
-			case storedCont == nil, !storedCont.Equal(*updatedCont), forceFieldWrite:
-				setFields = append(setFields, "pending_session.keys.f_nwk_s_int_key.key", *updatedCont)
-			}
-
-			switch storedCont, updatedCont := stored.GetSession().GetSessionKeys().GetFNwkSIntKey(), updated.GetSession().GetSessionKeys().GetFNwkSIntKey(); {
-			case storedCont == nil && updatedCont == nil:
-			case updatedCont == nil:
-				delFields = append(delFields, "session.keys.f_nwk_s_int_key.kek_label")
-				delFields = append(delFields, "session.keys.f_nwk_s_int_key.encrypted_key")
-			case storedCont == nil, !bytes.Equal(storedCont.EncryptedKey, updatedCont.EncryptedKey), forceFieldWrite:
-				setFields = append(setFields, "session.keys.f_nwk_s_int_key.encrypted_key", updatedCont.EncryptedKey)
-				fallthrough
-			case storedCont == nil, storedCont.KEKLabel != updatedCont.KEKLabel, forceFieldWrite:
-				setFields = append(setFields, "session.keys.f_nwk_s_int_key.kek_label", updatedCont.KEKLabel)
-			}
-			switch storedCont, updatedCont := stored.GetSession().GetSessionKeys().GetFNwkSIntKey().GetKey(), updated.GetSession().GetSessionKeys().GetFNwkSIntKey().GetKey(); {
-			case storedCont == nil && updatedCont == nil:
-			case updatedCont == nil:
-				delFields = append(delFields, "session.keys.f_nwk_s_int_key.key")
-			case storedCont == nil, !storedCont.Equal(*updatedCont):
-				setFields = append(setFields, "session.keys.f_nwk_s_int_key.key", *updatedCont)
-			}
-
-			switch storedCont, updatedCont := stored.GetSession(), updated.GetSession(); {
-			case storedCont == nil && updatedCont == nil:
-			case updatedCont == nil:
-				delFields = append(delFields, "session.last_f_cnt_up")
-			case storedCont == nil, storedCont.LastFCntUp != updatedCont.LastFCntUp, forceFieldWrite:
-				setFields = append(setFields, "session.last_f_cnt_up", updatedCont.LastFCntUp)
-			}
-
-			fk := ttnredis.Key(uk, fieldKey)
-			if len(delFields) > 0 {
-				p.HDel(ctx, fk, delFields...)
-			}
-			if len(setFields) > 0 {
-				p.HSet(ctx, fk, setFields...)
-			}
-
-			storedSupports32BitFCnt := deviceSupports32BitFCnt(stored)
-			updatedSupports32BitFCnt := deviceSupports32BitFCnt(updated)
-
-			if stored.GetPendingSession() == nil || updated.GetPendingSession() == nil ||
-				!updated.PendingSession.DevAddr.Equal(stored.PendingSession.DevAddr) {
-				if stored.GetPendingSession() != nil {
-					removeLegacyDevAddrMapping(ctx, p, r.addrKey(stored.PendingSession.DevAddr), uid)
-					removePendingDevAddrMapping(ctx, p, r.addrKey(stored.PendingSession.DevAddr), uid)
+			storedPendingSession := stored.GetPendingSession()
+			if updated.PendingSession != nil || storedPendingSession != nil {
+				removeStored, setAddr, setFields := func() (bool, bool, bool) {
+					switch {
+					case updated.PendingSession == nil:
+						return true, false, false
+					case storedPendingSession == nil:
+						return false, true, true
+					case !updated.PendingSession.DevAddr.Equal(storedPendingSession.DevAddr):
+						return true, true, true
+					}
+					storedPendingMACState := stored.GetPendingMACState()
+					return false, false, storedPendingMACState == nil ||
+						updated.PendingMACState.LoRaWANVersion != storedPendingMACState.LoRaWANVersion ||
+						!updated.PendingSession.FNwkSIntKey.Equal(storedPendingSession.FNwkSIntKey)
+				}()
+				if removeStored {
+					removeAddrMapping(ctx, p, PendingAddrKey(r.addrKey(storedPendingSession.DevAddr)), uid)
 				}
-
-				if updated.GetPendingSession() != nil {
-					p.SAdd(ctx, ttnredis.Key(r.addrKey(updated.PendingSession.DevAddr), pendingKey), uid)
-				}
-			}
-
-			if stored.GetSession() == nil || updated.GetSession() == nil ||
-				!updated.Session.DevAddr.Equal(stored.Session.DevAddr) ||
-				storedSupports32BitFCnt != updatedSupports32BitFCnt {
-				if stored.GetSession() != nil {
-					removeLegacyDevAddrMapping(ctx, p, r.addrKey(stored.Session.DevAddr), uid)
-					removeCurrentDevAddrMapping(ctx, p, r.addrKey(stored.Session.DevAddr), uid, storedSupports32BitFCnt)
-				}
-
-				if updated.GetSession() != nil {
-					z := &redis.Z{
-						Score:  float64(updated.Session.LastFCntUp),
+				if setAddr {
+					p.ZAdd(ctx, PendingAddrKey(r.addrKey(updated.PendingSession.DevAddr)), &redis.Z{
+						Score:  float64(time.Now().UnixNano()),
 						Member: uid,
+					})
+				}
+				if setFields {
+					b, err := MarshalDevicePendingSession(updated)
+					if err != nil {
+						return err
 					}
-					if !updatedSupports32BitFCnt {
-						p.ZAdd(ctx, ttnredis.Key(r.addrKey(updated.Session.DevAddr), shortFCntKey), z)
-					} else {
-						p.ZAdd(ctx, ttnredis.Key(r.addrKey(updated.Session.DevAddr), longFCntKey), z)
+					p.HSet(ctx, FieldKey(PendingAddrKey(r.addrKey(updated.PendingSession.DevAddr))), uid, b)
+				}
+			}
+
+			storedSession := stored.GetSession()
+			if updated.Session != nil || storedSession != nil {
+				removeStored, setAddr, setFields := func() (bool, bool, bool) {
+					switch {
+					case updated.Session == nil:
+						return true, false, false
+					case storedSession == nil:
+						return false, true, true
+					case !updated.Session.DevAddr.Equal(storedSession.DevAddr):
+						return true, true, true
 					}
+					storedMACState := stored.GetMACState()
+					storedMACSettings := stored.GetMACSettings()
+					return false, false, storedMACState == nil ||
+						updated.MACState.LoRaWANVersion != storedMACState.LoRaWANVersion ||
+						!updated.Session.FNwkSIntKey.Equal(storedSession.FNwkSIntKey) ||
+						updated.Session.LastFCntUp != storedSession.LastFCntUp ||
+						!updated.MACSettings.GetResetsFCnt().Equal(storedMACSettings.GetResetsFCnt()) ||
+						!updated.MACSettings.GetSupports32BitFCnt().Equal(storedMACSettings.GetSupports32BitFCnt())
+				}()
+				if removeStored {
+					removeAddrMapping(ctx, p, CurrentAddrKey(r.addrKey(storedSession.DevAddr)), uid)
+				}
+				if setAddr {
+					p.ZAdd(ctx, CurrentAddrKey(r.addrKey(updated.Session.DevAddr)), &redis.Z{
+						Score:  float64(updated.Session.LastFCntUp & 0xffff),
+						Member: uid,
+					})
+				}
+				if setFields {
+					b, err := MarshalDeviceCurrentSession(updated)
+					if err != nil {
+						return err
+					}
+					p.HSet(ctx, FieldKey(CurrentAddrKey(r.addrKey(updated.Session.DevAddr))), uid, b)
 				}
 			}
 

--- a/pkg/networkserver/redis/registry.go
+++ b/pkg/networkserver/redis/registry.go
@@ -328,9 +328,15 @@ func (r *DeviceRegistry) RangeByUplinkMatches(ctx context.Context, up *ttnpb.Upl
 			switch {
 			case idx == currentGTIdx:
 				uid, s, err = func() (string, string, error) {
+					var ackArg uint8
+					if pld.Ack {
+						ackArg = 1
+					}
 					var args []interface{}
 					if uid != "" {
-						args = []interface{}{uid}
+						args = []interface{}{ackArg, uid}
+					} else {
+						args = []interface{}{ackArg}
 					}
 					vs, err := ttnredis.RunInterfaceSliceScript(ctx, r.Redis, deviceMatchScanGTScript, []string{matchUIDKey, matchFieldKey}, args...).Result()
 					if err != nil {

--- a/pkg/networkserver/redis/registry.go
+++ b/pkg/networkserver/redis/registry.go
@@ -302,14 +302,14 @@ func (r *DeviceRegistry) RangeByUplinkMatches(ctx context.Context, up *ttnpb.Upl
 		return nil
 	}
 
+	// NOTE(1): Indexes must be consistent with lua/deviceMatch.lua.
+	// NOTE(2): Lua indexing starts from 1.
 	const (
 		currentLEIdx = 4
 		currentGTIdx = 5
 		pendingIdx   = 9
 	)
 	for _, v := range vs[1:] {
-		// NOTE(1): Indexes must be consistent with lua/deviceMatch.lua.
-		// NOTE(2): Lua indexing starts from 1.
 		idx, ok := v.(int64)
 		if !ok {
 			panic(fmt.Sprintf("expected match script `continue` type return value to be int64, got '%v'(%T)", v, v))

--- a/pkg/networkserver/redis/scripts.go
+++ b/pkg/networkserver/redis/scripts.go
@@ -61,13 +61,13 @@ if #to_scan > 1 then
 end
 return nil`)
 
-	deviceMatchScanScript = redis.NewScript(`for old_uid in ARGV do
-  local uid = redis.call('lindex', KEYS[1], 0)
+	deviceMatchScanScript = redis.NewScript(`for _, old_uid in ipairs(ARGV) do
+  local uid = redis.call('lindex', KEYS[1], -1)
   if uid ~= old_uid then
     return uid
   end
-  redis.call('ltrim', KEYS[1], 1, -1)
-  redis.call('hdel', KEYS[2], ARGV[1])
+  redis.call('ltrim', KEYS[1], 0, -2)
+  redis.call('hdel', KEYS[2], old_uid)
 end
-return redis.call('lindex', KEYS[1], 0)`)
+return redis.call('lindex', KEYS[1], -1)`)
 )

--- a/pkg/networkserver/redis/scripts.go
+++ b/pkg/networkserver/redis/scripts.go
@@ -49,20 +49,25 @@ if gt > 0 then
   table.insert(to_scan, 7)
 end
 if pivot > 0 or gt > 0 then
-  redis.call('restore', KEYS[9], 0, ARGV[2], redis.call('dump', KEYS[3]))
+  redis.call('restore', KEYS[9], ARGV[2], redis.call('dump', KEYS[3]))
 end
 if redis.call('sort', KEYS[4], 'by', 'nosort', 'store', KEYS[8]) > 0 then
-  redis.call('pexpire', KEYS[9], ARGV[2])
-  table.insert(to_scan, 9)
-  redis.call('restore', KEYS[10], 0, ARGV[2], redis.call('dump', KEYS[5]))
+  redis.call('pexpire', KEYS[8], ARGV[2])
+  table.insert(to_scan, 8)
+  redis.call('restore', KEYS[10], ARGV[2], redis.call('dump', KEYS[5]))
 end
 if #to_scan > 1 then
     return to_scan
 end
 return nil`)
 
-	deviceMatchScanScript = redis.NewScript(`if redis.call('lindex', KEYS[1], 0) == ARGV[1] then
+	deviceMatchScanScript = redis.NewScript(`for old_uid in ARGV do
+  local uid = redis.call('lindex', KEYS[1], 0)
+  if uid ~= old_uid then
+    return uid
+  end
   redis.call('ltrim', KEYS[1], 1, -1)
   redis.call('hdel', KEYS[2], ARGV[1])
-end`)
+end
+return redis.call('lindex', KEYS[1], 0)`)
 )

--- a/pkg/networkserver/redis/scripts.go
+++ b/pkg/networkserver/redis/scripts.go
@@ -49,12 +49,12 @@ if gt > 0 then
   table.insert(to_scan, 7)
 end
 if pivot > 0 or gt > 0 then
-  redis.call('copy', KEYS[3], KEYS[9])
+  redis.call('restore', KEYS[9], 0, ARGV[2], redis.call('dump', KEYS[3]))
 end
 if redis.call('sort', KEYS[4], 'by', 'nosort', 'store', KEYS[8]) > 0 then
   redis.call('pexpire', KEYS[9], ARGV[2])
   table.insert(to_scan, 9)
-  redis.call('copy', KEYS[5], KEYS[10])
+  redis.call('restore', KEYS[10], 0, ARGV[2], redis.call('dump', KEYS[5]))
 end
 if #to_scan > 1 then
     return to_scan

--- a/pkg/networkserver/redis/scripts.go
+++ b/pkg/networkserver/redis/scripts.go
@@ -12,49 +12,54 @@ var (
 	//
 	// KEYS[2] 	- sorted set of uids of devices matching current session DevAddr sorted ascending by LSB of LastFCntUp
 	// KEYS[3] 	- hash containing msgpack-encoded sessions for devices matching current session DevAddr keyed by uid
+	// KEYS[4] 	- sorted list of uids of devices matching with current session LastFCntUp LSB being lower than or equal to current
+	// KEYS[5] 	- sorted list of uids of devices matching with current session LastFCntUp LSB being greater than current
+	// KEYS[6]  - copy of KEYS[3]
 	//
-	// KEYS[4] 	- sorted set of uids of devices matching pending session DevAddr sorted ascending by creation time
-	// KEYS[5] 	- hash containing msgpack-encoded sessions for devices matching pending session DevAddr keyed by uid
-	//
-	// KEYS[6] 	- sorted list of uids of devices matching with current session LastFCntUp LSB being lower than or equalt to current
-	// KEYS[7] 	- sorted list of uids of devices matching with current session LastFCntUp LSB being greater than current
-	// KEYS[8]  - sorted list of uids of devices matching pending session DevAddr
-	//
-	// KEYS[9] - copy of KEYS[3]
-	// KEYS[10] - copy of KEYS[5]
+	// KEYS[7] 	- sorted set of uids of devices matching pending session DevAddr sorted ascending by creation time
+	// KEYS[8] 	- hash containing msgpack-encoded sessions for devices matching pending session DevAddr keyed by uid
+	// KEYS[9]  - sorted list of uids of devices matching pending session DevAddr
+	// KEYS[10] - copy of KEYS[8]
 	deviceMatchScript = redis.NewScript(`if redis.call('pexpire', KEYS[1], ARGV[2]) == 1 then
   return { 'result', redis.call('get', KEYS[1]) }
 end
 local to_scan = { 'scan' }
-for i=6,8 do
-  if redis.call('pexpire', KEYS[i], ARGV[2]) == 1 then
+local function scan_expiring(i)
+  local ret = redis.call('pexpire', KEYS[i], ARGV[2])
+  if ret == 1 then
     table.insert(to_scan, i)
+  end
+  return ret
+end
+if scan_expiring(4) + scan_expiring(5) > 0 then
+  redis.call('pexpire', KEYS[6], ARGV[2])
+end
+if #KEYS == 10 then
+  if scan_expiring(9) > 0 then
+    redis.call('pexpire', KEYS[10], ARGV[2])
   end
 end
 if #to_scan > 1 then
-  for i=9,10 do
-    redis.call('pexpire', KEYS[i], ARGV[2])
-  end
   return to_scan
 end
 local pivot = redis.call('zcount', KEYS[2], '-inf', ARGV[1])
 if pivot > 0 then
-  redis.call('sort', KEYS[2], 'by', 'nosort', 'limit', 0, pivot, 'store', KEYS[6])
-  redis.call('pexpire', KEYS[6], ARGV[2])
-  table.insert(to_scan, 6)
+  redis.call('sort', KEYS[2], 'by', 'nosort', 'limit', 0, pivot, 'store', KEYS[4])
+  redis.call('pexpire', KEYS[4], ARGV[2])
+  table.insert(to_scan, 4)
 end
-local gt = redis.call('sort', KEYS[2], 'by', 'nosort', 'limit', pivot, -1, 'store', KEYS[7])
+local gt = redis.call('sort', KEYS[2], 'by', 'nosort', 'limit', pivot, -1, 'store', KEYS[5])
 if gt > 0 then
-  redis.call('pexpire', KEYS[7], ARGV[2])
-  table.insert(to_scan, 7)
+  redis.call('pexpire', KEYS[5], ARGV[2])
+  table.insert(to_scan, 5)
 end
 if pivot > 0 or gt > 0 then
-  redis.call('restore', KEYS[9], ARGV[2], redis.call('dump', KEYS[3]))
+  redis.call('restore', KEYS[6], ARGV[2], redis.call('dump', KEYS[3]))
 end
-if redis.call('sort', KEYS[4], 'by', 'nosort', 'store', KEYS[8]) > 0 then
-  redis.call('pexpire', KEYS[8], ARGV[2])
-  table.insert(to_scan, 8)
-  redis.call('restore', KEYS[10], ARGV[2], redis.call('dump', KEYS[5]))
+if #KEYS == 10 and redis.call('sort', KEYS[7], 'by', 'nosort', 'store', KEYS[9]) > 0 then
+  redis.call('pexpire', KEYS[9], ARGV[2])
+  table.insert(to_scan, 9)
+  redis.call('restore', KEYS[10], ARGV[2], redis.call('dump', KEYS[8]))
 end
 if #to_scan > 1 then
     return to_scan

--- a/pkg/networkserver/redis/scripts.go
+++ b/pkg/networkserver/redis/scripts.go
@@ -75,4 +75,18 @@ return nil`)
   redis.call('hdel', KEYS[2], old_uid)
 end
 return redis.call('lindex', KEYS[1], -1)`)
+
+	deviceMatchScanGTScript = redis.NewScript(`for _, old_uid in ipairs(ARGV) do
+  local uid = redis.call('lindex', KEYS[1], -1)
+  if uid ~= old_uid then
+    return uid
+  end
+  redis.call('ltrim', KEYS[1], 0, -2)
+  redis.call('hdel', KEYS[2], old_uid)
+end
+local uid = redis.call('lindex', KEYS[1], -1)
+if uid then
+  return { uid, redis.call('hget', KEYS[2], uid) }
+end
+return nil`)
 )

--- a/pkg/networkserver/registry.go
+++ b/pkg/networkserver/registry.go
@@ -26,22 +26,22 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
 )
 
-type UplinkMatch interface {
-	ApplicationIdentifiers() ttnpb.ApplicationIdentifiers
-	DeviceID() string
-	LoRaWANVersion() ttnpb.MACVersion
-	FNwkSIntKey() *ttnpb.KeyEnvelope
-	FCnt() uint32
-	LastFCnt() uint32
-	IsPending() bool
-	ResetsFCnt() *pbtypes.BoolValue
+type UplinkMatch struct {
+	ApplicationIdentifiers ttnpb.ApplicationIdentifiers
+	DeviceID               string
+	LoRaWANVersion         ttnpb.MACVersion
+	FNwkSIntKey            *ttnpb.KeyEnvelope
+	LastFCnt               uint32
+	ResetsFCnt             *pbtypes.BoolValue
+	Supports32BitFCnt      *pbtypes.BoolValue
+	IsPending              bool
 }
 
 // DeviceRegistry is a registry, containing devices.
 type DeviceRegistry interface {
 	GetByEUI(ctx context.Context, joinEUI, devEUI types.EUI64, paths []string) (*ttnpb.EndDevice, context.Context, error)
 	GetByID(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, paths []string) (*ttnpb.EndDevice, context.Context, error)
-	RangeByUplinkMatches(ctx context.Context, up *ttnpb.UplinkMessage, cacheTTL time.Duration, f func(context.Context, UplinkMatch) (bool, error)) error
+	RangeByUplinkMatches(ctx context.Context, up *ttnpb.UplinkMessage, cacheTTL time.Duration, f func(context.Context, *UplinkMatch) (bool, error)) error
 	SetByID(ctx context.Context, appID ttnpb.ApplicationIdentifiers, devID string, paths []string, f func(context.Context, *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, context.Context, error)
 }
 

--- a/pkg/redis/generate_scripts.go
+++ b/pkg/redis/generate_scripts.go
@@ -59,7 +59,7 @@ var (
 )`))
 
 func isCommentLine(s string) bool {
-	return strings.HasPrefix(s, "--")
+	return strings.HasPrefix(strings.TrimSpace(s), "--")
 }
 
 func main() {
@@ -122,7 +122,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to format %q: %s", out, err)
 	}
-	if err := ioutil.WriteFile(out, b, 0644); err != nil {
+	if err := ioutil.WriteFile(out, b, 0o644); err != nil {
 		log.Fatalf("Failed to write to %q: %s", out, err)
 	}
 }

--- a/pkg/ttnpb/lorawan.go
+++ b/pkg/ttnpb/lorawan.go
@@ -762,6 +762,12 @@ func (v MACVersion) UseNwkKey() bool {
 	return v.Compare(MAC_V1_1) >= 0
 }
 
+// UseLegacyMIC reports whether v uses legacy MIC computation algorithm.
+// UseLegacyMIC panics, if v.Validate() returns non-nil error.
+func (v MACVersion) UseLegacyMIC() bool {
+	return v.Compare(MAC_V1_1) < 0
+}
+
 // RequireDevEUIForABP reports whether v requires ABP devices to have a DevEUI associated.
 // RequireDevEUIForABP panics, if v.Validate() returns non-nil error.
 func (v MACVersion) RequireDevEUIForABP() bool {

--- a/pkg/ttnpb/lorawan.go
+++ b/pkg/ttnpb/lorawan.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/blang/semver"
+	"github.com/vmihailenco/msgpack/v5"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 )
 
@@ -31,8 +32,7 @@ func (v MType) MarshalText() ([]byte, error) {
 
 // UnmarshalText implements encoding.TextUnmarshaler interface.
 func (v *MType) UnmarshalText(b []byte) error {
-	s := string(b)
-	if i, ok := MType_value[s]; ok {
+	if i, ok := MType_value[string(b)]; ok {
 		*v = MType(i)
 		return nil
 	}
@@ -59,8 +59,7 @@ func (v Major) MarshalText() ([]byte, error) {
 
 // UnmarshalText implements encoding.TextUnmarshaler interface.
 func (v *Major) UnmarshalText(b []byte) error {
-	s := string(b)
-	if i, ok := Major_value[s]; ok {
+	if i, ok := Major_value[string(b)]; ok {
 		*v = Major(i)
 		return nil
 	}
@@ -93,6 +92,14 @@ func (v MACVersion) MarshalText() ([]byte, error) {
 	return []byte(v.String()), nil
 }
 
+// EncodeMsgpack implements msgpack.CustomEncoder interface.
+func (v MACVersion) EncodeMsgpack(enc *msgpack.Encoder) error {
+	if v > 255 {
+		panic(fmt.Errorf("MACVersion enum exceeds 255"))
+	}
+	return enc.EncodeUint8(uint8(v))
+}
+
 // UnmarshalBinary implements encoding.BinaryMarshaler interface.
 func (v *MACVersion) UnmarshalBinary(b []byte) error {
 	if len(b) != 1 {
@@ -115,7 +122,17 @@ func (v *MACVersion) UnmarshalText(b []byte) error {
 			return nil
 		}
 	}
-	return errCouldNotParse("MACVersion")(string(b))
+	return errCouldNotParse("MACVersion")(s)
+}
+
+// DecodeMsgpack implements msgpack.CustomDecoder interface.
+func (v *MACVersion) DecodeMsgpack(dec *msgpack.Decoder) error {
+	i, err := dec.DecodeInt32()
+	if err != nil {
+		return err
+	}
+	*v = MACVersion(i)
+	return nil
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface.
@@ -149,7 +166,7 @@ func (v *PHYVersion) UnmarshalText(b []byte) error {
 			return nil
 		}
 	}
-	return errCouldNotParse("PHYVersion")(string(b))
+	return errCouldNotParse("PHYVersion")(s)
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface.
@@ -206,8 +223,7 @@ func (v *DataRateIndex) UnmarshalJSON(b []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler interface.
 func (v *RejoinType) UnmarshalText(b []byte) error {
-	s := string(b)
-	if i, ok := RejoinType_value[s]; ok {
+	if i, ok := RejoinType_value[string(b)]; ok {
 		*v = RejoinType(i)
 		return nil
 	}
@@ -229,8 +245,7 @@ func (v *RejoinType) UnmarshalJSON(b []byte) error {
 
 // UnmarshalText implements encoding.TextUnmarshaler interface.
 func (v *CFListType) UnmarshalText(b []byte) error {
-	s := string(b)
-	if i, ok := CFListType_value[s]; ok {
+	if i, ok := CFListType_value[string(b)]; ok {
 		*v = CFListType(i)
 		return nil
 	}
@@ -268,7 +283,7 @@ func (v *Class) UnmarshalText(b []byte) error {
 			return nil
 		}
 	}
-	return errCouldNotParse("Class")(string(b))
+	return errCouldNotParse("Class")(s)
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface.
@@ -291,8 +306,7 @@ func (v TxSchedulePriority) MarshalText() ([]byte, error) {
 
 // UnmarshalText implements encoding.TextUnmarshaler interface.
 func (v *TxSchedulePriority) UnmarshalText(b []byte) error {
-	s := string(b)
-	if i, ok := TxSchedulePriority_value[s]; ok {
+	if i, ok := TxSchedulePriority_value[string(b)]; ok {
 		*v = TxSchedulePriority(i)
 		return nil
 	}
@@ -330,7 +344,7 @@ func (v *MACCommandIdentifier) UnmarshalText(b []byte) error {
 			return nil
 		}
 	}
-	return errCouldNotParse("MACCommandIdentifier")(string(b))
+	return errCouldNotParse("MACCommandIdentifier")(s)
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface.
@@ -359,7 +373,7 @@ func (v *AggregatedDutyCycle) UnmarshalText(b []byte) error {
 			return nil
 		}
 	}
-	return errCouldNotParse("AggregatedDutyCycle")(string(b))
+	return errCouldNotParse("AggregatedDutyCycle")(s)
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface.
@@ -393,7 +407,7 @@ func (v *PingSlotPeriod) UnmarshalText(b []byte) error {
 			return nil
 		}
 	}
-	return errCouldNotParse("PingSlotPeriod")(string(b))
+	return errCouldNotParse("PingSlotPeriod")(s)
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface.
@@ -422,7 +436,7 @@ func (v *RejoinCountExponent) UnmarshalText(b []byte) error {
 			return nil
 		}
 	}
-	return errCouldNotParse("RejoinCountExponent")(string(b))
+	return errCouldNotParse("RejoinCountExponent")(s)
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface.
@@ -451,7 +465,7 @@ func (v *RejoinTimeExponent) UnmarshalText(b []byte) error {
 			return nil
 		}
 	}
-	return errCouldNotParse("RejoinTimeExponent")(string(b))
+	return errCouldNotParse("RejoinTimeExponent")(s)
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface.
@@ -480,7 +494,7 @@ func (v *RejoinPeriodExponent) UnmarshalText(b []byte) error {
 			return nil
 		}
 	}
-	return errCouldNotParse("RejoinPeriodExponent")(string(b))
+	return errCouldNotParse("RejoinPeriodExponent")(s)
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface.
@@ -514,7 +528,7 @@ func (v *DeviceEIRP) UnmarshalText(b []byte) error {
 			return nil
 		}
 	}
-	return errCouldNotParse("DeviceEIRP")(string(b))
+	return errCouldNotParse("DeviceEIRP")(s)
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface.
@@ -543,7 +557,7 @@ func (v *ADRAckLimitExponent) UnmarshalText(b []byte) error {
 			return nil
 		}
 	}
-	return errCouldNotParse("ADRAckLimitExponent")(string(b))
+	return errCouldNotParse("ADRAckLimitExponent")(s)
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface.
@@ -572,7 +586,7 @@ func (v *ADRAckDelayExponent) UnmarshalText(b []byte) error {
 			return nil
 		}
 	}
-	return errCouldNotParse("ADRAckDelayExponent")(string(b))
+	return errCouldNotParse("ADRAckDelayExponent")(s)
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface.
@@ -601,7 +615,7 @@ func (v *RxDelay) UnmarshalText(b []byte) error {
 			return nil
 		}
 	}
-	return errCouldNotParse("RxDelay")(string(b))
+	return errCouldNotParse("RxDelay")(s)
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface.
@@ -648,7 +662,7 @@ func (v *Minor) UnmarshalText(b []byte) error {
 			return nil
 		}
 	}
-	return errCouldNotParse("Minor")(string(b))
+	return errCouldNotParse("Minor")(s)
 }
 
 // UnmarshalJSON implements json.Unmarshaler interface.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/3552
Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/3569
Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/3254

#### Changes
<!-- What are the changes made in this pull request? -->

- Simplify the matching algorithm
- Optimize matching
	- Avoid matching pending sessions when ACK bit is set
	- Avoid matching FCnt rollover/reset for devices, which don't support 32-bit FCnt scheme *and* not support resets
- Rework algorithm
	- Workers may now process duplicate entries, each entry is processed at least once
	- Sort pending session matches by join time
	- Sort current session matches by LSB only
- Improve correctness
	- Relevant device states are copied on uplink - after the uplink is received device states may change, but we must consider the "old" state when matching and locking is not favorable here.
- Fix various bugs
- Reorganize store:
	- Now we store optimized msgpack-encoded device views (different whether it is pending or current session)

#### Testing

<!-- How did you verify that this change works? -->

Extensive integration testing, tested migrations with existing production data set

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Everything uplink and class A-downlink related, since this PR modifies the core feature of the Network Server.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
