### PR TITLE
Fix device overview fetching prop

### DIFF
--- a/pkg/webui/console/store/reducers/events.js
+++ b/pkg/webui/console/store/reducers/events.js
@@ -16,6 +16,7 @@ import { memoize } from 'lodash'
 
 import EVENT_STORE_LIMIT from '@console/constants/event-store-limit'
 import { EVENT_VERBOSE_FILTERS_REGEXP, EVENT_FILTER_MAP } from '@console/constants/event-filters'
+import CONNECTION_STATUS from '@console/constants/connection-status'
 
 import { getCombinedDeviceId } from '@ttn-lw/lib/selectors/id'
 
@@ -44,8 +45,6 @@ import {
   createClearEventsActionType,
   createSetEventsFilterActionType,
 } from '@console/store/actions/events'
-
-import CONNECTION_STATUS from '../../constants/connection-status'
 
 // Use memoized RegExp constructor to prevent costly instantiations since
 // filters are stored as strings and need to be converted for each event.

--- a/pkg/webui/console/store/selectors/events.js
+++ b/pkg/webui/console/store/selectors/events.js
@@ -12,18 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const selectEventsStore = (state, entityId) => state[entityId]
+import CONNECTION_STATUS from '@console/constants/connection-status'
+
+const selectEventsStore = (state, entityId) => state[entityId] || {}
 
 export const createEventsSelector = entity => (state, entityId) => {
   const store = selectEventsStore(state.events[entity], entityId)
 
-  return store ? store.events : []
+  return store.events || []
 }
 
 export const createEventsStatusSelector = entity => (state, entityId) => {
   const store = selectEventsStore(state.events[entity], entityId)
 
-  return store ? store.status : 'unknown'
+  return store.status || CONNECTION_STATUS.UNKNOWN
 }
 
 export const createEventsPausedSelector = entity => (state, entityId) => {
@@ -41,7 +43,7 @@ export const createEventsInterruptedSelector = entity => (state, entityId) => {
 export const createEventsErrorSelector = entity => (state, entityId) => {
   const store = selectEventsStore(state.events[entity], entityId)
 
-  return store ? store.error : undefined
+  return store.error
 }
 
 export const createEventsTruncatedSelector = entity => (state, entityId) => {


### PR DESCRIPTION
#### Summary
This quickfix PR fixes the end device overview crashing frequently when navigating to it due to a faulty fetching prop calculation.

#### Changes
- Fix the fetching state calculation for the data fetching of end devices
- Make event selectors more resilient
- Replace hard coded `unknown` value for connection statuses with value from constant module

#### Testing

Manual testing

#### Notes for Reviewers
Note that the issue was caused by the fetching calculation [being done using a `&&` instead of `||`](https://github.com/TheThingsNetwork/lorawan-stack/pull/4125/files#diff-8bce320369979944dafa7a4d096b83f464cdf14c58d2b76344d57839d64cb4fcR79) (cc @asmulko) causing the fetching state to be resolved too early and thus loading futher components without available data. I've noticed that we don't really account for the event stream being initialized only after the end device data is fetched which should be rare but theoretically possible. I've added this to the fetching calculation accordingly.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
