### PR TITLE
Change type of temp field to float32 in UDP stats message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
+- `temp` field of the UDP stats message is now type `float32` (pointer).
+
 ### Deprecated
 
 ### Removed

--- a/pkg/ttnpb/udp/packet_data.go
+++ b/pkg/ttnpb/udp/packet_data.go
@@ -115,7 +115,7 @@ type Stat struct {
 	LMST *uint32       `json:"lmst,omitempty"` // Sequence number of the first packet received from link testing mote (unsigned integer)
 	LMNW *uint32       `json:"lmnw,omitempty"` // Sequence number of the last packet received from link testing mote (unsigned integer)
 	LPPS *uint32       `json:"lpps,omitempty"` // Number of lost PPS pulses (unsigned integer)
-	Temp *int32        `json:"temp,omitempty"` // Temperature of the Gateway (signed integer)
+	Temp *float32      `json:"temp,omitempty"` // Temperature of the Gateway (signed float)
 	FPGA *uint32       `json:"fpga,omitempty"` // Version of Gateway FPGA (unsigned integer)
 	DSP  *uint32       `json:"dsp,omitempty"`  // Version of Gateway DSP software (unsigned interger)
 	HAL  *string       `json:"hal,omitempty"`  // Version of Gateway driver (format X.X.X)

--- a/pkg/ttnpb/udp/packet_data_test.go
+++ b/pkg/ttnpb/udp/packet_data_test.go
@@ -36,7 +36,8 @@ func TestStatusPacket(t *testing.T) {
 		   "rxfw":0,
 		   "ackr":0.0,
 		   "dwnb":0,
-		   "txnb":0
+		   "txnb":0,
+		   "temp":-23.5
 		}
 	 }`
 	var d Data
@@ -49,6 +50,8 @@ func TestStatusPacket(t *testing.T) {
 	a.So(d, should.NotBeNil)
 	a.So(d.Stat, should.NotBeNil)
 	a.So(*d.Stat.Alti, should.Equal, 66)
+	a.So(*d.Stat.Temp, should.Equal, -23.5)
+	a.So(d.Stat.RxNb, should.Equal, 0)
 	a.So(d.Stat.RxNb, should.Equal, 0)
 	a.So(d.Stat.RxOk, should.Equal, 0)
 	a.So(d.Stat.RxFW, should.Equal, 0)

--- a/pkg/ttnpb/udp/translation_test.go
+++ b/pkg/ttnpb/udp/translation_test.go
@@ -38,7 +38,7 @@ func timePtr(t time.Time) *time.Time { return &t }
 func TestStatusRaw(t *testing.T) {
 	a := assertions.New(t)
 
-	raw := []byte(`{"stat":{"rxfw":0,"hal":"5.1.0","fpga":2,"dsp":31,"lpps":2,"lmnw":3,"lmst":1,"lmok":3,"temp":30,"lati":52.34223,"long":5.29685,"txnb":0,"dwnb":0,"alti":66,"rxok":0,"boot":"2017-06-07 09:40:42 GMT","time":"2017-06-08 09:40:42 GMT","rxnb":0,"ackr":0.0}}`)
+	raw := []byte(`{"stat":{"rxfw":0,"hal":"5.1.0","fpga":2,"dsp":31,"lpps":2,"lmnw":3,"lmst":1,"lmok":3,"temp":30.5,"lati":52.34223,"long":5.29685,"txnb":0,"dwnb":0,"alti":66,"rxok":0,"boot":"2017-06-07 09:40:42 GMT","time":"2017-06-08 09:40:42 GMT","rxnb":0,"ackr":0.0}}`)
 	var statusData udp.Data
 	err := json.Unmarshal(raw, &statusData)
 	a.So(err, should.BeNil)
@@ -72,7 +72,7 @@ func TestStatusRaw(t *testing.T) {
 	a.So(status.Metrics["rxok"], should.AlmostEqual, 0)
 	a.So(status.Metrics["rxnb"], should.AlmostEqual, 0)
 	a.So(status.Metrics["ackr"], should.AlmostEqual, 0)
-	a.So(status.Metrics["temp"], should.AlmostEqual, 30)
+	a.So(status.Metrics["temp"], should.AlmostEqual, 30.5)
 	a.So(status.Metrics["lpps"], should.AlmostEqual, 2)
 	a.So(status.Metrics["lmnw"], should.AlmostEqual, 3)
 	a.So(status.Metrics["lmst"], should.AlmostEqual, 1)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #3633

#### Changes
<!-- What are the changes made in this pull request? -->

- Change field type
-  Update tests


#### Testing

<!-- How did you verify that this change works? -->

UT

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

I don't expect any since this field is actually used as `float32` when [translated to metrics](https://github.com/TheThingsNetwork/lorawan-stack/blob/04b4523d36a4f2505cdbfa158b60084300a57aa1/pkg/ttnpb/udp/translation.go#L227).

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
