### PR TITLE
Remove arm64 builds from snapshot workflows (no worries, we keep them in release workflows)

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -87,9 +87,7 @@ jobs:
       run: |
         docker tag lorawan-stack-dev:${{ github.sha }}-amd64 thethingsnetwork/lorawan-stack-dev:${{ github.sha }}-amd64
         docker push thethingsnetwork/lorawan-stack-dev:${{ github.sha }}-amd64
-        docker tag lorawan-stack-dev:${{ github.sha }}-arm64 thethingsnetwork/lorawan-stack-dev:${{ github.sha }}-arm64
-        docker push thethingsnetwork/lorawan-stack-dev:${{ github.sha }}-arm64
-        docker manifest create thethingsnetwork/lorawan-stack-dev:${{ github.sha }} thethingsnetwork/lorawan-stack-dev:${{ github.sha }}-amd64 thethingsnetwork/lorawan-stack-dev:${{ github.sha }}-arm64
+        docker manifest create thethingsnetwork/lorawan-stack-dev:${{ github.sha }} thethingsnetwork/lorawan-stack-dev:${{ github.sha }}-amd64
         docker manifest push thethingsnetwork/lorawan-stack-dev:${{ github.sha }}
       env:
         DOCKER_CLI_EXPERIMENTAL: enabled

--- a/.goreleaser.snapshot.yml
+++ b/.goreleaser.snapshot.yml
@@ -22,7 +22,6 @@ builds:
       - linux
     goarch:
       - amd64
-      - arm64
 
   - id: cli
     main: ./cmd/ttn-lw-cli
@@ -39,7 +38,6 @@ builds:
       - linux
     goarch:
       - amd64
-      - arm64
 
 dockers:
   - goos: linux
@@ -58,26 +56,6 @@ dockers:
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
     image_templates:
       - 'lorawan-stack-dev:{{ .FullCommit }}-amd64'
-    skip_push: true
-    extra_files:
-      - data
-      - public
-  - goos: linux
-    goarch: arm64
-    dockerfile: Dockerfile
-    use_buildx: true
-    binaries:
-      - ttn-lw-cli
-      - ttn-lw-stack
-    build_flag_templates:
-      - --platform=linux/arm64/v8
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.vendor=The Things Network Foundation"
-      - "--label=org.opencontainers.image.title=The Things Stack"
-      - "--label=org.opencontainers.image.url=https://www.thethingsindustries.com/docs"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-    image_templates:
-      - 'lorawan-stack-dev:{{ .FullCommit }}-arm64'
     skip_push: true
     extra_files:
       - data


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Let's remove arm64 builds from our snapshot workflow. We now have arm64 (and armv7) in our release builds, and it's a bit a waste of build time if we also have them in snapshots that we rarely use.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
