### PR TITLE
Use error codes for scripting runtime errors

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -7714,7 +7714,7 @@
   },
   "error:pkg/scripting/javascript:runtime": {
     "translations": {
-      "en": "runtime error"
+      "en": "{message}"
     },
     "description": {
       "package": "pkg/scripting/javascript",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This sets error codes for runtime and script errors, which get propagated back to the client.

This is now relevant since we have payload codec testing via gRPC so that we return proper (HTTP) error codes. This also alleviates our middleware from handling `Unknown` errors.

#### Changes
<!-- What are the changes made in this pull request? -->

- Use `Aborted` error codes where we used `Unknown` before
- Put the runtime error message in the error for better debugging

This isn't relevant for users so not updating the changelog.

#### Testing

<!-- How did you verify that this change works? -->

Unit testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
