### PR TITLE
Validate EUIs on AppSKey fetch

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -2627,9 +2627,27 @@
       "file": "applicationserver.go"
     }
   },
+  "error:pkg/applicationserver:no_dev_eui": {
+    "translations": {
+      "en": "no device EUI provided"
+    },
+    "description": {
+      "package": "pkg/applicationserver",
+      "file": "applicationserver.go"
+    }
+  },
   "error:pkg/applicationserver:no_device_session": {
     "translations": {
       "en": "no device session; check device activation"
+    },
+    "description": {
+      "package": "pkg/applicationserver",
+      "file": "applicationserver.go"
+    }
+  },
+  "error:pkg/applicationserver:no_join_eui": {
+    "translations": {
+      "en": "no join EUI provided"
     },
     "description": {
       "package": "pkg/applicationserver",

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -642,9 +642,19 @@ func (as *ApplicationServer) DownlinkQueueList(ctx context.Context, ids ttnpb.En
 	return queue, nil
 }
 
-var errJSUnavailable = errors.DefineUnavailable("join_server_unavailable", "Join Server unavailable for JoinEUI `{join_eui}`")
+var (
+	errJSUnavailable = errors.DefineUnavailable("join_server_unavailable", "Join Server unavailable for JoinEUI `{join_eui}`")
+	errNoDevEUI      = errors.DefineInvalidArgument("no_dev_eui", "no device EUI provided")
+	errNoJoinEUI     = errors.DefineInvalidArgument("no_join_eui", "no join EUI provided")
+)
 
 func (as *ApplicationServer) fetchAppSKey(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, sessionKeyID []byte) (ttnpb.KeyEnvelope, error) {
+	if ids.DevEui == nil {
+		return ttnpb.KeyEnvelope{}, errNoDevEUI.New()
+	}
+	if ids.JoinEui == nil {
+		return ttnpb.KeyEnvelope{}, errNoJoinEUI.New()
+	}
 	req := &ttnpb.SessionKeyRequest{
 		SessionKeyId: sessionKeyID,
 		DevEui:       *ids.DevEui,

--- a/pkg/applicationserver/grpc.go
+++ b/pkg/applicationserver/grpc.go
@@ -137,7 +137,6 @@ func (as *ApplicationServer) HandleUplink(ctx context.Context, req *ttnpb.NsAsHa
 	if err != nil {
 		return nil, err
 	}
-	// TODO: Merge downlink queue invalidations (https://github.com/TheThingsNetwork/lorawan-stack/issues/1523)
 	for _, up := range req.ApplicationUps {
 		if err := as.processUp(ctx, up, link); err != nil {
 			return nil, err


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://sentry.io/organizations/the-things-industries/issues/2661700857/?environment=ttn-prod-au1&project=2682566&referrer=alert_email

#### Changes
<!-- What are the changes made in this pull request? -->

- Do not attempt to dereference the device or join EUI unless they are set.


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The identifiers in the stack trace come from the Network Server. The NS fills the end device identifiers using the identifiers stored in its own store, which does not require the EUIs to be necessary set. This panic most likely comes from an end device which doesn't have the EUIs set correctly.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
