### PR TITLE
Improve cookie security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For details about compatibility between different releases, see the **Commitment
 - Do not print error line logs for rate limited gRPC and HTTP API requests.
 - The `ttn_lw_log_log_messages_total` metric was renamed to `ttn_lw_log_messages_total` and has an additional `error_name` label.
 - Authenticated users now have access to gateway status and location when those are set to public.
+- Cookies are no longer allowed in cross-origin requests to the HTTP API. Applications must instead use Bearer tokens in the Authorization header.
 
 ### Deprecated
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -8315,6 +8315,15 @@
       "file": "recover.go"
     }
   },
+  "error:pkg/webmiddleware:invalid_csrf_token": {
+    "translations": {
+      "en": "invalid csrf token"
+    },
+    "description": {
+      "package": "pkg/webmiddleware",
+      "file": "csrf.go"
+    }
+  },
   "error:pkg/webmiddleware:request_body_too_large": {
     "translations": {
       "en": "request body too large"

--- a/pkg/account/session/session.go
+++ b/pkg/account/session/session.go
@@ -16,6 +16,7 @@ package session
 
 import (
 	"context"
+	"net/http"
 	"runtime/trace"
 	"time"
 
@@ -50,6 +51,7 @@ func (s *Session) authCookie() *cookie.Cookie {
 		Name:     authCookieName,
 		Path:     "/",
 		HTTPOnly: true,
+		SameSite: http.SameSiteLaxMode,
 	}
 }
 

--- a/pkg/web/middleware/csrf.go
+++ b/pkg/web/middleware/csrf.go
@@ -41,9 +41,7 @@ func CSRF(lookupName, path string, authKey []byte) echo.MiddlewareFunc {
 					authKey,
 					csrf.CookieName(lookupName),
 					csrf.FieldName(lookupName),
-					csrf.Secure(c.Request().URL.Scheme == "https"),
 					csrf.Path(path),
-					csrf.SameSite(csrf.SameSiteStrictMode),
 				))(
 				pass(next),
 			)(c)

--- a/pkg/webmiddleware/csrf_test.go
+++ b/pkg/webmiddleware/csrf_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gorilla/csrf"
 	"github.com/smartystreets/assertions"
 	"github.com/smartystreets/assertions/should"
+	"go.thethings.network/lorawan-stack/v3/pkg/auth"
 )
 
 func TestCSRF(t *testing.T) {
@@ -29,14 +30,24 @@ func TestCSRF(t *testing.T) {
 	authKey := []byte("1234123412341234123412341234123412341234123412341234123412341234")
 	m := CSRF(authKey)
 
-	t.Run("Protects non-idempotent methods", func(t *testing.T) {
+	t.Run("Protects non-idempotent methods when using a Session Token", func(t *testing.T) {
 		r := httptest.NewRequest(http.MethodPost, "/", nil)
+		r.Header.Set("Authorization", "Bearer "+auth.JoinToken(auth.SessionToken, "XXX", "YYY"))
 		rec := httptest.NewRecorder()
 		m(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
 		})).ServeHTTP(rec, r)
 		res := rec.Result()
 		a.So(res.StatusCode, should.Equal, http.StatusForbidden)
+	})
+
+	t.Run("Allows non-idempotent methods when using an API Key", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodPost, "/", nil)
+		r.Header.Set("Authorization", "Bearer "+auth.JoinToken(auth.APIKey, "XXX", "YYY"))
+		rec := httptest.NewRecorder()
+		m(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		})).ServeHTTP(rec, r)
+		res := rec.Result()
+		a.So(res.StatusCode, should.Equal, http.StatusOK)
 	})
 
 	t.Run("Allows access with valid CSRF token", func(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR improves our cookie security by

1. No longer allowing browser credentials (cookies) in CORS requests.
2. Using `SameSite=Strict` and Secure attributes on cookies

Closes https://github.com/TheThingsIndustries/lorawan-stack/issues/2760

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove the conditional around the CORS headers
- Remove the `AllowCredentials: true`
- Make CSRF skip explicit, now that we don't have a CORS skip anymore.
- Add Secure and SameSite attributes to cookies
- Various consistency fixes

#### Testing

<!-- How did you verify that this change works? -->

Locally, but that doesn't actually cover cross-origin, so we still need to test that somehow.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Cross-Origin requests (from cluster Console to Identity Server) may fail because of the removed `AllowCredentials: true`, but I think that should be okay because the React app sets the Authorization header, not the browser.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
