### PR TITLE
Fix NS multicast MAC state after reset

### DIFF
--- a/cmd/ttn-lw-cli/commands/applications_downlink.go
+++ b/cmd/ttn-lw-cli/commands/applications_downlink.go
@@ -16,10 +16,8 @@ package commands
 
 import (
 	"os"
-	"reflect"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/io"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/api"
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/util"
@@ -27,11 +25,7 @@ import (
 )
 
 var (
-	setApplicationDownlinkFlags = func() *pflag.FlagSet {
-		flagSet := util.FieldFlags(&ttnpb.ApplicationDownlink{})
-		util.AddField(flagSet, "class-b-c.gateways", reflect.TypeOf([]ttnpb.GatewayAntennaIdentifiers{}), false)
-		return flagSet
-	}()
+	setApplicationDownlinkFlags = util.FieldFlags(&ttnpb.ApplicationDownlink{})
 )
 
 var (

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -2341,9 +2341,12 @@ func (ns *NetworkServer) ResetFactoryDefaults(ctx context.Context, req *ttnpb.Re
 		"lorawan_phy_version",
 		"lorawan_version",
 		"mac_settings",
+		"multicast",
 		"session.dev_addr",
-		"session.queued_application_downlinks",
 		"session.keys",
+		"session.queued_application_downlinks",
+		"supports_class_b",
+		"supports_class_c",
 		"supports_join",
 	)...), func(ctx context.Context, stored *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
 		if stored == nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/570#issuecomment-912386729
References https://github.com/TheThingsNetwork/lorawan-stack/pull/4528

#### Changes
<!-- What are the changes made in this pull request? -->

- Update the `GatewayAntennaIdentifiers` handling in the CLI. Since https://github.com/TheThingsNetwork/lorawan-stack/pull/4528 we are using slices of pointers, so the element type must be dereferenced one additional time (from pointer to actual type)
- Add the `multicast`, `supports_class_b` and `supports_class_c` to the registry operation done by the `ResetFactoryDefaults` RPC. The generated MAC state was wrong since it didn't take into account multicast/class B/class C settings


#### Testing

<!-- How did you verify that this change works? -->

The CLI change I've tested using 

```
ttn-lw-cli dev downlink push app1 dev1 --f-port=10 --frm-payload=ff --class-b-c.gateways=gtw1
```

Which wasn't usable before the dereferencing change - I would get the following error:

```
WARN	Using insecure connection to OAuth server
DEBUG	Using access token (valid until 3:15PM)
error:cmd/ttn-lw-cli/internal/util:flag_value (invalid flag value)
    class-b-c.gateways=[]*ttnpb.GatewayAntennaIdentifiers is not convertible to []string
    correlation_id=f5ce8166be714faabf02afbf5ade2448
exit status 255
```

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

The CLI was broken already, and the testing procedure is mentioned above.
The field mask fix can be tested using the original support issue.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
