### PR TITLE
Add CI workflow to triage new issues

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,21 @@
+name: Triage New Issues
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage:
+    name: Triage New Issues
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add "new" label
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['new']
+            })


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This adds a CI workflow for triaging new issues.