### PR TITLE
Add dynamic style for byte field

### DIFF
--- a/pkg/webui/components/input/input.styl
+++ b/pkg/webui/components/input/input.styl
@@ -113,7 +113,6 @@
 
 .byte
   font-weight: $fw.bold
-  letter-spacing: .05rem
 
 .code
   font-size: $fs.s


### PR DESCRIPTION
#### Summary

Closes #3784

#### Changes

- added dynamic style that calculates `max-width` for byte input based on `max` prop
- reduced spacing between byte pairs

Before:
![before](https://user-images.githubusercontent.com/72162194/107980624-4748e000-6fc9-11eb-943c-eadeb9a268af.png)

After:
![after](https://user-images.githubusercontent.com/72162194/107980631-4912a380-6fc9-11eb-9c9b-85eda312d39b.png)

#### Testing

Manually tested

#### Checklist

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
