### PR TITLE
Set User-Agent header in component HTTP client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ For details about compatibility between different releases, see the **Commitment
   - A `gs.up.repeat` event is emitted (once per minute maximum) for gateways that are stuck in a loop and forward the same uplink message.
 - For ABP sessions, the CLI now requests a DevAddr from the Network Server instead of generating one from the testing NetID.
 - Descriptions, tooltips and defaults for checkboxes for public gateway status and location in the Console.
+- All HTTP requests made by The Things Stack now contain a `User-Agent` header in the form of `TheThingsStack/{version}`.
 
 ### Deprecated
 

--- a/pkg/applicationserver/io/packages/loradms/v1/api/client.go
+++ b/pkg/applicationserver/io/packages/loradms/v1/api/client.go
@@ -23,7 +23,6 @@ import (
 	"path"
 
 	urlutil "go.thethings.network/lorawan-stack/v3/pkg/util/url"
-	"go.thethings.network/lorawan-stack/v3/pkg/version"
 )
 
 // Option is an option for the API client.
@@ -51,10 +50,7 @@ const (
 	basePath         = "/api/v1"
 )
 
-var (
-	userAgent        = "ttn-lw-application-server/" + version.TTN
-	DefaultServerURL *url.URL
-)
+var DefaultServerURL *url.URL
 
 type queryParam struct {
 	key, value string
@@ -73,7 +69,6 @@ func (c *Client) newRequest(ctx context.Context, method, category, entity, opera
 		return nil, err
 	}
 	req.Header.Set("Content-Type", contentType)
-	req.Header.Set("User-Agent", userAgent)
 	if c.token != "" {
 		req.Header.Set("Authorization", c.token)
 	}

--- a/pkg/applicationserver/io/packages/loragls/v3/api/client.go
+++ b/pkg/applicationserver/io/packages/loragls/v3/api/client.go
@@ -25,7 +25,6 @@ import (
 	"path"
 
 	urlutil "go.thethings.network/lorawan-stack/v3/pkg/util/url"
-	"go.thethings.network/lorawan-stack/v3/pkg/version"
 )
 
 // Option is an option for the API client.
@@ -51,10 +50,7 @@ const (
 	basePath         = "/api"
 )
 
-var (
-	userAgent        = "ttn-lw-application-server/" + version.TTN
-	DefaultServerURL *url.URL
-)
+var DefaultServerURL *url.URL
 
 func (c *Client) newRequest(ctx context.Context, version, method, category, operation string, body io.Reader) (*http.Request, error) {
 	u := urlutil.CloneURL(c.baseURL)
@@ -64,7 +60,6 @@ func (c *Client) newRequest(ctx context.Context, version, method, category, oper
 		return nil, err
 	}
 	req.Header.Set("Content-Type", contentType)
-	req.Header.Set("User-Agent", userAgent)
 	if c.token != "" {
 		req.Header.Set("Ocp-Apim-Subscription-Key", c.token)
 	}

--- a/pkg/applicationserver/io/web/webhooks.go
+++ b/pkg/applicationserver/io/web/webhooks.go
@@ -32,7 +32,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
-	"go.thethings.network/lorawan-stack/v3/pkg/version"
 	ttnweb "go.thethings.network/lorawan-stack/v3/pkg/web"
 	"go.thethings.network/lorawan-stack/v3/pkg/webhandlers"
 	"go.thethings.network/lorawan-stack/v3/pkg/webmiddleware"
@@ -40,8 +39,6 @@ import (
 )
 
 const namespace = "applicationserver/io/web"
-
-var userAgent = "ttn-lw-application-server/" + version.TTN
 
 // Sink processes HTTP requests.
 type Sink interface {
@@ -375,7 +372,6 @@ func (w *webhooks) newRequest(ctx context.Context, msg *ttnpb.ApplicationUp, hoo
 		req.Header.Set(domainHeader, domain)
 	}
 	req.Header.Set("Content-Type", format.ContentType)
-	req.Header.Set("User-Agent", userAgent)
 	return req, nil
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request wraps the `http.RoundTripper` used by the core component with one that sets a `User-Agent` header on requests that don't have an explicit `User-Agent` header.

#### Testing

<!-- How did you verify that this change works? -->

Local testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

If an (external) service was somehow depending on the previously used `ttn-lw-application-server/{version}` or `Go-http-client/{version}` user agent, that service will have to be updated.


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
