### PR TITLE
Add uplink latency histograms to NS and AS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For details about compatibility between different releases, see the **Commitment
   - The `console` format that prints logs as more human-friendly text. This is the new default.
   - The `json` format that prints logs as JSON. This is the recommended format for production deployments.
   - The `old` format (deprecated). This can be used if you need to adapt your log analysis tooling before v3.14.
+- `ttn_lw_gs_ns_uplink_latency_seconds`, `ttn_lw_ns_as_uplink_latency_seconds` and `ttn_lw_gtw_as_uplink_latency_seconds` metrics to track latency of uplink processing.
 
 ### Changed
 

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -898,6 +898,8 @@ func (as *ApplicationServer) handleUplink(ctx context.Context, ids ttnpb.EndDevi
 		uplink.LastAFCntDown = dev.Session.LastAFCntDown
 	}
 
+	registerUplinkLatency(ctx, uplink)
+
 	isDev, err := as.endDeviceFetcher.Get(ctx, ids, "locations")
 	if err != nil {
 		log.FromContext(ctx).WithError(err).Warn("Failed to retrieve end device locations")

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -1214,7 +1214,11 @@ func (ns *NetworkServer) HandleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 		fmt.Sprintf("ns:uplink:%s", events.NewCorrelationID()),
 	)...)
 	up.CorrelationIDs = events.CorrelationIDsFromContext(ctx)
+
+	registerUplinkLatency(ctx, up)
+
 	up.ReceivedAt = time.Now().UTC()
+
 	up.Payload = &ttnpb.Message{}
 	if err := lorawan.UnmarshalMessage(up.RawPayload, up.Payload); err != nil {
 		return nil, errDecodePayload.WithCause(err)

--- a/pkg/networkserver/observability.go
+++ b/pkg/networkserver/observability.go
@@ -186,7 +186,7 @@ var nsMetrics = &messageMetrics{
 			Subsystem: subsystem,
 			Name:      "uplink_gateways",
 			Help:      "Number of gateways that forwarded the uplink (within the deduplication window)",
-			Buckets:   []float64{1, 2, 3, 4, 5, 10, 20, 30, 40, 50},
+			Buckets:   []float64{1, 2, 3, 4, 5, 10},
 		},
 		nil,
 	),


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request adds uplink latency histogram metrics to the Network Server and Application Server.

We'll have:

1. `ttn_lw_gtw_as_uplink_latency_seconds`: Time between when the gateway received the message, and when the Application Server finished processing the message (before sending it to the application/integration). This includes Packet Broker latency and the de-duplication delay.
2. `ttn_lw_gs_ns_uplink_latency_seconds`: Time between when the Gateway Server (or Packet Broker Agent) received the message, and when the Network Server received it.
3. `ttn_lw_ns_as_uplink_latency_seconds`: Time between when the Network Server received the message and when the Application Server finished processing it.

The total processing latency in a The Things Stack cluster is `ttn_lw_gs_ns_uplink_latency_seconds` + `ttn_lw_ns_as_uplink_latency_seconds`.

Refs https://github.com/TheThingsIndustries/lorawan-stack-support/issues/415

#### Testing

<!-- How did you verify that this change works? -->

Just looking at http://localhost:1885/metrics

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
