### PR TITLE
Allow rate limiting configuration overrides from external sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ For details about compatibility between different releases, see the **Commitment
 - Previews for `*.update` events in the Console.
 - The Console can now show recent historical events in networks that have events storage enabled.
 - Add a new `mac_settings.desired_max_eirp` field that can be configured to set the desired MaxEIRP value per device.
+- Support loading rate limiting profile configuration from external sources. When set, they will override embedded configuration. See `rate-limiting.config-source`, `rate-limiting.directory`, `rate-limiting.url` and `rate-limiting.blob.*` configuration options.
 
 ### Changed
 

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -194,6 +194,7 @@ var startCommand = &cobra.Command{
 			&config.ServiceBase.FrequencyPlans.HTTPClient,
 			&config.ServiceBase.Interop.SenderClientCA.HTTPClient,
 			&config.ServiceBase.KeyVault.HTTPClient,
+			&config.ServiceBase.RateLimiting.HTTPClient,
 			&config.ServiceBase.Blob.HTTPClient,
 			&config.AS.Interop.InteropClient.BlobConfig.HTTPClient,
 			&config.NS.Interop.BlobConfig.HTTPClient,

--- a/config/messages.json
+++ b/config/messages.json
@@ -7541,6 +7541,15 @@
       "file": "qrcodegenerator.go"
     }
   },
+  "error:pkg/ratelimit:invalid_rate": {
+    "translations": {
+      "en": "invalid rate `{rate}` for profile `{name}`"
+    },
+    "description": {
+      "package": "pkg/ratelimit",
+      "file": "config.go"
+    }
+  },
   "error:pkg/ratelimit:rate_limit_exceeded": {
     "translations": {
       "en": "rate limit of `{rate}` accesses per minute exceeded for resource `{key}`"

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -164,7 +164,7 @@ func New(logger log.Stack, config *Config, opts ...Option) (c *Component, err er
 		taskStarter: StartTaskFunc(DefaultStartTask),
 	}
 
-	c.limiter, err = config.RateLimiting.New(ctx)
+	c.limiter, err = ratelimit.New(ctx, config.RateLimiting, config.Blob)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,7 +28,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	"go.thethings.network/lorawan-stack/v3/pkg/ratelimit"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
 )
@@ -586,7 +585,7 @@ func (m *Manager) setDefaults(prefix string, flags *pflag.FlagSet, config interf
 				}
 				flags.StringP(name, shorthand, def, description)
 
-			case []ratelimit.Profile:
+			case []RateLimitingProfile:
 				// Can only be set in the config file. Do not add command-line options
 
 			default:

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/auth/rights"
+	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/scheduling"
@@ -54,7 +55,7 @@ func (*srv) SupportsDownlinkClaim() bool { return true }
 
 var (
 	errUDPFrontendRecovered      = errors.DefineInternal("udp_frontend_recovered", "internal server error")
-	limitLogsConfig              = ratelimit.Profile{MaxPerMin: 1}
+	limitLogsConfig              = config.RateLimitingProfile{MaxPerMin: 1}
 	limitLogsSize           uint = 1 << 13
 )
 
@@ -68,7 +69,7 @@ func Serve(ctx context.Context, server io.Server, conn *net.UDPConn, config Conf
 	if config.RateLimiting.Enable {
 		firewall = NewRateLimitingFirewall(firewall, config.RateLimiting.Messages, config.RateLimiting.Threshold)
 	}
-	limitLogs, err := limitLogsConfig.New(ctx, limitLogsSize)
+	limitLogs, err := ratelimit.NewProfile(ctx, limitLogsConfig, limitLogsSize)
 	if err != nil {
 		return err
 	}

--- a/pkg/gatewayserver/io/ws/ws_test.go
+++ b/pkg/gatewayserver/io/ws/ws_test.go
@@ -43,7 +43,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	pfconfig "go.thethings.network/lorawan-stack/v3/pkg/pfconfig/lbslns"
 	"go.thethings.network/lorawan-stack/v3/pkg/pfconfig/shared"
-	"go.thethings.network/lorawan-stack/v3/pkg/ratelimit"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
@@ -1528,8 +1527,8 @@ func TestPingPong(t *testing.T) {
 func TestRateLimit(t *testing.T) {
 	t.Run("Accept", func(t *testing.T) {
 		maxRate := uint(3)
-		conf := ratelimit.Config{
-			Profiles: []ratelimit.Profile{{
+		conf := config.RateLimiting{
+			Profiles: []config.RateLimitingProfile{{
 				Name:         "accept connections",
 				MaxPerMin:    maxRate,
 				MaxBurst:     maxRate,

--- a/pkg/gatewayserver/io/ws/ws_util_test.go
+++ b/pkg/gatewayserver/io/ws/ws_util_test.go
@@ -31,7 +31,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/ws"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/ws/lbslns"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
-	"go.thethings.network/lorawan-stack/v3/pkg/ratelimit"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
 )
@@ -46,7 +45,7 @@ func mustHavePeer(ctx context.Context, c *component.Component, role ttnpb.Cluste
 	panic("could not connect to peer")
 }
 
-func withServer(t *testing.T, wsConfig ws.Config, rateLimitConf ratelimit.Config, f func(t *testing.T, is *mock.IdentityServer, serverAddress string)) {
+func withServer(t *testing.T, wsConfig ws.Config, rateLimitConf config.RateLimiting, f func(t *testing.T, is *mock.IdentityServer, serverAddress string)) {
 	ctx := log.NewContext(test.Context(), test.GetLogger(t))
 	ctx, cancelCtx := context.WithCancel(ctx)
 	defer cancelCtx()

--- a/pkg/ratelimit/rate_limit_test.go
+++ b/pkg/ratelimit/rate_limit_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/ratelimit"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
@@ -35,8 +36,8 @@ func (r *mockResource) Classes() []string { return r.classes }
 func TestRateLimit(t *testing.T) {
 	a := assertions.New(t)
 
-	limiter, err := ratelimit.Config{
-		Profiles: []ratelimit.Profile{
+	limiter, err := ratelimit.New(test.Context(), config.RateLimiting{
+		Profiles: []config.RateLimitingProfile{
 			{
 				Name:         "Default profile",
 				MaxPerMin:    maxRate,
@@ -56,7 +57,7 @@ func TestRateLimit(t *testing.T) {
 				Associations: []string{"override"},
 			},
 		},
-	}.New(test.Context())
+	}, config.BlobConfig{})
 	if !a.So(err, should.BeNil) {
 		t.FailNow()
 	}
@@ -144,5 +145,30 @@ func TestRateLimit(t *testing.T) {
 				a.So(tc.assertErr(ratelimit.Require(tc.limiter, resource)), should.BeTrue)
 			})
 		}
+	})
+
+	t.Run("ExternalConfig", func(t *testing.T) {
+		conf := config.RateLimiting{
+			ConfigSource: "directory",
+			Directory:    "testdata",
+			Memory: config.RateLimitingMemory{
+				MaxSize: 1024,
+			},
+			Profiles: []config.RateLimitingProfile{
+				{
+					MaxPerMin:    100,
+					Associations: []string{"assoc1"},
+				},
+			},
+		}
+
+		a := assertions.New(t)
+		limiter, err := ratelimit.New(test.Context(), conf, config.BlobConfig{})
+		a.So(err, should.BeNil)
+
+		resource := &mockResource{key: "key", classes: []string{"assoc1"}}
+		limit, result := limiter.RateLimit(resource)
+		a.So(limit, should.BeFalse)
+		a.So(result.Limit, should.Equal, 200)
 	})
 }

--- a/pkg/ratelimit/testdata/rate-limiting.yml
+++ b/pkg/ratelimit/testdata/rate-limiting.yml
@@ -1,0 +1,6 @@
+---
+profiles:
+  - name: override
+    max-per-min: 200
+    associations:
+      - assoc1


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsIndustries/lorawan-stack/issues/2676

#### Changes
<!-- What are the changes made in this pull request? -->

- Move rate limiting configuration to `pkg/config` package.
- Support loading profiles from external sources (directory, URL, bucket)
- External configuration has higher priority, allowing operators to maintain a core rate limiting configuration, and easily apply overrides as needed.

#### Testing

<!-- How did you verify that this change works? -->

- [X] locally
- [x] unit tests (TODO)


#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Draft until discussion in https://github.com/TheThingsIndustries/lorawan-stack/issues/2676 is resolved. Targetting 3.13.0 since this PR introduces configuration changes.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
