### PR TITLE
Set DevEui field in LBS downlink to a non-zero value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ For details about compatibility between different releases, see the **Commitment
 - CLI `gateway set --antenna.gain <gain>` command crashing when no gateway antennas are present.
 - Webhook template path variable expansion of query parameters.
 - LBS LNS Auth Secret displays garbage value when updated.
+- Transmit confirmation messages for LoRa Basics Station gateways.
 
 ### Security
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -4220,24 +4220,6 @@
       "file": "upstream.go"
     }
   },
-  "error:pkg/gatewayserver/io/ws/lbslns:no_clock_sync": {
-    "translations": {
-      "en": "no clock sync"
-    },
-    "description": {
-      "package": "pkg/gatewayserver/io/ws/lbslns",
-      "file": "downstream.go"
-    }
-  },
-  "error:pkg/gatewayserver/io/ws/lbslns:not_supported": {
-    "translations": {
-      "en": "not supported"
-    },
-    "description": {
-      "package": "pkg/gatewayserver/io/ws/lbslns",
-      "file": "messages.go"
-    }
-  },
   "error:pkg/gatewayserver/io/ws/lbslns:session_state_not_found": {
     "translations": {
       "en": "session state not found"

--- a/pkg/gatewayserver/io/ws/lbslns/discover_util_test.go
+++ b/pkg/gatewayserver/io/ws/lbslns/discover_util_test.go
@@ -16,25 +16,13 @@ package lbslns
 
 import (
 	"context"
-	"time"
 
-	"go.thethings.network/lorawan-stack/v3/pkg/component"
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/frequencyplans"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io"
 	"go.thethings.network/lorawan-stack/v3/pkg/ratelimit"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 )
-
-func mustHavePeer(ctx context.Context, c *component.Component, role ttnpb.ClusterRole) {
-	for i := 0; i < 20; i++ {
-		time.Sleep(20 * time.Millisecond)
-		if _, err := c.GetPeer(ctx, role, nil); err == nil {
-			return
-		}
-	}
-	panic("could not connect to peer")
-}
 
 type mockServer struct {
 	ids ttnpb.GatewayIdentifiers

--- a/pkg/gatewayserver/io/ws/lbslns/downstream.go
+++ b/pkg/gatewayserver/io/ws/lbslns/downstream.go
@@ -20,13 +20,10 @@ import (
 	"encoding/json"
 	"time"
 
-	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/ws"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/scheduling"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 )
-
-var errNoClockSync = errors.DefineUnavailable("no_clock_sync", "no clock sync")
 
 // DownlinkMessage is the LoRaWAN downlink message sent to the LoRa Basics Station.
 type DownlinkMessage struct {
@@ -88,8 +85,8 @@ func (f *lbsLNS) FromDownlink(ctx context.Context, uid string, down ttnpb.Downli
 	// Estimate the xtime based on the timestamp; xtime = timestamp - (rxdelay). The calculated offset is in microseconds.
 	dnmsg.XTime = xTime - int64(dnmsg.RxDelay*int(time.Second/time.Microsecond))
 
-	// This field is not used but needs to be defined for the station to parse the json.
-	dnmsg.DevEUI = "00-00-00-00-00-00-00-00"
+	// This field is not used but needs to be defined for the station to parse the json and should be non-zero for the station to return tx confirmations.
+	dnmsg.DevEUI = "00-00-00-00-00-00-00-01"
 
 	// Fix the Tx Parameters since we don't use the gateway scheduler.
 	dnmsg.Rx1DR = int(settings.DataRateIndex)

--- a/pkg/gatewayserver/io/ws/lbslns/downstream_test.go
+++ b/pkg/gatewayserver/io/ws/lbslns/downstream_test.go
@@ -28,8 +28,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
 )
 
-func timePtr(time time.Time) *time.Time { return &time }
-
 func TestFromDownlinkMessage(t *testing.T) {
 	var lbsLNS lbsLNS
 	ctx := log.NewContext(test.Context(), test.GetLogger(t))
@@ -63,7 +61,7 @@ func TestFromDownlinkMessage(t *testing.T) {
 				CorrelationIDs: []string{"correlation1"},
 			},
 			ExpectedDownlinkMessage: DownlinkMessage{
-				DevEUI:      "00-00-00-00-00-00-00-00",
+				DevEUI:      "00-00-00-00-00-00-00-01",
 				DeviceClass: 0,
 				Diid:        1,
 				Pdu:         "596d7868616d74686332356b4a334d3d3d",
@@ -94,7 +92,7 @@ func TestFromDownlinkMessage(t *testing.T) {
 				CorrelationIDs: []string{"correlation2"},
 			},
 			ExpectedDownlinkMessage: DownlinkMessage{
-				DevEUI:      "00-00-00-00-00-00-00-00",
+				DevEUI:      "00-00-00-00-00-00-00-01",
 				DeviceClass: 0,
 				Diid:        2,
 				Pdu:         "596d7868616d74686332356b4a334d3d3d",

--- a/pkg/gatewayserver/io/ws/lbslns/messages.go
+++ b/pkg/gatewayserver/io/ws/lbslns/messages.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/basicstation"
-	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 )
 
 // MessageType is the type of the message.
@@ -57,8 +56,6 @@ type DiscoverResponse struct {
 	URI   string           `json:"uri,omitempty"`
 	Error string           `json:"error,omitempty"`
 }
-
-var errNotSupported = errors.DefineFailedPrecondition("not_supported", "not supported")
 
 // Type returns the message type of the given data.
 func Type(data []byte) (string, error) {

--- a/pkg/gatewayserver/io/ws/ws_test.go
+++ b/pkg/gatewayserver/io/ws/ws_test.go
@@ -919,7 +919,7 @@ func TestTraffic(t *testing.T) {
 				},
 			},
 			ExpectedBSDownstream: lbslns.DownlinkMessage{
-				DevEUI:      "00-00-00-00-00-00-00-00",
+				DevEUI:      "00-00-00-00-00-00-00-01",
 				DeviceClass: 0,
 				Pdu:         "596d7868616d74686332356b4a334d3d3d",
 				Diid:        1,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #4085 

#### Changes
<!-- What are the changes made in this pull request? -->

- Set `DevEui` to `0000000000000001`. This is necessary to get Transmit Confirmation messages.
- Update tests
- Remove some unused definitions.


#### Testing

<!-- How did you verify that this change works? -->

Locally tested with a TTIG and an Uno
![TxConf](https://user-images.githubusercontent.com/13186113/125284776-3010e300-e31a-11eb-94e4-f5cce7627474.png)


##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Don't think there's any

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The reasoning was discussed offline with the LBS protocol experts and documented here; https://github.com/TheThingsIndustries/lorawan-stack-docs/pull/447

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
