### PR TITLE
Do not dial Packet Broker when no roles are enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ For details about compatibility between different releases, see the **Commitment
 - For ABP sessions, the CLI now requests a DevAddr from the Network Server instead of generating one from the testing NetID.
 - Descriptions, tooltips and defaults for checkboxes for public gateway status and location in the Console.
 - All HTTP requests made by The Things Stack now contain a `User-Agent` header in the form of `TheThingsStack/{version}`.
+- No connection to Packet Broker is being made when neither the Forwarder nor the Home Network role is enabled.
 
 ### Deprecated
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -7298,24 +7298,6 @@
       "file": "translation.go"
     }
   },
-  "error:pkg/packetbrokeragent:forwarder_disabled": {
-    "translations": {
-      "en": "Forwarder is disabled"
-    },
-    "description": {
-      "package": "pkg/packetbrokeragent",
-      "file": "grpc_gspba.go"
-    }
-  },
-  "error:pkg/packetbrokeragent:home_network_disabled": {
-    "translations": {
-      "en": "Home Network is disabled"
-    },
-    "description": {
-      "package": "pkg/packetbrokeragent",
-      "file": "grpc_nspba.go"
-    }
-  },
   "error:pkg/packetbrokeragent:inconsistent_bands": {
     "translations": {
       "en": "inconsistent bands"
@@ -7403,7 +7385,7 @@
     },
     "description": {
       "package": "pkg/packetbrokeragent",
-      "file": "grpc_pba.go"
+      "file": "grpc_disabled.go"
     }
   },
   "error:pkg/packetbrokeragent:registration": {

--- a/pkg/packetbrokeragent/grpc_disabled.go
+++ b/pkg/packetbrokeragent/grpc_disabled.go
@@ -1,0 +1,92 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packetbrokeragent
+
+import (
+	"context"
+
+	pbtypes "github.com/gogo/protobuf/types"
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+)
+
+type disabledServer struct {
+}
+
+var errNotEnabled = errors.DefineFailedPrecondition("not_enabled", "Packet Broker is not enabled")
+
+func (s disabledServer) GetInfo(context.Context, *pbtypes.Empty) (*ttnpb.PacketBrokerInfo, error) {
+	return nil, errNotEnabled.New()
+}
+
+func (s disabledServer) Register(context.Context, *pbtypes.Empty) (*ttnpb.PacketBrokerNetwork, error) {
+	return nil, errNotEnabled.New()
+}
+
+func (s disabledServer) Deregister(context.Context, *pbtypes.Empty) (*pbtypes.Empty, error) {
+	return nil, errNotEnabled.New()
+}
+
+func (s disabledServer) GetHomeNetworkDefaultRoutingPolicy(context.Context, *pbtypes.Empty) (*ttnpb.PacketBrokerDefaultRoutingPolicy, error) {
+	return nil, errNotEnabled.New()
+}
+
+func (s disabledServer) SetHomeNetworkDefaultRoutingPolicy(context.Context, *ttnpb.SetPacketBrokerDefaultRoutingPolicyRequest) (*pbtypes.Empty, error) {
+	return nil, errNotEnabled.New()
+}
+
+func (s disabledServer) DeleteHomeNetworkDefaultRoutingPolicy(context.Context, *pbtypes.Empty) (*pbtypes.Empty, error) {
+	return nil, errNotEnabled.New()
+}
+
+func (s disabledServer) ListHomeNetworkRoutingPolicies(context.Context, *ttnpb.ListHomeNetworkRoutingPoliciesRequest) (*ttnpb.PacketBrokerRoutingPolicies, error) {
+	return nil, errNotEnabled.New()
+}
+
+func (s disabledServer) GetHomeNetworkRoutingPolicy(context.Context, *ttnpb.PacketBrokerNetworkIdentifier) (*ttnpb.PacketBrokerRoutingPolicy, error) {
+	return nil, errNotEnabled.New()
+}
+
+func (s disabledServer) SetHomeNetworkRoutingPolicy(context.Context, *ttnpb.SetPacketBrokerRoutingPolicyRequest) (*pbtypes.Empty, error) {
+	return nil, errNotEnabled.New()
+}
+
+func (s disabledServer) DeleteHomeNetworkRoutingPolicy(context.Context, *ttnpb.PacketBrokerNetworkIdentifier) (*pbtypes.Empty, error) {
+	return nil, errNotEnabled.New()
+}
+
+func (s disabledServer) ListNetworks(context.Context, *ttnpb.ListPacketBrokerNetworksRequest) (*ttnpb.PacketBrokerNetworks, error) {
+	return nil, errNotEnabled.New()
+}
+
+func (s disabledServer) ListHomeNetworks(context.Context, *ttnpb.ListPacketBrokerHomeNetworksRequest) (*ttnpb.PacketBrokerNetworks, error) {
+	return nil, errNotEnabled.New()
+}
+
+func (s disabledServer) ListForwarderRoutingPolicies(context.Context, *ttnpb.ListForwarderRoutingPoliciesRequest) (*ttnpb.PacketBrokerRoutingPolicies, error) {
+	return nil, errNotEnabled.New()
+}
+
+func (s disabledServer) PublishDownlink(context.Context, *ttnpb.DownlinkMessage) (*pbtypes.Empty, error) {
+	return nil, errNotEnabled.New()
+}
+
+func (s disabledServer) PublishUplink(context.Context, *ttnpb.GatewayUplinkMessage) (*pbtypes.Empty, error) {
+	return nil, errNotEnabled.New()
+}
+
+func (s disabledServer) UpdateGateway(context.Context, *ttnpb.UpdatePacketBrokerGatewayRequest) (*ttnpb.UpdatePacketBrokerGatewayResponse, error) {
+	return nil, errNotEnabled.New()
+}

--- a/pkg/packetbrokeragent/grpc_gspba.go
+++ b/pkg/packetbrokeragent/grpc_gspba.go
@@ -58,16 +58,10 @@ type gsPbaServer struct {
 	mapperConn          *grpc.ClientConn
 }
 
-var errForwarderDisabled = errors.DefineFailedPrecondition("forwarder_disabled", "Forwarder is disabled")
-
 // PublishUplink is called by the Gateway Server when an uplink message arrives and needs to get forwarded to Packet Broker.
 func (s *gsPbaServer) PublishUplink(ctx context.Context, up *ttnpb.GatewayUplinkMessage) (*pbtypes.Empty, error) {
 	if err := clusterauth.Authorized(ctx); err != nil {
 		return nil, err
-	}
-
-	if s.upstreamCh == nil {
-		return nil, errForwarderDisabled.New()
 	}
 
 	ctx = events.ContextWithCorrelationID(ctx, append(

--- a/pkg/packetbrokeragent/grpc_nspba.go
+++ b/pkg/packetbrokeragent/grpc_nspba.go
@@ -20,7 +20,6 @@ import (
 
 	pbtypes "github.com/gogo/protobuf/types"
 	clusterauth "go.thethings.network/lorawan-stack/v3/pkg/auth/cluster"
-	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -31,16 +30,10 @@ type nsPbaServer struct {
 	downstreamCh     chan *downlinkMessage
 }
 
-var errHomeNetworkDisabled = errors.DefineFailedPrecondition("home_network_disabled", "Home Network is disabled")
-
 // PublishDownlink is called by the Network Server when a downlink message needs to get scheduled via Packet Broker.
 func (s *nsPbaServer) PublishDownlink(ctx context.Context, down *ttnpb.DownlinkMessage) (*pbtypes.Empty, error) {
 	if err := clusterauth.Authorized(ctx); err != nil {
 		return nil, err
-	}
-
-	if s.downstreamCh == nil {
-		return nil, errHomeNetworkDisabled.New()
 	}
 
 	ctx = events.ContextWithCorrelationID(ctx, append(

--- a/pkg/packetbrokeragent/grpc_pba.go
+++ b/pkg/packetbrokeragent/grpc_pba.go
@@ -39,14 +39,9 @@ type pbaServer struct {
 	cpConn *grpc.ClientConn
 }
 
-var errNotEnabled = errors.DefineFailedPrecondition("not_enabled", "Packet Broker is not enabled")
-
 func (s *pbaServer) GetInfo(ctx context.Context, _ *pbtypes.Empty) (*ttnpb.PacketBrokerInfo, error) {
 	if err := rights.RequireIsAdmin(ctx); err != nil {
 		return nil, err
-	}
-	if !s.forwarderConfig.Enable && !s.homeNetworkConfig.Enable {
-		return nil, errNotEnabled.New()
 	}
 
 	var (
@@ -109,9 +104,6 @@ var (
 func (s *pbaServer) Register(ctx context.Context, _ *pbtypes.Empty) (*ttnpb.PacketBrokerNetwork, error) {
 	if err := rights.RequireIsAdmin(ctx); err != nil {
 		return nil, err
-	}
-	if !s.forwarderConfig.Enable && !s.homeNetworkConfig.Enable {
-		return nil, errNotEnabled.New()
 	}
 	tenantID := s.tenantIDExtractor(ctx)
 	if tenantID == "" {
@@ -192,9 +184,6 @@ func (s *pbaServer) Deregister(ctx context.Context, _ *pbtypes.Empty) (*pbtypes.
 	if err := rights.RequireIsAdmin(ctx); err != nil {
 		return nil, err
 	}
-	if !s.forwarderConfig.Enable && !s.homeNetworkConfig.Enable {
-		return nil, errNotEnabled.New()
-	}
 	tenantID := s.tenantIDExtractor(ctx)
 	if tenantID == "" {
 		return nil, errNetwork.New()
@@ -214,7 +203,7 @@ func (s *pbaServer) GetHomeNetworkDefaultRoutingPolicy(ctx context.Context, _ *p
 	if err := rights.RequireIsAdmin(ctx); err != nil {
 		return nil, err
 	}
-	if !s.forwarderConfig.Enable && !s.homeNetworkConfig.Enable {
+	if !s.forwarderConfig.Enable {
 		return nil, errNotEnabled.New()
 	}
 
@@ -232,7 +221,7 @@ func (s *pbaServer) SetHomeNetworkDefaultRoutingPolicy(ctx context.Context, req 
 	if err := rights.RequireIsAdmin(ctx); err != nil {
 		return nil, err
 	}
-	if !s.forwarderConfig.Enable && !s.homeNetworkConfig.Enable {
+	if !s.forwarderConfig.Enable {
 		return nil, errNotEnabled.New()
 	}
 
@@ -254,7 +243,7 @@ func (s *pbaServer) DeleteHomeNetworkDefaultRoutingPolicy(ctx context.Context, _
 	if err := rights.RequireIsAdmin(ctx); err != nil {
 		return nil, err
 	}
-	if !s.forwarderConfig.Enable && !s.homeNetworkConfig.Enable {
+	if !s.forwarderConfig.Enable {
 		return nil, errNotEnabled.New()
 	}
 
@@ -274,7 +263,7 @@ func (s *pbaServer) ListHomeNetworkRoutingPolicies(ctx context.Context, req *ttn
 	if err := rights.RequireIsAdmin(ctx); err != nil {
 		return nil, err
 	}
-	if !s.forwarderConfig.Enable && !s.homeNetworkConfig.Enable {
+	if !s.forwarderConfig.Enable {
 		return nil, errNotEnabled.New()
 	}
 
@@ -343,7 +332,7 @@ func (s *pbaServer) GetHomeNetworkRoutingPolicy(ctx context.Context, req *ttnpb.
 	if err := rights.RequireIsAdmin(ctx); err != nil {
 		return nil, err
 	}
-	if !s.forwarderConfig.Enable && !s.homeNetworkConfig.Enable {
+	if !s.forwarderConfig.Enable {
 		return nil, errNotEnabled.New()
 	}
 
@@ -363,7 +352,7 @@ func (s *pbaServer) SetHomeNetworkRoutingPolicy(ctx context.Context, req *ttnpb.
 	if err := rights.RequireIsAdmin(ctx); err != nil {
 		return nil, err
 	}
-	if !s.forwarderConfig.Enable && !s.homeNetworkConfig.Enable {
+	if !s.forwarderConfig.Enable {
 		return nil, errNotEnabled.New()
 	}
 
@@ -387,7 +376,7 @@ func (s *pbaServer) DeleteHomeNetworkRoutingPolicy(ctx context.Context, req *ttn
 	if err := rights.RequireIsAdmin(ctx); err != nil {
 		return nil, err
 	}
-	if !s.forwarderConfig.Enable && !s.homeNetworkConfig.Enable {
+	if !s.forwarderConfig.Enable {
 		return nil, errNotEnabled.New()
 	}
 
@@ -408,9 +397,6 @@ func (s *pbaServer) DeleteHomeNetworkRoutingPolicy(ctx context.Context, req *ttn
 func (s *pbaServer) listNetworks(ctx context.Context, req func() ([]*packetbroker.NetworkOrTenant, uint32, error)) (*ttnpb.PacketBrokerNetworks, error) {
 	if err := rights.RequireIsAdmin(ctx); err != nil {
 		return nil, err
-	}
-	if !s.forwarderConfig.Enable && !s.homeNetworkConfig.Enable {
-		return nil, errNotEnabled.New()
 	}
 
 	networks, total, err := req()
@@ -501,7 +487,7 @@ func (s *pbaServer) ListForwarderRoutingPolicies(ctx context.Context, req *ttnpb
 	if err := rights.RequireIsAdmin(ctx); err != nil {
 		return nil, err
 	}
-	if !s.forwarderConfig.Enable && !s.homeNetworkConfig.Enable {
+	if !s.homeNetworkConfig.Enable {
 		return nil, errNotEnabled.New()
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Skip dialing Packet Broker Agent when neither Forwarder nor Home Network role are enabled.

#### Changes
<!-- What are the changes made in this pull request? -->

Check config to see if it makes sense to dial. If a role isn't enabled and a service depends on it, a server stub that returns disabled errors is used.

#### Testing

<!-- How did you verify that this change works? -->

Local testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
