### PR TITLE
Fix initial display of end device frame counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ For details about compatibility between different releases, see the **Commitment
 - Missing `authentication`, `remote_ip` and `user_agent` fields in events when using event backends other than `internal`.
 - Handling of `DLChannelReq` if dependent `NewChannelReq` was previously rejected.
 - Login after user registration leading to dead-end when originally coming from the Console.
+- Frame counter display of end devices on initial page load in the Console.
 
 ### Security
 

--- a/pkg/webui/console/components/entity-title-section/content/messages-count/index.js
+++ b/pkg/webui/console/components/entity-title-section/content/messages-count/index.js
@@ -39,7 +39,7 @@ MessagesCount.propTypes = {
   icon: PropTypes.string.isRequired,
   iconClassName: PropTypes.string,
   tooltipMessage: PropTypes.message.isRequired,
-  value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+  value: PropTypes.node.isRequired,
 }
 
 MessagesCount.defaultProps = {

--- a/pkg/webui/console/containers/device-title-section/device-title-section.js
+++ b/pkg/webui/console/containers/device-title-section/device-title-section.js
@@ -49,6 +49,7 @@ const DeviceTitleSection = props => {
   const showLastSeen = Boolean(lastSeen)
   const showUplinkCount = typeof uplinkFrameCount === 'number'
   const showDownlinkCount = typeof downlinkFrameCount === 'number'
+  const notAvailableElem = <Message content={sharedMessages.notAvailable} />
 
   return (
     <EntityTitleSection
@@ -71,22 +72,18 @@ const DeviceTitleSection = props => {
             ) : (
               <Status status="mediocre" label={m.lastSeenUnavailable} flipped />
             )}
-            {showUplinkCount && (
-              <Content.MessagesCount
-                icon="uplink"
-                value={uplinkFrameCount}
-                tooltipMessage={sharedMessages.uplinkFrameCount}
-                iconClassName={style.messageIcon}
-              />
-            )}
-            {showDownlinkCount && (
-              <Content.MessagesCount
-                icon="downlink"
-                value={downlinkFrameCount}
-                tooltipMessage={sharedMessages.downlinkFrameCount}
-                iconClassName={style.messageIcon}
-              />
-            )}
+            <Content.MessagesCount
+              icon="uplink"
+              value={showUplinkCount ? uplinkFrameCount : notAvailableElem}
+              tooltipMessage={sharedMessages.uplinkFrameCount}
+              iconClassName={showUplinkCount ? style.messageIcon : style.notAvailable}
+            />
+            <Content.MessagesCount
+              icon="downlink"
+              value={showDownlinkCount ? downlinkFrameCount : notAvailableElem}
+              tooltipMessage={sharedMessages.downlinkFrameCount}
+              iconClassName={showUplinkCount ? style.messageIcon : style.notAvailable}
+            />
           </>
         )}
       </Content>

--- a/pkg/webui/console/containers/device-title-section/device-title-section.styl
+++ b/pkg/webui/console/containers/device-title-section/device-title-section.styl
@@ -17,3 +17,6 @@
 
 .message-icon
   color: $c-active-blue
+
+.not-available
+  color: $tc-subtle-gray


### PR DESCRIPTION
#### Summary
Closes #3724 

#### Changes
- Apply frame counts of the EDs NS session on the initial fetch
- Always show frame counter icons in the ED title section (but use `n/a`, if not available)

#### Testing

- Manual (will add e2e once we can to traffic simulation)

##### Regressions

None.

#### Notes for Reviewers
I now use the network downlink frame counter. Not entirely sure whether that is the preferred value to display in the Console.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
