### PR TITLE
Remove usage of isolated yarn dependency in tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,8 +72,7 @@
     "webpack-dev-server": "^3.11.0",
     "webpack-plugin-hash-output": "^3.1.0",
     "webpack-shell-plugin": "https://github.com/cdeutsch/webpack-shell-plugin.git#bee537d",
-    "yargs": "^16.2.0",
-    "yarn": "^1.22.10"
+    "yargs": "^16.2.0"
   },
   "dependencies": {
     "@formatjs/intl-relativetimeformat": "^8.0.6",

--- a/tools/mage/js.go
+++ b/tools/mage/js.go
@@ -17,7 +17,6 @@ package ttnmage
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -39,33 +38,17 @@ func yarnWorkingDirectoryArg(elem ...string) string {
 	return fmt.Sprintf("--cwd=%s", filepath.Join(elem...))
 }
 
-func installYarn() error {
-	ok, err := target.Path(
-		filepath.Join("node_modules", "yarn"),
-	)
-	if err != nil {
-		return targetError(err)
-	}
-	if !ok {
-		return nil
-	}
-	if err := sh.RunV("npm", "install", "--no-package-lock", "--no-save", "--production=false", "yarn"); err != nil {
-		return fmt.Errorf("failed to install yarn: %w", err)
-	}
-	return nil
-}
-
 func execYarn(stdout, stderr io.Writer, args ...string) error {
-	_, err := sh.Exec(nil, stdout, stderr, "npx", append([]string{"yarn"}, args...)...)
+	_, err := sh.Exec(nil, stdout, stderr, "yarn", args...)
 	return err
 }
 
 func runYarn(args ...string) error {
-	return sh.Run("npx", append([]string{"yarn"}, args...)...)
+	return sh.Run("yarn", args...)
 }
 
 func runYarnV(args ...string) error {
-	return sh.RunV("npx", append([]string{"yarn"}, args...)...)
+	return sh.RunV("yarn", args...)
 }
 
 func (Js) runYarnCommand(cmd string, args ...string) error {
@@ -147,26 +130,10 @@ func (js Js) Deps() error {
 	if err != nil {
 		return targetError(err)
 	}
-	// installYarn updates modtime of node_modules, so we not only need to check that, but also the contents of node_modules.
-	// NOTE: Getting rid of installYarn and installing both yarn and the dependencies here does not work, since JsSDK.Build
-	// depends on yarn being available.
 	if !ok {
-		files, err := ioutil.ReadDir("node_modules")
-		if err != nil {
-			return fmt.Errorf("failed to read node_modules: %w", err)
-		}
-		if len(files) > 2 ||
-			js.isProductionMode() && len(files) > 1 {
-			// Check if it's only yarn and, in development mode, ttn-lw link installed in `node_modules`.
-			// Additionally, check whether the SDK was installed correctly.
-			// NOTE: There's no link in production mode.
-			if _, err := os.Stat(filepath.Join("node_modules", "ttn-lw", "dist")); !os.IsNotExist(err) {
-				return nil
-			}
-		}
+		return nil
 	}
-
-	mg.Deps(installYarn, JsSDK.Build)
+	mg.Deps(JsSDK.Build)
 	if !js.isProductionMode() {
 		if mg.Verbose() {
 			fmt.Println("Linking ttn-lw package")
@@ -232,7 +199,7 @@ func (js Js) Messages() error {
 	mg.Deps(js.Deps)
 	ok, err := target.Dir(
 		filepath.Join(".cache", "messages"),
-		filepath.Join("pkg", "webui", "console"),
+		filepath.Join("pkg", "webui"),
 	)
 	if err != nil {
 		return targetError(err)
@@ -377,7 +344,6 @@ func (js Js) Storybook() error {
 
 // Vulnerabilities runs yarn audit to check for vulnerable node packages.
 func (js Js) Vulnerabilities() error {
-	mg.Deps(installYarn)
 	if mg.Verbose() {
 		fmt.Println("Checking for vulnerabilities")
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14320,7 +14320,7 @@ tsutils@^3.17.1:
     tslib "^1.8.1"
 
 "ttn-lw@file:sdk/js":
-  version "3.13.0"
+  version "3.13.1"
   dependencies:
     arraybuffer-to-string "^1.0.2"
     axios "^0.21.1"
@@ -15294,11 +15294,6 @@ yargs@^16.2.0:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
-
-yarn@^1.22.10:
-  version "1.22.10"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.10.tgz#c99daa06257c80f8fa2c3f1490724e394c26b18c"
-  integrity sha512-IanQGI9RRPAN87VGTF7zs2uxkSyQSrSPsju0COgbsKQOOXr5LtcVPeyXWgwVa0ywG3d8dg6kSYKGBuYK021qeA==
 
 yauzl@^2.10.0:
   version "2.10.0"


### PR DESCRIPTION
#### Summary
Quickfix PR to remove the usage of `yarn` as dev dependency. 

#### Changes
- Remove separate `yarn` install from mage tooling
- Remove yarn as dev dependency from `package.json`


#### Testing

Manual and CI

#### Notes for Reviewers

Iirc, we used to fix the yarn version before, due to issues with inconsistent file hashes between builds. We don't store the `public` files of the webui as part of the binaries anymore, so it should not be an issue anymore. Most important is that hashes stay the same for the same input files for builds in the same environment. This should be the case as long as the yarn version remains the same.

Otherwise, I see no reason to complicate the build process by installing and running a separate `yarn` package, which also slows (fresh) builds by about 2 minutes. Note also that `yarn` is already [mentioned](https://github.com/TheThingsNetwork/lorawan-stack/blob/v3.13/DEVELOPMENT.md#development-environment) as prerequisite for running the build tooling in DEVELOPMENT.md

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
