### PR TITLE
Pass end device version identifiers to Javascript payload formatters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Added
 
+- Javascript payload formatters now receive an extra `version` input parameter containing the version identifiers (brand, model, band, firmware version and hardware version) of the device.
+  - The new `version` input contains the fields `brandID`, `modelID`, `bandID`, `firmwareVersion`, `hardwareVersion`.
+  - For the `decodeUplink(input)`, `decodeDownlink(input)` and `encodeDownlink(input)` payload formatters, you can access the identifiers as `input.version`.
+
 ### Changed
 
 - Allow the LinkADRReq commands to lower the data rate used by the end devices.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->


#### Changes
<!-- What are the changes made in this pull request? -->

- Pass end device version identifiers in Javascript payload formatters

#### Testing

<!-- How did you verify that this change works? -->

Unit tests, test locally

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- Local testing does not help with finding out if there is any serious performance penalty due to the extra parameters. 
- @johanstokking Should we support legacy formatters as well? Or simply document that people need to use the new payload formatter definitions (`decodeUplink`, `decodeDownlink`, `encodeDownlink`) payload formatters if they want to access the version identifiers?

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
