### PR TITLE
Add checks for admin and universal rights in context

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -2627,15 +2627,6 @@
       "file": "require.go"
     }
   },
-  "error:pkg/auth/rights:unauthenticated": {
-    "translations": {
-      "en": "unauthenticated"
-    },
-    "description": {
-      "package": "pkg/auth/rights",
-      "file": "require.go"
-    }
-  },
   "error:pkg/auth:invalid_hash": {
     "translations": {
       "en": "invalid hash"

--- a/config/messages.json
+++ b/config/messages.json
@@ -2528,9 +2528,27 @@
       "file": "require.go"
     }
   },
+  "error:pkg/auth/rights:insufficient_universal_rights": {
+    "translations": {
+      "en": "insufficient universal rights"
+    },
+    "description": {
+      "package": "pkg/auth/rights",
+      "file": "require.go"
+    }
+  },
   "error:pkg/auth/rights:insufficient_user_rights": {
     "translations": {
       "en": "insufficient rights for user `{uid}`"
+    },
+    "description": {
+      "package": "pkg/auth/rights",
+      "file": "require.go"
+    }
+  },
+  "error:pkg/auth/rights:no_admin": {
+    "translations": {
+      "en": "no admin"
     },
     "description": {
       "package": "pkg/auth/rights",
@@ -2591,9 +2609,27 @@
       "file": "require.go"
     }
   },
+  "error:pkg/auth/rights:no_universal_rights": {
+    "translations": {
+      "en": "no universal rights"
+    },
+    "description": {
+      "package": "pkg/auth/rights",
+      "file": "require.go"
+    }
+  },
   "error:pkg/auth/rights:no_user_rights": {
     "translations": {
       "en": "no rights for user `{uid}`"
+    },
+    "description": {
+      "package": "pkg/auth/rights",
+      "file": "require.go"
+    }
+  },
+  "error:pkg/auth/rights:unauthenticated": {
+    "translations": {
+      "en": "unauthenticated"
     },
     "description": {
       "package": "pkg/auth/rights",

--- a/pkg/auth/rights/auth_info.go
+++ b/pkg/auth/rights/auth_info.go
@@ -1,0 +1,49 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rights
+
+import (
+	"context"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+)
+
+// AuthInfo lists the authentication info with universal rights, whether the caller is admin and the authentication method.
+func AuthInfo(ctx context.Context) (authInfo *ttnpb.AuthInfoResponse, err error) {
+	if inCtx, ok := authInfoFromContext(ctx); ok {
+		return inCtx, nil
+	}
+	if inCtx, ok := cacheAuthInfoFromContext(ctx); ok {
+		return inCtx, nil
+	}
+	defer func() {
+		if err == nil {
+			cacheAuthInfoInContext(ctx, authInfo)
+		}
+	}()
+	fetcher, ok := fetcherFromContext(ctx)
+	if !ok {
+		panic(errNoFetcher)
+	}
+	authInfo, err = fetcher.AuthInfo(ctx)
+	if err != nil {
+		if errors.IsPermissionDenied(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return
+}

--- a/pkg/auth/rights/fetcher.go
+++ b/pkg/auth/rights/fetcher.go
@@ -23,8 +23,8 @@ import (
 	"google.golang.org/grpc"
 )
 
-// Fetcher interface for rights fetching.
-type Fetcher interface {
+// EntityFetcher provides an interface for fetching entity rights.
+type EntityFetcher interface {
 	ApplicationRights(context.Context, ttnpb.ApplicationIdentifiers) (*ttnpb.Rights, error)
 	ClientRights(context.Context, ttnpb.ClientIdentifiers) (*ttnpb.Rights, error)
 	GatewayRights(context.Context, ttnpb.GatewayIdentifiers) (*ttnpb.Rights, error)
@@ -32,51 +32,72 @@ type Fetcher interface {
 	UserRights(context.Context, ttnpb.UserIdentifiers) (*ttnpb.Rights, error)
 }
 
-// FetcherFunc is a function that implements the Fetcher interface.
+// AuthInfoFetcher provides an interface for fetching authentication info.
+type AuthInfoFetcher interface {
+	AuthInfo(context.Context) (*ttnpb.AuthInfoResponse, error)
+}
+
+// Fetcher provides an interface for rights fetching.
+type Fetcher interface {
+	EntityFetcher
+	AuthInfoFetcher
+}
+
+// EntityFetcherFunc is a function that implements the EntityFetcher interface.
 //
-// A FetcherFunc that returns all Application rights for any Application,
+// A EntityFetcherFunc that returns all Application rights for any Application,
 // would look like this:
 //
-//    fetcher := rights.FetcherFunc(func(ctx context.Context, ids ttnpb.Identifiers) (*ttnpb.Rights, error) {
+//    fetcher := rights.EntityFetcherFunc(func(ctx context.Context, ids ttnpb.Identifiers) (*ttnpb.Rights, error) {
 //    	rights := ttnpb.AllApplicationRights // Instead this usually comes from an identity server or a database.
 //    	return &rights, nil
 //    })
 //
-type FetcherFunc func(ctx context.Context, ids ttnpb.Identifiers) (*ttnpb.Rights, error)
+type EntityFetcherFunc func(ctx context.Context, ids ttnpb.Identifiers) (*ttnpb.Rights, error)
 
 // ApplicationRights implements the Fetcher interface.
-func (f FetcherFunc) ApplicationRights(ctx context.Context, ids ttnpb.ApplicationIdentifiers) (*ttnpb.Rights, error) {
+func (f EntityFetcherFunc) ApplicationRights(ctx context.Context, ids ttnpb.ApplicationIdentifiers) (*ttnpb.Rights, error) {
 	rights, err := f(ctx, ids)
 	registerRightsFetch(ctx, "application", rights, err)
 	return rights, err
 }
 
 // ClientRights implements the Fetcher interface.
-func (f FetcherFunc) ClientRights(ctx context.Context, ids ttnpb.ClientIdentifiers) (*ttnpb.Rights, error) {
+func (f EntityFetcherFunc) ClientRights(ctx context.Context, ids ttnpb.ClientIdentifiers) (*ttnpb.Rights, error) {
 	rights, err := f(ctx, ids)
 	registerRightsFetch(ctx, "client", rights, err)
 	return rights, err
 }
 
 // GatewayRights implements the Fetcher interface.
-func (f FetcherFunc) GatewayRights(ctx context.Context, ids ttnpb.GatewayIdentifiers) (*ttnpb.Rights, error) {
+func (f EntityFetcherFunc) GatewayRights(ctx context.Context, ids ttnpb.GatewayIdentifiers) (*ttnpb.Rights, error) {
 	rights, err := f(ctx, ids)
 	registerRightsFetch(ctx, "gateway", rights, err)
 	return rights, err
 }
 
 // OrganizationRights implements the Fetcher interface.
-func (f FetcherFunc) OrganizationRights(ctx context.Context, ids ttnpb.OrganizationIdentifiers) (*ttnpb.Rights, error) {
+func (f EntityFetcherFunc) OrganizationRights(ctx context.Context, ids ttnpb.OrganizationIdentifiers) (*ttnpb.Rights, error) {
 	rights, err := f(ctx, ids)
 	registerRightsFetch(ctx, "organization", rights, err)
 	return rights, err
 }
 
 // UserRights implements the Fetcher interface.
-func (f FetcherFunc) UserRights(ctx context.Context, ids ttnpb.UserIdentifiers) (*ttnpb.Rights, error) {
+func (f EntityFetcherFunc) UserRights(ctx context.Context, ids ttnpb.UserIdentifiers) (*ttnpb.Rights, error) {
 	rights, err := f(ctx, ids)
 	registerRightsFetch(ctx, "user", rights, err)
 	return rights, err
+}
+
+// AuthInfoFetcherFunc is a function thaty implements the AuthInfoFetcher interface.
+type AuthInfoFetcherFunc func(ctx context.Context) (*ttnpb.AuthInfoResponse, error)
+
+// AuthInfo implements the Fetcher interface.
+func (f AuthInfoFetcherFunc) AuthInfo(ctx context.Context) (*ttnpb.AuthInfoResponse, error) {
+	authInfo, err := f(ctx)
+	registerAuthInfoFetch(ctx, authInfo, err)
+	return authInfo, err
 }
 
 type fetcherKeyType struct{}
@@ -109,6 +130,24 @@ type accessFetcher struct {
 }
 
 var errNoISConn = errors.DefineUnavailable("no_identity_server_conn", "no connection to Identity Server")
+
+func (f accessFetcher) AuthInfo(ctx context.Context) (*ttnpb.AuthInfoResponse, error) {
+	cc := f.getConn(ctx)
+	if cc == nil {
+		return nil, errNoISConn.New()
+	}
+	callOpt, err := rpcmetadata.WithForwardedAuth(ctx, f.allowInsecure)
+	if err != nil {
+		return nil, err
+	}
+	ctx = rpcmetadata.WithForwardedRequestID(ctx)
+	authInfo, err := ttnpb.NewEntityAccessClient(cc).AuthInfo(ctx, ttnpb.Empty, callOpt)
+	registerAuthInfoFetch(ctx, authInfo, err)
+	if err != nil {
+		return nil, err
+	}
+	return authInfo, nil
+}
 
 func (f accessFetcher) ApplicationRights(ctx context.Context, appID ttnpb.ApplicationIdentifiers) (*ttnpb.Rights, error) {
 	cc := f.getConn(ctx)

--- a/pkg/auth/rights/mock_test.go
+++ b/pkg/auth/rights/mock_test.go
@@ -40,6 +40,7 @@ func (h *mockHandler) Handler(ctx context.Context, req interface{}) (interface{}
 
 type mockFetcher struct {
 	// Request vars
+	authInfoCtx     context.Context
 	applicationCtx  context.Context
 	applicationIDs  ttnpb.ApplicationIdentifiers
 	clientCtx       context.Context
@@ -52,6 +53,8 @@ type mockFetcher struct {
 	userIDs         ttnpb.UserIdentifiers
 
 	// Response vars
+	authInfoResponse   *ttnpb.AuthInfoResponse
+	authInfoError      error
 	applicationRights  *ttnpb.Rights
 	applicationError   error
 	clientRights       *ttnpb.Rights
@@ -62,6 +65,11 @@ type mockFetcher struct {
 	organizationError  error
 	userRights         *ttnpb.Rights
 	userError          error
+}
+
+func (f *mockFetcher) AuthInfo(ctx context.Context) (*ttnpb.AuthInfoResponse, error) {
+	f.authInfoCtx = ctx
+	return f.authInfoResponse, f.authInfoError
 }
 
 func (f *mockFetcher) ApplicationRights(ctx context.Context, ids ttnpb.ApplicationIdentifiers) (*ttnpb.Rights, error) {

--- a/pkg/auth/rights/require.go
+++ b/pkg/auth/rights/require.go
@@ -24,6 +24,22 @@ import (
 
 // Errors for no/insufficient rights.
 var (
+	ErrUnauthenticated = errors.DefineUnauthenticated(
+		"unauthenticated",
+		"unauthenticated",
+	)
+	ErrNoUniversalRights = errors.DefinePermissionDenied(
+		"no_universal_rights",
+		"no universal rights",
+	)
+	ErrInsufficientUniversalRights = errors.DefinePermissionDenied(
+		"insufficient_universal_rights",
+		"insufficient universal rights",
+	)
+	ErrNoAdmin = errors.DefinePermissionDenied(
+		"no_admin",
+		"no admin",
+	)
 	ErrNoApplicationRights = errors.DefinePermissionDenied(
 		"no_application_rights",
 		"no rights for application `{uid}`",
@@ -66,9 +82,57 @@ var (
 	)
 )
 
+// RequireAuthenticated checks that the context is authenticated.
+func RequireAuthenticated(ctx context.Context) error {
+	authInfo, err := AuthInfo(ctx)
+	if err != nil {
+		return err
+	}
+	if authInfo.GetIsAdmin() {
+		return nil
+	}
+	if authInfo.GetAPIKey() != nil {
+		return nil
+	} else if authInfo.GetOAuthAccessToken() != nil {
+		return nil
+	} else if authInfo.GetUserSession() != nil {
+		return nil
+	}
+	if len(authInfo.GetUniversalRights().GetRights()) > 0 {
+		return nil
+	}
+	return ErrUnauthenticated.New()
+}
+
+// RequireUniversal checks that the context contains the required universal rights.
+func RequireUniversal(ctx context.Context, required ...ttnpb.Right) error {
+	authInfo, err := AuthInfo(ctx)
+	if err != nil {
+		return err
+	}
+	if rights := authInfo.GetUniversalRights(); len(rights.GetRights()) == 0 {
+		return ErrNoUniversalRights.New()
+	} else if missing := ttnpb.RightsFrom(required...).Sub(rights).GetRights(); len(missing) > 0 {
+		return ErrInsufficientUniversalRights.WithAttributes("missing", missing)
+	}
+	return nil
+}
+
+// RequireIsAdmin checks that the context is authenticated as admin.
+func RequireIsAdmin(ctx context.Context) error {
+	authInfo, err := AuthInfo(ctx)
+	if err != nil {
+		return err
+	}
+	if !authInfo.GetIsAdmin() {
+		return ErrNoAdmin.New()
+	}
+	return nil
+}
+
 // RequireApplication checks that context contains the required rights for the
 // given application ID.
-func RequireApplication(ctx context.Context, id ttnpb.ApplicationIdentifiers, required ...ttnpb.Right) (err error) {
+func RequireApplication(ctx context.Context, id ttnpb.ApplicationIdentifiers, required ...ttnpb.Right) error {
 	uid := unique.ID(ctx, id)
 	rights, err := ListApplication(ctx, id)
 	if err != nil {

--- a/pkg/auth/rights/require.go
+++ b/pkg/auth/rights/require.go
@@ -24,10 +24,6 @@ import (
 
 // Errors for no/insufficient rights.
 var (
-	ErrUnauthenticated = errors.DefineUnauthenticated(
-		"unauthenticated",
-		"unauthenticated",
-	)
 	ErrNoUniversalRights = errors.DefinePermissionDenied(
 		"no_universal_rights",
 		"no universal rights",
@@ -81,28 +77,6 @@ var (
 		"insufficient rights for user `{uid}`",
 	)
 )
-
-// RequireAuthenticated checks that the context is authenticated.
-func RequireAuthenticated(ctx context.Context) error {
-	authInfo, err := AuthInfo(ctx)
-	if err != nil {
-		return err
-	}
-	if authInfo.GetIsAdmin() {
-		return nil
-	}
-	if authInfo.GetAPIKey() != nil {
-		return nil
-	} else if authInfo.GetOAuthAccessToken() != nil {
-		return nil
-	} else if authInfo.GetUserSession() != nil {
-		return nil
-	}
-	if len(authInfo.GetUniversalRights().GetRights()) > 0 {
-		return nil
-	}
-	return ErrUnauthenticated.New()
-}
 
 // RequireUniversal checks that the context contains the required universal rights.
 func RequireUniversal(ctx context.Context, required ...ttnpb.Right) error {

--- a/pkg/auth/rights/require_test.go
+++ b/pkg/auth/rights/require_test.go
@@ -30,16 +30,11 @@ import (
 )
 
 func requireAuthInfo(ctx context.Context) (res struct {
-	AuthenticatedErr error
-	UniversalErr     error
-	IsAdminErr       error
+	UniversalErr error
+	IsAdminErr   error
 }) {
 	var wg sync.WaitGroup
-	wg.Add(3)
-	go func() {
-		res.AuthenticatedErr = RequireAuthenticated(ctx)
-		wg.Done()
-	}()
+	wg.Add(2)
 	go func() {
 		res.UniversalErr = RequireUniversal(ctx, ttnpb.RIGHT_SEND_INVITES)
 		wg.Done()
@@ -89,9 +84,6 @@ func TestRequire(t *testing.T) {
 	a := assertions.New(t)
 
 	a.So(func() {
-		RequireAuthenticated(test.Context())
-	}, should.Panic)
-	a.So(func() {
 		RequireUniversal(test.Context(), ttnpb.RIGHT_SEND_INVITES)
 	}, should.Panic)
 	a.So(func() {
@@ -137,7 +129,6 @@ func TestRequire(t *testing.T) {
 	})
 
 	fooAuthInfoRes := requireAuthInfo(fooCtx)
-	a.So(fooAuthInfoRes.AuthenticatedErr, should.BeNil)
 	a.So(fooAuthInfoRes.UniversalErr, should.BeNil)
 	a.So(fooAuthInfoRes.IsAdminErr, should.BeNil)
 	fooEntityRes := requireRights(fooCtx, "foo")
@@ -157,7 +148,6 @@ func TestRequire(t *testing.T) {
 		userError:         mockErr,
 	})
 	errFetchAuthInfoRes := requireAuthInfo(errFetchCtx)
-	a.So(errFetchAuthInfoRes.AuthenticatedErr, should.Resemble, mockErr)
 	a.So(errFetchAuthInfoRes.UniversalErr, should.Resemble, mockErr)
 	a.So(errFetchAuthInfoRes.IsAdminErr, should.Resemble, mockErr)
 	errFetchEntityRes := requireRights(errFetchCtx, "foo")
@@ -177,7 +167,6 @@ func TestRequire(t *testing.T) {
 		userError:         errPermissionDenied,
 	})
 	permissionDeniedAuthInfoRes := requireAuthInfo(permissionDeniedFetchCtx)
-	a.So(errors.IsUnauthenticated(permissionDeniedAuthInfoRes.AuthenticatedErr), should.BeTrue)
 	a.So(errors.IsPermissionDenied(permissionDeniedAuthInfoRes.UniversalErr), should.BeTrue)
 	a.So(errors.IsPermissionDenied(permissionDeniedAuthInfoRes.IsAdminErr), should.BeTrue)
 	permissionDeniedEntityRes := requireRights(permissionDeniedFetchCtx, "foo")

--- a/pkg/auth/rights/rights.go
+++ b/pkg/auth/rights/rights.go
@@ -158,3 +158,41 @@ func cacheFromContext(ctx context.Context) (Rights, bool) {
 	}
 	return Rights{}, false
 }
+
+type authInfoKeyType struct{}
+
+var authInfoKey authInfoKeyType
+
+func authInfoFromContext(ctx context.Context) (*ttnpb.AuthInfoResponse, bool) {
+	if authInfo, ok := ctx.Value(authInfoKey).(*ttnpb.AuthInfoResponse); ok {
+		return authInfo, true
+	}
+	return nil, false
+}
+
+func NewContextWithAuthInfo(ctx context.Context, authInfo *ttnpb.AuthInfoResponse) context.Context {
+	return context.WithValue(ctx, authInfoKey, authInfo)
+}
+
+type authInfoCacheKeyType struct{}
+
+var authInfoCacheKey authInfoCacheKeyType
+
+// NewContextWithCache returns a derived context with an authentication info cache.
+// This should only be used for request contexts.
+func NewContextWithAuthInfoCache(ctx context.Context) context.Context {
+	return context.WithValue(ctx, authInfoCacheKey, &ttnpb.AuthInfoResponse{})
+}
+
+func cacheAuthInfoInContext(ctx context.Context, res *ttnpb.AuthInfoResponse) {
+	if authInfo, ok := ctx.Value(authInfoCacheKey).(*ttnpb.AuthInfoResponse); ok {
+		*authInfo = *res
+	}
+}
+
+func cacheAuthInfoFromContext(ctx context.Context) (*ttnpb.AuthInfoResponse, bool) {
+	if authInfo, ok := ctx.Value(authInfoCacheKey).(*ttnpb.AuthInfoResponse); ok {
+		return authInfo, true
+	}
+	return nil, false
+}

--- a/pkg/identityserver/entity_access.go
+++ b/pkg/identityserver/entity_access.go
@@ -288,6 +288,11 @@ func (is *IdentityServer) authInfo(ctx context.Context) (info *ttnpb.AuthInfoRes
 	return res, nil
 }
 
+// AuthInfo implements rights.AuthInfoFetcher.
+func (is *IdentityServer) AuthInfo(ctx context.Context) (*ttnpb.AuthInfoResponse, error) {
+	return is.authInfo(ctx)
+}
+
 // RequireAuthenticated checks the request context for authentication presence
 // and returns an error if there is none.
 func (is *IdentityServer) RequireAuthenticated(ctx context.Context) error {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Groundwork for #3771

#### Changes
<!-- What are the changes made in this pull request? -->

Add ~`RequireAuthenticated()`,~ `RequireIsAdmin()` and `RequireUniversal()`

#### Testing

<!-- How did you verify that this change works? -->

Unit testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This is integrated in `pkg/auth/rights`. There was some distinction necessary between entity rights and authentication info, which provides non-entity rights. I'm open to suggestions in naming things.

Example usage:

```go
func (s *pbaServer) Register(ctx context.Context, _ *pbtypes.Empty) (*ttnpb.PacketBrokerRegistration, error) {
	if err := rights.RequireIsAdmin(ctx); err != nil {
		return nil, err
	}
	...
}
```

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
