### PR TITLE
Change error for already used contact info validation token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ For details about compatibility between different releases, see the **Commitment
 - All external HTTP calls are now using TLS client configuration. This fixes issues where HTTP calls would fail if custom (e.g. self-signed) CAs were used.
 - All external HTTP calls are now using a default timeout. This fixes issues where HTTP calls would stall for a long time.
 - All value wrappers now are encoded and decoded as the value being wrapped in JSON. That means, that, e.g. format of `mac_settings.rx1_delay` is changed from `{"value": 2}` to just `2`.
+- Changed the error that is returned when attempting to validate already validated contact info.
+  - This requires a database schema migration (`ttn-lw-stack is-db migrate`) because of the added column.
 
 ### Deprecated
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -4841,6 +4841,15 @@
       "file": "contact_info_store.go"
     }
   },
+  "error:pkg/identityserver/store:validation_token_used": {
+    "translations": {
+      "en": "validation token already used"
+    },
+    "description": {
+      "package": "pkg/identityserver/store",
+      "file": "contact_info_store.go"
+    }
+  },
   "error:pkg/identityserver:access_token_mismatch": {
     "translations": {
       "en": "access token ID did not match user or client identifiers"

--- a/cypress/integration/smoke/contact-info-validation/index.js
+++ b/cypress/integration/smoke/contact-info-validation/index.js
@@ -37,8 +37,7 @@ const contactInfoValidation = defineSmokeTest('succeeds validating contact info'
   cy.reload()
   cy.findByTestId('error-notification')
     .should('be.visible')
-    .should('contain', 'was not found')
-    .should('contain', 'already been validated')
+    .should('contain', 'token already used')
 })
 
 export default [contactInfoValidation]

--- a/pkg/identityserver/store/contact_info_store_test.go
+++ b/pkg/identityserver/store/contact_info_store_test.go
@@ -153,5 +153,14 @@ func TestContactInfoValidation(t *testing.T) {
 		if a.So(info, should.HaveLength, 1) {
 			a.So(info[0].ValidatedAt, should.NotBeNil)
 		}
+
+		err = s.Validate(ctx, &ttnpb.ContactInfoValidation{
+			ID:    "validation-id",
+			Token: "validation-token",
+		})
+
+		if a.So(err, should.NotBeNil) {
+			a.So(errors.IsAlreadyExists(err), should.BeTrue)
+		}
 	})
 }

--- a/pkg/identityserver/store/contact_info_validation.go
+++ b/pkg/identityserver/store/contact_info_validation.go
@@ -33,6 +33,7 @@ type ContactInfoValidation struct {
 	ContactMethod int    `gorm:"not null"`
 	Value         string `gorm:"type:VARCHAR"`
 
+	Used      bool
 	ExpiresAt time.Time
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request changes the error that the IS returns when consuming a contact info validation token that was already used.

Closes #3833.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add column to DB model
- Introduce new error message

#### Testing

<!-- How did you verify that this change works? -->

- Unit test
- 🐒 
- 🐒 https://github.com/TheThingsNetwork/lorawan-stack/issues/3833#issuecomment-804156980

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
