### PR TITLE
Fix panic in DLChannelReq with rejected frequencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - Network Server DevStatusReq scheduling conditions in relation to frame counter value.
 - Missing `authentication`, `remote_ip` and `user_agent` fields in events when using event backends other than `internal`.
+- Handling of `DLChannelReq` if dependent `NewChannelReq` was previously rejected.
 
 ### Security
 

--- a/pkg/networkserver/mac/dl_channel.go
+++ b/pkg/networkserver/mac/dl_channel.go
@@ -49,8 +49,10 @@ func DeviceNeedsDLChannelReqAtIndex(dev *ttnpb.EndDevice, i int) bool {
 	if DeviceNeedsNewChannelReqAtIndex(dev, i) {
 		return desiredCh.DownlinkFrequency != desiredCh.UplinkFrequency
 	}
-	// NOTE: Given the conditional before DeviceNeedsNewChannelReqAtIndex call and since no NewChannelReq is required,
-	// len(dev.MACState.CurrentParameters.Channels) > i && dev.MACState.CurrentParameters.Channels[i] != nil.
+	// NOTE: NewChannelReq may be needed, but parameters could have been rejected before.
+	if i >= len(dev.MACState.CurrentParameters.Channels) || dev.MACState.CurrentParameters.Channels[i] == nil {
+		return false
+	}
 	return desiredCh.DownlinkFrequency != dev.MACState.CurrentParameters.Channels[i].DownlinkFrequency
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsIndustries/lorawan-stack/issues/2525

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix panic in DLChannelReq with rejected frequencies


#### Testing

<!-- How did you verify that this change works? -->

Unit tests

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.