### PR TITLE
Disable "Factory preset frequencies" field for US-like bands (Console)

### DIFF
--- a/pkg/webui/components/key-value-map/index.js
+++ b/pkg/webui/components/key-value-map/index.js
@@ -33,6 +33,7 @@ class KeyValueMap extends React.PureComponent {
   static propTypes = {
     addMessage: PropTypes.message,
     className: PropTypes.string,
+    disabled: PropTypes.bool,
     indexAsKey: PropTypes.bool,
     keyPlaceholder: PropTypes.message,
     name: PropTypes.string.isRequired,
@@ -58,6 +59,7 @@ class KeyValueMap extends React.PureComponent {
     addMessage: m.addEntry,
     indexAsKey: false,
     keyPlaceholder: '',
+    disabled: false,
   }
 
   @bind
@@ -100,6 +102,7 @@ class KeyValueMap extends React.PureComponent {
       addMessage,
       onBlur,
       indexAsKey,
+      disabled,
     } = this.props
 
     return (
@@ -127,6 +130,7 @@ class KeyValueMap extends React.PureComponent {
             type="button"
             message={addMessage}
             onClick={this.addEmptyEntry}
+            disabled={disabled}
             icon="add"
             secondary
           />

--- a/pkg/webui/console/lib/device-utils.js
+++ b/pkg/webui/console/lib/device-utils.js
@@ -156,3 +156,12 @@ export const getLastSeen = device => {
     }
   }
 }
+
+/**
+ * @param {string} freqPlan - End device frequency plan.
+ * @returns {boolean} - Whether end device frequency plan has a CFList type of ChMask (channel mask).
+ */
+export const hasCFListTypeChMask = (freqPlan = '') =>
+  freqPlan.startsWith('US_902_928') ||
+  freqPlan.startsWith('AU_915_928') ||
+  freqPlan.startsWith('CN_470_510')

--- a/pkg/webui/console/views/device-add/manual/form/form.js
+++ b/pkg/webui/console/views/device-add/manual/form/form.js
@@ -245,6 +245,11 @@ const ManualForm = props => {
     setDeviceClass(devClass)
   }, [])
 
+  const [freqPlan, setFreqPlan] = React.useState()
+  const handleFreqPlanChange = React.useCallback(band => {
+    setFreqPlan(band.value)
+  }, [])
+
   const handleIdPrefill = React.useCallback(() => {
     if (formRef.current) {
       const { values, setFieldValue } = formRef.current
@@ -413,6 +418,7 @@ const ManualForm = props => {
         required={nsEnabled}
         tooltipId={tooltipIds.FREQUENCY_PLAN}
         name="frequency_plan_id"
+        onChange={handleFreqPlanChange}
       />
       <hr />
       <AdvancedSettingsSection
@@ -424,6 +430,7 @@ const ManualForm = props => {
         onDeviceClassChange={handleDeviceClassChange}
         onDefaultNsSettingsChange={handleDefaultNsSettings}
         defaultNsSettings={defaultNsSettings}
+        freqPlan={freqPlan}
       />
       <hr />
       {!isMulticast && devEUIComponent}

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -503,6 +503,7 @@
   "console.views.device-add.manual.form.advanced-settings.classBandC": "Class B and class C",
   "console.views.device-add.manual.form.advanced-settings.useExternalServers": "Use external LoRaWAN backend servers",
   "console.views.device-add.manual.form.advanced-settings.multicastClassCapabilities": "LoRaWAN class for multicast downlinks",
+  "console.views.device-add.manual.form.advanced-settings.factoryFreqWarning": "In LoRaWAN, factory preset frequencies are only supported for bands with a CFList type of frequencies",
   "console.views.device-add.manual.form.form.register": "Register manually",
   "console.views.device-add.messages.repositoryTabTitle": "From The LoRaWAN Device Repository",
   "console.views.device-add.messages.manualTabTitle": "Manually",

--- a/pkg/webui/locales/xx.json
+++ b/pkg/webui/locales/xx.json
@@ -503,6 +503,7 @@
   "console.views.device-add.manual.form.advanced-settings.classBandC": "Xxxxx X xxx xxxxx X",
   "console.views.device-add.manual.form.advanced-settings.useExternalServers": "Xxx xxxxxxxx XxXxXXX xxxxxxx xxxxxxx",
   "console.views.device-add.manual.form.advanced-settings.multicastClassCapabilities": "XxXxXXX xxxxx xxx xxxxxxxxx xxxxxxxxx",
+  "console.views.device-add.manual.form.advanced-settings.factoryFreqWarning": "Xx XxXxXXX, xxxxxxx xxxxxx xxxxxxxxxxx xxx xxxx xxxxxxxxx xxx xxxxx xxxx x XXXxxx xxxx xx xxxxxxxxxxx",
   "console.views.device-add.manual.form.form.register": "Xxxxxxxx xxxxxxxx",
   "console.views.device-add.messages.repositoryTabTitle": "Xxxx Xxx XxXxXXX Xxxxxx Xxxxxxxxxx",
   "console.views.device-add.messages.manualTabTitle": "Xxxxxxxx",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/4431
<img width="566" alt="Screenshot 2021-07-28 at 15 56 20" src="https://user-images.githubusercontent.com/16374166/127325503-9e33039c-4eac-48ce-9aaf-5d5ac3d3dda4.png">



#### Changes
<!-- What are the changes made in this pull request? -->

- Adjust `<KeyValueMap />` component to check for the `disabled` prop
- Disable `factory_preset_frequencies` for certain bands, i.e. `AU_915_928`, `CN_470_510`, `US_902_928`


#### Testing

<!-- How did you verify that this change works? -->

Manual


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
