### PR TITLE
Publish Tx Ack failure result as string

### DIFF
--- a/pkg/gatewayserver/observability.go
+++ b/pkg/gatewayserver/observability.go
@@ -202,7 +202,7 @@ var gsMetrics = &messageMetrics{
 			Name:      "downlink_tx_failed_total",
 			Help:      "Total number of unsuccessfully emitted downlinks",
 		},
-		[]string{protocol},
+		[]string{protocol, "result"},
 	),
 }
 
@@ -335,5 +335,5 @@ func registerSuccessDownlink(ctx context.Context, gtw *ttnpb.Gateway, protocol s
 
 func registerFailDownlink(ctx context.Context, gtw *ttnpb.Gateway, ack *ttnpb.TxAcknowledgment, protocol string) {
 	events.Publish(evtTxFailureDown.NewWithIdentifiersAndData(ctx, gtw, ack.Result.String()))
-	gsMetrics.downlinkTxFailed.WithLabelValues(ctx, protocol).Inc()
+	gsMetrics.downlinkTxFailed.WithLabelValues(ctx, protocol, ack.Result.String()).Inc()
 }

--- a/pkg/gatewayserver/observability.go
+++ b/pkg/gatewayserver/observability.go
@@ -334,6 +334,6 @@ func registerSuccessDownlink(ctx context.Context, gtw *ttnpb.Gateway, protocol s
 }
 
 func registerFailDownlink(ctx context.Context, gtw *ttnpb.Gateway, ack *ttnpb.TxAcknowledgment, protocol string) {
-	events.Publish(evtTxFailureDown.NewWithIdentifiersAndData(ctx, gtw, ack.Result))
+	events.Publish(evtTxFailureDown.NewWithIdentifiersAndData(ctx, gtw, ack.Result.String()))
 	gsMetrics.downlinkTxFailed.WithLabelValues(ctx, protocol).Inc()
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #4336 

#### Changes
<!-- What are the changes made in this pull request? -->

- Use the `.String()` method of the result in the event.

#### Testing

<!-- How did you verify that this change works? -->

Local

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

NA

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
