### PR TITLE
Cache Root CA for TLS clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
+- Cache Root CA for client TLS configuration.
+
 ### Deprecated
 
 ### Removed


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #1432

#### Changes
<!-- What are the changes made in this pull request? -->

- Load Root CA once for tlsconfig.Client.
- Initiailze tls client config during component start (and also interop client initialization)

#### Testing

<!-- How did you verify that this change works? -->

Existing unit tests.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

There should not be any.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@htdvisser I considered adding `panic`s when `RootCAPemBytes` is empty but `RootCA` is not, but eventually decided against it. Also considered encapsulating the caching using the `FileReader` config, but that leads to lazy loading the root CA, which I am not a huge fan of.

@johanstokking Perhaps we can use something similar for client certificates and keys also?

Are there any potential issues that arise from keeping the root CA in memory?

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
