### PR TITLE
Do not call (*T).Fatal from non-test goroutine in Gateway Server

### DIFF
--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -784,12 +784,10 @@ func TestGatewayServer(t *testing.T) {
 
 							wg := &sync.WaitGroup{}
 							wg.Add(1)
+							var linkErr error
 							go func() {
 								defer wg.Done()
-								err := ptc.Link(ctx, t, ids, registeredGatewayKey, upCh, downCh)
-								if !errors.IsCanceled(err) {
-									t.Fatalf("Expected context canceled, but have %v", err)
-								}
+								linkErr = ptc.Link(ctx, t, ids, registeredGatewayKey, upCh, downCh)
 							}()
 
 							select {
@@ -807,6 +805,9 @@ func TestGatewayServer(t *testing.T) {
 
 							cancel()
 							wg.Wait()
+							if !errors.IsCanceled(linkErr) {
+								t.Fatalf("Expected context canceled, but have %v", linkErr)
+							}
 						})
 					}
 				})
@@ -873,12 +874,10 @@ func TestGatewayServer(t *testing.T) {
 
 						wg := &sync.WaitGroup{}
 						wg.Add(1)
+						var linkErr error
 						go func() {
 							defer wg.Done()
-							err := ptc.Link(ctx, t, ids, registeredGatewayKey, upCh, downCh)
-							if !errors.IsCanceled(err) {
-								t.Fatalf("Expected context canceled, but have %v", err)
-							}
+							linkErr = ptc.Link(ctx, t, ids, registeredGatewayKey, upCh, downCh)
 						}()
 
 						for _, locationInRxMetadata := range []bool{false, true} {
@@ -920,6 +919,9 @@ func TestGatewayServer(t *testing.T) {
 
 						cancel()
 						wg.Wait()
+						if !errors.IsCanceled(linkErr) {
+							t.Fatalf("Expected context canceled, but have %v", linkErr)
+						}
 					})
 				}
 			})
@@ -929,12 +931,10 @@ func TestGatewayServer(t *testing.T) {
 
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
+			var linkErr error
 			go func() {
 				defer wg.Done()
-				err := ptc.Link(ctx, t, ids, registeredGatewayKey, upCh, downCh)
-				if !errors.IsCanceled(err) {
-					t.Fatalf("Expected context canceled, but have %v", err)
-				}
+				linkErr = ptc.Link(ctx, t, ids, registeredGatewayKey, upCh, downCh)
 			}()
 
 			// Expected location for RxMetadata
@@ -1529,6 +1529,9 @@ func TestGatewayServer(t *testing.T) {
 
 			cancel()
 			wg.Wait()
+			if !errors.IsCanceled(linkErr) {
+				t.Fatalf("Expected context canceled, but have %v", linkErr)
+			}
 
 			// Wait for disconnection to be processed.
 			time.Sleep(timeout)

--- a/pkg/gatewayserver/io/grpc/grpc_test.go
+++ b/pkg/gatewayserver/io/grpc/grpc_test.go
@@ -125,18 +125,20 @@ func TestAuthentication(t *testing.T) {
 
 			wg := sync.WaitGroup{}
 			wg.Add(1)
+			var err error
 			go func() {
 				defer wg.Done()
-				_, err := client.LinkGateway(ctx, creds)
-				if tc.OK && err != nil && !a.So(errors.IsCanceled(err), should.BeTrue) {
-					t.Fatalf("Unexpected link error: %v", err)
-				}
-				if !tc.OK && !a.So(errors.IsCanceled(err), should.BeFalse) {
-					t.FailNow()
-				}
+				_, err = client.LinkGateway(ctx, creds)
 			}()
 
 			wg.Wait()
+
+			if tc.OK && err != nil && !a.So(errors.IsCanceled(err), should.BeTrue) {
+				t.Fatalf("Unexpected link error: %v", err)
+			}
+			if !tc.OK && !a.So(errors.IsCanceled(err), should.BeFalse) {
+				t.FailNow()
+			}
 		})
 	}
 }
@@ -195,7 +197,7 @@ func TestTraffic(t *testing.T) {
 	go func() {
 		for up := range upCh {
 			if err := stream.Send(up); err != nil {
-				t.Fatalf("Send failed: %v", err)
+				panic(err)
 			}
 		}
 	}()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #3808 

#### Changes
<!-- What are the changes made in this pull request? -->

- Do not call `(*T).Fatal` and `(*T).FailNow()` from non-test goroutines.

#### Testing

<!-- How did you verify that this change works? -->

- Unit tests succeed

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
