### PR TITLE
Initialize and cache device repository index outside Docker

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -99,12 +99,6 @@ jobs:
             .cache/sqldump.sql
             .env/admin_api_key.txt
           key: db-cache-${{ hashFiles('pkg/identityserver/store/**/*.go', 'cmd/ttn-lw-stack/commands/is-db.go') }}
-      - name: Initialize device repository db cache
-        id: dr-db-cache
-        uses: actions/cache@v2
-        with:
-          path: data/lorawan-devices-index
-          key: db-cache-${{ hashFiles('data/lorawan-devices') }}
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
@@ -129,6 +123,15 @@ jobs:
       - name: Make Mage
         run: make tools/bin/mage
         if: steps.tools-cache.outputs.cache-hit != 'true'
+      - name: Initialize device repository index cache
+        id: dr-index-cache
+        uses: actions/cache@v2
+        with:
+          path: data/lorawan-devices-index
+          key: dr-index-cache-${{ hashFiles('data/lorawan-devices') }}
+      - name: Create device repository index
+        run: tools/bin/mage dev:initDeviceRepo
+        if: steps.dr-index-cache.outputs.cache-hit != 'true'
       - name: Initialize stack environment
         run: tools/bin/mage init
       - name: Run test preparations

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -75,6 +75,15 @@ jobs:
     - name: Make Mage
       run: make tools/bin/mage
       if: steps.tools-cache.outputs.cache-hit != 'true'
+    - name: Initialize device repository index cache
+      id: dr-index-cache
+      uses: actions/cache@v2
+      with:
+        path: data/lorawan-devices-index
+        key: dr-index-cache-${{ hashFiles('data/lorawan-devices') }}
+    - name: Create device repository index
+      run: tools/bin/mage dev:initDeviceRepo
+      if: steps.dr-index-cache.outputs.cache-hit != 'true'
     - name: Install JS SDK dependencies
       run: tools/bin/mage jsSDK:deps
     - name: Build JS SDK

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -78,6 +78,15 @@ jobs:
     - name: Make Mage
       run: make tools/bin/mage
       if: steps.tools-cache.outputs.cache-hit != 'true'
+    - name: Initialize device repository index cache
+      id: dr-index-cache
+      uses: actions/cache@v2
+      with:
+        path: data/lorawan-devices-index
+        key: dr-index-cache-${{ hashFiles('data/lorawan-devices') }}
+    - name: Create device repository index
+      run: tools/bin/mage dev:initDeviceRepo
+      if: steps.dr-index-cache.outputs.cache-hit != 'true'
     - name: Auto-completion scripts
       run: tools/bin/mage cli:autocomplete
     - name: Install JS SDK dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,6 @@ RUN rm -rf /srv/ttn-lorawan/lorawan-frequency-plans/.git
 COPY data/lorawan-webhook-templates /srv/ttn-lorawan/lorawan-webhook-templates
 RUN rm -rf /srv/ttn-lorawan/lorawan-webhook-templates/.git
 
-COPY data/lorawan-devices /tmp/lorawan-devices
-RUN mkdir -p /srv/ttn-lorawan/lorawan-devices-index && \
-  /bin/ttn-lw-stack dr-db init --dr.source=directory --dr.directory="/tmp/lorawan-devices"
-
 FROM alpine:3.12
 
 RUN addgroup -g 886 thethings && adduser -u 886 -S -G thethings thethings
@@ -32,7 +28,7 @@ COPY public /srv/ttn-lorawan/public
 
 COPY --from=builder /srv/ttn-lorawan/lorawan-frequency-plans /srv/ttn-lorawan/lorawan-frequency-plans
 COPY --from=builder /srv/ttn-lorawan/lorawan-webhook-templates /srv/ttn-lorawan/lorawan-webhook-templates
-COPY --from=builder /srv/ttn-lorawan/lorawan-devices-index /srv/ttn-lorawan/lorawan-devices-index
+COPY data/lorawan-devices-index /srv/ttn-lorawan/lorawan-devices-index
 RUN chown thethings:thethings -R /srv/ttn-lorawan/lorawan-devices-index
 
 EXPOSE 1700/udp 1881 8881 1882 8882 1883 8883 1884 8884 1885 8885 1887 8887

--- a/tools/mage/dev.go
+++ b/tools/mage/dev.go
@@ -223,15 +223,17 @@ func (Dev) DBRedisCli() error {
 	return execDockerCompose("exec", "redis", "redis-cli")
 }
 
+// InitDeviceRepo initializes the device repository.
+func (Dev) InitDeviceRepo() error {
+	return runGo("./cmd/ttn-lw-stack", "dr-db", "init")
+}
+
 // InitStack initializes the Stack.
 func (Dev) InitStack() error {
 	if mg.Verbose() {
 		fmt.Println("Initializing the Stack")
 	}
 	if err := runGo("./cmd/ttn-lw-stack", "is-db", "init"); err != nil {
-		return err
-	}
-	if err := runGo("./cmd/ttn-lw-stack", "dr-db", "init"); err != nil {
 		return err
 	}
 	if err := runGo("./cmd/ttn-lw-stack", "is-db", "create-admin-user",
@@ -300,5 +302,5 @@ func (Dev) StartDevStack() error {
 }
 
 func init() {
-	initDeps = append(initDeps, Dev.Certificates)
+	initDeps = append(initDeps, Dev.Certificates, Dev.InitDeviceRepo)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR makes some changes to our dev tooling and CI workflows so that the device repository is initialized (and cached) by GitHub Actions and just copied into the Docker image instead of initializing it there.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
