### PR TITLE
Add missing polyfills for i18n functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ For details about compatibility between different releases, see the **Commitment
 - Parsing of ID6 encoded EUIs from Basic Station gateways.
 - Warnings about unknown fields when getting or searching for gateways.
 - Internal Server Errors from `pkg/identityserver/store`.
+- Console rendering blank pages in outdated browsers due to missing or incomplete internationalization API.
 
 ### Security
 

--- a/package.json
+++ b/package.json
@@ -75,6 +75,9 @@
     "yargs": "^17.0.1"
   },
   "dependencies": {
+    "@formatjs/intl-displaynames": "^5.2.2",
+    "@formatjs/intl-listformat": "^6.3.2",
+    "@formatjs/intl-pluralrules": "^4.1.2",
     "@formatjs/intl-relativetimeformat": "^8.0.6",
     "@sentry/browser": "^6.2.0",
     "@tippyjs/react": "^4.2.5",
@@ -90,7 +93,6 @@
     "formik": "^2.2.9",
     "history": "^4.10.1",
     "intl": "^1.2.5",
-    "intl-pluralrules": "^1.2.2",
     "leaflet": "^1.7.1",
     "lodash": "^4.17.21",
     "lottie-web": "^5.7.11",

--- a/pkg/webui/lib/components/with-locale.js
+++ b/pkg/webui/lib/components/with-locale.js
@@ -145,9 +145,29 @@ const UserLocale = ({ children }) => {
         )
       }
 
+      if (!window.Intl.DisplayNames) {
+        log(`Polyfilling Intl.DisplayNames`)
+        promises.push(
+          import(
+            /* webpackChunkName: "locale-display-names" */ '@formatjs/intl-displaynames/polyfill'
+          ),
+        )
+      }
+
+      if (!window.Intl.ListFormat) {
+        log(`Polyfilling Intl.ListFormat`)
+        promises.push(
+          import(/* webpackChunkName: "locale-list-format" */ '@formatjs/intl-listformat/polyfill'),
+        )
+      }
+
       if (!window.Intl.PluralRules) {
-        log(`Polyfilling Intl.PluralRules`)
-        promises.push(/* webpackChunkName: "locale-plural-rules" */ import('intl-pluralrules'))
+        log('Polyfilling Intl.PluralRules')
+        promises.push(
+          import(
+            /* webpackChunkName: "locale-plural-rules" */ '@formatjs/intl-pluralrules/polyfill'
+          ),
+        )
       }
 
       if (!window.Intl.RelativeTimeFormat) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1497,6 +1497,14 @@
   dependencies:
     tslib "^2.1.0"
 
+"@formatjs/ecma402-abstract@1.9.7":
+  version "1.9.7"
+  resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-1.9.7.tgz#92743737f6cfe16eb1666fe710121f8af26ecff5"
+  integrity sha512-Lu05JjSlL4QbXLiJHcljmWLSSKoxc4ed6aAz4ZPIJn7HsgzoObR4wKllFVcEWnIfiW8FIWITOZjXjoZ8MamSJA==
+  dependencies:
+    "@formatjs/intl-localematcher" "0.2.20"
+    tslib "^2.1.0"
+
 "@formatjs/fast-memoize@1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@formatjs/fast-memoize/-/fast-memoize-1.1.1.tgz#3006b58aca1e39a98aca213356b42da5d173f26b"
@@ -1527,12 +1535,46 @@
     "@formatjs/ecma402-abstract" "1.9.4"
     tslib "^2.1.0"
 
+"@formatjs/intl-displaynames@^5.2.2":
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-displaynames/-/intl-displaynames-5.2.2.tgz#7e5c9b99934ef9b8332e8a8ba1b42d0c08e13900"
+  integrity sha512-Xyl4KNhBUWroKzmOX7qXI008VazJMHZbebpRXhoQgjmFPGc87QBVjYcfwEmGHlRQgJ4L/bvQ6GNiN6b2Y96xUg==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.9.7"
+    "@formatjs/intl-localematcher" "0.2.20"
+    tslib "^2.1.0"
+
 "@formatjs/intl-listformat@6.2.6":
   version "6.2.6"
   resolved "https://registry.yarnpkg.com/@formatjs/intl-listformat/-/intl-listformat-6.2.6.tgz#4e3d6580df3b6ef737e5d7ce85bae7e065518ff9"
   integrity sha512-6FMdQY1+QKqJW5IhsVPFuEaR/uRiBKP+Y1oDvamZKzDfJ2vQmk9jqSF51VztlZH8XSfdO0IgvBzeRPHahKChQA==
   dependencies:
     "@formatjs/ecma402-abstract" "1.9.4"
+    tslib "^2.1.0"
+
+"@formatjs/intl-listformat@^6.3.2":
+  version "6.3.2"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-listformat/-/intl-listformat-6.3.2.tgz#50602b66b097b5f774ab81e737bf7d715fac7e60"
+  integrity sha512-9RiSmg8VPN+82c3MlHxQVX9pD20KcIyjOeDJBM9K9uieLR4X3v0RJneXj2yv6WyhHNhHvrhPmrWFjQYTowJLzQ==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.9.7"
+    "@formatjs/intl-localematcher" "0.2.20"
+    tslib "^2.1.0"
+
+"@formatjs/intl-localematcher@0.2.20":
+  version "0.2.20"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-localematcher/-/intl-localematcher-0.2.20.tgz#782aef53d1c1b6112ee67468dc59f9b8d1ba7b17"
+  integrity sha512-/Ro85goRZnCojzxOegANFYL0LaDIpdPjAukR7xMTjOtRx+3yyjR0ifGTOW3/Kjhmab3t6GnyHBYWZSudxEOxPA==
+  dependencies:
+    tslib "^2.1.0"
+
+"@formatjs/intl-pluralrules@^4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-pluralrules/-/intl-pluralrules-4.1.2.tgz#89f29c3f72edafd97d03005e1dec5af87742a269"
+  integrity sha512-mVHEfvXD8mgJkCKnUXKbRzqJgjKLI+xzNCKXSgsSHQuFjtgHtC3GfVmeQBMwhSXSSGsAd00xcODGLJW7NW4xtQ==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.9.7"
+    "@formatjs/intl-localematcher" "0.2.20"
     tslib "^2.1.0"
 
 "@formatjs/intl-relativetimeformat@^8.0.6":
@@ -8516,11 +8558,6 @@ intl-messageformat@9.7.1:
     "@formatjs/fast-memoize" "1.1.1"
     "@formatjs/icu-messageformat-parser" "2.0.7"
     tslib "^2.1.0"
-
-intl-pluralrules@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/intl-pluralrules/-/intl-pluralrules-1.2.2.tgz#2b73542a9502a8a3a742cdd917f3d969fb5482fe"
-  integrity sha512-SBdlNCJAhTA0I0uHg2dn7I+c6BCvSVk6zJ/01ozjwJK7BvKms9RH3w3Sd/Ag24KffZ/Yx6KJRCKAc7eE8TZLNg==
 
 intl@^1.2.5:
   version "1.2.5"


### PR DESCRIPTION
#### Summary

This PR adds missing polyfills for the `Intl` API. This has led to [blank pages in some older browser versions](https://www.thethingsnetwork.org/forum/t/blank-page-ttn-console/50629/9).

#### Changes
<!-- What are the changes made in this pull request? -->

- Add polyfill for `Intl.DisplayNames`
- Add polyfill for `Intl.ListFormat`
- Update polyfill for `Intl.PluralRules`

#### Testing

Manual testing.

#### Notes for Reviewers
Hard to tell if this will resolve the issue in the thread linked above, since I cannot currently reproduce. There might be other polyfills needed. It should at least resolve the error message that can be seen.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
