### PR TITLE
Improve Application Server end device fetcher network partition resilience

### DIFF
--- a/cmd/internal/shared/applicationserver/config.go
+++ b/cmd/internal/shared/applicationserver/config.go
@@ -47,6 +47,7 @@ var DefaultApplicationServerConfig = applicationserver.Config{
 		Downlinks: web.DownlinksConfig{PublicAddress: shared.DefaultPublicURL + "/api/v3"},
 	},
 	EndDeviceFetcher: applicationserver.EndDeviceFetcherConfig{
+		Timeout: 5 * time.Second,
 		Cache: applicationserver.EndDeviceFetcherCacheConfig{
 			Enable: true,
 			TTL:    5 * time.Minute,

--- a/cmd/internal/shared/applicationserver/config.go
+++ b/cmd/internal/shared/applicationserver/config.go
@@ -52,6 +52,11 @@ var DefaultApplicationServerConfig = applicationserver.Config{
 			Enable: true,
 			TTL:    5 * time.Minute,
 		},
+		CircuitBreaker: applicationserver.EndDeviceFetcherCircuitBreakerConfig{
+			Enable:    true,
+			Threshold: 10,
+			Timeout:   15 * time.Minute,
+		},
 	},
 	Distribution: applicationserver.DistributionConfig{
 		Timeout: time.Minute,

--- a/config/messages.json
+++ b/config/messages.json
@@ -2330,6 +2330,15 @@
       "file": "applicationserver.go"
     }
   },
+  "error:pkg/applicationserver:circuit_breaker_open": {
+    "translations": {
+      "en": "circuit breaker open"
+    },
+    "description": {
+      "package": "pkg/applicationserver",
+      "file": "device_fetcher.go"
+    }
+  },
   "error:pkg/applicationserver:device_not_found": {
     "translations": {
       "en": "device `{device_uid}` not found"
@@ -2366,9 +2375,18 @@
       "file": "registry.go"
     }
   },
+  "error:pkg/applicationserver:invalid_threshold": {
+    "translations": {
+      "en": "invalid threshold `{threshold}`"
+    },
+    "description": {
+      "package": "pkg/applicationserver",
+      "file": "config.go"
+    }
+  },
   "error:pkg/applicationserver:invalid_ttl": {
     "translations": {
-      "en": "Invalid TTL `{ttl}`"
+      "en": "invalid TTL `{ttl}`"
     },
     "description": {
       "package": "pkg/applicationserver",

--- a/pkg/applicationserver/config.go
+++ b/pkg/applicationserver/config.go
@@ -218,6 +218,7 @@ var (
 // NewFetcher creates an EndDeviceFetcher from config.
 func (c EndDeviceFetcherConfig) NewFetcher(comp *component.Component) (EndDeviceFetcher, error) {
 	fetcher := NewRegistryEndDeviceFetcher(comp)
+	fetcher = NewSingleFlightEndDeviceFetcher(fetcher)
 	if c.Cache.Enable {
 		if c.Cache.TTL <= 0 {
 			return nil, errInvalidTTL.WithAttributes("ttl", c.Cache.TTL)

--- a/pkg/applicationserver/config.go
+++ b/pkg/applicationserver/config.go
@@ -48,6 +48,7 @@ type InteropConfig struct {
 // EndDeviceFetcherConfig represents configuration for the end device fetcher in Application Server.
 type EndDeviceFetcherConfig struct {
 	Fetcher EndDeviceFetcher            `name:"-"`
+	Timeout time.Duration               `name:"timeout" description:"Timeout of the end device retrival operation"`
 	Cache   EndDeviceFetcherCacheConfig `name:"cache" description:"Cache configuration options for the end device fetcher"`
 }
 
@@ -219,6 +220,9 @@ var (
 func (c EndDeviceFetcherConfig) NewFetcher(comp *component.Component) (EndDeviceFetcher, error) {
 	fetcher := NewRegistryEndDeviceFetcher(comp)
 	fetcher = NewSingleFlightEndDeviceFetcher(fetcher)
+	if c.Timeout != 0 {
+		fetcher = NewTimeoutEndDeviceFetcher(fetcher, c.Timeout)
+	}
 	if c.Cache.Enable {
 		if c.Cache.TTL <= 0 {
 			return nil, errInvalidTTL.WithAttributes("ttl", c.Cache.TTL)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #3942

#### Changes
<!-- What are the changes made in this pull request? -->

- Cache end device fetch errors as part of the cached end device fetcher.
- Add and use a `singleflight.Group` end device fetcher.
- Add and use a timeout end device fetcher, that automatically adds a timeout to the context used for the `Get` call.
- Add a circuit breaker end device fetcher - when a burst of errors occurs, the circuit breaker opens and no `Get` calls are made - only an error is returned. The circuit breaker automatically closes and allows new attempts to be made after a specified timeout.

#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This affects the end device fetcher functionality of the Application Server. The blast radius of the changes is that the end device location is not going to be visible in the upstream messages. We can test this by simulating a network partition between AS and IS and seeing how traffic is affected.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The circuit breaker is outside the scope of the initial issue, but nonetheless I felt that the timeout and error caching will not help for windows of 15 minutes during which the IS is not available (with a timeout of 5 seconds per call, we're limited at 0.2 pps since the cache is per device).

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
