### PR TITLE
Disable uplink simulation when skipping payload crypto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Changed
 
 - User IDs now have a minimum length of 2 instead of 3, so that more users coming from v2 can keep their username.
+- Disabled device uplink simulation and downlink message sending when skipping payload crypto.
 
 ### Deprecated
 

--- a/cypress/integration/console/devices/messaging/edit.spec.js
+++ b/cypress/integration/console/devices/messaging/edit.spec.js
@@ -87,6 +87,35 @@ describe('End device messaging', () => {
 
       cy.findByTestId('error-notification').should('not.exist')
     })
+
+    it('disables uplink simulation when skip payload crypto is enabled', () => {
+      cy.visit(
+        `${Cypress.config(
+          'consoleRootPath',
+        )}/applications/${applicationId}/devices/${endDeviceId}/messaging/uplink`,
+      )
+
+      const response = {
+        skip_payload_crypto_override: true,
+        session: {},
+      }
+
+      cy.intercept(
+        'GET',
+        `as/applications/${applicationId}/devices/${endDeviceId}?field_mask=version_ids,formatters,skip_payload_crypto,skip_payload_crypto_override,session,pending_session`,
+        response,
+      )
+
+      cy.findByTestId('notification')
+        .should('be.visible')
+        .findByText(`Simulation is disabled for devices that skip payload crypto`)
+        .should('be.visible')
+
+      cy.findByLabelText('FPort').should('be.disabled')
+      cy.findByLabelText('Payload').should('be.disabled')
+
+      cy.findByRole('button', { name: 'Simulate uplink' }).should('be.disabled')
+    })
   })
 
   describe('Downlink', () => {
@@ -106,6 +135,38 @@ describe('End device messaging', () => {
         .findByText(
           `Downlinks can only be scheduled for end devices with a valid session. Please make sure your end device is properly connected to the network.`,
         )
+        .should('be.visible')
+
+      cy.findByLabelText('Replace downlink queue').should('be.disabled')
+      cy.findByLabelText('Push to downlink queue (append)').should('be.disabled')
+      cy.findByLabelText('FPort').should('be.disabled')
+      cy.findByLabelText('Payload').should('be.disabled')
+      cy.findByLabelText('Confirmed downlink').should('be.disabled')
+
+      cy.findByRole('button', { name: 'Schedule downlink' }).should('be.disabled')
+    })
+
+    it('disables downlink messaging when skip payload crypto is enabled', () => {
+      cy.visit(
+        `${Cypress.config(
+          'consoleRootPath',
+        )}/applications/${applicationId}/devices/${endDeviceId}/messaging/downlink`,
+      )
+
+      const response = {
+        skip_payload_crypto_override: true,
+        session: {},
+      }
+
+      cy.intercept(
+        'GET',
+        `as/applications/${applicationId}/devices/${endDeviceId}?field_mask=version_ids,formatters,skip_payload_crypto,skip_payload_crypto_override,session,pending_session`,
+        response,
+      )
+
+      cy.findByTestId('notification')
+        .should('be.visible')
+        .findByText(`Simulation is disabled for devices that skip payload crypto`)
         .should('be.visible')
 
       cy.findByLabelText('Replace downlink queue').should('be.disabled')

--- a/pkg/webui/console/components/downlink-form/connect.js
+++ b/pkg/webui/console/components/downlink-form/connect.js
@@ -16,19 +16,24 @@ import { connect } from 'react-redux'
 
 import api from '@console/api'
 
-import { selectSelectedApplicationId } from '@console/store/selectors/applications'
+import {
+  selectSelectedApplicationId,
+  selectApplicationLinkSkipPayloadCrypto,
+} from '@console/store/selectors/applications'
 import { selectSelectedDeviceId, selectSelectedDevice } from '@console/store/selectors/devices'
 
 const mapStateToProps = state => {
   const appId = selectSelectedApplicationId(state)
   const devId = selectSelectedDeviceId(state)
   const device = selectSelectedDevice(state)
+  const skipPayloadCrypto = selectApplicationLinkSkipPayloadCrypto(state)
 
   return {
     appId,
     devId,
     device,
     downlinkQueue: api.downlinkQueue,
+    skipPayloadCrypto,
   }
 }
 

--- a/pkg/webui/console/components/downlink-form/downlink-form.js
+++ b/pkg/webui/console/components/downlink-form/downlink-form.js
@@ -58,7 +58,7 @@ const validationSchema = Yup.object({
   ),
 })
 
-const DownlinkForm = ({ appId, devId, device, downlinkQueue }) => {
+const DownlinkForm = ({ appId, devId, device, downlinkQueue, skipPayloadCrypto }) => {
   const [error, setError] = useState('')
   const handleSubmit = useCallback(
     async (vals, { setSubmitting, resetForm }) => {
@@ -88,9 +88,14 @@ const DownlinkForm = ({ appId, devId, device, downlinkQueue }) => {
   }
 
   const validSession = device.session || device.pending_session
+  const payloadCryptoSkipped = device.skip_payload_crypto_override || skipPayloadCrypto
+  const deviceSimulationDisabled = !validSession || payloadCryptoSkipped
 
   return (
     <>
+      {payloadCryptoSkipped && (
+        <Notification content={sharedMessages.deviceSimulationDisabledWarning} warning small />
+      )}
       {!validSession && <Notification content={m.invalidSessionWarning} warning small />}
       <IntlHelmet title={m.scheduleDownlink} />
       <Form
@@ -98,7 +103,7 @@ const DownlinkForm = ({ appId, devId, device, downlinkQueue }) => {
         onSubmit={handleSubmit}
         initialValues={initialValues}
         validationSchema={validationSchema}
-        disabled={!validSession}
+        disabled={deviceSimulationDisabled}
       >
         <Form.SubTitle title={m.scheduleDownlink} />
         <Form.Field name="_mode" title={m.insertMode} component={RadioButton.Group}>
@@ -140,6 +145,7 @@ DownlinkForm.propTypes = {
     push: PropTypes.func.isRequired,
     replace: PropTypes.func.isRequired,
   }).isRequired,
+  skipPayloadCrypto: PropTypes.bool.isRequired,
 }
 
 export default DownlinkForm

--- a/pkg/webui/console/components/uplink-form/connect.js
+++ b/pkg/webui/console/components/uplink-form/connect.js
@@ -16,17 +16,24 @@ import { connect } from 'react-redux'
 
 import api from '@console/api'
 
-import { selectSelectedApplicationId } from '@console/store/selectors/applications'
-import { selectSelectedDeviceId } from '@console/store/selectors/devices'
+import {
+  selectSelectedApplicationId,
+  selectApplicationLinkSkipPayloadCrypto,
+} from '@console/store/selectors/applications'
+import { selectSelectedDeviceId, selectSelectedDevice } from '@console/store/selectors/devices'
 
 const mapStateToProps = state => {
   const appId = selectSelectedApplicationId(state)
   const devId = selectSelectedDeviceId(state)
+  const device = selectSelectedDevice(state)
+  const skipPayloadCrypto = selectApplicationLinkSkipPayloadCrypto(state)
 
   return {
     appId,
     devId,
+    device,
     simulateUplink: uplink => api.device.simulateUplink(appId, devId, uplink),
+    skipPayloadCrypto,
   }
 }
 

--- a/pkg/webui/console/components/uplink-form/uplink-form.js
+++ b/pkg/webui/console/components/uplink-form/uplink-form.js
@@ -15,6 +15,7 @@
 import React from 'react'
 import { defineMessages } from 'react-intl'
 
+import Notification from '@ttn-lw/components/notification'
 import SubmitButton from '@ttn-lw/components/submit-button'
 import Input from '@ttn-lw/components/input'
 import SubmitBar from '@ttn-lw/components/submit-bar'
@@ -50,7 +51,7 @@ const validationSchema = Yup.object({
 const initialValues = { f_port: 1, frm_payload: '' }
 
 const UplinkForm = props => {
-  const { simulateUplink } = props
+  const { simulateUplink, device, skipPayloadCrypto } = props
 
   const [error, setError] = React.useState('')
 
@@ -81,14 +82,20 @@ const UplinkForm = props => {
     [simulateUplink],
   )
 
+  const deviceSimulationDisabled = device.skip_payload_crypto_override || skipPayloadCrypto
+
   return (
     <>
+      {deviceSimulationDisabled && (
+        <Notification content={sharedMessages.deviceSimulationDisabledWarning} warning small />
+      )}
       <IntlHelmet title={m.simulateUplink} />
       <Form
         error={error}
         initialValues={initialValues}
         validationSchema={validationSchema}
         onSubmit={handleSubmit}
+        disabled={deviceSimulationDisabled}
       >
         <Form.SubTitle title={m.simulateUplink} />
         <Form.Field
@@ -117,7 +124,13 @@ const UplinkForm = props => {
 }
 
 UplinkForm.propTypes = {
+  device: PropTypes.device.isRequired,
   simulateUplink: PropTypes.func.isRequired,
+  skipPayloadCrypto: PropTypes.bool,
+}
+
+UplinkForm.defaultProps = {
+  skipPayloadCrypto: false,
 }
 
 export default UplinkForm

--- a/pkg/webui/console/store/selectors/applications.js
+++ b/pkg/webui/console/store/selectors/applications.js
@@ -90,3 +90,9 @@ export const selectApplicationLinkFormatters = state => {
 
   return link.default_formatters
 }
+
+export const selectApplicationLinkSkipPayloadCrypto = state => {
+  const link = selectApplicationLink(state) || {}
+
+  return link.skip_payload_crypto || false
+}

--- a/pkg/webui/lib/shared-messages.js
+++ b/pkg/webui/lib/shared-messages.js
@@ -121,6 +121,7 @@ export default defineMessages({
   deviceDescPlaceholder: 'Description for my new end device',
   deviceIdPlaceholder: 'my-new-device',
   deviceNamePlaceholder: 'My new end device',
+  deviceSimulationDisabledWarning: 'Simulation is disabled for devices that skip payload crypto',
   device: 'End device',
   devices: 'End devices',
   devID: 'End device ID',

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -698,6 +698,7 @@
   "lib.shared-messages.deviceDescPlaceholder": "Description for my new end device",
   "lib.shared-messages.deviceIdPlaceholder": "my-new-device",
   "lib.shared-messages.deviceNamePlaceholder": "My new end device",
+  "lib.shared-messages.deviceSimulationDisabledWarning": "Simulation is disabled for devices that skip payload crypto",
   "lib.shared-messages.device": "End device",
   "lib.shared-messages.devices": "End devices",
   "lib.shared-messages.devID": "End device ID",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -698,6 +698,7 @@
   "lib.shared-messages.deviceDescPlaceholder": "Xxxxxxxxxxx xxx xx xxx xxx xxxxxx",
   "lib.shared-messages.deviceIdPlaceholder": "xx-xxx-xxxxxx",
   "lib.shared-messages.deviceNamePlaceholder": "Xx xxx xxx xxxxxx",
+  "lib.shared-messages.deviceSimulationDisabledWarning": "Xxxxxxxxxx xx xxxxxxxx xxx xxxxxxx xxxx xxxx xxxxxxx xxxxxx",
   "lib.shared-messages.device": "Xxx xxxxxx",
   "lib.shared-messages.devices": "Xxx xxxxxxx",
   "lib.shared-messages.devID": "Xxx xxxxxx XX",


### PR DESCRIPTION
#### Summary

Closes #3913 

#### Changes

- Disabled device uplink simulation and downlink message sending when skipping payload crypto.

**Before:**
![simulate_before_1](https://user-images.githubusercontent.com/72162194/117039345-55c5ae80-ad11-11eb-8929-8e8196f93606.png)
![simulate_before_2](https://user-images.githubusercontent.com/72162194/117039870-ee5c2e80-ad11-11eb-9409-c79e95c03793.png)



**After:**
![simulate_after_1](https://user-images.githubusercontent.com/72162194/117039363-5b22f900-ad11-11eb-847a-c5ad5451b399.png)
![simulate_after_2](https://user-images.githubusercontent.com/72162194/117039370-5c542600-ad11-11eb-8dba-d7b55fc457cd.png)


#### Testing

- Added e2e tests

#### Checklist
- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
