### PR TITLE
Remove unused Application Server events

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -8396,24 +8396,6 @@
       "file": "observability.go"
     }
   },
-  "event:as.down.data.queue.invalid": {
-    "translations": {
-      "en": "invalid downlink data queue"
-    },
-    "description": {
-      "package": "pkg/applicationserver",
-      "file": "observability.go"
-    }
-  },
-  "event:as.down.data.queue.lost": {
-    "translations": {
-      "en": "lose downlink data queue"
-    },
-    "description": {
-      "package": "pkg/applicationserver",
-      "file": "observability.go"
-    }
-  },
   "event:as.down.data.receive": {
     "translations": {
       "en": "receive downlink data message"

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -994,6 +994,7 @@ func (as *ApplicationServer) handleDownlinkNack(ctx context.Context, ids ttnpb.E
 	}
 	_, err = as.deviceRegistry.Set(ctx, ids,
 		[]string{
+			"formatters",
 			"pending_session",
 			"session",
 			"skip_payload_crypto_override",
@@ -1015,7 +1016,7 @@ func (as *ApplicationServer) handleDownlinkNack(ctx context.Context, ids ttnpb.E
 			}
 
 			// Decrypt the message as it will be sent to upstream after handling it.
-			if err := as.decryptDownlinkMessage(ctx, ids, msg, link); err != nil {
+			if err := as.decryptAndDecodeDownlink(ctx, dev, msg, link.DefaultFormatters); err != nil {
 				return nil, nil, err
 			}
 

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -834,6 +834,11 @@ func (as *ApplicationServer) matchSession(ctx context.Context, ids ttnpb.EndDevi
 	return mask, nil
 }
 
+// storeUplink stores the provided *ttnpb.ApplicationUplink in the device uplink storage.
+// Only fields which are used by integrations are stored.
+// The fields which are stored are based on the following usages:
+// - io/packages/loragls/v3/package.go#multiFrameQuery
+// - io/packages/loragls/v3/api/objects.go#parseRxMetadata
 func (as *ApplicationServer) storeUplink(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, uplink *ttnpb.ApplicationUplink) error {
 	cleanUplink := &ttnpb.ApplicationUplink{
 		RxMetadata: make([]*ttnpb.RxMetadata, 0, len(uplink.RxMetadata)),

--- a/pkg/applicationserver/observability.go
+++ b/pkg/applicationserver/observability.go
@@ -114,16 +114,6 @@ var (
 		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
 		events.WithDataType(&ttnpb.ApplicationDownlink{}),
 	)
-	evtLostQueueDataDown = events.Define(
-		"as.down.data.queue.lost", "lose downlink data queue",
-		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
-		events.WithErrorDataType(),
-	)
-	evtInvalidQueueDataDown = events.Define(
-		"as.down.data.queue.invalid", "invalid downlink data queue",
-		events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
-		events.WithErrorDataType(),
-	)
 )
 
 const (


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/4126
References https://github.com/TheThingsNetwork/lorawan-stack/issues/2231#issuecomment-833586967
References https://github.com/TheThingsNetwork/lorawan-stack/pull/4127#discussion_r626644439

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove the `as.down.data.queue.invalid` and `as.down.data.queue.lost` events, as they are now not used.
- Document `as.storeUplink` in order to ensure we know actually why are we storing the fields in the first place.
- Replace `decryptDownlinkMessage` with `decryptAndDecodeDownlink` in order to avoid another registry `GET` on the device.