### PR TITLE
Add observability to upstream data dropped due to buffer full

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -9107,12 +9107,30 @@
       "file": "observability.go"
     }
   },
+  "event:gs.status.io.drop": {
+    "translations": {
+      "en": "drop gateway status"
+    },
+    "description": {
+      "package": "pkg/gatewayserver/io",
+      "file": "observability.go"
+    }
+  },
   "event:gs.status.receive": {
     "translations": {
       "en": "receive gateway status"
     },
     "description": {
       "package": "pkg/gatewayserver",
+      "file": "observability.go"
+    }
+  },
+  "event:gs.tx.ack.io.drop": {
+    "translations": {
+      "en": "drop tx ack message"
+    },
+    "description": {
+      "package": "pkg/gatewayserver/io",
       "file": "observability.go"
     }
   },
@@ -9140,6 +9158,15 @@
     },
     "description": {
       "package": "pkg/gatewayserver",
+      "file": "observability.go"
+    }
+  },
+  "event:gs.up.io.drop": {
+    "translations": {
+      "en": "drop uplink message"
+    },
+    "description": {
+      "package": "pkg/gatewayserver/io",
       "file": "observability.go"
     }
   },

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -260,7 +260,9 @@ func (c *Connection) HandleUp(up *ttnpb.UplinkMessage) error {
 		atomic.StoreInt64(&c.lastUplinkTime, up.ReceivedAt.UnixNano())
 		c.notifyStatsChanged()
 	default:
-		return errBufferFull.New()
+		err := errBufferFull.New()
+		registerDropBufferFull(c.ctx, c.gateway, "uplink", err)
+		return err
 	}
 	return nil
 }
@@ -282,7 +284,9 @@ func (c *Connection) HandleStatus(status *ttnpb.GatewayStatus) error {
 			}
 		}
 	default:
-		return errBufferFull.New()
+		err := errBufferFull.New()
+		registerDropBufferFull(c.ctx, c.gateway, "status", err)
+		return err
 	}
 	return nil
 }
@@ -295,7 +299,9 @@ func (c *Connection) HandleTxAck(ack *ttnpb.TxAcknowledgment) error {
 	case c.txAckCh <- ack:
 		c.notifyStatsChanged()
 	default:
-		return errBufferFull.New()
+		err := errBufferFull.New()
+		registerDropBufferFull(c.ctx, c.gateway, "txack", err)
+		return err
 	}
 	return nil
 }

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -261,7 +261,7 @@ func (c *Connection) HandleUp(up *ttnpb.UplinkMessage) error {
 		c.notifyStatsChanged()
 	default:
 		err := errBufferFull.New()
-		registerDropBufferFull(c.ctx, c.gateway, "uplink", err)
+		registerDropMessage(c.ctx, c.gateway, "uplink", err)
 		return err
 	}
 	return nil
@@ -285,7 +285,7 @@ func (c *Connection) HandleStatus(status *ttnpb.GatewayStatus) error {
 		}
 	default:
 		err := errBufferFull.New()
-		registerDropBufferFull(c.ctx, c.gateway, "status", err)
+		registerDropMessage(c.ctx, c.gateway, "status", err)
 		return err
 	}
 	return nil
@@ -300,7 +300,7 @@ func (c *Connection) HandleTxAck(ack *ttnpb.TxAcknowledgment) error {
 		c.notifyStatsChanged()
 	default:
 		err := errBufferFull.New()
-		registerDropBufferFull(c.ctx, c.gateway, "txack", err)
+		registerDropMessage(c.ctx, c.gateway, "txack", err)
 		return err
 	}
 	return nil


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Add observability to upstream data dropped due to buffer full
Refs: https://sentry.io/organizations/the-things-industries/issues/2636954540/?project=2682566&referrer=AssignedActivityEmail

#### Changes
<!-- What are the changes made in this pull request? -->

- Export metric and events when a message is dropped due a full process buffer.

#### Testing

<!-- How did you verify that this change works? -->

Local

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

NA

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
