### PR TITLE
Add application payload formatters e2e tests

### DIFF
--- a/cypress/integration/console/applications/create.spec.js
+++ b/cypress/integration/console/applications/create.spec.js
@@ -72,7 +72,7 @@ describe('Application create', () => {
     cy.location('pathname').should('eq', `${Cypress.config('consoleRootPath')}/applications/add`)
   })
 
-  it('successfully adds application', () => {
+  it('succeeds adding application', () => {
     cy.loginConsole({ user_id: user.ids.user_id, password: user.password })
     cy.visit(`${Cypress.config('consoleRootPath')}/applications/add`)
     cy.findByLabelText('Application ID').type(applicationId)

--- a/cypress/integration/console/applications/edit.spec.js
+++ b/cypress/integration/console/applications/edit.spec.js
@@ -36,7 +36,7 @@ describe('Application general settings', () => {
     cy.loginConsole({ user_id: user.ids.user_id, password: user.password })
   })
 
-  it('successfully edit application name and description', () => {
+  it('succeeds editing application name and description', () => {
     cy.visit(`${Cypress.config('consoleRootPath')}/applications/${applicationId}/general-settings`)
 
     cy.findByLabelText('Name').type('test-name')
@@ -51,7 +51,7 @@ describe('Application general settings', () => {
       .should('be.visible')
   })
 
-  it('successfully add application attributes', () => {
+  it('succeeds adding application attributes', () => {
     cy.visit(`${Cypress.config('consoleRootPath')}/applications/${applicationId}/general-settings`)
 
     cy.findByRole('button', { name: /Add attributes/ }).click()
@@ -68,7 +68,7 @@ describe('Application general settings', () => {
       .should('be.visible')
   })
 
-  it('successfully delete application', () => {
+  it('succeeds deleting application', () => {
     cy.visit(`${Cypress.config('consoleRootPath')}/applications/${applicationId}/general-settings`)
     cy.findByRole('button', { name: /Delete application/ }).click()
 

--- a/cypress/integration/console/gateways/create.spec.js
+++ b/cypress/integration/console/gateways/create.spec.js
@@ -78,7 +78,7 @@ describe('Gateway create', () => {
     cy.location('pathname').should('eq', `${Cypress.config('consoleRootPath')}/gateways/add`)
   })
 
-  it('successfully adds gateway', () => {
+  it('succeeds adding gateway', () => {
     cy.visit(`${Cypress.config('consoleRootPath')}/gateways/add`)
     cy.findByLabelText('Gateway ID').type(gatewayId)
     cy.findByLabelText('Frequency plan').selectOption(frequencyPlanId)

--- a/cypress/integration/console/gateways/location/create.spec.js
+++ b/cypress/integration/console/gateways/location/create.spec.js
@@ -103,7 +103,7 @@ describe('Gateway location create', () => {
     cy.findByRole('button', { name: /Remove location entry/ }).should('be.disabled')
   })
 
-  it('successfully saves location', () => {
+  it('succeeds saving location', () => {
     cy.visit(`${Cypress.config('consoleRootPath')}/gateways/${gatewayId}/location`)
     cy.findByLabelText('Latitude').type(coordinates.latitude)
     cy.findByLabelText('Longitude').type(coordinates.longitude)

--- a/cypress/integration/console/gateways/location/edit.spec.js
+++ b/cypress/integration/console/gateways/location/edit.spec.js
@@ -59,7 +59,7 @@ describe('Gateway location', () => {
     cy.loginConsole({ user_id: user.ids.user_id, password: user.password })
   })
 
-  it('successfully edits latitude, longitude, altitude', () => {
+  it('succeeds editing latitude, longitude, altitude', () => {
     cy.visit(`${Cypress.config('consoleRootPath')}/gateways/${gatewayId}/location`)
     cy.findByLabelText('Latitude').type(coordinates.latitude)
     cy.findByLabelText('Longitude').type(coordinates.longitude)
@@ -74,7 +74,7 @@ describe('Gateway location', () => {
       .should('be.visible')
   })
 
-  it('successfully edits latitude and longitude based map widget location change', () => {
+  it('succeeds editing latitude and longitude based map widget location change', () => {
     cy.visit(`${Cypress.config('consoleRootPath')}/gateways/${gatewayId}/location`)
     cy.findByTestId('location-map').should('be.visible')
     cy.findByTestId('location-map').click(30, 30)
@@ -92,7 +92,7 @@ describe('Gateway location', () => {
       .should('be.visible')
   })
 
-  it('successfully deletes location entry', () => {
+  it('succeeds deleting location entry', () => {
     cy.visit(`${Cypress.config('consoleRootPath')}/gateways/${gatewayId}/location`)
     cy.findByRole('button', { name: /Remove location entry/ }).click()
 

--- a/cypress/integration/console/organizations/create.spec.js
+++ b/cypress/integration/console/organizations/create.spec.js
@@ -57,7 +57,7 @@ describe('Organization create', () => {
     cy.location('pathname').should('eq', `${Cypress.config('consoleRootPath')}/organizations/add`)
   })
 
-  it('successfully adds organization', () => {
+  it('succeeds adding organization', () => {
     cy.findByLabelText('Organization ID').type(organizationId)
 
     cy.findByRole('button', { name: 'Create organization' })

--- a/cypress/integration/console/organizations/edit.spec.js
+++ b/cypress/integration/console/organizations/edit.spec.js
@@ -39,7 +39,7 @@ describe('Organization general settings', () => {
     )
   })
 
-  it('successfully edit organization name and description', () => {
+  it('succeeds editing organization name and description', () => {
     cy.findByLabelText('Name').type('test-name')
     cy.findByLabelText('Description').type('test-description')
 
@@ -52,7 +52,7 @@ describe('Organization general settings', () => {
       .should('be.visible')
   })
 
-  it('successfully delete organization', () => {
+  it('succeeds deleting organization', () => {
     cy.findByRole('button', { name: /Delete organization/ }).click()
 
     cy.findByTestId('modal-window')

--- a/cypress/integration/console/shared/payload-formatters/edit.spec.js
+++ b/cypress/integration/console/shared/payload-formatters/edit.spec.js
@@ -1,0 +1,506 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+describe('Payload formatters', () => {
+  const applicationId = 'test-application-payload-formatters'
+  const application = { ids: { application_id: applicationId } }
+  const userId = 'edit-app-payload-formatter-test-user'
+  const user = {
+    ids: { user_id: userId },
+    primary_email_address: 'edit-application-formatters-test-user@example.com',
+    password: 'ABCDefg123!',
+    password_confirm: 'ABCDefg123!',
+  }
+
+  const endDeviceId = 'end-device-payload-formatters-test'
+  const endDevice = {
+    application_server_address: 'localhost',
+    ids: {
+      device_id: endDeviceId,
+      dev_eui: '0000000000000001',
+      join_eui: '0000000000000000',
+    },
+    name: 'End Device Test Name',
+    description: 'End Device Test Description',
+    join_server_address: 'localhost',
+    network_server_address: 'localhost',
+  }
+  const endDeviceFieldMask = {
+    paths: [
+      'join_server_address',
+      'network_server_address',
+      'application_server_address',
+      'ids.dev_eui',
+      'ids.join_eui',
+      'name',
+      'description',
+    ],
+  }
+  const endDeviceRequestBody = {
+    end_device: endDevice,
+    field_mask: endDeviceFieldMask,
+  }
+
+  before(() => {
+    cy.dropAndSeedDatabase()
+    cy.createUser(user)
+    cy.loginConsole({ user_id: userId, password: user.password })
+    cy.createApplication(application, userId)
+    cy.createEndDevice(applicationId, endDeviceRequestBody)
+  })
+
+  describe('Application', () => {
+    describe('Uplink', () => {
+      beforeEach(() => {
+        cy.loginConsole({ user_id: userId, password: user.password })
+      })
+
+      it('succeeds changing formatter type to Javascript', () => {
+        cy.visit(
+          `${Cypress.config(
+            'consoleRootPath',
+          )}/applications/${applicationId}/payload-formatters/uplink`,
+        )
+
+        cy.findByLabelText('Javascript').check()
+        cy.findByTestId('code-editor').should('be.visible')
+
+        cy.findByRole('button', { name: 'Save changes' }).click()
+
+        cy.findByTestId('error-notification').should('not.exist')
+        cy.findByTestId('toast-notification')
+          .should('be.visible')
+          .findByText('Payload formatter updated')
+          .should('be.visible')
+      })
+
+      it('succeeds changing formatter type to GRPC service', () => {
+        cy.visit(
+          `${Cypress.config(
+            'consoleRootPath',
+          )}/applications/${applicationId}/payload-formatters/uplink`,
+        )
+
+        cy.findByLabelText('GRPC service').check()
+        cy.findByLabelText('Formatter parameter').type('localhost')
+
+        cy.findByRole('button', { name: 'Save changes' }).click()
+
+        cy.findByTestId('error-notification').should('not.exist')
+        cy.findByTestId('toast-notification')
+          .should('be.visible')
+          .findByText('Payload formatter updated')
+          .should('be.visible')
+      })
+
+      it('succeeds changing formatter type to CayenneLPP', () => {
+        cy.visit(
+          `${Cypress.config(
+            'consoleRootPath',
+          )}/applications/${applicationId}/payload-formatters/uplink`,
+        )
+
+        cy.findByLabelText('CayenneLPP').check()
+        cy.findByLabelText('Formatter parameter').should('not.exist')
+
+        cy.findByRole('button', { name: 'Save changes' }).click()
+
+        cy.findByTestId('error-notification').should('not.exist')
+        cy.findByTestId('toast-notification')
+          .should('be.visible')
+          .findByText('Payload formatter updated')
+          .should('be.visible')
+      })
+
+      it('succeeds changing formatter type to Repository', () => {
+        cy.visit(
+          `${Cypress.config(
+            'consoleRootPath',
+          )}/applications/${applicationId}/payload-formatters/uplink`,
+        )
+
+        cy.findByLabelText('Repository').check()
+        cy.findByLabelText('Formatter parameter').should('not.exist')
+
+        cy.findByRole('button', { name: 'Save changes' }).click()
+
+        cy.findByTestId('error-notification').should('not.exist')
+        cy.findByTestId('toast-notification')
+          .should('be.visible')
+          .findByText('Payload formatter updated')
+          .should('be.visible')
+      })
+
+      it('succeeds changing formatter type to None', () => {
+        cy.visit(
+          `${Cypress.config(
+            'consoleRootPath',
+          )}/applications/${applicationId}/payload-formatters/uplink`,
+        )
+
+        cy.findByLabelText('None').check()
+        cy.findByLabelText('Formatter parameter').should('not.exist')
+
+        cy.findByRole('button', { name: 'Save changes' }).click()
+
+        cy.findByTestId('error-notification').should('not.exist')
+        cy.findByTestId('toast-notification')
+          .should('be.visible')
+          .findByText('Payload formatter updated')
+          .should('be.visible')
+      })
+    })
+
+    describe('Downlink', () => {
+      beforeEach(() => {
+        cy.loginConsole({ user_id: userId, password: user.password })
+      })
+
+      it('succeeds changing formatter type to Javascript', () => {
+        cy.visit(
+          `${Cypress.config(
+            'consoleRootPath',
+          )}/applications/${applicationId}/payload-formatters/downlink`,
+        )
+
+        cy.findByLabelText('Javascript').check()
+        cy.findByTestId('code-editor').should('be.visible')
+
+        cy.findByRole('button', { name: 'Save changes' }).click()
+
+        cy.findByTestId('error-notification').should('not.exist')
+        cy.findByTestId('toast-notification')
+          .should('be.visible')
+          .findByText('Payload formatter updated')
+          .should('be.visible')
+      })
+
+      it('succeeds changing formatter type to GRPC service', () => {
+        cy.visit(
+          `${Cypress.config(
+            'consoleRootPath',
+          )}/applications/${applicationId}/payload-formatters/downlink`,
+        )
+
+        cy.findByLabelText('GRPC service').check()
+        cy.findByLabelText('Formatter parameter').type('localhost')
+
+        cy.findByRole('button', { name: 'Save changes' }).click()
+
+        cy.findByTestId('error-notification').should('not.exist')
+        cy.findByTestId('toast-notification')
+          .should('be.visible')
+          .findByText('Payload formatter updated')
+          .should('be.visible')
+      })
+
+      it('succeeds changing formatter type to CayenneLPP', () => {
+        cy.visit(
+          `${Cypress.config(
+            'consoleRootPath',
+          )}/applications/${applicationId}/payload-formatters/downlink`,
+        )
+
+        cy.findByLabelText('CayenneLPP').check()
+        cy.findByLabelText('Formatter parameter').should('not.exist')
+
+        cy.findByRole('button', { name: 'Save changes' }).click()
+
+        cy.findByTestId('error-notification').should('not.exist')
+        cy.findByTestId('toast-notification')
+          .should('be.visible')
+          .findByText('Payload formatter updated')
+          .should('be.visible')
+      })
+
+      it('succeeds changing formatter type to Repository', () => {
+        cy.visit(
+          `${Cypress.config(
+            'consoleRootPath',
+          )}/applications/${applicationId}/payload-formatters/downlink`,
+        )
+
+        cy.findByLabelText('Repository').check()
+        cy.findByLabelText('Formatter parameter').should('not.exist')
+
+        cy.findByRole('button', { name: 'Save changes' }).click()
+
+        cy.findByTestId('error-notification').should('not.exist')
+        cy.findByTestId('toast-notification')
+          .should('be.visible')
+          .findByText('Payload formatter updated')
+          .should('be.visible')
+      })
+
+      it('succeeds changing formatter type to None', () => {
+        cy.visit(
+          `${Cypress.config(
+            'consoleRootPath',
+          )}/applications/${applicationId}/payload-formatters/downlink`,
+        )
+
+        cy.findByLabelText('None').check()
+        cy.findByLabelText('Formatter parameter').should('not.exist')
+
+        cy.findByRole('button', { name: 'Save changes' }).click()
+
+        cy.findByTestId('error-notification').should('not.exist')
+        cy.findByTestId('toast-notification')
+          .should('be.visible')
+          .findByText('Payload formatter updated')
+          .should('be.visible')
+      })
+    })
+  })
+
+  describe('End Devices', () => {
+    describe('Uplink', () => {
+      beforeEach(() => {
+        cy.loginConsole({ user_id: userId, password: user.password })
+      })
+
+      it('succeeds changing formatter type to Javascript', () => {
+        cy.visit(
+          `${Cypress.config(
+            'consoleRootPath',
+          )}/applications/${applicationId}/devices/${endDeviceId}/payload-formatters/uplink`,
+        )
+
+        cy.findByLabelText('Javascript').check()
+        cy.findByTestId('code-editor').should('be.visible')
+
+        cy.findByRole('button', { name: 'Save changes' }).click()
+
+        cy.findByTestId('error-notification').should('not.exist')
+        cy.findByTestId('toast-notification')
+          .should('be.visible')
+          .findByText('Payload formatter updated')
+          .should('be.visible')
+      })
+
+      it('succeeds changing formatter type to GRPC service', () => {
+        cy.visit(
+          `${Cypress.config(
+            'consoleRootPath',
+          )}/applications/${applicationId}/devices/${endDeviceId}/payload-formatters/uplink`,
+        )
+
+        cy.findByLabelText('GRPC service').check()
+        cy.findByLabelText('Formatter parameter').type('localhost')
+
+        cy.findByRole('button', { name: 'Save changes' }).click()
+
+        cy.findByTestId('error-notification').should('not.exist')
+        cy.findByTestId('toast-notification')
+          .should('be.visible')
+          .findByText('Payload formatter updated')
+          .should('be.visible')
+      })
+
+      it('succeeds changing formatter type to CayenneLPP', () => {
+        cy.visit(
+          `${Cypress.config(
+            'consoleRootPath',
+          )}/applications/${applicationId}/devices/${endDeviceId}/payload-formatters/uplink`,
+        )
+
+        cy.findByLabelText('CayenneLPP').check()
+        cy.findByLabelText('Formatter parameter').should('not.exist')
+
+        cy.findByRole('button', { name: 'Save changes' }).click()
+
+        cy.findByTestId('error-notification').should('not.exist')
+        cy.findByTestId('toast-notification')
+          .should('be.visible')
+          .findByText('Payload formatter updated')
+          .should('be.visible')
+      })
+
+      it('succeeds changing formatter type to Repository', () => {
+        cy.visit(
+          `${Cypress.config(
+            'consoleRootPath',
+          )}/applications/${applicationId}/devices/${endDeviceId}/payload-formatters/uplink`,
+        )
+
+        cy.findByLabelText('Repository').check()
+        cy.findByLabelText('Formatter parameter').should('not.exist')
+
+        cy.findByRole('button', { name: 'Save changes' }).click()
+
+        cy.findByTestId('error-notification').should('not.exist')
+        cy.findByTestId('toast-notification')
+          .should('be.visible')
+          .findByText('Payload formatter updated')
+          .should('be.visible')
+      })
+
+      it('succeeds changing formatter type to None', () => {
+        cy.visit(
+          `${Cypress.config(
+            'consoleRootPath',
+          )}/applications/${applicationId}/devices/${endDeviceId}/payload-formatters/uplink`,
+        )
+
+        cy.findByLabelText('None').check()
+        cy.findByLabelText('Formatter parameter').should('not.exist')
+
+        cy.findByRole('button', { name: 'Save changes' }).click()
+
+        cy.findByTestId('error-notification').should('not.exist')
+        cy.findByTestId('toast-notification')
+          .should('be.visible')
+          .findByText('Payload formatter updated')
+          .should('be.visible')
+      })
+
+      it('succeeds changing formatter type to Application payload formatter', () => {
+        cy.visit(
+          `${Cypress.config(
+            'consoleRootPath',
+          )}/applications/${applicationId}/devices/${endDeviceId}/payload-formatters/uplink`,
+        )
+
+        cy.findByLabelText('Use application payload formatter').check()
+
+        cy.findByRole('button', { name: 'Save changes' }).click()
+
+        cy.findByTestId('error-notification').should('not.exist')
+        cy.findByTestId('toast-notification')
+          .should('be.visible')
+          .findByText('Payload formatter updated')
+          .should('be.visible')
+      })
+    })
+
+    describe('Downlink', () => {
+      beforeEach(() => {
+        cy.loginConsole({ user_id: userId, password: user.password })
+      })
+
+      it('succeeds changing formatter type to Javascript', () => {
+        cy.visit(
+          `${Cypress.config(
+            'consoleRootPath',
+          )}/applications/${applicationId}/devices/${endDeviceId}/payload-formatters/downlink`,
+        )
+
+        cy.findByLabelText('Javascript').check()
+        cy.findByTestId('code-editor').should('be.visible')
+
+        cy.findByRole('button', { name: 'Save changes' }).click()
+
+        cy.findByTestId('error-notification').should('not.exist')
+        cy.findByTestId('toast-notification')
+          .should('be.visible')
+          .findByText('Payload formatter updated')
+          .should('be.visible')
+      })
+
+      it('succeeds changing formatter type to GRPC service', () => {
+        cy.visit(
+          `${Cypress.config(
+            'consoleRootPath',
+          )}/applications/${applicationId}/devices/${endDeviceId}/payload-formatters/downlink`,
+        )
+
+        cy.findByLabelText('GRPC service').check()
+        cy.findByLabelText('Formatter parameter').type('localhost')
+
+        cy.findByRole('button', { name: 'Save changes' }).click()
+
+        cy.findByTestId('error-notification').should('not.exist')
+        cy.findByTestId('toast-notification')
+          .should('be.visible')
+          .findByText('Payload formatter updated')
+          .should('be.visible')
+      })
+
+      it('succeeds changing formatter type to CayenneLPP', () => {
+        cy.visit(
+          `${Cypress.config(
+            'consoleRootPath',
+          )}/applications/${applicationId}/devices/${endDeviceId}/payload-formatters/downlink`,
+        )
+
+        cy.findByLabelText('CayenneLPP').check()
+        cy.findByLabelText('Formatter parameter').should('not.exist')
+
+        cy.findByRole('button', { name: 'Save changes' }).click()
+
+        cy.findByTestId('error-notification').should('not.exist')
+        cy.findByTestId('toast-notification')
+          .should('be.visible')
+          .findByText('Payload formatter updated')
+          .should('be.visible')
+      })
+
+      it('succeeds changing formatter type to Repository', () => {
+        cy.visit(
+          `${Cypress.config(
+            'consoleRootPath',
+          )}/applications/${applicationId}/devices/${endDeviceId}/payload-formatters/downlink`,
+        )
+
+        cy.findByLabelText('Repository').check()
+        cy.findByLabelText('Formatter parameter').should('not.exist')
+
+        cy.findByRole('button', { name: 'Save changes' }).click()
+
+        cy.findByTestId('error-notification').should('not.exist')
+        cy.findByTestId('toast-notification')
+          .should('be.visible')
+          .findByText('Payload formatter updated')
+          .should('be.visible')
+      })
+
+      it('succeeds changing formatter type to None', () => {
+        cy.visit(
+          `${Cypress.config(
+            'consoleRootPath',
+          )}/applications/${applicationId}/devices/${endDeviceId}/payload-formatters/downlink`,
+        )
+
+        cy.findByLabelText('None').check()
+        cy.findByLabelText('Formatter parameter').should('not.exist')
+
+        cy.findByRole('button', { name: 'Save changes' }).click()
+
+        cy.findByTestId('error-notification').should('not.exist')
+        cy.findByTestId('toast-notification')
+          .should('be.visible')
+          .findByText('Payload formatter updated')
+          .should('be.visible')
+      })
+
+      it('succeeds changing formatter type to Application payload formatter', () => {
+        cy.visit(
+          `${Cypress.config(
+            'consoleRootPath',
+          )}/applications/${applicationId}/devices/${endDeviceId}/payload-formatters/downlink`,
+        )
+
+        cy.findByLabelText('Use application payload formatter').check()
+
+        cy.findByRole('button', { name: 'Save changes' }).click()
+
+        cy.findByTestId('error-notification').should('not.exist')
+        cy.findByTestId('toast-notification')
+          .should('be.visible')
+          .findByText('Payload formatter updated')
+          .should('be.visible')
+      })
+    })
+  })
+})

--- a/pkg/webui/components/code-editor/index.js
+++ b/pkg/webui/components/code-editor/index.js
@@ -154,7 +154,7 @@ class CodeEditor extends React.Component {
     }
 
     return (
-      <div className={editorCls}>
+      <div className={editorCls} data-test-id="code-editor">
         <ReactAce
           // Rendered options.
           theme="ttn"

--- a/pkg/webui/console/containers/device-payload-formatters/downlink.js
+++ b/pkg/webui/console/containers/device-payload-formatters/downlink.js
@@ -39,7 +39,7 @@ import {
 } from '@console/store/selectors/devices'
 
 @connect(
-  function(state) {
+  state => {
     const formatters = selectSelectedDeviceFormatters(state)
 
     return {
@@ -50,7 +50,7 @@ import {
   },
   { updateDevice: attachPromise(updateDevice) },
 )
-@withBreadcrumb('device.single.payload-formatters.downlink', function(props) {
+@withBreadcrumb('device.single.payload-formatters.downlink', props => {
   const { appId, devId } = props
 
   return (
@@ -84,7 +84,7 @@ class DevicePayloadFormatters extends React.PureComponent {
 
     const formatters = { ...(initialFormatters || {}) }
 
-    await updateDevice(appId, devId, {
+    return updateDevice(appId, devId, {
       formatters: {
         down_formatter: values.type,
         down_formatter_parameter: values.parameter,
@@ -92,7 +92,11 @@ class DevicePayloadFormatters extends React.PureComponent {
         up_formatter_parameter: formatters.up_formatter_parameter,
       },
     })
+  }
 
+  @bind
+  async onSubmitSuccess() {
+    const { devId } = this.props
     toast({
       title: devId,
       message: sharedMessages.payloadFormattersUpdateSuccess,

--- a/pkg/webui/console/containers/device-payload-formatters/uplink.js
+++ b/pkg/webui/console/containers/device-payload-formatters/uplink.js
@@ -39,7 +39,7 @@ import {
 } from '@console/store/selectors/devices'
 
 @connect(
-  function(state) {
+  state => {
     const formatters = selectSelectedDeviceFormatters(state)
 
     return {
@@ -50,7 +50,7 @@ import {
   },
   { updateDevice: attachPromise(updateDevice) },
 )
-@withBreadcrumb('device.single.payload-formatters.uplink', function(props) {
+@withBreadcrumb('device.single.payload-formatters.uplink', props => {
   const { appId, devId } = props
 
   return (


### PR DESCRIPTION
#### Summary

References #3606 

#### Changes

- Added application payload formatters e2e tests
- Added end device payload formatters e2e tests
- Added `toast` notification for end device downlink (use application payload formatter option) save success
- Renamed several tests according to testing guidelines

#### Checklist

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.