### PR TITLE
Speed up end-to-end tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,15 +31,15 @@ jobs:
           submodules: false
       - name: Get hash of code files
         id: get-hash
-        run: echo "::set-output name=hash::${{ hashFiles('*.go', 'go.mod', 'go.sum', 'pkg/**', 'tools/**', 'config/**', '!config/stack/ttn-lw-stack.yml', 'package.json', 'pkg/webui/**', 'sdk/js/**', 'yarn.lock', 'cypress/**', 'docker-compose.yml') }}"
+        run: echo "::set-output name=hash::${{ hashFiles('*.go', 'go.mod', 'go.sum', 'pkg/**', 'tools/**', 'config/**', 'package.json', 'pkg/webui/**', 'sdk/js/**', 'yarn.lock', 'cypress/**', 'docker-compose.yml') }}"
       - name: Get the cached result
         id: run-cache
         uses: actions/cache@v2
         with:
           path: .cache/passed
-          key: -run-cache-${{ steps.get-hash.outputs.hash }}-${{ github.run_id }}
+          key: run-cache-${{ steps.get-hash.outputs.hash }}-${{ github.run_id }}
           restore-keys: |
-            -run-cache-${{ steps.get-hash.outputs.hash }}
+            run-cache-${{ steps.get-hash.outputs.hash }}
       - name: Check cached result connected to the hashed files (if any)
         id: check-result
         continue-on-error: true
@@ -54,10 +54,10 @@ jobs:
       COCKROACHDB_COCKROACH_TAG: v19.2.12
       CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    # TODO: Enable next lines once parallelization is available
-    # strategy:
-    #   matrix:
-    #     machines: [1, 2, 3, 4]
+      RUN_HASH: ${{ needs.determine-if-required.outputs.hash }}
+    strategy:
+      matrix:
+        machines: [1, 2, 3, 4]
     needs: determine-if-required
     if: needs.determine-if-required.outputs.needs-to-run == 'true'
     steps:
@@ -166,6 +166,6 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .cache/passed
-          key: -run-cache-${{ needs.determine-if-required.outputs.hash }}
+          key: run-cache-${{ needs.determine-if-required.outputs.hash }}
       - name: Create result file for caching
         run: mkdir -p .cache && echo true > .cache/passed

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,33 @@ on:
       - 'docker-compose.yml'
 
 jobs:
+  determine-if-required:
+    name: Determine if run is required
+    runs-on: ubuntu-18.04
+    outputs:
+      needs-to-run: ${{ steps.check-result.outputs.passed != 'true' }}
+      hash: ${{ steps.get-hash.outputs.hash }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: false
+      - name: Get hash of code files
+        id: get-hash
+        run: echo "::set-output name=hash::${{ hashFiles('*.go', 'go.mod', 'go.sum', 'pkg/**', 'tools/**', 'config/**', '!config/stack/ttn-lw-stack.yml', 'package.json', 'pkg/webui/**', 'sdk/js/**', 'yarn.lock', 'cypress/**', 'docker-compose.yml') }}"
+      - name: Get the cached result
+        id: run-cache
+        uses: actions/cache@v2
+        with:
+          path: .cache/passed
+          key: -run-cache-${{ steps.get-hash.outputs.hash }}-${{ github.run_id }}
+          restore-keys: |
+            -run-cache-${{ steps.get-hash.outputs.hash }}
+      - name: Check cached result connected to the hashed files (if any)
+        id: check-result
+        continue-on-error: true
+        run: test -f .cache/passed && echo "::set-output name=passed::$(cat .cache/passed)"
   end-to-end:
     name: Frontend based (cypress)
     runs-on: ubuntu-18.04
@@ -25,18 +52,59 @@ jobs:
       # TODO: Remove this after we no longer depend on cockroach dump command
       # (https://github.com/TheThingsNetwork/lorawan-stack/issues/4184)
       COCKROACHDB_COCKROACH_TAG: v19.2.12
+      CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # TODO: Enable next lines once parallelization is available
+    # strategy:
+    #   matrix:
+    #     machines: [1, 2, 3, 4]
+    needs: determine-if-required
+    if: needs.determine-if-required.outputs.needs-to-run == 'true'
     steps:
       - name: Check out code
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
           submodules: true
+      - name: Get Yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(npx yarn cache dir)"
+      - name: Initialize Yarn module cache
+        id: yarn-cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Initialize babel cache
+        id: babel-cache
+        uses: actions/cache@v2
+        with:
+          path: .cache/babel
+          key: ${{ runner.os }}-babel-cache-${{ hashFiles('config/babel.config.json', 'config/webpack.config.babel.js') }}
+          restore-keys: |
+            ${{ runner.os }}-babel-cache-
       - name: Initialize public folder cache
         id: public-cache
         uses: actions/cache@v2
         with:
           path: public
           key: public-cache-${{ hashFiles('pkg/webui/**') }}-${{ hashFiles('sdk/js/**/*.js', 'sdk/js/generated/*.json') }}-${{ hashFiles('config/webpack.config.babel.js') }}-${{ hashFiles('yarn.lock', 'sdk/js/yarn.lock')}}
+      - name: Initialize SQL dump cache
+        id: db-cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            .cache/sqldump.sql
+            .env/admin_api_key.txt
+          key: db-cache-${{ hashFiles('pkg/identityserver/store/**/*.go', 'cmd/ttn-lw-stack/commands/is-db.go') }}
+      - name: Initialize device repository db cache
+        id: dr-db-cache
+        uses: actions/cache@v2
+        with:
+          path: data/lorawan-devices-index
+          key: db-cache-${{ hashFiles('data/lorawan-devices') }}
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
@@ -64,7 +132,13 @@ jobs:
       - name: Initialize stack environment
         run: tools/bin/mage init
       - name: Run test preparations
+        if: |
+          steps.db-cache.outputs.cache-hit != 'true' ||
+          steps.dr-db-cache.outputs.cache-hit != 'true'
         run: tools/bin/mage -v dev:dbStop dev:dbErase dev:dbStart dev:initStack dev:sqlDump
+      - name: Restore initialized sql db
+        if: steps.db-cache.outputs.cache-hit == 'true'
+        run: tools/bin/mage dev:dbStart dev:sqlRestore
       - name: Build frontend
         if: steps.public-cache.outputs.cache-hit != 'true'
         run: tools/bin/mage js:build
@@ -82,3 +156,16 @@ jobs:
         with:
           name: cypress-screenshots
           path: cypress/screenshots
+  cache-result:
+    name: Write result cache
+    runs-on: ubuntu-18.04
+    needs: [end-to-end, determine-if-required]
+    steps:
+      - name: Setup result cache to skip redundant runs
+        id: run-cache
+        uses: actions/cache@v2
+        with:
+          path: .cache/passed
+          key: -run-cache-${{ needs.determine-if-required.outputs.hash }}
+      - name: Create result file for caching
+        run: mkdir -p .cache && echo true > .cache/passed

--- a/config/cypress.json
+++ b/config/cypress.json
@@ -1,4 +1,5 @@
 {
+  "projectId": "uqdraf",
   "viewportHeight": 900,
   "viewportWidth": 1440,
   "defaultCommandTimeout": 10000,

--- a/tools/mage/dev.go
+++ b/tools/mage/dev.go
@@ -148,7 +148,7 @@ func (Dev) SQLRestore(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return db.Exec(fmt.Sprintf(`DROP DATABASE %s;
+	return db.Exec(fmt.Sprintf(`DROP DATABASE IF EXISTS %s;
 		CREATE DATABASE %s;
 		%s`,
 		devDatabaseName, devDatabaseName, string(b)),

--- a/tools/mage/js.go
+++ b/tools/mage/js.go
@@ -390,6 +390,15 @@ func (js Js) CypressHeadless() error {
 	if mg.Verbose() {
 		fmt.Println("Running Cypress E2E tests in headless mode")
 	}
+	ci := os.Getenv("CI")
+	if ci == "true" {
+		hash := os.Getenv("RUN_HASH")
+		shorthash := "none"
+		if len(hash) > 7 {
+			shorthash = hash[:7]
+		}
+		return js.runCypress("run", "--record", "--parallel", "--group", fmt.Sprintf("'%s'", shorthash))
+	}
 	return js.runCypress("run")
 }
 


### PR DESCRIPTION
#### Summary
This PR will speed up our end-to-end test by introducing more caching mechanisms and also skipping entire runs if there was a passed run associated with the current file hashes.

#### Changes
- Add babel cache
- Add yarn cache
- Add SQL dump cache
- Add device repository DB cache
- Add additional jobs enabling to skip redundant runs entirely

#### Testing

I've tested this manually on my private fork: https://github.com/kschiffer/lorawan-stack/actions/workflows/e2e.yml

##### Regressions

The caching could theoretically be invalidated incorrectly and cause false positives / false negatives.

#### Notes for Reviewers

The `determine-if-required` job is set up in a way to cater also for parallelization of the end-to-end test that we are planning to setup. I've moved these checks to separate jobs so that it will work properly as well also when parallelizing the runs using the `matrix` strategy in GitHub actions. The whole mechanism works by associating passed runs with the file hashes of any file that could affect the end-to-end test and using this stored data to determine whether a run can be skipped since it was already done before with the same file hashes.

One other thing to note is that since we cache the outcome of the e2e tests based on these files:
```
hashFiles('*.go', 'go.mod', 'go.sum', 'pkg/**', 'tools/**', 'config/**', 'package.json', 'pkg/webui/**', 'sdk/js/**', 'yarn.lock', 'cypress/**', 'docker-compose.yml')
```
We will have to update this set of files in the workflow when introducing new files that could affect the outcome of the e2e tests.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
