### PR TITLE
Set cups attributes only if value exists

### DIFF
--- a/pkg/basicstation/cups/update_info.go
+++ b/pkg/basicstation/cups/update_info.go
@@ -345,9 +345,15 @@ func (s *Server) UpdateInfo(c echo.Context) error {
 	}
 
 	gtw.Attributes[cupsLastSeenAttribute] = time.Now().UTC().Format(time.RFC3339)
-	gtw.Attributes[cupsStationAttribute] = req.Station
-	gtw.Attributes[cupsModelAttribute] = req.Model
-	gtw.Attributes[cupsPackageAttribute] = req.Package
+	if req.Station != "" {
+		gtw.Attributes[cupsStationAttribute] = req.Station
+	}
+	if req.Model != "" {
+		gtw.Attributes[cupsModelAttribute] = req.Model
+	}
+	if req.Package != "" {
+		gtw.Attributes[cupsPackageAttribute] = req.Package
+	}
 
 	registry, err = s.getRegistry(ctx, &gtw.GatewayIdentifiers)
 	if err != nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsIndustries/lorawan-stack-support/issues/342#event-4419418300

The docs don't require these fields so we'll need to check if they are actually set; https://doc.sm.tc/station/cupsproto.html#http-post-request

#### Changes
<!-- What are the changes made in this pull request? -->

- Check if the `req.CUPSPackage` value exists before setting it in the attributes.

#### Testing

<!-- How did you verify that this change works? -->

UT

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

NA

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
