### PR TITLE
Check whether locations are null in Console

### DIFF
--- a/cypress/integration/console/gateways/location/edit.spec.js
+++ b/cypress/integration/console/gateways/location/edit.spec.js
@@ -47,11 +47,21 @@ describe('Gateway location', () => {
     },
   }
 
+  const updatedGatewayNullLocation = {
+    gateway: {
+      antennas: [{ location: null }],
+      location_public: true,
+      update_location_from_status: false,
+    },
+    field_mask: {
+      paths: ['antennas', 'location_public', 'update_location_from_status'],
+    },
+  }
+
   before(() => {
     cy.dropAndSeedDatabase()
     cy.createUser(user)
     cy.createGateway(gateway, userId)
-    cy.updateGateway(gatewayId, updatedGatewayLocation)
   })
 
   beforeEach(() => {
@@ -59,6 +69,23 @@ describe('Gateway location', () => {
   })
 
   it('succeeds editing latitude, longitude, altitude', () => {
+    cy.updateGateway(gatewayId, updatedGatewayLocation)
+    cy.visit(`${Cypress.config('consoleRootPath')}/gateways/${gatewayId}/location`)
+    cy.findByLabelText('Latitude').type(coordinates.latitude)
+    cy.findByLabelText('Longitude').type(coordinates.longitude)
+    cy.findByLabelText('Altitude').type(coordinates.altitude)
+
+    cy.findByRole('button', { name: 'Save changes' }).click()
+
+    cy.findByTestId('error-notification').should('not.exist')
+    cy.findByTestId('toast-notification')
+      .should('be.visible')
+      .findByText(`Location updated`)
+      .should('be.visible')
+  })
+
+  it('suceeds editing the location when location was null', () => {
+    cy.updateGateway(gatewayId, updatedGatewayNullLocation)
     cy.visit(`${Cypress.config('consoleRootPath')}/gateways/${gatewayId}/location`)
     cy.findByLabelText('Latitude').type(coordinates.latitude)
     cy.findByLabelText('Longitude').type(coordinates.longitude)
@@ -74,6 +101,7 @@ describe('Gateway location', () => {
   })
 
   it('succeeds editing latitude and longitude based map widget location change', () => {
+    cy.updateGateway(gatewayId, updatedGatewayLocation)
     cy.visit(`${Cypress.config('consoleRootPath')}/gateways/${gatewayId}/location`)
     cy.findByTestId('location-map').should('be.visible')
     cy.findByTestId('location-map').click(30, 30)
@@ -92,6 +120,7 @@ describe('Gateway location', () => {
   })
 
   it('succeeds deleting location entry', () => {
+    cy.updateGateway(gatewayId, updatedGatewayLocation)
     cy.visit(`${Cypress.config('consoleRootPath')}/gateways/${gatewayId}/location`)
     cy.findByRole('button', { name: /Remove location entry/ }).click()
 
@@ -107,14 +136,8 @@ describe('Gateway location', () => {
       .should('be.visible')
       .findByText(`Location deleted`)
       .should('be.visible')
-    cy.findByLabelText('Latitude')
-      .should('have.attr', 'value')
-      .and('eq', '')
-    cy.findByLabelText('Longitude')
-      .should('have.attr', 'value')
-      .and('eq', '')
-    cy.findByLabelText('Altitude')
-      .should('have.attr', 'value')
-      .and('eq', '')
+    cy.findByLabelText('Latitude').should('have.attr', 'value').and('eq', '')
+    cy.findByLabelText('Longitude').should('have.attr', 'value').and('eq', '')
+    cy.findByLabelText('Altitude').should('have.attr', 'value').and('eq', '')
   })
 })

--- a/pkg/webui/console/components/location-form/index.js
+++ b/pkg/webui/console/components/location-form/index.js
@@ -63,6 +63,7 @@ const validationSchema = Yup.object().shape({
 // We consider location of an entity set iff at least one coordinate is set,
 // i.e. longitude, altitude, latitude.
 const hasLocationSet = location =>
+  location !== null &&
   typeof location === 'object' &&
   (typeof location.altitude !== 'undefined' ||
     typeof location.latitude !== 'undefined' ||

--- a/pkg/webui/console/containers/gateway-location-form/gateway-location-form.js
+++ b/pkg/webui/console/containers/gateway-location-form/gateway-location-form.js
@@ -72,6 +72,7 @@ const getRegistryLocation = antennas => {
   if (antennas) {
     for (const key of Object.keys(antennas)) {
       if (
+        antennas[key].location !== null &&
         typeof antennas[key].location === 'object' &&
         antennas[key].location.source === 'SOURCE_REGISTRY'
       ) {

--- a/pkg/webui/console/views/device-location/index.js
+++ b/pkg/webui/console/views/device-location/index.js
@@ -42,7 +42,11 @@ const getRegistryLocation = locations => {
   let registryLocation
   if (locations) {
     for (const key of Object.keys(locations)) {
-      if (typeof locations[key] === 'object' && locations[key].source === 'SOURCE_REGISTRY') {
+      if (
+        locations[key] !== null &&
+        typeof locations[key] === 'object' &&
+        locations[key].source === 'SOURCE_REGISTRY'
+      ) {
         registryLocation = { location: locations[key], key }
         break
       }

--- a/sdk/js/src/service/gateways.js
+++ b/sdk/js/src/service/gateways.js
@@ -48,14 +48,21 @@ class Gateways {
       const { antennas } = gateway
 
       for (const antenna of antennas) {
-        if (!('altitude' in antenna.location)) {
-          antenna.location.altitude = 0
-        }
-        if (!('longitude' in antenna.location)) {
-          antenna.location.longitude = 0
-        }
-        if (!('latitude' in antenna.location)) {
-          antenna.location.latitude = 0
+        if (
+          antenna !== null &&
+          typeof antenna === 'object' &&
+          antenna.location !== null &&
+          typeof antenna.location === 'object'
+        ) {
+          if (!('altitude' in antenna.location)) {
+            antenna.location.altitude = 0
+          }
+          if (!('longitude' in antenna.location)) {
+            antenna.location.longitude = 0
+          }
+          if (!('latitude' in antenna.location)) {
+            antenna.location.latitude = 0
+          }
         }
       }
     }


### PR DESCRIPTION
#### Summary
This quickfix makes sure the Console can handle `null` locations.

#### Changes
- Explicitly check for locations being not `null` before using its properties
- Add a end to end test for `null` locations

#### Testing

Manual testing and extended end2end tests.

#### Notes for Reviewers
`null` has the type `object` in JS 🤦 . Way to go...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
