### PR TITLE
Fix miscellaneous panics

### DIFF
--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -1202,8 +1202,8 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 		}
 		if err := st.WithFields(func(m map[string]*ttnpb.EndDevice) error {
 			fp, phy, err := DeviceFrequencyPlanAndBand(&ttnpb.EndDevice{
-				FrequencyPlanId:   m["frequency_plan_id"].FrequencyPlanId,
-				LorawanPhyVersion: m["lorawan_phy_version"].LorawanPhyVersion,
+				FrequencyPlanId:   m["frequency_plan_id"].GetFrequencyPlanId(),
+				LorawanPhyVersion: m["lorawan_phy_version"].GetLorawanPhyVersion(),
 			}, ns.FrequencyPlans)
 			if err != nil {
 				return err

--- a/pkg/provisioning/microchip.go
+++ b/pkg/provisioning/microchip.go
@@ -27,6 +27,9 @@ type microchip struct{}
 
 // UniqueID returns the serial number.
 func (p *microchip) UniqueID(entry *pbtypes.Struct) (string, error) {
+	if entry == nil {
+		return "", errEntry.New()
+	}
 	sn := entry.Fields["uniqueId"].GetStringValue()
 	if sn == "" {
 		return "", errEntry.New()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://sentry.io/organizations/the-things-industries/issues/2470206875/?project=2732897

#### Changes
<!-- What are the changes made in this pull request? -->

- Validate that the provisioning data actually exists in the Microchip provisioner
- Use getters in the NS validation in order to avoid `panic`ing on `Set`.


#### Testing

<!-- How did you verify that this change works? -->

N/A

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
