### PR TITLE
Fix global `event` variable usage in byte input

### DIFF
--- a/pkg/webui/components/input/byte.js
+++ b/pkg/webui/components/input/byte.js
@@ -150,7 +150,7 @@ export default class ByteInput extends React.Component {
     const { max, showPerChar } = this.props
     const { data } = evt.nativeEvent
 
-    let value = clean(event.target.value)
+    let value = clean(evt.target.value)
     const normalizedMax = showPerChar ? Math.ceil(max / 2) : max
 
     // Check if the value already has length equal to `max`.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Resolves https://sentry.io/organizations/the-things-industries/issues/2324190832/?project=2682566&statsPeriod=14d

#### Changes
<!-- What are the changes made in this pull request? -->

- Do not use the global `event` and use local `evt`.


#### Testing

<!-- How did you verify that this change works? -->

manual + e2e tests
##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Interaction with any byte input within the Console/Account apps

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
