### PR TITLE
Restrict length of search query in fetch table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ For details about compatibility between different releases, see the **Commitment
 - Not rendering site header and footer for error pages in some situations.
 - Not providing a copy button for error pages in some situations.
 - Improved errors for invalid URLs.
+- Limit length of search queries within tables in the Console to 50 to comply with API validation.
 
 ### Security
 

--- a/pkg/webui/containers/fetch-table/index.js
+++ b/pkg/webui/containers/fetch-table/index.js
@@ -113,6 +113,7 @@ class FetchTable extends Component {
     pathname: PropTypes.string.isRequired,
     searchItemsAction: PropTypes.func,
     searchPlaceholderMessage: PropTypes.message,
+    searchQueryMaxLength: PropTypes.number,
     searchable: PropTypes.bool,
     tableTitle: PropTypes.message,
     tabs: PropTypes.arrayOf(
@@ -135,6 +136,7 @@ class FetchTable extends Component {
     mayAdd: false,
     searchable: false,
     searchPlaceholderMessage: sharedMessages.searchById,
+    searchQueryMaxLength: 50,
     handlesPagination: false,
     fetching: false,
     totalCount: 0,
@@ -308,6 +310,7 @@ class FetchTable extends Component {
       entity,
       error,
       searchPlaceholderMessage,
+      searchQueryMaxLength,
       clickable,
     } = this.props
     const { page, query, tab, order, initialFetch } = this.state
@@ -353,6 +356,7 @@ class FetchTable extends Component {
                 placeholder={searchPlaceholderMessage}
                 className={style.searchBar}
                 inputWidth="full"
+                maxlength={searchQueryMaxLength}
               />
             )}
             {(Boolean(actionItems) || mayAdd) && (


### PR DESCRIPTION
#### Summary
Quickfix PR to restrict the length of the search query, which otherwise results in errors.

See: https://sentry.io/organizations/the-things-industries/issues/2262062907

#### Changes
- Restrict search query length using `maxlength`

#### Testing

Manual.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
