### PR TITLE
Improve toast message behavior

### DIFF
--- a/pkg/webui/components/offline-status/index.js
+++ b/pkg/webui/components/offline-status/index.js
@@ -44,6 +44,7 @@ const handleMessage = (message, type) => {
   }
 
   toast({
+    messageGroup: 'offline-status',
     message: { ...message, values: { applicationName: siteTitle } },
     type,
   })

--- a/pkg/webui/components/toast/index.js
+++ b/pkg/webui/components/toast/index.js
@@ -28,6 +28,7 @@ class ToastContainer extends React.Component {
     closeButton: PropTypes.oneOfType([PropTypes.bool, PropTypes.element]),
     closeOnClick: PropTypes.bool,
     hideProgressBar: PropTypes.bool,
+    limit: PropTypes.number,
     pauseOnFocusLoss: PropTypes.bool,
     pauseOnHover: PropTypes.bool,
     position: PropTypes.oneOf([
@@ -42,13 +43,14 @@ class ToastContainer extends React.Component {
   }
 
   static defaultProps = {
+    autoClose: undefined,
     position: 'bottom-right',
-    autoClose: 4000,
     closeButton: false,
     hideProgressBar: true,
     pauseOnHover: true,
     closeOnClick: true,
     pauseOnFocusLoss: true,
+    limit: 2,
     transition: cssTransition({ enter: style.slideInRight, exit: style.slideOutRight }),
   }
 

--- a/pkg/webui/components/toast/toast.js
+++ b/pkg/webui/components/toast/toast.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import React from 'react'
-import { toast as t } from 'react-toastify'
+import { toast as t, cssTransition } from 'react-toastify'
 
 import Notification from '@ttn-lw/components/notification'
 
@@ -22,44 +22,17 @@ import diff from '@ttn-lw/lib/diff'
 import style from './toast.styl'
 
 const createToast = () => {
-  const queue = []
   let lastMessage = undefined
+  let lastMessageGroup = undefined
   let toastId = null
-  let firstDispatched = false
+  let currentRender
 
   const show = toastOptions => {
-    const { INFO, SUCCESS, ERROR, WARNING, DEFAULT } = toast.types
-    const { title, message, type = DEFAULT, ...rest } = toastOptions
-
-    toastId = t(
-      <Notification
-        className={style.notification}
-        small
-        title={title}
-        content={message}
-        success={type === SUCCESS}
-        info={type === INFO}
-        error={type === ERROR}
-        warning={type === WARNING}
-        data-test-id="toast-notification"
-      />,
-      {
-        onClose: () => next(),
-        ...rest,
-      },
-    )
-  }
-
-  const next = () => {
-    const hasNext = queue.length > 0
-
-    if (!hasNext) {
-      firstDispatched = false
-    } else if (hasNext && !t.isActive(toastId)) {
-      const message = queue.shift()
-      lastMessage = message
-      show(message)
+    if (!currentRender) {
+      return
     }
+
+    toastId = t(currentRender, toastOptions)
   }
 
   const toast = options => {
@@ -72,11 +45,56 @@ const createToast = () => {
       return
     }
 
-    queue.push(options)
+    const { INFO, SUCCESS, ERROR, WARNING, DEFAULT } = toast.types
+    const { title, message, type = DEFAULT, messageGroup, ...toastOptions } = options
+    let autoClose = toastOptions.autoClose
 
-    if (!firstDispatched) {
-      firstDispatched = true
-      next()
+    if (!autoClose) {
+      let messageLength =
+        typeof message === 'string'
+          ? message.length
+          : typeof message === 'object' && message.defaultMessage
+          ? message.defaultMessage.length
+          : 0
+      if (title) {
+        messageLength +=
+          typeof title === 'string'
+            ? title.length
+            : typeof title === 'object' && title.defaultMessage
+            ? title.defaultMessage.length
+            : 0
+      }
+      // Calculate the reading time to use as `autoClose` duration.
+      autoClose = Math.min(12000, Math.max(5000, messageLength * 150))
+    }
+
+    currentRender = (
+      <Notification
+        className={style.notification}
+        small
+        title={title}
+        content={message}
+        success={type === SUCCESS}
+        info={type === INFO}
+        error={type === ERROR}
+        warning={type === WARNING}
+        data-test-id="toast-notification"
+      />
+    )
+
+    // For messages of the same message group, update the card rather than
+    // queuing up more messages.
+    if (t.isActive(toastId) && messageGroup === lastMessageGroup) {
+      t.update(toastId, {
+        ...toastOptions,
+        render: currentRender,
+        autoClose,
+        transition: cssTransition({ enter: style.beat, exit: style.slideOutRight }),
+      })
+    } else {
+      show({ autoClose, ...toastOptions })
+      lastMessage = toastOptions
+      lastMessageGroup = messageGroup
     }
   }
 

--- a/pkg/webui/components/toast/toast.styl
+++ b/pkg/webui/components/toast/toast.styl
@@ -27,6 +27,8 @@ div.toast
 .slide-out-right
   animation: slide-in-right 0.5s cubic-bezier(0.230, 1.000, 0.320, 1.000) both reverse
 
+.beat
+  animation: beat 0.5s cubic-bezier(0.230, 1.000, 0.320, 1.000) both
 
 @keyframes slide-in-right
   0%
@@ -37,4 +39,15 @@ div.toast
   100%
     -webkit-transform: translateX(0)
     transform: translateX(0)
+    opacity: 1
+
+@keyframes beat
+  0%
+    -webkit-transform: rotateX(0deg)
+    transform: scale(1.2)
+    opacity: 0
+
+  100%
+    -webkit-transform: rotateX(180deg)
+    transform: scale(1)
     opacity: 1

--- a/pkg/webui/console/api/index.js
+++ b/pkg/webui/console/api/index.js
@@ -75,7 +75,6 @@ tts.subscribe('warning', payload => {
     type: toast.types.WARNING,
     message: payload,
     preventConsecutive: true,
-    autoClose: 10000,
   })
 })
 


### PR DESCRIPTION
#### Summary
This quickfix PR will improve the behavior around toast messages in the Console.

#### Changes
- Use `messageGroup` to update existing toasts rather then queuing more
- Use a reading time calculation as the default duration of toast messages
- Allow 2 toasts to be visible at the same time
- Simplify some bits of the toast wrapper logic

#### Testing

Manual testing.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
