### PR TITLE
Store only metadata in the Application Server uplink storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
+- Application Server uplink storage will now store only uplink metadata.
+
 ### Deprecated
 
 ### Removed

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -1072,6 +1072,26 @@ matchSession:
 	return mask, nil
 }
 
+func (as *ApplicationServer) storeUplink(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, uplink *ttnpb.ApplicationUplink) error {
+	cleanUplink := &ttnpb.ApplicationUplink{
+		RxMetadata: make([]*ttnpb.RxMetadata, 0, len(uplink.RxMetadata)),
+		ReceivedAt: uplink.ReceivedAt,
+	}
+	for _, md := range uplink.RxMetadata {
+		cleanUplink.RxMetadata = append(cleanUplink.RxMetadata, &ttnpb.RxMetadata{
+			GatewayIdentifiers: ttnpb.GatewayIdentifiers{
+				GatewayID: md.GatewayID,
+			},
+			AntennaIndex:  md.AntennaIndex,
+			FineTimestamp: md.FineTimestamp,
+			Location:      md.Location,
+			RSSI:          md.RSSI,
+			SNR:           md.SNR,
+		})
+	}
+	return as.appUpsRegistry.Push(ctx, ids, cleanUplink)
+}
+
 func (as *ApplicationServer) handleUplink(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, uplink *ttnpb.ApplicationUplink, link *ttnpb.ApplicationLink) error {
 	ctx = log.NewContextWithField(ctx, "session_key_id", uplink.SessionKeyID)
 	dev, err := as.deviceRegistry.Set(ctx, ids,
@@ -1103,7 +1123,7 @@ func (as *ApplicationServer) handleUplink(ctx context.Context, ids ttnpb.EndDevi
 		if err := as.decryptAndDecodeUplink(ctx, dev, uplink, link.DefaultFormatters); err != nil {
 			return err
 		}
-		if err := as.appUpsRegistry.Push(ctx, ids, uplink); err != nil {
+		if err := as.storeUplink(ctx, ids, uplink); err != nil {
 			return err
 		}
 	} else if dev.Session != nil && dev.Session.AppSKey != nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/4018

#### Changes
<!-- What are the changes made in this pull request? -->

- Store only fields which are actually required by integrations, instead of the whole `ttnpb.ApplicationUplink`.


#### Testing

<!-- How did you verify that this change works? -->

Locally, with a device. Before this PR:

```
127.0.0.1:6379> lrange ttn:v3:as:applicationups:uid:app1.dev1 0 9999
 1) "ChABeTlFYtqvz8qGJDNGBjkOEGYYFyIBGTJbChAKBGd0dzESCGR/2v/+AHi4IJubkNQBRQAAkMFNAACQwV1mZuZAei8KEgoQCgRndHcxEghkf9r//gB4uBCbm5DUARoMCIb5xoQGEMr49/ABIPjK1J75DIgBAjodCggKBgjI0AcQBxAFGgM0LzUg4P/TnQMwm5uQ1AFCDAiG+caEBhDZ0KbxAWoFEICQjBY"
 2) "ChABeTlFYtqvz8qGJDNGBjkOEGYYFiIBGTJYChAKBGd0dzESCGR/2v/+AHi4IKPss9ABRQAA0MFNAADQwV0AABBBei8KEgoQCgRndHcxEghkf9r//gB4uBCj7LPQARoMCP74xoQGEJ2YoM4CILjxhZXcDDodCggKBgjI0AcQBxAFGgM0LzUg4Mq7nQMwo+yz0AFCDAj++MaEBhDS4onPAmoFEICQjBY"
 3) "ChABeTlFYtqvz8qGJDNGBjkOEGYYFSIBGDJbChAKBGd0dzESCGR/2v/+AHi4IMztn8wBRQAAyMFNAADIwV1mZuZAei8KEgoQCgRndHcxEghkf9r//gB4uBDM7Z/MARoMCPX4xoQGEJLa/tQDIOCZ8Ni7DIgBBjodCggKBgjI0AcQBxAFGgM0LzUg4OmEngMwzO2fzAFCDAj1+MaEBhC+k6DVA2oFEIDQxBg"
 4) "ChABeTlFYtqvz8qGJDNGBjkOEGYYFCIBGTJbChAKBGd0dzESCGR/2v/+AHi4IKznnMkBRQAAyMFNAADIwV0zMyNBei8KEgoQCgRndHcxEghkf9r//gB4uBCs55zJARoMCO/4xoQGENWn/7MCIOCvh4mkDIgBBTodCggKBgjI0AcQBxAFGgM0LzUgoM/4nQMwrOecyQFCDAjv+MaEBhCC6Mu0AmoFEICQjBY"
 5) "ChABeTlFYtqvz8qGJDNGBjkOEGYYEyIBGjJbChAKBGd0dzESCGR/2v/+AHi4IPvO/cQBRQAAcMFNAABwwV2amflAei8KEgoQCgRndHcxEghkf9r//gB4uBD7zv3EARoMCOb4xoQGEPyC9OICIPjwsPWCDIgBAjodCggKBgjI0AcQBxAFGgM0LzUg4P/TnQMw+879xAFCDAjm+MaEBhCf0MfjAmoFEICQjBY"
 6) "ChABeTlFYtqvz8qGJDNGBjkOEGYYEiIBGzJbChAKBGd0dzESCGR/2v/+AHi4IPyW+sABRQAAsMFNAACwwV3NzBxBei8KEgoQCgRndHcxEghkf9r//gB4uBD8lvrAARoMCN74xoQGEI6r9ZABIOC4w7rjC4gBBTodCggKBgjI0AcQBxAFGgM0LzUgoM/4nQMw/Jb6wAFCDAje+MaEBhDkzKORAWoFEICQjBY"
 7) "ChABeTlFYtqvz8qGJDNGBjkOEGYYESIBGDJaChAKBGd0dzESCGR/2v/+AHi4INSdhb0BRQAAYMFNAABgwV0AABhBei4KEgoQCgRndHcxEghkf9r//gB4uBDUnYW9ARoLCNb4xoQGEOnPgywgoNjv8MQLiAEFOh0KCAoGCMjQBxAHEAUaAzQvNSCgz/idAzDUnYW9AUILCNb4xoQGEMKX0yxqBRCAkIwW"
 8) "ChABeTlFYtqvz8qGJDNGBjkOEGYYECIBGzJbChAKBGd0dzESCGR/2v/+AHi4IPSsg7kBRQAAwMFNAADAwV1mZuZAei8KEgoQCgRndHcxEghkf9r//gB4uBD0rIO5ARoMCM34xoQGEKCX28ECIKDqlsKlC4gBBjodCggKBgjI0AcQBxAFGgM0LzUg4OmEngMw9KyDuQFCDAjN+MaEBhC5rIbCAmoFEICQjBY"
 9) "ChABeTlFYtqvz8qGJDNGBjkOEGYYDyIBGDJbChAKBGd0dzESCGR/2v/+AHi4IPyXkLUBRQAAkMFNAACQwV0zMyNBei8KEgoQCgRndHcxEghkf9r//gB4uBD8l5C1ARoMCMX4xoQGEODM7u0BIOCgu4aHC4gBBzodCggKBgjI0AcQBxAFGgM0LzUgoISRngMw/JeQtQFCDAjF+MaEBhCpms/uAWoFEICQjBY"
10) "ChABeTlFYtqvz8qGJDNGBjkOEGYYDiIBGDJbChAKBGd0dzESCGR/2v/+AHi4IIuLprEBRQAAwMFNAADAwV0zMwNBei8KEgoQCgRndHcxEghkf9r//gB4uBCLi6axARoMCL34xoQGELTmp9wBIPjNxpHpCogBAzodCggKBgjI0AcQBxAFGgM0LzUgoJrgnQMwi4umsQFCDAi9+MaEBhCZvuncAWoFEICQjBY"
11) "ChABeTlFYtqvz8qGJDNGBjkOEGYYDSIBGDJbChAKBGd0dzESCGR/2v/+AHi4IJOQi60BRQAAwMFNAADAwV0AABhBei8KEgoQCgRndHcxEghkf9r//gB4uBCTkIutARoMCLT4xoQGEMu3z68CILiU9p7ICogBATodCggKBgjI0AcQBxAFGgM0LzUgoOXHnQMwk5CLrQFCDAi0+MaEBhCO7b6wAmoFEICQjBY"
12) "ChABeTlFYtqvz8qGJDNGBjkOEGYYDCIBGjJaChAKBGd0dzESCGR/2v/+AHi4ILvHhqkBRQAAcMFNAABwwV0AABhBei4KEgoQCgRndHcxEghkf9r//gB4uBC7x4apARoLCKz4xoQGEJLBm1Ig+KSe26gKiAEEOh0KCAoGCMjQBxAHEAUaAzQvNSDgtOydAzC7x4apAUILCKz4xoQGENOB7FJqBRCAkIwW"
13) "ChABeTlFYtqvz8qGJDNGBjkOEGYYCyIBGjJYChAKBGd0dzESCGR/2v/+AHi4ILPjiaUBRQAAcMFNAABwwV0AAAhBei8KEgoQCgRndHcxEghkf9r//gB4uBCz44mlARoMCKP4xoQGEK36iZADILjGsNSJCjodCggKBgjI0AcQBxAFGgM0LzUg4Mq7nQMws+OJpQFCDAij+MaEBhCctraQA2oFEICQjBY"
14) "ChABeTlFYtqvz8qGJDNGBjkOEGYYCiIBGTJbChAKBGd0dzESCGR/2v/+AHi4ILupnaEBRQAAcMFNAABwwV0zMxNBei8KEgoQCgRndHcxEghkf9r//gB4uBC7qZ2hARoMCJv4xoQGEO2is+4CIPj0i83rCYgBBDodCggKBgjI0AcQBxAFGgM0LzUg4LTsnQMwu6mdoQFCDAib+MaEBhCgp5fvAmoFEICQjBY"
15) "ChABeTlFYtqvz8qGJDNGBjkOEGYYCSIBGTJbChAKBGd0dzESCGR/2v/+AHi4ILy39JwBRQAA2MFNAADYwV0AABBBei8KEgoQCgRndHcxEghkf9r//gB4uBC8t/ScARoMCJL4xoQGEKqDltMCIOCs0e3JCYgBBzodCggKBgjI0AcQBxAFGgM0LzUgoISRngMwvLf0nAFCDAiS+MaEBhD0+MDTAmoFEICQjBY"
16) "ChABeTlFYtqvz8qGJDNGBjkOEGYYCCIBGDJbChAKBGd0dzESCGR/2v/+AHi4IIOIupgBRQAAgMFNAACAwV0AABBBei8KEgoQCgRndHcxEghkf9r//gB4uBCDiLqYARoMCIn4xoQGELOsk60BILjXzoWnCYgBBDodCggKBgjI0AcQBxAFGgM0LzUg4LTsnQMwg4i6mAFCDAiJ+MaEBhD8rNetAWoFEICQjBY"
```

After the PR:
```
127.0.0.1:6379> lrange ttn:v3:as:applicationups:uid:app1.dev1 0 9999
 1) "MhIKBgoEZ3R3MUUAAHDBXc3MDEE6AgoAQgwIgvvGhAYQyqiwiQM"
 2) "MhIKBgoEZ3R3MUUAAGDBXQAAEEE6AgoAQgsI+vrGhAYQttOjGA"
 3) "MhIKBgoEZ3R3MUUAAHDBXQAA8EA6AgoAQgsI8vrGhAYQ6vrSZQ"
 4) "MhIKBgoEZ3R3MUUAAHDBXWZm5kA6AgoAQgsI6frGhAYQm6KDBg"
 5) "MhIKBgoEZ3R3MUUAAHDBXTMzE0E6AgoAQgwI4PrGhAYQtsKgqAM"
 6) "MhIKBgoEZ3R3MUUAAJDBXTMzE0E6AgoAQgsI2PrGhAYQktT+Qw"
 7) "MhIKBgoEZ3R3MUUAAIjBXc3MHEE6AgoAQgwI0PrGhAYQzPSRuwE"
 8) "MhIKBgoEZ3R3MUUAAJDBXQAAGEE6AgoAQgsIx/rGhAYQ4ce4XA"
 9) "MhIKBgoEZ3R3MUUAAJjBXQAAGEE6AgoAQgwIv/rGhAYQlsH48QE"
10) "MhIKBgoEZ3R3MUUAAJjBXQAAIEE6AgoAQgwIsfrGhAYQ5vvdoAE"
11) "MhIKBgoEZ3R3MUUAAMDBXQAAEEE6AgoAQgwIofrGhAYQ6fLeiwM"
12) "MhIKBgoEZ3R3MUUAANjBXQAAGEE6AgoAQgwIkfrGhAYQ3bGqhQI"
13) "MhIKBgoEZ3R3MUUAANDBXQAAGEE6AgoAQgwI//nGhAYQt4rd/gI"
14) "MhIKBgoEZ3R3MUUAAJDBXQAA8EA6AgoAQgwI7/nGhAYQvtmYwgE"
15) "MhIKBgoEZ3R3MUUAAMDBXTMzE0E6AgoAQgwI3vnGhAYQhaC0oAE"
16) "MhIKBgoEZ3R3MUUAANjBXQAAEEE6AgoAQgwI1/nGhAYQvKWy2AM"
```

In practice this space save may be both bigger, and smaller. It will be bigger in the cases in which the decoded payload was large, while it will be smaller for uplinks with lots of receptions (large `rx_metadata`). But space is always saved.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
