### PR TITLE
Avoid `SameSite=None` in cookies when not using TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- OAuth client login issues when not using TLS.
+
 ### Security
 
 ## [3.13.2] - 2021-06-17

--- a/pkg/web/cookie/cookie.go
+++ b/pkg/web/cookie/cookie.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"time"
 
+	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/webmiddleware"
 )
 
@@ -48,6 +49,8 @@ func (d *Cookie) new(r *http.Request) http.Cookie {
 	sameSite := d.SameSite
 	if sameSite == 0 {
 		sameSite = http.SameSiteLaxMode
+	} else if sameSite == http.SameSiteNoneMode && r.URL.Scheme == "http" {
+		log.FromContext(r.Context()).WithField("namespace", "web").Warn("SameSite=None will be rejected when not using TLS.")
 	}
 	return http.Cookie{
 		Name:     d.Name,


### PR DESCRIPTION
#### Summary
This quickfix will fix OAuth login for connections that don't use TLS (e.g. in development). Cookies with `SameSite=None` have to use the `Secure` flag, otherwise they can be rejected by browsers. `Secure` can however only be set when the connection uses TLS.

#### Changes
- Use `SameSite=Lax` when not using TLS in the OAuth state cookie
- Log a warning when cookies are set with `SameSite=None` without using TLS.


#### Testing

Manual testing.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
