### PR TITLE
Resolve frontend linter warnings

### DIFF
--- a/config/jest/files.transform.js
+++ b/config/jest/files.transform.js
@@ -15,7 +15,5 @@
 /* eslint-disable import/no-commonjs */
 
 module.exports = {
-  process: (src, filename) => {
-    return `module.exports = "${filename}";`
-  },
+  process: (src, filename) => `module.exports = "${filename}";`,
 }

--- a/config/jest/styles.transform.js
+++ b/config/jest/styles.transform.js
@@ -15,7 +15,5 @@
 /* eslint-disable import/no-commonjs */
 
 module.exports = {
-  process: () => {
-    return 'module.exports = {};'
-  },
+  process: () => 'module.exports = {};',
 }

--- a/config/storybook/center.js
+++ b/config/storybook/center.js
@@ -20,6 +20,4 @@ const style = {
   padding: '1rem',
 }
 
-export default props => {
-  return <div style={style}>{props.children}</div>
-}
+export default props => <div style={style}>{props.children}</div>

--- a/config/storybook/config.js
+++ b/config/storybook/config.js
@@ -36,18 +36,16 @@ const store = createStore(history)
 const req = require.context('../../pkg/webui/', true, /story\.js$/)
 const load = () => req.keys().forEach(req)
 
-addDecorator(story => {
-  return (
-    <EnvProvider env={env}>
-      <Provider store={store}>
-        <IntlProvider key="key" messages={{ ...messages, ...backendMessages }} locale="en-US">
-          <ConnectedRouter history={history}>
-            <Center>{story()}</Center>
-          </ConnectedRouter>
-        </IntlProvider>
-      </Provider>
-    </EnvProvider>
-  )
-})
+addDecorator(story => (
+  <EnvProvider env={env}>
+    <Provider store={store}>
+      <IntlProvider key="key" messages={{ ...messages, ...backendMessages }} locale="en-US">
+        <ConnectedRouter history={history}>
+          <Center>{story()}</Center>
+        </ConnectedRouter>
+      </IntlProvider>
+    </Provider>
+  </EnvProvider>
+))
 
 configure(load, module)

--- a/config/storybook/webpack.config.js
+++ b/config/storybook/webpack.config.js
@@ -29,9 +29,9 @@ module.exports = async ({ config, mode }) => {
   }
 
   // Filter plugins on allowed type.
-  const filteredPlugins = bundleConfig.plugins.filter(plugin => {
-    return allow.reduce((ok, klass) => ok || plugin instanceof klass, false)
-  })
+  const filteredPlugins = bundleConfig.plugins.filter(plugin =>
+    allow.reduce((ok, klass) => ok || plugin instanceof klass, false),
+  )
 
   // Compose storybook config, making use of stack webpack config.
   const cfg = {

--- a/config/webpack.config.babel.js
+++ b/config/webpack.config.babel.js
@@ -61,9 +61,7 @@ const r = SUPPORT_LOCALES.split(',').map(l => new RegExp(l.trim()))
 
 const filterLocales = (context, request, callback) => {
   if (context.endsWith('node_modules/intl/locale-data/jsonp')) {
-    const supported = r.reduce((acc, locale) => {
-      return acc || locale.test(request)
-    }, false)
+    const supported = r.reduce((acc, locale) => acc || locale.test(request), false)
 
     if (!supported) {
       return callback(null, `commonjs ${request}`)

--- a/pkg/webui/components/breadcrumbs/breadcrumbs.js
+++ b/pkg/webui/components/breadcrumbs/breadcrumbs.js
@@ -23,12 +23,12 @@ import style from './breadcrumbs.styl'
 
 const Breadcrumbs = ({ className, breadcrumbs }) => (
   <nav className={classnames(className, style.breadcrumbs)}>
-    {breadcrumbs.map((component, index) => {
-      return React.cloneElement(component, {
+    {breadcrumbs.map((component, index) =>
+      React.cloneElement(component, {
         key: index,
         isLast: index === breadcrumbs.length - 1,
-      })
-    })}
+      }),
+    )}
   </nav>
 )
 

--- a/pkg/webui/components/data-sheet/index.js
+++ b/pkg/webui/components/data-sheet/index.js
@@ -29,51 +29,47 @@ const m = defineMessages({
   noData: 'No data available',
 })
 
-const DataSheet = ({ className, data }) => {
-  return (
-    <table className={classnames(className, style.table)}>
-      <tbody>
-        {data.map((group, index) => {
-          return (
-            <React.Fragment key={`${group.header}_${index}`}>
-              <tr className={style.groupHeading}>
-                <th>
-                  <Message content={group.header} />
-                </th>
-              </tr>
-              {group.items.length > 0 ? (
-                group.items.map(item => {
-                  if (!item) {
-                    return null
-                  }
-                  const keyId = typeof item.key === 'object' ? item.key.id : item.key
-                  const subItems = item.subItems
-                    ? item.subItems.map((subItem, subIndex) => (
-                        <DataSheetRow sub item={subItem} key={`${keyId}_${index}_${subIndex}`} />
-                      ))
-                    : null
+const DataSheet = ({ className, data }) => (
+  <table className={classnames(className, style.table)}>
+    <tbody>
+      {data.map((group, index) => (
+        <React.Fragment key={`${group.header}_${index}`}>
+          <tr className={style.groupHeading}>
+            <th>
+              <Message content={group.header} />
+            </th>
+          </tr>
+          {group.items.length > 0 ? (
+            group.items.map(item => {
+              if (!item) {
+                return null
+              }
+              const keyId = typeof item.key === 'object' ? item.key.id : item.key
+              const subItems = item.subItems
+                ? item.subItems.map((subItem, subIndex) => (
+                    <DataSheetRow sub item={subItem} key={`${keyId}_${index}_${subIndex}`} />
+                  ))
+                : null
 
-                  return (
-                    <React.Fragment key={`${keyId}_${index}`}>
-                      <DataSheetRow item={item} />
-                      {subItems}
-                    </React.Fragment>
-                  )
-                })
-              ) : (
-                <tr>
-                  <th colSpan={2}>
-                    <Message content={m.noData} />
-                  </th>
-                </tr>
-              )}
-            </React.Fragment>
-          )
-        })}
-      </tbody>
-    </table>
-  )
-}
+              return (
+                <React.Fragment key={`${keyId}_${index}`}>
+                  <DataSheetRow item={item} />
+                  {subItems}
+                </React.Fragment>
+              )
+            })
+          ) : (
+            <tr>
+              <th colSpan={2}>
+                <Message content={m.noData} />
+              </th>
+            </tr>
+          )}
+        </React.Fragment>
+      ))}
+    </tbody>
+  </table>
+)
 
 DataSheet.propTypes = {
   className: PropTypes.string,

--- a/pkg/webui/components/form/index.js
+++ b/pkg/webui/components/form/index.js
@@ -135,7 +135,7 @@ const formRenderer = ({ children, ...rest }) => renderProps => {
 class Form extends React.PureComponent {
   static propTypes = {
     enableReinitialize: PropTypes.bool,
-    formikRef: PropTypes.shape({ current: PropTypes.any }),
+    formikRef: PropTypes.shape({ current: PropTypes.shape({}) }),
     initialValues: PropTypes.shape({}),
     onReset: PropTypes.func,
     onSubmit: PropTypes.func.isRequired,

--- a/pkg/webui/components/input/byte.js
+++ b/pkg/webui/components/input/byte.js
@@ -50,13 +50,9 @@ const mask = (min, max, showPerChar = false) => {
   return r
 }
 
-const upper = str => {
-  return str.toUpperCase()
-}
+const upper = str => str.toUpperCase()
 
-const clean = str => {
-  return str.replace(new RegExp(`[ ${PLACEHOLDER_CHAR}]`, 'g'), '')
-}
+const clean = str => str.replace(new RegExp(`[ ${PLACEHOLDER_CHAR}]`, 'g'), '')
 
 export default class ByteInput extends React.Component {
   static propTypes = {

--- a/pkg/webui/components/key-value-map/entry.js
+++ b/pkg/webui/components/key-value-map/entry.js
@@ -133,7 +133,7 @@ Entry.propTypes = {
   value: PropTypes.oneOfType([
     PropTypes.shape({
       key: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-      value: PropTypes.any,
+      value: PropTypes.shape({}),
     }),
     PropTypes.string,
   ]),

--- a/pkg/webui/components/link/index.js
+++ b/pkg/webui/components/link/index.js
@@ -109,7 +109,7 @@ Link.propTypes = {
       pathname: PropTypes.string,
       search: PropTypes.string,
       hash: PropTypes.string,
-      state: PropTypes.object,
+      state: PropTypes.shape({}),
     }),
   ]).isRequired,
 }

--- a/pkg/webui/components/navigation/bar/index.js
+++ b/pkg/webui/components/navigation/bar/index.js
@@ -25,9 +25,7 @@ import NavigationLink from '../link'
 
 import style from './bar.styl'
 
-const NavigationBar = ({ className, children }) => {
-  return <nav className={className}>{children}</nav>
-}
+const NavigationBar = ({ className, children }) => <nav className={className}>{children}</nav>
 
 NavigationBar.propTypes = {
   children: PropTypes.node.isRequired,

--- a/pkg/webui/components/navigation/link/index.js
+++ b/pkg/webui/components/navigation/link/index.js
@@ -30,30 +30,22 @@ const NavigationLink = ({
   activeClassName,
   onClick,
   ...rest
-}) => {
-  return (
-    <NavLink
-      to={path}
-      exact={exact}
-      className={classnames(className, style.link)}
-      activeClassName={activeClassName}
-      onClick={onClick}
-      {...rest}
-    >
-      {children}
-    </NavLink>
-  )
-}
+}) => (
+  <NavLink
+    to={path}
+    exact={exact}
+    className={classnames(className, style.link)}
+    activeClassName={activeClassName}
+    onClick={onClick}
+    {...rest}
+  >
+    {children}
+  </NavLink>
+)
 
-const NavigationAnchorLink = ({ className, children, path, ...rest }) => {
-  return (
-    <Link.BaseAnchor
-      href={path}
-      className={classnames(className, style.link)}
-      children={children}
-    />
-  )
-}
+const NavigationAnchorLink = ({ className, children, path, ...rest }) => (
+  <Link.BaseAnchor href={path} className={classnames(className, style.link)} children={children} />
+)
 
 NavigationLink.propTypes = {
   activeClassName: PropTypes.string,

--- a/pkg/webui/components/navigation/side/index.js
+++ b/pkg/webui/components/navigation/side/index.js
@@ -130,9 +130,10 @@ export class SideNavigation extends Component {
 
   @bind
   async onToggle() {
-    await this.setState(prev => {
-      return { isMinimized: !prev.isMinimized, preferMinimized: !prev.isMinimized }
-    })
+    await this.setState(prev => ({
+      isMinimized: !prev.isMinimized,
+      preferMinimized: !prev.isMinimized,
+    }))
     this.updateAppContainerClasses()
   }
 

--- a/pkg/webui/components/profile-dropdown/story.js
+++ b/pkg/webui/components/profile-dropdown/story.js
@@ -34,13 +34,11 @@ storiesOf('Profile Dropdown', module)
       propTables: [ProfileDropdown],
     })(story)(context),
   )
-  .add('Default', () => {
-    return (
-      <div style={{ height: '6rem' }}>
-        <ProfileDropdown style={{ marginLeft: '120px' }} userId="johndoe">
-          <Dropdown.Item title="Profile Settings" icon="settings" path="/profile-settings" />
-          <Dropdown.Item title="Logout" icon="power_settings_new" action={handleLogout} />
-        </ProfileDropdown>
-      </div>
-    )
-  })
+  .add('Default', () => (
+    <div style={{ height: '6rem' }}>
+      <ProfileDropdown style={{ marginLeft: '120px' }} userId="johndoe">
+        <Dropdown.Item title="Profile Settings" icon="settings" path="/profile-settings" />
+        <Dropdown.Item title="Logout" icon="power_settings_new" action={handleLogout} />
+      </ProfileDropdown>
+    </div>
+  ))

--- a/pkg/webui/components/profile-picture/story.js
+++ b/pkg/webui/components/profile-picture/story.js
@@ -33,10 +33,8 @@ storiesOf('Profile Picture', module)
       propTables: [ProfilePicture],
     })(story)(context),
   )
-  .add('Default', () => {
-    return (
-      <div style={{ height: '8rem' }}>
-        <ProfilePicture profilePicture={pp} />
-      </div>
-    )
-  })
+  .add('Default', () => (
+    <div style={{ height: '8rem' }}>
+      <ProfilePicture profilePicture={pp} />
+    </div>
+  ))

--- a/pkg/webui/components/safe-inspector/index.js
+++ b/pkg/webui/components/safe-inspector/index.js
@@ -26,11 +26,10 @@ import PropTypes from '@ttn-lw/lib/prop-types'
 
 import style from './safe-inspector.styl'
 
-const chunkArray = (array, chunkSize) => {
-  return Array.from({ length: Math.ceil(array.length / chunkSize) }, (_, index) =>
+const chunkArray = (array, chunkSize) =>
+  Array.from({ length: Math.ceil(array.length / chunkSize) }, (_, index) =>
     array.slice(index * chunkSize, (index + 1) * chunkSize),
   )
-}
 
 const selectText = node => {
   if (document.body.createTextRange) {

--- a/pkg/webui/components/table/section/index.js
+++ b/pkg/webui/components/table/section/index.js
@@ -16,19 +16,17 @@ import React from 'react'
 
 import PropTypes from '@ttn-lw/lib/prop-types'
 
-const Section = ({ className, component: Component, children, ...rest }) => {
-  return (
-    <Component className={className} {...rest}>
-      {React.Children.map(children, row =>
-        React.cloneElement(row, {
-          head: Component === 'thead',
-          body: Component === 'tbody',
-          foot: Component === 'tfoot',
-        }),
-      )}
-    </Component>
-  )
-}
+const Section = ({ className, component: Component, children, ...rest }) => (
+  <Component className={className} {...rest}>
+    {React.Children.map(children, row =>
+      React.cloneElement(row, {
+        head: Component === 'thead',
+        body: Component === 'tbody',
+        foot: Component === 'tfoot',
+      }),
+    )}
+  </Component>
+)
 
 Section.propTypes = {
   children: PropTypes.node,

--- a/pkg/webui/components/table/story/storyData.js
+++ b/pkg/webui/components/table/story/storyData.js
@@ -117,16 +117,16 @@ export default {
         align: 'center',
       },
     ],
-    rows: rows.map(r => {
-      return Object.assign({}, r, {
+    rows: rows.map(r =>
+      Object.assign({}, r, {
         options: (
           <div>
             <Button icon="settings" />
             <Button danger icon="delete" />
           </div>
         ),
-      })
-    }),
+      }),
+    ),
   },
   sortableExample: {
     headers: headers.map(header => {

--- a/pkg/webui/components/tabs/index.js
+++ b/pkg/webui/components/tabs/index.js
@@ -25,34 +25,31 @@ import Tab from './tab'
 
 import style from './tabs.styl'
 
-const Tabs = ({ className, active, tabs, onTabChange, divider, narrow }) => {
-  return (
-    <ul
-      className={classnames(className, style.tabs, { [style.divider]: divider })}
-      data-test-id="tabs"
-    >
-      {tabs.map(({ name, disabled, narrow: nrw, link, exact, icon, title, hidden }, index) => {
-        return (
-          !Boolean(hidden) && (
-            <Tab
-              key={index}
-              active={name === active}
-              name={name}
-              disabled={disabled}
-              onClick={onTabChange}
-              narrow={nrw || narrow}
-              link={link}
-              exact={exact}
-            >
-              {icon && <Icon icon={icon} className={style.icon} />}
-              <Message content={title} />
-            </Tab>
-          )
-        )
-      })}
-    </ul>
-  )
-}
+const Tabs = ({ className, active, tabs, onTabChange, divider, narrow }) => (
+  <ul
+    className={classnames(className, style.tabs, { [style.divider]: divider })}
+    data-test-id="tabs"
+  >
+    {tabs.map(
+      ({ name, disabled, narrow: nrw, link, exact, icon, title, hidden }, index) =>
+        !Boolean(hidden) && (
+          <Tab
+            key={index}
+            active={name === active}
+            name={name}
+            disabled={disabled}
+            onClick={onTabChange}
+            narrow={nrw || narrow}
+            link={link}
+            exact={exact}
+          >
+            {icon && <Icon icon={icon} className={style.icon} />}
+            <Message content={title} />
+          </Tab>
+        ),
+    )}
+  </ul>
+)
 
 Tabs.propTypes = {
   /** The name of the active tab. */

--- a/pkg/webui/console/api/index.js
+++ b/pkg/webui/console/api/index.js
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import axios from 'axios'
-
 import TTS, { STACK_COMPONENTS_MAP, AUTHORIZATION_MODES } from 'ttn-lw'
+import axios from 'axios'
 
 import toast from '@ttn-lw/components/toast'
 

--- a/pkg/webui/console/components/delete-modal-button/index.js
+++ b/pkg/webui/console/components/delete-modal-button/index.js
@@ -88,11 +88,11 @@ const DeleteModalButton = props => {
 DeleteModalButton.propTypes = {
   entityId: PropTypes.string.isRequired,
   entityName: PropTypes.string,
+  message: PropTypes.message.isRequired,
   onApprove: PropTypes.func,
   onCancel: PropTypes.func,
   shouldConfirm: PropTypes.bool,
   shouldPurge: PropTypes.bool,
-  message: PropTypes.message.isRequired,
 }
 
 DeleteModalButton.defaultProps = {

--- a/pkg/webui/console/components/webhook-form/mapping.js
+++ b/pkg/webui/console/components/webhook-form/mapping.js
@@ -59,32 +59,30 @@ const mapHeadersTypeFormValueToWebhookHeadersType = formValue =>
     )) ||
   null
 
-export const mapFormValuesToWebhook = (values, appId) => {
-  return {
-    ids: {
-      application_ids: {
-        application_id: appId,
-      },
-      webhook_id: values.webhook_id,
+export const mapFormValuesToWebhook = (values, appId) => ({
+  ids: {
+    application_ids: {
+      application_id: appId,
     },
-    base_url: values.base_url,
-    format: values.format,
-    headers: mapHeadersTypeFormValueToWebhookHeadersType(values.headers),
-    downlink_api_key: values.downlink_api_key,
-    uplink_message: mapMessageTypeFormValueToWebhookMessageType(values.uplink_message),
-    join_accept: mapMessageTypeFormValueToWebhookMessageType(values.join_accept),
-    downlink_ack: mapMessageTypeFormValueToWebhookMessageType(values.downlink_ack),
-    downlink_nack: mapMessageTypeFormValueToWebhookMessageType(values.downlink_nack),
-    downlink_sent: mapMessageTypeFormValueToWebhookMessageType(values.downlink_sent),
-    downlink_failed: mapMessageTypeFormValueToWebhookMessageType(values.downlink_failed),
-    downlink_queued: mapMessageTypeFormValueToWebhookMessageType(values.downlink_queued),
-    downlink_queue_invalidated: mapMessageTypeFormValueToWebhookMessageType(
-      values.downlink_queue_invalidated,
-    ),
-    location_solved: mapMessageTypeFormValueToWebhookMessageType(values.location_solved),
-    service_data: mapMessageTypeFormValueToWebhookMessageType(values.service_data),
-  }
-}
+    webhook_id: values.webhook_id,
+  },
+  base_url: values.base_url,
+  format: values.format,
+  headers: mapHeadersTypeFormValueToWebhookHeadersType(values.headers),
+  downlink_api_key: values.downlink_api_key,
+  uplink_message: mapMessageTypeFormValueToWebhookMessageType(values.uplink_message),
+  join_accept: mapMessageTypeFormValueToWebhookMessageType(values.join_accept),
+  downlink_ack: mapMessageTypeFormValueToWebhookMessageType(values.downlink_ack),
+  downlink_nack: mapMessageTypeFormValueToWebhookMessageType(values.downlink_nack),
+  downlink_sent: mapMessageTypeFormValueToWebhookMessageType(values.downlink_sent),
+  downlink_failed: mapMessageTypeFormValueToWebhookMessageType(values.downlink_failed),
+  downlink_queued: mapMessageTypeFormValueToWebhookMessageType(values.downlink_queued),
+  downlink_queue_invalidated: mapMessageTypeFormValueToWebhookMessageType(
+    values.downlink_queue_invalidated,
+  ),
+  location_solved: mapMessageTypeFormValueToWebhookMessageType(values.location_solved),
+  service_data: mapMessageTypeFormValueToWebhookMessageType(values.service_data),
+})
 
 export const blankValues = {
   webhook_id: undefined,

--- a/pkg/webui/console/containers/api-keys-table/index.js
+++ b/pkg/webui/console/containers/api-keys-table/index.js
@@ -32,13 +32,12 @@ const m = defineMessages({
   grantedRights: 'Granted Rights',
 })
 
-const formatRight = right => {
-  return right
+const formatRight = right =>
+  right
     .split('_')
     .slice(1)
     .map(r => r.charAt(0) + r.slice(1).toLowerCase())
     .join(' ')
-}
 
 const RIGHT_TAG_MAX_WIDTH = 140
 

--- a/pkg/webui/console/containers/fetch-select/index.js
+++ b/pkg/webui/console/containers/fetch-select/index.js
@@ -26,7 +26,7 @@ const formatOptions = options =>
 
 const { component, ...fieldPropTypes } = Field.propTypes
 
-export default function ({
+export default ({
   optionsSelector,
   errorSelector,
   fetchingSelector,
@@ -36,7 +36,7 @@ export default function ({
   optionsFormatter = formatOptions,
   defaultDescription,
   additionalOptions = [],
-}) {
+}) => {
   @storeConnect(
     state => ({
       options: optionsFormatter(optionsSelector(state)),

--- a/pkg/webui/console/containers/gateway-connection/connect.js
+++ b/pkg/webui/console/containers/gateway-connection/connect.js
@@ -32,15 +32,13 @@ import withConnectionReactor from './gateway-connection-reactor'
 
 export default GatewayConnection =>
   connect(
-    (state, ownProps) => {
-      return {
-        statistics: selectGatewayStatistics(state, ownProps),
-        error: selectGatewayStatisticsError(state, ownProps),
-        fetching: selectGatewayStatisticsIsFetching(state, ownProps),
-        latestEvent: selectLatestGatewayEvent(state, ownProps.gtwId),
-        lastSeen: selectGatewayLastSeen(state),
-      }
-    },
+    (state, ownProps) => ({
+      statistics: selectGatewayStatistics(state, ownProps),
+      error: selectGatewayStatisticsError(state, ownProps),
+      fetching: selectGatewayStatisticsIsFetching(state, ownProps),
+      latestEvent: selectLatestGatewayEvent(state, ownProps.gtwId),
+      lastSeen: selectGatewayLastSeen(state),
+    }),
     (dispatch, ownProps) => ({
       startStatistics: () => dispatch(startGatewayStatistics(ownProps.gtwId)),
       stopStatistics: () => dispatch(stopGatewayStatistics()),

--- a/pkg/webui/console/store/middleware/logics/identity-server.js
+++ b/pkg/webui/console/store/middleware/logics/identity-server.js
@@ -20,9 +20,7 @@ import * as is from '@console/store/actions/identity-server'
 
 const getIsConfigurationLogic = createRequestLogic({
   type: is.GET_IS_CONFIGURATION,
-  process: async () => {
-    return api.is.getConfiguration()
-  },
+  process: async () => api.is.getConfiguration(),
 })
 
 export default [getIsConfigurationLogic]

--- a/pkg/webui/console/store/reducers/gateways.js
+++ b/pkg/webui/console/store/reducers/gateways.js
@@ -38,12 +38,10 @@ const defaultState = {
   statistics: defaultStatisticsState,
 }
 
-const gateway = (state = {}, gateway) => {
-  return {
-    ...state,
-    ...gateway,
-  }
-}
+const gateway = (state = {}, gateway) => ({
+  ...state,
+  ...gateway,
+})
 
 const statistics = (state = defaultStatisticsState, { type, payload }) => {
   switch (type) {

--- a/pkg/webui/console/store/reducers/organizations.js
+++ b/pkg/webui/console/store/reducers/organizations.js
@@ -23,12 +23,10 @@ import {
   DELETE_ORG_SUCCESS,
 } from '@console/store/actions/organizations'
 
-const organization = (state = {}, organization) => {
-  return {
-    ...state,
-    ...organization,
-  }
-}
+const organization = (state = {}, organization) => ({
+  ...state,
+  ...organization,
+})
 
 const defaultState = {
   entities: {},

--- a/pkg/webui/console/views/admin-user-management-edit/index.js
+++ b/pkg/webui/console/views/admin-user-management-edit/index.js
@@ -59,9 +59,9 @@ const m = defineMessages({
   ({ userId, getUser }) => getUser(userId, ['name', 'primary_email_address', 'state', 'admin']),
   ({ fetching, user }) => fetching || !Boolean(user),
 )
-@withBreadcrumb('admin.user-management.edit', ({ userId }) => {
-  return <Breadcrumb path={`/admin/user-management/${userId}`} content={sharedMessages.edit} />
-})
+@withBreadcrumb('admin.user-management.edit', ({ userId }) => (
+  <Breadcrumb path={`/admin/user-management/${userId}`} content={sharedMessages.edit} />
+))
 export default class UserManagementEdit extends Component {
   static propTypes = {
     deleteUser: PropTypes.func.isRequired,

--- a/pkg/webui/console/views/admin-user-management/index.js
+++ b/pkg/webui/console/views/admin-user-management/index.js
@@ -35,9 +35,9 @@ import { mayManageUsers } from '@console/lib/feature-checks'
 import UserManagement from './admin-user-management'
 
 @withFeatureRequirement(mayManageUsers, { redirect: '/' })
-@withBreadcrumb('admin.user-management', () => {
-  return <Breadcrumb path={'/admin/user-management'} content={sharedMessages.userManagement} />
-})
+@withBreadcrumb('admin.user-management', () => (
+  <Breadcrumb path={'/admin/user-management'} content={sharedMessages.userManagement} />
+))
 export default class UserManagementRouter extends Component {
   static propTypes = {
     match: PropTypes.match.isRequired,

--- a/pkg/webui/console/views/application-data/index.js
+++ b/pkg/webui/console/views/application-data/index.js
@@ -43,9 +43,9 @@ const m = defineMessages({
 @withFeatureRequirement(mayViewApplicationEvents, {
   redirect: ({ appId }) => `/applications/${appId}`,
 })
-@withBreadcrumb('apps.single.data', props => {
-  return <Breadcrumb path={`/applications/${props.appId}/data`} content={sharedMessages.liveData} />
-})
+@withBreadcrumb('apps.single.data', props => (
+  <Breadcrumb path={`/applications/${props.appId}/data`} content={sharedMessages.liveData} />
+))
 export default class Data extends React.Component {
   static propTypes = {
     appId: PropTypes.string.isRequired,

--- a/pkg/webui/console/views/device-add/manual/wizard/network-settings-form/validation-schema.js
+++ b/pkg/webui/console/views/device-add/manual/wizard/network-settings-form/validation-schema.js
@@ -169,7 +169,7 @@ const validationSchema = Yup.object({
           .length(4 * 2, Yup.passValues(sharedMessages.validateLength)) // 4 Byte hex.
           .required(sharedMessages.validateRequired),
         keys: Yup.object().shape({
-          f_nwk_s_int_key: Yup.object({
+          f_nwk_s_int_key: Yup.object().shape({
             key: Yup.string()
               .length(16 * 2, Yup.passValues(sharedMessages.validateLength)) // 16 Byte hex.
               .required(sharedMessages.validateRequired),

--- a/pkg/webui/console/views/device-add/repository/validation-schema.js
+++ b/pkg/webui/console/views/device-add/repository/validation-schema.js
@@ -115,7 +115,7 @@ const validationSchema = Yup.object({
             .length(16 * 2, Yup.passValues(sharedMessages.validateLength))
             .required(sharedMessages.validateRequired),
         }),
-        f_nwk_s_int_key: Yup.object({
+        f_nwk_s_int_key: Yup.object().shape({
           key: Yup.string()
             .length(16 * 2, Yup.passValues(sharedMessages.validateLength))
             .required(sharedMessages.validateRequired),

--- a/pkg/webui/console/views/device-list/index.js
+++ b/pkg/webui/console/views/device-list/index.js
@@ -26,11 +26,9 @@ import sharedMessages from '@ttn-lw/lib/shared-messages'
 
 import { selectSelectedApplication } from '@console/store/selectors/applications'
 
-@connect((state, props) => {
-  return {
-    application: selectSelectedApplication(state),
-  }
-})
+@connect((state, props) => ({
+  application: selectSelectedApplication(state),
+}))
 class ApplicationDeviceList extends React.Component {
   render() {
     return (

--- a/pkg/webui/console/views/devices/index.js
+++ b/pkg/webui/console/views/devices/index.js
@@ -37,9 +37,9 @@ import { selectSelectedApplicationId } from '@console/store/selectors/applicatio
 @withFeatureRequirement(mayViewApplicationDevices, {
   redirect: ({ appId }) => `/applications/${appId}`,
 })
-@withBreadcrumb('devices', ({ appId }) => {
-  return <Breadcrumb path={`/applications/${appId}/devices`} content={sharedMessages.devices} />
-})
+@withBreadcrumb('devices', ({ appId }) => (
+  <Breadcrumb path={`/applications/${appId}/devices`} content={sharedMessages.devices} />
+))
 export default class Devices extends React.Component {
   static propTypes = {
     match: PropTypes.match.isRequired,

--- a/pkg/webui/console/views/gateways/index.js
+++ b/pkg/webui/console/views/gateways/index.js
@@ -30,9 +30,9 @@ import sharedMessages from '@ttn-lw/lib/shared-messages'
 import { mayViewGateways } from '@console/lib/feature-checks'
 
 @withFeatureRequirement(mayViewGateways, { redirect: '/' })
-@withBreadcrumb('gateways', props => {
-  return <Breadcrumb path="/gateways" content={sharedMessages.gateways} />
-})
+@withBreadcrumb('gateways', props => (
+  <Breadcrumb path="/gateways" content={sharedMessages.gateways} />
+))
 export default class Gateways extends React.Component {
   static propTypes = {
     match: PropTypes.match.isRequired,

--- a/pkg/webui/console/views/organization-data/organization-data.js
+++ b/pkg/webui/console/views/organization-data/organization-data.js
@@ -32,11 +32,9 @@ const m = defineMessages({
   orgData: 'Organization data',
 })
 
-@withBreadcrumb('orgs.single.data', props => {
-  return (
-    <Breadcrumb path={`/organizations/${props.orgId}/data`} content={sharedMessages.liveData} />
-  )
-})
+@withBreadcrumb('orgs.single.data', props => (
+  <Breadcrumb path={`/organizations/${props.orgId}/data`} content={sharedMessages.liveData} />
+))
 export default class Data extends React.Component {
   static propTypes = {
     orgId: PropTypes.string.isRequired,

--- a/pkg/webui/console/views/organizations/index.js
+++ b/pkg/webui/console/views/organizations/index.js
@@ -30,9 +30,9 @@ import sharedMessages from '@ttn-lw/lib/shared-messages'
 import { mayViewOrganizationsOfUser } from '@console/lib/feature-checks'
 
 @withFeatureRequirement(mayViewOrganizationsOfUser, { redirect: '/' })
-@withBreadcrumb('orgs', props => {
-  return <Breadcrumb path="/organizations" content={sharedMessages.organizations} />
-})
+@withBreadcrumb('orgs', props => (
+  <Breadcrumb path="/organizations" content={sharedMessages.organizations} />
+))
 class Organizations extends React.Component {
   static propTypes = {
     match: PropTypes.match.isRequired,

--- a/pkg/webui/lib/cache.js
+++ b/pkg/webui/lib/cache.js
@@ -39,6 +39,4 @@ export const remove = key => {
   return localStorage.removeItem(hashedKey)
 }
 
-export const clearAll = () => {
-  return localStorage.clear()
-}
+export const clearAll = () => localStorage.clear()

--- a/pkg/webui/lib/delay.js
+++ b/pkg/webui/lib/delay.js
@@ -12,6 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export default (t = 0) => {
-  return new Promise(resolve => setTimeout(resolve, t))
-}
+export default (t = 0) => new Promise(resolve => setTimeout(resolve, t))

--- a/pkg/webui/lib/store/selectors/pagination.js
+++ b/pkg/webui/lib/store/selectors/pagination.js
@@ -19,9 +19,7 @@ const createStoreSelectorByEntity = entity => state => selectStore(state)[entity
 export const createPaginationIdsSelectorByEntity = entity => {
   const storeSelector = createStoreSelectorByEntity(entity)
 
-  return state => {
-    return storeSelector(state).ids || []
-  }
+  return state => storeSelector(state).ids || []
 }
 
 export const createPaginationIdsSelectorByEntityAndId = entity => {
@@ -38,9 +36,7 @@ export const createPaginationIdsSelectorByEntityAndId = entity => {
 export const createPaginationTotalCountSelectorByEntity = entity => {
   const storeSelector = createStoreSelectorByEntity(entity)
 
-  return state => {
-    return storeSelector(state).totalCount
-  }
+  return state => storeSelector(state).totalCount
 }
 
 export const createPaginationTotalCountSelectorByEntityAndId = entity => {

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -17,7 +17,7 @@
     "test:watch": "../../node_modules/.bin/jest --watch",
     "definitions": "node util/http-mapper.js",
     "fmt": "yarn --cwd=\"../..\" prettier './sdk/js/src/**/*.js' './sdk/js/util/**/*.js' --write",
-    "lint": "yarn --cwd=\"../..\" eslint './sdk/js/src/**/**.js' './sdk/js/util/**/*.js' --no-ignore --color"
+    "lint": "yarn --cwd=\"../..\" eslint './sdk/js/src/**/**.js' './sdk/js/util/**/*.js' --no-ignore --color --max-warnings 0"
   },
   "eslintConfig": {
     "extends": "../../config/eslintrc.yaml",

--- a/sdk/js/src/index.test.js
+++ b/sdk/js/src/index.test.js
@@ -52,31 +52,29 @@ const mockDeviceData = {
   },
 }
 
-jest.mock('./api', () => {
-  return jest.fn().mockImplementation(() => {
-    return {
-      ApplicationRegistry: {
-        Get: jest.fn().mockResolvedValue({ data: mockApplicationData }),
-        List: jest.fn().mockResolvedValue({
-          data: { applications: [mockApplicationData] },
-          headers: { 'x-total-count': 1 },
-        }),
-      },
-      EndDeviceRegistry: {
-        Get: jest.fn().mockResolvedValue({ data: mockDeviceData }),
-      },
-      NsEndDeviceRegistry: {
-        Get: jest.fn().mockResolvedValue({ data: mockDeviceData }),
-      },
-      AsEndDeviceRegistry: {
-        Get: jest.fn().mockResolvedValue({ data: mockDeviceData }),
-      },
-      JsEndDeviceRegistry: {
-        Get: jest.fn().mockResolvedValue({ data: mockDeviceData }),
-      },
-    }
-  })
-})
+jest.mock('./api', () =>
+  jest.fn().mockImplementation(() => ({
+    ApplicationRegistry: {
+      Get: jest.fn().mockResolvedValue({ data: mockApplicationData }),
+      List: jest.fn().mockResolvedValue({
+        data: { applications: [mockApplicationData] },
+        headers: { 'x-total-count': 1 },
+      }),
+    },
+    EndDeviceRegistry: {
+      Get: jest.fn().mockResolvedValue({ data: mockDeviceData }),
+    },
+    NsEndDeviceRegistry: {
+      Get: jest.fn().mockResolvedValue({ data: mockDeviceData }),
+    },
+    AsEndDeviceRegistry: {
+      Get: jest.fn().mockResolvedValue({ data: mockDeviceData }),
+    },
+    JsEndDeviceRegistry: {
+      Get: jest.fn().mockResolvedValue({ data: mockDeviceData }),
+    },
+  })),
+)
 
 describe('SDK class', () => {
   const token = 'faketoken'

--- a/sdk/js/src/service/applications.test.js
+++ b/sdk/js/src/service/applications.test.js
@@ -36,19 +36,17 @@ const mockApplicationData = {
   ],
 }
 
-jest.mock('../api', () => {
-  return jest.fn().mockImplementation(() => {
-    return {
-      ApplicationRegistry: {
-        Get: jest.fn().mockResolvedValue({ data: mockApplicationData }),
-        List: jest.fn().mockResolvedValue({
-          data: { applications: [mockApplicationData] },
-          headers: { 'x-total-count': 1 },
-        }),
-      },
-    }
-  })
-})
+jest.mock('../api', () =>
+  jest.fn().mockImplementation(() => ({
+    ApplicationRegistry: {
+      Get: jest.fn().mockResolvedValue({ data: mockApplicationData }),
+      List: jest.fn().mockResolvedValue({
+        data: { applications: [mockApplicationData] },
+        headers: { 'x-total-count': 1 },
+      }),
+    },
+  })),
+)
 
 describe('Applications', () => {
   let applications

--- a/sdk/js/src/service/devices/split.js
+++ b/sdk/js/src/service/devices/split.js
@@ -78,9 +78,7 @@ const splitPaths = (paths = [], direction, base = {}, components = [IS, NS, AS, 
  * @returns {object} A request tree object, consisting of resulting paths for
  * each component eg: `{ is: ['ids'], as: ['session'], js: ['root_keys'] }`.
  */
-export const splitSetPaths = (paths, base, components) => {
-  return splitPaths(paths, 'set', base, components)
-}
+export const splitSetPaths = (paths, base, components) => splitPaths(paths, 'set', base, components)
 
 /**
  * A wrapper function to obtain a request tree for reading values to a device.
@@ -93,9 +91,7 @@ export const splitSetPaths = (paths, base, components) => {
  * @returns {object} A request tree object, consisting of resulting paths for
  * each component eg: `{ is: ['ids'], as: ['session'], js: ['root_keys'] }`.
  */
-export const splitGetPaths = (paths, base, components) => {
-  return splitPaths(paths, 'get', base, components)
-}
+export const splitGetPaths = (paths, base, components) => splitPaths(paths, 'get', base, components)
 
 /**
  * `makeRequests` will make the necessary api calls based on the request tree

--- a/tools/mage/js.go
+++ b/tools/mage/js.go
@@ -64,7 +64,7 @@ func (js Js) runWebpack(config string, args ...string) error {
 }
 
 func (js Js) runEslint(args ...string) error {
-	return js.runYarnCommand("eslint", append([]string{"--color", "--no-ignore"}, args...)...)
+	return js.runYarnCommand("eslint", append([]string{"--color", "--no-ignore", "--max-warnings", "0"}, args...)...)
 }
 
 func (js Js) waitOn() error {


### PR DESCRIPTION
 #### Summary
This quickfix will resolve all linter warnings of `eslint` and make the linting step in github actions fail also for warnings.

#### Changes
- Apply `eslint --fix` to codebase
- Apply manual warning fixes
- Add `--max-warnings 0` to eslint mage targets

##### Regressions

Should be caught by CI.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
