### PR TITLE
Report resource exhausted errors using warnings

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -6821,9 +6821,9 @@
       "file": "config.go"
     }
   },
-  "error:pkg/networkserver:downlink_queue_capacity_exceeded": {
+  "error:pkg/networkserver:downlink_queue_capacity": {
     "translations": {
-      "en": "Downlink queue capacity exceeded"
+      "en": "downlink queue capacity exceeded"
     },
     "description": {
       "package": "pkg/networkserver",

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -810,13 +810,13 @@ func (gs *GatewayServer) updateConnStats(conn connectionEntry) {
 	}
 
 	// Initial update, so that the gateway appears connected.
-	if err := gs.statsRegistry.Set(ctx, *ids, stats, ttnpb.GatewayConnectionStatsFieldPathsTopLevel); err != nil {
+	if err := gs.statsRegistry.Set(ctx, *ids, stats, ttnpb.GatewayConnectionStatsFieldPathsTopLevel); err != nil && !errors.IsCanceled(err) {
 		logger.WithError(err).Error("Failed to initialize connection stats")
 	}
 
 	defer func() {
 		logger.Debug("Delete connection stats")
-		if err := gs.statsRegistry.Set(gs.FromRequestContext(ctx), *ids, nil, nil); err != nil {
+		if err := gs.statsRegistry.Set(gs.FromRequestContext(ctx), *ids, nil, nil); err != nil && !errors.IsCanceled(err) {
 			logger.WithError(err).Error("Failed to clear connection stats")
 		}
 	}()
@@ -827,7 +827,7 @@ func (gs *GatewayServer) updateConnStats(conn connectionEntry) {
 		case <-conn.StatsChanged():
 		}
 		stats, paths := conn.Stats()
-		if err := gs.statsRegistry.Set(ctx, *ids, stats, paths); err != nil {
+		if err := gs.statsRegistry.Set(ctx, *ids, stats, paths); err != nil && !errors.IsCanceled(err) {
 			logger.WithError(err).Error("Failed to update connection stats")
 		}
 		timeout := time.After(gs.updateConnectionStatsDebounceTime)

--- a/pkg/networkserver/grpc_asns.go
+++ b/pkg/networkserver/grpc_asns.go
@@ -265,12 +265,12 @@ func matchQueuedApplicationDownlinks(ctx context.Context, dev *ttnpb.EndDevice, 
 	return nil
 }
 
-var errDownlinkQueueCapacityExceeded = errors.DefineResourceExhausted("downlink_queue_capacity_exceeded", "Downlink queue capacity exceeded")
+var errDownlinkQueueCapacity = errors.DefineResourceExhausted("downlink_queue_capacity", "downlink queue capacity exceeded")
 
 // DownlinkQueueReplace is called by the Application Server to completely replace the downlink queue for a device.
 func (ns *NetworkServer) DownlinkQueueReplace(ctx context.Context, req *ttnpb.DownlinkQueueRequest) (*pbtypes.Empty, error) {
 	if n := len(req.Downlinks); n > ns.downlinkQueueCapacity*2 {
-		return nil, errDownlinkQueueCapacityExceeded.New()
+		return nil, errDownlinkQueueCapacity.New()
 	} else if err := clusterauth.Authorized(ctx); err != nil {
 		return nil, err
 	}
@@ -309,7 +309,7 @@ func (ns *NetworkServer) DownlinkQueueReplace(ctx context.Context, req *ttnpb.Do
 				return nil, nil, err
 			}
 			if len(dev.Session.GetQueuedApplicationDownlinks()) > ns.downlinkQueueCapacity || len(dev.PendingSession.GetQueuedApplicationDownlinks()) > ns.downlinkQueueCapacity {
-				return nil, nil, errDownlinkQueueCapacityExceeded.New()
+				return nil, nil, errDownlinkQueueCapacity.New()
 			}
 			return dev, []string{
 				"session.queued_application_downlinks",
@@ -339,7 +339,7 @@ func (ns *NetworkServer) DownlinkQueueReplace(ctx context.Context, req *ttnpb.Do
 // DownlinkQueuePush is called by the Application Server to push a downlink to queue for a device.
 func (ns *NetworkServer) DownlinkQueuePush(ctx context.Context, req *ttnpb.DownlinkQueueRequest) (*pbtypes.Empty, error) {
 	if n := len(req.Downlinks); n > ns.downlinkQueueCapacity*2 {
-		return nil, errDownlinkQueueCapacityExceeded.New()
+		return nil, errDownlinkQueueCapacity.New()
 	} else if n == 0 {
 		return ttnpb.Empty, nil
 	} else if err := clusterauth.Authorized(ctx); err != nil {
@@ -369,7 +369,7 @@ func (ns *NetworkServer) DownlinkQueuePush(ctx context.Context, req *ttnpb.Downl
 				return nil, nil, err
 			}
 			if len(dev.Session.GetQueuedApplicationDownlinks()) > ns.downlinkQueueCapacity || len(dev.PendingSession.GetQueuedApplicationDownlinks()) > ns.downlinkQueueCapacity {
-				return nil, nil, errDownlinkQueueCapacityExceeded.New()
+				return nil, nil, errDownlinkQueueCapacity.New()
 			}
 			return dev, []string{
 				"session.queued_application_downlinks",

--- a/pkg/networkserver/registry.go
+++ b/pkg/networkserver/registry.go
@@ -68,7 +68,7 @@ func logRegistryRPCError(ctx context.Context, err error, msg string) {
 	switch {
 	case errors.IsNotFound(err), errors.IsInvalidArgument(err):
 		printLog = logger.Debug
-	case errors.IsFailedPrecondition(err):
+	case errors.IsFailedPrecondition(err), errors.IsResourceExhausted(err):
 		printLog = logger.Warn
 	default:
 		printLog = logger.Error

--- a/pkg/networkserver/registry.go
+++ b/pkg/networkserver/registry.go
@@ -66,7 +66,7 @@ func logRegistryRPCError(ctx context.Context, err error, msg string) {
 	logger := log.FromContext(ctx).WithError(err)
 	var printLog func(args ...interface{})
 	switch {
-	case errors.IsNotFound(err), errors.IsInvalidArgument(err):
+	case errors.IsNotFound(err), errors.IsInvalidArgument(err), errors.IsCanceled(err):
 		printLog = logger.Debug
 	case errors.IsFailedPrecondition(err), errors.IsResourceExhausted(err):
 		printLog = logger.Warn


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://sentry.io/organizations/the-things-industries/issues/2628907782/?project=2682566&sort=freq&statsPeriod=14d
References https://sentry.io/organizations/the-things-industries/issues/2607823479/events/7649caace2234c15a997e544d04c3f23/tags/?project=2682566&statsPeriod=14d

#### Changes
<!-- What are the changes made in this pull request? -->

- Log resource exhausted errors as `WARN` instead of `ERROR` in NS RPC calls
  - This caused application layer failures (pushing downlinks above the limit) to be logged as `ERROR`, eating through our Sentry subscription
  - I've checked the individual devices from the Sentry events - there is an application that pushes downlinks after every uplink (instead of maybe 'replace'), so probably someone tried to schedule an OTAA update and didn't realize that the queues may not be empty. We also don't really communicate this limit (and errors are not visible via MQTT).
- Log cancelled errors as `WARN` instead of `ERROR` in NS RPC calls
  - Gateways may disconnect (thus cancelling the connection context) while RPCs as running. The NS shouldn't consider those to be errors.
-  Do not log connection registry errors if they are cancelled errors
   - Again, if the gateways disconnect really quick (before the connection stats goroutine starts), this error would be logged


#### Testing

<!-- How did you verify that this change works? -->

N/A

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
