### PR TITLE
Handle non-UTF8 payloads in DTC

### DIFF
--- a/pkg/devicetemplates/tts.go
+++ b/pkg/devicetemplates/tts.go
@@ -21,6 +21,7 @@ import (
 	pbtypes "github.com/gogo/protobuf/types"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	ttnio "go.thethings.network/lorawan-stack/v3/pkg/util/io"
+	"golang.org/x/net/html/charset"
 )
 
 // TTS is the device template converter id.
@@ -40,6 +41,11 @@ func (t *tts) Format() *ttnpb.EndDeviceTemplateFormat {
 // Convert implements the devicetemplates.Converter interface.
 func (t *tts) Convert(ctx context.Context, r io.Reader, ch chan<- *ttnpb.EndDeviceTemplate) error {
 	defer close(ch)
+
+	r, err := charset.NewReader(r, "application/json")
+	if err != nil {
+		return err
+	}
 
 	dec := ttnio.NewJSONDecoder(r)
 	for {

--- a/pkg/util/io/io.go
+++ b/pkg/util/io/io.go
@@ -45,12 +45,12 @@ func NewJSONDecoder(r io.Reader) Decoder {
 }
 
 func (r *jsonDecoder) Decode(data interface{}) (paths []string, err error) {
-	t, err := r.rd.ReadByte()
+	t, _, err := r.rd.ReadRune()
 	if err != nil {
 		return nil, err
 	}
 	if t == '{' {
-		if err := r.rd.UnreadByte(); err != nil {
+		if err := r.rd.UnreadRune(); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This quickfix PR allows the `tts` end device template format to handle non-UTF8 encoded payloads. Such payloads may come from a Windows operating system, where encodings such as UTF16-LE are used.