### PR TITLE
Use worker pool in upstream handlers

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -4661,15 +4661,6 @@
       "file": "gatewayserver.go"
     }
   },
-  "error:pkg/gatewayserver:handler_recovered": {
-    "translations": {
-      "en": "internal server error"
-    },
-    "description": {
-      "package": "pkg/gatewayserver",
-      "file": "gatewayserver.go"
-    }
-  },
   "error:pkg/gatewayserver:host_handle": {
     "translations": {
       "en": "host `{host}` failed to handle message"

--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -1367,6 +1367,14 @@ func TestGatewayServer(t *testing.T) {
 									case <-time.After(timeout):
 										t.Fatal("Expected Tx acknowledgment event timeout")
 									}
+									select {
+									case ack := <-ns.TxAck():
+										if a.So(ack, should.NotBeNil) {
+											a.So(ack.TxAck, should.Resemble, expected)
+										}
+									case <-time.After(timeout):
+										t.Fatal("Expected Tx acknowledgment event timeout")
+									}
 								}
 								if tc.Up.GatewayStatus != nil && ptc.SupportsStatus {
 									select {

--- a/pkg/gatewayserver/observability.go
+++ b/pkg/gatewayserver/observability.go
@@ -108,14 +108,6 @@ var gsMetrics = &messageMetrics{
 		},
 		[]string{protocol},
 	),
-	upstreamHandlers: metrics.NewContextualGaugeVec(
-		prometheus.GaugeOpts{
-			Subsystem: subsystem,
-			Name:      "upstream_handlers",
-			Help:      "Number of upstream handlers",
-		},
-		[]string{host},
-	),
 	statusReceived: metrics.NewContextualCounterVec(
 		prometheus.CounterOpts{
 			Subsystem: subsystem,
@@ -212,7 +204,6 @@ func init() {
 
 type messageMetrics struct {
 	gatewaysConnected   *metrics.ContextualGaugeVec
-	upstreamHandlers    *metrics.ContextualGaugeVec
 	statusReceived      *metrics.ContextualCounterVec
 	statusForwarded     *metrics.ContextualCounterVec
 	statusDropped       *metrics.ContextualCounterVec
@@ -228,7 +219,6 @@ type messageMetrics struct {
 
 func (m messageMetrics) Describe(ch chan<- *prometheus.Desc) {
 	m.gatewaysConnected.Describe(ch)
-	m.upstreamHandlers.Describe(ch)
 	m.statusReceived.Describe(ch)
 	m.statusForwarded.Describe(ch)
 	m.statusDropped.Describe(ch)
@@ -244,7 +234,6 @@ func (m messageMetrics) Describe(ch chan<- *prometheus.Desc) {
 
 func (m messageMetrics) Collect(ch chan<- prometheus.Metric) {
 	m.gatewaysConnected.Collect(ch)
-	m.upstreamHandlers.Collect(ch)
 	m.statusReceived.Collect(ch)
 	m.statusForwarded.Collect(ch)
 	m.statusDropped.Collect(ch)
@@ -266,14 +255,6 @@ func registerGatewayConnect(ctx context.Context, ids ttnpb.GatewayIdentifiers, p
 func registerGatewayDisconnect(ctx context.Context, ids ttnpb.GatewayIdentifiers, protocol string) {
 	events.Publish(evtGatewayDisconnect.NewWithIdentifiersAndData(ctx, &ids, nil))
 	gsMetrics.gatewaysConnected.WithLabelValues(ctx, protocol).Dec()
-}
-
-func registerUpstreamHandlerStart(ctx context.Context, host string) {
-	gsMetrics.upstreamHandlers.WithLabelValues(ctx, host).Inc()
-}
-
-func registerUpstreamHandlerStop(ctx context.Context, host string) {
-	gsMetrics.upstreamHandlers.WithLabelValues(ctx, host).Dec()
 }
 
 func registerReceiveStatus(ctx context.Context, gtw *ttnpb.Gateway, status *ttnpb.GatewayStatus, protocol string) {

--- a/pkg/gatewayserver/upstream/mock/network_server.go
+++ b/pkg/gatewayserver/upstream/mock/network_server.go
@@ -33,7 +33,8 @@ type NS struct {
 // StartNS starts the mock NS.
 func StartNS(ctx context.Context) (*NS, string) {
 	ns := &NS{
-		upCh: make(chan *ttnpb.UplinkMessage, 1),
+		upCh:    make(chan *ttnpb.UplinkMessage, 1),
+		txAckCh: make(chan *ttnpb.GatewayTxAcknowledgment, 1),
 	}
 	srv := rpcserver.New(ctx)
 	ttnpb.RegisterGsNsServer(srv.Server, ns)

--- a/pkg/workerpool/workerpool.go
+++ b/pkg/workerpool/workerpool.go
@@ -59,9 +59,9 @@ type Config struct {
 	context.Context                  // The base context of the pool.
 	Name              string         // The name of the pool.
 	CreateHandler     HandlerFactory // The function that creates handlers.
-	MinWorkers        int            // The minimum number of workers in the pool.
+	MinWorkers        int            // The minimum number of workers in the pool. Use -1 to disable.
 	MaxWorkers        int            // The maximum number of workers in the pool.
-	QueueSize         int            // The size of the work queue.
+	QueueSize         int            // The size of the work queue. Use -1 to disable.
 	WorkerIdleTimeout time.Duration  // The maximum amount of time a worker will stay idle before closing.
 }
 
@@ -233,14 +233,24 @@ func NewWorkerPool(cfg Config) (WorkerPool, error) {
 	if cfg.WorkerIdleTimeout == 0 {
 		cfg.WorkerIdleTimeout = defaultWorkerIdleTimeout
 	}
-	if cfg.MinWorkers <= 0 {
+	// We treat 0 as being default initialized, and use the defaults.
+	if cfg.MinWorkers == 0 {
 		cfg.MinWorkers = defaultMinWorkers
+	}
+	// We treat negative values as explicitly disabling the minimum number of workers.
+	if cfg.MinWorkers < 0 {
+		cfg.MinWorkers = 0
 	}
 	if cfg.MaxWorkers <= 0 {
 		cfg.MaxWorkers = defaultMaxWorkers
 	}
-	if cfg.QueueSize <= 0 {
+	// We treat 0 as being default initialized, and use the defaults.
+	if cfg.QueueSize == 0 {
 		cfg.QueueSize = defaultQueueSize
+	}
+	// We treat negative values as explicitly disabling the queue.
+	if cfg.QueueSize < 0 {
+		cfg.QueueSize = 0
 	}
 	if cfg.MinWorkers > cfg.MaxWorkers {
 		cfg.MaxWorkers = cfg.MinWorkers


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/4659

#### Changes
<!-- What are the changes made in this pull request? -->

- Allow worker pools to be waited, and the queuing/minimal worker count to be disabled
- Use `pkg/workerpool` for GS upstream handlers
- Fix GS tests to actually listen for `TxAck`s coming from the NS mock
  - This would deadlock otherwise on `wg.Wait`, since a handler would be blocked on the channel write (and in tests channel writes don't use select)


#### Testing

<!-- How did you verify that this change works? -->

Unit testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Unit testing should cover this

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
