### PR TITLE
Create separate definition for URL parse errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ For details about compatibility between different releases, see the **Commitment
 - URL field validation in webhook forms in the Console when value is not trimmed.
 - Not rendering site header and footer for error pages in some situations.
 - Not providing a copy button for error pages in some situations.
+- Improved errors for invalid URLs.
 
 ### Security
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -3851,6 +3851,15 @@
       "file": "conversion.go"
     }
   },
+  "error:pkg/errors:url": {
+    "translations": {
+      "en": "invalid url `{url}`"
+    },
+    "description": {
+      "package": "pkg/errors",
+      "file": "conversion.go"
+    }
+  },
   "error:pkg/errors:validation": {
     "translations": {
       "en": "invalid `{field}`: {reason}"

--- a/pkg/errors/conversion.go
+++ b/pkg/errors/conversion.go
@@ -35,6 +35,7 @@ var (
 	errNetOperation      = DefineUnavailable("net_operation", "{message}", "message", "op", "net", "source", "address", "timeout", "temporary")
 
 	errRequest = Define("request", "request to `{url}` failed")
+	errURL     = DefineInvalidArgument("url", "invalid url `{url}`")
 
 	errX509UnknownAuthority = DefineUnavailable("x509_unknown_authority", "unknown certificate authority")
 )
@@ -115,7 +116,11 @@ func From(err error) (out *Error, ok bool) {
 		}
 		return e, true
 	case *url.Error:
-		e := build(errRequest, 0).WithAttributes(
+		definition := errRequest
+		if err.Op == "parse" {
+			definition = errURL
+		}
+		e := build(definition, 0).WithAttributes(
 			"url", err.URL,
 		)
 		if err.Err != nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a small pull request that adds an error definition for parse errors from `net/url`.

#### Changes
<!-- What are the changes made in this pull request? -->

- Create error definition
- Use it

#### Testing

<!-- How did you verify that this change works? -->

...

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

...

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
