### PR TITLE
Unify usage of custom HTTP clients

### DIFF
--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -190,27 +190,21 @@ var startCommand = &cobra.Command{
 
 		redisConsumerID := redis.Key(host, strconv.Itoa(os.Getpid()))
 
-		httpClient, err := c.HTTPClient(ctx)
-		if err != nil {
-			return err
-		}
-		if conf := config.ServiceBase.FrequencyPlans; conf.HTTPClient == nil {
-			conf.HTTPClient = httpClient
-		}
-		if conf := config.ServiceBase.Interop.SenderClientCA; conf.HTTPClient == nil {
-			conf.HTTPClient = httpClient
-		}
-		if conf := config.ServiceBase.KeyVault; conf.HTTPClient == nil {
-			conf.HTTPClient = httpClient
-		}
-		if conf := config.ServiceBase.Blob; conf.HTTPClient == nil {
-			conf.HTTPClient = httpClient
-		}
-		if conf := config.AS.Interop.InteropClient.BlobConfig; conf.HTTPClient == nil {
-			conf.HTTPClient = httpClient
-		}
-		if conf := config.NS.Interop.BlobConfig; conf.HTTPClient == nil {
-			conf.HTTPClient = httpClient
+		for _, httpClient := range []**http.Client{
+			&config.ServiceBase.FrequencyPlans.HTTPClient,
+			&config.ServiceBase.Interop.SenderClientCA.HTTPClient,
+			&config.ServiceBase.KeyVault.HTTPClient,
+			&config.ServiceBase.Blob.HTTPClient,
+			&config.AS.Interop.InteropClient.BlobConfig.HTTPClient,
+			&config.NS.Interop.BlobConfig.HTTPClient,
+		} {
+			if *httpClient != nil {
+				continue
+			}
+			*httpClient, err = c.HTTPClient(ctx)
+			if err != nil {
+				return err
+			}
 		}
 
 		if start.IdentityServer {

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -190,15 +190,27 @@ var startCommand = &cobra.Command{
 
 		redisConsumerID := redis.Key(host, strconv.Itoa(os.Getpid()))
 
-		transport, err := c.HTTPTransport(ctx)
+		httpClient, err := c.HTTPClient(ctx)
 		if err != nil {
 			return err
 		}
-		if conf := config.ServiceBase.FrequencyPlans; conf.Transport == nil {
-			conf.Transport = transport
+		if conf := config.ServiceBase.FrequencyPlans; conf.HTTPClient == nil {
+			conf.HTTPClient = httpClient
 		}
-		if conf := config.ServiceBase.Interop.SenderClientCA; conf.Transport == nil {
-			conf.Transport = transport
+		if conf := config.ServiceBase.Interop.SenderClientCA; conf.HTTPClient == nil {
+			conf.HTTPClient = httpClient
+		}
+		if conf := config.ServiceBase.KeyVault; conf.HTTPClient == nil {
+			conf.HTTPClient = httpClient
+		}
+		if conf := config.ServiceBase.Blob; conf.HTTPClient == nil {
+			conf.HTTPClient = httpClient
+		}
+		if conf := config.AS.Interop.InteropClient.BlobConfig; conf.HTTPClient == nil {
+			conf.HTTPClient = httpClient
+		}
+		if conf := config.NS.Interop.BlobConfig; conf.HTTPClient == nil {
+			conf.HTTPClient = httpClient
 		}
 
 		if start.IdentityServer {

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -97,7 +97,7 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 
 	baseConf := c.GetBaseConfig(ctx)
 
-	transport, err := c.HTTPTransport(ctx)
+	httpClient, err := c.HTTPClient(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -108,8 +108,8 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 			return c.GetTLSClientConfig(ctx)
 		}
 		interopConf.BlobConfig = baseConf.Blob
-		if interopConf.Transport == nil {
-			interopConf.Transport = transport
+		if interopConf.HTTPClient == nil {
+			interopConf.HTTPClient = httpClient
 		}
 
 		interopCl, err = interop.NewClient(ctx, interopConf)
@@ -206,8 +206,8 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 		c.RegisterWeb(webhooks)
 	}
 
-	if conf.Webhooks.Templates.Transport == nil {
-		conf.Webhooks.Templates.Transport = transport
+	if conf.Webhooks.Templates.HTTPClient == nil {
+		conf.Webhooks.Templates.HTTPClient = httpClient
 	}
 	if as.webhookTemplates, err = conf.Webhooks.Templates.NewTemplateStore(); err != nil {
 		return nil, err

--- a/pkg/applicationserver/io/web/config.go
+++ b/pkg/applicationserver/io/web/config.go
@@ -31,7 +31,7 @@ type TemplatesConfig struct {
 	URL         string            `name:"url" description:"Retrieve the webhook templates from a web server"`
 	LogoBaseURL string            `name:"logo-base-url" description:"The base URL for the logo storage"`
 
-	Transport http.RoundTripper `name:"-"`
+	HTTPClient *http.Client `name:"-"`
 }
 
 // TemplateStore contains the webhook templates.
@@ -56,7 +56,7 @@ func (c TemplatesConfig) NewTemplateStore() (TemplateStore, error) {
 		fallthrough
 	case c.URL != "":
 		var err error
-		fetcher, err = fetch.FromHTTP(c.Transport, c.URL, true)
+		fetcher, err = fetch.FromHTTP(c.HTTPClient, c.URL, true)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/applicationserver/io/web/grpc_webhooks_test.go
+++ b/pkg/applicationserver/io/web/grpc_webhooks_test.go
@@ -229,8 +229,8 @@ description: Bar`),
 			a := assertions.New(t)
 
 			config := web.TemplatesConfig{
-				Static:    tc.contents,
-				Transport: http.DefaultTransport,
+				Static:     tc.contents,
+				HTTPClient: http.DefaultClient,
 			}
 			store, err := config.NewTemplateStore()
 			a.So(err, should.BeNil)

--- a/pkg/blob/bucket_test.go
+++ b/pkg/blob/bucket_test.go
@@ -16,6 +16,7 @@ package blob_test
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -83,6 +84,7 @@ func TestAWS(t *testing.T) {
 	conf.AWS.Region = os.Getenv("AWS_REGION")
 	conf.AWS.AccessKeyID = os.Getenv("AWS_ACCESS_KEY_ID")
 	conf.AWS.SecretAccessKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
+	conf.HTTPClient = http.DefaultClient
 
 	if conf.AWS.Region == "" || conf.AWS.AccessKeyID == "" || conf.AWS.SecretAccessKey == "" {
 		t.Skip("Missing AWS credentials")

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -150,6 +150,8 @@ type KeyVault struct {
 	Provider string            `name:"provider" description:"Provider (static)"`
 	Cache    KeyVaultCache     `name:"cache"`
 	Static   map[string][]byte `name:"static"`
+
+	HTTPClient *http.Client `name:"-"`
 }
 
 // KeyVault returns an initialized crypto.KeyVault based on the configuration.
@@ -199,6 +201,8 @@ type BlobConfig struct {
 	Local    BlobConfigLocal `name:"local"`
 	AWS      BlobConfigAWS   `name:"aws"`
 	GCP      BlobConfigGCP   `name:"gcp"`
+
+	HTTPClient *http.Client `name:"-"`
 }
 
 // Bucket returns the requested blob bucket using the config.
@@ -207,7 +211,7 @@ func (c BlobConfig) Bucket(ctx context.Context, bucket string) (*blob.Bucket, er
 	case "local":
 		return ttnblob.Local(ctx, bucket, c.Local.Directory)
 	case "aws":
-		conf := aws.NewConfig()
+		conf := aws.NewConfig().WithHTTPClient(c.HTTPClient)
 		if c.AWS.Endpoint != "" {
 			conf = conf.WithEndpoint(c.AWS.Endpoint)
 		}
@@ -256,7 +260,7 @@ type FrequencyPlansConfig struct {
 	URL          string            `name:"url" description:"URL, which contains frequency plans"`
 	Blob         BlobPathConfig    `name:"blob"`
 
-	Transport http.RoundTripper `name:"-"`
+	HTTPClient *http.Client `name:"-"`
 }
 
 // Fetcher returns a fetch.Interface based on the configuration.
@@ -285,7 +289,7 @@ func (c FrequencyPlansConfig) Fetcher(ctx context.Context, blobConf BlobConfig) 
 	case "directory":
 		return fetch.FromFilesystem(c.Directory), nil
 	case "url":
-		return fetch.FromHTTP(c.Transport, c.URL, true)
+		return fetch.FromHTTP(c.HTTPClient, c.URL, true)
 	case "blob":
 		b, err := blobConf.Bucket(ctx, c.Blob.Bucket)
 		if err != nil {
@@ -307,7 +311,7 @@ type InteropClient struct {
 	GetFallbackTLSConfig func(ctx context.Context) (*tls.Config, error) `name:"-"`
 	BlobConfig           BlobConfig                                     `name:"-"`
 
-	Transport http.RoundTripper `name:"-"`
+	HTTPClient *http.Client `name:"-"`
 }
 
 // IsZero returns whether conf is empty.
@@ -342,7 +346,7 @@ func (c InteropClient) Fetcher(ctx context.Context) (fetch.Interface, error) {
 	case "directory":
 		return fetch.FromFilesystem(c.Directory), nil
 	case "url":
-		return fetch.FromHTTP(c.Transport, c.URL, true)
+		return fetch.FromHTTP(c.HTTPClient, c.URL, true)
 	case "blob":
 		b, err := c.BlobConfig.Bucket(ctx, c.Blob.Bucket)
 		if err != nil {
@@ -363,7 +367,7 @@ type SenderClientCA struct {
 
 	BlobConfig BlobConfig `name:"-"`
 
-	Transport http.RoundTripper `name:"-"`
+	HTTPClient *http.Client `name:"-"`
 }
 
 // Fetcher returns fetch.Interface defined by conf.
@@ -373,7 +377,7 @@ func (c SenderClientCA) Fetcher(ctx context.Context) (fetch.Interface, error) {
 	case "directory":
 		return fetch.FromFilesystem(c.Directory), nil
 	case "url":
-		return fetch.FromHTTP(c.Transport, c.URL, true)
+		return fetch.FromHTTP(c.HTTPClient, c.URL, true)
 	case "blob":
 		b, err := c.BlobConfig.Bucket(ctx, c.Blob.Bucket)
 		if err != nil {

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -205,6 +205,14 @@ type BlobConfig struct {
 	HTTPClient *http.Client `name:"-"`
 }
 
+// IsZero returns whether conf is empty.
+func (c BlobConfig) IsZero() bool {
+	return c.Provider == "" &&
+		c.Local == BlobConfigLocal{} &&
+		c.AWS == BlobConfigAWS{} &&
+		c.GCP == BlobConfigGCP{}
+}
+
 // Bucket returns the requested blob bucket using the config.
 func (c BlobConfig) Bucket(ctx context.Context, bucket string) (*blob.Bucket, error) {
 	switch c.Provider {
@@ -321,7 +329,7 @@ func (c InteropClient) IsZero() bool {
 		c.URL == "" &&
 		c.Blob.IsZero() &&
 		c.GetFallbackTLSConfig == nil &&
-		c.BlobConfig == BlobConfig{}
+		c.BlobConfig.IsZero()
 }
 
 // Fetcher returns fetch.Interface defined by conf.

--- a/pkg/fetch/fetch_test.go
+++ b/pkg/fetch/fetch_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func Example() {
-	fetcher, err := fetch.FromHTTP(http.DefaultTransport, "http://webserver.thethings.network/repository", true)
+	fetcher, err := fetch.FromHTTP(http.DefaultClient, "http://webserver.thethings.network/repository", true)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/fetch/http.go
+++ b/pkg/fetch/http.go
@@ -25,8 +25,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 )
 
-const timeout = 10 * time.Second
-
 type httpFetcher struct {
 	baseFetcher
 	httpClient *http.Client
@@ -64,13 +62,15 @@ func (f httpFetcher) File(pathElements ...string) ([]byte, error) {
 }
 
 // FromHTTP returns an object to fetch files from a webserver.
-func FromHTTP(transport http.RoundTripper, rootURL string, cache bool) (Interface, error) {
-	if transport == nil {
-		transport = http.DefaultTransport
+func FromHTTP(client *http.Client, rootURL string, cache bool) (Interface, error) {
+	if client == nil {
+		client = http.DefaultClient
 	}
 	if cache {
-		transport = &httpcache.Transport{
-			Transport:           transport,
+		cp := *client
+		client = &cp
+		client.Transport = &httpcache.Transport{
+			Transport:           client.Transport,
 			Cache:               httpcache.NewMemoryCache(),
 			MarkCachedResponses: true,
 		}
@@ -90,10 +90,7 @@ func FromHTTP(transport http.RoundTripper, rootURL string, cache bool) (Interfac
 		baseFetcher: baseFetcher{
 			latency: fetchLatency.WithLabelValues("http", rootURL),
 		},
-		httpClient: &http.Client{
-			Transport: transport,
-			Timeout:   timeout,
-		},
-		root: root,
+		httpClient: client,
+		root:       root,
 	}, nil
 }

--- a/pkg/fetch/http_test.go
+++ b/pkg/fetch/http_test.go
@@ -32,13 +32,13 @@ func TestHTTP(t *testing.T) {
 
 	// Invalid path
 	{
-		fetcher, err := fetch.FromHTTP(http.DefaultTransport, "", false)
+		fetcher, err := fetch.FromHTTP(http.DefaultClient, "", false)
 		if a.So(err, should.BeNil) && a.So(fetcher, should.NotBeNil) {
 			_, err = fetcher.File("test")
 			a.So(err, should.BeError)
 		}
 
-		fetcher, err = fetch.FromHTTP(http.DefaultTransport, "/asd", false)
+		fetcher, err = fetch.FromHTTP(http.DefaultClient, "/asd", false)
 		if a.So(err, should.NotBeNil) {
 			a.So(fetcher, should.BeNil)
 		}
@@ -53,7 +53,7 @@ func TestHTTP(t *testing.T) {
 	httpmock.RegisterResponder("GET", fmt.Sprintf("%s/success", serverHost), httpmock.NewStringResponder(200, content))
 	httpmock.RegisterResponder("GET", fmt.Sprintf("%s/fail", serverHost), httpmock.NewStringResponder(500, ""))
 
-	fetcher, err := fetch.FromHTTP(http.DefaultTransport, serverHost, false)
+	fetcher, err := fetch.FromHTTP(http.DefaultClient, serverHost, false)
 	if !a.So(err, should.BeNil) {
 		t.Fatalf("Failed to construct HTTP fetcher: %v", err)
 	}
@@ -100,7 +100,7 @@ func TestHTTPCache(t *testing.T) {
 
 	time.Sleep(10 * test.Delay)
 
-	fetcher, err := fetch.FromHTTP(http.DefaultTransport, fmt.Sprintf("http://%s", s.Addr), true)
+	fetcher, err := fetch.FromHTTP(http.DefaultClient, fmt.Sprintf("http://%s", s.Addr), true)
 	if !a.So(err, should.BeNil) {
 		t.Fatalf("Failed to construct HTTP fetcher: %v", err)
 	}

--- a/pkg/frequencyplans/frequencyplans_test.go
+++ b/pkg/frequencyplans/frequencyplans_test.go
@@ -35,7 +35,7 @@ func boolPtr(v bool) *bool                       { return &v }
 func durationPtr(v time.Duration) *time.Duration { return &v }
 
 func Example() {
-	fetcher, err := fetch.FromHTTP(http.DefaultTransport, "https://raw.githubusercontent.com/TheThingsNetwork/lorawan-frequency-plans", true)
+	fetcher, err := fetch.FromHTTP(http.DefaultClient, "https://raw.githubusercontent.com/TheThingsNetwork/lorawan-frequency-plans", true)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/identityserver/config.go
+++ b/pkg/identityserver/config.go
@@ -101,7 +101,7 @@ type emailTemplatesConfig struct {
 
 	Includes []string `name:"includes" description:"The email templates that will be preloaded on startup"`
 
-	Transport http.RoundTripper `name:"-"`
+	HTTPClient *http.Client `name:"-"`
 }
 
 // Fetcher returns a fetch.Interface based on the configuration.
@@ -130,7 +130,7 @@ func (c emailTemplatesConfig) Fetcher(ctx context.Context, blobConf config.BlobC
 	case "directory":
 		return fetch.FromFilesystem(c.Directory), nil
 	case "url":
-		return fetch.FromHTTP(c.Transport, c.URL, true)
+		return fetch.FromHTTP(c.HTTPClient, c.URL, true)
 	case "blob":
 		b, err := blobConf.Bucket(ctx, c.Blob.Bucket)
 		if err != nil {

--- a/pkg/identityserver/email.go
+++ b/pkg/identityserver/email.go
@@ -30,12 +30,12 @@ import (
 
 func (is *IdentityServer) initEmailTemplates(ctx context.Context) (*email.TemplateRegistry, error) {
 	config := is.configFromContext(ctx).Email.Templates
-	if config.Transport == nil {
-		transport, err := is.HTTPTransport(ctx)
+	if config.HTTPClient == nil {
+		httpClient, err := is.HTTPClient(ctx)
 		if err != nil {
 			return nil, err
 		}
-		config.Transport = transport
+		config.HTTPClient = httpClient
 	}
 	fetcher, err := config.Fetcher(ctx, is.Component.GetBaseConfig(ctx).Blob)
 	if err != nil {

--- a/pkg/interop/client.go
+++ b/pkg/interop/client.go
@@ -424,16 +424,17 @@ func NewClient(ctx context.Context, conf config.InteropClient) (*Client, error) 
 				}
 			}
 
-			var tr *http.Transport
-			if tlsConf != nil {
-				tr = &http.Transport{
-					TLSClientConfig: tlsConf,
-				}
+			tr := http.DefaultTransport.(*http.Transport).Clone()
+			if transport, ok := conf.HTTPClient.Transport.(*http.Transport); ok {
+				tr = transport.Clone()
 			}
+			if tlsConf != nil {
+				tr.TLSClientConfig = tlsConf
+			}
+			client := *conf.HTTPClient
+			client.Transport = tr
 			js = &joinServerHTTPClient{
-				Client: http.Client{
-					Transport: tr,
-				},
+				Client:         client,
 				NewRequestFunc: makeJoinServerHTTPRequestFunc("https", yamlJSConf.DNS, yamlJSConf.FQDN, yamlJSConf.Port, yamlJSConf.Paths, yamlJSConf.Headers),
 				Protocol:       yamlJSConf.Protocol,
 			}

--- a/pkg/interop/client_test.go
+++ b/pkg/interop/client_test.go
@@ -176,6 +176,7 @@ paths:
 				return config.InteropClient{
 						Directory:            confDir,
 						GetFallbackTLSConfig: func(context.Context) (*tls.Config, error) { return nil, nil },
+						HTTPClient:           http.DefaultClient,
 					}, func() error {
 						return os.RemoveAll(confDir)
 					}
@@ -294,6 +295,7 @@ paths:
 				return config.InteropClient{
 						Directory:            confDir,
 						GetFallbackTLSConfig: func(context.Context) (*tls.Config, error) { return nil, nil },
+						HTTPClient:           http.DefaultClient,
 					}, func() error {
 						return os.RemoveAll(confDir)
 					}
@@ -424,6 +426,7 @@ paths:
 				return config.InteropClient{
 						Directory:            confDir,
 						GetFallbackTLSConfig: func(context.Context) (*tls.Config, error) { return nil, nil },
+						HTTPClient:           http.DefaultClient,
 					}, func() error {
 						return os.RemoveAll(confDir)
 					}
@@ -559,6 +562,7 @@ paths:
 				return config.InteropClient{
 						Directory:            confDir,
 						GetFallbackTLSConfig: func(context.Context) (*tls.Config, error) { return nil, nil },
+						HTTPClient:           http.DefaultClient,
 					}, func() error {
 						return os.RemoveAll(confDir)
 					}
@@ -741,6 +745,7 @@ paths:
 				return config.InteropClient{
 						Directory:            confDir,
 						GetFallbackTLSConfig: func(context.Context) (*tls.Config, error) { return nil, nil },
+						HTTPClient:           http.DefaultClient,
 					}, func() error {
 						return os.RemoveAll(confDir)
 					}
@@ -859,6 +864,7 @@ paths:
 				return config.InteropClient{
 						Directory:            confDir,
 						GetFallbackTLSConfig: func(context.Context) (*tls.Config, error) { return nil, nil },
+						HTTPClient:           http.DefaultClient,
 					}, func() error {
 						return os.RemoveAll(confDir)
 					}
@@ -995,6 +1001,7 @@ paths:
 				return config.InteropClient{
 						Directory:            confDir,
 						GetFallbackTLSConfig: func(context.Context) (*tls.Config, error) { return nil, nil },
+						HTTPClient:           http.DefaultClient,
 					}, func() error {
 						return os.RemoveAll(confDir)
 					}
@@ -1144,6 +1151,7 @@ paths:
 				return config.InteropClient{
 						Directory:            confDir,
 						GetFallbackTLSConfig: func(context.Context) (*tls.Config, error) { return nil, nil },
+						HTTPClient:           http.DefaultClient,
 					}, func() error {
 						return os.RemoveAll(confDir)
 					}
@@ -1292,6 +1300,7 @@ paths:
 				return config.InteropClient{
 						Directory:            confDir,
 						GetFallbackTLSConfig: func(context.Context) (*tls.Config, error) { return nil, nil },
+						HTTPClient:           http.DefaultClient,
 					}, func() error {
 						return os.RemoveAll(confDir)
 					}

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -191,12 +191,12 @@ func New(c *component.Component, conf *Config, opts ...Option) (*NetworkServer, 
 			return c.GetTLSClientConfig(ctx)
 		}
 		interopConf.BlobConfig = c.GetBaseConfig(ctx).Blob
-		if interopConf.Transport == nil {
-			tr, err := c.HTTPTransport(ctx)
+		if interopConf.HTTPClient == nil {
+			httpClient, err := c.HTTPClient(ctx)
 			if err != nil {
 				return nil, err
 			}
-			interopConf.Transport = tr
+			interopConf.HTTPClient = httpClient
 		}
 
 		interopCl, err = interop.NewClient(ctx, interopConf)

--- a/pkg/pfconfig/semtechudp/semtechudp_test.go
+++ b/pkg/pfconfig/semtechudp/semtechudp_test.go
@@ -36,7 +36,7 @@ func TestBuild(t *testing.T) {
 		fetcher = fetch.FromFilesystem(localPath)
 	} else {
 		var err error
-		fetcher, err = fetch.FromHTTP(http.DefaultTransport, "https://raw.githubusercontent.com/TheThingsNetwork/lorawan-frequency-plans/master", true)
+		fetcher, err = fetch.FromHTTP(http.DefaultClient, "https://raw.githubusercontent.com/TheThingsNetwork/lorawan-frequency-plans/master", true)
 		if err != nil {
 			t.Fatalf("Failed to construct HTTP fetcher: %v", err)
 		}
@@ -49,7 +49,7 @@ func TestBuild(t *testing.T) {
 		referenceFetcher = fetch.FromFilesystem(referenceLocalPath)
 	} else {
 		var err error
-		referenceFetcher, err = fetch.FromHTTP(http.DefaultTransport, "https://raw.githubusercontent.com/TheThingsNetwork/gateway-conf/master", true)
+		referenceFetcher, err = fetch.FromHTTP(http.DefaultClient, "https://raw.githubusercontent.com/TheThingsNetwork/gateway-conf/master", true)
 		if err != nil {
 			t.Fatalf("Failed to construct HTTP fetcher: %v", err)
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/2533
References https://github.com/TheThingsNetwork/lorawan-stack/pull/3486

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove the LoRaCloud Geolocation custom `*http.Client`
- `fetch.FromHTTP` now takes a `*http.Client` instead of `http.RoundTripper`
  - This allows the caller to control the request timeouts (and removes redudant magic constants from our code base)
- Adapt HTTP fetcher configuration to use `*http.Client` instead of `http.RoundTripper`
  - Originally these configs contained a `http.RoundTripper` field which was used by `fetch.FromHTTP`
- AWS Blob access now uses a custom `*http.Client`
  - This is part of an ongoing effort to use timeouts for all of the operations that contact external services, including cloud provider services.
- The interop client no longer uses a custom `http.Client`.
  - The risk here was twofold - the transport used before didn't contain any timeouts, and the `http.Client` itself did not have a timeout.


#### Testing

<!-- How did you verify that this change works? -->

Unit testing and :monkey: testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Several HTTP fetcher initialization sites are now updated. Nonetheless, the changes are identical, and I've tested the webhook template fetcher (visit the webhook creation screen in the Console).

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
