### PR TITLE
Fix active styling of dropdown items

### DIFF
--- a/pkg/webui/components/dropdown/index.js
+++ b/pkg/webui/components/dropdown/index.js
@@ -76,12 +76,7 @@ const DropdownItem = ({
       <Message content={title} />
     </button>
   ) : external ? (
-    <Link.Anchor
-      href={path}
-      external
-      tabIndex={tabIndex}
-      className={classnames(style.button, activeClassName)}
-    >
+    <Link.Anchor href={path} external tabIndex={tabIndex} className={style.button}>
       {Boolean(iconElement) ? iconElement : null}
       <Message content={title} />
     </Link.Anchor>


### PR DESCRIPTION
#### Summary
Small quickfix of a bug that was introduced via #4465, causing the dropdown item of external links to be shown as active.

#### Changes
- Remove unnecessary active style for external links

#### Testing

Manual

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
