### PR TITLE
util: Remove enforcement of CSRF token for JS SDK initialization

### DIFF
--- a/sdk/js/src/api/http.js
+++ b/sdk/js/src/api/http.js
@@ -40,10 +40,10 @@ class Http {
         throw new Error('No valid key provided for key authorization')
       }
       authToken = new Token(authorization.key).get()
-    } else if (authorization.mode === AUTHORIZATION_MODES.SESSION) {
-      if (typeof authorization.csrfToken !== 'string') {
-        throw new Error('No valid CSRF token provided for session authorization')
-      }
+    } else if (
+      authorization.mode === AUTHORIZATION_MODES.SESSION &&
+      typeof authorization.csrfToken === 'string'
+    ) {
       csrfToken = authorization.csrfToken
     }
 


### PR DESCRIPTION
#### Summary
Remove enforcement of CSRF token for JS SDK initialization, which is not strictly necessary since there are services (used via idempotent methods) which do not require the token.

The primary reason to change this is that there are rare situations where we don't have a CSRF token in the frontend but still need to render something.

Backport from https://github.com/TheThingsIndustries/lorawan-stack/pull/2536

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove check for CSRF token during initialization with session authorization


#### Testing

Manual testing.

##### Regressions

Requests issued that require a CSRF token will not work when the SDK is instantiated without such token. Under normal circumstances we do pass as CSRF token however.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
