### PR TITLE
Fix injection of public path

### DIFF
--- a/config/root.js
+++ b/config/root.js
@@ -16,4 +16,4 @@
 /* exported __webpack_public_path__ */
 
 // Set the assets where webpack will load it's assets from.
-__webpack_public_path__ = (window.ASSETS_ROOT || '/assets').concat('/') // eslint-disable-line no-global-assign
+__webpack_public_path__ = (window.__ttn_config__.ASSETS_ROOT || '/assets').concat('/') // eslint-disable-line no-global-assign

--- a/pkg/webui/account.js
+++ b/pkg/webui/account.js
@@ -23,7 +23,7 @@ import store, { history } from '@account/store'
 import WithLocale from '@ttn-lw/lib/components/with-locale'
 import Init from '@ttn-lw/lib/components/init'
 
-import { selectSentryDsnConfig, selectAssetsRootPath } from '@ttn-lw/lib/selectors/env'
+import { selectSentryDsnConfig } from '@ttn-lw/lib/selectors/env'
 
 import '@ttn-lw/lib/yup'
 
@@ -31,12 +31,6 @@ import '@ttn-lw/lib/yup'
 if (selectSentryDsnConfig()) {
   Sentry.init(sentryConfig)
 }
-
-const assetsRoot = selectAssetsRootPath()
-
-// Set asset path based on passed env configuration.
-// eslint-disable-next-line no-undef
-__webpack_public_path__ = `${assetsRoot}/`
 
 const render = () => {
   const App = require('./account/views/app').default

--- a/pkg/webui/console.js
+++ b/pkg/webui/console.js
@@ -27,26 +27,17 @@ import Init from '@ttn-lw/lib/components/init'
 import WithLocale from '@ttn-lw/lib/components/with-locale'
 
 import env from '@ttn-lw/lib/env'
-import {
-  selectApplicationRootPath,
-  selectAssetsRootPath,
-  selectSentryDsnConfig,
-} from '@ttn-lw/lib/selectors/env'
+import { selectApplicationRootPath, selectSentryDsnConfig } from '@ttn-lw/lib/selectors/env'
 
 import createStore from './console/store'
 
 const sentryDsn = selectSentryDsnConfig()
 const appRoot = selectApplicationRootPath()
-const assetsRoot = selectAssetsRootPath()
 
 const history = createBrowserHistory({ basename: `${appRoot}/` })
 // Initialize sentry before creating store.
 if (sentryDsn) Sentry.init(sentryConfig)
 const store = createStore(history)
-
-// Set asset path based on passed env configuration.
-// eslint-disable-next-line no-undef
-__webpack_public_path__ = `${assetsRoot}/`
 
 const rootElement = document.getElementById('app')
 


### PR DESCRIPTION
#### Summary
This quickfix fixes the injection of the public directory via `__webpack_public_dir__` after being changed in #4493.
This will make sure that only the passed asset URL config is ever used and remove the warnings currently present in the Console:
```
The resource <URL> was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it has an appropriate `as` value and it is preloaded intentionally.
```

#### Changes
- Fix the asset URL resolution in `config/root.js`
- Remove setting of asset URL in the console/account entrypoints.

#### Testing

Manual.

#### Notes for Reviewers
I forgot about the fact that we already set the variable in `/console/root.js` when doing #4493.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
