### PR TITLE
Load historical events in the Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For details about compatibility between different releases, see the **Commitment
 - Filtering out verbose events in the event views in the Console.
 - The `gs.up.forward` event now includes the host an uplink was forwarded to.
 - Previews for `*.update` events in the Console.
+- The Console can now show recent historical events in networks that have events storage enabled.
 
 ### Changed
 

--- a/pkg/webui/console/constants/event-tail.js
+++ b/pkg/webui/console/constants/event-tail.js
@@ -1,0 +1,15 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export default 20

--- a/pkg/webui/console/store/middleware/logics/events.js
+++ b/pkg/webui/console/store/middleware/logics/events.js
@@ -112,9 +112,7 @@ const createEventsConnectLogics = (reducerName, entityName, onEventsStart) => {
         // Only get historical events emitted after the latest event in the
         // store to avoid duplicate historical events.
         const latestEvent = selectLatestEvent(getState(), id)
-        const after = Boolean(latestEvent)
-          ? new Date(Date.parse(latestEvent.time) + 1).toISOString()
-          : undefined
+        const after = Boolean(latestEvent) ? latestEvent.time : undefined
 
         try {
           channel = await onEventsStart([id], EVENT_TAIL, after)

--- a/pkg/webui/console/store/reducers/events.js
+++ b/pkg/webui/console/store/reducers/events.js
@@ -53,7 +53,7 @@ const MemoizedRegExp = memoize(RegExp)
 
 const addEvent = (state, event) => {
   const { events, filter } = state
-  const { paused, streamStartTime } = state
+  const { paused } = state
 
   if (paused && !event.name.startsWith('synthetic')) {
     return {}
@@ -73,12 +73,6 @@ const addEvent = (state, event) => {
   // timestamped before it. This is to avoid showing events before the synthetic
   // resumption event.
   if (events[0] && events[0].name === EVENT_STATUS_RESUMED && event.time < events[0].time) {
-    return {}
-  }
-
-  // When requesting historical events (with tail / after) it's possible that we
-  // still have some of those in the store, so we don't add them again.
-  if (event.time < streamStartTime && events.find(e => e.unique_id === event.unique_id)) {
     return {}
   }
 

--- a/pkg/webui/console/store/reducers/events.js
+++ b/pkg/webui/console/store/reducers/events.js
@@ -53,7 +53,7 @@ const MemoizedRegExp = memoize(RegExp)
 
 const addEvent = (state, event) => {
   const { events, filter } = state
-  const { paused } = state
+  const { paused, streamStartTime } = state
 
   if (paused && !event.name.startsWith('synthetic')) {
     return {}
@@ -73,6 +73,12 @@ const addEvent = (state, event) => {
   // timestamped before it. This is to avoid showing events before the synthetic
   // resumption event.
   if (events[0] && events[0].name === EVENT_STATUS_RESUMED && event.time < events[0].time) {
+    return {}
+  }
+
+  // When requesting historical events (with tail / after) it's possible that we
+  // still have some of those in the store, so we don't add them again.
+  if (event.time < streamStartTime && events.find(e => e.unique_id === event.unique_id)) {
     return {}
   }
 

--- a/pkg/webui/console/store/selectors/events.js
+++ b/pkg/webui/console/store/selectors/events.js
@@ -53,10 +53,10 @@ export const createEventsTruncatedSelector = entity => (state, entityId) => {
 export const createLatestEventSelector = entity => {
   const eventsSelector = createEventsSelector(entity)
 
-  const selectLatestEvent = (state, entityId) => {
+  const selectLatestEvent = (state, entityId, includeSynthetic = false) => {
     const events = eventsSelector(state, entityId)
 
-    return events[0]
+    return includeSynthetic ? events[0] : events.find(e => !e.isSynthetic)
   }
 
   return selectLatestEvent


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR makes the console load historical events.

This is a follow-up of https://github.com/TheThingsNetwork/lorawan-stack/pull/4084.

#### Changes
<!-- What are the changes made in this pull request? -->

- Request a tail of 10 events when starting the events stream
- Prevent duplicate events from getting stored (when opening/closing/opening the events stream while requesting history).

#### Testing

<!-- How did you verify that this change works? -->

Local testing:

<img width="1280" alt="Screen Shot 2021-05-12 at 16 27 35" src="https://user-images.githubusercontent.com/181308/117992178-00a42100-b33f-11eb-8325-d1dd085e3157.png">

Note that, while requesting a tail of 10, the verbosity filter hides some events, so we only see 7 events.

In https://github.com/TheThingsNetwork/lorawan-stack/pull/4084#issuecomment-828273930 @kschiffer was worried that something could go wrong when the `data` field of an event is missing (because it was evicted from the historical events cache). The "Receive uplink message" at 16:16:45 proves that this is not a problem. I also checked the code to make sure this won't crash:

https://github.com/TheThingsNetwork/lorawan-stack/blob/5d44e36897c921e864e3e05be5f68b6c9cf61d81/pkg/webui/console/components/events/utils/index.js#L49-L57

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
