### PR TITLE
Add package for toggling experimental features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For details about compatibility between different releases, see the **Commitment
   - `interop.public-tls-address`: public address of the interop server. The audience in the incoming OAuth 2.0 token from Packet Broker is verified against this address to ensure that other networks cannot impersonate as Packet Broker;
   - `interop.packet-broker.enabled`: enable Packet Broker to authenticate;
   - `interop.packet-broker.token-issuer`: the issuer of the incoming OAuth 2.0 token from Packet Broker is verified against this value.
+- Configuration option `experimental.features` to enable experimental features.
 
 ### Changed
 

--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -37,6 +37,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/internal/util"
 	conf "go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/experimental"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/io"
 	pkgversion "go.thethings.network/lorawan-stack/v3/pkg/version"
@@ -100,6 +101,9 @@ func preRun(tasks ...func() error) func(cmd *cobra.Command, args []string) error
 		if err = mgr.Unmarshal(config); err != nil {
 			return err
 		}
+
+		// enable configured experimental features
+		experimental.EnableFeatures(config.Experimental.Features...)
 
 		// create input decoder on Stdin
 		if rd, ok := cmdio.BufferedPipe(os.Stdin); ok {

--- a/cmd/ttn-lw-stack/commands/root.go
+++ b/cmd/ttn-lw-stack/commands/root.go
@@ -27,6 +27,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/shared/version"
 	conf "go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/experimental"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	logobservability "go.thethings.network/lorawan-stack/v3/pkg/log/middleware/observability"
 	logsentry "go.thethings.network/lorawan-stack/v3/pkg/log/middleware/sentry"
@@ -64,6 +65,9 @@ var (
 			if err = mgr.Unmarshal(config); err != nil {
 				return err
 			}
+
+			// enable configured experimental features
+			experimental.EnableFeatures(config.Experimental.Features...)
 
 			// initialize configuration fallbacks
 			if err := shared.InitializeFallbacks(&config.ServiceBase); err != nil {

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -30,6 +30,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/crypto"
 	"go.thethings.network/lorawan-stack/v3/pkg/crypto/cryptoutil"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/experimental"
 	"go.thethings.network/lorawan-stack/v3/pkg/fetch"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/redis"
@@ -38,8 +39,9 @@ import (
 
 // Base represents base component configuration.
 type Base struct {
-	Config []string `name:"config" shorthand:"c" description:"Location of the config files"`
-	Log    Log      `name:"log"`
+	Config       []string            `name:"config" shorthand:"c" description:"Location of the config files"`
+	Log          Log                 `name:"log"`
+	Experimental experimental.Config `name:"experimental"`
 }
 
 // Log represents configuration for the logger.

--- a/pkg/experimental/config.go
+++ b/pkg/experimental/config.go
@@ -1,0 +1,20 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package experimental
+
+// Config is the configuration for experimental features.
+type Config struct {
+	Features []string `name:"features" description:"Experimental features to activate"`
+}

--- a/pkg/experimental/experimental_test.go
+++ b/pkg/experimental/experimental_test.go
@@ -1,0 +1,51 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package experimental
+
+import (
+	"context"
+	"testing"
+
+	"github.com/smartystreets/assertions"
+	"github.com/smartystreets/assertions/should"
+)
+
+func TestExperimentalFeatures(t *testing.T) {
+	a := assertions.New(t)
+
+	r := NewRegistry()
+
+	ctx := NewContextWithRegistry(context.Background(), r)
+
+	feature := DefineFeature("experimental.feature", false)
+	a.So(feature.GetValue(ctx), should.BeFalse)
+	a.So(AllFeatures(ctx), should.Resemble, map[string]bool{"experimental.feature": false})
+	a.So(feature.GetValue(context.Background()), should.BeFalse)
+	a.So(AllFeatures(context.Background()), should.Resemble, map[string]bool{"experimental.feature": false})
+
+	r.EnableFeatures("experimental.feature")
+	a.So(feature.GetValue(ctx), should.BeTrue)
+	a.So(AllFeatures(ctx), should.Resemble, map[string]bool{"experimental.feature": true})
+	a.So(feature.GetValue(context.Background()), should.BeFalse)
+	a.So(AllFeatures(context.Background()), should.Resemble, map[string]bool{"experimental.feature": false})
+
+	EnableFeatures("experimental.feature")
+	r.DisableFeatures("experimental.feature")
+
+	a.So(feature.GetValue(ctx), should.BeFalse)
+	a.So(AllFeatures(ctx), should.Resemble, map[string]bool{"experimental.feature": false})
+	a.So(feature.GetValue(context.Background()), should.BeTrue)
+	a.So(AllFeatures(context.Background()), should.Resemble, map[string]bool{"experimental.feature": true})
+}

--- a/pkg/experimental/feature.go
+++ b/pkg/experimental/feature.go
@@ -1,0 +1,91 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package experimental
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// Feature is an experimental feature that can be enabled or disabled.
+type Feature struct {
+	name         string
+	defaultValue bool
+}
+
+var (
+	definedFeatures   = make(map[string]*Feature)
+	definedFeaturesMu sync.RWMutex
+)
+
+// DefineFeature defines an experimental feature.
+func DefineFeature(name string, defaultValue bool) *Feature {
+	definedFeaturesMu.Lock()
+	defer definedFeaturesMu.Unlock()
+	if _, exists := definedFeatures[name]; exists {
+		panic(fmt.Errorf("experimental feature %q already defined", name))
+	}
+	f := &Feature{name: name, defaultValue: defaultValue}
+	definedFeatures[name] = f
+	return f
+}
+
+// GetValue gets the value of the feature flag.
+// The value comes from the registry in the context, the global registry,
+// or the default value.
+func (f *Feature) GetValue(ctx context.Context) bool {
+	r := registryFromContext(ctx)
+	if r != nil {
+		if v, ok := r.getFeature(f.name); ok {
+			return v
+		}
+	}
+	if v, ok := globalRegistry.getFeature(f.name); ok {
+		return v
+	}
+	return f.defaultValue
+}
+
+// AllFeatures returns all features and their values.
+// The values come from the registry in the context, the global registry,
+// or the default value.
+func AllFeatures(ctx context.Context) map[string]bool {
+	definedFeaturesMu.RLock()
+	defer definedFeaturesMu.RUnlock()
+
+	features := make(map[string]bool, len(definedFeatures))
+	for k, v := range definedFeatures {
+		features[k] = v.defaultValue
+	}
+
+	globalFeatures := globalRegistry.allFeatures()
+	for k, v := range globalFeatures {
+		if _, isDefined := features[k]; isDefined {
+			features[k] = v
+		}
+	}
+
+	if r := registryFromContext(ctx); r != nil {
+		contextFeatures := r.allFeatures()
+		for k, v := range contextFeatures {
+			if _, isDefined := features[k]; isDefined {
+				features[k] = v
+			}
+		}
+	}
+
+	return features
+}

--- a/pkg/experimental/global.go
+++ b/pkg/experimental/global.go
@@ -1,0 +1,27 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package experimental
+
+var globalRegistry = NewRegistry()
+
+// EnableFeatures enables the given features on the global registry.
+func EnableFeatures(features ...string) {
+	globalRegistry.EnableFeatures(features...)
+}
+
+// DisableFeatures disables the given features on the global registry.
+func DisableFeatures(features ...string) {
+	globalRegistry.DisableFeatures(features...)
+}

--- a/pkg/experimental/registry.go
+++ b/pkg/experimental/registry.go
@@ -1,0 +1,89 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package experimental
+
+import (
+	"context"
+	"sync"
+)
+
+// Registry is a registry of enabled experimental features.
+type Registry struct {
+	mu       sync.RWMutex
+	features map[string]bool
+}
+
+// NewRegistry returns a new feature registry with the given features enabled.
+func NewRegistry(enabledFeatures ...string) *Registry {
+	r := &Registry{
+		features: make(map[string]bool),
+	}
+	for _, enabledFeature := range enabledFeatures {
+		r.features[enabledFeature] = true
+	}
+	return r
+}
+
+// EnableFeatures enables the given features.
+func (r *Registry) EnableFeatures(features ...string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, feature := range features {
+		r.features[feature] = true
+	}
+}
+
+// DisableFeatures disables the given features.
+func (r *Registry) DisableFeatures(features ...string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, feature := range features {
+		r.features[feature] = false
+	}
+}
+
+func (r *Registry) getFeature(feature string) (value, ok bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	value, ok = r.features[feature]
+	return
+}
+
+func (r *Registry) allFeatures() map[string]bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	features := make(map[string]bool, len(r.features))
+	for k, v := range r.features {
+		features[k] = v
+	}
+	return features
+}
+
+type registryContextKeyType struct{}
+
+var registryContextKey registryContextKeyType
+
+// NewContextWithRegistry returns a new context derived from the parent, that contains the given feature registry.
+func NewContextWithRegistry(parent context.Context, r *Registry) context.Context {
+	return context.WithValue(parent, registryContextKey, r)
+}
+
+func registryFromContext(ctx context.Context) *Registry {
+	r, ok := ctx.Value(registryContextKey).(*Registry)
+	if !ok {
+		return nil
+	}
+	return r
+}

--- a/pkg/jsonpb/ttn.go
+++ b/pkg/jsonpb/ttn.go
@@ -16,19 +16,16 @@ package jsonpb
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
-	"os"
-	"strconv"
 
 	"github.com/TheThingsIndustries/protoc-gen-go-json/jsonplugin"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"go.thethings.network/lorawan-stack/v3/pkg/experimental"
 )
 
-var jsonpluginFeatureFlag = func() bool {
-	b, _ := strconv.ParseBool(os.Getenv("TTN_LW_EXP_JSONPLUGIN"))
-	return b
-}()
+var jsonpluginFeatureFlag = experimental.DefineFeature("jsonpb.jsonplugin", false)
 
 // TTN returns the default TTN JSONPb marshaler.
 func TTN() *TTNMarshaler {
@@ -47,7 +44,7 @@ type TTNMarshaler struct {
 func (*TTNMarshaler) ContentType() string { return "application/json" }
 
 func (m *TTNMarshaler) Marshal(v interface{}) ([]byte, error) {
-	if jsonpluginFeatureFlag {
+	if jsonpluginFeatureFlag.GetValue(context.Background()) {
 		if marshaler, ok := v.(jsonplugin.Marshaler); ok {
 			b, err := jsonplugin.MarshalerConfig{
 				EnumsAsInts: true,
@@ -77,7 +74,7 @@ type TTNEncoder struct {
 }
 
 func (e *TTNEncoder) Encode(v interface{}) error {
-	if jsonpluginFeatureFlag {
+	if jsonpluginFeatureFlag.GetValue(context.Background()) {
 		if marshaler, ok := v.(jsonplugin.Marshaler); ok {
 			b, err := jsonplugin.MarshalerConfig{
 				EnumsAsInts: true,
@@ -99,7 +96,7 @@ func (e *TTNEncoder) Encode(v interface{}) error {
 }
 
 func (m *TTNMarshaler) Unmarshal(data []byte, v interface{}) error {
-	if jsonpluginFeatureFlag {
+	if jsonpluginFeatureFlag.GetValue(context.Background()) {
 		if unmarshaler, ok := v.(jsonplugin.Unmarshaler); ok {
 			return jsonplugin.UnmarshalerConfig{}.Unmarshal(data, unmarshaler)
 		}
@@ -117,7 +114,7 @@ type NewDecoder struct {
 }
 
 func (d *NewDecoder) Decode(v interface{}) error {
-	if jsonpluginFeatureFlag {
+	if jsonpluginFeatureFlag.GetValue(context.Background()) {
 		if unmarshaler, ok := v.(jsonplugin.Unmarshaler); ok {
 			var data json.RawMessage
 			err := json.NewDecoder(d.r).Decode(&data)

--- a/pkg/webui/template.go
+++ b/pkg/webui/template.go
@@ -23,13 +23,15 @@ import (
 	"strings"
 
 	echo "github.com/labstack/echo/v4"
+	"go.thethings.network/lorawan-stack/v3/pkg/experimental"
 )
 
 // Data contains data to render templates.
 type Data struct {
 	TemplateData
-	AppConfig interface{}
-	PageData  interface{}
+	AppConfig            interface{}
+	ExperimentalFeatures map[string]bool
+	PageData             interface{}
 }
 
 // TemplateData contains data to use in the App template.
@@ -96,6 +98,7 @@ const appHTML = `
 				ASSETS_ROOT:{{$assetsBaseURL}},
 				BRANDING_ROOT:{{$brandingBaseURL}},
 				APP_CONFIG:{{.AppConfig}},
+				EXPERIMENTAL_FEATURES:{{.ExperimentalFeatures}},
 				SITE_NAME:{{.SiteName}},
 				SITE_TITLE:{{.Title}},
 				SITE_SUB_TITLE:{{.SubTitle}},
@@ -167,9 +170,10 @@ func (t *AppTemplate) Render(w io.Writer, _ string, pageData interface{}, c echo
 	}
 	templateData.JSFiles = jsFiles
 	return t.template.Execute(w, Data{
-		TemplateData: templateData,
-		AppConfig:    c.Get("app_config"),
-		PageData:     pageData,
+		TemplateData:         templateData,
+		AppConfig:            c.Get("app_config"),
+		ExperimentalFeatures: experimental.AllFeatures(c.Request().Context()),
+		PageData:             pageData,
 	})
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request creates a new `pkg/experimental` package that will be used to manage toggles for experimental features.

Refs https://github.com/TheThingsIndustries/lorawan-stack/issues/1639
Refs https://github.com/TheThingsIndustries/lorawan-stack-aws/pull/524

#### Changes
<!-- What are the changes made in this pull request? -->

- Create `pkg/experimental`
- Update `pkg/jsonpb` to use `pkg/experimental` instead of `TTN_LW_EXP_JSONPLUGIN` env.

#### Testing

<!-- How did you verify that this change works? -->

Start The Things Stack with `TTN_LW_EXPERIMENTAL_FEATURES="jsonpb.jsonplugin"`.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

n/a

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Experimental features are also exposed to the Web UI (looks like `EXPERIMENTAL_FEATURES:{"jsonpb.jsonplugin":true}` in `config`). But it's important to note that experimental features **must** be defined in Go code, so if we want to use this for frontend-only feature, we'd still need to define them.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
