### PR TITLE
Preload fonts in the WebUIs to prevent FOUT

### DIFF
--- a/pkg/webui/components/header/header.styl
+++ b/pkg/webui/components/header/header.styl
@@ -34,14 +34,6 @@ mobile-styles($breakpoint)
     .profile-dropdown
       display: none
 
-    .right
-      .preload-icon
-        opacity: 0
-        font-size: .001px
-        position: absolute
-        top: -1px
-        right: -1px
-
     .mobile-menu
       display: flex
 

--- a/pkg/webui/components/header/index.js
+++ b/pkg/webui/components/header/index.js
@@ -18,7 +18,6 @@ import classnames from 'classnames'
 import hamburgerMenuNormal from '@assets/misc/hamburger-menu-normal.svg'
 import hamburgerMenuClose from '@assets/misc/hamburger-menu-close.svg'
 
-import Icon from '@ttn-lw/components/icon'
 import NavigationBar from '@ttn-lw/components/navigation/bar'
 import ProfileDropdown from '@ttn-lw/components/profile-dropdown'
 import MobileMenu from '@ttn-lw/components/mobile-menu'
@@ -76,7 +75,6 @@ const Header = ({
               {dropdownItems}
             </ProfileDropdown>
             <button onClick={handleMobileMenuClick} className={style.mobileMenuButton}>
-              <Icon className={style.preloadIcons} icon="." />
               <div className={style.hamburger}>
                 <img src={hamburgerGraphic} alt="Open Mobile Menu" />
               </div>

--- a/pkg/webui/lib/components/init.js
+++ b/pkg/webui/lib/components/init.js
@@ -18,6 +18,11 @@ import 'focus-visible/dist/focus-visible'
 import { setConfiguration } from 'react-grid-system'
 import { defineMessages } from 'react-intl'
 
+import SourceSansRegular from '@assets/fonts/source-sans-pro-v13-latin_latin-ext-regular.woff2'
+import SourceSans600 from '@assets/fonts/source-sans-pro-v13-latin_latin-ext-600.woff2'
+import SourceSans700 from '@assets/fonts/source-sans-pro-v13-latin_latin-ext-700.woff2'
+import IBMPlexMono from '@assets/fonts/ibm-plex-mono-regular.woff2'
+import MaterialIcons from '@assets/fonts/materialicons.woff2'
 import LAYOUT from '@ttn-lw/constants/layout'
 
 import Spinner from '@ttn-lw/components/spinner'
@@ -32,6 +37,9 @@ import '@ttn-lw/styles/main.styl'
 const m = defineMessages({
   initializing: 'Initializing…',
 })
+
+// Keep this list updated with fonts used in `/styles/fonts.styl`.
+const fontsToPreload = [SourceSansRegular, SourceSans600, SourceSans700, IBMPlexMono, MaterialIcons]
 
 setConfiguration({
   breakpoints: [
@@ -75,6 +83,16 @@ export default class Init extends React.PureComponent {
     const { initialize } = this.props
 
     initialize()
+
+    // Preload font files to avoid flashes of unstyled text.
+    for (const fontUrl of fontsToPreload) {
+      const linkElem = document.createElement('link')
+      linkElem.setAttribute('rel', 'preload')
+      linkElem.setAttribute('href', fontUrl)
+      linkElem.setAttribute('as', 'font')
+      linkElem.setAttribute('crossorigin', 'anonymous')
+      document.getElementsByTagName('head')[0].appendChild(linkElem)
+    }
   }
 
   render() {

--- a/pkg/webui/styles/fonts.styl
+++ b/pkg/webui/styles/fonts.styl
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Note: Make sure to add any font `*.woff2` font files here to the preload list
+// in `/lib/components/init.js` to the `fontsToPreload` array to have them
+// properly preloaded and avoid flashes of unstyled text on initial page load.
+
 // source-sans-pro-regular - latin_latin-ext
 @font-face
   font-family: 'Source Sans Pro'
@@ -20,7 +24,6 @@
   font-display: fallback
   src: url('../assets/fonts/source-sans-pro-v13-latin_latin-ext-regular.eot') // IE9 Compat Modes.
   src: local('Source Sans Pro Regular'), local('SourceSansPro-Regular'),
-      url('../assets/fonts/source-sans-pro-v13-latin_latin-ext-regular.eot?#iefix') format('embedded-opentype'), // @stylint ignore /* IE6-IE8 */
       url('../assets/fonts/source-sans-pro-v13-latin_latin-ext-regular.woff2') format('woff2'), // @stylint ignore /* Super Modern Browsers */
       url('../assets/fonts/source-sans-pro-v13-latin_latin-ext-regular.woff') format('woff'), // @stylint ignore /* Modern Browsers */
       url('../assets/fonts/source-sans-pro-v13-latin_latin-ext-regular.ttf') format('truetype'), // @stylint ignore /* Safari, Android, iOS */
@@ -33,7 +36,6 @@
   font-display: fallback
   src: url('../assets/fonts/source-sans-pro-v13-latin_latin-ext-600.eot') // IE9 Compat Modes.
   src: local('Source Sans Pro SemiBold'), local('SourceSansPro-SemiBold'),
-    url('../assets/fonts/source-sans-pro-v13-latin_latin-ext-600.eot?#iefix') format('embedded-opentype'), // @stylint ignore /* IE6-IE8 */
     url('../assets/fonts/source-sans-pro-v13-latin_latin-ext-600.woff2') format('woff2'), // @stylint ignore /* Super Modern Browsers */
     url('../assets/fonts/source-sans-pro-v13-latin_latin-ext-600.woff') format('woff'), // @stylint ignore /* Modern Browsers */
     url('../assets/fonts/source-sans-pro-v13-latin_latin-ext-600.ttf') format('truetype'), // @stylint ignore /* Safari, Android, iOS */
@@ -47,7 +49,6 @@
   font-display: fallback
   src: url('../assets/fonts/source-sans-pro-v13-latin_latin-ext-700.eot') // IE9 Compat Modes.
   src: local('Source Sans Pro Bold'), local('SourceSansPro-Bold'),
-      url('../assets/fonts/source-sans-pro-v13-latin_latin-ext-700.eot?#iefix') format('embedded-opentype'), // @stylint ignore /* IE6-IE8 */
       url('../assets/fonts/source-sans-pro-v13-latin_latin-ext-700.woff2') format('woff2'), // @stylint ignore /* Super Modern Browsers */
       url('../assets/fonts/source-sans-pro-v13-latin_latin-ext-700.woff') format('woff'), // @stylint ignore /* Modern Browsers */
       url('../assets/fonts/source-sans-pro-v13-latin_latin-ext-700.ttf') format('truetype'), // @stylint ignore /* Safari, Android, iOS */
@@ -60,7 +61,6 @@
   font-display: fallback
   src: url('../assets/fonts/ibm-plex-mono-regular.eot') // IE9 Compat Modes.
   src: local('IBM Plex Mono'), local('IBMPlexMono'),
-      url('../assets/fonts/ibm-plex-mono-regular.eot?#iefix') format('embedded-opentype'), // @stylint ignore /* IE6-IE8 */
       url('../assets/fonts/ibm-plex-mono-regular.woff2') format('woff2'), // @stylint ignore /* Super Modern Browsers */
       url('../assets/fonts/ibm-plex-mono-regular.woff') format('woff'), // @stylint ignore /* Modern Browsers */
       url('../assets/fonts/ibm-plex-mono-regular.ttf') format('truetype'), // @stylint ignore /* Safari, Android, iOS */


### PR DESCRIPTION
#### Summary
This quickfix PR will add a proper font preloading mechanism to the web UI that will prevent FOUT (flash of unstyled text) on initial page load.

#### Changes
<!-- What are the changes made in this pull request? -->

- Append font files as `<link rel="preload" as="font" ... />` to cause proper browser controlled file preloading
- Remove `.eot` bit of font-famliy definitions, since we dont support IE8 and smaller anyway


#### Testing

Manual testing.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
