### PR TITLE
Store recent data application uplinks in the Application Server 

### DIFF
--- a/cmd/internal/shared/applicationserver/config.go
+++ b/cmd/internal/shared/applicationserver/config.go
@@ -59,6 +59,9 @@ var DefaultApplicationServerConfig = applicationserver.Config{
 			Timeout:   15 * time.Minute,
 		},
 	},
+	UplinkStorage: applicationserver.UplinkStorageConfig{
+		Limit: 16,
+	},
 	Distribution: applicationserver.DistributionConfig{
 		Timeout: time.Minute,
 	},

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -295,6 +295,10 @@ var startCommand = &cobra.Command{
 			config.AS.Devices = &asredis.DeviceRegistry{
 				Redis: NewComponentDeviceRegistryRedis(*config, "as"),
 			}
+			config.AS.UplinkStorage.Registry = &asredis.ApplicationUplinkRegistry{
+				Redis: redis.New(config.Redis.WithNamespace("as", "applicationups")),
+				Limit: config.AS.UplinkStorage.Limit,
+			}
 			config.AS.Distribution.PubSub = &asdistribredis.PubSub{
 				Redis: redis.New(config.Cache.Redis.WithNamespace("as", "traffic")),
 			}

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -64,6 +64,7 @@ type ApplicationServer struct {
 
 	linkRegistry     LinkRegistry
 	deviceRegistry   DeviceRegistry
+	appUpsRegistry   ApplicationUplinkRegistry
 	formatters       messageprocessors.MapPayloadProcessor
 	webhooks         web.Webhooks
 	webhookTemplates web.TemplateStore
@@ -124,6 +125,7 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 		config:         conf,
 		linkRegistry:   conf.Links,
 		deviceRegistry: wrapEndDeviceRegistryWithReplacedFields(conf.Devices, replacedEndDeviceFields...),
+		appUpsRegistry: conf.UplinkStorage.Registry,
 		formatters: messageprocessors.MapPayloadProcessor{
 			ttnpb.PayloadFormatter_FORMATTER_JAVASCRIPT: javascript.New(),
 			ttnpb.PayloadFormatter_FORMATTER_CAYENNELPP: cayennelpp.New(),
@@ -1090,6 +1092,9 @@ func (as *ApplicationServer) handleUplink(ctx context.Context, ids ttnpb.EndDevi
 		if err := as.decryptAndDecodeUplink(ctx, dev, uplink, link.DefaultFormatters); err != nil {
 			return err
 		}
+		if err := as.appUpsRegistry.Push(ctx, ids, uplink); err != nil {
+			return err
+		}
 	} else if dev.Session != nil && dev.Session.AppSKey != nil {
 		uplink.AppSKey = dev.Session.AppSKey
 		uplink.LastAFCntDown = dev.Session.LastAFCntDown
@@ -1274,4 +1279,9 @@ func (as *ApplicationServer) GetMQTTConfig(ctx context.Context) (*config.MQTT, e
 		return nil, err
 	}
 	return &config.MQTT, nil
+}
+
+// RangeUplinks ranges the application uplinks and calls the callback function, until false is returned.
+func (as *ApplicationServer) RangeUplinks(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, paths []string, f func(ctx context.Context, up *ttnpb.ApplicationUplink) bool) error {
+	return as.appUpsRegistry.Range(ctx, ids, paths, f)
 }

--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -200,6 +200,14 @@ func TestApplicationServer(t *testing.T) {
 		t.Fatalf("Failed to set link in registry: %s", err)
 	}
 
+	applicationUpsRedisClient, applicationUpsFlush := test.NewRedis(ctx, "applicationserver_test", "applicationups")
+	defer applicationUpsFlush()
+	defer applicationUpsRedisClient.Close()
+	applicationUpsRegistry := &redis.ApplicationUplinkRegistry{
+		Redis: applicationUpsRedisClient,
+		Limit: 16,
+	}
+
 	webhooksRedisClient, webhooksFlush := test.NewRedis(ctx, "applicationserver_test", "webhooks")
 	defer webhooksFlush()
 	defer webhooksRedisClient.Close()
@@ -267,6 +275,10 @@ func TestApplicationServer(t *testing.T) {
 	config := &applicationserver.Config{
 		Devices: deviceRegistry,
 		Links:   linkRegistry,
+		UplinkStorage: applicationserver.UplinkStorageConfig{
+			Registry: applicationUpsRegistry,
+			Limit:    16,
+		},
 		MQTT: config.MQTT{
 			Listen: ":1883",
 		},

--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -2298,6 +2298,14 @@ func TestSkipPayloadCrypto(t *testing.T) {
 		t.Fatalf("Failed to set link in registry: %s", err)
 	}
 
+	applicationUpsRedisClient, applicationUpsFlush := test.NewRedis(ctx, "applicationserver_test", "applicationups")
+	defer applicationUpsFlush()
+	defer applicationUpsRedisClient.Close()
+	applicationUpsRegistry := &redis.ApplicationUplinkRegistry{
+		Redis: applicationUpsRedisClient,
+		Limit: 16,
+	}
+
 	distribRedisClient, distribFlush := test.NewRedis(ctx, "applicationserver_test", "traffic")
 	defer distribFlush()
 	defer distribRedisClient.Close()
@@ -2325,6 +2333,10 @@ func TestSkipPayloadCrypto(t *testing.T) {
 	config := &applicationserver.Config{
 		Devices: deviceRegistry,
 		Links:   linkRegistry,
+		UplinkStorage: applicationserver.UplinkStorageConfig{
+			Registry: applicationUpsRegistry,
+			Limit:    16,
+		},
 		EndDeviceFetcher: applicationserver.EndDeviceFetcherConfig{
 			Fetcher: &noopEndDeviceFetcher{},
 		},

--- a/pkg/applicationserver/applicationserver_util_test.go
+++ b/pkg/applicationserver/applicationserver_util_test.go
@@ -82,7 +82,38 @@ func (m MockLinkRegistry) Range(ctx context.Context, paths []string, f func(cont
 // Set calls SetFunc if set and panics otherwise.
 func (m MockLinkRegistry) Set(ctx context.Context, ids ttnpb.ApplicationIdentifiers, paths []string, f func(*ttnpb.ApplicationLink) (*ttnpb.ApplicationLink, []string, error)) (*ttnpb.ApplicationLink, error) {
 	if m.SetFunc == nil {
-		panic("Set called, bt not set")
+		panic("Set called, but not set")
 	}
 	return m.SetFunc(ctx, ids, paths, f)
+}
+
+// MockApplicationUplinkRegistry is a mock ApplicationUplinkRegistry used for testing.
+type MockApplicationUplinkRegistry struct {
+	RangeFunc func(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, paths []string, f func(context.Context, *ttnpb.ApplicationUplink) bool) error
+	PushFunc  func(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, up *ttnpb.ApplicationUplink) error
+	ClearFunc func(ctx context.Context, ids ttnpb.EndDeviceIdentifiers) error
+}
+
+// Range calls RangeFunc if set and panics otherwise.
+func (m MockApplicationUplinkRegistry) Range(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, paths []string, f func(context.Context, *ttnpb.ApplicationUplink) bool) error {
+	if m.RangeFunc == nil {
+		panic("Range called, but not set")
+	}
+	return m.RangeFunc(ctx, ids, paths, f)
+}
+
+// Push calls PushFunc if set and panics otherwise.
+func (m MockApplicationUplinkRegistry) Push(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, up *ttnpb.ApplicationUplink) error {
+	if m.PushFunc == nil {
+		panic("Push called, but not set")
+	}
+	return m.PushFunc(ctx, ids, up)
+}
+
+// Clear calls ClearFunc if set and panics otherwise.
+func (m MockApplicationUplinkRegistry) Clear(ctx context.Context, ids ttnpb.EndDeviceIdentifiers) error {
+	if m.ClearFunc == nil {
+		panic("Clear called, but not set")
+	}
+	return m.ClearFunc(ctx, ids)
 }

--- a/pkg/applicationserver/config.go
+++ b/pkg/applicationserver/config.go
@@ -71,6 +71,7 @@ type Config struct {
 	LinkMode         string                    `name:"link-mode" description:"Deprecated - mode to link applications to their Network Server (all, explicit)"`
 	Devices          DeviceRegistry            `name:"-"`
 	Links            LinkRegistry              `name:"-"`
+	UplinkStorage    UplinkStorageConfig       `name:"uplink-storage" description:"Application uplinks storage configuration"`
 	Distribution     DistributionConfig        `name:"distribution" description:"Distribution configuration"`
 	EndDeviceFetcher EndDeviceFetcherConfig    `name:"fetcher" description:"End Device fetcher configuration"`
 	MQTT             config.MQTT               `name:"mqtt" description:"MQTT configuration"`
@@ -91,6 +92,12 @@ var (
 	errWebhooksRegistry = errors.DefineInvalidArgument("webhooks_registry", "invalid webhooks registry")
 	errWebhooksTarget   = errors.DefineInvalidArgument("webhooks_target", "invalid webhooks target `{target}`")
 )
+
+// UplinkStorageConfig defines the configuration of the application uplinks storage used by integrations.
+type UplinkStorageConfig struct {
+	Registry ApplicationUplinkRegistry `name:"-"`
+	Limit    int64                     `name:"limit" description:"How many application uplinks should be stored"`
+}
 
 // WebhooksConfig defines the configuration of the webhooks integration.
 type WebhooksConfig struct {

--- a/pkg/applicationserver/config.go
+++ b/pkg/applicationserver/config.go
@@ -96,7 +96,7 @@ var (
 // UplinkStorageConfig defines the configuration of the application uplinks storage used by integrations.
 type UplinkStorageConfig struct {
 	Registry ApplicationUplinkRegistry `name:"-"`
-	Limit    int64                     `name:"limit" description:"How many application uplinks should be stored"`
+	Limit    int64                     `name:"limit" description:"Number of application uplinks to be stored"`
 }
 
 // WebhooksConfig defines the configuration of the webhooks integration.

--- a/pkg/applicationserver/grpc_deviceregistry.go
+++ b/pkg/applicationserver/grpc_deviceregistry.go
@@ -239,5 +239,8 @@ func (r asEndDeviceRegistryServer) Delete(ctx context.Context, ids *ttnpb.EndDev
 	if evt != nil {
 		events.Publish(evt)
 	}
+	if err := r.AS.appUpsRegistry.Clear(ctx, *ids); err != nil {
+		return nil, err
+	}
 	return ttnpb.Empty, nil
 }

--- a/pkg/applicationserver/io/io.go
+++ b/pkg/applicationserver/io/io.go
@@ -28,26 +28,36 @@ import (
 
 const bufferSize = 32
 
-// Server represents the Application Server to application frontends.
-type Server interface {
-	component.TaskStarter
-	// GetBaseConfig returns the component configuration.
-	GetBaseConfig(ctx context.Context) config.ServiceBase
-	// FillContext fills the given context.
-	// This method should only be used for request contexts.
-	FillContext(ctx context.Context) context.Context
+// PubSub represents the Application Server Pub/Sub capabilities to application frontends.
+type PubSub interface {
 	// Publish publishes upstream traffic to the Application Server.
 	Publish(ctx context.Context, up *ttnpb.ApplicationUp) error
 	// Subscribe subscribes an application or integration by its identifiers to the Application Server, and returns a
 	// Subscription for traffic and control. If the cluster parameter is true, the subscription receives all of the
 	// traffic of the application. Otherwise, only traffic that was processed locally is sent.
 	Subscribe(ctx context.Context, protocol string, ids *ttnpb.ApplicationIdentifiers, cluster bool) (*Subscription, error)
+}
+
+// DownlinkQueueOperator represents the Application Server downlink queue operations to application frontends.
+type DownlinkQueueOperator interface {
 	// DownlinkQueuePush pushes the given downlink messages to the end device's application downlink queue.
 	DownlinkQueuePush(context.Context, ttnpb.EndDeviceIdentifiers, []*ttnpb.ApplicationDownlink) error
 	// DownlinkQueueReplace replaces the end device's application downlink queue with the given downlink messages.
 	DownlinkQueueReplace(context.Context, ttnpb.EndDeviceIdentifiers, []*ttnpb.ApplicationDownlink) error
 	// DownlinkQueueList lists the application downlink queue of the given end device.
 	DownlinkQueueList(context.Context, ttnpb.EndDeviceIdentifiers) ([]*ttnpb.ApplicationDownlink, error)
+}
+
+// Server represents the Application Server to application frontends.
+type Server interface {
+	component.TaskStarter
+	PubSub
+	DownlinkQueueOperator
+	// GetBaseConfig returns the component configuration.
+	GetBaseConfig(ctx context.Context) config.ServiceBase
+	// FillContext fills the given context.
+	// This method should only be used for request contexts.
+	FillContext(ctx context.Context) context.Context
 	// HTTPClient returns a configured *http.Client.
 	HTTPClient(context.Context) (*http.Client, error)
 	// RateLimiter returns the rate limiter instance.

--- a/pkg/applicationserver/io/io.go
+++ b/pkg/applicationserver/io/io.go
@@ -48,11 +48,18 @@ type DownlinkQueueOperator interface {
 	DownlinkQueueList(context.Context, ttnpb.EndDeviceIdentifiers) ([]*ttnpb.ApplicationDownlink, error)
 }
 
+// UplinkStorage represents the Application Server uplink storage to application frontends.
+type UplinkStorage interface {
+	// RangeUplinks ranges the application uplinks and calls the callback function, until false is returned.
+	RangeUplinks(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, paths []string, f func(ctx context.Context, up *ttnpb.ApplicationUplink) bool) error
+}
+
 // Server represents the Application Server to application frontends.
 type Server interface {
 	component.TaskStarter
 	PubSub
 	DownlinkQueueOperator
+	UplinkStorage
 	// GetBaseConfig returns the component configuration.
 	GetBaseConfig(ctx context.Context) config.ServiceBase
 	// FillContext fills the given context.

--- a/pkg/applicationserver/redis/registry.go
+++ b/pkg/applicationserver/redis/registry.go
@@ -384,3 +384,74 @@ func (r *LinkRegistry) Set(ctx context.Context, ids ttnpb.ApplicationIdentifiers
 	}
 	return pb, nil
 }
+
+// ApplicationUplinkRegistry is a store for uplink messages.
+type ApplicationUplinkRegistry struct {
+	Redis *ttnredis.Client
+	Limit int64
+}
+
+func (r *ApplicationUplinkRegistry) uidKey(uid string) string {
+	return r.Redis.Key("uid", uid)
+}
+
+// Range ranges the uplink messagess and calls the callback function, until false is returned.
+func (r *ApplicationUplinkRegistry) Range(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, paths []string, f func(context.Context, *ttnpb.ApplicationUplink) bool) error {
+	defer trace.StartRegion(ctx, "range application uplinks").End()
+
+	uidKey := r.uidKey(unique.ID(ctx, ids))
+	ups, err := r.Redis.LRange(ctx, uidKey, 0, r.Limit-1).Result()
+	if err != nil {
+		return ttnredis.ConvertError(err)
+	}
+	for _, up := range ups {
+		pb := &ttnpb.ApplicationUplink{}
+		if err := ttnredis.UnmarshalProto(up, pb); err != nil {
+			return err
+		}
+		up := &ttnpb.ApplicationUplink{}
+		if err := up.SetFields(pb, paths...); err != nil {
+			return err
+		}
+		if !f(ctx, up) {
+			break
+		}
+	}
+
+	return nil
+}
+
+// Push pushes the provided uplink message to the storage.
+func (r *ApplicationUplinkRegistry) Push(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, up *ttnpb.ApplicationUplink) error {
+	defer trace.StartRegion(ctx, "push application uplink").End()
+
+	s, err := ttnredis.MarshalProto(up)
+	if err != nil {
+		return err
+	}
+
+	uidKey := r.uidKey(unique.ID(ctx, ids))
+	_, err = r.Redis.Pipelined(ctx, func(p redis.Pipeliner) error {
+		p.LPush(ctx, uidKey, s)
+		p.LTrim(ctx, uidKey, 0, r.Limit-1)
+		return nil
+	})
+	if err != nil {
+		return ttnredis.ConvertError(err)
+	}
+
+	return nil
+}
+
+// Clear empties the application uplink storage by the end device identifiers.
+func (r *ApplicationUplinkRegistry) Clear(ctx context.Context, ids ttnpb.EndDeviceIdentifiers) error {
+	defer trace.StartRegion(ctx, "clear application uplinks").End()
+
+	uidKey := r.uidKey(unique.ID(ctx, ids))
+	_, err := r.Redis.Del(ctx, uidKey).Result()
+	if err != nil {
+		return ttnredis.ConvertError(err)
+	}
+
+	return nil
+}

--- a/pkg/applicationserver/registry.go
+++ b/pkg/applicationserver/registry.go
@@ -126,3 +126,13 @@ type LinkRegistry interface {
 	// Set creates, updates or deletes the link by the application identifiers.
 	Set(ctx context.Context, ids ttnpb.ApplicationIdentifiers, paths []string, f func(*ttnpb.ApplicationLink) (*ttnpb.ApplicationLink, []string, error)) (*ttnpb.ApplicationLink, error)
 }
+
+// ApplicationUplinkRegistry is a store for uplink messages.
+type ApplicationUplinkRegistry interface {
+	// Range ranges the uplink messagess and calls the callback function, until false is returned.
+	Range(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, paths []string, f func(context.Context, *ttnpb.ApplicationUplink) bool) error
+	// Push pushes the provided uplink message to the storage.
+	Push(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, up *ttnpb.ApplicationUplink) error
+	// Clear empties the uplink messages storage by the end device identifiers.
+	Clear(ctx context.Context, ids ttnpb.EndDeviceIdentifiers) error
+}

--- a/pkg/applicationserver/registry_test.go
+++ b/pkg/applicationserver/registry_test.go
@@ -337,3 +337,68 @@ func TestLinkRegistry(t *testing.T) {
 		}
 	}
 }
+
+func TestApplicationUplinksRegistry(t *testing.T) {
+	namespace := [...]string{
+		"applicationserver_test",
+		"application_ups",
+	}
+	test.RunTest(t, test.TestConfig{
+		Func: func(ctx context.Context, a *assertions.Assertion) {
+			cl, flush := test.NewRedis(ctx, namespace[:]...)
+			defer flush()
+			defer cl.Close()
+			registry := &redis.ApplicationUplinkRegistry{
+				Redis: cl,
+				Limit: 16,
+			}
+
+			ids := ttnpb.EndDeviceIdentifiers{
+				ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{ApplicationID: "test-app"},
+				DeviceID:               "test-dev",
+			}
+
+			assertEmpty := func() {
+				err := registry.Range(ctx, ids, []string{}, func(ctx context.Context, up *ttnpb.ApplicationUplink) bool {
+					t.Fatal("list should be empty")
+					return false
+				})
+				a.So(err, should.BeNil)
+			}
+			assertEmpty()
+
+			push := func(start uint32, end uint32) {
+				for i := start; i < end; i++ {
+					err := registry.Push(ctx, ids, &ttnpb.ApplicationUplink{FCnt: uint32(i)})
+					a.So(err, should.BeNil)
+				}
+			}
+			push(0, 16)
+
+			assertList := func(start uint32, end uint32) {
+				found := make(map[uint32]struct{})
+				err := registry.Range(ctx, ids, []string{
+					"f_cnt",
+				}, func(ctx context.Context, up *ttnpb.ApplicationUplink) bool {
+					a.So(up.FCnt, should.BeBetweenOrEqual, start, end-1)
+					if _, f := found[up.FCnt]; f {
+						t.Fatalf("Uplink already seen: %d", up.FCnt)
+					}
+					found[up.FCnt] = struct{}{}
+					return true
+				})
+				a.So(err, should.BeNil)
+				a.So(len(found), should.Equal, end-start)
+			}
+			assertList(0, 16)
+
+			push(32, 64)
+			// Since we allow at most 16 uplinks, only the last 16 are stored.
+			assertList(48, 64)
+
+			err := registry.Clear(ctx, ids)
+			a.So(err, should.BeNil)
+			assertEmpty()
+		},
+	})
+}

--- a/pkg/applicationserver/registry_test.go
+++ b/pkg/applicationserver/registry_test.go
@@ -369,7 +369,7 @@ func TestApplicationUplinksRegistry(t *testing.T) {
 
 			push := func(start uint32, end uint32) {
 				for i := start; i < end; i++ {
-					err := registry.Push(ctx, ids, &ttnpb.ApplicationUplink{FCnt: uint32(i)})
+					err := registry.Push(ctx, ids, &ttnpb.ApplicationUplink{FCnt: i})
 					a.So(err, should.BeNil)
 				}
 			}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #4018

#### Changes
<!-- What are the changes made in this pull request? -->

- Break down the `io.Server` interface into multiple sub-interfaces, as it was getting too big.
- Add a data application uplink registry. 


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This PR adds a new store, for which unit tests are added. The usage of the functionality will be tested better as part of https://github.com/TheThingsNetwork/lorawan-stack/issues/4019.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This implementation diverges from the proposal due to the following reasons:
- We always fetch the full `ttnpb.EndDevice` from Redis, which means that we would always be pulling the stored uplinks while accessing an end device. This would increase the network traffic for minimal gains. _We could indeed avoid this by storing different fields in different keys, but that's added complexity for little gain._
- The device registry is available over gRPC, and we'd rather avoid exposing this storage to users, who will most likely misuse it. _We could simply disallow the field in the allowed field mask, indeed._
- We have better control over the keys, and can actually check how much storage is used by this functionality, in memory-critical situations.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
