### PR TITLE
Update connection stats with field mask paths

### DIFF
--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -1226,9 +1226,11 @@ func TestGatewayServer(t *testing.T) {
 
 						conn, ok := gs.GetConnection(ctx, ids)
 						a.So(ok, should.BeTrue)
-						a.So(conn.Stats(), should.NotBeNil)
+
+						stats, paths := conn.Stats()
+						a.So(stats, should.NotBeNil)
 						if config.Stats != nil {
-							a.So(config.Stats.Set(conn.Context(), ids, conn.Stats()), should.BeNil)
+							a.So(config.Stats.Set(conn.Context(), ids, stats, paths), should.BeNil)
 						}
 
 						stats, err := statsClient.GetGatewayConnectionStats(statsCtx, &ids)
@@ -1512,12 +1514,14 @@ func TestGatewayServer(t *testing.T) {
 
 						conn, ok := gs.GetConnection(ctx, ids)
 						a.So(ok, should.BeTrue)
-						a.So(conn.Stats(), should.NotBeNil)
+
+						stats, paths := conn.Stats()
+						a.So(stats, should.NotBeNil)
 						if config.Stats != nil {
-							a.So(config.Stats.Set(conn.Context(), ids, conn.Stats()), should.BeNil)
+							a.So(config.Stats.Set(conn.Context(), ids, stats, paths), should.BeNil)
 						}
 
-						stats, err := statsClient.GetGatewayConnectionStats(statsCtx, &ids)
+						stats, err = statsClient.GetGatewayConnectionStats(statsCtx, &ids)
 						if !a.So(err, should.BeNil) {
 							t.FailNow()
 						}

--- a/pkg/gatewayserver/grpc.go
+++ b/pkg/gatewayserver/grpc.go
@@ -46,5 +46,6 @@ func (gs *GatewayServer) GetGatewayConnectionStats(ctx context.Context, ids *ttn
 	if !ok {
 		return nil, errNotConnected.WithAttributes("gateway_uid", uid)
 	}
-	return val.(connectionEntry).Stats(), nil
+	stats, _ := val.(connectionEntry).Stats()
+	return stats, nil
 }

--- a/pkg/gatewayserver/redis/registry.go
+++ b/pkg/gatewayserver/redis/registry.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"runtime/trace"
 
+	"github.com/go-redis/redis/v8"
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	ttnredis "go.thethings.network/lorawan-stack/v3/pkg/redis"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/unique"
@@ -33,18 +35,29 @@ func (r *GatewayConnectionStatsRegistry) key(uid string) string {
 }
 
 // Set sets or clears the connection stats for a gateway.
-func (r *GatewayConnectionStatsRegistry) Set(ctx context.Context, ids ttnpb.GatewayIdentifiers, stats *ttnpb.GatewayConnectionStats) error {
+func (r *GatewayConnectionStatsRegistry) Set(ctx context.Context, ids ttnpb.GatewayIdentifiers, stats *ttnpb.GatewayConnectionStats, paths []string) error {
 	uid := unique.ID(ctx, ids)
 
 	defer trace.StartRegion(ctx, "set gateway connection stats").End()
 
+	uk := r.key(uid)
 	var err error
 	if stats == nil {
-		err = r.Redis.Del(ctx, r.key(uid)).Err()
+		err = r.Redis.Del(ctx, uk).Err()
 	} else {
-		_, err = ttnredis.SetProto(ctx, r.Redis, r.key(uid), stats, 0)
-	}
+		err = r.Redis.Watch(ctx, func(tx *redis.Tx) error {
+			pb := &ttnpb.GatewayConnectionStats{}
+			if err := ttnredis.GetProto(ctx, tx, uk).ScanProto(pb); err != nil && !errors.IsNotFound(err) {
+				return err
+			}
 
+			if err := pb.SetFields(stats, paths...); err != nil {
+				return err
+			}
+			_, err := ttnredis.SetProto(ctx, tx, uk, pb, 0)
+			return err
+		}, uk)
+	}
 	if err != nil {
 		return ttnredis.ConvertError(err)
 	}

--- a/pkg/gatewayserver/registry.go
+++ b/pkg/gatewayserver/registry.go
@@ -25,8 +25,8 @@ import (
 type GatewayConnectionStatsRegistry interface {
 	// Get returns connection stats for a gateway.
 	Get(ctx context.Context, ids ttnpb.GatewayIdentifiers) (*ttnpb.GatewayConnectionStats, error)
-	// Set sets or clears the connection stats for a gateway.
-	Set(ctx context.Context, ids ttnpb.GatewayIdentifiers, stats *ttnpb.GatewayConnectionStats) error
+	// Set sets, updates or clears the connection stats for a gateway. Only fields specified in the field mask paths are set.
+	Set(ctx context.Context, ids ttnpb.GatewayIdentifiers, stats *ttnpb.GatewayConnectionStats, paths []string) error
 }
 
 // EntityRegistry abstracts the Identity server gateway functions.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsIndustries/lorawan-stack/issues/2655

#### Changes
<!-- What are the changes made in this pull request? -->

- Change signature of `*io.Connection.Stats()` to return connection stats and list of field mask paths
- If stats registry already contains a proto, only the specified field mask paths are updated.

#### Testing

<!-- How did you verify that this change works? -->

Existing unit tests for stats not breaking. Unit tests for presence of appropriate field mask paths.

Having separate GS instances handling uplink/downlink is very hard to reproduce locally.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

There should not be any.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- `sub_bands` is only added if GS instance is handling downlink (otherwise the instance that handles uplink would always overwrite with zero values). If we ever have utilization statistics for uplink, we probably have to revisit this.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
