### PR TITLE
Fix `FetchTable` sending duplicate sentry errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@formatjs/intl-pluralrules": "^4.1.2",
     "@formatjs/intl-relativetimeformat": "^8.0.6",
     "@sentry/browser": "^6.12.0",
+    "@sentry/integrations": "^6.13.0",
     "@tippyjs/react": "^4.2.5",
     "autobind-decorator": "^2.4.0",
     "axios": "^0.21.1",

--- a/pkg/webui/components/error-notification/index.js
+++ b/pkg/webui/components/error-notification/index.js
@@ -19,16 +19,20 @@ import Notification from '@ttn-lw/components/notification'
 import { isBackend, toMessageProps, ingestError } from '@ttn-lw/lib/errors/utils'
 import PropTypes from '@ttn-lw/lib/prop-types'
 
-const ErrorNotification = ({ content, title, ...rest }) => {
+const ErrorNotification = ({ content, title, details, noIngest, ...rest }) => {
   const message = toMessageProps(content)
-  let details = undefined
+  let passedDetails = details
 
   useEffect(() => {
-    ingestError(content, { ingestedBy: 'ErrorNotification' })
-  }, [content])
+    if (!noIngest) {
+      ingestError(details, {
+        ingestedBy: 'ErrorNotification',
+      })
+    }
+  }, [content, details, noIngest])
 
-  if (isBackend(content)) {
-    details = content
+  if (isBackend(content) && !details) {
+    passedDetails = content
   }
   return (
     <Notification
@@ -36,7 +40,7 @@ const ErrorNotification = ({ content, title, ...rest }) => {
       content={message.content}
       title={title || message.title}
       messageValues={message.values}
-      details={details}
+      details={passedDetails}
       data-test-id="error-notification"
       {...rest}
     />
@@ -45,10 +49,14 @@ const ErrorNotification = ({ content, title, ...rest }) => {
 
 ErrorNotification.propTypes = {
   content: PropTypes.oneOfType([PropTypes.message, PropTypes.error, PropTypes.string]).isRequired,
+  details: PropTypes.oneOfType([PropTypes.string, PropTypes.shape({})]),
+  noIngest: PropTypes.bool,
   title: PropTypes.message,
 }
 
 ErrorNotification.defaultProps = {
+  details: undefined,
+  noIngest: false,
   title: undefined,
 }
 

--- a/pkg/webui/console/containers/applications-table/index.js
+++ b/pkg/webui/console/containers/applications-table/index.js
@@ -42,7 +42,6 @@ import {
   selectApplications,
   selectApplicationsTotalCount,
   selectApplicationsFetching,
-  selectApplicationsError,
 } from '@console/store/selectors/applications'
 
 const m = defineMessages({
@@ -171,7 +170,6 @@ const ApplicationsTable = props => {
       applications: selectApplications(state),
       totalCount: selectApplicationsTotalCount(state),
       fetching: selectApplicationsFetching(state),
-      error: selectApplicationsError(state),
       mayAdd: checkFromState(mayCreateApplications, state),
     }),
     [],

--- a/pkg/webui/console/containers/devices-table/index.js
+++ b/pkg/webui/console/containers/devices-table/index.js
@@ -52,7 +52,6 @@ import {
   selectDevices,
   selectDevicesTotalCount,
   selectDevicesFetching,
-  selectDevicesError,
   selectDeviceDerivedLastSeen,
 } from '@console/store/selectors/devices'
 
@@ -167,7 +166,6 @@ class DevicesTable extends React.Component {
       devices: decoratedDevices,
       totalCount: selectDevicesTotalCount(state),
       fetching: selectDevicesFetching(state),
-      error: selectDevicesError(state),
       mayAdd: mayCreateDevices,
     }
   }

--- a/pkg/webui/console/containers/gateways-table/index.js
+++ b/pkg/webui/console/containers/gateways-table/index.js
@@ -39,7 +39,6 @@ import {
   selectGateways,
   selectGatewaysTotalCount,
   selectGatewaysFetching,
-  selectGatewaysError,
 } from '@console/store/selectors/gateways'
 
 const m = defineMessages({
@@ -195,7 +194,6 @@ const GatewaysTable = props => {
       gateways: selectGateways(state),
       totalCount: selectGatewaysTotalCount(state),
       fetching: selectGatewaysFetching(state),
-      error: selectGatewaysError(state),
       mayAdd: checkFromState(mayCreateGateways, state),
     }),
     [],

--- a/pkg/webui/console/containers/organizations-table/index.js
+++ b/pkg/webui/console/containers/organizations-table/index.js
@@ -42,7 +42,6 @@ import {
   selectOrganizations,
   selectOrganizationsTotalCount,
   selectOrganizationsFetching,
-  selectOrganizationsError,
 } from '@console/store/selectors/organizations'
 
 const m = defineMessages({
@@ -175,7 +174,6 @@ const OrganizationsTable = props => {
       organizations: selectOrganizations(state),
       totalCount: selectOrganizationsTotalCount(state),
       fetching: selectOrganizationsFetching(state),
-      error: selectOrganizationsError(state),
       mayAdd: checkFromState(mayCreateOrganizations, state),
     }),
     [],

--- a/pkg/webui/console/containers/packet-broker-networks-table/index.js
+++ b/pkg/webui/console/containers/packet-broker-networks-table/index.js
@@ -33,7 +33,6 @@ import {
   selectPacketBrokerNetworks,
   selectPacketBrokerNetworksTotalCount,
   selectPacketBrokerNetworksFetching,
-  selectPacketBrokerNetworksError,
   selectPacketBrokerForwarderPolicyById,
   selectPacketBrokerHomeNetworkPolicyById,
   selectPacketBrokerOwnCombinedId,
@@ -142,7 +141,6 @@ class PacketBrokerNetworksTable extends Component {
       networks: decoratedNetworks,
       totalCount: selectPacketBrokerNetworksTotalCount(state),
       fetching: selectPacketBrokerNetworksFetching(state),
-      error: selectPacketBrokerNetworksError(state),
       mayAdd: false,
     }
   }

--- a/pkg/webui/console/containers/users-table/index.js
+++ b/pkg/webui/console/containers/users-table/index.js
@@ -35,7 +35,6 @@ import {
   selectUsers,
   selectUsersTotalCount,
   selectUsersFetching,
-  selectUsersError,
 } from '@console/store/selectors/users'
 
 import style from './users-table.styl'
@@ -140,7 +139,6 @@ export default class UsersTable extends Component {
       users: selectUsers(state),
       totalCount: selectUsersTotalCount(state),
       fetching: selectUsersFetching(state),
-      error: selectUsersError(state),
       mayAdd: checkFromState(mayManageUsers, state),
     }
   }

--- a/pkg/webui/console/views/application-api-keys-list/index.js
+++ b/pkg/webui/console/views/application-api-keys-list/index.js
@@ -31,7 +31,6 @@ import {
   selectApiKeys,
   selectApiKeysTotalCount,
   selectApiKeysFetching,
-  selectApiKeysError,
 } from '@console/store/selectors/api-keys'
 
 export default class ApplicationApiKeys extends React.Component {
@@ -55,7 +54,6 @@ export default class ApplicationApiKeys extends React.Component {
       keys: selectApiKeys(state, id),
       totalCount: selectApiKeysTotalCount(state, id),
       fetching: selectApiKeysFetching(state),
-      error: selectApiKeysError(state),
     }
   }
 

--- a/pkg/webui/console/views/application-collaborators-list/index.js
+++ b/pkg/webui/console/views/application-collaborators-list/index.js
@@ -31,7 +31,6 @@ import {
   selectCollaborators,
   selectCollaboratorsTotalCount,
   selectCollaboratorsFetching,
-  selectCollaboratorsError,
 } from '@console/store/selectors/collaborators'
 
 export default class ApplicationCollaborators extends React.Component {
@@ -55,7 +54,6 @@ export default class ApplicationCollaborators extends React.Component {
       collaborators: selectCollaborators(state, id),
       fetching: selectCollaboratorsFetching(state),
       totalCount: selectCollaboratorsTotalCount(state, id),
-      error: selectCollaboratorsError(state),
     }
   }
 

--- a/pkg/webui/console/views/gateway-api-keys-list/index.js
+++ b/pkg/webui/console/views/gateway-api-keys-list/index.js
@@ -31,7 +31,6 @@ import {
   selectApiKeys,
   selectApiKeysTotalCount,
   selectApiKeysFetching,
-  selectApiKeysError,
 } from '@console/store/selectors/api-keys'
 
 export default class GatewayApiKeys extends React.Component {
@@ -55,7 +54,6 @@ export default class GatewayApiKeys extends React.Component {
       keys: selectApiKeys(state, id),
       totalCount: selectApiKeysTotalCount(state, id),
       fetching: selectApiKeysFetching(state),
-      error: selectApiKeysError(state),
     }
   }
 

--- a/pkg/webui/console/views/gateway-collaborators-list/index.js
+++ b/pkg/webui/console/views/gateway-collaborators-list/index.js
@@ -33,7 +33,6 @@ import {
   selectCollaborators,
   selectCollaboratorsTotalCount,
   selectCollaboratorsFetching,
-  selectCollaboratorsError,
 } from '@console/store/selectors/collaborators'
 
 @connect(state => ({
@@ -60,7 +59,6 @@ export default class GatewayCollaborators extends React.Component {
       collaborators: selectCollaborators(state, id),
       fetching: selectCollaboratorsFetching(state),
       totalCount: selectCollaboratorsTotalCount(state, id),
-      error: selectCollaboratorsError(state),
     }
   }
 

--- a/pkg/webui/constants/sentry.js
+++ b/pkg/webui/constants/sentry.js
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import * as Integrations from '@sentry/integrations'
+
 import env from '@ttn-lw/lib/env'
 
 const sentryConfig = {
   dsn: env.sentryDsn,
   release: process.env.VERSION,
   normalizeDepth: 10,
+  integrations: [new Integrations.Dedupe()],
   beforeSend: event => {
     if (event.extra.state && event.extra.state.user) {
       delete event.extra.state.user.user.name

--- a/pkg/webui/containers/fetch-table/index.js
+++ b/pkg/webui/containers/fetch-table/index.js
@@ -381,6 +381,7 @@ class FetchTable extends Component {
               className={style.errorMessage}
               content={{ ...m.errorMessage, values: { entity } }}
               details={error}
+              noIngest
             />
           )}
           <Tabular

--- a/pkg/webui/containers/fetch-table/index.js
+++ b/pkg/webui/containers/fetch-table/index.js
@@ -83,7 +83,6 @@ class FetchTable extends Component {
     clickable: PropTypes.bool,
     dispatch: PropTypes.func.isRequired,
     entity: PropTypes.string.isRequired,
-    error: PropTypes.error,
     fetching: PropTypes.bool,
     fetchingSearch: PropTypes.bool,
     filterValidator: PropTypes.func,
@@ -147,7 +146,6 @@ class FetchTable extends Component {
     tableTitle: undefined,
     tabs: [],
     actionItems: null,
-    error: undefined,
     clickable: true,
   }
 
@@ -183,16 +181,20 @@ class FetchTable extends Component {
   }
 
   @bind
-  fetchItems() {
+  async fetchItems() {
     const { dispatch, pageSize, searchItemsAction, getItemsAction } = this.props
 
     const filters = { ...this.state, limit: pageSize }
 
-    if (filters.query && searchItemsAction) {
-      return dispatch(attachPromise(searchItemsAction(filters)))
-    }
+    try {
+      if (filters.query && searchItemsAction) {
+        await dispatch(attachPromise(searchItemsAction(filters)))
+      }
 
-    return dispatch(attachPromise(getItemsAction(filters)))
+      await dispatch(attachPromise(getItemsAction(filters)))
+    } catch (error) {
+      this.setState({ error })
+    }
   }
 
   @bind
@@ -308,12 +310,11 @@ class FetchTable extends Component {
       pathname,
       actionItems,
       entity,
-      error,
       searchPlaceholderMessage,
       searchQueryMaxLength,
       clickable,
     } = this.props
-    const { page, query, tab, order, initialFetch } = this.state
+    const { page, query, tab, order, initialFetch, error } = this.state
     let orderDirection, orderBy
 
     // Parse order string.
@@ -379,6 +380,7 @@ class FetchTable extends Component {
             <ErrorNotification
               className={style.errorMessage}
               content={{ ...m.errorMessage, values: { entity } }}
+              details={error}
             />
           )}
           <Tabular

--- a/pkg/webui/lib/errors/utils.js
+++ b/pkg/webui/lib/errors/utils.js
@@ -248,6 +248,9 @@ export const isSentryWorthy = error =>
  * @returns {string} The Sentry error title.
  */
 export const getSentryErrorTitle = error => {
+  if (typeof error === 'string') {
+    return `invalid string error: "${error}"`
+  }
   if (typeof error !== 'object') {
     return `invalid error type: ${error}`
   }
@@ -272,6 +275,8 @@ export const getSentryErrorTitle = error => {
     return error.code
   } else if ('statusCode' in error) {
     return `status code: ${error.statusCode}`
+  } else if ('id' in error && 'defaultMessage' in error) {
+    return error.defaultMessage
   }
 
   return 'untitled or empty error'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2043,6 +2043,16 @@
     "@sentry/utils" "6.12.0"
     tslib "^1.9.3"
 
+"@sentry/integrations@^6.13.0":
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-6.13.0.tgz#a0bba39671125cd9c6b80a1a23519e7fa7558ac1"
+  integrity sha512-VXTs0oMdZZSD0INeaTpzhc/yFN4vH1LlQqJptTatf3WW9t45sph2AlYrPcVI1FSqONwaiDyDNjo8Vn919Hh4Fw==
+  dependencies:
+    "@sentry/types" "6.13.0"
+    "@sentry/utils" "6.13.0"
+    localforage "^1.8.1"
+    tslib "^1.9.3"
+
 "@sentry/minimal@6.12.0":
   version "6.12.0"
   resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.12.0.tgz#cbe20e95056cedb9709d7d5b2119ef95206a9f8c"
@@ -2057,12 +2067,25 @@
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.12.0.tgz#b7395688a79403c6df8d8bb8d81deb8222519853"
   integrity sha512-urtgLzE4EDMAYQHYdkgC0Ei9QvLajodK1ntg71bGn0Pm84QUpaqpPDfHRU+i6jLeteyC7kWwa5O5W1m/jrjGXA==
 
+"@sentry/types@6.13.0":
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.13.0.tgz#a8ad870c6ecb407cbe9ca883b0688bacb30daacf"
+  integrity sha512-04ZVmz4txuI3w1KS81eByppvvMfOINj7jZYnO5zX/S3cjHiOpAJiZkN/k9tTi1Ua3td8bEkQLB6Cxrq9MSiH3Q==
+
 "@sentry/utils@6.12.0":
   version "6.12.0"
   resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.12.0.tgz#3de261e8d11bdfdc7add64a3065d43517802e975"
   integrity sha512-oRHQ7TH5TSsJqoP9Gqq25Jvn9LKexXfAh/OoKwjMhYCGKGhqpDNUIZVgl9DWsGw5A5N5xnQyLOxDfyRV5RshdA==
   dependencies:
     "@sentry/types" "6.12.0"
+    tslib "^1.9.3"
+
+"@sentry/utils@6.13.0":
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.13.0.tgz#c75647890a5a9dfdb3df321517aa4886c8715b03"
+  integrity sha512-e82DBwjYqWkNmafIkHnbqirK4t7WCmqCGaoo1Et6vTRCBS4GthWvS6EzaozY7EKs/TzsfIiDdTLGTbYMQOq9Zw==
+  dependencies:
+    "@sentry/types" "6.13.0"
     tslib "^1.9.3"
 
 "@sideway/address@^4.1.0":
@@ -8452,6 +8475,11 @@ ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
+
 immer@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/immer/-/immer-1.10.0.tgz#bad67605ba9c810275d91e1c2a47d4582e98286d"
@@ -9957,6 +9985,13 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lie@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
+  integrity sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=
+  dependencies:
+    immediate "~3.0.5"
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -10058,6 +10093,13 @@ loader-utils@^2.0.0:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^2.1.2"
+
+localforage@^1.8.1:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.10.0.tgz#5c465dc5f62b2807c3a84c0c6a1b1b3212781dd4"
+  integrity sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==
+  dependencies:
+    lie "3.1.1"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -14780,7 +14822,7 @@ tsutils@^3.17.1:
     tslib "^1.8.1"
 
 "ttn-lw@file:sdk/js":
-  version "3.14.2"
+  version "3.15.0"
   dependencies:
     arraybuffer-to-string "^1.0.2"
     axios "^0.21.1"


### PR DESCRIPTION
#### Summary
This quickfix PR will fix the `<FetchTable />` container sending multiple sentry events for the same error.

#### Changes
- Add `noIngest` prop to not ingest errors again via the `<ErrorNotification />`
- Fix unhandled promise rejections within `fetchItems()`
  - Wrap the promisified fetch action around a try/catch block and use resulting error if need be
- Add `Dedupe()` sentry integration to avoid sending events with the same fingerprint more than once
- Improve extraction of the error title for Sentry

#### Testing

Manually using the dev sentry project

#### Notes for Reviewers
We currently see many duplicate events for errors related to the fetch item container. This is because both the request action utility and the error notification component will capture the error.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
