### PR TITLE
Fix end device access with limited rights in the Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Fixed
 
 - Generated CLI configuration for The Things Stack Community Edition.
+- End device access with limited rights in the Console.
 
 ### Security
 

--- a/pkg/webui/console/store/middleware/logics/devices.js
+++ b/pkg/webui/console/store/middleware/logics/devices.js
@@ -75,9 +75,12 @@ const getDevicesListLogic = createRequestLogic({
 
     if (options.withLastSeen) {
       const macStateFetching = data.end_devices.map(async device => {
-        const deviceResult = await api.device.get(appId, device.ids.device_id, 'mac_state', [
-          STACK_COMPONENTS_MAP.ns,
-        ])
+        const deviceResult = await api.device.get(
+          appId,
+          device.ids.device_id,
+          'mac_state.recent_uplinks',
+          [STACK_COMPONENTS_MAP.ns],
+        )
         if ('mac_state' in deviceResult) {
           device.mac_state = deviceResult.mac_state
         }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

From the community slack:
> Giving "View devices in application" permission gives "error listing devices" without "View device keys ..." added to perms to see a device page.

This PR makes sure that the users without `RIGHT_APPLICATION_DEVICES_READ_KEYS`, but with `RIGHT_APPLICATION_DEVICES_READ` can list application end devices and view them in the Console

#### Changes
<!-- What are the changes made in this pull request? -->

- Check for `RIGHT_APPLICATION_DEVICES_READ_KEYS` when requesting last seen info


#### Testing

<!-- How did you verify that this change works? -->

Manual


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
