### PR TITLE
Add previews for events with google.protobuf.Value data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For details about compatibility between different releases, see the **Commitment
 - Support for loading Device Repository profiles from different vendors if specified. This allows reusing standard end device profiles from module makers and LoRaWAN end device stack vendors.
 - Filtering out verbose events in the event views in the Console.
 - The `gs.up.forward` event now includes the host an uplink was forwarded to.
+- Previews for `*.update` events in the Console.
 
 ### Changed
 

--- a/pkg/webui/console/components/events/previews/value.js
+++ b/pkg/webui/console/components/events/previews/value.js
@@ -1,0 +1,39 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react'
+
+import PropTypes from '@ttn-lw/lib/prop-types'
+
+import DescriptionList from './shared/description-list'
+import JSONPayload from './shared/json-payload'
+
+const Value = React.memo(({ event }) => {
+  const { data } = event
+  return (
+    <DescriptionList>
+      {Array.isArray(data.value) || typeof data.value === 'object' ? (
+        <JSONPayload data={data.value} />
+      ) : (
+        <DescriptionList.Item value={data.value} />
+      )}
+    </DescriptionList>
+  )
+})
+
+Value.propTypes = {
+  event: PropTypes.event.isRequired,
+}
+
+export default Value

--- a/pkg/webui/console/components/events/utils/definitions.js
+++ b/pkg/webui/console/components/events/utils/definitions.js
@@ -22,6 +22,7 @@ import JoinRequest from '../previews/join-request'
 import JoinResponse from '../previews/join-response'
 import GatewayStatus from '../previews/gateway-status'
 import ErrorDetails from '../previews/error-details'
+import Value from '../previews/value'
 
 export const eventIconMap = [
   {
@@ -105,6 +106,7 @@ export const dataTypeMap = {
   JoinResponse,
   ErrorDetails,
   GatewayStatus,
+  Value,
 }
 
 export const applicationUpMessages = [


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This adds previews for event data of type `google.protobuf.Value`.

#### Testing

<!-- How did you verify that this change works? -->

Locally. It looks like this:

<img width="1280" alt="Screen Shot 2021-05-12 at 15 37 33" src="https://user-images.githubusercontent.com/181308/117984294-ffbbc100-b337-11eb-956f-b1b0ea6bbbac.png">

Note the `["description"]` for the "Update gateway" event, and the `cluster` for the "Forward uplink message" event.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
