### PR TITLE
Drop duplicate uplinks based on payload, frequency and antenna index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ For details about compatibility between different releases, see the **Commitment
 ### Changed
 
 - Low-level log messages from the `go-redis` library are printed only when the log level is set to `DEBUG`.
+- GS will discard repeated gateway uplink messages (often received due to buggy gateway forwarder implementations). A gateway uplink is considered to be repeated when it has the same payload, frequency and antenna index as the last one.
+  - The new `gs_uplink_repeated_total` metric counts how many repeated uplinks have been discarded.
+  - A `gs.up.repeat` event is emitted (once per minute maximum) for gateways that are stuck in a loop and forward the same uplink message.
 
 ### Deprecated
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -9026,6 +9026,15 @@
       "file": "observability.go"
     }
   },
+  "event:gs.up.repeat": {
+    "translations": {
+      "en": "received repeated uplink message from gateway"
+    },
+    "description": {
+      "package": "pkg/gatewayserver/io",
+      "file": "observability.go"
+    }
+  },
   "event:invitation.create": {
     "translations": {
       "en": "create invitation"

--- a/pkg/gatewayserver/io/io_internal_test.go
+++ b/pkg/gatewayserver/io/io_internal_test.go
@@ -1,0 +1,130 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io
+
+import (
+	"testing"
+
+	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+)
+
+func TestIsRepeatedUplink(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		this     *uplinkMessage
+		that     *uplinkMessage
+		repeated bool
+	}{
+		{
+			name: "Repeated",
+			this: &uplinkMessage{
+				payload:   []byte{1, 2, 3},
+				frequency: 1000000,
+				antennas:  []uint32{1},
+			},
+			that: &uplinkMessage{
+				payload:   []byte{1, 2, 3},
+				frequency: 1000000,
+				antennas:  []uint32{1},
+			},
+			repeated: true,
+		},
+		{
+			name: "DifferentFrequency",
+			this: &uplinkMessage{
+				payload:   []byte{1, 2, 3},
+				frequency: 1000000,
+			},
+			that: &uplinkMessage{
+				payload:   []byte{1, 2, 3},
+				frequency: 1100000,
+			},
+			repeated: false,
+		},
+		{
+			name: "DifferentAntenna",
+			this: &uplinkMessage{
+				payload:   []byte{1, 2, 3},
+				frequency: 1000000,
+				antennas:  []uint32{1},
+			},
+			that: &uplinkMessage{
+				payload:   []byte{1, 2, 3},
+				frequency: 1000000,
+				antennas:  []uint32{1, 2},
+			},
+			repeated: false,
+		},
+		{
+			name: "DifferentPayload",
+			this: &uplinkMessage{
+				payload:   []byte{1, 2, 4},
+				frequency: 1000000,
+				antennas:  []uint32{1},
+			},
+			that: &uplinkMessage{
+				payload:   []byte{1, 2, 3},
+				frequency: 1000000,
+				antennas:  []uint32{1},
+			},
+			repeated: false,
+		},
+		{
+			name: "DifferentPayloadSize",
+			this: &uplinkMessage{
+				payload:   []byte{1, 2},
+				frequency: 1000000,
+				antennas:  []uint32{1},
+			},
+			that: &uplinkMessage{
+				payload:   []byte{1, 2, 3},
+				frequency: 1000000,
+				antennas:  []uint32{1},
+			},
+			repeated: false,
+		},
+		{
+			name: "NilMessage",
+			this: nil,
+			that: &uplinkMessage{
+				payload:   []byte{1, 2, 3},
+				frequency: 1000000,
+			},
+			repeated: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := assertions.New(t)
+
+			a.So(isRepeatedUplink(tc.this, tc.that), should.Equal, tc.repeated)
+			a.So(isRepeatedUplink(tc.that, tc.this), should.Equal, tc.repeated)
+		})
+	}
+}
+
+func TestUplinkMessageFromProto(t *testing.T) {
+	a := assertions.New(t)
+	a.So(uplinkMessageFromProto(&ttnpb.UplinkMessage{
+		RawPayload: []byte{1, 2, 3},
+		Settings:   ttnpb.TxSettings{Frequency: 100000},
+		RxMetadata: []*ttnpb.RxMetadata{{AntennaIndex: 0}, {AntennaIndex: 3}},
+	}), should.Resemble, &uplinkMessage{
+		payload:   []byte{1, 2, 3},
+		frequency: 100000,
+		antennas:  []uint32{0, 3},
+	})
+}

--- a/pkg/gatewayserver/io/observability.go
+++ b/pkg/gatewayserver/io/observability.go
@@ -1,0 +1,66 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.thethings.network/lorawan-stack/v3/pkg/events"
+	"go.thethings.network/lorawan-stack/v3/pkg/metrics"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+)
+
+type messageMetrics struct {
+	repeatedUplinks *metrics.ContextualCounterVec
+}
+
+// Describe implements prometheus.Collector.
+func (m *messageMetrics) Describe(ch chan<- *prometheus.Desc) {
+	m.repeatedUplinks.Describe(ch)
+}
+
+// Collect implements prometheus.Collector.
+func (m *messageMetrics) Collect(ch chan<- prometheus.Metric) {
+	m.repeatedUplinks.Collect(ch)
+}
+
+var ioMetrics = &messageMetrics{
+	repeatedUplinks: metrics.NewContextualCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: "gs",
+			Name:      "uplink_repeated_total",
+			Help:      "Total number of repeated gateway uplinks",
+		},
+		[]string{"protocol"},
+	),
+}
+
+var evtRepeatUp = events.Define(
+	"gs.up.repeat", "received repeated uplink message from gateway",
+	events.WithVisibility(ttnpb.RIGHT_GATEWAY_TRAFFIC_READ),
+	events.WithDataType(&ttnpb.GatewayIdentifiers{}),
+)
+
+func registerRepeatUp(ctx context.Context, emitEvent bool, gtw *ttnpb.Gateway, protocol string) {
+	ioMetrics.repeatedUplinks.WithLabelValues(ctx, protocol).Inc()
+	if emitEvent {
+		events.Publish(evtRepeatUp.NewWithIdentifiersAndData(ctx, gtw, nil))
+	}
+}
+
+func init() {
+	metrics.MustRegister(ioMetrics)
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #4095 

#### Changes
<!-- What are the changes made in this pull request? -->

- Store the last uplink message received from an `*io.Connection`
- When a new uplink is received, compare it with the last stored message (payload, antenna index, freqeuency). Discard the message if it's a duplicate.

#### Testing

<!-- How did you verify that this change works? -->

Unit testing. Test locally and observe that normal traffic still goes through without issues.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

...

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@johanstokking The implementation follows the suggestion in #4095, but perhaps we should consider doing this in the `*io.Connection` side instead. This would prevent forwarding messages that we know will be discarded later. This is also related to the uplink count stats (with the current implementation, we count duplicate uplinks in the gateway stats.

@htdvisser `registerDropUplink` is _very_ chatty in this situation. Some ideas would be: (a) use a separate metric (b) emit an event only once per X seconds. What do you think?

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
