### PR TITLE
Revert rename of unique.ToClientID

### DIFF
--- a/pkg/unique/unique.go
+++ b/pkg/unique/unique.go
@@ -55,8 +55,8 @@ func ToApplicationID(uid string) (id ttnpb.ApplicationIdentifiers, err error) {
 	return id, nil
 }
 
-// ToClientId returns the client identifier of the specified unique ID.
-func ToClientId(uid string) (id ttnpb.ClientIdentifiers, err error) {
+// ToClientID returns the client identifier of the specified unique ID.
+func ToClientID(uid string) (id ttnpb.ClientIdentifiers, err error) {
 	id.ClientId = uid
 	if err := id.ValidateFields("client_id"); err != nil {
 		return ttnpb.ClientIdentifiers{}, errUniqueIdentifier.WithCause(err).WithAttributes("uid", uid)

--- a/pkg/unique/unique_test.go
+++ b/pkg/unique/unique_test.go
@@ -84,12 +84,12 @@ func TestRoundtrip(t *testing.T) {
 		{
 			ttnpb.ClientIdentifiers{ClientId: "foo"},
 			"foo",
-			func(uid string) (ttnpb.IDStringer, error) { return ToClientId(uid) },
+			func(uid string) (ttnpb.IDStringer, error) { return ToClientID(uid) },
 		},
 		{
 			&ttnpb.ClientIdentifiers{ClientId: "foo"},
 			"foo",
-			func(uid string) (ttnpb.IDStringer, error) { return ToClientId(uid) },
+			func(uid string) (ttnpb.IDStringer, error) { return ToClientID(uid) },
 		},
 		{
 			ttnpb.EndDeviceIdentifiers{
@@ -179,7 +179,7 @@ func TestValidatorForIdentifiers(t *testing.T) {
 		{
 			"ClientId",
 			func(uid string) ttnpb.IDStringer { return ttnpb.ClientIdentifiers{ClientId: uid} },
-			func(uid string) (ttnpb.IDStringer, error) { return ToClientId(uid) },
+			func(uid string) (ttnpb.IDStringer, error) { return ToClientID(uid) },
 		},
 		{
 			"GatewayID",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This reverts the rename of `unique.ToClientID` that accidentally landed in #4137.