### PR TITLE
Fix sentry error ingestion in error notifications

### DIFF
--- a/pkg/webui/components/error-notification/index.js
+++ b/pkg/webui/components/error-notification/index.js
@@ -25,7 +25,7 @@ const ErrorNotification = ({ content, title, details, noIngest, ...rest }) => {
 
   useEffect(() => {
     if (!noIngest) {
-      ingestError(details, {
+      ingestError(details || content, {
         ingestedBy: 'ErrorNotification',
       })
     }


### PR DESCRIPTION
#### Summary
Quickfix for an issue introduced via #4643 which causes errors ingested by the error notification component being sent as `undefined`.

#### Changes
- Fix ingesting `detail` prop only


#### Testing

Manual testing.

#### Notes for Reviewers
This is the reason why [errors like these](https://sentry.io/organizations/the-things-industries/issues/2691990954/?project=2682566) are surfacing, which are wrongfully registered as new errors.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
