### PR TITLE
Add config option to grant admins all rights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Added
 
+- Configuration option `is.admin-rights.all` to grant admins all rights, including `_KEYS` and `_ALL`.
+
 ### Changed
 
 ### Deprecated

--- a/pkg/identityserver/config.go
+++ b/pkg/identityserver/config.go
@@ -71,6 +71,9 @@ type Config struct {
 		CreateGateways      bool `name:"create-gateways" description:"Allow non-admin users to create gateways in their user account"`
 		CreateOrganizations bool `name:"create-organizations" description:"Allow non-admin users to create organizations in their user account"`
 	} `name:"user-rights"`
+	AdminRights struct {
+		All bool `name:"all" description:"Grant all rights to admins, including _KEYS and _ALL"`
+	} `name:"admin-rights"`
 	Email struct {
 		email.Config `name:",squash"`
 		SendGrid     sendgrid.Config      `name:"sendgrid"`

--- a/pkg/identityserver/entity_access.go
+++ b/pkg/identityserver/entity_access.go
@@ -261,7 +261,11 @@ func (is *IdentityServer) authInfo(ctx context.Context) (info *ttnpb.AuthInfoRes
 			// Normal user.
 			if user.Admin {
 				res.IsAdmin = true
-				res.UniversalRights = ttnpb.AllAdminRights.Implied().Intersect(userRights)
+				if is.configFromContext(ctx).AdminRights.All {
+					res.UniversalRights = ttnpb.AllRights.Implied().Intersect(userRights)
+				} else {
+					res.UniversalRights = ttnpb.AllAdminRights.Implied().Intersect(userRights)
+				}
 			}
 		case ttnpb.STATE_REJECTED:
 			// Go to profile page, delete account.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This adds a config option that makes the Identity Server grant all rights (including `_KEYS` and `_ALL`) to admin users.

Refs https://github.com/TheThingsIndustries/lorawan-stack-support/issues/269

#### Changes
<!-- What are the changes made in this pull request? -->

- Define new config to grant really all rights to admins (default is current behavior: false)
- Read new config

#### Testing

<!-- How did you verify that this change works? -->

- Start The Things Stack with the option disabled
- Create a non-admin user
- With the non-admin user, create an application and end device
- With the admin user, check that you can NOT read device keys
- Restart The Things Stack with the option disabled
- With the admin user, check that you can now read device keys

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
