### PR TITLE
Return non-zero exit status for invalid commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - Validation of OAuth token exchange requests from the CLI.
 - Validation of join-request types when using the Crypto Server backend.
+- The CLI now properly returns a non-zero exit status code for invalid commands.
 
 ### Security
 

--- a/cmd/internal/commands/util.go
+++ b/cmd/internal/commands/util.go
@@ -1,0 +1,29 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"github.com/spf13/cobra"
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+)
+
+var errInvalidCommand = errors.DefineInvalidArgument("invalid_command", "invalid command", "args")
+
+func NeedSubcommandRunE(cmd *cobra.Command, args []string) error {
+	if err := cmd.Help(); err != nil {
+		return err
+	}
+	return errInvalidCommand.WithAttributes("args", args)
+}

--- a/cmd/ttn-lw-cli/commands/applications.go
+++ b/cmd/ttn-lw-cli/commands/applications.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/util"
@@ -74,6 +75,7 @@ var (
 		Use:     "applications",
 		Aliases: []string{"application", "apps", "app", "a"},
 		Short:   "Application commands",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	applicationsListCommand = &cobra.Command{
 		Use:     "list",

--- a/cmd/ttn-lw-cli/commands/applications_access.go
+++ b/cmd/ttn-lw-cli/commands/applications_access.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -63,6 +64,7 @@ var (
 		Use:     "collaborators",
 		Aliases: []string{"collaborator", "members", "member"},
 		Short:   "Manage application collaborators",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	applicationCollaboratorsList = &cobra.Command{
 		Use:     "list [application-id]",
@@ -191,6 +193,7 @@ var (
 		Use:     "api-keys",
 		Aliases: []string{"api-key"},
 		Short:   "Manage application API keys",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	applicationAPIKeysList = &cobra.Command{
 		Use:     "list [application-id]",

--- a/cmd/ttn-lw-cli/commands/applications_activation_settings.go
+++ b/cmd/ttn-lw-cli/commands/applications_activation_settings.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/util"
@@ -38,6 +39,7 @@ var (
 	applicationActivationSettingsCommand = &cobra.Command{
 		Use:   "activation-settings",
 		Short: "Application activation settings commands",
+		RunE:  commands.NeedSubcommandRunE,
 	}
 	applicationActivationSettingsGetCommand = &cobra.Command{
 		Use:   "get [application-id]",

--- a/cmd/ttn-lw-cli/commands/applications_claim.go
+++ b/cmd/ttn-lw-cli/commands/applications_claim.go
@@ -16,6 +16,7 @@ package commands
 
 import (
 	"github.com/spf13/cobra"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 )
@@ -24,6 +25,7 @@ var (
 	applicationClaim = &cobra.Command{
 		Use:   "claim",
 		Short: "Manage claim settings in applications",
+		RunE:  commands.NeedSubcommandRunE,
 	}
 	applicationClaimAuthorize = &cobra.Command{
 		Use:   "authorize [application-id]",

--- a/cmd/ttn-lw-cli/commands/applications_downlink.go
+++ b/cmd/ttn-lw-cli/commands/applications_downlink.go
@@ -18,6 +18,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/util"
@@ -32,6 +33,7 @@ var (
 	applicationsDownlinkCommand = &cobra.Command{
 		Use:   "downlink",
 		Short: "Application downlink commands",
+		RunE:  commands.NeedSubcommandRunE,
 	}
 	applicationsDownlinkPushCommand = &cobra.Command{
 		Use:   "push [application-id] [device-id]",

--- a/cmd/ttn-lw-cli/commands/applications_link.go
+++ b/cmd/ttn-lw-cli/commands/applications_link.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/util"
@@ -47,6 +48,7 @@ var (
 	applicationsLinkCommand = &cobra.Command{
 		Use:   "link",
 		Short: "Application link commands",
+		RunE:  commands.NeedSubcommandRunE,
 	}
 	applicationsLinkGetCommand = &cobra.Command{
 		Use:     "get [application-id]",

--- a/cmd/ttn-lw-cli/commands/applications_packages.go
+++ b/cmd/ttn-lw-cli/commands/applications_packages.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/util"
@@ -146,6 +147,7 @@ var (
 		Use:     "packages",
 		Aliases: []string{"package", "pkg", "pkgs"},
 		Short:   "Application packages commands",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	applicationsPackagesListCommand = &cobra.Command{
 		Use:     "list",
@@ -172,6 +174,7 @@ var (
 		Use:     "associations",
 		Aliases: []string{"assoc", "assocs"},
 		Short:   "Application packages associations commands",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	applicationsPackageAssociationGetCommand = &cobra.Command{
 		Use:     "get [application-id] [device-id] [f-port]",
@@ -317,6 +320,7 @@ var (
 		Use:     "default-associations",
 		Aliases: []string{"def-assoc", "def-assocs"},
 		Short:   "Application packages default associations commands",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	applicationsPackageDefaultAssociationGetCommand = &cobra.Command{
 		Use:     "get [application-id] [f-port]",

--- a/cmd/ttn-lw-cli/commands/applications_pubsub.go
+++ b/cmd/ttn-lw-cli/commands/applications_pubsub.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/util"
@@ -109,6 +110,7 @@ var (
 		Use:     "pubsubs",
 		Aliases: []string{"pubsub", "ps"},
 		Short:   "Application pub/sub commands",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	applicationsPubSubsGetFormatsCommand = &cobra.Command{
 		Use:     "get-formats",

--- a/cmd/ttn-lw-cli/commands/applications_webhooks.go
+++ b/cmd/ttn-lw-cli/commands/applications_webhooks.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/util"
@@ -82,6 +83,7 @@ var (
 		Use:     "webhooks",
 		Aliases: []string{"webhook"},
 		Short:   "Application webhooks commands",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	applicationsWebhooksGetFormatsCommand = &cobra.Command{
 		Use:     "get-formats",

--- a/cmd/ttn-lw-cli/commands/clients.go
+++ b/cmd/ttn-lw-cli/commands/clients.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/util"
@@ -73,6 +74,7 @@ var (
 		Use:     "clients",
 		Aliases: []string{"client", "cli", "c"},
 		Short:   "Client commands",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	clientsListCommand = &cobra.Command{
 		Use:     "list",

--- a/cmd/ttn-lw-cli/commands/clients_access.go
+++ b/cmd/ttn-lw-cli/commands/clients_access.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -50,6 +51,7 @@ var (
 		Use:     "collaborators",
 		Aliases: []string{"collaborator", "members", "member"},
 		Short:   "Manage client collaborators",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	clientCollaboratorsList = &cobra.Command{
 		Use:     "list [client-id]",

--- a/cmd/ttn-lw-cli/commands/contact_info.go
+++ b/cmd/ttn-lw-cli/commands/contact_info.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/gogo/protobuf/types"
 	"github.com/spf13/cobra"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/util"
@@ -144,6 +145,7 @@ func contactInfoCommands(entity string, getID func(cmd *cobra.Command, args []st
 	cmd := &cobra.Command{
 		Use:   "contact-info",
 		Short: fmt.Sprintf("Manage %s contact info", entity),
+		RunE:  commands.NeedSubcommandRunE,
 	}
 	list := &cobra.Command{
 		Use:     fmt.Sprintf("list [%s-id]", entity),

--- a/cmd/ttn-lw-cli/commands/end_device_templates.go
+++ b/cmd/ttn-lw-cli/commands/end_device_templates.go
@@ -24,6 +24,7 @@ import (
 	pbtypes "github.com/gogo/protobuf/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/util"
@@ -70,6 +71,7 @@ var (
 		Use:     "templates",
 		Aliases: []string{"template", "tmpl"},
 		Short:   "End Device template commands",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	endDeviceTemplatesExtendCommand = &cobra.Command{
 		Use:               "extend [flags]",

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -29,6 +29,7 @@ import (
 	pbtypes "github.com/gogo/protobuf/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/util"
@@ -189,6 +190,7 @@ var (
 		Use:     "end-devices",
 		Aliases: []string{"end-device", "devices", "device", "dev", "ed", "d"},
 		Short:   "End Device commands",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	endDevicesListFrequencyPlans = &cobra.Command{
 		Use:               "list-frequency-plans",

--- a/cmd/ttn-lw-cli/commands/gateways.go
+++ b/cmd/ttn-lw-cli/commands/gateways.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/util"
@@ -117,6 +118,7 @@ var (
 		Use:     "gateways",
 		Aliases: []string{"gateway", "gtw", "g"},
 		Short:   "Gateway commands",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	gatewaysListFrequencyPlans = &cobra.Command{
 		Use:               "list-frequency-plans",

--- a/cmd/ttn-lw-cli/commands/gateways_access.go
+++ b/cmd/ttn-lw-cli/commands/gateways_access.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -50,6 +51,7 @@ var (
 		Use:     "collaborators",
 		Aliases: []string{"collaborator", "members", "member"},
 		Short:   "Manage gateway collaborators",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	gatewayCollaboratorsList = &cobra.Command{
 		Use:     "list [gateway-id]",
@@ -178,6 +180,7 @@ var (
 		Use:     "api-keys",
 		Aliases: []string{"api-key"},
 		Short:   "Manage gateway API keys",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	gatewayAPIKeysList = &cobra.Command{
 		Use:     "list [gateway-id]",

--- a/cmd/ttn-lw-cli/commands/organizations.go
+++ b/cmd/ttn-lw-cli/commands/organizations.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/util"
@@ -71,6 +72,7 @@ var (
 		Use:     "organizations",
 		Aliases: []string{"organization", "org", "o"},
 		Short:   "Organization commands",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	organizationsListCommand = &cobra.Command{
 		Use:     "list",

--- a/cmd/ttn-lw-cli/commands/organizations_access.go
+++ b/cmd/ttn-lw-cli/commands/organizations_access.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -50,6 +51,7 @@ var (
 		Use:     "collaborators",
 		Aliases: []string{"collaborator", "members", "member"},
 		Short:   "Manage organization collaborators",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	organizationCollaboratorsList = &cobra.Command{
 		Use:     "list [organization-id]",
@@ -178,6 +180,7 @@ var (
 		Use:     "api-keys",
 		Aliases: []string{"api-key"},
 		Short:   "Manage organization API keys",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	organizationAPIKeysList = &cobra.Command{
 		Use:     "list [organization-id]",

--- a/cmd/ttn-lw-cli/commands/packetbroker.go
+++ b/cmd/ttn-lw-cli/commands/packetbroker.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
@@ -136,6 +137,7 @@ var (
 		Use:     "packetbroker",
 		Aliases: []string{"pb"},
 		Short:   "Packet Broker commands",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	packetBrokerInfoCommand = &cobra.Command{
 		Use:   "info",
@@ -186,11 +188,13 @@ var (
 		Use:     "home-networks",
 		Aliases: []string{"home-network", "homenetworks", "homenetwork", "hn"},
 		Short:   "Home Network commands",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	packetBrokerHomeNetworksPoliciesCommand = &cobra.Command{
 		Use:     "policies",
 		Aliases: []string{"policy", "po"},
 		Short:   "Manage Home Network routing policies",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	packetBrokerHomeNetworksPolicyListCommand = &cobra.Command{
 		Use:     "list",
@@ -351,11 +355,13 @@ for the Home Network (by NetID and tenant ID).`,
 		Use:     "forwarders",
 		Aliases: []string{"forwarder", "fwd"},
 		Short:   "Forwarder commands",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	packetBrokerForwardersPoliciesCommand = &cobra.Command{
 		Use:     "policies",
 		Aliases: []string{"policy", "po"},
 		Short:   "Manage Forwarder routing policies",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	packetBrokerForwardersPoliciesListCommand = &cobra.Command{
 		Use:   "list",

--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -59,6 +59,7 @@ var (
 		SilenceUsage:      true,
 		Short:             "The Things Network Command-line Interface",
 		PersistentPreRunE: preRun(checkAuth, refreshToken, requireAuth),
+		RunE:              commands.NeedSubcommandRunE,
 		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
 			// clean up the API
 			api.CloseAll()

--- a/cmd/ttn-lw-cli/commands/simulate.go
+++ b/cmd/ttn-lw-cli/commands/simulate.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/util"
@@ -449,6 +450,7 @@ var (
 		Use:     "simulate",
 		Aliases: []string{"sim"},
 		Short:   "Simulation commands",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	simulateJoinRequestCommand = &cobra.Command{
 		Use:    "gateway-join-request",

--- a/cmd/ttn-lw-cli/commands/storage_integration.go
+++ b/cmd/ttn-lw-cli/commands/storage_integration.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -58,6 +59,7 @@ var (
 	endDevicesStorageCommand = &cobra.Command{
 		Use:   "storage",
 		Short: "Storage Integration",
+		RunE:  commands.NeedSubcommandRunE,
 	}
 	endDeviceStorageGetCommand = &cobra.Command{
 		Use:   "get [application-id] [device-id]",
@@ -88,6 +90,7 @@ var (
 	applicationsStorageCommand = &cobra.Command{
 		Use:   "storage",
 		Short: "Storage Integration",
+		RunE:  commands.NeedSubcommandRunE,
 	}
 	applicationsStorageGetCommand = &cobra.Command{
 		Use:   "get [application-id]",

--- a/cmd/ttn-lw-cli/commands/users.go
+++ b/cmd/ttn-lw-cli/commands/users.go
@@ -22,6 +22,7 @@ import (
 	"github.com/howeyc/gopass"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/util"
@@ -99,6 +100,7 @@ var (
 		Use:     "users",
 		Aliases: []string{"user", "usr", "u"},
 		Short:   "User commands",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	usersListCommand = &cobra.Command{
 		Use:     "list",

--- a/cmd/ttn-lw-cli/commands/users_access.go
+++ b/cmd/ttn-lw-cli/commands/users_access.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -50,6 +51,7 @@ var (
 		Use:     "api-keys",
 		Aliases: []string{"api-key"},
 		Short:   "Manage user API keys",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	userAPIKeysList = &cobra.Command{
 		Use:     "list [user-id]",

--- a/cmd/ttn-lw-cli/commands/users_invitations.go
+++ b/cmd/ttn-lw-cli/commands/users_invitations.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
@@ -45,6 +46,7 @@ var (
 		Use:     "invitations",
 		Aliases: []string{"invitation"},
 		Short:   "Manage user invitations",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	userInvitationsList = &cobra.Command{
 		Use:     "list",

--- a/cmd/ttn-lw-cli/commands/users_oauth.go
+++ b/cmd/ttn-lw-cli/commands/users_oauth.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
@@ -57,10 +58,12 @@ var (
 	oauthCommand = &cobra.Command{
 		Use:   "oauth",
 		Short: "Manage OAuth authorizations and access tokens",
+		RunE:  commands.NeedSubcommandRunE,
 	}
 	oauthAuthorizationsCommand = &cobra.Command{
 		Use:   "authorizations",
 		Short: "Manage OAuth authorizations",
+		RunE:  commands.NeedSubcommandRunE,
 	}
 	oauthAuthorizationsListCommand = &cobra.Command{
 		Use:     "list [user-id]",
@@ -133,6 +136,7 @@ var (
 		Use:     "access-tokens",
 		Aliases: []string{"tokens"},
 		Short:   "Manage OAuth tokens",
+		RunE:    commands.NeedSubcommandRunE,
 	}
 	oauthAccessTokensListCommand = &cobra.Command{
 		Use:     "list [user-id] [client-id]",

--- a/cmd/ttn-lw-stack/commands/dr_db.go
+++ b/cmd/ttn-lw-stack/commands/dr_db.go
@@ -16,12 +16,14 @@ package commands
 
 import (
 	"github.com/spf13/cobra"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 )
 
 var (
 	drDBCommand = &cobra.Command{
 		Use:   "dr-db",
 		Short: "Device Repository commands",
+		RunE:  commands.NeedSubcommandRunE,
 	}
 	drInitCommand = &cobra.Command{
 		Use:   "init",

--- a/cmd/ttn-lw-stack/commands/is_db.go
+++ b/cmd/ttn-lw-stack/commands/is_db.go
@@ -17,6 +17,7 @@ package commands
 import (
 	"github.com/jinzhu/gorm"
 	"github.com/spf13/cobra"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	"go.thethings.network/lorawan-stack/v3/pkg/identityserver/store"
 	"go.thethings.network/lorawan-stack/v3/pkg/identityserver/store/migrations"
 )
@@ -25,6 +26,7 @@ var (
 	isDBCommand = &cobra.Command{
 		Use:   "is-db",
 		Short: "Manage the Identity Server database",
+		RunE:  commands.NeedSubcommandRunE,
 	}
 	isDBInitCommand = &cobra.Command{
 		Use:   "init",

--- a/cmd/ttn-lw-stack/commands/ns_db.go
+++ b/cmd/ttn-lw-stack/commands/ns_db.go
@@ -21,6 +21,7 @@ import (
 	"github.com/go-redis/redis/v8"
 	"github.com/spf13/cobra"
 	"github.com/vmihailenco/msgpack/v5"
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	nsredis "go.thethings.network/lorawan-stack/v3/pkg/networkserver/redis"
 	ttnredis "go.thethings.network/lorawan-stack/v3/pkg/redis"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -31,6 +32,7 @@ var (
 	nsDBCommand = &cobra.Command{
 		Use:   "ns-db",
 		Short: "Manage Network Server database",
+		RunE:  commands.NeedSubcommandRunE,
 	}
 	nsDBPruneCommand = &cobra.Command{
 		Use:   "prune",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #4091 

#### Changes
<!-- What are the changes made in this pull request? -->

- Add a common `NeedSubcommandRunE` function, printing help message and returning an error
- Set `RunE` for all top-level commands of ttn-lw-cli and ttn-lw-stack to return an error. 

#### Testing

<!-- How did you verify that this change works? -->

Test locally

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Draft since this is not a too elegant solution, see https://github.com/TheThingsNetwork/lorawan-stack/issues/4091#issuecomment-832522696

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
