### PR TITLE
Allow external application servers to provide the downlink session key ID

### DIFF
--- a/pkg/applicationserver/io/grpc/grpc_test.go
+++ b/pkg/applicationserver/io/grpc/grpc_test.go
@@ -261,7 +261,7 @@ func TestTraffic(t *testing.T) {
 				EndDeviceIdentifiers: ids,
 				Downlinks: []*ttnpb.ApplicationDownlink{
 					{
-						SessionKeyID:   []byte{0x11, 0x22, 0x33, 0x44}, // This gets discarded.
+						SessionKeyID:   []byte{0x11, 0x22, 0x33, 0x44},
 						FPort:          1,
 						FRMPayload:     []byte{0x01, 0x01, 0x01},
 						Confirmed:      true,
@@ -293,6 +293,7 @@ func TestTraffic(t *testing.T) {
 			a.So(res.Downlinks, should.HaveLength, 3)
 			a.So(res.Downlinks, should.Resemble, []*ttnpb.ApplicationDownlink{
 				{
+					SessionKeyID:   []byte{0x11, 0x22, 0x33, 0x44},
 					FPort:          1,
 					Confirmed:      true,
 					FRMPayload:     []byte{0x01, 0x01, 0x01},

--- a/pkg/applicationserver/io/io.go
+++ b/pkg/applicationserver/io/io.go
@@ -143,6 +143,7 @@ func CleanDownlinks(items []*ttnpb.ApplicationDownlink) []*ttnpb.ApplicationDown
 	res := make([]*ttnpb.ApplicationDownlink, 0, len(items))
 	for _, item := range items {
 		res = append(res, &ttnpb.ApplicationDownlink{
+			SessionKeyID:   item.SessionKeyID, // SessionKeyID must be set when skipping application payload crypto.
 			FPort:          item.FPort,
 			FCnt:           item.FCnt, // FCnt must be set when skipping application payload crypto.
 			FRMPayload:     item.FRMPayload,

--- a/pkg/applicationserver/payload.go
+++ b/pkg/applicationserver/payload.go
@@ -36,11 +36,16 @@ func (as *ApplicationServer) encodeAndEncryptDownlinks(ctx context.Context, dev 
 		skipPayloadCrypto := as.skipPayloadCrypto(ctx, link, dev, session)
 		for _, item := range items {
 			fCnt := session.LastAFCntDown + 1
+			sessionKeyID := session.SessionKeyID
 			if skipPayloadCrypto {
 				fCnt = item.FCnt
+
+				if len(item.SessionKeyID) > 0 {
+					sessionKeyID = item.SessionKeyID
+				}
 			}
 			encryptedItem := &ttnpb.ApplicationDownlink{
-				SessionKeyID:   session.SessionKeyID,
+				SessionKeyID:   sessionKeyID,
 				FPort:          item.FPort,
 				FCnt:           fCnt,
 				FRMPayload:     item.FRMPayload,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-aws-integration/issues/30

#### Changes
<!-- What are the changes made in this pull request? -->

- Compute the `LastAFCntDown` from the `MinFCntDown` correctly, clamping at 0
- Propagate the session key ID from the caller when the application layer encryption is skipped. This occurs only if such a session key ID has been provided


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
