### PR TITLE
Ensure JS processor can manipulate input bytes

### DIFF
--- a/pkg/messageprocessors/javascript/javascript.go
+++ b/pkg/messageprocessors/javascript/javascript.go
@@ -140,6 +140,10 @@ func (h *host) DecodeUplink(ctx context.Context, ids ttnpb.EndDeviceIdentifiers,
 		%s
 
 		function main(input) {
+			input = {
+				bytes: input.bytes.slice(),
+				fPort: input.fPort,
+			}
 			if (typeof decodeUplink === 'function') {
 				return decodeUplink(input);
 			}
@@ -195,6 +199,10 @@ func (h *host) DecodeDownlink(ctx context.Context, ids ttnpb.EndDeviceIdentifier
 		%s
 
 		function main(input) {
+			input = {
+				bytes: input.bytes.slice(),
+				fPort: input.fPort,
+			}
 			return decodeDownlink(input);
 		}
 	`, script)

--- a/pkg/messageprocessors/javascript/javascript_test.go
+++ b/pkg/messageprocessors/javascript/javascript_test.go
@@ -426,6 +426,21 @@ func TestDecodeUplink(t *testing.T) {
 		err := host.DecodeUplink(ctx, ids, nil, message, script)
 		a.So(err, should.HaveSameErrorDefinitionAs, errOutputErrors.WithAttributes("errors", "error 1, error 2"))
 	}
+
+	// Splice input bytes.
+	{
+		script := `
+		function decodeUplink(input) {
+			return {
+				data: {
+					bytes: input.bytes.splice(0, 1),
+				}
+			}
+		}
+		`
+		err := host.DecodeUplink(ctx, ids, nil, message, script)
+		a.So(err, should.BeNil)
+	}
 }
 
 func TestDecodeDownlink(t *testing.T) {
@@ -541,5 +556,20 @@ func TestDecodeDownlink(t *testing.T) {
 		`
 		err := host.DecodeDownlink(ctx, ids, nil, message, script)
 		a.So(err, should.HaveSameErrorDefinitionAs, errOutputErrors.WithAttributes("errors", "error 1, error 2"))
+	}
+
+	// Splice input bytes.
+	{
+		script := `
+		function decodeDownlink(input) {
+			return {
+				data: {
+					bytes: input.bytes.splice(0, 1),
+				}
+			}
+		}
+		`
+		err := host.DecodeDownlink(ctx, ids, nil, message, script)
+		a.So(err, should.BeNil)
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #3635

#### Changes
<!-- What are the changes made in this pull request? -->

- Expose `input.bytes` as a native JavaScript array as opposed to a Go Slice.


#### Testing

<!-- How did you verify that this change works? -->

Using the script in the issue.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None are expected.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I've pushed this `quickfix` since v3 gains more attention and people are expecting their payload formatters from v2 to work out of the box. I've also had to 'rebuild' the whole object because apparently it's not possible to just update `input.bytes`.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
