### PR TITLE
Remove option to select target components in end device import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Removed
 
+- Option to select targeted stack components during end device import in the Console.
+
 ### Fixed
 
 - LoRaWAN Backend Interfaces 1.1 fields that were used in 1.0 (most notably `SenderNSID` and `ReceiverNSID`). Usage of `NSID` is now only supported with LoRaWAN Backend Interfaces 1.1 as specified.

--- a/pkg/webui/console/containers/device-importer/index.js
+++ b/pkg/webui/console/containers/device-importer/index.js
@@ -213,12 +213,7 @@ export default class DeviceImporter extends Component {
   @bind
   async handleSubmit(values) {
     const { appId, jsConfig, nsConfig, asConfig } = this.props
-    const {
-      format_id,
-      data,
-      set_claim_auth_code,
-      components: { js: jsSelected, as: asSelected, ns: nsSelected },
-    } = values
+    const { format_id, data, set_claim_auth_code } = values
 
     let devices = []
 
@@ -249,19 +244,19 @@ export default class DeviceImporter extends Component {
       // Apply default values.
       for (const deviceAndFieldMask of devices) {
         const { end_device: device, field_mask } = deviceAndFieldMask
-        if (set_claim_auth_code && jsSelected) {
+        if (set_claim_auth_code && jsConfig.enabled) {
           device.claim_authentication_code = { value: randomByteString(4 * 2) }
           field_mask.paths.push('claim_authentication_code')
         }
-        if (device.supports_join && !device.join_server_address && jsConfig.enabled && jsSelected) {
+        if (device.supports_join && !device.join_server_address && jsConfig.enabled) {
           device.join_server_address = new URL(jsConfig.base_url).hostname
           field_mask.paths.push('join_server_address')
         }
-        if (!device.application_server_address && asConfig.enabled && asSelected) {
+        if (!device.application_server_address && asConfig.enabled) {
           device.application_server_address = new URL(asConfig.base_url).hostname
           field_mask.paths.push('application_server_address')
         }
-        if (!device.network_server_address && nsConfig.enabled && nsSelected) {
+        if (!device.network_server_address && nsConfig.enabled) {
           device.network_server_address = new URL(nsConfig.base_url).hostname
           field_mask.paths.push('network_server_address')
         }
@@ -464,14 +459,13 @@ export default class DeviceImporter extends Component {
     const initialValues = {
       format_id: '',
       data: '',
-      set_claim_auth_code: false,
-      components: availableComponents.reduce((o, c) => ({ ...o, [c]: true }), {}),
+      set_claim_auth_code: true,
     }
     return (
       <Row>
         <Col md={8}>
           <DeviceImportForm
-            components={availableComponents}
+            jsEnabled={availableComponents.includes('js')}
             initialValues={initialValues}
             onSubmit={this.handleSubmit}
           />

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -129,7 +129,7 @@
   "console.components.device-import-form.index.claiming": "Claiming",
   "console.components.device-import-form.index.setClaimAuthCode": "Set claim authentication code",
   "console.components.device-import-form.index.targetedComponents": "Targeted components",
-  "console.components.device-import-form.index.advancedSectionTitle": "Advanced claiming and component settings",
+  "console.components.device-import-form.index.advancedSectionTitle": "Advanced end device claiming settings",
   "console.components.device-import-form.index.infoText": "You can use the import functionality to register multiple end devices at once by uploading a file containing the registration information in one of the available formats. For more information, see also our documentation on <DocLink>Importing End Devices</DocLink>.",
   "console.components.downlink-form.downlink-form.insertMode": "Insert Mode",
   "console.components.downlink-form.downlink-form.payloadType": "Payload type",


### PR DESCRIPTION
#### Summary
Quickfix to remove the option to select targeted components in the end device import form in the Console.

<details><summary>Screenshots</summary>

Before:
![image](https://user-images.githubusercontent.com/5710611/136575936-f657f820-b5f5-4da7-b36a-98cae40e3dae.png)

After:
![image](https://user-images.githubusercontent.com/5710611/136575400-fda34335-1549-4f15-b680-034b93d2381f.png)
</details>

#### Changes
- Remove component checkboxes
- Adapt logic slightly

#### Testing

Manual testing.

#### Notes for Reviewers
This option turned out to be confusing at best and there are no real use case for these options.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
