### PR TITLE
Fix stream listeners reset in JS SDK

### DIFF
--- a/sdk/js/src/api/stream/shared.js
+++ b/sdk/js/src/api/stream/shared.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 export const notify = (listener, ...args) => {
-  if (listener !== null) {
+  if (typeof listener === 'function') {
     listener(...args)
   }
 }

--- a/sdk/js/src/api/stream/stream-node.js
+++ b/sdk/js/src/api/stream/stream-node.js
@@ -85,11 +85,11 @@ export default async (payload, url) => {
       })
       stream.on('end', () => {
         notify(listeners[EVENTS.CLOSE])
-        listeners = null
+        listeners = {}
       })
       stream.on('error', error => {
         notify(listeners[EVENTS.ERROR], error)
-        listeners = null
+        listeners = {}
       })
     })
 

--- a/sdk/js/src/api/stream/stream.js
+++ b/sdk/js/src/api/stream/stream.js
@@ -80,7 +80,7 @@ export default async (payload, url) => {
   const onChunk = ({ done, value }) => {
     if (done) {
       notify(listeners[EVENTS.CLOSE])
-      listeners = null
+      listeners = {}
       return
     }
 
@@ -104,7 +104,7 @@ export default async (payload, url) => {
     .then(onChunk)
     .catch(error => {
       notify(listeners[EVENTS.ERROR], error)
-      listeners = null
+      listeners = {}
     })
 
   return {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Should resolve https://sentry.io/organizations/the-things-industries/issues/2232970178/?project=2682566&query=is%3Aunresolved

#### Changes
<!-- What are the changes made in this pull request? -->

- Set listeners after error/close events to an empty array instead of `null`


#### Testing

<!-- How did you verify that this change works? -->

manual


#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

In certain cases the console calls `channel.close()` after and error in the events stream which throws an exception because `listeners` are set to `null`.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
