### PR TITLE
Cache GS calls to the IS for UDP gateways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Changed
 
 - Allow the LinkADRReq commands to lower the data rate used by the end devices.
+- Temporarily cache the result of calls to the Identity Server made by the Gateway Server for UDP gateways.
 
 ### Deprecated
 

--- a/pkg/gatewayserver/io/udp/config.go
+++ b/pkg/gatewayserver/io/udp/config.go
@@ -14,7 +14,11 @@
 
 package udp
 
-import "time"
+import (
+	"time"
+
+	"github.com/bluele/gcache"
+)
 
 // RateLimitingConfig contains configuration settings for the rate limiting
 // capabilities of the UDP gateway frontend firewall.
@@ -49,6 +53,8 @@ type Config struct {
 	AddrChangeBlock time.Duration `name:"addr-change-block" description:"Time to block traffic when a gateway's address changes"`
 	// RateLimitingConfig is the configuration for the rate limiting firewall capabilities.
 	RateLimiting RateLimitingConfig `name:"rate-limiting"`
+	// GatewayIdentifiersCache is used to cache gateway identifiers that are fetched from the Entity Registry.
+	GatewayIdentifiersCache gcache.Cache `name:"-"`
 }
 
 // DefaultConfig contains the default configuration.
@@ -65,4 +71,5 @@ var DefaultConfig = Config{
 		Messages:  10,
 		Threshold: 10 * time.Millisecond,
 	},
+	GatewayIdentifiersCache: gcache.New(1000).Expiration(time.Minute).LFU().Build(),
 }

--- a/pkg/gatewayserver/io/udp/server.go
+++ b/pkg/gatewayserver/io/udp/server.go
@@ -1,0 +1,60 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package udp
+
+import (
+	"context"
+
+	"github.com/bluele/gcache"
+	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io"
+	"go.thethings.network/lorawan-stack/v3/pkg/log"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+)
+
+type gsWithIdentifiersCache struct {
+	io.Server
+	cache gcache.Cache
+}
+
+type fillGatewayContextResult struct {
+	ctx context.Context
+	ids ttnpb.GatewayIdentifiers
+	err error
+}
+
+// FillGatewayContext implements the io.Server interface, and caches the identifiers fetched by the Entity Registry.
+func (s *gsWithIdentifiersCache) FillGatewayContext(ctx context.Context, ids ttnpb.GatewayIdentifiers) (context.Context, ttnpb.GatewayIdentifiers, error) {
+	if cached, err := s.cache.Get(ids); err == nil {
+		if result, ok := cached.(*fillGatewayContextResult); ok {
+			return result.ctx, result.ids, result.err
+		}
+	}
+	result := &fillGatewayContextResult{}
+	result.ctx, result.ids, result.err = s.Server.FillGatewayContext(ctx, ids)
+	if err := s.cache.Set(ids, result); err != nil {
+		log.FromContext(ctx).WithError(err).Debug("Failed to cache gateway identifiers")
+	}
+	return result.ctx, result.ids, result.err
+}
+
+func newServerWithIdentifiersCache(server io.Server, cache gcache.Cache) io.Server {
+	if cache == nil {
+		return server
+	}
+	return &gsWithIdentifiersCache{
+		Server: server,
+		cache:  cache,
+	}
+}

--- a/pkg/gatewayserver/io/udp/server_test.go
+++ b/pkg/gatewayserver/io/udp/server_test.go
@@ -1,0 +1,84 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package udp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bluele/gcache"
+	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/v3/pkg/component"
+	componenttest "go.thethings.network/lorawan-stack/v3/pkg/component/test"
+	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io"
+	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/mock"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/types"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+)
+
+type mockServer struct {
+	io.Server
+	called map[ttnpb.GatewayIdentifiers]int
+}
+
+func (s *mockServer) FillGatewayContext(ctx context.Context, ids ttnpb.GatewayIdentifiers) (context.Context, ttnpb.GatewayIdentifiers, error) {
+	s.called[ids]++
+	return ctx, ids, nil
+}
+
+func TestGatewayIdentifiersCache(t *testing.T) {
+	a := assertions.New(t)
+	c := componenttest.NewComponent(t, &component.Config{})
+	componenttest.StartComponent(t, c)
+	defer c.Close()
+
+	gs := mock.NewServer(c)
+
+	ttl := time.Minute
+	clock := gcache.NewFakeClock()
+	cache := gcache.New(1000).Clock(clock).Expiration(ttl).Build()
+
+	m := &mockServer{gs, make(map[ttnpb.GatewayIdentifiers]int)}
+
+	server := newServerWithIdentifiersCache(m, cache)
+
+	ids := ttnpb.GatewayIdentifiers{EUI: &types.EUI64{1, 1, 1, 1, 1, 1, 1, 1}}
+	ids2 := ttnpb.GatewayIdentifiers{EUI: &types.EUI64{1, 1, 1, 1, 1, 1, 1, 2}}
+	var fetched ttnpb.GatewayIdentifiers
+
+	// Cold cache, ensure server.FillGatewayContext() was called
+	_, fetched, _ = server.FillGatewayContext(test.Context(), ids)
+	a.So(m.called[ids], should.Equal, 1)
+	a.So(fetched, should.Resemble, ids)
+
+	// Warm cache, ensure cache is used
+	_, fetched, _ = server.FillGatewayContext(test.Context(), ids)
+	a.So(m.called[ids], should.Equal, 1)
+
+	clock.Advance(ttl + time.Second)
+
+	// Cache expired, ensure server.FillGatewayContext() is called again
+	_, fetched, _ = server.FillGatewayContext(test.Context(), ids)
+	a.So(m.called[ids], should.Equal, 2)
+	a.So(fetched, should.Resemble, ids)
+
+	// Different identifiers
+	_, fetched, _ = server.FillGatewayContext(test.Context(), ids2)
+	a.So(m.called[ids2], should.Equal, 1)
+	a.So(fetched, should.Resemble, ids2)
+}

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -75,7 +75,7 @@ func Serve(ctx context.Context, server io.Server, conn *net.UDPConn, config Conf
 	s := &srv{
 		ctx:      ctx,
 		config:   config,
-		server:   server,
+		server:   newServerWithIdentifiersCache(server, config.GatewayIdentifiersCache),
 		conn:     conn,
 		packetCh: make(chan encoding.Packet, config.PacketBuffer),
 		firewall: firewall,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/issues/2437

#### Changes
<!-- What are the changes made in this pull request? -->

- Wrap `(io.Server).FillGatewayContext` for the UDP frontend and cache results.
- Add a `GatewayIdentifiersCache` option in `gatewayserver.Config`. The TTL for entries is currently hard-coded to 1 minute.

#### Testing

<!-- How did you verify that this change works? -->

- Unit tests

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

- Changes to the Entity Registry will render entries in the cache out of date. This may cause temporary issues until the cache key expires.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
