### PR TITLE
Allow LinkADRReq commands to lower the datarate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
+- Allow the LinkADRReq commands to lower the data rate used by the end devices.
+
 ### Deprecated
 
 ### Removed

--- a/pkg/networkserver/mac/link_adr.go
+++ b/pkg/networkserver/mac/link_adr.go
@@ -106,9 +106,6 @@ func generateLinkADRReq(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Ban
 		dev.MACState.DesiredParameters.ADRDataRateIndex > phy.MaxADRDataRateIndex {
 		return linkADRReqParameters{}, false, ErrCorruptedMACState.New()
 	}
-	if dev.MACState.CurrentParameters.ADRDataRateIndex > minDataRateIndex {
-		minDataRateIndex = dev.MACState.CurrentParameters.ADRDataRateIndex
-	}
 	if dev.MACState.DesiredParameters.ADRDataRateIndex < minDataRateIndex || dev.MACState.DesiredParameters.ADRDataRateIndex > maxDataRateIndex {
 		return linkADRReqParameters{}, false, ErrCorruptedMACState.New()
 	}

--- a/pkg/networkserver/mac/link_adr_test.go
+++ b/pkg/networkserver/mac/link_adr_test.go
@@ -115,22 +115,6 @@ func TestLinkADRReq(t *testing.T) {
 			},
 		},
 		{
-			Name:                    "data rate too low",
-			BandID:                  band.EU_863_870,
-			LoRaWANVersion:          ttnpb.MAC_V1_0_3,
-			LoRaWANPHYVersion:       ttnpb.PHY_V1_0_3_REV_A,
-			CurrentChannels:         MakeDefaultEU868DesiredChannels(),
-			CurrentADRNbTrans:       1,
-			CurrentADRDataRateIndex: ttnpb.DATA_RATE_2,
-			DesiredChannels:         MakeDefaultEU868DesiredChannels(),
-			DesiredADRDataRateIndex: ttnpb.DATA_RATE_1,
-			DesiredADRNbTrans:       1,
-			ErrorAssertion: func(t *testing.T, err error) bool {
-				a, _ := test.New(t)
-				return a.So(err, should.BeError)
-			},
-		},
-		{
 			Name:                   "TX power too high",
 			BandID:                 band.EU_863_870,
 			LoRaWANVersion:         ttnpb.MAC_V1_0_3,
@@ -268,19 +252,28 @@ func TestLinkADRReq(t *testing.T) {
 			BandID:                  band.EU_863_870,
 			LoRaWANVersion:          ttnpb.MAC_V1_0_1,
 			LoRaWANPHYVersion:       ttnpb.PHY_V1_0_1,
-			CurrentADRDataRateIndex: ttnpb.DATA_RATE_1,
+			CurrentADRDataRateIndex: ttnpb.DATA_RATE_5,
 			CurrentADRNbTrans:       1,
 			CurrentChannels:         MakeDefaultEU868DesiredChannels(),
-			DesiredADRDataRateIndex: ttnpb.DATA_RATE_5,
+			DesiredADRDataRateIndex: ttnpb.DATA_RATE_1,
 			DesiredADRNbTrans:       1,
 			DesiredADRTxPowerIndex:  3,
 			DesiredChannels:         MakeDefaultEU868DesiredChannels(),
 			RejectedADRDataRateIndexes: []ttnpb.DataRateIndex{
-				ttnpb.DATA_RATE_1,
 				ttnpb.DATA_RATE_2,
 				ttnpb.DATA_RATE_3,
 				ttnpb.DATA_RATE_4,
-				ttnpb.DATA_RATE_5,
+			},
+			Commands: []*ttnpb.MACCommand_LinkADRReq{
+				{
+					ChannelMask: []bool{
+						true, true, true, true, true, true, true, true,
+						false, false, false, false, false, false, false, false,
+					},
+					DataRateIndex: ttnpb.DATA_RATE_1,
+					TxPowerIndex:  3,
+					NbTrans:       1,
+				},
 			},
 		},
 		{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/379

#### Changes
<!-- What are the changes made in this pull request? -->

- Allow `LinkADRReq` commands to lower the data rate index, based on the MAC state desired parameters.


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This should affect only devices with 'custom ADR' enabled, and the unit tests cover this. The ADR algorithm used by the NS still only attempts to increase the data rate index:

https://github.com/TheThingsNetwork/lorawan-stack/blob/7f3a8dc840427ec8ce25bf653ca69bfc16e13ac8/pkg/networkserver/mac/adr.go#L193-L195

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This needs better physical testing, but I'm not sure what test setup we should use.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
