### PR TITLE
Make handling of temporary token TTLs consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ For details about compatibility between different releases, see the **Commitment
 ### Added
 
 - Configuration option `is.admin-rights.all` to grant admins all rights, including `_KEYS` and `_ALL`.
+- Configuration option `is.user-registration.contact-info-validation.token-ttl` to customize the validity of contact information validation tokens.
 - `ttn-lw-stack` CLI command for creating an API Key with full rights on a user.
 
 ### Changed
 
 - Packet Broker API version to `v3.2.0-tts` and routing API to `v1.0.2-tts`.
+- Emails with temporary tokens now also show when these tokens expire. Custom email templates can use `{{ .TTL }}` and `{{ .FormatTTL }}` to render the expiry durations.
 
 ### Deprecated
 

--- a/cmd/internal/shared/identityserver/config.go
+++ b/cmd/internal/shared/identityserver/config.go
@@ -50,6 +50,7 @@ var DefaultIdentityServerConfig = identityserver.Config{
 func init() {
 	DefaultIdentityServerConfig.AuthCache.MembershipTTL = 10 * time.Minute
 	DefaultIdentityServerConfig.UserRegistration.Invitation.TokenTTL = 7 * 24 * time.Hour
+	DefaultIdentityServerConfig.UserRegistration.ContactInfoValidation.TokenTTL = 2 * 24 * time.Hour
 	DefaultIdentityServerConfig.UserRegistration.PasswordRequirements.MinLength = 8
 	DefaultIdentityServerConfig.UserRegistration.PasswordRequirements.MaxLength = 1000
 	DefaultIdentityServerConfig.UserRegistration.PasswordRequirements.MinUppercase = 1

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/disintegration/imaging v1.6.2
 	github.com/dlclark/regexp2 v1.2.1 // indirect
 	github.com/dop251/goja v0.0.0-20200824171909-536f9d946569
+	github.com/dustin/go-humanize v1.0.0
 	github.com/eclipse/paho.mqtt.golang v1.2.1-0.20200918111050-ba85050a1f23
 	github.com/envoyproxy/protoc-gen-validate v0.4.0
 	github.com/felixge/httpsnoop v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,7 @@ github.com/dlclark/regexp2 v1.2.1 h1:Ff/S0snjr1oZHUNOkvA/gP6KUaMg5vDDl3Qnhjnwgm8
 github.com/dlclark/regexp2 v1.2.1/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dop251/goja v0.0.0-20200824171909-536f9d946569 h1:AxkwZ0s3TcKY72KTv9l3Bo4/fBFXxjavZUSBcZZwEM0=
 github.com/dop251/goja v0.0.0-20200824171909-536f9d946569/go.mod h1:Mw6PkjjMXWbTj+nnj4s3QPXq1jaT0s5pC0iFD4+BOAA=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eaigner/dkim v0.0.0-20150301120808-6fe4a7ee9cfb/go.mod h1:FSCIHbrqk7D01Mj8y/jW+NS1uoCerr+ad+IckTHTFf4=
 github.com/eclipse/paho.mqtt.golang v1.2.1-0.20200918111050-ba85050a1f23 h1:znRijtV5P9m5mmDsy4oesCPlCIPDILTj4wosaZWsTpY=

--- a/pkg/identityserver/config.go
+++ b/pkg/identityserver/config.go
@@ -37,7 +37,8 @@ type Config struct {
 			TokenTTL time.Duration `name:"token-ttl" description:"TTL of user invitation tokens"`
 		} `name:"invitation"`
 		ContactInfoValidation struct {
-			Required bool `name:"required" description:"Require contact info validation for new users"`
+			Required bool          `name:"required" description:"Require contact info validation for new users"`
+			TokenTTL time.Duration `name:"token-ttl" description:"TTL of contact info validation tokens"`
 		} `name:"contact-info-validation"`
 		AdminApproval struct {
 			Required bool `name:"required" description:"Require admin approval for new users"`

--- a/pkg/identityserver/contact_info_registry.go
+++ b/pkg/identityserver/contact_info_registry.go
@@ -45,8 +45,8 @@ func (is *IdentityServer) requestContactInfoValidation(ctx context.Context, ids 
 		return nil, err
 	}
 	now := time.Now()
-	emailValidationsTTL := 48 * time.Hour
-	emailValidationsExpireAt := now.Add(emailValidationsTTL)
+	ttl := is.configFromContext(ctx).UserRegistration.ContactInfoValidation.TokenTTL
+	expires := now.Add(ttl)
 	emailValidations := make(map[string]*ttnpb.ContactInfoValidation)
 	for _, info := range contactInfo {
 		if info.ContactMethod == ttnpb.CONTACT_METHOD_EMAIL && info.ValidatedAt == nil {
@@ -61,7 +61,7 @@ func (is *IdentityServer) requestContactInfoValidation(ctx context.Context, ids 
 					Token:     key,
 					Entity:    ids,
 					CreatedAt: &now,
-					ExpiresAt: &emailValidationsExpireAt,
+					ExpiresAt: &expires,
 				}
 				emailValidations[info.Value] = validation
 			}
@@ -95,7 +95,7 @@ func (is *IdentityServer) requestContactInfoValidation(ctx context.Context, ids 
 					Data:  data,
 					ID:    validation.ID,
 					Token: validation.Token,
-					TTL:   emailValidationsTTL,
+					TTL:   ttl,
 				}
 			})
 			if err != nil {

--- a/pkg/identityserver/emails/invitation.go
+++ b/pkg/identityserver/emails/invitation.go
@@ -14,10 +14,18 @@
 
 package emails
 
+import "time"
+
 // Invitation is the email that is sent when a user is invited to the network.
 type Invitation struct {
 	Data
 	InvitationToken string
+	TTL             time.Duration
+}
+
+// FormatTTL formats the TTL.
+func (i Invitation) FormatTTL() string {
+	return formatTTL(i.TTL)
 }
 
 // TemplateName returns the name of the template to use for this email.
@@ -36,6 +44,11 @@ You can use this token for the "--invitation-token" flag when creating a user fr
 If you wish to register using web interface, follow the link below:
 
 {{ .Network.IdentityServerURL }}/register?invitation_token={{ .InvitationToken }}
+
+{{- if .TTL }}
+
+These invitation links expire {{ .FormatTTL }}.
+{{ end -}}
 `
 
 // DefaultTemplates returns the default templates for this email.

--- a/pkg/identityserver/emails/temporary_password.go
+++ b/pkg/identityserver/emails/temporary_password.go
@@ -14,10 +14,18 @@
 
 package emails
 
+import "time"
+
 // TemporaryPassword is the email that is sent when users request a temporary password.
 type TemporaryPassword struct {
 	Data
 	TemporaryPassword string
+	TTL               time.Duration
+}
+
+// FormatTTL formats the TTL.
+func (t TemporaryPassword) FormatTTL() string {
+	return formatTTL(t.TTL)
 }
 
 // TemplateName returns the name of the template to use for this email.
@@ -36,6 +44,11 @@ Temporary Password: {{.TemporaryPassword}}
 If you wish to change the password using web interface, follow the link below:
 
 {{ .Network.IdentityServerURL }}/update-password?user={{ .User.ID }}&current={{ .TemporaryPassword }}
+
+{{- if .TTL }}
+
+This temporary password expires {{ .FormatTTL }}.
+{{ end -}}
 `
 
 // DefaultTemplates returns the default templates for this email.

--- a/pkg/identityserver/emails/ttl.go
+++ b/pkg/identityserver/emails/ttl.go
@@ -1,0 +1,57 @@
+// Copyright © 2020 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package emails
+
+import (
+	"math"
+	"time"
+
+	humanize "github.com/dustin/go-humanize"
+)
+
+const (
+	day   = 24 * time.Hour
+	week  = 7 * day
+	month = 30 * day
+	year  = 12 * month
+)
+
+func formatTTL(d time.Duration) string {
+	now := time.Now()
+	return humanize.CustomRelTime(now.Add(d), now, "ago", "from now", []humanize.RelTimeMagnitude{
+		{D: time.Second, Format: "now", DivBy: time.Second},
+		{D: 2 * time.Second, Format: "a second %s", DivBy: 1},
+
+		{D: time.Minute, Format: "%d seconds %s", DivBy: time.Second},
+		{D: 2 * time.Minute, Format: "a minute %s", DivBy: 1},
+
+		{D: time.Hour, Format: "%d minutes %s", DivBy: time.Minute},
+		{D: 2 * time.Hour, Format: "an hour %s", DivBy: 1},
+
+		{D: day, Format: "%d hours %s", DivBy: time.Hour},
+		{D: 2 * day, Format: "a day %s", DivBy: 1},
+
+		{D: week, Format: "%d days %s", DivBy: day},
+		{D: 2 * week, Format: "a week %s", DivBy: 1},
+
+		{D: month, Format: "%d weeks %s", DivBy: week},
+		{D: 2 * month, Format: "a month %s", DivBy: 1},
+
+		{D: year, Format: "%d months %s", DivBy: month},
+		{D: 2 * year, Format: "a year %s", DivBy: 1},
+
+		{D: math.MaxInt64, Format: "%d years %s", DivBy: year},
+	})
+}

--- a/pkg/identityserver/emails/validate.go
+++ b/pkg/identityserver/emails/validate.go
@@ -24,6 +24,11 @@ type Validate struct {
 	TTL   time.Duration
 }
 
+// FormatTTL formats the TTL.
+func (v Validate) FormatTTL() string {
+	return formatTTL(v.TTL)
+}
+
 // TemplateName returns the name of the template to use for this email.
 func (Validate) TemplateName() string { return "validate" }
 
@@ -39,9 +44,9 @@ Confirm via web interface:
 Confirm via command-line interface:
 ttn-lw-cli {{.Entity.Type}}s contact-info validate {{.ID}} {{.Token}}
 
-{{- with .TTL }}
+{{- if .TTL }}
 
-These confirmation links will expire in {{ .Hours }} hour{{ if gt .Hours 1.0 }}s{{ end }}.
+These confirmation links expire {{ .FormatTTL }}.
 {{ end -}}
 `
 

--- a/pkg/identityserver/invitation_registry.go
+++ b/pkg/identityserver/invitation_registry.go
@@ -53,10 +53,13 @@ func (is *IdentityServer) sendInvitation(ctx context.Context, in *ttnpb.SendInvi
 	if err != nil {
 		return nil, err
 	}
+	now := time.Now()
+	ttl := is.configFromContext(ctx).UserRegistration.Invitation.TokenTTL
+	expires := now.Add(ttl)
 	invitation := &ttnpb.Invitation{
 		Email:     in.Email,
 		Token:     token,
-		ExpiresAt: time.Now().Add(is.configFromContext(ctx).UserRegistration.Invitation.TokenTTL),
+		ExpiresAt: expires,
 	}
 	err = is.withDatabase(ctx, func(db *gorm.DB) (err error) {
 		invitation, err = store.GetInvitationStore(db).CreateInvitation(ctx, invitation)
@@ -71,6 +74,7 @@ func (is *IdentityServer) sendInvitation(ctx context.Context, in *ttnpb.SendInvi
 		return &emails.Invitation{
 			Data:            data,
 			InvitationToken: invitation.Token,
+			TTL:             ttl,
 		}
 	})
 	if err != nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR improves consistency of how we handle temporary tokens that we send in emails.

#### Changes
<!-- What are the changes made in this pull request? -->

- Make the TTL of contact info validation tokens configurable (this was already configurable for invitation tokens)
- Write in all emails how long a token is valid

#### Testing

<!-- How did you verify that this change works? -->

```
You have been invited to join The Things Stack for LoRaWAN.

Your Invitation Token is: PPVP2VQZGWBMSQ7EZUF3OGEW72ZV5JQ3E5DYXQG7V3W6QRZJBY2Q

You can use this token for the "--invitation-token" flag when creating a user from the command-line interface.

If you wish to register using web interface, follow the link below:

http://localhost:1885/oauth/register?invitation_token=PPVP2VQZGWBMSQ7EZUF3OGEW72ZV5JQ3E5DYXQG7V3W6QRZJBY2Q

These invitation links expire a week from now.
```

```
Your email address will be used as contact for user "htdvisser".

Confirm via web interface:
http://localhost:1885/oauth/validate?reference=RREMS3HQ7HBWM4CMUH37UWA4H6A4EQMUQS3CBHA&token=V2BKPUVB3OHE7EHOTSHFFS2XIL4LDORDNP6OTLEHE6X64K27GJKQ

Confirm via command-line interface:
ttn-lw-cli users contact-info validate RREMS3HQ7HBWM4CMUH37UWA4H6A4EQMUQS3CBHA V2BKPUVB3OHE7EHOTSHFFS2XIL4LDORDNP6OTLEHE6X64K27GJKQ

These confirmation links expire 2 days from now.
```

```
A temporary password was requested for your user "htdvisser" on The Things Stack for LoRaWAN.

This temporary password can only be used once, and only to change the password of your account.

Temporary Password: KUHG5ESH6VGIAKTKW3K7PNMVSBUPKOYDMK4CLZVNUTV3NGPFYQNA

If you wish to change the password using web interface, follow the link below:

http://localhost:1885/oauth/update-password?user=htdvisser&current=KUHG5ESH6VGIAKTKW3K7PNMVSBUPKOYDMK4CLZVNUTV3NGPFYQNA

This temporary password expires an hour from now.
```

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
