### PR TITLE
Fix device payload formatter view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- End device payload formatter view crashing in the Console.
+- End device overview frequently crashing in the Console.
+
 ### Security
 
 ## [3.13.0] - 2021-05-20

--- a/pkg/webui/console/store/reducers/events.js
+++ b/pkg/webui/console/store/reducers/events.js
@@ -16,6 +16,7 @@ import { memoize } from 'lodash'
 
 import EVENT_STORE_LIMIT from '@console/constants/event-store-limit'
 import { EVENT_VERBOSE_FILTERS_REGEXP, EVENT_FILTER_MAP } from '@console/constants/event-filters'
+import CONNECTION_STATUS from '@console/constants/connection-status'
 
 import { getCombinedDeviceId } from '@ttn-lw/lib/selectors/id'
 
@@ -44,8 +45,6 @@ import {
   createClearEventsActionType,
   createSetEventsFilterActionType,
 } from '@console/store/actions/events'
-
-import CONNECTION_STATUS from '../../constants/connection-status'
 
 // Use memoized RegExp constructor to prevent costly instantiations since
 // filters are stored as strings and need to be converted for each event.

--- a/pkg/webui/console/store/selectors/events.js
+++ b/pkg/webui/console/store/selectors/events.js
@@ -12,18 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const selectEventsStore = (state, entityId) => state[entityId]
+import CONNECTION_STATUS from '@console/constants/connection-status'
+
+const selectEventsStore = (state, entityId) => state[entityId] || {}
 
 export const createEventsSelector = entity => (state, entityId) => {
   const store = selectEventsStore(state.events[entity], entityId)
 
-  return store ? store.events : []
+  return store.events || []
 }
 
 export const createEventsStatusSelector = entity => (state, entityId) => {
   const store = selectEventsStore(state.events[entity], entityId)
 
-  return store ? store.status : 'unknown'
+  return store.status || CONNECTION_STATUS.UNKNOWN
 }
 
 export const createEventsPausedSelector = entity => (state, entityId) => {
@@ -41,7 +43,7 @@ export const createEventsInterruptedSelector = entity => (state, entityId) => {
 export const createEventsErrorSelector = entity => (state, entityId) => {
   const store = selectEventsStore(state.events[entity], entityId)
 
-  return store ? store.error : undefined
+  return store.error
 }
 
 export const createEventsTruncatedSelector = entity => (state, entityId) => {

--- a/pkg/webui/console/views/device-payload-formatters/index.js
+++ b/pkg/webui/console/views/device-payload-formatters/index.js
@@ -21,7 +21,6 @@ import Breadcrumb from '@ttn-lw/components/breadcrumbs/breadcrumb'
 import Tab from '@ttn-lw/components/tabs'
 
 import NotFoundRoute from '@ttn-lw/lib/components/not-found-route'
-import withRequest from '@ttn-lw/lib/components/with-request'
 
 import DeviceUplinkPayloadFormatters from '@console/containers/device-payload-formatters/uplink'
 import DeviceDownlinkPayloadFormatters from '@console/containers/device-payload-formatters/downlink'
@@ -29,32 +28,15 @@ import DeviceDownlinkPayloadFormatters from '@console/containers/device-payload-
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 import PropTypes from '@ttn-lw/lib/prop-types'
 
-import { getApplicationLink } from '@console/store/actions/link'
-
-import {
-  selectApplicationLink,
-  selectApplicationLinkFetching,
-  selectSelectedApplicationId,
-} from '@console/store/selectors/applications'
+import { selectSelectedApplicationId } from '@console/store/selectors/applications'
 import { selectSelectedDeviceId } from '@console/store/selectors/devices'
 
 import style from './device-payload-formatters.styl'
 
-@connect(
-  state => {
-    const link = selectApplicationLink(state)
-    const fetching = selectApplicationLinkFetching(state)
-
-    return {
-      appId: selectSelectedApplicationId(state),
-      devId: selectSelectedDeviceId(state),
-      fetching: fetching || !link,
-    }
-  },
-  {
-    getApplicationLink,
-  },
-)
+@connect(state => ({
+  appId: selectSelectedApplicationId(state),
+  devId: selectSelectedDeviceId(state),
+}))
 @withBreadcrumb('device.single.payload-formatters', props => {
   const { appId, devId } = props
   return (
@@ -64,7 +46,6 @@ import style from './device-payload-formatters.styl'
     />
   )
 })
-@withRequest(({ getApplicationLink, appId }) => getApplicationLink(appId, ['default_formatters']))
 export default class DevicePayloadFormatters extends Component {
   static propTypes = {
     match: PropTypes.match.isRequired,


### PR DESCRIPTION
#### Summary
This quickfix fixes the payload formatter view for end devices, which is currently crashing.

#### Changes
- Remove application link request from payload formatter view component
  - Application link infos are already fetched higher up the component hierarchy [on the device entity level](https://github.com/TheThingsNetwork/lorawan-stack/blob/v3.13/pkg/webui/console/views/device/index.js#L86): https://github.com/TheThingsNetwork/lorawan-stack/pull/4125 

#### Testing

Manual testing and e2es

#### Notes for Reviewers
This has been introduced via #4125, which [added a request for the application link info on the device entity level](https://github.com/TheThingsNetwork/lorawan-stack/blob/v3.13/pkg/webui/console/views/device/index.js#L86). With the payload formatter view also launching an application link request the `withRequest()`'s in the component tree would cause endless fetching loops.

I'm not sure how this sneaked through the e2es... Likely connected to skipping some e2es before #4185 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
