### PR TITLE
Fix firewall message rate limitting

### DIFF
--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -171,10 +171,9 @@ func (s *srv) handlePackets() {
 
 			if s.firewall != nil {
 				if err := s.firewall.Filter(packet); err != nil {
-					if errors.IsResourceExhausted(err) && ratelimit.Require(s.limitLogs, ratelimit.NewCustomResource(eui.String())) == nil {
-						break
+					if !errors.IsResourceExhausted(err) || ratelimit.Require(s.limitLogs, ratelimit.NewCustomResource(eui.String())) == nil {
+						logger.WithError(err).Warn("Packet filtered")
 					}
-					logger.WithError(err).Warn("Packet filtered")
 					break
 				}
 			}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes the `Packet Filtered` message spam when a gateway attempts to send too many packets per second.

#### Changes
<!-- What are the changes made in this pull request? -->

- Log the `Packet Filtered` message only if the error is not an resource exhausted one, or the rate limitting allows it.


#### Testing

<!-- How did you verify that this change works? -->

N/A

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
