### PR TITLE
Add uint32 notation for device address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - Payload formatter testing functionality in the Console.
 - Options in the Identity Server to reject passwords that contain the user ID (`is.user-registration.password-requirements.reject-user-id`) or common passwords (`is.user-registration.password-requirements.reject-common`).
+- C-Style uint32_t representation for end device address field.
 
 ### Changed
 

--- a/config/storybook/preview-head.html
+++ b/config/storybook/preview-head.html
@@ -1,4 +1,8 @@
 <script>
-  window.__ttn_config__ = {}
+  window.__ttn_config__ = {
+    APP_CONFIG: {
+      documentation_base_url: 'https://thethingsstack.io',
+    },
+  }
 </script>
 <script src="/libs.bundle.js"></script>

--- a/pkg/webui/components/data-sheet/index.js
+++ b/pkg/webui/components/data-sheet/index.js
@@ -85,6 +85,8 @@ DataSheet.propTypes = {
       /** A list of items for the group. */
       items: PropTypes.arrayOf(
         PropTypes.shape({
+          /** Whether uint32_t notation should be enabled for byte representation. */
+          enableUint32: PropTypes.bool,
           /** The key of the item. */
           key: PropTypes.message,
           /** The value of the item. */
@@ -124,6 +126,7 @@ const DataSheetRow = ({ item, sub }) => {
             isBytes={item.type === 'byte'}
             small
             data={item.value}
+            enableUint32={item.enableUint32}
           />
         ) : (
           item.value || (
@@ -137,6 +140,8 @@ const DataSheetRow = ({ item, sub }) => {
 
 DataSheetRow.propTypes = {
   item: PropTypes.shape({
+    /** Whether uint32_t notation should be enabled for byte representation. */
+    enableUint32: PropTypes.bool,
     /** The key of the item. */
     key: PropTypes.message,
     /** The value of the item. */

--- a/pkg/webui/components/data-sheet/story.js
+++ b/pkg/webui/components/data-sheet/story.js
@@ -46,6 +46,13 @@ const testData = [
     header: 'Activation Info',
     items: [
       { key: 'Device EUI', value: '1212121212', type: 'byte', sensitive: false },
+      {
+        key: 'Device EUI with Uint32_t',
+        value: '1212121212',
+        type: 'byte',
+        sensitive: false,
+        enableUint32: true,
+      },
       { key: 'Join EUI', value: '1212121212', type: 'byte', sensitive: false },
       {
         key: 'Value with Nesting',

--- a/pkg/webui/console/views/device-overview/index.js
+++ b/pkg/webui/console/views/device-overview/index.js
@@ -178,7 +178,13 @@ class DeviceOverview extends React.Component {
 
     if (Object.keys(sessionKeys).length > 0) {
       sessionInfoData.items.push(
-        { key: sharedMessages.devAddr, value: ids.dev_addr, type: 'byte', sensitive: false },
+        {
+          key: sharedMessages.devAddr,
+          value: ids.dev_addr,
+          type: 'byte',
+          sensitive: false,
+          enableUint32: true,
+        },
         {
           key: sharedMessages.nwkSKey,
           value: f_nwk_s_int_key.key,


### PR DESCRIPTION
#### Summary

Closes #4014 

#### Changes

- Added C-Style uint32_t representation for device address field

Before:
No option

After:
![after_1](https://user-images.githubusercontent.com/72162194/114913727-36321900-9e2a-11eb-8e1a-8fd355ab0a3d.png)


#### Testing

- Manually tested

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
