### PR TITLE
Add placeholder storage-db command for open-source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ For details about compatibility between different releases, see the **Commitment
 - Payload size limit calculation in Network Server.
 - Occasional panic in Network Server on downlink with corrupted device states.
 - Occasional panic in Identity Server on extracting log fields from invalid requests.
+- Print an error message stating that the Storage Integration is not available in the open source edition of The Things Stack when trying to execute `ttn-lw-stack storage-db` commands.
 
 ### Security
 

--- a/cmd/ttn-lw-stack/commands/storage_db.go
+++ b/cmd/ttn-lw-stack/commands/storage_db.go
@@ -1,0 +1,40 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+)
+
+var (
+	errStorageIntegrationNotAvailable = errors.DefineUnimplemented("storage_integration_not_available", "Storage Integration not available")
+
+	storageDBCommand = &cobra.Command{
+		Use:   "storage-db",
+		Short: "Manage the Storage Integration database",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Println("The storage integration is not available in the open-source version of The Things Stack.")
+			fmt.Println("For more information, see https://www.thethingsindustries.com/docs/integrations/storage/")
+			return errStorageIntegrationNotAvailable.New()
+		},
+	}
+)
+
+func init() {
+	Root.AddCommand(storageDBCommand)
+}

--- a/config/messages.json
+++ b/config/messages.json
@@ -1700,6 +1700,15 @@
       "file": "is_db_create_admin_user.go"
     }
   },
+  "error:cmd/ttn-lw-stack/commands:storage_integration_not_available": {
+    "translations": {
+      "en": "Storage Integration not available"
+    },
+    "description": {
+      "package": "cmd/ttn-lw-stack/commands",
+      "file": "storage_db.go"
+    }
+  },
   "error:cmd/ttn-lw-stack/commands:unknown_component": {
     "translations": {
       "en": "unknown component `{component}`"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #3984

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `ttn-lw-stack storage-db` command, which simply prints an error message that the storage integration is not available 
in the open source version

#### Testing

<!-- How did you verify that this change works? -->

Run locally

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
