### PR TITLE
Set session keys as byte in device overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ For details about compatibility between different releases, see the **Commitment
 - Device Repository component to integrate [Device Repository](https://github.com/TheThingsNetwork/lorawan-devices) with The Things Stack. See the `dr` configuration section.
   - The Device Repository database is bundled automatically into Docker release images. See the `ttn-lw-stack dr-db init` command to manually fetch the latest changes.
 - Device repository service to the JavaScript SDK.
+- Choosing array representation for end device session keys as well as gateway EUI.
 
 ### Changed
 

--- a/cypress/integration/console/shared/overview/overview.spec.js
+++ b/cypress/integration/console/shared/overview/overview.spec.js
@@ -91,7 +91,7 @@ describe('Overview', () => {
       cy.findByRole('link', { name: /0 API key/ }).should('be.visible')
 
       cy.findByRole('row', { name: new RegExp(gatewayId) }).should('be.visible')
-      cy.findByText(new RegExp(gateway.ids.eui)).should('be.visible')
+      cy.findByRole('row', { name: new RegExp(gateway.ids.eui) }).should('be.visible')
       cy.findByText(new RegExp(gateway.description)).should('be.visible')
       cy.findByText(new RegExp(gateway.gateway_server_address)).should('be.visible')
       cy.findByText(new RegExp(gateway.frequency_plan_id)).should('be.visible')

--- a/pkg/webui/console/views/device-overview/index.js
+++ b/pkg/webui/console/views/device-overview/index.js
@@ -182,22 +182,22 @@ class DeviceOverview extends React.Component {
         {
           key: sharedMessages.nwkSKey,
           value: f_nwk_s_int_key.key,
-          type: 'code',
+          type: 'byte',
           sensitive: true,
         },
         {
           key: sharedMessages.sNwkSIKey,
           value: s_nwk_s_int_key.key,
-          type: 'code',
+          type: 'byte',
           sensitive: true,
         },
         {
           key: sharedMessages.nwkSEncKey,
           value: nwk_s_enc_key.key,
-          type: 'code',
+          type: 'byte',
           sensitive: true,
         },
-        { key: sharedMessages.appSKey, value: app_s_key.key, type: 'code', sensitive: true },
+        { key: sharedMessages.appSKey, value: app_s_key.key, type: 'byte', sensitive: true },
       )
     }
 

--- a/pkg/webui/console/views/gateway-overview/gateway-overview.js
+++ b/pkg/webui/console/views/gateway-overview/gateway-overview.js
@@ -114,7 +114,7 @@ export default class GatewayOverview extends React.Component {
           {
             key: sharedMessages.gatewayEUI,
             value: ids.eui,
-            type: 'code',
+            type: 'byte',
             sensitive: false,
           },
           {


### PR DESCRIPTION
#### Summary
This quickfix PR will set the session keys and gateway EUI in the Console as "bytes", which were wrongfully set as "code". When set as bytes, it is possible to change the formatting to an array with byte order settings.

![image](https://user-images.githubusercontent.com/5710611/107346244-c79cac00-6ac4-11eb-9606-b20e2c786153.png)
(these are throwaway keys)

#### Changes
- Set session keys as byte in device overview
- Set gateway EUI as byte in gateway overview


#### Testing

Manual.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
