### PR TITLE
Backport application packages scalability fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Added
 
+- New config option `--as.packages.timeout` to control the message processing timeout of application packages.
+
 ### Changed
 
 ### Deprecated

--- a/cmd/internal/shared/applicationserver/config.go
+++ b/cmd/internal/shared/applicationserver/config.go
@@ -74,6 +74,7 @@ var DefaultApplicationServerConfig = applicationserver.Config{
 	Packages: applicationserver.ApplicationPackagesConfig{
 		Config: packages.Config{
 			Workers: 16,
+			Timeout: 10 * time.Second,
 		},
 	},
 	Formatters: applicationserver.FormattersConfig{

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -309,9 +309,14 @@ var startCommand = &cobra.Command{
 			config.AS.PubSub.Registry = &asiopsredis.PubSubRegistry{
 				Redis: redis.New(config.Redis.WithNamespace("as", "io", "pubsub")),
 			}
-			config.AS.Packages.Registry = &asioapredis.ApplicationPackagesRegistry{
-				Redis: redis.New(config.Redis.WithNamespace("as", "io", "applicationpackages")),
+			applicationPackagesRegistry := &asioapredis.ApplicationPackagesRegistry{
+				Redis:   redis.New(config.Redis.WithNamespace("as", "io", "applicationpackages")),
+				LockTTL: 10 * time.Second,
 			}
+			if err := applicationPackagesRegistry.Init(ctx); err != nil {
+				return shared.ErrInitializeApplicationServer.WithCause(err)
+			}
+			config.AS.Packages.Registry = applicationPackagesRegistry
 			if config.AS.Webhooks.Target != "" {
 				config.AS.Webhooks.Registry = &asiowebredis.WebhookRegistry{
 					Redis: redis.New(config.Redis.WithNamespace("as", "io", "webhooks")),

--- a/pkg/applicationserver/config.go
+++ b/pkg/applicationserver/config.go
@@ -225,7 +225,7 @@ func (c ApplicationPackagesConfig) NewApplicationPackages(ctx context.Context, s
 	// Initialize LoRa Cloud Geolocation v3 package handler
 	handlers[loracloudgeolocationv3.PackageName] = loracloudgeolocationv3.New(server, c.Registry)
 
-	return packages.New(ctx, server, c.Registry, handlers, c.Workers)
+	return packages.New(ctx, server, c.Registry, handlers, c.Workers, c.Timeout)
 }
 
 var (

--- a/pkg/applicationserver/io/packages/config.go
+++ b/pkg/applicationserver/io/packages/config.go
@@ -14,7 +14,10 @@
 
 package packages
 
+import "time"
+
 // Config contains configuration options for application packages.
 type Config struct {
-	Workers int `name:"workers" description:"Number of workers per application package"`
+	Workers int           `name:"workers" description:"Number of workers per application package"`
+	Timeout time.Duration `name:"timeout" description:"Message processing timeout"`
 }

--- a/pkg/applicationserver/io/packages/registry.go
+++ b/pkg/applicationserver/io/packages/registry.go
@@ -44,8 +44,14 @@ type DefaultAssociationRegistry interface {
 	WithPagination(ctx context.Context, limit, page uint32, total *int64) context.Context
 }
 
-// Registry is a registry for application package associations.
+// TransactionRegistry is a registry for application packages transactions.
+type TransactionRegistry interface {
+	EndDeviceTransaction(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, fPort uint32, packageName string, fn func(ctx context.Context) error) error
+}
+
+// Registry is a registry for application packages.
 type Registry interface {
 	AssociationRegistry
 	DefaultAssociationRegistry
+	TransactionRegistry
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/pull/2843

#### Changes
<!-- What are the changes made in this pull request? -->

- Add a processing timeout to application packages processing. Defaults to 10 seconds
  - Previously we had none, so packages could deadlock if they didn't do HTTP requests (since the HTTP client does have a timeout built in)
- Add a transaction registry that allows application packages to have distributed mutexes

#### Testing

<!-- How did you verify that this change works? -->

Local testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This adds a very light limit on the processing time. No other changes are expected.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Already reviewed in the original PR https://github.com/TheThingsIndustries/lorawan-stack/pull/2843 . This is just cherry-picking.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
