### PR TITLE
Increase hash size used during uplink matching and deduplication

### DIFF
--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -755,7 +755,7 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 		matched *matchResult
 		ok      bool
 	)
-	const matchTTL = time.Minute
+	var matchTTL = ns.collectionWindow(ctx)
 	if err := ns.devices.RangeByUplinkMatches(ctx, up, matchTTL,
 		func(ctx context.Context, match *UplinkMatch) (bool, error) {
 			ctx = log.NewContextWithFields(ctx, log.Fields(

--- a/pkg/networkserver/redis/redis.go
+++ b/pkg/networkserver/redis/redis.go
@@ -17,10 +17,10 @@ package redis
 
 import (
 	"encoding/base64"
-	"hash/fnv"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	ttnredis "go.thethings.network/lorawan-stack/v3/pkg/redis"
+	"golang.org/x/crypto/sha3"
 )
 
 type keyer interface {
@@ -38,7 +38,7 @@ func uidLastInvalidationKey(r keyer, uid string) string {
 var keyEncoding = base64.RawStdEncoding
 
 func uplinkPayloadHash(b []byte) string {
-	h := fnv.New64a()
+	h := sha3.New224()
 	_, _ = h.Write(b)
 	return keyEncoding.EncodeToString(h.Sum(nil))
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/573

#### Changes
<!-- What are the changes made in this pull request? -->

- Change hashing algorithm used during deduplication and matching to `SHA3-224`, from `FNV-1a`
- Lower matching cache TTL to the collection window (200 ms + 1 second = 1.2 seconds by default), down from one minute

#### Testing

<!-- How did you verify that this change works? -->

Not applicable.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Not applicable.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

In v2, deduplication used to hash the payload using `MD5`, which is a 128 bit hash. In v3, after https://github.com/TheThingsNetwork/lorawan-stack/pull/2837 we are using `FNV-1a`, which is a 64 bit hash. I think we are seeing collisions, but I don't see a better way to test this than to disable the hashing completely. 

I would argue that a small LoRaWAN frame (think of about 1 byte per application payload) has a very low entropy, so maybe it's not impossible that this what we are seeing here.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
