### PR TITLE
Improve Sentry reporting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/eclipse/paho.mqtt.golang v1.3.4
 	github.com/envoyproxy/protoc-gen-validate v0.4.0
 	github.com/felixge/httpsnoop v1.0.2
-	github.com/getsentry/sentry-go v0.10.0
+	github.com/getsentry/sentry-go v0.11.0
 	github.com/go-redis/redis/v8 v8.4.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/gddo v0.0.0-20210115222349-20d68f94ee1f

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/garyburd/redigo v1.1.1-0.20170914051019-70e1b1943d4f/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/gavv/httpexpect v2.0.0+incompatible/go.mod h1:x+9tiU1YnrOvnB725RkpoLv1M62hOWzwo5OXotisrKc=
-github.com/getsentry/sentry-go v0.10.0 h1:6gwY+66NHKqyZrdi6O2jGdo7wGdo9b3B69E01NFgT5g=
-github.com/getsentry/sentry-go v0.10.0/go.mod h1:kELm/9iCblqUYh+ZRML7PNdCvEuw24wBvJPYyi86cws=
+github.com/getsentry/sentry-go v0.11.0 h1:qro8uttJGvNAMr5CLcFI9CHR0aDzXl0Vs3Pmw/oTPg8=
+github.com/getsentry/sentry-go v0.11.0/go.mod h1:KBQIxiZAetw62Cj8Ri964vAEWVdgfaUCn30Q3bCvANo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=
 github.com/gin-gonic/gin v1.4.0/go.mod h1:OW2EZn3DO8Ln9oIKOvM++LBO+5UPHJJDH72/q/3rZdM=

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -17,10 +17,12 @@
 package errors
 
 import (
+	"encoding/hex"
 	"fmt"
 	"sync/atomic"
 
 	"github.com/golang/protobuf/proto"
+	uuid "github.com/satori/go.uuid"
 	"google.golang.org/grpc/codes"
 )
 
@@ -87,7 +89,11 @@ type Interface interface {
 
 // build an error from the definition, skipping the first frames of the call stack.
 func build(d *Definition, skip int) *Error {
-	e := Error{Definition: d, grpcStatus: new(atomic.Value)}
+	e := Error{
+		Definition:    d,
+		correlationID: hex.EncodeToString(uuid.NewV4().Bytes()),
+		grpcStatus:    new(atomic.Value),
+	}
 	if skip > 0 {
 		e.stack = callers(skip)
 	}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -87,12 +87,22 @@ type Interface interface {
 	Details() (details []proto.Message)
 }
 
+var generateCorrelationIDs = true
+
+// GenerateCorrelationIDs configures whether random correlation IDs are generated
+// for each error. This is enabled by default.
+func GenerateCorrelationIDs(enable bool) {
+	generateCorrelationIDs = enable
+}
+
 // build an error from the definition, skipping the first frames of the call stack.
 func build(d *Definition, skip int) *Error {
 	e := Error{
-		Definition:    d,
-		correlationID: hex.EncodeToString(uuid.NewV4().Bytes()),
-		grpcStatus:    new(atomic.Value),
+		Definition: d,
+		grpcStatus: new(atomic.Value),
+	}
+	if generateCorrelationIDs {
+		e.correlationID = hex.EncodeToString(uuid.NewV4().Bytes())
 	}
 	if skip > 0 {
 		e.stack = callers(skip)

--- a/pkg/errors/grpc.go
+++ b/pkg/errors/grpc.go
@@ -16,10 +16,8 @@ package errors
 
 import (
 	"context"
-	"encoding/hex"
 
 	"github.com/golang/protobuf/proto"
-	uuid "github.com/satori/go.uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -117,9 +115,6 @@ func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		res, err := handler(ctx, req)
 		if ttnErr, ok := From(err); ok {
-			if ttnErr.correlationID == "" {
-				ttnErr.correlationID = hex.EncodeToString(uuid.NewV4().Bytes()) // Compliant with Sentry.
-			}
 			err = ttnErr
 		}
 		return res, err
@@ -131,9 +126,6 @@ func StreamServerInterceptor() grpc.StreamServerInterceptor {
 	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		err := handler(srv, stream)
 		if ttnErr, ok := From(err); ok {
-			if ttnErr.correlationID == "" {
-				ttnErr.correlationID = hex.EncodeToString(uuid.NewV4().Bytes()) // Compliant with Sentry.
-			}
 			err = ttnErr
 		}
 		return err

--- a/pkg/errors/web/middleware_test.go
+++ b/pkg/errors/web/middleware_test.go
@@ -32,6 +32,8 @@ func TestErrorHandling(t *testing.T) {
 
 	ttnNotFound := errors.DefineNotFound("test_not_found", "test not found")
 
+	errors.GenerateCorrelationIDs(false)
+
 	for _, tc := range []struct {
 		Name  string
 		Error error
@@ -110,5 +112,4 @@ func TestErrorHandling(t *testing.T) {
 			a.So(string(b), should.EqualJSON, tc.JSON)
 		})
 	}
-
 }

--- a/pkg/networkserver/downlink_test.go
+++ b/pkg/networkserver/downlink_test.go
@@ -44,6 +44,8 @@ import (
 func TestProcessDownlinkTask(t *testing.T) {
 	// TODO: Refactor. (https://github.com/TheThingsNetwork/lorawan-stack/issues/2475)
 
+	errors.GenerateCorrelationIDs(false)
+
 	const appIDString = "process-downlink-test-app-id"
 	appID := ttnpb.ApplicationIdentifiers{ApplicationId: appIDString}
 	const devID = "process-downlink-test-dev-id"

--- a/pkg/rpcmiddleware/sentry/sentry.go
+++ b/pkg/rpcmiddleware/sentry/sentry.go
@@ -18,15 +18,18 @@ package sentry
 import (
 	"context"
 	"fmt"
+	"net"
 	"strings"
 
 	"github.com/getsentry/sentry-go"
 	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
+	"go.thethings.network/lorawan-stack/v3/pkg/auth"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	sentryerrors "go.thethings.network/lorawan-stack/v3/pkg/errors/sentry"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 )
 
 func reportError(ctx context.Context, method string, err error) {
@@ -38,7 +41,6 @@ func reportError(ctx context.Context, method string, err error) {
 	switch code {
 	case codes.Unknown,
 		codes.Internal,
-		codes.Unimplemented,
 		codes.DataLoss:
 	default:
 		return // ignore
@@ -52,35 +54,76 @@ func reportError(ctx context.Context, method string, err error) {
 		errEvent.Request = &sentry.Request{}
 	}
 	errEvent.Request.URL = method
-	errEvent.Request.Headers = make(map[string]string)
-	errEvent.Tags["grpc.method"] = method
+	if p, ok := peer.FromContext(ctx); ok && p.Addr != nil && p.Addr.String() != "pipe" {
+		if host, _, err := net.SplitHostPort(p.Addr.String()); err == nil {
+			errEvent.User.IPAddress = host
+		}
+	}
 	errEvent.Tags["grpc.code"] = code.String()
+	errEvent.Request.Headers = make(map[string]string)
+
 	if md, ok := metadata.FromOutgoingContext(ctx); ok {
-		if requestID := md["x-request-id"]; len(requestID) > 0 {
-			errEvent.Tags["grpc.request_id"] = requestID[0]
-		}
 		for k, v := range md {
-			if k == "grpc-trace-bin" {
+			if len(v) == 0 {
 				continue
+			}
+			switch strings.ToLower(k) {
+			case "cookie", "grpc-trace-bin":
+				continue // ingored header
+			case "authorization":
+				parts := strings.SplitN(v[len(v)-1], " ", 2)
+				if len(parts) == 2 && strings.ToLower(parts[0]) == "bearer" {
+					if tokenType, tokenID, _, err := auth.SplitToken(parts[1]); err == nil {
+						errEvent.Tags["auth.token_type"] = tokenType.String()
+						errEvent.Tags["auth.token_id"] = tokenID
+					}
+				}
+				continue // ignored header
+			case "x-request-id":
+				errEvent.Tags["request_id"] = v[len(v)-1]
 			}
 			errEvent.Request.Headers[k] = strings.Join(v, " ")
 		}
 	}
+
 	if md, ok := metadata.FromIncomingContext(ctx); ok {
-		if requestID := md["x-request-id"]; len(requestID) > 0 {
-			errEvent.Tags["grpc.request_id"] = requestID[0]
-		}
 		for k, v := range md {
-			if k == "grpc-trace-bin" {
+			if len(v) == 0 {
 				continue
+			}
+			switch strings.ToLower(k) {
+			case "grpcgateway-authorization",
+				"cookie", "grpcgateway-cookie",
+				"grpc-trace-bin":
+				continue // ingored header
+			case "authorization":
+				parts := strings.SplitN(v[len(v)-1], " ", 2)
+				if len(parts) == 2 && strings.ToLower(parts[0]) == "bearer" {
+					if tokenType, tokenID, _, err := auth.SplitToken(parts[1]); err == nil {
+						errEvent.Tags["auth.token_type"] = tokenType.String()
+						errEvent.Tags["auth.token_id"] = tokenID
+					}
+				}
+				continue // ingored header
+			case "x-request-id":
+				errEvent.Tags["request_id"] = v[len(v)-1]
 			}
 			errEvent.Request.Headers[k] = strings.Join(v, " ")
 		}
 	}
+
 	for k, v := range grpc_ctxtags.Extract(ctx).Values() {
-		if val := fmt.Sprint(v); len(val) < 64 {
-			errEvent.Tags[k] = val
+		if strings.HasPrefix(k, "grpc.request.") {
+			k = "req." + strings.TrimPrefix(k, "grpc.request.")
 		}
+		if len(k) > 32 {
+			continue
+		}
+		val := fmt.Sprint(v)
+		if len(val) > 200 {
+			continue
+		}
+		errEvent.Tags[k] = val
 	}
 
 	// Capture the event.

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -265,8 +265,8 @@ github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4
 github.com/garyburd/redigo v1.1.1-0.20170914051019-70e1b1943d4f/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/gavv/httpexpect v2.0.0+incompatible/go.mod h1:x+9tiU1YnrOvnB725RkpoLv1M62hOWzwo5OXotisrKc=
 github.com/getsentry/raven-go v0.0.0-20180121060056-563b81fc02b7/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
-github.com/getsentry/sentry-go v0.10.0 h1:6gwY+66NHKqyZrdi6O2jGdo7wGdo9b3B69E01NFgT5g=
-github.com/getsentry/sentry-go v0.10.0/go.mod h1:kELm/9iCblqUYh+ZRML7PNdCvEuw24wBvJPYyi86cws=
+github.com/getsentry/sentry-go v0.11.0 h1:qro8uttJGvNAMr5CLcFI9CHR0aDzXl0Vs3Pmw/oTPg8=
+github.com/getsentry/sentry-go v0.11.0/go.mod h1:KBQIxiZAetw62Cj8Ri964vAEWVdgfaUCn30Q3bCvANo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=
 github.com/gin-gonic/gin v1.4.0/go.mod h1:OW2EZn3DO8Ln9oIKOvM++LBO+5UPHJJDH72/q/3rZdM=


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request improves our Sentry reporting.

#### Changes
<!-- What are the changes made in this pull request? -->

- Upgrade Sentry SDK to latest version
- Make sure errors always have a correlation ID
- Make Sentry show all messages in error chain instead of first only
- Use Sentry SDK Contexts instead of deprecated Extras
- Add IP address information to Sentry report
- Exclude Authorization and Cookie headers from Sentry report (but keep token type and token ID)
- Add user ID information to Sentry report when available
- Always create tags for `auth.token_type`, `auth.token_id`, `grpc.service`, `grpc.method`, `request_id`
- Try to create tags for anything that ends with `_id`, `_uid`, `_eui`.

#### Testing

<!-- How did you verify that this change works? -->

🐒 

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

n/a

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

nil

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
