### PR TITLE
Application Server session recovery improvements

### DIFF
--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -1048,6 +1048,20 @@ func TestApplicationServer(t *testing.T) {
 					{
 						Name: "RegisteredDevice/JoinAccept/WithAppSKey/WithQueue",
 						IDs:  registeredDevice.EndDeviceIdentifiers,
+						ResetQueue: []*ttnpb.ApplicationDownlink{
+							{
+								SessionKeyID: []byte{0x22},
+								FPort:        11,
+								FCnt:         11,
+								FRMPayload:   []byte{0x69, 0x65, 0x9f, 0x8f},
+							},
+							{
+								SessionKeyID: []byte{0x22},
+								FPort:        22,
+								FCnt:         22,
+								FRMPayload:   []byte{0xb, 0x8f, 0x94, 0xe6},
+							},
+						},
 						Message: &ttnpb.ApplicationUp{
 							EndDeviceIdentifiers: withDevAddr(registeredDevice.EndDeviceIdentifiers, types.DevAddr{0x33, 0x33, 0x33, 0x33}),
 							Up: &ttnpb.ApplicationUp_JoinAccept{
@@ -1099,7 +1113,7 @@ func TestApplicationServer(t *testing.T) {
 										KEKLabel:     "test",
 									},
 								},
-								LastAFCntDown: 12,
+								LastAFCntDown: 0,
 								StartedAt:     dev.Session.StartedAt,
 							})
 							a.So(dev.PendingSession, should.Resemble, &ttnpb.Session{
@@ -1133,7 +1147,7 @@ func TestApplicationServer(t *testing.T) {
 								{
 									SessionKeyID: []byte{0x22},
 									FPort:        22,
-									FCnt:         12,
+									FCnt:         22,
 									FRMPayload:   []byte{0x2, 0x2, 0x2, 0x2},
 									DecodedPayload: &pbtypes.Struct{
 										Fields: map[string]*pbtypes.Value{
@@ -1532,7 +1546,7 @@ func TestApplicationServer(t *testing.T) {
 										KEKLabel:     "test",
 									},
 								},
-								LastAFCntDown: 3,
+								LastAFCntDown: 44,
 								StartedAt:     dev.Session.StartedAt,
 							})
 							a.So(dev.PendingSession, should.Resemble, &ttnpb.Session{
@@ -1550,14 +1564,14 @@ func TestApplicationServer(t *testing.T) {
 							a.So(queue, should.Resemble, []*ttnpb.ApplicationDownlink{
 								{
 									SessionKeyID: []byte{0x33},
-									FPort:        11,
+									FPort:        22,
 									FCnt:         2,
-									FRMPayload:   []byte{0x1, 0x1, 0x1, 0x1},
+									FRMPayload:   []byte{0x2, 0x2, 0x2, 0x2},
 									DecodedPayload: &pbtypes.Struct{
 										Fields: map[string]*pbtypes.Value{
 											"sum": {
 												Kind: &pbtypes.Value_NumberValue{
-													NumberValue: 4, // Payload formatter sums the bytes in FRMPayload.
+													NumberValue: 8, // Payload formatter sums the bytes in FRMPayload.
 												},
 											},
 										},
@@ -1565,14 +1579,14 @@ func TestApplicationServer(t *testing.T) {
 								},
 								{
 									SessionKeyID: []byte{0x33},
-									FPort:        22,
-									FCnt:         3,
-									FRMPayload:   []byte{0x2, 0x2, 0x2, 0x2},
+									FPort:        11,
+									FCnt:         44,
+									FRMPayload:   []byte{0x1, 0x1, 0x1, 0x1},
 									DecodedPayload: &pbtypes.Struct{
 										Fields: map[string]*pbtypes.Value{
 											"sum": {
 												Kind: &pbtypes.Value_NumberValue{
-													NumberValue: 8, // Payload formatter sums the bytes in FRMPayload.
+													NumberValue: 4, // Payload formatter sums the bytes in FRMPayload.
 												},
 											},
 										},

--- a/pkg/networkserver/grpc_asns.go
+++ b/pkg/networkserver/grpc_asns.go
@@ -248,7 +248,7 @@ func matchQueuedApplicationDownlinks(ctx context.Context, dev *ttnpb.EndDevice, 
 		return err
 	}
 	if len(unmatched) > 0 {
-		return errUnknownSession.New()
+		return errUnknownSession.WithDetails(makeDownlinkQueueOperationErrorDetails())
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #4067 

#### Changes
<!-- What are the changes made in this pull request? -->

- Broke down `as.downlinkQueueOp` as it was huge and did too many things at once:
  -  Observation logic has been moved to `registerReceiveDownlinks` / `as.registerDropDownlinks` / `as.registerForwardDownlinks`
  - The retry loop (that basically syncs the session between AS and NS) is now part of `as.attemptDownlinkQueueOp`
  - The downlink encode + encryption is now part of `as.encodeAndEncryptDownlinks`
- Flattened `as.handleJoinAccept` near the 'invalidate downlinks', as the nesting made it very hard to see what was happening.
- As part of the JoinAccept handling, the invalidated downlinks may be decrypted using what is called a 'ternary session'. A ternary session is simply the old `dev.PendingSession`. This occurs when the device attempted to join the network twice, but didn't confirm the session via an uplink.
- `as.matchSession` no longer recalculates the queue when it doesn't recognize the session (i.e. it's not `dev.Session`, nor `dev.PendingSession`). The assumption here is that the Network Server has thrown away the 'old' queue for what is probably a long time, as session confirmation swaps the pending session queue with the current queue. If the AS is in the position in which it never actually saw this session before, there is no way the queue in the Network Server is not empty (as there is no other entity that could have touched the session queue, or the pending session queue).
- Downlink queue invalidations are now handled via pushes, instead of replaces. The Network Server 'evicts' this downlink queue upon invalidation, so we have no reason to actually replace the queue. This protects us from cases during which we wrongfully replace valid items inserted by an application between the invalidation and the handling.
- Downlink nacks are now handled via pushes, in order to avoid replacing a valid queue with an old queue. I understand that this behavior is changed from what we did before, but I bring the following arguments:
  - The NS is already allowed to schedule the next downlinks in the queue - we're just racing with it if we attempt to put this item at the front of the queue.
  - When https://github.com/TheThingsNetwork/lorawan-stack/issues/3642 will be done, the NS will automatically retry the uplink 'at the front of the queue'. 
  - We generally lost this item often, as the `AFCntDown` was generally too low while handling the nack anyway.
  - The push is not destructive towards the queue.
- It should no longer be possible for the AS to fail downlink queue operations. Any downlink queue operations that we do now go via `as.attemptDownlinkQueueOp`, which will automatically sync the session between the AS and the NS.

#### Testing

<!-- How did you verify that this change works? -->

I've tested this locally with a 1.0.3A device in class A without any issues. My queue was carried across rejoins (something which was unstable before), and I didn't encounter at any points dropped items.

~Nonetheless this requires better class C testing, as class C was generally the 'catalyst' for these issues. I will pick this up soon, but the work may already be reviewed.~

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This PR changes the logic used by the following situations:
- The queue changes on `JoinAccept`
- The queue changes on `DownlinkQueueInvalidated`
- The queue changes on `DownlinkNack`

All of these have been tested in class A, ~but still require class C testing~.

Edit: Class C is done and looks promising.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@johanstokking is the main reviewer.

I consider this PR to be close to water tight. But please poke holes if you see any.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
