### PR TITLE
Improve plumbing error reporting

### DIFF
--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -275,6 +275,7 @@ func (as *ApplicationServer) Publish(ctx context.Context, up *ttnpb.ApplicationU
 }
 
 func (as *ApplicationServer) processUp(ctx context.Context, up *ttnpb.ApplicationUp, link *ttnpb.ApplicationLink) error {
+	ctx = log.NewContextWithField(ctx, "device_uid", unique.ID(ctx, up.EndDeviceIdentifiers))
 	ctx = events.ContextWithCorrelationID(ctx, append(up.CorrelationIDs, fmt.Sprintf("as:up:%s", events.NewCorrelationID()))...)
 	up.CorrelationIDs = events.CorrelationIDsFromContext(ctx)
 	registerReceiveUp(ctx, up)
@@ -648,7 +649,6 @@ func (as *ApplicationServer) fetchAppSKey(ctx context.Context, ids ttnpb.EndDevi
 }
 
 func (as *ApplicationServer) handleUp(ctx context.Context, up *ttnpb.ApplicationUp, link *ttnpb.ApplicationLink) (pass bool, err error) {
-	ctx = log.NewContextWithField(ctx, "device_uid", unique.ID(ctx, up.EndDeviceIdentifiers))
 	if up.Simulated {
 		return true, as.handleSimulatedUp(ctx, up, link)
 	}

--- a/pkg/applicationserver/io/packages/packages.go
+++ b/pkg/applicationserver/io/packages/packages.go
@@ -27,6 +27,8 @@ import (
 	"google.golang.org/grpc"
 )
 
+const namespace = "applicationserver/io/packages"
+
 type server struct {
 	ctx context.Context
 
@@ -43,7 +45,7 @@ type Server interface {
 
 // New returns an application packages server wrapping the given registries and handlers.
 func New(ctx context.Context, io io.Server, registry Registry, handlers map[string]ApplicationPackageHandler) (Server, error) {
-	ctx = log.NewContextWithField(ctx, "namespace", "applicationserver/io/packages")
+	ctx = log.NewContextWithField(ctx, "namespace", namespace)
 	s := &server{
 		ctx:      ctx,
 		io:       io,
@@ -65,8 +67,9 @@ func New(ctx context.Context, io io.Server, registry Registry, handlers map[stri
 				case <-sub.Context().Done():
 					return sub.Context().Err()
 				case up := <-sub.Up():
-					if err := s.handleUp(up.Context, up.ApplicationUp); err != nil {
-						log.FromContext(up.Context).WithError(err).Warn("Failed to handle message")
+					ctx := log.NewContextWithField(up.Context, "namespace", namespace)
+					if err := s.handleUp(ctx, up.ApplicationUp); err != nil {
+						log.FromContext(ctx).WithError(err).Warn("Failed to handle message")
 					}
 				}
 			}

--- a/pkg/applicationserver/io/web/webhooks.go
+++ b/pkg/applicationserver/io/web/webhooks.go
@@ -39,6 +39,8 @@ import (
 	"google.golang.org/api/googleapi"
 )
 
+const namespace = "applicationserver/io/web"
+
 var userAgent = "ttn-lw-application-server/" + version.TTN
 
 // Sink processes HTTP requests.
@@ -150,7 +152,7 @@ type webhooks struct {
 
 // NewWebhooks returns a new Webhooks.
 func NewWebhooks(ctx context.Context, server io.Server, registry WebhookRegistry, target Sink, downlinks DownlinksConfig) (Webhooks, error) {
-	ctx = log.NewContextWithField(ctx, "namespace", "applicationserver/io/web")
+	ctx = log.NewContextWithField(ctx, "namespace", namespace)
 	w := &webhooks{
 		ctx:       ctx,
 		server:    server,
@@ -173,8 +175,9 @@ func NewWebhooks(ctx context.Context, server io.Server, registry WebhookRegistry
 				case <-sub.Context().Done():
 					return sub.Context().Err()
 				case up := <-sub.Up():
-					if err := w.handleUp(up.Context, up.ApplicationUp); err != nil {
-						log.FromContext(up.Context).WithError(err).Warn("Failed to handle message")
+					ctx := log.NewContextWithField(up.Context, "namespace", namespace)
+					if err := w.handleUp(ctx, up.ApplicationUp); err != nil {
+						log.FromContext(ctx).WithError(err).Warn("Failed to handle message")
 					}
 				}
 			}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR improves the error reporting of the errors that occur when a frontend fails to process a message. 

This `quickfix` was inspired by the `WARN Send message failed error=error:pkg/applicationserver/io:buffer_full (buffer is full) namespace=applicationserver/io/packages` error spam which does not provide a significant amount of information about which message has been dropped (application UID, end device UID).

#### Changes
<!-- What are the changes made in this pull request? -->

- Inject the `device_uid` in `as.processUp` (`processUp` serves as the entry point for uplinks, be them from the NS, or another AS frontend)
- Report such errors using the context of the uplink, and add the `protocol` / `namespace` of the handler that failed.


#### Testing

<!-- How did you verify that this change works? -->

Monkey patched the methods to always return an error. The resulting errors:

```
  WARN Failed to publish message                device_uid=app1.dev1 error=a_fake_error grpc.method=HandleUplink grpc.service=ttn.lorawan.v3.NsAs namespace=applicationserver/distribution protocol=webhooks request_id=01F01A38GTSFWD0RYEH3WG6H8E
  WARN Failed to publish message                device_uid=app1.dev1 error=a_fake_error grpc.method=HandleUplink grpc.service=ttn.lorawan.v3.NsAs namespace=applicationserver/distribution protocol=applicationpackages request_id=01F01A38GTSFWD0RYEH3WG6H8E
```

```
  WARN Failed to handle message                 device_uid=app1.dev1 error=a_fake_error grpc.method=HandleUplink grpc.service=ttn.lorawan.v3.NsAs namespace=applicationserver/io/packages protocol=applicationpackages request_id=01F01A0JZKZETVFTHYJWBC9D7H
```

```
  WARN Failed to handle message                 device_uid=app1.dev1 error=a_fake_error grpc.method=HandleUplink grpc.service=ttn.lorawan.v3.NsAs namespace=applicationserver/io/web protocol=webhooks request_id=01F01A4YRNEASNMZKYPP7CK1TN
```

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This PR only changes the contexts used for error reporting. Actual lifetimes are unaffected and no regressions are expected.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
