### PR TITLE
Revert docker ids field to binaries

### DIFF
--- a/.goreleaser.release.yml
+++ b/.goreleaser.release.yml
@@ -208,7 +208,7 @@ dockers:
   - goos: linux
     goarch: amd64
     dockerfile: Dockerfile
-    ids:
+    binaries:
       - ttn-lw-cli
       - ttn-lw-stack
     image_templates:

--- a/.goreleaser.snapshot.yml
+++ b/.goreleaser.snapshot.yml
@@ -46,7 +46,7 @@ dockers:
     goarch: amd64
     dockerfile: Dockerfile
     use_buildx: true
-    ids:
+    binaries:
       - ttn-lw-cli
       - ttn-lw-stack
     build_flag_templates:
@@ -66,7 +66,7 @@ dockers:
     goarch: arm64
     dockerfile: Dockerfile
     use_buildx: true
-    ids:
+    binaries:
       - ttn-lw-cli
       - ttn-lw-stack
     build_flag_templates:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Go releaser seems to now fail to find the `ttn-lw-stack` and `ttn-lw-cli` binaries; https://github.com/TheThingsNetwork/lorawan-stack/runs/2279461345

Could be that the change to `docker.ids` is not processed although the [official documentation](https://goreleaser.com/deprecations#dockerbinaries) says that it's supported from `v0.154.0` (and we use `v0.161.0`). There might be supplementary changes for this to work  🤷 
Refs; https://github.com/TheThingsNetwork/lorawan-stack/pull/4025/files

#### Changes
<!-- What are the changes made in this pull request? -->

- Revert to using `binaries` in the dockers blocks.

#### Testing

<!-- How did you verify that this change works? -->

We'll know when we push the tag again.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

NA


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
