### PR TITLE
Fix toasts getting stuck

### DIFF
--- a/pkg/webui/components/toast/index.js
+++ b/pkg/webui/components/toast/index.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import React from 'react'
-import { ToastContainer as Container, Slide } from 'react-toastify'
+import { ToastContainer as Container, cssTransition } from 'react-toastify'
 
 import PropTypes from '@ttn-lw/lib/prop-types'
 
@@ -49,7 +49,7 @@ class ToastContainer extends React.Component {
     pauseOnHover: true,
     closeOnClick: true,
     pauseOnFocusLoss: true,
-    transition: Slide,
+    transition: cssTransition({ enter: style.slideInRight, exit: style.slideOutRight }),
   }
 
   render() {

--- a/pkg/webui/components/toast/toast.styl
+++ b/pkg/webui/components/toast/toast.styl
@@ -20,3 +20,21 @@ div.toast
 
   .notification
     margin: 0
+
+.slide-in-right
+  animation: slide-in-right 0.5s cubic-bezier(0.230, 1.000, 0.320, 1.000) both
+
+.slide-out-right
+  animation: slide-in-right 0.5s cubic-bezier(0.230, 1.000, 0.320, 1.000) both reverse
+
+
+@keyframes slide-in-right
+  0%
+    -webkit-transform: translateX(70rem)
+    transform: translateX(70rem)
+    opacity: 0
+
+  100%
+    -webkit-transform: translateX(0)
+    transform: translateX(0)
+    opacity: 1


### PR DESCRIPTION
#### Summary
This quickfix will fix transitions within `<Toast />`, which currently causes toasts to hang.

#### Changes
- Use css transitions for toasts

#### Testing

Manual.

#### Notes for Reviewers
This came via the latest update of `react-toast`

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
