### PR TITLE
Improve profile picture filename assertion

### DIFF
--- a/cypress/integration/account/profile-settings.spec.js
+++ b/cypress/integration/account/profile-settings.spec.js
@@ -125,7 +125,7 @@ describe('Account App profile settings', () => {
     cy.findByAltText('Current image')
       .should('be.visible')
       .and('have.attr', 'src')
-      .and('match', /^\/assets\/blob\/profile_pictures\/profile-settings-test-user\..*\.png/)
+      .and('match', /^\/assets\/blob\/profile_pictures\/profile-settings-test-user.*\.png/)
   })
 
   it('succeeds deleting the account', () => {


### PR DESCRIPTION
#### Summary
Small one-line fix to reduce the diff between TTSOS and TTSE.

#### Changes
- Use the same regex to check for filenames as in TTSE


#### Testing

- e2e tests

#### Notes for Reviewers
Had to [change the regex](https://github.com/TheThingsIndustries/lorawan-stack/pull/2578/commits/d987c7578f5e456be3b2abe8f4576373aecad680) since it was not working for TTSE and I don't want to have to different regex for both.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
