### PR TITLE
Fix PBA report deadlock

### DIFF
--- a/pkg/packetbrokeragent/agent.go
+++ b/pkg/packetbrokeragent/agent.go
@@ -660,7 +660,10 @@ func (a *Agent) handleDownlinkMessage(ctx context.Context, down *packetbroker.Ro
 				Error: packetbroker.DownlinkMessageProcessingError_DOWNLINK_INTERNAL,
 			}
 		}
-		reportCh <- report
+		select {
+		case <-ctx.Done():
+		case reportCh <- report:
+		}
 	}()
 
 	for _, filler := range a.tenantContextFillers {
@@ -1002,7 +1005,10 @@ func (a *Agent) handleUplinkMessage(ctx context.Context, up *packetbroker.Routed
 				Value: packetbroker.UplinkMessageProcessingError_UPLINK_INTERNAL,
 			}
 		}
-		reportCh <- report
+		select {
+		case <-ctx.Done():
+		case reportCh <- report:
+		}
 	}()
 
 	if err := a.decryptUplink(ctx, up.Message); err != nil {

--- a/pkg/packetbrokeragent/agent.go
+++ b/pkg/packetbrokeragent/agent.go
@@ -402,6 +402,9 @@ func (a *Agent) publishUplink(ctx context.Context) error {
 
 	wg := &sync.WaitGroup{}
 	defer wg.Wait()
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	var workers int32
 
 	for {
@@ -1100,6 +1103,9 @@ func (a *Agent) publishDownlink(ctx context.Context) error {
 
 	wg := &sync.WaitGroup{}
 	defer wg.Wait()
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	var workers int32
 
 	for {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fix PBA deadlock when an operation (`handleUplink`/`handleDownlink`) deadlocks while attempting to report the status.
This occurs if for example the context is cancelled due to some kind of error:
- An error occurs, and the `subscribeDownlink` / `subscribeUplink` task starts to stop (i.e. cancels the context).
- The reporting workers stop, as their context expired. So does the goroutine that picks up the reports and sends them to workers.
- A downlink/uplink worker attempts to report that the context was cancelled, but the goroutine that distributes the reports has been stopped (since the context stopped).
- Deadlock, as `wg.Wait()` in the task will never finish, since the main workers cannot finish as they cannot write their reports.
#### Changes
<!-- What are the changes made in this pull request? -->

- Select the context while writing to the report channel.
- Cancel the context in the forwarders, for symmetry reasons.


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This ensures that channel writes cannot deadlock, but no other changes are expected.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

If you are fine with the changes, please merge this as well and deploy it. We've seen this happen in production.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
