### PR TITLE
Fix Application Server panic on TLV overflow

### DIFF
--- a/pkg/applicationserver/io/io.go
+++ b/pkg/applicationserver/io/io.go
@@ -17,6 +17,7 @@ package io
 import (
 	"context"
 
+	"go.thethings.network/lorawan-stack/v3/pkg/component"
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/errorcontext"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
@@ -27,6 +28,7 @@ const bufferSize = 32
 
 // Server represents the Application Server to application frontends.
 type Server interface {
+	component.TaskStarter
 	// GetBaseConfig returns the component configuration.
 	GetBaseConfig(ctx context.Context) config.ServiceBase
 	// FillContext fills the given context.

--- a/pkg/applicationserver/io/packages/loradms/v1/package.go
+++ b/pkg/applicationserver/io/packages/loradms/v1/package.go
@@ -236,7 +236,7 @@ func (p *DeviceManagementPackage) parseStreamRecords(ctx context.Context, record
 	if records == nil || !data.GetUseTLVEncoding() {
 		return nil
 	}
-	f := func(tag uint8, length uint8, bytes []byte) error {
+	f := func(tag uint8, length int, bytes []byte) error {
 		loraUp := &objects.LoRaUplink{
 			Timestamp: originalTimestamp,
 		}

--- a/pkg/applicationserver/io/packages/loradms/v1/tlv_encoding.go
+++ b/pkg/applicationserver/io/packages/loradms/v1/tlv_encoding.go
@@ -21,13 +21,14 @@ import (
 
 var errTLVRecordTooSmall = errors.DefineInvalidArgument("tlv_record_too_small", "TLV record payload is too small")
 
-func parseTLVPayload(record objects.Hex, f func(uint8, uint8, []byte) error) error {
+func parseTLVPayload(record objects.Hex, f func(uint8, int, []byte) error) error {
 	for len(record) >= 2 {
 		tag := record[0]
-		length := record[1]
-		if int(length+2) > len(record) {
+		length := int(record[1])
+		if length+2 > len(record) {
 			return errTLVRecordTooSmall.New()
 		}
+
 		bytes := []byte(record[2 : 2+length])
 		record = record[length+2:]
 

--- a/pkg/applicationserver/io/packages/loradms/v1/tlv_encoding_test.go
+++ b/pkg/applicationserver/io/packages/loradms/v1/tlv_encoding_test.go
@@ -26,19 +26,24 @@ import (
 func TestTLVEncoding(t *testing.T) {
 	a := assertions.New(t)
 
-	a.So(parseTLVPayload(objects.Hex{0xbb, 0xaa}, func(tag uint8, size uint8, data []byte) error {
+	a.So(parseTLVPayload(objects.Hex{0xbb, 0xaa}, func(tag uint8, size int, data []byte) error {
 		return fmt.Errorf("foo")
 	}), should.NotBeNil)
 
-	a.So(parseTLVPayload(objects.Hex{0x01, 0x02, 0xbb, 0xaa}, func(tag uint8, size uint8, data []byte) error {
+	a.So(parseTLVPayload(objects.Hex{0x01, 0x02, 0xbb, 0xaa}, func(tag uint8, size int, data []byte) error {
 		a.So(tag, should.Equal, 0x01)
 		a.So(size, should.Equal, 0x02)
 		a.So(data, should.Resemble, []byte{0xbb, 0xaa})
 		return nil
 	}), should.BeNil)
 
-	a.So(parseTLVPayload(objects.Hex{0xff, 0x02, 0xff}, func(tag uint8, size uint8, data []byte) error {
-		t.Fatal("f shouldn't be called")
+	a.So(parseTLVPayload(objects.Hex{0xff, 0x02, 0xff}, func(tag uint8, size int, data []byte) error {
+		t.Fatal("f should not be called")
+		return nil
+	}), should.NotBeNil)
+
+	a.So(parseTLVPayload(objects.Hex{0xff, 0xff, 0xff}, func(tag uint8, size int, data []byte) error {
+		t.Fatal("f should not be called")
 		return nil
 	}), should.NotBeNil)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes the following `panic`:

```
panic: runtime error: slice bounds out of range [2:1]
goroutine 80 [running]:
go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io/packages/loradms/v1.parseTLVPayload(0xc00b7a7d20, 0x3, 0x8, 0xc004e852a0, 0xc00984ae40, 0xc00be4d700)
	/home/runner/work/lorawan-stack/lorawan-stack/pkg/applicationserver/io/packages/loradms/v1/tlv_encoding.go:31 +0x23f
go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io/packages/loradms/v1.(*DeviceManagementPackage).parseStreamRecords(0xc000c1f5c0, 0x33bab60, 0xc00984ae40, 0xc00be4d680, 0x1, 0x4, 0xc00b699480, 0xc0083933e0, 0xc00099d600, 0xc002831fc0, ...)
	/home/runner/work/lorawan-stack/lorawan-stack/pkg/applicationserver/io/packages/loradms/v1/package.go:258 +0x135
go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io/packages/loradms/v1.(*DeviceManagementPackage).sendUplink(0xc000c1f5c0, 0x33bab60, 0xc00984ae40, 0xc00b699480, 0xc00926f200, 0xc0083933e0, 0x0, 0xc00984ae10)
	/home/runner/work/lorawan-stack/lorawan-stack/pkg/applicationserver/io/packages/loradms/v1/package.go:164 +0x7a8
go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io/packages/loradms/v1.(*DeviceManagementPackage).HandleUp(0xc000c1f5c0, 0x33bab60, 0xc00984ae10, 0xc0076f1260, 0x0, 0xc00b699480, 0x0, 0x0)
	/home/runner/work/lorawan-stack/lorawan-stack/pkg/applicationserver/io/packages/loradms/v1/package.go:113 +0x5a5
go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io/packages.(*server).handleUp(0xc000c20840, 0x33bab60, 0xc0078edc50, 0xc00b699480, 0x1, 0x0)
	/home/runner/work/lorawan-stack/lorawan-stack/pkg/applicationserver/io/packages/packages.go:121 +0x351
go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io/packages.New.func1(0x33bab60, 0xc000cb33e0, 0xc000c20c00, 0xc000c20840)
	/home/runner/work/lorawan-stack/lorawan-stack/pkg/applicationserver/io/packages/packages.go:64 +0x185
created by go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io/packages.New
	/home/runner/work/lorawan-stack/lorawan-stack/pkg/applicationserver/io/packages/packages.go:56 +0x1b3
```

#### Changes
<!-- What are the changes made in this pull request? -->

- Consider the length of the TLV payload as `int`. Otherwise we are doing math with `byte`s which can overflow on addition (255 + 2 = 1 in `byte`).
- Allow AS frontends to start tasks.
- Run the application packages and webhooks traffic handlers inside a task.

#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This changes the TLV decoding algorithm in order to ensure that calculations are correct. Unit tests cover the changes.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

At some point we may consider using `io.Server.StartTask` instead of `go` in the MQTT and Webhooks frontends. I'd say we should do the same in the Gateway Server, instead of `recover`ing in different places.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
