### PR TITLE
Remove init step from e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -119,8 +119,8 @@ jobs:
       - name: Create device repository index
         run: tools/bin/mage dev:initDeviceRepo
         if: steps.dr-index-cache.outputs.cache-hit != 'true'
-      - name: Initialize stack environment
-        run: tools/bin/mage init
+      - name: Generate certs
+        run: tools/bin/mage dev:certificates
       - name: Run test preparations
         if: |
           steps.db-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
#### Summary
This quickfix PR removes the `mage init` step from the end-to-end test workflow.

#### Changes
- Replace init step from e2e workflow with just `dev:certificates`


#### Testing

Via this PR CI

#### Notes for Reviewers

The init step would cause the `dev:initDeviceRepo` step to always be run regardless of the cache. I've checked the init step in mage and believe that it is not necessary to run it, since it initializes functionality that is not used by the e2es or it potentially reruns things that have already been initialized.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
