### PR TITLE
Use TLS client config instead of server

### DIFF
--- a/pkg/basicstation/cups/config.go
+++ b/pkg/basicstation/cups/config.go
@@ -61,6 +61,8 @@ func (conf ServerConfig) NewServer(c *component.Component, customOpts ...Option)
 			}),
 		)
 	}
+	// The Server.tlsConfig is used when dialing a CUPS or an LNS server to query its certificate chain.
+	// When dialing servers with self-signed certs, the Root CA of target server must either be trusted by the system or added explicitly via the `--tls.root-ca` option.
 	if tlsConfig, err := c.GetTLSClientConfig(c.Context()); err == nil {
 		opts = append(opts, WithTLSConfig(tlsConfig))
 	}

--- a/pkg/basicstation/cups/config.go
+++ b/pkg/basicstation/cups/config.go
@@ -61,7 +61,7 @@ func (conf ServerConfig) NewServer(c *component.Component, customOpts ...Option)
 			}),
 		)
 	}
-	if tlsConfig, err := c.GetTLSServerConfig(c.Context()); err == nil {
+	if tlsConfig, err := c.GetTLSClientConfig(c.Context()); err == nil {
 		opts = append(opts, WithTLSConfig(tlsConfig))
 	}
 	s := NewServer(c, append(opts, customOpts...)...)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Use TLS client config instead of server. This is used to dial CUPS/LNS servers and fetch the CA. Before the fix, this would error with servers with self-signed certs.

This requires some AWS PRs.
- https://github.com/TheThingsIndustries/lorawan-stack-aws/pull/474
- A follow up for Docker; https://github.com/TheThingsIndustries/lorawan-stack-aws/pull/476

#### Changes
<!-- What are the changes made in this pull request? -->

- Initialize the server's `tlsConfig` field with the component's Client and not Server TLS config.

#### Testing

<!-- How did you verify that this change works? -->

Local stack using a `ca.pem` file.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

I don't think there's any.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
