### PR TITLE
Use basic events PubSub instead of noop

### DIFF
--- a/cmd/internal/shared/events.go
+++ b/cmd/internal/shared/events.go
@@ -21,6 +21,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/component"
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
+	"go.thethings.network/lorawan-stack/v3/pkg/events/basic"
 	"go.thethings.network/lorawan-stack/v3/pkg/events/cloud"
 	"go.thethings.network/lorawan-stack/v3/pkg/events/redis"
 	_ "gocloud.dev/pubsub/awssnssqs" // AWS backend for PubSub.
@@ -31,7 +32,8 @@ import (
 func InitializeEvents(ctx context.Context, taskStarter component.TaskStarter, conf config.ServiceBase) error {
 	switch conf.Events.Backend {
 	case "internal":
-		return nil // this is the default.
+		events.SetDefaultPubSub(basic.NewPubSub())
+		return nil
 	case "redis":
 		events.SetDefaultPubSub(redis.NewPubSub(ctx, taskStarter, conf.Events.Redis))
 		return nil


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This fixes the initialization of the default events PubSub.

Broken in #3748

@adriansmares thanks for catching this before it landed in a release.

#### Testing

<!-- How did you verify that this change works? -->

🐒 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
    - This didn't land in a release yet
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
