### PR TITLE
Fix some unnecessary rerenders in the Console

### DIFF
--- a/pkg/webui/console/store/reducers/devices.js
+++ b/pkg/webui/console/store/reducers/devices.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { mergeWith, merge } from 'lodash'
+import { mergeWith } from 'lodash'
 
 import { EVENT_END_DEVICE_HEARTBEAT_FILTERS_REGEXP } from '@console/constants/event-filters'
 
@@ -41,11 +41,16 @@ const downlinkFrameCountEvent = 'ns.down.data.schedule.attempt'
 
 const mergeDerived = (state, id, derived) =>
   Object.keys(derived).length > 0
-    ? merge({}, state, {
+    ? {
+        ...state,
         derived: {
-          [id]: derived,
+          ...state.derived,
+          [id]: {
+            ...state.derived[id],
+            ...derived,
+          },
         },
-      })
+      }
     : state
 
 const devices = (state = defaultState, { type, payload, event }) => {

--- a/pkg/webui/console/store/reducers/rights.js
+++ b/pkg/webui/console/store/reducers/rights.js
@@ -17,7 +17,10 @@ import createRequestActions from '@ttn-lw/lib/store/actions/create-request-actio
 import { createGetRightsListActionType } from '@console/store/actions/rights'
 
 const defaultState = {
-  rights: [],
+  rights: {
+    regular: [],
+    pseudo: [],
+  },
 }
 
 const createNamedRightsReducer = (reducerName = '') => {
@@ -29,7 +32,10 @@ const createNamedRightsReducer = (reducerName = '') => {
       case GET_LIST_SUCCESS:
         return {
           ...state,
-          rights: payload,
+          rights: {
+            regular: payload.filter(right => !right.endsWith('_ALL')),
+            pseudo: payload.filter(right => right.endsWith('_ALL')),
+          },
         }
       default:
         return state

--- a/pkg/webui/console/store/selectors/applications.js
+++ b/pkg/webui/console/store/selectors/applications.js
@@ -48,6 +48,7 @@ export const selectApplicationDerivedById = (state, id) => selectApplicationDeri
 export const selectApplicationById = (state, id) => selectApplicationEntitiesStore(state)[id]
 export const selectSelectedApplicationId = state =>
   selectApplicationStore(state).selectedApplication
+export const selectApplicationNameById = (state, id) => (selectApplicationById(state) || {}).name
 export const selectSelectedApplication = state =>
   selectApplicationById(state, selectSelectedApplicationId(state))
 export const selectApplicationFetching = createFetchingSelector(GET_APP_BASE)

--- a/pkg/webui/console/store/selectors/rights.js
+++ b/pkg/webui/console/store/selectors/rights.js
@@ -17,11 +17,11 @@ const selectRightsStore = (state, entity) => state.rights[entity]
 export const createRightsSelector = entity => state => {
   const store = selectRightsStore(state, entity)
 
-  return store.rights.filter(right => !right.endsWith('_ALL'))
+  return store.rights.regular
 }
 
 export const createPseudoRightsSelector = entity => state => {
   const store = selectRightsStore(state, entity)
 
-  return store.rights.filter(right => right.endsWith('_ALL'))
+  return store.rights.pseudo
 }

--- a/pkg/webui/console/views/device/index.js
+++ b/pkg/webui/console/views/device/index.js
@@ -100,47 +100,44 @@ import style from './device.styl'
     stopStream: id => dispatch(stopDeviceEventsStream(id)),
   }),
 )
-@withRequest(
-  ({ appId, devId, loadDeviceData, mayReadKeys }) => {
-    const selector = [
-      'name',
-      'description',
-      'version_ids',
-      'frequency_plan_id',
-      'mac_settings',
-      'resets_join_nonces',
-      'supports_class_b',
-      'supports_class_c',
-      'supports_join',
-      'lorawan_version',
-      'lorawan_phy_version',
-      'network_server_address',
-      'application_server_address',
-      'join_server_address',
-      'locations',
-      'formatters',
-      'multicast',
-      'net_id',
-      'application_server_id',
-      'application_server_kek_label',
-      'network_server_kek_label',
-      'claim_authentication_code',
-      'mac_state.recent_uplinks',
-      'attributes',
-      'skip_payload_crypto',
-      'skip_payload_crypto_override',
-    ]
+@withRequest(({ appId, devId, loadDeviceData, mayReadKeys }) => {
+  const selector = [
+    'name',
+    'description',
+    'version_ids',
+    'frequency_plan_id',
+    'mac_settings',
+    'resets_join_nonces',
+    'supports_class_b',
+    'supports_class_c',
+    'supports_join',
+    'lorawan_version',
+    'lorawan_phy_version',
+    'network_server_address',
+    'application_server_address',
+    'join_server_address',
+    'locations',
+    'formatters',
+    'multicast',
+    'net_id',
+    'application_server_id',
+    'application_server_kek_label',
+    'network_server_kek_label',
+    'claim_authentication_code',
+    'mac_state.recent_uplinks',
+    'attributes',
+    'skip_payload_crypto',
+    'skip_payload_crypto_override',
+  ]
 
-    if (mayReadKeys) {
-      selector.push('session')
-      selector.push('pending_session')
-      selector.push('root_keys')
-    }
+  if (mayReadKeys) {
+    selector.push('session')
+    selector.push('pending_session')
+    selector.push('root_keys')
+  }
 
-    return loadDeviceData(appId, devId, selector, { ignoreNotFound: true })
-  },
-  ({ fetching, device }) => fetching,
-)
+  return loadDeviceData(appId, devId, selector, { ignoreNotFound: true })
+})
 @withBreadcrumb('device.single', props => {
   const {
     devId,


### PR DESCRIPTION
#### Summary
This quickfix PR will fix unnecessary rerenders in the Console, for applications and devices.

#### Changes
- Replace usage of `_.merge()` in reducers
- Avoid thunked selectors for rights
- Some small cleanup


#### Testing

Manual and CI.

#### Notes for Reviewers
I've noticed that the application view currently rerender for every state update (most frequently when a application message arrives). This was due to how the `rights` selector worked, which would always apply a filter on the plain array in the store, causing the value to be reassigned to a new array for every selection and hence triggering rerenders. A similar thing happens for devices, where we used `_.merge()` to merge the `derived` object into the state, this would cause a deep clone to be created for every such update.

There are likely more such issues throughout the codebase but those were the most pressing from what I could see. We should take more caution on how we use selectors, how we mutate state and also avoid thunked, unmemoized functions in `connect()`.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
