### PR TITLE
Fix query parameter path variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ For details about compatibility between different releases, see the **Commitment
 - Network Server ADR algorithm data rate adjustment behavior on negative margin.
 - CLI `gateway set --antenna.remove` command failing to remove gateway antennas in some cases.
 - CLI `gateway set --antenna.gain <gain>` command crashing when no gateway antennas are present.
+- Webhook template path variable expansion of query parameters.
 
 ### Security
 

--- a/go.mod
+++ b/go.mod
@@ -88,11 +88,12 @@ require (
 	github.com/jaytaylor/html2text v0.0.0-20200412013138-3577fbdbcff7
 	github.com/jinzhu/gorm v1.9.16
 	github.com/jmhodges/levigo v1.0.0 // indirect
+	github.com/jtacoma/uritemplates v1.0.0
 	github.com/kr/pretty v0.2.1
 	github.com/labstack/echo/v4 v4.1.16
 	github.com/labstack/gommon v0.3.0
 	github.com/lib/pq v1.10.1
-	github.com/mattn/go-isatty v0.0.12
+	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/nats-io/nats-server/v2 v2.2.2
@@ -132,7 +133,7 @@ require (
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e
 	golang.org/x/oauth2 v0.0.0-20210427180440-81ed05c6b58c
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	google.golang.org/api v0.46.0
+	google.golang.org/api v0.46.0 // indirect
 	// NOTE: google.golang.org/genproto is actually pinned to v0.0.0-20200513103714-09dca8ec2884 above.
 	google.golang.org/genproto v0.0.0-20210429181445-86c259c2b4ab
 	// NOTE: google.golang.org/grpc is actually pinned to v1.33.1 above.

--- a/go.sum
+++ b/go.sum
@@ -476,6 +476,8 @@ github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/jtacoma/uritemplates v1.0.0 h1:xwx5sBF7pPAb0Uj8lDC1Q/aBPpOFyQza7OC705ZlLCo=
+github.com/jtacoma/uritemplates v1.0.0/go.mod h1:IhIICdE9OcvgUnGwTtJxgBQ+VrTrti5PcbLVSJianO8=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=

--- a/pkg/applicationserver/io/web/util_test.go
+++ b/pkg/applicationserver/io/web/util_test.go
@@ -40,6 +40,8 @@ var (
 		ApplicationIdentifiers: registeredApplicationID,
 		DeviceId:               "foo-device",
 		DevAddr:                devAddrPtr(types.DevAddr{0x42, 0xff, 0xff, 0xff}),
+		DevEui:                 &test.DefaultDevEUI,
+		JoinEui:                &test.DefaultJoinEUI,
 	}
 	unregisteredDeviceID = ttnpb.EndDeviceIdentifiers{
 		ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{

--- a/pkg/applicationserver/io/web/webhooks_test.go
+++ b/pkg/applicationserver/io/web/webhooks_test.go
@@ -88,10 +88,10 @@ func TestWebhooks(t *testing.T) {
 						DownlinkAPIKey: "foo.secret",
 						Format:         "json",
 						UplinkMessage: &ttnpb.ApplicationWebhook_Message{
-							Path: tc.prefix + "up",
+							Path: tc.prefix + "up{?devEUI}",
 						},
 						JoinAccept: &ttnpb.ApplicationWebhook_Message{
-							Path: tc.prefix + "join",
+							Path: tc.prefix + "join{?joinEUI}",
 						},
 						DownlinkAck: &ttnpb.ApplicationWebhook_Message{
 							Path: tc.prefix + "down/ack",
@@ -194,7 +194,7 @@ func TestWebhooks(t *testing.T) {
 									},
 								},
 								OK:  true,
-								URL: fmt.Sprintf("%s/up", baseURL),
+								URL: fmt.Sprintf("%s/up?devEUI=%s", baseURL, registeredDeviceID.DevEui),
 							},
 							{
 								Name: "UplinkMessage/UnregisteredDevice",
@@ -222,7 +222,7 @@ func TestWebhooks(t *testing.T) {
 									},
 								},
 								OK:  true,
-								URL: fmt.Sprintf("%s/join", baseURL),
+								URL: fmt.Sprintf("%s/join?joinEUI=%s", baseURL, registeredDeviceID.JoinEui),
 							},
 							{
 								Name: "DownlinkMessage/Ack",

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -506,6 +506,8 @@ github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/jtacoma/uritemplates v1.0.0 h1:xwx5sBF7pPAb0Uj8lDC1Q/aBPpOFyQza7OC705ZlLCo=
+github.com/jtacoma/uritemplates v1.0.0/go.mod h1:IhIICdE9OcvgUnGwTtJxgBQ+VrTrti5PcbLVSJianO8=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/503

#### Changes
<!-- What are the changes made in this pull request? -->

- Change the path variables library to https://github.com/jtacoma/uritemplates
- Add tests for query parameter templates


#### Testing

<!-- How did you verify that this change works? -->

Unit testing and manual testing (including the URL style from the ticket)

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Unit tests should cover this.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The old library (https://pkg.go.dev/google.golang.org/api/googleapi) cannot handle query path variables, as it operations only on `URL.Path` and `URL.RawPath`. This causes the library to wrongfully put the query parameters inside `URL.Path` instead of `URL.Query`. The query parameters are then escaped (as you cannot have ? in `Path`) and thus rendered unusable.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
