### PR TITLE
Do not print rate limiting error logs for RPC calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
+- Do not print error line logs for rate limited gRPC and HTTP API requests.
+
 ### Deprecated
 
 ### Removed

--- a/pkg/rpcmiddleware/rpclog/rpclog.go
+++ b/pkg/rpcmiddleware/rpclog/rpclog.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"google.golang.org/grpc/grpclog"
 )
@@ -99,3 +100,7 @@ func (l *ttnGrpcLogger) Fatalf(format string, args ...interface{}) {
 func (l *ttnGrpcLogger) V(int) bool {
 	return true
 } // TODO: Use when log.Interface supports this
+
+func shouldSuppressError(err error) bool {
+	return errors.IsResourceExhausted(err)
+}

--- a/pkg/rpcmiddleware/rpclog/server_interceptors.go
+++ b/pkg/rpcmiddleware/rpclog/server_interceptors.go
@@ -41,6 +41,9 @@ func UnaryServerInterceptor(ctx context.Context, opts ...Option) grpc.UnaryServe
 				return resp, err
 			}
 		}
+		if shouldSuppressError(err) {
+			return resp, err
+		}
 
 		onceFields = onceFields.WithField(
 			"duration", time.Since(startTime).Round(time.Microsecond*100),
@@ -88,6 +91,9 @@ func StreamServerInterceptor(ctx context.Context, opts ...Option) grpc.StreamSer
 			if _, ok := o.ignoreMethods[info.FullMethod]; ok {
 				return err
 			}
+		}
+		if shouldSuppressError(err) {
+			return err
 		}
 
 		onceFields = onceFields.WithField(

--- a/pkg/webmiddleware/log.go
+++ b/pkg/webmiddleware/log.go
@@ -25,6 +25,10 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/webhandlers"
 )
 
+func shouldSuppressError(httpStatus int) bool {
+	return httpStatus == http.StatusTooManyRequests
+}
+
 // Log returns a middleware that logs requests.
 // If logger is nil, the logger will be extracted from the context.
 func Log(logger log.Interface, ignorePathsArray []string) MiddlewareFunc {
@@ -58,6 +62,9 @@ func Log(logger log.Interface, ignorePathsArray []string) MiddlewareFunc {
 				if _, ignore := ignorePaths[r.URL.Path]; ignore {
 					return
 				}
+			}
+			if shouldSuppressError(metrics.Code) {
+				return
 			}
 
 			logFields = logFields.With(map[string]interface{}{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Do not print error message logs for errors of type ResourceExhausted. This is to avoid filling up the logs.

#### Changes
<!-- What are the changes made in this pull request? -->

- Override interceptors for HTTP and gRPC servers, and do not print messages if the error is of type ResourceExhausted
- Override interceptor for gRPC clients, because it is used by the gRPC gateway.

#### Testing

<!-- How did you verify that this change works? -->

Locally

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None. Rate limited requests can still be observed with the metrics.

##### Notes for Reviewers

Targetting 3.12.2 since this is a pretty straightforward change.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
