### PR TITLE
Fix offline status toast issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Fixed
 
 - LoRaWAN Backend Interfaces 1.1 fields that were used in 1.0 (most notably `SenderNSID` and `ReceiverNSID`). Usage of `NSID` is now only supported with LoRaWAN Backend Interfaces 1.1 as specified.
+- Connection status not being shown as toast notification.
 
 ### Security
 

--- a/pkg/webui/components/offline-status/index.js
+++ b/pkg/webui/components/offline-status/index.js
@@ -47,6 +47,7 @@ const handleMessage = (message, type) => {
   toast({
     messageGroup: 'offline-status',
     message: { ...message, values: { applicationName: siteTitle } },
+    preventConsecutive: true,
     type,
   })
 }

--- a/pkg/webui/console/store/middleware/logics/gateways.js
+++ b/pkg/webui/console/store/middleware/logics/gateways.js
@@ -220,6 +220,8 @@ const startGatewayStatisticsLogic = createLogic({
 
 const updateGatewayStatisticsLogic = createRequestLogic({
   type: gateways.UPDATE_GTW_STATS,
+  throttle: 1000,
+  latest: true,
   process: async ({ action }) => {
     const { id } = action.payload
 

--- a/pkg/webui/containers/footer/index.js
+++ b/pkg/webui/containers/footer/index.js
@@ -22,15 +22,15 @@ import { selectOnlineStatus } from '@ttn-lw/lib/store/selectors/status'
 const Footer = props => {
   const onlineStatus = useSelector(selectOnlineStatus)
 
-  return <FooterComponent onlineStatus={onlineStatus} {...props} />
+  return <FooterComponent {...props} onlineStatus={onlineStatus} />
 }
 
-const { onlineStatus, ...propTypes } = FooterComponent.propTypes
+const { onlineStatus: onlineStatusPropType, ...propTypes } = FooterComponent.propTypes
 
 Footer.propTypes = propTypes
 
-Footer.defaultProps = {
-  ...FooterComponent.defaultProps,
-}
+const { onlineStatus: onlineStatusDefaultProp, ...defaultProps } = FooterComponent.defaultProps
+
+Footer.defaultProps = defaultProps
 
 export default Footer

--- a/pkg/webui/lib/store/logics/status.js
+++ b/pkg/webui/lib/store/logics/status.js
@@ -36,6 +36,8 @@ let connectionCheckResolve
 
 const connectionManagementLogic = createLogic({
   type: status.SET_CONNECTION_STATUS,
+  debounce: 1000,
+  latest: true,
   process: async ({ action }, dispatch, done) => {
     if (action.payload.onlineStatus === ONLINE_STATUS.CHECKING) {
       if (action.meta && action.meta._attachPromise) {
@@ -75,6 +77,7 @@ const connectionCheckLogic = createLogic({
   // also trigger reconnection attempts, which is why this action is throttled
   // to 3 seconds.
   throttle: 3000,
+  latest: true,
   validate: ({ action, getState }, allow, reject) => {
     if (selectIsOfflineStatus(getState()) && navigator.onLine) {
       return allow(action)
@@ -103,8 +106,8 @@ const connectionCheckFailLogic = createLogic({
   cancelType: status.ATTEMPT_RECONNECT_SUCCESS,
   warnTimeout: 65000,
   process: (_, dispatch, done) => {
-    // Use increasing intervals, capped at 1min to prevent request spamming.
-    interval = Math.min(interval * 1.5, 60000)
+    // Use increasing intervals, capped at 30min to prevent request spamming.
+    interval = Math.min(interval * 1.5, 30 * 60 * 1000)
     periodicCheck = setTimeout(connectionCheck(dispatch, done), interval)
   },
 })


### PR DESCRIPTION
#### Summary
This PR fixes small issues with the online/offline status toasts.

#### Changes
- Fix default props of footer container. This was preventing toasts from being displayed (in OS only)
- Avoid consecutive status toasts seen after many status changes while not having the browser tab active

#### Testing

Manual testing

##### Regressions

None.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
