### PR TITLE
Fix conflict when registering end devices in the Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - Ocassional race condition in uplink matching with replicated Network Server instances.
 - Ocassional race condition when matching pending sessions.
+- Conflict error when registering an end device via the wizard in the Console.
 
 ### Security
 

--- a/pkg/webui/components/wizard/form/next-button.js
+++ b/pkg/webui/components/wizard/form/next-button.js
@@ -33,7 +33,7 @@ const m = defineMessages({
 const WizardNextButton = props => {
   const { isLastStep, completeMessage, validationContext, validationSchema } = props
   const { currentStepId, steps, onStepComplete } = useWizardContext()
-  const { disabled, submitForm, isSubmitting, isValidating, values } = useFormContext()
+  const { disabled, isSubmitting, isValidating, values } = useFormContext()
 
   const stepIndex = steps.findIndex(({ id }) => id === currentStepId)
   const { title: nextStepTitle } = steps[Math.min(stepIndex + 1, steps.length - 1)] || {
@@ -48,8 +48,7 @@ const WizardNextButton = props => {
 
   const handleClick = React.useCallback(() => {
     onStepComplete(validationSchema.cast(values, { context: validationContext }))
-    submitForm()
-  }, [onStepComplete, submitForm, validationContext, validationSchema, values])
+  }, [onStepComplete, validationContext, validationSchema, values])
 
   return (
     <Button


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes issue that often happens when registering a new end device via the wizard.

Reproduce:
1. Use firefox for this (does not happen in Chrome all the time)
2. Navigate to `/console/applications/{app_id}/devices/add/manual`
3. Open dev tools console
4. Fill in the fields and submit
5. See the `409` error returned by the second request to IS

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove imperative call to `submitForm` in the wizard


#### Testing

<!-- How did you verify that this change works? -->

Manually tested in firefox/chrome and safari for both dev and prod builds

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

There is no need to call `submitForm` manually, formik does that for us automatically.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
