### PR TITLE
Disable map link click in overview

### DIFF
--- a/pkg/webui/components/map/widget/index.js
+++ b/pkg/webui/components/map/widget/index.js
@@ -15,6 +15,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
+import Link from '@ttn-lw/components/link'
 import LocationMap from '@ttn-lw/components/map'
 import WidgetContainer from '@ttn-lw/components/widget-container'
 
@@ -73,7 +74,7 @@ export default class MapWidget extends React.Component {
   }
 
   render() {
-    const { path } = this.props
+    const { path, markers } = this.props
 
     return (
       <WidgetContainer
@@ -81,7 +82,9 @@ export default class MapWidget extends React.Component {
         toAllUrl={path}
         linkMessage={sharedMessages.changeLocation}
       >
-        {this.Map}
+        <Link to={path} disabled={markers && markers.length > 0}>
+          {this.Map}
+        </Link>
       </WidgetContainer>
     )
   }

--- a/pkg/webui/components/widget-container/index.js
+++ b/pkg/webui/components/widget-container/index.js
@@ -35,11 +35,7 @@ const WidgetContainer = ({ children, title, toAllUrl, linkMessage, className }) 
         <Message content={linkMessage} /> →
       </Link>
     </div>
-    <div className={style.body}>
-      <Link className={style.bodyLink} to={toAllUrl}>
-        {children}
-      </Link>
-    </div>
+    <div className={style.body}>{children}</div>
   </aside>
 )
 

--- a/pkg/webui/components/widget-container/widget-container.styl
+++ b/pkg/webui/components/widget-container/widget-container.styl
@@ -30,6 +30,3 @@
 
 .see-all-link
   text-decoration: none
-
-.body-link
-  color: inherit

--- a/pkg/webui/console/components/events/widget.js
+++ b/pkg/webui/console/components/events/widget.js
@@ -15,6 +15,7 @@
 import React from 'react'
 import classnames from 'classnames'
 
+import Link from '@ttn-lw/components/link'
 import WidgetContainer from '@ttn-lw/components/widget-container'
 import Status from '@ttn-lw/components/status'
 
@@ -43,18 +44,22 @@ const EventsWidget = ({ toAllUrl, className, events, scoped, entityId }) => {
       linkMessage={m.seeAllActivity}
       className={className}
     >
-      <div className={classnames(style.body, style.widgetContainer)} data-test-id="events-widget">
-        {events.length === 0 ? (
-          <EmptyMessage entityId={entityId} />
-        ) : (
-          <ol>
-            {events.slice(0, 6).map(event => {
-              const eventId = getEventId(event)
-              return <Event event={event} eventId={eventId} key={eventId} scoped={scoped} widget />
-            })}
-          </ol>
-        )}
-      </div>
+      <Link to={toAllUrl}>
+        <div className={classnames(style.body, style.widgetContainer)} data-test-id="events-widget">
+          {events.length === 0 ? (
+            <EmptyMessage entityId={entityId} />
+          ) : (
+            <ol>
+              {events.slice(0, 6).map(event => {
+                const eventId = getEventId(event)
+                return (
+                  <Event event={event} eventId={eventId} key={eventId} scoped={scoped} widget />
+                )
+              })}
+            </ol>
+          )}
+        </div>
+      </Link>
     </WidgetContainer>
   )
 }


### PR DESCRIPTION
#### Summary

Map overview widget should not navigate to location settings via map click, if map is already set (@kschiffer)

#### Changes

- Disabled `Link` click in map widget, when `markers` are set  

#### Testing

- Manually tested

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
