### PR TITLE
Fix absolute time schedule conflict handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ For details about compatibility between different releases, see the **Commitment
 - Conflict error when registering an end device via the wizard in the Console.
 - Pagination in the `List` and `ListTokens` RPCs of the `OAuthAuthorizationRegistry`.
 - Event name on user login.
+- Retrying downlink messages with absolute time on other gateways when one downlink path reports a scheduling conflict.
 
 ### Security
 

--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -1401,7 +1401,7 @@ func TestGatewayServer(t *testing.T) {
 						},
 						ErrorAssertion: errors.IsAborted,
 						RxWindowDetailsAssertion: []func(error) bool{
-							errors.IsResourceExhausted,  // Rx1 conflicts with previous.
+							errors.IsAlreadyExists,      // Rx1 conflicts with previous.
 							errors.IsFailedPrecondition, // Rx2 not provided.
 						},
 					},

--- a/pkg/gatewayserver/io/io_test.go
+++ b/pkg/gatewayserver/io/io_test.go
@@ -209,7 +209,7 @@ func TestFlow(t *testing.T) {
 			},
 			ErrorAssertion: errors.IsAborted,
 			RxErrorAssertion: []func(error) bool{
-				errors.IsResourceExhausted,  // Rx1 conflicts with previous.
+				errors.IsAlreadyExists,      // Rx1 conflicts with previous.
 				errors.IsFailedPrecondition, // Rx2 not provided.
 			},
 		},

--- a/pkg/gatewayserver/scheduling/scheduler.go
+++ b/pkg/gatewayserver/scheduling/scheduler.go
@@ -262,7 +262,7 @@ func (s *Scheduler) syncWithUplinkToken(token *ttnpb.UplinkToken) bool {
 }
 
 var (
-	errConflict              = errors.DefineResourceExhausted("conflict", "scheduling conflict")
+	errConflict              = errors.DefineAlreadyExists("conflict", "scheduling conflict")
 	errTooLate               = errors.DefineFailedPrecondition("too_late", "too late to transmission scheduled time (delta is `{delta}`)")
 	errNoClockSync           = errors.DefineUnavailable("no_clock_sync", "no clock sync")
 	errNoAbsoluteGatewayTime = errors.DefineAborted("no_absolute_gateway_time", "no absolute gateway time")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fixes https://github.com/TheThingsIndustries/lorawan-stack-support/issues/225

#### Changes
<!-- What are the changes made in this pull request? -->

Changes the error code that Gateway Server returns on a downlink path from `ResourceExhausted` to `AlreadyExists`.

Network Server sees `ResourceExhausted` as non-retryable error for scheduling downlink messages with an absolute time. This means that currently, if any downlink path has a conflict with an already scheduled downlink message, the Network Server will not try other gateways. This pull request changes that behavior: `AlreadyExists` is retryable and will result in other downlink paths being tried.

#### Testing

<!-- How did you verify that this change works? -->

Unit testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Should be none.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
