### PR TITLE
Extract error message props from errors with `error_paths`

### DIFF
--- a/pkg/webui/console/components/events/previews/error-details.js
+++ b/pkg/webui/console/components/events/previews/error-details.js
@@ -21,7 +21,7 @@ import PropTypes from '@ttn-lw/lib/prop-types'
 import style from './previews.styl'
 
 const ErrorPreview = React.memo(({ event }) => (
-  <ErrorMessage className={style.plainText} content={event.data} withRootCause />
+  <ErrorMessage className={style.plainText} content={event.data} withRootCause convertBackticks />
 ))
 
 ErrorPreview.propTypes = {

--- a/pkg/webui/lib/components/error-message/index.js
+++ b/pkg/webui/lib/components/error-message/index.js
@@ -17,12 +17,7 @@ import React from 'react'
 import Message from '@ttn-lw/lib/components/message'
 
 import PropTypes from '@ttn-lw/lib/prop-types'
-import {
-  hasCauses,
-  getBackendErrorRootCause,
-  toMessageProps,
-  isBackend,
-} from '@ttn-lw/lib/errors/utils'
+import { toMessageProps, isBackend } from '@ttn-lw/lib/errors/utils'
 
 const ErrorMessage = ({ content, withRootCause, className, ...rest }) => {
   const baseProps = {
@@ -32,23 +27,18 @@ const ErrorMessage = ({ content, withRootCause, className, ...rest }) => {
     ...rest,
   }
 
-  if (withRootCause && hasCauses(content)) {
-    const rootProps = { ...baseProps, ...toMessageProps(content) }
-    const causeProps = { ...baseProps, ...toMessageProps(getBackendErrorRootCause(content)) }
+  const messageProps = toMessageProps(content, true)
 
+  if (withRootCause && messageProps.length > 1) {
     return (
       <span className={baseProps.className}>
-        <Message {...rootProps} />: <Message {...causeProps} />
+        <Message {...baseProps} {...messageProps[1]} />:{' '}
+        <Message {...baseProps} {...messageProps[0]} />
       </span>
     )
   }
 
-  const props = {
-    ...toMessageProps(content),
-    ...baseProps,
-  }
-
-  return <Message {...props} />
+  return <Message {...baseProps} {...messageProps[0]} />
 }
 
 ErrorMessage.propTypes = {


### PR DESCRIPTION
#### Summary
This PR fixes i18n message extraction from errors with `error_paths`, as well as optimizing extraction of multiple message props for a single error (for each level)

Closes #4648 

#### Changes
- Add utils to extract message props from `error_paths` array within error details
- Convert backticks within error details displayed within events
- Enable extracting all error props when an error object has multips extractable messages
- Update and extend unit tests accordingly


#### Testing

Unit tests and manual testing on the staging environment.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
