### PR TITLE
Propagate OAuth2 configuration provider errors

### DIFF
--- a/pkg/web/oauthclient/callback.go
+++ b/pkg/web/oauthclient/callback.go
@@ -72,7 +72,11 @@ func (oc *OAuthClient) HandleCallback(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	token, err := oc.oauth(c).Exchange(ctx, code)
+	conf, err := oc.oauth(c)
+	if err != nil {
+		return err
+	}
+	token, err := conf.Exchange(ctx, code)
 	if err != nil {
 		var retrieveError *oauth2.RetrieveError
 		if stderrors.As(err, &retrieveError) {

--- a/pkg/web/oauthclient/login.go
+++ b/pkg/web/oauthclient/login.go
@@ -37,5 +37,9 @@ func (oc *OAuthClient) HandleLogin(c echo.Context) error {
 		return err
 	}
 
-	return c.Redirect(http.StatusFound, oc.oauth(c).AuthCodeURL(state.Secret))
+	conf, err := oc.oauth(c)
+	if err != nil {
+		return err
+	}
+	return c.Redirect(http.StatusFound, conf.AuthCodeURL(state.Secret))
 }

--- a/pkg/web/oauthclient/oauthclient.go
+++ b/pkg/web/oauthclient/oauthclient.go
@@ -98,7 +98,7 @@ func (oc *OAuthClient) configFromContext(ctx context.Context) *Config {
 	return &oc.config
 }
 
-func (oc *OAuthClient) defaultOAuth(c echo.Context) *oauth2.Config {
+func (oc *OAuthClient) defaultOAuth(c echo.Context) (*oauth2.Config, error) {
 	config := oc.configFromContext(c.Request().Context())
 
 	authorizeURL := config.AuthorizeURL
@@ -120,5 +120,5 @@ func (oc *OAuthClient) defaultOAuth(c echo.Context) *oauth2.Config {
 			AuthURL:   authorizeURL,
 			AuthStyle: oauth2.AuthStyleInParams,
 		},
-	}
+	}, nil
 }

--- a/pkg/web/oauthclient/options.go
+++ b/pkg/web/oauthclient/options.go
@@ -23,7 +23,7 @@ import (
 type Option func(*OAuthClient)
 
 // OAuth2ConfigProvider provides an OAuth2 client config based on the context.
-type OAuth2ConfigProvider func(echo.Context) *oauth2.Config
+type OAuth2ConfigProvider func(echo.Context) (*oauth2.Config, error)
 
 // WithOAuth2ConfigProvider overrides the default OAuth2 configuration provider.
 func WithOAuth2ConfigProvider(provider OAuth2ConfigProvider) Option {

--- a/pkg/web/oauthclient/token.go
+++ b/pkg/web/oauthclient/token.go
@@ -43,7 +43,11 @@ func (oc *OAuthClient) freshToken(c echo.Context) (*oauth2.Token, error) {
 	if err != nil {
 		return nil, err
 	}
-	freshToken, err := oc.oauth(c).TokenSource(ctx, token).Token()
+	conf, err := oc.oauth(c)
+	if err != nil {
+		return nil, err
+	}
+	freshToken, err := conf.TokenSource(ctx, token).Token()
 	if err != nil {
 		var retrieveError *oauth2.RetrieveError
 		if stderrors.As(err, &retrieveError) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This quickfix allows the `oauthclient.OAuth2ConfigProvider` to return an `error`. Before this change, the provider would return a `nil` config on error, causing panics.