### PR TITLE
Add read only option for rights selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Added
 
+- Read-only option for rights selection in the Console.
+
 ### Changed
 
 - Allow the LinkADRReq commands to lower the data rate used by the end devices.

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -241,6 +241,7 @@
   "console.components.rights-group.index.outOfOwnScopePseudoRight": "This {entityType} has a wildcard right that you don't have. The {entityType} can therefore only be removed entirely.",
   "console.components.rights-group.index.grantType": "Grant type",
   "console.components.rights-group.index.allCurrentAndFutureRights": "Grant all current and future rights",
+  "console.components.rights-group.index.grantAllReadOnlyRights": "Grant all read-only rights",
   "console.components.rights-group.index.selectIndividualRights": "Grant individual rights",
   "console.components.uplink-form.uplink-form.simulateUplink": "Simulate uplink",
   "console.components.uplink-form.uplink-form.payloadDescription": "The desired payload bytes of the uplink message",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -241,6 +241,7 @@
   "console.components.rights-group.index.outOfOwnScopePseudoRight": "Xxxx {entityType} xxx x xxxxxxxx xxxxx xxxx xxx xxx'x xxxx. Xxx {entityType} xxx xxxxxxxxx xxxx xx xxxxxxx xxxxxxxx.",
   "console.components.rights-group.index.grantType": "Xxxxx xxxx",
   "console.components.rights-group.index.allCurrentAndFutureRights": "Xxxxx xxx xxxxxxx xxx xxxxxx xxxxxx",
+  "console.components.rights-group.index.grantAllReadOnlyRights": "Xxxxx xxx xxxx-xxxx xxxxxx",
   "console.components.rights-group.index.selectIndividualRights": "Xxxxx xxxxxxxxxx xxxxxx",
   "console.components.uplink-form.uplink-form.simulateUplink": "Xxxxxxxx xxxxxx",
   "console.components.uplink-form.uplink-form.payloadDescription": "Xxx xxxxxxx xxxxxxx xxxxx xx xxx xxxxxx xxxxxxx",


### PR DESCRIPTION
#### Summary

Closes #3991

#### Changes

- Added read-only option for rights selection

Before:
![before_readonly_1](https://user-images.githubusercontent.com/72162194/115108665-625caf80-9f7a-11eb-9921-88276c606588.png)


After:
![after_readonly_1](https://user-images.githubusercontent.com/72162194/115108667-64bf0980-9f7a-11eb-8f2c-b696d3834f5a.png)


#### Testing

- Manually tested

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
