### PR TITLE
Extend error handling in Console (root errors)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ For details about compatibility between different releases, see the **Commitment
 - `description` field not being fetched in edit user form (admin only) in the Console.
 - Ignore invalid configuration when printing configuration with `ttn-lw-cli config` or `ttn-lw-stack config`.
 - Emails about API key changes.
+- Avoid rendering blank pages in the Console for certain errors.
 
 ### Security
 

--- a/pkg/webui/account.js
+++ b/pkg/webui/account.js
@@ -21,6 +21,8 @@ import sentryConfig from '@ttn-lw/constants/sentry'
 import store, { history } from '@account/store'
 
 import WithLocale from '@ttn-lw/lib/components/with-locale'
+import { ErrorView } from '@ttn-lw/lib/components/error-view'
+import { FullViewErrorRaw } from '@ttn-lw/lib/components/full-view-error'
 import Init from '@ttn-lw/lib/components/init'
 
 import { selectSentryDsnConfig } from '@ttn-lw/lib/selectors/env'
@@ -36,14 +38,16 @@ const render = () => {
   const App = require('./account/views/app').default
 
   DOM.render(
-    <Provider store={store}>
-      <WithLocale>
-        <div id="modal-container" />
-        <Init>
-          <App history={history} />
-        </Init>
-      </WithLocale>
-    </Provider>,
+    <ErrorView ErrorComponent={FullViewErrorRaw}>
+      <Provider store={store}>
+        <WithLocale>
+          <div id="modal-container" />
+          <Init>
+            <App history={history} />
+          </Init>
+        </WithLocale>
+      </Provider>
+    </ErrorView>,
     document.getElementById('app'),
   )
 }

--- a/pkg/webui/console.js
+++ b/pkg/webui/console.js
@@ -23,6 +23,8 @@ import sentryConfig from '@ttn-lw/constants/sentry'
 import { BreadcrumbsProvider } from '@ttn-lw/components/breadcrumbs/context'
 
 import { EnvProvider } from '@ttn-lw/lib/components/env'
+import { ErrorView } from '@ttn-lw/lib/components/error-view'
+import { FullViewErrorRaw } from '@ttn-lw/lib/components/full-view-error'
 import Init from '@ttn-lw/lib/components/init'
 import WithLocale from '@ttn-lw/lib/components/with-locale'
 
@@ -45,17 +47,19 @@ const render = () => {
   const App = require('./console/views/app').default
 
   DOM.render(
-    <EnvProvider env={env}>
-      <Provider store={store}>
-        <WithLocale>
-          <Init>
-            <BreadcrumbsProvider>
-              <App history={history} />
-            </BreadcrumbsProvider>
-          </Init>
-        </WithLocale>
-      </Provider>
-    </EnvProvider>,
+    <ErrorView ErrorComponent={FullViewErrorRaw}>
+      <EnvProvider env={env}>
+        <Provider store={store}>
+          <WithLocale>
+            <Init>
+              <BreadcrumbsProvider>
+                <App history={history} />
+              </BreadcrumbsProvider>
+            </Init>
+          </WithLocale>
+        </Provider>
+      </EnvProvider>
+    </ErrorView>,
     rootElement,
   )
 }

--- a/pkg/webui/lib/components/error-view.js
+++ b/pkg/webui/lib/components/error-view.js
@@ -18,12 +18,15 @@ import { withRouter } from 'react-router-dom'
 import { ingestError } from '@ttn-lw/lib/errors/utils'
 import PropTypes from '@ttn-lw/lib/prop-types'
 
-@withRouter
 class ErrorView extends React.Component {
   static propTypes = {
     ErrorComponent: PropTypes.oneOfType([PropTypes.elementType, PropTypes.func]).isRequired,
     children: PropTypes.node.isRequired,
-    history: PropTypes.history.isRequired,
+    history: PropTypes.history,
+  }
+
+  static defaultProps = {
+    history: undefined,
   }
 
   state = {
@@ -47,12 +50,14 @@ class ErrorView extends React.Component {
 
     // Clear the error when the route changes (e.g. user clicking a link).
     const { history } = this.props
-    this.unlisten = history.listen((location, action) => {
-      if (this.state.hasCaught) {
-        this.setState({ hasCaught: false, error: undefined })
-        this.unlisten()
-      }
-    })
+    if (history) {
+      this.unlisten = history.listen((location, action) => {
+        if (this.state.hasCaught) {
+          this.setState({ hasCaught: false, error: undefined })
+          this.unlisten()
+        }
+      })
+    }
   }
 
   render() {
@@ -67,4 +72,6 @@ class ErrorView extends React.Component {
   }
 }
 
-export default ErrorView
+const ErrorViewWithRouter = withRouter(ErrorView)
+
+export { ErrorViewWithRouter as default, ErrorView }

--- a/pkg/webui/lib/components/full-view-error/error.styl
+++ b/pkg/webui/lib/components/full-view-error/error.styl
@@ -49,8 +49,8 @@
 
   &-sub
     display: block
-    margin-bottom: $cs.xl
-    
+    margin-bottom: $cs.l
+
   pre
     width: 100%
     background-color: $c-backdrop

--- a/pkg/webui/lib/components/full-view-error/index.js
+++ b/pkg/webui/lib/components/full-view-error/index.js
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { FullViewError, FullViewErrorInner } from './error'
+import { FullViewError, FullViewErrorInner, FullViewErrorRaw } from './error'
 import connect from './connect'
 
 const ConnectedFullErrorView = connect(FullViewError)
 
-export { ConnectedFullErrorView as default, FullViewError, FullViewErrorInner }
+export { ConnectedFullErrorView as default, FullViewError, FullViewErrorInner, FullViewErrorRaw }

--- a/pkg/webui/lib/components/init.js
+++ b/pkg/webui/lib/components/init.js
@@ -104,9 +104,11 @@ export default class Init extends React.PureComponent {
 
     if (!initialized) {
       return (
-        <Spinner center>
-          <Message content={m.initializing} />
-        </Spinner>
+        <div style={{ height: '100vh' }}>
+          <Spinner center>
+            <Message content={m.initializing} />
+          </Spinner>
+        </div>
       )
     }
 

--- a/pkg/webui/lib/shared-messages.js
+++ b/pkg/webui/lib/shared-messages.js
@@ -187,7 +187,7 @@ export default defineMessages({
   general: 'General',
   generalInformation: 'General information',
   generalSettings: 'General settings',
-  getSupport: 'Get Support',
+  getSupport: 'Get support',
   gsServerAddressDescription: 'The address of the Gateway Server to connect to',
   hardware: 'Hardware',
   hardwareVersion: 'Hardware version',

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -949,7 +949,7 @@
   "lib.shared-messages.general": "General",
   "lib.shared-messages.generalInformation": "General information",
   "lib.shared-messages.generalSettings": "General settings",
-  "lib.shared-messages.getSupport": "Get Support",
+  "lib.shared-messages.getSupport": "Get support",
   "lib.shared-messages.gsServerAddressDescription": "The address of the Gateway Server to connect to",
   "lib.shared-messages.hardware": "Hardware",
   "lib.shared-messages.hardwareVersion": "Hardware version",


### PR DESCRIPTION
#### Summary
This quickfix PR extends the error handling in the WebUIs for errors that occur high up in the component hierarchy and hence cannot use any context. Currently such errors will cause a blank page.

#### Changes
- Add a `FullViewErrorRaw` component that will render errors without any context (eg. router, locale)
- Modify `ErrorView` to work also without router context
- Add a root error boundary to the entry point of Console and Account app
- Fix a small styling bug for the spinner of the `Init` component
- Fix wrong capitalization for the `Get support` message


#### Testing

Manual testing. Some coverage by our existing e2es too.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
