### PR TITLE
Make pkg errors always use pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ For details about compatibility between different releases, see the **Commitment
 - End device access with limited rights in the Console.
 - Parsing of ID6 encoded EUIs from Basic Station gateways.
 - Warnings about unknown fields when getting or searching for gateways.
+- Internal Server Errors from `pkg/identityserver/store`.
 
 ### Security
 

--- a/pkg/crypto/errors.go
+++ b/pkg/crypto/errors.go
@@ -20,7 +20,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 )
 
-func errInvalidSize(typeName, typeDescription, expectedSize string) errors.Definition {
+func errInvalidSize(typeName, typeDescription, expectedSize string) *errors.Definition {
 	return errors.DefineInvalidArgument(
 		fmt.Sprintf("%s_size", typeName),
 		fmt.Sprintf("invalid %s size of {size} bytes, expected %s bytes", typeDescription, expectedSize),

--- a/pkg/encoding/lorawan/errors.go
+++ b/pkg/encoding/lorawan/errors.go
@@ -35,12 +35,12 @@ var (
 
 const valueKey = "value"
 
-type valueErr func(interface{}) errors.Error
+type valueErr func(interface{}) *errors.Error
 
 func unexpectedValue(err interface {
-	WithAttributes(kv ...interface{}) errors.Error
+	WithAttributes(kv ...interface{}) *errors.Error
 }) valueErr {
-	return func(value interface{}) errors.Error {
+	return func(value interface{}) *errors.Error {
 		return err.WithAttributes(valueKey, value)
 	}
 }
@@ -77,11 +77,11 @@ func errExpectedLengthEncodedTwoChoices(lorawanField string, expected1, expected
 	return unexpectedValue(errEncodedFieldLengthTwoChoices.WithAttributes("lorawan_field", lorawanField, "expected_1", expected1, "expected_2", expected2))
 }
 
-func errFailedEncoding(lorawanField string) errors.Error {
+func errFailedEncoding(lorawanField string) *errors.Error {
 	return errEncode.WithAttributes("lorawan_field", lorawanField)
 }
 
-func errFailedDecoding(lorawanField string) errors.Error {
+func errFailedDecoding(lorawanField string) *errors.Error {
 	return errDecode.WithAttributes("lorawan_field", lorawanField)
 }
 
@@ -89,7 +89,7 @@ func errUnknown(lorawanField string) valueErr {
 	return unexpectedValue(errUnknownField.WithAttributes("lorawan_field", lorawanField))
 }
 
-func errMissing(lorawanField string) errors.Error {
+func errMissing(lorawanField string) *errors.Error {
 	return errUnknownField.WithAttributes("lorawan_field", lorawanField)
 }
 

--- a/pkg/errors/attributes.go
+++ b/pkg/errors/attributes.go
@@ -100,23 +100,38 @@ func (e *Error) mergeAttributes(kv ...interface{}) {
 
 // WithAttributes returns the error with the given attributes set.
 // Any conflicting attributes in the Error will be overwritten.
-func (e Error) WithAttributes(kv ...interface{}) Error {
-	e.mergeAttributes(kv...)
-	return e
+func (e *Error) WithAttributes(kv ...interface{}) *Error {
+	if e == nil {
+		return e
+	}
+	deriv := *e
+	deriv.mergeAttributes(kv...)
+	return &deriv
 }
 
 // WithAttributes returns a new error from the definition, and sets the given attributes.
-func (d Definition) WithAttributes(kv ...interface{}) Error {
+func (d *Definition) WithAttributes(kv ...interface{}) *Error {
+	if d == nil {
+		return nil
+	}
 	e := build(d, 0) // Don't refactor this to build(...).WithAttributes(...)
 	e.mergeAttributes(kv...)
 	return e
 }
 
 // Attributes of the error.
-func (e Error) Attributes() map[string]interface{} { return e.attributes }
+func (e *Error) Attributes() map[string]interface{} {
+	if e == nil {
+		return nil
+	}
+	return e.attributes
+}
 
 // PublicAttributes of the error.
-func (e Error) PublicAttributes() map[string]interface{} {
+func (e *Error) PublicAttributes() map[string]interface{} {
+	if e == nil {
+		return nil
+	}
 	if len(e.attributes) == 0 {
 		return nil
 	}
@@ -137,10 +152,10 @@ nextAttr:
 }
 
 // Attributes are not present in the error definition, so this just returns nil.
-func (d Definition) Attributes() map[string]interface{} { return nil }
+func (d *Definition) Attributes() map[string]interface{} { return nil }
 
 // PublicAttributes are not present in the error definition, so this just returns nil.
-func (d Definition) PublicAttributes() map[string]interface{} { return nil }
+func (d *Definition) PublicAttributes() map[string]interface{} { return nil }
 
 // Attributes returns the attributes of the errors, if they implement Attributes().
 // If more than one error is passed, subsequent error attributes will be added if not set.

--- a/pkg/errors/causes.go
+++ b/pkg/errors/causes.go
@@ -36,23 +36,35 @@ func (e *Error) setCause(cause error) {
 
 // WithCause returns the error with the given cause set.
 // Overwriting an existing cause in the Error will cause a panic.
-func (e Error) WithCause(cause error) Error {
-	e.setCause(cause)
-	return e
+func (e *Error) WithCause(cause error) *Error {
+	if e == nil {
+		return nil
+	}
+	dup := *e
+	dup.setCause(cause)
+	return &dup
 }
 
 // WithCause returns a new error from the definition, and sets the cause of the error.
-func (d Definition) WithCause(cause error) Error {
+func (d *Definition) WithCause(cause error) *Error {
+	if d == nil {
+		return nil
+	}
 	e := build(d, 0) // Don't refactor this to build(...).WithCause(...)
 	e.setCause(cause)
 	return e
 }
 
 // Cause returns the cause of the error.
-func (e Error) Cause() error { return e.cause }
+func (e *Error) Cause() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
 
 // Cause returns ret root cause of the error, in this case the descriptor itself.
-func (d Definition) Cause() error { return nil }
+func (*Definition) Cause() error { return nil }
 
 // Cause returns the cause of the given error, if any.
 func Cause(err error) error {

--- a/pkg/errors/causes_test.go
+++ b/pkg/errors/causes_test.go
@@ -25,9 +25,9 @@ import (
 func TestCause(t *testing.T) {
 	a := assertions.New(t)
 
-	var cause = errors.New("cause")
+	cause := errors.New("cause")
 
-	var errInvalidFoo = errors.DefineInvalidArgument("test_cause_invalid_foo", "Invalid Foo: {foo}", "foo")
+	errInvalidFoo := errors.DefineInvalidArgument("test_cause_invalid_foo", "Invalid Foo: {foo}", "foo")
 
 	a.So(errInvalidFoo.Cause(), should.EqualErrorOrDefinition, nil)
 	a.So(errors.RootCause(errInvalidFoo), should.EqualErrorOrDefinition, errInvalidFoo)
@@ -39,15 +39,15 @@ func TestCause(t *testing.T) {
 	}, should.Panic)
 
 	a.So(err1, should.HaveSameErrorDefinitionAs, errInvalidFoo)
-	a.So(err1.Cause(), should.EqualErrorOrDefinition, &cause)
-	a.So(errors.RootCause(err1), should.EqualErrorOrDefinition, &cause)
-	a.So(errors.Stack(err1), should.Resemble, []error{err1, &cause})
+	a.So(err1.Cause(), should.EqualErrorOrDefinition, cause)
+	a.So(errors.RootCause(err1), should.EqualErrorOrDefinition, cause)
+	a.So(errors.Stack(err1), should.Resemble, []error{err1, cause})
 
-	var errInvalidBar = errors.DefineInvalidArgument("test_cause_invalid_bar", "Invalid Bar")
-	err2 := errInvalidBar.WithCause(&err1)
+	errInvalidBar := errors.DefineInvalidArgument("test_cause_invalid_bar", "Invalid Bar")
+	err2 := errInvalidBar.WithCause(err1)
 
 	a.So(err2, should.HaveSameErrorDefinitionAs, errInvalidBar)
-	a.So(err2.Cause(), should.EqualErrorOrDefinition, &err1)
-	a.So(errors.RootCause(err2), should.EqualErrorOrDefinition, &cause)
-	a.So(errors.Stack(err2), should.Resemble, []error{err2, &err1, &cause})
+	a.So(err2.Cause(), should.EqualErrorOrDefinition, err1)
+	a.So(errors.RootCause(err2), should.EqualErrorOrDefinition, cause)
+	a.So(errors.Stack(err2), should.Resemble, []error{err2, err1, cause})
 }

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -27,7 +27,10 @@ type coder interface {
 // Code of the error.
 // If the code is invalid or unknown, this tries to get the code from the cause of this error.
 // This code is consistent with google.golang.org/genproto/googleapis/rpc/code and google.golang.org/grpc/codes.
-func (e Error) Code() uint32 {
+func (e *Error) Code() uint32 {
+	if e == nil {
+		return 0
+	}
 	if e.code != 0 && e.code != uint32(codes.Unknown) {
 		return e.code
 	}

--- a/pkg/errors/comparison_test.go
+++ b/pkg/errors/comparison_test.go
@@ -40,11 +40,8 @@ func TestResembles(t *testing.T) {
 	errInvalidArgument := defInvalidArgument.WithAttributes("foo", "bar")
 	grpcErrInvalidArgument := errInvalidArgument.GRPCStatus().Err()
 
-	// Errors and definitions resemble all pointer/non-pointer combinations:
+	// Errors and definitions resemble:
 	a.So(errors.Resemble(errInvalidArgument, defInvalidArgument), should.BeTrue)
-	a.So(errors.Resemble(errInvalidArgument, &defInvalidArgument), should.BeTrue)
-	a.So(errors.Resemble(&errInvalidArgument, defInvalidArgument), should.BeTrue)
-	a.So(errors.Resemble(&errInvalidArgument, &defInvalidArgument), should.BeTrue)
 
 	// Should resemble gRPC error:
 	a.So(errors.Resemble(grpcErrInvalidArgument, defInvalidArgument), should.BeTrue)

--- a/pkg/errors/correlation.go
+++ b/pkg/errors/correlation.go
@@ -15,7 +15,12 @@
 package errors
 
 // CorrelationID of the error.
-func (e Error) CorrelationID() string { return e.correlationID }
+func (e *Error) CorrelationID() string {
+	if e == nil {
+		return ""
+	}
+	return e.correlationID
+}
 
 // CorrelationID is not present in the error definition, so this just returns an empty string.
-func (d Definition) CorrelationID() string { return "" }
+func (*Definition) CorrelationID() string { return "" }

--- a/pkg/errors/definitions.go
+++ b/pkg/errors/definitions.go
@@ -48,13 +48,26 @@ type DefinitionInterface interface {
 }
 
 // Namespace of the error.
-func (d Definition) Namespace() string { return d.namespace }
+func (d *Definition) Namespace() string {
+	if d == nil {
+		return ""
+	}
+	return d.namespace
+}
 
 // Name of the error.
-func (d Definition) Name() string { return d.name }
+func (d *Definition) Name() string {
+	if d == nil {
+		return ""
+	}
+	return d.name
+}
 
 // FullName returns the full name (namespace:name) of the error.
-func (d Definition) FullName() string {
+func (d *Definition) FullName() string {
+	if d == nil {
+		return ""
+	}
 	namespace := d.namespace
 	if namespace == "" {
 		namespace = "unknown"
@@ -67,18 +80,36 @@ func (d Definition) FullName() string {
 }
 
 // MessageFormat of the error.
-func (d Definition) MessageFormat() string { return d.messageFormat }
+func (d *Definition) MessageFormat() string {
+	if d == nil {
+		return ""
+	}
+	return d.messageFormat
+}
 
 // Code of the error.
 // This code is consistent with google.golang.org/genproto/googleapis/rpc/code and google.golang.org/grpc/codes.
-func (d Definition) Code() uint32 { return d.code }
+func (d *Definition) Code() uint32 {
+	if d == nil {
+		return 0
+	}
+	return d.code
+}
 
-func (d Definition) String() string {
+func (d *Definition) String() string {
+	if d == nil {
+		return ""
+	}
 	return fmt.Sprintf("error:%s (%s)", d.FullName(), d.messageFormat)
 }
 
 // Error implements the error interface.
-func (d Definition) Error() string { return d.String() }
+func (d *Definition) Error() string {
+	if d == nil {
+		return ""
+	}
+	return d.String()
+}
 
 var messageFormatArgument = regexp.MustCompile(`\{[\s]*([a-z0-9_]+)`)
 
@@ -99,7 +130,7 @@ func messageFormatArguments(messageFormat string) (args []string) {
 	return
 }
 
-func define(code uint32, name, messageFormat string, publicAttributes ...string) Definition {
+func define(code uint32, name, messageFormat string, publicAttributes ...string) *Definition {
 	ns := namespace(3)
 	if code == 0 {
 		code = uint32(codes.Unknown)
@@ -143,7 +174,7 @@ nextArg:
 	desc := i18n.Define(fmt.Sprintf("error:%s", fullName), def.messageFormat)
 	desc.SetSource(2)
 
-	return def
+	return &def
 }
 
 // Definitions of registered errors.
@@ -151,36 +182,36 @@ nextArg:
 var Definitions = make(map[string]*Definition)
 
 // Define defines a registered error of type Unknown.
-func Define(name, messageFormat string, publicAttributes ...string) Definition {
+func Define(name, messageFormat string, publicAttributes ...string) *Definition {
 	return define(uint32(codes.Unknown), name, messageFormat, publicAttributes...)
 }
 
 // DefineInvalidArgument defines a registered error of type InvalidArgument.
-func DefineInvalidArgument(name, messageFormat string, publicAttributes ...string) Definition {
+func DefineInvalidArgument(name, messageFormat string, publicAttributes ...string) *Definition {
 	def := define(uint32(codes.InvalidArgument), name, messageFormat, publicAttributes...)
 	return def
 }
 
 // DefineDeadlineExceeded defines a registered error of type DeadlineExceeded.
-func DefineDeadlineExceeded(name, messageFormat string, publicAttributes ...string) Definition {
+func DefineDeadlineExceeded(name, messageFormat string, publicAttributes ...string) *Definition {
 	def := define(uint32(codes.DeadlineExceeded), name, messageFormat, publicAttributes...)
 	return def
 }
 
 // DefineCanceled defines a registered error of type Canceled.
-func DefineCanceled(name, messageFormat string, publicAttributes ...string) Definition {
+func DefineCanceled(name, messageFormat string, publicAttributes ...string) *Definition {
 	def := define(uint32(codes.Canceled), name, messageFormat, publicAttributes...)
 	return def
 }
 
 // DefineNotFound defines a registered error of type NotFound.
-func DefineNotFound(name, messageFormat string, publicAttributes ...string) Definition {
+func DefineNotFound(name, messageFormat string, publicAttributes ...string) *Definition {
 	def := define(uint32(codes.NotFound), name, messageFormat, publicAttributes...)
 	return def
 }
 
 // DefineAlreadyExists defines a registered error of type AlreadyExists.
-func DefineAlreadyExists(name, messageFormat string, publicAttributes ...string) Definition {
+func DefineAlreadyExists(name, messageFormat string, publicAttributes ...string) *Definition {
 	def := define(uint32(codes.AlreadyExists), name, messageFormat, publicAttributes...)
 	return def
 }
@@ -191,13 +222,13 @@ func DefineAlreadyExists(name, messageFormat string, publicAttributes ...string)
 // using incorrect credentials or credentials with insufficient rights.
 // If the client attempts to perform the action without providing any form
 // of authentication, Unauthenticated should be used instead.
-func DefinePermissionDenied(name, messageFormat string, publicAttributes ...string) Definition {
+func DefinePermissionDenied(name, messageFormat string, publicAttributes ...string) *Definition {
 	def := define(uint32(codes.PermissionDenied), name, messageFormat, publicAttributes...)
 	return def
 }
 
 // DefineResourceExhausted defines a registered error of type ResourceExhausted.
-func DefineResourceExhausted(name, messageFormat string, publicAttributes ...string) Definition {
+func DefineResourceExhausted(name, messageFormat string, publicAttributes ...string) *Definition {
 	def := define(uint32(codes.ResourceExhausted), name, messageFormat, publicAttributes...)
 	return def
 }
@@ -205,13 +236,13 @@ func DefineResourceExhausted(name, messageFormat string, publicAttributes ...str
 // DefineFailedPrecondition defines a registered error of type FailedPrecondition.
 // Use Unavailable if the client can retry just the failing call.
 // Use Aborted if the client should retry at a higher-level.
-func DefineFailedPrecondition(name, messageFormat string, publicAttributes ...string) Definition {
+func DefineFailedPrecondition(name, messageFormat string, publicAttributes ...string) *Definition {
 	def := define(uint32(codes.FailedPrecondition), name, messageFormat, publicAttributes...)
 	return def
 }
 
 // DefineAborted defines a registered error of type Aborted.
-func DefineAborted(name, messageFormat string, publicAttributes ...string) Definition {
+func DefineAborted(name, messageFormat string, publicAttributes ...string) *Definition {
 	def := define(uint32(codes.Aborted), name, messageFormat, publicAttributes...)
 	return def
 }
@@ -219,31 +250,31 @@ func DefineAborted(name, messageFormat string, publicAttributes ...string) Defin
 // OutOfRange - not used for now
 
 // Unimplemented defines a registered error of type Unimplemented.
-func DefineUnimplemented(name, messageFormat string, publicAttributes ...string) Definition {
+func DefineUnimplemented(name, messageFormat string, publicAttributes ...string) *Definition {
 	def := define(uint32(codes.Unimplemented), name, messageFormat, publicAttributes...)
 	return def
 }
 
 // DefineInternal defines a registered error of type Internal.
-func DefineInternal(name, messageFormat string, publicAttributes ...string) Definition {
+func DefineInternal(name, messageFormat string, publicAttributes ...string) *Definition {
 	def := define(uint32(codes.Internal), name, messageFormat, publicAttributes...)
 	return def
 }
 
 // DefineUnavailable defines a registered error of type Unavailable.
-func DefineUnavailable(name, messageFormat string, publicAttributes ...string) Definition {
+func DefineUnavailable(name, messageFormat string, publicAttributes ...string) *Definition {
 	def := define(uint32(codes.Unavailable), name, messageFormat, publicAttributes...)
 	return def
 }
 
 // DefineDataLoss defines a registered error of type DataLoss.
-func DefineDataLoss(name, messageFormat string, publicAttributes ...string) Definition {
+func DefineDataLoss(name, messageFormat string, publicAttributes ...string) *Definition {
 	def := define(uint32(codes.DataLoss), name, messageFormat, publicAttributes...)
 	return def
 }
 
 // DefineCorruption is the same as DefineDataLoss.
-func DefineCorruption(name, messageFormat string, publicAttributes ...string) Definition {
+func DefineCorruption(name, messageFormat string, publicAttributes ...string) *Definition {
 	def := define(uint32(codes.DataLoss), name, messageFormat, publicAttributes...)
 	return def
 }
@@ -253,13 +284,16 @@ func DefineCorruption(name, messageFormat string, publicAttributes ...string) De
 // without providing any form of authentication.
 // If the client attempts to perform the action using incorrect credentials
 // or credentials with insufficient rights, PermissionDenied should be used instead.
-func DefineUnauthenticated(name, messageFormat string, publicAttributes ...string) Definition {
+func DefineUnauthenticated(name, messageFormat string, publicAttributes ...string) *Definition {
 	def := define(uint32(codes.Unauthenticated), name, messageFormat, publicAttributes...)
 	return def
 }
 
 // New returns a new error from the definition. This is not required, but will
 // add a stack trace for improved debugging.
-func (d Definition) New() Error {
+func (d *Definition) New() *Error {
+	if d == nil {
+		return nil
+	}
 	return build(d, 0) // Don't refactor this to build(...).WithCause(...)
 }

--- a/pkg/errors/details.go
+++ b/pkg/errors/details.go
@@ -30,20 +30,30 @@ func (e *Error) addDetails(details ...proto.Message) {
 
 // WithDetails returns the error with the given details set.
 // This appends to any existing details in the Error.
-func (e Error) WithDetails(details ...proto.Message) Error {
-	e.addDetails(details...)
-	return e
+func (e *Error) WithDetails(details ...proto.Message) *Error {
+	if e == nil {
+		return e
+	}
+	dup := *e
+	dup.addDetails(details...)
+	return &dup
 }
 
 // WithDetails returns a new error from the definition, and sets the given details.
-func (d Definition) WithDetails(details ...proto.Message) Error {
+func (d *Definition) WithDetails(details ...proto.Message) *Error {
+	if d == nil {
+		return nil
+	}
 	e := build(d, 0) // Don't refactor this to build(...).WithDetails(...)
 	e.addDetails(details...)
 	return e
 }
 
 // Details of the error. Usually structs from ttnpb or google.golang.org/genproto/googleapis/rpc/errdetails.
-func (e Error) Details() (details []proto.Message) {
+func (e *Error) Details() (details []proto.Message) {
+	if e == nil {
+		return nil
+	}
 	if e.cause != nil {
 		details = append(details, Details(e.cause)...)
 	}
@@ -54,7 +64,7 @@ func (e Error) Details() (details []proto.Message) {
 }
 
 // Details are not present in the error definition, so this just returns nil.
-func (d Definition) Details() []proto.Message { return nil }
+func (*Definition) Details() []proto.Message { return nil }
 
 // Details gets the details of the error.
 func Details(err error) []proto.Message {

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -26,8 +26,8 @@ import (
 
 // New returns an error that formats as the given text.
 // This way of creating errors should be avoided if possible.
-func New(text string) Error {
-	return build(Definition{
+func New(text string) *Error {
+	return build(&Definition{
 		namespace:     namespace(2),
 		messageFormat: text,
 		code:          uint32(codes.Unknown),
@@ -36,7 +36,7 @@ func New(text string) Error {
 
 // Error is a rich error implementation.
 type Error struct {
-	Definition
+	*Definition
 	*stack
 	correlationID string
 	cause         error
@@ -45,15 +45,26 @@ type Error struct {
 	grpcStatus    *atomic.Value
 }
 
-func (e Error) String() string {
+func (e *Error) String() string {
+	if e == nil {
+		return ""
+	}
 	return fmt.Sprintf("error:%s (%s)", e.FullName(), e.FormatMessage(e.PublicAttributes()))
 }
 
 // Error implements the error interface.
-func (e Error) Error() string { return e.String() }
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.String()
+}
 
 // Fields implements the log.Fielder interface.
-func (e Error) Fields() map[string]interface{} {
+func (e *Error) Fields() map[string]interface{} {
+	if e == nil {
+		return nil
+	}
 	res := make(map[string]interface{})
 	pref := "error_cause"
 	for cause := Cause(e); cause != nil; cause = Cause(cause) {
@@ -75,10 +86,10 @@ type Interface interface {
 }
 
 // build an error from the definition, skipping the first frames of the call stack.
-func build(d Definition, skip int) Error {
+func build(d *Definition, skip int) *Error {
 	e := Error{Definition: d, grpcStatus: new(atomic.Value)}
 	if skip > 0 {
 		e.stack = callers(skip)
 	}
-	return e
+	return &e
 }

--- a/pkg/errors/grpc.go
+++ b/pkg/errors/grpc.go
@@ -19,15 +19,15 @@ import (
 	"encoding/hex"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 // FromGRPCStatus converts the gRPC status message into an Error.
-func FromGRPCStatus(status *status.Status) Error {
-	err := build(Definition{
+func FromGRPCStatus(status *status.Status) *Error {
+	err := build(&Definition{
 		code:          uint32(status.Code()),
 		messageFormat: status.Message(),
 	}, 0)
@@ -46,7 +46,7 @@ func FromGRPCStatus(status *status.Status) Error {
 		err.details = rest
 	}
 	if details != nil {
-		setErrorDetails(&err, details)
+		setErrorDetails(err, details)
 	}
 	return err
 }
@@ -82,7 +82,10 @@ func (d *Definition) setGRPCStatus() {
 }
 
 // GRPCStatus returns the Definition as a gRPC status message.
-func (d Definition) GRPCStatus() *status.Status {
+func (d *Definition) GRPCStatus() *status.Status {
+	if d == nil {
+		return nil
+	}
 	return d.grpcStatus // initialized when defined (with setGRPCStatus).
 }
 
@@ -159,6 +162,7 @@ func (w wrappedStream) SendMsg(m interface{}) error {
 	}
 	return err
 }
+
 func (w wrappedStream) RecvMsg(m interface{}) error {
 	err := w.ClientStream.RecvMsg(m)
 	if ttnErr, ok := From(err); ok {

--- a/pkg/errors/http.go
+++ b/pkg/errors/http.go
@@ -75,12 +75,12 @@ func ToHTTPStatusCode(err error) int {
 }
 
 // FromHTTPStatusCode maps an HTTP response code to an error.
-func FromHTTPStatusCode(status int, publicAttributes ...string) Error {
+func FromHTTPStatusCode(status int, publicAttributes ...string) *Error {
 	code := uint32(codes.Unknown)
 	if c, ok := httpErrorCodes[status]; ok {
 		code = c
 	}
-	return build(Definition{
+	return build(&Definition{
 		namespace:        namespace(2),
 		messageFormat:    http.StatusText(status),
 		publicAttributes: publicAttributes,
@@ -109,5 +109,5 @@ func FromHTTP(resp *http.Response) error {
 	if decErr := json.NewDecoder(resp.Body).Decode(&err); decErr != nil {
 		return decErr
 	}
-	return err
+	return &err
 }

--- a/pkg/errors/json.go
+++ b/pkg/errors/json.go
@@ -27,12 +27,18 @@ var JSONCodec interface {
 } = jsonpb.TTN()
 
 // MarshalJSON implements json.Marshaler.
-func (d Definition) MarshalJSON() ([]byte, error) {
+func (d *Definition) MarshalJSON() ([]byte, error) {
+	if d == nil {
+		return []byte("null"), nil
+	}
 	return JSONCodec.Marshal(d.GRPCStatus().Proto())
 }
 
 // MarshalJSON implements json.Marshaler.
-func (e Error) MarshalJSON() ([]byte, error) {
+func (e *Error) MarshalJSON() ([]byte, error) {
+	if e == nil {
+		return []byte("null"), nil
+	}
 	return JSONCodec.Marshal(e.GRPCStatus().Proto())
 }
 
@@ -41,11 +47,11 @@ func (e Error) MarshalJSON() ([]byte, error) {
 // This func is purely implemented for consistency. In practice,
 // you probably want to unmarshal into an *Error instead of a *Definition.
 func (d *Definition) UnmarshalJSON(data []byte) error {
-	e := new(Error)
+	e := &Error{Definition: &Definition{}}
 	if err := e.UnmarshalJSON(data); err != nil {
 		return err
 	}
-	*d = e.Definition
+	*d = *e.Definition
 	return nil
 }
 
@@ -55,6 +61,7 @@ func (e *Error) UnmarshalJSON(data []byte) error {
 	if err := JSONCodec.Unmarshal(data, s); err != nil {
 		return err
 	}
-	*e = FromGRPCStatus(status.FromProto(s))
+	errFromStatus := FromGRPCStatus(status.FromProto(s))
+	*e = *errFromStatus
 	return nil
 }

--- a/pkg/errors/json_test.go
+++ b/pkg/errors/json_test.go
@@ -35,7 +35,7 @@ func TestJSONConversion(t *testing.T) {
 	var unmarshaledDef errors.Definition
 	err = json.Unmarshal(b, &unmarshaledDef)
 	a.So(err, should.BeNil)
-	a.So(unmarshaledDef, should.EqualErrorOrDefinition, errDef)
+	a.So(&unmarshaledDef, should.EqualErrorOrDefinition, errDef)
 
 	errHello := errDef.WithAttributes("foo", "bar", "baz", "qux")
 	errHelloExpected := errDef.WithAttributes("foo", "bar")
@@ -46,5 +46,5 @@ func TestJSONConversion(t *testing.T) {
 	var unmarshaled errors.Error
 	err = json.Unmarshal(b, &unmarshaled)
 	a.So(err, should.BeNil)
-	a.So(unmarshaled, should.EqualErrorOrDefinition, errHelloExpected)
+	a.So(&unmarshaled, should.EqualErrorOrDefinition, errHelloExpected)
 }

--- a/pkg/errors/message_format.go
+++ b/pkg/errors/message_format.go
@@ -19,7 +19,10 @@ import "github.com/gotnospirit/messageformat"
 var formatter, _ = messageformat.New()
 
 // FormatMessage formats the message using the given attributes.
-func (d Definition) FormatMessage(attributes map[string]interface{}) string {
+func (d *Definition) FormatMessage(attributes map[string]interface{}) string {
+	if d == nil {
+		return ""
+	}
 	if len(attributes) == 0 {
 		return d.messageFormat
 	}

--- a/pkg/errors/std.go
+++ b/pkg/errors/std.go
@@ -26,21 +26,30 @@ var (
 )
 
 // Unwrap makes the Error implement error unwrapping.
-func (e Error) Unwrap() error {
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
 	return e.cause
 }
 
 // Is makes the Error implement error comparison.
-func (e Error) Is(target error) bool {
+func (e *Error) Is(target error) bool {
+	if e == nil {
+		return target == nil
+	}
 	return Resemble(e, target)
 }
 
 // Unwrap makes the Definition implement error unwrapping.
-func (Definition) Unwrap() error {
+func (*Definition) Unwrap() error {
 	return nil
 }
 
 // Is makes the Definition implement error comparison.
-func (d Definition) Is(target error) bool {
+func (d *Definition) Is(target error) bool {
+	if d == nil {
+		return target == nil
+	}
 	return Resemble(d, target)
 }

--- a/pkg/gatewayserver/scheduling/scheduler_test.go
+++ b/pkg/gatewayserver/scheduling/scheduler_test.go
@@ -59,7 +59,7 @@ func TestScheduleAtWithBandDutyCycle(t *testing.T) {
 		MedianRTT               *time.Duration
 		ExpectedToa             time.Duration
 		ExpectedStarts          scheduling.ConcentratorTime
-		ExpectedError           *errors.Definition
+		ExpectedError           errors.DefinitionInterface
 	}{
 		{
 			PayloadSize: 10,
@@ -79,7 +79,7 @@ func TestScheduleAtWithBandDutyCycle(t *testing.T) {
 			Priority:    ttnpb.TxSchedulePriority_NORMAL,
 			ExpectedToa: 41216 * time.Microsecond,
 			// Too late for transmission with ScheduleTimeShort.
-			ExpectedError: &scheduling.ErrTooLate,
+			ExpectedError: scheduling.ErrTooLate,
 		},
 		{
 			SyncWithGatewayAbsolute: true,
@@ -100,7 +100,7 @@ func TestScheduleAtWithBandDutyCycle(t *testing.T) {
 			Priority:    ttnpb.TxSchedulePriority_NORMAL,
 			ExpectedToa: 2465792 * time.Microsecond,
 			// Too late for transmission with ScheduleTimeShort.
-			ExpectedError: &scheduling.ErrTooLate,
+			ExpectedError: scheduling.ErrTooLate,
 		},
 		{
 			PayloadSize: 10,
@@ -121,7 +121,7 @@ func TestScheduleAtWithBandDutyCycle(t *testing.T) {
 			NPercentileRTT: durationPtr(550 * time.Millisecond),
 			ExpectedToa:    41216 * time.Microsecond,
 			// Too late for transmission with RTT.
-			ExpectedError: &scheduling.ErrTooLate,
+			ExpectedError: scheduling.ErrTooLate,
 		},
 		{
 			SyncWithGatewayAbsolute: true,
@@ -143,7 +143,7 @@ func TestScheduleAtWithBandDutyCycle(t *testing.T) {
 			NPercentileRTT: durationPtr(500 * time.Millisecond),
 			ExpectedToa:    2465792 * time.Microsecond,
 			// Too late for transmission with RTT.
-			ExpectedError: &scheduling.ErrTooLate,
+			ExpectedError: scheduling.ErrTooLate,
 		},
 		{
 			PayloadSize: 51,
@@ -163,7 +163,7 @@ func TestScheduleAtWithBandDutyCycle(t *testing.T) {
 			Priority:    ttnpb.TxSchedulePriority_NORMAL,
 			ExpectedToa: 2465792 * time.Microsecond,
 			// Exceeding dwell time of 2 seconds.
-			ExpectedError: &scheduling.ErrDwellTime,
+			ExpectedError: scheduling.ErrDwellTime,
 		},
 		{
 			PayloadSize: 16,
@@ -242,7 +242,7 @@ func TestScheduleAtWithBandDutyCycle(t *testing.T) {
 			Priority:    ttnpb.TxSchedulePriority_NORMAL,
 			ExpectedToa: 41216 * time.Microsecond,
 			// Overlapping with previous transmission.
-			ExpectedError: &scheduling.ErrConflict,
+			ExpectedError: scheduling.ErrConflict,
 		},
 		{
 			PayloadSize: 10,
@@ -262,7 +262,7 @@ func TestScheduleAtWithBandDutyCycle(t *testing.T) {
 			Priority:    ttnpb.TxSchedulePriority_NORMAL,
 			ExpectedToa: 41216 * time.Microsecond,
 			// Right after previous transmission; not respecting time-off-air.
-			ExpectedError: &scheduling.ErrConflict,
+			ExpectedError: scheduling.ErrConflict,
 		},
 		{
 			PayloadSize: 10,
@@ -301,7 +301,7 @@ func TestScheduleAtWithBandDutyCycle(t *testing.T) {
 			Priority:    ttnpb.TxSchedulePriority_NORMAL,
 			ExpectedToa: 1318912 * time.Microsecond,
 			// Exceeds duty-cycle limitation of 1% in 868.0 - 868.6.
-			ExpectedError: &scheduling.ErrDutyCycle,
+			ExpectedError: scheduling.ErrDutyCycle,
 		},
 	} {
 		tcok := t.Run(strconv.Itoa(i), func(t *testing.T) {
@@ -330,7 +330,7 @@ func TestScheduleAtWithBandDutyCycle(t *testing.T) {
 				Priority:    tc.Priority,
 			})
 			if tc.ExpectedError != nil {
-				if !a.So(err, should.HaveSameErrorDefinitionAs, *tc.ExpectedError) {
+				if !a.So(err, should.HaveSameErrorDefinitionAs, tc.ExpectedError) {
 					t.Fatalf("Unexpected error: %v", err)
 				}
 				return

--- a/pkg/identityserver/store/store.go
+++ b/pkg/identityserver/store/store.go
@@ -344,10 +344,9 @@ func (l logger) Print(v ...interface{}) {
 	case "log", "error":
 		if err, ok := v[2].(error); ok {
 			err = convertError(err)
-			if errors.IsAlreadyExists(err) {
-				return // no problem.
+			if errors.Resemble(err, errDatabase) {
+				logger.WithError(err).Error("Database error")
 			}
-			logger.WithError(err).Error("Database error")
 			return
 		}
 		logger.Error(fmt.Sprint(v[2:]...))

--- a/pkg/interop/errors.go
+++ b/pkg/interop/errors.go
@@ -49,10 +49,12 @@ var (
 	ErrFrameSize          = defineError("frame_size", ResultFrameSizeError, "frame size error")
 )
 
-var errorResults = make(map[string]ResultCode)
-var resultErrors = make(map[ResultCode]errors.Definition)
+var (
+	errorResults = make(map[string]ResultCode)
+	resultErrors = make(map[ResultCode]*errors.Definition)
+)
 
-func defineError(name string, result ResultCode, message string) errors.Definition {
+func defineError(name string, result ResultCode, message string) *errors.Definition {
 	definition := errors.DefineInvalidArgument(name, message)
 	errorResults[definition.FullName()] = result
 	resultErrors[result] = definition

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -270,7 +270,7 @@ func (ns *NetworkServer) Get(ctx context.Context, req *ttnpb.GetEndDeviceRequest
 	return ttnpb.FilterGetEndDevice(dev, req.FieldMask.GetPaths()...)
 }
 
-func newInvalidFieldValueError(field string) errors.Error {
+func newInvalidFieldValueError(field string) *errors.Error {
 	return errInvalidFieldValue.WithAttributes("field", field)
 }
 

--- a/pkg/oauth/server.go
+++ b/pkg/oauth/server.go
@@ -204,7 +204,7 @@ func (s *server) output(c echo.Context, resp *osin.Response) error {
 			} else if _, isURIValidationError := resp.InternalError.(osin.UriValidationError); isURIValidationError {
 				osinErr = errInvalidRedirectURI.WithCause(resp.InternalError)
 			} else {
-				osinErr = osinErr.(errors.Definition).WithCause(resp.InternalError)
+				osinErr = osinErr.(*errors.Definition).WithCause(resp.InternalError)
 			}
 		}
 		log.FromContext(c.Request().Context()).WithError(osinErr).Warn("OAuth error")

--- a/pkg/rpcmiddleware/validator/validator_test.go
+++ b/pkg/rpcmiddleware/validator/validator_test.go
@@ -21,10 +21,10 @@ import (
 
 	"github.com/gogo/protobuf/types"
 	"github.com/smartystreets/assertions"
-	"github.com/smartystreets/assertions/should"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	. "go.thethings.network/lorawan-stack/v3/pkg/rpcmiddleware/validator"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
 	"google.golang.org/grpc"
 )
 
@@ -122,7 +122,7 @@ func TestUnaryServerInterceptor(t *testing.T) {
 		err: testErr,
 	}}, info, handler)
 	if a.So(err, should.BeError) {
-		a.So(err, should.Resemble, &testErr)
+		a.So(err, should.EqualErrorOrDefinition, testErr)
 	}
 
 	res, err = intercept(ctx, &msgWithValidateContext{}, info, handler)
@@ -136,7 +136,7 @@ func TestUnaryServerInterceptor(t *testing.T) {
 		err: testErr,
 	}}, info, handler)
 	if a.So(err, should.BeError) {
-		a.So(err, should.Resemble, &testErr)
+		a.So(err, should.EqualErrorOrDefinition, testErr)
 	}
 
 	_, err = intercept(ctx, &msgWithFieldMask{
@@ -256,7 +256,7 @@ func TestStreamServerInterceptor(t *testing.T) {
 		}}
 		err = stream.RecvMsg(subject)
 		if a.So(err, should.BeError) {
-			a.So(err, should.Resemble, &testErr)
+			a.So(err, should.EqualErrorOrDefinition, testErr)
 		}
 
 		subject = &msgWithValidateContext{}
@@ -271,7 +271,7 @@ func TestStreamServerInterceptor(t *testing.T) {
 		}}
 		err = stream.RecvMsg(subject)
 		if a.So(err, should.BeError) {
-			a.So(err, should.Resemble, &testErr)
+			a.So(err, should.EqualErrorOrDefinition, testErr)
 		}
 
 		subject = &msgWithFieldMask{

--- a/pkg/ttnpb/errors.go
+++ b/pkg/ttnpb/errors.go
@@ -129,12 +129,12 @@ func init() {
 	}
 }
 
-type valueErr func(interface{}) errors.Error
+type valueErr func(interface{}) *errors.Error
 
 func unexpectedValue(err interface {
-	WithAttributes(kv ...interface{}) errors.Error
+	WithAttributes(kv ...interface{}) *errors.Error
 }) valueErr {
-	return func(value interface{}) errors.Error {
+	return func(value interface{}) *errors.Error {
 		return err.WithAttributes(valueKey, value)
 	}
 }
@@ -160,6 +160,6 @@ func errCouldNotParse(lorawanField string) valueErr {
 	return unexpectedValue(errParse.WithAttributes("field", lorawanField))
 }
 
-func errMissing(lorawanField string) errors.Error {
+func errMissing(lorawanField string) *errors.Error {
 	return errMissingField.WithAttributes("field", lorawanField)
 }

--- a/pkg/web/oauthclient/callback.go
+++ b/pkg/web/oauthclient/callback.go
@@ -16,7 +16,6 @@ package oauthclient
 
 import (
 	"context"
-	"encoding/json"
 	stderrors "errors"
 	"net/http"
 
@@ -95,8 +94,8 @@ func (oc *OAuthClient) HandleCallback(c echo.Context) error {
 		var retrieveError *oauth2.RetrieveError
 		if stderrors.As(err, &retrieveError) {
 			var ttnErr errors.Error
-			if decErr := json.Unmarshal(retrieveError.Body, &ttnErr); decErr == nil {
-				return errExchange.WithCause(ttnErr)
+			if decErr := ttnErr.UnmarshalJSON(retrieveError.Body); decErr == nil {
+				return errExchange.WithCause(&ttnErr)
 			}
 		}
 		return errExchange.WithCause(err)

--- a/pkg/web/oauthclient/token.go
+++ b/pkg/web/oauthclient/token.go
@@ -15,7 +15,6 @@
 package oauthclient
 
 import (
-	"encoding/json"
 	stderrors "errors"
 	"net/http"
 	"time"
@@ -52,8 +51,8 @@ func (oc *OAuthClient) freshToken(c echo.Context) (*oauth2.Token, error) {
 		var retrieveError *oauth2.RetrieveError
 		if stderrors.As(err, &retrieveError) {
 			var ttnErr errors.Error
-			if decErr := json.Unmarshal(retrieveError.Body, &ttnErr); decErr == nil {
-				return nil, errRefresh.WithCause(ttnErr)
+			if decErr := ttnErr.UnmarshalJSON(retrieveError.Body); decErr == nil {
+				return nil, errRefresh.WithCause(&ttnErr)
 			}
 		}
 		return nil, errRefresh.WithCause(err)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request resolves the "internal server error" part of https://github.com/TheThingsNetwork/lorawan-stack/issues/4496. 

Apparently we're recovering from a panic caused by `runtime error: comparing uncomparable type errors.Error`. We typically shouldn't compare errors (from `pkg/errors`) with `==`, but GORM seems to do that internally 🤷.

At some point in the future we should probably refactor `pkg/errors`, also to bring it more in line with Go 1.13 errors. But for now, I think it's sufficient to do a small refactor that makes sure we always use pointers to our error structs.

#### Changes
<!-- What are the changes made in this pull request? -->

- Change all methods on `Error` and `Definition` to use pointers
- Update the rest of the codebase accordingly
- Small unrelated change (but still related to the issue): Stop logging errors other than database errors in the IS store.

#### Testing

<!-- How did you verify that this change works? -->

Updated existing unit tests, tested by reproducing the issue.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Maybe if we're doing something weird with typed nil errors.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
