### PR TITLE
Prevent removing last _ALL right from entity collaborator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Changed
 
 - Cache Root CA for client TLS configuration.
+- Identity Server no longer allows removing the `_ALL` right from entity collaborators if that leaves the entity without any collaborator that has the `_ALL` right.
 
 ### Deprecated
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -5174,6 +5174,15 @@
       "file": "application_registry.go"
     }
   },
+  "error:pkg/identityserver:application_needs_collaborator": {
+    "translations": {
+      "en": "every application needs at least one collaborator with all rights"
+    },
+    "description": {
+      "package": "pkg/identityserver",
+      "file": "application_access.go"
+    }
+  },
   "error:pkg/identityserver:claim_authentication_code": {
     "translations": {
       "en": "invalid claim authentication code"
@@ -5181,6 +5190,15 @@
     "description": {
       "package": "pkg/identityserver",
       "file": "gateway_registry.go"
+    }
+  },
+  "error:pkg/identityserver:client_needs_collaborator": {
+    "translations": {
+      "en": "every client needs at least one collaborator with all rights"
+    },
+    "description": {
+      "package": "pkg/identityserver",
+      "file": "client_access.go"
     }
   },
   "error:pkg/identityserver:client_update_admin_field": {
@@ -5244,6 +5262,15 @@
     "description": {
       "package": "pkg/identityserver",
       "file": "gateway_registry.go"
+    }
+  },
+  "error:pkg/identityserver:gateway_needs_collaborator": {
+    "translations": {
+      "en": "every gateway needs at least one collaborator with all rights"
+    },
+    "description": {
+      "package": "pkg/identityserver",
+      "file": "gateway_access.go"
     }
   },
   "error:pkg/identityserver:invalid_authorization": {
@@ -5352,6 +5379,15 @@
     "description": {
       "package": "pkg/identityserver",
       "file": "user_registry.go"
+    }
+  },
+  "error:pkg/identityserver:organization_needs_collaborator": {
+    "translations": {
+      "en": "every organization needs at least one collaborator with all rights"
+    },
+    "description": {
+      "package": "pkg/identityserver",
+      "file": "organization_access.go"
     }
   },
   "error:pkg/identityserver:password_contains_user_id": {

--- a/pkg/identityserver/application_access.go
+++ b/pkg/identityserver/application_access.go
@@ -27,6 +27,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/identityserver/store"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/unique"
 )
 
 var (
@@ -227,6 +228,8 @@ func (is *IdentityServer) getApplicationCollaborator(ctx context.Context, req *t
 	return res, nil
 }
 
+var errApplicationNeedsCollaborator = errors.DefineFailedPrecondition("application_needs_collaborator", "every application needs at least one collaborator with all rights")
+
 func (is *IdentityServer) setApplicationCollaborator(ctx context.Context, req *ttnpb.SetApplicationCollaboratorRequest) (*pbtypes.Empty, error) {
 	// Require that caller has rights to manage collaborators.
 	if err := rights.RequireApplication(ctx, req.ApplicationIdentifiers, ttnpb.RIGHT_APPLICATION_SETTINGS_COLLABORATORS); err != nil {
@@ -235,25 +238,50 @@ func (is *IdentityServer) setApplicationCollaborator(ctx context.Context, req *t
 
 	err := is.withDatabase(ctx, func(db *gorm.DB) error {
 		store := is.getMembershipStore(ctx, db)
+		existingRights, err := store.GetMember(
+			ctx,
+			&req.Collaborator.OrganizationOrUserIdentifiers,
+			req.ApplicationIdentifiers.GetEntityIdentifiers(),
+		)
+		if err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+		existingRights = existingRights.Implied()
+		newRights := ttnpb.RightsFrom(req.Collaborator.Rights...).Implied()
+		addedRights := newRights.Sub(existingRights)
+		removedRights := existingRights.Sub(newRights)
 
-		if len(req.Collaborator.Rights) > 0 {
-			newRights := ttnpb.RightsFrom(req.Collaborator.Rights...)
-			existingRights, err := store.GetMember(
-				ctx,
-				&req.Collaborator.OrganizationOrUserIdentifiers,
-				req.ApplicationIdentifiers.GetEntityIdentifiers(),
-			)
-
-			if err != nil && !errors.IsNotFound(err) {
+		// Require the caller to have all added rights.
+		if len(addedRights.GetRights()) > 0 {
+			if err := rights.RequireApplication(ctx, req.ApplicationIdentifiers, addedRights.GetRights()...); err != nil {
 				return err
 			}
-			// Require the caller to have all added rights.
-			if err := rights.RequireApplication(ctx, req.ApplicationIdentifiers, newRights.Sub(existingRights).GetRights()...); err != nil {
+		}
+
+		// Unless we're deleting the collaborator, require the caller to have all removed rights.
+		if len(newRights.GetRights()) > 0 && len(removedRights.GetRights()) > 0 {
+			if err := rights.RequireApplication(ctx, req.ApplicationIdentifiers, removedRights.GetRights()...); err != nil {
 				return err
 			}
-			// Require the caller to have all removed rights.
-			if err := rights.RequireApplication(ctx, req.ApplicationIdentifiers, existingRights.Sub(newRights).GetRights()...); err != nil {
+		}
+
+		if removedRights.IncludesAll(ttnpb.RIGHT_APPLICATION_ALL) {
+			memberRights, err := is.getMembershipStore(ctx, db).FindMembers(ctx, req.ApplicationIdentifiers.GetEntityIdentifiers())
+			if err != nil {
 				return err
+			}
+			var hasOtherOwner bool
+			for member, rights := range memberRights {
+				if unique.ID(ctx, member) == unique.ID(ctx, &req.Collaborator.OrganizationOrUserIdentifiers) {
+					continue
+				}
+				if rights.Implied().IncludesAll(ttnpb.RIGHT_APPLICATION_ALL) {
+					hasOtherOwner = true
+					break
+				}
+			}
+			if !hasOtherOwner {
+				return errApplicationNeedsCollaborator.New()
 			}
 		}
 

--- a/pkg/identityserver/application_access_test.go
+++ b/pkg/identityserver/application_access_test.go
@@ -259,7 +259,7 @@ func TestApplicationAccessCRUD(t *testing.T) {
 
 		a.So(err, should.BeNil)
 		if a.So(rights, should.NotBeNil) {
-			a.So(rights.Rights, should.NotBeEmpty)
+			a.So(rights.Rights, should.Contain, ttnpb.RIGHT_APPLICATION_ALL)
 		}
 
 		modifiedApplicationID := applicationID
@@ -351,6 +351,24 @@ func TestApplicationAccessCRUD(t *testing.T) {
 		a.So(err, should.BeNil)
 		if a.So(res, should.NotBeNil) {
 			a.So(res.Rights, should.Resemble, []ttnpb.Right{ttnpb.RIGHT_APPLICATION_ALL})
+		}
+
+		_, err = reg.SetCollaborator(ctx, &ttnpb.SetApplicationCollaboratorRequest{
+			ApplicationIdentifiers: applicationID,
+			Collaborator: ttnpb.Collaborator{
+				OrganizationOrUserIdentifiers: *collaboratorID,
+			},
+		}, creds)
+
+		a.So(err, should.BeNil)
+
+		res, err = reg.GetCollaborator(ctx, &ttnpb.GetApplicationCollaboratorRequest{
+			ApplicationIdentifiers:        applicationID,
+			OrganizationOrUserIdentifiers: *collaboratorID,
+		}, creds)
+
+		if a.So(err, should.NotBeNil) {
+			a.So(errors.IsNotFound(err), should.BeTrue)
 		}
 	})
 }

--- a/pkg/identityserver/client_access.go
+++ b/pkg/identityserver/client_access.go
@@ -27,6 +27,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/identityserver/store"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/unique"
 )
 
 var (
@@ -83,6 +84,8 @@ func (is *IdentityServer) getClientCollaborator(ctx context.Context, req *ttnpb.
 	return res, nil
 }
 
+var errClientNeedsCollaborator = errors.DefineFailedPrecondition("client_needs_collaborator", "every client needs at least one collaborator with all rights")
+
 func (is *IdentityServer) setClientCollaborator(ctx context.Context, req *ttnpb.SetClientCollaboratorRequest) (*pbtypes.Empty, error) {
 	// Require that caller has rights to manage collaborators.
 	if err := rights.RequireClient(ctx, req.ClientIdentifiers, ttnpb.RIGHT_CLIENT_ALL); err != nil {
@@ -92,24 +95,50 @@ func (is *IdentityServer) setClientCollaborator(ctx context.Context, req *ttnpb.
 	err := is.withDatabase(ctx, func(db *gorm.DB) error {
 		store := is.getMembershipStore(ctx, db)
 
-		if len(req.Collaborator.Rights) > 0 {
-			newRights := ttnpb.RightsFrom(req.Collaborator.Rights...)
-			existingRights, err := store.GetMember(
-				ctx,
-				&req.Collaborator.OrganizationOrUserIdentifiers,
-				req.ClientIdentifiers.GetEntityIdentifiers(),
-			)
+		existingRights, err := store.GetMember(
+			ctx,
+			&req.Collaborator.OrganizationOrUserIdentifiers,
+			req.ClientIdentifiers.GetEntityIdentifiers(),
+		)
+		if err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+		existingRights = existingRights.Implied()
+		newRights := ttnpb.RightsFrom(req.Collaborator.Rights...).Implied()
+		addedRights := newRights.Sub(existingRights)
+		removedRights := existingRights.Sub(newRights)
 
-			if err != nil && !errors.IsNotFound(err) {
+		// Require the caller to have all added rights.
+		if len(addedRights.GetRights()) > 0 {
+			if err := rights.RequireClient(ctx, req.ClientIdentifiers, addedRights.GetRights()...); err != nil {
 				return err
 			}
-			// Require the caller to have all added rights.
-			if err := rights.RequireClient(ctx, req.ClientIdentifiers, newRights.Sub(existingRights).GetRights()...); err != nil {
+		}
+
+		// Unless we're deleting the collaborator, require the caller to have all removed rights.
+		if len(newRights.GetRights()) > 0 && len(removedRights.GetRights()) > 0 {
+			if err := rights.RequireClient(ctx, req.ClientIdentifiers, removedRights.GetRights()...); err != nil {
 				return err
 			}
-			// Require the caller to have all removed rights.
-			if err := rights.RequireClient(ctx, req.ClientIdentifiers, existingRights.Sub(newRights).GetRights()...); err != nil {
+		}
+
+		if removedRights.IncludesAll(ttnpb.RIGHT_CLIENT_ALL) {
+			memberRights, err := is.getMembershipStore(ctx, db).FindMembers(ctx, req.ClientIdentifiers.GetEntityIdentifiers())
+			if err != nil {
 				return err
+			}
+			var hasOtherOwner bool
+			for member, rights := range memberRights {
+				if unique.ID(ctx, member) == unique.ID(ctx, &req.Collaborator.OrganizationOrUserIdentifiers) {
+					continue
+				}
+				if rights.Implied().IncludesAll(ttnpb.RIGHT_CLIENT_ALL) {
+					hasOtherOwner = true
+					break
+				}
+			}
+			if !hasOtherOwner {
+				return errClientNeedsCollaborator.New()
 			}
 		}
 

--- a/pkg/identityserver/client_access_test.go
+++ b/pkg/identityserver/client_access_test.go
@@ -176,5 +176,23 @@ func TestClientAccessCRUD(t *testing.T) {
 		if a.So(res, should.NotBeNil) {
 			a.So(res.Rights, should.Resemble, []ttnpb.Right{ttnpb.RIGHT_CLIENT_ALL})
 		}
+
+		_, err = reg.SetCollaborator(ctx, &ttnpb.SetClientCollaboratorRequest{
+			ClientIdentifiers: clientID,
+			Collaborator: ttnpb.Collaborator{
+				OrganizationOrUserIdentifiers: *collaboratorID,
+			},
+		}, creds)
+
+		a.So(err, should.BeNil)
+
+		res, err = reg.GetCollaborator(ctx, &ttnpb.GetClientCollaboratorRequest{
+			ClientIdentifiers:             clientID,
+			OrganizationOrUserIdentifiers: *collaboratorID,
+		}, creds)
+
+		if a.So(err, should.NotBeNil) {
+			a.So(errors.IsNotFound(err), should.BeTrue)
+		}
 	})
 }

--- a/pkg/identityserver/gateway_access.go
+++ b/pkg/identityserver/gateway_access.go
@@ -27,6 +27,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/identityserver/store"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/unique"
 )
 
 var (
@@ -227,6 +228,8 @@ func (is *IdentityServer) getGatewayCollaborator(ctx context.Context, req *ttnpb
 	return res, nil
 }
 
+var errGatewayNeedsCollaborator = errors.DefineFailedPrecondition("gateway_needs_collaborator", "every gateway needs at least one collaborator with all rights")
+
 func (is *IdentityServer) setGatewayCollaborator(ctx context.Context, req *ttnpb.SetGatewayCollaboratorRequest) (*pbtypes.Empty, error) {
 	// Require that caller has rights to manage collaborators.
 	if err := rights.RequireGateway(ctx, req.GatewayIdentifiers, ttnpb.RIGHT_GATEWAY_SETTINGS_COLLABORATORS); err != nil {
@@ -235,24 +238,50 @@ func (is *IdentityServer) setGatewayCollaborator(ctx context.Context, req *ttnpb
 	err := is.withDatabase(ctx, func(db *gorm.DB) error {
 		store := is.getMembershipStore(ctx, db)
 
-		if len(req.Collaborator.Rights) > 0 {
-			newRights := ttnpb.RightsFrom(req.Collaborator.Rights...)
-			existingRights, err := store.GetMember(
-				ctx,
-				&req.Collaborator.OrganizationOrUserIdentifiers,
-				req.GatewayIdentifiers.GetEntityIdentifiers(),
-			)
+		existingRights, err := store.GetMember(
+			ctx,
+			&req.Collaborator.OrganizationOrUserIdentifiers,
+			req.GatewayIdentifiers.GetEntityIdentifiers(),
+		)
+		if err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+		existingRights = existingRights.Implied()
+		newRights := ttnpb.RightsFrom(req.Collaborator.Rights...).Implied()
+		addedRights := newRights.Sub(existingRights)
+		removedRights := existingRights.Sub(newRights)
 
-			if err != nil && !errors.IsNotFound(err) {
+		// Require the caller to have all added rights.
+		if len(addedRights.GetRights()) > 0 {
+			if err := rights.RequireGateway(ctx, req.GatewayIdentifiers, addedRights.GetRights()...); err != nil {
 				return err
 			}
-			// Require the caller to have all added rights.
-			if err := rights.RequireGateway(ctx, req.GatewayIdentifiers, newRights.Sub(existingRights).GetRights()...); err != nil {
+		}
+
+		// Unless we're deleting the collaborator, require the caller to have all removed rights.
+		if len(newRights.GetRights()) > 0 && len(removedRights.GetRights()) > 0 {
+			if err := rights.RequireGateway(ctx, req.GatewayIdentifiers, removedRights.GetRights()...); err != nil {
 				return err
 			}
-			// Require the caller to have all removed rights.
-			if err := rights.RequireGateway(ctx, req.GatewayIdentifiers, existingRights.Sub(newRights).GetRights()...); err != nil {
+		}
+
+		if removedRights.IncludesAll(ttnpb.RIGHT_GATEWAY_ALL) {
+			memberRights, err := is.getMembershipStore(ctx, db).FindMembers(ctx, req.GatewayIdentifiers.GetEntityIdentifiers())
+			if err != nil {
 				return err
+			}
+			var hasOtherOwner bool
+			for member, rights := range memberRights {
+				if unique.ID(ctx, member) == unique.ID(ctx, &req.Collaborator.OrganizationOrUserIdentifiers) {
+					continue
+				}
+				if rights.Implied().IncludesAll(ttnpb.RIGHT_GATEWAY_ALL) {
+					hasOtherOwner = true
+					break
+				}
+			}
+			if !hasOtherOwner {
+				return errGatewayNeedsCollaborator.New()
 			}
 		}
 

--- a/pkg/identityserver/gateway_access_test.go
+++ b/pkg/identityserver/gateway_access_test.go
@@ -354,6 +354,24 @@ func TestGatewayAccessCRUD(t *testing.T) {
 		if a.So(res, should.NotBeNil) {
 			a.So(res.Rights, should.Resemble, []ttnpb.Right{ttnpb.RIGHT_GATEWAY_ALL})
 		}
+
+		_, err = reg.SetCollaborator(ctx, &ttnpb.SetGatewayCollaboratorRequest{
+			GatewayIdentifiers: gatewayID,
+			Collaborator: ttnpb.Collaborator{
+				OrganizationOrUserIdentifiers: *collaboratorID,
+			},
+		}, creds)
+
+		a.So(err, should.BeNil)
+
+		res, err = reg.GetCollaborator(ctx, &ttnpb.GetGatewayCollaboratorRequest{
+			GatewayIdentifiers:            gatewayID,
+			OrganizationOrUserIdentifiers: *collaboratorID,
+		}, creds)
+
+		if a.So(err, should.NotBeNil) {
+			a.So(errors.IsNotFound(err), should.BeTrue)
+		}
 	})
 }
 

--- a/pkg/identityserver/organization_access_test.go
+++ b/pkg/identityserver/organization_access_test.go
@@ -353,6 +353,24 @@ func TestOrganizationAccessCRUD(t *testing.T) {
 		if a.So(res, should.NotBeNil) {
 			a.So(res.Rights, should.Resemble, []ttnpb.Right{ttnpb.RIGHT_ORGANIZATION_ALL})
 		}
+
+		_, err = reg.SetCollaborator(ctx, &ttnpb.SetOrganizationCollaboratorRequest{
+			OrganizationIdentifiers: organizationID,
+			Collaborator: ttnpb.Collaborator{
+				OrganizationOrUserIdentifiers: *collaboratorID,
+			},
+		}, creds)
+
+		a.So(err, should.BeNil)
+
+		res, err = reg.GetCollaborator(ctx, &ttnpb.GetOrganizationCollaboratorRequest{
+			OrganizationIdentifiers:       organizationID,
+			OrganizationOrUserIdentifiers: *collaboratorID,
+		}, creds)
+
+		if a.So(err, should.NotBeNil) {
+			a.So(errors.IsNotFound(err), should.BeTrue)
+		}
 	})
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request changes the SetCollaborator RPCs of the Identity Server to ensure that every entity has at least one collaborator with the `_ALL` right.

We previously thought that users deleting their own account was a problem and worked on handling that (https://github.com/TheThingsNetwork/lorawan-stack/issues/3458 / https://github.com/TheThingsNetwork/lorawan-stack/pull/3616; eventually dropped), but in fact it's much more common for users to accidentally revoke their collaborator access from their entities, which should be solved by this PR.

Refs https://www.thethingsnetwork.org/forum/t/move-your-ttig-to-v3-yes/49287/59?u=htdvisser

#### Testing

<!-- How did you verify that this change works? -->

I've extended the existing tests a little, but couldn't reliably cover the error itself because of the randomly populated database. Luckily we can still monkey-test this:

<img width="1280" alt="Screen Shot 2021-07-29 at 14 13 27" src="https://user-images.githubusercontent.com/181308/127489761-328df016-5b39-48c1-8b7e-087311ce480d.png">

⚠️ The error message was updated after I took the screenshot. The message is now

> every gateway needs at least one collaborator with all rights

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This could make it impossible to update collaborators of entities that already don't have a collaborator with the `_ALL` right.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This doesn't fully cover accidental loss of access to entities when rights are granted through organizations, but I think it's already better than having no protection at all.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
