### PR TITLE
Show a warning about admin collaborators always retain all rights

### DIFF
--- a/pkg/webui/lib/shared-messages.js
+++ b/pkg/webui/lib/shared-messages.js
@@ -91,6 +91,10 @@ export default defineMessages({
   collaboratorId: 'Collaborator ID',
   collaboratorIdPlaceholder: 'collaborator-id',
   collaboratorWarningSelf: 'Changing your own rights could result in loss of access',
+  collaboratorWarningAdmin:
+    'This user is an administrator that will retain all rights to all entities regardless of collaborator status',
+  collaboratorWarningAdminSelf:
+    'As an administrator, you aways retain all rights to all entities regardless of collaborator status',
   collaboratorModalWarning: 'Are you sure you want to remove {collaboratorId} as a collaborator?',
   collaboratorModalWarningSelf:
     'Are you sure you want to remove yourself as a collaborator? Access to this entity will be lost until someone else adds you as a collaborator again.',

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -891,6 +891,8 @@
   "lib.shared-messages.collaboratorId": "Collaborator ID",
   "lib.shared-messages.collaboratorIdPlaceholder": "collaborator-id",
   "lib.shared-messages.collaboratorWarningSelf": "Changing your own rights could result in loss of access",
+  "lib.shared-messages.collaboratorWarningAdmin": "This user is an administrator that will retain all rights to all entities regardless of collaborator status",
+  "lib.shared-messages.collaboratorWarningAdminSelf": "As an administrator, you aways retain all rights to all entities regardless of collaborator status",
   "lib.shared-messages.collaboratorModalWarning": "Are you sure you want to remove {collaboratorId} as a collaborator?",
   "lib.shared-messages.collaboratorModalWarningSelf": "Are you sure you want to remove yourself as a collaborator? Access to this entity will be lost until someone else adds you as a collaborator again.",
   "lib.shared-messages.collaboratorRemove": "Collaborator remove",


### PR DESCRIPTION
#### Summary
This quickfix PR will clarify the effects of changing collaborators that are admins.

![image](https://user-images.githubusercontent.com/5710611/136209350-17b7b27b-b17d-4cbe-9429-c9febdd3b92c.png)
![image](https://user-images.githubusercontent.com/5710611/136209505-fc3a242c-baa6-4f31-a9ea-e61ee488207b.png)


#### Changes
- Also fetch the associated user when fetching a collaborator
- Check whether a collaborator is an admin and render a warning

#### Testing

Manual testing.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
