### PR TITLE
Implement Backend Interfaces `HomeNSReq` in Identity Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For details about compatibility between different releases, see the **Commitment
   - `interop.public-tls-address`: public address of the interop server. The audience in the incoming OAuth 2.0 token from Packet Broker is verified against this address to ensure that other networks cannot impersonate as Packet Broker;
   - `interop.packet-broker.enabled`: enable Packet Broker to authenticate;
   - `interop.packet-broker.token-issuer`: the issuer of the incoming OAuth 2.0 token from Packet Broker is verified against this value.
+- Support for LoRaWAN Backend Interfaces in Identity Server to obtain an end device's NetID and NSID (Network Server address). This adds the configuration option `is.network.net-id`: the NetID of the network. When running a Network Server, make sure that this is the same value as `ns.net-id`.
 - Configuration option `experimental.features` to enable experimental features.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ For details about compatibility between different releases, see the **Commitment
   - `interop.public-tls-address`: public address of the interop server. The audience in the incoming OAuth 2.0 token from Packet Broker is verified against this address to ensure that other networks cannot impersonate as Packet Broker;
   - `interop.packet-broker.enabled`: enable Packet Broker to authenticate;
   - `interop.packet-broker.token-issuer`: the issuer of the incoming OAuth 2.0 token from Packet Broker is verified against this value.
-- Support for LoRaWAN Backend Interfaces in Identity Server to obtain an end device's NetID and NSID (Network Server address). This adds the configuration option `is.network.net-id`: the NetID of the network. When running a Network Server, make sure that this is the same value as `ns.net-id`.
+- Support for LoRaWAN Backend Interfaces in Identity Server to obtain an end device's NetID and NSID (Network Server address). This adds the following configuration options:
+  - `is.network.net-id`: the NetID of the network. When running a Network Server, make sure that this is the same value as `ns.net-id`.
+  - `is.network.tenant-id`: the Tenant ID in the host NetID. Leave blank if you the NetID that you use is dedicated for the Identity Server.
 - Configuration option `experimental.features` to enable experimental features.
 
 ### Changed

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -421,8 +421,8 @@ type PacketBrokerInteropAuth struct {
 
 // InteropServer represents the server-side interoperability through LoRaWAN Backend Interfaces configuration.
 type InteropServer struct {
-	ListenTLS        string `name:"listen-tls" description:"Address for the interop server to listen on"`
-	PublicTLSAddress string `name:"public-tls-address" description:"Public address of the interop server"`
+	ListenTLS        string `name:"listen-tls" description:"Address for the interop server for LoRaWAN Backend Interfaces to listen on"`
+	PublicTLSAddress string `name:"public-tls-address" description:"Public address of the interop server for LoRaWAN Backend Interfaces"`
 
 	SenderClientCA           SenderClientCA    `name:"sender-client-ca"`
 	SenderClientCADeprecated map[string]string `name:"sender-client-cas" description:"Path to PEM encoded file with client CAs of sender IDs to trust; deprecated - use sender-client-ca instead"`
@@ -439,7 +439,7 @@ type ServiceBase struct {
 	Events           Events               `name:"events"`
 	GRPC             GRPC                 `name:"grpc"`
 	HTTP             HTTP                 `name:"http"`
-	Interop          InteropServer        `name:"interop" description:"LoRaWAN Backend Interfaces interoperability configuration"`
+	Interop          InteropServer        `name:"interop"`
 	TLS              tlsconfig.Config     `name:"tls"`
 	Sentry           Sentry               `name:"sentry"`
 	Blob             BlobConfig           `name:"blob"`

--- a/pkg/identityserver/config.go
+++ b/pkg/identityserver/config.go
@@ -104,7 +104,8 @@ type Config struct {
 		InitCounter      int64                `name:"init-counter" description:"Initial counter value for the addresses to be issued (default 0)"`
 	} `name:"dev-eui-block" description:"IEEE MAC block used to issue DevEUIs to devices that are not yet programmed"`
 	Network struct {
-		NetID ttntypes.NetID `name:"net-id" description:"NetID of this network"`
+		NetID    ttntypes.NetID `name:"net-id" description:"NetID of this network"`
+		TenantID string         `name:"tenant-id" description:"Tenant ID in the host NetID"`
 	} `name:"network"`
 }
 

--- a/pkg/identityserver/config.go
+++ b/pkg/identityserver/config.go
@@ -102,7 +102,10 @@ type Config struct {
 		ApplicationLimit int                  `name:"application-limit" description:"Maximum DevEUI addresses to be issued per application"`
 		Prefix           ttntypes.EUI64Prefix `name:"prefix" description:"DevEUI block prefix"`
 		InitCounter      int64                `name:"init-counter" description:"Initial counter value for the addresses to be issued (default 0)"`
-	} `name:"dev-eui-block" description:"IEEE MAC block used to issue DevEUI's to devices that are not yet programmed"`
+	} `name:"dev-eui-block" description:"IEEE MAC block used to issue DevEUIs to devices that are not yet programmed"`
+	Network struct {
+		NetID ttntypes.NetID `name:"net-id" description:"NetID of this network"`
+	} `name:"network"`
 }
 
 type emailTemplatesConfig struct {

--- a/pkg/identityserver/http_interop.go
+++ b/pkg/identityserver/http_interop.go
@@ -1,0 +1,80 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package identityserver
+
+import (
+	"context"
+
+	pbtypes "github.com/gogo/protobuf/types"
+	"github.com/jinzhu/gorm"
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/identityserver/store"
+	"go.thethings.network/lorawan-stack/v3/pkg/interop"
+	"go.thethings.network/lorawan-stack/v3/pkg/log"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/types"
+)
+
+type interopServer struct {
+	*IdentityServer
+	interop.Authorizer
+}
+
+func (srv interopServer) HomeNSRequest(ctx context.Context, in *interop.HomeNSReq) (*interop.HomeNSAns, error) {
+	ctx = log.NewContextWithField(ctx, "namespace", "identityserver/interop")
+	if err := srv.RequireAuthorized(ctx); err != nil {
+		return nil, err
+	}
+
+	ids := &ttnpb.EndDeviceIdentifiers{
+		JoinEui: (*types.EUI64)(&in.ReceiverID),
+		DevEui:  (*types.EUI64)(&in.DevEUI),
+	}
+
+	var dev *ttnpb.EndDevice
+	err := srv.withDatabase(ctx, func(db *gorm.DB) (err error) {
+		dev, err = store.GetEndDeviceStore(db).GetEndDevice(ctx, ids, &pbtypes.FieldMask{
+			Paths: []string{"network_server_address"},
+		})
+		return err
+	})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, interop.ErrUnknownDevEUI.WithCause(err)
+		}
+		return nil, err
+	}
+
+	header, err := in.AnswerHeader()
+	if err != nil {
+		return nil, interop.ErrMalformedMessage.WithCause(err)
+	}
+	ans := &interop.HomeNSAns{
+		JsNsMessageHeader: interop.JsNsMessageHeader{
+			MessageHeader: header,
+			SenderID:      in.ReceiverID,
+			ReceiverID:    in.SenderID,
+			ReceiverNSID:  in.SenderNSID,
+		},
+		Result: interop.Result{
+			ResultCode: interop.ResultSuccess,
+		},
+		HNetID: interop.NetID(srv.configFromContext(ctx).Network.NetID),
+	}
+	if in.ProtocolVersion.SupportsNSID() {
+		ans.HNSID = &dev.NetworkServerAddress
+	}
+	return ans, nil
+}

--- a/pkg/identityserver/http_interop.go
+++ b/pkg/identityserver/http_interop.go
@@ -33,7 +33,7 @@ type interopServer struct {
 	interop.Authorizer
 }
 
-func (srv interopServer) hNSID(ctx context.Context, dev *ttnpb.EndDevice) string {
+func (srv *interopServer) hNSID(ctx context.Context, dev *ttnpb.EndDevice) string {
 	hNSID := dev.NetworkServerAddress
 	if tid := srv.configFromContext(ctx).Network.TenantID; tid != "" {
 		hNSID = fmt.Sprintf("%s@%s", tid, hNSID)
@@ -41,7 +41,7 @@ func (srv interopServer) hNSID(ctx context.Context, dev *ttnpb.EndDevice) string
 	return hNSID
 }
 
-func (srv interopServer) HomeNSRequest(ctx context.Context, in *interop.HomeNSReq) (*interop.HomeNSAns, error) {
+func (srv *interopServer) HomeNSRequest(ctx context.Context, in *interop.HomeNSReq) (*interop.HomeNSAns, error) {
 	ctx = log.NewContextWithField(ctx, "namespace", "identityserver/interop")
 	if err := srv.RequireAuthorized(ctx); err != nil {
 		return nil, err

--- a/pkg/identityserver/http_interop_test.go
+++ b/pkg/identityserver/http_interop_test.go
@@ -37,21 +37,24 @@ func TestInteropServer(t *testing.T) {
 
 		joinEUI := types.EUI64{1, 2, 3, 4, 5, 6, 7, 8}
 		devEUI := types.EUI64{8, 7, 6, 5, 4, 3, 2, 1}
-
-		_, err := store.GetEndDeviceStore(is.db).CreateEndDevice(ctx, &ttnpb.EndDevice{
-			EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
-				ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{
-					ApplicationId: "test-app-id",
-				},
-				DeviceId: "test-device-id",
-				JoinEui:  &joinEUI,
-				DevEui:   &devEUI,
+		id := ttnpb.EndDeviceIdentifiers{
+			ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{
+				ApplicationId: "test-app-id",
 			},
+			DeviceId: "test-device-id",
+			JoinEui:  &joinEUI,
+			DevEui:   &devEUI,
+		}
+
+		store := store.GetEndDeviceStore(is.db)
+		_, err := store.CreateEndDevice(ctx, &ttnpb.EndDevice{
+			EndDeviceIdentifiers: id,
 			NetworkServerAddress: "thethings.example.com",
 		})
 		if !a.So(err, should.BeNil) {
 			t.FailNow()
 		}
+		defer store.DeleteEndDevice(ctx, &id)
 
 		ctx := interop.NewContextWithNetworkServerAuthInfo(ctx, &interop.NetworkServerAuthInfo{
 			NetID:     types.NetID{0x0, 0x0, 0x0},

--- a/pkg/identityserver/http_interop_test.go
+++ b/pkg/identityserver/http_interop_test.go
@@ -1,0 +1,118 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package identityserver
+
+import (
+	"testing"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/identityserver/store"
+	"go.thethings.network/lorawan-stack/v3/pkg/interop"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/types"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+	"google.golang.org/grpc"
+)
+
+func TestInteropServer(t *testing.T) {
+	a, ctx := test.New(t)
+
+	testWithIdentityServer(t, func(is *IdentityServer, _ *grpc.ClientConn) {
+		srv := &interopServer{
+			IdentityServer: is,
+		}
+
+		joinEUI := types.EUI64{1, 2, 3, 4, 5, 6, 7, 8}
+		devEUI := types.EUI64{8, 7, 6, 5, 4, 3, 2, 1}
+
+		_, err := store.GetEndDeviceStore(is.db).CreateEndDevice(ctx, &ttnpb.EndDevice{
+			EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
+				ApplicationIdentifiers: ttnpb.ApplicationIdentifiers{
+					ApplicationId: "test-app-id",
+				},
+				DeviceId: "test-device-id",
+				JoinEui:  &joinEUI,
+				DevEui:   &devEUI,
+			},
+			NetworkServerAddress: "thethings.example.com",
+		})
+		if !a.So(err, should.BeNil) {
+			t.FailNow()
+		}
+
+		ctx := interop.NewContextWithNetworkServerAuthInfo(ctx, &interop.NetworkServerAuthInfo{
+			NetID:     types.NetID{0x0, 0x0, 0x0},
+			Addresses: []string{"localhost"},
+		})
+
+		// Test a known device with Backend Interfaces 1.0
+		ans, err := srv.HomeNSRequest(ctx, &interop.HomeNSReq{
+			NsJsMessageHeader: interop.NsJsMessageHeader{
+				MessageHeader: interop.MessageHeader{
+					ProtocolVersion: interop.ProtocolV1_0,
+					TransactionID:   42,
+					MessageType:     interop.MessageTypeHomeNSReq,
+				},
+				SenderID:   interop.NetID{0x0, 0x0, 0x0},
+				ReceiverID: interop.EUI64(joinEUI),
+			},
+			DevEUI: interop.EUI64(devEUI),
+		})
+		if !a.So(err, should.BeNil) {
+			t.FailNow()
+		}
+		a.So(ans.HNetID, should.Equal, interop.NetID(test.DefaultNetID))
+		a.So(ans.HNSID, should.BeNil) // Backend Interfaces 1.0 does not support this
+
+		// Test a known device with Backend Interfaces 1.1
+		ans, err = srv.HomeNSRequest(ctx, &interop.HomeNSReq{
+			NsJsMessageHeader: interop.NsJsMessageHeader{
+				MessageHeader: interop.MessageHeader{
+					ProtocolVersion: interop.ProtocolV1_1,
+					TransactionID:   42,
+					MessageType:     interop.MessageTypeHomeNSReq,
+				},
+				SenderID:   interop.NetID{0x0, 0x0, 0x0},
+				ReceiverID: interop.EUI64(joinEUI),
+			},
+			DevEUI: interop.EUI64(devEUI),
+		})
+		if !a.So(err, should.BeNil) {
+			t.FailNow()
+		}
+		a.So(ans.HNetID, should.Equal, interop.NetID(test.DefaultNetID))
+		if a.So(ans.HNSID, should.NotBeNil) {
+			a.So(*ans.HNSID, should.Equal, "thethings.example.com")
+		}
+
+		// Test an unknown device
+		_, err = srv.HomeNSRequest(ctx, &interop.HomeNSReq{
+			NsJsMessageHeader: interop.NsJsMessageHeader{
+				MessageHeader: interop.MessageHeader{
+					ProtocolVersion: interop.ProtocolV1_1,
+					TransactionID:   42,
+					MessageType:     interop.MessageTypeHomeNSReq,
+				},
+				SenderID:   interop.NetID{0x0, 0x0, 0x0},
+				ReceiverID: interop.EUI64(joinEUI),
+			},
+			DevEUI: interop.EUI64{8, 8, 8, 8, 8, 8, 8, 8},
+		})
+		if !a.So(errors.IsNotFound(err), should.BeTrue) {
+			t.FailNow()
+		}
+	})
+}

--- a/pkg/identityserver/http_interop_test.go
+++ b/pkg/identityserver/http_interop_test.go
@@ -95,7 +95,7 @@ func TestInteropServer(t *testing.T) {
 		}
 		a.So(ans.HNetID, should.Equal, interop.NetID(test.DefaultNetID))
 		if a.So(ans.HNSID, should.NotBeNil) {
-			a.So(*ans.HNSID, should.Equal, "thethings.example.com")
+			a.So(*ans.HNSID, should.Equal, "test@thethings.example.com")
 		}
 
 		// Test an unknown device

--- a/pkg/identityserver/identityserver.go
+++ b/pkg/identityserver/identityserver.go
@@ -28,6 +28,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/email"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/identityserver/store"
+	"go.thethings.network/lorawan-stack/v3/pkg/interop"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/oauth"
 	"go.thethings.network/lorawan-stack/v3/pkg/redis"
@@ -177,6 +178,7 @@ func New(c *component.Component, config *Config) (is *IdentityServer, err error)
 	c.RegisterGRPC(is)
 	c.RegisterWeb(is.oauth)
 	c.RegisterWeb(is.account)
+	c.RegisterInterop(is)
 
 	return is, nil
 }
@@ -229,6 +231,11 @@ func (is *IdentityServer) RegisterHandlers(s *runtime.ServeMux, conn *grpc.Clien
 	ttnpb.RegisterEndDeviceRegistrySearchHandler(is.Context(), s, conn)
 	ttnpb.RegisterOAuthAuthorizationRegistryHandler(is.Context(), s, conn)
 	ttnpb.RegisterContactInfoRegistryHandler(is.Context(), s, conn)
+}
+
+// RegisterInterop registers the LoRaWAN Backend Interfaces interoperability services.
+func (is *IdentityServer) RegisterInterop(srv *interop.Server) {
+	srv.RegisterIS(&interopServer{IdentityServer: is})
 }
 
 // Roles returns the roles that the Identity Server fulfills.

--- a/pkg/identityserver/identityserver_test.go
+++ b/pkg/identityserver/identityserver_test.go
@@ -350,6 +350,7 @@ func getIdentityServer(t *testing.T) (*IdentityServer, *grpc.ClientConn) {
 	conf.DevEUIBlock.Prefix = euiBlock
 	conf.DevEUIBlock.ApplicationLimit = 3
 	conf.Network.NetID = test.DefaultNetID
+	conf.Network.TenantID = "test"
 	is, err := New(c, conf)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/identityserver/identityserver_test.go
+++ b/pkg/identityserver/identityserver_test.go
@@ -349,6 +349,7 @@ func getIdentityServer(t *testing.T) (*IdentityServer, *grpc.ClientConn) {
 	conf.DevEUIBlock.Enabled = true
 	conf.DevEUIBlock.Prefix = euiBlock
 	conf.DevEUIBlock.ApplicationLimit = 3
+	conf.Network.NetID = test.DefaultNetID
 	is, err := New(c, conf)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/joinserver/http_interop.go
+++ b/pkg/joinserver/http_interop.go
@@ -84,10 +84,8 @@ func (srv interopServer) JoinRequest(ctx context.Context, in *interop.JoinReq) (
 			return nil, interop.ErrActivation.WithCause(err)
 		case errors.Resemble(err, errMICMismatch):
 			return nil, interop.ErrMIC.WithCause(err)
-		case errors.Resemble(err, errRegistryOperation):
-			if errors.IsNotFound(errors.Cause(err)) {
-				return nil, interop.ErrUnknownDevEUI.WithCause(err)
-			}
+		case errors.IsNotFound(err):
+			return nil, interop.ErrUnknownDevEUI.WithCause(err)
 		}
 		return nil, interop.ErrJoinReq.WithCause(err)
 	}
@@ -126,11 +124,8 @@ func (srv interopServer) HomeNSRequest(ctx context.Context, in *interop.HomeNSRe
 
 	netID, nsID, err := srv.JS.GetHomeNetID(ctx, types.EUI64(in.ReceiverID), types.EUI64(in.DevEUI), InteropAuthorizer)
 	if err != nil {
-		switch {
-		case errors.Resemble(err, errRegistryOperation):
-			if errors.IsNotFound(errors.Cause(err)) {
-				return nil, interop.ErrUnknownDevEUI.WithCause(err)
-			}
+		if errors.IsNotFound(err) {
+			return nil, interop.ErrUnknownDevEUI.WithCause(err)
 		}
 		return nil, err
 	}
@@ -181,10 +176,8 @@ func (srv interopServer) AppSKeyRequest(ctx context.Context, in *interop.AppSKey
 		switch {
 		case errors.IsPermissionDenied(err):
 			return nil, interop.ErrActivation.WithCause(err)
-		case errors.Resemble(err, errRegistryOperation):
-			if errors.IsNotFound(errors.Cause(err)) {
-				return nil, interop.ErrUnknownDevEUI.WithCause(err)
-			}
+		case errors.IsNotFound(err):
+			return nil, interop.ErrUnknownDevEUI.WithCause(err)
 		}
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #4678 

#### Changes
<!-- What are the changes made in this pull request? -->

- Make interop server aware of IS vs JS registration; IS takes precedence just for serving `HomeNSReq`. A stand-alone JS will use its end device registry, a stand-alone IS will only support `HomeNSReq` through its end device registry, and a combination of IS and JS will serve `HomeNSReq` from through IS and the join flow through JS
- IS config
	- NetID of the network. This should match the `ns.net-id` value. See reviewer notes below
	- Whether interop is enabled

#### Testing

<!-- How did you verify that this change works? -->

Unit testing and local integration testing.

Test setup from #4723:

```bash
curl -H "Content-Type: application/json" \
	-H "Authorization: Bearer $token" \
	-d '{"ProtocolVersion":"1.1","MessageType":"HomeNSReq","SenderID":"000000","SenderNSID":"localhost","ReceiverID":"70B3D57ED0000000","DevEUI":"1122334455667788"}' \
	https://localhost:8886

{"ProtocolVersion":"1.1","TransactionID":0,"MessageType":"HomeNSAns","SenderID":"70B3D57ED0000000","ReceiverID":"000000","ReceiverNSID":"localhost","Result":{"ResultCode":"Success"},"HNSID":"localhost","HNetID":"000001"}
```

Debug logs:

```
DEBUG	Run database query	{"duration": 0.006, "http.method": "POST", "http.path": "/", "message_type": "HomeNSReq", "namespace": "db", "peer.address": "[::1]:62431", "protocol_version": "1.1", "query": "SELECT id, created_at, updated_at, application_id, device_id, join_eui, dev_eui, network_server_address FROM \"end_devices\"  WHERE (join_eui = $1) AND (dev_eui = $2) ORDER BY \"end_devices\".\"id\" ASC LIMIT 1", "receiver_id": "70B3D57ED0000000", "request_id": "01FHFMYEAT549JT9VD9JGVR80N", "rows": 1, "sender_id": "000000", "source": "end_device_store.go:150", "values": ["70B3D57ED0000000","1122334455667788"]}
INFO	Request handled	{"duration": 0.0084, "http.method": "POST", "http.path": "/", "http.status": 200, "namespace": "interop", "peer.address": "[::1]:62431", "request_id": "01FHFMYEAT549JT9VD9JGVR80N"}
```

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None expected

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@htdvisser is the main reviewer

~Adding `is.net-id` is debatable. Let's discuss in #4678.~

It was agreed that `is.network.net-id` and `is.network.tenant-id` are the way to go.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
