### PR TITLE
Convert functions to arrow functions

### DIFF
--- a/config/jest/files.transform.js
+++ b/config/jest/files.transform.js
@@ -15,7 +15,7 @@
 /* eslint-disable import/no-commonjs */
 
 module.exports = {
-  process(src, filename) {
+  process: (src, filename) => {
     return `module.exports = "${filename}";`
   },
 }

--- a/config/jest/setup.js
+++ b/config/jest/setup.js
@@ -18,7 +18,7 @@ global.snapshotDiff = snapshotDiff
 
 /* eslint-disable no-console */
 const originalConsoleError = console.error
-console.error = function(message, ...args) {
+console.error = (message, ...args) => {
   console.log(message)
   if (/(Invalid prop|Failed prop type|Failed context type)/gi.test(message)) {
     throw new Error(message)

--- a/config/jest/styles.transform.js
+++ b/config/jest/styles.transform.js
@@ -15,7 +15,7 @@
 /* eslint-disable import/no-commonjs */
 
 module.exports = {
-  process() {
+  process: () => {
     return 'module.exports = {};'
   },
 }

--- a/config/storybook/center.js
+++ b/config/storybook/center.js
@@ -20,6 +20,6 @@ const style = {
   padding: '1rem',
 }
 
-export default function(props) {
+export default props => {
   return <div style={style}>{props.children}</div>
 }

--- a/config/storybook/config.js
+++ b/config/storybook/config.js
@@ -36,7 +36,7 @@ const store = createStore(history)
 const req = require.context('../../pkg/webui/', true, /story\.js$/)
 const load = () => req.keys().forEach(req)
 
-addDecorator(function(story) {
+addDecorator(story => {
   return (
     <EnvProvider env={env}>
       <Provider store={store}>

--- a/config/storybook/store.js
+++ b/config/storybook/store.js
@@ -20,7 +20,7 @@ const createRootReducer = history =>
     router: connectRouter(history),
   })
 
-export default function(history) {
+export default history => {
   const middleware = applyMiddleware(routerMiddleware(history))
 
   return createStore(createRootReducer(history), compose(middleware))

--- a/config/storybook/webpack.config.js
+++ b/config/storybook/webpack.config.js
@@ -22,14 +22,14 @@ const { default: bundleConfig, styleConfig } = require('../webpack.config.babel.
 // List of allowed plugins.
 const allow = [MiniCssExtractPlugin]
 
-module.exports = async function({ config, mode }) {
+module.exports = async ({ config, mode }) => {
   if (mode === 'PRODUCTION') {
     const webpack = require('webpack')
     allow.push(webpack.DllReferencePlugin)
   }
 
   // Filter plugins on allowed type.
-  const filteredPlugins = bundleConfig.plugins.filter(function(plugin) {
+  const filteredPlugins = bundleConfig.plugins.filter(plugin => {
     return allow.reduce((ok, klass) => ok || plugin instanceof klass, false)
   })
 

--- a/config/webpack.config.babel.js
+++ b/config/webpack.config.babel.js
@@ -59,6 +59,47 @@ const modules = [path.resolve(context, 'node_modules')]
 
 const r = SUPPORT_LOCALES.split(',').map(l => new RegExp(l.trim()))
 
+const filterLocales = (context, request, callback) => {
+  if (context.endsWith('node_modules/intl/locale-data/jsonp')) {
+    const supported = r.reduce((acc, locale) => {
+      return acc || locale.test(request)
+    }, false)
+
+    if (!supported) {
+      return callback(null, `commonjs ${request}`)
+    }
+  }
+  callback()
+}
+
+// Env selects and merges the environments for the passed object based on
+// `NODE_ENV`, which can have the all, development and production keys.
+const env = (obj = {}) => {
+  if (!obj) {
+    return obj
+  }
+
+  const all = obj.all
+  const dev = obj.development
+  const prod = obj.production
+
+  if (Array.isArray(all) || Array.isArray(dev) || Array.isArray(prod)) {
+    return [...(all || []), ...(production ? prod || [] : dev || [])]
+  }
+
+  if (
+    (dev !== undefined && typeof dev !== 'object') ||
+    (prod !== undefined && typeof prod !== 'object')
+  ) {
+    return production ? prod : dev
+  }
+
+  return {
+    ...(all || {}),
+    ...(production ? prod || {} : dev || {}),
+  }
+}
+
 // Export the style config for usage in the storybook config.
 export const styleConfig = {
   test: /\.(styl|css)$/,
@@ -265,45 +306,4 @@ export default {
       }),
     ],
   }),
-}
-
-function filterLocales(context, request, callback) {
-  if (context.endsWith('node_modules/intl/locale-data/jsonp')) {
-    const supported = r.reduce(function(acc, locale) {
-      return acc || locale.test(request)
-    }, false)
-
-    if (!supported) {
-      return callback(null, `commonjs ${request}`)
-    }
-  }
-  callback()
-}
-
-// Env selects and merges the environments for the passed object based on
-// `NODE_ENV`, which can have the all, development and production keys.
-function env(obj = {}) {
-  if (!obj) {
-    return obj
-  }
-
-  const all = obj.all
-  const dev = obj.development
-  const prod = obj.production
-
-  if (Array.isArray(all) || Array.isArray(dev) || Array.isArray(prod)) {
-    return [...(all || []), ...(production ? prod || [] : dev || [])]
-  }
-
-  if (
-    (dev !== undefined && typeof dev !== 'object') ||
-    (prod !== undefined && typeof prod !== 'object')
-  ) {
-    return production ? prod : dev
-  }
-
-  return {
-    ...(all || {}),
-    ...(production ? prod || {} : dev || {}),
-  }
 }

--- a/pkg/webui/account/store/index.js
+++ b/pkg/webui/account/store/index.js
@@ -22,7 +22,6 @@ import { createBrowserHistory } from 'history'
 import sensitiveFields from '@ttn-lw/constants/sensitive-data'
 
 import { selectApplicationRootPath } from '@ttn-lw/lib/selectors/env'
-
 import omitDeep from '@ttn-lw/lib/omit'
 import dev from '@ttn-lw/lib/dev'
 import env from '@ttn-lw/lib/env'

--- a/pkg/webui/account/views/overview/index.js
+++ b/pkg/webui/account/views/overview/index.js
@@ -25,6 +25,7 @@ import Message from '@ttn-lw/lib/components/message'
 import ProfileCard from '@account/containers/profile-card'
 
 import sharedMessages from '@ttn-lw/lib/shared-messages'
+
 import { selectConsoleUrl } from '@account/lib/selectors/app-config'
 
 import { selectUser } from '@account/store/selectors/user'

--- a/pkg/webui/components/breadcrumbs/breadcrumb/index.js
+++ b/pkg/webui/components/breadcrumbs/breadcrumb/index.js
@@ -23,7 +23,7 @@ import PropTypes from '@ttn-lw/lib/prop-types'
 
 import style from './breadcrumb.styl'
 
-const Breadcrumb = function({ className, path, content, isLast }) {
+const Breadcrumb = ({ className, path, content, isLast }) => {
   const isRawText = typeof content === 'string' || typeof content === 'number'
   let Component
   let componentProps

--- a/pkg/webui/components/breadcrumbs/breadcrumbs.js
+++ b/pkg/webui/components/breadcrumbs/breadcrumbs.js
@@ -23,7 +23,7 @@ import style from './breadcrumbs.styl'
 
 const Breadcrumbs = ({ className, breadcrumbs }) => (
   <nav className={classnames(className, style.breadcrumbs)}>
-    {breadcrumbs.map(function(component, index) {
+    {breadcrumbs.map((component, index) => {
       return React.cloneElement(component, {
         key: index,
         isLast: index === breadcrumbs.length - 1,

--- a/pkg/webui/components/breadcrumbs/context.js
+++ b/pkg/webui/components/breadcrumbs/context.js
@@ -66,54 +66,53 @@ class BreadcrumbsProvider extends React.Component {
   }
 }
 
-const withBreadcrumb = (id, element) =>
-  function(Component) {
-    class BreadcrumbsConsumer extends React.Component {
-      static propTypes = {
-        add: PropTypes.func.isRequired,
-        breadcrumb: PropTypes.oneOfType([PropTypes.func, PropTypes.element]).isRequired,
-        remove: PropTypes.func.isRequired,
-      }
-
-      constructor(props) {
-        super(props)
-
-        this.add()
-      }
-
-      add() {
-        const { add, breadcrumb } = this.props
-
-        add(id, breadcrumb)
-      }
-
-      remove() {
-        const { remove } = this.props
-
-        remove(id)
-      }
-
-      componentWillUnmount() {
-        this.remove()
-      }
-
-      render() {
-        const { add, remove, breadcrumb, ...rest } = this.props
-
-        return <Component {...rest} />
-      }
+const withBreadcrumb = (id, element) => Component => {
+  class BreadcrumbsConsumer extends React.Component {
+    static propTypes = {
+      add: PropTypes.func.isRequired,
+      breadcrumb: PropTypes.oneOfType([PropTypes.func, PropTypes.element]).isRequired,
+      remove: PropTypes.func.isRequired,
     }
 
-    const BreadcrumbsConsumerContainer = props => (
-      <Consumer>
-        {({ add, remove }) => (
-          <BreadcrumbsConsumer {...props} add={add} remove={remove} breadcrumb={element(props)} />
-        )}
-      </Consumer>
-    )
+    constructor(props) {
+      super(props)
 
-    return BreadcrumbsConsumerContainer
+      this.add()
+    }
+
+    add() {
+      const { add, breadcrumb } = this.props
+
+      add(id, breadcrumb)
+    }
+
+    remove() {
+      const { remove } = this.props
+
+      remove(id)
+    }
+
+    componentWillUnmount() {
+      this.remove()
+    }
+
+    render() {
+      const { add, remove, breadcrumb, ...rest } = this.props
+
+      return <Component {...rest} />
+    }
   }
+
+  const BreadcrumbsConsumerContainer = props => (
+    <Consumer>
+      {({ add, remove }) => (
+        <BreadcrumbsConsumer {...props} add={add} remove={remove} breadcrumb={element(props)} />
+      )}
+    </Consumer>
+  )
+
+  return BreadcrumbsConsumerContainer
+}
 
 withBreadcrumb.displayName = 'withBreadcrumb'
 

--- a/pkg/webui/components/breadcrumbs/story.js
+++ b/pkg/webui/components/breadcrumbs/story.js
@@ -28,7 +28,7 @@ storiesOf('Breadcrumbs', module)
       propTables: [Breadcrumbs, Breadcrumb],
     })(story)(context),
   )
-  .add('Default', function() {
+  .add('Default', () => {
     const breadcrumbs = [
       <Breadcrumb key="1" path="/applications" content="Applications" />,
       <Breadcrumb key="2" path="/applications/test-app" content="test-app" />,

--- a/pkg/webui/components/code-editor/index.js
+++ b/pkg/webui/components/code-editor/index.js
@@ -87,7 +87,7 @@ class CodeEditor extends React.Component {
   onFocus(evt) {
     const { onFocus } = this.props
 
-    this.setState({ focus: true }, function() {
+    this.setState({ focus: true }, () => {
       if (onFocus) {
         onFocus(evt)
       }
@@ -98,7 +98,7 @@ class CodeEditor extends React.Component {
   onBlur(evt) {
     const { onBlur } = this.props
 
-    this.setState({ focus: false }, function() {
+    this.setState({ focus: false }, () => {
       if (onBlur) {
         onBlur(evt)
       }

--- a/pkg/webui/components/code-editor/ttn-theme.js
+++ b/pkg/webui/components/code-editor/ttn-theme.js
@@ -13,15 +13,14 @@
 // limitations under the License.
 
 // eslint-disable-next-line no-undef
-ace.define('ace/theme/ttn', ['require', 'exports', 'module', 'ace/lib/dom'], function(
-  acequire,
-  exports,
-  module,
-) {
-  exports.isDark = false
-  exports.cssClass = 'ace-ttn'
-  exports.cssText =
-    '\
+ace.define(
+  'ace/theme/ttn',
+  ['require', 'exports', 'module', 'ace/lib/dom'],
+  (acequire, exports, module) => {
+    exports.isDark = false
+    exports.cssClass = 'ace-ttn'
+    exports.cssText =
+      '\
 .ace_scroller.ace_scroll-left {\
   box-shadow: none;\
 }\
@@ -139,6 +138,7 @@ margin-top: -1px;\
 background: none;\
 }'
 
-  const dom = acequire('../lib/dom')
-  dom.importCssString(exports.cssText, exports.cssClass)
-})
+    const dom = acequire('../lib/dom')
+    dom.importCssString(exports.cssText, exports.cssClass)
+  },
+)

--- a/pkg/webui/components/data-sheet/index.js
+++ b/pkg/webui/components/data-sheet/index.js
@@ -29,11 +29,11 @@ const m = defineMessages({
   noData: 'No data available',
 })
 
-const DataSheet = function({ className, data }) {
+const DataSheet = ({ className, data }) => {
   return (
     <table className={classnames(className, style.table)}>
       <tbody>
-        {data.map(function(group, index) {
+        {data.map((group, index) => {
           return (
             <React.Fragment key={`${group.header}_${index}`}>
               <tr className={style.groupHeading}>
@@ -42,7 +42,7 @@ const DataSheet = function({ className, data }) {
                 </th>
               </tr>
               {group.items.length > 0 ? (
-                group.items.map(function(item) {
+                group.items.map(item => {
                   if (!item) {
                     return null
                   }
@@ -106,7 +106,7 @@ DataSheet.defaultProps = {
   className: undefined,
 }
 
-const DataSheetRow = function({ item, sub }) {
+const DataSheetRow = ({ item, sub }) => {
   const isSafeInspector = item.type === 'byte' || item.type === 'code'
   const rowStyle = classnames({
     [style.sub]: sub,

--- a/pkg/webui/components/form/field/story.js
+++ b/pkg/webui/components/form/field/story.js
@@ -30,7 +30,7 @@ import Yup from '@ttn-lw/lib/yup'
 
 import Form from '..'
 
-const handleSubmit = function(data, { resetForm }) {
+const handleSubmit = (data, { resetForm }) => {
   action('Submit')(data)
   setTimeout(() => resetForm({ values: data }), 1000)
 }

--- a/pkg/webui/components/form/index.js
+++ b/pkg/webui/components/form/index.js
@@ -111,26 +111,25 @@ class InnerForm extends React.PureComponent {
   }
 }
 
-const formRenderer = ({ children, ...rest }) =>
-  function(renderProps) {
-    const { className, error, errorTitle, info, infoTitle, disabled } = rest
-    const { handleSubmit, ...restFormikProps } = renderProps
+const formRenderer = ({ children, ...rest }) => renderProps => {
+  const { className, error, errorTitle, info, infoTitle, disabled } = rest
+  const { handleSubmit, ...restFormikProps } = renderProps
 
-    return (
-      <InnerForm
-        className={className}
-        formError={error}
-        formErrorTitle={errorTitle}
-        formInfo={info}
-        formInfoTitle={infoTitle}
-        handleSubmit={handleSubmit}
-        disabled={disabled}
-        {...restFormikProps}
-      >
-        {children}
-      </InnerForm>
-    )
-  }
+  return (
+    <InnerForm
+      className={className}
+      formError={error}
+      formErrorTitle={errorTitle}
+      formInfo={info}
+      formInfoTitle={infoTitle}
+      handleSubmit={handleSubmit}
+      disabled={disabled}
+      {...restFormikProps}
+    >
+      {children}
+    </InnerForm>
+  )
+}
 
 class Form extends React.PureComponent {
   static propTypes = {

--- a/pkg/webui/components/form/story.js
+++ b/pkg/webui/components/form/story.js
@@ -28,7 +28,7 @@ import Yup from '@ttn-lw/lib/yup'
 
 import Form from '.'
 
-const handleSubmit = function(data, { resetForm }) {
+const handleSubmit = (data, { resetForm }) => {
   action('Submit')(data)
   setTimeout(() => resetForm({ values: data }), 1000)
 }

--- a/pkg/webui/components/icon/index.js
+++ b/pkg/webui/components/icon/index.js
@@ -67,7 +67,7 @@ const hardcoded = {
   user_management: 'how_to_reg',
 }
 
-const Icon = function({ icon, className, nudgeUp, nudgeDown, small, large, ...rest }) {
+const Icon = ({ icon, className, nudgeUp, nudgeDown, small, large, ...rest }) => {
   const classname = classnames(style.icon, className, {
     [style.nudgeUp]: nudgeUp,
     [style.nudgeDown]: nudgeDown,

--- a/pkg/webui/components/input/byte.js
+++ b/pkg/webui/components/input/byte.js
@@ -26,7 +26,7 @@ const PLACEHOLDER_CHAR = '·'
 const hex = /[0-9a-f]/i
 
 const masks = {}
-const mask = function(min, max, showPerChar = false) {
+const mask = (min, max, showPerChar = false) => {
   const key = `${min}-${max}`
   if (masks[key]) {
     return masks[key]
@@ -50,11 +50,11 @@ const mask = function(min, max, showPerChar = false) {
   return r
 }
 
-const upper = function(str) {
+const upper = str => {
   return str.toUpperCase()
 }
 
-const clean = function(str) {
+const clean = str => {
   return str.replace(new RegExp(`[ ${PLACEHOLDER_CHAR}]`, 'g'), '')
 }
 
@@ -138,7 +138,7 @@ export default class ByteInput extends React.Component {
         i = inputElement.value.length
       }
 
-      setTimeout(function() {
+      setTimeout(() => {
         inputElement.focus()
         inputElement.setSelectionRange(i, i)
       }, 0)

--- a/pkg/webui/components/navigation/bar/index.js
+++ b/pkg/webui/components/navigation/bar/index.js
@@ -25,7 +25,7 @@ import NavigationLink from '../link'
 
 import style from './bar.styl'
 
-const NavigationBar = function({ className, children }) {
+const NavigationBar = ({ className, children }) => {
   return <nav className={className}>{children}</nav>
 }
 

--- a/pkg/webui/components/navigation/link/index.js
+++ b/pkg/webui/components/navigation/link/index.js
@@ -22,7 +22,7 @@ import PropTypes from '@ttn-lw/lib/prop-types'
 
 import style from './link.styl'
 
-const NavigationLink = function({
+const NavigationLink = ({
   className,
   children,
   path,
@@ -30,7 +30,7 @@ const NavigationLink = function({
   activeClassName,
   onClick,
   ...rest
-}) {
+}) => {
   return (
     <NavLink
       to={path}
@@ -45,7 +45,7 @@ const NavigationLink = function({
   )
 }
 
-const NavigationAnchorLink = function({ className, children, path, ...rest }) {
+const NavigationAnchorLink = ({ className, children, path, ...rest }) => {
   return (
     <Link.BaseAnchor
       href={path}

--- a/pkg/webui/components/navigation/side/index.js
+++ b/pkg/webui/components/navigation/side/index.js
@@ -130,7 +130,7 @@ export class SideNavigation extends Component {
 
   @bind
   async onToggle() {
-    await this.setState(function(prev) {
+    await this.setState(prev => {
       return { isMinimized: !prev.isMinimized, preferMinimized: !prev.isMinimized }
     })
     this.updateAppContainerClasses()

--- a/pkg/webui/components/navigation/side/story.js
+++ b/pkg/webui/components/navigation/side/story.js
@@ -29,7 +29,7 @@ storiesOf('Navigation', module)
       propTables: [SideNavigation],
     })(story)(context),
   )
-  .add('SideNavigation', function() {
+  .add('SideNavigation', () => {
     const header = {
       title: 'test-application',
       icon: 'application',

--- a/pkg/webui/components/profile-dropdown/story.js
+++ b/pkg/webui/components/profile-dropdown/story.js
@@ -20,7 +20,7 @@ import Dropdown from '@ttn-lw/components/dropdown'
 
 import ProfileDropdown from '.'
 
-const handleLogout = function() {
+const handleLogout = () => {
   // eslint-disable-next-line no-console
   console.log('Click')
 }
@@ -34,7 +34,7 @@ storiesOf('Profile Dropdown', module)
       propTables: [ProfileDropdown],
     })(story)(context),
   )
-  .add('Default', function() {
+  .add('Default', () => {
     return (
       <div style={{ height: '6rem' }}>
         <ProfileDropdown style={{ marginLeft: '120px' }} userId="johndoe">

--- a/pkg/webui/components/profile-picture/story.js
+++ b/pkg/webui/components/profile-picture/story.js
@@ -33,7 +33,7 @@ storiesOf('Profile Picture', module)
       propTables: [ProfilePicture],
     })(story)(context),
   )
-  .add('Default', function() {
+  .add('Default', () => {
     return (
       <div style={{ height: '8rem' }}>
         <ProfilePicture profilePicture={pp} />

--- a/pkg/webui/components/radio-button/group/index.js
+++ b/pkg/webui/components/radio-button/group/index.js
@@ -22,11 +22,11 @@ import style from './group.styl'
 
 export const RadioGroupContext = React.createContext()
 
-function findCheckedRadio(children) {
+const findCheckedRadio = children => {
   let value
   let matched = false
 
-  React.Children.forEach(children, function(radio) {
+  React.Children.forEach(children, radio => {
     if (radio && radio.props && !matched && radio.props.checked) {
       value = radio.props.value
       matched = true

--- a/pkg/webui/components/safe-inspector/index.js
+++ b/pkg/webui/components/safe-inspector/index.js
@@ -26,13 +26,13 @@ import PropTypes from '@ttn-lw/lib/prop-types'
 
 import style from './safe-inspector.styl'
 
-function chunkArray(array, chunkSize) {
+const chunkArray = (array, chunkSize) => {
   return Array.from({ length: Math.ceil(array.length / chunkSize) }, (_, index) =>
     array.slice(index * chunkSize, (index + 1) * chunkSize),
   )
 }
 
-function selectText(node) {
+const selectText = node => {
   if (document.body.createTextRange) {
     const range = document.body.createTextRange()
     range.moveToElementText(node)

--- a/pkg/webui/components/status/index.js
+++ b/pkg/webui/components/status/index.js
@@ -29,7 +29,7 @@ const m = defineMessages({
   unknown: 'unknown',
 })
 
-const Status = function({
+const Status = ({
   intl,
   className,
   status,
@@ -39,7 +39,7 @@ const Status = function({
   children,
   title,
   flipped,
-}) {
+}) => {
   const cls = classnames(style.status, {
     [style.statusGood]: status === 'good',
     [style.statusBad]: status === 'bad',

--- a/pkg/webui/components/submit-bar/index.js
+++ b/pkg/webui/components/submit-bar/index.js
@@ -21,7 +21,7 @@ import PropTypes from '@ttn-lw/lib/prop-types'
 
 import style from './submit-bar.styl'
 
-const SubmitBar = function(props) {
+const SubmitBar = props => {
   const { className, children, align } = props
 
   const cls = classnames(className, style.bar, style[`bar-${align}`])

--- a/pkg/webui/components/table/cell/index.js
+++ b/pkg/webui/components/table/cell/index.js
@@ -21,7 +21,7 @@ import PropTypes from '@ttn-lw/lib/prop-types'
 
 import style from './cell.styl'
 
-const Cell = function({
+const Cell = ({
   className,
   component: Component,
   centered,
@@ -30,7 +30,7 @@ const Cell = function({
   width,
   children,
   ...rest
-}) {
+}) => {
   const cellClassNames = classnames(className, style.cell, {
     [style.cellCentered]: centered,
     [style.cellSmall]: small,

--- a/pkg/webui/components/table/index.js
+++ b/pkg/webui/components/table/index.js
@@ -107,10 +107,10 @@ class Tabular extends React.Component {
     const paginatedData = this.handlePagination(data)
     const rows =
       paginatedData.length > 0 ? (
-        paginatedData.map(function(row, rowKey) {
+        paginatedData.map((row, rowKey) => {
           return (
             <Table.Row key={rowKey} id={rowKey} onClick={onRowClick}>
-              {headers.map(function(header, index) {
+              {headers.map((header, index) => {
                 const value = headers[index].getValue
                   ? headers[index].getValue(row)
                   : getByPath(row, headers[index].name)

--- a/pkg/webui/components/table/section/index.js
+++ b/pkg/webui/components/table/section/index.js
@@ -16,7 +16,7 @@ import React from 'react'
 
 import PropTypes from '@ttn-lw/lib/prop-types'
 
-const Section = function({ className, component: Component, children, ...rest }) {
+const Section = ({ className, component: Component, children, ...rest }) => {
   return (
     <Component className={className} {...rest}>
       {React.Children.map(children, row =>

--- a/pkg/webui/components/table/story/storyData.js
+++ b/pkg/webui/components/table/story/storyData.js
@@ -121,7 +121,7 @@ export default {
         centered: true,
       },
     ],
-    rows: rows.map(function(r) {
+    rows: rows.map(r => {
       return Object.assign({}, r, {
         options: (
           <div>
@@ -133,7 +133,7 @@ export default {
     }),
   },
   sortableExample: {
-    headers: headers.map(function(header) {
+    headers: headers.map(header => {
       if (header.name === 'devices' || header.name === 'appId') {
         return Object.assign({}, header, {
           sortable: true,

--- a/pkg/webui/components/tabs/index.js
+++ b/pkg/webui/components/tabs/index.js
@@ -25,10 +25,10 @@ import Tab from './tab'
 
 import style from './tabs.styl'
 
-const Tabs = function({ className, active, tabs, onTabChange, divider, narrow }) {
+const Tabs = ({ className, active, tabs, onTabChange, divider, narrow }) => {
   return (
     <ul className={classnames(className, style.tabs, { [style.divider]: divider })}>
-      {tabs.map(function({ name, disabled, narrow: nrw, link, exact, icon, title, hidden }, index) {
+      {tabs.map(({ name, disabled, narrow: nrw, link, exact, icon, title, hidden }, index) => {
         return (
           !Boolean(hidden) && (
             <Tab

--- a/pkg/webui/components/tabs/story.js
+++ b/pkg/webui/components/tabs/story.js
@@ -52,12 +52,12 @@ storiesOf('Tabs', module)
       propTablesExclude: [Example],
     })(story)(context),
   )
-  .add('Default', function() {
+  .add('Default', () => {
     const tabs = [{ title: 'All', name: 'all' }, { title: 'Starred', name: 'starred' }]
 
     return <Example tabs={tabs} active={tabs[0].name} />
   })
-  .add('Default (disabled)', function() {
+  .add('Default (disabled)', () => {
     const tabs = [
       { title: 'All', name: 'all' },
       { title: 'Starred', name: 'starred', disabled: true },
@@ -65,12 +65,12 @@ storiesOf('Tabs', module)
 
     return <Example tabs={tabs} active={tabs[0].name} />
   })
-  .add('Default (narrow)', function() {
+  .add('Default (narrow)', () => {
     const tabs = [{ title: 'All', name: 'all' }, { title: 'Starred', name: 'starred' }]
 
     return <Example tabs={tabs} active={tabs[0].name} narrow />
   })
-  .add('With icons', function() {
+  .add('With icons', () => {
     const tabs = [
       { title: 'People', name: 'people', icon: 'organization' },
       { title: 'Data', name: 'data', icon: 'data' },
@@ -78,7 +78,7 @@ storiesOf('Tabs', module)
 
     return <Example tabs={tabs} active={tabs[0].name} narrow />
   })
-  .add('With icons (disabled)', function() {
+  .add('With icons (disabled)', () => {
     const tabs = [
       { title: 'People', name: 'people', icon: 'organization' },
       { title: 'Data', name: 'data', icon: 'data', disabled: true },
@@ -86,7 +86,7 @@ storiesOf('Tabs', module)
 
     return <Example tabs={tabs} active={tabs[0].name} />
   })
-  .add('Link', function() {
+  .add('Link', () => {
     const tabs = [
       { title: 'People', name: 'people', link: '/people' },
       { title: 'Data', name: 'data', link: '/data' },
@@ -94,7 +94,7 @@ storiesOf('Tabs', module)
 
     return <Example tabs={tabs} />
   })
-  .add('Link (disabled)', function() {
+  .add('Link (disabled)', () => {
     const tabs = [
       { title: 'People', name: 'people', link: '/people' },
       { title: 'Data', name: 'data', link: '/data', disabled: true },
@@ -102,7 +102,7 @@ storiesOf('Tabs', module)
 
     return <Example tabs={tabs} />
   })
-  .add('Link (narrow)', function() {
+  .add('Link (narrow)', () => {
     const tabs = [
       { title: 'People', name: 'people', link: '/people' },
       { title: 'Data', name: 'data', link: '/data' },

--- a/pkg/webui/components/tag/index.js
+++ b/pkg/webui/components/tag/index.js
@@ -19,7 +19,7 @@ import PropTypes from '@ttn-lw/lib/prop-types'
 
 import style from './tag.styl'
 
-const Tag = function(props) {
+const Tag = props => {
   const { content, className } = props
 
   return <div className={classnames(className, style.tag)}>{content}</div>

--- a/pkg/webui/components/toast/toast.js
+++ b/pkg/webui/components/toast/toast.js
@@ -21,13 +21,13 @@ import diff from '@ttn-lw/lib/diff'
 
 import style from './toast.styl'
 
-const createToast = function() {
+const createToast = () => {
   const queue = []
   let lastMessage = undefined
   let toastId = null
   let firstDispatched = false
 
-  const show = function(toastOptions) {
+  const show = toastOptions => {
     const { INFO, SUCCESS, ERROR, WARNING, DEFAULT } = toast.types
     const { title, message, type = DEFAULT, ...rest } = toastOptions
 
@@ -50,7 +50,7 @@ const createToast = function() {
     )
   }
 
-  const next = function() {
+  const next = () => {
     const hasNext = queue.length > 0
 
     if (!hasNext) {
@@ -62,7 +62,7 @@ const createToast = function() {
     }
   }
 
-  const toast = function(options) {
+  const toast = options => {
     // Prevent flooding of identical messages (if wished).
     if (
       options.preventConsecutive &&

--- a/pkg/webui/console/api/index.js
+++ b/pkg/webui/console/api/index.js
@@ -83,10 +83,10 @@ tts.subscribe('warning', payload => {
 
 export default {
   console: {
-    token() {
+    token: () => {
       return instance.get(`${appRoot}/api/auth/token`)
     },
-    async logout() {
+    logout: async () => {
       const headers = token => ({
         headers: { 'X-CSRF-Token': token },
       })
@@ -115,7 +115,7 @@ export default {
     },
   },
   clients: {
-    get(client_id) {
+    get: client_id => {
       return instance.get(`${isBaseUrl}/is/clients/${client_id}`)
     },
   },

--- a/pkg/webui/console/components/api-key-modal/index.js
+++ b/pkg/webui/console/components/api-key-modal/index.js
@@ -36,7 +36,7 @@ Note: After closing this window, the value of the key secret will not be accessi
 Make sure to copy and store it in a safe place now.`,
 })
 
-const ApiKeyModal = function(props) {
+const ApiKeyModal = props => {
   const { visible, secret, rights, ...rest } = props
 
   if (!visible) {

--- a/pkg/webui/console/components/join-eui-prefixes-input/compute-prefix.js
+++ b/pkg/webui/console/components/join-eui-prefixes-input/compute-prefix.js
@@ -23,7 +23,7 @@ const CHAR_BYTES = 4
  * @param {number} length - The length of the prefix.
  * @returns {Array} - A list of join EUI prefixes.
  */
-function computePrefixes(joinEUI, length = 0) {
+const computePrefixes = (joinEUI, length = 0) => {
   if (length % CHAR_BYTES === 0) {
     return [joinEUI.slice(0, Math.ceil(length / CHAR_BYTES))]
   }

--- a/pkg/webui/console/components/join-eui-prefixes-input/compute-prefix_test.js
+++ b/pkg/webui/console/components/join-eui-prefixes-input/compute-prefix_test.js
@@ -14,7 +14,7 @@
 
 import computePrefixes from './compute-prefix'
 
-describe('Compute JoinEUI prefix', function() {
+describe('Compute JoinEUI prefix', () => {
   describe('when computing prefix lengths that round exactly to characters', () => {
     const joinEUI = '1'.repeat(16)
 

--- a/pkg/webui/console/components/rights-group/index.js
+++ b/pkg/webui/console/components/rights-group/index.js
@@ -40,7 +40,7 @@ const m = defineMessages({
   selectIndividualRights: 'Grant individual rights',
 })
 
-const computeProps = function(props) {
+const computeProps = props => {
   const { value, pseudoRight: grantablePseudoRight, rights: grantableRights } = props
 
   // Extract the pseudo right from own rights or granted rights.
@@ -227,7 +227,7 @@ class RightsGroup extends React.Component {
     }
 
     // Marshal rights to key/value for checkbox group.
-    const rightsValues = derivedRights.reduce(function(acc, right) {
+    const rightsValues = derivedRights.reduce((acc, right) => {
       acc[right] = allSelected || individualRightValue.includes(right)
 
       return acc

--- a/pkg/webui/console/components/webhook-form/mapping.js
+++ b/pkg/webui/console/components/webhook-form/mapping.js
@@ -59,7 +59,7 @@ const mapHeadersTypeFormValueToWebhookHeadersType = formValue =>
     )) ||
   null
 
-export const mapFormValuesToWebhook = function(values, appId) {
+export const mapFormValuesToWebhook = (values, appId) => {
   return {
     ids: {
       application_ids: {

--- a/pkg/webui/console/containers/api-keys-table/index.js
+++ b/pkg/webui/console/containers/api-keys-table/index.js
@@ -32,7 +32,7 @@ const m = defineMessages({
   grantedRights: 'Granted Rights',
 })
 
-const formatRight = function(right) {
+const formatRight = right => {
   return right
     .split('_')
     .slice(1)
@@ -47,9 +47,7 @@ const headers = [
     name: 'id',
     displayName: m.keyId,
     width: 30,
-    render(id) {
-      return <span className={style.keyId}>{id}</span>
-    },
+    render: id => <span className={style.keyId}>{id}</span>,
   },
   {
     name: 'name',
@@ -60,7 +58,7 @@ const headers = [
     name: 'rights',
     displayName: m.grantedRights,
     width: 40,
-    render(rights) {
+    render: rights => {
       const tags = rights.map(r => (
         <Tag className={style.rightTag} content={formatRight(r)} key={r} />
       ))

--- a/pkg/webui/console/containers/collaborators-table/index.js
+++ b/pkg/webui/console/containers/collaborators-table/index.js
@@ -48,7 +48,7 @@ export default class CollaboratorsTable extends Component {
       {
         name: 'ids',
         displayName: m.id,
-        render(ids) {
+        render: ids => {
           const isUser = 'user_ids' in ids
           const collaboratorId = getCollaboratorId({ ids })
           if (isUser && collaboratorId === props.currentUserId) {
@@ -65,7 +65,7 @@ export default class CollaboratorsTable extends Component {
       {
         name: 'ids',
         displayName: sharedMessages.type,
-        render(ids) {
+        render: ids => {
           const isUser = 'user_ids' in ids
           const icon = isUser ? 'user' : 'organization'
 
@@ -80,7 +80,7 @@ export default class CollaboratorsTable extends Component {
       {
         name: 'rights',
         displayName: sharedMessages.rights,
-        render(rights) {
+        render: rights => {
           for (let i = 0; i < rights.length; i++) {
             if (rights[i].includes('_ALL')) {
               return <Message content={sharedMessages.all} />

--- a/pkg/webui/console/containers/devices-table/index.js
+++ b/pkg/webui/console/containers/devices-table/index.js
@@ -89,14 +89,12 @@ const headers = [
     displayName: sharedMessages.created,
     sortable: true,
     width: 12,
-    render(datetime) {
-      return <DateTime.Relative value={datetime} />
-    },
+    render: datetime => <DateTime.Relative value={datetime} />,
   },
 ]
 
 @connect(
-  function(state) {
+  state => {
     return {
       appId: selectSelectedApplicationId(state),
       deviceTemplateFormats: selectDeviceTemplateFormats(state),

--- a/pkg/webui/console/containers/gateway-connection/connect.js
+++ b/pkg/webui/console/containers/gateway-connection/connect.js
@@ -32,7 +32,7 @@ import withConnectionReactor from './gateway-connection-reactor'
 
 export default GatewayConnection =>
   connect(
-    function(state, ownProps) {
+    (state, ownProps) => {
       return {
         statistics: selectGatewayStatistics(state, ownProps),
         error: selectGatewayStatisticsError(state, ownProps),

--- a/pkg/webui/console/containers/gateway-title-section/connect.js
+++ b/pkg/webui/console/containers/gateway-title-section/connect.js
@@ -60,7 +60,7 @@ const mapStateToProps = (state, props) => {
 }
 
 const mapDispatchToProps = dispatch => ({
-  loadData(mayViewCollaborators, mayViewApiKeys, gtwId) {
+  loadData: (mayViewCollaborators, mayViewApiKeys, gtwId) => {
     if (mayViewCollaborators) {
       dispatch(getCollaboratorsList('gateway', gtwId))
     }

--- a/pkg/webui/console/containers/gateways-table/index.js
+++ b/pkg/webui/console/containers/gateways-table/index.js
@@ -71,7 +71,7 @@ const headers = [
     name: 'status',
     width: 18,
     displayName: sharedMessages.status,
-    render(status) {
+    render: status => {
       let indicator = 'unknown'
       let label = sharedMessages.unknown
 

--- a/pkg/webui/console/containers/organization-title-section/connect.js
+++ b/pkg/webui/console/containers/organization-title-section/connect.js
@@ -60,7 +60,7 @@ const mapStateToProps = (state, props) => {
 }
 
 const mapDispatchToProps = dispatch => ({
-  loadData(mayViewCollaborators, mayViewApiKeys, orgId) {
+  loadData: (mayViewCollaborators, mayViewApiKeys, orgId) => {
     if (mayViewCollaborators) {
       dispatch(getCollaboratorsList('organization', orgId))
     }

--- a/pkg/webui/console/containers/pubsubs-table/index.js
+++ b/pkg/webui/console/containers/pubsubs-table/index.js
@@ -44,7 +44,7 @@ const headers = [
     width: 40,
   },
   {
-    getValue(row) {
+    getValue: row => {
       if (row.nats) {
         const res = row.nats.server_url.match(natsUrlRegexp)
         return res ? res[8] : ''
@@ -62,7 +62,7 @@ const headers = [
     width: 9,
   },
   {
-    getValue(row) {
+    getValue: row => {
       if (row.nats) {
         return 'NATS'
       } else if (row.mqtt) {

--- a/pkg/webui/console/containers/users-table/index.js
+++ b/pkg/webui/console/containers/users-table/index.js
@@ -58,7 +58,7 @@ export default class UsersTable extends Component {
         width: 28,
         sortable: true,
         sortKey: 'user_id',
-        render(ids) {
+        render: ids => {
           const userId = getUserId({ ids })
           if (userId === props.currentUserId) {
             return (
@@ -88,7 +88,7 @@ export default class UsersTable extends Component {
         displayName: sharedMessages.state,
         width: 15,
         sortable: true,
-        render(state) {
+        render: state => {
           let indicator = 'unknown'
           let label = sharedMessages.notSet
           switch (state) {
@@ -121,7 +121,7 @@ export default class UsersTable extends Component {
         name: 'admin',
         displayName: sharedMessages.admin,
         width: 7,
-        render(isAdmin) {
+        render: isAdmin => {
           if (isAdmin) {
             return <Icon className={style.icon} icon="check" />
           }

--- a/pkg/webui/console/lib/random-bytes.js
+++ b/pkg/webui/console/lib/random-bytes.js
@@ -14,9 +14,8 @@
 
 import crypto from 'crypto'
 
-export default function randomByteString(len, type = 'hex') {
-  return crypto
+export default (len, type = 'hex') =>
+  crypto
     .randomBytes(type === 'hex' ? Math.floor(len / 2) : len)
     .toString(type)
     .toUpperCase()
-}

--- a/pkg/webui/console/store/index.js
+++ b/pkg/webui/console/store/index.js
@@ -44,7 +44,7 @@ if (env.sentryDsn) {
   ]
 }
 
-export default function(history) {
+export default history => {
   const middleware = applyMiddleware(...middlewares, routerMiddleware(history))
 
   const store = createStore(createRootReducer(history), composeEnhancers(middleware))

--- a/pkg/webui/console/store/middleware/logics/application-packages.js
+++ b/pkg/webui/console/store/middleware/logics/application-packages.js
@@ -23,7 +23,7 @@ import {
 
 const getApplicationPackagesDefaultAssociationLogic = createRequestLogic({
   type: GET_APP_PKG_DEFAULT_ASSOC,
-  process({ action }) {
+  process: ({ action }) => {
     const { appId, fPort } = action.payload
     const { selector } = action.meta
     return api.application.packages.getDefaultAssociation(appId, fPort, selector)
@@ -32,7 +32,7 @@ const getApplicationPackagesDefaultAssociationLogic = createRequestLogic({
 
 const setApplicationPackagesDefaultAssociationLogic = createRequestLogic({
   type: SET_APP_PKG_DEFAULT_ASSOC,
-  process({ action }) {
+  process: ({ action }) => {
     const { appId, fPort, data } = action.payload
     const { selector } = action.meta
     return api.application.packages.setDefaultAssociation(appId, fPort, data, selector)

--- a/pkg/webui/console/store/middleware/logics/collaborators.js
+++ b/pkg/webui/console/store/middleware/logics/collaborators.js
@@ -20,7 +20,7 @@ import * as collaborators from '@console/store/actions/collaborators'
 
 const validParentTypes = ['application', 'gateway', 'organization']
 
-const parentTypeValidator = function({ action }, allow) {
+const parentTypeValidator = ({ action }, allow) => {
   if (!validParentTypes.includes(action.payload.parentType)) {
     // Do not reject the action but throw an error, as this is an implementation
     // error.
@@ -32,7 +32,7 @@ const parentTypeValidator = function({ action }, allow) {
 const getCollaboratorLogic = createRequestLogic({
   type: collaborators.GET_COLLABORATOR,
   validate: parentTypeValidator,
-  process({ action }) {
+  process: ({ action }) => {
     const { parentType, parentId, collaboratorId, isUser } = action.payload
 
     return isUser
@@ -44,7 +44,7 @@ const getCollaboratorLogic = createRequestLogic({
 const getCollaboratorsLogic = createRequestLogic({
   type: collaborators.GET_COLLABORATORS_LIST,
   validate: parentTypeValidator,
-  async process({ getState, action }) {
+  process: async ({ getState, action }) => {
     const { parentType, parentId, params } = action.payload
     const res = await api[parentType].collaborators.list(parentId, params)
     return { entities: res.collaborators, totalCount: res.totalCount }

--- a/pkg/webui/console/store/middleware/logics/configuration.js
+++ b/pkg/webui/console/store/middleware/logics/configuration.js
@@ -25,7 +25,7 @@ import {
 
 const getNsFrequencyPlansLogic = createRequestLogic({
   type: configuration.GET_NS_FREQUENCY_PLANS,
-  validate({ getState, action }, allow, reject) {
+  validate: ({ getState, action }, allow, reject) => {
     const plansNs = selectNsFrequencyPlans(getState())
     if (plansNs && plansNs.length) {
       reject()
@@ -33,7 +33,7 @@ const getNsFrequencyPlansLogic = createRequestLogic({
       allow(action)
     }
   },
-  async process() {
+  process: async () => {
     const frequencyPlans = (await api.configuration.listNsFrequencyPlans()).frequency_plans
 
     return frequencyPlans
@@ -42,7 +42,7 @@ const getNsFrequencyPlansLogic = createRequestLogic({
 
 const getGsFrequencyPlansLogic = createRequestLogic({
   type: configuration.GET_GS_FREQUENCY_PLANS,
-  validate({ getState, action }, allow, reject) {
+  validate: ({ getState, action }, allow, reject) => {
     const plansGs = selectGsFrequencyPlans(getState())
     if (plansGs && plansGs.length) {
       reject()
@@ -50,7 +50,7 @@ const getGsFrequencyPlansLogic = createRequestLogic({
       allow(action)
     }
   },
-  async process() {
+  process: async () => {
     const frequencyPlans = (await api.configuration.listGsFrequencyPlans()).frequency_plans
 
     return frequencyPlans

--- a/pkg/webui/console/store/middleware/logics/devices.js
+++ b/pkg/webui/console/store/middleware/logics/devices.js
@@ -23,7 +23,7 @@ import createEventsConnectLogics from './events'
 
 const getDeviceLogic = createRequestLogic({
   type: devices.GET_DEV,
-  async process({ action }, dispatch) {
+  process: async ({ action }, dispatch) => {
     const {
       payload: { appId, deviceId },
       meta: { selector, options },
@@ -37,7 +37,7 @@ const getDeviceLogic = createRequestLogic({
 const updateDeviceLogic = createRequestLogic(
   {
     type: devices.UPDATE_DEV,
-    async process({ action }) {
+    process: async ({ action }) => {
       const {
         payload: { appId, deviceId, patch },
       } = action
@@ -51,7 +51,7 @@ const updateDeviceLogic = createRequestLogic(
 
 const getDevicesListLogic = createRequestLogic({
   type: devices.GET_DEVICES_LIST,
-  async process({ action }) {
+  process: async ({ action }) => {
     const {
       id: appId,
       params: { page, limit, order, query },
@@ -77,7 +77,7 @@ const getDevicesListLogic = createRequestLogic({
 
 const getDeviceTemplateFormatsLogic = createRequestLogic({
   type: deviceTemplateFormats.GET_DEVICE_TEMPLATE_FORMATS,
-  async process() {
+  process: async () => {
     const formats = await api.deviceTemplates.listFormats()
     return formats
   },

--- a/pkg/webui/console/store/middleware/logics/gateways.js
+++ b/pkg/webui/console/store/middleware/logics/gateways.js
@@ -33,7 +33,7 @@ import createEventsConnectLogics from './events'
 
 const getGatewayLogic = createRequestLogic({
   type: gateways.GET_GTW,
-  async process({ action }, dispatch) {
+  process: async ({ action }, dispatch) => {
     const { payload, meta } = action
     const { id = {} } = payload
     const selector = meta.selector || ''
@@ -45,7 +45,7 @@ const getGatewayLogic = createRequestLogic({
 
 const updateGatewayLogic = createRequestLogic({
   type: gateways.UPDATE_GTW,
-  async process({ action }) {
+  process: async ({ action }) => {
     const {
       payload: { id, patch },
     } = action
@@ -57,7 +57,7 @@ const updateGatewayLogic = createRequestLogic({
 
 const deleteGatewayLogic = createRequestLogic({
   type: gateways.DELETE_GTW,
-  async process({ action }) {
+  process: async ({ action }) => {
     const { id } = action.payload
 
     await api.gateway.delete(id)
@@ -69,7 +69,7 @@ const deleteGatewayLogic = createRequestLogic({
 const getGatewaysLogic = createRequestLogic({
   type: gateways.GET_GTWS_LIST,
   latest: true,
-  async process({ action }) {
+  process: async ({ action }) => {
     const {
       params: { page, limit, query, order },
     } = action.payload
@@ -128,7 +128,7 @@ const getGatewaysLogic = createRequestLogic({
 
 const getGatewaysRightsLogic = createRequestLogic({
   type: gateways.GET_GTWS_RIGHTS_LIST,
-  async process({ action }, dispatch, done) {
+  process: async ({ action }, dispatch, done) => {
     const { id } = action.payload
     const result = await api.rights.gateways(id)
     return result.rights.sort()
@@ -142,7 +142,7 @@ const startGatewayStatisticsLogic = createLogic({
   processOptions: {
     dispatchMultiple: true,
   },
-  async process({ cancelled$, action, getState }, dispatch, done) {
+  process: async ({ cancelled$, action, getState }, dispatch, done) => {
     const { id } = action.payload
     const { timeout = 60000 } = action.meta
 
@@ -203,7 +203,7 @@ const startGatewayStatisticsLogic = createLogic({
 
 const updateGatewayStatisticsLogic = createRequestLogic({
   type: gateways.UPDATE_GTW_STATS,
-  async process({ action }) {
+  process: async ({ action }) => {
     const { id } = action.payload
 
     const stats = await api.gateway.stats(id)

--- a/pkg/webui/console/store/middleware/logics/identity-server.js
+++ b/pkg/webui/console/store/middleware/logics/identity-server.js
@@ -20,7 +20,7 @@ import * as is from '@console/store/actions/identity-server'
 
 const getIsConfigurationLogic = createRequestLogic({
   type: is.GET_IS_CONFIGURATION,
-  async process() {
+  process: async () => {
     return api.is.getConfiguration()
   },
 })

--- a/pkg/webui/console/store/middleware/logics/init.js
+++ b/pkg/webui/console/store/middleware/logics/init.js
@@ -22,7 +22,7 @@ import * as init from '@console/store/actions/init'
 
 const consoleAppLogic = createRequestLogic({
   type: init.INITIALIZE,
-  async process(_, dispatch) {
+  process: async (_, dispatch) => {
     dispatch(user.getUserRights())
 
     let info, rights

--- a/pkg/webui/console/store/middleware/logics/join-server.js
+++ b/pkg/webui/console/store/middleware/logics/join-server.js
@@ -20,7 +20,7 @@ import * as js from '@console/store/actions/join-server'
 
 const getJoinEUIPrefixesLogic = createRequestLogic({
   type: js.GET_JOIN_EUI_PREFIXES,
-  async process() {
+  process: async () => {
     const { prefixes } = await api.js.joinEUIPrefixes.list()
 
     return prefixes

--- a/pkg/webui/console/store/middleware/logics/organizations.js
+++ b/pkg/webui/console/store/middleware/logics/organizations.js
@@ -24,7 +24,7 @@ import createEventsConnectLogics from './events'
 
 const getOrganizationLogic = createRequestLogic({
   type: organizations.GET_ORG,
-  async process({ action }, dispatch) {
+  process: async ({ action }, dispatch) => {
     const {
       payload: { id },
       meta: { selector },
@@ -38,7 +38,7 @@ const getOrganizationLogic = createRequestLogic({
 const getOrganizationsLogic = createRequestLogic({
   type: organizations.GET_ORGS_LIST,
   latest: true,
-  async process({ action }) {
+  process: async ({ action }) => {
     const {
       params: { page, limit, order, query },
     } = action.payload
@@ -64,7 +64,7 @@ const getOrganizationsLogic = createRequestLogic({
 
 const createOrganizationLogic = createRequestLogic({
   type: organizations.CREATE_ORG,
-  async process({ action, getState }) {
+  process: async ({ action, getState }) => {
     const userId = selectUserId(getState())
 
     return api.organizations.create(userId, action.payload)
@@ -73,7 +73,7 @@ const createOrganizationLogic = createRequestLogic({
 
 const updateOrganizationLogic = createRequestLogic({
   type: organizations.UPDATE_ORG,
-  async process({ action }) {
+  process: async ({ action }) => {
     const { id, patch } = action.payload
 
     const result = await api.organization.update(id, patch)
@@ -84,7 +84,7 @@ const updateOrganizationLogic = createRequestLogic({
 
 const deleteOrganizationLogic = createRequestLogic({
   type: organizations.DELETE_ORG,
-  async process({ action }) {
+  process: async ({ action }) => {
     const { id } = action.payload
 
     await api.organization.delete(id)
@@ -95,7 +95,7 @@ const deleteOrganizationLogic = createRequestLogic({
 
 const getOrganizationsRightsLogic = createRequestLogic({
   type: organizations.GET_ORGS_RIGHTS_LIST,
-  async process({ action }) {
+  process: async ({ action }) => {
     const { id } = action.payload
     const result = await api.rights.organizations(id)
     return result.rights.sort()

--- a/pkg/webui/console/store/middleware/logics/pubsubs.js
+++ b/pkg/webui/console/store/middleware/logics/pubsubs.js
@@ -21,7 +21,7 @@ import * as pubsubFormats from '@console/store/actions/pubsub-formats'
 
 const getPubsubLogic = createRequestLogic({
   type: pubsubs.GET_PUBSUB,
-  async process({ action }) {
+  process: async ({ action }) => {
     const {
       payload: { appId, pubsubId },
       meta: { selector },
@@ -32,7 +32,7 @@ const getPubsubLogic = createRequestLogic({
 
 const getPubsubsLogic = createRequestLogic({
   type: pubsubs.GET_PUBSUBS_LIST,
-  async process({ action }) {
+  process: async ({ action }) => {
     const { appId } = action.payload
     const res = await api.application.pubsubs.list(appId)
     return { entities: res.pubsubs, totalCount: res.totalCount }
@@ -41,7 +41,7 @@ const getPubsubsLogic = createRequestLogic({
 
 const updatePubsubsLogic = createRequestLogic({
   type: pubsubs.UPDATE_PUBSUB,
-  async process({ action }) {
+  process: async ({ action }) => {
     const { appId, pubsubId, patch } = action.payload
 
     return api.application.pubsubs.update(appId, pubsubId, patch)
@@ -50,7 +50,7 @@ const updatePubsubsLogic = createRequestLogic({
 
 const getPubsubFormatsLogic = createRequestLogic({
   type: pubsubFormats.GET_PUBSUB_FORMATS,
-  async process() {
+  process: async () => {
     const { formats } = await api.application.pubsubs.getFormats()
     return formats
   },

--- a/pkg/webui/console/store/middleware/logics/user.js
+++ b/pkg/webui/console/store/middleware/logics/user.js
@@ -32,7 +32,7 @@ const logoutSequence = async () => {
 export default [
   createRequestLogic({
     type: user.LOGOUT,
-    async process() {
+    process: async () => {
       try {
         await logoutSequence()
       } catch (err) {

--- a/pkg/webui/console/store/middleware/logics/users.js
+++ b/pkg/webui/console/store/middleware/logics/users.js
@@ -20,7 +20,7 @@ import * as users from '@console/store/actions/users'
 
 const getUserLogic = createRequestLogic({
   type: users.GET_USER,
-  process({ action }, dispatch) {
+  process: ({ action }, dispatch) => {
     const {
       payload: { id },
       meta: { selector },
@@ -32,7 +32,7 @@ const getUserLogic = createRequestLogic({
 
 const updateUserLogic = createRequestLogic({
   type: users.UPDATE_USER,
-  process({ action }, dispatch) {
+  process: ({ action }, dispatch) => {
     const {
       payload: { id, patch },
     } = action
@@ -43,7 +43,7 @@ const updateUserLogic = createRequestLogic({
 
 const deleteUserLogic = createRequestLogic({
   type: users.DELETE_USER,
-  async process({ action }, dispatch) {
+  process: async ({ action }, dispatch) => {
     const {
       payload: { id },
     } = action
@@ -56,7 +56,7 @@ const deleteUserLogic = createRequestLogic({
 
 const getUsersLogic = createRequestLogic({
   type: users.GET_USERS_LIST,
-  async process({ action }) {
+  process: async ({ action }) => {
     const {
       params: { page, limit, query, order },
     } = action.payload
@@ -80,7 +80,7 @@ const getUsersLogic = createRequestLogic({
 
 const createUserLogic = createRequestLogic({
   type: users.CREATE_USER,
-  process({ action }, dispatch) {
+  process: ({ action }, dispatch) => {
     const {
       payload: { user },
     } = action

--- a/pkg/webui/console/store/middleware/logics/webhooks.js
+++ b/pkg/webui/console/store/middleware/logics/webhooks.js
@@ -22,7 +22,7 @@ import * as webhookTemplates from '@console/store/actions/webhook-templates'
 
 const getWebhookLogic = createRequestLogic({
   type: webhooks.GET_WEBHOOK,
-  async process({ action }) {
+  process: async ({ action }) => {
     const {
       payload: { appId, webhookId },
       meta: { selector },
@@ -33,7 +33,7 @@ const getWebhookLogic = createRequestLogic({
 
 const getWebhooksLogic = createRequestLogic({
   type: webhooks.GET_WEBHOOKS_LIST,
-  async process({ action }) {
+  process: async ({ action }) => {
     const {
       payload: { appId },
       meta: { selector },
@@ -45,7 +45,7 @@ const getWebhooksLogic = createRequestLogic({
 
 const updateWebhookLogic = createRequestLogic({
   type: webhooks.UPDATE_WEBHOOK,
-  async process({ action }) {
+  process: async ({ action }) => {
     const { appId, webhookId, patch } = action.payload
 
     return api.application.webhooks.update(appId, webhookId, patch)
@@ -54,7 +54,7 @@ const updateWebhookLogic = createRequestLogic({
 
 const getWebhookFormatsLogic = createRequestLogic({
   type: webhookFormats.GET_WEBHOOK_FORMATS,
-  async process() {
+  process: async () => {
     const { formats } = await api.application.webhooks.getFormats()
     return formats
   },
@@ -62,7 +62,7 @@ const getWebhookFormatsLogic = createRequestLogic({
 
 const getWebhookTemplateLogic = createRequestLogic({
   type: webhookTemplates.GET_WEBHOOK_TEMPLATE,
-  async process({ action }) {
+  process: async ({ action }) => {
     const { id } = action.payload
     const { selector } = action.meta
     const template = await api.application.webhooks.getTemplate(id, selector)
@@ -73,7 +73,7 @@ const getWebhookTemplateLogic = createRequestLogic({
 
 const getWebhookTemplatesLogic = createRequestLogic({
   type: webhookTemplates.LIST_WEBHOOK_TEMPLATES,
-  async process({ action }) {
+  process: async ({ action }) => {
     const { selector } = action.meta
     const { templates } = await api.application.webhooks.listTemplates(selector)
 

--- a/pkg/webui/console/store/reducers/application-packages.js
+++ b/pkg/webui/console/store/reducers/application-packages.js
@@ -21,7 +21,7 @@ const defaultState = {
   default: undefined,
 }
 
-const applicationPackages = function(state = defaultState, { type, payload }) {
+const applicationPackages = (state = defaultState, { type, payload }) => {
   switch (type) {
     case GET_APP_PKG_DEFAULT_ASSOC_SUCCESS:
     case SET_APP_PKG_DEFAULT_ASSOC_SUCCESS:

--- a/pkg/webui/console/store/reducers/applications.js
+++ b/pkg/webui/console/store/reducers/applications.js
@@ -23,7 +23,7 @@ import {
   DELETE_APP_SUCCESS,
 } from '@console/store/actions/applications'
 
-const application = function(state = {}, application) {
+const application = (state = {}, application) => {
   return {
     ...state,
     ...application,
@@ -36,7 +36,7 @@ const defaultState = {
   applicationDeviceCount: undefined,
 }
 
-const applications = function(state = defaultState, { type, payload }) {
+const applications = (state = defaultState, { type, payload }) => {
   switch (type) {
     case GET_APP:
       return {
@@ -45,7 +45,7 @@ const applications = function(state = defaultState, { type, payload }) {
       }
     case GET_APPS_LIST_SUCCESS:
       const entities = payload.entities.reduce(
-        function(acc, app) {
+        (acc, app) => {
           const id = getApplicationId(app)
 
           acc[id] = application(acc[id], app)

--- a/pkg/webui/console/store/reducers/collaborators.js
+++ b/pkg/webui/console/store/reducers/collaborators.js
@@ -30,7 +30,7 @@ const collaborator = (state = {}, collaborator) => ({
   ...collaborator,
 })
 
-const collaborators = function(state = defaultState, { type, payload }) {
+const collaborators = (state = defaultState, { type, payload }) => {
   switch (type) {
     case GET_COLLABORATOR:
       return {

--- a/pkg/webui/console/store/reducers/configuration.js
+++ b/pkg/webui/console/store/reducers/configuration.js
@@ -22,7 +22,7 @@ const defaultState = {
   gsFrequencyPlans: undefined,
 }
 
-const configuration = function(state = defaultState, { type, payload }) {
+const configuration = (state = defaultState, { type, payload }) => {
   switch (type) {
     case GET_NS_FREQUENCY_PLANS_SUCCESS:
       return {

--- a/pkg/webui/console/store/reducers/device-template-formats.js
+++ b/pkg/webui/console/store/reducers/device-template-formats.js
@@ -18,7 +18,7 @@ const defaultState = {
   formats: undefined,
 }
 
-const deviceTemplateFormats = function(state = defaultState, { type, payload }) {
+const deviceTemplateFormats = (state = defaultState, { type, payload }) => {
   switch (type) {
     case GET_DEVICE_TEMPLATE_FORMATS_SUCCESS:
       return {

--- a/pkg/webui/console/store/reducers/events.js
+++ b/pkg/webui/console/store/reducers/events.js
@@ -91,7 +91,7 @@ const defaultState = {
   status: CONNECTION_STATUS.DISCONNECTED,
 }
 
-const createNamedEventReducer = function(reducerName = '') {
+const createNamedEventReducer = (reducerName = '') => {
   const START_EVENTS = createStartEventsStreamActionType(reducerName)
   const START_EVENTS_SUCCESS = createStartEventsStreamSuccessActionType(reducerName)
   const START_EVENTS_FAILURE = createStartEventsStreamFailureActionType(reducerName)
@@ -103,7 +103,7 @@ const createNamedEventReducer = function(reducerName = '') {
   const CLEAR_EVENTS = createClearEventsActionType(reducerName)
   const EVENT_STREAM_CLOSED = createEventStreamClosedActionType(reducerName)
 
-  return function(state = defaultState, action) {
+  return (state = defaultState, action) => {
     switch (action.type) {
       case START_EVENTS:
         return {
@@ -176,7 +176,7 @@ const createNamedEventReducer = function(reducerName = '') {
   }
 }
 
-const createNamedEventsReducer = function(reducerName = '') {
+const createNamedEventsReducer = (reducerName = '') => {
   const START_EVENTS = createStartEventsStreamActionType(reducerName)
   const START_EVENTS_SUCCESS = createStartEventsStreamSuccessActionType(reducerName)
   const START_EVENTS_FAILURE = createStartEventsStreamFailureActionType(reducerName)
@@ -189,7 +189,7 @@ const createNamedEventsReducer = function(reducerName = '') {
   const EVENT_STREAM_CLOSED = createEventStreamClosedActionType(reducerName)
   const event = createNamedEventReducer(reducerName)
 
-  return function(state = {}, action) {
+  return (state = {}, action) => {
     if (!action.id) {
       return state
     }

--- a/pkg/webui/console/store/reducers/gateways.js
+++ b/pkg/webui/console/store/reducers/gateways.js
@@ -38,14 +38,14 @@ const defaultState = {
   statistics: defaultStatisticsState,
 }
 
-const gateway = function(state = {}, gateway) {
+const gateway = (state = {}, gateway) => {
   return {
     ...state,
     ...gateway,
   }
 }
 
-const statistics = function(state = defaultStatisticsState, { type, payload }) {
+const statistics = (state = defaultStatisticsState, { type, payload }) => {
   switch (type) {
     case UPDATE_GTW_STATS_SUCCESS:
       return {
@@ -71,7 +71,7 @@ const statistics = function(state = defaultStatisticsState, { type, payload }) {
   }
 }
 
-const gateways = function(state = defaultState, action) {
+const gateways = (state = defaultState, action) => {
   const { type, payload } = action
 
   switch (type) {
@@ -102,7 +102,7 @@ const gateways = function(state = defaultState, action) {
       }
     case GET_GTWS_LIST_SUCCESS:
       const entities = payload.entities.reduce(
-        function(acc, gtw) {
+        (acc, gtw) => {
           const id = getGatewayId(gtw)
 
           acc[id] = gateway(acc[id], gtw)

--- a/pkg/webui/console/store/reducers/init.js
+++ b/pkg/webui/console/store/reducers/init.js
@@ -18,7 +18,7 @@ const defaultState = {
   initialized: false,
 }
 
-const app = function(state = defaultState, action) {
+const app = (state = defaultState, action) => {
   switch (action.type) {
     case INITIALIZE_SUCCESS:
       return {

--- a/pkg/webui/console/store/reducers/organizations.js
+++ b/pkg/webui/console/store/reducers/organizations.js
@@ -23,7 +23,7 @@ import {
   DELETE_ORG_SUCCESS,
 } from '@console/store/actions/organizations'
 
-const organization = function(state = {}, organization) {
+const organization = (state = {}, organization) => {
   return {
     ...state,
     ...organization,
@@ -35,7 +35,7 @@ const defaultState = {
   selectedOrganization: null,
 }
 
-const organizations = function(state = defaultState, { type, payload }) {
+const organizations = (state = defaultState, { type, payload }) => {
   switch (type) {
     case GET_ORG:
       return {
@@ -44,7 +44,7 @@ const organizations = function(state = defaultState, { type, payload }) {
       }
     case GET_ORGS_LIST_SUCCESS:
       const entities = payload.entities.reduce(
-        function(acc, org) {
+        (acc, org) => {
           const id = getOrganizationId(org)
 
           acc[id] = organization(acc[id], org)

--- a/pkg/webui/console/store/reducers/pubsub-formats.js
+++ b/pkg/webui/console/store/reducers/pubsub-formats.js
@@ -18,7 +18,7 @@ const defaultState = {
   formats: undefined,
 }
 
-const pubsubs = function(state = defaultState, { type, payload }) {
+const pubsubs = (state = defaultState, { type, payload }) => {
   switch (type) {
     case GET_PUBSUB_FORMATS_SUCCESS:
       return {

--- a/pkg/webui/console/store/reducers/pubsubs.js
+++ b/pkg/webui/console/store/reducers/pubsubs.js
@@ -29,7 +29,7 @@ const defaultState = {
   entities: {},
 }
 
-const pubsubs = function(state = defaultState, { type, payload }) {
+const pubsubs = (state = defaultState, { type, payload }) => {
   switch (type) {
     case GET_PUBSUB:
       return {

--- a/pkg/webui/console/store/reducers/tests/applications_test.js
+++ b/pkg/webui/console/store/reducers/tests/applications_test.js
@@ -28,108 +28,108 @@ import {
   deleteApplicationFailure,
 } from '../../actions/applications'
 
-describe('Applications reducer', function() {
+describe('Applications reducer', () => {
   const defaultState = {
     entities: {},
     selectedApplication: null,
   }
 
-  it('returns the initial state', function() {
+  it('returns the initial state', () => {
     expect(reducer(undefined, { type: '@@TEST_INIT', payload: {} })).toEqual(defaultState)
   })
 
-  it('ignores `getApplicationFailure` action', function() {
+  it('ignores `getApplicationFailure` action', () => {
     expect(reducer(defaultState, getApplicationFailure({ status: 404 }))).toEqual(defaultState)
   })
 
-  it('ignores `updateApplicationFailure` action', function() {
+  it('ignores `updateApplicationFailure` action', () => {
     expect(reducer(defaultState, updateApplicationFailure({ status: 404 }))).toEqual(defaultState)
   })
 
-  it('ignores `getApplicationsFailure` action', function() {
+  it('ignores `getApplicationsFailure` action', () => {
     expect(reducer(defaultState, getApplicationsFailure({ status: 404 }))).toEqual(defaultState)
   })
 
-  it('ignores `updateApplication` action', function() {
+  it('ignores `updateApplication` action', () => {
     expect(reducer(defaultState, updateApplication('test-id', {}))).toEqual(defaultState)
   })
 
-  it('ignores `deleteApplicationFailure` action', function() {
+  it('ignores `deleteApplicationFailure` action', () => {
     expect(reducer(defaultState, deleteApplicationFailure({ status: 404 }))).toEqual(defaultState)
   })
 
-  it('ignores `deleteApplication` action', function() {
+  it('ignores `deleteApplication` action', () => {
     expect(reducer(defaultState, deleteApplication('test-id'))).toEqual(defaultState)
   })
 
-  describe('when requesting a single application', function() {
+  describe('when requesting a single application', () => {
     const testApplicationId = 'test-app-id'
     const testApplication = { ids: { application_id: testApplicationId }, name: 'test-app' }
     let newState
 
-    beforeAll(function() {
+    beforeAll(() => {
       newState = reducer(defaultState, getApplication(testApplicationId))
     })
 
-    it('sets `selectedApplication` on `getApplication` action', function() {
+    it('sets `selectedApplication` on `getApplication` action', () => {
       expect(newState.selectedApplication).toEqual(testApplicationId)
     })
 
-    it('does not update `entities` on `getApplication` action', function() {
+    it('does not update `entities` on `getApplication` action', () => {
       expect(newState.entities).toEqual(defaultState.entities)
     })
 
-    describe('when receiving an application', function() {
-      beforeAll(function() {
+    describe('when receiving an application', () => {
+      beforeAll(() => {
         newState = reducer(newState, getApplicationSuccess(testApplication))
       })
 
-      it('does change `selectedApplication` on `getApplicationSuccess`', function() {
+      it('does change `selectedApplication` on `getApplicationSuccess`', () => {
         expect(newState.selectedApplication).toEqual(testApplicationId)
       })
 
-      it('adds new application to `entities` on `getApplicationSuccess`', function() {
+      it('adds new application to `entities` on `getApplicationSuccess`', () => {
         expect(Object.keys(newState.entities)).toHaveLength(1)
         expect(newState.entities[testApplicationId]).toEqual(testApplication)
       })
 
-      describe('when it updates application', function() {
+      describe('when it updates application', () => {
         const updatedTestApplication = {
           ids: { application_id: testApplicationId },
           name: 'updated-test-app',
         }
         let updatedState
 
-        beforeAll(function() {
+        beforeAll(() => {
           updatedState = reducer(newState, updateApplicationSuccess(updatedTestApplication))
         })
 
-        it('does not change `selectedApplication` on `updateApplicationSuccess`', function() {
+        it('does not change `selectedApplication` on `updateApplicationSuccess`', () => {
           expect(updatedState.selectedApplication).toEqual(testApplicationId)
         })
 
-        it('updates application in `entities` on `updateApplicationSuccess` action', function() {
+        it('updates application in `entities` on `updateApplicationSuccess` action', () => {
           expect(updatedState.entities[testApplicationId].name).toEqual(updatedTestApplication.name)
         })
       })
 
-      describe('when deleting an application', function() {
+      describe('when deleting an application', () => {
         let updatedState
 
-        beforeAll(function() {
+        beforeAll(() => {
           updatedState = reducer(newState, deleteApplicationSuccess({ id: testApplicationId }))
         })
 
-        it('removes `selectedApplication` on `deleteApplicationSuccess`', function() {
+        it('removes `selectedApplication` on `deleteApplicationSuccess`', () => {
           expect(updatedState.selectedApplication).toBeNull()
         })
 
-        it('removes application in `entities` on `deleteApplicationSuccess` action', function() {
+        it('removes application in `entities` on `deleteApplicationSuccess` action', () => {
           expect(updatedState.entities[testApplicationId]).toBeUndefined()
         })
       })
 
-      describe('when requesting another application', function() {
+      describe('when requesting another application', () => {
         const otherTestApplicationId = 'another-test-app-id'
         const otherTestApplication = {
           ids: { application_id: otherTestApplicationId },
@@ -137,54 +137,54 @@ describe('Applications reducer', function() {
         }
         let updatedState
 
-        beforeAll(function() {
+        beforeAll(() => {
           updatedState = reducer(newState, getApplication(otherTestApplicationId))
         })
 
-        it('sets `selectedApplication` on `getApplication` action', function() {
+        it('sets `selectedApplication` on `getApplication` action', () => {
           expect(updatedState.selectedApplication).toEqual(otherTestApplicationId)
         })
 
-        it('does not update `entities` on `getApplication` action', function() {
+        it('does not update `entities` on `getApplication` action', () => {
           expect(Object.keys(updatedState.entities)).toHaveLength(1)
           expect(updatedState.entities[testApplicationId]).toEqual(testApplication)
         })
 
-        describe('when receiving application', function() {
-          beforeAll(function() {
+        describe('when receiving application', () => {
+          beforeAll(() => {
             updatedState = reducer(updatedState, getApplicationSuccess(otherTestApplication))
           })
 
-          it('does not change `selectedApplication` on `getApplicationSuccess`', function() {
+          it('does not change `selectedApplication` on `getApplicationSuccess`', () => {
             expect(updatedState.selectedApplication).toEqual(otherTestApplicationId)
           })
 
-          it('keeps previously received application in `entities`', function() {
+          it('keeps previously received application in `entities`', () => {
             expect(updatedState.entities[testApplicationId]).toEqual(testApplication)
           })
 
-          it('adds new application to `entities` on `getApplicationSuccess`', function() {
+          it('adds new application to `entities` on `getApplicationSuccess`', () => {
             expect(Object.keys(updatedState.entities)).toHaveLength(2)
             expect(updatedState.entities[otherTestApplicationId]).toEqual(otherTestApplication)
           })
         })
       })
 
-      describe('when requesting a list of applications', function() {
-        beforeAll(function() {
+      describe('when requesting a list of applications', () => {
+        beforeAll(() => {
           newState = reducer(newState, getApplicationsList({}))
         })
 
-        it('does not change `selectedApplication` on `getApplicationList` action', function() {
+        it('does not change `selectedApplication` on `getApplicationList` action', () => {
           expect(newState.selectedApplication).toEqual(testApplicationId)
         })
 
-        it('does not change `entities` on `getApplicationList` action', function() {
+        it('does not change `entities` on `getApplicationList` action', () => {
           expect(Object.keys(newState.entities)).toHaveLength(1)
           expect(newState.entities[testApplicationId]).toEqual(testApplication)
         })
 
-        describe('when receiving a list of applications', function() {
+        describe('when receiving a list of applications', () => {
           const entities = [
             { ids: { application_id: 'test-app-1' }, name: 'test-app-1' },
             { ids: { application_id: 'test-app-2' }, name: 'test-app-2' },
@@ -192,15 +192,15 @@ describe('Applications reducer', function() {
           ]
           const totalCount = entities.length
 
-          beforeAll(function() {
+          beforeAll(() => {
             newState = reducer(newState, getApplicationsSuccess({ entities, totalCount }))
           })
 
-          it('does not remove previously received application on `getApplicationsSuccess` action', function() {
+          it('does not remove previously received application on `getApplicationsSuccess` action', () => {
             expect(newState.entities[testApplicationId]).toEqual(testApplication)
           })
 
-          it('adds new applications to `entities` on `getApplicationSuccess`', function() {
+          it('adds new applications to `entities` on `getApplicationSuccess`', () => {
             expect(Object.keys(newState.entities)).toHaveLength(4)
             for (const app of entities) {
               expect(newState.entities[app.ids.application_id]).toEqual(app)

--- a/pkg/webui/console/store/reducers/tests/gateways_test.js
+++ b/pkg/webui/console/store/reducers/tests/gateways_test.js
@@ -28,106 +28,106 @@ import {
   deleteGatewayFailure,
 } from '../../actions/gateways'
 
-describe('Gateways reducer', function() {
+describe('Gateways reducer', () => {
   const defaultState = {
     entities: {},
     selectedGateway: null,
     statistics: {},
   }
 
-  it('returns the initial state', function() {
+  it('returns the initial state', () => {
     expect(reducer(undefined, { type: '@@TEST_INIT', payload: {} })).toEqual(defaultState)
   })
 
-  it('ignores `getGatewayFailure` action', function() {
+  it('ignores `getGatewayFailure` action', () => {
     expect(reducer(defaultState, getGatewayFailure({ status: 404 }))).toEqual(defaultState)
   })
 
-  it('ignores `updateGatewayFailure` action', function() {
+  it('ignores `updateGatewayFailure` action', () => {
     expect(reducer(defaultState, updateGatewayFailure({ status: 404 }))).toEqual(defaultState)
   })
 
-  it('ignores `getGatewaysListFailure` action', function() {
+  it('ignores `getGatewaysListFailure` action', () => {
     expect(reducer(defaultState, getGatewaysListFailure({ status: 404 }))).toEqual(defaultState)
   })
 
-  it('ignores `updateGateway` action', function() {
+  it('ignores `updateGateway` action', () => {
     expect(reducer(defaultState, updateGateway('test-id', {}))).toEqual(defaultState)
   })
 
-  it('ignores `deleteGatewayFailure` action', function() {
+  it('ignores `deleteGatewayFailure` action', () => {
     expect(reducer(defaultState, deleteGatewayFailure({ status: 404 }))).toEqual(defaultState)
   })
 
-  it('ignores `deleteGateway` action', function() {
+  it('ignores `deleteGateway` action', () => {
     expect(reducer(defaultState, deleteGateway('test-id'))).toEqual(defaultState)
   })
 
-  describe('when requesting a single gateway', function() {
+  describe('when requesting a single gateway', () => {
     const testGatewayId = 'tesrt-gtw-id'
     const testGateway = { ids: { gateway_id: testGatewayId }, name: 'test-gtw-name' }
     let newState
 
-    beforeAll(function() {
+    beforeAll(() => {
       newState = reducer(defaultState, getGateway(testGatewayId))
     })
 
-    it('sets `selectedGateway` on `getGateway` action', function() {
+    it('sets `selectedGateway` on `getGateway` action', () => {
       expect(newState.selectedGateway).toEqual(testGatewayId)
     })
 
-    it('updates `entities` on `getGateway` action', function() {
+    it('updates `entities` on `getGateway` action', () => {
       expect(newState.entities).toEqual(defaultState.entities)
     })
 
-    describe('when it receives the gateway', function() {
-      beforeAll(function() {
+    describe('when it receives the gateway', () => {
+      beforeAll(() => {
         newState = reducer(newState, getGatewaySuccess(testGateway))
       })
 
-      it('does not change `selectedGateway` on `getGatewaySuccess` action', function() {
+      it('does not change `selectedGateway` on `getGatewaySuccess` action', () => {
         expect(newState.selectedGateway).toEqual(testGatewayId)
       })
 
-      it('adds new gateway to `entities` on `getGatewaySuccess` action', function() {
+      it('adds new gateway to `entities` on `getGatewaySuccess` action', () => {
         expect(Object.keys(newState.entities)).toHaveLength(1)
         expect(newState.entities[testGatewayId]).toEqual(testGateway)
       })
 
-      describe('when it updates the gateway', function() {
+      describe('when it updates the gateway', () => {
         const updatedTestGateway = { ids: { gateway_id: testGatewayId }, name: 'updated-test-gtw' }
         let updatedState
 
-        beforeAll(function() {
+        beforeAll(() => {
           updatedState = reducer(newState, updateGatewaySuccess(updatedTestGateway))
         })
 
-        it('does not change `selectedGateway` on `updateGatewaySuccess` action', function() {
+        it('does not change `selectedGateway` on `updateGatewaySuccess` action', () => {
           expect(updatedState.selectedGateway).toEqual(testGatewayId)
         })
 
-        it('updates the gateway in `entities` on `updateGatewaySuccess` action', function() {
+        it('updates the gateway in `entities` on `updateGatewaySuccess` action', () => {
           expect(updatedState.entities[testGatewayId].name).toEqual(updatedTestGateway.name)
         })
       })
 
-      describe('when deleting the gateway', function() {
+      describe('when deleting the gateway', () => {
         let updatedState
 
-        beforeAll(function() {
+        beforeAll(() => {
           updatedState = reducer(newState, deleteGatewaySuccess({ id: testGatewayId }))
         })
 
-        it('removes `selectedGateway` on `deleteGatewaySuccess` action', function() {
+        it('removes `selectedGateway` on `deleteGatewaySuccess` action', () => {
           expect(updatedState.selectedGateway).toBeNull()
         })
 
-        it('removes gateway in `entities` on `deleteGatewaySuccess` action', function() {
+        it('removes gateway in `entities` on `deleteGatewaySuccess` action', () => {
           expect(updatedState.entities[testGatewayId]).toBeUndefined()
         })
       })
 
-      describe('when requesting another gateway', function() {
+      describe('when requesting another gateway', () => {
         const otherTestGatewayId = 'another-test-gtw-id'
         const otherTestGateway = {
           ids: { gateway_id: otherTestGatewayId },
@@ -135,54 +135,54 @@ describe('Gateways reducer', function() {
         }
         let updatedState
 
-        beforeAll(function() {
+        beforeAll(() => {
           updatedState = reducer(newState, getGateway(otherTestGatewayId))
         })
 
-        it('sets `selectedGateway` on `getGateway` action', function() {
+        it('sets `selectedGateway` on `getGateway` action', () => {
           expect(updatedState.selectedGateway).toEqual(otherTestGatewayId)
         })
 
-        it('does not update `entities` on `getGateway` action', function() {
+        it('does not update `entities` on `getGateway` action', () => {
           expect(Object.keys(updatedState.entities)).toHaveLength(1)
           expect(updatedState.entities[testGatewayId]).toEqual(testGateway)
         })
 
-        describe('when receiving the gateway', function() {
-          beforeAll(function() {
+        describe('when receiving the gateway', () => {
+          beforeAll(() => {
             updatedState = reducer(updatedState, getGatewaySuccess(otherTestGateway))
           })
 
-          it('does not change `selectedGateway` on `getGatewaySuccess` action', function() {
+          it('does not change `selectedGateway` on `getGatewaySuccess` action', () => {
             expect(updatedState.selectedGateway).toEqual(otherTestGatewayId)
           })
 
-          it('keeps previously received gateway in `entities`', function() {
+          it('keeps previously received gateway in `entities`', () => {
             expect(updatedState.entities[testGatewayId]).toEqual(testGateway)
           })
 
-          it('adds new gateway to `entities` on `getGatewaySuccess`', function() {
+          it('adds new gateway to `entities` on `getGatewaySuccess`', () => {
             expect(Object.keys(updatedState.entities)).toHaveLength(2)
             expect(updatedState.entities[otherTestGatewayId]).toEqual(otherTestGateway)
           })
         })
       })
 
-      describe('requesting a list of gateways', function() {
-        beforeAll(function() {
+      describe('requesting a list of gateways', () => {
+        beforeAll(() => {
           newState = reducer(newState, getGatewaysList({}))
         })
 
-        it('does not change `selectedGateway` on `getGatewaysList` action', function() {
+        it('does not change `selectedGateway` on `getGatewaysList` action', () => {
           expect(newState.selectedGateway).toEqual(testGatewayId)
         })
 
-        it('does not change `entities` on `getGatewaysList` action', function() {
+        it('does not change `entities` on `getGatewaysList` action', () => {
           expect(Object.keys(newState.entities)).toHaveLength(1)
           expect(newState.entities[testGatewayId]).toEqual(testGateway)
         })
 
-        describe('receiving the list of gateways', function() {
+        describe('receiving the list of gateways', () => {
           const entities = [
             { ids: { gateway_id: 'test-gtw-1' }, name: 'test-gtw-1' },
             { ids: { gateway_id: 'test-gtw-2' }, name: 'test-gtw-2' },
@@ -190,15 +190,15 @@ describe('Gateways reducer', function() {
           ]
           const totalCount = entities.length
 
-          beforeAll(function() {
+          beforeAll(() => {
             newState = reducer(newState, getGatewaysListSuccess({ entities, totalCount }))
           })
 
-          it('does not remove previously received gateway on `getGatewaysListSuccess` action', function() {
+          it('does not remove previously received gateway on `getGatewaysListSuccess` action', () => {
             expect(newState.entities[testGatewayId]).toEqual(testGateway)
           })
 
-          it('adds new gateways to `entities` on `getGatewaysListSuccess`', function() {
+          it('adds new gateways to `entities` on `getGatewaysListSuccess`', () => {
             expect(Object.keys(newState.entities)).toHaveLength(4)
             for (const gtw of entities) {
               expect(newState.entities[gtw.ids.gateway_id]).toEqual(gtw)

--- a/pkg/webui/console/store/reducers/webhook-formats.js
+++ b/pkg/webui/console/store/reducers/webhook-formats.js
@@ -18,7 +18,7 @@ const defaultState = {
   formats: undefined,
 }
 
-const webhooks = function(state = defaultState, { type, payload }) {
+const webhooks = (state = defaultState, { type, payload }) => {
   switch (type) {
     case GET_WEBHOOK_FORMATS_SUCCESS:
       return {

--- a/pkg/webui/console/store/reducers/webhook-templates.js
+++ b/pkg/webui/console/store/reducers/webhook-templates.js
@@ -23,7 +23,7 @@ const defaultState = {
   entities: undefined,
 }
 
-const webhookTemplates = function(state = defaultState, { type, payload }) {
+const webhookTemplates = (state = defaultState, { type, payload }) => {
   switch (type) {
     case LIST_WEBHOOK_TEMPLATES_SUCCESS:
       const entities = payload.reduce(

--- a/pkg/webui/console/store/reducers/webhooks.js
+++ b/pkg/webui/console/store/reducers/webhooks.js
@@ -29,7 +29,7 @@ const defaultState = {
   entities: {},
 }
 
-const webhooks = function(state = defaultState, { type, payload }) {
+const webhooks = (state = defaultState, { type, payload }) => {
   switch (type) {
     case GET_WEBHOOK:
       return {

--- a/pkg/webui/console/store/selectors/application-packages.js
+++ b/pkg/webui/console/store/selectors/application-packages.js
@@ -19,7 +19,7 @@ import { GET_APP_PKG_DEFAULT_ASSOC } from '@console/store/actions/application-pa
 
 const selectApplicationPackagesStore = state => state.applicationPackages
 
-export const selectApplicationPackageDefaultAssociation = function(state) {
+export const selectApplicationPackageDefaultAssociation = state => {
   const store = selectApplicationPackagesStore(state)
 
   return store.default || {}

--- a/pkg/webui/console/store/selectors/collaborators.js
+++ b/pkg/webui/console/store/selectors/collaborators.js
@@ -36,14 +36,14 @@ export const selectSelectedCollaborator = state =>
   selectCollaboratorById(state, selectSelectedCollaboratorId(state))
 export const selectCollaboratorFetching = createFetchingSelector(GET_COLLABORATOR_BASE)
 export const selectCollaboratorError = createErrorSelector(GET_COLLABORATOR_BASE)
-export const selectUserCollaborator = function(state) {
+export const selectUserCollaborator = state => {
   const collaborator = selectSelectedCollaborator(state)
 
   if (collaborator && 'user_ids' in collaborator.ids) {
     return collaborator
   }
 }
-export const selectOrganizationCollaborator = function(state) {
+export const selectOrganizationCollaborator = state => {
   const collaborator = selectSelectedCollaborator(state)
 
   if (collaborator && 'organization_ids' in collaborator.ids) {

--- a/pkg/webui/console/store/selectors/configuration.js
+++ b/pkg/webui/console/store/selectors/configuration.js
@@ -22,13 +22,13 @@ import {
 
 const selectConfigurationStore = state => state.configuration
 
-export const selectGsFrequencyPlans = function(state) {
+export const selectGsFrequencyPlans = state => {
   const store = selectConfigurationStore(state)
 
   return store.gsFrequencyPlans || []
 }
 
-export const selectNsFrequencyPlans = function(state) {
+export const selectNsFrequencyPlans = state => {
   const store = selectConfigurationStore(state)
 
   return store.nsFrequencyPlans || []

--- a/pkg/webui/console/store/selectors/device-template-formats.js
+++ b/pkg/webui/console/store/selectors/device-template-formats.js
@@ -19,7 +19,7 @@ import { GET_DEVICE_TEMPLATE_FORMATS_BASE } from '@console/store/actions/device-
 
 const selectDeviceTemplateFormatsStore = state => state.deviceTemplateFormats
 
-export const selectDeviceTemplateFormats = function(state) {
+export const selectDeviceTemplateFormats = state => {
   const store = selectDeviceTemplateFormatsStore(state)
 
   return store.formats || {}

--- a/pkg/webui/console/store/selectors/events.js
+++ b/pkg/webui/console/store/selectors/events.js
@@ -14,56 +14,52 @@
 
 const selectEventsStore = (state, entityId) => state[entityId]
 
-export const createEventsSelector = entity =>
-  function(state, entityId) {
-    const store = selectEventsStore(state.events[entity], entityId)
+export const createEventsSelector = entity => (state, entityId) => {
+  const store = selectEventsStore(state.events[entity], entityId)
 
-    return store ? store.events : []
-  }
+  return store ? store.events : []
+}
 
-export const createEventsStatusSelector = entity =>
-  function(state, entityId) {
-    const store = selectEventsStore(state.events[entity], entityId)
+export const createEventsStatusSelector = entity => (state, entityId) => {
+  const store = selectEventsStore(state.events[entity], entityId)
 
-    return store ? store.status : 'unknown'
-  }
+  return store ? store.status : 'unknown'
+}
 
-export const createEventsPausedSelector = entity =>
-  function(state, entityId) {
-    const store = selectEventsStore(state.events[entity], entityId)
+export const createEventsPausedSelector = entity => (state, entityId) => {
+  const store = selectEventsStore(state.events[entity], entityId)
 
-    return Boolean(store.paused)
-  }
+  return Boolean(store.paused)
+}
 
-export const createEventsInterruptedSelector = entity =>
-  function(state, entityId) {
-    const store = selectEventsStore(state.events[entity], entityId)
+export const createEventsInterruptedSelector = entity => (state, entityId) => {
+  const store = selectEventsStore(state.events[entity], entityId)
 
-    return Boolean(store.interrupted)
-  }
+  return Boolean(store.interrupted)
+}
 
-export const createEventsErrorSelector = entity =>
-  function(state, entityId) {
-    const store = selectEventsStore(state.events[entity], entityId)
+export const createEventsErrorSelector = entity => (state, entityId) => {
+  const store = selectEventsStore(state.events[entity], entityId)
 
-    return store ? store.error : undefined
-  }
+  return store ? store.error : undefined
+}
 
-export const createEventsTruncatedSelector = entity =>
-  function(state, entityId) {
-    const store = selectEventsStore(state.events[entity], entityId)
+export const createEventsTruncatedSelector = entity => (state, entityId) => {
+  const store = selectEventsStore(state.events[entity], entityId)
 
-    return Boolean(store.truncated)
-  }
+  return Boolean(store.truncated)
+}
 
-export const createLatestEventSelector = function(entity) {
+export const createLatestEventSelector = entity => {
   const eventsSelector = createEventsSelector(entity)
 
-  return function selectLatestEvent(state, entityId) {
+  const selectLatestEvent = (state, entityId) => {
     const events = eventsSelector(state, entityId)
 
     return events[0]
   }
+
+  return selectLatestEvent
 }
 
 export const createInterruptedStreamsSelector = entity => state => {

--- a/pkg/webui/console/store/selectors/gateways.js
+++ b/pkg/webui/console/store/selectors/gateways.js
@@ -80,7 +80,7 @@ export const selectGatewayRightsFetching = createFetchingSelector(GET_GTWS_RIGHT
 
 // Statistics.
 export const selectGatewayStatisticsConnectError = createErrorSelector(START_GTW_STATS_BASE)
-export const selectGatewayStatisticsUpdateError = function(state) {
+export const selectGatewayStatisticsUpdateError = state => {
   const statistics = selectGatewayStatisticsStore(state) || {}
 
   return statistics.error
@@ -91,7 +91,7 @@ export const selectGatewayStatisticsIsFetching = createFetchingSelector([
   START_GTW_STATS_BASE,
   UPDATE_GTW_STATS_BASE,
 ])
-export const selectGatewayStatistics = function(state) {
+export const selectGatewayStatistics = state => {
   const statistics = selectGatewayStatisticsStore(state) || {}
 
   return statistics.stats

--- a/pkg/webui/console/store/selectors/join-server.js
+++ b/pkg/webui/console/store/selectors/join-server.js
@@ -19,7 +19,7 @@ import { GET_JOIN_EUI_PREFIXES_BASE } from '@console/store/actions/join-server'
 
 const selectJsStore = state => state.js
 
-export const selectJoinEUIPrefixes = function(state) {
+export const selectJoinEUIPrefixes = state => {
   const store = selectJsStore(state)
 
   return store.prefixes

--- a/pkg/webui/console/store/selectors/pubsub-formats.js
+++ b/pkg/webui/console/store/selectors/pubsub-formats.js
@@ -19,7 +19,7 @@ import { GET_PUBSUB_FORMATS_BASE } from '@console/store/actions/pubsub-formats'
 
 const selectPubsubFormatsStore = state => state.pubsubFormats
 
-export const selectPubsubFormats = function(state) {
+export const selectPubsubFormats = state => {
   const store = selectPubsubFormatsStore(state)
 
   return store.formats || {}

--- a/pkg/webui/console/store/selectors/tests/error_test.js
+++ b/pkg/webui/console/store/selectors/tests/error_test.js
@@ -14,68 +14,68 @@
 
 import { createErrorSelector } from '@ttn-lw/lib/store/selectors/error'
 
-describe('Error selectors', function() {
+describe('Error selectors', () => {
   const BASE_ACTION_TYPE = 'BASE_ACTION'
   let initialState = null
 
-  describe('when created with a single base action type', function() {
+  describe('when created with a single base action type', () => {
     const selector = createErrorSelector(BASE_ACTION_TYPE)
 
-    beforeAll(function() {
+    beforeAll(() => {
       initialState = { ui: { error: {} } }
     })
 
-    describe('has no errors', function() {
-      it('should return `undefined`', function() {
+    describe('has no errors', () => {
+      it('should return `undefined`', () => {
         expect(selector(initialState)).toBeUndefined()
       })
     })
 
-    describe('has error', function() {
+    describe('has error', () => {
       const error = { status: 404 }
 
-      beforeAll(function() {
+      beforeAll(() => {
         initialState.ui.error[BASE_ACTION_TYPE] = error
       })
 
-      it('return the error object', function() {
+      it('return the error object', () => {
         expect(selector(initialState)).toEqual(error)
       })
     })
   })
 
-  describe('when created with two base action types', function() {
+  describe('when created with two base action types', () => {
     const BASE_ACTION_TYPE_OTHER = 'BASE_ACTION_OTHER'
     const selector = createErrorSelector([BASE_ACTION_TYPE, BASE_ACTION_TYPE_OTHER])
 
-    beforeAll(function() {
+    beforeAll(() => {
       initialState = { ui: { error: {} } }
     })
 
-    describe('when there is no error', function() {
-      it('return `undefined`', function() {
+    describe('when there is no error', () => {
+      it('return `undefined`', () => {
         expect(selector(initialState)).toBeUndefined()
       })
     })
 
-    describe('when there is an error', function() {
+    describe('when there is an error', () => {
       const not_found = { status: 404 }
       const forbidden = { status: 403 }
 
-      beforeAll(function() {
+      beforeAll(() => {
         initialState.ui.error[BASE_ACTION_TYPE] = not_found
       })
 
-      it('return the error object', function() {
+      it('return the error object', () => {
         expect(selector(initialState)).toEqual(not_found)
       })
 
-      describe('when there are two errors', function() {
-        beforeAll(function() {
+      describe('when there are two errors', () => {
+        beforeAll(() => {
           initialState.ui.error[BASE_ACTION_TYPE_OTHER] = forbidden
         })
 
-        it('return the first error object', function() {
+        it('return the first error object', () => {
           expect(selector(initialState)).toEqual(not_found)
         })
       })

--- a/pkg/webui/console/store/selectors/tests/fetching_test.js
+++ b/pkg/webui/console/store/selectors/tests/fetching_test.js
@@ -14,63 +14,63 @@
 
 import { createFetchingSelector } from '@ttn-lw/lib/store/selectors/fetching'
 
-describe('Fetching selectors', function() {
+describe('Fetching selectors', () => {
   const BASE_ACTION_TYPE = 'BASE_ACTION'
   let initialState = null
 
-  describe('when created with a single base action type', function() {
+  describe('when created with a single base action type', () => {
     const selector = createFetchingSelector(BASE_ACTION_TYPE)
 
-    beforeAll(function() {
+    beforeAll(() => {
       initialState = { ui: { fetching: {} } }
     })
 
-    describe('when it has no fetching entries', function() {
-      it('returns `false`', function() {
+    describe('when it has no fetching entries', () => {
+      it('returns `false`', () => {
         expect(selector(initialState)).toBe(false)
       })
     })
 
-    describe('when it has fetching entry', function() {
-      beforeAll(function() {
+    describe('when it has fetching entry', () => {
+      beforeAll(() => {
         initialState.ui.fetching[BASE_ACTION_TYPE] = true
       })
 
-      it('return `true`', function() {
+      it('return `true`', () => {
         expect(selector(initialState)).toBe(true)
       })
     })
   })
 
-  describe('when created with two base action types', function() {
+  describe('when created with two base action types', () => {
     const BASE_ACTION_TYPE_OTHER = 'BASE_ACTION_OTHER'
     const selector = createFetchingSelector([BASE_ACTION_TYPE, BASE_ACTION_TYPE_OTHER])
 
-    beforeAll(function() {
+    beforeAll(() => {
       initialState = { ui: { fetching: {} } }
     })
 
-    describe('when it has no fetching entries', function() {
-      it('return `false`', function() {
+    describe('when it has no fetching entries', () => {
+      it('return `false`', () => {
         expect(selector(initialState)).toBe(false)
       })
     })
 
-    describe('when it has a fetching entry', function() {
-      beforeAll(function() {
+    describe('when it has a fetching entry', () => {
+      beforeAll(() => {
         initialState.ui.fetching[BASE_ACTION_TYPE] = true
       })
 
-      it('return `true`', function() {
+      it('return `true`', () => {
         expect(selector(initialState)).toBe(true)
       })
 
-      describe('when it has two fetching entries', function() {
-        beforeAll(function() {
+      describe('when it has two fetching entries', () => {
+        beforeAll(() => {
           initialState.ui.fetching[BASE_ACTION_TYPE_OTHER] = true
         })
 
-        it('return `true`', function() {
+        it('return `true`', () => {
           expect(selector(initialState)).toBe(true)
         })
       })

--- a/pkg/webui/console/store/selectors/webhook-formats.js
+++ b/pkg/webui/console/store/selectors/webhook-formats.js
@@ -19,7 +19,7 @@ import { GET_WEBHOOK_FORMATS_BASE } from '@console/store/actions/webhook-formats
 
 const selectWebhookFormatsStore = state => state.webhookFormats
 
-export const selectWebhookFormats = function(state) {
+export const selectWebhookFormats = state => {
   const store = selectWebhookFormatsStore(state)
 
   return store.formats || {}

--- a/pkg/webui/console/store/selectors/webhook-templates.js
+++ b/pkg/webui/console/store/selectors/webhook-templates.js
@@ -23,7 +23,7 @@ import {
 const selectWebhookTemplatesStore = state => state.webhookTemplates
 const selectWebhookTemplatesEntitiesStore = state => selectWebhookTemplatesStore(state).entities
 
-export const selectWebhookTemplateById = function(state, id) {
+export const selectWebhookTemplateById = (state, id) => {
   const entities = selectWebhookTemplatesEntitiesStore(state)
   if (!Boolean(entities)) return undefined
 
@@ -32,7 +32,7 @@ export const selectWebhookTemplateById = function(state, id) {
 export const selectWebhookTemplateError = createErrorSelector(GET_WEBHOOK_TEMPLATE_BASE)
 export const selectWebhookTemplateFetching = createFetchingSelector(GET_WEBHOOK_TEMPLATE_BASE)
 
-export const selectWebhookTemplates = function(state) {
+export const selectWebhookTemplates = state => {
   const { entities } = selectWebhookTemplatesStore(state)
 
   if (!Boolean(entities)) return undefined

--- a/pkg/webui/console/views/admin-user-management-edit/index.js
+++ b/pkg/webui/console/views/admin-user-management-edit/index.js
@@ -59,7 +59,7 @@ const m = defineMessages({
   ({ userId, getUser }) => getUser(userId, ['name', 'primary_email_address', 'state', 'admin']),
   ({ fetching, user }) => fetching || !Boolean(user),
 )
-@withBreadcrumb('admin.user-management.edit', function({ userId }) {
+@withBreadcrumb('admin.user-management.edit', ({ userId }) => {
   return <Breadcrumb path={`/admin/user-management/${userId}`} content={sharedMessages.edit} />
 })
 export default class UserManagementEdit extends Component {

--- a/pkg/webui/console/views/admin-user-management/index.js
+++ b/pkg/webui/console/views/admin-user-management/index.js
@@ -35,7 +35,7 @@ import { mayManageUsers } from '@console/lib/feature-checks'
 import UserManagement from './admin-user-management'
 
 @withFeatureRequirement(mayManageUsers, { redirect: '/' })
-@withBreadcrumb('admin.user-management', function() {
+@withBreadcrumb('admin.user-management', () => {
   return <Breadcrumb path={'/admin/user-management'} content={sharedMessages.userManagement} />
 })
 export default class UserManagementRouter extends Component {

--- a/pkg/webui/console/views/application-collaborator-add/application-collaborator-add.js
+++ b/pkg/webui/console/views/application-collaborator-add/application-collaborator-add.js
@@ -25,7 +25,7 @@ import CollaboratorForm from '@console/components/collaborator-form'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 import PropTypes from '@ttn-lw/lib/prop-types'
 
-@withBreadcrumb('apps.single.collaborators.add', function(props) {
+@withBreadcrumb('apps.single.collaborators.add', props => {
   const appId = props.appId
   return (
     <Breadcrumb path={`/applications/${appId}/collaborators/add`} content={sharedMessages.add} />

--- a/pkg/webui/console/views/application-collaborator-edit/application-collaborator-edit.js
+++ b/pkg/webui/console/views/application-collaborator-edit/application-collaborator-edit.js
@@ -34,7 +34,7 @@ const isUser = collaborator => collaborator.ids && 'user_ids' in collaborator.id
   ({ getCollaborator }) => getCollaborator(),
   ({ fetching, collaborator }) => fetching || !Boolean(collaborator),
 )
-@withBreadcrumb('apps.single.collaborators.edit', function(props) {
+@withBreadcrumb('apps.single.collaborators.edit', props => {
   const { appId, collaboratorId, collaboratorType } = props
 
   return (

--- a/pkg/webui/console/views/application-collaborator-edit/connect.js
+++ b/pkg/webui/console/views/application-collaborator-edit/connect.js
@@ -58,10 +58,10 @@ const mapStateToProps = (state, props) => {
 }
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-  getCollaborator(appId, collaboratorId, isUser) {
+  getCollaborator: (appId, collaboratorId, isUser) => {
     dispatch(getCollaborator('application', appId, collaboratorId, isUser))
   },
-  redirectToList(appId) {
+  redirectToList: appId => {
     dispatch(replace(`/applications/${appId}/collaborators`))
   },
   updateCollaborator: (appId, patch) => api.application.collaborators.update(appId, patch),

--- a/pkg/webui/console/views/application-data/index.js
+++ b/pkg/webui/console/views/application-data/index.js
@@ -43,7 +43,7 @@ const m = defineMessages({
 @withFeatureRequirement(mayViewApplicationEvents, {
   redirect: ({ appId }) => `/applications/${appId}`,
 })
-@withBreadcrumb('apps.single.data', function(props) {
+@withBreadcrumb('apps.single.data', props => {
   return <Breadcrumb path={`/applications/${props.appId}/data`} content={sharedMessages.liveData} />
 })
 export default class Data extends React.Component {

--- a/pkg/webui/console/views/application-general-settings/index.js
+++ b/pkg/webui/console/views/application-general-settings/index.js
@@ -98,7 +98,7 @@ const validationSchema = Yup.object().shape({
 @withFeatureRequirement(mayEditBasicApplicationInfo, {
   redirect: ({ appId }) => `/applications/${appId}`,
 })
-@withBreadcrumb('apps.single.general-settings', function(props) {
+@withBreadcrumb('apps.single.general-settings', props => {
   const { appId } = props
 
   return (

--- a/pkg/webui/console/views/application-general-settings/mapping.js
+++ b/pkg/webui/console/views/application-general-settings/mapping.js
@@ -35,7 +35,7 @@ export const mapAttributesFormValueToAttributes = formValue =>
     )) ||
   null
 
-export const mapFormValuesToApplication = function(values) {
+export const mapFormValuesToApplication = values => {
   return {
     name: values.name,
     description: values.description,

--- a/pkg/webui/console/views/application-integrations-lora-cloud/index.js
+++ b/pkg/webui/console/views/application-integrations-lora-cloud/index.js
@@ -102,7 +102,7 @@ const LoRaCloud = () => {
   )
 }
 
-export default withBreadcrumb('apps.single.integrations.lora-cloud', function(props) {
+export default withBreadcrumb('apps.single.integrations.lora-cloud', props => {
   const { appId } = props
 
   return (

--- a/pkg/webui/console/views/application-integrations-mqtt/index.js
+++ b/pkg/webui/console/views/application-integrations-mqtt/index.js
@@ -60,7 +60,7 @@ const m = defineMessages({
 @withFeatureRequirement(mayViewMqttConnectionInfo, {
   redirect: ({ appId }) => `/applications/${appId}`,
 })
-@withBreadcrumb('apps.single.integrations.mqtt', function(props) {
+@withBreadcrumb('apps.single.integrations.mqtt', props => {
   const { appId } = props
 
   return (

--- a/pkg/webui/console/views/application-integrations-pubsub-add/index.js
+++ b/pkg/webui/console/views/application-integrations-pubsub-add/index.js
@@ -40,7 +40,7 @@ import { selectSelectedApplicationId } from '@console/store/selectors/applicatio
     navigateToList: appId => dispatch(push(`/applications/${appId}/integrations/pubsubs`)),
   }),
 )
-@withBreadcrumb('apps.single.integrations.add', function(props) {
+@withBreadcrumb('apps.single.integrations.add', props => {
   const { appId } = props
   return (
     <Breadcrumb path={`/applications/${appId}/integrations/add`} content={sharedMessages.add} />

--- a/pkg/webui/console/views/application-integrations-pubsub-edit/application-integrations-pubsub-edit.js
+++ b/pkg/webui/console/views/application-integrations-pubsub-edit/application-integrations-pubsub-edit.js
@@ -35,7 +35,7 @@ const m = defineMessages({
   deleteSuccess: 'Pub/Sub deleted',
 })
 
-@withBreadcrumb('apps.single.integrations.edit', function(props) {
+@withBreadcrumb('apps.single.integrations.edit', props => {
   const {
     appId,
     match: {

--- a/pkg/webui/console/views/application-integrations-webhook-add-form/index.js
+++ b/pkg/webui/console/views/application-integrations-webhook-add-form/index.js
@@ -62,7 +62,7 @@ const m = defineMessages({
     navigateToList: appId => dispatch(push(`/applications/${appId}/integrations/webhooks`)),
   }),
 )
-@withBreadcrumb('apps.single.integrations.webhooks.various.add', function(props) {
+@withBreadcrumb('apps.single.integrations.webhooks.various.add', props => {
   const { appId, templateId, webhookTemplate: { name } = {}, isCustom } = props
   let breadcrumbContent = m.customWebhook
   if (!templateId) {

--- a/pkg/webui/console/views/application-integrations-webhook-edit/application-integrations-webhook-edit.js
+++ b/pkg/webui/console/views/application-integrations-webhook-edit/application-integrations-webhook-edit.js
@@ -36,7 +36,7 @@ const m = defineMessages({
   deleteSuccess: 'Webhook deleted',
 })
 
-@withBreadcrumb('apps.single.integrations.webhooks.edit', function(props) {
+@withBreadcrumb('apps.single.integrations.webhooks.edit', props => {
   const {
     appId,
     match: {

--- a/pkg/webui/console/views/device-data/index.js
+++ b/pkg/webui/console/views/device-data/index.js
@@ -32,7 +32,7 @@ import { selectSelectedDevice, selectSelectedDeviceId } from '@console/store/sel
 
 import style from './device-data.styl'
 
-@connect(function(state, props) {
+@connect((state, props) => {
   const device = selectSelectedDevice(state)
   return {
     device,
@@ -40,7 +40,7 @@ import style from './device-data.styl'
     devIds: device && device.ids,
   }
 })
-@withBreadcrumb('device.single.data', function(props) {
+@withBreadcrumb('device.single.data', props => {
   const { devId } = props
   const { appId } = props.match.params
   return (

--- a/pkg/webui/console/views/device-import/index.js
+++ b/pkg/webui/console/views/device-import/index.js
@@ -42,7 +42,7 @@ const m = defineMessages({
   deviceTemplateFormats: selectDeviceTemplateFormats(state),
   deviceTemplateFormatsFetching: selectDeviceTemplateFormatsFetching(state),
 }))
-@withBreadcrumb('devices.import', function(props) {
+@withBreadcrumb('devices.import', props => {
   const { appId } = props
   return (
     <Breadcrumb path={`/applications/${appId}/devices/import`} content={sharedMessages.import} />

--- a/pkg/webui/console/views/device-list/index.js
+++ b/pkg/webui/console/views/device-list/index.js
@@ -26,7 +26,7 @@ import sharedMessages from '@ttn-lw/lib/shared-messages'
 
 import { selectSelectedApplication } from '@console/store/selectors/applications'
 
-@connect(function(state, props) {
+@connect((state, props) => {
   return {
     application: selectSelectedApplication(state),
   }

--- a/pkg/webui/console/views/device-location/index.js
+++ b/pkg/webui/console/views/device-location/index.js
@@ -38,7 +38,7 @@ const m = defineMessages({
   setDeviceLocation: 'Set end device location',
 })
 
-const getRegistryLocation = function(locations) {
+const getRegistryLocation = locations => {
   let registryLocation
   if (locations) {
     for (const key of Object.keys(locations)) {
@@ -59,7 +59,7 @@ const getRegistryLocation = function(locations) {
   }),
   { updateDevice: attachPromise(updateDevice) },
 )
-@withBreadcrumb('device.single.location', function(props) {
+@withBreadcrumb('device.single.location', props => {
   const { devId, appId } = props
   return (
     <Breadcrumb

--- a/pkg/webui/console/views/devices/index.js
+++ b/pkg/webui/console/views/devices/index.js
@@ -37,7 +37,7 @@ import { selectSelectedApplicationId } from '@console/store/selectors/applicatio
 @withFeatureRequirement(mayViewApplicationDevices, {
   redirect: ({ appId }) => `/applications/${appId}`,
 })
-@withBreadcrumb('devices', function({ appId }) {
+@withBreadcrumb('devices', ({ appId }) => {
   return <Breadcrumb path={`/applications/${appId}/devices`} content={sharedMessages.devices} />
 })
 export default class Devices extends React.Component {

--- a/pkg/webui/console/views/gateway-collaborator-edit/index.js
+++ b/pkg/webui/console/views/gateway-collaborator-edit/index.js
@@ -74,10 +74,10 @@ import {
     }
   },
   dispatch => ({
-    getCollaborator(gtwId, collaboratorId, isUser) {
+    getCollaborator: (gtwId, collaboratorId, isUser) => {
       dispatch(getCollaborator('gateway', gtwId, collaboratorId, isUser))
     },
-    redirectToList(gtwId) {
+    redirectToList: gtwId => {
       dispatch(replace(`/gateways/${gtwId}/collaborators`))
     },
   }),

--- a/pkg/webui/console/views/gateway-general-settings/index.js
+++ b/pkg/webui/console/views/gateway-general-settings/index.js
@@ -62,7 +62,7 @@ import m from './messages'
 @withFeatureRequirement(mayEditBasicGatewayInformation, {
   redirect: ({ gtwId }) => `/gateways/${gtwId}`,
 })
-@withBreadcrumb('gateways.single.general-settings', function(props) {
+@withBreadcrumb('gateways.single.general-settings', props => {
   const { gtwId } = props
 
   return (

--- a/pkg/webui/console/views/gateway/index.js
+++ b/pkg/webui/console/views/gateway/index.js
@@ -61,7 +61,7 @@ import {
 } from '@console/store/selectors/gateways'
 
 @connect(
-  function(state, props) {
+  (state, props) => {
     const gtwId = props.match.params.gtwId
     const gateway = selectSelectedGateway(state)
 
@@ -101,7 +101,7 @@ import {
     ]),
   ({ fetching, gateway }) => fetching || !Boolean(gateway),
 )
-@withBreadcrumb('gateways.single', function(props) {
+@withBreadcrumb('gateways.single', props => {
   const {
     gtwId,
     gateway: { name },

--- a/pkg/webui/console/views/gateways/index.js
+++ b/pkg/webui/console/views/gateways/index.js
@@ -30,7 +30,7 @@ import sharedMessages from '@ttn-lw/lib/shared-messages'
 import { mayViewGateways } from '@console/lib/feature-checks'
 
 @withFeatureRequirement(mayViewGateways, { redirect: '/' })
-@withBreadcrumb('gateways', function(props) {
+@withBreadcrumb('gateways', props => {
   return <Breadcrumb path="/gateways" content={sharedMessages.gateways} />
 })
 export default class Gateways extends React.Component {

--- a/pkg/webui/console/views/organization-api-key-add/organization-api-key-add.js
+++ b/pkg/webui/console/views/organization-api-key-add/organization-api-key-add.js
@@ -25,7 +25,7 @@ import { ApiKeyCreateForm } from '@console/components/api-key-form'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 import PropTypes from '@ttn-lw/lib/prop-types'
 
-@withBreadcrumb('orgs.single.api-keys.add', function(props) {
+@withBreadcrumb('orgs.single.api-keys.add', props => {
   const orgId = props.orgId
   return <Breadcrumb path={`/organizations/${orgId}/api-keys/add`} content={sharedMessages.add} />
 })

--- a/pkg/webui/console/views/organization-api-key-edit/connect.js
+++ b/pkg/webui/console/views/organization-api-key-edit/connect.js
@@ -36,7 +36,7 @@ import {
 
 export default OrganizationApiKeyEdit =>
   connect(
-    function(state, props) {
+    (state, props) => {
       const { apiKeyId } = props.match.params
 
       const keyFetching = selectApiKeyFetching(state)
@@ -55,7 +55,7 @@ export default OrganizationApiKeyEdit =>
       }
     },
     dispatch => ({
-      getApiKey(orgId, keyId) {
+      getApiKey: (orgId, keyId) => {
         dispatch(getApiKey('organization', orgId, keyId))
       },
       deleteOrganizationApiKeySuccess: orgId =>

--- a/pkg/webui/console/views/organization-api-key-edit/organization-api-key-edit.js
+++ b/pkg/webui/console/views/organization-api-key-edit/organization-api-key-edit.js
@@ -24,7 +24,7 @@ import { ApiKeyEditForm } from '@console/components/api-key-form'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 import PropTypes from '@ttn-lw/lib/prop-types'
 
-@withBreadcrumb('orgs.single.api-keys.edit', function(props) {
+@withBreadcrumb('orgs.single.api-keys.edit', props => {
   const { orgId, keyId } = props
 
   return (

--- a/pkg/webui/console/views/organization-collaborator-edit/connect.js
+++ b/pkg/webui/console/views/organization-collaborator-edit/connect.js
@@ -62,10 +62,10 @@ export default OrganizationCollaboratorEdit =>
       }
     },
     dispatch => ({
-      getOrganizationCollaborator(orgId, collaboratorId, isUser) {
+      getOrganizationCollaborator: (orgId, collaboratorId, isUser) => {
         dispatch(getCollaborator('organization', orgId, collaboratorId, isUser))
       },
-      redirectToList(orgId) {
+      redirectToList: orgId => {
         dispatch(replace(`/organizations/${orgId}/collaborators`))
       },
       updateOrganizationCollaborator: (orgId, collaborator) =>

--- a/pkg/webui/console/views/organization-collaborator-edit/organization-collaborator-edit.js
+++ b/pkg/webui/console/views/organization-collaborator-edit/organization-collaborator-edit.js
@@ -25,7 +25,7 @@ import CollaboratorForm from '@console/components/collaborator-form'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 import PropTypes from '@ttn-lw/lib/prop-types'
 
-@withBreadcrumb('orgs.single.collaborators.edit', function(props) {
+@withBreadcrumb('orgs.single.collaborators.edit', props => {
   const { orgId, collaboratorId, collaboratorType } = props
 
   return (

--- a/pkg/webui/console/views/organization-collaborators/index.js
+++ b/pkg/webui/console/views/organization-collaborators/index.js
@@ -40,7 +40,7 @@ import { selectSelectedOrganizationId } from '@console/store/selectors/organizat
 @withFeatureRequirement(mayViewOrEditOrganizationCollaborators, {
   redirect: ({ orgId }) => `/organizations/${orgId}`,
 })
-@withBreadcrumb('orgs.single.collaborators', function(props) {
+@withBreadcrumb('orgs.single.collaborators', props => {
   const { match } = props
   const { orgId } = match.params
 

--- a/pkg/webui/console/views/organization-data/organization-data.js
+++ b/pkg/webui/console/views/organization-data/organization-data.js
@@ -32,7 +32,7 @@ const m = defineMessages({
   orgData: 'Organization data',
 })
 
-@withBreadcrumb('orgs.single.data', function(props) {
+@withBreadcrumb('orgs.single.data', props => {
   return (
     <Breadcrumb path={`/organizations/${props.orgId}/data`} content={sharedMessages.liveData} />
   )

--- a/pkg/webui/console/views/organizations/index.js
+++ b/pkg/webui/console/views/organizations/index.js
@@ -30,7 +30,7 @@ import sharedMessages from '@ttn-lw/lib/shared-messages'
 import { mayViewOrganizationsOfUser } from '@console/lib/feature-checks'
 
 @withFeatureRequirement(mayViewOrganizationsOfUser, { redirect: '/' })
-@withBreadcrumb('orgs', function(props) {
+@withBreadcrumb('orgs', props => {
   return <Breadcrumb path="/organizations" content={sharedMessages.organizations} />
 })
 class Organizations extends React.Component {

--- a/pkg/webui/constants/sentry.js
+++ b/pkg/webui/constants/sentry.js
@@ -18,7 +18,7 @@ const sentryConfig = {
   dsn: env.sentryDsn,
   release: process.env.VERSION,
   normalizeDepth: 10,
-  beforeSend(event) {
+  beforeSend: event => {
     if (event.extra.state && event.extra.state.user) {
       delete event.extra.state.user.user.name
     }

--- a/pkg/webui/lib/cache.js
+++ b/pkg/webui/lib/cache.js
@@ -18,7 +18,7 @@ import stringToHash from '@ttn-lw/lib/string-to-hash'
 const hash = stringToHash(selectApplicationRootPath())
 const hashKey = key => `${key}-${hash}`
 
-export function get(key) {
+export const get = key => {
   const hashedKey = hashKey(key)
   const value = localStorage.getItem(hashedKey)
   try {
@@ -28,17 +28,17 @@ export function get(key) {
   }
 }
 
-export function set(key, val) {
+export const set = (key, val) => {
   const hashedKey = hashKey(key)
   const value = JSON.stringify(val)
   localStorage.setItem(hashedKey, value)
 }
 
-export function remove(key) {
+export const remove = key => {
   const hashedKey = hashKey(key)
   return localStorage.removeItem(hashedKey)
 }
 
-export function clearAll() {
+export const clearAll = () => {
   return localStorage.clear()
 }

--- a/pkg/webui/lib/components/env.js
+++ b/pkg/webui/lib/components/env.js
@@ -18,7 +18,7 @@ import displayName from 'react-display-name'
 import PropTypes from '@ttn-lw/lib/prop-types'
 import { warn } from '@ttn-lw/lib/log'
 
-export const withEnv = function(Component) {
+export const withEnv = Component => {
   const Base =
     Component.prototype instanceof React.Component ? React.Component : React.PureComponent
 

--- a/pkg/webui/lib/components/scroll-to-top.js
+++ b/pkg/webui/lib/components/scroll-to-top.js
@@ -15,7 +15,7 @@
 import { useEffect } from 'react'
 import { useLocation } from 'react-router-dom'
 
-export default function ScrollToTop() {
+export default () => {
   const { pathname } = useLocation()
 
   useEffect(() => {

--- a/pkg/webui/lib/cookie.js
+++ b/pkg/webui/lib/cookie.js
@@ -18,7 +18,7 @@
  * @param {string} key - The key of the entry to extract.
  * @returns {string} The extracted value.
  */
-export default function(key) {
+export default key => {
   const matches = document.cookie.match(
     new RegExp(`(?:^|; )${key.replace(/([.$?*|{}()[\]\\/+^])/g, '\\$1')}=([^;]*)`),
   )

--- a/pkg/webui/lib/cookie_test.js
+++ b/pkg/webui/lib/cookie_test.js
@@ -14,57 +14,57 @@
 
 import getCookieValue from './cookie'
 
-describe('Cookie utils', function() {
-  describe('when `document.cookie` is empty', function() {
-    it('returns `undefined`', function() {
+describe('Cookie utils', () => {
+  describe('when `document.cookie` is empty', () => {
+    it('returns `undefined`', () => {
       const value = getCookieValue('missingKey')
 
       expect(value).toBeUndefined()
     })
   })
 
-  describe('when `document.cookie` has a single entry', function() {
+  describe('when `document.cookie` has a single entry', () => {
     const key = 'testKey'
     const value = 'testValue'
 
-    beforeEach(function() {
+    beforeEach(() => {
       document.cookie = `${key}=${value}`
     })
 
-    afterEach(function() {
+    afterEach(() => {
       document.cookie = `${key}=; expires=Thu, 01 Jan 1970 00:00:00 GMT`
     })
 
-    it('extracts value for existing key', function() {
+    it('extracts value for existing key', () => {
       expect(getCookieValue(key)).toBe(value)
     })
 
-    it('returns `undefined` for non existing key', function() {
+    it('returns `undefined` for non existing key', () => {
       expect(getCookieValue('nonExistingKey')).toBeUndefined()
     })
   })
 
-  describe('when `document.cookie` has multiple entries', function() {
+  describe('when `document.cookie` has multiple entries', () => {
     const key1 = 'testKey1'
     const key2 = 'testKey2'
     const value1 = 'testValue1'
     const value2 = 'testValue2'
 
-    beforeEach(function() {
+    beforeEach(() => {
       document.cookie = `${key1}=${value1}`
       document.cookie = `${key2}=${value2}`
     })
 
-    afterEach(function() {
+    afterEach(() => {
       document.cookie = `${key1}=; expires=Thu, 01 Jan 1970 00:00:00 GMT`
       document.cookie = `${key2}=; expires=Thu, 01 Jan 1970 00:00:00 GMT`
     })
 
-    it('extracts the value of the first entry', function() {
+    it('extracts the value of the first entry', () => {
       expect(getCookieValue(key1)).toBe(value1)
     })
 
-    it('extracts the value of the second entry', function() {
+    it('extracts the value of the second entry', () => {
       expect(getCookieValue(key2)).toBe(value2)
     })
   })

--- a/pkg/webui/lib/debounce.js
+++ b/pkg/webui/lib/debounce.js
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export default function debounce(f, ms) {
+export default (f, ms) => {
   let timer = null
   let cancelled = false
   return {
-    debouncedFunction(...args) {
-      const onComplete = function() {
+    debounced: (...args) => {
+      const onComplete = () => {
         if (!cancelled) {
           f(...args)
         }
@@ -28,7 +28,7 @@ export default function debounce(f, ms) {
       }
       timer = setTimeout(onComplete, ms)
     },
-    cancel() {
+    cancel: () => {
       cancelled = true
     },
   }

--- a/pkg/webui/lib/delay.js
+++ b/pkg/webui/lib/delay.js
@@ -12,6 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export default function(t = 0) {
+export default (t = 0) => {
   return new Promise(resolve => setTimeout(resolve, t))
 }

--- a/pkg/webui/lib/diff.js
+++ b/pkg/webui/lib/diff.js
@@ -25,10 +25,10 @@ import { observableDiff, applyChange } from 'deep-diff'
  * @returns {object} - A new object representing the structural differences
  * between `original` and `updated`.
  */
-export default function(original, updated, exclude = []) {
+export default (original, updated, exclude = []) => {
   const result = {}
 
-  observableDiff(original, updated, function(d) {
+  observableDiff(original, updated, d => {
     const entry = d.path[d.path.length - 1]
     if (!exclude.includes(entry)) {
       applyChange(result, undefined, d)

--- a/pkg/webui/lib/errors/grpc-error-map.js
+++ b/pkg/webui/lib/errors/grpc-error-map.js
@@ -36,7 +36,7 @@ const errorMap = {
   '16': '401',
 }
 
-export default function getHttpErrorFromRpcError(rpcError) {
+export default rpcError => {
   if (typeof rpcError !== 'string' && typeof rpcError !== 'number') {
     return undefined
   }

--- a/pkg/webui/lib/from.js
+++ b/pkg/webui/lib/from.js
@@ -51,7 +51,7 @@
  * @returns {Array} - An array of values from a for which the key in b had a
  * trueish value.
  */
-export default function(a = {}, b = {}, only) {
+export default (a = {}, b = {}, only) => {
   const res = []
   for (const key in b) {
     if (!b[key] || !(key in a) || (only && !only.includes(key))) {

--- a/pkg/webui/lib/generate-doc-url.js
+++ b/pkg/webui/lib/generate-doc-url.js
@@ -14,7 +14,7 @@
 
 import { selectApplicationConfig, selectDocumentationUrlConfig } from './selectors/env'
 
-export default function generateDocUrl(path) {
+export default path => {
   if (selectApplicationConfig() && selectDocumentationUrlConfig()) {
     return selectDocumentationUrlConfig().concat(path)
   }

--- a/pkg/webui/lib/get-by-path.js
+++ b/pkg/webui/lib/get-by-path.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export default function getByPath(ob, path) {
+export default (ob, path) => {
   const paths = path.split('.')
   if (paths.length === 1) {
     return ob[path]

--- a/pkg/webui/lib/hooks/use-root-class.js
+++ b/pkg/webui/lib/hooks/use-root-class.js
@@ -21,7 +21,7 @@ export default (className, id = 'app') => {
     for (const cls of classNamesList) {
       containerClasses.add(cls)
     }
-    return function cleanup() {
+    return () => {
       for (const cls of classNamesList) {
         containerClasses.remove(cls)
       }

--- a/pkg/webui/lib/log.js
+++ b/pkg/webui/lib/log.js
@@ -16,20 +16,22 @@
 
 import dev from './dev'
 
-export function warn(...args) {
+export const warn = (...args) => {
   if (dev) {
     console.warn(...args)
   }
 }
 
-export function error(...args) {
+export const error = (...args) => {
   if (dev) {
     console.warn(...args)
   }
 }
 
-export default function log(...args) {
+const log = (...args) => {
   if (dev) {
     console.log(...args)
   }
 }
+
+export default log

--- a/pkg/webui/lib/omit.js
+++ b/pkg/webui/lib/omit.js
@@ -26,9 +26,9 @@
  * @param {object|Array} value - Multinested object or array.
  * @param {string[]} key - Array of properties / keys to exclude from `value`.
  * @param {string[]} regexp - Regular expression for excluding properties from `value`.
- * @returns {object|Array} The new object/array without specified properties/keys.
+ * @returns {object|Array} The ininew object/array without specified properties/keys.
  */
-export default function omitDeep(value, key, regexp = /(?!)/) {
+const omitDeep = (value, key, regexp = /(?!)/) => {
   if (Array.isArray(value)) {
     return value.map(i => omitDeep(i, key))
   } else if (typeof value === 'object' && value !== null) {
@@ -39,3 +39,5 @@ export default function omitDeep(value, key, regexp = /(?!)/) {
   }
   return value
 }
+
+export default omitDeep

--- a/pkg/webui/lib/omit_test.js
+++ b/pkg/webui/lib/omit_test.js
@@ -144,49 +144,49 @@ const stateObject = {
   gatewayStatus: {},
 }
 
-describe('Omit utils', function() {
-  describe('when object is empty', function() {
+describe('Omit utils', () => {
+  describe('when object is empty', () => {
     const object = {}
-    it('returns same object', function() {
+    it('returns same object', () => {
       const result = omitDeep(object, ['value'])
 
       expect(result).toStrictEqual(object)
     })
   })
 
-  describe('when array of values is empty', function() {
+  describe('when array of values is empty', () => {
     const values = []
-    it('returns same object', function() {
+    it('returns same object', () => {
       const result = omitDeep(stateObject, values)
 
       expect(result).toStrictEqual(stateObject)
     })
   })
 
-  describe('when object and values are empty', function() {
+  describe('when object and values are empty', () => {
     const object = {}
     const values = []
-    it('returns same object', function() {
+    it('returns same object', () => {
       const result = omitDeep(object, values)
 
       expect(result).toStrictEqual(object)
     })
   })
 
-  describe('when excluding the single top level property', function() {
+  describe('when excluding the single top level property', () => {
     const values = ['gateways']
 
-    it('omits object `gateways` property', function() {
+    it('omits object `gateways` property', () => {
       const result = omitDeep(stateObject, values)
 
       expect(result.gateways).toBeUndefined()
     })
   })
 
-  describe('when excluding multiple top level and nested properties', function() {
+  describe('when excluding multiple top level and nested properties', () => {
     const values = ['apiKeys', 'ids']
 
-    it('omits all occurrences of `apiKeys` and `ids`', function() {
+    it('omits all occurrences of `apiKeys` and `ids`', () => {
       const result = omitDeep(stateObject, values)
 
       expect(result.pagination.gateways.totalCount).toStrictEqual(

--- a/pkg/webui/lib/store/actions/create-request-actions.js
+++ b/pkg/webui/lib/store/actions/create-request-actions.js
@@ -14,7 +14,7 @@
 
 import { createAction } from 'redux-actions'
 
-export default function(baseType, requestPayloadCreator, requestMetaCreator) {
+export default (baseType, requestPayloadCreator, requestMetaCreator) => {
   const requestType = `${baseType}_REQUEST`
   const successType = `${baseType}_SUCCESS`
   const failureType = `${baseType}_FAILURE`

--- a/pkg/webui/lib/store/middleware/request-promise-middleware.js
+++ b/pkg/webui/lib/store/middleware/request-promise-middleware.js
@@ -21,20 +21,19 @@ import { CancelablePromise } from 'cancelable-promise'
  * @param {object} store - The store to apply the middleware to.
  * @returns {object} The middleware.
  */
-const requestPromiseMiddleware = store => next =>
-  function(action) {
-    if (action.meta && action.meta._attachPromise) {
-      return new CancelablePromise(function(resolve, reject) {
-        action.meta = {
-          ...action.meta,
-          _resolve: resolve,
-          _reject: reject,
-        }
-        next(action)
-      })
-    }
-
-    return next(action)
+const requestPromiseMiddleware = store => next => action => {
+  if (action.meta && action.meta._attachPromise) {
+    return new CancelablePromise((resolve, reject) => {
+      action.meta = {
+        ...action.meta,
+        _resolve: resolve,
+        _reject: reject,
+      }
+      next(action)
+    })
   }
+
+  return next(action)
+}
 
 export default requestPromiseMiddleware

--- a/pkg/webui/lib/store/reducers/pagination.js
+++ b/pkg/webui/lib/store/reducers/pagination.js
@@ -24,11 +24,11 @@ const defaultState = {
   totalCount: undefined,
 }
 
-export const createNamedPaginationReducer = function(reducerName, entityIdSelector) {
+export const createNamedPaginationReducer = (reducerName, entityIdSelector) => {
   const [{ success: GET_PAGINATION_SUCCESS }] = createPaginationRequestActions(reducerName)
   const [{ success: DELETE_PAGINATION_SUCCESS }] = createPaginationDeleteActions(reducerName)
 
-  return function(state = defaultState, { type, payload }) {
+  return (state = defaultState, { type, payload }) => {
     switch (type) {
       case GET_PAGINATION_SUCCESS:
         return {
@@ -48,13 +48,13 @@ export const createNamedPaginationReducer = function(reducerName, entityIdSelect
   }
 }
 
-export const createNamedPaginationReducerById = function(reducerName, entityIdSelector) {
+export const createNamedPaginationReducerById = (reducerName, entityIdSelector) => {
   const [{ success: GET_PAGINATION_SUCCESS }] = createPaginationByIdRequestActions(reducerName)
   const [{ success: DELETE_PAGINATION_SUCCESS }] = createPaginationByIdDeleteActions(reducerName)
   const [, { success }] = createPaginationDeleteActions(reducerName)
   const paginationReducer = createNamedPaginationReducer(reducerName, entityIdSelector)
 
-  return function(state = {}, action) {
+  return (state = {}, action) => {
     const { id } = action.payload
 
     if (!id) {

--- a/pkg/webui/lib/store/reducers/tests/error_test.js
+++ b/pkg/webui/lib/store/reducers/tests/error_test.js
@@ -14,45 +14,45 @@
 
 import reducer from '../ui/error'
 
-describe('Error reducers', function() {
+describe('Error reducers', () => {
   const BASE = 'BASE_ACTION'
   const REQUEST = `${BASE}_REQUEST`
   const SUCCESS = `${BASE}_SUCCESS`
   const FAILURE = `${BASE}_FAILURE`
   const defaultState = {}
 
-  it('return the initial state', function() {
+  it('return the initial state', () => {
     expect(reducer(undefined, {})).toEqual({})
   })
 
-  describe('when dispatching an invalid action type', function() {
-    it('ignores the base type', function() {
+  describe('when dispatching an invalid action type', () => {
+    it('ignores the base type', () => {
       expect(reducer(defaultState, { type: BASE })).toEqual(defaultState)
     })
   })
 
-  describe('when dispatching the `failure` action', function() {
+  describe('when dispatching the `failure` action', () => {
     const error = { status: 404 }
     let newState
 
-    beforeAll(function() {
+    beforeAll(() => {
       newState = reducer(defaultState, { type: FAILURE, payload: error, error: true })
     })
 
-    it('set the error', function() {
+    it('set the error', () => {
       expect(newState).toEqual({ [BASE]: error })
     })
 
-    describe('when dispatching the `success` action', function() {
-      it('reset the error', function() {
+    describe('when dispatching the `success` action', () => {
+      it('reset the error', () => {
         expect(reducer(newState, { type: SUCCESS })).toEqual({
           [BASE]: undefined,
         })
       })
     })
 
-    describe('when dispatching the `request` action', function() {
-      it('reset the error', function() {
+    describe('when dispatching the `request` action', () => {
+      it('reset the error', () => {
         expect(reducer(newState, { type: REQUEST })).toEqual({
           [BASE]: undefined,
         })

--- a/pkg/webui/lib/store/reducers/tests/fetching_test.js
+++ b/pkg/webui/lib/store/reducers/tests/fetching_test.js
@@ -14,39 +14,39 @@
 
 import reducer from '../ui/fetching'
 
-describe('Fetching reducers', function() {
+describe('Fetching reducers', () => {
   const BASE = 'BASE_ACTION'
   const REQUEST = `${BASE}_REQUEST`
   const SUCCESS = `${BASE}_SUCCESS`
   const FAILURE = `${BASE}_FAILURE`
 
-  it('return the initial state', function() {
+  it('return the initial state', () => {
     expect(reducer(undefined, {})).toEqual({})
   })
 
-  describe('when dispatching invalid action type', function() {
-    it('ignore the action', function() {
+  describe('when dispatching invalid action type', () => {
+    it('ignore the action', () => {
       expect(reducer({}, { type: BASE })).toEqual({})
     })
   })
 
-  describe('when dispatching the `request` action', function() {
-    it('set fetching to `true`', function() {
+  describe('when dispatching the `request` action', () => {
+    it('set fetching to `true`', () => {
       expect(reducer({}, { type: REQUEST })).toEqual({
         [BASE]: true,
       })
     })
 
-    describe('when dispatching the `success` action', function() {
-      it('set fetching to `false`', function() {
+    describe('when dispatching the `success` action', () => {
+      it('set fetching to `false`', () => {
         expect(reducer({}, { type: SUCCESS })).toEqual({
           [BASE]: false,
         })
       })
     })
 
-    describe('when dispatching the `failure` action', function() {
-      it('set fetching to `false`', function() {
+    describe('when dispatching the `failure` action', () => {
+      it('set fetching to `false`', () => {
         expect(reducer({}, { type: FAILURE })).toEqual({
           [BASE]: false,
         })

--- a/pkg/webui/lib/store/reducers/tests/pagination_test.js
+++ b/pkg/webui/lib/store/reducers/tests/pagination_test.js
@@ -20,11 +20,11 @@ import {
   createPaginationByIdDeleteActions,
 } from '../../actions/pagination'
 
-describe('Pagination reducers', function() {
+describe('Pagination reducers', () => {
   const NAME = 'ENTITY'
   const entityIdSelector = entity => entity.id
 
-  describe('flat', function() {
+  describe('flat', () => {
     const reducer = createNamedPaginationReducer(NAME, entityIdSelector)
     const defaultState = { ids: [], totalCount: undefined }
 
@@ -35,63 +35,63 @@ describe('Pagination reducers', function() {
       failure: failureDelete,
     } = createPaginationDeleteActions(NAME)[1]
 
-    it('return the initial state', function() {
+    it('return the initial state', () => {
       expect(reducer(undefined, { payload: {} })).toEqual(defaultState)
     })
 
-    it('ignore the get `request` action', function() {
+    it('ignore the get `request` action', () => {
       expect(reducer(defaultState, request())).toEqual(defaultState)
     })
 
-    it('ignore the get `failure` action', function() {
+    it('ignore the get `failure` action', () => {
       expect(reducer(defaultState, failure())).toEqual(defaultState)
     })
 
-    it('ignore the delete `request` action', function() {
+    it('ignore the delete `request` action', () => {
       expect(reducer(defaultState, requestDelete('test-id'))).toEqual(defaultState)
     })
 
-    it('ignore the delete `failure` action', function() {
+    it('ignore the delete `failure` action', () => {
       expect(reducer(defaultState, failureDelete())).toEqual(defaultState)
     })
 
-    describe('when receiving the `success` action', function() {
+    describe('when receiving the `success` action', () => {
       const entities = [{ id: '1', name: 'name1' }, { id: '2', name: 'name2' }]
       const totalCount = entities.length
       const action = success({ entities, totalCount })
 
       let newState = null
 
-      beforeAll(function() {
+      beforeAll(() => {
         newState = reducer(defaultState, action)
       })
 
-      it('update the state', function() {
+      it('update the state', () => {
         expect(newState).not.toEqual(defaultState)
       })
 
-      it('store ids only', function() {
+      it('store ids only', () => {
         const { ids } = newState
 
         expect(ids).toEqual(entities.map(e => e.id))
       })
 
-      it('store `totalCount`', function() {
+      it('store `totalCount`', () => {
         const { totalCount: newTotalCount } = newState
 
         expect(newTotalCount).toEqual(totalCount)
       })
 
-      describe('when deleting an entity', function() {
-        beforeAll(function() {
+      describe('when deleting an entity', () => {
+        beforeAll(() => {
           newState = reducer(newState, successDelete({ id: entities[0].id }))
         })
 
-        it('decrease `totalCount`', function() {
+        it('decrease `totalCount`', () => {
           expect(newState.totalCount).toEqual(entities.length - 1)
         })
 
-        it('remove deleted id from `ids`', function() {
+        it('remove deleted id from `ids`', () => {
           expect(newState.ids).toHaveLength(entities.length - 1)
           expect(newState.ids).toEqual(expect.not.arrayContaining(entities))
         })
@@ -99,7 +99,7 @@ describe('Pagination reducers', function() {
     })
   })
 
-  describe('when querying by id', function() {
+  describe('when querying by id', () => {
     const reducer = createNamedPaginationReducerById(NAME, entityIdSelector)
     const defaultState = {}
     const entityId = 'parent-id'
@@ -111,90 +111,90 @@ describe('Pagination reducers', function() {
       failure: failureDelete,
     } = createPaginationByIdDeleteActions(NAME)[1]
 
-    it('return the initial state', function() {
+    it('return the initial state', () => {
       expect(reducer(undefined, { payload: {} })).toEqual(defaultState)
     })
 
-    it('ignore the `request` action', function() {
+    it('ignore the `request` action', () => {
       expect(reducer(defaultState, request(entityId))).toEqual(defaultState)
     })
 
-    it('ignore the `failure` action', function() {
+    it('ignore the `failure` action', () => {
       expect(reducer(defaultState, failure({}))).toEqual(defaultState)
     })
 
-    it('ignore the delete `request` action', function() {
+    it('ignore the delete `request` action', () => {
       expect(reducer(defaultState, requestDelete('test-id', 'target-test-id'))).toEqual(
         defaultState,
       )
     })
 
-    it('ignore the delete `failure` action', function() {
+    it('ignore the delete `failure` action', () => {
       expect(reducer(defaultState, failureDelete('test-id'))).toEqual(defaultState)
     })
 
-    describe('when receiving the `success` action', function() {
+    describe('when receiving the `success` action', () => {
       const entities = [{ id: '1', name: 'name1' }, { id: '2', name: 'name2' }]
       const totalCount = entities.length
       const action = success({ id: entityId, entities, totalCount })
 
       let newState = null
 
-      beforeAll(function() {
+      beforeAll(() => {
         newState = reducer(defaultState, action)
       })
 
-      it('ignore without `id` in the payload', function() {
+      it('ignore without `id` in the payload', () => {
         const updatedState = reducer(defaultState, success({ entities: [], totalCount }))
 
         expect(updatedState).toEqual(defaultState)
       })
 
-      it('update the state', function() {
+      it('update the state', () => {
         expect(newState).not.toEqual(defaultState)
       })
 
-      it('store results per entity id', function() {
+      it('store results per entity id', () => {
         const { [entityId]: results } = newState
 
         expect(results).not.toBeUndefined()
       })
 
-      it('only store ids', function() {
+      it('only store ids', () => {
         const { [entityId]: results } = newState
 
         expect(results.ids).toEqual(entities.map(entityIdSelector))
       })
 
-      it('store `totalCount`', function() {
+      it('store `totalCount`', () => {
         const { [entityId]: results } = newState
 
         expect(results.totalCount).toEqual(totalCount)
       })
 
-      describe('deletes entity', function() {
+      describe('deletes entity', () => {
         let updatedState
 
-        beforeAll(function() {
+        beforeAll(() => {
           updatedState = reducer(
             newState,
             successDelete({ id: entityId, targetId: entities[0].id }),
           )
         })
 
-        it('decrease `totalCount`', function() {
+        it('decrease `totalCount`', () => {
           const { [entityId]: results } = updatedState
           expect(results.totalCount).toEqual(entities.length - 1)
         })
 
-        it('remove deleted id from `ids`', function() {
+        it('remove deleted id from `ids`', () => {
           const { [entityId]: results } = updatedState
           expect(results.ids).toHaveLength(entities.length - 1)
           expect(results.ids).toEqual(expect.not.arrayContaining(entities))
         })
       })
 
-      describe('when receiving the `success` action for another entity', function() {
+      describe('when receiving the `success` action for another entity', () => {
         const otherEntityId = 'other-entity-id'
         const otherEntities = [
           { id: '3', name: 'name3' },
@@ -210,15 +210,15 @@ describe('Pagination reducers', function() {
 
         let otherNewState = null
 
-        beforeAll(function() {
+        beforeAll(() => {
           otherNewState = reducer(newState, action)
         })
 
-        it('update the state', function() {
+        it('update the state', () => {
           expect(otherNewState).not.toEqual(newState)
         })
 
-        it('preserve previous entries', function() {
+        it('preserve previous entries', () => {
           const { [entityId]: results } = otherNewState
 
           expect(results).not.toBeUndefined()
@@ -226,40 +226,40 @@ describe('Pagination reducers', function() {
           expect(results.totalCount).toEqual(totalCount)
         })
 
-        it('store results per entity id', function() {
+        it('store results per entity id', () => {
           const { [otherEntityId]: results } = otherNewState
 
           expect(results).not.toBeUndefined()
         })
 
-        it('only store ids', function() {
+        it('only store ids', () => {
           const { [otherEntityId]: results } = otherNewState
 
           expect(results.ids).toEqual(otherEntities.map(e => e.id))
         })
 
-        it('store `totalCount`', function() {
+        it('store `totalCount`', () => {
           const { [otherEntityId]: results } = otherNewState
 
           expect(results.totalCount).toEqual(otherTotalCount)
         })
 
-        describe('when deleting an entity', function() {
+        describe('when deleting an entity', () => {
           let updatedState
 
-          beforeAll(function() {
+          beforeAll(() => {
             updatedState = reducer(
               otherNewState,
               successDelete({ id: otherEntityId, targetId: otherEntities[0].id }),
             )
           })
 
-          it('decrease `totalCount`', function() {
+          it('decrease `totalCount`', () => {
             const { [entityId]: results } = updatedState
             expect(results.totalCount).toEqual(otherEntities.length - 1)
           })
 
-          it('remove deleted id from `ids`', function() {
+          it('remove deleted id from `ids`', () => {
             const { [entityId]: results } = updatedState
             expect(results.ids).toHaveLength(otherEntities.length - 1)
             expect(results.ids).toEqual(expect.not.arrayContaining(otherEntities))

--- a/pkg/webui/lib/store/reducers/ui/error.js
+++ b/pkg/webui/lib/store/reducers/ui/error.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const error = function(state = {}, action) {
+const error = (state = {}, action) => {
   const { type, payload: errorValue } = action
 
   const matches = /(.*)_(REQUEST|SUCCESS|FAILURE)/.exec(type)

--- a/pkg/webui/lib/store/reducers/ui/fetching.js
+++ b/pkg/webui/lib/store/reducers/ui/fetching.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const fetching = function(state = {}, action) {
+const fetching = (state = {}, action) => {
   const { type } = action
   const matches = /(.*)_(REQUEST|SUCCESS|FAILURE)/.exec(type)
 

--- a/pkg/webui/lib/store/selectors/error.js
+++ b/pkg/webui/lib/store/selectors/error.js
@@ -31,17 +31,16 @@ const getErrorStoreEntrySelector = (state, baseActionType) =>
  * @param {Array} actions - A list of base action types or a single base action type.
  * @returns {object} The error object matching one of the base action types.
  */
-export const createErrorSelector = actions =>
-  function(state) {
-    if (!Array.isArray(actions)) {
-      return getErrorStoreEntrySelector(state, actions)
-    }
+export const createErrorSelector = actions => state => {
+  if (!Array.isArray(actions)) {
+    return getErrorStoreEntrySelector(state, actions)
+  }
 
-    for (const action of actions) {
-      const error = getErrorStoreEntrySelector(state, action)
+  for (const action of actions) {
+    const error = getErrorStoreEntrySelector(state, action)
 
-      if (Boolean(error)) {
-        return error
-      }
+    if (Boolean(error)) {
+      return error
     }
   }
+}

--- a/pkg/webui/lib/store/selectors/fetching.js
+++ b/pkg/webui/lib/store/selectors/fetching.js
@@ -31,11 +31,10 @@ const selectFetchingEntry = (state, id) => selectFetchingStore(state)[id] || fal
  * @returns {boolean} `true` if one of the base action types is in the `fetching` state,
  * `false` otherwise.
  */
-export const createFetchingSelector = actions =>
-  function(state) {
-    if (!Array.isArray(actions)) {
-      return selectFetchingEntry(state, actions)
-    }
-
-    return actions.some(action => selectFetchingEntry(state, action))
+export const createFetchingSelector = actions => state => {
+  if (!Array.isArray(actions)) {
+    return selectFetchingEntry(state, actions)
   }
+
+  return actions.some(action => selectFetchingEntry(state, action))
+}

--- a/pkg/webui/lib/store/selectors/pagination.js
+++ b/pkg/webui/lib/store/selectors/pagination.js
@@ -16,18 +16,18 @@ const selectStore = state => state.pagination
 
 const createStoreSelectorByEntity = entity => state => selectStore(state)[entity] || {}
 
-export const createPaginationIdsSelectorByEntity = function(entity) {
+export const createPaginationIdsSelectorByEntity = entity => {
   const storeSelector = createStoreSelectorByEntity(entity)
 
-  return function(state) {
+  return state => {
     return storeSelector(state).ids || []
   }
 }
 
-export const createPaginationIdsSelectorByEntityAndId = function(entity) {
+export const createPaginationIdsSelectorByEntityAndId = entity => {
   const storeSelector = createStoreSelectorByEntity(entity)
 
-  return function(state, id) {
+  return (state, id) => {
     const store = storeSelector(state)
     const storeById = store[id] || {}
 
@@ -35,18 +35,18 @@ export const createPaginationIdsSelectorByEntityAndId = function(entity) {
   }
 }
 
-export const createPaginationTotalCountSelectorByEntity = function(entity) {
+export const createPaginationTotalCountSelectorByEntity = entity => {
   const storeSelector = createStoreSelectorByEntity(entity)
 
-  return function(state) {
+  return state => {
     return storeSelector(state).totalCount
   }
 }
 
-export const createPaginationTotalCountSelectorByEntityAndId = function(entity) {
+export const createPaginationTotalCountSelectorByEntityAndId = entity => {
   const storeSelector = createStoreSelectorByEntity(entity)
 
-  return function(state, id) {
+  return (state, id) => {
     const store = storeSelector(state)
     const storeById = store[id] || {}
 

--- a/pkg/webui/lib/string-to-hash.js
+++ b/pkg/webui/lib/string-to-hash.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export default function(string) {
+export default string => {
   let hash = 0
   let chr = 0
   if (string.length === 0) return hash

--- a/pkg/webui/lib/to-input-date.js
+++ b/pkg/webui/lib/to-input-date.js
@@ -19,7 +19,7 @@
  * @returns {string} 'yyyy-mm-dd' or undefined.
  */
 
-export default function(d) {
+export default d => {
   if (Object.prototype.toString.call(d) !== '[object Date]' || isNaN(d.getTime())) {
     return undefined
   }

--- a/pkg/webui/lib/to-input-date_test.js
+++ b/pkg/webui/lib/to-input-date_test.js
@@ -14,28 +14,28 @@
 
 import toInputDate from './to-input-date'
 
-describe('To input date converter', function() {
-  describe('when using a correct argument', function() {
+describe('To input date converter', () => {
+  describe('when using a correct argument', () => {
     const date = new Date('2020-09-24T12:00:00Z')
 
-    it('returns a string length equal to 10', function() {
+    it('returns a string length equal to 10', () => {
       expect(toInputDate(date)).toHaveLength(10)
     })
 
-    it('returns a string of yyyy-mm--dd format', function() {
+    it('returns a string of yyyy-mm--dd format', () => {
       expect(toInputDate(date)).toMatch(/([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))/)
     })
   })
 
-  describe('when unsing an incorrect argument', function() {
+  describe('when unsing an incorrect argument', () => {
     const string = 'ABC123'
     const date = new Date('ABC123')
 
-    it('returns undefined when using a random string', function() {
+    it('returns undefined when using a random string', () => {
       expect(toInputDate(string)).toBe(undefined)
     })
 
-    it('returns undefined when using an invalid date', function() {
+    it('returns undefined when using an invalid date', () => {
       expect(toInputDate(date)).toBe(undefined)
     })
   })

--- a/pkg/webui/lib/yup.js
+++ b/pkg/webui/lib/yup.js
@@ -28,9 +28,9 @@ class NullableStringSchemaType extends StringSchema {
     const self = this
 
     /* eslint-disable prefer-arrow/prefer-arrow-functions */
-    self.withMutation(function() {
+    self.withMutation(() => {
       self
-        .transform(function(value) {
+        .transform(value => {
           if (self.isType(value) && Boolean(value)) {
             return value
           }

--- a/sdk/js/src/api/index.test.js
+++ b/sdk/js/src/api/index.test.js
@@ -59,9 +59,9 @@ jest.mock('../../generated/api-definition.json', () => ({
   },
 }))
 
-describe('API class', function() {
+describe('API class', () => {
   let api
-  beforeEach(function() {
+  beforeEach(() => {
     api = new Api(
       'http',
       { mode: 'key', key: 'ABCDEFG' },
@@ -75,12 +75,12 @@ describe('API class', function() {
     api._connector.handleRequest = jest.fn()
   })
 
-  it('applies api definitions correctly', function() {
+  it('applies api definitions correctly', () => {
     expect(api.ApplicationRegistry.Create).toBeDefined()
     expect(typeof api.ApplicationRegistry.Create).toBe('function')
   })
 
-  it('applies parameters correctly', function() {
+  it('applies parameters correctly', () => {
     api.ApplicationRegistry.Create(
       { routeParams: { 'collaborator.user_ids.user_id': 'test' } },
       { name: 'test-name' },
@@ -96,13 +96,13 @@ describe('API class', function() {
     )
   })
 
-  it('throws when parameters mismatch', function() {
-    expect(function() {
+  it('throws when parameters mismatch', () => {
+    expect(() => {
       api.ApplicationRegistry.Create({ 'some.other.param': 'test' })
     }).toThrow()
   })
 
-  it('respects the search query', function() {
+  it('respects the search query', () => {
     api.ApplicationRegistry.List(undefined, { limit: 2, page: 1 })
 
     expect(api._connector.handleRequest).toHaveBeenCalledTimes(1)
@@ -115,7 +115,7 @@ describe('API class', function() {
     )
   })
 
-  it('sets stream value to true for streaming endpoints', function() {
+  it('sets stream value to true for streaming endpoints', () => {
     api.ApplicationRegistry.Events()
 
     expect(api._connector.handleRequest).toHaveBeenCalledTimes(1)

--- a/sdk/js/src/api/stream/shared.js
+++ b/sdk/js/src/api/stream/shared.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export const notify = function(listener, ...args) {
+export const notify = (listener, ...args) => {
   if (listener !== null) {
     listener(...args)
   }

--- a/sdk/js/src/examples/basic.js
+++ b/sdk/js/src/examples/basic.js
@@ -37,33 +37,33 @@ const appData = {
   description: `Some description ${hash}`,
 }
 
-async function createApplication() {
+const createApplication = async () => {
   const firstApp = await tts.Applications.create('testuser', appData)
   console.log(firstApp)
 }
 
-async function getApplication() {
+const getApplication = async () => {
   const firstApp = await tts.Applications.getById(appName)
   console.log(firstApp)
 }
 
-async function listApplications() {
+const listApplications = async () => {
   const apps = await tts.Applications.getAll()
   console.log(apps)
 }
 
-async function updateApplication() {
+const updateApplication = async () => {
   const patch = { description: 'New description' }
   const res = await tts.Applications.updateById(appName, patch)
   console.log(res)
 }
 
-async function deleteApplication() {
+const deleteApplication = async () => {
   await tts.Applications.deleteById(appName)
   await tts.Applications.deleteById(`second-app-${hash}`)
 }
 
-async function main() {
+const main = async () => {
   try {
     await createApplication()
     await getApplication()

--- a/sdk/js/src/index.test.js
+++ b/sdk/js/src/index.test.js
@@ -52,8 +52,8 @@ const mockDeviceData = {
   },
 }
 
-jest.mock('./api', function() {
-  return jest.fn().mockImplementation(function() {
+jest.mock('./api', () => {
+  return jest.fn().mockImplementation(() => {
     return {
       ApplicationRegistry: {
         Get: jest.fn().mockResolvedValue({ data: mockApplicationData }),
@@ -78,7 +78,7 @@ jest.mock('./api', function() {
   })
 })
 
-describe('SDK class', function() {
+describe('SDK class', () => {
   const token = 'faketoken'
   const tts = new TTS({
     authorization: {
@@ -89,13 +89,13 @@ describe('SDK class', function() {
     stackConfig: { is: 'http://localhost:1885/api/v3' },
   })
 
-  it('instanciates successfully', async function() {
+  it('instanciates successfully', async () => {
     expect(tts).toBeDefined()
     expect(tts).toBeInstanceOf(TTS)
     expect(tts.Applications).toBeInstanceOf(Applications)
   })
 
-  it('retrieves application instance correctly', async function() {
+  it('retrieves application instance correctly', async () => {
     const app = await tts.Applications.getById('test')
     expect(app).toBeDefined()
   })

--- a/sdk/js/src/service/applications.test.js
+++ b/sdk/js/src/service/applications.test.js
@@ -36,8 +36,8 @@ const mockApplicationData = {
   ],
 }
 
-jest.mock('../api', function() {
-  return jest.fn().mockImplementation(function() {
+jest.mock('../api', () => {
+  return jest.fn().mockImplementation(() => {
     return {
       ApplicationRegistry: {
         Get: jest.fn().mockResolvedValue({ data: mockApplicationData }),
@@ -50,23 +50,23 @@ jest.mock('../api', function() {
   })
 })
 
-describe('Applications', function() {
+describe('Applications', () => {
   let applications
-  beforeEach(function() {
+  beforeEach(() => {
     const Api = require('../api')
 
     const Applications = require('./applications').default
     applications = new Applications(new Api(), { defaultUserId: 'testuser' })
   })
 
-  describe('when using proxied results', function() {
-    it('initializes correctly', function() {
+  describe('when using proxied results', () => {
+    it('initializes correctly', () => {
       jest.resetModules()
 
       expect(applications._api).toBeDefined()
     })
 
-    it('returns an application instance on getById()', async function() {
+    it('returns an application instance on getById()', async () => {
       jest.resetModules()
 
       const app = await applications.getById('test')
@@ -74,7 +74,7 @@ describe('Applications', function() {
       expect(app.ids.application_id).toBe('test')
     })
 
-    it('returns an application list on getAll()', async function() {
+    it('returns an application list on getAll()', async () => {
       jest.resetModules()
 
       const result = await applications.getAll()

--- a/sdk/js/src/service/devices/split.js
+++ b/sdk/js/src/service/devices/split.js
@@ -34,7 +34,7 @@ const { is: IS, ns: NS, as: AS, js: JS } = STACK_COMPONENTS_MAP
  * @returns {object} A request tree object, consisting of resulting paths for
  * each component eg: `{ is: ['ids'], as: ['session'], js: ['root_keys'] }`.
  */
-function splitPaths(paths = [], direction, base = {}, components = [IS, NS, AS, JS]) {
+const splitPaths = (paths = [], direction, base = {}, components = [IS, NS, AS, JS]) => {
   const result = base
   const retrieveIndex = direction === 'get' ? 0 : 1
 
@@ -48,7 +48,7 @@ function splitPaths(paths = [], direction, base = {}, components = [IS, NS, AS, 
 
     const definition = '_root' in subtree ? subtree._root[retrieveIndex] : subtree[retrieveIndex]
 
-    const map = function(requestTree, component, path) {
+    const map = (requestTree, component, path) => {
       if (components.includes(component)) {
         result[component] = !result[component] ? [path] : [...result[component], path]
       }
@@ -78,7 +78,7 @@ function splitPaths(paths = [], direction, base = {}, components = [IS, NS, AS, 
  * @returns {object} A request tree object, consisting of resulting paths for
  * each component eg: `{ is: ['ids'], as: ['session'], js: ['root_keys'] }`.
  */
-export function splitSetPaths(paths, base, components) {
+export const splitSetPaths = (paths, base, components) => {
   return splitPaths(paths, 'set', base, components)
 }
 
@@ -93,7 +93,7 @@ export function splitSetPaths(paths, base, components) {
  * @returns {object} A request tree object, consisting of resulting paths for
  * each component eg: `{ is: ['ids'], as: ['session'], js: ['root_keys'] }`.
  */
-export function splitGetPaths(paths, base, components) {
+export const splitGetPaths = (paths, base, components) => {
   return splitPaths(paths, 'get', base, components)
 }
 
@@ -114,7 +114,7 @@ export function splitGetPaths(paths, base, components) {
  * @returns {object} An array of device registry responses together with the
  * paths (field_mask) that they were requested with.
  */
-export async function makeRequests(
+export const makeRequests = async (
   api,
   stackConfig,
   operation,
@@ -122,7 +122,7 @@ export async function makeRequests(
   params,
   payload = {},
   ignoreNotFound = false,
-) {
+) => {
   const isCreate = operation === 'create'
   const isSet = operation === 'set'
   const isDelete = operation === 'delete'
@@ -130,13 +130,13 @@ export async function makeRequests(
 
   // Use a wrapper for the api calls to control the result object and allow
   // ignoring not found errors per component, if wished.
-  const requestWrapper = async function(
+  const requestWrapper = async (
     call,
     params,
     component,
     payload,
     ignoreRequestNotFound = ignoreNotFound,
-  ) {
+  ) => {
     const res = { hasAttempted: true, component, paths: requestTree[component], hasErrored: false }
     try {
       const result = await call(params, !isDelete ? payload : undefined)
@@ -151,7 +151,7 @@ export async function makeRequests(
   }
 
   // Split end device payload per stack component.
-  function splitPayload(payload = {}, paths, base = {}) {
+  const splitPayload = (payload = {}, paths, base = {}) => {
     if (!Boolean(payload.end_device)) {
       return payload
     }

--- a/sdk/js/src/util/combine-streams.js
+++ b/sdk/js/src/util/combine-streams.js
@@ -19,7 +19,7 @@
  * @returns {object} The stream subscription object with the `on` function for
  * attaching listeners and the `close` function to close the stream.
  */
-const combinedStream = async function(streams) {
+const combinedStream = async streams => {
   if (!(streams instanceof Array) || streams.length === 0) {
     throw new Error('Cannot combine streams with invalid stream array.')
   } else if (streams.length === 1) {

--- a/sdk/js/src/util/events.js
+++ b/sdk/js/src/util/events.js
@@ -20,15 +20,15 @@ class EventHandler {
     })
 
     this.eventHandlers = {}
-    this.dispatchEvent = function(event, payload) {
+    this.dispatchEvent = (event, payload) => {
       if (this.eventHandlers[event]) {
         for (const handler of this.eventHandlers[event]) {
           handler(payload)
         }
       }
-    }.bind(this)
+    }
 
-    this.subscribe = function(event, handler) {
+    this.subscribe = (event, handler) => {
       if (!Object.values(this.EVENTS).includes(event)) {
         throw new Error(`Cannot subscribe to unsupported event type "${event}"`)
       }
@@ -36,16 +36,16 @@ class EventHandler {
         ...this.eventHandlers,
         [event]: this.eventHandlers[event] ? [...this.eventHandlers[event], handler] : [handler],
       }
-    }.bind(this)
+    }
 
-    this.unsubscribe = function(event) {
+    this.unsubscribe = event => {
       if (!Object.values(this.EVENTS).includes(event)) {
         throw new Error(`Cannot unsubscribe from unsupported event type "${event}"`)
       }
       if (this.eventHandlers[event]) {
         delete this.eventHandlers[event]
       }
-    }.bind(this)
+    }
   }
 }
 

--- a/sdk/js/src/util/marshaler.js
+++ b/sdk/js/src/util/marshaler.js
@@ -127,7 +127,7 @@ class Marshaler {
     // structure (e.g. for oneoffs). Through the remap argument, it can be
     // accounted for that by remapping these paths.
     if (remaps) {
-      paths = paths.map(function(path) {
+      paths = paths.map(path => {
         for (const remap of remaps) {
           if (path.startsWith(remap[0])) {
             return path.replace(remap[0], remap[1])

--- a/sdk/js/util/device-field-mask-mapper.js
+++ b/sdk/js/util/device-field-mask-mapper.js
@@ -69,7 +69,7 @@ traverse(result).forEach(function() {
 fs.writeFile(
   `${__dirname}/../generated/device-entity-map.json`,
   JSON.stringify(result, null, 2),
-  function(err) {
+  err => {
     if (err) {
       return console.error(err)
     }

--- a/sdk/js/util/http-mapper.js
+++ b/sdk/js/util/http-mapper.js
@@ -20,7 +20,7 @@ const fs = require('fs')
 const api = require('../generated/api.json')
 const allowedFieldMaskPaths = require('../generated/allowed-field-mask-paths.json')
 
-function map(files) {
+const map = files => {
   const result = {}
   const paramRegex = /{([a-z._]+)}/gm
 
@@ -60,7 +60,7 @@ function map(files) {
 fs.writeFile(
   `${__dirname}/../generated/api-definition.json`,
   JSON.stringify(map(api.files), null, 2),
-  function(err) {
+  err => {
     if (err) {
       return console.error(err)
     }


### PR DESCRIPTION
#### Summary
This draft PR is my suggestion to convert all functions to arrow functions at once. It hence resolves all linter warnings.

Closes #3540 

#### Changes
- Convert functions to arrow functions, where possible (all hail to regexp search and replace and prettier)
- Resolve two minor import statement warnings in the Account App


#### Testing

The end-to-end test will make sure that there are no critical bugs introduced. I've additionally done manual testing.

##### Regressions

None.

#### Notes for Reviewers
@bafonins please let me know whether you can agree to merging this. I've described the reasons why I would personally prefer doing so in #3540 and I'm also pushing this because we will be updating `prettier` via a split-up of (#3787). The new prettier rules will enforce a space between function symbol and parentheses. This will not affect us as much if we have all function converted to arrow functions.

There were a few anonymous functions which made use of `this` and `.bind(this)` (mostly in the SDK). I've either left them as they were or adjusted the implementation to work with arrow functions. The linter will not nag for non-arrow anonymous functions that use the `this` keyword.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
