### PR TITLE
Improve resilience and errors

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -7352,6 +7352,15 @@
       "file": "grpc_disabled.go"
     }
   },
+  "error:pkg/packetbrokeragent:packet_broker_internal": {
+    "translations": {
+      "en": "internal Packet Broker error"
+    },
+    "description": {
+      "package": "pkg/packetbrokeragent",
+      "file": "grpc_gspba.go"
+    }
+  },
   "error:pkg/packetbrokeragent:registration": {
     "translations": {
       "en": "get registration information"

--- a/pkg/gatewayserver/upstream/packetbroker/packetbroker.go
+++ b/pkg/gatewayserver/upstream/packetbroker/packetbroker.go
@@ -183,7 +183,11 @@ func (h *Handler) ConnectGateway(ctx context.Context, ids ttnpb.GatewayIdentifie
 		}
 		lastCounters = now
 
-		res, err := pbaClient.UpdateGateway(ctx, req, h.Cluster.WithClusterAuth())
+		pbaConn, err := h.Cluster.GetPeerConn(ctx, ttnpb.ClusterRole_PACKET_BROKER_AGENT, &ids)
+		if err != nil {
+			return errPacketBrokerAgentNotFound.WithCause(err)
+		}
+		res, err := ttnpb.NewGsPbaClient(pbaConn).UpdateGateway(ctx, req, h.Cluster.WithClusterAuth())
 		if err != nil {
 			log.FromContext(ctx).WithError(err).Warn("Failed to update gateway")
 			onlineTTL = nil

--- a/pkg/packetbrokeragent/grpc_gspba.go
+++ b/pkg/packetbrokeragent/grpc_gspba.go
@@ -92,7 +92,10 @@ func (s *gsPbaServer) PublishUplink(ctx context.Context, up *ttnpb.GatewayUplink
 	}
 }
 
-var errNoGatewayID = errors.DefineFailedPrecondition("no_gateway_id", "no gateway identifier provided or included in configuration")
+var (
+	errNoGatewayID          = errors.DefineFailedPrecondition("no_gateway_id", "no gateway identifier provided or included in configuration")
+	errPacketBrokerInternal = errors.DefineAborted("packet_broker_internal", "internal Packet Broker error")
+)
 
 // UpdateGateway is called by Gateway Server to update a gateway.
 func (s *gsPbaServer) UpdateGateway(ctx context.Context, req *ttnpb.UpdatePacketBrokerGatewayRequest) (*ttnpb.UpdatePacketBrokerGatewayResponse, error) {
@@ -172,6 +175,9 @@ func (s *gsPbaServer) UpdateGateway(ctx context.Context, req *ttnpb.UpdatePacket
 	_, err := mappingpb.NewMapperClient(s.mapperConn).UpdateGateway(ctx, updateReq)
 	if err != nil {
 		log.FromContext(ctx).WithError(err).Warn("Failed to update gateway")
+		if errors.IsInternal(err) {
+			return nil, errPacketBrokerInternal.WithCause(err)
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Improve resilience against PB internal errors and PBA going down.

#### Changes
<!-- What are the changes made in this pull request? -->

- PB `Internal` errors (to PBA) are now coded as `Aborted` (to GS; it's not PBA internal)
- GS gets a new PBA peer every time it wants to update the gateway

#### Testing

<!-- How did you verify that this change works? -->

Unit tests should cover this

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None expected

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
