### PR TITLE
Fix text overflow in webhook tiles

### DIFF
--- a/pkg/webui/console/views/application-integrations-webhook-add-choose/application-integrations-webhook-add-choose.styl
+++ b/pkg/webui/console/views/application-integrations-webhook-add-choose/application-integrations-webhook-add-choose.styl
@@ -56,6 +56,8 @@
   .description
     display: block
     line-height: 1.3
+    overflow: hidden
+    text-overflow: ellipsis
 
   .logo
     box-sizing: border-box


### PR DESCRIPTION
#### Summary
Quickfix to fix text-overflow in webhook tiles.

![image](https://user-images.githubusercontent.com/5710611/130634074-8ab83240-ac72-4adf-8f51-5b106e8b58d5.png)

#### Changes
- Set styles to use `text-overflow`: `ellipsis`


#### Testing

Manual.


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
