### PR TITLE
Skip the application uplink queue if the peer is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - Cache Root CA for client TLS configuration.
 - Identity Server no longer allows removing the `_ALL` right from entity collaborators if that leaves the entity without any collaborator that has the `_ALL` right.
+- The Network Server application uplink queue may now be skipped if the Application Server peer is available at enqueue time.
 
 ### Deprecated
 

--- a/pkg/networkserver/observability.go
+++ b/pkg/networkserver/observability.go
@@ -232,6 +232,14 @@ var nsMetrics = &messageMetrics{
 		},
 		[]string{messageType},
 	),
+
+	uplinkSenders: metrics.NewGauge(
+		prometheus.GaugeOpts{
+			Subsystem: subsystem,
+			Name:      "uplink_senders_count",
+			Help:      "Application Uplink sender workers count",
+		},
+	),
 }
 
 func init() {
@@ -251,6 +259,8 @@ type messageMetrics struct {
 
 	downlinkAttempted *metrics.ContextualCounterVec
 	downlinkForwarded *metrics.ContextualCounterVec
+
+	uplinkSenders prometheus.Gauge
 }
 
 func (m messageMetrics) Describe(ch chan<- *prometheus.Desc) {
@@ -266,6 +276,8 @@ func (m messageMetrics) Describe(ch chan<- *prometheus.Desc) {
 
 	m.downlinkAttempted.Describe(ch)
 	m.downlinkForwarded.Describe(ch)
+
+	m.uplinkSenders.Describe(ch)
 }
 
 func (m messageMetrics) Collect(ch chan<- prometheus.Metric) {
@@ -281,6 +293,8 @@ func (m messageMetrics) Collect(ch chan<- prometheus.Metric) {
 
 	m.downlinkAttempted.Collect(ch)
 	m.downlinkForwarded.Collect(ch)
+
+	m.uplinkSenders.Collect(ch)
 }
 
 func mTypeLabel(mType ttnpb.MType) string {
@@ -364,4 +378,12 @@ func registerForwardConfirmedDataDownlink(ctx context.Context) {
 
 func registerForwardJoinAcceptDownlink(ctx context.Context) {
 	nsMetrics.downlinkForwarded.WithLabelValues(ctx, joinAcceptDownlinkMTypeLabel).Inc()
+}
+
+func registerUplinkSenderStarted() {
+	nsMetrics.uplinkSenders.Inc()
+}
+
+func registerUplinkSenderFinished() {
+	nsMetrics.uplinkSenders.Dec()
 }

--- a/pkg/networkserver/utils.go
+++ b/pkg/networkserver/utils.go
@@ -19,12 +19,14 @@ import (
 	"fmt"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/band"
+	"go.thethings.network/lorawan-stack/v3/pkg/component"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	. "go.thethings.network/lorawan-stack/v3/pkg/networkserver/internal"
 	"go.thethings.network/lorawan-stack/v3/pkg/networkserver/internal/time"
 	"go.thethings.network/lorawan-stack/v3/pkg/networkserver/mac"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/unique"
 )
 
 // nsScheduleWindow returns minimum time.Duration between downlink being added to the queue and it being sent to GS for transmission.
@@ -381,9 +383,63 @@ func (ns *NetworkServer) enqueueApplicationUplinks(ctx context.Context, ups ...*
 	if n == 0 {
 		return
 	}
-	logger := log.FromContext(ctx).WithField("uplink_count", n)
-	logger.Debug("Enqueue application uplinks for sending to Application Server")
-	if err := ns.applicationUplinks.Add(ctx, ups...); err != nil {
-		logger.WithError(err).Warn("Failed to enqueue application uplinks for sending to Application Server")
+
+	enqueue := func(ctx context.Context, ups ...*ttnpb.ApplicationUp) {
+		log.FromContext(ctx).Debug("Enqueue application uplinks for sending to Application Server")
+		if err := ns.applicationUplinks.Add(ctx, ups...); err != nil {
+			log.FromContext(ctx).WithError(err).Warn("Failed to enqueue application uplinks for sending to Application Server")
+		}
 	}
+
+	send := func(ctx context.Context, appID ttnpb.ApplicationIdentifiers, ups ...*ttnpb.ApplicationUp) error {
+		conn, err := ns.GetPeerConn(ctx, ttnpb.ClusterRole_APPLICATION_SERVER, &appID)
+		if err != nil {
+			log.FromContext(ctx).WithError(err).Warn("Failed to get Application Server peer")
+			return err
+		}
+		if err := ns.sendApplicationUplinks(ctx, ttnpb.NewNsAsClient(conn), appID, ups...); err != nil {
+			log.FromContext(ctx).WithError(err).Error("Failed to send application uplinks")
+			return err
+		}
+		return nil
+	}
+
+	partitionAndSend := func(ctx context.Context) error {
+		registerUplinkSenderStarted()
+		defer registerUplinkSenderFinished()
+
+		m := make(map[string][]*ttnpb.ApplicationUp)
+		for _, up := range ups {
+			appID := up.ApplicationIdentifiers.ApplicationId
+			m[appID] = append(m[appID], up)
+		}
+		for id, ups := range m {
+			appID := ttnpb.ApplicationIdentifiers{
+				ApplicationId: id,
+			}
+			ctx := log.NewContextWithFields(ctx, log.Fields(
+				"application_uid", unique.ID(ctx, appID),
+				"uplink_count", len(ups),
+			))
+			if err := send(ctx, appID, ups...); err != nil {
+				log.FromContext(ctx).WithError(err).Warn("Failed to send application uplinks to Application Server")
+				enqueue(ctx, ups...)
+			}
+		}
+		return nil
+	}
+
+	if !ns.uplinkQueueSemaphore.TryAcquire(1) {
+		enqueue(ctx, ups...)
+		return
+	}
+
+	ns.StartTask(&component.TaskConfig{
+		Context: ns.FromRequestContext(ctx),
+		ID:      sendApplicationUplinkTaskName,
+		Func:    partitionAndSend,
+		Done:    func() { ns.uplinkQueueSemaphore.Release(1) },
+		Restart: component.TaskRestartNever,
+		Backoff: component.DialTaskBackoffConfig,
+	})
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #4360 

#### Changes
<!-- What are the changes made in this pull request? -->

- The Network Server application uplink queue is now skipped if the Network Server successfully retrieves the Application Server peer and submits the uplinks.
  - The submission is done in a separate task. The concurrency is limited to 1024 tasks. When all tasks have been used, the NS automatically enqueues the uplinks.


#### Testing

<!-- How did you verify that this change works? -->

Unit testing and local testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

We'll have more uplinks in memory after this change, but that's still faster than the queue path.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
