### PR TITLE
Return non-zero exit code on invalid commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Fixed
 
 - OAuth token exchange for OAuth clients that use Basic auth.
+- The CLI now properly returns a non-zero exit status code on invalid commands.
 
 ### Security
 

--- a/cmd/ttn-lw-cli/main.go
+++ b/cmd/ttn-lw-cli/main.go
@@ -24,11 +24,15 @@ import (
 )
 
 func main() {
-	if err := commands.Root.Execute(); err != nil {
+	cmd, err := commands.Root.ExecuteC()
+	if err != nil {
 		if errors.IsCanceled(err) {
 			os.Exit(130)
 		}
 		cli_errors.PrintStack(os.Stderr, err)
 		os.Exit(-1)
+	}
+	if cmd.Run == nil && cmd.RunE == nil {
+		os.Exit(2)
 	}
 }

--- a/cmd/ttn-lw-stack/main.go
+++ b/cmd/ttn-lw-stack/main.go
@@ -23,8 +23,12 @@ import (
 )
 
 func main() {
-	if err := commands.Root.Execute(); err != nil {
+	cmd, err := commands.Root.ExecuteC()
+	if err != nil {
 		errors.PrintStack(os.Stderr, err)
 		os.Exit(-1)
+	}
+	if cmd.Run == nil && cmd.RunE == nil {
+		os.Exit(2)
 	}
 }

--- a/tools/mage/go.go
+++ b/tools/mage/go.go
@@ -232,7 +232,7 @@ func (Go) TestBinaries() error {
 		fmt.Println("Testing Go binaries")
 	}
 	for _, binary := range goBinaries {
-		_, err := outputGo("run", binary, "--help")
+		_, err := outputGo("run", binary, "config")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #4091 

Replaces #4129, thanks @htdvisser for suggesting a much more elegant solution.

#### Changes
<!-- What are the changes made in this pull request? -->

- If `Run` and `RunE` are empty, no sub-command has been matched, so return a non-zero exit status code.

#### Testing

<!-- How did you verify that this change works? -->

Locally

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

There should not be any

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
