### PR TITLE
Redirect back to login when OAuth authorization request is denied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ For details about compatibility between different releases, see the **Commitment
 - Not rendering site header and footer for error pages in some situations.
 - Not providing a copy button for error pages in some situations.
 - Improved errors for invalid URLs.
+- Rendering an error in the Console after the OIDC-authentication was cancelled instead of redirecting back to the login page.
 
 ### Security
 

--- a/cypress/integration/smoke/authorization/index.js
+++ b/cypress/integration/smoke/authorization/index.js
@@ -65,13 +65,11 @@ const abortAuthorization = defineSmokeTest(
     cy.findByLabelText('Password').type(`${user.password}{enter}`)
 
     // Deny authorization.
-    cy.location('pathname').should('contain', `${Cypress.config('accountAppRootPath')}/authorize`)
     cy.findByRole('button', { name: /Cancel/ }).click()
 
-    // Check Console error.
-    cy.location('pathname').should('eq', `${Cypress.config('consoleRootPath')}/oauth/callback`)
-    cy.findByTestId('full-error-view').should('exist')
-    cy.findByText('Forbidden').should('be.visible')
+    // Check redirects.
+    cy.location('pathname').should('eq', `${Cypress.config('consoleRootPath')}/`)
+    cy.location('pathname').should('contain', `${Cypress.config('accountAppRootPath')}/authorize`)
   },
 )
 

--- a/pkg/web/oauthclient/callback.go
+++ b/pkg/web/oauthclient/callback.go
@@ -59,6 +59,16 @@ func (oc *OAuthClient) HandleCallback(c echo.Context) error {
 	if err := c.Bind(&response); err != nil {
 		return err
 	}
+	if response.Error == "access_denied" {
+		// The `access_denied` error usually means that the authorization request
+		// was actively denied by the user. In that case, it is best to redirect
+		// back to the page root, which will enable to restart the authorization
+		// process if wished.
+		ctx := c.Request().Context()
+		config := oc.configFromContext(ctx)
+		oc.removeStateCookie(c)
+		return c.Redirect(http.StatusFound, config.RootURL)
+	}
 	if err := response.ValidateContext(c.Request().Context()); err != nil {
 		return err
 	}


### PR DESCRIPTION
#### Summary

This PR improves the UX when canceling the OAuth authorization request by redirecting back to the login page instead of rendering an error.

Closes #4564

#### Changes
- Make the `oauthclient` utility redirect to the `rootURL` when the OIDC-authentication was aborted. This will lead to another redirect back to the login page.

#### Testing

Manual testing by modifying the database to not make the console client skip the authorization, similar to how we do it in our end-to-end tests.

##### Regressions

I don't think there should be any.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
