### PR TITLE
ns: Demote 'Transmission number exceeds maximum warning' to info

### DIFF
--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -339,7 +339,7 @@ func (ns *NetworkServer) matchAndHandleDataUplink(ctx context.Context, dev *ttnp
 						break
 					}
 					if nbTrans >= maxNbTrans {
-						log.FromContext(ctx).Warn("Transmission number exceeds maximum")
+						log.FromContext(ctx).Info("Transmission number exceeds maximum")
 						return nil, false, nil
 					}
 					nbTrans++


### PR DESCRIPTION
#### Summary
This PR changes the `Transmission number exceeds maximum warning` warning to an `INFO` message.

#### Changes
Changed warning to info

#### Testing
If this change compiles, it'll work.

##### Regressions
None

#### Notes for Reviewers
This message is a result of normal behavior of the stack. Having too many retransmissions is a normal occurrence, and users shouldn't be warned about this.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
