### PR TITLE
Fix AS session recovery for imported devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - Validation of OAuth token exchange requests from the CLI.
 - Validation of join-request types when using the Crypto Server backend.
+- Application Server session recovery functionality for imported devices.
 
 ### Security
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/417

This bug occurs when the `SessionKeyID` is not provided by a real Join Server, but rather random (as is the case for imported devices). The AS will attempt to fetch the `AppSKey` using this fake `SessionKeyID` and fail.

#### Changes
<!-- What are the changes made in this pull request? -->

- If the `SessionKeyID` did not change, do not attempt to retrieve it. Just update the `LastAFCntDown` of the respective session.


#### Testing

<!-- How did you verify that this change works? -->

1. Test that session recovery does not depend on the JS if the session key ID did not change:

Current device session:
```
# ttn-lw-cli dev get app1 dev1 --session.last-a-f-cnt-down --session.keys.session-key-id
{
  "ids": {
    "device_id": "dev1",
    "application_ids": {
      "application_id": "app1"
    },
    "dev_eui": "0016C001FF00006D",
    "join_eui": "0016C001FFFE0001",
    "dev_addr": "01BA545B"
  },
  "created_at": "2021-05-04T11:28:53.280Z",
  "updated_at": "2021-05-04T12:57:31.874577732Z",
  "network_server_address": "localhost",
  "application_server_address": "localhost",
  "session": {
    "dev_addr": "00000000",
    "keys": {
      "session_key_id": "AXk3cwdHHwJu4l7QFCB0oA=="
    },
    "last_a_f_cnt_down": 3,
    "started_at": "0001-01-01T00:00:00Z"
  }
}
```

'Brick' the session:
```
# ttn-lw-cli dev set app1 dev1 --session.last-a-f-cnt-down=0
{
  "ids": {
    "device_id": "dev1",
    "application_ids": {
      "application_id": "app1"
    },
    "dev_eui": "0016C001FF00006D",
    "join_eui": "0016C001FFFE0001"
  },
  "created_at": "2021-05-04T11:28:53.280Z",
  "updated_at": "2021-05-04T12:57:58.258085974Z",
  "application_server_address": "localhost",
  "session": {
    "dev_addr": "00000000",
    "keys": {

    },
    "started_at": "0001-01-01T00:00:00Z"
  }
}
```

Ensure that the JoinServer can no longer provide this key:
```
./mage dev:dbrediscli                   
127.0.0.1:6379> keys ttn:v3:js:keys:*
1) "ttn:v3:js:keys:id:0016C001FFFE0001:0016C001FF00006D:AXk3U8HzVnVt7RCYPSfX5g"
2) "ttn:v3:js:keys:id:0016C001FFFE0001:0016C001FF00006D:AXk3cwdHHwJu4l7QFCB0oA"
127.0.0.1:6379> del ttn:v3:js:keys:id:0016C001FFFE0001:0016C001FF00006D:AXk3cwdHHwJu4l7QFCB0oA
(integer) 1
127.0.0.1:6379> 
```

Downlinks still work after this operation.

I've also ran the same 'steps' with an ABP device, just to make sure that the `DevAddr` fallback still works.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

AS session recovery is affected by this, and the tests above ensure that other functionality related to this was not affected.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I would like to backport this to the `v3.12.2` branch, for snapshot purposes. This affects TTSC customers.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
