### PR TITLE
Allow h2c connections to web server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ with the exception that this project **does not** follow Semantic Versioning.
 
 For details about compatibility between different releases, see the **Commitments and Releases** section of our README.
 
-## [v3.14.0] - Upcoming
+## [Unreleased]
 
 ### Added
 
@@ -27,6 +27,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Changed
 
 - When a gateway uplink message contains duplicate data uplinks, only the one with the highest RSSI are forwarded.
+- The HTTP port now allows HTTP/2 connections over cleartext (h2c).
 
 ### Deprecated
 
@@ -43,20 +44,6 @@ For details about compatibility between different releases, see the **Commitment
 - LBS LNS Auth Secret displays garbage value when updated.
 - Transmit confirmation messages for LoRa Basics Station gateways.
 - Instability and frequent crashes when internet connection is lost in the Console.
-
-### Security
-
-## [Unreleased]
-
-### Added
-
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
 
 ### Security
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request makes a small change to the web server, so that it allows HTTP/2 over cleartext (h2c).

This will allow TLS-terminating proxies to multiplex multiple requests over the same upstream connection.

#### Testing

<!-- How did you verify that this change works? -->

`curl --http2-prior-knowledge -v http://localhost:1885/api/v3/auth_info` and see if it uses HTTP/2.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
    - Small unrelated change: clean up CHANGELOG.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
