### PR TITLE
Add frontend caches to release workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,6 +15,7 @@ on:
       - 'yarn.lock'
       - 'cypress/**'
       - 'docker-compose.yml'
+      - '.github/workflows/e2e.yml'
 
 jobs:
   determine-if-required:
@@ -77,20 +78,6 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - name: Initialize babel cache
-        id: babel-cache
-        uses: actions/cache@v2
-        with:
-          path: .cache/babel
-          key: ${{ runner.os }}-babel-cache-${{ hashFiles('config/babel.config.json', 'config/webpack.config.babel.js') }}
-          restore-keys: |
-            ${{ runner.os }}-babel-cache-
-      - name: Initialize public folder cache
-        id: public-cache
-        uses: actions/cache@v2
-        with:
-          path: public
-          key: public-cache-${{ hashFiles('pkg/webui/**') }}-${{ hashFiles('sdk/js/**/*.js', 'sdk/js/generated/*.json') }}-${{ hashFiles('config/webpack.config.babel.js') }}-${{ hashFiles('yarn.lock', 'sdk/js/yarn.lock')}}
       - name: Initialize SQL dump cache
         id: db-cache
         uses: actions/cache@v2
@@ -142,6 +129,21 @@ jobs:
       - name: Restore initialized sql db
         if: steps.db-cache.outputs.cache-hit == 'true'
         run: tools/bin/mage dev:dbStart dev:sqlRestore
+      - name: Initialize public folder cache
+        id: public-cache
+        uses: actions/cache@v2
+        with:
+          path: public
+          key: public-cache-${{ hashFiles('pkg/webui/**', 'sdk/js/**/*.js', 'sdk/js/generated/*.json', 'config/webpack.config.babel.js', 'yarn.lock', 'sdk/js/yarn.lock')}}
+      - name: Initialize babel cache
+        id: babel-cache
+        uses: actions/cache@v2
+        if: steps.public-cache.outputs.cache-hit != 'true'
+        with:
+          path: .cache/babel
+          key: ${{ runner.os }}-babel-cache-${{ hashFiles('config/babel.config.json', 'config/webpack.config.babel.js') }}
+          restore-keys: |
+            ${{ runner.os }}-babel-cache-
       - name: Build frontend
         if: steps.public-cache.outputs.cache-hit != 'true'
         run: tools/bin/mage js:build

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -13,105 +13,113 @@ jobs:
     name: Snapshot release
     runs-on: ubuntu-18.04
     steps:
-    - name: Check out code
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-        submodules: true
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-    - name: Login to Docker Hub
-      uses: docker/login-action@v1
-      with:
-        username: '${{ secrets.DOCKERHUB_USERNAME }}'
-        password: '${{ secrets.DOCKERHUB_PASSWORD }}'
-    - name: Set up Node
-      uses: actions/setup-node@v2-beta
-      with:
-        node-version: '~14'
-    - name: Get Yarn cache directory path
-      id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(npx yarn cache dir)"
-    - name: Initialize Yarn module cache
-      id: yarn-cache
-      uses: actions/cache@v2
-      with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: '~1.16'
-    - name: Initialize Go module cache
-      uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - name: Download Go dependencies
-      run: go mod download
-    - name: Download Go tool dependencies
-      run: |
-        cd tools
-        go mod download
-    - name: Initialize Go build cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/go-build
-        key: ${{ runner.os }}-go-build-${{ github.ref }}
-        restore-keys: |
-          ${{ runner.os }}-go-build-refs/heads/v
-    - name: Initialize tool binary cache
-      id: tools-cache
-      uses: actions/cache@v2
-      with:
-        path: tools/bin
-        key: ${{ runner.os }}-tools-${{ hashFiles('tools/**') }}
-    - name: Make Mage
-      run: make tools/bin/mage
-      if: steps.tools-cache.outputs.cache-hit != 'true'
-    - name: Initialize device repository index cache
-      id: dr-index-cache
-      uses: actions/cache@v2
-      with:
-        path: data/lorawan-devices-index
-        key: dr-index-cache-${{ hashFiles('data/lorawan-devices') }}
-    - name: Create device repository index
-      run: tools/bin/mage dev:initDeviceRepo
-      if: steps.dr-index-cache.outputs.cache-hit != 'true'
-    - name: Install JS SDK dependencies
-      run: tools/bin/mage jsSDK:deps
-    - name: Build JS SDK
-      run: tools/bin/mage jsSDK:clean jsSDK:build
-    - name: Install JS dependencies
-      if: steps.yarn-cache.outputs.cache-hit != 'true'
-      run: tools/bin/mage js:deps
-      timeout-minutes: 5
-    - name: Build frontend
-      run: tools/bin/mage js:clean js:build
-    - name: Check for diff
-      run: tools/bin/mage git:diff
-    - name: Import the signing key
-      run: |
-        printf '%s' '${{ secrets.SIGNATURE_PASSPHRASE }}' >/tmp/gpg_passphrase
-        cat /tmp/gpg_passphrase | gpg --passphrase-fd 0 --no-tty --batch --import gpg_signing_key
-    - name: Run Goreleaser
-      uses: goreleaser/goreleaser-action@v2
-      with:
-        version: 'v0.161.1'
-        args: release --config .goreleaser.snapshot.yml --snapshot --timeout 60m
-      env:
-        SIGN_KEY_NAME: ${{ secrets.SIGN_KEY_NAME }}
-    - name: Tag and Push Docker images
-      run: |
-        docker tag lorawan-stack-dev:${{ github.sha }}-amd64 thethingsnetwork/lorawan-stack-dev:${{ github.sha }}-amd64
-        docker push thethingsnetwork/lorawan-stack-dev:${{ github.sha }}-amd64
-        docker manifest create thethingsnetwork/lorawan-stack-dev:${{ github.sha }} thethingsnetwork/lorawan-stack-dev:${{ github.sha }}-amd64
-        docker manifest push thethingsnetwork/lorawan-stack-dev:${{ github.sha }}
-      env:
-        DOCKER_CLI_EXPERIMENTAL: enabled
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: '${{ secrets.DOCKERHUB_USERNAME }}'
+          password: '${{ secrets.DOCKERHUB_PASSWORD }}'
+      - name: Set up Node
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: '~14'
+      - name: Get Yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(npx yarn cache dir)"
+      - name: Initialize Yarn module cache
+        id: yarn-cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '~1.16'
+      - name: Initialize Go module cache
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Download Go dependencies
+        run: go mod download
+      - name: Download Go tool dependencies
+        run: |
+          cd tools
+          go mod download
+      - name: Initialize Go build cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/go-build
+          key: ${{ runner.os }}-go-build-${{ github.ref }}
+          restore-keys: |
+            ${{ runner.os }}-go-build-refs/heads/v
+      - name: Initialize tool binary cache
+        id: tools-cache
+        uses: actions/cache@v2
+        with:
+          path: tools/bin
+          key: ${{ runner.os }}-tools-${{ hashFiles('tools/**') }}
+      - name: Make Mage
+        run: make tools/bin/mage
+        if: steps.tools-cache.outputs.cache-hit != 'true'
+      - name: Initialize device repository index cache
+        id: dr-index-cache
+        uses: actions/cache@v2
+        with:
+          path: data/lorawan-devices-index
+          key: dr-index-cache-${{ hashFiles('data/lorawan-devices') }}
+      - name: Create device repository index
+        run: tools/bin/mage dev:initDeviceRepo
+        if: steps.dr-index-cache.outputs.cache-hit != 'true'
+      - name: Initialize public folder cache
+        id: public-cache
+        uses: actions/cache@v2
+        with:
+          path: public
+          key: public-cache-${{ hashFiles('pkg/webui/**', 'sdk/js/**/*.js', 'sdk/js/generated/*.json', 'config/webpack.config.babel.js', 'yarn.lock', 'sdk/js/yarn.lock')}}
+      - name: Initialize babel cache
+        id: babel-cache
+        uses: actions/cache@v2
+        if: steps.public-cache.outputs.cache-hit != 'true'
+        with:
+          path: .cache/babel
+          key: ${{ runner.os }}-babel-cache-${{ hashFiles('config/babel.config.json', 'config/webpack.config.babel.js') }}
+          restore-keys: |
+            ${{ runner.os }}-babel-cache-
+      - name: Build frontend
+        run: tools/bin/mage js:build
+        if: steps.public-cache.outputs.cache-hit != 'true'
+      - name: Check for diff
+        run: tools/bin/mage git:diff
+      - name: Import the signing key
+        run: |
+          printf '%s' '${{ secrets.SIGNATURE_PASSPHRASE }}' >/tmp/gpg_passphrase
+          cat /tmp/gpg_passphrase | gpg --passphrase-fd 0 --no-tty --batch --import gpg_signing_key
+      - name: Run Goreleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: 'v0.161.1'
+          args: release --config .goreleaser.snapshot.yml --snapshot --timeout 60m
+        env:
+          SIGN_KEY_NAME: ${{ secrets.SIGN_KEY_NAME }}
+      - name: Tag and Push Docker images
+        run: |
+          docker tag lorawan-stack-dev:${{ github.sha }}-amd64 thethingsnetwork/lorawan-stack-dev:${{ github.sha }}-amd64
+          docker push thethingsnetwork/lorawan-stack-dev:${{ github.sha }}-amd64
+          docker manifest create thethingsnetwork/lorawan-stack-dev:${{ github.sha }} thethingsnetwork/lorawan-stack-dev:${{ github.sha }}-amd64
+          docker manifest push thethingsnetwork/lorawan-stack-dev:${{ github.sha }}
+        env:
+          DOCKER_CLI_EXPERIMENTAL: enabled


### PR DESCRIPTION
#### Summary
This quickfix PR adds caching for frontend builds to the snapshot github action workflow. This will speed up builds as well as provide caches for PR builds.

Closes #3480 

#### Changes
- Add public folder cache to `release-snapshot` workflow
- Add babel cache to `release-snapshot` workflow
- Simplify frontend steps in `release-snapshot` workflow
- Simplify cache key for public folder

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
