### PR TITLE
Make list of allowed values in storage command flags consistent

### DIFF
--- a/cmd/ttn-lw-cli/commands/storage_integration_util.go
+++ b/cmd/ttn-lw-cli/commands/storage_integration_util.go
@@ -16,6 +16,7 @@ package commands
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	pbtypes "github.com/gogo/protobuf/types"
@@ -43,7 +44,8 @@ func getStoredUpFlags() *pflag.FlagSet {
 	for k := range ttnpb.StoredApplicationUpTypes {
 		types = append(types, k)
 	}
-	flags.String("type", "", fmt.Sprintf("message type (%s)", strings.Join(types, "|")))
+	sort.Strings(types)
+	flags.String("type", "", fmt.Sprintf("message type (allowed values: %s)", strings.Join(types, ", ")))
 
 	return flags
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a small fix for how the documentation for the `--type` flag in the `storage` commands of the CLI is rendered.

#### Changes
<!-- What are the changes made in this pull request? -->

- Added sorting to prevent it from changing every time (very annoying in `lorawan-stack-docs`)
- Made more consistent with how we render allowed values for enums.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Not sure how we should handle the special case of the empty string. Any suggestions?

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
	- Not necessary
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
	- I think this is too small to be listed
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
