### PR TITLE
Store schema version in ns-db migrate command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ For details about compatibility between different releases, see the **Commitment
 
 - When a gateway uplink message contains duplicate data uplinks, only the one with the highest RSSI are forwarded.
 - The HTTP port now allows HTTP/2 connections over cleartext (h2c).
+- `ttn-lw-stack ns-db migrate` command records the schema version and only performs migrations if on a newer version.
+  - Use the `--force` flag to force perform migrations.
 
 ### Deprecated
 

--- a/pkg/networkserver/redis/registry.go
+++ b/pkg/networkserver/redis/registry.go
@@ -42,6 +42,9 @@ var (
 	errReadOnlyField        = errors.DefineInvalidArgument("read_only_field", "read-only field `{field}`")
 )
 
+// SchemaVersion is the Network Server database schema version. Bump when a migration is required.
+const SchemaVersion = 1
+
 // DeviceRegistry is an implementation of networkserver.DeviceRegistry.
 type DeviceRegistry struct {
 	Redis   *ttnredis.Client


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #4112 

#### Changes
<!-- What are the changes made in this pull request? -->

- Read schema version and only run migrations if needed 
- Record schema version after a successful migration run.
- Add `--force` flag to override this logic and always run migrations (if required)

#### Testing

<!-- How did you verify that this change works? -->

Locally

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

`ns_db.go` already contains quite a lot of logic and raw Redis commands, so I went with a very simple implementation approach. 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [X] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
