### PR TITLE
Fix out of memory issues for device import in the Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ For details about compatibility between different releases, see the **Commitment
 - The CLI now properly returns a non-zero exit status code on invalid commands.
 - Gateway connection requests with zero EUI are rejected.
 - End device payload formatter reset to `FORMATTER_NONE` in the Console.
+- Memory issues when importing end devices in the Console.
 
 ### Security
 

--- a/pkg/webui/components/code-editor/index.js
+++ b/pkg/webui/components/code-editor/index.js
@@ -18,6 +18,7 @@ import classnames from 'classnames'
 import bind from 'autobind-decorator'
 
 import PropTypes from '@ttn-lw/lib/prop-types'
+import combineRefs from '@ttn-lw/lib/combine-refs'
 
 import 'brace/mode/javascript'
 import 'brace/mode/json'
@@ -32,6 +33,7 @@ class CodeEditor extends React.Component {
     commands: PropTypes.arrayOf(PropTypes.shape({})),
     /** See `https://github.com/ajaxorg/ace/wiki/Configuring-Ace`. */
     editorOptions: PropTypes.shape({}),
+    editorRef: PropTypes.shape({ current: PropTypes.shape({}) }),
     /** The height of the editor. */
     height: PropTypes.string,
     /** The language to highlight. */
@@ -74,6 +76,7 @@ class CodeEditor extends React.Component {
     scrollToBottom: false,
     showGutter: true,
     value: '',
+    editorRef: null,
   }
 
   constructor(props) {
@@ -131,6 +134,7 @@ class CodeEditor extends React.Component {
       minLines,
       maxLines,
       commands,
+      editorRef,
     } = this.props
 
     const { focus } = this.state
@@ -180,7 +184,7 @@ class CodeEditor extends React.Component {
           onBlur={this.onBlur}
           editorProps={{ $blockScrolling: Infinity }}
           commands={commands}
-          ref={this.aceRef}
+          ref={editorRef ? combineRefs([this.aceRef, editorRef]) : this.aceRef}
         />
       </div>
     )

--- a/pkg/webui/components/input/index.js
+++ b/pkg/webui/components/input/index.js
@@ -21,6 +21,7 @@ import Icon from '@ttn-lw/components/icon'
 import Spinner from '@ttn-lw/components/spinner'
 import Button from '@ttn-lw/components/button'
 
+import combineRefs from '@ttn-lw/lib/combine-refs'
 import PropTypes from '@ttn-lw/lib/prop-types'
 
 import ByteInput from './byte'
@@ -28,20 +29,6 @@ import Toggled from './toggled'
 import Generate from './generate'
 
 import style from './input.styl'
-
-/**
- * Merges multiple refs.
- *
- * @param {Array<object>} refs - A list of refs to be merged.
- * @returns {Function} - The ref callback with the DOM element that is assigned to every ref in `refs`.
- */
-const mergeRefs = refs => val => {
-  refs.forEach(ref => {
-    if (typeof ref === 'object') {
-      ref.current = val
-    }
-  })
-}
 
 class Input extends React.Component {
   static propTypes = {
@@ -214,7 +201,7 @@ class Input extends React.Component {
     const passedProps = {
       ...rest,
       ...(type === 'byte' ? { showPerChar } : {}),
-      ref: inputRef ? mergeRefs([this.input, inputRef]) : this.input,
+      ref: inputRef ? combineRefs([this.input, inputRef]) : this.input,
     }
 
     return (

--- a/pkg/webui/lib/combine-refs.js
+++ b/pkg/webui/lib/combine-refs.js
@@ -1,0 +1,29 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Combines multiple refs.
+ *
+ * @param {Array<object>} refs - A list of refs to be merged.
+ * @returns {Function} - The ref callback with the DOM element that is assigned to every ref in `refs`.
+ */
+const combineRefs = refs => val => {
+  refs.forEach(ref => {
+    if (typeof ref === 'object') {
+      ref.current = val
+    }
+  })
+}
+
+export default combineRefs


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/4178

#### Changes
<!-- What are the changes made in this pull request? -->

- Reset code-editor `undoManager` for device import
- Some small clean up


#### Testing

<!-- How did you verify that this change works? -->

Manual


#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The issue is caused by `ace-editor` persisting all values in memory to allow undo/redo functionality within the editor. With this fix in place I was able to import 600 devices without any issues/crashes and not exceeding 400mb of memory.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
