### PR TITLE
Prevent UDP gateways log message floods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Changed
 
 - Default value of `gs.udp.addr-change-block` is now 0, which disables the IP firewall for UDP traffic. Deployments that need to enforce the IP check should set a value greater than 0. Note that the new default value makes UDP connections less secure.
+- Prevent flooding logs with "Packet Filtered" messages when UDP gateways exceed the maximum rate limit. Only one message per minute will be printed for each gateway.
 
 ### Deprecated
 

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -24,6 +24,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/bluele/gcache"
 	"go.thethings.network/lorawan-stack/v3/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io"
@@ -44,12 +45,19 @@ type srv struct {
 	packetCh    chan encoding.Packet
 	connections sync.Map
 	firewall    Firewall
+
+	rateLimitedGateways gcache.Cache
 }
 
 func (*srv) Protocol() string            { return "udp" }
 func (*srv) SupportsDownlinkClaim() bool { return true }
 
 var errUDPFrontendRecovered = errors.DefineInternal("udp_frontend_recovered", "internal server error")
+
+const (
+	rateLimitedGatewaysCacheSize int = 1 << 10
+	rateLimitedGatewaysCacheTTL      = time.Minute
+)
 
 // Serve serves the UDP frontend.
 func Serve(ctx context.Context, server io.Server, conn *net.UDPConn, config Config) error {
@@ -68,6 +76,8 @@ func Serve(ctx context.Context, server io.Server, conn *net.UDPConn, config Conf
 		conn:     conn,
 		packetCh: make(chan encoding.Packet, config.PacketBuffer),
 		firewall: firewall,
+
+		rateLimitedGateways: gcache.New(rateLimitedGatewaysCacheSize).LFU().Expiration(rateLimitedGatewaysCacheTTL).Build(),
 	}
 	go s.gc()
 	go func() {
@@ -150,6 +160,12 @@ func (s *srv) handlePackets() {
 
 			if s.firewall != nil {
 				if err := s.firewall.Filter(packet); err != nil {
+					if errors.IsResourceExhausted(err) {
+						if s.rateLimitedGateways.Has(eui) {
+							break
+						}
+						s.rateLimitedGateways.Set(eui, &struct{}{})
+					}
 					logger.WithError(err).Warn("Packet filtered")
 					break
 				}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #3839 

#### Changes
<!-- What are the changes made in this pull request? -->

- Maintain an LFU cache with gateways where the rate limit has been exceeded.
- If error is of type Resource Exhausted, log the message if the gateway is not in the list of rate limited gateways.

#### Testing

<!-- How did you verify that this change works? -->

Integration testing with UDP gateway

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

There should not be any.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
