### PR TITLE
Packet Broker authentication update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Added
 
+- Support for enhanced security policies of Packet Broker services.
+
 ### Changed
 
 ### Deprecated

--- a/pkg/packetbrokeragent/agent.go
+++ b/pkg/packetbrokeragent/agent.go
@@ -168,7 +168,12 @@ func New(c *component.Component, conf *Config, opts ...Option) (*Agent, error) {
 		if !conf.Insecure {
 			tlsConfig = c
 		}
-		authenticator = newOAuth2(ctx, conf.OAuth2, tlsConfig)
+		authenticator = newOAuth2(ctx, conf.OAuth2, tlsConfig,
+			conf.IAMAddress,
+			conf.ControlPlaneAddress,
+			conf.DataPlaneAddress,
+			conf.MapperAddress,
+		)
 	}
 
 	homeNetworkClusterID := conf.HomeNetworkClusterID

--- a/pkg/packetbrokeragent/authenticator.go
+++ b/pkg/packetbrokeragent/authenticator.go
@@ -74,7 +74,7 @@ func (a *oauth2Authenticator) AuthInfo(ctx context.Context) (ttnpb.PacketBrokerN
 				NetID    uint32 `json:"nid"`
 				TenantID string `json:"tid"`
 			} `json:"ns"`
-		} `json:"https://iam.packetbroker.org/claims"`
+		} `json:"https://iam.packetbroker.net/claims"`
 	}
 	if err := parsed.UnsafeClaimsWithoutVerification(&claims); err != nil {
 		return ttnpb.PacketBrokerNetworkIdentifier{}, errOAuth2Token.WithCause(err)

--- a/pkg/packetbrokeragent/authenticator.go
+++ b/pkg/packetbrokeragent/authenticator.go
@@ -17,6 +17,9 @@ package packetbrokeragent
 import (
 	"context"
 	"crypto/tls"
+	"net"
+	"net/url"
+	"strings"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/component"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
@@ -43,13 +46,30 @@ type oauth2Authenticator struct {
 	tlsConfig   tlsConfigurator
 }
 
-func newOAuth2(ctx context.Context, oauth2Config OAuth2Config, tlsConfig tlsConfigurator) authenticator {
+func newOAuth2(ctx context.Context, oauth2Config OAuth2Config, tlsConfig tlsConfigurator, targetAddresses ...string) authenticator {
+	hosts := make(map[string]bool, len(targetAddresses))
+	for _, addr := range targetAddresses {
+		if addr == "" {
+			continue
+		}
+		if h, _, err := net.SplitHostPort(addr); err == nil {
+			addr = h
+		}
+		hosts[addr] = true
+	}
+	audience := make([]string, 0, len(hosts))
+	for h := range hosts {
+		audience = append(audience, h)
+	}
 	config := clientcredentials.Config{
 		ClientID:     oauth2Config.ClientID,
 		ClientSecret: oauth2Config.ClientSecret,
 		Scopes:       []string{"networks"},
 		AuthStyle:    oauth2.AuthStyleInParams,
 		TokenURL:     oauth2Config.TokenURL,
+		EndpointParams: url.Values{
+			"audience": []string{strings.Join(audience, " ")},
+		},
 	}
 	return &oauth2Authenticator{
 		tokenSource: config.TokenSource(ctx),

--- a/pkg/packetbrokeragent/authenticator_internal_test.go
+++ b/pkg/packetbrokeragent/authenticator_internal_test.go
@@ -36,7 +36,7 @@ func TestOAuth2(t *testing.T) {
 	authenticator := &oauth2Authenticator{
 		tokenSource: tokenSourceFunc(func() (*oauth2.Token, error) {
 			return &oauth2.Token{
-				AccessToken: "eyJhbGciOiJFZERTQSIsImtpZCI6InByb2QtMjAyMC0xMi0yOCIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MjgyNTk1MjAsImh0dHBzOi8vaWFtLnBhY2tldGJyb2tlci5vcmcvY2xhaW1zIjp7Im5zIjpbeyJuaWQiOjE5LCJ0aWQiOiJ0dGkifV0sInJpZ2h0cyI6WzAsNCw3LDgsOSwxMCwxMV19LCJpYXQiOjE2MjgyNTU5MjAsImlzcyI6Imh0dHBzOi8vaWFtLnBhY2tldGJyb2tlci5uZXQiLCJqdGkiOiIwMUZDRFNWN1hURVg0NlZRUjlLMTJFMVFFMiJ9.AA",
+				AccessToken: "eyJhbGciOiJFZERTQSIsImtpZCI6InByb2QtMjAyMC0xMi0yOCIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MjgyNTk1MjAsImh0dHBzOi8vaWFtLnBhY2tldGJyb2tlci5uZXQvY2xhaW1zIjp7Im5zIjpbeyJuaWQiOjE5LCJ0aWQiOiJ0dGkifV0sInJpZ2h0cyI6WzAsNCw3LDgsOSwxMCwxMV19LCJpYXQiOjE2MjgyNTU5MjAsImlzcyI6Imh0dHBzOi8vaWFtLnBhY2tldGJyb2tlci5uZXQiLCJqdGkiOiIwMUZDRFNWN1hURVg0NlZRUjlLMTJFMVFFMiJ9.AA",
 				TokenType:   "bearer",
 				Expiry:      time.Date(2021, 8, 6, 14, 19, 0, 0, time.UTC),
 			}, nil


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Packet Broker token updates to prepare for more strict security requirements enforced by future deployments of Packet Broker.

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/4689

#### Changes
<!-- What are the changes made in this pull request? -->

- Use new token claims namespace. Packet Broker will be issuing tokens with the old and the new namespace for the time being, but the old namespace will be discontinued as of December 2nd. See https://status.packetbroker.net/incidents/td2d4mps1gw4
- Provide audience; all known addresses in TTS config are passed as audience. This is enforced from December 2nd. See https://status.packetbroker.net/incidents/sxwvg9k9nl8r

#### Testing

<!-- How did you verify that this change works? -->

Local integration testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None expected

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
