### PR TITLE
Add profile settings link to dropdown menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ For details about compatibility between different releases, see the **Commitment
 - Session and MAC state import functionality. This means that devices can be migrated without rejoin.
 - Rate limiting for HTTP endpoints, gRPC endpoints, MQTT, UDP and WebSockets connections.
   - Rate limiting is disabled by default. Refer to the `rate-limiting` configuration entry to enable.
+- Profile settings link to header dropdown menu.
 
 ### Changed
 

--- a/cmd/internal/shared/console/config.go
+++ b/cmd/internal/shared/console/config.go
@@ -44,6 +44,7 @@ var DefaultConsoleConfig = console.Config{
 		},
 		FrontendConfig: console.FrontendConfig{
 			DocumentationBaseURL: "https://thethingsstack.io",
+			AccountURL:           "/oauth",
 			StackConfig: console.StackConfig{
 				IS:   webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},
 				GS:   webui.APIConfig{Enabled: true, BaseURL: shared.DefaultPublicURL + "/api/v3"},

--- a/cypress/integration/smoke/index.js
+++ b/cypress/integration/smoke/index.js
@@ -20,6 +20,7 @@ import organizationTests from './organizations'
 import forgotPasswordTests from './forgot-password'
 import contactInfoValidationTests from './contact-info-validation'
 import authorizationTests from './authorization'
+import profileSettingsTests from './profile-settings'
 
 export default [
   ...registrationTests,
@@ -30,4 +31,5 @@ export default [
   ...forgotPasswordTests,
   ...contactInfoValidationTests,
   ...authorizationTests,
+  ...profileSettingsTests,
 ]

--- a/cypress/integration/smoke/profile-settings/index.js
+++ b/cypress/integration/smoke/profile-settings/index.js
@@ -1,0 +1,64 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { defineSmokeTest } from '../utils'
+
+const profileSettingsNavigation = defineSmokeTest('succeeds navigating to Account App', () => {
+  const user = {
+    ids: { user_id: 'test-account-app-user' },
+    primary_email_address: 'test-account-app-user@example.com',
+    password: 'ABCDefg123!',
+    password_confirm: 'ABCDefg123!',
+    name: 'Test Account App User',
+  }
+
+  cy.createUser(user)
+  cy.loginConsole({ user_id: user.ids.user_id, password: user.password })
+  cy.visit(Cypress.config('consoleRootPath'))
+
+  cy.get('header').within(() => {
+    cy.findByTestId('profile-dropdown')
+      .should('contain', user.name)
+      .as('profileDropdown')
+
+    cy.get('@profileDropdown').click()
+
+    cy.get('@profileDropdown')
+      .findByText(/Profile settings/)
+      .should('have.attr', 'href', '/oauth/profile-settings')
+      .should('have.attr', 'target', 'blank')
+
+    cy.get('@profileDropdown')
+      .findByText('Profile settings')
+      .then(link => {
+        cy.visit(link.prop('href'))
+        cy.location('pathname').should('eq', '/oauth/profile-settings')
+      })
+  })
+
+  cy.findByText('General settings', { selector: 'h3' })
+    .closest('[data-test-id="collapsible-section"]')
+    .within(() => {
+      cy.findByRole('button', { name: 'Expand' }).click()
+    })
+
+  cy.findByRole('button', { name: 'Save changes' }).click()
+  cy.findByTestId('error-notification').should('not.exist')
+  cy.findByTestId('toast-notification')
+    .should('be.visible')
+    .findByText('Profile updated')
+    .should('be.visible')
+})
+
+export default [profileSettingsNavigation]

--- a/pkg/console/config.go
+++ b/pkg/console/config.go
@@ -43,6 +43,7 @@ type FrontendConfig struct {
 	Language             string `json:"language" name:"-"`
 	SupportLink          string `json:"support_link" name:"support-link" description:"The URI that the support button will point to"`
 	StackConfig          `json:"stack_config" name:",squash"`
+	AccountURL           string `json:"account_url" name:"account-url" description:"The URL that points to the root of the Account"`
 }
 
 // Config is the configuration for the Console.

--- a/pkg/webui/components/dropdown/index.js
+++ b/pkg/webui/components/dropdown/index.js
@@ -17,6 +17,7 @@ import classnames from 'classnames'
 import { NavLink } from 'react-router-dom'
 
 import Icon from '@ttn-lw/components/icon'
+import Link from '@ttn-lw/components/link'
 
 import Message from '@ttn-lw/lib/components/message'
 
@@ -46,7 +47,7 @@ Dropdown.defaultProps = {
   onItemsClick: () => null,
 }
 
-const DropdownItem = ({ icon, title, path, action, exact, showActive, tabIndex }) => {
+const DropdownItem = ({ icon, title, path, action, exact, showActive, tabIndex, external }) => {
   const iconElement = icon && <Icon className={style.icon} icon={icon} nudgeUp />
   const activeClassName = classnames({
     [style.active]: showActive,
@@ -56,6 +57,11 @@ const DropdownItem = ({ icon, title, path, action, exact, showActive, tabIndex }
       {iconElement}
       <Message content={title} />
     </button>
+  ) : external ? (
+    <Link.Anchor href={path} external tabIndex={tabIndex}>
+      {iconElement}
+      <Message content={title} />
+    </Link.Anchor>
   ) : (
     <NavLink activeClassName={activeClassName} to={path} exact={exact} tabIndex={tabIndex}>
       {iconElement}
@@ -72,6 +78,7 @@ const DropdownItem = ({ icon, title, path, action, exact, showActive, tabIndex }
 DropdownItem.propTypes = {
   action: PropTypes.func,
   exact: PropTypes.bool,
+  external: PropTypes.bool,
   icon: PropTypes.string.isRequired,
   path: PropTypes.string,
   showActive: PropTypes.bool,
@@ -82,6 +89,7 @@ DropdownItem.propTypes = {
 DropdownItem.defaultProps = {
   action: undefined,
   exact: false,
+  external: false,
   path: undefined,
   showActive: true,
   tabIndex: '0',

--- a/pkg/webui/console/containers/header/index.js
+++ b/pkg/webui/console/containers/header/index.js
@@ -23,6 +23,7 @@ import Dropdown from '@ttn-lw/components/dropdown'
 import PropTypes from '@ttn-lw/lib/prop-types'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 
+import selectAccountUrl from '@console/lib/selectors/app-config'
 import {
   checkFromState,
   mayViewApplications,
@@ -37,6 +38,8 @@ import { logout } from '@console/store/actions/user'
 import { selectUser } from '@console/store/selectors/user'
 
 import Logo from '../logo'
+
+const accountUrl = selectAccountUrl()
 
 @withRouter
 @connect(
@@ -138,6 +141,12 @@ class Header extends Component {
 
     const dropdownItems = (
       <React.Fragment>
+        <Dropdown.Item
+          title={sharedMessages.profileSettings}
+          icon="user"
+          path={`${accountUrl}/profile-settings`}
+          external
+        />
         {mayManageUsers && (
           <Dropdown.Item
             title={sharedMessages.userManagement}

--- a/pkg/webui/console/lib/selectors/app-config.js
+++ b/pkg/webui/console/lib/selectors/app-config.js
@@ -1,0 +1,19 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { selectApplicationConfig } from '@ttn-lw/lib/selectors/env'
+
+const selectAccountUrl = () => selectApplicationConfig().account_url
+
+export default selectAccountUrl


### PR DESCRIPTION
#### Summary

Closes #3930 

#### Changes

- Added external profile settings link to dropdown menu in header

Before:
![before](https://user-images.githubusercontent.com/72162194/112134407-65f85300-8bd5-11eb-99fa-c75be1bf5749.png)

After:
![after_1_profile_settings](https://user-images.githubusercontent.com/72162194/113442485-cdde4300-93f8-11eb-8ee3-6759d958b8ad.png)



#### Testing

- manually tested

#### Checklist

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.

