### PR TITLE
Improve uplink data event preview

### DIFF
--- a/pkg/webui/console/components/events/events.styl
+++ b/pkg/webui/console/components/events/events.styl
@@ -72,10 +72,14 @@ $event-container-height = 40px
     background-color: white
     display: flex
 
-.verbose-checkbox
-  margin-top: 0
+.toggle-container
+  display: flex
+  align-items: center
   color: $tc-subtle-gray
   margin-right: $cs.s
+
+.toggle-label
+  margin-right: $cs.xs
 
 .widget-container
   border-normal()

--- a/pkg/webui/console/components/events/index.js
+++ b/pkg/webui/console/components/events/index.js
@@ -20,7 +20,7 @@ import { EVENT_VERBOSE_FILTERS_REGEXP } from '@console/constants/event-filters'
 import hamburgerMenuClose from '@assets/misc/hamburger-menu-close.svg'
 
 import Button from '@ttn-lw/components/button'
-import Checkbox from '@ttn-lw/components/checkbox'
+import Switch from '@ttn-lw/components/switch'
 import Icon from '@ttn-lw/components/icon'
 
 import Message from '@ttn-lw/lib/components/message'
@@ -83,13 +83,10 @@ const Events = React.memo(
             <div className={style.stickyContainer}>
               <div className={style.actions}>
                 {!disableFiltering && (
-                  <Checkbox
-                    className={style.verboseCheckbox}
-                    onChange={handleVerboseFilterChange}
-                    label={m.verboseStream}
-                    value={!Boolean(filter)}
-                    name="verbose-stream"
-                  />
+                  <label className={style.toggleContainer}>
+                    <Message content={m.verboseStream} className={style.toggleLabel} />
+                    <Switch onChange={handleVerboseFilterChange} checked={!Boolean(filter)} />
+                  </label>
                 )}
                 <Button
                   onClick={onPause}

--- a/pkg/webui/console/components/events/messages.js
+++ b/pkg/webui/console/components/events/messages.js
@@ -23,6 +23,7 @@ const messages = defineMessages({
   fCnt: 'FCnt',
   rawPayload: 'Raw payload',
   txPower: 'Tx Power',
+  dataRate: 'Data rate',
   bandwidth: 'Bandwidth',
   metrics: 'Metrics',
   versions: 'Versions',

--- a/pkg/webui/console/components/events/messages.js
+++ b/pkg/webui/console/components/events/messages.js
@@ -54,6 +54,8 @@ const messages = defineMessages({
     'Old events have been truncated to save memory. The current event limit per stream is {limit}.',
   eventUnavailable: 'This event is not available anymore. It was likely truncated to save memory.',
   verboseStream: 'Verbose stream',
+  confirmedDownlink: 'Confirmed downlink',
+  confirmedUplink: 'Confirmed uplink',
 })
 
 export default messages

--- a/pkg/webui/console/components/events/previews/application-uplink.js
+++ b/pkg/webui/console/components/events/previews/application-uplink.js
@@ -34,6 +34,8 @@ const ApplicationUplinkPreview = React.memo(({ event }) => {
   }
 
   const bandwidth = getByPath(data, 'settings.data_rate.lora.bandwidth')
+  const spreadingFactor = getByPath(data, 'settings.data_rate.lora.spreading_factor')
+  const dataRate = `SF${spreadingFactor}BW${bandwidth / 1000}`
 
   return (
     <DescriptionList>
@@ -49,9 +51,9 @@ const ApplicationUplinkPreview = React.memo(({ event }) => {
         <DescriptionList.Byte title={messages.MACPayload} data={data.frm_payload} convertToHex />
       )}
       <DescriptionList.Item title={messages.fPort} data={data.f_port} />
+      <DescriptionList.Item title={messages.dataRate} data={dataRate} />
       <DescriptionList.Item title={messages.snr} data={snr} />
       <DescriptionList.Item title={messages.rssi} data={rssi} />
-      <DescriptionList.Item title={messages.bandwidth} data={bandwidth} />
     </DescriptionList>
   )
 })

--- a/pkg/webui/console/components/events/previews/downlink-message.js
+++ b/pkg/webui/console/components/events/previews/downlink-message.js
@@ -14,6 +14,8 @@
 
 import React from 'react'
 
+import Message from '@ttn-lw/lib/components/message'
+
 import PropTypes from '@ttn-lw/lib/prop-types'
 import getByPath from '@ttn-lw/lib/get-by-path'
 
@@ -23,16 +25,17 @@ import DescriptionList from './shared/description-list'
 
 const DownLinkMessagePreview = React.memo(({ event }) => {
   const { data } = event
+
   if ('scheduled' in data) {
-    const rawPayload = getByPath(data, 'raw_payload')
     const txPower = getByPath(data, 'scheduled.downlink.tx_power')
     const bandwidth = getByPath(data, 'scheduled.data_rate.lora.bandwidth')
+    const spreadingFactor = getByPath(data, 'scheduled.data_rate.lora.spreading_factor')
+    const dataRate = `SF${spreadingFactor}BW${bandwidth / 1000}`
 
     return (
       <DescriptionList>
-        <DescriptionList.Byte title={messages.rawPayload} data={rawPayload} convertToHex />
         <DescriptionList.Item title={messages.txPower} data={txPower} />
-        <DescriptionList.Item title={messages.bandwidth} data={bandwidth} />
+        <DescriptionList.Item title={messages.dataRate} data={dataRate} />
       </DescriptionList>
     )
   }
@@ -63,11 +66,17 @@ const DownLinkMessagePreview = React.memo(({ event }) => {
     const frmPayload = getByPath(data, 'payload.mac_payload.frm_payload')
     const rx1Delay = getByPath(data, 'request.rx1_delay')
     const fPort = getByPath(data, 'payload.mac_payload.f_port')
+    const isConfirmed = getByPath(data, 'payload.m_hdr.m_type') === 'CONFIRMED_DOWN'
 
     return (
       <DescriptionList>
         <DescriptionList.Byte title={messages.devAddr} data={devAddr} />
         <DescriptionList.Item title={messages.fPort} data={fPort} />
+        {isConfirmed && (
+          <DescriptionList.Item>
+            <Message content={messages.confirmedDownlink} />
+          </DescriptionList.Item>
+        )}
         <DescriptionList.Byte title={messages.MACPayload} data={frmPayload} convertToHex />
         <DescriptionList.Item title={messages.rx1Delay} data={rx1Delay} />
       </DescriptionList>

--- a/pkg/webui/console/components/events/previews/shared/description-list/byte.js
+++ b/pkg/webui/console/components/events/previews/shared/description-list/byte.js
@@ -43,6 +43,7 @@ const DescriptionListByteItem = ({ title, data: rawData, convertToHex }) => {
         <SafeInspector
           data={data}
           hideable={false}
+          truncateAfter={8}
           initiallyVisible
           small
           noCopy

--- a/pkg/webui/console/components/events/previews/shared/description-list/description-list.styl
+++ b/pkg/webui/console/components/events/previews/shared/description-list/description-list.styl
@@ -22,7 +22,7 @@
   align-items: center
 
   &:not(:last-child)
-    padding-right: $cs.s
+    margin-right: $cs.s
 
   .term
     color: $tc-subtle-gray
@@ -30,8 +30,15 @@
     &:after
       content: ':'
 
+  dt
+    margin-right: $cs.xs
+
+  dd
+    margin-left: 0
+
 .value
-  margin-left: $cs.xs
+  & > div:not(:last-child)
+    margin-right: $cs.s
 
 .empty-byte
   color: $tc-subtle-gray

--- a/pkg/webui/console/components/events/previews/shared/description-list/item.js
+++ b/pkg/webui/console/components/events/previews/shared/description-list/item.js
@@ -32,7 +32,7 @@ const DescriptionListItem = props => {
   if (!Boolean(title)) {
     return (
       <div className={classnames(className, style.container)}>
-        <div className={style.value}>{content}</div>
+        <div className={classnames(style.value, style.onlyValue)}>{content}</div>
       </div>
     )
   }

--- a/pkg/webui/console/components/events/previews/shared/json-payload/index.js
+++ b/pkg/webui/console/components/events/previews/shared/json-payload/index.js
@@ -15,6 +15,7 @@
 import React from 'react'
 import classnames from 'classnames'
 import { defineMessages } from 'react-intl'
+import { isPlainObject } from 'lodash'
 
 import Message from '@ttn-lw/lib/components/message'
 
@@ -31,9 +32,10 @@ const ARRAY_PLACEHOLDER = '[…]'
 
 const KeyValue = ({ entryKey, entryValue, showKey }) => {
   let renderValue
-  if (Array.isArray(entryValue)) {
+
+  if (Array.isArray(entryValue) && !entryValue.every(e => typeof e !== 'object')) {
     renderValue = ARRAY_PLACEHOLDER
-  } else if (typeof entryValue === 'object') {
+  } else if (isPlainObject(entryValue)) {
     renderValue = OBJECT_PLACEHOLDER
   } else {
     renderValue = JSON.stringify(entryValue)

--- a/pkg/webui/console/components/events/story/event-data.js
+++ b/pkg/webui/console/components/events/story/event-data.js
@@ -925,7 +925,7 @@ export const deviceEvents = [
       raw_payload: 'QAsAACeCygADAwHUcPJPkw==',
       payload: {
         m_hdr: {
-          m_type: 'UNCONFIRMED_UP',
+          m_type: 'CONFIRMED_UP',
         },
         mic: 'cPJPkw==',
         mac_payload: {
@@ -994,6 +994,160 @@ export const deviceEvents = [
       rights: ['RIGHT_APPLICATION_TRAFFIC_READ'],
     },
     unique_id: '01EK2R8FQNEB3B8SFNH0G68KH3',
+  },
+  {
+    name: 'as.up.data.forward',
+    time: '2021-07-07T10:50:00.680482189Z',
+    identifiers: [
+      {
+        device_ids: {
+          device_id: 'test-dev-01',
+          application_ids: {
+            application_id: 'tti-ch-test-app',
+          },
+        },
+      },
+      {
+        device_ids: {
+          device_id: 'test-dev-01',
+          application_ids: {
+            application_id: 'tti-ch-test-app',
+          },
+          dev_eui: '0004A30B001C1452',
+          join_eui: '800000000000000C',
+          dev_addr: '26001B76',
+        },
+      },
+    ],
+    data: {
+      '@type': 'type.googleapis.com/ttn.lorawan.v3.ApplicationUp',
+      end_device_ids: {
+        device_id: 'test-dev-01',
+        application_ids: {
+          application_id: 'tti-ch-test-app',
+        },
+        dev_eui: '0004A30B001C1452',
+        join_eui: '800000000000000C',
+        dev_addr: '26001B76',
+      },
+      correlation_ids: [
+        'as:up:01FA09DFHJ0FSWAPWDD3E1RDG6',
+        'gs:conn:01FA04C0D25ZM679FXF7QWM6KP',
+        'gs:up:host:01FA04C0DNXVBNVWGSE75FVSA6',
+        'gs:uplink:01FA09DF9YWNEX9JG4HEHWFH7P',
+        'ns:uplink:01FA09DFA04J4K1MNR9BRR965B',
+        'rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01FA09DFA0AX0HZF8K14SY5FGD',
+        'rpc:/ttn.lorawan.v3.NsAs/HandleUplink:01FA09DFGTZGDEHM5SVR1N8GTH',
+      ],
+      received_at: '2021-07-07T10:50:00.647244290Z',
+      uplink_message: {
+        session_key_id: 'AXp0WUMkz75V+jY5OX88DA==',
+        f_port: 1,
+        f_cnt: 420,
+        frm_payload: 'AQ==',
+        decoded_payload: {
+          bytes: [1],
+        },
+        rx_metadata: [
+          {
+            gateway_ids: {
+              gateway_id: 'ttig-12e8',
+              eui: '58A0CBFFFE8012E8',
+            },
+            time: '2021-07-07T10:50:00.328195095Z',
+            timestamp: 994712508,
+            rssi: -89,
+            channel_rssi: -89,
+            snr: 9,
+            uplink_token:
+              'ChcKFQoJdHRpZy0xMmU4EghYoMv//oAS6BC8t6jaAxoMCNiNlocGEJy7s7YBIOCs8cv5mQE=',
+          },
+        ],
+        settings: {
+          data_rate: {
+            lora: {
+              bandwidth: 125000,
+              spreading_factor: 7,
+            },
+          },
+          data_rate_index: 5,
+          coding_rate: '4/5',
+          frequency: '867900000',
+          timestamp: 994712508,
+          time: '2021-07-07T10:50:00.328195095Z',
+        },
+        received_at: '2021-07-07T10:50:00.384736040Z',
+        consumed_airtime: '0.046336s',
+      },
+    },
+    correlation_ids: [
+      'as:up:01FA09DFHJ0FSWAPWDD3E1RDG6',
+      'gs:conn:01FA04C0D25ZM679FXF7QWM6KP',
+      'gs:up:host:01FA04C0DNXVBNVWGSE75FVSA6',
+      'gs:uplink:01FA09DF9YWNEX9JG4HEHWFH7P',
+      'ns:uplink:01FA09DFA04J4K1MNR9BRR965B',
+      'rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01FA09DFA0AX0HZF8K14SY5FGD',
+      'rpc:/ttn.lorawan.v3.NsAs/HandleUplink:01FA09DFGTZGDEHM5SVR1N8GTH',
+    ],
+    origin: 'ip-redacted.eu-west-1.compute.internal',
+    context: {
+      'tenant-id': 'CgN0dGk=',
+    },
+    visibility: {
+      rights: ['RIGHT_APPLICATION_TRAFFIC_READ', 'RIGHT_APPLICATION_TRAFFIC_READ'],
+    },
+    unique_id: '01FA09DFK84FJP29A5SGZT4AXP',
+  },
+  {
+    name: 'as.down.data.forward',
+    time: '2021-07-07T16:05:48.130282074Z',
+    identifiers: [
+      {
+        device_ids: {
+          device_id: 'ttn-uno',
+          application_ids: {
+            application_id: 'tti-playground',
+          },
+        },
+      },
+      {
+        device_ids: {
+          device_id: 'ttn-uno',
+          application_ids: {
+            application_id: 'tti-playground',
+          },
+        },
+      },
+    ],
+    data: {
+      '@type': 'type.googleapis.com/ttn.lorawan.v3.ApplicationDownlink',
+      f_port: 1,
+      frm_payload: 'EjRWeA==',
+      correlation_ids: [
+        'as:downlink:01FA0VFPY8V67MGSEVGFAZ6TMV',
+        'rpc:/ttn.lorawan.v3.AppAs/DownlinkQueuePush:d394eb5c-0d7b-403b-afc1-6da77b84f8c4',
+      ],
+    },
+    correlation_ids: [
+      'as:downlink:01FA0VFPY8V67MGSEVGFAZ6TMV',
+      'rpc:/ttn.lorawan.v3.AppAs/DownlinkQueuePush:d394eb5c-0d7b-403b-afc1-6da77b84f8c4',
+    ],
+    origin: 'ip-redacted.eu-west-1.compute.internal',
+    context: {
+      'tenant-id': 'CgN0dGk=',
+    },
+    visibility: {
+      rights: ['RIGHT_APPLICATION_TRAFFIC_READ', 'RIGHT_APPLICATION_TRAFFIC_READ'],
+    },
+    authentication: {
+      type: 'Bearer',
+      token_type: 'AccessToken',
+      token_id: '7IGVW7HUOO6YUHHVB7INWYXFXJSXBXKGINAKYYI',
+    },
+    remote_ip: '11.111.1.111',
+    user_agent:
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.101 Safari/537.36',
+    unique_id: '01FA0VFPZ2SZ66BXHT3HZJFAEC',
   },
 ].reverse()
 

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -146,6 +146,7 @@
   "console.components.events.messages.fCnt": "FCnt",
   "console.components.events.messages.rawPayload": "Raw payload",
   "console.components.events.messages.txPower": "Tx Power",
+  "console.components.events.messages.dataRate": "Data rate",
   "console.components.events.messages.bandwidth": "Bandwidth",
   "console.components.events.messages.metrics": "Metrics",
   "console.components.events.messages.versions": "Versions",

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -172,6 +172,8 @@
   "console.components.events.messages.eventsTruncated": "Old events have been truncated to save memory. The current event limit per stream is {limit}.",
   "console.components.events.messages.eventUnavailable": "This event is not available anymore. It was likely truncated to save memory.",
   "console.components.events.messages.verboseStream": "Verbose stream",
+  "console.components.events.messages.confirmedDownlink": "Confirmed downlink",
+  "console.components.events.messages.confirmedUplink": "Confirmed uplink",
   "console.components.events.previews.shared.json-payload.index.invalid": "Invalid JSON",
   "console.components.join-eui-prefixes-input.index.empty": "No prefix",
   "console.components.join-eui-prefixes-input.index.zeroInput": "Fill with zeros",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -172,6 +172,8 @@
   "console.components.events.messages.eventsTruncated": "Xxx xxxxxx xxxx xxxx xxxxxxxxx xx xxxx xxxxxx. Xxx xxxxxxx xxxxx xxxxx xxx xxxxxx xx {limit}.",
   "console.components.events.messages.eventUnavailable": "Xxxx xxxxx xx xxx xxxxxxxxx xxxxxxx. Xx xxx xxxxxx xxxxxxxxx xx xxxx xxxxxx.",
   "console.components.events.messages.verboseStream": "Xxxxxxx xxxxxx",
+  "console.components.events.messages.confirmedDownlink": "Xxxxxxxxx xxxxxxxx",
+  "console.components.events.messages.confirmedUplink": "Xxxxxxxxx xxxxxx",
   "console.components.events.previews.shared.json-payload.index.invalid": "Xxxxxxx XXXX",
   "console.components.join-eui-prefixes-input.index.empty": "Xx xxxxxx",
   "console.components.join-eui-prefixes-input.index.zeroInput": "Xxxx xxxx xxxxx",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -146,6 +146,7 @@
   "console.components.events.messages.fCnt": "XXxx",
   "console.components.events.messages.rawPayload": "Xxx xxxxxxx",
   "console.components.events.messages.txPower": "Xx Xxxxx",
+  "console.components.events.messages.dataRate": "Xxxx xxxx",
   "console.components.events.messages.bandwidth": "Xxxxxxxxx",
   "console.components.events.messages.metrics": "Xxxxxxx",
   "console.components.events.messages.versions": "Xxxxxxxx",


### PR DESCRIPTION
#### Summary
Closes #4219 

#### Changes
- Display data rate (with both bandwidth and spreading factor) in `UplinkMessage` and `DownlinkMessage` event preview
- Remove `MAC payload` and `Raw Payload` previews
- Remove Raw payload and MAC payload from `UplinkMessage` event
- Improve JSON preview of arrays within decoded payloads (show preview instead of ellipsis, when array consists only of primitives)
- Mark confirmed uplinks and downlinks in event previews
- Use a UI switch instead of checkbox for controlling stream verbosity

![image](https://user-images.githubusercontent.com/5710611/124802898-bf07af00-df58-11eb-9170-131b259e849d.png)

#### Testing

Manual

#### Notes for Reviewers
I removed `MAC Payload` and `Raw Payload` because I believe they are of little interest (at least for the preview)

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
