### PR TITLE
Fix not displaying value type events

### DIFF
--- a/pkg/webui/console/components/events/previews/value.js
+++ b/pkg/webui/console/components/events/previews/value.js
@@ -26,7 +26,7 @@ const Value = React.memo(({ event }) => {
       {Array.isArray(data.value) || typeof data.value === 'object' ? (
         <JSONPayload data={data.value} />
       ) : (
-        <DescriptionList.Item value={data.value} />
+        <DescriptionList.Item data={data.value} />
       )}
     </DescriptionList>
   )


### PR DESCRIPTION
#### Summary
This quickfix PR fixes the Console currently not displaying plain string values of `Value` type events.

Before:
![image](https://user-images.githubusercontent.com/5710611/135521229-7631f99b-4e0a-4d7c-b713-8f8cd5b8b334.png)
After:
![image](https://user-images.githubusercontent.com/5710611/135520967-aca776ff-2115-4031-98b7-33869f1d28d4.png)


#### Changes
- Use correct `data` prop instead of `item`

#### Testing

Manual.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
