### PR TITLE
Expose stack domain as header

### DIFF
--- a/pkg/applicationserver/io/web/webhooks_test.go
+++ b/pkg/applicationserver/io/web/webhooks_test.go
@@ -399,6 +399,7 @@ func TestWebhooks(t *testing.T) {
 									"https://example.com/api/v3/as/applications/foo-app/webhooks/foo-hook/devices/foo-device/down/push")
 								a.So(req.Header.Get("X-Downlink-Replace"), should.Equal,
 									"https://example.com/api/v3/as/applications/foo-app/webhooks/foo-hook/devices/foo-device/down/replace")
+								a.So(req.Header.Get("X-Tts-Domain"), should.Equal, "example.com")
 								actualBody, err := ioutil.ReadAll(req.Body)
 								if !a.So(err, should.BeNil) {
 									t.FailNow()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/3795

#### Changes
<!-- What are the changes made in this pull request? -->

- Add the `X-Tts-Domain` header to webhook requests.


#### Testing

<!-- How did you verify that this change works? -->

Unit testing is enough for this.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I've went a bit against the tide and reused the downlink configuration `PublicAddress`/`PublicTLSAddress`. I'm not entirely sure what the added value / use case is for another domain field here, but I'm open to arguments.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
