### PR TITLE
Use workerpool in the UDP frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
+- The Gateway Server worker pools may now drop workers if they are idle for too long.
+
 ### Deprecated
 
 ### Removed

--- a/config/messages.json
+++ b/config/messages.json
@@ -4265,15 +4265,6 @@
       "file": "firewall_ratelimit.go"
     }
   },
-  "error:pkg/gatewayserver/io/udp:udp_frontend_recovered": {
-    "translations": {
-      "en": "internal server error"
-    },
-    "description": {
-      "package": "pkg/gatewayserver/io/udp",
-      "file": "udp.go"
-    }
-  },
   "error:pkg/gatewayserver/io/ws/lbslns:empty_gateway_eui": {
     "translations": {
       "en": "empty gateway EUI"

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/mohae/deepcopy"
 	"go.thethings.network/lorawan-stack/v3/pkg/band"
+	"go.thethings.network/lorawan-stack/v3/pkg/component"
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/errorcontext"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
@@ -71,6 +72,7 @@ type Server interface {
 	RateLimiter() ratelimit.Interface
 	// ValidateGatewayID validates the ID of the gateway.
 	ValidateGatewayID(ctx context.Context, ids ttnpb.GatewayIdentifiers) error
+	component.TaskStarter
 }
 
 // Connection is a connection to a gateway managed by a frontend.

--- a/pkg/gatewayserver/io/mock/server.go
+++ b/pkg/gatewayserver/io/mock/server.go
@@ -131,6 +131,11 @@ func (s *server) UnclaimDownlink(ctx context.Context, ids ttnpb.GatewayIdentifie
 	return nil
 }
 
+// StartTask implements io.Server.
+func (s *server) StartTask(cfg *component.TaskConfig) {
+	component.DefaultStartTask(cfg)
+}
+
 func (s *server) HasDownlinkClaim(ctx context.Context, ids ttnpb.GatewayIdentifiers) bool {
 	_, ok := s.downlinkClaims.Load(unique.ID(ctx, ids))
 	return ok

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -16,10 +16,7 @@ package udp
 
 import (
 	"context"
-	"fmt"
 	"net"
-	"os"
-	"runtime/debug"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -35,6 +32,7 @@ import (
 	encoding "go.thethings.network/lorawan-stack/v3/pkg/ttnpb/udp"
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
 	"go.thethings.network/lorawan-stack/v3/pkg/unique"
+	"go.thethings.network/lorawan-stack/v3/pkg/workerpool"
 )
 
 type srv struct {
@@ -43,7 +41,6 @@ type srv struct {
 
 	server      io.Server
 	conn        *net.UDPConn
-	packetCh    chan encoding.Packet
 	connections sync.Map
 	firewall    Firewall
 
@@ -54,14 +51,15 @@ func (*srv) Protocol() string            { return "udp" }
 func (*srv) SupportsDownlinkClaim() bool { return true }
 
 var (
-	errUDPFrontendRecovered      = errors.DefineInternal("udp_frontend_recovered", "internal server error")
-	limitLogsConfig              = config.RateLimitingProfile{MaxPerMin: 1}
-	limitLogsSize           uint = 1 << 13
+	limitLogsConfig      = config.RateLimitingProfile{MaxPerMin: 1}
+	limitLogsSize   uint = 1 << 13
 )
 
 // Serve serves the UDP frontend.
 func Serve(ctx context.Context, server io.Server, conn *net.UDPConn, config Config) error {
 	ctx = log.NewContextWithField(ctx, "namespace", "gatewayserver/io/udp")
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	var firewall Firewall
 	if config.AddrChangeBlock > 0 {
 		firewall = NewMemoryFirewall(ctx, config.AddrChangeBlock)
@@ -78,29 +76,30 @@ func Serve(ctx context.Context, server io.Server, conn *net.UDPConn, config Conf
 		config:   config,
 		server:   server,
 		conn:     conn,
-		packetCh: make(chan encoding.Packet, config.PacketBuffer),
 		firewall: firewall,
 
 		limitLogs: limitLogs,
+	}
+	wp, err := workerpool.NewWorkerPool(workerpool.Config{
+		Component:     server,
+		Context:       ctx,
+		Name:          "udp",
+		CreateHandler: workerpool.StaticHandlerFactory(s.handlePacket),
+		MaxWorkers:    config.PacketHandlers,
+		QueueSize:     config.PacketBuffer,
+	})
+	if err != nil {
+		return err
 	}
 	go s.gc()
 	go func() {
 		<-ctx.Done()
 		s.conn.Close()
 	}()
-	for i := 0; i < config.PacketHandlers; i++ {
-		go s.handlePackets()
-	}
-	return s.read()
+	return s.read(wp)
 }
 
-func (s *srv) read() (err error) {
-	defer func() {
-		retrievedErr := recoverUDPFrontend(s.ctx)
-		if retrievedErr != nil {
-			err = retrievedErr
-		}
-	}()
+func (s *srv) read(wp workerpool.WorkerPool) error {
 	var buf [65507]byte
 	for {
 		n, addr, err := s.conn.ReadFromUDP(buf[:])
@@ -112,10 +111,11 @@ func (s *srv) read() (err error) {
 		}
 		now := time.Now()
 		ctx := log.NewContextWithField(s.ctx, "remote_addr", addr.String())
+		logger := log.FromContext(ctx)
 
 		if err := ratelimit.Require(s.server.RateLimiter(), ratelimit.GatewayUDPTrafficResource(addr)); err != nil {
 			if ratelimit.Require(s.limitLogs, ratelimit.NewCustomResource(addr.IP.String())) == nil {
-				log.FromContext(s.ctx).WithError(err).Warn("Drop packet")
+				logger.WithError(err).Warn("Drop packet")
 			}
 			continue
 		}
@@ -127,67 +127,58 @@ func (s *srv) read() (err error) {
 			GatewayAddr: addr,
 			ReceivedAt:  now,
 		}
-		if err = packet.UnmarshalBinary(packetBuf); err != nil {
-			log.FromContext(ctx).WithError(err).Debug("Failed to unmarshal packet")
+		if err := packet.UnmarshalBinary(packetBuf); err != nil {
+			logger.WithError(err).Debug("Failed to unmarshal packet")
 			continue
 		}
 		switch packet.PacketType {
 		case encoding.PullData, encoding.PushData, encoding.TxAck:
 		default:
-			log.FromContext(ctx).WithField("packet_type", packet.PacketType).Debug("Invalid packet type for uplink")
+			logger.WithField("packet_type", packet.PacketType).Debug("Invalid packet type for uplink")
 			continue
 		}
 		if packet.GatewayEUI == nil {
-			log.FromContext(ctx).Debug("No gateway EUI in uplink message")
+			logger.Debug("No gateway EUI in uplink message")
 			continue
 		}
 
-		select {
-		case s.packetCh <- packet:
-		default:
-			log.FromContext(ctx).Warn("Packet handlers busy, dropping packet")
+		if err := wp.Publish(ctx, packet); err != nil {
+			logger.WithError(err).Warn("UDP packet publishing failed")
 		}
 	}
 }
 
-func (s *srv) handlePackets() {
-	defer recoverUDPFrontend(s.ctx)
-	for {
-		select {
-		case <-s.ctx.Done():
-			return
+func (s *srv) handlePacket(ctx context.Context, pkt interface{}) {
+	packet := pkt.(encoding.Packet)
 
-		case packet := <-s.packetCh:
-			eui := *packet.GatewayEUI
-			ctx := log.NewContextWithField(s.ctx, "gateway_eui", eui)
-			logger := log.FromContext(ctx)
+	eui := *packet.GatewayEUI
+	ctx = log.NewContextWithField(ctx, "gateway_eui", eui)
+	logger := log.FromContext(ctx)
 
-			switch packet.PacketType {
-			case encoding.PullData, encoding.PushData:
-				if err := s.writeAckFor(packet); err != nil {
-					logger.WithError(err).Warn("Failed to write acknowledgment")
-				}
-			}
-
-			if s.firewall != nil {
-				if err := s.firewall.Filter(packet); err != nil {
-					if !errors.IsResourceExhausted(err) || ratelimit.Require(s.limitLogs, ratelimit.NewCustomResource(eui.String())) == nil {
-						logger.WithError(err).Warn("Packet filtered")
-					}
-					break
-				}
-			}
-
-			cs, err := s.connect(ctx, eui)
-			if err != nil {
-				logger.WithError(err).Warn("Failed to connect")
-				break
-			}
-
-			if err := s.handleUp(cs.io.Context(), cs, packet); err != nil {
-				logger.WithError(err).Warn("Failed to handle upstream packet")
-			}
+	switch packet.PacketType {
+	case encoding.PullData, encoding.PushData:
+		if err := s.writeAckFor(packet); err != nil {
+			logger.WithError(err).Warn("Failed to write acknowledgment")
 		}
+	}
+
+	if s.firewall != nil {
+		if err := s.firewall.Filter(packet); err != nil {
+			if !errors.IsResourceExhausted(err) || ratelimit.Require(s.limitLogs, ratelimit.NewCustomResource(eui.String())) == nil {
+				logger.WithError(err).Warn("Packet filtered")
+			}
+			return
+		}
+	}
+
+	cs, err := s.connect(ctx, eui)
+	if err != nil {
+		logger.WithError(err).Warn("Failed to connect")
+		return
+	}
+
+	if err := s.handleUp(cs.io.Context(), cs, packet); err != nil {
+		logger.WithError(err).Warn("Failed to handle upstream packet")
 	}
 }
 
@@ -529,20 +520,4 @@ type state struct {
 	startHandleDownMu sync.RWMutex
 
 	tokens io.DownlinkTokens
-}
-
-func recoverUDPFrontend(ctx context.Context) error {
-	if p := recover(); p != nil {
-		fmt.Fprintln(os.Stderr, p)
-		os.Stderr.Write(debug.Stack())
-		var err error
-		if pErr, ok := p.(error); ok {
-			err = errUDPFrontendRecovered.WithCause(pErr)
-		} else {
-			err = errUDPFrontendRecovered.WithAttributes("panic", p)
-		}
-		log.FromContext(ctx).WithError(err).Error("UDP frontend failed")
-		return err
-	}
-	return nil
 }

--- a/pkg/gatewayserver/io/ws/lbslns/discover_util_test.go
+++ b/pkg/gatewayserver/io/ws/lbslns/discover_util_test.go
@@ -17,6 +17,7 @@ package lbslns
 import (
 	"context"
 
+	"go.thethings.network/lorawan-stack/v3/pkg/component"
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/frequencyplans"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io"
@@ -62,4 +63,8 @@ func (srv mockServer) RateLimiter() ratelimit.Interface {
 
 func (srv mockServer) ValidateGatewayID(ctx context.Context, ids ttnpb.GatewayIdentifiers) error {
 	return ids.ValidateContext(ctx)
+}
+
+func (srv mockServer) StartTask(cfg *component.TaskConfig) {
+	component.DefaultStartTask(cfg)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR migrates the UDP packet worker pool to use `pkg/workerpool`

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove manual recovery from the handlers and the main reader (`Serve` runs `read`, and `Serve` is called from a task, which automatically recovers)
- Use `pkg/workerpool` to submit and handle traffic


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Shouldn't happen. We've tested the worker pool in the Application Server integrations with great success.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This migration allows us to observe better the status of workers, as `pkg/workerpool` comes with batteries included when it comes to metrics (number of busy/idle workers, evolution of number of workers, queue size, processing latency, and work drops).

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
