### PR TITLE
Use event time as fallback for "last seen"

### DIFF
--- a/pkg/webui/console/store/reducers/applications.js
+++ b/pkg/webui/console/store/reducers/applications.js
@@ -89,7 +89,7 @@ const applications = (state = defaultState, { type, payload, event }) => {
       }
     case GET_APP_EVENT_MESSAGE_SUCCESS:
       if (heartbeatFilterRegExp.test(event.name)) {
-        const lastSeen = getByPath(event, 'data.received_at')
+        const lastSeen = getByPath(event, 'data.received_at') || event.time
         const id = getApplicationId(event.identifiers[0].device_ids)
 
         // Update the application's derived last seen value, if the current


### PR DESCRIPTION
#### Summary
This quickfix PR makes the Console use the `event.time` as a fallback for determining the "last seen" information for applications.

#### Changes
- Use `event.time` as fallback for derived `lastSeen` value of applications

#### Testing

Manual

#### Notes for Reviewers

This is necessary because historical data does not always contain the `event.data`, depending on the retention settings. If the event data is not present, the next best thing is to use the timestamp of the event itself, which, under normal circumstances, should be only milliseconds apart.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
