### PR TITLE
Make CLI configuration for TTS Cloud and TTS Community Edition easier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ For details about compatibility between different releases, see the **Commitment
   - Use the `--force` flag to force perform migrations.
 - Any authenticated user in the network can now list the collaborators of entities in the network.
 - The search RPCs no longer require fields to be specified in the field mask when those fields are already specified as filters.
+- When generating client configuration with the CLI `use` command, automatically set the correct Identity Server and OAuth Server addresses for The Things Stack Cloud and The Things Stack Community Edition.
 
 ### Deprecated
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -1430,6 +1430,15 @@
       "file": "gateways_claim.go"
     }
   },
+  "error:cmd/ttn-lw-cli/commands:invalid_hostname": {
+    "translations": {
+      "en": "`{hostname}` is not a valid hostname"
+    },
+    "description": {
+      "package": "cmd/ttn-lw-cli/commands",
+      "file": "use.go"
+    }
+  },
   "error:cmd/ttn-lw-cli/commands:invalid_target_cups_trust": {
     "translations": {
       "en": "invalid target CUPS trust"
@@ -1464,6 +1473,15 @@
     "description": {
       "package": "cmd/ttn-lw-cli/commands",
       "file": "end_device_templates.go"
+    }
+  },
+  "error:cmd/ttn-lw-cli/commands:missing_tenant_id": {
+    "translations": {
+      "en": "missing tenant ID in hostname"
+    },
+    "description": {
+      "package": "cmd/ttn-lw-cli/commands",
+      "file": "use.go"
     }
   },
   "error:cmd/ttn-lw-cli/commands:network_server_disabled": {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #4016
Closes #3591

#### Changes
<!-- What are the changes made in this pull request? -->

- When passing a TTS Cloud or TTS Community Edition hostname, configure OAuth and Identity Server address.
- Validate hostname passed to `ttn-lw-cli use` command.

#### Testing

<!-- How did you verify that this change works? -->

```
$ ttn-lw-cli use nam1.cloud.thethings.network
INFO    Configuring for The Things Stack Community Edition      {"cluster_id": "nam1"}
INFO    Set OAuth Server address        {"address": "https://eu1.cloud.thethings.network/oauth"}
INFO    Set Identity Server gRPC address        {"address": "eu1.cloud.thethings.industries:8884"}
INFO    Config file for nam1.cloud.thethings.network written in .ttn-lw-cli.yml

$ ttn-lw-cli use tti.nam1.cloud.thethings.industries
INFO    Configuring for The Things Stack Cloud  {"cluster_id": "nam1", "tenant_id": "tti"}
INFO    Set OAuth Server address        {"address": "https://tti.eu1.cloud.thethings.industries/oauth"}
INFO    Set Identity Server gRPC address        {"address": "tti.eu1.cloud.thethings.industries:8884"}
INFO    Config file for tti.nam1.cloud.thethings.industries written in .ttn-lw-cli.yml
```

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Changed the implementation to the one suggested by the review comments.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
