### PR TITLE
Add missing CLI commands for getting a single collaborator or api key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For details about compatibility between different releases, see the **Commitment
 - CUPS redirection.
   - This requires a database schema migration (`ttn-lw-stack is-db migrate`) because of the added columns.
 - Configuration option (`is.user-registration.enabled`) to enable or disable user registrations.
+- Missing CLI commands for getting single API keys or collaborators for entities.
 
 ### Changed
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request adds missing CLI commands for getting single collaborators or API keys for entities. The API for this was added in #665 and #1001, and the Console already supported it, but the CLI didn't.

#### Testing

<!-- How did you verify that this change works? -->

🐒 for applications, so unless I made stupid copy-paste mistakes that should be fine.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
