### PR TITLE
Clear EUI in gateway rights query

### DIFF
--- a/pkg/identityserver/rights.go
+++ b/pkg/identityserver/rights.go
@@ -163,7 +163,9 @@ func (is *IdentityServer) ClientRights(ctx context.Context, cliIDs ttnpb.ClientI
 }
 
 // GatewayRights returns the rights the caller has on the given gateway.
+// The query for the gateway only considers the Gateway ID and not the EUI (if provided).
 func (is *IdentityServer) GatewayRights(ctx context.Context, gtwIDs ttnpb.GatewayIdentifiers) (*ttnpb.Rights, error) {
+	gtwIDs.Eui = nil
 	entity, universal, err := is.getRights(ctx, gtwIDs.GetEntityIdentifiers())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Clear EUI in gateway rights query. This fixes a hard to track bug which prevented the Gateway EUI from being editable.

#### Changes
<!-- What are the changes made in this pull request? -->

- Set the EUI to nil before querying a Gateway while checking rights.

#### Testing

<!-- How did you verify that this change works? -->

Manually tested with a local stack. 

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

I don't think there's any but @htdvisser knows best.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
