### PR TITLE
Update widget container link style

### DIFF
--- a/pkg/webui/console/components/events/events.styl
+++ b/pkg/webui/console/components/events/events.styl
@@ -260,3 +260,6 @@ $event-container-height = 40px
 
   &-title
     font-weight: $fw.bold
+
+.body-link
+  color: inherit

--- a/pkg/webui/console/components/events/widget.js
+++ b/pkg/webui/console/components/events/widget.js
@@ -44,7 +44,7 @@ const EventsWidget = ({ toAllUrl, className, events, scoped, entityId }) => {
       linkMessage={m.seeAllActivity}
       className={className}
     >
-      <Link to={toAllUrl}>
+      <Link className={style.bodyLink} to={toAllUrl}>
         <div className={classnames(style.body, style.widgetContainer)} data-test-id="events-widget">
           {events.length === 0 ? (
             <EmptyMessage entityId={entityId} />


### PR DESCRIPTION
#### Summary

References #4116 

#### Changes

- Update widget container link style

Before:
![before_style](https://user-images.githubusercontent.com/72162194/117784182-f1907680-b24b-11eb-890e-df1c5f87d843.png)

After:
![after_style](https://user-images.githubusercontent.com/72162194/117784176-f05f4980-b24b-11eb-8adc-9a7015299652.png)




#### Testing

- Manually tested


#### Notes for Reviewers

- #4116 removed a class, that affected how links are displayed in widget. Reverting that change

#### Checklist

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
