### PR TITLE
Limit payload formatter length in the Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - Gateway antenna placement; unknown, indoor or outdoor. This can now be specified with CLI, e.g. for the first antenna: `ttn-lw-cli gateways set <gateway-id> --antenna.index 0 --antenna.placement OUTDOOR`. The antenna placement will be reported to Packet Broker Mapper.
   - This requires a database schema migration (`ttn-lw-stack is-db migrate`) because of the added columns.
+- Payload formatter length validation in the Console.
 
 ### Changed
 

--- a/pkg/webui/console/components/payload-formatters-form/index.js
+++ b/pkg/webui/console/components/payload-formatters-form/index.js
@@ -70,13 +70,19 @@ const validationSchema = Yup.object().shape({
     .required(sharedMessages.validateRequired),
   [FIELD_NAMES.JAVASCRIPT]: Yup.string().when(FIELD_NAMES.SELECT, {
     is: TYPES.JAVASCRIPT,
-    then: Yup.string().required(sharedMessages.validateRequired),
+    then: Yup.string()
+      .required(sharedMessages.validateRequired)
+      // See https://github.com/TheThingsNetwork/lorawan-stack/blob/v3.14/api/messages.proto#L380
+      // for validation requirements.
+      .max(40960, Yup.passValues(sharedMessages.validateTooLong)),
   }),
   [FIELD_NAMES.GRPC]: Yup.string()
     .matches(addressRegexp, Yup.passValues(sharedMessages.validateAddressFormat))
     .when(FIELD_NAMES.SELECT, {
       is: TYPES.GRPC,
-      then: Yup.string().required(sharedMessages.validateRequired),
+      then: Yup.string()
+        .required(sharedMessages.validateRequired)
+        .max(40960, Yup.passValues(sharedMessages.validateTooLong)),
     }),
 })
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://sentry.io/organizations/the-things-industries/issues/2015318983/events/f6548f1d17b1491bb858fa51ae3245cd/?project=2682566

#### Changes
<!-- What are the changes made in this pull request? -->

- Add validation for payload formatters in the Console based on protos, see https://github.com/TheThingsNetwork/lorawan-stack/blob/v3.14/api/messages.proto#L380 and https://github.com/TheThingsNetwork/lorawan-stack/blob/v3.14/api/messages.proto#L384


#### Testing

<!-- How did you verify that this change works? -->

Manual

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

We are currently getting a lot of issues in sentry when backend returns 400 for payload formatters that exceed allowed size.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
