### PR TITLE
Fix FCnt reset handling

### DIFF
--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -273,6 +273,7 @@ func (ns *NetworkServer) matchAndHandleDataUplink(ctx context.Context, dev *ttnp
 		dev.MACState != nil &&
 		pld.DevAddr.Equal(dev.Session.DevAddr) &&
 		cmacFMatchResult.LoRaWANVersion.UseLegacyMIC() == dev.MACState.LoRaWANVersion.UseLegacyMIC() &&
+		cmacFMatchResult.FullFCnt == pld.FCnt,
 		cmacFMatchResult.FullFCnt == FullFCnt(uint16(pld.FCnt), dev.Session.LastFCntUp, mac.DeviceSupports32BitFCnt(dev, ns.defaultMACSettings)):
 		fNwkSIntKey, err := cryptoutil.UnwrapAES128Key(ctx, dev.Session.FNwkSIntKey, ns.KeyVault)
 		if err != nil {

--- a/pkg/networkserver/redis/registry.go
+++ b/pkg/networkserver/redis/registry.go
@@ -334,7 +334,9 @@ func (r *DeviceRegistry) RangeByUplinkMatches(ctx context.Context, up *ttnpb.Upl
 		for {
 			var s string
 			switch {
-			case idx == currentGTIdx:
+			// TODO: Re-enable optimization (https://github.com/TheThingsNetwork/lorawan-stack/pull/3738).
+			//case idx == currentGTIdx:
+			case false:
 				uid, s, err = func() (string, string, error) {
 					var ackArg uint8
 					if pld.Ack {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/3728

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix FCnt check on reset for devices with 32-bit frame counters
- Disable optimization for FCnt reset and 32-bit rollover matching cases


#### Testing

<!-- How did you verify that this change works? -->

```sh
ses=$(cli dev get test-app2 test-dev-c --session)
dev_addr=$(echo "${ses}" | jq -r '.session.dev_addr')
f_nwk_s_int_key=$(echo "${ses}" | jq -r '.session.keys.f_nwk_s_int_key.key')
echo "${ses}" | jq
cli simulate gateway-uplink --lorawan-phy-version "1.0.3-a" --lorawan-version "1.0.3" --gateway-id test-gtw --dev-addr "${dev_addr}" --f_nwk_s_int_key "${f_nwk_s_int_key}" --f_cnt 0x42
cli simulate gateway-uplink --lorawan-phy-version "1.0.3-a" --lorawan-version "1.0.3" --gateway-id test-gtw --dev-addr "${dev_addr}" --f_nwk_s_int_key "${f_nwk_s_int_key}" --f_cnt "${1:-"0x02"}"
```

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Optimization needs more time for fixing and that will be done in https://github.com/TheThingsNetwork/lorawan-stack/pull/3738

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.