### PR TITLE
Add option to connect LBS gateways to plaintext LNS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ For details about compatibility between different releases, see the **Commitment
 ### Added
 
 - New config option `--as.packages.timeout` to control the message processing timeout of application packages.
+- Option to connect LBS gateways to plaintext LNS.
+  - This should only be used for local testing.
+  - If a TTS instance is used as the LNS, the `require_authenticated_connection` field for the gateway must be unset and the `--gs.basic-station.allow-unauthenticated` option for the GS must be set.
 
 ### Changed
 

--- a/pkg/basicstation/cups/server.go
+++ b/pkg/basicstation/cups/server.go
@@ -234,6 +234,9 @@ func parseAddress(defaultScheme, address string) (scheme, host, port string, err
 		case "wss":
 			port = "8887"
 		}
+	} else if port == "1887" {
+		// Allow user to force a plain text LNS connection by setting the port.
+		scheme = "ws"
 	}
 	return
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsIndustries/lorawan-stack/issues/2831

#### Changes
<!-- What are the changes made in this pull request? -->

- Skip sending LNS credentials to the gateway if port `1887` is used.

#### Testing

<!-- How did you verify that this change works? -->

- UT and test server + local TTS instance for LNS

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Tested those as well.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I would agree if you think this part is funky; 
https://github.com/TheThingsNetwork/lorawan-stack/blob/239f1eadac3e1e06b9c4c35344569785fbc86214/pkg/basicstation/cups/server.go#L237-L240


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
