### PR TITLE
dr: Overwrite old index files with dr-db init by default

### DIFF
--- a/cmd/ttn-lw-stack/commands/dr_db.go
+++ b/cmd/ttn-lw-stack/commands/dr_db.go
@@ -37,6 +37,6 @@ var (
 func init() {
 	Root.AddCommand(drDBCommand)
 
-	drInitCommand.Flags().Bool("overwrite", false, "Overwrite existing index files")
+	drInitCommand.Flags().Bool("overwrite", true, "Overwrite existing index files")
 	drDBCommand.AddCommand(drInitCommand)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Quickfix PR, overwrite index files by default so that `ttn-lw-stack dr-db init` does not fail if index already exists.