### PR TITLE
Fix propagation of caller details in events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Fixed
 
 - Network Server DevStatusReq scheduling conditions in relation to frame counter value.
+- Missing `authentication`, `remote_ip` and `user_agent` fields in events when using event backends other than `internal`.
 
 ### Security
 

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -65,9 +65,19 @@ func local(evt Event) *event {
 				CorrelationIDs: evt.CorrelationIDs(),
 				Origin:         evt.Origin(),
 				Visibility:     evt.Visibility(),
+				UserAgent:      evt.UserAgent(),
+				RemoteIP:       evt.RemoteIP(),
 			},
 			data:   evt.Data(),
 			caller: evt.Caller(),
+		}
+		authentication := &ttnpb.Event_Authentication{
+			Type:      evt.AuthType(),
+			TokenType: evt.AuthTokenType(),
+			TokenID:   evt.AuthTokenID(),
+		}
+		if authentication.TokenID != "" || authentication.TokenType != "" || authentication.Type != "" {
+			localEvent.innerEvent.Authentication = authentication
 		}
 	}
 	return localEvent
@@ -139,26 +149,9 @@ func (e event) Caller() string                          { return e.caller }
 func (e event) Visibility() *ttnpb.Rights               { return e.innerEvent.Visibility }
 func (e event) UserAgent() string                       { return e.innerEvent.UserAgent }
 func (e event) RemoteIP() string                        { return e.innerEvent.RemoteIP }
-func (e event) AuthType() string {
-	if e.innerEvent.Authentication == nil {
-		return ""
-	}
-	return e.innerEvent.Authentication.Type
-}
-
-func (e event) AuthTokenType() string {
-	if e.innerEvent.Authentication == nil {
-		return ""
-	}
-	return e.innerEvent.Authentication.TokenType
-}
-
-func (e event) AuthTokenID() string {
-	if e.innerEvent.Authentication == nil {
-		return ""
-	}
-	return e.innerEvent.Authentication.TokenID
-}
+func (e event) AuthType() string                        { return e.innerEvent.GetAuthentication().GetType() }
+func (e event) AuthTokenType() string                   { return e.innerEvent.GetAuthentication().GetTokenType() }
+func (e event) AuthTokenID() string                     { return e.innerEvent.GetAuthentication().GetTokenID() }
 
 var hostname string
 
@@ -253,6 +246,9 @@ func FromProto(pb *ttnpb.Event) (Event, error) {
 			CorrelationIDs: pb.CorrelationIDs,
 			Origin:         pb.Origin,
 			Visibility:     pb.Visibility,
+			Authentication: pb.Authentication,
+			RemoteIP:       pb.RemoteIP,
+			UserAgent:      pb.UserAgent,
 		},
 	}, nil
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This fixes propagation of caller details (user agent, remote IP and auth info) in events when events need to be converted.

#### Changes
<!-- What are the changes made in this pull request? -->

- Make event conversion consider UserAgent, RemoteIP and Authentication fields.

#### Testing

<!-- How did you verify that this change works? -->

- `export TTN_LW_EVENTS_BACKEND=redis`
- Start the Stack
- Update something in the Console

<img width="1280" alt="Screen Shot 2021-01-18 at 16 28 37" src="https://user-images.githubusercontent.com/181308/104934272-3d23c980-59aa-11eb-963f-53c9e2a4c6be.png">

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
