### PR TITLE
Improve worker pool pressure propagation

### DIFF
--- a/pkg/workerpool/observability.go
+++ b/pkg/workerpool/observability.go
@@ -82,6 +82,10 @@ var poolMetrics = &workPoolMetrics{
 	),
 }
 
+func init() {
+	metrics.MustRegister(poolMetrics)
+}
+
 func registerWorkerStarted(ctx context.Context, name string) {
 	poolMetrics.workersStarted.WithLabelValues(ctx, name).Inc()
 	poolMetrics.workersStopped.WithLabelValues(ctx, name)

--- a/pkg/workerpool/observability.go
+++ b/pkg/workerpool/observability.go
@@ -31,6 +31,7 @@ type workPoolMetrics struct {
 	workersStopped *metrics.ContextualCounterVec
 	workEnqueued   *metrics.ContextualCounterVec
 	workDequeued   *metrics.ContextualCounterVec
+	workDropped    *metrics.ContextualCounterVec
 }
 
 func (m workPoolMetrics) Describe(ch chan<- *prometheus.Desc) {
@@ -38,6 +39,7 @@ func (m workPoolMetrics) Describe(ch chan<- *prometheus.Desc) {
 	m.workersStopped.Describe(ch)
 	m.workEnqueued.Describe(ch)
 	m.workDequeued.Describe(ch)
+	m.workDropped.Describe(ch)
 }
 
 func (m workPoolMetrics) Collect(ch chan<- prometheus.Metric) {
@@ -45,6 +47,7 @@ func (m workPoolMetrics) Collect(ch chan<- prometheus.Metric) {
 	m.workersStopped.Collect(ch)
 	m.workEnqueued.Collect(ch)
 	m.workDequeued.Collect(ch)
+	m.workDropped.Collect(ch)
 }
 
 var poolMetrics = &workPoolMetrics{
@@ -80,6 +83,14 @@ var poolMetrics = &workPoolMetrics{
 		},
 		[]string{poolLabel},
 	),
+	workDropped: metrics.NewContextualCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "work_dropped",
+			Help:      "Amount of work dropped",
+		},
+		[]string{poolLabel},
+	),
 }
 
 func init() {
@@ -102,4 +113,8 @@ func registerWorkEnqueued(ctx context.Context, name string) {
 
 func registerWorkDequeued(ctx context.Context, name string) {
 	poolMetrics.workDequeued.WithLabelValues(ctx, name).Inc()
+}
+
+func registerWorkDropped(ctx context.Context, name string) {
+	poolMetrics.workDropped.WithLabelValues(ctx, name).Inc()
 }

--- a/pkg/workerpool/utils.go
+++ b/pkg/workerpool/utils.go
@@ -1,0 +1,34 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workerpool
+
+import (
+	"context"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/log"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+)
+
+// HandlerFactoryFromUplinkHandler converts a static uplink handler to a HandlerFactory.
+func HandlerFactoryFromUplinkHandler(handler func(context.Context, *ttnpb.ApplicationUp) error) HandlerFactory {
+	h := func(ctx context.Context, item interface{}) {
+		up := item.(*ttnpb.ApplicationUp)
+
+		if err := handler(ctx, up); err != nil {
+			log.FromContext(ctx).WithError(err).Warn("Failed to submit message")
+		}
+	}
+	return StaticHandlerFactory(h)
+}

--- a/pkg/workerpool/workerpool.go
+++ b/pkg/workerpool/workerpool.go
@@ -175,6 +175,7 @@ func (wp *workerPool) Publish(ctx context.Context, item interface{}) error {
 			return nil
 
 		case <-time.After(wp.WorkerBusyTimeout):
+			registerWorkDropped(ctx, wp.Name)
 			return errPoolFull.New()
 		}
 	}

--- a/pkg/workerpool/workerpool.go
+++ b/pkg/workerpool/workerpool.go
@@ -25,7 +25,13 @@ import (
 
 const (
 	// defaultWorkerIdleTimeout is the duration after which an idle worker stops to save resources.
-	defaultWorkerIdleTimeout = (1 << 10) * time.Millisecond
+	defaultWorkerIdleTimeout = 1 * time.Second
+	// defaultQueueSize is the default queue size for the worker pool.
+	defaultQueueSize = 32
+	// defaultMinWorkers is the default number of minimum workers kept in the pool.
+	defaultMinWorkers = 4
+	// defaultMaxWorkers is the default number of maximum workers kept in the pool.
+	defaultMaxWorkers = 64
 )
 
 // Component contains a minimal component.Component definition.
@@ -63,8 +69,8 @@ type Config struct {
 // The workers are created on demand and live as long as work is available.
 type WorkerPool interface {
 	// Publish publishes an item to the worker pool to be processed.
-	// Publish does not block indefinitely, and may spawn a worker
-	// in order to fullfil the work load.
+	// Publish may spawn a worker in order to fullfil the work load.
+	// Publish does not block.
 	Publish(ctx context.Context, item interface{}) error
 }
 
@@ -75,8 +81,18 @@ type contextualItem struct {
 
 type workerPool struct {
 	Config
-	q       chan *contextualItem
+
+	mainQueue chan *contextualItem // mainQueue allows items to be buffered between publishers and workers.
+	fastQueue chan *contextualItem // fastQueue allows direct communication between publishers and idle workers.
+
 	workers int32
+}
+
+func (wp *workerPool) handle(ctx context.Context, it *contextualItem, handler Handler) {
+	registerWorkerBusy(wp.Name)
+	defer registerWorkerIdle(wp.Name)
+	defer registerWorkProcessed(it.ctx, wp.Name)
+	handler(it.ctx, it.item)
 }
 
 func (wp *workerPool) workerBody(handler Handler, initialWork *contextualItem) func(context.Context) error {
@@ -88,11 +104,13 @@ func (wp *workerPool) workerBody(handler Handler, initialWork *contextualItem) f
 			}
 		}()
 
-		registerWorkerStarted(wp.Config, wp.Name)
-		defer registerWorkerStopped(wp.Context, wp.Name)
+		defer registerWorkerStopped(wp.Name)
+
+		registerWorkerIdle(wp.Name)
+		defer registerWorkerBusy(wp.Name)
 
 		if initialWork != nil {
-			handler(initialWork.ctx, initialWork.item)
+			wp.handle(ctx, initialWork, handler)
 		}
 
 		for {
@@ -109,9 +127,12 @@ func (wp *workerPool) workerBody(handler Handler, initialWork *contextualItem) f
 					return nil
 				}
 
-			case item := <-wp.q:
-				registerWorkDequeued(ctx, wp.Name)
-				handler(item.ctx, item.item)
+			case item := <-wp.fastQueue:
+				wp.handle(ctx, item, handler)
+
+			case item := <-wp.mainQueue:
+				registerWorkDequeued(wp.Name)
+				wp.handle(ctx, item, handler)
 			}
 		}
 	}
@@ -129,6 +150,8 @@ func (wp *workerPool) spawnWorker(initialWork *contextualItem) (bool, error) {
 		return false, nil
 	}
 
+	registerWorkerStarted(wp.Name)
+
 	wp.StartTask(&component.TaskConfig{
 		Context: wp.Context,
 		ID:      wp.Name,
@@ -143,11 +166,17 @@ func (wp *workerPool) spawnWorker(initialWork *contextualItem) (bool, error) {
 var errPoolFull = errors.DefineResourceExhausted("pool_full", "the worker pool is full")
 
 // enqueueSpawn attempts to enqueue the work item, spawning a worker task if possible.
-// If the pool can pickup the work, the work is enqueued.
-// If the pool is full, enqueueSpawn will attempt to spawn a worker task.
-// If the worker task has been created, it will automatically handle the work item.
-// Otherwise, the work item is dropped.
+// If an idle worker can pickup the work, the work is provided to the idle worker.
+// If the work item can be enqueued, it will be enqueued, and the pool will attempt
+// to spawn an extra worker.
+// If the work cannot be enqueued, the pool will attempt to spawn an extra worker
+// that will handle the work. If this fails, the work is dropped.
 func (wp *workerPool) enqueueSpawn(ctx context.Context, it *contextualItem) error {
+	// select is fair, and as such if two possible communication paths are possible
+	// (both fastQueue, and mainQueue) the one which will proceed is chosen based
+	// on a uniform pseudo-random selection. As such, we initially attempt to submit
+	// the work directly via the fast queue, and only if that fails we attempt to use
+	// the main buffered queue.
 	select {
 	case <-wp.Done():
 		return wp.Err()
@@ -155,19 +184,39 @@ func (wp *workerPool) enqueueSpawn(ctx context.Context, it *contextualItem) erro
 	case <-ctx.Done():
 		return ctx.Err()
 
-	case wp.q <- it:
-		registerWorkEnqueued(ctx, wp.Name)
+	case wp.fastQueue <- it:
 		return nil
 
 	default:
-		spawned, err := wp.spawnWorker(it)
-		if err != nil || spawned {
-			return err
-		}
-
-		registerWorkDropped(ctx, wp.Name)
-		return errPoolFull.New()
 	}
+
+	select {
+	case <-wp.Done():
+		return wp.Err()
+
+	case <-ctx.Done():
+		return ctx.Err()
+
+	case wp.fastQueue <- it:
+		return nil
+
+	case wp.mainQueue <- it:
+		registerWorkEnqueued(wp.Name)
+		it = nil
+
+	default:
+	}
+
+	spawned, err := wp.spawnWorker(it)
+	// err == nil if spawned || it == nil
+	// which is fine as the work is either picked up by the new worker
+	// or was already placed in the queue.
+	if err != nil || spawned || it == nil {
+		return err
+	}
+
+	registerWorkDropped(it.ctx, wp.Name)
+	return errPoolFull.New()
 }
 
 // Publish implements WorkerPool.
@@ -184,13 +233,13 @@ func NewWorkerPool(cfg Config) (WorkerPool, error) {
 		cfg.WorkerIdleTimeout = defaultWorkerIdleTimeout
 	}
 	if cfg.MinWorkers <= 0 {
-		cfg.MinWorkers = 1
+		cfg.MinWorkers = defaultMinWorkers
 	}
 	if cfg.MaxWorkers <= 0 {
-		cfg.MaxWorkers = 1
+		cfg.MaxWorkers = defaultMaxWorkers
 	}
 	if cfg.QueueSize <= 0 {
-		cfg.QueueSize = 1
+		cfg.QueueSize = defaultQueueSize
 	}
 	if cfg.MinWorkers > cfg.MaxWorkers {
 		cfg.MaxWorkers = cfg.MinWorkers
@@ -198,7 +247,9 @@ func NewWorkerPool(cfg Config) (WorkerPool, error) {
 
 	wp := &workerPool{
 		Config: cfg,
-		q:      make(chan *contextualItem, cfg.QueueSize),
+
+		mainQueue: make(chan *contextualItem, cfg.QueueSize),
+		fastQueue: make(chan *contextualItem, 0),
 	}
 
 	for i := 0; i < wp.MinWorkers; i++ {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/4607

#### Changes
<!-- What are the changes made in this pull request? -->

- Register the `pkg/workerpool` metrics
- Add work dropped/processed metric, and idle workers metric
- Extract the common pipping between webhooks and application packages to `pkg/workpool` / `pkg/applicationserver/io`
- Improve webhook pressure propagation, from the publishers to the workers
  - We now have an workpool between the `*io.Subscription` and the actual matching process. This ensures that the pressure of the subscription is correctly propagated towards the workers, resulting in more workers being spawned
  - The same mechanism was (and still is) used by the application packages frontend
- The worker timeout has been increased to 1 second
  - During tests, even on high constant load I've observed worker 'churn' (shutdowns followed by new spawns). I think that the idle timeout of 128ms is way too tight for the GC / scheduling algorithm in general
- Workers can now spawn with initial work
  - This improves pressure propagation between publishers and workers, as the publisher no longer have to wait
- Publishers may skip the queue altogether if an idle worker is available
  - This is achieved via the unbuffered channel `fastQueue`, which 'matches' a publisher with an idle worker
  - If there are no idle workers available, a worker is spawned if possible

#### Testing

<!-- How did you verify that this change works? -->

`curl http://localhost:1885/metrics` now returns:

```
# HELP ttn_lw_workerpool_work_processed Amount of work processed
# TYPE ttn_lw_workerpool_work_processed counter
ttn_lw_workerpool_work_processed{pool="application_packages_fanout"} 21328
ttn_lw_workerpool_work_processed{pool="webhooks"} 21328
ttn_lw_workerpool_work_processed{pool="webhooks_fanout"} 21328
# HELP ttn_lw_workerpool_work_queue_size Amount of work enqueued
# TYPE ttn_lw_workerpool_work_queue_size gauge
ttn_lw_workerpool_work_queue_size{pool="webhooks"} 0
# HELP ttn_lw_workerpool_workers_idle Number of idle workers
# TYPE ttn_lw_workerpool_workers_idle gauge
ttn_lw_workerpool_workers_idle{pool="application_packages_fanout"} 1
ttn_lw_workerpool_workers_idle{pool="application_packages_lora-cloud-device-management-v1"} 1
ttn_lw_workerpool_workers_idle{pool="application_packages_lora-cloud-geolocation-v3"} 1
ttn_lw_workerpool_workers_idle{pool="webhooks"} 1
ttn_lw_workerpool_workers_idle{pool="webhooks_fanout"} 1
# HELP ttn_lw_workerpool_workers_started Number of workers started
# TYPE ttn_lw_workerpool_workers_started counter
ttn_lw_workerpool_workers_started{pool="application_packages_fanout"} 6
ttn_lw_workerpool_workers_started{pool="application_packages_lora-cloud-device-management-v1"} 1
ttn_lw_workerpool_workers_started{pool="application_packages_lora-cloud-geolocation-v3"} 1
ttn_lw_workerpool_workers_started{pool="webhooks"} 794
ttn_lw_workerpool_workers_started{pool="webhooks_fanout"} 5
# HELP ttn_lw_workerpool_workers_stopped Number of workers stopped
# TYPE ttn_lw_workerpool_workers_stopped counter
ttn_lw_workerpool_workers_stopped{pool="application_packages_fanout"} 5
ttn_lw_workerpool_workers_stopped{pool="application_packages_lora-cloud-device-management-v1"} 0
ttn_lw_workerpool_workers_stopped{pool="application_packages_lora-cloud-geolocation-v3"} 0
ttn_lw_workerpool_workers_stopped{pool="webhooks"} 793
ttn_lw_workerpool_workers_stopped{pool="webhooks_fanout"} 4
```

I've tested this with variable pressure (4 uplinks per second, 8 uplinks per second, 16 uplinks per second). No drops are observed, as long as there are enough workers.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
