### PR TITLE
Evict invalidated downlink queue on DonwlinkQueueInvalidated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Downlink queue eviction on FCnt mismatch.
 - End device payload formatter view crashing in the Console.
 - End device overview frequently crashing in the Console.
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/pull/2754

Evict the current downlink queue if a successful scheduling attempt has caused a `DownlinkQueueInvalidated` event.

#### Changes
<!-- What are the changes made in this pull request? -->

- Evict the downlink queue when a successful scheduling attempt has caused a `DownlinkQueueInvalidated` event. I thought we were already doing this, but this does not happen when the invalidation is caused by a network (`FPort=0`) downlink.
- Do not partition `dev.Session.QueuedApplicationDownlinks`. It is not possible to have in `dev.Session` downlinks whose `SessionKeyID` differs from `dev.Session.SessionKeyID`, as the downlinks are partitioned when pushed/replaced. This is code that's from the 'one queue to rule them all' era.
- If the application downlink does not fit the frame due to the presence of `FOpts`, skip the whole downlink queue. Otherwise we may append the following downlinks twice.

#### Testing

<!-- How did you verify that this change works? -->

Original patch has been tested on a production environment.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Application downlink queue invalidations are affected by this, but the queue itself is already quite broken.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
