### PR TITLE
Automatically retry rate limited requests in JS SDK

### DIFF
--- a/pkg/webui/console/api/index.js
+++ b/pkg/webui/console/api/index.js
@@ -75,6 +75,7 @@ tts.subscribe('warning', payload => {
     type: toast.types.WARNING,
     message: payload,
     preventConsecutive: true,
+    autoClose: 10000,
   })
 })
 

--- a/sdk/js/src/util/constants.js
+++ b/sdk/js/src/util/constants.js
@@ -33,3 +33,5 @@ export const AUTHORIZATION_MODES = Object.freeze({
   KEY: 'key',
   SESSION: 'session',
 })
+
+export const RATE_LIMIT_RETRIES = 5


### PR DESCRIPTION
#### Summary
This PR will enable the JS SDK to retry requests (up to 5 times) that returned a `429 Too many requests`, based on the information in the `x-rate-limit-retry` header.

Closes #4270

#### Changes
- Add logic to retry http requests launched by the JS SDK
- Increase timeout of toast warnings, so they can be read properly

#### Testing

Manual testing using the following config:
```yml
rate-limiting:
  profiles:
    - name: HTTP servers
      max-per-min: 10
      associations:
        - http
```

##### Regressions

This touches the way that http requests are made in the JS SDK, as such it could introduce issues around that.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
