### PR TITLE
Improve logging for OAuth server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For details about compatibility between different releases, see the **Commitment
   - This requires a database schema migration (`ttn-lw-stack is-db migrate`) because of the added columns.
 - Payload formatter length validation in the Console.
 - User session management (listing and deleting) in the Identity Server and the CLI.
+- Improved logging for the OAuth server.
 
 ### Changed
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -4735,7 +4735,7 @@
   },
   "error:pkg/identityserver/store:access_token_not_found": {
     "translations": {
-      "en": "access token not found"
+      "en": "access token `{access_token_id}` not found"
     },
     "description": {
       "package": "pkg/identityserver/store",

--- a/pkg/identityserver/store/oauth_store.go
+++ b/pkg/identityserver/store/oauth_store.go
@@ -215,7 +215,7 @@ func (s *oauthStore) CreateAuthorizationCode(ctx context.Context, code *ttnpb.OA
 func (s *oauthStore) GetAuthorizationCode(ctx context.Context, code string) (*ttnpb.OAuthAuthorizationCode, error) {
 	defer trace.StartRegion(ctx, "get authorization code").End()
 	if code == "" {
-		return nil, errAuthorizationCodeNotFound.New()
+		return nil, errAuthorizationCodeNotFound.WithAttributes("authorization_code", code)
 	}
 	var codeModel AuthorizationCode
 	err := s.query(ctx, AuthorizationCode{}).Where(AuthorizationCode{
@@ -223,7 +223,7 @@ func (s *oauthStore) GetAuthorizationCode(ctx context.Context, code string) (*tt
 	}).Preload("Client").Preload("User.Account").First(&codeModel).Error
 	if err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return nil, errAuthorizationCodeNotFound.New()
+			return nil, errAuthorizationCodeNotFound.WithAttributes("authorization_code", code)
 		}
 	}
 	return codeModel.toPB(), nil
@@ -231,7 +231,7 @@ func (s *oauthStore) GetAuthorizationCode(ctx context.Context, code string) (*tt
 
 func (s *oauthStore) DeleteAuthorizationCode(ctx context.Context, code string) error {
 	if code == "" {
-		return errAuthorizationCodeNotFound.New()
+		return errAuthorizationCodeNotFound.WithAttributes("authorization_code", code)
 	}
 	defer trace.StartRegion(ctx, "delete authorization code").End()
 	err := s.query(ctx, AuthorizationCode{}).Where(AuthorizationCode{
@@ -239,7 +239,7 @@ func (s *oauthStore) DeleteAuthorizationCode(ctx context.Context, code string) e
 	}).Delete(&AuthorizationCode{}).Error
 	if err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return errAuthorizationCodeNotFound.New()
+			return errAuthorizationCodeNotFound.WithAttributes("authorization_code", code)
 		}
 		return err
 	}
@@ -310,7 +310,7 @@ func (s *oauthStore) ListAccessTokens(ctx context.Context, userIDs *ttnpb.UserId
 
 func (s *oauthStore) GetAccessToken(ctx context.Context, id string) (*ttnpb.OAuthAccessToken, error) {
 	if id == "" {
-		return nil, errAccessTokenNotFound.New()
+		return nil, errAccessTokenNotFound.WithAttributes("access_token_id", id)
 	}
 	defer trace.StartRegion(ctx, "get access token").End()
 	var tokenModel struct {
@@ -325,7 +325,7 @@ func (s *oauthStore) GetAccessToken(ctx context.Context, id string) (*ttnpb.OAut
 		Where(AccessToken{TokenID: id}).Scan(&tokenModel).Error
 	if err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return nil, errAccessTokenNotFound.New()
+			return nil, errAccessTokenNotFound.WithAttributes("access_token_id", id)
 		}
 	}
 	tokenProto := tokenModel.AccessToken.toPB()
@@ -336,7 +336,7 @@ func (s *oauthStore) GetAccessToken(ctx context.Context, id string) (*ttnpb.OAut
 
 func (s *oauthStore) DeleteAccessToken(ctx context.Context, id string) error {
 	if id == "" {
-		return errAccessTokenNotFound.New()
+		return errAccessTokenNotFound.WithAttributes("access_token_id", id)
 	}
 	defer trace.StartRegion(ctx, "delete access token").End()
 	err := s.query(ctx, AccessToken{}).Where(AccessToken{
@@ -344,7 +344,7 @@ func (s *oauthStore) DeleteAccessToken(ctx context.Context, id string) error {
 	}).Delete(&AccessToken{}).Error
 	if err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return errAccessTokenNotFound.New()
+			return errAccessTokenNotFound.WithAttributes("access_token_id", id)
 		}
 		return err
 	}

--- a/pkg/identityserver/store/store.go
+++ b/pkg/identityserver/store/store.go
@@ -291,7 +291,7 @@ var (
 
 	errAuthorizationNotFound     = errors.DefineNotFound("authorization_not_found", "authorization of `{user_id}` for `{client_id}` not found")
 	errAuthorizationCodeNotFound = errors.DefineNotFound("authorization_code_not_found", "authorization code not found")
-	errAccessTokenNotFound       = errors.DefineNotFound("access_token_not_found", "access token not found")
+	errAccessTokenNotFound       = errors.DefineNotFound("access_token_not_found", "access token `{access_token_id}` not found")
 
 	errAPIKeyNotFound = errors.DefineNotFound("api_key_not_found", "API key not found")
 

--- a/pkg/oauth/oauth.go
+++ b/pkg/oauth/oauth.go
@@ -29,6 +29,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/jsonpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 )
 
@@ -245,6 +246,11 @@ func (s *server) Token(c echo.Context) error {
 	if err := tokenRequest.ValidateContext(req.Context()); err != nil {
 		return err
 	}
+
+	req = req.WithContext(
+		log.NewContextWithField(req.Context(), "oauth_client_id", tokenRequest.ClientID),
+	)
+	c.SetRequest(req)
 
 	req.Form = tokenRequest.Values()
 	req.PostForm = req.Form


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

While investigating #4375 I noticed that server logs for our OAuth server were not always helpful, so this Pull Request improves that.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add error attributes for "not found" errors
- Include OAuth client ID in token request logs
- Derive internal OAuth logger from request context
- Match some common errors from the OSIN library

#### Testing

<!-- How did you verify that this change works? -->

Locally:

```
WARN	OAuth authorization_code error	{"http.method": "POST", "http.path": "/oauth/token", "namespace": "web", "oauth_client_id": "console", "oauth_error": "invalid_grant", "oauth_error_message": "authorization data is expired", "peer.address": "127.0.0.1:56378", "request_id": "01FA2PQY2FX9ADQ5T3APPWBNJD"}
WARN	OAuth error	{"error": "error:pkg/oauth:invalid_grant (invalid, expired or revoked authorization code)", "http.method": "POST", "http.path": "/oauth/token", "namespace": "web", "oauth_client_id": "console", "peer.address": "127.0.0.1:56378", "request_id": "01FA2PQY2FX9ADQ5T3APPWBNJD"}
```

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None expected

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
