### PR TITLE
Remove Packet Broker metadata from same cluster

### DIFF
--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -698,7 +698,7 @@ var handleDataUplinkGetPaths = [...]string{
 }
 
 // mergeMetadata merges the metadata collected for up.
-// mergeMetadata mutates up.RxMetadata discarding any existing up.RxMetadata value.
+// mergeMetadata mutates up.RxMetadata.
 func (ns *NetworkServer) mergeMetadata(ctx context.Context, up *ttnpb.UplinkMessage) {
 	mds, err := ns.uplinkDeduplicator.AccumulatedMetadata(ctx, up)
 	if err != nil {
@@ -708,6 +708,31 @@ func (ns *NetworkServer) mergeMetadata(ctx context.Context, up *ttnpb.UplinkMess
 	up.RxMetadata = mds
 	log.FromContext(ctx).WithField("metadata_count", len(up.RxMetadata)).Debug("Merged metadata")
 	registerMergeMetadata(ctx, up)
+}
+
+// filterMetadata filters the collected metadata.
+// filterMetadata removes metadata from Packet Broker that has been received from a forwarder that identifies like this
+// Network Server identifies itself. This is to avoid that failed downlink attempts through Gateway Server lead to
+// downlink scheduling attempts through Packet Broker, ending up on the same Gateway Server that already failed to schedule.
+// filterMetadata mutates up.RxMetadata.
+func (ns *NetworkServer) filterMetadata(ctx context.Context, up *ttnpb.UplinkMessage) {
+	mds := make([]*ttnpb.RxMetadata, 0, len(up.RxMetadata))
+	for _, md := range up.RxMetadata {
+		if pbMD := md.GetPacketBroker(); pbMD != nil {
+			if pbMD.ForwarderNetId.Equal(ns.netID) &&
+				pbMD.ForwarderClusterId == ns.clusterID {
+				continue
+			}
+		}
+		mds = append(mds, md)
+	}
+	up.RxMetadata = mds
+	if d := cap(mds) - len(mds); d > 0 {
+		log.FromContext(ctx).WithFields(log.Fields(
+			"metadata_count", len(mds),
+			"filtered_count", d,
+		)).Debug("Filtered metadata")
+	}
 }
 
 func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkMessage) (err error) {
@@ -825,6 +850,7 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 	case <-ns.deduplicationDone(ctx, up):
 	}
 	ns.mergeMetadata(ctx, up)
+	ns.filterMetadata(ctx, up)
 
 	for _, f := range matched.DeferredMACHandlers {
 		evs, err := f(ctx, matched.Device, up)
@@ -1145,6 +1171,7 @@ func (ns *NetworkServer) handleJoinRequest(ctx context.Context, up *ttnpb.Uplink
 	case <-ns.deduplicationDone(ctx, up):
 	}
 	ns.mergeMetadata(ctx, up)
+	ns.filterMetadata(ctx, up)
 	macState.RecentUplinks = []*ttnpb.UplinkMessage{{
 		Payload:            up.Payload,
 		Settings:           up.Settings,

--- a/pkg/networkserver/internal/test/test.go
+++ b/pkg/networkserver/internal/test/test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/mohae/deepcopy"
 	"go.thethings.network/lorawan-stack/v3/pkg/band"
+	"go.thethings.network/lorawan-stack/v3/pkg/cluster"
 	"go.thethings.network/lorawan-stack/v3/pkg/crypto"
 	"go.thethings.network/lorawan-stack/v3/pkg/encoding/lorawan"
 	"go.thethings.network/lorawan-stack/v3/pkg/frequencyplans"
@@ -168,6 +169,28 @@ var (
 			Snr:                    -7,
 			UplinkToken:            []byte("token-gtw-4"),
 			DownlinkPathConstraint: ttnpb.DOWNLINK_PATH_CONSTRAINT_PREFER_OTHER,
+		},
+	}
+	PacketBrokerRxMetadata = [...]*ttnpb.RxMetadata{
+		{
+			GatewayIdentifiers: ttnpb.GatewayIdentifiers{GatewayId: cluster.PacketBrokerGatewayID.GatewayId},
+			Snr:                4.2,
+			UplinkToken:        []byte("token-pb-1"),
+			PacketBroker: &ttnpb.PacketBrokerMetadata{
+				ForwarderNetId:     test.DefaultNetID,
+				ForwarderClusterId: "test-cluster",
+			},
+			DownlinkPathConstraint: ttnpb.DOWNLINK_PATH_CONSTRAINT_NEVER,
+		},
+		{
+			GatewayIdentifiers: ttnpb.GatewayIdentifiers{GatewayId: cluster.PacketBrokerGatewayID.GatewayId},
+			Snr:                1.8,
+			UplinkToken:        []byte("token-pb-2"),
+			PacketBroker: &ttnpb.PacketBrokerMetadata{
+				ForwarderNetId:     test.DefaultNetID,
+				ForwarderClusterId: "other-cluster",
+			},
+			DownlinkPathConstraint: ttnpb.DOWNLINK_PATH_CONSTRAINT_NEVER,
 		},
 	}
 

--- a/pkg/networkserver/networkserver_flow_test.go
+++ b/pkg/networkserver/networkserver_flow_test.go
@@ -212,6 +212,7 @@ func makeOTAAFlowTest(conf OTAAFlowTestConfig) func(context.Context, TestEnviron
 			RxMetadatas: [][]*ttnpb.RxMetadata{
 				DefaultRxMetadata[:2],
 				DefaultRxMetadata[2:],
+				PacketBrokerRxMetadata[:],
 			},
 			CorrelationIDs: []string{"GsNs-data-0"},
 
@@ -409,6 +410,7 @@ func TestFlow(t *testing.T) {
 						return &d
 					}()
 					nsConf.NetID = test.Must(types.NewNetID(2, []byte{1, 2, 3})).(types.NetID)
+					nsConf.ClusterID = "test-cluster"
 					nsConf.DeduplicationWindow = (1 << 8) * test.Delay
 					nsConf.CooldownWindow = (1 << 11) * test.Delay
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Remove Packet Broker metadata from same cluster

Also addresses https://github.com/TheThingsNetwork/lorawan-stack/pull/3603#issuecomment-876327450 cc @rvolosatovs 

#### Changes
<!-- What are the changes made in this pull request? -->

- Filter Packet Broker metadata where the forwarder network equals the current Network Server. This is to avoid that packets that are received through Packet Broker are added to the deduplicated RX metadata, which are in turn used for downlink scheduling. This should drastically reduce failed and redundant downlink scheduling attempts through Packet Broker. Currently, when scheduling through GS doesn't work, NS tries scheduling through Packet Broker, but without filtering RX metadata, it will end up at the very same GS.
- Also fixed usage of `fallthrough`

#### Testing

<!-- How did you verify that this change works? -->

Current flow tests do not support distinguishing between input RX metadata and expected RX metadata. This PR doesn't really introduce the need for testing that.

Also, current flow tests do not support scheduling through Packet Broker. The `AssertScheduleDownlink()` only supports the `NsGs` interface. I think this will become relevant to include in tests at some point, but only when we get feedback from Packet Broker that a downlink message has or has not been scheduled, and another attempt through Packet Broker can be made. If Packet Broker won't support it itself, that is. So let's see about this later.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None expected

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
