### PR TITLE
Cache UDP connection errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For details about compatibility between different releases, see the **Commitment
 - Searching for gateways by EUI.
 - Searching for users and OAuth clients by state.
 - Gateway Server forwards Tx Acknowlegdment packets to the Network Server for scheduled downlinks. These can be used by the Network Server to forward `downlink_ack` upstream messages to the Application Server.
+- UDP connection error caching. The duration can be configured via the `gs.udp.connection-error-expires` configuration entry.
 
 ### Changed
 

--- a/pkg/gatewayserver/io/udp/config.go
+++ b/pkg/gatewayserver/io/udp/config.go
@@ -38,6 +38,10 @@ type Config struct {
 	// ConnectionExpires defines for how long a connection remains valid while no pull data, push data or Tx
 	// acknowledgment is received.
 	ConnectionExpires time.Duration `name:"connection-expires" description:"Time after which a connection of a gateway expires"`
+	// ConnectionErrorExpires defines for how long an existing connection is cached by the Gateway Server when there is a connection error
+	// before initiating a new connection. This ensures that packet handlers are not being stalled by gateways which cannot connect but
+	// still attempt to do so.
+	ConnectionErrorExpires time.Duration `name:"connection-error-expires" description:"Time after which a connection error of a gateway expires"`
 	// ScheduleLateTime defines the time in advance to the actual transmission the downlink message should be scheduled to
 	// the gateway.
 	ScheduleLateTime time.Duration `name:"schedule-late-time" description:"Time in advance to send downlink to the gateway when scheduling late"`
@@ -49,12 +53,13 @@ type Config struct {
 
 // DefaultConfig contains the default configuration.
 var DefaultConfig = Config{
-	PacketHandlers:      1 << 4,
-	PacketBuffer:        50,
-	DownlinkPathExpires: 15 * time.Second, // Expire downlink after missing typically 3 PULL_DATA messages.
-	ConnectionExpires:   1 * time.Minute,  // Expire connection after missing typically 2 status messages.
-	ScheduleLateTime:    800 * time.Millisecond,
-	AddrChangeBlock:     0, // Release address when the connection expires.
+	PacketHandlers:         1 << 4,
+	PacketBuffer:           50,
+	DownlinkPathExpires:    15 * time.Second, // Expire downlink after missing typically 3 PULL_DATA messages.
+	ConnectionExpires:      1 * time.Minute,  // Expire connection after missing typically 2 status messages.
+	ConnectionErrorExpires: 5 * time.Minute,
+	ScheduleLateTime:       800 * time.Millisecond,
+	AddrChangeBlock:        0, // Release address when the connection expires.
 	RateLimiting: RateLimitingConfig{
 		Enable:    true,
 		Messages:  10,

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -466,6 +466,9 @@ func (s *srv) gc() {
 				default:
 					return true
 				}
+				if state.ioErr != nil {
+					return true
+				}
 				select {
 				case <-state.io.Context().Done():
 					logger.Debug("Connection context done")

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -201,7 +201,12 @@ func (s *srv) connect(ctx context.Context, eui types.EUI64) (*state, error) {
 		var err error
 		defer func() {
 			if err != nil {
-				s.connections.Delete(eui)
+				delete := func() { s.connections.Delete(eui) }
+				if expiration := s.config.ConnectionErrorExpires; expiration != 0 {
+					time.AfterFunc(expiration, delete)
+				} else {
+					delete()
+				}
 			}
 			cs.io, cs.ioErr = io, err
 			close(cs.ioWait)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This quickfix PR adds an error caching mechanism to the UDP connection logic. This ensures that gateways that cannot connect do not stale the hot-path while the GS tries to process their connection attempt.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `gs.udp.connection-error-expires`. Can be set to `0` to disable.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
