### PR TITLE
Add option to use cross site cookies for oauth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For details about compatibility between different releases, see the **Commitment
 
 - Email sent to admins when an OAuth client is requested by a non-admin user.
 - Packet Broker UI in the Console (admin only). 
+- New config option `--console.oauth.cross-site-cookie` to control access to OAuth state cookie between origins.
+  - This option needs to be set to `true` (default is `false`) in multi-cluster deployments in order to support OAuth clients that use POST callbacks.
 
 ### Changed
 
@@ -30,6 +32,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - Parse error in Webhook Templates.
 - Application deletion handling in the Console.
+- Error when logging into the Console when using connections without TLS.
 
 ### Security
 

--- a/cmd/internal/shared/console/config.go
+++ b/cmd/internal/shared/console/config.go
@@ -24,11 +24,12 @@ import (
 // DefaultConsoleConfig is the default configuration for the Console.
 var DefaultConsoleConfig = console.Config{
 	OAuth: oauthclient.Config{
-		AuthorizeURL: shared.DefaultOAuthPublicURL + "/authorize",
-		LogoutURL:    shared.DefaultOAuthPublicURL + "/logout",
-		TokenURL:     shared.DefaultOAuthPublicURL + "/token",
-		ClientID:     "console",
-		ClientSecret: "console",
+		AuthorizeURL:    shared.DefaultOAuthPublicURL + "/authorize",
+		LogoutURL:       shared.DefaultOAuthPublicURL + "/logout",
+		TokenURL:        shared.DefaultOAuthPublicURL + "/token",
+		ClientID:        "console",
+		ClientSecret:    "console",
+		CrossSiteCookie: false,
 	},
 	UI: console.UIConfig{
 		TemplateData: webui.TemplateData{

--- a/pkg/web/oauthclient/config.go
+++ b/pkg/web/oauthclient/config.go
@@ -24,6 +24,8 @@ type Config struct {
 	ClientID     string `name:"client-id" description:"The OAuth client ID"`
 	ClientSecret string `name:"client-secret" description:"The OAuth client secret" json:"-"`
 
+	CrossSiteCookie bool `name:"cross-site-cookie" description:"Whether to make OAuth cookies accessible cross-site"`
+
 	StateCookieName string `name:"-"`
 	AuthCookieName  string `name:"-"`
 

--- a/pkg/web/oauthclient/cookie_state.go
+++ b/pkg/web/oauthclient/cookie_state.go
@@ -36,12 +36,16 @@ func init() {
 
 // StateCookie returns the cookie storing the state of the console.
 func (oc *OAuthClient) StateCookie() *cookie.Cookie {
+	sameSite := http.SameSiteLaxMode
+	if oc.config.CrossSiteCookie {
+		sameSite = http.SameSiteNoneMode
+	}
 	return &cookie.Cookie{
 		Name:     oc.config.StateCookieName,
 		HTTPOnly: true,
 		Path:     oc.getMountPath(),
 		MaxAge:   10 * time.Minute,
-		SameSite: http.SameSiteNoneMode,
+		SameSite: sameSite,
 	}
 }
 


### PR DESCRIPTION
#### Summary
This quickfix adds a config option to the `oauthclient` package to allow for more fine-grained control over cookie security.
This will also solve a bug in which it is impossible to sign into the Console when not using TLS. This is due to currently using `SameSite=none` for the OAuth state cookie, which some browsers will block when not using the `Secure` flag.

#### Changes
- Add config option `CrossSiteCookies` to `oauthclient.Config`
- Add default for this option `false`
- Use option to determine `SameSite` option for the state cookie of the OAuth process

#### Testing

Manual testing.

##### Regressions

As we have seen before, changes to our cookie logic can have many hard to foresee issues. So @htdvisser please also test.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
