### PR TITLE
Generate release notes from CHANGELOG

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -107,7 +107,6 @@ This is a checklist for releases. This is filled in by both the releaser and the
 
 #### Post Release
 
-- [ ] Edit the release notes on the Github releases page, which is typically copied from `CHANGELOG.md`.
 - [ ] For non RC releases, push the Docker latest tag.
     ```bash
     $ versionDockerTag=${version#"v"} # v3.6.1 -> 3.6.1

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - 'v3.[0-9]+.[0-9]+'
-      - 'v3.[0-9]+.[0-9]+-rc[0-9]'
 
 env:
   NODE_ENV: production
@@ -72,15 +71,22 @@ jobs:
     - name: Determine date
       id: date
       run: echo "::set-output name=value::$(date +%Y-%m-%d)"
-    - name: Generate CHANGELOG reference
-      uses: actions/github-script@v2
-      id: changelog_reference
+    - name: Get version from tag
+      id: version
+      uses: actions/github-script@v3
       with:
-        result-encoding: string
         script: |
-          const tag = context.ref.slice('refs/tags/v'.length);
-          const tagParts = tag.split('.');
-          require('fs').writeFileSync('/tmp/release-notes.md', `[Release notes](https://github.com/TheThingsNetwork/lorawan-stack/blob/${tag}/CHANGELOG.md#${tagParts[0]}${tagParts[1]}${tagParts[2]}---${{ steps.date.outputs.value }})`);
+          const tag = context.ref.slice("refs/tags/".length);
+          const majorMinorPatchRegex = /^v([0-9]+)\.([0-9]+)\.([0-9]+)$/;
+          const majorMinorPatch = tag.match(majorMinorPatchRegex);
+          if (!majorMinorPatch) {
+            throw `invalid version tag: ${tag}`;
+          }
+          return majorMinorPatch[0].slice(1);
+        result-encoding: string
+    - name: Generate Release Notes
+      run: |
+        awk '/^## \[${{ steps.version.outputs.result }}\]/{flag=1;next} /^## \[/{flag=0} flag' CHANGELOG.md > /tmp/release-notes.md
     - name: Run Goreleaser
       uses: goreleaser/goreleaser-action@v2
       with:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

With this PR we should no longer have to edit the release notes on GitHub after a release. Instead, the release workflow will automatically select the right section from the CHANGELOG and use that.

#### Testing

<!-- How did you verify that this change works? -->

Not enough, because this only runs when we tag a release 😒 

- We know that the "Get version from tag" script works, because we use it in other workflows
- I tested the `awk` command locally

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

- If it errors, we can just fix it and re-tag.
- If it has incorrect output, we can still manually edit the release notes on GitHub.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
