### PR TITLE
Create console oauth client before admin API key during initialization of development environment

### DIFF
--- a/tools/mage/dev.go
+++ b/tools/mage/dev.go
@@ -253,6 +253,20 @@ func (Dev) InitStack() error {
 	); err != nil {
 		return err
 	}
+	if err := runGo("./cmd/ttn-lw-stack", "is-db", "create-oauth-client",
+		"--id", "console",
+		"--name", "Console",
+		"--owner", "admin",
+		"--secret", "console",
+		"--redirect-uri", "https://localhost:8885/console/oauth/callback",
+		"--redirect-uri", "http://localhost:1885/console/oauth/callback",
+		"--redirect-uri", "/console/oauth/callback",
+		"--logout-redirect-uri", "https://localhost:8885/console",
+		"--logout-redirect-uri", "http://localhost:1885/console",
+		"--logout-redirect-uri", "/console",
+	); err != nil {
+		return err
+	}
 	var key ttnpb.APIKey
 	var jsonVal []byte
 	var err error
@@ -265,22 +279,10 @@ func (Dev) InitStack() error {
 	if err := json.Unmarshal(jsonVal, &key); err != nil {
 		return err
 	}
-
 	if err := writeToFile(filepath.Join(devDir, "admin_api_key.txt"), []byte(key.Key)); err != nil {
 		return err
 	}
-	return runGo("./cmd/ttn-lw-stack", "is-db", "create-oauth-client",
-		"--id", "console",
-		"--name", "Console",
-		"--owner", "admin",
-		"--secret", "console",
-		"--redirect-uri", "https://localhost:8885/console/oauth/callback",
-		"--redirect-uri", "http://localhost:1885/console/oauth/callback",
-		"--redirect-uri", "/console/oauth/callback",
-		"--logout-redirect-uri", "https://localhost:8885/console",
-		"--logout-redirect-uri", "http://localhost:1885/console",
-		"--logout-redirect-uri", "/console",
-	)
+	return nil
 }
 
 // StartDevStack starts TTS in end-to-end test configuration.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Small change to create console oauth client before writing API admin key file during initialization of a new development environment.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Less confusion in case of permission errors.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
