### PR TITLE
Revert uploading protos to S3

### DIFF
--- a/.goreleaser.release.yml
+++ b/.goreleaser.release.yml
@@ -202,7 +202,6 @@ blobs:
     - cli
     folder: "{{ .Version }}"
     extra_files:
-    - glob: ./api/*.proto
     - glob: ./CHANGELOG.md
 
 dockers:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Uploading proto files, as added in https://github.com/TheThingsNetwork/lorawan-stack/pull/4040 turned out to be a bit too messy, since those files aren't uploaded in a subfolder, so this PR reverts that change.