### PR TITLE
Release multi-arch Docker images

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -19,6 +19,10 @@ jobs:
       with:
         fetch-depth: 0
         submodules: true
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
     - name: Login to Docker Hub
       uses: docker/login-action@v1
       with:

--- a/.goreleaser.release.yml
+++ b/.goreleaser.release.yml
@@ -211,12 +211,91 @@ dockers:
     binaries:
       - ttn-lw-cli
       - ttn-lw-stack
+    use_buildx: true
+    build_flag_templates:
+      - --platform=linux/amd64
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.vendor=The Things Network Foundation"
+      - "--label=org.opencontainers.image.title=The Things Stack"
+      - "--label=org.opencontainers.image.url=https://www.thethingsindustries.com/docs"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
     image_templates:
-      - 'thethingsnetwork/lorawan-stack:{{ .Major }}.{{ .Minor }}'
-      - 'thethingsnetwork/lorawan-stack:{{ .Version }}'
-      - 'ghcr.io/thethingsnetwork/lorawan-stack:{{ .Major }}.{{ .Minor }}'
-      - 'ghcr.io/thethingsnetwork/lorawan-stack:{{ .Version }}'
+      - 'thethingsnetwork/lorawan-stack:{{ .Major }}.{{ .Minor }}-amd64'
+      - 'thethingsnetwork/lorawan-stack:{{ .Version }}-amd64'
+      - 'ghcr.io/thethingsnetwork/lorawan-stack:{{ .Major }}.{{ .Minor }}-amd64'
+      - 'ghcr.io/thethingsnetwork/lorawan-stack:{{ .Version }}-amd64'
     skip_push: false
     extra_files:
       - data
       - public
+  - goos: linux
+    goarch: arm64
+    dockerfile: Dockerfile
+    binaries:
+      - ttn-lw-cli
+      - ttn-lw-stack
+    use_buildx: true
+    build_flag_templates:
+      - --platform=linux/arm64/v8
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.vendor=The Things Network Foundation"
+      - "--label=org.opencontainers.image.title=The Things Stack"
+      - "--label=org.opencontainers.image.url=https://www.thethingsindustries.com/docs"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    image_templates:
+      - 'thethingsnetwork/lorawan-stack:{{ .Major }}.{{ .Minor }}-arm64'
+      - 'thethingsnetwork/lorawan-stack:{{ .Version }}-arm64'
+      - 'ghcr.io/thethingsnetwork/lorawan-stack:{{ .Major }}.{{ .Minor }}-arm64'
+      - 'ghcr.io/thethingsnetwork/lorawan-stack:{{ .Version }}-arm64'
+    skip_push: false
+    extra_files:
+      - data
+      - public
+  - goos: linux
+    goarch: arm
+    goarm: 7
+    dockerfile: Dockerfile
+    binaries:
+      - ttn-lw-cli
+      - ttn-lw-stack
+    use_buildx: true
+    build_flag_templates:
+      - --platform=linux/arm/v7
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.vendor=The Things Network Foundation"
+      - "--label=org.opencontainers.image.title=The Things Stack"
+      - "--label=org.opencontainers.image.url=https://www.thethingsindustries.com/docs"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+    image_templates:
+      - 'thethingsnetwork/lorawan-stack:{{ .Major }}.{{ .Minor }}-armv7'
+      - 'thethingsnetwork/lorawan-stack:{{ .Version }}-armv7'
+      - 'ghcr.io/thethingsnetwork/lorawan-stack:{{ .Major }}.{{ .Minor }}-armv7'
+      - 'ghcr.io/thethingsnetwork/lorawan-stack:{{ .Version }}-armv7'
+    skip_push: false
+    extra_files:
+      - data
+      - public
+docker_manifests:
+  - name_template: thethingsnetwork/lorawan-stack:{{ .Major }}.{{ .Minor }}
+    image_templates:
+      - thethingsnetwork/lorawan-stack:{{ .Major }}.{{ .Minor }}-amd64
+      - thethingsnetwork/lorawan-stack:{{ .Major }}.{{ .Minor }}-arm64
+      - thethingsnetwork/lorawan-stack:{{ .Major }}.{{ .Minor }}-armv7
+  - name_template: thethingsnetwork/lorawan-stack:{{ .Version }}
+    image_templates:
+      - thethingsnetwork/lorawan-stack:{{ .Version }}-amd64
+      - thethingsnetwork/lorawan-stack:{{ .Version }}-arm64
+      - thethingsnetwork/lorawan-stack:{{ .Version }}-armv7
+  - name_template: ghcr.io/thethingsnetwork/lorawan-stack:{{ .Major }}.{{ .Minor }}
+    image_templates:
+      - ghcr.io/thethingsnetwork/lorawan-stack:{{ .Major }}.{{ .Minor }}-amd64
+      - ghcr.io/thethingsnetwork/lorawan-stack:{{ .Major }}.{{ .Minor }}-arm64
+      - ghcr.io/thethingsnetwork/lorawan-stack:{{ .Major }}.{{ .Minor }}-armv7
+  - name_template: ghcr.io/thethingsnetwork/lorawan-stack:{{ .Version }}
+    image_templates:
+      - ghcr.io/thethingsnetwork/lorawan-stack:{{ .Version }}-amd64
+      - ghcr.io/thethingsnetwork/lorawan-stack:{{ .Version }}-arm64
+      - ghcr.io/thethingsnetwork/lorawan-stack:{{ .Version }}-armv7

--- a/.goreleaser.snapshot.yml
+++ b/.goreleaser.snapshot.yml
@@ -70,7 +70,7 @@ dockers:
       - ttn-lw-cli
       - ttn-lw-stack
     build_flag_templates:
-      - --platform=linux/arm64
+      - --platform=linux/arm64/v8
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.vendor=The Things Network Foundation"
       - "--label=org.opencontainers.image.title=The Things Stack"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This updates the release workflow to create multi-arch Docker images including amd64, arm64 (that was already added to snapshots in #3986) and armv7 (for Raspberry Pi's).

#### Testing

<!-- How did you verify that this change works? -->

Most of this was already tested with the snapshots (#3986). The `docker_manifests` is new, and we don't really have a nice way of testing this without tagging a release.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

If this errors, we'd need to fix it and re-tag the release, which isn't ideal, but won't break production either.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
