### PR TITLE
Disable ADR for multicast devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ For details about compatibility between different releases, see the **Commitment
 - Current and future rights selection for organization collaborators in the Console.
 - Current and future rights selection for user api keys in the Console.
 - Low or no throughput of message handling from Packet Broker when the ingress is high when Packet Broker Agent starts.
+- Unset ADR bit in downlink messages to multicast devices.
 
 ### Security
 

--- a/pkg/networkserver/mac/utils.go
+++ b/pkg/networkserver/mac/utils.go
@@ -149,6 +149,9 @@ func DeviceUseADR(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings, phy *band.Ba
 	if !phy.EnableADR {
 		return false
 	}
+	if dev.Multicast {
+		return false
+	}
 	if dev.MACSettings != nil && dev.MACSettings.UseADR != nil {
 		return dev.MACSettings.UseADR.Value
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/462

#### Changes
<!-- What are the changes made in this pull request? -->

- Disable ADR for multicast devices

#### Testing

<!-- How did you verify that this change works? -->

Did not test

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Should be none; there is no uplink on multicast sessions so end devices should already be ignoring the ADR bit.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
