### PR TITLE
Move webmiddleware peer test to test package

### DIFF
--- a/pkg/webmiddleware/peer_test.go
+++ b/pkg/webmiddleware/peer_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package webmiddleware
+package webmiddleware_test
 
 import (
 	"net/http"
@@ -20,7 +20,8 @@ import (
 	"testing"
 
 	"github.com/smartystreets/assertions"
-	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+	"github.com/smartystreets/assertions/should"
+	. "go.thethings.network/lorawan-stack/v3/pkg/webmiddleware"
 	"google.golang.org/grpc/peer"
 )
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quickfix for the test of the web middleware that extracts the peer from the request. The import of `go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should` created cycles, so I removed the import, and to be sure, moved the test to a test package.