### PR TITLE
Generate DevAddr for ABP session on NS when creating end device in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For details about compatibility between different releases, see the **Commitment
 - GS will discard repeated gateway uplink messages (often received due to buggy gateway forwarder implementations). A gateway uplink is considered to be repeated when it has the same payload, frequency and antenna index as the last one.
   - The new `gs_uplink_repeated_total` metric counts how many repeated uplinks have been discarded.
   - A `gs.up.repeat` event is emitted (once per minute maximum) for gateways that are stuck in a loop and forward the same uplink message.
+- For ABP sessions, the CLI now requests a DevAddr from the Network Server instead of generating one from the testing NetID.
 
 ### Deprecated
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request changes how the CLI gets a DevAddr when creating an ABP session. Instead of the CLI generating a random DevAddr in the testing NetID, it now requests a DevAddr from the Network Server.

cc: @descartes

#### Testing

<!-- How did you verify that this change works? -->

```
ttn-lw-cli end-devices create \
  --application-id hylke-app \
  --device-id hylke-dev \
  --abp --with-session \
  --lorawan-version 1.0.2 --lorawan-phy-version 1.0.2-b \
  --frequency-plan-id EU_863_870
```

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
