### PR TITLE
Fix validation of webhook base URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Fixed
 
 - Entity purge handling for non-admin users in the Console.
+- URL field validation in webhook forms in the Console when value is not trimmed.
 
 ### Security
 

--- a/pkg/webui/console/components/webhook-form/index.js
+++ b/pkg/webui/console/components/webhook-form/index.js
@@ -58,6 +58,8 @@ const m = defineMessages({
   templateInformation: 'Template information',
   enabledMessages: 'Enabled messages',
   endpointSettings: 'Endpoint settings',
+  updateErrorTitle: 'Could not update webhook',
+  createErrorTitle: 'Could not create webhook',
 })
 
 const headerCheck = headers =>
@@ -209,6 +211,7 @@ export default class WebhookForm extends Component {
           validationSchema={validationSchema}
           initialValues={initialValues}
           error={error}
+          errorTitle={update ? m.updateErrorTitle : m.createErrorTitle}
           formikRef={this.form}
         >
           <Form.SubTitle title={sharedMessages.generalSettings} />

--- a/pkg/webui/lib/regexp.js
+++ b/pkg/webui/lib/regexp.js
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export const url = /\b((http|https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))/
+export const url = /^\b((http|https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))$/
 export const id = /^[a-z0-9](?:[-]?[a-z0-9]){2,}$/

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -297,6 +297,8 @@
   "console.components.webhook-form.index.templateInformation": "Template information",
   "console.components.webhook-form.index.enabledMessages": "Enabled messages",
   "console.components.webhook-form.index.endpointSettings": "Endpoint settings",
+  "console.components.webhook-form.index.updateErrorTitle": "Could not update webhook",
+  "console.components.webhook-form.index.createErrorTitle": "Could not create webhook",
   "console.components.webhook-template-form.index.createTemplate": "Create {template} webhook",
   "console.components.webhook-template-form.index.idPlaceholder": "my-new-{templateId}-webhook",
   "console.components.webhook-template-form.index.templateSettings": "Template settings",


### PR DESCRIPTION
#### Summary
This quickfix PR will fix validation of the base URL field in the webhook forms. It's currently possible to submit untrimmed values which will cause a submit error.

See also: https://sentry.io/organizations/the-things-industries/issues/2015318983/events/81226f4659b443649266bd6570ec1040/?project=2682566&query=frontendOrigin%3ATrue+is%3Aunresolved&statsPeriod=14d

#### Changes
- Fix URL regexp used by `Yup`
- Add an error title to the webhook form.

#### Testing

Manual testing.

##### Regressions

None.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
