### PR TITLE
Fix missing object checks in JS SDK

### DIFF
--- a/sdk/js/src/api/http.js
+++ b/sdk/js/src/api/http.js
@@ -140,7 +140,10 @@ class Http {
           statusCode = response.status
         } catch (err) {
           if (
+            typeof err === 'object' &&
             'response' in err &&
+            typeof err.response === 'object' &&
+            err.response !== null &&
             'status' in err.response &&
             err.response.status === 429 &&
             retries <= RATE_LIMIT_RETRIES


### PR DESCRIPTION
#### Summary
This quickfix will fix an issue resulting from the `result` prop of error responses potentially being `undefined`.

#### Changes
- Add type checks for the axios error response to make sure object properties can be probed

#### Testing

Manual


#### Notes for Reviewers
This is a regression introduced via #4270 

Results in `with-request.js?8810:78 Uncaught TypeError: Cannot use 'in' operator to search for 'status' in undefined` when axios returns an error with emtpy `response` prop, which e.g. happens for network errors.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
