### PR TITLE
Fix LoRaCloud Geolocation Services request path

### DIFF
--- a/pkg/applicationserver/io/packages/loragls/v3/api/client.go
+++ b/pkg/applicationserver/io/packages/loragls/v3/api/client.go
@@ -56,7 +56,7 @@ var (
 	DefaultServerURL *url.URL
 )
 
-func (c *Client) newRequest(ctx context.Context, version, method, category, operation string, body io.Reader) (*http.Request, error) {
+func (c *Client) newRequest(ctx context.Context, method, version, category, operation string, body io.Reader) (*http.Request, error) {
 	u := urlutil.CloneURL(c.baseURL)
 	u.Path = path.Join(basePath, version, category, operation)
 	req, err := http.NewRequestWithContext(ctx, method, u.String(), body)
@@ -72,8 +72,8 @@ func (c *Client) newRequest(ctx context.Context, version, method, category, oper
 }
 
 // Do executes a new HTTP request with the given parameters and body and returns the response.
-func (c *Client) Do(ctx context.Context, version, method, category, operation string, body io.Reader) (*http.Response, error) {
-	req, err := c.newRequest(ctx, version, method, category, operation, body)
+func (c *Client) Do(ctx context.Context, method, version, category, operation string, body io.Reader) (*http.Response, error) {
+	req, err := c.newRequest(ctx, method, version, category, operation, body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/applicationserver/io/packages/loragls/v3/api/client_test.go
+++ b/pkg/applicationserver/io/packages/loragls/v3/api/client_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"testing"
@@ -273,7 +272,7 @@ func TestClient(t *testing.T) {
 				request       interface{}
 				response      interface{}
 				do            func(ctx context.Context, a *assertions.Assertion)
-				assertRequest func(t *testing.T, a *assertions.Assertion, body io.Reader)
+				assertRequest func(t *testing.T, a *assertions.Assertion, req *http.Request)
 			}{
 				{
 					name:     "SingleFrameRequest",
@@ -285,9 +284,11 @@ func TestClient(t *testing.T) {
 							a.So(resp.LocationSolverResponse, should.Resemble, singleFrameResponse)
 						}
 					},
-					assertRequest: func(t *testing.T, a *assertions.Assertion, body io.Reader) {
+					assertRequest: func(t *testing.T, a *assertions.Assertion, req *http.Request) {
+						a.So(req.URL.Path, should.Equal, "/api/v3/solve/singleframe")
+
 						request := &api.SingleFrameRequest{}
-						a.So(json.NewDecoder(body).Decode(request), should.BeNil)
+						a.So(json.NewDecoder(req.Body).Decode(request), should.BeNil)
 						a.So(request, should.Resemble, singleFrameRequest)
 					},
 				},
@@ -301,9 +302,11 @@ func TestClient(t *testing.T) {
 							a.So(resp.LocationSolverResponse, should.Resemble, multiFrameResponse)
 						}
 					},
-					assertRequest: func(t *testing.T, a *assertions.Assertion, body io.Reader) {
+					assertRequest: func(t *testing.T, a *assertions.Assertion, req *http.Request) {
+						a.So(req.URL.Path, should.Equal, "/api/v3/solve/multiframe")
+
 						request := &api.MultiFrameRequest{}
-						a.So(json.NewDecoder(body).Decode(request), should.BeNil)
+						a.So(json.NewDecoder(req.Body).Decode(request), should.BeNil)
 						a.So(request, should.Resemble, multiFrameRequest)
 					},
 				},
@@ -317,9 +320,11 @@ func TestClient(t *testing.T) {
 							a.So(resp.GNSSLocationSolverResponse, should.Resemble, gnssResponse)
 						}
 					},
-					assertRequest: func(t *testing.T, a *assertions.Assertion, body io.Reader) {
+					assertRequest: func(t *testing.T, a *assertions.Assertion, req *http.Request) {
+						a.So(req.URL.Path, should.Equal, "/api/v3/solve/gnss_lr1110_singleframe")
+
 						request := &api.GNSSRequest{}
-						a.So(json.NewDecoder(body).Decode(request), should.BeNil)
+						a.So(json.NewDecoder(req.Body).Decode(request), should.BeNil)
 						a.So(request, should.Resemble, gnssRequest)
 					},
 				},
@@ -333,9 +338,11 @@ func TestClient(t *testing.T) {
 							a.So(resp.WiFiLocationSolverResponse, should.Resemble, wifiResponse)
 						}
 					},
-					assertRequest: func(t *testing.T, a *assertions.Assertion, body io.Reader) {
+					assertRequest: func(t *testing.T, a *assertions.Assertion, req *http.Request) {
+						a.So(req.URL.Path, should.Equal, "/api/v2/loraWifi")
+
 						request := &api.WiFiRequest{}
-						a.So(json.NewDecoder(body).Decode(request), should.BeNil)
+						a.So(json.NewDecoder(req.Body).Decode(request), should.BeNil)
 						a.So(request, should.Resemble, wifiRequest)
 					},
 				},
@@ -356,7 +363,7 @@ func TestClient(t *testing.T) {
 
 					req := <-reqChan
 					if a.So(req, should.NotBeNil) {
-						tc.assertRequest(t, a, req.Body)
+						tc.assertRequest(t, a, req)
 					}
 				})
 			}

--- a/pkg/webui/console/constants/event-filters.js
+++ b/pkg/webui/console/constants/event-filters.js
@@ -23,6 +23,7 @@ export const EVENT_VERBOSE_FILTERS = [
   'as.*.drop',
   'as.down.data.forward',
   'as.up.data.forward',
+  'as.up.service.forward',
   'gs.down.send',
   'gs.gateway.connect',
   'gs.gateway.disconnect',

--- a/pkg/webui/console/constants/event-filters.js
+++ b/pkg/webui/console/constants/event-filters.js
@@ -22,6 +22,7 @@ const filterListToRegExpString = array =>
 export const EVENT_VERBOSE_FILTERS = [
   'as.*.drop',
   'as.down.data.forward',
+  'as.up.location.forward',
   'as.up.data.forward',
   'as.up.service.forward',
   'gs.down.send',

--- a/pkg/webui/console/containers/lora-cloud-gls-form/index.js
+++ b/pkg/webui/console/containers/lora-cloud-gls-form/index.js
@@ -63,12 +63,12 @@ const m = defineMessages({
 })
 
 const LORACLOUD_GLS_QUERY_LABELS = Object.freeze([
-  { value: 'TDOARSSI', label: 'LoRa® TOA/RSSI' },
+  { value: 'TOARSSI', label: 'LoRa® TOA/RSSI' },
   { value: 'GNSS', label: 'GNSS' },
   { value: 'TOAWIFI', label: 'TOA/WiFi' },
 ])
 const LORACLOUD_GLS_QUERY_TYPES = Object.freeze({
-  TDOARSSI: 'TDOARSSI',
+  TOARSSI: 'TOARSSI',
   GNSS: 'GNSS',
   TOAWIFI: 'TOAWIFI',
 })
@@ -80,10 +80,10 @@ const validationSchema = Yup.object()
       token: Yup.string().required(sharedMessages.validateRequired),
       query: Yup.string()
         .oneOf(LORACLOUD_GLS_QUERY_VALUES)
-        .default(LORACLOUD_GLS_QUERY_TYPES.TDOARSSI)
+        .default(LORACLOUD_GLS_QUERY_TYPES.TOARSSI)
         .required(sharedMessages.validateRequired),
       multi_frame: Yup.boolean().when('query', {
-        is: LORACLOUD_GLS_QUERY_TYPES.TDOARSSI,
+        is: LORACLOUD_GLS_QUERY_TYPES.TOARSSI,
         then: schema => schema.default(false).required(sharedMessages.validateRequired),
         otherwise: schema => schema.strip(),
       }),
@@ -224,7 +224,7 @@ const LoRaCloudGLSForm = () => {
           onChange={handleQueryTypeChange}
           required
         />
-        {queryType === LORACLOUD_GLS_QUERY_TYPES.TDOARSSI && (
+        {queryType === LORACLOUD_GLS_QUERY_TYPES.TOARSSI && (
           <>
             <Form.Field
               component={Checkbox}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/4267

#### Changes
<!-- What are the changes made in this pull request? -->

- Allow service data and location solved events to be shown to the user without the verbose filter being turned off
- Fix the enum value for Single Frame TDOA used by the Console
- Fix the URL for GLS requests and add unit tests for it.


#### Testing

<!-- How did you verify that this change works? -->

I've simulated the following uplink (3 gateways) with a GLS token set:

<details>

```json
{
	"@type": "type.googleapis.com/ttn.lorawan.v3.ApplicationUp",
	"end_device_ids": {
		"device_id": "lora-edge-tracker",
		"application_ids": {
			"application_id": "lr1110-demo-app"
		},
		"dev_eui": "0016C001F0003FB4",
		"join_eui": "0016C001FFFE0001",
		"dev_addr": "260BEF32"
	},
	"correlation_ids": [
		"as:up:01F8WK2QQX7ZEC84MHWRSC38EE",
		"gs:conn:01F8WG8JN5NDZKBFMQ8SQQKWYP",
		"gs:up:host:01F8WG8JNFRJC3JTR2H2Z0BG3Y",
		"gs:uplink:01F8WK2QH8NMK3P4NFTZGBR5GB",
		"ns:uplink:01F8WK2QH966XZCD1ZQJ0P7NNY",
		"rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01F8WK2QH98NG2WBBKDZ1G2N5Y",
		"rpc:/ttn.lorawan.v3.NsAs/HandleUplink:01F8WK2QQXSYVT2MPMKFJ6GE8M"
	],
	"received_at": "2021-06-23T14:06:14.782929535Z",
	"uplink_message": {
		"session_key_id": "dHRuLWx3LWludGVyb3AtZ2VuZXJhdGVkOgF6OPwRrO6mV4E+zf6B7Qg=",
		"f_port": 199,
		"f_cnt": 13,
		"frm_payload": "FC64AM0IKr9kZrPHyprQZGazUs2GsgIg4NcS16WwlXULbSijCFsOhf12q7BOJl40oqBl3ZGMxhsud2nmOasqSaZEl3HX7u7REp9+fvG/k9OpnVFVVfWZw0ai87j6KzdCBgmQFKg=",
		"rx_metadata": [{
				"gateway_ids": {
					"gateway_id": "snejra-rak-gw",
					"eui": "B827EBFFFE8A9E3C"
				},
				"timestamp": 2956865323,
				"rssi": -100.0,
				"channel_rssi": -100.0,
				"snr": 17.7,
				"location": {
					"latitude": 51.50119,
					"longitude": -0.142003,
					"source": "SOURCE_REGISTRY"
				},
				"uplink_token": "ChsKGQoNc25lanJhLXJhay1ndxIIuCfr//6KnjwQq974gQsaDAjW/8yGBhC87e+OAiD4/6CXh1Y=",
				"channel_index": 1
			},
			{
				"gateway_ids": {
					"gateway_id": "migration-demo-gw",
					"eui": "B827EBFFFE8DB885"
				},
				"time": "2021-06-23T14:06:14.541707Z",
				"timestamp": 2374686131,
				"rssi": -116.0,
				"channel_rssi": -116.0,
				"snr": 3.3,
				"location": {
					"latitude": 51.51019,
					"longitude": -0.142003,
					"source": "SOURCE_REGISTRY"
				},
				"uplink_token": "Ch8KHQoRbWlncmF0aW9uLWRlbW8tZ3cSCLgn6//+jbiFELOrq+wIGgwI1v/MhgYQ56HrjgIguIbLso5F",
				"channel_index": 1
			},
			{
				"gateway_ids": {
					"gateway_id": "migration-demo-gw2",
					"eui": "B827EBFFFE8DB886"
				},
				"time": "2021-06-23T14:06:14.541707Z",
				"timestamp": 2374686131,
				"rssi": -116.0,
				"channel_rssi": -116.0,
				"snr": 3.5,
				"location": {
					"latitude": 51.50569,
					"longitude": -0.129482,
					"source": "SOURCE_REGISTRY"
				},
				"uplink_token": "Ch8KHQoRbWlncmF0aW9uLWRlbW8tZ3cSCLgn6//+jbiFELOrq+wIGgwI1v/MhgYQ56HrjgIguIbLso5F",
				"channel_index": 1
			}
		],
		"settings": {
			"data_rate": {
				"lora": {
					"bandwidth": 125000,
					"spreading_factor": 7
				}
			},
			"data_rate_index": 5,
			"coding_rate": "4/5",
			"frequency": "868300000",
			"timestamp": 2956865323
		},
		"received_at": "2021-06-23T14:06:14.569960357Z",
		"consumed_airtime": "0.194816s"
	}
}
```

</details>

It results in two events, the service data and the location solved:

<details>

```json
{
  "name": "as.up.service.forward",
  "time": "2021-06-23T16:56:57.840937772Z",
  "identifiers": [
    {
      "device_ids": {
        "device_id": "dev1",
        "application_ids": {
          "application_id": "app1"
        },
        "dev_eui": "0016C001F0003FB4",
        "join_eui": "0016C001FFFE0001",
        "dev_addr": "260BEF32"
      }
    }
  ],
  "data": {
    "@type": "type.googleapis.com/ttn.lorawan.v3.ApplicationUp",
    "end_device_ids": {
      "device_id": "dev1",
      "application_ids": {
        "application_id": "app1"
      },
      "dev_eui": "0016C001F0003FB4",
      "join_eui": "0016C001FFFE0001",
      "dev_addr": "260BEF32"
    },
    "correlation_ids": [
      "as:packages:loracloudglsv3:01F8WWVAKEAVEWGATGF2JZ95CG",
      "as:up:01F8WK2QQX7ZEC84MHWRSC38EE",
      "as:up:01F8WWVAK9DHNW5WYJRQZ38PVM",
      "as:up:01F8WWVAQG3DA4XFAVZHX0V4AP",
      "gs:conn:01F8WG8JN5NDZKBFMQ8SQQKWYP",
      "gs:up:host:01F8WG8JNFRJC3JTR2H2Z0BG3Y",
      "gs:uplink:01F8WK2QH8NMK3P4NFTZGBR5GB",
      "ns:uplink:01F8WK2QH966XZCD1ZQJ0P7NNY",
      "rpc:/ttn.lorawan.v3.AppAs/SimulateUplink:01F8WWVAJ52RSCBY21MNC21EBX",
      "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01F8WK2QH98NG2WBBKDZ1G2N5Y",
      "rpc:/ttn.lorawan.v3.NsAs/HandleUplink:01F8WK2QQXSYVT2MPMKFJ6GE8M"
    ],
    "received_at": "2021-06-23T16:56:57.840692321Z",
    "service_data": {
      "service": "lora-cloud-geolocation-v3",
      "data": {
        "result": {
          "HDOP": null,
          "algorithmType": "Rssi",
          "locationEst": {
            "latitude": 51.501591,
            "longitude": -0.141631,
            "toleranceHoriz": 300
          },
          "numUsedGateways": 3
        },
        "warnings": [
          "524d55b013dae2a4f218b9684c3e98413a32ccd7046f91d74ab0bef7d3adde30: setting missing altitude to 0",
          "97f92cc083c4fd0d4f4f8756a094947aef4bb4e0db027dea26d4e5fc83f9ff0c: setting missing altitude to 0",
          "caebca000e6517b947e9789e8e332365080335e046b1c2d98188f9259f5df784: setting missing altitude to 0",
          "524d55b013dae2a4f218b9684c3e98413a32ccd7046f91d74ab0bef7d3adde30: ignore missing 'toa' value",
          "97f92cc083c4fd0d4f4f8756a094947aef4bb4e0db027dea26d4e5fc83f9ff0c: ignore missing 'toa' value",
          "caebca000e6517b947e9789e8e332365080335e046b1c2d98188f9259f5df784: ignore missing 'toa' value"
        ]
      }
    }
  },
  "correlation_ids": [
    "as:packages:loracloudglsv3:01F8WWVAKEAVEWGATGF2JZ95CG",
    "as:up:01F8WK2QQX7ZEC84MHWRSC38EE",
    "as:up:01F8WWVAK9DHNW5WYJRQZ38PVM",
    "as:up:01F8WWVAQG3DA4XFAVZHX0V4AP",
    "gs:conn:01F8WG8JN5NDZKBFMQ8SQQKWYP",
    "gs:up:host:01F8WG8JNFRJC3JTR2H2Z0BG3Y",
    "gs:uplink:01F8WK2QH8NMK3P4NFTZGBR5GB",
    "ns:uplink:01F8WK2QH966XZCD1ZQJ0P7NNY",
    "rpc:/ttn.lorawan.v3.AppAs/SimulateUplink:01F8WWVAJ52RSCBY21MNC21EBX",
    "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01F8WK2QH98NG2WBBKDZ1G2N5Y",
    "rpc:/ttn.lorawan.v3.NsAs/HandleUplink:01F8WK2QQXSYVT2MPMKFJ6GE8M"
  ],
  "origin": "A98BCD2222F1",
  "visibility": {
    "rights": [
      "RIGHT_APPLICATION_TRAFFIC_READ"
    ]
  },
  "unique_id": "01F8WWVAQG93S6CW4XZS91ZKMB"
}
```

</details>

<details>

```json
{
  "name": "as.up.location.forward",
  "time": "2021-06-23T16:56:57.841335104Z",
  "identifiers": [
    {
      "device_ids": {
        "device_id": "dev1",
        "application_ids": {
          "application_id": "app1"
        },
        "dev_eui": "0016C001F0003FB4",
        "join_eui": "0016C001FFFE0001",
        "dev_addr": "260BEF32"
      }
    }
  ],
  "data": {
    "@type": "type.googleapis.com/ttn.lorawan.v3.ApplicationUp",
    "end_device_ids": {
      "device_id": "dev1",
      "application_ids": {
        "application_id": "app1"
      },
      "dev_eui": "0016C001F0003FB4",
      "join_eui": "0016C001FFFE0001",
      "dev_addr": "260BEF32"
    },
    "correlation_ids": [
      "as:packages:loracloudglsv3:01F8WWVAKEAVEWGATGF2JZ95CG",
      "as:up:01F8WK2QQX7ZEC84MHWRSC38EE",
      "as:up:01F8WWVAK9DHNW5WYJRQZ38PVM",
      "as:up:01F8WWVAQHXP6QNDH2MA41R133",
      "gs:conn:01F8WG8JN5NDZKBFMQ8SQQKWYP",
      "gs:up:host:01F8WG8JNFRJC3JTR2H2Z0BG3Y",
      "gs:uplink:01F8WK2QH8NMK3P4NFTZGBR5GB",
      "ns:uplink:01F8WK2QH966XZCD1ZQJ0P7NNY",
      "rpc:/ttn.lorawan.v3.AppAs/SimulateUplink:01F8WWVAJ52RSCBY21MNC21EBX",
      "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01F8WK2QH98NG2WBBKDZ1G2N5Y",
      "rpc:/ttn.lorawan.v3.NsAs/HandleUplink:01F8WK2QQXSYVT2MPMKFJ6GE8M"
    ],
    "received_at": "2021-06-23T16:56:57.841112987Z",
    "location_solved": {
      "service": "lora-cloud-geolocation-v3-Rssi",
      "location": {
        "latitude": 51.501591,
        "longitude": -0.141631,
        "accuracy": 300,
        "source": "SOURCE_LORA_RSSI_GEOLOCATION"
      }
    }
  },
  "correlation_ids": [
    "as:packages:loracloudglsv3:01F8WWVAKEAVEWGATGF2JZ95CG",
    "as:up:01F8WK2QQX7ZEC84MHWRSC38EE",
    "as:up:01F8WWVAK9DHNW5WYJRQZ38PVM",
    "as:up:01F8WWVAQHXP6QNDH2MA41R133",
    "gs:conn:01F8WG8JN5NDZKBFMQ8SQQKWYP",
    "gs:up:host:01F8WG8JNFRJC3JTR2H2Z0BG3Y",
    "gs:uplink:01F8WK2QH8NMK3P4NFTZGBR5GB",
    "ns:uplink:01F8WK2QH966XZCD1ZQJ0P7NNY",
    "rpc:/ttn.lorawan.v3.AppAs/SimulateUplink:01F8WWVAJ52RSCBY21MNC21EBX",
    "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01F8WK2QH98NG2WBBKDZ1G2N5Y",
    "rpc:/ttn.lorawan.v3.NsAs/HandleUplink:01F8WK2QQXSYVT2MPMKFJ6GE8M"
  ],
  "origin": "A98BCD2222F1",
  "visibility": {
    "rights": [
      "RIGHT_APPLICATION_TRAFFIC_READ"
    ]
  },
  "unique_id": "01F8WWVAQH9NKQZ73GEESXKDEK"
}
```

</details>

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This changes the console filters intentionally and fixes the path for the requests themselves. This has been tested extensively.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
