### PR TITLE
Allow authenticated callers to list collaborator identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ For details about compatibility between different releases, see the **Commitment
 - The HTTP port now allows HTTP/2 connections over cleartext (h2c).
 - `ttn-lw-stack ns-db migrate` command records the schema version and only performs migrations if on a newer version.
   - Use the `--force` flag to force perform migrations.
+- Any authenticated user in the network can now list the collaborators of entities in the network.
 
 ### Deprecated
 

--- a/pkg/identityserver/application_access.go
+++ b/pkg/identityserver/application_access.go
@@ -283,9 +283,13 @@ func (is *IdentityServer) setApplicationCollaborator(ctx context.Context, req *t
 }
 
 func (is *IdentityServer) listApplicationCollaborators(ctx context.Context, req *ttnpb.ListApplicationCollaboratorsRequest) (collaborators *ttnpb.Collaborators, err error) {
-	if err = rights.RequireApplication(ctx, req.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_SETTINGS_COLLABORATORS); err != nil {
+	if err = is.RequireAuthenticated(ctx); err != nil {
 		return nil, err
 	}
+	if err = rights.RequireApplication(ctx, req.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_SETTINGS_COLLABORATORS); err != nil {
+		defer func() { collaborators = collaborators.PublicSafe() }()
+	}
+
 	var total uint64
 	ctx = store.WithPagination(ctx, req.Limit, req.Page, &total)
 	defer func() {

--- a/pkg/identityserver/application_access_test.go
+++ b/pkg/identityserver/application_access_test.go
@@ -182,7 +182,7 @@ func TestApplicationAccessPermissionDenied(t *testing.T) {
 		})
 
 		if a.So(err, should.NotBeNil) {
-			a.So(errors.IsPermissionDenied(err), should.BeTrue)
+			a.So(errors.IsUnauthenticated(err), should.BeTrue)
 		}
 		a.So(collaborators, should.BeNil)
 

--- a/pkg/identityserver/client_access.go
+++ b/pkg/identityserver/client_access.go
@@ -139,8 +139,11 @@ func (is *IdentityServer) setClientCollaborator(ctx context.Context, req *ttnpb.
 }
 
 func (is *IdentityServer) listClientCollaborators(ctx context.Context, req *ttnpb.ListClientCollaboratorsRequest) (collaborators *ttnpb.Collaborators, err error) {
-	if err = is.RequireAuthenticated(ctx); err != nil { // Client collaborators can be seen by all authenticated users.
+	if err = is.RequireAuthenticated(ctx); err != nil {
 		return nil, err
+	}
+	if err = rights.RequireClient(ctx, req.ClientIdentifiers, ttnpb.RIGHT_CLIENT_ALL); err != nil {
+		defer func() { collaborators = collaborators.PublicSafe() }()
 	}
 	var total uint64
 	ctx = store.WithPagination(ctx, req.Limit, req.Page, &total)

--- a/pkg/identityserver/gateway_access.go
+++ b/pkg/identityserver/gateway_access.go
@@ -282,8 +282,11 @@ func (is *IdentityServer) setGatewayCollaborator(ctx context.Context, req *ttnpb
 }
 
 func (is *IdentityServer) listGatewayCollaborators(ctx context.Context, req *ttnpb.ListGatewayCollaboratorsRequest) (collaborators *ttnpb.Collaborators, err error) {
-	if err = rights.RequireGateway(ctx, req.GatewayIdentifiers, ttnpb.RIGHT_GATEWAY_SETTINGS_COLLABORATORS); err != nil {
+	if err = is.RequireAuthenticated(ctx); err != nil {
 		return nil, err
+	}
+	if err = rights.RequireGateway(ctx, req.GatewayIdentifiers, ttnpb.RIGHT_GATEWAY_SETTINGS_COLLABORATORS); err != nil {
+		defer func() { collaborators = collaborators.PublicSafe() }()
 	}
 	var total uint64
 	ctx = store.WithPagination(ctx, req.Limit, req.Page, &total)

--- a/pkg/identityserver/gateway_access_test.go
+++ b/pkg/identityserver/gateway_access_test.go
@@ -184,7 +184,7 @@ func TestGatewayAccessPermissionDenied(t *testing.T) {
 		})
 
 		if a.So(err, should.NotBeNil) {
-			a.So(errors.IsPermissionDenied(err), should.BeTrue)
+			a.So(errors.IsUnauthenticated(err), should.BeTrue)
 		}
 		a.So(collaborators, should.BeNil)
 

--- a/pkg/identityserver/organization_access.go
+++ b/pkg/identityserver/organization_access.go
@@ -283,8 +283,11 @@ func (is *IdentityServer) setOrganizationCollaborator(ctx context.Context, req *
 }
 
 func (is *IdentityServer) listOrganizationCollaborators(ctx context.Context, req *ttnpb.ListOrganizationCollaboratorsRequest) (collaborators *ttnpb.Collaborators, err error) {
-	if err = rights.RequireOrganization(ctx, req.OrganizationIdentifiers, ttnpb.RIGHT_ORGANIZATION_SETTINGS_MEMBERS); err != nil {
+	if err = is.RequireAuthenticated(ctx); err != nil {
 		return nil, err
+	}
+	if err = rights.RequireOrganization(ctx, req.OrganizationIdentifiers, ttnpb.RIGHT_ORGANIZATION_SETTINGS_MEMBERS); err != nil {
+		defer func() { collaborators = collaborators.PublicSafe() }()
 	}
 	var total uint64
 	ctx = store.WithPagination(ctx, req.Limit, req.Page, &total)

--- a/pkg/identityserver/organization_access_test.go
+++ b/pkg/identityserver/organization_access_test.go
@@ -183,7 +183,7 @@ func TestOrganizationAccessPermissionDenied(t *testing.T) {
 		})
 
 		if a.So(err, should.NotBeNil) {
-			a.So(errors.IsPermissionDenied(err), should.BeTrue)
+			a.So(errors.IsUnauthenticated(err), should.BeTrue)
 		}
 		a.So(collaborators, should.BeNil)
 

--- a/pkg/ttnpb/public.go
+++ b/pkg/ttnpb/public.go
@@ -147,3 +147,27 @@ func (u *User) PublicSafe() *User {
 	safe.ContactInfo = onlyPublicContactInfo(safe.ContactInfo)
 	return &safe
 }
+
+// PublicSafe returns only the identifiers of the collaborators.
+func (c *Collaborators) PublicSafe() *Collaborators {
+	if c == nil {
+		return nil
+	}
+	safe := Collaborators{
+		Collaborators: make([]*Collaborator, len(c.Collaborators)),
+	}
+	for i, collaborator := range c.Collaborators {
+		safe.Collaborators[i] = collaborator.PublicSafe()
+	}
+	return &safe
+}
+
+// PublicSafe returns only the identifiers of the collaborator.
+func (c *Collaborator) PublicSafe() *Collaborator {
+	if c == nil {
+		return nil
+	}
+	return &Collaborator{
+		OrganizationOrUserIdentifiers: c.OrganizationOrUserIdentifiers,
+	}
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request makes all ListCollaborators RPCs more consistent by letting authenticated callers in a network list the collaborators on all entities of that network, which was previously only implemented for OAuth clients.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `PublicSafe` method on `Collaborator`s that only returns the identifiers (not the rights).
- Make all `ListCollaborators` RPCs use the same rights check.

#### Testing

<!-- How did you verify that this change works? -->

Updated existing unit tests.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This will be very useful for users of The Things Stack Community Edition who may want to find out which user(s)/organization(s) collaborate on a gateway.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
