### PR TITLE
Do not panic on nil EndDeviceVersionIdentifiers

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -5975,6 +5975,15 @@
       "file": "cayennelpp.go"
     }
   },
+  "error:pkg/messageprocessors/devicerepository:no_version_identifiers": {
+    "translations": {
+      "en": "no version identifiers for device"
+    },
+    "description": {
+      "package": "pkg/messageprocessors/devicerepository",
+      "file": "devicerepository.go"
+    }
+  },
   "error:pkg/messageprocessors/javascript:input": {
     "translations": {
       "en": "invalid input"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Quickfix PR, fixes a panic when the Device Repository message processor is executed with `version == nil`, which is a valid scenario for the AS. 

#### Testing

<!-- How did you verify that this change works? -->

- Unit tests

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
