### PR TITLE
Fix grpc address of the IS for TTS CE in the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Generated CLI configuration for The Things Stack Community Edition.
+
 ### Security
 
 ## [3.14.1] - 2021-08-06

--- a/cmd/ttn-lw-cli/commands/use.go
+++ b/cmd/ttn-lw-cli/commands/use.go
@@ -123,7 +123,7 @@ var (
 				clusterID := matches[1]
 				logger.WithField("cluster_id", clusterID).Info("Configuring for The Things Stack Community Edition")
 				conf.OAuthServerAddress = "https://eu1.cloud.thethings.network/oauth"
-				conf.IdentityServerGRPCAddress = fmt.Sprintf("eu1.cloud.thethings.industries:%d", discover.DefaultPorts[!insecure])
+				conf.IdentityServerGRPCAddress = fmt.Sprintf("eu1.cloud.thethings.network:%d", discover.DefaultPorts[!insecure])
 				logger.WithField("address", conf.OAuthServerAddress).Info("Set OAuth Server address")
 				logger.WithField("address", conf.IdentityServerGRPCAddress).Info("Set Identity Server gRPC address")
 			}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fix grpc address of the IS for TTS CE in the CLI

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix grpc address of the IS for TTS CE in the CLI

#### Testing

<!-- How did you verify that this change works? -->

Locally built and tested

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

NA

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
