### PR TITLE
Disable UDP IP firewall by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
+- Default value of `gs.udp.addr-change-block` is now 0, which disables the IP firewall for UDP traffic. Deployments that need to enforce the IP check should set a value greater than 0. Note that the new default value makes UDP connections less secure.
+
 ### Deprecated
 
 ### Removed

--- a/pkg/gatewayserver/io/udp/config.go
+++ b/pkg/gatewayserver/io/udp/config.go
@@ -54,7 +54,7 @@ var DefaultConfig = Config{
 	DownlinkPathExpires: 15 * time.Second, // Expire downlink after missing typically 3 PULL_DATA messages.
 	ConnectionExpires:   1 * time.Minute,  // Expire connection after missing typically 2 status messages.
 	ScheduleLateTime:    800 * time.Millisecond,
-	AddrChangeBlock:     1 * time.Minute, // Release address when the connection expires.
+	AddrChangeBlock:     0, // Release address when the connection expires.
 	RateLimiting: RateLimitingConfig{
 		Enable:    true,
 		Messages:  10,

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -58,7 +58,7 @@ func Serve(ctx context.Context, server io.Server, conn *net.UDPConn, config Conf
 	if config.AddrChangeBlock > 0 {
 		firewall = NewMemoryFirewall(ctx, config.AddrChangeBlock)
 	}
-	if config.RateLimiting.Enable == true {
+	if config.RateLimiting.Enable {
 		firewall = NewRateLimitingFirewall(firewall, config.RateLimiting.Messages, config.RateLimiting.Threshold)
 	}
 	s := &srv{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Disable UDP IP firewall by default. Closes #3894 

#### Changes
<!-- What are the changes made in this pull request? -->

- Set the default value of 0 (0 is equivalent to `0 * time.Second` for `time.Duration`)
- Add note on security of new setting.


#### Testing

<!-- How did you verify that this change works? -->

No new functions added. Only config value. 

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

I don't think there'd be any.


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
