### PR TITLE
Range over map when checking data rate for bands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ For details about compatibility between different releases, see the **Commitment
 - Emails to admins about requested OAuth clients.
 - `session` handling for joined OTAA end devices in the Console.
 - Empty Join Server address handling in end device creation form in the Console.
+- Data Rate to data rate index matching for uplinks and downlinks.
 
 ### Security
 

--- a/pkg/band/band.go
+++ b/pkg/band/band.go
@@ -121,13 +121,14 @@ func (b Band) FindSubBand(frequency uint64) (SubBandParameters, bool) {
 
 // FindUplinkDataRate returns the uplink data rate with index by API data rate, if any.
 func (b Band) FindUplinkDataRate(dr ttnpb.DataRate) (ttnpb.DataRateIndex, DataRate, bool) {
-	// Note: Some bands (e.g. US915) contain identical data rates under different indexes.
-	// It seems to be a convention in the spec for uplink-only data rates to be at indexes
-	// lower than downlink-only indexes, hence match the smallest index.
-	// However, this is not currently possible since we store these indices in a map and
-	// we cannot guarantee the order of traversal.
-	for i, bDR := range b.DataRates {
-		if bDR.Rate.Equal(dr) {
+	for i := ttnpb.DATA_RATE_0; i <= ttnpb.DATA_RATE_15; i++ {
+		// NOTE: Some bands (e.g. US915) contain identical data rates under different indexes.
+		// It seems to be a convention in the spec for uplink-only data rates to be at indexes
+		// lower than downlink-only indexes, hence match the smallest index.
+		// NOTE(2): A more robust solution could be to record a list of uplink-only data rates
+		// per band and only match those here, however it is more complex and is not necessary.
+		bDR, ok := b.DataRates[i]
+		if ok && bDR.Rate.Equal(dr) {
 			return i, bDR, true
 		}
 	}
@@ -137,8 +138,9 @@ func (b Band) FindUplinkDataRate(dr ttnpb.DataRate) (ttnpb.DataRateIndex, DataRa
 // FindDownlinkDataRate returns the downlink data rate with index by API data rate, if any.
 func (b Band) FindDownlinkDataRate(dr ttnpb.DataRate) (ttnpb.DataRateIndex, DataRate, bool) {
 	// NOTE: See notes in FindUplinkDataRate explaining the order of scanning data rates.
-	for i, bDR := range b.DataRates {
-		if bDR.Rate.Equal(dr) {
+	for i := ttnpb.DATA_RATE_15; i >= ttnpb.DATA_RATE_0; i-- {
+		bDR, ok := b.DataRates[i]
+		if ok && bDR.Rate.Equal(dr) {
 			return i, bDR, true
 		}
 	}

--- a/pkg/band/band.go
+++ b/pkg/band/band.go
@@ -121,14 +121,13 @@ func (b Band) FindSubBand(frequency uint64) (SubBandParameters, bool) {
 
 // FindUplinkDataRate returns the uplink data rate with index by API data rate, if any.
 func (b Band) FindUplinkDataRate(dr ttnpb.DataRate) (ttnpb.DataRateIndex, DataRate, bool) {
-	for i := ttnpb.DataRateIndex(0); int(i) < len(b.DataRates); i++ {
-		// NOTE: Some bands (e.g. US915) contain identical data rates under different indexes.
-		// It seems to be a convention in the spec for uplink-only data rates to be at indexes
-		// lower than downlink-only indexes, hence match the smallest index.
-		// NOTE(2): A more robust solution could be to record a list of uplink-only data rates
-		// per band and only match those here, however it is more complex and is not necessary.
-		bDR, ok := b.DataRates[i]
-		if ok && bDR.Rate.Equal(dr) {
+	// Note: Some bands (e.g. US915) contain identical data rates under different indexes.
+	// It seems to be a convention in the spec for uplink-only data rates to be at indexes
+	// lower than downlink-only indexes, hence match the smallest index.
+	// However, this is not currently possible since we store these indices in a map and
+	// we cannot guarantee the order of traversal.
+	for i, bDR := range b.DataRates {
+		if bDR.Rate.Equal(dr) {
 			return i, bDR, true
 		}
 	}
@@ -138,9 +137,8 @@ func (b Band) FindUplinkDataRate(dr ttnpb.DataRate) (ttnpb.DataRateIndex, DataRa
 // FindDownlinkDataRate returns the downlink data rate with index by API data rate, if any.
 func (b Band) FindDownlinkDataRate(dr ttnpb.DataRate) (ttnpb.DataRateIndex, DataRate, bool) {
 	// NOTE: See notes in FindUplinkDataRate explaining the order of scanning data rates.
-	for i := ttnpb.DataRateIndex(len(b.DataRates) - 1); int(i) >= 0; i-- {
-		bDR, ok := b.DataRates[i]
-		if ok && bDR.Rate.Equal(dr) {
+	for i, bDR := range b.DataRates {
+		if bDR.Rate.Equal(dr) {
 			return i, bDR, true
 		}
 	}

--- a/pkg/band/band_test.go
+++ b/pkg/band/band_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/v3/pkg/band"
 	. "go.thethings.network/lorawan-stack/v3/pkg/band"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
@@ -572,4 +573,69 @@ func TestFindSubBand(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestFindDataRate(t *testing.T) {
+	a := assertions.New(t)
+
+	// US_902_928
+	testBand, _ := Get(band.US_902_928, ttnpb.RP001_V1_0_2_REV_B)
+	dr := ttnpb.DataRate{
+		Modulation: &ttnpb.DataRate_Lora{
+			Lora: &ttnpb.LoRaDataRate{
+				Bandwidth:       500000,
+				SpreadingFactor: 8,
+			},
+		},
+	}
+	index, _, ok := testBand.FindDownlinkDataRate(dr)
+	a.So(ok, should.BeTrue)
+	if index != ttnpb.DATA_RATE_12 && index != ttnpb.DATA_RATE_4 {
+		t.Fatalf("Invalid index, expected 4 or 12. Got %d", index)
+	}
+
+	dr = ttnpb.DataRate{
+		Modulation: &ttnpb.DataRate_Lora{
+			Lora: &ttnpb.LoRaDataRate{
+				Bandwidth:       500000,
+				SpreadingFactor: 8,
+			},
+		},
+	}
+	index, _, ok = testBand.FindUplinkDataRate(dr)
+	a.So(ok, should.BeTrue)
+	if index != ttnpb.DATA_RATE_12 && index != ttnpb.DATA_RATE_4 {
+		t.Fatalf("Invalid index, expected 4 or 12. Got %d", index)
+	}
+
+	// AU_915_928
+	testBand, _ = Get(band.AU_915_928, ttnpb.RP001_V1_0_3_REV_A)
+	dr = ttnpb.DataRate{
+		Modulation: &ttnpb.DataRate_Lora{
+			Lora: &ttnpb.LoRaDataRate{
+				Bandwidth:       500000,
+				SpreadingFactor: 12,
+			},
+		},
+	}
+	index, _, ok = testBand.FindDownlinkDataRate(dr)
+	a.So(ok, should.BeTrue)
+	if index != ttnpb.DATA_RATE_12 && index != ttnpb.DATA_RATE_8 {
+		t.Fatalf("Invalid index, expected 8 or 12. Got %d", index)
+	}
+
+	dr = ttnpb.DataRate{
+		Modulation: &ttnpb.DataRate_Lora{
+			Lora: &ttnpb.LoRaDataRate{
+				Bandwidth:       500000,
+				SpreadingFactor: 12,
+			},
+		},
+	}
+	index, _, ok = testBand.FindUplinkDataRate(dr)
+	a.So(ok, should.BeTrue)
+	if index != ttnpb.DATA_RATE_12 && index != ttnpb.DATA_RATE_8 {
+		t.Fatalf("Invalid index, expected 8 or 12. Got %d", index)
+	}
+
 }

--- a/pkg/band/band_test.go
+++ b/pkg/band/band_test.go
@@ -590,8 +590,8 @@ func TestFindDataRate(t *testing.T) {
 	}
 	index, _, ok := testBand.FindDownlinkDataRate(dr)
 	a.So(ok, should.BeTrue)
-	if index != ttnpb.DATA_RATE_12 && index != ttnpb.DATA_RATE_4 {
-		t.Fatalf("Invalid index, expected 4 or 12. Got %d", index)
+	if index != ttnpb.DATA_RATE_12 {
+		t.Fatalf("Invalid index, expected 12. Got %d", index)
 	}
 
 	dr = ttnpb.DataRate{
@@ -604,8 +604,8 @@ func TestFindDataRate(t *testing.T) {
 	}
 	index, _, ok = testBand.FindUplinkDataRate(dr)
 	a.So(ok, should.BeTrue)
-	if index != ttnpb.DATA_RATE_12 && index != ttnpb.DATA_RATE_4 {
-		t.Fatalf("Invalid index, expected 4 or 12. Got %d", index)
+	if index != ttnpb.DATA_RATE_4 {
+		t.Fatalf("Invalid index, expected 4. Got %d", index)
 	}
 
 	// AU_915_928
@@ -620,8 +620,8 @@ func TestFindDataRate(t *testing.T) {
 	}
 	index, _, ok = testBand.FindDownlinkDataRate(dr)
 	a.So(ok, should.BeTrue)
-	if index != ttnpb.DATA_RATE_12 && index != ttnpb.DATA_RATE_8 {
-		t.Fatalf("Invalid index, expected 8 or 12. Got %d", index)
+	if index != ttnpb.DATA_RATE_8 {
+		t.Fatalf("Invalid index, expected 8. Got %d", index)
 	}
 
 	dr = ttnpb.DataRate{
@@ -634,8 +634,8 @@ func TestFindDataRate(t *testing.T) {
 	}
 	index, _, ok = testBand.FindUplinkDataRate(dr)
 	a.So(ok, should.BeTrue)
-	if index != ttnpb.DATA_RATE_12 && index != ttnpb.DATA_RATE_8 {
-		t.Fatalf("Invalid index, expected 8 or 12. Got %d", index)
+	if index != ttnpb.DATA_RATE_8 {
+		t.Fatalf("Invalid index, expected 8. Got %d", index)
 	}
 
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Range over map when checking data rate for bands. Fixes; https://thethingsindustries.slack.com/archives/C06UQSMPB/p1633004312030800

#### Changes
<!-- What are the changes made in this pull request? -->

- Simply range over the map and compare instead of (incorrectly) choosing the order of traversal.
- Add targeted test cases.

#### Testing

<!-- How did you verify that this change works? -->

UT + existing cases should over this.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

UT/ staging tests should cover this.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This is easier than I made it out to be.. ;) 
#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
