### PR TITLE
Fix field mask warning in gateway view

### DIFF
--- a/pkg/webui/console/components/gateway-data-form/index.js
+++ b/pkg/webui/console/components/gateway-data-form/index.js
@@ -214,6 +214,7 @@ class GatewayDataForm extends React.Component {
           onChange={this.handleFrequencyPlanChange}
           tooltipId={tooltipIds.FREQUENCY_PLAN}
           warning={showFrequencyPlanWarning ? sharedMessages.frequencyPlanWarning : undefined}
+          required
         />
         <Form.Field
           title={sharedMessages.gatewayScheduleDownlinkLate}

--- a/pkg/webui/console/containers/gateways-table/index.js
+++ b/pkg/webui/console/containers/gateways-table/index.js
@@ -116,7 +116,7 @@ class GatewaysTable extends React.Component {
 
       return getGatewaysList(
         params,
-        ['name', 'description', 'frequency_plan_id', 'gateway_server_address'],
+        ['name', 'description', 'frequency_plan_ids', 'gateway_server_address'],
         { withStatus: true, isSearch: tab === ALL_TAB || query.length > 0 },
       )
     }

--- a/pkg/webui/console/views/gateway/index.js
+++ b/pkg/webui/console/views/gateway/index.js
@@ -90,7 +90,7 @@ import {
       'name',
       'description',
       'enforce_duty_cycle',
-      'frequency_plan_id',
+      'frequency_plan_ids',
       'gateway_server_address',
       'antennas',
       'location_public',


### PR DESCRIPTION
#### Summary
One line fix to correct the field mask for frequency plans for gateways. This currently causes a warning in the gateway list view in the Console. See https://github.com/TheThingsIndustries/lorawan-stack-support/issues/531#event-5090911598

#### Changes
- Change `frequency_plan` field mask to `frequency_plans`

#### Testing

Manual.

##### Regressions

None.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
