### PR TITLE
Use correct assets URL in frontend

### DIFF
--- a/pkg/webui/account.js
+++ b/pkg/webui/account.js
@@ -23,7 +23,7 @@ import store, { history } from '@account/store'
 import WithLocale from '@ttn-lw/lib/components/with-locale'
 import Init from '@ttn-lw/lib/components/init'
 
-import { selectSentryDsnConfig } from '@ttn-lw/lib/selectors/env'
+import { selectSentryDsnConfig, selectAssetsRootPath } from '@ttn-lw/lib/selectors/env'
 
 import '@ttn-lw/lib/yup'
 
@@ -31,6 +31,12 @@ import '@ttn-lw/lib/yup'
 if (selectSentryDsnConfig()) {
   Sentry.init(sentryConfig)
 }
+
+const assetsRoot = selectAssetsRootPath()
+
+// Set asset path based on passed env configuration.
+// eslint-disable-next-line no-undef
+__webpack_public_path__ = `${assetsRoot}/`
 
 const render = () => {
   const App = require('./account/views/app').default

--- a/pkg/webui/console.js
+++ b/pkg/webui/console.js
@@ -27,15 +27,26 @@ import Init from '@ttn-lw/lib/components/init'
 import WithLocale from '@ttn-lw/lib/components/with-locale'
 
 import env from '@ttn-lw/lib/env'
-import { selectApplicationRootPath } from '@ttn-lw/lib/selectors/env'
+import {
+  selectApplicationRootPath,
+  selectAssetsRootPath,
+  selectSentryDsnConfig,
+} from '@ttn-lw/lib/selectors/env'
 
 import createStore from './console/store'
 
+const sentryDsn = selectSentryDsnConfig()
 const appRoot = selectApplicationRootPath()
+const assetsRoot = selectAssetsRootPath()
+
 const history = createBrowserHistory({ basename: `${appRoot}/` })
 // Initialize sentry before creating store.
-if (env.sentryDsn) Sentry.init(sentryConfig)
+if (sentryDsn) Sentry.init(sentryConfig)
 const store = createStore(history)
+
+// Set asset path based on passed env configuration.
+// eslint-disable-next-line no-undef
+__webpack_public_path__ = `${assetsRoot}/`
 
 const rootElement = document.getElementById('app')
 


### PR DESCRIPTION
#### Summary
This quickfix PR will make sure that the web UIs use the correct asset URL everywhere.

#### Changes
- Use dynamic `__webpack_public_path__` way of setting the assets URL


#### Testing

CI should be enough.

#### Notes for Reviewers
We currently use `/assets` in many places instead of the passed `ASSETS_ROOT` URL. This has not been a problem in our deployments, since both URLs work. But it will become a problem when using a different path than relative `/assets`. Also font preloading is not working as it should now, due to two different URLs being used for preloading and actual loading via the CSS.

E.g.
`https://tti.staging1.cloud.thethings.industries/assets/packet-broker.443f32ab8be6b3c3732c158925ff0527.svg`
vs
`https://assets.cloud.thethings.industries/packet-broker.443f32ab8be6b3c3732c158925ff0527.svg`

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
