### PR TITLE
Enable using promisified dispatch in request logics

### DIFF
--- a/pkg/webui/account/store/middleware/init.js
+++ b/pkg/webui/account/store/middleware/init.js
@@ -14,11 +14,10 @@
 
 import { createLogic } from 'redux-logic'
 
-import store from '@account/store'
-
 import api from '@account/api'
 
 import { isUnauthenticatedError } from '@ttn-lw/lib/errors/utils'
+import { promisifyDispatch } from '@ttn-lw/lib/store/middleware/request-promise-middleware'
 import attachPromise from '@ttn-lw/lib/store/actions/attach-promise'
 
 import * as init from '@account/store/actions/init'
@@ -32,7 +31,7 @@ const accountAppInitLogic = createLogic({
       try {
         // Using `store.dispatch` since redux logic's dispatch won't return
         // the (promisified) action result like regular dispatch does.
-        await store.dispatch(
+        await promisifyDispatch(dispatch)(
           attachPromise(
             user.getUser(meResult.data.user.ids.user_id, [
               'profile_picture',

--- a/pkg/webui/console/store/middleware/logics/collaborators.js
+++ b/pkg/webui/console/store/middleware/logics/collaborators.js
@@ -15,9 +15,10 @@
 import api from '@console/api'
 
 import createRequestLogic from '@ttn-lw/lib/store/logics/create-request-logic'
+import attachPromise from '@ttn-lw/lib/store/actions/attach-promise'
 
 import * as collaborators from '@console/store/actions/collaborators'
-import { getUserSuccess } from '@console/store/actions/users'
+import { getUser } from '@console/store/actions/users'
 
 const validParentTypes = ['application', 'gateway', 'organization']
 
@@ -39,11 +40,10 @@ const getCollaboratorLogic = createRequestLogic({
     if (isUser) {
       // Also retrieve the user to be able to determine whether
       // it is an admin user.
-      const user = await api.users.get(collaboratorId, 'admin')
       try {
-        dispatch(getUserSuccess(user))
+        await dispatch(attachPromise(getUser(collaboratorId, 'admin')))
       } catch {
-        // Do not fail the action when the user could not be fetched.
+        // Do not fail the action if the user could not be fetched.
       }
     }
 

--- a/pkg/webui/lib/store/logics/create-request-logic.js
+++ b/pkg/webui/lib/store/logics/create-request-logic.js
@@ -28,7 +28,7 @@ import {
   attemptReconnect,
   ATTEMPT_RECONNECT,
 } from '@ttn-lw/lib/store/actions/status'
-import { promisifiedDispatch } from '@ttn-lw/lib/store/middleware/request-promise-middleware'
+import { promisifyDispatch } from '@ttn-lw/lib/store/middleware/request-promise-middleware'
 import attachPromise, { getResultActionFromType } from '@ttn-lw/lib/store/actions/attach-promise'
 import { selectIsCheckingStatus } from '@ttn-lw/lib/store/selectors/status'
 
@@ -76,6 +76,7 @@ const createRequestLogic = (
     process: async (deps, dispatch, done) => {
       const { action, getState, cancelled$, action$ } = deps
       const promiseAttached = action.meta && action.meta._attachPromise
+      const promisifiedDispatch = promisifyDispatch(dispatch)
       let actionSubscription
 
       if (!noCancelOnRouteChange) {
@@ -113,7 +114,7 @@ const createRequestLogic = (
           }
 
           // Run the logic process.
-          const res = await options.process(deps, dispatch)
+          const res = await options.process(deps, promisifiedDispatch)
           success = true
 
           // After successful request, dispatch success action.
@@ -149,7 +150,7 @@ const createRequestLogic = (
               // It is necessary to promisify the dispatch function explicitly again
               // even though we already have a middleware to do that since`redux-logic`
               // modifies the dispatch function to return the original input action.
-              connectionChecking = promisifiedDispatch(dispatch)(attachPromise(setStatusChecking()))
+              connectionChecking = promisifiedDispatch(attachPromise(setStatusChecking()))
             }
 
             // Trigger a retry once the app is back online.

--- a/pkg/webui/lib/store/middleware/request-promise-middleware.js
+++ b/pkg/webui/lib/store/middleware/request-promise-middleware.js
@@ -15,14 +15,14 @@
 import { CancelablePromise } from 'cancelable-promise'
 
 /**
- * `promisifiedDispatch` is a decorator for the dispatch function that attaches
+ * `promisifyDispatch` is a decorator for the dispatch function that attaches
  * a cancelable promise to the action that it will use as return value.
  * You should usually use the middleware instead.
  *
  * @param {object} dispatch - The to be decorated dispatch function.
  * @returns {Function} - The decorated dispatch function.
  */
-export const promisifiedDispatch = dispatch => action => {
+export const promisifyDispatch = dispatch => action => {
   if (action.meta && action.meta._attachPromise && !action.meta._resolve && !action.meta._reject) {
     return new CancelablePromise((resolve, reject) => {
       action.meta = {
@@ -43,6 +43,6 @@ export const promisifiedDispatch = dispatch => action => {
  * @param {object} store - The store to apply the middleware to.
  * @returns {object} The middleware.
  */
-const requestPromiseMiddleware = store => promisifiedDispatch
+const requestPromiseMiddleware = store => promisifyDispatch
 
 export default requestPromiseMiddleware


### PR DESCRIPTION
#### Summary
This quickfix PR changes the `createRequestLogic` utility to enable the usage of promisified dispatching. This will enable us orchestrating different logics without recreating the logic's processes.

#### Changes
- Pass a promisified dispatch function within `createRequestLogic` utility
- Update some logics to make use of the new feature
- Rename `promisifiedDispatch` utility to the more fitting `promisifyDispatch`

#### Testing

- Manual testing and existing CIs should ensure that there are no regressions

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
