### PR TITLE
Fix handling of FCnt resets and 32-bit FCnt rollovers

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -6092,6 +6092,24 @@
       "file": "registry.go"
     }
   },
+  "error:pkg/networkserver/redis:field": {
+    "translations": {
+      "en": "invalid field `{field}`"
+    },
+    "description": {
+      "package": "pkg/networkserver/redis",
+      "file": "registry.go"
+    }
+  },
+  "error:pkg/networkserver/redis:field_count": {
+    "translations": {
+      "en": "invalid field count '{count}'"
+    },
+    "description": {
+      "package": "pkg/networkserver/redis",
+      "file": "registry.go"
+    }
+  },
   "error:pkg/networkserver/redis:invalid_device": {
     "translations": {
       "en": "device is invalid"
@@ -7367,6 +7385,15 @@
     },
     "description": {
       "package": "pkg/ttnpb/udp",
+      "file": "errors.go"
+    }
+  },
+  "error:pkg/ttnpb:field": {
+    "translations": {
+      "en": "invalid field `{field}`"
+    },
+    "description": {
+      "package": "pkg/ttnpb",
       "file": "errors.go"
     }
   },

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -273,6 +273,7 @@ func (ns *NetworkServer) matchAndHandleDataUplink(ctx context.Context, dev *ttnp
 		dev.MACState != nil &&
 		pld.DevAddr.Equal(dev.Session.DevAddr) &&
 		cmacFMatchResult.LoRaWANVersion.UseLegacyMIC() == dev.MACState.LoRaWANVersion.UseLegacyMIC() &&
+		cmacFMatchResult.FullFCnt == pld.FCnt,
 		cmacFMatchResult.FullFCnt == FullFCnt(uint16(pld.FCnt), dev.Session.LastFCntUp, mac.DeviceSupports32BitFCnt(dev, ns.defaultMACSettings)):
 		fNwkSIntKey, err := cryptoutil.UnwrapAES128Key(ctx, dev.Session.FNwkSIntKey, ns.KeyVault)
 		if err != nil {

--- a/pkg/networkserver/redis/lua/deviceMatchScanGT.lua
+++ b/pkg/networkserver/redis/lua/deviceMatchScanGT.lua
@@ -19,8 +19,8 @@ for _, old_uid in ipairs(ARGV) do
   if uid ~= old_uid then
     local s = redis.call('hget', KEYS[2], uid)
     local m = cmsgpack.unpack(s)
-    if not m.Supports32BitFCnt or m.Supports32BitFCnt.value
-      or ack == 0 and m.ResetsFCnt and m.ResetsFCnt.value then
+    if not m.supports_32_bit_f_cnt or m.supports_32_bit_f_cnt.value
+      or ack == 0 and m.resets_f_cnt and m.resets_f_cnt.value then
       return { uid, s }
     end
   end
@@ -32,8 +32,8 @@ local uid = redis.call('lindex', KEYS[1], -1)
 while uid do
   local s = redis.call('hget', KEYS[2], uid)
   local m = cmsgpack.unpack(s)
-  if not m.Supports32BitFCnt or m.Supports32BitFCnt.value
-    or ack == 0 and m.ResetsFCnt and m.ResetsFCnt.value then
+  if not m.supports_32_bit_f_cnt or m.supports_32_bit_f_cnt.value
+    or ack == 0 and m.resets_f_cnt and m.resets_f_cnt.value then
     return { uid, s }
   end
   redis.call('ltrim', KEYS[1], 0, -2)

--- a/pkg/networkserver/redis/registry.go
+++ b/pkg/networkserver/redis/registry.go
@@ -113,7 +113,7 @@ func (r *DeviceRegistry) GetByEUI(ctx context.Context, joinEUI, devEUI types.EUI
 	return pb, ctx, nil
 }
 
-type uplinkMatchSession struct {
+type UplinkMatchSession struct {
 	FNwkSIntKey       *ttnpb.KeyEnvelope
 	ResetsFCnt        *pbtypes.BoolValue
 	Supports32BitFCnt *pbtypes.BoolValue
@@ -121,12 +121,12 @@ type uplinkMatchSession struct {
 	LastFCnt          uint32
 }
 
-type uplinkMatchPendingSession struct {
+type UplinkMatchPendingSession struct {
 	FNwkSIntKey    *ttnpb.KeyEnvelope
 	LoRaWANVersion ttnpb.MACVersion
 }
 
-type uplinkMatchResult struct {
+type UplinkMatchResult struct {
 	FNwkSIntKey       *ttnpb.KeyEnvelope
 	ResetsFCnt        *pbtypes.BoolValue
 	Supports32BitFCnt *pbtypes.BoolValue
@@ -228,7 +228,7 @@ func decodeBoolValue(dec *msgpack.Decoder) (*pbtypes.BoolValue, error) {
 var errInvalidField = errors.DefineInvalidArgument("field", "invalid field `{field}`")
 
 // EncodeMsgpack implements msgpack.CustomEncoder interface.
-func (v uplinkMatchSession) EncodeMsgpack(enc *msgpack.Encoder) error {
+func (v UplinkMatchSession) EncodeMsgpack(enc *msgpack.Encoder) error {
 	fs := []func(enc *msgpack.Encoder) error{
 		makeEncodeFNwkSIntField(v.FNwkSIntKey),
 		makeEncodeLoRaWANVersionField(v.LoRaWANVersion),
@@ -246,7 +246,7 @@ func (v uplinkMatchSession) EncodeMsgpack(enc *msgpack.Encoder) error {
 }
 
 // DecodeMsgpack implements msgpack.CustomDecoder interface.
-func (v *uplinkMatchSession) DecodeMsgpack(dec *msgpack.Decoder) error {
+func (v *UplinkMatchSession) DecodeMsgpack(dec *msgpack.Decoder) error {
 	n, err := dec.DecodeMapLen()
 	if err != nil {
 		return err
@@ -303,7 +303,7 @@ func (v *uplinkMatchSession) DecodeMsgpack(dec *msgpack.Decoder) error {
 }
 
 // EncodeMsgpack implements msgpack.CustomEncoder interface.
-func (v uplinkMatchPendingSession) EncodeMsgpack(enc *msgpack.Encoder) error {
+func (v UplinkMatchPendingSession) EncodeMsgpack(enc *msgpack.Encoder) error {
 	return encodeStruct(enc,
 		makeEncodeFNwkSIntField(v.FNwkSIntKey),
 		makeEncodeLoRaWANVersionField(v.LoRaWANVersion),
@@ -311,7 +311,7 @@ func (v uplinkMatchPendingSession) EncodeMsgpack(enc *msgpack.Encoder) error {
 }
 
 // DecodeMsgpack implements msgpack.CustomDecoder interface.
-func (v *uplinkMatchPendingSession) DecodeMsgpack(dec *msgpack.Decoder) error {
+func (v *UplinkMatchPendingSession) DecodeMsgpack(dec *msgpack.Decoder) error {
 	n, err := dec.DecodeMapLen()
 	if err != nil {
 		return err
@@ -347,7 +347,7 @@ func (v *uplinkMatchPendingSession) DecodeMsgpack(dec *msgpack.Decoder) error {
 }
 
 // EncodeMsgpack implements msgpack.CustomEncoder interface.
-func (v uplinkMatchResult) EncodeMsgpack(enc *msgpack.Encoder) error {
+func (v UplinkMatchResult) EncodeMsgpack(enc *msgpack.Encoder) error {
 	fs := []func(enc *msgpack.Encoder) error{
 		makeEncodeFNwkSIntField(v.FNwkSIntKey),
 		makeEncodeLoRaWANVersionField(v.LoRaWANVersion),
@@ -379,7 +379,7 @@ func (v uplinkMatchResult) EncodeMsgpack(enc *msgpack.Encoder) error {
 }
 
 // DecodeMsgpack implements msgpack.CustomDecoder interface.
-func (v *uplinkMatchResult) DecodeMsgpack(dec *msgpack.Decoder) error {
+func (v *UplinkMatchResult) DecodeMsgpack(dec *msgpack.Decoder) error {
 	n, err := dec.DecodeMapLen()
 	if err != nil {
 		return err
@@ -540,7 +540,7 @@ func (r *DeviceRegistry) RangeByUplinkMatches(ctx context.Context, up *ttnpb.Upl
 			return errNoUplinkMatch.New()
 		}
 		ctx := log.NewContextWithField(ctx, "match_key", matchResultKey)
-		res := &uplinkMatchResult{}
+		res := &UplinkMatchResult{}
 		if err := msgpack.Unmarshal([]byte(s), res); err != nil {
 			log.FromContext(ctx).WithError(err).Error("Failed to unmarshal match result")
 			return errDatabaseCorruption.WithCause(err)
@@ -675,7 +675,7 @@ func (r *DeviceRegistry) RangeByUplinkMatches(ctx context.Context, up *ttnpb.Upl
 			}
 			var m *networkserver.UplinkMatch
 			if idx == pendingIdx {
-				ses := &uplinkMatchPendingSession{}
+				ses := &UplinkMatchPendingSession{}
 				err = msgpack.Unmarshal([]byte(s), ses)
 				if err == nil {
 					m = &networkserver.UplinkMatch{
@@ -687,7 +687,7 @@ func (r *DeviceRegistry) RangeByUplinkMatches(ctx context.Context, up *ttnpb.Upl
 					}
 				}
 			} else {
-				ses := &uplinkMatchSession{}
+				ses := &UplinkMatchSession{}
 				err = msgpack.Unmarshal([]byte(s), ses)
 				if err == nil {
 					m = &networkserver.UplinkMatch{
@@ -710,7 +710,7 @@ func (r *DeviceRegistry) RangeByUplinkMatches(ctx context.Context, up *ttnpb.Upl
 				return errNoUplinkMatch.WithCause(err)
 			}
 			if ok {
-				b, err := msgpack.Marshal(uplinkMatchResult{
+				b, err := msgpack.Marshal(UplinkMatchResult{
 					UID:               uid,
 					LoRaWANVersion:    m.LoRaWANVersion,
 					FNwkSIntKey:       m.FNwkSIntKey,
@@ -758,7 +758,7 @@ func removeAddrMapping(ctx context.Context, r redis.Cmdable, addrKey, uid string
 }
 
 func MarshalDeviceCurrentSession(dev *ttnpb.EndDevice) ([]byte, error) {
-	return msgpack.Marshal(uplinkMatchSession{
+	return msgpack.Marshal(UplinkMatchSession{
 		LoRaWANVersion:    dev.GetMACState().GetLoRaWANVersion(),
 		FNwkSIntKey:       dev.GetSession().GetFNwkSIntKey(),
 		LastFCnt:          dev.GetSession().GetLastFCntUp(),
@@ -768,7 +768,7 @@ func MarshalDeviceCurrentSession(dev *ttnpb.EndDevice) ([]byte, error) {
 }
 
 func MarshalDevicePendingSession(dev *ttnpb.EndDevice) ([]byte, error) {
-	return msgpack.Marshal(uplinkMatchSession{
+	return msgpack.Marshal(UplinkMatchSession{
 		LoRaWANVersion: dev.GetPendingMACState().GetLoRaWANVersion(),
 		FNwkSIntKey:    dev.GetPendingSession().GetFNwkSIntKey(),
 	})

--- a/pkg/networkserver/redis/registry_internal_test.go
+++ b/pkg/networkserver/redis/registry_internal_test.go
@@ -1,0 +1,97 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redis
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-redis/redis/v8"
+	"github.com/smartystreets/assertions"
+	"github.com/smartystreets/assertions/should"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/types"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
+)
+
+func TestMsgpackCompatibility(t *testing.T) {
+	_, ctx := test.New(t)
+	cl, flush := test.NewRedis(ctx, "test", "devices")
+	t.Cleanup(func() {
+		flush()
+		if err := cl.Close(); err != nil {
+			t.Errorf("Failed to close Redis device registry client: %s", test.FormatError(err))
+		}
+	})
+	for _, v := range []interface{}{
+		uplinkMatchSession{},
+		uplinkMatchSession{
+			FNwkSIntKey: &keyEnvelope{
+				Key: &types.AES128Key{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+			},
+		},
+		uplinkMatchSession{
+			LoRaWANVersion: ttnpb.MAC_V1_0_3,
+		},
+		uplinkMatchSession{
+			FNwkSIntKey: &keyEnvelope{
+				Key: &types.AES128Key{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+			},
+			LoRaWANVersion: ttnpb.MAC_V1_0_3,
+		},
+		uplinkMatchSession{
+			FNwkSIntKey: &keyEnvelope{
+				Key: &types.AES128Key{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+			},
+			LoRaWANVersion:    ttnpb.MAC_V1_0_3,
+			Supports32BitFCnt: &boolValue{Value: true},
+		},
+		uplinkMatchSession{
+			FNwkSIntKey: &keyEnvelope{
+				Key: &types.AES128Key{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+			},
+			LoRaWANVersion: ttnpb.MAC_V1_0_3,
+			ResetsFCnt:     &boolValue{Value: true},
+		},
+		uplinkMatchSession{
+			FNwkSIntKey: &keyEnvelope{
+				Key: &types.AES128Key{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+			},
+			LoRaWANVersion: ttnpb.MAC_V1_0_3,
+			LastFCnt:       42,
+		},
+		uplinkMatchSession{
+			FNwkSIntKey: &keyEnvelope{
+				Key: &types.AES128Key{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+			},
+			LoRaWANVersion:    ttnpb.MAC_V1_0_3,
+			ResetsFCnt:        &boolValue{Value: true},
+			Supports32BitFCnt: &boolValue{Value: false},
+			LastFCnt:          42,
+		},
+		uplinkMatchPendingSession{},
+		uplinkMatchResult{},
+	} {
+		v := v
+		b := test.Must(marshalMsgpack(v)).([]byte)
+		test.RunSubtestFromContext(ctx, test.SubtestConfig{
+			Name: fmt.Sprintf("%v %s", v, b),
+			Func: func(ctx context.Context, _ *testing.T, a *assertions.Assertion) {
+				a.So(redis.NewScript(`cmsgpack.unpack(ARGV[1])`).Run(ctx, cl, nil, b).Err(), should.Resemble, redis.Nil)
+			},
+		})
+	}
+}

--- a/pkg/networkserver/redis/registry_internal_test.go
+++ b/pkg/networkserver/redis/registry_internal_test.go
@@ -100,14 +100,14 @@ func TestMsgpackCompatibility(t *testing.T) {
 		LuaExpr string
 	}{
 		{
-			Value: uplinkMatchPendingSession{
+			Value: UplinkMatchPendingSession{
 				FNwkSIntKey:    test.DefaultFNwkSIntKeyEnvelopeWrapped,
 				LoRaWANVersion: test.DefaultMACVersion,
 			},
 			LuaExpr: makeExprWithDefaults(),
 		},
 		{
-			Value: uplinkMatchPendingSession{
+			Value: UplinkMatchPendingSession{
 				FNwkSIntKey:    test.DefaultFNwkSIntKeyEnvelope,
 				LoRaWANVersion: test.DefaultMACVersion,
 			},
@@ -118,14 +118,14 @@ func TestMsgpackCompatibility(t *testing.T) {
 		},
 
 		{
-			Value: uplinkMatchSession{
+			Value: UplinkMatchSession{
 				FNwkSIntKey:    test.DefaultFNwkSIntKeyEnvelopeWrapped,
 				LoRaWANVersion: test.DefaultMACVersion,
 			},
 			LuaExpr: makeExprWithDefaults(),
 		},
 		{
-			Value: uplinkMatchSession{
+			Value: UplinkMatchSession{
 				FNwkSIntKey:    test.DefaultFNwkSIntKeyEnvelope,
 				LoRaWANVersion: test.DefaultMACVersion,
 			},
@@ -135,7 +135,7 @@ func TestMsgpackCompatibility(t *testing.T) {
 			),
 		},
 		{
-			Value: uplinkMatchSession{
+			Value: UplinkMatchSession{
 				FNwkSIntKey:       test.DefaultFNwkSIntKeyEnvelopeWrapped,
 				LoRaWANVersion:    test.DefaultMACVersion,
 				Supports32BitFCnt: &pbtypes.BoolValue{Value: false},
@@ -145,7 +145,7 @@ func TestMsgpackCompatibility(t *testing.T) {
 			),
 		},
 		{
-			Value: uplinkMatchSession{
+			Value: UplinkMatchSession{
 				FNwkSIntKey:       test.DefaultFNwkSIntKeyEnvelopeWrapped,
 				LoRaWANVersion:    test.DefaultMACVersion,
 				Supports32BitFCnt: &pbtypes.BoolValue{Value: true},
@@ -155,7 +155,7 @@ func TestMsgpackCompatibility(t *testing.T) {
 			),
 		},
 		{
-			Value: uplinkMatchSession{
+			Value: UplinkMatchSession{
 				FNwkSIntKey:    test.DefaultFNwkSIntKeyEnvelopeWrapped,
 				LoRaWANVersion: test.DefaultMACVersion,
 				ResetsFCnt:     &pbtypes.BoolValue{Value: true},
@@ -165,7 +165,7 @@ func TestMsgpackCompatibility(t *testing.T) {
 			),
 		},
 		{
-			Value: uplinkMatchSession{
+			Value: UplinkMatchSession{
 				FNwkSIntKey:    test.DefaultFNwkSIntKeyEnvelopeWrapped,
 				LoRaWANVersion: test.DefaultMACVersion,
 				ResetsFCnt:     &pbtypes.BoolValue{Value: false},
@@ -175,7 +175,7 @@ func TestMsgpackCompatibility(t *testing.T) {
 			),
 		},
 		{
-			Value: uplinkMatchSession{
+			Value: UplinkMatchSession{
 				FNwkSIntKey:    test.DefaultFNwkSIntKeyEnvelopeWrapped,
 				LoRaWANVersion: test.DefaultMACVersion,
 				LastFCnt:       42,
@@ -185,7 +185,7 @@ func TestMsgpackCompatibility(t *testing.T) {
 			),
 		},
 		{
-			Value: uplinkMatchSession{
+			Value: UplinkMatchSession{
 				FNwkSIntKey:       test.DefaultFNwkSIntKeyEnvelopeWrapped,
 				LoRaWANVersion:    test.DefaultMACVersion,
 				ResetsFCnt:        &pbtypes.BoolValue{Value: true},
@@ -200,7 +200,7 @@ func TestMsgpackCompatibility(t *testing.T) {
 		},
 
 		{
-			Value: uplinkMatchResult{
+			Value: UplinkMatchResult{
 				FNwkSIntKey:    test.DefaultFNwkSIntKeyEnvelopeWrapped,
 				LoRaWANVersion: test.DefaultMACVersion,
 				UID:            "test-uid",
@@ -210,7 +210,7 @@ func TestMsgpackCompatibility(t *testing.T) {
 			),
 		},
 		{
-			Value: uplinkMatchResult{
+			Value: UplinkMatchResult{
 				FNwkSIntKey:    test.DefaultFNwkSIntKeyEnvelope,
 				LoRaWANVersion: test.DefaultMACVersion,
 				UID:            "test-uid",
@@ -222,7 +222,7 @@ func TestMsgpackCompatibility(t *testing.T) {
 			),
 		},
 		{
-			Value: uplinkMatchResult{
+			Value: UplinkMatchResult{
 				FNwkSIntKey:       test.DefaultFNwkSIntKeyEnvelopeWrapped,
 				LoRaWANVersion:    test.DefaultMACVersion,
 				Supports32BitFCnt: &pbtypes.BoolValue{Value: false},
@@ -234,7 +234,7 @@ func TestMsgpackCompatibility(t *testing.T) {
 			),
 		},
 		{
-			Value: uplinkMatchResult{
+			Value: UplinkMatchResult{
 				FNwkSIntKey:       test.DefaultFNwkSIntKeyEnvelopeWrapped,
 				LoRaWANVersion:    test.DefaultMACVersion,
 				Supports32BitFCnt: &pbtypes.BoolValue{Value: true},
@@ -246,7 +246,7 @@ func TestMsgpackCompatibility(t *testing.T) {
 			),
 		},
 		{
-			Value: uplinkMatchResult{
+			Value: UplinkMatchResult{
 				FNwkSIntKey:    test.DefaultFNwkSIntKeyEnvelopeWrapped,
 				LoRaWANVersion: test.DefaultMACVersion,
 				UID:            "test-uid",
@@ -258,7 +258,7 @@ func TestMsgpackCompatibility(t *testing.T) {
 			),
 		},
 		{
-			Value: uplinkMatchResult{
+			Value: UplinkMatchResult{
 				FNwkSIntKey:    test.DefaultFNwkSIntKeyEnvelopeWrapped,
 				LoRaWANVersion: test.DefaultMACVersion,
 				UID:            "test-uid",
@@ -270,7 +270,7 @@ func TestMsgpackCompatibility(t *testing.T) {
 			),
 		},
 		{
-			Value: uplinkMatchResult{
+			Value: UplinkMatchResult{
 				FNwkSIntKey:    test.DefaultFNwkSIntKeyEnvelopeWrapped,
 				LoRaWANVersion: test.DefaultMACVersion,
 				UID:            "test-uid",
@@ -282,7 +282,7 @@ func TestMsgpackCompatibility(t *testing.T) {
 			),
 		},
 		{
-			Value: uplinkMatchResult{
+			Value: UplinkMatchResult{
 				FNwkSIntKey:       test.DefaultFNwkSIntKeyEnvelopeWrapped,
 				LoRaWANVersion:    test.DefaultMACVersion,
 				UID:               "test-uid",
@@ -298,7 +298,7 @@ func TestMsgpackCompatibility(t *testing.T) {
 			),
 		},
 		{
-			Value: uplinkMatchResult{
+			Value: UplinkMatchResult{
 				FNwkSIntKey:       test.DefaultFNwkSIntKeyEnvelopeWrapped,
 				LoRaWANVersion:    test.DefaultMACVersion,
 				UID:               "test-uid",

--- a/pkg/networkserver/redis/registry_internal_test.go
+++ b/pkg/networkserver/redis/registry_internal_test.go
@@ -25,6 +25,10 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
+	pbtypes "github.com/gogo/protobuf/types"
+	"github.com/vmihailenco/msgpack/v5"
+
+
 )
 
 func TestMsgpackCompatibility(t *testing.T) {
@@ -37,56 +41,100 @@ func TestMsgpackCompatibility(t *testing.T) {
 		}
 	})
 	for _, v := range []interface{}{
-		uplinkMatchSession{},
-		uplinkMatchSession{
-			FNwkSIntKey: &keyEnvelope{
+		// uplinkMatchSession{},
+		// uplinkMatchSession{
+		// 	FNwkSIntKey: &ttnpb.KeyEnvelope{
+		// 		Key: &types.AES128Key{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+		// 	},
+		// },
+		// uplinkMatchSession{
+		// 	LoRaWANVersion: ttnpb.MAC_V1_0_3,
+		// },
+		// uplinkMatchSession{
+		// 	FNwkSIntKey: &ttnpb.KeyEnvelope{
+		// 		Key: &types.AES128Key{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+		// 	},
+		// 	LoRaWANVersion: ttnpb.MAC_V1_0_3,
+		// },
+		// uplinkMatchSession{
+		// 	FNwkSIntKey: &ttnpb.KeyEnvelope{
+		// 		Key: &types.AES128Key{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+		// 	},
+		// 	LoRaWANVersion:    ttnpb.MAC_V1_0_3,
+		// 	Supports32BitFCnt: &pbtypes.BoolValue{Value: true},
+		// },
+		// uplinkMatchSession{
+		// 	FNwkSIntKey: &ttnpb.KeyEnvelope{
+		// 		Key: &types.AES128Key{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+		// 	},
+		// 	LoRaWANVersion: ttnpb.MAC_V1_0_3,
+		// 	ResetsFCnt:     &pbtypes.BoolValue{Value: true},
+		// },
+		// uplinkMatchSession{
+		// 	FNwkSIntKey: &ttnpb.KeyEnvelope{
+		// 		Key: &types.AES128Key{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+		// 	},
+		// 	LoRaWANVersion: ttnpb.MAC_V1_0_3,
+		// 	LastFCnt:       42,
+		// },
+		// uplinkMatchSession{
+		// 	FNwkSIntKey: &ttnpb.KeyEnvelope{
+		// 		Key: &types.AES128Key{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+		// 	},
+		// 	LoRaWANVersion:    ttnpb.MAC_V1_0_3,
+		// 	ResetsFCnt:        &pbtypes.BoolValue{Value: true},
+		// 	Supports32BitFCnt: &pbtypes.BoolValue{Value: false},
+		// 	LastFCnt:          42,
+		// },
+		// uplinkMatchPendingSession{},
+		uplinkMatchResult{},
+		uplinkMatchResult{
+			FNwkSIntKey: &ttnpb.KeyEnvelope{
 				Key: &types.AES128Key{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 			},
 		},
-		uplinkMatchSession{
+		uplinkMatchResult{
 			LoRaWANVersion: ttnpb.MAC_V1_0_3,
 		},
-		uplinkMatchSession{
-			FNwkSIntKey: &keyEnvelope{
+		uplinkMatchResult{
+			FNwkSIntKey: &ttnpb.KeyEnvelope{
 				Key: &types.AES128Key{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 			},
 			LoRaWANVersion: ttnpb.MAC_V1_0_3,
 		},
-		uplinkMatchSession{
-			FNwkSIntKey: &keyEnvelope{
+		uplinkMatchResult{
+			FNwkSIntKey: &ttnpb.KeyEnvelope{
 				Key: &types.AES128Key{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 			},
 			LoRaWANVersion:    ttnpb.MAC_V1_0_3,
-			Supports32BitFCnt: &boolValue{Value: true},
+			Supports32BitFCnt: &pbtypes.BoolValue{Value: true},
 		},
-		uplinkMatchSession{
-			FNwkSIntKey: &keyEnvelope{
+		uplinkMatchResult{
+			FNwkSIntKey: &ttnpb.KeyEnvelope{
 				Key: &types.AES128Key{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 			},
 			LoRaWANVersion: ttnpb.MAC_V1_0_3,
-			ResetsFCnt:     &boolValue{Value: true},
+			ResetsFCnt:     &pbtypes.BoolValue{Value: true},
 		},
-		uplinkMatchSession{
-			FNwkSIntKey: &keyEnvelope{
+		uplinkMatchResult{
+			FNwkSIntKey: &ttnpb.KeyEnvelope{
 				Key: &types.AES128Key{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 			},
 			LoRaWANVersion: ttnpb.MAC_V1_0_3,
 			LastFCnt:       42,
 		},
-		uplinkMatchSession{
-			FNwkSIntKey: &keyEnvelope{
+		uplinkMatchResult{
+			FNwkSIntKey: &ttnpb.KeyEnvelope{
 				Key: &types.AES128Key{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 			},
 			LoRaWANVersion:    ttnpb.MAC_V1_0_3,
-			ResetsFCnt:        &boolValue{Value: true},
-			Supports32BitFCnt: &boolValue{Value: false},
+			ResetsFCnt:        &pbtypes.BoolValue{Value: true},
+			Supports32BitFCnt: &pbtypes.BoolValue{Value: false},
 			LastFCnt:          42,
 		},
-		uplinkMatchPendingSession{},
-		uplinkMatchResult{},
 	} {
 		v := v
-		b := test.Must(marshalMsgpack(v)).([]byte)
+		b := test.Must(msgpack.Marshal(v)).([]byte)
 		test.RunSubtestFromContext(ctx, test.SubtestConfig{
 			Name: fmt.Sprintf("%v %s", v, b),
 			Func: func(ctx context.Context, _ *testing.T, a *assertions.Assertion) {

--- a/pkg/networkserver/redis/scripts.go
+++ b/pkg/networkserver/redis/scripts.go
@@ -83,8 +83,8 @@ for _, old_uid in ipairs(ARGV) do
   if uid ~= old_uid then
     local s = redis.call('hget', KEYS[2], uid)
     local m = cmsgpack.unpack(s)
-    if not m.Supports32BitFCnt or m.Supports32BitFCnt.value
-      or ack == 0 and m.ResetsFCnt and m.ResetsFCnt.value then
+    if not m.supports_32_bit_f_cnt or m.supports_32_bit_f_cnt.value
+      or ack == 0 and m.resets_f_cnt and m.resets_f_cnt.value then
       return { uid, s }
     end
   end
@@ -95,8 +95,8 @@ local uid = redis.call('lindex', KEYS[1], -1)
 while uid do
   local s = redis.call('hget', KEYS[2], uid)
   local m = cmsgpack.unpack(s)
-  if not m.Supports32BitFCnt or m.Supports32BitFCnt.value
-    or ack == 0 and m.ResetsFCnt and m.ResetsFCnt.value then
+  if not m.supports_32_bit_f_cnt or m.supports_32_bit_f_cnt.value
+    or ack == 0 and m.resets_f_cnt and m.resets_f_cnt.value then
     return { uid, s }
   end
   redis.call('ltrim', KEYS[1], 0, -2)

--- a/pkg/ttnpb/errors.go
+++ b/pkg/ttnpb/errors.go
@@ -144,6 +144,8 @@ var (
 	errFieldBound         = errors.DefineInvalidArgument("field_bound", "`{field}` should be between `{min}` and `{max}`", valueKey)
 	errMissingIdentifiers = errors.DefineInvalidArgument("missing_identifiers", "missing identifiers")
 	errParse              = errors.DefineInvalidArgument("parse", "could not parse `{value}` into `{field}`", valueKey)
+
+	errInvalidField = errors.DefineInvalidArgument("field", "invalid field `{field}`")
 )
 
 func errExpectedLowerOrEqual(lorawanField string, max interface{}) valueErr {

--- a/pkg/types/aeskey.go
+++ b/pkg/types/aeskey.go
@@ -17,6 +17,8 @@ package types
 import (
 	"encoding/hex"
 	"strings"
+
+	"github.com/vmihailenco/msgpack/v5"
 )
 
 // AES128Key is an 128-bit AES key.
@@ -71,4 +73,26 @@ func (key AES128Key) MarshalText() ([]byte, error) { return marshalTextBytes(key
 func (key *AES128Key) UnmarshalText(data []byte) error {
 	*key = [16]byte{}
 	return unmarshalTextBytes(key[:], data)
+}
+
+// EncodeMsgpack implements msgpack.CustomEncoder interface.
+func (key AES128Key) EncodeMsgpack(enc *msgpack.Encoder) error {
+	// TODO: Implement
+	panic("unimplemented")
+	return nil
+}
+
+// DecodeMsgpack implements msgpack.CustomDecoder interface.
+func (key *AES128Key) DecodeMsgpack(dec *msgpack.Decoder) error {
+	b, err := dec.DecodeBytes()
+	if err != nil {
+		return err
+	}
+	if len(b) != 16 {
+		// TODO: Error
+		panic("unimplemented")
+	}
+	*key = [16]byte{}
+	copy(key[:], b)
+	return nil
 }

--- a/pkg/types/aeskey.go
+++ b/pkg/types/aeskey.go
@@ -77,21 +77,22 @@ func (key *AES128Key) UnmarshalText(data []byte) error {
 
 // EncodeMsgpack implements msgpack.CustomEncoder interface.
 func (key AES128Key) EncodeMsgpack(enc *msgpack.Encoder) error {
-	// TODO: Implement
-	return enc.EncodeString(string(key[:]))
+	return enc.EncodeString(hex.EncodeToString(key[:]))
 }
 
 // DecodeMsgpack implements msgpack.CustomDecoder interface.
 func (key *AES128Key) DecodeMsgpack(dec *msgpack.Decoder) error {
-	b, err := dec.DecodeBytes()
+	s, err := dec.DecodeString()
+	if err != nil {
+		return err
+	}
+	b, err := hex.DecodeString(s)
 	if err != nil {
 		return err
 	}
 	if len(b) != 16 {
-		// TODO: Error
-		panic("unimplemented")
+		return errInvalidLength.New()
 	}
-	*key = [16]byte{}
-	copy(key[:], b)
+	copy(key[:], b[:])
 	return nil
 }

--- a/pkg/types/aeskey.go
+++ b/pkg/types/aeskey.go
@@ -78,8 +78,7 @@ func (key *AES128Key) UnmarshalText(data []byte) error {
 // EncodeMsgpack implements msgpack.CustomEncoder interface.
 func (key AES128Key) EncodeMsgpack(enc *msgpack.Encoder) error {
 	// TODO: Implement
-	panic("unimplemented")
-	return nil
+	return enc.EncodeString(string(key[:]))
 }
 
 // DecodeMsgpack implements msgpack.CustomDecoder interface.

--- a/pkg/util/test/cluster_test.go
+++ b/pkg/util/test/cluster_test.go
@@ -19,5 +19,7 @@ import (
 	. "go.thethings.network/lorawan-stack/v3/pkg/util/test"
 )
 
-var _ cluster.Cluster = MockCluster{}
-var _ cluster.Peer = MockPeer{}
+var (
+	_ cluster.Cluster = MockCluster{}
+	_ cluster.Peer    = MockPeer{}
+)

--- a/pkg/util/test/test.go
+++ b/pkg/util/test/test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/crypto"
+	"go.thethings.network/lorawan-stack/v3/pkg/crypto/cryptoutil"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -54,10 +55,36 @@ var (
 
 	DefaultSessionKeyID = []byte("test-session-key-id")
 
+	DefaultKEK      = types.AES128Key{0x42, 0x42, 0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+	DefaultKEKLabel = "test-kek-label"
+
 	DefaultAppSKey     = crypto.DeriveAppSKey(DefaultNwkKey, DefaultJoinNonce, DefaultJoinEUI, DefaultDevNonce)
 	DefaultFNwkSIntKey = crypto.DeriveFNwkSIntKey(DefaultNwkKey, DefaultJoinNonce, DefaultJoinEUI, DefaultDevNonce)
 	DefaultNwkSEncKey  = crypto.DeriveNwkSEncKey(DefaultNwkKey, DefaultJoinNonce, DefaultJoinEUI, DefaultDevNonce)
 	DefaultSNwkSIntKey = crypto.DeriveSNwkSIntKey(DefaultNwkKey, DefaultJoinNonce, DefaultJoinEUI, DefaultDevNonce)
+
+	DefaultAppSKeyEnvelope = &ttnpb.KeyEnvelope{
+		Key: &DefaultAppSKey,
+	}
+	DefaultFNwkSIntKeyEnvelope = &ttnpb.KeyEnvelope{
+		Key: &DefaultFNwkSIntKey,
+	}
+	DefaultNwkSEncKeyEnvelope = &ttnpb.KeyEnvelope{
+		Key: &DefaultNwkSEncKey,
+	}
+	DefaultSNwkSIntKeyEnvelope = &ttnpb.KeyEnvelope{
+		Key: &DefaultSNwkSIntKey,
+	}
+
+	DefaultAppSKeyEnvelopeWrapped     = Must(cryptoutil.WrapAES128KeyWithKEK(Context(), DefaultAppSKey, DefaultKEKLabel, DefaultKEK)).(*ttnpb.KeyEnvelope)
+	DefaultFNwkSIntKeyEnvelopeWrapped = Must(cryptoutil.WrapAES128KeyWithKEK(Context(), DefaultFNwkSIntKey, DefaultKEKLabel, DefaultKEK)).(*ttnpb.KeyEnvelope)
+	DefaultNwkSEncKeyEnvelopeWrapped  = Must(cryptoutil.WrapAES128KeyWithKEK(Context(), DefaultNwkSEncKey, DefaultKEKLabel, DefaultKEK)).(*ttnpb.KeyEnvelope)
+	DefaultSNwkSIntKeyEnvelopeWrapped = Must(cryptoutil.WrapAES128KeyWithKEK(Context(), DefaultSNwkSIntKey, DefaultKEKLabel, DefaultKEK)).(*ttnpb.KeyEnvelope)
+
+	DefaultAppSKeyWrapped     = DefaultAppSKeyEnvelopeWrapped.EncryptedKey
+	DefaultFNwkSIntKeyWrapped = DefaultFNwkSIntKeyEnvelopeWrapped.EncryptedKey
+	DefaultNwkSEncKeyWrapped  = DefaultNwkSEncKeyEnvelopeWrapped.EncryptedKey
+	DefaultSNwkSIntKeyWrapped = DefaultSNwkSIntKeyEnvelopeWrapped.EncryptedKey
 
 	DefaultNetID   = Must(types.NewNetID(2, []byte{0x00, 0x42, 0xff})).(types.NetID)
 	DefaultDevAddr = Must(types.NewDevAddr(DefaultNetID, []byte{0x00, 0x02, 0xff, 0xff})).(types.DevAddr)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/3728
Refs https://github.com/TheThingsNetwork/lorawan-stack/pull/3743

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix msgpack encoding of sessions
- Fix FCnt check on reset for devices with 32-bit frame counters
- Migrate sessions created on 3.11 snapshot to new format


#### Testing

<!-- How did you verify that this change works? -->

Unit tests, integration testing
```sh
ses=$(cli dev get test-app2 test-dev-c --session)
dev_addr=$(echo "${ses}" | jq -r '.session.dev_addr')
f_nwk_s_int_key=$(echo "${ses}" | jq -r '.session.keys.f_nwk_s_int_key.key')
echo "${ses}" | jq
cli simulate gateway-uplink --lorawan-phy-version "1.0.3-a" --lorawan-version "1.0.3" --gateway-id test-gtw --dev-addr "${dev_addr}" --f_nwk_s_int_key "${f_nwk_s_int_key}" --f_cnt 0x42
cli simulate gateway-uplink --lorawan-phy-version "1.0.3-a" --lorawan-version "1.0.3" --gateway-id test-gtw --dev-addr "${dev_addr}" --f_nwk_s_int_key "${f_nwk_s_int_key}" --f_cnt "${1:-"0x02"}"
```

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
