### PR TITLE
Improve fetch table loading UI

### DIFF
--- a/pkg/webui/components/table/index.js
+++ b/pkg/webui/components/table/index.js
@@ -122,7 +122,7 @@ class Tabular extends React.Component {
           </Table.Row>
         ))
       ) : (
-        <Table.Empty colSpan={headers.length} message={emptyMessage} />
+        <Table.Empty colSpan={headers.length} message={!loading ? emptyMessage : undefined} />
       )
 
     const pagination = paginated ? (

--- a/pkg/webui/components/table/table/index.js
+++ b/pkg/webui/components/table/table/index.js
@@ -30,7 +30,7 @@ import style from './table.styl'
 const Empty = ({ className, colSpan, message }) => (
   <Row className={classnames(className, style.emptyMessageRow)} clickable={false}>
     <DataCell colSpan={colSpan}>
-      <Message className={style.emptyMessage} content={message} />
+      {Boolean(message) && <Message className={style.emptyMessage} content={message} />}
     </DataCell>
   </Row>
 )


### PR DESCRIPTION
#### Summary
This quickfix PR improves the loading behavior of `<FetchTable />` in a way that it will not show old items on initial fetch.

#### Changes
- Change `<FetchTable />` to hide existing items on initial fetch
- Remove the `No items found` message when in loading state


#### Testing

Manual.

#### Notes for Reviewers
Adding this to avoid briefly showing e.g. end devices of other applications when navigating to a different application.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
