### PR TITLE
Add error boundary to datetime component

### DIFF
--- a/pkg/webui/console/components/last-seen/index.js
+++ b/pkg/webui/console/components/last-seen/index.js
@@ -38,7 +38,11 @@ const LastSeen = props => {
   return (
     <div className={classnames(className, style.container)}>
       {!short && <Message className={style.message} content={sharedMessages.lastSeen} />}
-      <DateTime.Relative value={lastSeen} computeDelta={computeDeltaInSeconds} />
+      <DateTime.Relative
+        value={lastSeen}
+        computeDelta={computeDeltaInSeconds}
+        firstToLower={!short}
+      />
     </div>
   )
 }

--- a/pkg/webui/lib/components/date-time/index.js
+++ b/pkg/webui/lib/components/date-time/index.js
@@ -14,6 +14,7 @@
 
 import React from 'react'
 import { FormattedDate, FormattedTime } from 'react-intl'
+import bind from 'autobind-decorator'
 
 import Message from '@ttn-lw/lib/components/message'
 
@@ -24,6 +25,22 @@ import { warn } from '@ttn-lw/lib/log'
 import RelativeTime from './relative'
 
 class DateTime extends React.PureComponent {
+  state = { hasError: false }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true }
+  }
+
+  @bind
+  renderUnknown() {
+    const { className, firstToLower } = this.props
+    return (
+      <time className={className}>
+        <Message content={sharedMessages.unknown} firstToLower={firstToLower} />
+      </time>
+    )
+  }
+
   renderDateTime(formattedDate, formattedTime, dateValue) {
     const { className, children, date, time } = this.props
 
@@ -42,11 +59,7 @@ class DateTime extends React.PureComponent {
 
     if (isNaN(dateValue)) {
       warn('Invalid date passed to DateTime component')
-      return (
-        <time className={className}>
-          <Message content={sharedMessages.unknown} firstToLower />
-        </time>
-      )
+      return this.renderUnknown()
     }
 
     return (
@@ -58,6 +71,11 @@ class DateTime extends React.PureComponent {
 
   render() {
     const { value, dateFormatOptions, timeFormatOptions } = this.props
+    const { hasError } = this.state
+
+    if (hasError) {
+      return this.renderUnknown()
+    }
 
     let dateValue = value
     if (!(value instanceof Date)) {
@@ -85,6 +103,8 @@ DateTime.propTypes = {
   date: PropTypes.bool,
   /** Whether to show the time. */
   dateFormatOptions: PropTypes.shape({}),
+  /** Whether to convert the first character of the resulting message to lowercase. */
+  firstToLower: PropTypes.bool,
   // See https://formatjs.io/docs/react-intl/components/#formatteddate
   time: PropTypes.bool,
   // See https://formatjs.io/docs/react-intl/components/#formattedtime
@@ -101,6 +121,7 @@ DateTime.defaultProps = {
   children: undefined,
   date: true,
   time: true,
+  firstToLower: true,
   dateFormatOptions: {
     year: 'numeric',
     month: 'short',

--- a/pkg/webui/lib/components/date-time/relative.js
+++ b/pkg/webui/lib/components/date-time/relative.js
@@ -22,10 +22,18 @@ import DateTime from '.'
 const formatInSeconds = (from, to) => Math.floor((from - to) / 1000)
 
 const RelativeTime = props => {
-  const { className, value, unit, computeDelta, updateIntervalInSeconds, children } = props
+  const {
+    className,
+    value,
+    unit,
+    computeDelta,
+    updateIntervalInSeconds,
+    firstToLower,
+    children,
+  } = props
 
   return (
-    <DateTime className={className} value={value}>
+    <DateTime className={className} value={value} firstToLower={firstToLower}>
       {dateTime => {
         const from = new Date(dateTime)
         const to = new Date()
@@ -53,6 +61,8 @@ RelativeTime.propTypes = {
   className: PropTypes.string,
   /** A function to compute relative delta in specified time units in the `unit` prop. */
   computeDelta: PropTypes.func,
+  /** Whether to convert the first character of the resulting message to lowercase. */
+  firstToLower: PropTypes.bool,
   /** The unit to calculate relative date time. */
   unit: PropTypes.oneOf(['second', 'minute', 'hour', 'day', 'week', 'month', 'year']),
   /** The interval that the component will re-render in seconds. */
@@ -68,6 +78,7 @@ RelativeTime.propTypes = {
 RelativeTime.defaultProps = {
   children: dateTime => dateTime,
   className: undefined,
+  firstToLower: true,
   updateIntervalInSeconds: 1,
   unit: 'second',
   computeDelta: formatInSeconds,


### PR DESCRIPTION
#### Summary
This quickfix is a temporary fix for crashes in the application overview and device list in the Console. This will prevent the whole site from crashing in such events but only the `<DateTime />` component that encountered the issue. We will use this preliminary fix until we found the root cause of this issue.

Related: https://github.com/TheThingsIndustries/lorawan-stack-support/issues/440

#### Changes
- Add an error boundary to `<DateTime />` component
- Small fix for correct casing of the `Unknown` message within 

#### Testing

Manual tests.

#### Notes for Reviewers
I only tested by manually throwing errors within `<DateTime.Relative />` so I don't know for sure if it also catches the `Too many rerenders` error.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
