### PR TITLE
Use original context while reporting message status in PBA

### DIFF
--- a/pkg/packetbrokeragent/agent.go
+++ b/pkg/packetbrokeragent/agent.go
@@ -368,13 +368,6 @@ func (a *Agent) dialContext(ctx context.Context, target string, dialOpts ...grpc
 	return grpc.DialContext(ctx, target, opts...)
 }
 
-const (
-	// workerIdleTimeout is the duration after which an idle worker stops to save resources.
-	workerIdleTimeout = (1 << 7) * time.Millisecond
-	// workerBusyTimeout is the duration after which a message is dropped if all workers are busy.
-	workerBusyTimeout = (1 << 6) * time.Millisecond
-)
-
 func (a *Agent) publishUplink(ctx context.Context) error {
 	ctx = log.NewContextWithFields(ctx, log.Fields(
 		"forwarder_net_id", a.netID,

--- a/pkg/packetbrokeragent/agent.go
+++ b/pkg/packetbrokeragent/agent.go
@@ -598,7 +598,7 @@ func (a *Agent) handleDownlinkMessage(ctx context.Context, down *packetbroker.Ro
 		DownlinkToken:        down.Message.DownlinkToken,
 		State:                packetbroker.MessageDeliveryState_PROCESSED,
 	}
-	defer func() {
+	defer func(ctx context.Context) {
 		if err != nil && report.Result == nil {
 			report.Result = &packetbroker.DownlinkMessageDeliveryStateChange_Error{
 				Error: packetbroker.DownlinkMessageProcessingError_DOWNLINK_INTERNAL,
@@ -607,7 +607,7 @@ func (a *Agent) handleDownlinkMessage(ctx context.Context, down *packetbroker.Ro
 		if err := reportPool.Publish(ctx, report); err != nil {
 			logger.WithError(err).Warn("Forwarder downlink reporter enqueuer busy, drop message")
 		}
-	}()
+	}(ctx)
 
 	for _, filler := range a.tenantContextFillers {
 		var err error
@@ -914,7 +914,7 @@ func (a *Agent) handleUplinkMessage(ctx context.Context, up *packetbroker.Routed
 		ForwarderUplinkToken: up.Message.ForwarderUplinkToken,
 		State:                packetbroker.MessageDeliveryState_PROCESSED,
 	}
-	defer func() {
+	defer func(ctx context.Context) {
 		if err != nil && report.Error == nil {
 			report.Error = &packetbroker.UplinkMessageProcessingErrorValue{
 				Value: packetbroker.UplinkMessageProcessingError_UPLINK_INTERNAL,
@@ -923,7 +923,7 @@ func (a *Agent) handleUplinkMessage(ctx context.Context, up *packetbroker.Routed
 		if err := reportPool.Publish(ctx, report); err != nil {
 			logger.WithError(err).Warn("Home Network uplink reporter enqueuer busy, drop message")
 		}
-	}()
+	}(ctx)
 
 	if err := a.decryptUplink(ctx, up.Message); err != nil {
 		logger.WithError(err).Warn("Failed to decrypt message")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/4666

#### Changes
<!-- What are the changes made in this pull request? -->

- Use the original (pre-filled) context while submitting PBA traffic reports
  - This otherwise marks the traffic as being processed for a particular tenant, which is a metric we're already tracking separately in PBA metrics

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
