### PR TITLE
Remove hardware specific fields in LBS Router Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ For details about compatibility between different releases, see the **Commitment
   - The default cap is at 4KB, see the new `as.formatters.max-parameter-length` config option.
   - A maximum cap of 16KB per script is set at the API level.
   - This only prevents setting large payload formatter scripts for new devices and applications; it does not remove payload formatters from existing applications and devices. Scripts sourced from the Device Repository are not affected. See [issue #4053](https://github.com/TheThingsNetwork/lorawan-stack/issues/4053) for more context on this change.
+- LoRa Basics Station `router_config` message omits hardware specific fields.
 
 ### Deprecated
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -7460,6 +7460,15 @@
       "file": "lbslns.go"
     }
   },
+  "error:pkg/pfconfig/lbslns:invalid_key": {
+    "translations": {
+      "en": "key `{key}` invalid"
+    },
+    "description": {
+      "package": "pkg/pfconfig/lbslns",
+      "file": "lbslns.go"
+    }
+  },
   "error:pkg/pfconfig/shared:empty_gateway_server_address": {
     "translations": {
       "en": "gateway server address is empty"

--- a/pkg/gatewayserver/io/ws/ws_test.go
+++ b/pkg/gatewayserver/io/ws/ws_test.go
@@ -542,25 +542,16 @@ func TestVersion(t *testing.T) {
 					{7, 250, 0},
 					{0, 0, 0},
 				},
-				SX1301Config: []shared.SX1301Config{
+				SX1301Config: []pfconfig.LBSSX1301Config{
 					{
-						LoRaWANPublic: true,
-						ClockSource:   1,
-						AntennaGain:   0,
-						Radios: []shared.RFConfig{
+						Radios: []pfconfig.LBSRFConfig{
 							{
-								Enable:     true,
-								Frequency:  867500000,
-								TxEnable:   true,
-								RSSIOffset: -166,
+								Enable:    true,
+								Frequency: 867500000,
 							},
 							{
-								Enable:     true,
-								Frequency:  868500000,
-								TxEnable:   false,
-								TxFreqMin:  0,
-								TxFreqMax:  0,
-								RSSIOffset: -166,
+								Enable:    true,
+								Frequency: 868500000,
 							},
 						},
 						Channels: []shared.IFConfig{
@@ -575,7 +566,6 @@ func TestVersion(t *testing.T) {
 						},
 						LoRaStandardChannel: &shared.IFConfig{Enable: true, Radio: 0, IFValue: 800000, Bandwidth: 250000, SpreadFactor: 7, Datarate: 0},
 						FSKChannel:          &shared.IFConfig{Enable: true, Radio: 0, IFValue: 1300000, Bandwidth: 125000, SpreadFactor: 0, Datarate: 50000},
-						TxLUTConfigs:        []shared.TxLUTConfig{},
 					},
 				},
 			},
@@ -625,25 +615,16 @@ func TestVersion(t *testing.T) {
 				NoCCA:       true,
 				NoDwellTime: true,
 				NoDutyCycle: true,
-				SX1301Config: []shared.SX1301Config{
+				SX1301Config: []pfconfig.LBSSX1301Config{
 					{
-						LoRaWANPublic: true,
-						ClockSource:   1,
-						AntennaGain:   0,
-						Radios: []shared.RFConfig{
+						Radios: []pfconfig.LBSRFConfig{
 							{
-								Enable:     true,
-								Frequency:  867500000,
-								TxEnable:   true,
-								RSSIOffset: -166,
+								Enable:    true,
+								Frequency: 867500000,
 							},
 							{
-								Enable:     true,
-								Frequency:  868500000,
-								TxEnable:   false,
-								TxFreqMin:  0,
-								TxFreqMax:  0,
-								RSSIOffset: -166,
+								Enable:    true,
+								Frequency: 868500000,
 							},
 						},
 						Channels: []shared.IFConfig{
@@ -658,7 +639,6 @@ func TestVersion(t *testing.T) {
 						},
 						LoRaStandardChannel: &shared.IFConfig{Enable: true, Radio: 0, IFValue: 800000, Bandwidth: 250000, SpreadFactor: 7, Datarate: 0},
 						FSKChannel:          &shared.IFConfig{Enable: true, Radio: 0, IFValue: 1300000, Bandwidth: 125000, SpreadFactor: 0, Datarate: 50000},
-						TxLUTConfigs:        []shared.TxLUTConfig{},
 					},
 				},
 			},

--- a/pkg/pfconfig/lbslns/lbslbs_test.go
+++ b/pkg/pfconfig/lbslns/lbslbs_test.go
@@ -100,21 +100,16 @@ func TestGetRouterConfig(t *testing.T) {
 				NoCCA:       true,
 				NoDutyCycle: true,
 				NoDwellTime: true,
-				SX1301Config: []shared.SX1301Config{
+				SX1301Config: []LBSSX1301Config{
 					{
-						LoRaWANPublic: true,
-						ClockSource:   0,
-						AntennaGain:   0,
-						Radios: []shared.RFConfig{
+						Radios: []LBSRFConfig{
 							{
 								Enable:    true,
 								Frequency: 922300000,
-								TxEnable:  true,
 							},
 							{
 								Enable:    false,
 								Frequency: 923000000,
-								TxEnable:  false,
 							},
 						},
 						Channels: []shared.IFConfig{
@@ -175,21 +170,16 @@ func TestGetRouterConfig(t *testing.T) {
 					[3]int{8, 500, 0},
 					[3]int{7, 500, 0},
 				},
-				SX1301Config: []shared.SX1301Config{
+				SX1301Config: []LBSSX1301Config{
 					{
-						LoRaWANPublic: true,
-						ClockSource:   0,
-						AntennaGain:   0,
-						Radios: []shared.RFConfig{
+						Radios: []LBSRFConfig{
 							{
 								Enable:    true,
 								Frequency: 922300000,
-								TxEnable:  true,
 							},
 							{
 								Enable:    false,
 								Frequency: 923000000,
-								TxEnable:  false,
 							},
 						},
 						Channels: []shared.IFConfig{
@@ -303,21 +293,16 @@ func TestGetRouterConfigWithMultipleFP(t *testing.T) {
 				NoCCA:       true,
 				NoDutyCycle: true,
 				NoDwellTime: true,
-				SX1301Config: []shared.SX1301Config{
+				SX1301Config: []LBSSX1301Config{
 					{
-						LoRaWANPublic: true,
-						ClockSource:   0,
-						AntennaGain:   0,
-						Radios: []shared.RFConfig{
+						Radios: []LBSRFConfig{
 							{
 								Enable:    true,
 								Frequency: 924300000,
-								TxEnable:  true,
 							},
 							{
 								Enable:    false,
 								Frequency: 925000000,
-								TxEnable:  false,
 							},
 						},
 						Channels: []shared.IFConfig{
@@ -334,19 +319,14 @@ func TestGetRouterConfigWithMultipleFP(t *testing.T) {
 						FSKChannel:          &shared.IFConfig{Enable: false, Radio: 0, IFValue: 0, Bandwidth: 0, SpreadFactor: 0, Datarate: 0},
 					},
 					{
-						LoRaWANPublic: true,
-						ClockSource:   0,
-						AntennaGain:   0,
-						Radios: []shared.RFConfig{
+						Radios: []LBSRFConfig{
 							{
 								Enable:    true,
 								Frequency: 924300000,
-								TxEnable:  true,
 							},
 							{
 								Enable:    false,
 								Frequency: 925000000,
-								TxEnable:  false,
 							},
 						},
 						Channels: []shared.IFConfig{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Remove hardware specific fields in LBS Router Config

- Closes #2130 
- Refs; 
  - https://www.thethingsnetwork.org/forum/t/any-way-to-edit-the-ttnv3-gateway-global-conf-json/44847 
  - https://www.thethingsnetwork.org/forum/t/unable-to-connect-multitech-conduit-aep-to-ttn-v3/44257
  - https://www.thethingsnetwork.org/forum/t/multitech-conduit-ap-v3-basic-station/39612
- Potentially also addresses #1303 (needs testing)

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove hardware specific fields
- Testing

#### Testing

<!-- How did you verify that this change works? -->

UT and gateway testing

**Before** 
```
{"msgtype":"router_config","NetID":null,"JoinEui":null,"region":"EU863","hwspec":"sx1301/1","freq_range":[863000000,870000000],"DRs":[[12,125,0],[11,125,0],[10,125,0],[9,125,0],[8,125,0],[7,125,0],[7,250,0],[0,0,0],[0,0,0],[0,0,0],[0,0,0],[0,0,0],[0,0,0],[0,0,0],[0,0,0],[0,0,0]],"sx1301_conf":[{"lorawan_public":true,"clksrc":1,"antenna_gain":0,"radio_0":{"enable":true,"freq":867500000,"rssi_offset":-166,"tx_enable":true},"radio_1":{"enable":true,"freq":868500000,"rssi_offset":-166,"tx_enable":false},"chan_multiSF_0":{"enable":true,"radio":1,"if":-400000},"chan_multiSF_1":{"enable":true,"radio":1,"if":-200000},"chan_multiSF_2":{"enable":true,"radio":1,"if":0},"chan_multiSF_3":{"enable":true,"radio":0,"if":-400000},"chan_multiSF_4":{"enable":true,"radio":0,"if":-200000},"chan_multiSF_5":{"enable":true,"radio":0,"if":0},"chan_multiSF_6":{"enable":true,"radio":0,"if":200000},"chan_multiSF_7":{"enable":true,"radio":0,"if":400000},"chan_Lora_std":{"enable":true,"radio":1,"if":-200000,"bandwidth":250000,"spread_factor":7},"chan_FSK":{"enable":true,"radio":1,"if":300000,"bandwidth":125000,"datarate":50000}}],"nocca":true,"nodc":true,"nodwell":true,"MuxTime":1621329026.3940437}
```

**After**

```
{"msgtype":"router_config","NetID":null,"JoinEui":null,"region":"EU863","hwspec":"sx1301/1","freq_range":[863000000,870000000],"DRs":[[12,125,0],[11,125,0],[10,125,0],[9,125,0],[8,125,0],[7,125,0],[7,250,0],[0,0,0],[0,0,0],[0,0,0],[0,0,0],[0,0,0],[0,0,0],[0,0,0],[0,0,0],[0,0,0]],"sx1301_conf":[{"radio_0":{"enable":true,"freq":867500000},"radio_1":{"enable":true,"freq":868500000},"chan_multiSF_0":{"enable":true,"radio":1,"if":-400000},"chan_multiSF_1":{"enable":true,"radio":1,"if":-200000},"chan_multiSF_2":{"enable":true,"radio":1,"if":0},"chan_multiSF_3":{"enable":true,"radio":0,"if":-400000},"chan_multiSF_4":{"enable":true,"radio":0,"if":-200000},"chan_multiSF_5":{"enable":true,"radio":0,"if":0},"chan_multiSF_6":{"enable":true,"radio":0,"if":200000},"chan_multiSF_7":{"enable":true,"radio":0,"if":400000},"chan_Lora_std":{"enable":true,"radio":1,"if":-200000},"chan_FSK":{"enable":true,"radio":1,"if":300000}}],"nocca":true,"nodc":true,"nodwell":true,"MuxTime":1621348545.551693}
```

TTIG
```
1970-01-01 00:01:15.623 [TCE:VERB] Connecting to MUX...
1970-01-01 00:01:16.660 [TCE:VERB] Connected to MUX.
2021-05-19 07:57:29.909 [RAL:INFO] Lora gateway library version: Version: 5.0.1;
2021-05-19 07:57:29.912 [RAL:VERB] Connecting to device:
2021-05-19 07:57:29.914 [RAL:DEBU] X130x txlut table (0 entries)
2021-05-19 07:57:29.917 [RAL:VERB] X1301 rxrfchain 0: enable=1 freq=867.5MHz rssi_offset=-166.000000 type=2 tx_enable=1 tx_notch_freq=0
2021-05-19 07:57:29.929 [RAL:VERB] X1301 rxrfchain 1: enable=1 freq=868.5MHz rssi_offset=-166.000000 type=2 tx_enable=0 tx_notch_freq=0
2021-05-19 07:57:29.941 [RAL:VERB] X1301 ifchain  0: enable=1 rf_chain=1 freq=-400000 bandwidth=0 datarate=0 sync_word=0/0
2021-05-19 07:57:29.952 [RAL:VERB] X1301 ifchain  1: enable=1 rf_chain=1 freq=-200000 bandwidth=0 datarate=0 sync_word=0/0
2021-05-19 07:57:29.963 [RAL:VERB] X1301 ifchain  2: enable=1 rf_chain=1 freq=0 bandwidth=0 datarate=0 sync_word=0/0
2021-05-19 07:57:29.973 [RAL:VERB] X1301 ifchain  3: enable=1 rf_chain=0 freq=-400000 bandwidth=0 datarate=0 sync_word=0/0
2021-05-19 07:57:29.984 [RAL:VERB] X1301 ifchain  4: enable=1 rf_chain=0 freq=-200000 bandwidth=0 datarate=0 sync_word=0/0
2021-05-19 07:57:29.995 [RAL:VERB] X1301 ifchain  5: enable=1 rf_chain=0 freq=0 bandwidth=0 datarate=0 sync_word=0/0
2021-05-19 07:57:30.005 [RAL:VERB] X1301 ifchain  6: enable=1 rf_chain=0 freq=200000 bandwidth=0 datarate=0 sync_word=0/0
2021-05-19 07:57:30.016 [RAL:VERB] X1301 ifchain  7: enable=1 rf_chain=0 freq=400000 bandwidth=0 datarate=0 sync_word=0/0
2021-05-19 07:57:30.027 [RAL:VERB] X1301 ifchain  8: enable=1 rf_chain=1 freq=-200000 bandwidth=2 datarate=2 sync_word=0/0
2021-05-19 07:57:30.037 [RAL:VERB] X1301 ifchain  9: enable=1 rf_chain=1 freq=300000 bandwidth=3 datarate=50000 sync_word=0/0
2021-05-19 07:57:30.049 [RAL:VERB] X130x LBT not enabled
2021-05-19 07:57:30.054 [RAL:VERB] tation device:  (PP capture disabled)
INFO: FPGA supported features: [TX filter]  [pectral can]  [LBT]
2021-05-19 07:57:34.472 [RAL:VERB] Concentrator started (4s411ms)
2021-05-19 07:57:34.474 [2E:INFO] Configuring for region: EU863 -- 863.0MHz..870.0MHz
2021-05-19 07:57:34.477 [2E:VERB]   DR0  F12/BW125
2021-05-19 07:57:34.480 [2E:VERB]   DR1  F11/BW125
2021-05-19 07:57:34.484 [2E:VERB]   DR2  F10/BW125
2021-05-19 07:57:34.489 [2E:VERB]   DR3  F9/BW125
2021-05-19 07:57:34.494 [2E:VERB]   DR4  F8/BW125
2021-05-19 07:57:34.498 [2E:VERB]   DR5  F7/BW125
2021-05-19 07:57:34.503 [2E:VERB]   DR6  F7/BW250
2021-05-19 07:57:34.508 [2E:VERB]   DR7  FK
2021-05-19 07:57:34.512 [2E:VERB]   DR8  FK
2021-05-19 07:57:34.516 [2E:VERB]   DR9  FK
2021-05-19 07:57:34.520 [2E:VERB]   DR10 FK
2021-05-19 07:57:34.524 [2E:VERB]   DR11 FK
2021-05-19 07:57:34.529 [2E:VERB]   DR12 FK
2021-05-19 07:57:34.533 [2E:VERB]   DR13 FK
2021-05-19 07:57:34.537 [2E:VERB]   DR14 FK
2021-05-19 07:57:34.543 [2E:VERB]   DR15 FK
2021-05-19 07:57:34.545 [2E:VERB]   TX power: 16.0 dBm EIRP
2021-05-19 07:57:34.551 [2E:VERB]             27.0 dBm EIRP for 869.4MHz..869.65MHz
2021-05-19 07:57:34.558 [2E:VERB]   JoinEui list: 0 entries
2021-05-19 07:57:34.563 [2E:VERB]   NetID filter: FFFFFFFF-FFFFFFFF-FFFFFFFF-FFFFFFFF
2021-05-19 07:57:34.571 [2E:VERB]   Dev/test settings: nocca=1 nodc=1 nodwell=1
2021-05-19 07:57:34.586 [Y:DEBU]   Free Heap: 40008 (min=17672) wifi=5 mh=7 cups=8 tc=4
2021-05-19 07:57:36.690 [2E:VERB] RX 868.1MHz DR5 F7/BW125 snr=9.0 rssi=-79 xtime=0x4D0000005733E3 - updf mhdr=40 DevAddr=26001248 FCtrl=80 FCnt=4698 FOpts=[] 6649AC9A..6144 mic=-384521857 (21 bytes)
2021-05-19 07:57:39.589 [Y:DEBU]   Free Heap: 39648 (min=17672) wifi=5 mh=7 cups=8 tc=4
2021-05-19 07:57:41.053 [2E:VERB] RX 868.1MHz DR5 F7/BW125 snr=-3.2 rssi=-112 xtime=0x4D00000099D0E3 - updf mhdr=40 DevAddr=154E14BD FCtrl=80 FCnt=3067 FOpts=[] 0158E341..8C18 mic=1857193231 (60 bytes)
```

Multitech Conduit AEP (with FW 5.3.3)
```
2021-05-19 09:46:33.885 [TCE:VERB] Connecting to MUXS...
2021-05-19 09:46:33.911 [TCE:VERB] Connected to MUXS.
2021-05-19 09:46:33.915 [S2E:WARN] Feature not supported in production level code (router_config) - ignored: nocca
2021-05-19 09:46:33.915 [S2E:WARN] Feature not supported in production level code (router_config) - ignored: nodc
2021-05-19 09:46:33.915 [S2E:WARN] Feature not supported in production level code (router_config) - ignored: nodwell
2021-05-19 09:48:10.643 [RAL:INFO] Lora gateway library version: Version: 5.0.1-mts-7;
2021-05-19 09:48:10.689 [RAL:VERB] Connecting to device: /dev/spidev0.0
2021-05-19 09:48:10.689 [RAL:VERB] SX1301 txlut  0:  dig_gain=0 pa_gain=0 dac_gain=3 mix_gain=11 rf_power=-6
2021-05-19 09:48:10.689 [RAL:VERB] SX1301 txlut  1:  dig_gain=0 pa_gain=0 dac_gain=3 mix_gain=13 rf_power=-3
2021-05-19 09:48:10.689 [RAL:VERB] SX1301 txlut  2:  dig_gain=0 pa_gain=1 dac_gain=3 mix_gain=9 rf_power=0
2021-05-19 09:48:10.689 [RAL:VERB] SX1301 txlut  3:  dig_gain=0 pa_gain=1 dac_gain=3 mix_gain=10 rf_power=3
2021-05-19 09:48:10.689 [RAL:VERB] SX1301 txlut  4:  dig_gain=0 pa_gain=1 dac_gain=3 mix_gain=12 rf_power=6
2021-05-19 09:48:10.690 [RAL:VERB] SX1301 txlut  5:  dig_gain=0 pa_gain=2 dac_gain=3 mix_gain=10 rf_power=10
2021-05-19 09:48:10.690 [RAL:VERB] SX1301 txlut  6:  dig_gain=0 pa_gain=2 dac_gain=3 mix_gain=11 rf_power=11
2021-05-19 09:48:10.690 [RAL:VERB] SX1301 txlut  7:  dig_gain=0 pa_gain=2 dac_gain=3 mix_gain=11 rf_power=12
2021-05-19 09:48:10.690 [RAL:VERB] SX1301 txlut  8:  dig_gain=2 pa_gain=2 dac_gain=3 mix_gain=12 rf_power=13
2021-05-19 09:48:10.690 [RAL:VERB] SX1301 txlut  9:  dig_gain=0 pa_gain=2 dac_gain=3 mix_gain=13 rf_power=14
2021-05-19 09:48:10.690 [RAL:VERB] SX1301 txlut 10:  dig_gain=0 pa_gain=2 dac_gain=3 mix_gain=15 rf_power=16
2021-05-19 09:48:10.690 [RAL:VERB] SX1301 txlut 11:  dig_gain=0 pa_gain=3 dac_gain=3 mix_gain=10 rf_power=20
2021-05-19 09:48:10.690 [RAL:VERB] SX1301 txlut 12:  dig_gain=0 pa_gain=3 dac_gain=3 mix_gain=12 rf_power=23
2021-05-19 09:48:10.690 [RAL:VERB] SX1301 txlut 13:  dig_gain=0 pa_gain=3 dac_gain=3 mix_gain=13 rf_power=25
2021-05-19 09:48:10.690 [RAL:VERB] SX1301 txlut 14:  dig_gain=0 pa_gain=3 dac_gain=3 mix_gain=15 rf_power=26
2021-05-19 09:48:10.690 [RAL:VERB] SX1301 txlut 15:  dig_gain=0 pa_gain=3 dac_gain=3 mix_gain=15 rf_power=27
2021-05-19 09:48:10.691 [RAL:VERB] SX1301 rxrfchain 0: enable=1 freq=867.5MHz rssi_offset=-162.000000 type=2 tx_enable=1 tx_notch_freq=0
2021-05-19 09:48:10.691 [RAL:VERB] SX1301 rxrfchain 1: enable=1 freq=868.5MHz rssi_offset=-162.000000 type=2 tx_enable=0 tx_notch_freq=0
2021-05-19 09:48:10.691 [RAL:VERB] SX1301 ifchain  0: enable=1 rf_chain=1 freq=-400000 bandwidth=0 datarate=0 sync_word=0/0
2021-05-19 09:48:10.691 [RAL:VERB] SX1301 ifchain  1: enable=1 rf_chain=1 freq=-200000 bandwidth=0 datarate=0 sync_word=0/0
2021-05-19 09:48:10.691 [RAL:VERB] SX1301 ifchain  2: enable=1 rf_chain=1 freq=0 bandwidth=0 datarate=0 sync_word=0/0
2021-05-19 09:48:10.692 [RAL:VERB] SX1301 ifchain  3: enable=1 rf_chain=0 freq=-400000 bandwidth=0 datarate=0 sync_word=0/0
2021-05-19 09:48:10.692 [RAL:VERB] SX1301 ifchain  4: enable=1 rf_chain=0 freq=-200000 bandwidth=0 datarate=0 sync_word=0/0
2021-05-19 09:48:10.692 [RAL:VERB] SX1301 ifchain  5: enable=1 rf_chain=0 freq=0 bandwidth=0 datarate=0 sync_word=0/0
2021-05-19 09:48:10.692 [RAL:VERB] SX1301 ifchain  6: enable=1 rf_chain=0 freq=200000 bandwidth=0 datarate=0 sync_word=0/0
2021-05-19 09:48:10.692 [RAL:VERB] SX1301 ifchain  7: enable=1 rf_chain=0 freq=400000 bandwidth=0 datarate=0 sync_word=0/0
2021-05-19 09:48:10.692 [RAL:VERB] SX1301 ifchain  8: enable=1 rf_chain=1 freq=-200000 bandwidth=2 datarate=2 sync_word=0/0
2021-05-19 09:48:10.692 [RAL:VERB] SX1301 ifchain  9: enable=1 rf_chain=1 freq=300000 bandwidth=3 datarate=50000 sync_word=0/0
2021-05-19 09:48:10.693 [RAL:VERB] SX130x LBT not enabled
2021-05-19 09:48:10.693 [RAL:VERB] Station device: /dev/spidev0.0 (PPS capture enabled)
2021-05-19 09:48:13.725 [RAL:VERB] Concentrator started (3s31ms)
2021-05-19 09:48:13.725 [S2E:INFO] Configuring for region: EU863 -- 863.0MHz..870.0MHz
2021-05-19 09:48:13.726 [S2E:VERB]   DR0  SF12/BW125
2021-05-19 09:48:13.726 [S2E:VERB]   DR1  SF11/BW125
2021-05-19 09:48:13.726 [S2E:VERB]   DR2  SF10/BW125
2021-05-19 09:48:13.726 [S2E:VERB]   DR3  SF9/BW125
2021-05-19 09:48:13.726 [S2E:VERB]   DR4  SF8/BW125
2021-05-19 09:48:13.726 [S2E:VERB]   DR5  SF7/BW125
2021-05-19 09:48:13.726 [S2E:VERB]   DR6  SF7/BW250
2021-05-19 09:48:13.726 [S2E:VERB]   DR7  FSK
2021-05-19 09:48:13.726 [S2E:VERB]   DR8  FSK
2021-05-19 09:48:13.726 [S2E:VERB]   DR9  FSK
2021-05-19 09:48:13.726 [S2E:VERB]   DR10 FSK
2021-05-19 09:48:13.727 [S2E:VERB]   DR11 FSK
2021-05-19 09:48:13.727 [S2E:VERB]   DR12 FSK
2021-05-19 09:48:13.727 [S2E:VERB]   DR13 FSK
2021-05-19 09:48:13.727 [S2E:VERB]   DR14 FSK
2021-05-19 09:48:13.727 [S2E:VERB]   DR15 FSK
2021-05-19 09:48:13.727 [S2E:VERB]   TX power: 16.0 dBm EIRP
2021-05-19 09:48:13.727 [S2E:VERB]             27.0 dBm EIRP for 869.4MHz..869.65MHz
2021-05-19 09:48:13.727 [S2E:VERB]   JoinEui list: 0 entries
2021-05-19 09:48:13.727 [S2E:VERB]   NetID filter: FFFFFFFF-FFFFFFFF-FFFFFFFF-FFFFFFFF
2021-05-19 09:48:13.727 [S2E:VERB]   Dev/test settings: nocca=0 nodc=0 nodwell=0
2021-05-19 09:48:18.923 [S2E:VERB] RX 867.7MHz DR0 SF12/BW125 snr=-14.5 rssi=-115 xtime=0x440000007491BC - updf mhdr=40 DevAddr=26012EB3 FCtrl=80 FCnt=34845 FOpts=[] 010A2DA5..82F1 mic=384054224 (25 bytes)
2021-05-19 09:48:55.761 [SYN:INFO] MCU/SX130X drift stats: min: -5.7ppm  q50: -12.8ppm  q80: +26.2ppm  max: -72.8ppm - threshold q90: -54.2ppm
2021-05-19 09:48:55.762 [SYN:INFO] Mean MCU drift vs SX130X#0: -11.8ppm
2021-05-19 09:48:56.162 [S2E:VERB] RX 867.1MHz DR5 SF7/BW125 snr=-3.5 rssi=-116 xtime=0x44000002AD1C3B - updf mhdr=40 DevAddr=26001A76 FCtrl=80 FCnt=20744 FOpts=[] 0105 mic=1013809990 (14 bytes)
2021-05-19 09:49:02.228 [S2E:VERB] RX 867.5MHz DR5 SF7/BW125 snr=-1.5 rssi=-115 xtime=0x4400000309E154 - updf mhdr=40 DevAddr=26001A76 FCtrl=80 FCnt=20744 FOpts=[] 0105 mic=1013809990 (14 bytes)
2021-05-19 09:49:08.316 [S2E:VERB] RX 868.3MHz DR5 SF7/BW125 snr=-1.8 rssi=-114 xtime=0x4400000366A6FB - updf mhdr=40 DevAddr=26001A76 FCtrl=80 FCnt=20744 FOpts=[] 0105 mic=1013809990 (14 bytes)
2021-05-19 09:49:14.677 [SYN:INFO] Time sync qualities: min=252 q90=313 max=531 (previous q90=2147483647)
2021-05-19 09:49:37.794 [SYN:INFO] MCU/SX130X drift stats: min: -2.4ppm  q50: -12.8ppm  q80: -15.2ppm  max: -17.6ppm - threshold q90: -16.7ppm
2021-05-19 09:49:37.794 [SYN:INFO] Mean MCU drift vs SX130X#0: -11.7ppm
```

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Tested for regressions.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Ref: 
- https://doc.sm.tc/station/gw_v1.5.html
- https://doc.sm.tc/station/gw_v2.html#sx1301conf-object
- https://doc.sm.tc/station/gw_v2.html?highlight=sx1301conf

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
