### PR TITLE
Skip payload encryption using link level overrides in RPCs

### DIFF
--- a/pkg/applicationserver/applicationserver_util_test.go
+++ b/pkg/applicationserver/applicationserver_util_test.go
@@ -55,3 +55,34 @@ type noopEndDeviceFetcher struct{}
 func (noopEndDeviceFetcher) Get(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, fieldMaskPaths ...string) (*ttnpb.EndDevice, error) {
 	return nil, errNotFound.New()
 }
+
+// MockLinkRegistry is a mock LinkRegistry used for testing.
+type MockLinkRegistry struct {
+	GetFunc   func(ctx context.Context, ids ttnpb.ApplicationIdentifiers, paths []string) (*ttnpb.ApplicationLink, error)
+	RangeFunc func(ctx context.Context, paths []string, f func(context.Context, ttnpb.ApplicationIdentifiers, *ttnpb.ApplicationLink) bool) error
+	SetFunc   func(ctx context.Context, ids ttnpb.ApplicationIdentifiers, paths []string, f func(*ttnpb.ApplicationLink) (*ttnpb.ApplicationLink, []string, error)) (*ttnpb.ApplicationLink, error)
+}
+
+// Get calls GetFunc if set and panics otherwise.
+func (m MockLinkRegistry) Get(ctx context.Context, ids ttnpb.ApplicationIdentifiers, paths []string) (*ttnpb.ApplicationLink, error) {
+	if m.GetFunc == nil {
+		panic("Get called, but not set")
+	}
+	return m.GetFunc(ctx, ids, paths)
+}
+
+// Range calls RangeFunc if set and panics otherwise.
+func (m MockLinkRegistry) Range(ctx context.Context, paths []string, f func(context.Context, ttnpb.ApplicationIdentifiers, *ttnpb.ApplicationLink) bool) error {
+	if m.RangeFunc == nil {
+		panic("Range called, but not set")
+	}
+	return m.RangeFunc(ctx, paths, f)
+}
+
+// Set calls SetFunc if set and panics otherwise.
+func (m MockLinkRegistry) Set(ctx context.Context, ids ttnpb.ApplicationIdentifiers, paths []string, f func(*ttnpb.ApplicationLink) (*ttnpb.ApplicationLink, []string, error)) (*ttnpb.ApplicationLink, error) {
+	if m.SetFunc == nil {
+		panic("Set called, bt not set")
+	}
+	return m.SetFunc(ctx, ids, paths, f)
+}

--- a/pkg/applicationserver/grpc_deviceregistry.go
+++ b/pkg/applicationserver/grpc_deviceregistry.go
@@ -94,7 +94,11 @@ func (r asEndDeviceRegistryServer) Get(ctx context.Context, req *ttnpb.GetEndDev
 	if dev.GetPendingSession() != nil && ttnpb.HasAnyField(req.FieldMask.Paths,
 		"pending_session.keys.app_s_key.key",
 	) {
-		if !dev.SkipPayloadCryptoOverride.GetValue() {
+		link, err := r.AS.getLink(ctx, req.ApplicationIdentifiers)
+		if err != nil {
+			return nil, err
+		}
+		if !r.AS.skipPayloadCrypto(ctx, link, dev, dev.PendingSession) {
 			sk, err := cryptoutil.UnwrapSelectedSessionKeys(ctx, r.AS.KeyVault, dev.PendingSession.SessionKeys, "pending_session.keys", req.FieldMask.Paths...)
 			if err != nil {
 				return nil, err
@@ -105,7 +109,11 @@ func (r asEndDeviceRegistryServer) Get(ctx context.Context, req *ttnpb.GetEndDev
 	if dev.GetSession() != nil && ttnpb.HasAnyField(req.FieldMask.Paths,
 		"session.keys.app_s_key.key",
 	) {
-		if !dev.SkipPayloadCryptoOverride.GetValue() {
+		link, err := r.AS.getLink(ctx, req.ApplicationIdentifiers)
+		if err != nil {
+			return nil, err
+		}
+		if !r.AS.skipPayloadCrypto(ctx, link, dev, dev.Session) {
 			sk, err := cryptoutil.UnwrapSelectedSessionKeys(ctx, r.AS.KeyVault, dev.Session.SessionKeys, "session.keys", req.FieldMask.Paths...)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->
This quickfix ensures that the `Get` end-device RPC does respect the link-level `skip_payload_crypto`.

#### Changes
<!-- What are the changes made in this pull request? -->

- Use `as.skipPayloadCrypto` instead of `dev.SkipPayloadCryptoOverride` only


#### Testing

<!-- How did you verify that this change works? -->

- Set link-level `skip_payload_crypto`
- Attempt to retrieve device session and expect key to be wrapped
 
##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Not expected. Testing should cover this.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
