### PR TITLE
Use "needs/triage" label instead of "new" in issue triage

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -8,7 +8,7 @@ jobs:
     name: Triage New Issues
     runs-on: ubuntu-latest
     steps:
-      - name: Add "new" label
+      - name: Add "needs/triage" label
         uses: actions/github-script@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -17,5 +17,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              labels: ['new']
+              labels: ['needs/triage']
             })


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

As discussed during today's call, we'd prefer this label to be called `needs/triage`.