### PR TITLE
util: Fix task invocation counter

### DIFF
--- a/pkg/component/tasks.go
+++ b/pkg/component/tasks.go
@@ -152,8 +152,7 @@ func DefaultStartTask(conf *TaskConfig) {
 				done()
 			}
 		}()
-		invocation := uint(1)
-		for {
+		for invocation := uint(1); ; invocation++ {
 			if invocation == 0 {
 				logger.Warn("Invocation count rollover detected")
 				invocation = 1
@@ -195,7 +194,6 @@ func DefaultStartTask(conf *TaskConfig) {
 				return
 			case <-time.After(s):
 			}
-			invocation++
 		}
 	}()
 }


### PR DESCRIPTION
#### Summary
The `invocation` counter wouldn't always be incremented. Consider this code:

```
package main

import (
	"context"
	"time"

	"go.thethings.network/lorawan-stack/v3/pkg/component"
)

func main() {
	ctx, cancel := context.WithCancel(context.Background())
	counter := 0
	bo := component.TaskBackoffConfig{
		0.0,
		func(ctx context.Context, executionDuration time.Duration, invocation uint, err error) time.Duration {
			counter++
			print(invocation)
			print("\n")
			return 0
		},
	}
	tc := component.TaskConfig{
		ctx,
		"example",
		func(_ context.Context) error { return nil },
		func() {},
		component.TaskRestartAlways,
		&bo,
	}
	component.DefaultStartTask(&tc)
	for counter < 10 {
	}
	cancel()
}
```

it should print numbers from 1 to 10, but it prints 1 ten times. This is because the backoff function returns `0`, which makes the task loop `continue`, which skips `invocation++` at the end.

#### Changes
When task loop wants to `continue`, it increases the invocation counter first.

#### Testing
Local test with code above.

##### Regressions
None

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
