### PR TITLE
Expand toggle sections with invalid fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Fixed
 
 - LoRaWAN Backend Interfaces 1.1 fields that were used in 1.0 (most notably `SenderNSID` and `ReceiverNSID`). Usage of `NSID` is now only supported with LoRaWAN Backend Interfaces 1.1 as specified.
+- Collapsed form fields sections that contain fields that had validation errors when submitting a form now expand automatically.
 
 ### Security
 

--- a/pkg/webui/components/form/index.js
+++ b/pkg/webui/components/form/index.js
@@ -98,7 +98,7 @@ class InnerForm extends React.PureComponent {
     } = this.props
 
     return (
-      <form className={classnames(style.container, className)} onSubmit={handleSubmit}>
+      <form className={classnames(style.container, className)} onSubmit={handleSubmit} noValidate>
         {(formError || formInfo) && (
           <div style={{ outline: 'none' }} ref={this.notificationRef} tabIndex="-1">
             {formError && <ErrorNotification content={formError} title={formErrorTitle} small />}


### PR DESCRIPTION
#### Summary
Follow up from #4684, with added fixes and improvements. Many thanks to @brycechampaign for co-authoring this 👍!

Closes #4558.

#### Changes
- Remove HTML5 form validation form our forms (we use our own validation system)
- Make form sections aware of the form fields they render and automatically expand the section when it has an invalid field

#### Testing

Manual testing. See reproduction steps in #4558.

#### Notes for Reviewers
The HTML5 validation was previously preventing the submit logic from being fired when a field was deemed as invalid by the browser. E.g. when entering a `e` into a number field (this is possible because it can be used to enter exponents) and trying to submit. Instead of working around that, I concluded that we don't need the HTML5 validation since we have our own validation system in place which takes care of any input error anyway and does not trigger arbitrary side-effects such as blocking the `onSubmit` handler. This also streamlines the validation UX.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
