### PR TITLE
Do not decode FPort = 0 uplink messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Changed
 
 - The Gateway Server worker pools may now drop workers if they are idle for too long.
+- FPort = 0 uplinks are no longer decoded by the Application Server, and the Network Server no longer provides the frame payload to the Application Server for these messages.
 
 ### Deprecated
 

--- a/pkg/applicationserver/payload.go
+++ b/pkg/applicationserver/payload.go
@@ -130,6 +130,9 @@ func (as *ApplicationServer) decryptUplink(ctx context.Context, dev *ttnpb.EndDe
 }
 
 func (as *ApplicationServer) decodeUplink(ctx context.Context, dev *ttnpb.EndDevice, uplink *ttnpb.ApplicationUplink, defaultFormatters *ttnpb.MessagePayloadFormatters) error {
+	if uplink.FPort == 0 {
+		return nil
+	}
 	var formatter ttnpb.PayloadFormatter
 	var parameter string
 	if dev.Formatters != nil {

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -950,6 +950,10 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 		log.FromContext(ctx).WithError(err).Error("Failed to update downlink task queue after data uplink")
 	}
 	if !matched.IsRetransmission {
+		var frmPayload []byte
+		if pld.FPort != 0 {
+			frmPayload = pld.FrmPayload
+		}
 		queuedApplicationUplinks = append(queuedApplicationUplinks, &ttnpb.ApplicationUp{
 			EndDeviceIdentifiers: stored.EndDeviceIdentifiers,
 			CorrelationIds:       up.CorrelationIds,
@@ -958,7 +962,7 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 					Confirmed:       up.Payload.MType == ttnpb.MType_CONFIRMED_UP,
 					FCnt:            pld.FullFCnt,
 					FPort:           pld.FPort,
-					FrmPayload:      pld.FrmPayload,
+					FrmPayload:      frmPayload,
 					RxMetadata:      up.RxMetadata,
 					SessionKeyId:    stored.Session.SessionKeyId,
 					Settings:        up.Settings,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/4668

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/332
References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/338
(Both references are on _why_ we are still sending the `FPort=0` messages to the Application Server in the first place. There is also an argument to be made that the metadata can be used for geolocation purposes.)

#### Changes
<!-- What are the changes made in this pull request? -->

- The Network Server no longer provides the frame payload for `FPort=0` messages
- The Application Server no longer attempts to decode uplinks with `FPort=0`


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Integrations that depend on the fact that the frame payload is available for `FPort=0` messages will not like this change. With that being said, generally people use the _existence_ of the uplink, not the contents of the payload (and the payload is generally empty from what we know).
#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
