### PR TITLE
Optimize Application Server worker pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For details about compatibility between different releases, see the **Commitment
 - Update to Go 1.17.
 - LBS timestamp rollover threshold.
 - Layout of error pages.
+- The Application Server worker pools may now drop workers if they are idle for too long.
 
 ### Deprecated
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -2420,15 +2420,6 @@
       "file": "templates.go"
     }
   },
-  "error:pkg/applicationserver/io/web:queue_full": {
-    "translations": {
-      "en": "the queue is full"
-    },
-    "description": {
-      "package": "pkg/applicationserver/io/web",
-      "file": "webhooks.go"
-    }
-  },
   "error:pkg/applicationserver/io/web:rate_limit_exceeded": {
     "translations": {
       "en": "rate limit exceeded"

--- a/config/messages.json
+++ b/config/messages.json
@@ -8477,6 +8477,15 @@
       "file": "cookie.go"
     }
   },
+  "error:pkg/workerpool:pool_full": {
+    "translations": {
+      "en": "the worker pool is full"
+    },
+    "description": {
+      "package": "pkg/workerpool",
+      "file": "workerpool.go"
+    }
+  },
   "event:account.user.login_failed": {
     "translations": {
       "en": "login user failure"

--- a/pkg/applicationserver/io/io.go
+++ b/pkg/applicationserver/io/io.go
@@ -76,6 +76,8 @@ type Server interface {
 	DownlinkQueueOperator
 	UplinkStorage
 	Cluster
+	// FromRequestContext decouples the lifetime of the provided context from the values found in the context.
+	FromRequestContext(context.Context) context.Context
 	// GetBaseConfig returns the component configuration.
 	GetBaseConfig(ctx context.Context) config.ServiceBase
 	// FillContext fills the given context.

--- a/pkg/applicationserver/io/web/observability.go
+++ b/pkg/applicationserver/io/web/observability.go
@@ -26,13 +26,6 @@ const (
 )
 
 var webhookMetrics = &messageMetrics{
-	webhookQueue: metrics.NewGauge(
-		prometheus.GaugeOpts{
-			Subsystem: subsystem,
-			Name:      "queue_size",
-			Help:      "Webhook queue size",
-		},
-	),
 	webhooksSent: metrics.NewCounter(
 		prometheus.CounterOpts{
 			Subsystem: subsystem,
@@ -51,35 +44,23 @@ var webhookMetrics = &messageMetrics{
 }
 
 func init() {
-	webhookMetrics.webhookQueue.Set(0)
 	webhookMetrics.webhooksSent.Add(0)
 	metrics.MustRegister(webhookMetrics)
 }
 
 type messageMetrics struct {
-	webhookQueue   prometheus.Gauge
 	webhooksSent   prometheus.Counter
 	webhooksFailed *prometheus.CounterVec
 }
 
 func (m messageMetrics) Describe(ch chan<- *prometheus.Desc) {
-	m.webhookQueue.Describe(ch)
 	m.webhooksSent.Describe(ch)
 	m.webhooksFailed.Describe(ch)
 }
 
 func (m messageMetrics) Collect(ch chan<- prometheus.Metric) {
-	m.webhookQueue.Collect(ch)
 	m.webhooksSent.Collect(ch)
 	m.webhooksFailed.Collect(ch)
-}
-
-func registerWebhookQueued() {
-	webhookMetrics.webhookQueue.Inc()
-}
-
-func registerWebhookDequeued() {
-	webhookMetrics.webhookQueue.Dec()
 }
 
 func registerWebhookSent() {

--- a/pkg/workerpool/observability.go
+++ b/pkg/workerpool/observability.go
@@ -1,0 +1,101 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workerpool
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.thethings.network/lorawan-stack/v3/pkg/metrics"
+)
+
+const (
+	subsystem = "workerpool"
+	poolLabel = "pool"
+)
+
+type workPoolMetrics struct {
+	workersStarted *metrics.ContextualCounterVec
+	workersStopped *metrics.ContextualCounterVec
+	workEnqueued   *metrics.ContextualCounterVec
+	workDequeued   *metrics.ContextualCounterVec
+}
+
+func (m workPoolMetrics) Describe(ch chan<- *prometheus.Desc) {
+	m.workersStarted.Describe(ch)
+	m.workersStopped.Describe(ch)
+	m.workEnqueued.Describe(ch)
+	m.workDequeued.Describe(ch)
+}
+
+func (m workPoolMetrics) Collect(ch chan<- prometheus.Metric) {
+	m.workersStarted.Collect(ch)
+	m.workersStopped.Collect(ch)
+	m.workEnqueued.Collect(ch)
+	m.workDequeued.Collect(ch)
+}
+
+var poolMetrics = &workPoolMetrics{
+	workersStarted: metrics.NewContextualCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "workers_started",
+			Help:      "Number of workers started",
+		},
+		[]string{poolLabel},
+	),
+	workersStopped: metrics.NewContextualCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "workers_stopped",
+			Help:      "Number of workers stopped",
+		},
+		[]string{poolLabel},
+	),
+	workEnqueued: metrics.NewContextualCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "work_enqueued",
+			Help:      "Amount of work enqueued",
+		},
+		[]string{poolLabel},
+	),
+	workDequeued: metrics.NewContextualCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "work_dequeued",
+			Help:      "Amount of work dequeued",
+		},
+		[]string{poolLabel},
+	),
+}
+
+func registerWorkerStarted(ctx context.Context, name string) {
+	poolMetrics.workersStarted.WithLabelValues(ctx, name).Inc()
+	poolMetrics.workersStopped.WithLabelValues(ctx, name)
+}
+
+func registerWorkerStopped(ctx context.Context, name string) {
+	poolMetrics.workersStopped.WithLabelValues(ctx, name).Inc()
+}
+
+func registerWorkEnqueued(ctx context.Context, name string) {
+	poolMetrics.workEnqueued.WithLabelValues(ctx, name).Inc()
+	poolMetrics.workDequeued.WithLabelValues(ctx, name)
+}
+
+func registerWorkDequeued(ctx context.Context, name string) {
+	poolMetrics.workDequeued.WithLabelValues(ctx, name).Inc()
+}

--- a/pkg/workerpool/workerpool.go
+++ b/pkg/workerpool/workerpool.go
@@ -1,0 +1,234 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workerpool
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/component"
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+)
+
+const (
+	// defaultWorkerIdleTimeout is the duration after which an idle worker stops to save resources.
+	defaultWorkerIdleTimeout = (1 << 7) * time.Millisecond
+	// defaultWorkerBusyTimeout is the duration after which a message is dropped if all workers are busy.
+	defaultWorkerBusyTimeout = (1 << 6) * time.Millisecond
+)
+
+// Component contains a minimal component.Component definition.
+type Component interface {
+	StartTask(*component.TaskConfig)
+	FromRequestContext(context.Context) context.Context
+}
+
+// Handler is a function that processes items published to the worker pool.
+type Handler func(ctx context.Context, item interface{})
+
+// HandlerFactory is a function that creates a Handler.
+type HandlerFactory func() (Handler, error)
+
+// StaticHandlerFactory creates a HandlerFactory that always returns the same handler.
+func StaticHandlerFactory(f Handler) HandlerFactory {
+	return func() (Handler, error) {
+		return f, nil
+	}
+}
+
+// Config is the configuration of the worker pool.
+type Config struct {
+	Component
+	context.Context                  // The base context of the pool.
+	Name              string         // The name of the pool.
+	CreateHandler     HandlerFactory // The function that creates handlers.
+	MinWorkers        int            // The minimum number of workers in the pool.
+	MaxWorkers        int            // The maximum number of workers in the pool.
+	QueueSize         int            // The size of the work queue.
+	WorkerIdleTimeout time.Duration  // The maximum amount of time a worker will stay idle before closing.
+	WorkerBusyTimeout time.Duration  // The maximum amount of time a publisher will wait before dropping the message.
+}
+
+// WorkerPool is a dynamic pool of workers to which work items can be published.
+// The workers are created on demand and live as long as work is available.
+type WorkerPool interface {
+	// Publish publishes an item to the worker pool to be processed.
+	// Publish does not block indefinitely, and may spawn a worker
+	// in order to fullfil the work load.
+	Publish(ctx context.Context, item interface{}) error
+}
+
+type contextualItem struct {
+	ctx  context.Context
+	item interface{}
+}
+
+type workerPool struct {
+	Config
+	q       chan *contextualItem
+	workers int32
+}
+
+func (wp *workerPool) workerBody(handler Handler) func(context.Context) error {
+	worker := func(ctx context.Context) error {
+		var decremented bool
+		defer func() {
+			if !decremented {
+				atomic.AddInt32(&wp.workers, -1)
+			}
+		}()
+
+		registerWorkerStarted(wp.Config, wp.Name)
+		defer registerWorkerStopped(wp.Context, wp.Name)
+
+		for {
+			select {
+			case <-wp.Done():
+				return wp.Err()
+
+			case <-ctx.Done():
+				return ctx.Err()
+
+			case <-time.After(wp.WorkerIdleTimeout):
+				if decrementIfGreaterThan(&wp.workers, int32(wp.MinWorkers)) {
+					decremented = true
+					return nil
+				}
+
+			case item := <-wp.q:
+				registerWorkDequeued(ctx, wp.Name)
+				handler(item.ctx, item.item)
+			}
+		}
+	}
+	return worker
+}
+
+func (wp *workerPool) spawnWorker() error {
+	handler, err := wp.CreateHandler()
+	if err != nil {
+		return err
+	}
+
+	if !incrementIfSmallerThan(&wp.workers, int32(wp.MaxWorkers)) {
+		return nil
+	}
+
+	wp.StartTask(&component.TaskConfig{
+		Context: wp.Context,
+		ID:      wp.Name,
+		Func:    wp.workerBody(handler),
+		Restart: component.TaskRestartNever,
+		Backoff: component.DefaultTaskBackoffConfig,
+	})
+
+	return nil
+}
+
+var errPoolFull = errors.DefineResourceExhausted("pool_full", "the worker pool is full")
+
+// Publish implements WorkerPool.
+func (wp *workerPool) Publish(ctx context.Context, item interface{}) error {
+	it := &contextualItem{
+		ctx:  wp.FromRequestContext(ctx),
+		item: item,
+	}
+
+	select {
+	case <-wp.Done():
+		return wp.Err()
+
+	case <-ctx.Done():
+		return ctx.Err()
+
+	case wp.q <- it:
+		registerWorkEnqueued(ctx, wp.Name)
+		return nil
+
+	default:
+		if err := wp.spawnWorker(); err != nil {
+			return err
+		}
+
+		select {
+		case <-wp.Done():
+			return wp.Err()
+
+		case <-ctx.Done():
+			return ctx.Err()
+
+		case wp.q <- it:
+			registerWorkEnqueued(ctx, wp.Name)
+			return nil
+
+		case <-time.After(wp.WorkerBusyTimeout):
+			return errPoolFull.New()
+		}
+	}
+}
+
+// NewWorkerPool creates a new WorkerPool with the provided configuration.
+func NewWorkerPool(cfg Config) (WorkerPool, error) {
+	if cfg.WorkerBusyTimeout == 0 {
+		cfg.WorkerBusyTimeout = defaultWorkerBusyTimeout
+	}
+	if cfg.WorkerIdleTimeout == 0 {
+		cfg.WorkerIdleTimeout = defaultWorkerIdleTimeout
+	}
+	if cfg.MinWorkers <= 0 {
+		cfg.MinWorkers = 1
+	}
+	if cfg.MaxWorkers <= 0 {
+		cfg.MaxWorkers = 1
+	}
+	if cfg.QueueSize < 0 {
+		cfg.QueueSize = 0
+	}
+	if cfg.MinWorkers > cfg.MaxWorkers {
+		cfg.MaxWorkers = cfg.MinWorkers
+	}
+
+	wp := &workerPool{
+		Config: cfg,
+		q:      make(chan *contextualItem, cfg.QueueSize),
+	}
+
+	for i := 0; i < wp.MinWorkers; i++ {
+		if err := wp.spawnWorker(); err != nil {
+			return nil, err
+		}
+	}
+
+	return wp, nil
+}
+
+func incrementIfSmallerThan(i *int32, max int32) bool {
+	for v := atomic.LoadInt32(i); v < max; v = atomic.LoadInt32(i) {
+		if atomic.CompareAndSwapInt32(i, v, v+1) {
+			return true
+		}
+	}
+	return false
+}
+
+func decrementIfGreaterThan(i *int32, min int32) bool {
+	for v := atomic.LoadInt32(i); v > min; v = atomic.LoadInt32(i) {
+		if atomic.CompareAndSwapInt32(i, v, v-1) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/4606

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `pkg/workerpool`, which contains the generic worker pool that spawns workers on demand
- Refactor the application packages frontend to use the `pkg/workerpool` pool instead of the manually spawned tasks
  - A small deviation that you will see here is that there is a worker pool added between the `io.Subscription` and the actual worker pools of each package. This is intentional and allows us to decide to which package we need to send a particular uplink to in parallel. 
- Refactor the webhooks frontend to use the `pkg/workerpool` pool instead of the manually spawned goroutines

#### Testing

<!-- How did you verify that this change works? -->

Unit testing and local testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This changes the piping used by the Application Server worker pools. The unit tests cover this.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
