### PR TITLE
Fix manual device creation tab

### DIFF
--- a/pkg/webui/console/views/device-add/device-add.js
+++ b/pkg/webui/console/views/device-add/device-add.js
@@ -41,7 +41,7 @@ const DeviceAdd = props => {
   const tabs = React.useMemo(
     () => [
       { title: messages.repositoryTabTitle, link: `${url}/repository`, name: 'repository' },
-      { title: messages.manualTabTitle, link: `${url}/manual`, name: 'manual' },
+      { title: messages.manualTabTitle, link: `${url}/manual`, name: 'manual', exact: false },
     ],
     [url],
   )


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes manual device creation tab highlight.

<details>
<summary>Screenshots</summary>
Before:
<img width="582" alt="Screenshot 2021-02-02 at 12 55 47" src="https://user-images.githubusercontent.com/16374166/106590903-4c804680-6556-11eb-94fc-50555172716e.png">

With this fix:
<img width="582" alt="Screenshot 2021-02-02 at 12 56 02" src="https://user-images.githubusercontent.com/16374166/106590926-530ebe00-6556-11eb-805d-d0f2fa556e34.png">



</details>

#### Changes
<!-- What are the changes made in this pull request? -->

- Set `exact` to `false` to allow highlighting the tab when on `.../manual/steps`


#### Testing

<!-- How did you verify that this change works? -->

Manual testing


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
