### PR TITLE
Fix login and registration for users with a 2 character user ID 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - LoRaWAN Backend Interfaces 1.1 fields that were used in 1.0 (most notably `SenderNSID` and `ReceiverNSID`). Usage of `NSID` is now only supported with LoRaWAN Backend Interfaces 1.1 as specified.
 - Connection status not being shown as toast notification.
+- Registering and logging in users with 2 character user IDs in the Account App.
 
 ### Security
 

--- a/pkg/webui/account/views/create-account/index.js
+++ b/pkg/webui/account/views/create-account/index.js
@@ -34,7 +34,7 @@ import style from '@account/views/front/front.styl'
 
 import Yup from '@ttn-lw/lib/yup'
 import { selectApplicationSiteName, selectEnableUserRegistration } from '@ttn-lw/lib/selectors/env'
-import { id as userRegexp } from '@ttn-lw/lib/regexp'
+import { userId as userIdRegexp } from '@ttn-lw/lib/regexp'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 import PropTypes from '@ttn-lw/lib/prop-types'
 import createPasswordValidationSchema from '@ttn-lw/lib/create-password-validation-schema'
@@ -56,7 +56,7 @@ const baseValidationSchema = Yup.object().shape({
   user_id: Yup.string()
     .min(2, Yup.passValues(sharedMessages.validateTooShort))
     .max(36, Yup.passValues(sharedMessages.validateTooLong))
-    .matches(userRegexp, Yup.passValues(sharedMessages.validateIdFormat))
+    .matches(userIdRegexp, Yup.passValues(sharedMessages.validateIdFormat))
     .required(sharedMessages.validateRequired),
   name: Yup.string()
     .min(3, Yup.passValues(sharedMessages.validateTooShort))

--- a/pkg/webui/account/views/forgot-password/index.js
+++ b/pkg/webui/account/views/forgot-password/index.js
@@ -31,7 +31,7 @@ import style from '@account/views/front/front.styl'
 
 import Yup from '@ttn-lw/lib/yup'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
-import { id as userRegexp } from '@ttn-lw/lib/regexp'
+import { userId as userIdRegexp } from '@ttn-lw/lib/regexp'
 import { selectApplicationSiteName } from '@ttn-lw/lib/selectors/env'
 import PropTypes from '@ttn-lw/lib/prop-types'
 
@@ -48,7 +48,7 @@ const validationSchema = Yup.object().shape({
   user_id: Yup.string()
     .min(2, Yup.passValues(sharedMessages.validateTooShort))
     .max(36, Yup.passValues(sharedMessages.validateTooLong))
-    .matches(userRegexp, Yup.passValues(sharedMessages.validateIdFormat))
+    .matches(userIdRegexp, Yup.passValues(sharedMessages.validateIdFormat))
     .required(sharedMessages.validateRequired),
 })
 

--- a/pkg/webui/account/views/login/index.js
+++ b/pkg/webui/account/views/login/index.js
@@ -35,7 +35,7 @@ import {
   selectApplicationSiteTitle,
 } from '@ttn-lw/lib/selectors/env'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
-import { id as userRegexp } from '@ttn-lw/lib/regexp'
+import { userId as userIdRegexp } from '@ttn-lw/lib/regexp'
 
 import { selectEnableUserRegistration } from '@account/lib/selectors/app-config'
 
@@ -56,7 +56,7 @@ const validationSchema = Yup.object().shape({
   user_id: Yup.string()
     .min(2, Yup.passValues(sharedMessages.validateTooShort))
     .max(36, Yup.passValues(sharedMessages.validateTooLong))
-    .matches(userRegexp, Yup.passValues(sharedMessages.validateIdFormat))
+    .matches(userIdRegexp, Yup.passValues(sharedMessages.validateIdFormat))
     .required(sharedMessages.validateRequired)
     .trim(),
   password: Yup.string().required(sharedMessages.validateRequired),

--- a/pkg/webui/console/components/collaborator-form/index.js
+++ b/pkg/webui/console/components/collaborator-form/index.js
@@ -31,8 +31,7 @@ import Yup from '@ttn-lw/lib/yup'
 import { getCollaboratorId } from '@ttn-lw/lib/selectors/id'
 import PropTypes from '@ttn-lw/lib/prop-types'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
-
-import { id as collaboratorIdRegexp } from '@console/lib/regexp'
+import { userId as collaboratorIdRegexp } from '@ttn-lw/lib/regexp'
 
 import { selectUserId } from '@console/store/selectors/user'
 import { selectUserById } from '@console/store/selectors/users'

--- a/pkg/webui/console/components/user-data-form/index.js
+++ b/pkg/webui/console/components/user-data-form/index.js
@@ -28,8 +28,7 @@ import Yup from '@ttn-lw/lib/yup'
 import PropTypes from '@ttn-lw/lib/prop-types'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 import createPasswordValidationSchema from '@ttn-lw/lib/create-password-validation-schema'
-
-import { userId as userIdRegexp } from '@console/lib/regexp'
+import { userId as userIdRegexp } from '@ttn-lw/lib/regexp'
 
 const capitalize = str => str.charAt(0).toUpperCase() + str.slice(1)
 

--- a/pkg/webui/console/lib/regexp.js
+++ b/pkg/webui/console/lib/regexp.js
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export const id = /^[a-z0-9]+(-[a-z0-9]+)*$/
-export const userId = /^[a-z0-9](?:[-]?[a-z0-9]){1,}$/
 export const noSpaces = /^\S*$/
 export const apiKey = /^NNSXS.[A-Z0-9]{39}.[A-Z0-9]{52}$/
 export const address = new RegExp(

--- a/pkg/webui/console/views/device-add/manual/form/validation-schema.js
+++ b/pkg/webui/console/views/device-add/manual/form/validation-schema.js
@@ -15,8 +15,9 @@
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 import Yup from '@ttn-lw/lib/yup'
 import getHostFromUrl from '@ttn-lw/lib/host-from-url'
+import { id as deviceIdRegexp } from '@ttn-lw/lib/regexp'
 
-import { id as deviceIdRegexp, address as addressRegexp } from '@console/lib/regexp'
+import { address as addressRegexp } from '@console/lib/regexp'
 import { ACTIVATION_MODES, parseLorawanMacVersion } from '@console/lib/device-utils'
 
 import { REGISTRATION_TYPES } from '../../utils'

--- a/pkg/webui/console/views/device-general-settings/identity-server-form/validation-schema.js
+++ b/pkg/webui/console/views/device-general-settings/identity-server-form/validation-schema.js
@@ -14,6 +14,7 @@
 
 import Yup from '@ttn-lw/lib/yup'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
+import { id as deviceIdRegexp } from '@ttn-lw/lib/regexp'
 
 import {
   attributeValidCheck,
@@ -21,7 +22,7 @@ import {
   attributeKeyTooLongCheck,
   attributeValueTooLongCheck,
 } from '@console/lib/attributes'
-import { id as deviceIdRegexp, address as addressRegexp } from '@console/lib/regexp'
+import { address as addressRegexp } from '@console/lib/regexp'
 import { parseLorawanMacVersion, generate16BytesKey } from '@console/lib/device-utils'
 
 const toUndefined = value => (!Boolean(value) ? undefined : value)

--- a/pkg/webui/console/views/gateway-general-settings/basic-settings-form/validation-schema.js
+++ b/pkg/webui/console/views/gateway-general-settings/basic-settings-form/validation-schema.js
@@ -14,6 +14,7 @@
 
 import Yup from '@ttn-lw/lib/yup'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
+import { id as gatewayIdRegexp } from '@ttn-lw/lib/regexp'
 
 import {
   attributeValidCheck,
@@ -21,10 +22,7 @@ import {
   attributeKeyTooLongCheck,
   attributeValueTooLongCheck,
 } from '@console/lib/attributes'
-import {
-  id as gatewayIdRegexp,
-  addressWithOptionalScheme as addressWithOptionalSchemeRegexp,
-} from '@console/lib/regexp'
+import { addressWithOptionalScheme as addressWithOptionalSchemeRegexp } from '@console/lib/regexp'
 
 const validationSchema = Yup.object().shape({
   ids: Yup.object().shape({

--- a/pkg/webui/lib/regexp.js
+++ b/pkg/webui/lib/regexp.js
@@ -14,3 +14,4 @@
 
 export const url = /^\b((http|https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))$/
 export const id = /^[a-z0-9](?:[-]?[a-z0-9]){2,}$/
+export const userId = /^[a-z0-9](?:[-]?[a-z0-9]){1,}$/


### PR DESCRIPTION
#### Summary
This quickfix fixes the IDs we use for user IDs and generic IDs. Due to using the wrong regexp in the login form, we currently do not allow users with 2 character user IDs to register or login.

See https://github.com/TheThingsIndustries/lorawan-stack-support/issues/575

#### Changes
- Refactor common regexps into `webui/lib/regexp`
- Refactor imports accordingly
- Use correct user ID regexp in the validation schema of the login form in the Account App


#### Testing

Manual + existing e2e

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
