### PR TITLE
Record worker pool processing latency

### DIFF
--- a/pkg/workerpool/workerpool.go
+++ b/pkg/workerpool/workerpool.go
@@ -92,6 +92,7 @@ func (wp *workerPool) handle(ctx context.Context, it *contextualItem, handler Ha
 	registerWorkerBusy(wp.Name)
 	defer registerWorkerIdle(wp.Name)
 	defer registerWorkProcessed(it.ctx, wp.Name)
+	defer registerWorkLatency(wp.Name, time.Now())
 	handler(it.ctx, it.item)
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/4607

#### Changes
<!-- What are the changes made in this pull request? -->

- Record worker pool message processing latency


#### Testing

<!-- How did you verify that this change works? -->

Locally

```
# HELP ttn_lw_workerpool_work_latency_seconds Histogram of message processing latency (seconds)
# TYPE ttn_lw_workerpool_work_latency_seconds histogram
ttn_lw_workerpool_work_latency_seconds_bucket{pool="application_packages_fanout",le="0.2"} 1
ttn_lw_workerpool_work_latency_seconds_bucket{pool="application_packages_fanout",le="0.4"} 1
ttn_lw_workerpool_work_latency_seconds_bucket{pool="application_packages_fanout",le="0.6"} 1
ttn_lw_workerpool_work_latency_seconds_bucket{pool="application_packages_fanout",le="0.8"} 1
ttn_lw_workerpool_work_latency_seconds_bucket{pool="application_packages_fanout",le="1"} 1
ttn_lw_workerpool_work_latency_seconds_bucket{pool="application_packages_fanout",le="2"} 1
ttn_lw_workerpool_work_latency_seconds_bucket{pool="application_packages_fanout",le="+Inf"} 1
ttn_lw_workerpool_work_latency_seconds_sum{pool="application_packages_fanout"} 0.002519473
ttn_lw_workerpool_work_latency_seconds_count{pool="application_packages_fanout"} 1
ttn_lw_workerpool_work_latency_seconds_bucket{pool="webhooks_fanout",le="0.2"} 1
ttn_lw_workerpool_work_latency_seconds_bucket{pool="webhooks_fanout",le="0.4"} 1
ttn_lw_workerpool_work_latency_seconds_bucket{pool="webhooks_fanout",le="0.6"} 1
ttn_lw_workerpool_work_latency_seconds_bucket{pool="webhooks_fanout",le="0.8"} 1
ttn_lw_workerpool_work_latency_seconds_bucket{pool="webhooks_fanout",le="1"} 1
ttn_lw_workerpool_work_latency_seconds_bucket{pool="webhooks_fanout",le="2"} 1
ttn_lw_workerpool_work_latency_seconds_bucket{pool="webhooks_fanout",le="+Inf"} 1
ttn_lw_workerpool_work_latency_seconds_sum{pool="webhooks_fanout"} 0.020933429
ttn_lw_workerpool_work_latency_seconds_count{pool="webhooks_fanout"} 1
```

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
