### PR TITLE
Evict downlink queue of the pending session on join accept

### DIFF
--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -1731,6 +1731,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context, consumerID str
 							SNwkSIntKey:  dev.PendingMacState.QueuedJoinAccept.Keys.SNwkSIntKey,
 							NwkSEncKey:   dev.PendingMacState.QueuedJoinAccept.Keys.NwkSEncKey,
 						},
+						QueuedApplicationDownlinks: nil,
 					}
 					dev.PendingMacState.PendingJoinRequest = &dev.PendingMacState.QueuedJoinAccept.Request
 					dev.PendingMacState.QueuedJoinAccept = nil
@@ -1747,6 +1748,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context, consumerID str
 						"pending_mac_state.rx_windows_available",
 						"pending_session.dev_addr",
 						"pending_session.keys",
+						"pending_session.queued_application_downlinks",
 					}, nil
 				}
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://sentry.io/organizations/the-things-industries/issues/2288551302/events/025faecbfcce495b9afee709f7b319e6/?project=2682566

#### Changes
<!-- What are the changes made in this pull request? -->

- Clear the pending session downlink queue in the Network Server while generating the new pending session. 

#### Testing

<!-- How did you verify that this change works? -->

Local testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Since the `session_key_id` of these downlinks would be all over the place (basically one for each previous join attempt), these downlinks would be dropped anyway. At least now we don't risk filling the queue with useless downlinks.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I thought we were doing this. We were not doing this, and as a result devices that were stuck in a join loop (JoinAccept being generated but not reaching the device) would end up having new downlinks being pushed contiguously.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
