### PR TITLE
Remove superfluous babel run during serve target

### DIFF
--- a/config/webpack.config.babel.js
+++ b/config/webpack.config.babel.js
@@ -305,7 +305,7 @@ export default {
         filepath: path.resolve(context, PUBLIC_DIR, 'libs.bundle.js'),
       }),
       new ShellPlugin({
-        onBuildExit: [`${MAGE} js:translations`],
+        onBuildExit: [`${MAGE} js:extractLocaleFiles`],
       }),
     ],
   }),

--- a/tools/mage/js.go
+++ b/tools/mage/js.go
@@ -183,7 +183,7 @@ func (js Js) Build() error {
 
 // Serve runs webpack-dev-server.
 func (js Js) Serve() error {
-	mg.Deps(js.Deps, js.Translations, js.BackendTranslations, js.BuildDll)
+	mg.Deps(js.Deps, js.ExtractLocaleFiles, js.BackendTranslations, js.BuildDll)
 	if mg.Verbose() {
 		fmt.Println("Running Webpack for Main Bundle in watch mode")
 	}
@@ -219,9 +219,14 @@ func (js Js) Messages() error {
 	return execYarn(nil, os.Stderr, "babel", filepath.Join("pkg", "webui"))
 }
 
-// Translations builds the frontend locale files.
-func (js Js) Translations() error {
-	mg.Deps(js.Deps, js.Messages)
+// Translations writes the babel message files and converts them into locale files.
+func (js Js) Translations() {
+	mg.Deps(js.Messages)
+	mg.Deps(js.ExtractLocaleFiles)
+}
+
+// ExtractLocaleFiles extracts the locale files from the babel message files.
+func (js Js) ExtractLocaleFiles() error {
 	ok, err := target.Dir(
 		filepath.Join("pkg", "webui", "locales", "en.json"),
 		filepath.Join(".cache", "messages"),

--- a/tools/mage/translations.js
+++ b/tools/mage/translations.js
@@ -299,7 +299,7 @@ const main = async function () {
   }
 
   await writeLocales(updated)
-  console.log('Done.')
+  console.log('Locale files updated.')
 }
 
 main().catch(function (err) {


### PR DESCRIPTION
#### Summary
Quickfix PR to improve the performance of `js:serve`, which currently runs a superfluous babel command initially and also during the serve process itself.

#### Changes
- Add new mage target `js.extractLocaleFiles` that does not depend on `js:messages`
- Run this new command during `js:serve` (instead of `js:translations`)


#### Testing

Manual.

#### Notes for Reviewers
Currently `js:messages` runs as a dependency of `js:translations`. When running `js:serve` both commands will run, which will cause `babel pkg/webui` to be run which is a lenghty process that is not actually needed since `js:serve` will by itself run babel and update the messages. All we need is to extract the locale file during the serve process, to keep the messages up to date. Running the babel command in between is unnecessary.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
