### PR TITLE
Log drain errors only if the send did not fail

### DIFF
--- a/pkg/networkserver/utils.go
+++ b/pkg/networkserver/utils.go
@@ -399,7 +399,6 @@ func (ns *NetworkServer) enqueueApplicationUplinks(ctx context.Context, ups ...*
 			return err
 		}
 		if err := ns.sendApplicationUplinks(ctx, ttnpb.NewNsAsClient(conn), appID, ups...); err != nil {
-			log.FromContext(ctx).WithError(err).Error("Failed to send application uplinks")
 			return err
 		}
 		return nil


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://sentry.io/organizations/the-things-industries/issues/2628889957/?project=2682566&query=is%3Aunresolved

#### Changes
<!-- What are the changes made in this pull request? -->

- Do not log the uplink send errors as `ERROR` unless they are related to the task logic

#### Testing

<!-- How did you verify that this change works? -->

N/A

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

We report an error even if the Application Server cannot actually process the uplinks. This PR makes it such that such errors are logged as `WARN`, while the rest are `ERROR`.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
