### PR TITLE
For duplicate data uplinks, keep the one with highest RSSI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
+- When a gateway uplink message contains duplicate data uplinks, only the one with the highest RSSI are forwarded.
+
 ### Deprecated
 
 ### Removed

--- a/pkg/gatewayserver/io/grpc/grpc.go
+++ b/pkg/gatewayserver/io/grpc/grpc.go
@@ -130,7 +130,7 @@ func (s *impl) LinkGateway(link ttnpb.GtwGs_LinkGatewayServer) error {
 				"uplink_count", len(msg.UplinkMessages),
 			)).Debug("Received message")
 
-			for _, up := range msg.UplinkMessages {
+			for _, up := range io.UniqueUplinkMessagesByRSSI(msg.UplinkMessages) {
 				up.ReceivedAt = now
 				if err := conn.HandleUp(up); err != nil {
 					logger.WithError(err).Warn("Failed to handle uplink message")

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -295,7 +295,7 @@ func (s *srv) handleUp(ctx context.Context, state *state, packet encoding.Packet
 			logger.WithError(err).Warn("Failed to unmarshal packet")
 			return err
 		}
-		for _, up := range msg.UplinkMessages {
+		for _, up := range io.UniqueUplinkMessagesByRSSI(msg.UplinkMessages) {
 			up.ReceivedAt = packet.ReceivedAt
 			if err := state.io.HandleUp(up); err != nil {
 				logger.WithError(err).Warn("Failed to handle uplink message")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #4095 (refs https://github.com/TheThingsNetwork/lorawan-stack/issues/4095#issuecomment-838443803)

#### Changes
<!-- What are the changes made in this pull request? -->

- Introduce `io.DropDuplicatesByRSSI()`, which de-duplicates a list of gateway uplinks. When two or more uplinks contain the same payload, only the one with the highest RSSI is kept.
- Use it in gRPC and UDP frontends.

#### Testing

<!-- How did you verify that this change works? -->

Unit tests

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Adds a few more memory allocations per uplink, but it should not be a problem.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

`DropDuplicatesByRSSI` is a terrible name.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [X] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
