### PR TITLE
Support new WiFi TLV format

### DIFF
--- a/pkg/applicationserver/io/packages/loradms/v1/tlv_encoding.go
+++ b/pkg/applicationserver/io/packages/loradms/v1/tlv_encoding.go
@@ -21,7 +21,7 @@ import (
 
 var errTLVRecordTooSmall = errors.DefineInvalidArgument("tlv_record_too_small", "TLV record payload is too small")
 
-func parseTLVPayload(record objects.Hex, f func(uint8, int, []byte) error) error {
+func parseTLVPayload(record objects.Hex, f func(uint8, []byte) error) error {
 	for len(record) >= 2 {
 		tag := record[0]
 		length := int(record[1])
@@ -32,7 +32,7 @@ func parseTLVPayload(record objects.Hex, f func(uint8, int, []byte) error) error
 		bytes := []byte(record[2 : 2+length])
 		record = record[length+2:]
 
-		if err := f(tag, length, bytes); err != nil {
+		if err := f(tag, bytes); err != nil {
 			return err
 		}
 	}

--- a/pkg/applicationserver/io/packages/loradms/v1/tlv_encoding_test.go
+++ b/pkg/applicationserver/io/packages/loradms/v1/tlv_encoding_test.go
@@ -26,23 +26,23 @@ import (
 func TestTLVEncoding(t *testing.T) {
 	a := assertions.New(t)
 
-	a.So(parseTLVPayload(objects.Hex{0xbb, 0xaa}, func(tag uint8, size int, data []byte) error {
+	a.So(parseTLVPayload(objects.Hex{0xbb, 0xaa}, func(tag uint8, data []byte) error {
 		return fmt.Errorf("foo")
 	}), should.NotBeNil)
 
-	a.So(parseTLVPayload(objects.Hex{0x01, 0x02, 0xbb, 0xaa}, func(tag uint8, size int, data []byte) error {
+	a.So(parseTLVPayload(objects.Hex{0x01, 0x02, 0xbb, 0xaa}, func(tag uint8, data []byte) error {
 		a.So(tag, should.Equal, 0x01)
-		a.So(size, should.Equal, 0x02)
+		a.So(data, should.HaveLength, 2)
 		a.So(data, should.Resemble, []byte{0xbb, 0xaa})
 		return nil
 	}), should.BeNil)
 
-	a.So(parseTLVPayload(objects.Hex{0xff, 0x02, 0xff}, func(tag uint8, size int, data []byte) error {
+	a.So(parseTLVPayload(objects.Hex{0xff, 0x02, 0xff}, func(tag uint8, data []byte) error {
 		t.Fatal("f should not be called")
 		return nil
 	}), should.NotBeNil)
 
-	a.So(parseTLVPayload(objects.Hex{0xff, 0xff, 0xff}, func(tag uint8, size int, data []byte) error {
+	a.So(parseTLVPayload(objects.Hex{0xff, 0xff, 0xff}, func(tag uint8, data []byte) error {
 		t.Fatal("f should not be called")
 		return nil
 	}), should.NotBeNil)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR adds support for the new WiFi query format for LoRaCloud modem devices, which uses tag `0x0E`

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove the length used by the parser callback, as `len(bytes)` is available
- Add support for the new WiFi query format. The first 5 bytes are dropped as they are not used by DAS at the moment
  - The first byte is a version, while the next 4 are a timestamp


#### Testing

<!-- How did you verify that this change works? -->

Unit testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

cc @ogimenez-smtc 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
