### PR TITLE
Update end device messaging downlink functionality

### DIFF
--- a/cypress/integration/console/devices/messaging/edit.spec.js
+++ b/cypress/integration/console/devices/messaging/edit.spec.js
@@ -1,0 +1,121 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+describe('End device messaging', () => {
+  const userId = 'main-overview-test-user'
+  const user = {
+    ids: { user_id: userId },
+    primary_email_address: 'view-overview-test-user@example.com',
+    password: 'ABCDefg123!',
+    password_confirm: 'ABCDefg123!',
+  }
+
+  const applicationId = 'app-end-devices-overview-test'
+  const application = {
+    ids: { application_id: applicationId },
+    name: 'Application End Devices Test Name',
+    description: `Application End Devices Test Description`,
+  }
+
+  const endDeviceId = 'end-device-overview-test'
+  const endDevice = {
+    application_server_address: 'localhost',
+    ids: {
+      device_id: endDeviceId,
+      dev_eui: '0000000000000001',
+      join_eui: '0000000000000000',
+    },
+    name: 'End Device Test Name',
+    description: 'End Device Test Description',
+    join_server_address: 'localhost',
+    network_server_address: 'localhost',
+  }
+  const endDeviceFieldMask = {
+    paths: [
+      'join_server_address',
+      'network_server_address',
+      'application_server_address',
+      'ids.dev_eui',
+      'ids.join_eui',
+      'name',
+      'description',
+    ],
+  }
+  const endDeviceRequestBody = {
+    end_device: endDevice,
+    field_mask: endDeviceFieldMask,
+  }
+
+  before(() => {
+    cy.dropAndSeedDatabase()
+    cy.createUser(user)
+    cy.loginConsole({ user_id: userId, password: user.password })
+    cy.createApplication(application, userId)
+    cy.createEndDevice(applicationId, endDeviceRequestBody)
+  })
+
+  describe('Uplink', () => {
+    beforeEach(() => {
+      cy.loginConsole({ user_id: user.ids.user_id, password: user.password })
+    })
+
+    it('succeeds sending uplink message', () => {
+      cy.visit(
+        `${Cypress.config(
+          'consoleRootPath',
+        )}/applications/${applicationId}/devices/${endDeviceId}/messaging/uplink`,
+      )
+
+      cy.findByLabelText('FPort').type('1')
+      cy.findByLabelText('Payload').type('0000')
+
+      cy.findByRole('button', { name: 'Simulate uplink' }).click()
+
+      cy.findByTestId('toast-notification')
+        .should('be.visible')
+        .and('contain', 'Uplink sent')
+
+      cy.findByTestId('error-notification').should('not.exist')
+    })
+  })
+
+  describe('Downlink', () => {
+    beforeEach(() => {
+      cy.loginConsole({ user_id: user.ids.user_id, password: user.password })
+    })
+
+    it('fails sending downlink message without valid session', () => {
+      cy.visit(
+        `${Cypress.config(
+          'consoleRootPath',
+        )}/applications/${applicationId}/devices/${endDeviceId}/messaging/downlink`,
+      )
+
+      cy.findByTestId('notification')
+        .should('be.visible')
+        .findByText(
+          `Downlinks can only be scheduled for end devices with a valid session. Please make sure your end device is properly connected to the network.`,
+        )
+        .should('be.visible')
+
+      cy.findByLabelText('Replace downlink queue').should('be.disabled')
+      cy.findByLabelText('Push to downlink queue (append)').should('be.disabled')
+      cy.findByLabelText('FPort').should('be.disabled')
+      cy.findByLabelText('Payload').should('be.disabled')
+      cy.findByLabelText('Confirmed downlink').should('be.disabled')
+
+      cy.findByRole('button', { name: 'Schedule downlink' }).should('be.disabled')
+    })
+  })
+})

--- a/pkg/webui/console/components/downlink-form/connect.js
+++ b/pkg/webui/console/components/downlink-form/connect.js
@@ -17,15 +17,17 @@ import { connect } from 'react-redux'
 import api from '@console/api'
 
 import { selectSelectedApplicationId } from '@console/store/selectors/applications'
-import { selectSelectedDeviceId } from '@console/store/selectors/devices'
+import { selectSelectedDeviceId, selectSelectedDevice } from '@console/store/selectors/devices'
 
 const mapStateToProps = state => {
   const appId = selectSelectedApplicationId(state)
   const devId = selectSelectedDeviceId(state)
+  const device = selectSelectedDevice(state)
 
   return {
     appId,
     devId,
+    device,
     downlinkQueue: api.downlinkQueue,
   }
 }

--- a/pkg/webui/console/components/downlink-form/downlink-form.js
+++ b/pkg/webui/console/components/downlink-form/downlink-form.js
@@ -15,6 +15,7 @@
 import React, { useState, useCallback } from 'react'
 import { defineMessages } from 'react-intl'
 
+import Notification from '@ttn-lw/components/notification'
 import SubmitButton from '@ttn-lw/components/submit-button'
 import RadioButton from '@ttn-lw/components/radio-button'
 import Checkbox from '@ttn-lw/components/checkbox'
@@ -39,6 +40,8 @@ const m = defineMessages({
   scheduleDownlink: 'Schedule downlink',
   downlinkSuccess: 'Downlink scheduled',
   payloadDescription: 'The desired payload bytes of the downlink message',
+  invalidSessionWarning:
+    'Downlinks can only be scheduled for end devices with a valid session. Please make sure your end device is properly connected to the network.',
 })
 
 const validationSchema = Yup.object({
@@ -57,7 +60,7 @@ const validationSchema = Yup.object({
   ),
 })
 
-const DownlinkForm = ({ appId, devId, downlinkQueue }) => {
+const DownlinkForm = ({ appId, devId, device, downlinkQueue }) => {
   const [error, setError] = useState('')
   const handleSubmit = useCallback(
     async (vals, { setSubmitting, resetForm }) => {
@@ -86,14 +89,18 @@ const DownlinkForm = ({ appId, devId, downlinkQueue }) => {
     frm_payload: '',
   }
 
+  const validSession = device.session || device.pending_session
+
   return (
     <>
+      {!validSession && <Notification content={m.invalidSessionWarning} warning small />}
       <IntlHelmet title={m.scheduleDownlink} />
       <Form
         error={error}
         onSubmit={handleSubmit}
         initialValues={initialValues}
         validationSchema={validationSchema}
+        disabled={!validSession}
       >
         <Form.SubTitle title={m.scheduleDownlink} />
         <Form.Field name="_mode" title={m.insertMode} component={RadioButton.Group}>
@@ -129,6 +136,7 @@ const DownlinkForm = ({ appId, devId, downlinkQueue }) => {
 DownlinkForm.propTypes = {
   appId: PropTypes.string.isRequired,
   devId: PropTypes.string.isRequired,
+  device: PropTypes.device.isRequired,
   downlinkQueue: PropTypes.shape({
     list: PropTypes.func.isRequired,
     push: PropTypes.func.isRequired,

--- a/pkg/webui/console/store/selectors/devices.js
+++ b/pkg/webui/console/store/selectors/devices.js
@@ -51,19 +51,19 @@ export const selectDeviceFetching = createFetchingSelector(GET_DEV_BASE)
 export const selectDeviceError = createErrorSelector(GET_DEV_BASE)
 
 // Derived.
-export const selectDeviceUplinkFrameCount = function(state, appId, devId) {
+export const selectDeviceUplinkFrameCount = (state, appId, devId) => {
   const derived = selectDeviceDerivedById(state, combineDeviceIds(appId, devId))
   if (!Boolean(derived)) return undefined
 
   return derived.uplinkFrameCount
 }
-export const selectDeviceDownlinkFrameCount = function(state, appId, devId) {
+export const selectDeviceDownlinkFrameCount = (state, appId, devId) => {
   const derived = selectDeviceDerivedById(state, combineDeviceIds(appId, devId))
   if (!Boolean(derived)) return undefined
 
   return derived.downlinkFrameCount
 }
-export const selectDeviceLastSeen = function(state, appId, devId) {
+export const selectDeviceLastSeen = (state, appId, devId) => {
   const derived = selectDeviceDerivedById(state, combineDeviceIds(appId, devId))
   if (!Boolean(derived)) return undefined
 

--- a/pkg/webui/console/views/device/index.js
+++ b/pkg/webui/console/views/device/index.js
@@ -60,7 +60,7 @@ import { selectSelectedApplicationId } from '@console/store/selectors/applicatio
 import style from './device.styl'
 
 @connect(
-  function(state, props) {
+  (state, props) => {
     const devId = props.match.params.devId
     const appId = selectSelectedApplicationId(state)
     const device = selectSelectedDevice(state)
@@ -114,6 +114,7 @@ import style from './device.styl'
 
     if (mayReadKeys) {
       selector.push('session')
+      selector.push('pending_session')
       selector.push('root_keys')
     }
 
@@ -121,7 +122,7 @@ import style from './device.styl'
   },
   ({ fetching, device }) => fetching || !Boolean(device),
 )
-@withBreadcrumb('device.single', function(props) {
+@withBreadcrumb('device.single', props => {
   const {
     devId,
     appId,

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -125,6 +125,7 @@
   "console.components.downlink-form.downlink-form.scheduleDownlink": "Schedule downlink",
   "console.components.downlink-form.downlink-form.downlinkSuccess": "Downlink scheduled",
   "console.components.downlink-form.downlink-form.payloadDescription": "The desired payload bytes of the downlink message",
+  "console.components.downlink-form.downlink-form.invalidSessionWarning": "Downlinks can only be scheduled for end devices with a valid session. Please make sure your end device is properly connected to the network.",
   "console.components.events.messages.payload": "Payload",
   "console.components.events.messages.MACPayload": "MAC payload",
   "console.components.events.messages.devAddr": "DevAddr",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -125,6 +125,7 @@
   "console.components.downlink-form.downlink-form.scheduleDownlink": "Xxxxxxxx xxxxxxxx",
   "console.components.downlink-form.downlink-form.downlinkSuccess": "Xxxxxxxx xxxxxxxxx",
   "console.components.downlink-form.downlink-form.payloadDescription": "Xxx xxxxxxx xxxxxxx xxxxx xx xxx xxxxxxxx xxxxxxx",
+  "console.components.downlink-form.downlink-form.invalidSessionWarning": "Xxxxxxxxx xxx xxxx xx xxxxxxxxx xxx xxx xxxxxxx xxxx x xxxxx xxxxxxx. Xxxxxx xxxx xxxx xxxx xxx xxxxxx xx xxxxxxxx xxxxxxxxx xx xxx xxxxxxx.",
   "console.components.events.messages.payload": "Xxxxxxx",
   "console.components.events.messages.MACPayload": "XXX xxxxxxx",
   "console.components.events.messages.devAddr": "XxxXxxx",


### PR DESCRIPTION
#### Summary

Closes #3850 
References #3606

#### Changes

- Disable sending downlink messages for end devices without session or without pending session
- Added end device messaging e2e tests

Before:
![downlink_before](https://user-images.githubusercontent.com/72162194/109821285-7fddf000-7c3e-11eb-8110-b51510b49d9f.png)


After:
![downlink_after](https://user-images.githubusercontent.com/72162194/109820703-eadaf700-7c3d-11eb-919c-37577dd0663d.png)

#### Testing

- e2e tests

#### Checklist

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.

