### PR TITLE
Return error on uplink simulation if skip payload crypto

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -1835,6 +1835,15 @@
       "file": "grpc.go"
     }
   },
+  "error:pkg/applicationserver/io/grpc:payload_crypto_skipped": {
+    "translations": {
+      "en": "payload crypto skipped"
+    },
+    "description": {
+      "package": "pkg/applicationserver/io/grpc",
+      "file": "grpc.go"
+    }
+  },
   "error:pkg/applicationserver/io/mqtt:not_authorized": {
     "translations": {
       "en": "not authorized"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/3913

#### Changes
<!-- What are the changes made in this pull request? -->

- If the end device has payload encryption skipping enabled (link/end device level), disable uplink simulation


#### Testing

<!-- How did you verify that this change works? -->

I've enabled payload crypto skipping at link level:

```
curl 'http://localhost:1885/api/v3/as/applications/app1/link' -X PUT  -H 'Content-Type: application/json;charset=utf-8' -H 'Authorization: Bearer mrr' - --data-raw '{"link":{"skip_payload_crypto":true, "default_formatters":{"down_formatter":"FORMATTER_NONE","down_formatter_parameter":"","up_formatter":"FORMATTER_JAVASCRIPT","up_formatter_parameter":"function decodeUplink(input) {\n  return {\n    data: {\n      bytes: input.bytes\n    },\n    warnings: [],\n    errors: []\n  };\n}"}},"field_mask":{"paths":["default_formatters.down_formatter","default_formatters.down_formatter_parameter","default_formatters.up_formatter","default_formatters.up_formatter_parameter", "skip_payload_crypto"]}}'
```

And then tried to simulate an uplink, which failed with the expected error.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
