### PR TITLE
Worker pool testing harness

### DIFF
--- a/pkg/applicationserver/io/web/webhooks_test.go
+++ b/pkg/applicationserver/io/web/webhooks_test.go
@@ -50,11 +50,7 @@ func (mockComponent) FromRequestContext(ctx context.Context) context.Context {
 }
 
 func createdPooledSink(ctx context.Context, t *testing.T, sink web.Sink) web.Sink {
-	q, err := web.NewPooledSink(ctx, mockComponent{}, web.StaticSinkFactory(sink), 1, 4)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return q
+	return web.NewPooledSink(ctx, mockComponent{}, sink, 1, 4)
 }
 
 func TestWebhooks(t *testing.T) {

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -731,19 +731,15 @@ func (gs *GatewayServer) handleUpstream(conn connectionEntry) {
 			gtw:           gtw,
 			correlationID: fmt.Sprintf("gs:up:host:%s", events.NewCorrelationID()),
 		}
-		wp, err := workerpool.NewWorkerPool(workerpool.Config{
-			Component:     gs,
-			Context:       ctx,
-			Name:          fmt.Sprintf("upstream_handlers_%v", name),
-			CreateHandler: workerpool.StaticHandlerFactory(host.handlePacket),
-			MinWorkers:    -1,
-			MaxWorkers:    32,
-			QueueSize:     -1,
+		wp := workerpool.NewWorkerPool(workerpool.Config{
+			Component:  gs,
+			Context:    ctx,
+			Name:       fmt.Sprintf("upstream_handlers_%v", name),
+			Handler:    host.handlePacket,
+			MinWorkers: -1,
+			MaxWorkers: 32,
+			QueueSize:  -1,
 		})
-		if err != nil {
-			conn.Disconnect(err)
-			return
-		}
 		defer wp.Wait()
 		host.pool = wp
 		hosts = append(hosts, host)

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -80,17 +80,14 @@ func Serve(ctx context.Context, server io.Server, conn *net.UDPConn, config Conf
 
 		limitLogs: limitLogs,
 	}
-	wp, err := workerpool.NewWorkerPool(workerpool.Config{
-		Component:     server,
-		Context:       ctx,
-		Name:          "udp",
-		CreateHandler: workerpool.StaticHandlerFactory(s.handlePacket),
-		MaxWorkers:    config.PacketHandlers,
-		QueueSize:     config.PacketBuffer,
+	wp := workerpool.NewWorkerPool(workerpool.Config{
+		Component:  server,
+		Context:    ctx,
+		Name:       "udp",
+		Handler:    s.handlePacket,
+		MaxWorkers: config.PacketHandlers,
+		QueueSize:  config.PacketBuffer,
 	})
-	if err != nil {
-		return err
-	}
 	go s.gc()
 	go func() {
 		<-ctx.Done()

--- a/pkg/workerpool/utils.go
+++ b/pkg/workerpool/utils.go
@@ -21,8 +21,8 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 )
 
-// HandlerFactoryFromUplinkHandler converts a static uplink handler to a HandlerFactory.
-func HandlerFactoryFromUplinkHandler(handler func(context.Context, *ttnpb.ApplicationUp) error) HandlerFactory {
+// HandlerFromUplinkHandler converts a static uplink handler to a Handler.
+func HandlerFromUplinkHandler(handler func(context.Context, *ttnpb.ApplicationUp) error) Handler {
 	h := func(ctx context.Context, item interface{}) {
 		up := item.(*ttnpb.ApplicationUp)
 
@@ -30,5 +30,5 @@ func HandlerFactoryFromUplinkHandler(handler func(context.Context, *ttnpb.Applic
 			log.FromContext(ctx).WithError(err).Warn("Failed to submit message")
 		}
 	}
-	return StaticHandlerFactory(h)
+	return h
 }

--- a/pkg/workerpool/workerpool_test.go
+++ b/pkg/workerpool/workerpool_test.go
@@ -1,0 +1,219 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workerpool
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/component"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+)
+
+func TestAtomicConditionals(t *testing.T) {
+	var release sync.WaitGroup
+	release.Add(1)
+
+	var wg sync.WaitGroup
+
+	var increaseFailures sync.Map
+	var decreaseFailures sync.Map
+
+	value := int32(5_000)
+	lowerBound := int32(100)
+	upperBound := int32(10_000)
+	for k := 0; k < 100_000; k++ {
+		k := k
+
+		wg.Add(1)
+		go func() {
+			release.Wait()
+			defer wg.Done()
+			if incrementIfSmallerThan(&value, upperBound) {
+				if v := atomic.LoadInt32(&value); v > upperBound {
+					increaseFailures.Store(k, v)
+				}
+			}
+		}()
+
+		wg.Add(1)
+		go func() {
+			release.Wait()
+			defer wg.Done()
+			if decrementIfGreaterThan(&value, lowerBound) {
+				if v := atomic.LoadInt32(&value); v < lowerBound {
+					decreaseFailures.Store(k, v)
+				}
+			}
+		}()
+
+		wg.Add(1)
+		go func() {
+			release.Wait()
+			defer wg.Done()
+			if v := atomic.LoadInt32(&value); v > upperBound {
+				increaseFailures.Store(k, v)
+			}
+			if v := atomic.LoadInt32(&value); v < lowerBound {
+				decreaseFailures.Store(k, v)
+			}
+		}()
+	}
+
+	release.Done()
+	wg.Wait()
+
+	increaseFailures.Range(func(ki interface{}, vi interface{}) bool {
+		k, v := ki.(int), vi.(int32)
+		t.Errorf("Value %v exceeded upper bound %v in test %v", v, upperBound, k)
+		return true
+	})
+
+	decreaseFailures.Range(func(ki interface{}, vi interface{}) bool {
+		k, v := ki.(int), vi.(int32)
+		t.Errorf("Value %v exceeded lower bound %v in test %v", v, lowerBound, k)
+		return true
+	})
+}
+
+var (
+	fastTimeout = test.Delay
+	slowTimeout = 10 * test.Delay
+	testTimeout = 100 * test.Delay
+)
+
+func TestWorkerPool(t *testing.T) {
+	for _, workerIdleTimeout := range []time.Duration{slowTimeout, fastTimeout} {
+		for _, queueSize := range []int{-1, 0, 1} {
+			for _, minWorkers := range []int{-1, 0, 1} {
+				for _, maxWorkers := range []int{0, 1} {
+					name := fmt.Sprintf(
+						"minWorkers/%v/maxWorkers/%v/queueSize/%v/idleTimeout/%v",
+						minWorkers,
+						maxWorkers,
+						queueSize,
+						workerIdleTimeout,
+					)
+					t.Run(name, func(t *testing.T) {
+						t.Parallel()
+						testWorkerPool(t, minWorkers, maxWorkers, queueSize, workerIdleTimeout)
+					})
+				}
+			}
+		}
+	}
+}
+
+func testWorkerPool(t *testing.T, minWorkers int, maxWorkers int, queueSize int, workerIdleTimeout time.Duration) {
+	a, ctx := test.New(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	workCtx := context.WithValue(ctx, "foo", "bar")
+
+	var workToBeDone, workDone, workFailed, duplicatedWork sync.Map
+	handlerCalls := int32(0)
+	handler := func(ctx context.Context, item interface{}) {
+		atomic.AddInt32(&handlerCalls, 1)
+		a.So(ctx, should.HaveParentContextOrEqual, workCtx)
+		if item == -1 {
+			panic("boom")
+		}
+		if _, exists := workDone.LoadOrStore(item, 0); exists {
+			duplicatedWork.Store(item, 0)
+		}
+	}
+
+	wp := NewWorkerPool(Config{
+		Component:         &mockComponent{},
+		Context:           ctx,
+		Handler:           handler,
+		MinWorkers:        minWorkers,
+		MaxWorkers:        maxWorkers,
+		QueueSize:         queueSize,
+		WorkerIdleTimeout: workerIdleTimeout,
+	})
+
+	totalWork := 100_000
+	expectedHandlerCalls := int32(0)
+	for i := 0; i < totalWork; i++ {
+		if err := wp.Publish(workCtx, i); err != nil {
+			workFailed.Store(i, 0)
+		} else {
+			workToBeDone.Store(i, 0)
+			expectedHandlerCalls++
+		}
+
+		if rand.Intn(100) < 5 {
+			if err := wp.Publish(workCtx, -1); err == nil {
+				expectedHandlerCalls++
+			}
+		}
+	}
+
+	time.Sleep(testTimeout)
+	cancel()
+	wp.Wait()
+
+	var countDone, countToBeDone, countFailed int
+	workDone.Range(func(k, v interface{}) bool {
+		_, failed := workFailed.Load(k)
+		a.So(failed, should.BeFalse)
+
+		_, toBeDone := workToBeDone.Load(k)
+		a.So(toBeDone, should.BeTrue)
+
+		countDone++
+
+		return true
+	})
+	workToBeDone.Range(func(k, v interface{}) bool {
+		_, done := workDone.Load(k)
+		a.So(done, should.BeTrue)
+
+		countToBeDone++
+
+		return true
+	})
+	workFailed.Range(func(k, v interface{}) bool {
+		countFailed++
+
+		return true
+	})
+	duplicatedWork.Range(func(k, v interface{}) bool {
+		t.Fatalf("Item %v was processed multiple times", k)
+		return true
+	})
+
+	a.So(countDone, should.Equal, countToBeDone)
+	a.So(countFailed, should.Equal, totalWork-countDone)
+	a.So(handlerCalls, should.Equal, expectedHandlerCalls)
+}
+
+type mockComponent struct{}
+
+func (*mockComponent) StartTask(cfg *component.TaskConfig) {
+	component.DefaultStartTask(cfg)
+}
+
+func (*mockComponent) FromRequestContext(ctx context.Context) context.Context {
+	return ctx
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/4607

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove the ability to generate handlers on demand (the handler factory concept)
  - This feature created ambiguity for the `Publish` call, as the item may be queued, but the creation of a new worker may fail. The caller now doesn't know if he should attempt to resubmit the item or not. This also could have led to situations in which workers can no longer be created but items are still in the queue
  - This simplifies most of the call sites, and all of them had static handlers anyway (minus the webhooks)
- Spawn a worker on `panic`, in order to avoid falling behind the minimal number of workers
  - In practice, the worker would have been spawned on the next `Publish`, but during testing I've hit this particular issue when there can be at most 1 worker spawned at the time, it panics, and there are still items in the queue which are not processed until `Publish` is called again
- Introduce a testing harness for `pkg/workerpool`
  - New tests for the conditional increments / decrements
  - A set of test cases that push the limits of the minimum/maximum worker counts and queue sizes
      - Every item for which `Publish` did not fail is processed exactly once
      - Every item for which `Publish` did fail is not processed
      - No other items are processed
  - We also test that the pool behaves correctly when some items panic. As part of the tests, about 5% of the work items cause a panic
- Introduce a (basic) benchmarking harness for `pkg/workerpool`
  - Uses the default parameters of the pool
  - Varies the producer delay (so entry PPS) and consumer delay (so exit PPS)

The results on my machine are:

```
goos: linux
goarch: amd64
pkg: go.thethings.network/lorawan-stack/v3/pkg/workerpool
cpu: Intel(R) Core(TM) i7-6700HQ CPU @ 2.60GHz
BenchmarkWorkerPool/processingDelay/5ms/publishingDelay/5ms-8         	       1	5616981385 ns/op	        54.00 dropped	     63946 published	         1.008 queueDelayMS	23184808 B/op	  704369 allocs/op
BenchmarkWorkerPool/processingDelay/5ms/publishingDelay/10ms-8        	       1	10675325046 ns/op	         0 dropped	     64000 published	         0.0009687 queueDelayMS	20701048 B/op	  578360 allocs/op
BenchmarkWorkerPool/processingDelay/5ms/publishingDelay/50ms-8        	       1	50994860804 ns/op	         0 dropped	     64000 published	         0 queueDelayMS	20652408 B/op	  578277 allocs/op
BenchmarkWorkerPool/processingDelay/10ms/publishingDelay/5ms-8        	       1	5675990274 ns/op	     30223 dropped	     33777 published	         4.492 queueDelayMS	19977424 B/op	  614828 allocs/op
BenchmarkWorkerPool/processingDelay/10ms/publishingDelay/10ms-8       	       1	10690789991 ns/op	         8.000 dropped	     63992 published	         1.322 queueDelayMS	22586280 B/op	  701898 allocs/op
BenchmarkWorkerPool/processingDelay/10ms/publishingDelay/50ms-8       	       1	51108205618 ns/op	         0 dropped	     64000 published	         0 queueDelayMS	20680216 B/op	  578455 allocs/op
BenchmarkWorkerPool/processingDelay/50ms/publishingDelay/5ms-8        	       1	5694501109 ns/op	     56878 dropped	      7122 published	        24.34 queueDelayMS	17624888 B/op	  534881 allocs/op
BenchmarkWorkerPool/processingDelay/50ms/publishingDelay/10ms-8       	       1	10691858955 ns/op	     50541 dropped	     13459 published	        24.34 queueDelayMS	18192448 B/op	  553992 allocs/op
BenchmarkWorkerPool/processingDelay/50ms/publishingDelay/50ms-8       	       1	51052396468 ns/op	        46.00 dropped	     63954 published	        12.32 queueDelayMS	22616232 B/op	  704611 allocs/op
```

The way I interpret them is that queue 'physics' check out - if the producers have more PPS than the PPS that the pool can consume, the messages are dropped, and the delay for the queued items is minimal.

#### Testing

<!-- How did you verify that this change works? -->

Unit testing for the first change, while introducing new tests for `pkg/workerpool`

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This reverts back webhooks to a shared `*http.Client`, but no other changes are expected.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
