### PR TITLE
Add GCS to cluster config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Added
 
 - Contextual tooltips to form fields in the Console.
+- Gateway Configuration Server to the cluster package.
 
 ### Changed
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -173,6 +173,7 @@ func defaultNew(ctx context.Context, config *Config, options ...Option) (Cluster
 	c.addPeer("cs", config.CryptoServer, ttnpb.ClusterRole_CRYPTO_SERVER)
 	c.addPeer("pba", config.PacketBrokerAgent, ttnpb.ClusterRole_PACKET_BROKER_AGENT)
 	c.addPeer("dr", config.DeviceRepository, ttnpb.ClusterRole_DEVICE_REPOSITORY)
+	c.addPeer("gcs", config.GatewayConfigurationServer, ttnpb.ClusterRole_GATEWAY_CONFIGURATION_SERVER)
 
 	for _, join := range config.Join {
 		c.peers[join] = &peer{

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -55,13 +55,14 @@ func TestCluster(t *testing.T) {
 	go grpc.NewServer().Serve(lis)
 
 	config := Config{
-		Address:           lis.Addr().String(),
-		IdentityServer:    lis.Addr().String(),
-		GatewayServer:     lis.Addr().String(),
-		NetworkServer:     lis.Addr().String(),
-		ApplicationServer: lis.Addr().String(),
-		JoinServer:        lis.Addr().String(),
-		Join:              []string{lis.Addr().String()},
+		Address:                    lis.Addr().String(),
+		IdentityServer:             lis.Addr().String(),
+		GatewayServer:              lis.Addr().String(),
+		NetworkServer:              lis.Addr().String(),
+		ApplicationServer:          lis.Addr().String(),
+		JoinServer:                 lis.Addr().String(),
+		GatewayConfigurationServer: lis.Addr().String(),
+		Join:                       []string{lis.Addr().String()},
 	}
 
 	ctx := test.Context()
@@ -101,6 +102,9 @@ func TestCluster(t *testing.T) {
 	js, err := c.GetPeer(ctx, ttnpb.ClusterRole_JOIN_SERVER, nil)
 	a.So(js, should.NotBeNil)
 	a.So(err, should.BeNil)
+	gcs, err := c.GetPeer(ctx, ttnpb.ClusterRole_GATEWAY_CONFIGURATION_SERVER, nil)
+	a.So(gcs, should.NotBeNil)
+	a.So(err, should.BeNil)
 
 	// Test Packet Broker Agent override; Packet Broker Agent is not in the cluster.
 	pba, err := c.GetPeer(ctx, ttnpb.ClusterRole_GATEWAY_SERVER, &PacketBrokerGatewayID)
@@ -110,7 +114,7 @@ func TestCluster(t *testing.T) {
 	a.So(c.Leave(), should.BeNil)
 
 	for _, peer := range []Peer{
-		ac, er, gs, ns, as, js,
+		ac, er, gs, ns, as, js, gcs,
 	} {
 		cc, err := peer.Conn()
 		a.So(cc, should.NotBeNil)

--- a/pkg/cluster/config.go
+++ b/pkg/cluster/config.go
@@ -16,18 +16,19 @@ package cluster
 
 // Config represents clustering configuration.
 type Config struct {
-	Join              []string `name:"join" description:"Addresses of cluster peers to join"`
-	Name              string   `name:"name" description:"Name of the current cluster peer (default: $HOSTNAME)"`
-	Address           string   `name:"address" description:"Address to use for cluster communication"`
-	IdentityServer    string   `name:"identity-server" description:"Address for the Identity Server"`
-	GatewayServer     string   `name:"gateway-server" description:"Address for the Gateway Server"`
-	NetworkServer     string   `name:"network-server" description:"Address for the Network Server"`
-	ApplicationServer string   `name:"application-server" description:"Address for the Application Server"`
-	JoinServer        string   `name:"join-server" description:"Address for the Join Server"`
-	CryptoServer      string   `name:"crypto-server" description:"Address for the Crypto Server"`
-	PacketBrokerAgent string   `name:"packet-broker-agent" description:"Address of the Packet Broker Agent"`
-	DeviceRepository  string   `name:"device-repository" description:"Address for the Device Repository"`
-	TLS               bool     `name:"tls" description:"Do cluster gRPC over TLS"`
-	TLSServerName     string   `name:"tls-server-name" description:"Server name to use in TLS handshake to cluster peers"`
-	Keys              []string `name:"keys" description:"Keys used to communicate between components of the cluster. The first one will be used by the cluster to identify itself"`
+	Join                       []string `name:"join" description:"Addresses of cluster peers to join"`
+	Name                       string   `name:"name" description:"Name of the current cluster peer (default: $HOSTNAME)"`
+	Address                    string   `name:"address" description:"Address to use for cluster communication"`
+	IdentityServer             string   `name:"identity-server" description:"Address for the Identity Server"`
+	GatewayServer              string   `name:"gateway-server" description:"Address for the Gateway Server"`
+	NetworkServer              string   `name:"network-server" description:"Address for the Network Server"`
+	ApplicationServer          string   `name:"application-server" description:"Address for the Application Server"`
+	JoinServer                 string   `name:"join-server" description:"Address for the Join Server"`
+	CryptoServer               string   `name:"crypto-server" description:"Address for the Crypto Server"`
+	PacketBrokerAgent          string   `name:"packet-broker-agent" description:"Address of the Packet Broker Agent"`
+	DeviceRepository           string   `name:"device-repository" description:"Address for the Device Repository"`
+	GatewayConfigurationServer string   `name:"gateway-configuration-server" description:"Address for the Gateway Configuration Server"`
+	TLS                        bool     `name:"tls" description:"Do cluster gRPC over TLS"`
+	TLSServerName              string   `name:"tls-server-name" description:"Server name to use in TLS handshake to cluster peers"`
+	Keys                       []string `name:"keys" description:"Keys used to communicate between components of the cluster. The first one will be used by the cluster to identify itself"`
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a small fix for the cluster components  to discover the Gateway Configuration Server.
Refs https://github.com/TheThingsIndustries/lorawan-stack-aws/issues/410

#### Changes
<!-- What are the changes made in this pull request? -->

- Add GCS to cluster config and defaults.
- Update tests

#### Testing

<!-- How did you verify that this change works? -->

UT

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None that I can think of.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This adds a config but is backwards compatible so I think we can target `v3.12.2`.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
