### PR TITLE
Add options to reject common passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Added
 
 - Payload formatter testing functionality in the Console.
+- Options in the Identity Server to reject passwords that contain the user ID (`is.user-registration.password-requirements.reject-user-id`) or common passwords (`is.user-registration.password-requirements.reject-common`).
 
 ### Changed
 

--- a/cmd/internal/shared/identityserver/config.go
+++ b/cmd/internal/shared/identityserver/config.go
@@ -59,6 +59,7 @@ func init() {
 	DefaultIdentityServerConfig.UserRegistration.PasswordRequirements.MaxLength = 1000
 	DefaultIdentityServerConfig.UserRegistration.PasswordRequirements.MinUppercase = 1
 	DefaultIdentityServerConfig.UserRegistration.PasswordRequirements.MinDigits = 1
+	DefaultIdentityServerConfig.UserRegistration.PasswordRequirements.RejectUserID = true
 	DefaultIdentityServerConfig.Email.Network.Name = DefaultIdentityServerConfig.OAuth.UI.SiteName
 	DefaultIdentityServerConfig.Email.Network.IdentityServerURL = shared.DefaultOAuthPublicURL
 	DefaultIdentityServerConfig.Email.Network.ConsoleURL = shared.DefaultConsolePublicURL

--- a/config/messages.json
+++ b/config/messages.json
@@ -5048,6 +5048,15 @@
       "file": "client_registry.go"
     }
   },
+  "error:pkg/identityserver:common_password": {
+    "translations": {
+      "en": "must not be too common"
+    },
+    "description": {
+      "package": "pkg/identityserver",
+      "file": "user_registry.go"
+    }
+  },
   "error:pkg/identityserver:db_needs_migration": {
     "translations": {
       "en": "the database needs to be migrated"
@@ -5195,6 +5204,24 @@
   "error:pkg/identityserver:old_password": {
     "translations": {
       "en": "incorrect old password"
+    },
+    "description": {
+      "package": "pkg/identityserver",
+      "file": "user_registry.go"
+    }
+  },
+  "error:pkg/identityserver:password_contains_user_id": {
+    "translations": {
+      "en": "must not contain user ID"
+    },
+    "description": {
+      "package": "pkg/identityserver",
+      "file": "user_registry.go"
+    }
+  },
+  "error:pkg/identityserver:password_equals_old": {
+    "translations": {
+      "en": "must not equal old password"
     },
     "description": {
       "package": "pkg/identityserver",

--- a/pkg/identityserver/config.go
+++ b/pkg/identityserver/config.go
@@ -47,11 +47,13 @@ type Config struct {
 			Required bool `name:"required" description:"Require admin approval for new users"`
 		} `name:"admin-approval"`
 		PasswordRequirements struct {
-			MinLength    int `name:"min-length" description:"Minimum password length"`
-			MaxLength    int `name:"max-length" description:"Maximum password length"`
-			MinUppercase int `name:"min-uppercase" description:"Minimum number of uppercase letters"`
-			MinDigits    int `name:"min-digits" description:"Minimum number of digits"`
-			MinSpecial   int `name:"min-special" description:"Minimum number of special characters"`
+			MinLength    int  `name:"min-length" description:"Minimum password length"`
+			MaxLength    int  `name:"max-length" description:"Maximum password length"`
+			MinUppercase int  `name:"min-uppercase" description:"Minimum number of uppercase letters"`
+			MinDigits    int  `name:"min-digits" description:"Minimum number of digits"`
+			MinSpecial   int  `name:"min-special" description:"Minimum number of special characters"`
+			RejectUserID bool `name:"reject-user-id" description:"Reject passwords that contain user ID"`
+			RejectCommon bool `name:"reject-common" description:"Reject common passwords"`
 		} `name:"password-requirements"`
 	} `name:"user-registration"`
 	AuthCache struct {

--- a/pkg/identityserver/user_registry_test.go
+++ b/pkg/identityserver/user_registry_test.go
@@ -39,6 +39,8 @@ func TestValidatePasswordStrength(t *testing.T) {
 		"āaa123➉@#":    false, // No uppercase characters.
 		"āaaAAA➉@#":    false, // No digits.
 		"āaaAAA➉23":    false, // No special characters.
+		"myusername":   false, // Contains username.
+		"password1":    false, // Too common.
 		"āaaAAA123!@#": true,
 		"       1A":    true,
 		"āaa	AAA123 ": true,
@@ -54,9 +56,11 @@ func TestValidatePasswordStrength(t *testing.T) {
 				conf.UserRegistration.PasswordRequirements.MinUppercase = 1
 				conf.UserRegistration.PasswordRequirements.MinDigits = 1
 				conf.UserRegistration.PasswordRequirements.MinSpecial = 1
+				conf.UserRegistration.PasswordRequirements.RejectUserID = true
+				conf.UserRegistration.PasswordRequirements.RejectCommon = true
 				ctx := context.WithValue(is.Context(), ctxKey, &conf)
 
-				err := is.validatePasswordStrength(ctx, p)
+				err := is.validatePasswordStrength(ctx, "username", p)
 				if ok {
 					a.So(err, should.BeNil)
 				} else {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request adds options to the Identity Server that reject common passwords such as ones that contain the username (this is enabled by default), or any of the most frequently used passwords (this is not enabled by default).

Refs https://github.com/TheThingsIndustries/lorawan-stack-support/issues/388 / `[SEC-47]`

With thanks to @ohidulserniabat for suggesting this.

#### Testing

<!-- How did you verify that this change works? -->

Unit tests

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None expected.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
