### PR TITLE
Fix GCS Panic on UDP gateway conf generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ For details about compatibility between different releases, see the **Commitment
 - Event name on user login.
 - Application uplink queue handling in Network Server.
 - Application Server session desynchronization with the Network Server. The Application Server will now attempt to synchronize the end device session view on downlink queue operational errors. This fixes the `f_cnt_too_low` and `unknown_session` errors reported on downlink queue push and replace.
+- Panic while generating SX1301 config for frequency plans without radio configuration.
 
 ### Security
 

--- a/pkg/pfconfig/cpf/cpf.go
+++ b/pkg/pfconfig/cpf/cpf.go
@@ -85,9 +85,12 @@ func BuildLorad(gtw *ttnpb.Gateway, fps *frequencyplans.Store) (*LoradConfig, er
 	if err != nil {
 		return nil, err
 	}
-	sx1301Conf, err := shared.BuildSX1301Config(fp)
-	if err != nil {
-		return nil, err
+	sx1301Conf := &shared.SX1301Config{}
+	if len(fp.Radios) != 0 {
+		sx1301Conf, err = shared.BuildSX1301Config(fp)
+		if err != nil {
+			return nil, err
+		}
 	}
 	var gatewayConf LoradGatewayConf
 	if len(gtw.Antennas) > 0 {

--- a/pkg/pfconfig/lbslns/lbslns.go
+++ b/pkg/pfconfig/lbslns/lbslns.go
@@ -112,6 +112,9 @@ func GetRouterConfig(bandID string, fps map[string]*frequencyplans.FrequencyPlan
 	conf.NoDwellTime = !isProd
 
 	for _, fp := range fps {
+		if len(fp.Radios) == 0 {
+			continue
+		}
 		sx1301Conf, err := shared.BuildSX1301Config(fp)
 		// These fields are not defined in the v1.5 ref design https://doc.sm.tc/station/gw_v1.5.html#rfconf-object and would cause a parsing error.
 		sx1301Conf.Radios[0].TxFreqMin = 0

--- a/pkg/pfconfig/semtechudp/semtechudp.go
+++ b/pkg/pfconfig/semtechudp/semtechudp.go
@@ -58,12 +58,13 @@ func Build(gateway *ttnpb.Gateway, store *frequencyplans.Store) (*Config, error)
 	if err != nil {
 		return nil, err
 	}
-	sx1301Config, err := shared.BuildSX1301Config(frequencyPlan)
-	if err != nil {
-		return nil, err
+	if len(frequencyPlan.Radios) != 0 {
+		sx1301Config, err := shared.BuildSX1301Config(frequencyPlan)
+		if err != nil {
+			return nil, err
+		}
+		c.SX1301Conf = *sx1301Config
 	}
-
-	c.SX1301Conf = *sx1301Config
 
 	return &c, nil
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fix Panic while generating SX1301 config for frequency plans without radio configuration.

Closes https://github.com/TheThingsIndustries/lorawan-stack/issues/2602

#### Changes
<!-- What are the changes made in this pull request? -->

- If there are no radios configured the frequency plan (ex: ISM2400), use an empty SX1301 block.

#### Testing

<!-- How did you verify that this change works? -->

- Run stack locally
- Create gateway with 
- Query `global_conf.json`

```json
{
  "SX1301_conf": {
    "lorawan_public": false,
    "clksrc": 0,
    "antenna_gain": 0
  },
  "gateway_conf": {
    "gateway_ID": "50A0CBFFFE800000",
    "server_address": "localhost",
    "serv_port_up": 1700,
    "serv_port_down": 1700,
    "servers": [
      {
        "gateway_ID": "50A0CBFFFE800000",
        "server_address": "localhost",
        "serv_port_up": 1700,
        "serv_port_down": 1700,
        "serv_enabled": true
      }
    ]
  }
}
```

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

NA


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
