### PR TITLE
Fix cypress grouping in e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -200,7 +200,7 @@ jobs:
           config: baseUrl=http://localhost:1885
           record: true
           parallel: true
-          group: ${{ needs.determine-if-required.outputs.hash }}
+          group: main-${{ needs.determine-if-required.outputs.hash }}
       - name: Upload logs
         uses: actions/upload-artifact@v2
         if: failure()
@@ -264,9 +264,7 @@ jobs:
           config: baseUrl=http://localhost:1885
           browser: firefox
           record: true
-          parallel: true
           spec: cypress/integration/smoke/smoke.spec.js
-          group: ${{ needs.determine-if-required.outputs.hash }}
       - name: Upload logs
         uses: actions/upload-artifact@v2
         if: failure()


### PR DESCRIPTION
#### Summary
This quickfix fixes grouping of Cypress runs.

#### Changes
- Use different groups for chrome and ff runs

#### Testing
- Using the CI run of this PR

#### Notes for Reviewers
This slipped through because on my private fork cypress runs cannot use parallelization...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
