### PR TITLE
Allow access to gateway status and location when public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - Do not print error line logs for rate limited gRPC and HTTP API requests.
 - The `ttn_lw_log_log_messages_total` metric was renamed to `ttn_lw_log_messages_total` and has an additional `error_name` label.
+- Authenticated users now have access to gateway status and location when those are set to public.
 
 ### Deprecated
 

--- a/pkg/identityserver/gateway_access_test.go
+++ b/pkg/identityserver/gateway_access_test.go
@@ -43,6 +43,8 @@ func init() {
 			ttnpb.RIGHT_GATEWAY_ALL,
 		}
 	}
+	userGateways(&defaultUser.UserIdentifiers).Gateways[0].StatusPublic = false
+	userGateways(&defaultUser.UserIdentifiers).Gateways[0].LocationPublic = false
 }
 
 func TestGatewayAccessNotFound(t *testing.T) {

--- a/pkg/ttnpb/public.go
+++ b/pkg/ttnpb/public.go
@@ -83,6 +83,7 @@ var PublicGatewayFields = append(PublicEntityFields,
 	"description",
 	"frequency_plan_id",
 	"status_public",
+	"gateway_server_address", // only public if status_public=true
 	"location_public",
 	"antennas", // only public if location_public=true
 )
@@ -96,6 +97,9 @@ func (g *Gateway) PublicSafe() *Gateway {
 	var safe Gateway
 	safe.SetFields(g, PublicGatewayFields...)
 	safe.ContactInfo = onlyPublicContactInfo(safe.ContactInfo)
+	if !safe.StatusPublic {
+		safe.GatewayServerAddress = ""
+	}
 	if !safe.LocationPublic {
 		safe.Antennas = nil
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR makes changes in the rights API of the Identity Server to return the `RIGHT_GATEWAY_STATUS_READ` and `RIGHT_GATEWAY_LOCATION_READ` rights for authenticated users on gateways that have `status_public` and `location_public` respectively.

Closes #3994

#### Changes
<!-- What are the changes made in this pull request? -->

- See above
- Additionally: Make rights functions for other entities consistent

#### Testing

<!-- How did you verify that this change works? -->

- Updated existing unit tests
- 🐒 

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

API consumers that relied on "caller has _any_ rights on this gateway" to show/hide functionality may break for some gateways, but those should have used more specific rights to show/hide functionality anyway.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
