### PR TITLE
Remove usage of deprecated `skip_payload_crypto` in the Console

### DIFF
--- a/cypress/integration/console/devices/messaging/edit.spec.js
+++ b/cypress/integration/console/devices/messaging/edit.spec.js
@@ -81,9 +81,7 @@ describe('End device messaging', () => {
 
       cy.findByRole('button', { name: 'Simulate uplink' }).click()
 
-      cy.findByTestId('toast-notification')
-        .should('be.visible')
-        .and('contain', 'Uplink sent')
+      cy.findByTestId('toast-notification').should('be.visible').and('contain', 'Uplink sent')
 
       cy.findByTestId('error-notification').should('not.exist')
     })
@@ -102,7 +100,7 @@ describe('End device messaging', () => {
 
       cy.intercept(
         'GET',
-        `as/applications/${applicationId}/devices/${endDeviceId}?field_mask=version_ids,formatters,skip_payload_crypto,skip_payload_crypto_override,session,pending_session`,
+        `as/applications/${applicationId}/devices/${endDeviceId}?field_mask=version_ids,formatters,skip_payload_crypto_override,session,pending_session`,
         response,
       )
 
@@ -160,7 +158,7 @@ describe('End device messaging', () => {
 
       cy.intercept(
         'GET',
-        `as/applications/${applicationId}/devices/${endDeviceId}?field_mask=version_ids,formatters,skip_payload_crypto,skip_payload_crypto_override,session,pending_session`,
+        `as/applications/${applicationId}/devices/${endDeviceId}?field_mask=version_ids,formatters,skip_payload_crypto_override,session,pending_session`,
         response,
       )
 

--- a/pkg/webui/console/views/device-general-settings/application-server-form/index.js
+++ b/pkg/webui/console/views/device-general-settings/application-server-form/index.js
@@ -33,9 +33,9 @@ import messages from '../messages'
 
 const validationSchema = Yup.object()
   .shape({
-    skip_payload_crypto: Yup.boolean().default(false),
+    skip_payload_crypto_override: Yup.boolean().default(false),
     session: Yup.object().when(
-      ['skip_payload_crypto', '$mayEditKeys'],
+      ['skip_payload_crypto_override', '$mayEditKeys'],
       (skipPayloadCrypto, mayEditKeys, schema) => {
         if (skipPayloadCrypto || !mayEditKeys) {
           return schema.strip()
@@ -63,7 +63,7 @@ const ApplicationServerForm = React.memo(props => {
 
   const validationContext = React.useMemo(() => ({ mayEditKeys }), [mayEditKeys])
   const initialValues = React.useMemo(() => {
-    const { session = {}, skip_payload_crypto } = device
+    const { session = {}, skip_payload_crypto_override } = device
     const {
       keys = {
         app_s_key: {
@@ -74,7 +74,7 @@ const ApplicationServerForm = React.memo(props => {
 
     return validationSchema.cast(
       {
-        skip_payload_crypto,
+        skip_payload_crypto_override,
         session: {
           keys: {
             app_s_key: keys.app_s_key,
@@ -88,7 +88,7 @@ const ApplicationServerForm = React.memo(props => {
   const formRef = React.useRef(null)
   const sessionRef = React.useRef(device.session)
 
-  const [skipCrypto, setSkipCrypto] = React.useState(device.skip_payload_crypto || false)
+  const [skipCrypto, setSkipCrypto] = React.useState(device.skip_payload_crypto_override || false)
   const handleSkipCryptoChange = React.useCallback(
     evt => {
       const { checked } = evt.target
@@ -100,7 +100,7 @@ const ApplicationServerForm = React.memo(props => {
           validationSchema.cast(
             {
               ...values,
-              skip_payload_crypto: checked,
+              skip_payload_crypto_override: checked,
               session: {
                 keys: {
                   app_s_key: {
@@ -117,7 +117,7 @@ const ApplicationServerForm = React.memo(props => {
           validationSchema.cast(
             {
               ...values,
-              skip_payload_crypto: checked,
+              skip_payload_crypto_override: checked,
               // Reset initial app_s_key value.
               session: sessionRef.current || '',
             },
@@ -165,7 +165,7 @@ const ApplicationServerForm = React.memo(props => {
       <Form.Field
         autoFocus
         title={sharedMessages.skipCryptoTitle}
-        name="skip_payload_crypto"
+        name="skip_payload_crypto_override"
         description={sharedMessages.skipCryptoDescription}
         component={Checkbox}
         onChange={handleSkipCryptoChange}

--- a/pkg/webui/console/views/device/index.js
+++ b/pkg/webui/console/views/device/index.js
@@ -132,7 +132,6 @@ import style from './device.styl'
     'claim_authentication_code',
     'mac_state.recent_uplinks',
     'attributes',
-    'skip_payload_crypto',
     'skip_payload_crypto_override',
   ]
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Remove usage of `skip_payload_crypto` in AS form. Replace it with the new field `skip_payload_crypto_override`

#### Changes
<!-- What are the changes made in this pull request? -->

- Replace `skip_payload_crypto` with `skip_payload_crypto_override` for end device entity


#### Testing

<!-- How did you verify that this change works? -->

Manual

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This also fixes the issue with message simulation for end devices. One can reproduce this by going through these steps:
1. Create a new ABP end device
2. Go to the AS form and enable `skip_payload_crypto` checkbox
3. Go to to the messaging tab of this device 
4. See the form being available for submission

With PR the form is properly displaying the warning notification that message simulation is disabled for devices with `skip_payload_crypto` set to `true`.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
