### PR TITLE
Add Client Requested email template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Added
 
+- Email sent to admins when an OAuth client is requested by a non-admin user.
+
 ### Changed
 
 - Low-level log messages from the `go-redis` library are printed only when the log level is set to `DEBUG`.

--- a/pkg/identityserver/emails/client_requested.go
+++ b/pkg/identityserver/emails/client_requested.go
@@ -1,0 +1,80 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package emails
+
+import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+
+// ClientRequested is the email that is sent to admins when a user requests an OAuth client.
+type ClientRequested struct {
+	Data
+	Client       *ttnpb.Client
+	Collaborator *ttnpb.OrganizationOrUserIdentifiers
+}
+
+// TemplateName returns the name of the template to use for this email.
+func (ClientRequested) TemplateName() string { return "client_requested" }
+
+const clientRequestedSubject = `OAuth client registration of {{ .Entity.ID }} needs review`
+
+const clientRequestedText = `Dear {{ .User.Name }},
+
+A new OAuth client "{{ .Entity.ID }}" was just registered by {{ .Collaborator.EntityType }} "{{ .Collaborator.IDString }}" on {{ .Network.Name }} and needs admin approval.
+
+Name: {{ .Client.Name }}
+Description: {{ .Client.Description }}
+
+Grants:
+{{- with .Client.Grants }}
+{{- range . }}
+- {{ . }}
+{{- end }}
+{{- else }} (none)
+{{- end }}
+
+Rights:
+{{- with .Client.Rights }}
+{{- range . }}
+- {{ . }}
+{{- end }}
+{{- else }} (none)
+{{- end }}
+
+Redirect URIs:
+{{- with .Client.RedirectURIs }}
+{{- range . }}
+- {{ . }}
+{{- end }}
+{{- else }} (none)
+{{- end }}
+
+Logout Redirect URIs:
+{{- with .Client.LogoutRedirectURIs }}
+{{- range . }}
+- {{ . }}
+{{- end }}
+{{- else }} (none)
+{{- end }}
+
+You can use the command-line interface to approve (or reject) the OAuth client:
+
+ttn-lw-cli clients set {{ .Entity.ID }} --state APPROVED (or --state REJECTED) --state-description "..."
+
+For more information on how to use the command-line interface, please refer to the documentation: {{ documentation_url "/getting-started/cli/" }}.
+`
+
+// DefaultTemplates returns the default templates for this email.
+func (ClientRequested) DefaultTemplates() (subject, html, text string) {
+	return clientRequestedSubject, "", clientRequestedText
+}

--- a/pkg/identityserver/emails/user_requested.go
+++ b/pkg/identityserver/emails/user_requested.go
@@ -29,17 +29,17 @@ func (u UserRequested) ConsoleURL() string {
 // TemplateName returns the name of the template to use for this email.
 func (UserRequested) TemplateName() string { return "user_requested" }
 
-const userRequestedSubject = `User {{ .Entity.ID }} is waiting for approval`
+const userRequestedSubject = `User registration of {{ .Entity.ID }} needs review`
 
 const userRequestedText = `Dear {{ .User.Name }},
 
-User "{{ .Entity.ID }}" wants to join {{ .Network.Name }}.
+A new user "{{ .Entity.ID }}" was just registered on {{ .Network.Name }} and needs admin approval.
 
 You can go to {{ .ConsoleURL }} to view and approve (or reject) the user.
 
 If you prefer to use the command-line interface, you can run the following command:
 
-ttn-lw-cli users set {{ .Entity.ID }} --state APPROVED (or --state REJECTED)
+ttn-lw-cli users set {{ .Entity.ID }} --state APPROVED (or --state REJECTED) --state-description "..."
 
 For more information on how to use the command-line interface, please refer to the documentation: {{ documentation_url "/getting-started/cli/" }}.
 `


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request adds an email template for emails sent to admins when a non-admin user requests an OAuth client.

```
Dear admin,

A new OAuth client "foobar-gtw-manager" was just registered by user "hylke" on The Things Stack for LoRaWAN and needs admin approval.

Name: FooBar gateway manager
Description: Manage your gateway on the FooBar platform

Grants:
- GRANT_AUTHORIZATION_CODE

Rights:
- RIGHT_GATEWAY_ALL
- RIGHT_USER_INFO

Redirect URIs:
- https://example.com/oauth/callback/login

Logout Redirect URIs: (none)

You can use the command-line interface to approve (or reject) the OAuth client:

ttn-lw-cli clients set foobar-gtw-manager --state APPROVED (or --state REJECTED) --state-description "..."

For more information on how to use the command-line interface, please refer to the documentation: https://www.thethingsindustries.com/docs/getting-started/cli.
```

Closes #4242

#### Testing

<!-- How did you verify that this change works? -->

🐒 

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Nothing unrelated was touched, so not expecting anything.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
