### PR TITLE
Return correct error when no state cookie is stored

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -8414,7 +8414,16 @@
       "file": "oauthclient.go"
     }
   },
-  "error:pkg/web/oauthclient:no_state": {
+  "error:pkg/web/oauthclient:no_state_cookie": {
+    "translations": {
+      "en": "no state cookie stored"
+    },
+    "description": {
+      "package": "pkg/web/oauthclient",
+      "file": "callback.go"
+    }
+  },
+  "error:pkg/web/oauthclient:no_state_param": {
     "translations": {
       "en": "no state parameter present in request"
     },

--- a/pkg/web/oauthclient/callback.go
+++ b/pkg/web/oauthclient/callback.go
@@ -25,11 +25,12 @@ import (
 )
 
 var (
-	errRefused      = errors.DefinePermissionDenied("refused", "refused by OAuth server", "reason")
-	errNoStateParam = errors.DefinePermissionDenied("no_state", "no state parameter present in request")
-	errNoCodeParam  = errors.DefinePermissionDenied("no_code", "no code parameter present in request")
-	errInvalidState = errors.DefinePermissionDenied("invalid_state", "invalid state parameter")
-	errExchange     = errors.DefinePermissionDenied("exchange", "token exchange refused")
+	errRefused       = errors.DefinePermissionDenied("refused", "refused by OAuth server", "reason")
+	errNoStateParam  = errors.DefinePermissionDenied("no_state_param", "no state parameter present in request")
+	errNoStateCookie = errors.DefinePermissionDenied("no_state_cookie", "no state cookie stored")
+	errNoCodeParam   = errors.DefinePermissionDenied("no_code", "no code parameter present in request")
+	errInvalidState  = errors.DefinePermissionDenied("invalid_state", "invalid state parameter")
+	errExchange      = errors.DefinePermissionDenied("exchange", "token exchange refused")
 )
 
 type oauthAuthorizeResponse struct {
@@ -64,13 +65,16 @@ func (oc *OAuthClient) HandleCallback(c echo.Context) error {
 	}
 
 	stateCookie, err := oc.getStateCookie(c)
+	value, acErr := oc.getAuthCookie(c)
 	if err != nil {
 		// Running the callback without state cookie often occurs when re-running
 		// the callback after successful token exchange (e.g. using the browser's
 		// back button after logging in). If there is a valid auth cookie, we just
 		// redirect back to the client mount instead of showing an error.
-		value, err := oc.getAuthCookie(c)
-		if err == nil && value.AccessToken != "" {
+		if acErr != nil {
+			return errNoStateCookie
+		}
+		if value.AccessToken != "" {
 			config := oc.configFromContext(c.Request().Context())
 			return c.Redirect(http.StatusFound, config.RootURL)
 		}


### PR DESCRIPTION
#### Summary
Quickfix PR to make sure the correct error is returned when the state cookie misses in the OAuth client. Currently, it would return an Unauthorized:`No auth cookie` error.

#### Changes
- Return `no_state_cookie` error when the callback fails due to a missing state cookie (and no auth cookie being present already)

#### Testing

Manual.

##### Regressions

None.

#### Notes for Reviewers
Working on this to improve the relevance of returned errors during console login in conjunction with #4617 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
