### PR TITLE
Return error when creating validation while old one still valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Do not initiate new contact info validations when old validations are still pending.
+
 ### Security
 
 ## [3.10.5] - 2020-12-23

--- a/config/messages.json
+++ b/config/messages.json
@@ -4445,6 +4445,15 @@
       "file": "store.go"
     }
   },
+  "error:pkg/identityserver/store:validation_already_exists": {
+    "translations": {
+      "en": "contact info validation already exists"
+    },
+    "description": {
+      "package": "pkg/identityserver/store",
+      "file": "contact_info_store.go"
+    }
+  },
   "error:pkg/identityserver/store:validation_token": {
     "translations": {
       "en": "validation token not found"

--- a/config/messages.json
+++ b/config/messages.json
@@ -4679,6 +4679,15 @@
       "file": "invitation_registry.go"
     }
   },
+  "error:pkg/identityserver:no_validation_needed": {
+    "translations": {
+      "en": "no validation needed for this contact info"
+    },
+    "description": {
+      "package": "pkg/identityserver",
+      "file": "contact_info_registry.go"
+    }
+  },
   "error:pkg/identityserver:oauth_client_rejected": {
     "translations": {
       "en": "OAuth client was rejected"
@@ -4875,6 +4884,15 @@
     "description": {
       "package": "pkg/identityserver",
       "file": "user_registry.go"
+    }
+  },
+  "error:pkg/identityserver:validations_already_sent": {
+    "translations": {
+      "en": "validations for this contact info already sent"
+    },
+    "description": {
+      "package": "pkg/identityserver",
+      "file": "contact_info_registry.go"
     }
   },
   "error:pkg/interop:activation": {

--- a/pkg/identityserver/store/contact_info_store.go
+++ b/pkg/identityserver/store/contact_info_store.go
@@ -144,6 +144,8 @@ func (s *contactInfoStore) SetContactInfo(ctx context.Context, entityID ttnpb.Id
 	return pb, nil
 }
 
+var errValidationAlreadyExists = errors.DefineAlreadyExists("validation_already_exists", "contact info validation already exists")
+
 func (s *contactInfoStore) CreateValidation(ctx context.Context, validation *ttnpb.ContactInfoValidation) (*ttnpb.ContactInfoValidation, error) {
 	defer trace.StartRegion(ctx, "create contact info validation").End()
 	var (
@@ -170,6 +172,21 @@ func (s *contactInfoStore) CreateValidation(ctx context.Context, validation *ttn
 	model.EntityType, model.EntityID = entityTypeForID(validation.Entity), entity.PrimaryKey()
 	model.ContactMethod = int(contactMethod)
 	model.Value = value
+
+	var existing ContactInfoValidation
+	err = s.query(ctx, ContactInfoValidation{}).Where(ContactInfoValidation{
+		EntityID:      model.EntityID,
+		EntityType:    model.EntityType,
+		ContactMethod: model.ContactMethod,
+		Value:         model.Value,
+	}).Where("expires_at > ?", cleanTime(time.Now())).First(&existing).Error
+	switch {
+	case err == nil:
+		return nil, errValidationAlreadyExists.New()
+	case gorm.IsRecordNotFoundError(err):
+	default:
+		return nil, err
+	}
 
 	if err = s.createEntity(ctx, &model); err != nil {
 		return nil, err

--- a/pkg/identityserver/store/contact_info_store_test.go
+++ b/pkg/identityserver/store/contact_info_store_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jinzhu/gorm"
 	"github.com/smartystreets/assertions"
 	"github.com/smartystreets/assertions/should"
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
 )
@@ -126,6 +127,18 @@ func TestContactInfoValidation(t *testing.T) {
 		})
 
 		a.So(err, should.BeNil)
+
+		_, err = s.CreateValidation(ctx, &ttnpb.ContactInfoValidation{
+			ID:          "validation-id",
+			Token:       "other-token",
+			Entity:      usr.EntityIdentifiers(),
+			ContactInfo: info,
+			ExpiresAt:   &expiresAt,
+		})
+
+		if a.So(err, should.NotBeNil) {
+			a.So(errors.IsAlreadyExists(err), should.BeTrue)
+		}
 
 		err = s.Validate(ctx, &ttnpb.ContactInfoValidation{
 			ID:    "validation-id",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This makes the Identity Server return an error when requesting contact info validation while an existing validation is still in progress.

Closes #1333

#### Changes
<!-- What are the changes made in this pull request? -->

- Make the store return an error if there is a previous (not expired) validation for the same values

#### Testing

<!-- How did you verify that this change works? -->

Unit tests in the store

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Most of the diff in `pkg/identityserver/contact_info_registry.go` is because I changed the `if` to an `if not` with early exit. Hide the irrelevant diff by telling GitHub to "ignore whitespace".

~I think this PR will conflict with #3625, so I'll rebase after that one is merged.~

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
