### PR TITLE
Fix state cookie Max-Age

### DIFF
--- a/pkg/web/oauthclient/cookie_state.go
+++ b/pkg/web/oauthclient/cookie_state.go
@@ -17,7 +17,6 @@ package oauthclient
 import (
 	"encoding/gob"
 	"net/http"
-	"time"
 
 	echo "github.com/labstack/echo/v4"
 	"go.thethings.network/lorawan-stack/v3/pkg/random"


### PR DESCRIPTION
#### Summary
This quickfix PR fixes the set `Max-Age` property of the state cookie.

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix `MaxAge` calculation in the cookie util
- ~~Set `MaxAge` to 0 (meaning unlimited) for the OAuth state cookie~~

#### Testing

Manual testing.

#### Notes for Reviewers
Two things here:
- The calculation of the time period in the cookie util was wrong, it is expecting an integer of seconds, but got Nanoseconds / 1000 instead. This caused the state cookie to be valid for years, instead of 10 minutes as set in the oauth package.
- However, also 10 minutes is not desirable, since it would mean that the login screen would lose effectiveness after 10 minutes, leading to a error, since the state cookie has since expired. I think it is fine to not set any expiry for the state cookie. The official OAuth specification also makes no note on any recommended expiry.

So in practice, this change should not have any effect unless the login screen is kept open for years. Still, I wanted to fix this quirk.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
