### PR TITLE
Do not print invalid configuration keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ For details about compatibility between different releases, see the **Commitment
 - Console rendering blank pages in outdated browsers due to missing or incomplete internationalization API.
 - Error in edit user form (Console) when submitting without making any changes.
 - `description` field not being fetched in edit user form (admin only) in the Console.
+- Ignore invalid configuration when printing configuration with `ttn-lw-cli config` or `ttn-lw-stack config`.
 
 ### Security
 

--- a/cmd/internal/commands/config.go
+++ b/cmd/internal/commands/config.go
@@ -48,6 +48,10 @@ func Config(mgr *config.Manager) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			space := 0
 			for _, key := range mgr.AllKeys() {
+				// Skip keys for which no flag is defined (e.g. invalid configuration keys read from a config file)
+				if cmd.Flags().Lookup(key) == nil {
+					continue
+				}
 				if len(key)+8 > space {
 					space = len(key) + 8
 				}
@@ -62,6 +66,10 @@ func Config(mgr *config.Manager) *cobra.Command {
 				return strings.Join(s, ",")
 			}
 			for _, key := range mgr.AllKeys() {
+				// Skip keys for which no flag is defined (e.g. invalid configuration keys read from a config file)
+				if cmd.Flags().Lookup(key) == nil {
+					continue
+				}
 				flagOrEnv, val := key, mgr.Get(key)
 				switch {
 				case useYml:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #4530 

#### Changes
<!-- What are the changes made in this pull request? -->

- When iterating over configuration keys, ignore the ones without any flags set.

#### Testing

<!-- How did you verify that this change works? -->

Test with invalid configuration and `ttn-lw-cli config` and `ttn-lw-stack config` commands. Also made sure that no existing config is removed from the output.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Change was suggested in https://github.com/TheThingsNetwork/lorawan-stack/issues/4530#issuecomment-899526439. Included an inline comment for future reference.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
