### PR TITLE
Fix OAuth token exchange for clients that use Basic auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- OAuth token exchange for OAuth clients that use Basic auth.
+
 ### Security
 
 ## [3.12.3] - 2021-05-06

--- a/pkg/oauth/oauth.go
+++ b/pkg/oauth/oauth.go
@@ -239,7 +239,10 @@ func (s *server) Token(c echo.Context) error {
 	if err := c.Bind(&tokenRequest); err != nil {
 		return err
 	}
-	if err := tokenRequest.ValidateContext(c.Request().Context()); err != nil {
+	if username, password, ok := req.BasicAuth(); ok {
+		tokenRequest.ClientID, tokenRequest.ClientSecret = username, password
+	}
+	if err := tokenRequest.ValidateContext(req.Context()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This fixes the token exchange flow for OAuth clients that use Basic Auth.

Refs https://github.com/TheThingsIndustries/lorawan-stack-support/issues/421

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
