### PR TITLE
Add JoinEUI and DevEUI in simulated uplinks

### DIFF
--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -135,7 +135,7 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 		AS:       as,
 		kekLabel: conf.DeviceKEKLabel,
 	}
-	as.grpc.appAs = iogrpc.New(as, iogrpc.WithMQTTConfigProvider(as))
+	as.grpc.appAs = iogrpc.New(as, iogrpc.WithMQTTConfigProvider(as), iogrpc.WithEndDeviceFetcher(as.endDeviceFetcher))
 
 	ctx, cancel := context.WithCancel(as.Context())
 	defer func() {

--- a/pkg/applicationserver/io/grpc/grpc.go
+++ b/pkg/applicationserver/io/grpc/grpc.go
@@ -42,9 +42,9 @@ type EndDeviceFetcher interface {
 	Get(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, fieldMaskPaths ...string) (*ttnpb.EndDevice, error)
 }
 
-type noopFetcher struct{}
+type defaultFetcher struct{}
 
-func (f *noopFetcher) Get(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, fieldMaskPaths ...string) (*ttnpb.EndDevice, error) {
+func (f *defaultFetcher) Get(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, fieldMaskPaths ...string) (*ttnpb.EndDevice, error) {
 	return &ttnpb.EndDevice{EndDeviceIdentifiers: ids}, nil
 }
 
@@ -70,7 +70,7 @@ func WithEndDeviceFetcher(f EndDeviceFetcher) Option {
 
 // New returns a new gRPC frontend.
 func New(server io.Server, opts ...Option) ttnpb.AppAsServer {
-	i := &impl{server: server, fetcher: &noopFetcher{}}
+	i := &impl{server: server, fetcher: &defaultFetcher{}}
 	for _, opt := range opts {
 		opt.apply(i)
 	}

--- a/pkg/applicationserver/io/grpc/grpc_util_test.go
+++ b/pkg/applicationserver/io/grpc/grpc_util_test.go
@@ -123,8 +123,23 @@ func (is *mockIS) ListRights(ctx context.Context, ids *ttnpb.ApplicationIdentifi
 				ttnpb.RIGHT_APPLICATION_DEVICES_WRITE,
 				ttnpb.RIGHT_APPLICATION_TRAFFIC_READ,
 				ttnpb.RIGHT_APPLICATION_TRAFFIC_DOWN_WRITE,
+				ttnpb.RIGHT_APPLICATION_TRAFFIC_UP_WRITE,
 			)
 		}
 	}
 	return
+}
+
+type mockFetcher struct {
+	calledWithPaths      []string
+	calledWithIdentifers ttnpb.EndDeviceIdentifiers
+
+	dev *ttnpb.EndDevice
+	err error
+}
+
+func (f *mockFetcher) Get(_ context.Context, ids ttnpb.EndDeviceIdentifiers, fieldMaskPaths ...string) (*ttnpb.EndDevice, error) {
+	f.calledWithPaths = fieldMaskPaths
+	f.calledWithIdentifers = ids
+	return f.dev, f.err
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #3818 

#### Changes
<!-- What are the changes made in this pull request? -->

- Add a `WithEndDeviceFetcher` option to the gRPC frontend.
- Configure during AS initialization.
- Fix a panic when SimulateUplink is called with a nil message.

#### Testing

<!-- How did you verify that this change works? -->

- Unit tests
- Test locally, with simulated uplinks from CLI and console:

```
$ cli events --application-id $APP | jq '{name: .name, ids: .data.end_device_ids}' -c
{"name":"as.up.data.receive","ids":null}
{"name":"as.up.data.forward","ids":{"device_id":"dev1","application_ids":{"application_id":"app1"},"dev_eui":"0101010101010101","join_eui":"0101010101010101"}}
```

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
