### PR TITLE
Support Packet Broker authentication through Backend Interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,13 @@ For details about compatibility between different releases, see the **Commitment
 ### Added
 
 - Support for enhanced security policies of Packet Broker services.
-- Backend Interfaces middleware to extract proxy headers from trusted proxies. This adds a configuration `interop.trusted-proxies` that is similar to the existing `http.trusted-proxies` option.
 - Handling of MAC and PHY versions in end device forms based on selected frequency plan in the Console.
 - Support for scheduling downlink messages as JSON in the Console.
+- Backend Interfaces middleware to extract proxy headers from trusted proxies. This adds a configuration `interop.trusted-proxies` that is similar to the existing `http.trusted-proxies` option.
+- Support for Packet Broker authentication through LoRaWAN Backend Interfaces. This adds the following configuration options:
+  - `interop.public-tls-address`: public address of the interop server. The audience in the incoming OAuth 2.0 token from Packet Broker is verified against this address to ensure that other networks cannot impersonate as Packet Broker;
+  - `interop.packet-broker.enabled`: enable Packet Broker to authenticate;
+  - `interop.packet-broker.token-issuer`: the issuer of the incoming OAuth 2.0 token from Packet Broker is verified against this value.
 
 ### Changed
 

--- a/cmd/internal/shared/config.go
+++ b/cmd/internal/shared/config.go
@@ -21,6 +21,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/config/tlsconfig"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
+	"go.thethings.network/lorawan-stack/v3/pkg/packetbroker"
 	"go.thethings.network/lorawan-stack/v3/pkg/redis"
 	"golang.org/x/crypto/acme"
 )
@@ -72,7 +73,13 @@ var DefaultHTTPConfig = config.HTTP{
 
 // DefaultInteropServerConfig is the default interop server config.
 var DefaultInteropServerConfig = config.InteropServer{
-	ListenTLS: ":8886",
+	ListenTLS:        ":8886",
+	PublicTLSAddress: "https://" + DefaultPublicHost + ":8886",
+	TrustedProxies:   []string{"127.0.0.0/8", "10.0.0.0/8", "100.64.0.0/10", "172.16.0.0/12", "192.168.0.0/16"},
+	PacketBroker: config.PacketBrokerInteropAuth{
+		Enabled:     true,
+		TokenIssuer: packetbroker.DefaultTokenIssuer,
+	},
 }
 
 // DefaultGRPCConfig is the default config for GRPC.

--- a/cmd/internal/shared/config.go
+++ b/cmd/internal/shared/config.go
@@ -75,7 +75,6 @@ var DefaultHTTPConfig = config.HTTP{
 var DefaultInteropServerConfig = config.InteropServer{
 	ListenTLS:        ":8886",
 	PublicTLSAddress: "https://" + DefaultPublicHost + ":8886",
-	TrustedProxies:   []string{"127.0.0.0/8", "10.0.0.0/8", "100.64.0.0/10", "172.16.0.0/12", "192.168.0.0/16"},
 	PacketBroker: config.PacketBrokerInteropAuth{
 		Enabled:     true,
 		TokenIssuer: packetbroker.DefaultTokenIssuer,

--- a/cmd/internal/shared/config.go
+++ b/cmd/internal/shared/config.go
@@ -73,10 +73,9 @@ var DefaultHTTPConfig = config.HTTP{
 
 // DefaultInteropServerConfig is the default interop server config.
 var DefaultInteropServerConfig = config.InteropServer{
-	ListenTLS:        ":8886",
-	PublicTLSAddress: "https://" + DefaultPublicHost + ":8886",
+	ListenTLS: ":8886",
 	PacketBroker: config.PacketBrokerInteropAuth{
-		Enabled:     true,
+		Enabled:     false,
 		TokenIssuer: packetbroker.DefaultTokenIssuer,
 	},
 }

--- a/config/messages.json
+++ b/config/messages.json
@@ -5822,6 +5822,15 @@
       "file": "errors.go"
     }
   },
+  "error:pkg/interop:not_packet_broker_cluster": {
+    "translations": {
+      "en": "caller not authenticated as Packet Broker cluster"
+    },
+    "description": {
+      "package": "pkg/interop",
+      "file": "server_authn_token.go"
+    }
+  },
   "error:pkg/interop:not_registered": {
     "translations": {
       "en": "not registered"
@@ -7352,6 +7361,33 @@
       "file": "server.go"
     }
   },
+  "error:pkg/packetbroker:fetch_token": {
+    "translations": {
+      "en": "fetch token"
+    },
+    "description": {
+      "package": "pkg/packetbroker",
+      "file": "token.go"
+    }
+  },
+  "error:pkg/packetbroker:not_authorized": {
+    "translations": {
+      "en": "not authorized"
+    },
+    "description": {
+      "package": "pkg/packetbroker",
+      "file": "token.go"
+    }
+  },
+  "error:pkg/packetbroker:oauth2_token": {
+    "translations": {
+      "en": "invalid OAuth 2.0 token"
+    },
+    "description": {
+      "package": "pkg/packetbroker",
+      "file": "token.go"
+    }
+  },
   "error:pkg/packetbrokeragent:authentication_mode": {
     "translations": {
       "en": "invalid authentication mode `{mode}`"
@@ -7494,15 +7530,6 @@
     "description": {
       "package": "pkg/packetbrokeragent",
       "file": "grpc_disabled.go"
-    }
-  },
-  "error:pkg/packetbrokeragent:oauth2_token": {
-    "translations": {
-      "en": "invalid OAuth 2.0 token for network authentication"
-    },
-    "description": {
-      "package": "pkg/packetbrokeragent",
-      "file": "authenticator.go"
     }
   },
   "error:pkg/packetbrokeragent:packet_broker_internal": {

--- a/config/messages.json
+++ b/config/messages.json
@@ -5813,6 +5813,15 @@
       "file": "client.go"
     }
   },
+  "error:pkg/interop:no_public_tls_address": {
+    "translations": {
+      "en": "no public TLS address configured for interop"
+    },
+    "description": {
+      "package": "pkg/interop",
+      "file": "errors.go"
+    }
+  },
   "error:pkg/interop:no_roaming_agreement": {
     "translations": {
       "en": "no roaming agreement"

--- a/pkg/component/interop.go
+++ b/pkg/component/interop.go
@@ -48,8 +48,7 @@ func (c *Component) interopEndpoints() []Endpoint {
 	return []Endpoint{
 		// TODO: Enable TCP endpoint (https://github.com/TheThingsNetwork/lorawan-stack/issues/717)
 		NewTLSEndpoint(c.config.Interop.ListenTLS, "Interop",
-			// TODO: Change to RequestClientCert (https://github.com/TheThingsNetwork/lorawan-stack/issues/718).
-			WithTLSClientAuth(tls.RequireAndVerifyClientCert, c.interop.ClientCAPool(), nil),
+			WithTLSClientAuth(tls.VerifyClientCertIfGiven, c.interop.ClientCAPool(), nil),
 			WithNextProtos("h2", "http/1.1"),
 		),
 	}

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -411,12 +411,22 @@ func (c SenderClientCA) Fetcher(ctx context.Context) (fetch.Interface, error) {
 	}
 }
 
+// PacketBrokerInteropAuth respresents authen
+type PacketBrokerInteropAuth struct {
+	Enabled     bool   `name:"enabled" description:"Enable Packet Broker to authenticate"`
+	TokenIssuer string `name:"token-issuer" description:"Required issuer of Packet Broker tokens"`
+}
+
 // InteropServer represents the server-side interoperability through LoRaWAN Backend Interfaces configuration.
 type InteropServer struct {
-	ListenTLS                string            `name:"listen-tls" description:"Address for the interop server to listen on"`
-	TrustedProxies           []string          `name:"trusted-proxies" description:"CIDRs of trusted reverse proxies"`
+	ListenTLS        string   `name:"listen-tls" description:"Address for the interop server to listen on"`
+	PublicTLSAddress string   `name:"public-tls-address" description:"Public address of the interop server"`
+	TrustedProxies   []string `name:"trusted-proxies" description:"CIDRs of trusted reverse proxies"`
+
 	SenderClientCA           SenderClientCA    `name:"sender-client-ca"`
 	SenderClientCADeprecated map[string]string `name:"sender-client-cas" description:"Path to PEM encoded file with client CAs of sender IDs to trust; deprecated - use sender-client-ca instead"`
+
+	PacketBroker PacketBrokerInteropAuth `name:"packet-broker"`
 }
 
 // ServiceBase represents base service configuration.

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -419,9 +419,8 @@ type PacketBrokerInteropAuth struct {
 
 // InteropServer represents the server-side interoperability through LoRaWAN Backend Interfaces configuration.
 type InteropServer struct {
-	ListenTLS        string   `name:"listen-tls" description:"Address for the interop server to listen on"`
-	PublicTLSAddress string   `name:"public-tls-address" description:"Public address of the interop server"`
-	TrustedProxies   []string `name:"trusted-proxies" description:"CIDRs of trusted reverse proxies"`
+	ListenTLS        string `name:"listen-tls" description:"Address for the interop server to listen on"`
+	PublicTLSAddress string `name:"public-tls-address" description:"Public address of the interop server"`
 
 	SenderClientCA           SenderClientCA    `name:"sender-client-ca"`
 	SenderClientCADeprecated map[string]string `name:"sender-client-cas" description:"Path to PEM encoded file with client CAs of sender IDs to trust; deprecated - use sender-client-ca instead"`
@@ -438,7 +437,7 @@ type ServiceBase struct {
 	Events           Events               `name:"events"`
 	GRPC             GRPC                 `name:"grpc"`
 	HTTP             HTTP                 `name:"http"`
-	Interop          InteropServer        `name:"interop"`
+	Interop          InteropServer        `name:"interop" description:"LoRaWAN Backend Interfaces interoperability configuration"`
 	TLS              tlsconfig.Config     `name:"tls"`
 	Sentry           Sentry               `name:"sentry"`
 	Blob             BlobConfig           `name:"blob"`

--- a/pkg/interop/errors.go
+++ b/pkg/interop/errors.go
@@ -19,6 +19,7 @@ import (
 )
 
 var (
+	errNoPublicTLSAddress  = errors.DefineFailedPrecondition("no_public_tls_address", "no public TLS address configured for interop")
 	errUnknownMACVersion   = errors.DefineInvalidArgument("unknown_mac_version", "unknown MAC version")
 	errInvalidLength       = errors.DefineInvalidArgument("invalid_length", "invalid length")
 	errInvalidRequestType  = errors.DefineInvalidArgument("invalid_request_type", "invalid request type `{type}`")

--- a/pkg/interop/messages.go
+++ b/pkg/interop/messages.go
@@ -25,8 +25,10 @@ type MessageHeader struct {
 	MessageType     MessageType
 	SenderID,
 	ReceiverID string
-	SenderToken   Buffer `json:",omitempty"`
-	ReceiverToken Buffer `json:",omitempty"`
+	SenderNSID    *string `json:",omitempty"`
+	ReceiverNSID  *string `json:",omitempty"`
+	SenderToken   Buffer  `json:",omitempty"`
+	ReceiverToken Buffer  `json:",omitempty"`
 }
 
 // AnswerHeader returns the header of the answer message.
@@ -41,8 +43,10 @@ func (h MessageHeader) AnswerHeader() (MessageHeader, error) {
 		MessageType:     ansType,
 		ReceiverToken:   h.SenderToken,
 		ReceiverID:      h.SenderID,
+		ReceiverNSID:    h.SenderNSID,
 		SenderID:        h.ReceiverID,
 		SenderToken:     h.ReceiverToken,
+		SenderNSID:      h.ReceiverNSID,
 	}, nil
 }
 

--- a/pkg/interop/server.go
+++ b/pkg/interop/server.go
@@ -204,6 +204,7 @@ func (s *Server) handle() http.Handler {
 		}
 		ctx, err = senderAuthenticator.Authenticate(ctx, r, data)
 		if err != nil {
+			logger.WithError(err).Warn("Failed to authenticate")
 			writeError(w, r, header, err)
 			return
 		}

--- a/pkg/interop/server.go
+++ b/pkg/interop/server.go
@@ -114,8 +114,6 @@ func NewServer(c Component, contextFillers []fillcontext.Filler, conf config.Int
 		js:                 &noopServer{},
 	}
 
-	var proxyConfiguration webmiddleware.ProxyConfiguration
-	proxyConfiguration.ParseAndAddTrusted(conf.TrustedProxies...)
 	s.router = mux.NewRouter()
 	s.router.NotFoundHandler = http.HandlerFunc(webhandlers.NotFound)
 	s.router.Use(
@@ -123,7 +121,6 @@ func NewServer(c Component, contextFillers []fillcontext.Filler, conf config.Int
 		mux.MiddlewareFunc(webmiddleware.FillContext(contextFillers...)),
 		mux.MiddlewareFunc(webmiddleware.RequestURL()),
 		mux.MiddlewareFunc(webmiddleware.RequestID()),
-		mux.MiddlewareFunc(webmiddleware.ProxyHeaders(proxyConfiguration)),
 		mux.MiddlewareFunc(webmiddleware.MaxBody(1<<15)), // 32 kB.
 		mux.MiddlewareFunc(webmiddleware.Log(logger, nil)),
 		mux.MiddlewareFunc(ratelimit.HTTPMiddleware(c.RateLimiter(), "http:interop")),

--- a/pkg/interop/server.go
+++ b/pkg/interop/server.go
@@ -98,7 +98,11 @@ func NewServer(c Component, contextFillers []fillcontext.Filler, conf config.Int
 	tokenVerifiers := make(map[string]tokenVerifier)
 	if conf.PacketBroker.Enabled {
 		iss := conf.PacketBroker.TokenIssuer
-		aud := conf.PublicTLSAddress // The token audience must match the configured public TLS address.
+		// The token audience must match the configured public TLS address. Therefore, a non-empty value must be set.
+		aud := conf.PublicTLSAddress
+		if aud == "" {
+			return nil, errNoPublicTLSAddress.New()
+		}
 		tokenVerifier, err := newPacketBrokerTokenVerifier(ctx, iss, aud, c)
 		if err != nil {
 			return nil, err

--- a/pkg/interop/server.go
+++ b/pkg/interop/server.go
@@ -81,8 +81,8 @@ type Component interface {
 
 // NewServer builds a new server.
 func NewServer(c Component, contextFillers []fillcontext.Filler, conf config.InteropServer) (*Server, error) {
-	ctx := c.Context()
-	logger := log.FromContext(ctx).WithField("namespace", "interop")
+	ctx := log.NewContextWithField(c.Context(), "namespace", "interop")
+	logger := log.FromContext(ctx)
 
 	senderClientCAs, err := fetchSenderClientCAs(ctx, conf)
 	if err != nil {

--- a/pkg/interop/server_authn_mtls.go
+++ b/pkg/interop/server_authn_mtls.go
@@ -1,0 +1,45 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interop
+
+import (
+	"context"
+	"crypto/tls"
+)
+
+func (s *Server) verifySenderCertificate(ctx context.Context, senderID string, state *tls.ConnectionState) (addrs []string, err error) {
+	// TODO: Support reading TLS client certificate from proxy headers (https://github.com/TheThingsNetwork/lorawan-stack/issues/717).
+	senderClientCAs, err := s.SenderClientCAs(ctx, senderID)
+	if err != nil {
+		return nil, err
+	}
+	for _, chain := range state.VerifiedChains {
+		peerCert, clientCA := chain[0], chain[len(chain)-1]
+		for _, senderClientCA := range senderClientCAs {
+			if clientCA.Equal(senderClientCA) {
+				// If the TLS client certificate contains DNS addresses, use those. Otherwise, fallback to using CommonName as address.
+				if len(peerCert.DNSNames) > 0 {
+					addrs = append([]string(nil), peerCert.DNSNames...)
+				} else {
+					addrs = []string{peerCert.Subject.CommonName}
+				}
+				return
+			}
+		}
+	}
+	// TODO: Verify state.PeerCertificates[0] with senderClientCAs as Roots and state.PeerCertificates[1:] as Intermediates.
+	// (https://github.com/TheThingsNetwork/lorawan-stack/issues/718).
+	return nil, errUnauthenticated.New()
+}

--- a/pkg/interop/server_authn_token.go
+++ b/pkg/interop/server_authn_token.go
@@ -1,0 +1,73 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interop
+
+import (
+	"context"
+	"net/http"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/packetbroker"
+	"go.thethings.network/lorawan-stack/v3/pkg/types"
+	"gopkg.in/square/go-jose.v2/jwt"
+)
+
+type packetBrokerTokenVerifier struct {
+	publicKeyProvider packetbroker.PublicKeyProvider
+	issuer, audience  string
+}
+
+type httpClientProvider interface {
+	HTTPClient(context.Context) (*http.Client, error)
+}
+
+func newPacketBrokerTokenVerifier(ctx context.Context, issuer, audience string, httpClient httpClientProvider) (tokenVerifier, error) {
+	client, err := httpClient.HTTPClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &packetBrokerTokenVerifier{
+		publicKeyProvider: packetbroker.CachePublicKey(
+			packetbroker.PublicKeyFromURL(client, packetbroker.TokenPublicKeysURL(issuer)),
+			packetbroker.DefaultPublicKeyCacheTTL,
+		),
+		issuer:   issuer,
+		audience: audience,
+	}, nil
+}
+
+var errNotPacketBrokerCluster = errors.DefinePermissionDenied("not_packet_broker_cluster", "caller not authenticated as Packet Broker cluster")
+
+// VerifyNetworkServer verifies the token as Packet Broker cluster token; only Packet Broker clusters can authenticate.
+// Packet Broker clusters are authenticated as NetID 000000 and the cluster ID as NSID.
+// Packet Broker networks are not allowed to authenticate through LoRaWAN Backend Interfaces.
+func (v packetBrokerTokenVerifier) VerifyNetworkServer(ctx context.Context, token *jwt.JSONWebToken) (*NetworkServerAuthInfo, error) {
+	claims, err := packetbroker.Verify(ctx, token, v.publicKeyProvider, v.issuer, v.audience)
+	if err != nil {
+		return nil, err
+	}
+	if !claims.PacketBroker.Cluster {
+		return nil, errNotPacketBrokerCluster.New()
+	}
+	return &NetworkServerAuthInfo{
+		NetID:     types.NetID{0x0, 0x0, 0x0},
+		Addresses: []string{claims.Subject},
+	}, nil
+}
+
+// VerifyApplicationServer returns an Unauthenticated error; Packet Broker never authenticates as Application Server.
+func (v packetBrokerTokenVerifier) VerifyApplicationServer(context.Context, *jwt.JSONWebToken) (*ApplicationServerAuthInfo, error) {
+	return nil, errUnauthenticated.New()
+}

--- a/pkg/interop/server_authz.go
+++ b/pkg/interop/server_authz.go
@@ -41,7 +41,7 @@ func (a Authorizer) RequireAddress(ctx context.Context, addr string) error {
 	} else {
 		return errUnauthenticated.New()
 	}
-	return verifySenderNSID(authInfo.GetAddresses(), addr)
+	return verifySenderNSID(authInfo.addressPatterns(), addr)
 }
 
 // RequireID returns an error if the given NetID is not authorized in the context.

--- a/pkg/interop/server_test.go
+++ b/pkg/interop/server_test.go
@@ -19,13 +19,13 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/interop"
-	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/ratelimit"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
@@ -43,6 +43,10 @@ func (c *mockComponent) Context() context.Context {
 
 func (c *mockComponent) RateLimiter() ratelimit.Interface {
 	return &ratelimit.NoopRateLimiter{}
+}
+
+func (c *mockComponent) HTTPClient(context.Context) (*http.Client, error) {
+	return http.DefaultClient, nil
 }
 
 type mockTarget struct {
@@ -79,11 +83,12 @@ func TestServer(t *testing.T) {
 		Name              string
 		JS                interop.JoinServer
 		ClientTLSConfig   *tls.Config
+		PacketBrokerToken bool
 		RequestBody       interface{}
 		ResponseAssertion func(*testing.T, *http.Response) bool
 	}{
 		{
-			Name:            "Empty",
+			Name:            "ClientTLS/Empty",
 			ClientTLSConfig: makeClientTLSConfig(),
 			ResponseAssertion: func(t *testing.T, res *http.Response) bool {
 				a := assertions.New(t)
@@ -91,7 +96,7 @@ func TestServer(t *testing.T) {
 			},
 		},
 		{
-			Name:            "JoinReq/InvalidSenderID",
+			Name:            "ClientTLS/JoinReq/InvalidSenderID",
 			ClientTLSConfig: makeClientTLSConfig(),
 			RequestBody: &interop.JoinReq{
 				NsJsMessageHeader: interop.NsJsMessageHeader{
@@ -118,7 +123,7 @@ func TestServer(t *testing.T) {
 			},
 		},
 		{
-			Name:            "JoinReq/NotRegistered",
+			Name:            "ClientTLS/JoinReq/NotRegistered",
 			ClientTLSConfig: makeClientTLSConfig(),
 			RequestBody: &interop.JoinReq{
 				NsJsMessageHeader: interop.NsJsMessageHeader{
@@ -145,7 +150,7 @@ func TestServer(t *testing.T) {
 			},
 		},
 		{
-			Name: "JoinReq/UnknownDevEUI",
+			Name: "ClientTLS/JoinReq/UnknownDevEUI",
 			JS: mockTarget{
 				JoinRequestFunc: func(ctx context.Context, req *interop.JoinReq) (*interop.JoinAns, error) {
 					if err := authorizer.RequireAuthorized(ctx); err != nil {
@@ -180,7 +185,7 @@ func TestServer(t *testing.T) {
 			},
 		},
 		{
-			Name: "JoinReq/Unauthenticated NSID",
+			Name: "ClientTLS/JoinReq/Unauthenticated NSID",
 			JS: mockTarget{
 				JoinRequestFunc: func(ctx context.Context, req *interop.JoinReq) (*interop.JoinAns, error) {
 					if err := authorizer.RequireAuthorized(ctx); err != nil {
@@ -216,7 +221,7 @@ func TestServer(t *testing.T) {
 			},
 		},
 		{
-			Name: "JoinReq/UnknownDevEUI",
+			Name: "ClientTLS/JoinReq/Success",
 			JS: mockTarget{
 				JoinRequestFunc: func(ctx context.Context, req *interop.JoinReq) (*interop.JoinAns, error) {
 					if err := authorizer.RequireAuthorized(ctx); err != nil {
@@ -238,8 +243,8 @@ func TestServer(t *testing.T) {
 								MessageType:     interop.MessageTypeJoinAns,
 								TransactionID:   req.TransactionID,
 							},
-							SenderID:   interop.EUI64{0x42, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
-							ReceiverID: interop.NetID{0x0, 0x0, 0x01},
+							SenderID:   req.ReceiverID,
+							ReceiverID: req.SenderID,
 						},
 						PHYPayload:   bytes.Repeat([]byte{0x42}, 42),
 						FNwkSIntKey:  (*interop.KeyEnvelope)(test.DefaultFNwkSIntKeyEnvelopeWrapped),
@@ -277,43 +282,122 @@ func TestServer(t *testing.T) {
 					a.So(msg.ReceiverID, should.Resemble, interop.NetID{0x0, 0x0, 0x01})
 			},
 		},
-	} {
-		t.Run(tc.Name, func(t *testing.T) {
-			a, ctx := test.New(t)
-			ctx = log.NewContext(ctx, test.GetLogger(t))
-
-			s, err := interop.NewServer(&mockComponent{ctx}, nil, config.InteropServer{
-				SenderClientCA: config.SenderClientCA{
-					Source:    "directory",
-					Directory: "testdata",
+		{
+			Name: "PacketBroker/HomeNSReq/Success",
+			JS: mockTarget{
+				HomeNSRequestFunc: func(ctx context.Context, req *interop.HomeNSReq) (*interop.HomeNSAns, error) {
+					if err := authorizer.RequireAuthorized(ctx); err != nil {
+						return nil, err
+					}
+					if err := authorizer.RequireNetID(ctx, types.NetID{0x0, 0x0, 0x0}); err != nil {
+						return nil, err
+					}
+					if err := authorizer.RequireAddress(ctx, "test.packetbroker.io"); err != nil {
+						return nil, err
+					}
+					return &interop.HomeNSAns{
+						JsNsMessageHeader: interop.JsNsMessageHeader{
+							MessageHeader: interop.MessageHeader{
+								ProtocolVersion: req.ProtocolVersion,
+								MessageType:     interop.MessageTypeHomeNSAns,
+								TransactionID:   req.TransactionID,
+							},
+							SenderID:     req.ReceiverID,
+							ReceiverID:   req.SenderID,
+							ReceiverNSID: req.SenderNSID,
+						},
+						Result: interop.Result{
+							ResultCode: interop.ResultSuccess,
+						},
+						HNetID: interop.NetID{0x0, 0x0, 0x1},
+						HNSID:  stringPtr("localhost:4242"),
+					}, nil
 				},
-			})
-			if !a.So(err, should.BeNil) {
-				t.Fatal("Failed to instantiate interop server")
-			}
-			if tc.JS != nil {
-				s.RegisterJS(tc.JS)
-			}
+			},
+			PacketBrokerToken: true,
+			RequestBody: &interop.HomeNSReq{
+				NsJsMessageHeader: interop.NsJsMessageHeader{
+					MessageHeader: interop.MessageHeader{
+						MessageType:     interop.MessageTypeHomeNSReq,
+						ProtocolVersion: interop.ProtocolV1_1,
+					},
+					SenderID:   interop.NetID{0x0, 0x0, 0x0},
+					SenderNSID: stringPtr("test.packetbroker.io"),
+					ReceiverID: interop.EUI64{0x42, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+				},
+				DevEUI: interop.EUI64{0x42, 0xff, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+			},
+			ResponseAssertion: func(t *testing.T, res *http.Response) bool {
+				a := assertions.New(t)
+				if !a.So(res.StatusCode, should.Equal, http.StatusOK) {
+					return false
+				}
+				var msg interop.HomeNSAns
+				err := json.NewDecoder(res.Body).Decode(&msg)
+				return a.So(err, should.BeNil) &&
+					a.So(msg.Result.ResultCode, should.Equal, interop.ResultSuccess) &&
+					a.So(msg.SenderID, should.Resemble, interop.EUI64{0x42, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}) &&
+					a.So(msg.ReceiverID, should.Resemble, interop.NetID{0x0, 0x0, 0x0}) &&
+					a.So(msg.ReceiverNSID, should.Resemble, stringPtr("test.packetbroker.io")) &&
+					a.So(msg.HNetID, should.Resemble, interop.NetID{0x0, 0x0, 0x1}) &&
+					a.So(msg.HNSID, should.Resemble, stringPtr("localhost:4242"))
+			},
+		},
+	} {
+		tc := tc
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.Name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				ctx, cancel := context.WithCancel(ctx)
+				defer cancel()
 
-			srv := newTLSServer(s)
-			defer srv.Close()
+				pbIssuer, pbToken := makePacketBrokerTokenIssuer(ctx, "test.packetbroker.io")
 
-			client := srv.Client()
-			if tc.ClientTLSConfig != nil {
-				client.Transport.(*http.Transport).TLSClientConfig = tc.ClientTLSConfig
-			}
+				s, err := interop.NewServer(&mockComponent{ctx}, nil, config.InteropServer{
+					SenderClientCA: config.SenderClientCA{
+						Source:    "directory",
+						Directory: "testdata",
+					},
+					PacketBroker: config.PacketBrokerInteropAuth{
+						Enabled:     true,
+						TokenIssuer: pbIssuer, // Subject is the NSID and is used as authorized address.
+					},
+					PublicTLSAddress: "https://localhost", // Used as Packet Broker token audience.
+				})
+				if !a.So(err, should.BeNil) {
+					t.Fatal("Failed to instantiate interop server")
+				}
+				if tc.JS != nil {
+					s.RegisterJS(tc.JS)
+				}
 
-			buf, err := json.Marshal(tc.RequestBody)
-			if !a.So(err, should.BeNil) {
-				t.Fatal("Failed to marshal request body")
-			}
-			res, err := client.Post(srv.URL, "application/json", bytes.NewReader(buf))
-			if !a.So(err, should.BeNil) {
-				t.Fatal("Request failed")
-			}
-			if !tc.ResponseAssertion(t, res) {
-				t.FailNow()
-			}
+				srv := newTLSServer(s)
+				defer srv.Close()
+
+				buf, err := json.Marshal(tc.RequestBody)
+				if !a.So(err, should.BeNil) {
+					t.Fatal("Failed to marshal request body")
+				}
+				req := test.Must(http.NewRequest(http.MethodPost, srv.URL, bytes.NewReader(buf))).(*http.Request)
+				req.Header.Set("Content-Type", "application/json")
+
+				client := srv.Client()
+				if tc.ClientTLSConfig != nil {
+					client.Transport.(*http.Transport).TLSClientConfig = tc.ClientTLSConfig
+				}
+				if tc.PacketBrokerToken {
+					req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", pbToken("https://localhost")))
+				}
+
+				res, err := client.Do(req)
+				if !a.So(err, should.BeNil) {
+					t.Fatal("Request failed")
+				}
+				if !tc.ResponseAssertion(t, res) {
+					t.FailNow()
+				}
+			},
 		})
 	}
 }

--- a/pkg/joinserver/joinserver_test.go
+++ b/pkg/joinserver/joinserver_test.go
@@ -1483,7 +1483,7 @@ func TestHandleJoin(t *testing.T) {
 		{
 			Name: "1.0.0/interop auth/new device",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return interop.NewContextWithNetworkServerAuthInfo(ctx, interop.NetworkServerAuthInfo{
+				return interop.NewContextWithNetworkServerAuthInfo(ctx, &interop.NetworkServerAuthInfo{
 					NetID:     types.NetID{0x42, 0xff, 0xff},
 					Addresses: []string{"*.test.org"},
 				})
@@ -1575,7 +1575,7 @@ func TestHandleJoin(t *testing.T) {
 		{
 			Name: "1.0.0/NetID mismatch",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return interop.NewContextWithNetworkServerAuthInfo(ctx, interop.NetworkServerAuthInfo{
+				return interop.NewContextWithNetworkServerAuthInfo(ctx, &interop.NetworkServerAuthInfo{
 					Addresses: []string{nsAddr},
 				})
 			},
@@ -1629,7 +1629,7 @@ func TestHandleJoin(t *testing.T) {
 		{
 			Name: "1.0.0/no NetID",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return interop.NewContextWithNetworkServerAuthInfo(ctx, interop.NetworkServerAuthInfo{
+				return interop.NewContextWithNetworkServerAuthInfo(ctx, &interop.NetworkServerAuthInfo{
 					Addresses: []string{nsAddr},
 				})
 			},
@@ -1682,7 +1682,7 @@ func TestHandleJoin(t *testing.T) {
 		{
 			Name: "1.0.0/address not authorized",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return interop.NewContextWithNetworkServerAuthInfo(ctx, interop.NetworkServerAuthInfo{
+				return interop.NewContextWithNetworkServerAuthInfo(ctx, &interop.NetworkServerAuthInfo{
 					Addresses: []string{"other.hostname.local"},
 				})
 			},
@@ -2476,7 +2476,7 @@ func TestGetAppSKey(t *testing.T) {
 		{
 			Name: "Address not authorized",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return interop.NewContextWithApplicationServerAuthInfo(ctx, interop.ApplicationServerAuthInfo{
+				return interop.NewContextWithApplicationServerAuthInfo(ctx, &interop.ApplicationServerAuthInfo{
 					Addresses: []string{"other.hostname.local"},
 				})
 			},
@@ -2671,7 +2671,7 @@ func TestGetAppSKey(t *testing.T) {
 		{
 			Name: "Matching request/interop auth/address ID",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return interop.NewContextWithApplicationServerAuthInfo(ctx, interop.ApplicationServerAuthInfo{
+				return interop.NewContextWithApplicationServerAuthInfo(ctx, &interop.ApplicationServerAuthInfo{
 					Addresses: []string{"as.test.org"},
 				})
 			},
@@ -2728,7 +2728,7 @@ func TestGetAppSKey(t *testing.T) {
 		{
 			Name: "Matching request/interop auth/custom ID",
 			ContextFunc: func(ctx context.Context) context.Context {
-				return interop.NewContextWithApplicationServerAuthInfo(ctx, interop.ApplicationServerAuthInfo{
+				return interop.NewContextWithApplicationServerAuthInfo(ctx, &interop.ApplicationServerAuthInfo{
 					ASID: "test-as-id",
 				})
 			},

--- a/pkg/packetbroker/packetbroker.go
+++ b/pkg/packetbroker/packetbroker.go
@@ -1,0 +1,31 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packetbroker
+
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	DefaultTokenIssuer       = "https://iam.packetbroker.net"
+	DefaultTokenURL          = DefaultTokenIssuer + "/token"
+	DefaultPublicKeyCacheTTL = 10 * time.Minute
+)
+
+// TokenPublicKeysURL returns the URL with public keys with which a token are signed.
+func TokenPublicKeysURL(issuer string) string {
+	return fmt.Sprintf("%s/.well-known/jwks.json", issuer)
+}

--- a/pkg/packetbroker/token.go
+++ b/pkg/packetbroker/token.go
@@ -1,0 +1,139 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packetbroker
+
+import (
+	"context"
+	"net"
+	"net/url"
+	"strings"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+	"gopkg.in/square/go-jose.v2/jwt"
+)
+
+// Scope defines a scope of claims to request in the token.
+type Scope string
+
+const (
+	ScopeNetworks Scope = "networks"
+)
+
+const (
+	defaultTokenURL        = "https://iam.packetbroker.net/token"
+	defaultTokenPublicKeys = "https://iam.packetbroker.net/.well-known/jwks.json"
+)
+
+type tokenOptions struct {
+	tokenURL string
+	scopes   []Scope
+	audience []string
+}
+
+// TokenOption customizes fetching a Packet Broker token.
+type TokenOption func(o *tokenOptions)
+
+// WithTokenURL customizes the token URL.
+func WithTokenURL(tokenURL string) TokenOption {
+	return func(o *tokenOptions) {
+		o.tokenURL = tokenURL
+	}
+}
+
+// WithScope customizes the scope.
+func WithScope(scopes ...Scope) TokenOption {
+	return func(o *tokenOptions) {
+		o.scopes = append(o.scopes, scopes...)
+	}
+}
+
+// WithAudienceFromAddresses provides the service addresses for which the token will be valid.
+// The host parts of the addresses are used as the token audience.
+func WithAudienceFromAddresses(addresses ...string) TokenOption {
+	return func(o *tokenOptions) {
+		hosts := make(map[string]bool, len(addresses))
+		for _, addr := range addresses {
+			if addr == "" {
+				continue
+			}
+			if h, _, err := net.SplitHostPort(addr); err == nil {
+				addr = h
+			}
+			hosts[addr] = true
+		}
+		for h := range hosts {
+			o.audience = append(o.audience, h)
+		}
+	}
+}
+
+// TokenSource returns a new OAuth 2.0 token source using Packet Broker credentials.
+func TokenSource(ctx context.Context, clientID, clientSecret string, opts ...TokenOption) oauth2.TokenSource {
+	o := tokenOptions{
+		tokenURL: defaultTokenURL,
+	}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	scopes := make([]string, len(o.scopes))
+	for i, s := range o.scopes {
+		scopes[i] = string(s)
+	}
+	config := clientcredentials.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		Scopes:       scopes,
+		AuthStyle:    oauth2.AuthStyleInParams,
+		TokenURL:     o.tokenURL,
+	}
+	if len(o.audience) > 0 {
+		config.EndpointParams = url.Values{
+			"audience": []string{strings.Join(o.audience, " ")},
+		}
+	}
+	return config.TokenSource(ctx)
+}
+
+var errOAuth2Token = errors.DefineUnauthenticated("oauth2_token", "invalid OAuth 2.0 token for network authentication")
+
+// UnverifiedNetworkIdentifier returns the Packet Broker network identifier from the given token.
+// This function does not verify the token.
+func UnverifiedNetworkIdentifier(token *oauth2.Token) (ttnpb.PacketBrokerNetworkIdentifier, error) {
+	parsed, err := jwt.ParseSigned(token.AccessToken)
+	if err != nil {
+		return ttnpb.PacketBrokerNetworkIdentifier{}, errOAuth2Token.WithCause(err)
+	}
+	var claims struct {
+		PacketBroker struct {
+			Networks []struct {
+				NetID    uint32 `json:"nid"`
+				TenantID string `json:"tid"`
+			} `json:"ns"`
+		} `json:"https://iam.packetbroker.net/claims"`
+	}
+	if err := parsed.UnsafeClaimsWithoutVerification(&claims); err != nil {
+		return ttnpb.PacketBrokerNetworkIdentifier{}, errOAuth2Token.WithCause(err)
+	}
+	if len(claims.PacketBroker.Networks) == 0 {
+		return ttnpb.PacketBrokerNetworkIdentifier{}, errOAuth2Token.New()
+	}
+	return ttnpb.PacketBrokerNetworkIdentifier{
+		NetId:    claims.PacketBroker.Networks[0].NetID,
+		TenantId: claims.PacketBroker.Networks[0].TenantID,
+	}, nil
+}

--- a/pkg/packetbroker/token_test.go
+++ b/pkg/packetbroker/token_test.go
@@ -1,0 +1,291 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packetbroker_test
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/packetbroker"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+	"golang.org/x/oauth2"
+	"gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2/jwt"
+)
+
+func TestToken(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		clientID,
+		clientSecret string
+		opts                       []packetbroker.TokenOption
+		tokenRequestAssertion      func(a *assertions.Assertion, vars url.Values) bool
+		tokenRequestErrorAssertion func(a *assertions.Assertion, err error) bool
+		tokenClaims                func() packetbroker.IAMTokenClaims
+		audience                   string
+		tokenAssertion             func(a *assertions.Assertion, token string) bool
+		tokenClaimsAssertion       func(a *assertions.Assertion, claims packetbroker.TokenClaims) bool
+		tokenClaimsErrorAssertion  func(a *assertions.Assertion, err error) bool
+	}{
+		{
+			name:         "Success",
+			clientID:     "test",
+			clientSecret: "secret",
+			opts: []packetbroker.TokenOption{
+				packetbroker.WithScope(packetbroker.ScopeNetworks),
+				packetbroker.WithAudienceFromAddresses("iam.packetbroker.net:443"),
+			},
+			tokenRequestAssertion: func(a *assertions.Assertion, vars url.Values) bool {
+				return a.So(vars["scope"], should.Resemble, []string{"networks"}) &&
+					a.So(vars["audience"], should.Resemble, []string{"iam.packetbroker.net"})
+			},
+			tokenClaims: func() packetbroker.IAMTokenClaims {
+				return packetbroker.IAMTokenClaims{
+					Networks: []packetbroker.TokenNetworkClaim{
+						{
+							NetID:    0x000013,
+							TenantID: "ttn",
+						},
+					},
+				}
+			},
+			audience: "iam.packetbroker.net",
+			tokenAssertion: func(a *assertions.Assertion, token string) bool {
+				id, err := packetbroker.UnverifiedNetworkIdentifier(token)
+				return a.So(err, should.BeNil) &&
+					a.So(id.NetId, should.Equal, 0x000013) &&
+					a.So(id.TenantId, should.Equal, "ttn")
+			},
+			tokenClaimsAssertion: func(a *assertions.Assertion, claims packetbroker.TokenClaims) bool {
+				return a.So(claims.PacketBroker.Cluster, should.BeFalse)
+			},
+		},
+		{
+			name:         "BadRequest",
+			clientID:     "test",
+			clientSecret: "secret",
+			opts: []packetbroker.TokenOption{
+				packetbroker.WithScope(packetbroker.ScopeNetworks),
+				packetbroker.WithAudienceFromAddresses("iam.packetbroker.net:443"),
+			},
+			tokenRequestAssertion: func(a *assertions.Assertion, vars url.Values) bool {
+				if !a.So(vars["scope"], should.Resemble, []string{"networks"}) ||
+					!a.So(vars["audience"], should.Resemble, []string{"iam.packetbroker.net"}) {
+					return false
+				}
+				return false // The request is invalid
+			},
+			tokenRequestErrorAssertion: func(a *assertions.Assertion, err error) bool {
+				var retrieveErr *oauth2.RetrieveError
+				if !errors.As(err, &retrieveErr) {
+					return false
+				}
+				return a.So(retrieveErr.Response.StatusCode, should.Equal, http.StatusBadRequest)
+			},
+		},
+		{
+			name:         "InvalidAudience",
+			clientID:     "test",
+			clientSecret: "secret",
+			opts: []packetbroker.TokenOption{
+				packetbroker.WithScope(packetbroker.ScopeNetworks),
+				packetbroker.WithAudienceFromAddresses("iam.packetbroker.net:443"),
+			},
+			tokenRequestAssertion: func(a *assertions.Assertion, vars url.Values) bool {
+				return a.So(vars["scope"], should.Resemble, []string{"networks"}) &&
+					a.So(vars["audience"], should.Resemble, []string{"iam.packetbroker.net"})
+			},
+			tokenClaims: func() packetbroker.IAMTokenClaims {
+				return packetbroker.IAMTokenClaims{
+					Networks: []packetbroker.TokenNetworkClaim{
+						{
+							NetID:    0x000013,
+							TenantID: "ttn",
+						},
+					},
+				}
+			},
+			audience: "cp.packetbroker.net", // The audience is wrong, verification will fail
+			tokenAssertion: func(a *assertions.Assertion, token string) bool {
+				id, err := packetbroker.UnverifiedNetworkIdentifier(token)
+				return a.So(err, should.BeNil) &&
+					a.So(id.NetId, should.Equal, 0x000013) &&
+					a.So(id.TenantId, should.Equal, "ttn")
+			},
+			tokenClaimsErrorAssertion: func(a *assertions.Assertion, err error) bool {
+				return a.So(errors.IsPermissionDenied(err), should.BeTrue)
+			},
+		},
+	} {
+		tc := tc
+		test.RunSubtest(t, test.SubtestConfig{
+			Name:     tc.name,
+			Parallel: true,
+			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+				public, private, err := ed25519.GenerateKey(nil)
+				if !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
+				const issuer = "https://thethings.example.com"
+				var (
+					publicJWK = jose.JSONWebKey{
+						Key:       public,
+						KeyID:     "test",
+						Algorithm: "EdDSA",
+					}
+					privateJWK = jose.JSONWebKey{
+						Key:       private,
+						KeyID:     "test",
+						Algorithm: "EdDSA",
+					}
+					tokenRequests,
+					publicKeyRequests uint32
+				)
+
+				router := mux.NewRouter()
+				router.Handle("/token", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					atomic.AddUint32(&tokenRequests, 1)
+					if err := r.ParseForm(); err != nil {
+						w.WriteHeader(http.StatusBadRequest)
+						return
+					}
+					clientID, clientSecret, ok := r.BasicAuth()
+					if !ok {
+						clientID, clientSecret = r.PostFormValue("client_id"), r.PostFormValue("client_secret")
+					}
+					if clientID != tc.clientID || clientSecret != tc.clientSecret {
+						t.Log("Wrong credentials")
+						w.WriteHeader(http.StatusUnauthorized)
+						return
+					}
+					if !tc.tokenRequestAssertion(a, r.PostForm) {
+						w.WriteHeader(http.StatusBadRequest)
+						return
+					}
+					signer, err := jose.NewSigner(jose.SigningKey{
+						Algorithm: jose.SignatureAlgorithm(privateJWK.Algorithm),
+						Key:       privateJWK,
+					}, new(jose.SignerOptions).WithType("JWT"))
+					if err != nil {
+						t.Errorf("Instantiate signer: %s", err)
+						w.WriteHeader(http.StatusInternalServerError)
+						return
+					}
+					claims := packetbroker.TokenClaims{
+						Claims: jwt.Claims{
+							ID:       "test",
+							Subject:  "test",
+							IssuedAt: jwt.NewNumericDate(time.Now()),
+							Expiry:   jwt.NewNumericDate(time.Now().Add(time.Hour)),
+							Issuer:   issuer,
+						},
+						PacketBroker: tc.tokenClaims(),
+					}
+					if aud := r.PostFormValue("audience"); aud != "" {
+						claims.Audience = jwt.Audience(strings.Split(aud, " "))
+					}
+					accessToken, err := jwt.Signed(signer).Claims(claims).CompactSerialize()
+					if err != nil {
+						t.Errorf("Serialize token: %s", err)
+						w.WriteHeader(http.StatusInternalServerError)
+						return
+					}
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					token := &oauth2.Token{
+						AccessToken: accessToken,
+						TokenType:   "bearer",
+						Expiry:      claims.Expiry.Time(),
+					}
+					json.NewEncoder(w).Encode(token)
+				})).Methods(http.MethodPost)
+				router.Handle("/.well-known/jwks.json", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					atomic.AddUint32(&publicKeyRequests, 1)
+					jwks := jose.JSONWebKeySet{
+						Keys: []jose.JSONWebKey{publicJWK},
+					}
+					w.WriteHeader(http.StatusOK)
+					json.NewEncoder(w).Encode(jwks)
+				})).Methods(http.MethodGet)
+
+				srv := httptest.NewServer(router)
+				defer srv.Close()
+
+				tokenSource := packetbroker.TokenSource(ctx, tc.clientID, tc.clientSecret,
+					append(tc.opts, packetbroker.WithTokenURL(fmt.Sprintf("%s/token", srv.URL)))...,
+				)
+
+				keyProvider := packetbroker.CachePublicKey(
+					packetbroker.PublicKeyFromURL(srv.Client(), fmt.Sprintf("%s/.well-known/jwks.json", srv.URL)),
+					time.Hour,
+				)
+
+				// Repeat a couple of times to test token and public key cache.
+				for i := 0; i < 10; i++ {
+					token, err := tokenSource.Token()
+					if err != nil {
+						if tc.tokenRequestErrorAssertion == nil {
+							t.Fatalf("Unexpected error: %s", err)
+						}
+						if !tc.tokenRequestErrorAssertion(a, err) {
+							t.FailNow()
+						}
+						return
+					} else if !a.So(err, should.BeNil) || tc.tokenRequestErrorAssertion != nil {
+						t.FailNow()
+					}
+
+					if !tc.tokenAssertion(a, token.AccessToken) {
+						t.FailNow()
+					}
+
+					claims, err := packetbroker.ParseAndVerify(ctx, token, keyProvider, issuer, tc.audience)
+					if err != nil {
+						if tc.tokenClaimsErrorAssertion == nil {
+							t.Fatalf("Unexpected error: %s", err)
+						}
+						if !tc.tokenClaimsErrorAssertion(a, err) {
+							t.FailNow()
+						}
+						return
+					} else if !a.So(err, should.BeNil) || tc.tokenClaimsErrorAssertion != nil {
+						t.FailNow()
+					}
+					if !tc.tokenClaimsAssertion(a, claims) {
+						t.FailNow()
+					}
+				}
+
+				// The token is cached by the reusable token source of the standard library.
+				a.So(tokenRequests, should.Equal, 1)
+				// The public key is cached by using CachePublicKey().
+				a.So(publicKeyRequests, should.Equal, 1)
+			},
+		})
+	}
+}

--- a/pkg/packetbrokeragent/authenticator.go
+++ b/pkg/packetbrokeragent/authenticator.go
@@ -57,7 +57,7 @@ func (a *oauth2Authenticator) AuthInfo(ctx context.Context) (ttnpb.PacketBrokerN
 	if err != nil {
 		return ttnpb.PacketBrokerNetworkIdentifier{}, err
 	}
-	return packetbroker.NetworkIdentifier(token)
+	return packetbroker.UnverifiedNetworkIdentifier(token.AccessToken)
 }
 
 func (a *oauth2Authenticator) DialOptions(ctx context.Context) (res []grpc.DialOption, err error) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Support Packet Broker authentication through Backend Interfaces.

Closes #4677 
Closes #4703 
Unblocks #4678 

#### Changes
<!-- What are the changes made in this pull request? -->

Next to TLS mutual authentication, the interop server for Backend Interfaces now also optionally verifies tokens via the HTTP Authorization header.

The only token issuer supported is currently Packet Broker. The way this works is that if a JWT is detected and the issuer matches with the configured issuer (by default `https://iam.packetbroker.net`), its signature is verified against the public keys hosted by this issuer. Also the audience is verified against the public TLS address of the interop server, to avoid that TTS deployment A can use a token from Packet Broker on TTS deployment B.

#### Testing

<!-- How did you verify that this change works? -->

Unit testing and local integration testing.

I happen to have Packet Broker running locally (issuer `https://localhost:1916`) so I can do something like:

```bash
$ client_id=...
$ client_secret=...
$ curl -d 'client_id=$client_id&client_secret=$client_secret&grant_type=client_credentials&audience=https://localhost:8886' http://localhost:1916/token
```

The returned token is a Packet Broker cluster token, that is, not a network but a Packet Broker routing cluster. The claims of such a token look like this:

```json
{
  "aud": [
    "https://localhost:8886"
  ],
  "exp": 1633625722,
  "https://iam.packetbroker.net/claims": {
    "c": true,
    "rights": [0, 1, 4, 5, 6]
  },
  "iat": 1633622122,
  "iss": "http://localhost:1916",
  "jti": "01FHDQEQHYGK6VDN7F8FH60V68",
  "sub": "localhost"
}
```

With the compact serialized token in `$token`, this now works:

```bash
curl -H "Content-Type: application/json" \
 	-H "Authorization: Bearer $token" \
	-d '{"ProtocolVersion":"1.1","MessageType":"HomeNSReq","SenderID":"000000","SenderNSID":"localhost","ReceiverID":"70B3D57ED0000000","DevEUI":"1122334455667788"}' \
	https://localhost:8886

{"ProtocolVersion":"1.1","TransactionID":0,"MessageType":"HomeNSAns","SenderID":"70B3D57ED0000000","ReceiverID":"000000","ReceiverNSID":"localhost","Result":{"ResultCode":"Success"},"HNSID":"localhost","HNetID":"000001"}
```

The following checks are in place:
1. The token's issuer `iss` matches the configured Packet Broker token issuer
2. The token is signed by a private key belonging to a public key that is advertised at `<issuer>/.well-known/jwks.json`. This is refreshed at most every 10 minutes
3. The token's audience `aud` contains the public TLS address of The Things Stack interop server
4. The token's Packet Broker claims has cluster (`c`) set to `true` (that is, it's Packet Broker itself, like Packet Broker Router; not a token issued for a Packet Broker network or CLI)
5. The token is valid in time (now is between `iat` and `exp`)
6. The token's subject `sub` has to match the `SenderNSID`. In production, this will be something like `eu.packetbroker.io`
7. The `SenderID` must be `000000`

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None expected

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@adriansmares please review everything

@htdvisser please review:
- https://github.com/TheThingsNetwork/lorawan-stack/commit/1485f6906ddc30d846d4881e4e5694a1ae8a2cd9
- https://github.com/TheThingsNetwork/lorawan-stack/commit/5520e1b2df1d0ea43cc414663a76075de7a54460

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
