### PR TITLE
Fix prepush hooks dependency on TTI remote

### DIFF
--- a/tools/mage/git.go
+++ b/tools/mage/git.go
@@ -230,6 +230,11 @@ func (g Git) prePush(stdin string, args ...string) error {
 		switch n := err.ExitCode(); n {
 		case 1:
 			return nil
+		case 128:
+			if mg.Verbose() {
+				fmt.Println("Unable to check presence of TTI marker commit: hash not found")
+			}
+			return nil
 		default:
 			return fmt.Errorf("expected exit code of 1, got %d", n)
 		}


### PR DESCRIPTION
#### Summary
This quickfix resolves an issue that would require a base commit ref of the proprietary stack to be fetched in order to push.

#### Changes
- Allow exit code 128 when checking whether the commit is an ancestor of the TTI base ref


#### Testing

Manual.

##### Regressions

None.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
