### PR TITLE
Backport NS matching error details

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -6569,6 +6569,15 @@
       "file": "errors.go"
     }
   },
+  "error:pkg/networkserver/redis:candidate": {
+    "translations": {
+      "en": "candidate failed matching"
+    },
+    "description": {
+      "package": "pkg/networkserver/redis",
+      "file": "registry.go"
+    }
+  },
   "error:pkg/networkserver/redis:database_corruption": {
     "translations": {
       "en": "database is corrupted"
@@ -6599,6 +6608,15 @@
   "error:pkg/networkserver/redis:field_count": {
     "translations": {
       "en": "invalid field count '{count}'"
+    },
+    "description": {
+      "package": "pkg/networkserver/redis",
+      "file": "registry.go"
+    }
+  },
+  "error:pkg/networkserver/redis:found_no_match_marker": {
+    "translations": {
+      "en": "found no match marker"
     },
     "description": {
       "package": "pkg/networkserver/redis",
@@ -6657,6 +6675,24 @@
     "description": {
       "package": "pkg/networkserver/redis",
       "file": "application_uplink_queue.go"
+    }
+  },
+  "error:pkg/networkserver/redis:no_candidate_match": {
+    "translations": {
+      "en": "no candidate matches uplink"
+    },
+    "description": {
+      "package": "pkg/networkserver/redis",
+      "file": "registry.go"
+    }
+  },
+  "error:pkg/networkserver/redis:no_candidates": {
+    "translations": {
+      "en": "no device candidates found"
+    },
+    "description": {
+      "package": "pkg/networkserver/redis",
+      "file": "registry.go"
     }
   },
   "error:pkg/networkserver/redis:no_uplink_match": {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/pull/2925
References https://github.com/TheThingsNetwork/lorawan-stack/pull/4672

#### Changes
<!-- What are the changes made in this pull request? -->

- Backport the matching error details improvements
- Log connection stats errors as `WARN`, and use a decoupled context for the operations
  - Gateway connections are flaky at scale - the `ctx` may be cancelled often, and since it's an `errorcontext`, the `Err()` is not always using the cancelled error code.
  - Example: `{"level":"error","msg":"Failed to update connection stats","endpoint":"/traffic/:id","error":"error:pkg/redis:store (store error)","error_cause":"websocket: close 1006 (abnormal closure): unexpected EOF","gateway_uid":"*","method":"GET","namespace":"gatewayserver/io/ws","protocol":"ws","remote_addr":"*","request_id":"*","tenant_id":"ttn","url":"/traffic/eui-*"}`


#### Testing

<!-- How did you verify that this change works? -->

N/A

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
