### PR TITLE
Fix GoReleaser config

### DIFF
--- a/.goreleaser.release.yml
+++ b/.goreleaser.release.yml
@@ -144,7 +144,7 @@ brews:
   - name: ttn-lw-stack
     ids:
       - stack
-    github:
+    tap:
       owner: TheThingsNetwork
       name: homebrew-lorawan-stack
     commit_author:
@@ -172,7 +172,7 @@ brews:
   - name: ttn-lw-cli
     ids:
       - cli
-    github:
+    tap:
       owner: TheThingsNetwork
       name: homebrew-lorawan-stack
     commit_author:

--- a/.goreleaser.release.yml
+++ b/.goreleaser.release.yml
@@ -210,7 +210,7 @@ dockers:
       - 'thethingsnetwork/lorawan-stack:{{ .Version }}'
       - 'ghcr.io/thethingsnetwork/lorawan-stack:{{ .Major }}.{{ .Minor }}'
       - 'ghcr.io/thethingsnetwork/lorawan-stack:{{ .Version }}'
-    skip_push: auto
+    skip_push: false
     extra_files:
       - data
       - public


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quick fix for the CI tooling. It fixes the issue that prevented the `rc1` release from getting built correctly (see https://github.com/TheThingsNetwork/lorawan-stack/runs/1760852762?check_suite_focus=true#step:23:140) as well as the deprecated `brews.github` (see https://goreleaser.com/deprecations#brewsgithub).

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
