### PR TITLE
Check if the application session key is available before access

### DIFF
--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -312,7 +312,7 @@ func (as *ApplicationServer) publishUp(ctx context.Context, up *ttnpb.Applicatio
 // This method returns true if the AppSKey of the given session is wrapped and cannot be unwrapped by the Application
 // Server, and if the end device's skip_payload_crypto_override is true or if the link's skip_payload_crypto is true.
 func (as *ApplicationServer) skipPayloadCrypto(ctx context.Context, link *ttnpb.ApplicationLink, dev *ttnpb.EndDevice, session *ttnpb.Session) bool {
-	if session != nil {
+	if session != nil && session.AppSKey != nil {
 		if _, err := cryptoutil.UnwrapAES128Key(ctx, session.AppSKey, as.KeyVault); err == nil {
 			return false
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://www.thethingsnetwork.org/forum/t/internal-server-error/44472/3

This quickfix ensures that `as.skipPayloadCrypto` does not `panic` if a session is available, but the `AppSKey` is `nil`.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add a nil-check for `session.AppSKey`

#### Testing

<!-- How did you verify that this change works? -->

Tested locally with an unset `AppSKey`. 

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Not expected. 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
