### PR TITLE
Skip building Mage on cache hit in CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -53,12 +53,14 @@ jobs:
           cd tools
           go mod download
       - name: Initialize tool binary cache
+        id: tools-cache
         uses: actions/cache@v2
         with:
           path: tools/bin
           key: ${{ runner.os }}-tools-${{ hashFiles('tools/**') }}
       - name: Make Mage
         run: make tools/bin/mage
+        if: steps.tools-cache.outputs.cache-hit != 'true'
       - name: Initialize stack environment
         run: tools/bin/mage init
       - name: Run test preparations

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -40,12 +40,14 @@ jobs:
         cd tools
         go mod download
     - name: Initialize tool binary cache
+      id: tools-cache
       uses: actions/cache@v2
       with:
         path: tools/bin
         key: ${{ runner.os }}-tools-${{ hashFiles('tools/**') }}
     - name: Make Mage
       run: make tools/bin/mage
+      if: steps.tools-cache.outputs.cache-hit != 'true'
     - name: Editor config
       uses: snow-actions/eclint@v1.0.1
       # TODO: Fix EditorConfig errors and remove

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,7 @@ name: Go Code
 on:
   pull_request:
     paths:
+    - '.github/workflows/go.yml'
     - '*.go'
     - '.revive.toml'
     - 'cmd/**'
@@ -37,12 +38,14 @@ jobs:
         cd tools
         go mod download
     - name: Initialize tool binary cache
+      id: tools-cache
       uses: actions/cache@v2
       with:
         path: tools/bin
         key: ${{ runner.os }}-tools-${{ hashFiles('tools/**') }}
     - name: Make Mage
       run: make tools/bin/mage
+      if: steps.tools-cache.outputs.cache-hit != 'true'
     - name: Remove unnecessary type conversions
       run: tools/bin/mage go:unconvert
     - name: Format code
@@ -107,12 +110,14 @@ jobs:
         cd tools
         go mod download
     - name: Initialize tool binary cache
+      id: tools-cache
       uses: actions/cache@v2
       with:
         path: tools/bin
         key: ${{ runner.os }}-tools-${{ hashFiles('tools/**') }}
     - name: Make Mage
       run: make tools/bin/mage
+      if: steps.tools-cache.outputs.cache-hit != 'true'
     - name: Test binary execution
       run: tools/bin/mage go:testBinaries
     - name: Test code and send coverage to Coveralls

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -3,6 +3,7 @@ name: JS Code
 on:
   pull_request:
     paths:
+    - '.github/workflows/js.yml'
     - 'config/**'
     - '!config/stack/ttn-lw-stack.yml'
     - 'Makefile'
@@ -51,12 +52,14 @@ jobs:
         cd tools
         go mod download
     - name: Initialize tool binary cache
+      id: tools-cache
       uses: actions/cache@v2
       with:
         path: tools/bin
         key: ${{ runner.os }}-tools-${{ hashFiles('tools/**') }}
     - name: Make Mage
       run: make tools/bin/mage
+      if: steps.tools-cache.outputs.cache-hit != 'true'
     - name: Install JS SDK dependencies
       run: tools/bin/mage jsSDK:deps
     - name: Generate JS SDK allowed field masks
@@ -119,12 +122,14 @@ jobs:
         cd tools
         go mod download
     - name: Initialize tool binary cache
+      id: tools-cache
       uses: actions/cache@v2
       with:
         path: tools/bin
         key: ${{ runner.os }}-tools-${{ hashFiles('tools/**') }}
     - name: Make Mage
       run: make tools/bin/mage
+      if: steps.tools-cache.outputs.cache-hit != 'true'
     - name: Install JS SDK dependencies
       run: tools/bin/mage jsSDK:deps
     - name: Build JS SDK

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -25,12 +25,14 @@ jobs:
         cd tools
         go mod download
     - name: Initialize tool binary cache
+      id: tools-cache
       uses: actions/cache@v2
       with:
         path: tools/bin
         key: ${{ runner.os }}-tools-${{ hashFiles('tools/**') }}
     - name: Make Mage
       run: make tools/bin/mage
+      if: steps.tools-cache.outputs.cache-hit != 'true'
     - name: Download protoc image
       run: tools/bin/mage proto:image
     - name: Generate protos

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -60,12 +60,14 @@ jobs:
         cd tools
         go mod download
     - name: Initialize tool binary cache
+      id: tools-cache
       uses: actions/cache@v2
       with:
         path: tools/bin
         key: ${{ runner.os }}-tools-${{ hashFiles('tools/**') }}
     - name: Make Mage
       run: make tools/bin/mage
+      if: steps.tools-cache.outputs.cache-hit != 'true'
     - name: Install JS SDK dependencies
       run: tools/bin/mage jsSDK:deps
     - name: Build JS SDK

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -57,6 +57,7 @@ jobs:
         go mod download
     - name: Make Mage
       run: make tools/bin/mage
+      if: steps.tools-cache.outputs.cache-hit != 'true'
     - name: Auto-completion scripts
       run: tools/bin/mage cli:autocomplete
     - name: Install JS SDK dependencies


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR contains the CI optimization that skips building Mage on cache hits.

This should shave ~30 seconds off each build that uses Mage.

Both #4245 and #4250 are doing this in separate workflows, so I thought it would be better to do the optimization in a separate PR and have those other PRs focus on specific workflows.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
