### PR TITLE
Fix LoRaCloud GLS WiFi support on empty fields

### DIFF
--- a/pkg/applicationserver/io/packages/loradms/v1/api/uplinks.go
+++ b/pkg/applicationserver/io/packages/loradms/v1/api/uplinks.go
@@ -15,9 +15,7 @@
 package api
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"net/http"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io/packages/loradms/v1/api/objects"
@@ -32,12 +30,7 @@ const uplinkEntity = "uplink"
 
 // Send sends the given uplink to the Device Management service.
 func (u *Uplinks) Send(ctx context.Context, uplinks objects.DeviceUplinks) (objects.DeviceUplinkResponses, error) {
-	buffer := bytes.NewBuffer(nil)
-	err := json.NewEncoder(buffer).Encode(uplinks)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := u.cl.Do(ctx, http.MethodPost, uplinkEntity, "", sendOperation, buffer)
+	resp, err := u.cl.Do(ctx, http.MethodPost, uplinkEntity, "", sendOperation, uplinks)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/applicationserver/io/packages/loragls/v3/api/client_test.go
+++ b/pkg/applicationserver/io/packages/loragls/v3/api/client_test.go
@@ -221,7 +221,7 @@ var (
 				GatewayID: "gtw1",
 				RSSI:      123.4,
 				SNR:       234.5,
-				TOA:       float64Ptr(234.5),
+				TDOA:      234,
 				AntennaLocation: api.AntennaLocation{
 					Latitude:  234.5,
 					Longitude: 678.9,
@@ -232,7 +232,7 @@ var (
 				GatewayID: "gtw2",
 				RSSI:      234.5,
 				SNR:       345.7,
-				TOA:       float64Ptr(456.7),
+				TDOA:      456,
 				AntennaLocation: api.AntennaLocation{
 					Latitude:  345.5,
 					Longitude: 567.9,

--- a/pkg/applicationserver/io/packages/loragls/v3/api/objects.go
+++ b/pkg/applicationserver/io/packages/loragls/v3/api/objects.go
@@ -114,7 +114,10 @@ func parseRxMetadata(ctx context.Context, m *ttnpb.RxMetadata) (Gateway, Uplink)
 
 // BuildSingelFrameRequest builds a SingleFrameRequest from the provided metadata.
 func BuildSingleFrameRequest(ctx context.Context, metadata []*ttnpb.RxMetadata) *SingleFrameRequest {
-	r := &SingleFrameRequest{}
+	r := &SingleFrameRequest{
+		Gateways: []Gateway{},
+		Frame:    Frame{},
+	}
 	for _, m := range metadata {
 		if m.Location == nil {
 			continue
@@ -135,7 +138,10 @@ type MultiFrameRequest struct {
 
 // BuildMultiFrameRequest builds a MultiFrameRequest from the provided metadata.
 func BuildMultiFrameRequest(ctx context.Context, mds [][]*ttnpb.RxMetadata) *MultiFrameRequest {
-	r := &MultiFrameRequest{}
+	r := &MultiFrameRequest{
+		Gateways: []Gateway{},
+		Frames:   []Frame{},
+	}
 	gateways := map[string]struct{}{}
 	for _, metadata := range mds {
 		frame := Frame{}

--- a/pkg/applicationserver/io/packages/loragls/v3/package.go
+++ b/pkg/applicationserver/io/packages/loragls/v3/package.go
@@ -102,7 +102,7 @@ func New(server io.Server, registry packages.Registry) packages.ApplicationPacka
 
 func (p *GeolocationPackage) singleFrameQuery(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, up *ttnpb.ApplicationUplink, data *Data, client *api.Client) (api.AbstractLocationSolverResponse, error) {
 	req := api.BuildSingleFrameRequest(ctx, up.RxMetadata)
-	if len(req.Gateways) < 3 {
+	if len(req.Gateways) < 1 {
 		return nil, nil
 	}
 	resp, err := client.SolveSingleFrame(ctx, req)
@@ -157,7 +157,7 @@ func (p *GeolocationPackage) multiFrameQuery(ctx context.Context, ids ttnpb.EndD
 	}
 
 	req := api.BuildMultiFrameRequest(ctx, mds)
-	if len(req.Gateways) < 3 {
+	if len(req.Gateways) < 1 {
 		return nil, nil
 	}
 	resp, err := client.SolveMultiFrame(ctx, req)
@@ -169,7 +169,7 @@ func (p *GeolocationPackage) multiFrameQuery(ctx context.Context, ids ttnpb.EndD
 
 func (p *GeolocationPackage) wifiQuery(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, up *ttnpb.ApplicationUplink, data *Data, client *api.Client) (api.AbstractLocationSolverResponse, error) {
 	req := api.BuildWiFiRequest(ctx, up.RxMetadata, up.DecodedPayload)
-	if len(req.WiFiAccessPoints) == 0 && len(req.LoRaWAN) < 3 {
+	if len(req.LoRaWAN) < 1 {
 		return nil, nil
 	}
 	resp, err := client.SolveWiFi(ctx, req)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #4267

#### Changes
<!-- What are the changes made in this pull request? -->

- Clean up both DAS and GLS packages from unused params / redundant code (marshaling)
- Log DAS and GLS requests in `DEBUG` level
- Make sure empty slices are actually empty slices (`[]` in JSON) instead of `nil`
- Add TDOA (`toa` in the actual message) when doing v2 WiFi requests. 0 when unavailable
- Lower the number of required gateways for location queries to 1

#### Testing

<!-- How did you verify that this change works? -->

1. GNSS payload (adding this here for @nejraselimovic):

<details>

`01c80a2de80aa204a887c4906d0054529b38908a0000a4a677e5f2307548650e07bf1d20a10aa735c779b8483515fa72388d17a96a9e0ebb0923`

</details>

results in:

<details>

```json
{
  "name": "as.up.service.forward",
  "time": "2021-06-25T14:48:19.456210593Z",
  "identifiers": [
    {
      "device_ids": {
        "device_id": "modem",
        "application_ids": {
          "application_id": "app1"
        },
        "dev_eui": "0016C001F000406E",
        "join_eui": "0016C001FFFE0001"
      }
    }
  ],
  "data": {
    "@type": "type.googleapis.com/ttn.lorawan.v3.ApplicationUp",
    "end_device_ids": {
      "device_id": "modem",
      "application_ids": {
        "application_id": "app1"
      },
      "dev_eui": "0016C001F000406E",
      "join_eui": "0016C001FFFE0001"
    },
    "correlation_ids": [
      "as:packages:loracloudglsv3:01F91T9725A58X0N251K4TXEJM",
      "as:up:01F91T9722PXSEZS7WB5FM47M8",
      "as:up:01F91T977ZS5GTSFYY3E3X7FZK",
      "rpc:/ttn.lorawan.v3.AppAs/SimulateUplink:01F91T970S3EEHKEPJ25PW45KM"
    ],
    "received_at": "2021-06-25T14:48:19.455991097Z",
    "service_data": {
      "service": "lora-cloud-geolocation-v3",
      "data": {
        "result": {
          "accuracy": 40.2,
          "capture_time_gps": 1308667011.188021,
          "capture_time_utc": 1624631793.188022,
          "ecef": [
            3966763.68,
            381399.13,
            4963362.96
          ],
          "gdop": 2.99,
          "llh": [
            51.42695,
            5.49203,
            81.91
          ]
        },
        "warnings": []
      }
    }
  },
  "correlation_ids": [
    "as:packages:loracloudglsv3:01F91T9725A58X0N251K4TXEJM",
    "as:up:01F91T9722PXSEZS7WB5FM47M8",
    "as:up:01F91T977ZS5GTSFYY3E3X7FZK",
    "rpc:/ttn.lorawan.v3.AppAs/SimulateUplink:01F91T970S3EEHKEPJ25PW45KM"
  ],
  "origin": "A98BCD2222F1",
  "visibility": {
    "rights": [
      "RIGHT_APPLICATION_TRAFFIC_READ"
    ]
  },
  "unique_id": "01F91T9780KY6A12FA6G5P2YKW"
}
```

</details>

<details>

```json
{
  "name": "as.up.location.forward",
  "time": "2021-06-25T14:48:19.456661213Z",
  "identifiers": [
    {
      "device_ids": {
        "device_id": "modem",
        "application_ids": {
          "application_id": "app1"
        },
        "dev_eui": "0016C001F000406E",
        "join_eui": "0016C001FFFE0001"
      }
    }
  ],
  "data": {
    "@type": "type.googleapis.com/ttn.lorawan.v3.ApplicationUp",
    "end_device_ids": {
      "device_id": "modem",
      "application_ids": {
        "application_id": "app1"
      },
      "dev_eui": "0016C001F000406E",
      "join_eui": "0016C001FFFE0001"
    },
    "correlation_ids": [
      "as:packages:loracloudglsv3:01F91T9725A58X0N251K4TXEJM",
      "as:up:01F91T9722PXSEZS7WB5FM47M8",
      "as:up:01F91T9780KQA9H2ERSR7V95E4",
      "rpc:/ttn.lorawan.v3.AppAs/SimulateUplink:01F91T970S3EEHKEPJ25PW45KM"
    ],
    "received_at": "2021-06-25T14:48:19.456393972Z",
    "location_solved": {
      "service": "lora-cloud-geolocation-v3-gnss",
      "location": {
        "latitude": 51.42695,
        "longitude": 5.49203,
        "altitude": 81,
        "accuracy": 40,
        "source": "SOURCE_GPS"
      }
    }
  },
  "correlation_ids": [
    "as:packages:loracloudglsv3:01F91T9725A58X0N251K4TXEJM",
    "as:up:01F91T9722PXSEZS7WB5FM47M8",
    "as:up:01F91T9780KQA9H2ERSR7V95E4",
    "rpc:/ttn.lorawan.v3.AppAs/SimulateUplink:01F91T970S3EEHKEPJ25PW45KM"
  ],
  "origin": "A98BCD2222F1",
  "visibility": {
    "rights": [
      "RIGHT_APPLICATION_TRAFFIC_READ"
    ]
  },
  "unique_id": "01F91T9780RKEFPGXHS9XNXG1H"
}
```

</details>

2. WiFi payload:

This requires two things:
- The nearby WiFi access points should be part of the message `decoded_payload` (so they should be provided by the payload formatter)
  - You can use the following payload formatter to have some static access points:
<details>

```js
function decodeUplink(input) {
  return {
    data: {
      access_points: [
        {
          bssid: "00:02:01:53:8B:50",
          rssi: -20,
        },
        {
          bssid: "00:02:13:44:55:20",
          rssi: -80,
        }
      ]
    },
    warnings: [],
    errors: []
  };
}
```

</details>

- The uplink should contain some gateways that actually have a location:
<details>

```json
{
	"@type": "type.googleapis.com/ttn.lorawan.v3.ApplicationUp",
	"end_device_ids": {
		"device_id": "lora-edge-tracker",
		"application_ids": {
			"application_id": "lr1110-demo-app"
		}
	},
	"correlation_ids": [
		"as:up:01F8WK2QQX7ZEC84MHWRSC38EE",
		"gs:conn:01F8WG8JN5NDZKBFMQ8SQQKWYP",
		"gs:up:host:01F8WG8JNFRJC3JTR2H2Z0BG3Y",
		"gs:uplink:01F8WK2QH8NMK3P4NFTZGBR5GB",
		"ns:uplink:01F8WK2QH966XZCD1ZQJ0P7NNY",
		"rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01F8WK2QH98NG2WBBKDZ1G2N5Y",
		"rpc:/ttn.lorawan.v3.NsAs/HandleUplink:01F8WK2QQXSYVT2MPMKFJ6GE8M"
	],
	"received_at": "2021-06-23T14:06:14.782929535Z",
	"uplink_message": {
		"session_key_id": "dHRuLWx3LWludGVyb3AtZ2VuZXJhdGVkOgF6OPwRrO6mV4E+zf6B7Qg=",
		"f_port": 199,
		"f_cnt": 13,
		"frm_payload": "FC64AM0IKr9kZrPHyprQZGazUs2GsgIg4NcS16WwlXULbSijCFsOhf12q7BOJl40oqBl3ZGMxhsud2nmOasqSaZEl3HX7u7REp9+fvG/k9OpnVFVVfWZw0ai87j6KzdCBgmQFKg=",
		"rx_metadata": [{
				"gateway_ids": {
					"gateway_id": "snejra-rak-gw",
					"eui": "B827EBFFFE8A9E3C"
				},
				"timestamp": 2956865323,
				"rssi": -86.0,
				"channel_rssi": -86.0,
				"snr": 15.0,
				"fine_timestamp": 10000,
				"location": {
					"latitude": 46.98886,
					"longitude": 6.91287,
					"source": "SOURCE_REGISTRY"
				},
				"uplink_token": "ChsKGQoNc25lanJhLXJhay1ndxIIuCfr//6KnjwQq974gQsaDAjW/8yGBhC87e+OAiD4/6CXh1Y=",
				"channel_index": 1
			},
			{
				"gateway_ids": {
					"gateway_id": "snejra-rak-gw2",
					"eui": "B827EBFFFE8A9E3D"
				},
				"timestamp": 2956865323,
				"rssi": -87.0,
				"channel_rssi": -87.0,
				"snr": 15.0,
				"fine_timestamp": 5000,
				"location": {
					"latitude": 46.98886,
					"longitude": 6.91287,
					"source": "SOURCE_REGISTRY"
				},
				"uplink_token": "ChsKGQoNc25lanJhLXJhay1ndxIIuCfr//6KnjwQq974gQsaDAjW/8yGBhC87e+OAiD4/6CXh1Y=",
				"channel_index": 1
			},
			{
				"gateway_ids": {
					"gateway_id": "snejra-rak-gw3",
					"eui": "B827EBFFFE8A9E3E"
				},
				"timestamp": 2956865323,
				"rssi": -89.0,
				"channel_rssi": -89.0,
				"snr": 15.0,
				"fine_timestamp": 8000,
				"location": {
					"latitude": 46.983753,
					"longitude": 6.906008,
					"source": "SOURCE_REGISTRY"
				},
				"uplink_token": "ChsKGQoNc25lanJhLXJhay1ndxIIuCfr//6KnjwQq974gQsaDAjW/8yGBhC87e+OAiD4/6CXh1Y=",
				"channel_index": 1
			},
			{
				"gateway_ids": {
					"gateway_id": "snejra-rak-gw4",
					"eui": "B827EBFFFE8A9E3E"
				},
				"timestamp": 2956865323,
				"rssi": -89.0,
				"channel_rssi": -89.0,
				"snr": 15.0,
				"fine_timestamp": 20000,
				"location": {
					"latitude": 46.983753,
					"longitude": 6.906008,
					"source": "SOURCE_REGISTRY"
				},
				"uplink_token": "ChsKGQoNc25lanJhLXJhay1ndxIIuCfr//6KnjwQq974gQsaDAjW/8yGBhC87e+OAiD4/6CXh1Y=",
				"channel_index": 1
			}

		],
		"settings": {
			"data_rate": {
				"lora": {
					"bandwidth": 125000,
					"spreading_factor": 7
				}
			},
			"data_rate_index": 5,
			"coding_rate": "4/5",
			"frequency": "868300000",
			"timestamp": 2956865323
		},
		"received_at": "2021-06-23T14:06:14.569960357Z",
		"consumed_airtime": "0.194816s"
	}
}
```

</details>

Using both of these results in the following service data / location solved:

<details>

```json
{
  "name": "as.up.service.forward",
  "time": "2021-06-25T14:59:00.723672732Z",
  "identifiers": [
    {
      "device_ids": {
        "device_id": "modem",
        "application_ids": {
          "application_id": "app1"
        },
        "dev_eui": "0016C001F000406E",
        "join_eui": "0016C001FFFE0001"
      }
    }
  ],
  "data": {
    "@type": "type.googleapis.com/ttn.lorawan.v3.ApplicationUp",
    "end_device_ids": {
      "device_id": "modem",
      "application_ids": {
        "application_id": "app1"
      },
      "dev_eui": "0016C001F000406E",
      "join_eui": "0016C001FFFE0001"
    },
    "correlation_ids": [
      "as:packages:loracloudglsv3:01F91TWS4MB1KN9JN7ZE734HMR",
      "as:up:01F8WK2QQX7ZEC84MHWRSC38EE",
      "as:up:01F91TWS4D7ZGYNWQA0Y9DVTXX",
      "as:up:01F91TWSFKD5RPNWWNPW2X8VRM",
      "gs:conn:01F8WG8JN5NDZKBFMQ8SQQKWYP",
      "gs:up:host:01F8WG8JNFRJC3JTR2H2Z0BG3Y",
      "gs:uplink:01F8WK2QH8NMK3P4NFTZGBR5GB",
      "ns:uplink:01F8WK2QH966XZCD1ZQJ0P7NNY",
      "rpc:/ttn.lorawan.v3.AppAs/SimulateUplink:01F91TWS3924HW6VN8F305098P",
      "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01F8WK2QH98NG2WBBKDZ1G2N5Y",
      "rpc:/ttn.lorawan.v3.NsAs/HandleUplink:01F8WK2QQXSYVT2MPMKFJ6GE8M"
    ],
    "received_at": "2021-06-25T14:59:00.723460573Z",
    "service_data": {
      "service": "lora-cloud-geolocation-v3",
      "data": {
        "errors": [],
        "result": {
          "accuracy": 450,
          "algorithmType": "Wifi",
          "altitude": 0,
          "latitude": 47.225123,
          "longitude": 8.824899,
          "numberOfGatewaysReceived": 0,
          "numberOfGatewaysUsed": 0
        },
        "warnings": []
      }
    }
  },
  "correlation_ids": [
    "as:packages:loracloudglsv3:01F91TWS4MB1KN9JN7ZE734HMR",
    "as:up:01F8WK2QQX7ZEC84MHWRSC38EE",
    "as:up:01F91TWS4D7ZGYNWQA0Y9DVTXX",
    "as:up:01F91TWSFKD5RPNWWNPW2X8VRM",
    "gs:conn:01F8WG8JN5NDZKBFMQ8SQQKWYP",
    "gs:up:host:01F8WG8JNFRJC3JTR2H2Z0BG3Y",
    "gs:uplink:01F8WK2QH8NMK3P4NFTZGBR5GB",
    "ns:uplink:01F8WK2QH966XZCD1ZQJ0P7NNY",
    "rpc:/ttn.lorawan.v3.AppAs/SimulateUplink:01F91TWS3924HW6VN8F305098P",
    "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01F8WK2QH98NG2WBBKDZ1G2N5Y",
    "rpc:/ttn.lorawan.v3.NsAs/HandleUplink:01F8WK2QQXSYVT2MPMKFJ6GE8M"
  ],
  "origin": "A98BCD2222F1",
  "visibility": {
    "rights": [
      "RIGHT_APPLICATION_TRAFFIC_READ"
    ]
  },
  "unique_id": "01F91TWSFKQJD0WAWMA5AWRF28"
}
```

</details>

<details>

```json
{
  "name": "as.up.location.forward",
  "time": "2021-06-25T14:59:00.724014361Z",
  "identifiers": [
    {
      "device_ids": {
        "device_id": "modem",
        "application_ids": {
          "application_id": "app1"
        },
        "dev_eui": "0016C001F000406E",
        "join_eui": "0016C001FFFE0001"
      }
    }
  ],
  "data": {
    "@type": "type.googleapis.com/ttn.lorawan.v3.ApplicationUp",
    "end_device_ids": {
      "device_id": "modem",
      "application_ids": {
        "application_id": "app1"
      },
      "dev_eui": "0016C001F000406E",
      "join_eui": "0016C001FFFE0001"
    },
    "correlation_ids": [
      "as:packages:loracloudglsv3:01F91TWS4MB1KN9JN7ZE734HMR",
      "as:up:01F8WK2QQX7ZEC84MHWRSC38EE",
      "as:up:01F91TWS4D7ZGYNWQA0Y9DVTXX",
      "as:up:01F91TWSFKSPEY4FBA41M7HB25",
      "gs:conn:01F8WG8JN5NDZKBFMQ8SQQKWYP",
      "gs:up:host:01F8WG8JNFRJC3JTR2H2Z0BG3Y",
      "gs:uplink:01F8WK2QH8NMK3P4NFTZGBR5GB",
      "ns:uplink:01F8WK2QH966XZCD1ZQJ0P7NNY",
      "rpc:/ttn.lorawan.v3.AppAs/SimulateUplink:01F91TWS3924HW6VN8F305098P",
      "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01F8WK2QH98NG2WBBKDZ1G2N5Y",
      "rpc:/ttn.lorawan.v3.NsAs/HandleUplink:01F8WK2QQXSYVT2MPMKFJ6GE8M"
    ],
    "received_at": "2021-06-25T14:59:00.723825795Z",
    "location_solved": {
      "service": "lora-cloud-geolocation-v3-Wifi",
      "location": {
        "latitude": 47.225123,
        "longitude": 8.824899,
        "accuracy": 450,
        "source": "SOURCE_WIFI_RSSI_GEOLOCATION"
      }
    }
  },
  "correlation_ids": [
    "as:packages:loracloudglsv3:01F91TWS4MB1KN9JN7ZE734HMR",
    "as:up:01F8WK2QQX7ZEC84MHWRSC38EE",
    "as:up:01F91TWS4D7ZGYNWQA0Y9DVTXX",
    "as:up:01F91TWSFKSPEY4FBA41M7HB25",
    "gs:conn:01F8WG8JN5NDZKBFMQ8SQQKWYP",
    "gs:up:host:01F8WG8JNFRJC3JTR2H2Z0BG3Y",
    "gs:uplink:01F8WK2QH8NMK3P4NFTZGBR5GB",
    "ns:uplink:01F8WK2QH966XZCD1ZQJ0P7NNY",
    "rpc:/ttn.lorawan.v3.AppAs/SimulateUplink:01F91TWS3924HW6VN8F305098P",
    "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01F8WK2QH98NG2WBBKDZ1G2N5Y",
    "rpc:/ttn.lorawan.v3.NsAs/HandleUplink:01F8WK2QQXSYVT2MPMKFJ6GE8M"
  ],
  "origin": "A98BCD2222F1",
  "visibility": {
    "rights": [
      "RIGHT_APPLICATION_TRAFFIC_READ"
    ]
  },
  "unique_id": "01F91TWSFM9CZRM6S1Q6FCF89W"
}
```

</details>

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

WiFi was already quite broken when the TDOA was missing, and GNSS is new testing.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
