### PR TITLE
Fix panic in DLChannelReq with rejected frequencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Handling of `DLChannelReq` if dependent `NewChannelReq` was previously rejected.
+
 ### Security
 
 ## [3.10.7] - 2021-01-14

--- a/pkg/networkserver/mac/dl_channel.go
+++ b/pkg/networkserver/mac/dl_channel.go
@@ -49,8 +49,10 @@ func DeviceNeedsDLChannelReqAtIndex(dev *ttnpb.EndDevice, i int) bool {
 	if DeviceNeedsNewChannelReqAtIndex(dev, i) {
 		return desiredCh.DownlinkFrequency != desiredCh.UplinkFrequency
 	}
-	// NOTE: Given the conditional before DeviceNeedsNewChannelReqAtIndex call and since no NewChannelReq is required,
-	// len(dev.MACState.CurrentParameters.Channels) > i && dev.MACState.CurrentParameters.Channels[i] != nil.
+	// NOTE: NewChannelReq may be needed, but parameters could have been rejected before.
+	if i >= len(dev.MACState.CurrentParameters.Channels) || dev.MACState.CurrentParameters.Channels[i] == nil {
+		return false
+	}
 	return desiredCh.DownlinkFrequency != dev.MACState.CurrentParameters.Channels[i].DownlinkFrequency
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Backport #3688

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix panic in DLChannelReq with rejected frequencies

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
