### PR TITLE
Standardize io metrics subsystem

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -9098,6 +9098,42 @@
       "file": "observability.go"
     }
   },
+  "event:gs.io.status.drop": {
+    "translations": {
+      "en": "drop gateway status"
+    },
+    "description": {
+      "package": "pkg/gatewayserver/io",
+      "file": "observability.go"
+    }
+  },
+  "event:gs.io.tx.ack.drop": {
+    "translations": {
+      "en": "drop tx ack message"
+    },
+    "description": {
+      "package": "pkg/gatewayserver/io",
+      "file": "observability.go"
+    }
+  },
+  "event:gs.io.up.drop": {
+    "translations": {
+      "en": "drop uplink message"
+    },
+    "description": {
+      "package": "pkg/gatewayserver/io",
+      "file": "observability.go"
+    }
+  },
+  "event:gs.io.up.repeat": {
+    "translations": {
+      "en": "received repeated uplink message from gateway"
+    },
+    "description": {
+      "package": "pkg/gatewayserver/io",
+      "file": "observability.go"
+    }
+  },
   "event:gs.status.drop": {
     "translations": {
       "en": "drop gateway status"
@@ -9116,30 +9152,12 @@
       "file": "observability.go"
     }
   },
-  "event:gs.status.io.drop": {
-    "translations": {
-      "en": "drop gateway status"
-    },
-    "description": {
-      "package": "pkg/gatewayserver/io",
-      "file": "observability.go"
-    }
-  },
   "event:gs.status.receive": {
     "translations": {
       "en": "receive gateway status"
     },
     "description": {
       "package": "pkg/gatewayserver",
-      "file": "observability.go"
-    }
-  },
-  "event:gs.tx.ack.io.drop": {
-    "translations": {
-      "en": "drop tx ack message"
-    },
-    "description": {
-      "package": "pkg/gatewayserver/io",
       "file": "observability.go"
     }
   },
@@ -9170,30 +9188,12 @@
       "file": "observability.go"
     }
   },
-  "event:gs.up.io.drop": {
-    "translations": {
-      "en": "drop uplink message"
-    },
-    "description": {
-      "package": "pkg/gatewayserver/io",
-      "file": "observability.go"
-    }
-  },
   "event:gs.up.receive": {
     "translations": {
       "en": "receive uplink message"
     },
     "description": {
       "package": "pkg/gatewayserver",
-      "file": "observability.go"
-    }
-  },
-  "event:gs.up.repeat": {
-    "translations": {
-      "en": "received repeated uplink message from gateway"
-    },
-    "description": {
-      "package": "pkg/gatewayserver/io",
       "file": "observability.go"
     }
   },

--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -1277,13 +1277,13 @@ func TestGatewayServer(t *testing.T) {
 								a := assertions.New(t)
 
 								upEvents := map[string]events.Channel{}
-								for _, event := range []string{"gs.up.receive", "gs.down.tx.success", "gs.down.tx.fail", "gs.status.receive", "gs.up.repeat"} {
+								for _, event := range []string{"gs.up.receive", "gs.down.tx.success", "gs.down.tx.fail", "gs.status.receive", "gs.io.up.repeat"} {
 									upEvents[event] = make(events.Channel, 5)
 								}
 								defer test.SetDefaultEventsPubSub(&test.MockEventPubSub{
 									PublishFunc: func(ev events.Event) {
 										switch name := ev.Name(); name {
-										case "gs.up.receive", "gs.down.tx.success", "gs.down.tx.fail", "gs.status.receive", "gs.up.repeat":
+										case "gs.up.receive", "gs.down.tx.success", "gs.down.tx.fail", "gs.status.receive", "gs.io.up.repeat":
 											go func() {
 												upEvents[name] <- ev
 											}()
@@ -1308,8 +1308,8 @@ func TestGatewayServer(t *testing.T) {
 
 								if tc.RepeatUpEvent && !ptc.DeduplicatesUplinks {
 									select {
-									case evt := <-upEvents["gs.up.repeat"]:
-										a.So(evt.Name(), should.Equal, "gs.up.repeat")
+									case evt := <-upEvents["gs.io.up.repeat"]:
+										a.So(evt.Name(), should.Equal, "gs.io.up.repeat")
 									case <-time.After(timeout):
 										t.Fatal("Expected repeat uplink event timeout")
 									}

--- a/pkg/gatewayserver/io/observability.go
+++ b/pkg/gatewayserver/io/observability.go
@@ -24,6 +24,8 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 )
 
+const subsystem = "gs_io"
+
 type messageMetrics struct {
 	repeatedUplinks *metrics.ContextualCounterVec
 	droppedMessages *metrics.ContextualCounterVec
@@ -44,7 +46,7 @@ func (m *messageMetrics) Collect(ch chan<- prometheus.Metric) {
 var ioMetrics = &messageMetrics{
 	repeatedUplinks: metrics.NewContextualCounterVec(
 		prometheus.CounterOpts{
-			Subsystem: "gs",
+			Subsystem: subsystem,
 			Name:      "uplink_repeated_total",
 			Help:      "Total number of repeated gateway uplinks",
 		},
@@ -52,7 +54,7 @@ var ioMetrics = &messageMetrics{
 	),
 	droppedMessages: metrics.NewContextualCounterVec(
 		prometheus.CounterOpts{
-			Subsystem: "gs",
+			Subsystem: subsystem,
 			Name:      "message_dropped_total",
 			Help:      "Total number of messages dropped",
 		},
@@ -62,22 +64,22 @@ var ioMetrics = &messageMetrics{
 
 var (
 	evtRepeatUp = events.Define(
-		"gs.up.repeat", "received repeated uplink message from gateway",
+		"gs.io.up.repeat", "received repeated uplink message from gateway",
 		events.WithVisibility(ttnpb.RIGHT_GATEWAY_TRAFFIC_READ),
 		events.WithDataType(&ttnpb.GatewayIdentifiers{}),
 	)
 	evtDropUplink = events.Define(
-		"gs.up.io.drop", "drop uplink message",
+		"gs.io.up.drop", "drop uplink message",
 		events.WithVisibility(ttnpb.RIGHT_GATEWAY_TRAFFIC_READ),
 		events.WithErrorDataType(),
 	)
 	evtDropStatus = events.Define(
-		"gs.status.io.drop", "drop gateway status",
+		"gs.io.status.drop", "drop gateway status",
 		events.WithVisibility(ttnpb.RIGHT_GATEWAY_STATUS_READ),
 		events.WithErrorDataType(),
 	)
 	evtDropTxAck = events.Define(
-		"gs.tx.ack.io.drop", "drop tx ack message",
+		"gs.io.tx.ack.drop", "drop tx ack message",
 		events.WithVisibility(ttnpb.RIGHT_GATEWAY_TRAFFIC_READ),
 		events.WithErrorDataType(),
 	)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/4632

#### Changes
<!-- What are the changes made in this pull request? -->

- Standardize the subsystem used by `io` as `gs_io`
  - Otherwise it could clash with the top level `gatewayserver` package, albeit this didn't happen in pratice
- Standardize the events namespace as `gs.io`

#### Testing

<!-- How did you verify that this change works? -->

N/A

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@KrishnaIyer I think this may be better than what I originally agreed in https://github.com/TheThingsNetwork/lorawan-stack/pull/4632, since it's more uniform

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
