### PR TITLE
Fix permissions to view gateway details in the Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Permissions issue for reading and writing gateway secrets in the Console.
+
 ### Security
 
 ## [3.13.1] - 2021-06-04

--- a/pkg/webui/console/lib/feature-checks.js
+++ b/pkg/webui/console/lib/feature-checks.js
@@ -164,6 +164,14 @@ export const mayViewGatewayConfJson = {
   rightsSelector: selectGatewayRights,
   check: rights => rights.includes('RIGHT_GATEWAY_INFO') && gcsEnabled,
 }
+export const mayViewGatewaySecrets = {
+  rightsSelector: selectGatewayRights,
+  check: rights => rights.includes('RIGHT_GATEWAY_READ_SECRETS'),
+}
+export const mayEditGatewaySecrets = {
+  rightsSelector: selectGatewayRights,
+  check: rights => rights.includes('RIGHT_GATEWAY_WRITE_SECRETS'),
+}
 
 // Organization related feature checks.
 export const mayViewOrganizationInformation = {

--- a/pkg/webui/console/views/gateway-general-settings/basic-settings-form/index.js
+++ b/pkg/webui/console/views/gateway-general-settings/basic-settings-form/index.js
@@ -43,6 +43,7 @@ const BasicSettingsForm = React.memo(props => {
     onDeleteFailure,
     onDeleteSuccess,
     mayDeleteGateway,
+    mayEditSecrets,
   } = props
 
   const [error, setError] = React.useState(undefined)
@@ -149,6 +150,7 @@ const BasicSettingsForm = React.memo(props => {
         description={sharedMessages.lbsLNSSecretDescription}
         name="lbs_lns_secret.value"
         component={Input}
+        disabled={!mayEditSecrets}
       />
       <Form.Field
         title={sharedMessages.gatewayStatus}
@@ -208,6 +210,7 @@ const BasicSettingsForm = React.memo(props => {
 BasicSettingsForm.propTypes = {
   gateway: PropTypes.gateway.isRequired,
   mayDeleteGateway: PropTypes.shape({}).isRequired,
+  mayEditSecrets: PropTypes.bool.isRequired,
   onDelete: PropTypes.func.isRequired,
   onDeleteFailure: PropTypes.func.isRequired,
   onDeleteSuccess: PropTypes.func.isRequired,

--- a/pkg/webui/console/views/gateway-general-settings/index.js
+++ b/pkg/webui/console/views/gateway-general-settings/index.js
@@ -32,7 +32,12 @@ import attachPromise from '@ttn-lw/lib/store/actions/attach-promise'
 import PropTypes from '@ttn-lw/lib/prop-types'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 
-import { mayEditBasicGatewayInformation, mayDeleteGateway } from '@console/lib/feature-checks'
+import {
+  checkFromState,
+  mayEditBasicGatewayInformation,
+  mayDeleteGateway,
+  mayEditGatewaySecrets,
+} from '@console/lib/feature-checks'
 import { mapFormValueToAttributes } from '@console/lib/attributes'
 
 import { updateGateway, deleteGateway } from '@console/store/actions/gateways'
@@ -47,6 +52,7 @@ import m from './messages'
   state => ({
     gateway: selectSelectedGateway(state),
     gtwId: selectSelectedGatewayId(state),
+    mayEditSecrets: checkFromState(mayEditGatewaySecrets, state),
   }),
   dispatch => ({
     ...bindActionCreators(
@@ -77,6 +83,7 @@ export default class GatewayGeneralSettings extends React.Component {
     deleteGateway: PropTypes.func.isRequired,
     gateway: PropTypes.gateway.isRequired,
     gtwId: PropTypes.string.isRequired,
+    mayEditSecrets: PropTypes.bool.isRequired,
     onDeleteSuccess: PropTypes.func.isRequired,
     updateGateway: PropTypes.func.isRequired,
   }
@@ -146,7 +153,7 @@ export default class GatewayGeneralSettings extends React.Component {
   }
 
   render() {
-    const { gateway } = this.props
+    const { gateway, mayEditSecrets } = this.props
 
     return (
       <Container>
@@ -167,6 +174,7 @@ export default class GatewayGeneralSettings extends React.Component {
                 onDeleteSuccess={this.handleDeleteSuccess}
                 onDeleteFailure={this.handleDeleteFailure}
                 mayDeleteGateway={mayDeleteGateway}
+                mayEditSecrets={mayEditSecrets}
               />
             </Collapse>
             <Collapse

--- a/pkg/webui/console/views/gateway/index.js
+++ b/pkg/webui/console/views/gateway/index.js
@@ -37,12 +37,14 @@ import PropTypes from '@ttn-lw/lib/prop-types'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 
 import {
+  checkFromState,
   mayViewGatewayInfo,
   mayViewGatewayEvents,
   mayViewOrEditGatewayLocation,
   mayViewOrEditGatewayCollaborators,
   mayViewOrEditGatewayApiKeys,
   mayEditBasicGatewayInformation,
+  mayViewGatewaySecrets,
 } from '@console/lib/feature-checks'
 
 import {
@@ -71,6 +73,7 @@ import {
       error: selectGatewayError(state) || selectGatewayRightsError(state),
       fetching: selectGatewayFetching(state) || selectGatewayRightsFetching(state),
       rights: selectGatewayRights(state),
+      mayViewSecrets: checkFromState(mayViewGatewaySecrets, state),
     }
   },
   dispatch => ({
@@ -82,8 +85,8 @@ import {
   }),
 )
 @withRequest(
-  ({ gtwId, loadData }) =>
-    loadData(gtwId, [
+  ({ gtwId, loadData, mayViewSecrets }) => {
+    const selector = [
       'name',
       'description',
       'enforce_duty_cycle',
@@ -91,7 +94,6 @@ import {
       'gateway_server_address',
       'antennas',
       'location_public',
-      'lbs_lns_secret',
       'status_public',
       'auto_update',
       'schedule_downlink_late',
@@ -100,7 +102,14 @@ import {
       'schedule_anytime_delay',
       'attributes',
       'require_authenticated_connection',
-    ]),
+    ]
+
+    if (mayViewSecrets) {
+      selector.push('lbs_lns_secret')
+    }
+
+    return loadData(gtwId, selector)
+  },
   ({ fetching, gateway }) => fetching || !Boolean(gateway),
 )
 @withBreadcrumb('gateways.single', props => {


### PR DESCRIPTION
Check rights for reading and writing gateway secrets before fetching or submitting

<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/405

#### Changes
<!-- What are the changes made in this pull request? -->

- Check for `RIGHT_GATEWAY_READ_SECRETS` when fetching gateway secrets
- Check for `RIGHT_GATEWAY_WRITE_SECRETS` when submitting gateway secrets


#### Testing

<!-- How did you verify that this change works? -->

Manual


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
