### PR TITLE
Update goreleaser glob pattern for nfpm

### DIFF
--- a/.goreleaser.release.yml
+++ b/.goreleaser.release.yml
@@ -107,7 +107,7 @@ nfpms:
       - redis
       - cockroach
     contents:
-      - src: "public/**/*"
+      - src: "public/**"
         dst: "/srv/ttn-lorawan/public"
       - src: "config/completion/bash/*"
         dst: "/usr/share/bash-completion/completions"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Our usage of the glob `/**/*` seems invalid; https://github.com/goreleaser/nfpm/issues/256

We only notice this since we updated our go releaser version here; https://github.com/TheThingsNetwork/lorawan-stack/commit/8b41e3b63f89fa444da37afe7a7acef4d3d1f38b

#### Changes
<!-- What are the changes made in this pull request? -->

- The recommended change is to [drop the second catch-all block](https://github.com/goreleaser/nfpm/issues/256#issuecomment-728536627).

#### Testing

<!-- How did you verify that this change works? -->

🤷 

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

NA

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I don't know if this'll work

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
