### PR TITLE
Speed up Go CI workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -120,19 +120,18 @@ jobs:
       if: steps.tools-cache.outputs.cache-hit != 'true'
     - name: Test binary execution
       run: tools/bin/mage go:testBinaries
-    - name: Test code and send coverage to Coveralls
+    - name: Test code
       env:
         SQL_DB_ADDRESS: localhost:${{ job.services.postgres.ports['5432'] }}
         SQL_DB_AUTH: 'root:root'
         REDIS_ADDRESS: localhost:${{ job.services.redis.ports['6379'] }}
         TEST_REDIS: '1'
         TEST_SLOWDOWN: '8'
-        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         AWS_REGION: ${{ secrets.AWS_REGION }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_TEST_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_TEST_SECRET_ACCESS_KEY }}
         GCP_CREDENTIALS: ${{ secrets.GCP_TEST_CREDENTIALS }}
         TEST_BUCKET: lorawan-stack-test-bucket
-      run: tools/bin/mage go:coveralls
+      run: tools/bin/mage go:test
     - name: Check for diff
       run: tools/bin/mage git:diff

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -109,6 +109,16 @@ jobs:
       run: |
         cd tools
         go mod download
+    - name: Initialize Go build cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/go-build
+        # NOTE: head_ref only works on pull_request.
+        key: ${{ runner.os }}-go-build-refs/heads/${{ github.head_ref }}
+        # NOTE: base_ref only works on pull_request.
+        restore-keys: |
+          ${{ runner.os }}-go-build-refs/heads/${{ github.base_ref }}
+          ${{ runner.os }}-go-build-refs/heads/v
     - name: Initialize tool binary cache
       id: tools-cache
       uses: actions/cache@v2

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -59,6 +59,13 @@ jobs:
       run: |
         cd tools
         go mod download
+    - name: Initialize Go build cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/go-build
+        key: ${{ runner.os }}-go-build-${{ github.ref }}
+        restore-keys: |
+          ${{ runner.os }}-go-build-refs/heads/v
     - name: Initialize tool binary cache
       id: tools-cache
       uses: actions/cache@v2

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -49,12 +49,32 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: '~1.16'
+    - name: Initialize Go module cache
+      uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
     - name: Download Go dependencies
       run: go mod download
     - name: Download Go tool dependencies
       run: |
         cd tools
         go mod download
+    - name: Initialize Go build cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/go-build
+        key: ${{ runner.os }}-go-build-${{ github.ref }}
+        restore-keys: |
+          ${{ runner.os }}-go-build-refs/heads/v
+    - name: Initialize tool binary cache
+      id: tools-cache
+      uses: actions/cache@v2
+      with:
+        path: tools/bin
+        key: ${{ runner.os }}-tools-${{ hashFiles('tools/**') }}
     - name: Make Mage
       run: make tools/bin/mage
       if: steps.tools-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request aims to speed up our Go CI workflow.

#### Changes
<!-- What are the changes made in this pull request? -->

1. Remove Coveralls. This allows us to benefit from Go's test cache
2. Add Go Build caching. When a new PR is opened, it tries to restore the cache from the target branch of the pull request (that's why we now also run this on `v3.*` snapshots).

#### Testing

<!-- How did you verify that this change works? -->

I tested this in https://github.com/TheThingsNetwork/lorawan-stack/pull/4250

- Before: https://github.com/TheThingsNetwork/lorawan-stack/runs/2791359333?check_suite_focus=true (13m 21s)
- Without Coveralls: https://github.com/TheThingsNetwork/lorawan-stack/runs/2791714775?check_suite_focus=true (9m 43s)
- With cache: https://github.com/TheThingsNetwork/lorawan-stack/runs/2791843052?check_suite_focus=true (6m 44s)

🚀 

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
