### PR TITLE
Update email templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ For details about compatibility between different releases, see the **Commitment
 - Network Server matching mapping in the database.
   - This requires a database migration (`ttn-lw-stack ns-db migrate`).
 - Sending a non-empty implicitly specified field disallowed field will now cause RPCs to fail. E.g. if RPC supports paths `A` and `A.B`, sending value with `A.C` non-empty and field mask `A` would result in an error.
+- Improved content of emails sent by the Identity Server.
 
 ### Deprecated
 

--- a/pkg/email/funcs.go
+++ b/pkg/email/funcs.go
@@ -16,11 +16,21 @@ package email
 
 import (
 	"html/template"
+	"path"
 	"strings"
 )
 
+const documentationBaseURL = "https://www.thethingsindustries.com/docs"
+
 var defaultFuncs = template.FuncMap{
 	"strings": func() stringsFuncs { return stringsFuncs{} },
+	"documentation_url": func(elems ...string) string {
+		p := path.Join(elems...)
+		if !strings.HasPrefix(p, "/") {
+			p = "/" + p
+		}
+		return documentationBaseURL + p
+	},
 }
 
 type stringsFuncs struct{}

--- a/pkg/identityserver/application_access.go
+++ b/pkg/identityserver/application_access.go
@@ -99,7 +99,7 @@ func (is *IdentityServer) createApplicationAPIKey(ctx context.Context, req *ttnp
 	events.Publish(evtCreateApplicationAPIKey.NewWithIdentifiersAndData(ctx, req.ApplicationIdentifiers, nil))
 	err = is.SendContactsEmail(ctx, req.EntityIdentifiers(), func(data emails.Data) email.MessageData {
 		data.SetEntity(req.EntityIdentifiers())
-		return &emails.APIKeyCreated{Data: data, Identifier: key.PrettyName(), Rights: key.Rights}
+		return &emails.APIKeyCreated{Data: data, Key: key, Rights: key.Rights}
 	})
 	if err != nil {
 		log.FromContext(ctx).WithError(err).Error("Could not send API key creation notification email")
@@ -192,7 +192,7 @@ func (is *IdentityServer) updateApplicationAPIKey(ctx context.Context, req *ttnp
 	events.Publish(evtUpdateApplicationAPIKey.NewWithIdentifiersAndData(ctx, req.ApplicationIdentifiers, nil))
 	err = is.SendContactsEmail(ctx, req.EntityIdentifiers(), func(data emails.Data) email.MessageData {
 		data.SetEntity(req.EntityIdentifiers())
-		return &emails.APIKeyChanged{Data: data, Identifier: key.PrettyName(), Rights: key.Rights}
+		return &emails.APIKeyChanged{Data: data, Key: key, Rights: key.Rights}
 	})
 	if err != nil {
 		log.FromContext(ctx).WithError(err).Error("Could not send API key update notification email")

--- a/pkg/identityserver/emails/api_key_created.go
+++ b/pkg/identityserver/emails/api_key_created.go
@@ -14,13 +14,31 @@
 
 package emails
 
-import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+import (
+	"fmt"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+)
 
 // APIKeyCreated is the email that is sent when users creates a new API key
 type APIKeyCreated struct {
 	Data
-	Identifier string
-	Rights     []ttnpb.Right
+	Key    *ttnpb.APIKey
+	Rights []ttnpb.Right
+}
+
+// Identifier returns the pretty name of the API key.
+// The naming of this method is for compatibility reasons.
+func (a APIKeyCreated) Identifier() string {
+	return a.Key.PrettyName()
+}
+
+// ConsoleURL returns the URL to the API key in the Console.
+func (a APIKeyCreated) ConsoleURL() string {
+	if a.Entity.Type == "user" {
+		return fmt.Sprintf("%s/user/api-keys/%s", a.Network.ConsoleURL, a.Key.ID)
+	}
+	return fmt.Sprintf("%s/%ss/%s/api-keys/%s", a.Network.ConsoleURL, a.Entity.Type, a.Entity.ID, a.Key.ID)
 }
 
 // TemplateName returns the name of the template to use for this email.
@@ -33,6 +51,15 @@ const apiKeyCreatedText = `Dear {{.User.Name}},
 A new API key "{{.Identifier}}" has been created for {{.Entity.Type}} "{{.Entity.ID}}" on {{.Network.Name}} with the following rights:
 {{range $right := .Rights}} 
 {{$right}} {{end}}
+
+You can go to {{.ConsoleURL}} to view and edit this API key in the Console.
+
+If you prefer to use the command-line interface, you can run the following commands to view or edit this API key:
+
+ttn-lw-cli {{.Entity.Type}}s api-keys get --{{.Entity.Type}}-id {{.Entity.ID}} --api-key-id {{.Key.ID}}
+ttn-lw-cli {{.Entity.Type}}s api-keys set --{{.Entity.Type}}-id {{.Entity.ID}} --api-key-id {{.Key.ID}}
+
+For more information on how to use the command-line interface, please refer to the documentation: {{ documentation_url "/getting-started/cli/" }}.
 `
 
 // DefaultTemplates returns the default templates for this email.

--- a/pkg/identityserver/emails/collaborator_changed.go
+++ b/pkg/identityserver/emails/collaborator_changed.go
@@ -14,12 +14,21 @@
 
 package emails
 
-import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+import (
+	"fmt"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+)
 
 // CollaboratorChanged is the email that is sent when a collaborator is changed
 type CollaboratorChanged struct {
 	Data
 	Collaborator ttnpb.Collaborator
+}
+
+// ConsoleURL returns the URL to the collaborator in the Console.
+func (c CollaboratorChanged) ConsoleURL() string {
+	return fmt.Sprintf("%s/%ss/%s/collaborators/%s/%s", c.Network.ConsoleURL, c.Entity.Type, c.Entity.ID, c.Collaborator.EntityIdentifiers().EntityType(), c.Collaborator.EntityIdentifiers().IDString())
 }
 
 // TemplateName returns the name of the template to use for this email.
@@ -32,6 +41,15 @@ const collaboratorChangedBody = `Dear {{.User.Name}},
 The collaborator "{{.Collaborator.EntityIdentifiers.IDString}}" of {{.Entity.Type}} "{{.Entity.ID}}" on {{.Network.Name}} now has the following rights:
 {{range $right := .Collaborator.Rights}}
 {{$right}} {{end}}
+
+You can go to {{.ConsoleURL}} to view and edit this collaborator in the Console.
+
+If you prefer to use the command-line interface, you can run the following commands to view or edit this collaborator:
+
+ttn-lw-cli {{.Entity.Type}}s collaborators get --{{.Entity.Type}}-id {{.Entity.ID}} --{{.Collaborator.EntityIdentifiers.EntityType}}-id {{.Collaborator.EntityIdentifiers.IDString}}
+ttn-lw-cli {{.Entity.Type}}s collaborators set --{{.Entity.Type}}-id {{.Entity.ID}} --{{.Collaborator.EntityIdentifiers.EntityType}}-id {{.Collaborator.EntityIdentifiers.IDString}}
+
+For more information on how to use the command-line interface, please refer to the documentation: {{ documentation_url "/getting-started/cli/" }}.
 `
 
 // DefaultTemplates returns the default templates for this email.

--- a/pkg/identityserver/emails/invitation.go
+++ b/pkg/identityserver/emails/invitation.go
@@ -37,18 +37,18 @@ const invitationText = `Hello,
 
 You have been invited to join {{ .Network.Name }}.
 
-Your Invitation Token is: {{ .InvitationToken }}
+You can now go to {{ .Network.IdentityServerURL }}/register?invitation_token={{ .InvitationToken }} to register your user.
 
-You can use this token for the "--invitation-token" flag when creating a user from the command-line interface.
-
-If you wish to register using web interface, follow the link below:
-
-{{ .Network.IdentityServerURL }}/register?invitation_token={{ .InvitationToken }}
+If you prefer to use the command-line interface, you can add "--invitation-token {{ .InvitationToken }}" when running the "ttn-lw-cli users create" command.
 
 {{- if .TTL }}
 
-These invitation links expire {{ .FormatTTL }}.
-{{ end -}}
+Your invitation expires {{ .FormatTTL }}, so register your user before then.
+{{- end }}
+
+After successful registration, you can go to {{ .Network.ConsoleURL }} to start adding devices and gateways.
+
+For more information on how how to get started, please refer to the documentation: {{ documentation_url "/getting-started/" }}.
 `
 
 // DefaultTemplates returns the default templates for this email.

--- a/pkg/identityserver/emails/temporary_password.go
+++ b/pkg/identityserver/emails/temporary_password.go
@@ -37,18 +37,18 @@ const temporaryPasswordText = `Dear {{.User.Name}},
 
 A temporary password was requested for your user "{{.User.ID}}" on {{.Network.Name}}.
 
-This temporary password can only be used once, and only to change the password of your account.
+You can now go to {{ .Network.IdentityServerURL }}/update-password?user={{ .User.ID }}&current={{ .TemporaryPassword }} to change your password.
 
-Temporary Password: {{.TemporaryPassword}}
+If you prefer to use the command-line interface, you can run the following command:
 
-If you wish to change the password using web interface, follow the link below:
+ttn-lw-cli users update-password --user-id {{.User.ID}} --old {{ .TemporaryPassword }} (add --revoke-all-access if you want to logout everywhere)
 
-{{ .Network.IdentityServerURL }}/update-password?user={{ .User.ID }}&current={{ .TemporaryPassword }}
+For more information on how to use the command-line interface, please refer to the documentation: {{ documentation_url "/getting-started/cli/" }}.
 
 {{- if .TTL }}
 
-This temporary password expires {{ .FormatTTL }}.
-{{ end -}}
+Your temporary password expires {{ .FormatTTL }}, so change your password before then.
+{{- end }}
 `
 
 // DefaultTemplates returns the default templates for this email.

--- a/pkg/identityserver/emails/user_requested.go
+++ b/pkg/identityserver/emails/user_requested.go
@@ -14,9 +14,16 @@
 
 package emails
 
+import "fmt"
+
 // UserRequested is the email that is sent to admins when a user requests to join the network.
 type UserRequested struct {
 	Data
+}
+
+// ConsoleURL returns the URL to the user in the Console.
+func (u UserRequested) ConsoleURL() string {
+	return fmt.Sprintf("%s/admin/user-management/%s", u.Network.ConsoleURL, u.Entity.ID)
 }
 
 // TemplateName returns the name of the template to use for this email.
@@ -28,10 +35,13 @@ const userRequestedText = `Dear {{ .User.Name }},
 
 User "{{ .Entity.ID }}" wants to join {{ .Network.Name }}.
 
-You can approve or reject them in the Console or using the Command-line interface.
+You can go to {{ .ConsoleURL }} to view and approve (or reject) the user.
 
-You can read how exactly to do this in the user management guide:
-https://thethingsstack.io/latest/getting-started/user-management/
+If you prefer to use the command-line interface, you can run the following command:
+
+ttn-lw-cli users set {{ .Entity.ID }} --state APPROVED (or --state REJECTED)
+
+For more information on how to use the command-line interface, please refer to the documentation: {{ documentation_url "/getting-started/cli/" }}.
 `
 
 // DefaultTemplates returns the default templates for this email.

--- a/pkg/identityserver/emails/validate.go
+++ b/pkg/identityserver/emails/validate.go
@@ -38,16 +38,18 @@ const validateText = `Please confirm your email address for {{.Network.Name}}.
 
 Your email address will be used as contact for {{.Entity.Type}} "{{.Entity.ID}}".
 
-Confirm via web interface:
-{{ .Network.IdentityServerURL }}/validate?reference={{ .ID }}&token={{ .Token }}
+You can go to {{ .Network.IdentityServerURL }}/validate?reference={{ .ID }}&token={{ .Token }} to confirm your email address.
 
-Confirm via command-line interface:
+If you prefer to use the command-line interface, you can run the following command:
+
 ttn-lw-cli {{.Entity.Type}}s contact-info validate {{.ID}} {{.Token}}
+
+For more information on how to use the command-line interface, please refer to the documentation: {{ documentation_url "/getting-started/cli/" }}.
 
 {{- if .TTL }}
 
-These confirmation links expire {{ .FormatTTL }}.
-{{ end -}}
+The confirmation token expires {{ .FormatTTL }}, so confirm your email address before then.
+{{- end }}
 `
 
 // DefaultTemplates returns the default templates for this email.

--- a/pkg/identityserver/gateway_access.go
+++ b/pkg/identityserver/gateway_access.go
@@ -99,7 +99,7 @@ func (is *IdentityServer) createGatewayAPIKey(ctx context.Context, req *ttnpb.Cr
 	events.Publish(evtCreateGatewayAPIKey.NewWithIdentifiersAndData(ctx, req.GatewayIdentifiers, nil))
 	err = is.SendContactsEmail(ctx, req.EntityIdentifiers(), func(data emails.Data) email.MessageData {
 		data.SetEntity(req.EntityIdentifiers())
-		return &emails.APIKeyCreated{Data: data, Identifier: key.PrettyName(), Rights: key.Rights}
+		return &emails.APIKeyCreated{Data: data, Key: key, Rights: key.Rights}
 	})
 	if err != nil {
 		log.FromContext(ctx).WithError(err).Error("Could not send API key creation notification email")
@@ -192,7 +192,7 @@ func (is *IdentityServer) updateGatewayAPIKey(ctx context.Context, req *ttnpb.Up
 	events.Publish(evtUpdateGatewayAPIKey.NewWithIdentifiersAndData(ctx, req.GatewayIdentifiers, nil))
 	err = is.SendContactsEmail(ctx, req.EntityIdentifiers(), func(data emails.Data) email.MessageData {
 		data.SetEntity(req.EntityIdentifiers())
-		return &emails.APIKeyChanged{Data: data, Identifier: key.PrettyName(), Rights: key.Rights}
+		return &emails.APIKeyChanged{Data: data, Key: key, Rights: key.Rights}
 	})
 	if err != nil {
 		log.FromContext(ctx).WithError(err).Error("Could not send API key update notification email")

--- a/pkg/identityserver/organization_access.go
+++ b/pkg/identityserver/organization_access.go
@@ -99,7 +99,7 @@ func (is *IdentityServer) createOrganizationAPIKey(ctx context.Context, req *ttn
 	events.Publish(evtCreateOrganizationAPIKey.NewWithIdentifiersAndData(ctx, req.OrganizationIdentifiers, nil))
 	err = is.SendContactsEmail(ctx, req.EntityIdentifiers(), func(data emails.Data) email.MessageData {
 		data.SetEntity(req.EntityIdentifiers())
-		return &emails.APIKeyCreated{Data: data, Identifier: key.PrettyName(), Rights: key.Rights}
+		return &emails.APIKeyCreated{Data: data, Key: key, Rights: key.Rights}
 	})
 	if err != nil {
 		log.FromContext(ctx).WithError(err).Error("Could not send API key creation notification email")
@@ -192,7 +192,7 @@ func (is *IdentityServer) updateOrganizationAPIKey(ctx context.Context, req *ttn
 	events.Publish(evtUpdateOrganizationAPIKey.NewWithIdentifiersAndData(ctx, req.OrganizationIdentifiers, nil))
 	err = is.SendContactsEmail(ctx, req.EntityIdentifiers(), func(data emails.Data) email.MessageData {
 		data.SetEntity(req.EntityIdentifiers())
-		return &emails.APIKeyChanged{Data: data, Identifier: key.PrettyName(), Rights: key.Rights}
+		return &emails.APIKeyChanged{Data: data, Key: key, Rights: key.Rights}
 	})
 	if err != nil {
 		log.FromContext(ctx).WithError(err).Error("Could not send API key update notification email")

--- a/pkg/identityserver/user_access.go
+++ b/pkg/identityserver/user_access.go
@@ -79,7 +79,7 @@ func (is *IdentityServer) createUserAPIKey(ctx context.Context, req *ttnpb.Creat
 	events.Publish(evtCreateUserAPIKey.NewWithIdentifiersAndData(ctx, req.UserIdentifiers, nil))
 	err = is.SendUserEmail(ctx, &req.UserIdentifiers, func(data emails.Data) email.MessageData {
 		data.SetEntity(req.EntityIdentifiers())
-		return &emails.APIKeyCreated{Data: data, Identifier: key.PrettyName(), Rights: key.Rights}
+		return &emails.APIKeyCreated{Data: data, Key: key, Rights: key.Rights}
 	})
 	if err != nil {
 		log.FromContext(ctx).WithError(err).Error("Could not send API key created notification email")
@@ -172,7 +172,7 @@ func (is *IdentityServer) updateUserAPIKey(ctx context.Context, req *ttnpb.Updat
 	events.Publish(evtUpdateUserAPIKey.NewWithIdentifiersAndData(ctx, req.UserIdentifiers, nil))
 	err = is.SendUserEmail(ctx, &req.UserIdentifiers, func(data emails.Data) email.MessageData {
 		data.SetEntity(req.EntityIdentifiers())
-		return &emails.APIKeyChanged{Data: data, Identifier: key.PrettyName(), Rights: key.Rights}
+		return &emails.APIKeyChanged{Data: data, Key: key, Rights: key.Rights}
 	})
 	if err != nil {
 		log.FromContext(ctx).WithError(err).Error("Could not send API key update notification email")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull requests updates our email templates to make the web UI (the Console) the primary entrypoint for user actions instead of the CLI.

Closes #3674

#### Testing

<!-- How did you verify that this change works? -->

Run The Things Stack, perform actions that trigger emails.

```
Hello,

You have been invited to join The Things Stack for LoRaWAN.

You can now go to http://localhost:1885/oauth/register?invitation_token=6UCDXBY4VXE5XEWK3X5VTQI6KV4DC4CHYIWIG4654YW4MEBRHFZA to register your user.

If you prefer to use the command-line interface, you can add "--invitation-token 6UCDXBY4VXE5XEWK3X5VTQI6KV4DC4CHYIWIG4654YW4MEBRHFZA" when running the "ttn-lw-cli users create" command.

Your invitation expires a week from now.
```

```
Dear admin,

User "hylke" wants to join The Things Stack for LoRaWAN.

You can go to http://localhost:1885/console/admin/user-management/hylke to view and approve (or reject) the user.

If you prefer to use the command-line interface, you can run the following command:

ttn-lw-cli users set hylke --state APPROVED (or --state REJECTED)
```

```
Please confirm your email address for The Things Stack for LoRaWAN.

Your email address will be used as contact for user "hylke".

You can go to http://localhost:1885/oauth/validate?reference=RKKD2IY2GYBEGBAJ63VPDWLSINY2CDHFZFMROPY&token=MKAP6ICOWZIRA52OE43TCE7OEUK6QCZDZ4VEEEZRZ3CJYD5AHFGQ to confirm your email address.

If you prefer to use the command-line interface, you can run the following command:

ttn-lw-cli users contact-info validate RKKD2IY2GYBEGBAJ63VPDWLSINY2CDHFZFMROPY MKAP6ICOWZIRA52OE43TCE7OEUK6QCZDZ4VEEEZRZ3CJYD5AHFGQ

These confirmation links expire 2 days from now.
```

```
Dear Hylke,

Your user "hylke" on The Things Stack for LoRaWAN is now approved.
```

Note that this same ☝️ email template is also used when OAuth clients are approved. We may want to add some if/else blocks to tell users that they can visit the console at `{{.Network.ConsoleURL}}`, but that may get a bit messy.

```
Dear Hylke,

A temporary password was requested for your user "hylke" on The Things Stack for LoRaWAN.

You can now go to http://localhost:1885/oauth/update-password?user=hylke&current=BNT7NOZ3URKLMTHTH5UG4NGL2RVDJHG2CKDLVZCDVVQVISG7NNRA to change your password.

If you prefer to use the command-line interface, you can run the following command:

ttn-lw-cli users update-password --user-id hylke --old BNT7NOZ3URKLMTHTH5UG4NGL2RVDJHG2CKDLVZCDVVQVISG7NNRA (add --revoke-all-access if you want to logout everywhere)

Your temporary password expires an hour from now.
```

```
Dear Admin,

A new API key "BKP5TVJLVUBPNVC6TBYQC4QRNYZQUBNXBQ4QLAI (Demo)" has been created for application "admin-app" on The Things Stack for LoRaWAN with the following rights:

RIGHT_APPLICATION_DEVICES_READ
RIGHT_APPLICATION_DEVICES_READ_KEYS
RIGHT_APPLICATION_DEVICES_WRITE
RIGHT_APPLICATION_DEVICES_WRITE_KEYS
RIGHT_APPLICATION_INFO
RIGHT_APPLICATION_SETTINGS_BASIC
RIGHT_APPLICATION_SETTINGS_PACKAGES
RIGHT_APPLICATION_TRAFFIC_READ

You can go to http://localhost:1885/console/applications/admin-app/api-keys/BKP5TVJLVUBPNVC6TBYQC4QRNYZQUBNXBQ4QLAI to view and edit this API key in the Console.

If you prefer to use the command-line interface, you can run the following commands to view or edit this API key:

ttn-lw-cli applications api-keys get --application-id admin-app --api-key-id BKP5TVJLVUBPNVC6TBYQC4QRNYZQUBNXBQ4QLAI
ttn-lw-cli applications api-keys set --application-id admin-app --api-key-id BKP5TVJLVUBPNVC6TBYQC4QRNYZQUBNXBQ4QLAI
```

```
Dear Admin,

The collaborator "hylke" of application "admin-app" on The Things Stack for LoRaWAN now has the following rights:

RIGHT_APPLICATION_ALL

You can go to http://localhost:1885/console/applications/admin-app/collaborators/user/hylke to view and edit this collaborator in the Console.

If you prefer to use the command-line interface, you can run the following commands to view or edit this collaborator:

ttn-lw-cli applications collaborators get --application-id admin-app --user-id hylke
ttn-lw-cli applications collaborators set --application-id admin-app --user-id hylke
```

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Unless I skipped an email during testing, I'm pretty sure that we're not trying to render undefined variables.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The `api-keys get` and `collaborators get` commands didn't exist in the CLI, I'm adding those in a separate pull request: #3677.

For multi-cluster deployments this requires https://github.com/TheThingsIndustries/cluster-picker/issues/3

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
	- [ ] Will open a documentation PR to describe the changed template variables
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
