### PR TITLE
Use `SameSite=Lax` for all cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
+- Relaxed the cookie policy for cross-origin requests from Strict to Lax.
+
 ### Deprecated
 
 ### Removed

--- a/pkg/account/session/session.go
+++ b/pkg/account/session/session.go
@@ -16,7 +16,6 @@ package session
 
 import (
 	"context"
-	"net/http"
 	"runtime/trace"
 	"time"
 
@@ -51,7 +50,6 @@ func (s *Session) authCookie() *cookie.Cookie {
 		Name:     authCookieName,
 		Path:     "/",
 		HTTPOnly: true,
-		SameSite: http.SameSiteLaxMode,
 	}
 }
 

--- a/pkg/web/cookie/cookie.go
+++ b/pkg/web/cookie/cookie.go
@@ -47,7 +47,7 @@ type Cookie struct {
 func (d *Cookie) new(r *http.Request) http.Cookie {
 	sameSite := d.SameSite
 	if sameSite == 0 {
-		sameSite = http.SameSiteStrictMode
+		sameSite = http.SameSiteLaxMode
 	}
 	return http.Cookie{
 		Name:     d.Name,

--- a/pkg/webmiddleware/csrf.go
+++ b/pkg/webmiddleware/csrf.go
@@ -37,7 +37,7 @@ func CSRF(authKey []byte, opts ...csrf.Option) MiddlewareFunc {
 				return
 			}
 			defaultOptions := []csrf.Option{
-				csrf.SameSite(csrf.SameSiteStrictMode),
+				csrf.SameSite(csrf.SameSiteLaxMode),
 				csrf.Secure(r.URL.Scheme == "https"),
 				csrf.ErrorHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					// In some cases we do want to execute the CSRF middleware, so that a CSRF token is set


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quick fix for a user-reported issue in v3.13.1 where the strict cookie policy broke some functionality. Therefore we decided to revert to `SameSite=Lax` as the default while we investigate if and where it's possible to use `SameSite=Strict`.

Refs https://github.com/TheThingsIndustries/lorawan-stack-support/issues/452

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
