### PR TITLE
Add highlight for frame counter in live data events

### DIFF
--- a/pkg/webui/console/components/events/previews/shared/description-list/description-list.styl
+++ b/pkg/webui/console/components/events/previews/shared/description-list/description-list.styl
@@ -42,3 +42,12 @@
   &:after
     content: '>'
 
+.highlight
+  line-height: 1.9rem;
+  border: 1px solid $c-divider-dark;
+  font-family: 'IBM Plex Mono', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace
+  display: inline
+  background-color: white
+  height: 100%
+  padding: 0 $cs.xs
+  border-radius: $br.s

--- a/pkg/webui/console/components/events/previews/shared/description-list/item.js
+++ b/pkg/webui/console/components/events/previews/shared/description-list/item.js
@@ -22,7 +22,7 @@ import PropTypes from '@ttn-lw/lib/prop-types'
 import style from './description-list.styl'
 
 const DescriptionListItem = props => {
-  const { className, children, data, title } = props
+  const { className, children, data, title, highlight } = props
   const content = children || data
 
   if (!Boolean(content)) {
@@ -42,7 +42,7 @@ const DescriptionListItem = props => {
       <dt className={style.term}>
         <Message content={title} />
       </dt>
-      <dd className={style.value}>{content}</dd>
+      <dd className={classnames(style.value, { [style.highlight]: highlight })}>{content}</dd>
     </div>
   )
 }
@@ -51,6 +51,7 @@ DescriptionListItem.propTypes = {
   children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
   className: PropTypes.string,
   data: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  highlight: PropTypes.bool,
   title: PropTypes.message,
 }
 
@@ -58,6 +59,7 @@ DescriptionListItem.defaultProps = {
   children: undefined,
   data: undefined,
   className: undefined,
+  highlight: false,
   title: undefined,
 }
 

--- a/pkg/webui/console/components/events/previews/uplink-message.js
+++ b/pkg/webui/console/components/events/previews/uplink-message.js
@@ -49,8 +49,8 @@ const UplinkMessagePreview = React.memo(({ event }) => {
   return (
     <DescriptionList>
       <DescriptionList.Byte title={messages.devAddr} data={devAddr} />
+      <DescriptionList.Item title={messages.fCnt} data={fCnt} highlight />
       <DescriptionList.Item title={messages.fPort} data={fPort} />
-      <DescriptionList.Item title={messages.fCnt} data={fCnt} />
       <DescriptionList.Byte title={sharedMessages.joinEUI} data={joinEui} />
       <DescriptionList.Byte title={sharedMessages.devEUI} data={devEui} />
       <DescriptionList.Byte title={messages.MACPayload} data={frmPayload} convertToHex />


### PR DESCRIPTION
#### Summary

Closes #3716 

#### Changes

- added highlight prop for description list item
- added highlight for frame Counter (FCnt) in live data events

Before:
![before](https://user-images.githubusercontent.com/72162194/107862363-16e03500-6e55-11eb-973f-a76d13360850.png)

After:
![after](https://user-images.githubusercontent.com/72162194/107862364-18a9f880-6e55-11eb-9b55-e7df73156ccd.png)


#### Testing

Manually tested

#### Checklist

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.

