### PR TITLE
Lower log level of missing class A downlink

### DIFF
--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -1178,7 +1178,7 @@ func (ns *NetworkServer) attemptClassADataDownlink(ctx context.Context, dev *ttn
 		)
 	}
 	if err != nil {
-		log.FromContext(ctx).WithError(err).Error("Failed to generate class A downlink, skip class A downlink slot")
+		log.FromContext(ctx).WithError(err).Warn("Failed to generate class A downlink, skip class A downlink slot")
 		if genState.ApplicationDownlink != nil {
 			dev.Session.QueuedApplicationDownlinks = append([]*ttnpb.ApplicationDownlink{genState.ApplicationDownlink}, dev.Session.QueuedApplicationDownlinks...)
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This lowers the log level of the `Failed to generate class A downlink, skip class A downlink slot` error to warning.

I think this occurs when the `ADRAckReq` / uplink acks are sent via the network initiated downlink slot (class B / class C), while the class A downlink slot is also available. 

Both tasks can exist concurrently, but if the class B / C tasks runs before the class A task, the class A task may have no work to do when it actually runs.