### PR TITLE
Fix/4558 expand toggle sections when validation fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - Emails to admins about requested OAuth clients.
 - `session` handling for joined OTAA end devices in the Console.
+- `FormCollapseSection` components that contain fields that had validation errors when submitting a form should automatically expand.
 
 ### Security
 

--- a/pkg/webui/components/form/section/index.js
+++ b/pkg/webui/components/form/section/index.js
@@ -33,15 +33,24 @@ const m = defineMessages({
 // `<FormCollapseSection />` aggregates a set of form fields under common title as well as adds
 // functionality to hide or show the fields.
 const FormCollapseSection = props => {
-  const { className, id, title, onCollapse, isCollapsed, initiallyCollapsed, children } = props
+  const {
+    className,
+    id,
+    title,
+    onCollapse,
+    isCollapsed,
+    initiallyCollapsed,
+    children,
+    errorTitles,
+  } = props
   const { formatMessage } = useIntl()
-  const { disabled } = useFormContext()
+  const { disabled, errors, isSubmitting } = useFormContext()
 
   // Check if the component is 'controlled'. When the `isCollapsed` prop is passed the component
   // is considered as 'uncontrolled' and it's state must be controlled from the outside.
   const isControlled = typeof isCollapsed === 'undefined'
-
   const [collapsed, setCollapsed] = React.useState(initiallyCollapsed)
+
   const onExpandedChange = React.useCallback(() => {
     if (isControlled) {
       setCollapsed(collapsed => !collapsed)
@@ -49,6 +58,20 @@ const FormCollapseSection = props => {
       onCollapse()
     }
   }, [isControlled, onCollapse])
+
+  // Trigger an expand if there is an error in a field within the section when submitting.
+  // Uses `errorTitles` to determine what types of errors should trigger an expand.
+  React.useEffect(() => {
+    if (isSubmitting) {
+      for (let i = 0; i < errorTitles.length; i++) {
+        const title = errorTitles[i]
+        if (errors[title]) {
+          setCollapsed(false)
+          break
+        }
+      }
+    }
+  }, [isSubmitting])
 
   const isSectionClosed = isControlled ? collapsed : isCollapsed
 
@@ -81,6 +104,7 @@ FormCollapseSection.propTypes = {
   isCollapsed: PropTypes.bool,
   onCollapse: PropTypes.func,
   title: PropTypes.message.isRequired,
+  errorTitles: PropTypes.array,
 }
 
 FormCollapseSection.defaultProps = {
@@ -88,6 +112,7 @@ FormCollapseSection.defaultProps = {
   onCollapse: () => null,
   isCollapsed: undefined,
   initiallyCollapsed: true,
+  errorTitles: [],
 }
 
 export default FormCollapseSection

--- a/pkg/webui/components/form/story.js
+++ b/pkg/webui/components/form/story.js
@@ -142,7 +142,11 @@ storiesOf('Form', module)
           <Radio label="Radio 2" value="radio2" />
           <Radio label="Radio 3" value="radio3" />
         </Form.Field>
-        <Form.CollapseSection title="Optional information" id="optional-section">
+        <Form.CollapseSection
+          title="Optional information"
+          id="optional-section"
+          errorTitles={['about']}
+        >
           <Form.Field
             component={Input}
             type="textarea"

--- a/pkg/webui/console/components/device-import-form/index.js
+++ b/pkg/webui/console/components/device-import-form/index.js
@@ -159,7 +159,11 @@ export default class DeviceBulkCreateForm extends Component {
               name="data"
               required
             />
-            <Form.CollapseSection id="advanced-settings" title={m.advancedSectionTitle}>
+            <Form.CollapseSection
+              id="advanced-settings"
+              title={m.advancedSectionTitle}
+              errorTitles={['components', 'set_claim_auth_code']}
+            >
               <Form.Field
                 onChange={this.handleComponentChange}
                 component={Checkbox.Group}

--- a/pkg/webui/console/components/mac-settings-section/index.js
+++ b/pkg/webui/console/components/mac-settings-section/index.js
@@ -107,6 +107,7 @@ const MacSettingsSection = props => {
       initiallyCollapsed={initiallyCollapsed}
       onCollapse={handleIsCollapsedChange}
       isCollapsed={isCollapsed}
+      errorTitles={['mac_settings']}
     >
       <Form.Field
         title={sharedMessages.frameCounterWidth}

--- a/pkg/webui/console/views/device-add/manual/form/advanced-settings.js
+++ b/pkg/webui/console/views/device-add/manual/form/advanced-settings.js
@@ -89,7 +89,7 @@ const AdvancedSettingsSection = props => {
     onJsAddressChange,
   } = props
 
-  const { values: formValues } = useFormContext()
+  const { values: formValues, isValidating, isSubmitting } = useFormContext()
   const { mac_settings: macSettings } = formValues
 
   const isOTAA = activationMode === ACTIVATION_MODES.OTAA
@@ -113,11 +113,20 @@ const AdvancedSettingsSection = props => {
     [onDefaultNsSettingsChange],
   )
 
+  // List of error types that should trigger an expand if present during form submission.
+  const errorTitles = [
+    'mac_settings',
+    '_device_class',
+    'network_server_address',
+    'join_server_address',
+  ]
+
   return (
     <Form.CollapseSection
       className={style.advancesSection}
       id="advanced-settings"
       title={m.advancedSectionTitle}
+      errorTitles={errorTitles}
     >
       <Form.Field
         title={sharedMessages.activationMode}

--- a/pkg/webui/console/views/device-add/manual/form/form.js
+++ b/pkg/webui/console/views/device-add/manual/form/form.js
@@ -728,7 +728,16 @@ const ManualForm = props => {
         <Radio label={messages.multipleRegistration} value={REGISTRATION_TYPES.MULTIPLE} />
       </Form.Field>
       <SubmitBar>
-        <Form.Submit message={messages.submitTitle} component={SubmitButton} />
+        <Form.Submit
+          message={messages.submitTitle}
+          component={SubmitButton}
+          onClick={e => {
+            e.preventDefault()
+            if (formRef.current) {
+              formRef.current.handleSubmit()
+            }
+          }}
+        />
       </SubmitBar>
     </Form>
   )


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #4558 

#### Changes
<!-- What are the changes made in this pull request? -->

- Extend `FormCollapseSection` component to expand when a section contains fields that had validation errors when submitting a form.
- Fix errors within collapse sections on the manual device-add form blocking Formik submission and validation handlers.
- Pass `errorTitles` props to FormCollapseSection instances to specify what errors should trigger an expand.

#### Testing

<!-- How did you verify that this change works? -->

Manual testing was performed, as recommended by the original issue.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

On the manual device form, which directly accesses the Formik submission handler and bypasses native HTML validation that was previously performed when the form is submitted, modifications may need to be done to the validation schema to make sure all edge cases are caught. For example, it is possible to enter the letter "e" into number fields, but native HTML validation would raise an error if the entered number was invalid when the form is submitted. But since native submit behavior is prevented, it may be necessary to make sure the validation schema provided to the Formik handlers catches these cases.

Testing was performed manually by comparing what values could be entered into certain inputs within collapse sections and submitted before and after native form submission behavior was prevented.
#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I was hoping to keep changes limited to the reusable components such as `FormCollapseSection`, but I had trouble implementing a solution that would automatically work for all forms using the `FormCollapseSection` component. I implemented the `errorTitles` prop to be passed to `FormCollapseSection` instances in order to specify what errors caught by Formik would cause an expand, but it would be cleaner to find a way to automatically determine if a child field produced an error. 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
