### PR TITLE
Return plaintext values for update gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ For details about compatibility between different releases, see the **Commitment
 - CLI `gateway set --antenna.remove` command failing to remove gateway antennas in some cases.
 - CLI `gateway set --antenna.gain <gain>` command crashing when no gateway antennas are present.
 - Webhook template path variable expansion of query parameters.
+- LBS LNS Auth Secret displays garbage value when updated.
 
 ### Security
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -5237,15 +5237,6 @@
       "file": "gateway_registry.go"
     }
   },
-  "error:pkg/identityserver:gateway_secret_encryption_key_not_found": {
-    "translations": {
-      "en": "a gateway secret encryption key with id `{id}` not found"
-    },
-    "description": {
-      "package": "pkg/identityserver",
-      "file": "gateway_registry.go"
-    }
-  },
   "error:pkg/identityserver:invalid_authorization": {
     "translations": {
       "en": "invalid authorization"

--- a/pkg/identityserver/gateway_registry.go
+++ b/pkg/identityserver/gateway_registry.go
@@ -552,7 +552,7 @@ func (is *IdentityServer) updateGateway(ctx context.Context, req *ttnpb.UpdateGa
 		gtw.LBSLNSSecret.Value = ptLBSLNSSecret
 	}
 	if len(ptTargetCUPSKeySecret) != 0 {
-		gtw.TargetCUPSKey.Value = ptCACSecret
+		gtw.TargetCUPSKey.Value = ptTargetCUPSKeySecret
 	}
 
 	return gtw, nil

--- a/pkg/identityserver/gateway_registry.go
+++ b/pkg/identityserver/gateway_registry.go
@@ -64,11 +64,10 @@ var (
 )
 
 var (
-	errAdminsCreateGateways       = errors.DefinePermissionDenied("admins_create_gateways", "gateways may only be created by admins, or in organizations")
-	errGatewayEUITaken            = errors.DefineAlreadyExists("gateway_eui_taken", "a gateway with EUI `{gateway_eui}` is already registered as `{gateway_id}`")
-	errGatewaySecretEncryptionKey = errors.DefineNotFound("gateway_secret_encryption_key_not_found", "a gateway secret encryption key with id `{id}` not found")
-	errAdminsPurgeGateways        = errors.DefinePermissionDenied("admins_purge_gateways", "gateways may only be purged by admins")
-	errClaimAuthenticationCode    = errors.DefineInvalidArgument("claim_authentication_code", "invalid claim authentication code")
+	errAdminsCreateGateways    = errors.DefinePermissionDenied("admins_create_gateways", "gateways may only be created by admins, or in organizations")
+	errGatewayEUITaken         = errors.DefineAlreadyExists("gateway_eui_taken", "a gateway with EUI `{gateway_eui}` is already registered as `{gateway_id}`")
+	errAdminsPurgeGateways     = errors.DefinePermissionDenied("admins_purge_gateways", "gateways may only be purged by admins")
+	errClaimAuthenticationCode = errors.DefineInvalidArgument("claim_authentication_code", "invalid claim authentication code")
 )
 
 func (is *IdentityServer) createGateway(ctx context.Context, req *ttnpb.CreateGatewayRequest) (gtw *ttnpb.Gateway, err error) {
@@ -439,6 +438,10 @@ func (is *IdentityServer) updateGateway(ctx context.Context, req *ttnpb.UpdateGa
 			return nil, err
 		}
 	}
+
+	// Store plaintext values to return in the response to clients.
+	var ptLBSLNSSecret, ptCACSecret, ptTargetCUPSKeySecret []byte
+
 	// Backwards compatibility for frequency_plan_id field.
 	if ttnpb.HasAnyField(req.FieldMask.GetPaths(), "frequency_plan_id") {
 		if !ttnpb.HasAnyField(req.FieldMask.GetPaths(), "frequency_plan_ids") {
@@ -464,6 +467,7 @@ func (is *IdentityServer) updateGateway(ctx context.Context, req *ttnpb.UpdateGa
 			return nil, err
 		} else if req.LBSLNSSecret != nil {
 			value := req.LBSLNSSecret.Value
+			ptLBSLNSSecret = req.LBSLNSSecret.Value
 			if is.config.Gateways.EncryptionKeyID != "" {
 				value, err = is.KeyVault.Encrypt(ctx, req.LBSLNSSecret.Value, is.config.Gateways.EncryptionKeyID)
 				if err != nil {
@@ -483,6 +487,7 @@ func (is *IdentityServer) updateGateway(ctx context.Context, req *ttnpb.UpdateGa
 			return nil, err
 		} else if req.TargetCUPSKey != nil {
 			value := req.TargetCUPSKey.Value
+			ptTargetCUPSKeySecret = req.TargetCUPSKey.Value
 			if is.config.Gateways.EncryptionKeyID != "" {
 				value, err = is.KeyVault.Encrypt(ctx, req.TargetCUPSKey.Value, is.config.Gateways.EncryptionKeyID)
 				if err != nil {
@@ -503,6 +508,7 @@ func (is *IdentityServer) updateGateway(ctx context.Context, req *ttnpb.UpdateGa
 		} else if req.ClaimAuthenticationCode != nil {
 			if err := validateClaimAuthenticationCode(*req.ClaimAuthenticationCode); err == nil {
 				value := req.ClaimAuthenticationCode.Secret.Value
+				ptCACSecret = req.ClaimAuthenticationCode.Secret.Value
 				if is.config.Gateways.EncryptionKeyID != "" {
 					value, err = is.KeyVault.Encrypt(ctx, value, is.config.Gateways.EncryptionKeyID)
 					if err != nil {
@@ -538,6 +544,17 @@ func (is *IdentityServer) updateGateway(ctx context.Context, req *ttnpb.UpdateGa
 		return nil, err
 	}
 	events.Publish(evtUpdateGateway.NewWithIdentifiersAndData(ctx, &req.GatewayIdentifiers, req.FieldMask.GetPaths()))
+
+	if len(ptCACSecret) != 0 {
+		gtw.ClaimAuthenticationCode.Secret.Value = ptCACSecret
+	}
+	if len(ptLBSLNSSecret) != 0 {
+		gtw.LBSLNSSecret.Value = ptLBSLNSSecret
+	}
+	if len(ptTargetCUPSKeySecret) != 0 {
+		gtw.TargetCUPSKey.Value = ptCACSecret
+	}
+
 	return gtw, nil
 }
 

--- a/pkg/identityserver/gateway_registry_test.go
+++ b/pkg/identityserver/gateway_registry_test.go
@@ -555,16 +555,18 @@ func TestGatewaysSecrets(t *testing.T) {
 			a.So(errors.IsPermissionDenied(err), should.BeTrue)
 		}
 
+		updatedSecretValue := []byte("my new secret value")
+
 		updated, err := reg.Update(ctx, &ttnpb.UpdateGatewayRequest{
 			Gateway: ttnpb.Gateway{
 				GatewayIdentifiers: created.GatewayIdentifiers,
 				LBSLNSSecret: &ttnpb.Secret{
-					Value: []byte("my new secret value"),
+					Value: updatedSecretValue,
 				},
 				ClaimAuthenticationCode: &otherGtwClaimAuthCode,
 				TargetCUPSURI:           otherTargetCUPSURI,
 				TargetCUPSKey: &ttnpb.Secret{
-					Value: []byte("my new secret value"),
+					Value: updatedSecretValue,
 				},
 			},
 			FieldMask: &pbtypes.FieldMask{Paths: []string{"lbs_lns_secret", "claim_authentication_code", "target_cups_key", "target_cups_uri"}},
@@ -573,8 +575,11 @@ func TestGatewaysSecrets(t *testing.T) {
 		a.So(err, should.BeNil)
 		a.So(updated, should.NotBeNil)
 		a.So(updated.LBSLNSSecret, should.NotBeNil)
+		a.So(updated.LBSLNSSecret.Value, should.Resemble, updatedSecretValue)
 		a.So(updated.ClaimAuthenticationCode, should.NotBeNil)
+		a.So(updated.ClaimAuthenticationCode.Secret.Value, should.Resemble, otherGtwClaimAuthCode.Secret.Value)
 		a.So(updated.TargetCUPSKey, should.NotBeNil)
+		a.So(updated.TargetCUPSKey.Value, should.Resemble, updatedSecretValue)
 
 		got, err = reg.Get(ctx, &ttnpb.GetGatewayRequest{
 			GatewayIdentifiers: created.GatewayIdentifiers,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #4066 

#### Changes
<!-- What are the changes made in this pull request? -->

- Return plaintext values of secrets set in `UpdateGateway`.
- Remove unused error message.

#### Testing

<!-- How did you verify that this change works? -->

Local stack

![Screenshot 2021-07-05 at 11 27 16](https://user-images.githubusercontent.com/13186113/124450049-58319c80-dd84-11eb-9ceb-a028ba7ea2c8.png)


##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Don't expect any since I don't expect clients to use the encrypted value that this RPC used to return for anything.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@htdvisser If there's a prettier way to do this, let me know.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
