### PR TITLE
Add validation exception for CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Validation of OAuth token exchange requests from the CLI.
+
 ### Security
 
 ## [3.12.2] - 2021-04-30

--- a/pkg/oauth/oauth.go
+++ b/pkg/oauth/oauth.go
@@ -200,7 +200,8 @@ func (req *tokenRequest) ValidateContext(ctx context.Context) error {
 	if strings.TrimSpace(req.ClientID) == "" {
 		return errMissingClientID.New()
 	}
-	if strings.TrimSpace(req.ClientSecret) == "" {
+	if strings.TrimSpace(req.ClientSecret) == "" &&
+		req.ClientID != "cli" { // NOTE: Compatibility: The CLI does not have a client secret.
 		return errMissingClientSecret.New()
 	}
 	if err := (&ttnpb.ClientIdentifiers{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quick fix that adds an exception to the validation of OAuth token exchange requests.

This exception allows the CLI, that has a hard-coded empty string as client secret, to perform OAuth token exchanges.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
