### PR TITLE
Disable end-to-end test videos

### DIFF
--- a/config/cypress.json
+++ b/config/cypress.json
@@ -3,5 +3,6 @@
   "viewportWidth": 1440,
   "defaultCommandTimeout": 10000,
   "ignoreTestFiles": "!*.spec.js",
-  "animationDistanceThreshold": 3
+  "animationDistanceThreshold": 3,
+  "video": false
 }


### PR DESCRIPTION
#### Summary
This quickfix PR improves our e2e setup by speeding up running times by disabling the video feature as well as improving ~~utility of the test logs by adding the screenshots to the uploaded artifacts~~.

References #3480

#### Changes
- Disable video in cypress config
- ~~Add e2e step that uploads the generated screenshots as artifacts (screenshots are generated on failed tests only)~~ (duplicate with https://github.com/TheThingsNetwork/lorawan-stack/pull/3758)


#### Testing

We can see in the test run of this PR if everything works as expected.

#### Notes for Reviewers

The generation of videos currently takes 2-18 seconds for each test spec. We could also upload these as artifacts but I don't think their utility offsets the time that it takes to produce them. If there's a e2e failure, we'll mostly run the tests ourselves in interactive mode to debug anyway. Screenshots and logs should give us similar but way cheaper insight.

In any case, it makes no sense to let cypress time consumingly create and process videos if we don't even upload them.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
