### PR TITLE
Do not parametrize chunk name

### DIFF
--- a/pkg/webui/lib/components/with-locale.js
+++ b/pkg/webui/lib/components/with-locale.js
@@ -236,9 +236,7 @@ const LocaleLoader = ({ children }) => {
       if (window.Intl.DateTimeFormat.polyfilled) {
         log(`Polyfilling DateTimeFormat for language ${language}`)
         promises.push(
-          import(
-            /* webpackChunkName: "locale.[request]" */ '@formatjs/intl-datetimeformat/add-all-tz'
-          ),
+          import(/* webpackChunkName: "locale" */ '@formatjs/intl-datetimeformat/add-all-tz'),
           import(
             /* webpackChunkName: "locale.[request]" */ `@formatjs/intl-datetimeformat/locale-data/${language}`
           ),


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/4559

#### Changes
<!-- What are the changes made in this pull request? -->

- Do not parametrize the chunk name for `@formatjs/intl-datetimeformat/add-all-tz`, as there is no variable as part of that import
  - This caused the `[request]` to not be replaced during the build process, and resulted in a file whose name contained `[request]`, breaking globing used by `goreleaser`
  - See https://github.com/webpack/webpack/issues/9075


#### Testing

<!-- How did you verify that this change works? -->

N/A

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
