### PR TITLE
Make JS lint steps verbose

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -3,147 +3,147 @@ name: JS Code
 on:
   pull_request:
     paths:
-    - '.github/workflows/js.yml'
-    - 'config/**'
-    - '!config/stack/ttn-lw-stack.yml'
-    - 'Makefile'
-    - 'package.json'
-    - 'pkg/webui/**'
-    - '!pkg/webui/**.go'
-    - 'sdk/js/**'
-    - 'tools/**'
-    - 'yarn.lock'
+      - '.github/workflows/js.yml'
+      - 'config/**'
+      - '!config/stack/ttn-lw-stack.yml'
+      - 'Makefile'
+      - 'package.json'
+      - 'pkg/webui/**'
+      - '!pkg/webui/**.go'
+      - 'sdk/js/**'
+      - 'tools/**'
+      - 'yarn.lock'
 
 jobs:
   quality:
     name: Code Quality
     runs-on: ubuntu-18.04
     steps:
-    - name: Check out code
-      uses: actions/checkout@v2
-    - name: Set up Node
-      uses: actions/setup-node@v2-beta
-      with:
-        node-version: '~14'
-    - name: Get Yarn cache directory path
-      id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(npx yarn cache dir)"
-    - name: Initialize Yarn module cache
-      id: yarn-cache
-      uses: actions/cache@v2
-      with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: '~1.16'
-    - name: Initialize Go module cache
-      uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - name: Download Go tool dependencies
-      run: |
-        cd tools
-        go mod download
-    - name: Initialize tool binary cache
-      id: tools-cache
-      uses: actions/cache@v2
-      with:
-        path: tools/bin
-        key: ${{ runner.os }}-tools-${{ hashFiles('tools/**') }}
-    - name: Make Mage
-      run: make tools/bin/mage
-      if: steps.tools-cache.outputs.cache-hit != 'true'
-    - name: Install JS SDK dependencies
-      run: tools/bin/mage jsSDK:deps
-    - name: Generate JS SDK allowed field masks
-      run: tools/bin/mage jsSDK:allowedFieldMaskPaths jsSDK:deviceFieldMasks
-    - name: Build JS SDK
-      run: tools/bin/mage jsSDK:clean jsSDK:build
-    - name: Install JS dependencies
-      if: steps.yarn-cache.outputs.cache-hit != 'true'
-      run: tools/bin/mage js:deps
-      timeout-minutes: 5
-    - name: Generate JS translations
-      run: tools/bin/mage js:translations js:backendTranslations
-    - name: Lint JS SDK code
-      run: tools/bin/mage jsSDK:lint
-    - name: Lint frontend code
-      run: tools/bin/mage js:lint
-    - name: Check for diff
-      run: tools/bin/mage git:diff
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up Node
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: '~14'
+      - name: Get Yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(npx yarn cache dir)"
+      - name: Initialize Yarn module cache
+        id: yarn-cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '~1.16'
+      - name: Initialize Go module cache
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Download Go tool dependencies
+        run: |
+          cd tools
+          go mod download
+      - name: Initialize tool binary cache
+        id: tools-cache
+        uses: actions/cache@v2
+        with:
+          path: tools/bin
+          key: ${{ runner.os }}-tools-${{ hashFiles('tools/**') }}
+      - name: Make Mage
+        run: make tools/bin/mage
+        if: steps.tools-cache.outputs.cache-hit != 'true'
+      - name: Install JS SDK dependencies
+        run: tools/bin/mage jsSDK:deps
+      - name: Generate JS SDK allowed field masks
+        run: tools/bin/mage jsSDK:allowedFieldMaskPaths jsSDK:deviceFieldMasks
+      - name: Build JS SDK
+        run: tools/bin/mage jsSDK:clean jsSDK:build
+      - name: Install JS dependencies
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: tools/bin/mage js:deps
+        timeout-minutes: 5
+      - name: Generate JS translations
+        run: tools/bin/mage js:translations js:backendTranslations
+      - name: Lint JS SDK code
+        run: tools/bin/mage -v jsSDK:lint
+      - name: Lint frontend code
+        run: tools/bin/mage -v js:lint
+      - name: Check for diff
+        run: tools/bin/mage git:diff
 
   test:
     name: Tests
     runs-on: ubuntu-18.04
     steps:
-    - name: Check out code
-      uses: actions/checkout@v2
-    - name: Set up Node
-      uses: actions/setup-node@v2-beta
-      with:
-        node-version: '14'
-    - name: Get Yarn cache directory path
-      id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(npx yarn cache dir)"
-    - name: Initialize Yarn module cache
-      id: yarn-cache
-      uses: actions/cache@v2
-      with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: '~1.16'
-    - name: Initialize public folder cache
-      id: public-cache
-      uses: actions/cache@v2
-      with:
-        path: public
-        key: public-cache-${{ hashFiles('pkg/webui/**') }}-${{ hashFiles('sdk/js/**/*.js', 'sdk/js/generated/*.json') }}-${{ hashFiles('config/webpack.config.babel.js') }}-${{ hashFiles('yarn.lock', 'sdk/js/yarn.lock')}}
-    - name: Initialize Go module cache
-      uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - name: Download Go tool dependencies
-      run: |
-        cd tools
-        go mod download
-    - name: Initialize tool binary cache
-      id: tools-cache
-      uses: actions/cache@v2
-      with:
-        path: tools/bin
-        key: ${{ runner.os }}-tools-${{ hashFiles('tools/**') }}
-    - name: Make Mage
-      run: make tools/bin/mage
-      if: steps.tools-cache.outputs.cache-hit != 'true'
-    - name: Install JS SDK dependencies
-      run: tools/bin/mage jsSDK:deps
-    - name: Build JS SDK
-      run: tools/bin/mage jsSDK:clean jsSDK:build
-    - name: Install JS dependencies
-      if: steps.yarn-cache.outputs.cache-hit != 'true'
-      run: tools/bin/mage js:deps
-      timeout-minutes: 5
-    - name: Build frontend
-      if: steps.public-cache.outputs.cache-hit != 'true'
-      run: tools/bin/mage js:build
-    - name: Test JS SDK code
-      run: tools/bin/mage jsSDK:test
-    - name: Test frontend code
-      run: tools/bin/mage js:test
-    - name: Check for diff
-      run: tools/bin/mage git:diff
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up Node
+        uses: actions/setup-node@v2-beta
+        with:
+          node-version: '14'
+      - name: Get Yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(npx yarn cache dir)"
+      - name: Initialize Yarn module cache
+        id: yarn-cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '~1.16'
+      - name: Initialize public folder cache
+        id: public-cache
+        uses: actions/cache@v2
+        with:
+          path: public
+          key: public-cache-${{ hashFiles('pkg/webui/**') }}-${{ hashFiles('sdk/js/**/*.js', 'sdk/js/generated/*.json') }}-${{ hashFiles('config/webpack.config.babel.js') }}-${{ hashFiles('yarn.lock', 'sdk/js/yarn.lock')}}
+      - name: Initialize Go module cache
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Download Go tool dependencies
+        run: |
+          cd tools
+          go mod download
+      - name: Initialize tool binary cache
+        id: tools-cache
+        uses: actions/cache@v2
+        with:
+          path: tools/bin
+          key: ${{ runner.os }}-tools-${{ hashFiles('tools/**') }}
+      - name: Make Mage
+        run: make tools/bin/mage
+        if: steps.tools-cache.outputs.cache-hit != 'true'
+      - name: Install JS SDK dependencies
+        run: tools/bin/mage jsSDK:deps
+      - name: Build JS SDK
+        run: tools/bin/mage jsSDK:clean jsSDK:build
+      - name: Install JS dependencies
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
+        run: tools/bin/mage js:deps
+        timeout-minutes: 5
+      - name: Build frontend
+        if: steps.public-cache.outputs.cache-hit != 'true'
+        run: tools/bin/mage js:build
+      - name: Test JS SDK code
+        run: tools/bin/mage jsSDK:test
+      - name: Test frontend code
+        run: tools/bin/mage js:test
+      - name: Check for diff
+        run: tools/bin/mage git:diff


### PR DESCRIPTION
#### Summary
This quickfix PR will make the lint mage targets verbose.

#### Changes
- Add `-v` flag to frontend linting mage targets
- Adjust whitespace

#### Notes for Reviewers
I does not make sense to me to run this step silently. It means having to run the whole process again locally when something fails, which is just a time killer.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
