### PR TITLE
Fix possible race condition in uplink matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Fixed
 
 - Synchronization in Gateway Server scheduler that caused race conditions in scheduling downlink traffic.
+- Ocassional race condition in uplink matching with replicated Network Server instances.
 
 ## [3.11.0] - 2021-02-10
 

--- a/pkg/networkserver/redis/lua/deviceMatch.lua
+++ b/pkg/networkserver/redis/lua/deviceMatch.lua
@@ -19,8 +19,8 @@
 --
 -- KEYS[2] 	- sorted set of uids of devices matching current session DevAddr sorted ascending by LSB of LastFCntUp
 -- KEYS[3] 	- hash containing msgpack-encoded sessions for devices matching current session DevAddr keyed by uid
--- KEYS[4] 	- sorted list of uids of devices matching with current session LastFCntUp LSB being lower than or equal to current
--- KEYS[5] 	- sorted list of uids of devices matching with current session LastFCntUp LSB being greater than current
+-- KEYS[4] 	- sorted list of uids of devices matching with current session LastFCntUp LSB being lower than or equal to uplink LSB
+-- KEYS[5] 	- sorted list of uids of devices matching with current session LastFCntUp LSB being greater than uplink LSB
 -- KEYS[6]  - copy of KEYS[3]
 --
 -- KEYS[7] 	- sorted set of uids of devices matching pending session DevAddr sorted ascending by creation time

--- a/pkg/networkserver/redis/lua/deviceMatchScan.lua
+++ b/pkg/networkserver/redis/lua/deviceMatchScan.lua
@@ -14,6 +14,9 @@
 
 for _, old_uid in ipairs(ARGV) do
   local uid = redis.call('lindex', KEYS[1], -1)
+  if not uid then
+    return nil
+  end
   if uid ~= old_uid then
     return uid
   end

--- a/pkg/networkserver/redis/lua/deviceMatchScanGT.lua
+++ b/pkg/networkserver/redis/lua/deviceMatchScanGT.lua
@@ -16,6 +16,9 @@ local ack = ARGV[1]
 table.remove(ARGV, 1)
 for _, old_uid in ipairs(ARGV) do
   local uid = redis.call('lindex', KEYS[1], -1)
+  if not uid then
+    return nil
+  end
   if uid ~= old_uid then
     local s = redis.call('hget', KEYS[2], uid)
     local m = cmsgpack.unpack(s)

--- a/pkg/networkserver/redis/scripts.go
+++ b/pkg/networkserver/redis/scripts.go
@@ -12,8 +12,8 @@ var (
 	//
 	// KEYS[2] 	- sorted set of uids of devices matching current session DevAddr sorted ascending by LSB of LastFCntUp
 	// KEYS[3] 	- hash containing msgpack-encoded sessions for devices matching current session DevAddr keyed by uid
-	// KEYS[4] 	- sorted list of uids of devices matching with current session LastFCntUp LSB being lower than or equal to current
-	// KEYS[5] 	- sorted list of uids of devices matching with current session LastFCntUp LSB being greater than current
+	// KEYS[4] 	- sorted list of uids of devices matching with current session LastFCntUp LSB being lower than or equal to uplink LSB
+	// KEYS[5] 	- sorted list of uids of devices matching with current session LastFCntUp LSB being greater than uplink LSB
 	// KEYS[6]  - copy of KEYS[3]
 	//
 	// KEYS[7] 	- sorted set of uids of devices matching pending session DevAddr sorted ascending by creation time
@@ -68,6 +68,9 @@ return nil`)
 
 	deviceMatchScanScript = redis.NewScript(`for _, old_uid in ipairs(ARGV) do
   local uid = redis.call('lindex', KEYS[1], -1)
+  if not uid then
+    return nil
+  end
   if uid ~= old_uid then
     return uid
   end
@@ -80,6 +83,9 @@ return redis.call('lindex', KEYS[1], -1)`)
 table.remove(ARGV, 1)
 for _, old_uid in ipairs(ARGV) do
   local uid = redis.call('lindex', KEYS[1], -1)
+  if not uid then
+    return nil
+  end
   if uid ~= old_uid then
     local s = redis.call('hget', KEYS[2], uid)
     local m = cmsgpack.unpack(s)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fix race condition with multi-instance NSes on matching

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix race condition with multi-instance NSes on matching

#### Testing

<!-- How did you verify that this change works? -->

integration testing with single instance, if anyone can assist here - that'd be helpful

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
