### PR TITLE
Decouple context lifetime before gateway IDs unclaim

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -238,7 +238,10 @@ func (c *Component) AddContextFiller(f fillcontext.Filler) {
 // FromRequestContext returns a derived context from the component context with key values from the request context.
 // This can be used to decouple the lifetime from the request context while keeping security information.
 func (c *Component) FromRequestContext(ctx context.Context) context.Context {
-	return c.ctx
+	return &crossContext{
+		valueCtx:  ctx,
+		cancelCtx: c.ctx,
+	}
 }
 
 // Start starts the component.

--- a/pkg/component/context.go
+++ b/pkg/component/context.go
@@ -1,0 +1,45 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package component
+
+import (
+	"context"
+	"time"
+)
+
+type crossContext struct {
+	cancelCtx context.Context
+	valueCtx  context.Context
+}
+
+// Deadline implements context.Context using the cancel context.
+func (ctx *crossContext) Deadline() (deadline time.Time, ok bool) {
+	return ctx.cancelCtx.Deadline()
+}
+
+// Done implements context.Context using the cancel context.
+func (ctx *crossContext) Done() <-chan struct{} {
+	return ctx.cancelCtx.Done()
+}
+
+// Err implements context.Context using the cancel context.
+func (ctx *crossContext) Err() error {
+	return ctx.cancelCtx.Err()
+}
+
+// Value implements context.Context using the value context.
+func (ctx *crossContext) Value(key interface{}) interface{} {
+	return ctx.valueCtx.Value(key)
+}

--- a/pkg/component/context_test.go
+++ b/pkg/component/context_test.go
@@ -1,0 +1,57 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package component_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/v3/pkg/component"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+)
+
+func TestContextDecoupling(t *testing.T) {
+	a := assertions.New(t)
+
+	c, err := component.New(test.GetLogger(t), &component.Config{})
+	a.So(err, should.BeNil)
+
+	dl := time.Now().Add(1 * time.Second)
+
+	ctx := test.Context()
+	ctx = context.WithValue(ctx, "key", "value")
+	ctx, cancel := context.WithDeadline(ctx, dl)
+	defer cancel()
+
+	ctx = c.FromRequestContext(ctx)
+	deadline, set := ctx.Deadline()
+	a.So(deadline, should.NotEqual, dl)
+	a.So(set, should.BeFalse)
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("Context expired")
+	case <-time.After(time.Second):
+		a.So(ctx.Err(), should.BeNil)
+	}
+
+	val := ctx.Value("key")
+	strVal, ok := val.(string)
+	a.So(ok, should.BeTrue)
+	a.So(strVal, should.Equal, "value")
+}

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -62,6 +62,8 @@ type Server interface {
 	ClaimDownlink(ctx context.Context, ids ttnpb.GatewayIdentifiers) error
 	// UnclaimDownlink releases the claim of the downlink path for the given gateway.
 	UnclaimDownlink(ctx context.Context, ids ttnpb.GatewayIdentifiers) error
+	// FromRequestContext decouples the lifetime of the provided context from the values found in the context.
+	FromRequestContext(ctx context.Context) context.Context
 }
 
 // Connection is a connection to a gateway managed by a frontend.

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -334,6 +334,7 @@ func (s *srv) handleDown(ctx context.Context, state *state) error {
 	}
 	logger.Info("Downlink path claimed")
 	defer func() {
+		ctx := s.server.FromRequestContext(ctx)
 		if err := s.server.UnclaimDownlink(ctx, state.io.Gateway().GatewayIdentifiers); err != nil {
 			logger.WithError(err).Error("Failed to unclaim downlink path")
 			return

--- a/pkg/gatewayserver/io/ws/lbslns/discover_util_test.go
+++ b/pkg/gatewayserver/io/ws/lbslns/discover_util_test.go
@@ -62,3 +62,7 @@ func (srv mockServer) ClaimDownlink(ctx context.Context, ids ttnpb.GatewayIdenti
 func (srv mockServer) UnclaimDownlink(ctx context.Context, ids ttnpb.GatewayIdentifiers) error {
 	return nil
 }
+
+func (srv mockServer) FromRequestContext(ctx context.Context) context.Context {
+	return ctx
+}

--- a/pkg/gatewayserver/upstream/ns/ns.go
+++ b/pkg/gatewayserver/upstream/ns/ns.go
@@ -32,6 +32,7 @@ type Cluster interface {
 	WithClusterAuth() grpc.CallOption
 	ClaimIDs(ctx context.Context, ids ttnpb.Identifiers) error
 	UnclaimIDs(ctx context.Context, ids ttnpb.Identifiers) error
+	FromRequestContext(ctx context.Context) context.Context
 }
 
 // Handler is the upstream handler.
@@ -73,6 +74,7 @@ func (h *Handler) ConnectGateway(ctx context.Context, ids ttnpb.GatewayIdentifie
 	}
 	logger.Info("Downlink path claimed")
 	defer func() {
+		ctx := h.cluster.FromRequestContext(ctx)
 		if err := h.cluster.UnclaimIDs(ctx, ids); err != nil {
 			logger.WithError(err).Error("Failed to unclaim downlink path")
 			return


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #3840

#### Changes
<!-- What are the changes made in this pull request? -->

- On `Component.FromRequestContext`, keep the context values in the new context, but use the lifetime of the component.
- Use `FromRequestContext` before `UnclaimIDs` and `UnclaimDownlink`.

#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Not expected.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This implementation for `FromRequestContext` should land in TTSE as well.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
