### PR TITLE
Disable PR labeling workflow for dependabot PRs

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -5,7 +5,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v2
-      if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-      with:
-        repo-token: '${{ secrets.GITHUB_TOKEN }}'
+      - uses: actions/labeler@v2
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !startsWith(github.actor, 'dependabot') }}
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
#### Summary
Quickfix to remove PR label workflow from PRs opened by `dependabot`.

#### Changes
- Add condition to PR label workflow


#### Testing

- Manual

#### Notes for Reviewers
For some reason the workflow fails initially for these PRs. We don't need to label them anyway since they are already labeled by `dependabot`

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
