### PR TITLE
Get updated location and visibility settings

### DIFF
--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -147,6 +147,7 @@ func New(c *component.Component, conf *Config, opts ...Option) (gs *GatewayServe
 			handler = ns.NewHandler(gs.Context(), c, c, prefix)
 		case "packetbroker":
 			handler = packetbroker.NewHandler(gs.Context(), packetbroker.Config{
+				GatewayRegistry: gs.entityRegistry,
 				Cluster:         c,
 				DevAddrPrefixes: prefix,
 				UpdateInterval:  conf.PacketBroker.UpdateGatewayInterval,

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -270,7 +270,7 @@ func (s *srv) handleUp(ctx context.Context, state *state, packet encoding.Packet
 			state.downlinkTaskDone.Add(1)
 			go func() {
 				defer state.downlinkTaskDone.Done()
-				if err := s.handleDown(ctx, state); err != nil {
+				if err := s.handleDown(ctx, state); err != nil && !errors.Is(err, errDownlinkPathExpired) {
 					logger.WithError(err).Warn("Failed to handle downstream packet")
 				}
 			}()

--- a/pkg/gatewayserver/upstream/packetbroker/packetbroker.go
+++ b/pkg/gatewayserver/upstream/packetbroker/packetbroker.go
@@ -44,7 +44,13 @@ type Config struct {
 	UpdateJitter    float64
 	OnlineTTLMargin time.Duration
 	DevAddrPrefixes []types.DevAddrPrefix
+	GatewayRegistry GatewayRegistry
 	Cluster         Cluster
+}
+
+// GatewayRegistry is a store with gateways.
+type GatewayRegistry interface {
+	Get(ctx context.Context, req *ttnpb.GetGatewayRequest) (*ttnpb.Gateway, error)
 }
 
 // Cluster represents the interface the cluster.
@@ -136,6 +142,23 @@ func (h *Handler) ConnectGateway(ctx context.Context, ids ttnpb.GatewayIdentifie
 		case <-h.nextUpdateGateway(onlineTTL):
 		}
 
+		// Get the gateway from Identity Server. Some settings may have changed by a collaborator.
+		gtw, err := h.GatewayRegistry.Get(ctx, &ttnpb.GetGatewayRequest{
+			GatewayIdentifiers: ids,
+			FieldMask: &pbtypes.FieldMask{
+				Paths: []string{
+					"antennas",
+					"location_public",
+					"status_public",
+					"update_location_from_status",
+				},
+			},
+		})
+		if err != nil {
+			log.FromContext(ctx).WithError(err).Warn("Failed to get gateway")
+			return err
+		}
+
 		req := &ttnpb.UpdatePacketBrokerGatewayRequest{
 			Gateway: &ttnpb.Gateway{
 				GatewayIdentifiers: ids,
@@ -152,9 +175,17 @@ func (h *Handler) ConnectGateway(ctx context.Context, ids ttnpb.GatewayIdentifie
 		// Only update the location when it is public and when it may be updated from status messages.
 		// location_public should only be in the field mask if the location is known, so only when a location in the status.
 		// This is to avoid that the location gets reset when there is no location in the status.
-		if gtw.LocationPublic && gtw.UpdateLocationFromStatus {
-			if status, _, ok := conn.StatusStats(); ok && len(status.GetAntennaLocations()) > 0 && status.AntennaLocations[0] != nil {
-				loc := *status.AntennaLocations[0]
+		if gtw.LocationPublic {
+			var (
+				loc ttnpb.Location
+				ok  bool
+			)
+			if status, _, ok := conn.StatusStats(); ok && gtw.UpdateLocationFromStatus && len(status.GetAntennaLocations()) > 0 && status.AntennaLocations[0] != nil {
+				loc, ok = *status.AntennaLocations[0], true
+			} else if len(gtw.Antennas) > 0 && gtw.Antennas[0].Location != nil {
+				loc, ok = *gtw.Antennas[0].Location, true
+			}
+			if ok {
 				loc.Source = ttnpb.SOURCE_GPS
 				req.Gateway.LocationPublic = true
 				req.Gateway.Antennas = []ttnpb.GatewayAntenna{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Get updated location and visibility settings while the gateway is connected.

#### Changes
<!-- What are the changes made in this pull request? -->

Roughly every 5 minutes, Gateway Server will fetch the latest location and visibility settings from Identity Server.

#### Testing

<!-- How did you verify that this change works? -->

None; we currently don't test the Packet Broker upstream

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

We may also want to deploy PBA with IS and let PBA subscribe to gateway update events. That will also be useful to update administrative and technical contact information in Packet Broker. Still, Gateway Server needs to get the latest visibility settings and whether status messages should update the location while the gateway is connected.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
