### PR TITLE
Prefill end device ID on dev_eui change in the Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Added
 
 - Pagination flags for the `users oauth authorizations list` and `users oauth access-tokens list` CLI commands.
+- End device ID generation based on DevEUI in The LoRaWAN Device Repository creation form in the Console.
 
 ### Changed
 

--- a/cypress/integration/console/devices/create-repository.spec.js
+++ b/cypress/integration/console/devices/create-repository.spec.js
@@ -129,16 +129,16 @@ describe('End device repository create', () => {
         cy.findDescriptionByLabelText('Frequency plan')
           .should('contain', 'The frequency plan used by the end device')
           .and('be.visible')
-        cy.findByLabelText('DevEUI').should('be.visible')
-        cy.findDescriptionByLabelText('DevEUI')
-          .should('contain', 'The DevEUI is the unique identifier for this end device')
-          .and('be.visible')
         cy.findByLabelText('AppEUI').should('be.visible')
         cy.findDescriptionByLabelText('AppEUI')
           .should(
             'contain',
             'The AppEUI uniquely identifies the owner of the end device. If no AppEUI is provided by the device manufacturer (usually for development), it can be filled with zeros.',
           )
+          .and('be.visible')
+        cy.findByLabelText('DevEUI').should('be.visible')
+        cy.findDescriptionByLabelText('DevEUI')
+          .should('contain', 'The DevEUI is the unique identifier for this end device')
           .and('be.visible')
         cy.findByLabelText('AppKey').should('be.visible')
         cy.findDescriptionByLabelText('AppKey')
@@ -157,16 +157,39 @@ describe('End device repository create', () => {
       })
 
       it('succeeds registering the things uno', () => {
-        const devId = 'the-things-uno-test'
+        const devEui = generateHexValue(16)
 
         selectUno()
 
         // End device registration.
         cy.findByLabelText('Frequency plan').selectOption('EU_863_870_TTN')
-        cy.findByLabelText('DevEUI').type(generateHexValue(16))
         cy.findByLabelText('AppEUI').type(generateHexValue(16))
+        cy.findByLabelText('DevEUI').type(devEui)
         cy.findByLabelText('AppKey').type(generateHexValue(32))
-        cy.findByLabelText('End device ID').type(devId)
+        cy.findByLabelText('End device ID').should('have.value', devEui)
+
+        cy.findByRole('button', { name: 'Register end device' }).click()
+
+        cy.location('pathname').should(
+          'eq',
+          `${Cypress.config('consoleRootPath')}/applications/${appId}/devices/${devEui}`,
+        )
+        cy.findByTestId('full-error-view').should('not.exist')
+      })
+
+      it('succeeds registering the things uno with custom ID', () => {
+        const devId = 'uno-custom-id'
+
+        selectUno()
+
+        // End device registration.
+        cy.findByLabelText('Frequency plan').selectOption('EU_863_870_TTN')
+        cy.findByLabelText('AppEUI').type(generateHexValue(16))
+        cy.findByLabelText('DevEUI').type(generateHexValue(16))
+        cy.findByLabelText('AppKey').type(generateHexValue(32))
+        cy.findByLabelText('End device ID')
+          .clear()
+          .type(devId)
 
         cy.findByRole('button', { name: 'Register end device' }).click()
 
@@ -178,28 +201,28 @@ describe('End device repository create', () => {
       })
 
       it('succeeds registering the things node', () => {
-        const devId = 'the-things-node-test'
+        const devEui = generateHexValue(16)
 
         selectNode()
 
         // End device registration.
         cy.findByLabelText('Frequency plan').selectOption('EU_863_870_TTN')
-        cy.findByLabelText('DevEUI').type(generateHexValue(16))
+        cy.findByLabelText('DevEUI').type(devEui)
         cy.findByLabelText('AppEUI').type(generateHexValue(16))
         cy.findByLabelText('AppKey').type(generateHexValue(32))
-        cy.findByLabelText('End device ID').type(devId)
+        cy.findByLabelText('End device ID').should('have.value', devEui)
 
         cy.findByRole('button', { name: 'Register end device' }).click()
 
         cy.location('pathname').should(
           'eq',
-          `${Cypress.config('consoleRootPath')}/applications/${appId}/devices/${devId}`,
+          `${Cypress.config('consoleRootPath')}/applications/${appId}/devices/${devEui}`,
         )
         cy.findByTestId('full-error-view').should('not.exist')
       })
 
       it('succeeds registering two the things uno', () => {
-        const devId1 = 'the-things-uno-test-1'
+        const devEui1 = generateHexValue(16)
 
         // End device selection.
         selectUno()
@@ -207,9 +230,9 @@ describe('End device repository create', () => {
         // End device registration.
         cy.findByLabelText('Frequency plan').selectOption('EU_863_870_TTN')
         cy.findByLabelText('AppEUI').type(generateHexValue(16))
-        cy.findByLabelText('DevEUI').type(generateHexValue(16))
+        cy.findByLabelText('DevEUI').type(devEui1)
         cy.findByLabelText('AppKey').type(generateHexValue(32))
-        cy.findByLabelText('End device ID').type(devId1)
+        cy.findByLabelText('End device ID').should('have.value', devEui1)
         cy.findByLabelText('Register another end device of this type').check()
 
         cy.findByRole('button', { name: 'Register end device' }).click()
@@ -219,19 +242,19 @@ describe('End device repository create', () => {
           .findByText('End device registered')
           .should('be.visible')
 
-        const devId2 = 'the-things-uno-test-2'
+        const devEui2 = generateHexValue(16)
 
         // End device registration.
-        cy.findByLabelText('DevEUI').type(generateHexValue(16))
+        cy.findByLabelText('DevEUI').type(devEui2)
         cy.findByLabelText('AppKey').type(generateHexValue(32))
-        cy.findByLabelText('End device ID').type(devId2)
+        cy.findByLabelText('End device ID').should('have.value', devEui2)
         cy.findByLabelText('View registered end device').check()
 
         cy.findByRole('button', { name: 'Register end device' }).click()
 
         cy.location('pathname').should(
           'eq',
-          `${Cypress.config('consoleRootPath')}/applications/${appId}/devices/${devId2}`,
+          `${Cypress.config('consoleRootPath')}/applications/${appId}/devices/${devEui2}`,
         )
         cy.findByTestId('full-error-view').should('not.exist')
       })

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -93,7 +93,13 @@ const disableGatewayServer = config => {
 
 /** General utitlies. */
 
-const generateHexValue = length => crypto.randomBytes(length).toString('hex')
+/**
+ * Generates pseudorandom hex value.
+ *
+ * @param {number} length -  The length of the resulting hex value.
+ * @returns {string} - Pseudorandom hex value of length `length`.
+ */
+const generateHexValue = length => crypto.randomBytes(Math.floor(length / 2)).toString('hex')
 
 export {
   disableIdentityServer,

--- a/pkg/webui/components/form/field/index.js
+++ b/pkg/webui/components/form/field/index.js
@@ -29,7 +29,7 @@ import FormContext from '../context'
 
 import style from './field.styl'
 
-export function getPassThroughProps(props, excludeProps) {
+export const getPassThroughProps = (props, excludeProps) => {
   const rest = {}
   for (const property of Object.keys(props)) {
     if (!excludeProps[property]) {
@@ -39,7 +39,7 @@ export function getPassThroughProps(props, excludeProps) {
   return rest
 }
 
-const isValueEmpty = function(value) {
+const isValueEmpty = value => {
   if (value === null || value === undefined) {
     return true
   }

--- a/pkg/webui/components/form/field/index.js
+++ b/pkg/webui/components/form/field/index.js
@@ -74,6 +74,7 @@ class FormField extends React.Component {
     glossaryId: PropTypes.string,
     glossaryTerm: PropTypes.message,
     name: PropTypes.string.isRequired,
+    onBlur: PropTypes.func,
     onChange: PropTypes.func,
     readOnly: PropTypes.bool,
     required: PropTypes.bool,
@@ -87,6 +88,7 @@ class FormField extends React.Component {
     encode: value => value,
     decode: value => value,
     onChange: () => null,
+    onBlur: () => null,
     warning: '',
     description: '',
     glossaryTerm: '',
@@ -152,13 +154,15 @@ class FormField extends React.Component {
 
   @bind
   handleBlur(event) {
-    const { name } = this.props
+    const { name, onBlur } = this.props
     const { validateOnBlur, setFieldTouched } = this.context
 
     if (validateOnBlur) {
       const value = this.extractValue(event)
       setFieldTouched(name, !isValueEmpty(value))
     }
+
+    onBlur(event)
   }
 
   render() {

--- a/pkg/webui/components/input/index.js
+++ b/pkg/webui/components/input/index.js
@@ -29,6 +29,20 @@ import Generate from './generate'
 
 import style from './input.styl'
 
+/**
+ * Merges multiple refs.
+ *
+ * @param {Array<object>} refs - A list of refs to be merged.
+ * @returns {Function} - The ref callback with the DOM element that is assigned to every ref in `refs`.
+ */
+const mergeRefs = refs => val => {
+  refs.forEach(ref => {
+    if (typeof ref === 'object') {
+      ref.current = val
+    }
+  })
+}
+
 class Input extends React.Component {
   static propTypes = {
     action: PropTypes.shape({
@@ -49,8 +63,9 @@ class Input extends React.Component {
     component: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     disabled: PropTypes.bool,
     error: PropTypes.bool,
-    forwardedRef: PropTypes.shape({}),
+    forwardedRef: PropTypes.shape({ current: PropTypes.shape({}) }),
     icon: PropTypes.string,
+    inputRef: PropTypes.shape({ current: PropTypes.shape({}) }),
     inputWidth: PropTypes.inputWidth,
     intl: PropTypes.shape({
       formatMessage: PropTypes.func,
@@ -98,6 +113,7 @@ class Input extends React.Component {
     valid: false,
     value: '',
     warning: false,
+    inputRef: null,
     forwardedRef: null,
   }
 
@@ -105,7 +121,7 @@ class Input extends React.Component {
     focus: false,
   }
 
-  input = React.createRef()
+  input = React.createRef(null)
 
   focus() {
     if (this.input.current) {
@@ -147,9 +163,10 @@ class Input extends React.Component {
       intl,
       code,
       action,
-      forwardedRef,
       autoComplete,
       showPerChar,
+      forwardedRef,
+      inputRef,
       ...rest
     } = this.props
 
@@ -197,6 +214,7 @@ class Input extends React.Component {
     const passedProps = {
       ...rest,
       ...(type === 'byte' ? { showPerChar } : {}),
+      ref: inputRef ? mergeRefs([this.input, inputRef]) : this.input,
     }
 
     return (
@@ -204,7 +222,6 @@ class Input extends React.Component {
         <div className={inputCls} style={inputStyle}>
           {icon && <Icon className={style.icon} icon={icon} />}
           <Component
-            ref={this.input}
             key="i"
             className={style.input}
             type={type}

--- a/pkg/webui/console/views/device-add/repository/device-registration/index.js
+++ b/pkg/webui/console/views/device-add/repository/device-registration/index.js
@@ -48,7 +48,7 @@ const m = defineMessages({
 })
 
 const Registration = props => {
-  const { template, fetching, prefixes, mayEditKeys } = props
+  const { template, fetching, prefixes, mayEditKeys, onIdPrefill } = props
   const state = useRepositoryContext()
   const hasTemplate = Boolean(template)
 
@@ -99,6 +99,7 @@ const Registration = props => {
             required
             component={Input}
             glossaryId={glossaryId.DEV_EUI}
+            onBlur={onIdPrefill}
           />
           <Form.Field
             required
@@ -239,6 +240,7 @@ const Registration = props => {
 Registration.propTypes = {
   fetching: PropTypes.bool,
   mayEditKeys: PropTypes.bool.isRequired,
+  onIdPrefill: PropTypes.func.isRequired,
   prefixes: PropTypes.euiPrefixes.isRequired,
   template: PropTypes.shape({
     end_device: PropTypes.shape({

--- a/pkg/webui/console/views/device-add/repository/device-registration/index.js
+++ b/pkg/webui/console/views/device-add/repository/device-registration/index.js
@@ -48,9 +48,14 @@ const m = defineMessages({
 })
 
 const Registration = props => {
-  const { template, fetching, prefixes, mayEditKeys, onIdPrefill } = props
+  const { template, fetching, prefixes, mayEditKeys, onIdPrefill, onIdSelect } = props
   const state = useRepositoryContext()
   const hasTemplate = Boolean(template)
+  const idInputRef = React.useRef(null)
+
+  const handleIdFocus = React.useCallback(() => {
+    onIdSelect(idInputRef)
+  }, [idInputRef, onIdSelect])
 
   if (!hasTemplate || (fetching && !hasTemplate)) {
     return (
@@ -228,6 +233,8 @@ const Registration = props => {
         name="ids.device_id"
         placeholder={sharedMessages.deviceIdPlaceholder}
         component={Input}
+        onFocus={handleIdFocus}
+        inputRef={idInputRef}
       />
       <Form.Field title={m.afterRegistration} name="_registration" component={Radio.Group}>
         <Radio label={m.singleRegistration} value={REGISTRATION_TYPES.SINGLE} />
@@ -241,6 +248,7 @@ Registration.propTypes = {
   fetching: PropTypes.bool,
   mayEditKeys: PropTypes.bool.isRequired,
   onIdPrefill: PropTypes.func.isRequired,
+  onIdSelect: PropTypes.func.isRequired,
   prefixes: PropTypes.euiPrefixes.isRequired,
   template: PropTypes.shape({
     end_device: PropTypes.shape({

--- a/pkg/webui/console/views/device-add/repository/repository.js
+++ b/pkg/webui/console/views/device-add/repository/repository.js
@@ -192,13 +192,24 @@ const DeviceRepository = props => {
   )
 
   const handleIdPrefill = React.useCallback(() => {
-    if (formRef.current) {
-      const { values, errors, setFieldValue } = formRef.current
+    if (formRef && formRef.current) {
+      const { values, setFieldValue } = formRef.current
 
       // Do not overwrite a value that the user has already set.
       if (values.ids.device_id === initialValues.ids.device_id) {
-        const generatedId = generateDeviceId(values, errors)
+        const generatedId = generateDeviceId(values)
         setFieldValue('ids.device_id', generatedId)
+      }
+    }
+  }, [])
+  const handleIdTextSelect = React.useCallback(idInputRef => {
+    if (idInputRef && idInputRef.current) {
+      const { values } = formRef.current
+      const { setSelectionRange } = idInputRef.current
+
+      const generatedId = generateDeviceId(values)
+      if (generatedId.length > 0 && generatedId === values.ids.device_id) {
+        setSelectionRange.call(idInputRef.current, 0, generatedId.length)
       }
     }
   }, [])
@@ -290,6 +301,7 @@ const DeviceRepository = props => {
                 prefixes={prefixes}
                 mayEditKeys={mayEditKeys}
                 onIdPrefill={handleIdPrefill}
+                onIdSelect={handleIdTextSelect}
               />
             ) : (
               <Message content={m.enterDataDescription} component="p" />

--- a/pkg/webui/console/views/device-add/repository/repository.js
+++ b/pkg/webui/console/views/device-add/repository/repository.js
@@ -54,7 +54,7 @@ import reducer, {
   hasAnySelectedOther,
   hasCompletedSelection,
 } from './reducer'
-import validationSchema, { initialValues } from './validation-schema'
+import validationSchema, { initialValues, devEUISchema } from './validation-schema'
 
 import style from './repository.styl'
 
@@ -67,6 +67,19 @@ const m = defineMessages({
   createSuccess: 'End device registered',
   register: 'Register from The LoRaWAN Device Repository',
 })
+
+const generateDeviceId = (device = {}) => {
+  const { ids: idsValues = {} } = device
+
+  try {
+    devEUISchema.validateSync(idsValues.dev_eui)
+    return idsValues.dev_eui.toLowerCase()
+  } catch (e) {
+    // We dont want to use invalid `dev_eui` as `device_id`.
+  }
+
+  return initialValues.ids.device_id || ''
+}
 
 const stateToFormValues = state => ({
   ...initialValues,
@@ -153,6 +166,7 @@ const DeviceRepository = props => {
               message: m.createSuccess,
             })
             resetForm({
+              errors: {},
               values: {
                 ...castedValues,
                 ...initialValues,
@@ -176,6 +190,18 @@ const DeviceRepository = props => {
     },
     [appId, createDevice, createDeviceSuccess, handleSetError, validationContext],
   )
+
+  const handleIdPrefill = React.useCallback(() => {
+    if (formRef.current) {
+      const { values, errors, setFieldValue } = formRef.current
+
+      // Do not overwrite a value that the user has already set.
+      if (values.ids.device_id === initialValues.ids.device_id) {
+        const generatedId = generateDeviceId(values, errors)
+        setFieldValue('ids.device_id', generatedId)
+      }
+    }
+  }, [])
 
   const hasSelectedOther = hasAnySelectedOther(state)
   const hasCompleted = hasCompletedSelection(state)
@@ -263,6 +289,7 @@ const DeviceRepository = props => {
                 fetching={templateFetching}
                 prefixes={prefixes}
                 mayEditKeys={mayEditKeys}
+                onIdPrefill={handleIdPrefill}
               />
             ) : (
               <Message content={m.enterDataDescription} component="p" />

--- a/pkg/webui/console/views/device-add/repository/validation-schema.js
+++ b/pkg/webui/console/views/device-add/repository/validation-schema.js
@@ -218,4 +218,4 @@ const initialValues = {
   _registration: REGISTRATION_TYPES.SINGLE,
 }
 
-export { validationSchema as default, initialValues }
+export { validationSchema as default, initialValues, devEUISchema }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR adds functionality to generate end device ID based on `dev_eui` value.
References https://github.com/TheThingsNetwork/lorawan-stack/issues/3522

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `generateDeviceId` to DR form
- Fix `onBlur` handling for `<Field />`
- Use arrow functions if `<Field />`
- Extend e2e tests for DR creation
- Adjust `generateHexValue`

#### Testing

<!-- How did you verify that this change works? -->

Manual and e2e tests


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
