### PR TITLE
Use uplink data rate index for ADR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
+- Network Server now takes uplink data rate index for ADR.
+
 ### Deprecated
 
 ### Removed

--- a/pkg/networkserver/networkserver_flow_test.go
+++ b/pkg/networkserver/networkserver_flow_test.go
@@ -42,7 +42,7 @@ func frequencyPlanMACCommands(macVersion ttnpb.MACVersion, phyVersion ttnpb.PHYV
 	case test.EUFrequencyPlanID:
 		linkADRReq := &ttnpb.MACCommand_LinkADRReq{
 			ChannelMask:   []bool{true, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false},
-			DataRateIndex: ttnpb.DATA_RATE_4,
+			DataRateIndex: ttnpb.DATA_RATE_5,
 			TxPowerIndex:  1,
 			NbTrans:       1,
 		}
@@ -55,7 +55,7 @@ func frequencyPlanMACCommands(macVersion ttnpb.MACVersion, phyVersion ttnpb.PHYV
 		linkADRReqs := []MACCommander{
 			&ttnpb.MACCommand_LinkADRReq{
 				ChannelMask:   []bool{false, false, false, false, false, false, false, false, true, true, true, true, true, true, true, true},
-				DataRateIndex: ttnpb.DATA_RATE_2,
+				DataRateIndex: ttnpb.DATA_RATE_3,
 				TxPowerIndex:  1,
 				NbTrans:       1,
 			},
@@ -65,7 +65,7 @@ func frequencyPlanMACCommands(macVersion ttnpb.MACVersion, phyVersion ttnpb.PHYV
 				&ttnpb.MACCommand_LinkADRReq{
 					ChannelMask:        []bool{false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false},
 					ChannelMaskControl: 7,
-					DataRateIndex:      ttnpb.DATA_RATE_2,
+					DataRateIndex:      ttnpb.DATA_RATE_3,
 					TxPowerIndex:       1,
 					NbTrans:            1,
 				},
@@ -85,7 +85,7 @@ func frequencyPlanMACCommands(macVersion ttnpb.MACVersion, phyVersion ttnpb.PHYV
 		}
 		linkADRReq := &ttnpb.MACCommand_LinkADRReq{
 			ChannelMask:   []bool{true, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false},
-			DataRateIndex: ttnpb.DATA_RATE_4,
+			DataRateIndex: ttnpb.DATA_RATE_5,
 			TxPowerIndex:  1,
 			NbTrans:       1,
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/3901

#### Changes
<!-- What are the changes made in this pull request? -->

- Use uplink data rate index for ADR


#### Testing

<!-- How did you verify that this change works? -->

Unit tests. Note that flow tests now schedule LinkADRReqs with DR index 1 higher, since preceeding uplink uses DR index 1 instead of previous 0.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.