### PR TITLE
Rate Limiting configuration quickfixes

### DIFF
--- a/pkg/basicstation/cups/server.go
+++ b/pkg/basicstation/cups/server.go
@@ -197,7 +197,7 @@ func NewServer(c *component.Component, options ...Option) *Server {
 
 // RegisterRoutes implements web.Registerer
 func (s *Server) RegisterRoutes(web *web.Server) {
-	web.POST("/update-info", s.UpdateInfo, ratelimit.EchoMiddleware(s.component.RateLimiter(), "basicstation:cups"))
+	web.POST("/update-info", s.UpdateInfo, ratelimit.EchoMiddleware(s.component.RateLimiter(), "http:gcs:cups"))
 }
 
 func getContext(c echo.Context) context.Context {

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -54,7 +54,7 @@ func (*srv) SupportsDownlinkClaim() bool { return true }
 
 var (
 	errUDPFrontendRecovered      = errors.DefineInternal("udp_frontend_recovered", "internal server error")
-	limitLogsConfig              = ratelimit.Profile{MaxRatePerMin: 1}
+	limitLogsConfig              = ratelimit.Profile{MaxPerMin: 1}
 	limitLogsSize           uint = 1 << 13
 )
 

--- a/pkg/gatewayserver/io/ws/ws_test.go
+++ b/pkg/gatewayserver/io/ws/ws_test.go
@@ -1530,10 +1530,10 @@ func TestRateLimit(t *testing.T) {
 		maxRate := uint(3)
 		conf := ratelimit.Config{
 			Profiles: []ratelimit.Profile{{
-				Name:          "accept connections",
-				MaxRatePerMin: maxRate,
-				MaxBurst:      maxRate,
-				Associations:  []string{"gs:accept:ws"},
+				Name:         "accept connections",
+				MaxPerMin:    maxRate,
+				MaxBurst:     maxRate,
+				Associations: []string{"gs:accept:ws"},
 			}},
 		}
 		withServer(t, defaultConfig, conf, func(t *testing.T, _ *mock.IdentityServer, serverAddress string) {

--- a/pkg/ratelimit/config.go
+++ b/pkg/ratelimit/config.go
@@ -27,10 +27,10 @@ const defaultMaxSize = 1 << 12
 
 // Profile represents configuration for a rate limiting class.
 type Profile struct {
-	Name          string   `name:"name" description:"Rate limiting class name"`
-	MaxRatePerMin uint     `name:"max-rate-per-min" description:"Maximum allowed rate per minute"`
-	MaxBurst      uint     `name:"max-burst" description:"Maximum rate allowed for short bursts"`
-	Associations  []string `name:"associations" description:"List of classes to apply this profile on"`
+	Name         string   `name:"name" description:"Rate limiting class name"`
+	MaxPerMin    uint     `name:"max-per-min" description:"Maximum allowed rate (per minute)"`
+	MaxBurst     uint     `name:"max-burst" description:"Maximum rate allowed for short bursts"`
+	Associations []string `name:"associations" description:"List of classes to apply this profile on"`
 }
 
 // MemoryConfig represents configuration for the in-memory rate limiting store.
@@ -82,10 +82,10 @@ func (c Profile) New(ctx context.Context, size uint) (Interface, error) {
 		return nil, err
 	}
 	if c.MaxBurst == 0 {
-		c.MaxBurst = c.MaxRatePerMin
+		c.MaxBurst = c.MaxPerMin
 	}
 	quota := throttled.RateQuota{
-		MaxRate:  throttled.PerMin(int(c.MaxRatePerMin)),
+		MaxRate:  throttled.PerMin(int(c.MaxPerMin)),
 		MaxBurst: int(c.MaxBurst - 1),
 	}
 	limiter, err := throttled.NewGCRARateLimiter(store, quota)

--- a/pkg/ratelimit/rate_limit_test.go
+++ b/pkg/ratelimit/rate_limit_test.go
@@ -38,22 +38,22 @@ func TestRateLimit(t *testing.T) {
 	limiter, err := ratelimit.Config{
 		Profiles: []ratelimit.Profile{
 			{
-				Name:          "Default profile",
-				MaxRatePerMin: maxRate,
-				MaxBurst:      maxRate,
-				Associations:  []string{"default"},
+				Name:         "Default profile",
+				MaxPerMin:    maxRate,
+				MaxBurst:     maxRate,
+				Associations: []string{"default"},
 			},
 			{
-				Name:          "Multiple associations",
-				MaxRatePerMin: maxRate,
-				MaxBurst:      maxRate,
-				Associations:  []string{"assoc1", "assoc2"},
+				Name:         "Multiple associations",
+				MaxPerMin:    maxRate,
+				MaxBurst:     maxRate,
+				Associations: []string{"assoc1", "assoc2"},
 			},
 			{
-				Name:          "Override",
-				MaxRatePerMin: overrideRate,
-				MaxBurst:      overrideRate,
-				Associations:  []string{"override"},
+				Name:         "Override",
+				MaxPerMin:    overrideRate,
+				MaxBurst:     overrideRate,
+				Associations: []string{"override"},
 			},
 		},
 	}.New(test.Context())


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Quickfix PR follow up of #3920, adjust some configuration names for consistency

#### Changes
<!-- What are the changes made in this pull request? -->

- Use `max-per-min` instead of `max-rate-per-min`
- Use `http:gcs:cups` instead of `basicstation:cups`

#### Testing

<!-- How did you verify that this change works? -->

Unit tests do not break.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

3.12 is not released yet, we can afford to make this change.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
