### PR TITLE
Move authorization code view to authenticated views

### DIFF
--- a/cypress/integration/account/code.spec.js
+++ b/cypress/integration/account/code.spec.js
@@ -12,9 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+const user = {
+  ids: { user_id: 'authorization-code-test-user' },
+  name: 'Test User',
+  primary_email_address: 'test-user@example.com',
+  password: 'ABCDefg123!',
+  password_confirm: 'ABCDefg123!',
+}
+
 describe('Account App code view', () => {
   before(() => {
     cy.dropAndSeedDatabase()
+    cy.createUser(user)
+  })
+
+  beforeEach(() => {
+    cy.loginAccountApp({ user_id: user.ids.user_id, password: user.password })
   })
 
   it('displays UI elements in place', () => {
@@ -29,6 +42,6 @@ describe('Account App code view', () => {
 
   it('redirects back if no code is supplied', () => {
     cy.visit(`${Cypress.config('accountAppRootPath')}/code`)
-    cy.location('pathname').should('eq', `${Cypress.config('accountAppRootPath')}/login`)
+    cy.location('pathname').should('eq', `${Cypress.config('accountAppRootPath')}/`)
   })
 })

--- a/pkg/webui/account/views/code/code.styl
+++ b/pkg/webui/account/views/code/code.styl
@@ -12,24 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Overview from '@account/views/overview'
-import ProfileSettings from '@account/views/profile-settings'
-import Code from '@account/views/code'
+.code
+  margin-bottom: $cs.m
 
-export default [
-  {
-    path: '/',
-    exact: true,
-    component: Overview,
-  },
-  {
-    path: '/profile-settings',
-    exact: true,
-    component: ProfileSettings,
-  },
-  {
-    path: '/code',
-    exact: true,
-    component: Code,
-  },
-]
+.code-description
+  text-margin-bottom($cs.xl)
+  display: block

--- a/pkg/webui/account/views/code/index.js
+++ b/pkg/webui/account/views/code/index.js
@@ -16,17 +16,18 @@ import React from 'react'
 import Query from 'query-string'
 import { Redirect } from 'react-router-dom'
 import { defineMessages } from 'react-intl'
+import { Container, Col, Row } from 'react-grid-system'
 
 import SafeInspector from '@ttn-lw/components/safe-inspector'
 import Button from '@ttn-lw/components/button'
+import PageTitle from '@ttn-lw/components/page-title'
 
 import Message from '@ttn-lw/lib/components/message'
-import IntlHelmet from '@ttn-lw/lib/components/intl-helmet'
 
-import style from '@account/views/front/front.styl'
-
-import { selectApplicationSiteName, selectApplicationSiteTitle } from '@ttn-lw/lib/selectors/env'
+import { selectApplicationSiteTitle } from '@ttn-lw/lib/selectors/env'
 import PropTypes from '@ttn-lw/lib/prop-types'
+
+import style from './code.styl'
 
 const m = defineMessages({
   code: 'Authorization code',
@@ -34,7 +35,6 @@ const m = defineMessages({
   backToAccount: 'Back to {siteTitle}',
 })
 
-const siteName = selectApplicationSiteName()
 const siteTitle = selectApplicationSiteTitle()
 
 const Code = ({ location }) => {
@@ -45,30 +45,30 @@ const Code = ({ location }) => {
   }
 
   return (
-    <>
-      <div className={style.form}>
-        <IntlHelmet title={m.createANewAccount} />
-        <h1 className={style.title}>
-          {siteName}
-          <br />
-          <Message content={m.code} component="strong" />
-        </h1>
-        <hr className={style.hRule} />
-        <Message content={m.codeDescription} component="label" className={style.codeDescription} />
-        <SafeInspector
-          data={query.code}
-          initiallyVisible
-          hideable={false}
-          isBytes={false}
-          className={style.code}
-        />
-        <Button.Link
-          to="/"
-          icon="keyboard_arrow_left"
-          message={{ ...m.backToAccount, values: { siteTitle } }}
-        />
-      </div>
-    </>
+    <Container>
+      <Row>
+        <Col lg={4} md={6} sm={12}>
+          <PageTitle title={m.code} />
+          <Message
+            content={m.codeDescription}
+            component="label"
+            className={style.codeDescription}
+          />
+          <SafeInspector
+            data={query.code}
+            initiallyVisible
+            hideable={false}
+            isBytes={false}
+            className={style.code}
+          />
+          <Button.Link
+            to="/"
+            icon="keyboard_arrow_left"
+            message={{ ...m.backToAccount, values: { siteTitle } }}
+          />
+        </Col>
+      </Row>
+    </Container>
   )
 }
 

--- a/pkg/webui/account/views/front/front.styl
+++ b/pkg/webui/account/views/front/front.styl
@@ -100,7 +100,7 @@
 .submit-button
   min-width: 8rem
 
-.code, .spinner
+.spinner
   margin-bottom: $cs.m
 
 .buttons
@@ -131,6 +131,6 @@
   +media-query-min($bp.s)
     display: static
 
-.code-description, .error-description
+.error-description
   text-margin-bottom($cs.xl)
   display: block

--- a/pkg/webui/account/views/front/index.js
+++ b/pkg/webui/account/views/front/index.js
@@ -28,7 +28,6 @@ import ForgotPassword from '@account/views/forgot-password'
 import UpdatePassword from '@account/views/update-password'
 import FrontNotFound from '@account/views/front-not-found'
 import Validate from '@account/views/validate'
-import Code from '@account/views/code'
 
 import { selectApplicationRootPath } from '@ttn-lw/lib/selectors/env'
 import PropTypes from '@ttn-lw/lib/prop-types'
@@ -48,7 +47,6 @@ const FrontView = ({ location }) => {
             <Route path="/forgot-password" component={ForgotPassword} />
             <Route path="/update-password" component={UpdatePassword} />
             <Route path="/validate" component={Validate} />
-            <Route path="/code" component={Code} />
             <Redirect exact from="/" to="/login" />
             {authRoutes.map(({ path, exact }) => (
               <Route path={path} exact={exact} key={path}>


### PR DESCRIPTION
#### Summary
This quickfix PR moves the authorization code view to the authenticated views. See https://github.com/TheThingsIndustries/lorawan-stack-support/issues/347

#### Changes
- Move auth code view to authenticated views
- Update cypress tests


#### Testing

Updated cypress tests and did manual testing.

##### Regressions

None.

#### Notes for Reviewers
The view was only visible in logged out state but to get the auth code, the user is logged in which lead to a 404.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
