### PR TITLE
Set timeout for updating gateways

### DIFF
--- a/pkg/gatewayserver/upstream/packetbroker/packetbroker.go
+++ b/pkg/gatewayserver/upstream/packetbroker/packetbroker.go
@@ -242,7 +242,6 @@ func (h *Handler) ConnectGateway(ctx context.Context, ids ttnpb.GatewayIdentifie
 			return errPacketBrokerAgentNotFound.WithCause(err)
 		}
 		ctx, cancel := context.WithTimeout(ctx, updateGatewayTimeout)
-		defer cancel()
 		res, err := ttnpb.NewGsPbaClient(pbaConn).UpdateGateway(ctx, req, h.Cluster.WithClusterAuth())
 		if err != nil {
 			log.FromContext(ctx).WithError(err).Warn("Failed to update gateway")
@@ -250,6 +249,7 @@ func (h *Handler) ConnectGateway(ctx context.Context, ids ttnpb.GatewayIdentifie
 		} else {
 			onlineTTL = res.OnlineTtl
 		}
+		cancel()
 	}
 }
 

--- a/pkg/gatewayserver/upstream/packetbroker/packetbroker.go
+++ b/pkg/gatewayserver/upstream/packetbroker/packetbroker.go
@@ -31,7 +31,8 @@ import (
 )
 
 const (
-	publishUplinkTimeout = 3 * time.Second
+	publishUplinkTimeout = 2 * time.Second
+	updateGatewayTimeout = 2 * time.Second
 
 	DefaultUpdateGatewayInterval = 5 * time.Minute
 	DefaultUpdateGatewayJitter   = 0.2
@@ -240,6 +241,8 @@ func (h *Handler) ConnectGateway(ctx context.Context, ids ttnpb.GatewayIdentifie
 		if err != nil {
 			return errPacketBrokerAgentNotFound.WithCause(err)
 		}
+		ctx, cancel := context.WithTimeout(ctx, updateGatewayTimeout)
+		defer cancel()
 		res, err := ttnpb.NewGsPbaClient(pbaConn).UpdateGateway(ctx, req, h.Cluster.WithClusterAuth())
 		if err != nil {
 			log.FromContext(ctx).WithError(err).Warn("Failed to update gateway")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Set timeout for updating gateways

#### Changes
<!-- What are the changes made in this pull request? -->

Use timeout of 2 seconds for updating a gateway. This avoids throughput issues when there are thousands of gateways that need to be updated. The (default) 5 minute interval and 20% jitter will do the rest.

The timeout for publishing uplink messages has been decreased from 3 to 2 seconds.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

There's now some load shedding when GS starts and thousands of gateways are connecting. That's fine; we take away some load from Packet Broker Mapper.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
