### PR TITLE
Disconnect gateways when relevant fields change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ For details about compatibility between different releases, see the **Commitment
 - Opt out of Packet Broker for individual gateways, see the new `disable_packet_broker_forwarding` gateway option.
   - This requires a database schema migration (`ttn-lw-stack is-db migrate`) because of the added columns.
   - This is only relevant when Packet Broker is enabled and configured by the network operator.
+- Gateways are now disconnected when settings affecting the connection with Gateway Server change. Use the `gs.fetch-gateway-interval` and `gs.fetch-interval-jitter` to configure how often the gateway is fetched from the entity registry.
 
 ### Changed
 

--- a/cmd/internal/shared/gatewayserver/config.go
+++ b/cmd/internal/shared/gatewayserver/config.go
@@ -29,7 +29,10 @@ import (
 // DefaultGatewayServerConfig is the default configuration for the GatewayServer.
 var DefaultGatewayServerConfig = gatewayserver.Config{
 	RequireRegisteredGateways:         false,
+	FetchGatewayInterval:              10 * time.Minute,
+	FetchGatewayJitter:                0.2,
 	UpdateGatewayLocationDebounceTime: time.Hour,
+	UpdateConnectionStatsDebounceTime: 3 * time.Second,
 	Forward: map[string][]string{
 		"": {"00000000/0"},
 	},
@@ -62,5 +65,4 @@ var DefaultGatewayServerConfig = gatewayserver.Config{
 		Listen:                 ":1887",
 		ListenTLS:              ":8887",
 	},
-	UpdateConnectionStatsDebounceTime: 3 * time.Second,
 }

--- a/config/messages.json
+++ b/config/messages.json
@@ -4562,6 +4562,15 @@
       "file": "gatewayserver.go"
     }
   },
+  "error:pkg/gatewayserver:gateway_changed": {
+    "translations": {
+      "en": "gateway changed in registry"
+    },
+    "description": {
+      "package": "pkg/gatewayserver",
+      "file": "gatewayserver.go"
+    }
+  },
   "error:pkg/gatewayserver:gateway_eui_not_registered": {
     "translations": {
       "en": "gateway EUI `{eui}` is not registered"

--- a/pkg/gatewayserver/config.go
+++ b/pkg/gatewayserver/config.go
@@ -51,6 +51,9 @@ type Config struct {
 
 	Stats GatewayConnectionStatsRegistry `name:"-"`
 
+	FetchGatewayInterval time.Duration `name:"fetch-gateway-interval" description:"Fetch gateway interval"`
+	FetchGatewayJitter   float64       `name:"fetch-gateway-jitter" description:"Jitter (fraction) to apply to the get interval to randomize intervals"`
+
 	UpdateGatewayLocationDebounceTime time.Duration `name:"update-gateway-location-debounce-time" description:"Debounce time for gateway location updates from status messages"`
 	UpdateConnectionStatsDebounceTime time.Duration `name:"update-connection-stats-debounce-time" description:"Time before repeated refresh of the gateway connection stats"`
 

--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -95,6 +95,8 @@ func TestGatewayServer(t *testing.T) {
 				gsConfig := &gatewayserver.Config{
 					RequireRegisteredGateways:         false,
 					UpdateGatewayLocationDebounceTime: 0,
+					FetchGatewayInterval:              time.Minute,
+					FetchGatewayJitter:                1,
 					MQTT: config.MQTT{
 						Listen: ":1882",
 					},

--- a/pkg/gatewayserver/io/udp/firewall.go
+++ b/pkg/gatewayserver/io/udp/firewall.go
@@ -15,7 +15,6 @@
 package udp
 
 import (
-	"bytes"
 	"context"
 	"net"
 	"sync"
@@ -78,7 +77,7 @@ func (f *memoryFirewall) Filter(packet encoding.Packet) error {
 	val, ok := f.m.Load(eui)
 	if ok {
 		a := val.(addrTime)
-		if !bytes.Equal(a.IP, packet.GatewayAddr.IP) && a.lastSeen.Add(f.addrChangeBlock).After(now) {
+		if !a.IP.Equal(packet.GatewayAddr.IP) && a.lastSeen.Add(f.addrChangeBlock).After(now) {
 			return errAlreadyConnected.WithAttributes(
 				"connected_ip", a.IP.String(),
 				"connecting_ip", packet.GatewayAddr.IP.String(),

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -246,6 +246,12 @@ func (s *srv) connect(ctx context.Context, eui types.EUI64) (*state, error) {
 		if cs.ioErr != nil {
 			return nil, cs.ioErr
 		}
+		// The connection may be disconnected and is awaiting garbage collection, see gc().
+		// The connection cannot be deleted from the map at this point, because before that, the downlink tasks must be
+		// awaited, which is not desirable here in the hot path.
+		if err := cs.io.Context().Err(); err != nil {
+			return nil, err
+		}
 	}
 	return cs, nil
 }

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -488,7 +488,7 @@ func (s *srv) gc() {
 						lastSeenPush := time.Unix(0, atomic.LoadInt64(&state.lastSeenPush))
 						if time.Since(lastSeenPush) > s.config.ConnectionExpires {
 							logger.Debug("Connection expired")
-							state.io.Disconnect(errConnectionExpired)
+							state.io.Disconnect(errConnectionExpired.New())
 							state.downlinkTaskDone.Wait()
 							s.connections.Delete(k)
 						}

--- a/pkg/gatewayserver/io/udp/udp_util_test.go
+++ b/pkg/gatewayserver/io/udp/udp_util_test.go
@@ -34,8 +34,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
 )
 
-func durationPtr(d time.Duration) *time.Duration { return &d }
-
 func generatePushData(eui types.EUI64, status bool, timestamps ...time.Duration) encoding.Packet {
 	packet := encoding.Packet{
 		GatewayEUI:      &eui,

--- a/pkg/gatewayserver/upstream/packetbroker/packetbroker.go
+++ b/pkg/gatewayserver/upstream/packetbroker/packetbroker.go
@@ -161,23 +161,6 @@ func (h *Handler) ConnectGateway(ctx context.Context, ids ttnpb.GatewayIdentifie
 		case <-h.nextUpdateGateway(onlineTTL):
 		}
 
-		// Get the gateway from Identity Server. Some settings may have changed by a collaborator.
-		gtw, err := h.GatewayRegistry.Get(ctx, &ttnpb.GetGatewayRequest{
-			GatewayIdentifiers: ids,
-			FieldMask: &pbtypes.FieldMask{
-				Paths: []string{
-					"antennas",
-					"location_public",
-					"status_public",
-					"update_location_from_status",
-				},
-			},
-		})
-		if err != nil {
-			log.FromContext(ctx).WithError(err).Warn("Failed to get gateway")
-			return err
-		}
-
 		req := &ttnpb.UpdatePacketBrokerGatewayRequest{
 			Gateway: &ttnpb.PacketBrokerGateway{
 				Ids: &ttnpb.PacketBrokerGateway_GatewayIdentifiers{
@@ -199,16 +182,8 @@ func (h *Handler) ConnectGateway(ctx context.Context, ids ttnpb.GatewayIdentifie
 		// location_public should only be in the field mask if the location is known, so only when a location in the status.
 		// This is to avoid that the location gets reset when there is no location in the status.
 		if gtw.LocationPublic {
-			var (
-				loc ttnpb.Location
-				ok  bool
-			)
 			if status, _, ok := conn.StatusStats(); ok && gtw.UpdateLocationFromStatus && len(status.GetAntennaLocations()) > 0 && status.AntennaLocations[0] != nil {
-				loc, ok = *status.AntennaLocations[0], true
-			} else if len(gtw.Antennas) > 0 && gtw.Antennas[0].Location != nil {
-				loc, ok = *gtw.Antennas[0].Location, true
-			}
-			if ok {
+				loc := *status.AntennaLocations[0]
 				loc.Source = ttnpb.SOURCE_GPS
 				req.Gateway.LocationPublic = true
 				req.Gateway.Antennas = []*ttnpb.GatewayAntenna{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/4411

#### Changes
<!-- What are the changes made in this pull request? -->

- Watch gateway regularly, disconnect when relevant fields change
- Return a connection error early in the UDP frontend; disconnections from the server are cleaned up by the garbage collector
- Remove automatically fetching the gateway in the PB upstream

#### Testing

<!-- How did you verify that this change works? -->

🐒 

gRPC example:

```
g/errors", "grpc.method": "LinkGateway", "grpc.service": "ttn.lorawan.v3.GtwGs", "grpc_code": "Canceled", "namespace": "grpc"}
error:pkg/gatewayserver:gateway_changed (gateway changed in registry)
    correlation_id=d45799648f2747efb70ac96f3f60d572
```

MQTT and Basic Station have proper disconnect support which is already tested. I believe that the UDP disconnection logic works too.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@adriansmares is the main reviewer

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
