### PR TITLE
Return search fields even if not in field mask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ For details about compatibility between different releases, see the **Commitment
 - `ttn-lw-stack ns-db migrate` command records the schema version and only performs migrations if on a newer version.
   - Use the `--force` flag to force perform migrations.
 - Any authenticated user in the network can now list the collaborators of entities in the network.
+- The search RPCs no longer require fields to be specified in the field mask when those fields are already specified as filters.
 
 ### Deprecated
 

--- a/pkg/identityserver/registry_search.go
+++ b/pkg/identityserver/registry_search.go
@@ -50,7 +50,20 @@ func (rs *registrySearch) SearchApplications(ctx context.Context, req *ttnpb.Sea
 	if err != nil {
 		return nil, err
 	}
-	req.FieldMask = cleanFieldMaskPaths(ttnpb.ApplicationFieldPathsNested, req.FieldMask, getPaths, nil)
+	var searchFields []string
+	if req.IDContains != "" {
+		searchFields = append(searchFields, "ids")
+	}
+	if req.NameContains != "" {
+		searchFields = append(searchFields, "name")
+	}
+	if req.DescriptionContains != "" {
+		searchFields = append(searchFields, "description")
+	}
+	if len(req.AttributesContain) > 0 {
+		searchFields = append(searchFields, "attributes")
+	}
+	req.FieldMask = cleanFieldMaskPaths(ttnpb.ApplicationFieldPathsNested, req.FieldMask, append(getPaths, searchFields...), nil)
 	if req.Deleted {
 		ctx = store.WithSoftDeleted(ctx, true)
 	}
@@ -95,7 +108,23 @@ func (rs *registrySearch) SearchClients(ctx context.Context, req *ttnpb.SearchCl
 	if err != nil {
 		return nil, err
 	}
-	req.FieldMask = cleanFieldMaskPaths(ttnpb.ClientFieldPathsNested, req.FieldMask, getPaths, nil)
+	var searchFields []string
+	if req.IDContains != "" {
+		searchFields = append(searchFields, "ids")
+	}
+	if req.NameContains != "" {
+		searchFields = append(searchFields, "name")
+	}
+	if req.DescriptionContains != "" {
+		searchFields = append(searchFields, "description")
+	}
+	if len(req.AttributesContain) > 0 {
+		searchFields = append(searchFields, "attributes")
+	}
+	if len(req.State) > 0 {
+		searchFields = append(searchFields, "state")
+	}
+	req.FieldMask = cleanFieldMaskPaths(ttnpb.ClientFieldPathsNested, req.FieldMask, append(getPaths, searchFields...), nil)
 	if req.Deleted {
 		ctx = store.WithSoftDeleted(ctx, true)
 	}
@@ -146,7 +175,20 @@ func (rs *registrySearch) SearchGateways(ctx context.Context, req *ttnpb.SearchG
 			req.FieldMask.Paths = append(req.FieldMask.GetPaths(), "frequency_plan_ids")
 		}
 	}
-	req.FieldMask = cleanFieldMaskPaths(ttnpb.GatewayFieldPathsNested, req.FieldMask, getPaths, []string{"frequency_plan_id"})
+	var searchFields []string
+	if req.IDContains != "" {
+		searchFields = append(searchFields, "ids")
+	}
+	if req.NameContains != "" {
+		searchFields = append(searchFields, "name")
+	}
+	if req.DescriptionContains != "" {
+		searchFields = append(searchFields, "description")
+	}
+	if len(req.AttributesContain) > 0 {
+		searchFields = append(searchFields, "attributes")
+	}
+	req.FieldMask = cleanFieldMaskPaths(ttnpb.GatewayFieldPathsNested, req.FieldMask, append(getPaths, searchFields...), nil)
 	if req.Deleted {
 		ctx = store.WithSoftDeleted(ctx, true)
 	}
@@ -197,7 +239,20 @@ func (rs *registrySearch) SearchOrganizations(ctx context.Context, req *ttnpb.Se
 	if err != nil {
 		return nil, err
 	}
-	req.FieldMask = cleanFieldMaskPaths(ttnpb.OrganizationFieldPathsNested, req.FieldMask, getPaths, nil)
+	var searchFields []string
+	if req.IDContains != "" {
+		searchFields = append(searchFields, "ids")
+	}
+	if req.NameContains != "" {
+		searchFields = append(searchFields, "name")
+	}
+	if req.DescriptionContains != "" {
+		searchFields = append(searchFields, "description")
+	}
+	if len(req.AttributesContain) > 0 {
+		searchFields = append(searchFields, "attributes")
+	}
+	req.FieldMask = cleanFieldMaskPaths(ttnpb.OrganizationFieldPathsNested, req.FieldMask, append(getPaths, searchFields...), nil)
 	if req.Deleted {
 		ctx = store.WithSoftDeleted(ctx, true)
 	}
@@ -245,7 +300,23 @@ func (rs *registrySearch) SearchUsers(ctx context.Context, req *ttnpb.SearchUser
 	if member != nil {
 		return nil, errSearchForbidden.New()
 	}
-	req.FieldMask = cleanFieldMaskPaths(ttnpb.UserFieldPathsNested, req.FieldMask, getPaths, nil)
+	var searchFields []string
+	if req.IDContains != "" {
+		searchFields = append(searchFields, "ids")
+	}
+	if req.NameContains != "" {
+		searchFields = append(searchFields, "name")
+	}
+	if req.DescriptionContains != "" {
+		searchFields = append(searchFields, "description")
+	}
+	if len(req.AttributesContain) > 0 {
+		searchFields = append(searchFields, "attributes")
+	}
+	if len(req.State) > 0 {
+		searchFields = append(searchFields, "state")
+	}
+	req.FieldMask = cleanFieldMaskPaths(ttnpb.UserFieldPathsNested, req.FieldMask, append(getPaths, searchFields...), nil)
 	if req.Deleted {
 		ctx = store.WithSoftDeleted(ctx, true)
 	}
@@ -290,7 +361,20 @@ func (rs *registrySearch) SearchEndDevices(ctx context.Context, req *ttnpb.Searc
 	if err != nil {
 		return nil, err
 	}
-	req.FieldMask = cleanFieldMaskPaths(ttnpb.EndDeviceFieldPathsNested, req.FieldMask, getPaths, nil)
+	var searchFields []string
+	if req.IDContains != "" {
+		searchFields = append(searchFields, "ids")
+	}
+	if req.NameContains != "" {
+		searchFields = append(searchFields, "name")
+	}
+	if req.DescriptionContains != "" {
+		searchFields = append(searchFields, "description")
+	}
+	if len(req.AttributesContain) > 0 {
+		searchFields = append(searchFields, "attributes")
+	}
+	req.FieldMask = cleanFieldMaskPaths(ttnpb.EndDeviceFieldPathsNested, req.FieldMask, append(getPaths, searchFields...), nil)
 	ctx = store.WithOrder(ctx, req.Order)
 	var total uint64
 	ctx = store.WithPagination(ctx, req.Limit, req.Page, &total)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a small pull request that makes the search RPCs return the fields that you're searching for, even if you don't specify them explicitly in the field mask.

Backport from https://github.com/TheThingsIndustries/lorawan-stack/pull/2833

#### Testing

<!-- How did you verify that this change works? -->

CLI

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

I don't expect any

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
