### PR TITLE
all: Use SameSite=None for OAuth state cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Changed
 
 - Relaxed the cookie policy for cross-origin requests from Strict to Lax.
+- Changed the cookie policy for OAuth state to None.
 
 ### Deprecated
 

--- a/pkg/web/oauthclient/cookie_state.go
+++ b/pkg/web/oauthclient/cookie_state.go
@@ -41,6 +41,7 @@ func (oc *OAuthClient) StateCookie() *cookie.Cookie {
 		HTTPOnly: true,
 		Path:     oc.getMountPath(),
 		MaxAge:   10 * time.Minute,
+		SameSite: http.SameSiteNoneMode,
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a follow-up of https://github.com/TheThingsNetwork/lorawan-stack/pull/4238.

In addition to setting `SameSite=Lax` we also need to set `SameSite=None` on OAuth state cookies, since some OAuth providers (including OIDC providers) actually need to send cross-origin requests that include these cookies.

Refs https://github.com/TheThingsIndustries/lorawan-stack-support/issues/452

#### Testing

<!-- How did you verify that this change works? -->

Difficult to test, let's deploy a snapshot ASAP.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
