### PR TITLE
Close event stream when caller rights revoked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Changed
 
 - Network Server now takes uplink data rate index for ADR.
+- Event streams are now closed when the callers rights are revoked.
 
 ### Deprecated
 

--- a/pkg/events/grpc/grpc.go
+++ b/pkg/events/grpc/grpc.go
@@ -98,6 +98,9 @@ func (srv *EventsServer) Stream(req *ttnpb.StreamEventsRequest, stream ttnpb.Eve
 		case evt := <-ch:
 			isVisible, err := rightsutil.EventIsVisible(ctx, evt)
 			if err != nil {
+				if err := rights.RequireAny(ctx, req.Identifiers...); err != nil {
+					return err
+				}
 				log.FromContext(ctx).WithError(err).Warn("Failed to check event visibility")
 				continue
 			}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a small fix that closes the event stream if the rights of the caller are revoked while the stream is active. This will prevent a lot of "Failed to check event visibility" warnings if that happens.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
