### PR TITLE
Rewrite membership lookup queries in IS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ For details about compatibility between different releases, see the **Commitment
 - The NSID field of LoRaWAN Backend Interfaces 1.1 is now interpreted as Network Server address. Clients authenticating with `SenderNSID` must be authenticated as a Network Server with that address (see Security below).
 - Searching for entity IDs is now case insensitive.
 - Renamed entitie's "Last seen" to "Last activity" in the Console.
+- The database queries for determining the rights of users on entities have been rewritten to reduce the number of round-trips to the database.
 
 ### Deprecated
 

--- a/pkg/identityserver/rights.go
+++ b/pkg/identityserver/rights.go
@@ -73,42 +73,20 @@ func (is *IdentityServer) getRights(ctx context.Context, entityID *ttnpb.EntityI
 		return nil, universalRights, nil
 	}
 
+	// If the caller is requesting a user, and they're not that user (see above),
+	// they don't have rights on it, so nothing more to do.
+	if entityID.GetUserIds() != nil {
+		return nil, universalRights, nil
+	}
+
 	err = is.withDatabase(ctx, func(db *gorm.DB) error {
-		membershipStore := is.getMembershipStore(ctx, db)
-
-		// Find direct membership rights of the organization or user.
-		directMemberRights, err := membershipStore.GetMember(ctx, ouID, entityID)
-		if err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-
-		// Expand the pseudo-rights.
-		entityRights = directMemberRights.Implied()
-
-		// If entityRights already includes all potential rights,
-		// there's nothing more to do.
-		if len(allPotentialRights.Sub(entityRights).GetRights()) == 0 {
-			return nil
-		}
-
-		// If the caller is not a user, there's nothing more to do.
-		usrID := ouID.GetUserIds()
-		if usrID == nil {
-			return nil
-		}
-
-		// Find indirect memberships (through organizations).
-		// TODO: Cache this (https://github.com/TheThingsNetwork/lorawan-stack/issues/443).
-		commonOrganizations, err := membershipStore.FindIndirectMemberships(ctx, usrID, entityID)
+		membershipChains, err := is.getMembershipStore(ctx, db).FindAccountMembershipChains(ctx, ouID, entityID.EntityType(), entityID.IDString())
 		if err != nil {
 			return err
 		}
-		for _, commonOrganization := range commonOrganizations {
-			rightsOnOrganization := commonOrganization.RightsOnOrganization.Implied()
-			organizationRights := commonOrganization.OrganizationRights.Implied()
-			entityRights = entityRights.Union(rightsOnOrganization.Intersect(organizationRights))
+		for _, chain := range membershipChains {
+			entityRights = entityRights.Union(chain.GetRights())
 		}
-
 		return nil
 	})
 	if err != nil {

--- a/pkg/identityserver/store/entity_search.go
+++ b/pkg/identityserver/store/entity_search.go
@@ -86,7 +86,7 @@ func (s *entitySearch) queryMembership(ctx context.Context, query *gorm.DB, enti
 	if member == nil {
 		return query
 	}
-	membershipsQuery := (&membershipStore{store: s.store}).queryMemberships(ctx, member, entityType, true).Select("entity_id").QueryExpr()
+	membershipsQuery := (&membershipStore{store: s.store}).queryMemberships(ctx, member, entityType, nil, true).Select(`"direct_memberships"."entity_id"`).QueryExpr()
 	if entityType == "organization" {
 		query = query.Where(`"accounts"."account_type" = ? AND "accounts"."account_id" IN (?)`, entityType, membershipsQuery)
 	} else {

--- a/pkg/identityserver/store/membership_store.go
+++ b/pkg/identityserver/store/membership_store.go
@@ -137,67 +137,103 @@ func (s *membershipStore) FindMemberships(ctx context.Context, accountID *ttnpb.
 	return identifiers, nil
 }
 
-// IndirectMembership returns an indirect membership through an organization.
-type IndirectMembership struct {
-	RightsOnOrganization *ttnpb.Rights
-	*ttnpb.OrganizationIdentifiers
-	OrganizationRights *ttnpb.Rights
+type membershipChain struct {
+	IndirectAccountType       string
+	IndirectAccountFriendlyID string
+	IndirectAccountRights     Rights
+	DirectAccountType         string
+	DirectAccountFriendlyID   string
+	DirectAccountRights       Rights
+	EntityType                string
+	EntityFriendlyID          string
 }
 
-func (s *membershipStore) FindIndirectMemberships(ctx context.Context, userID *ttnpb.UserIdentifiers, entityID *ttnpb.EntityIdentifiers) ([]IndirectMembership, error) {
-	defer trace.StartRegion(ctx, fmt.Sprintf("find indirect memberships of user on %s", entityID.EntityType())).End()
-	userQuery := s.query(WithoutSoftDeleted(ctx), Account{}).
-		Select(`"accounts"."id"`).
-		Where(`"accounts"."account_type" = 'user' AND "accounts"."uid" = ?`, userID.IDString()).
-		QueryExpr()
-	entityQuery := s.query(ctx, modelForID(entityID), withID(entityID)).
-		Select(fmt.Sprintf(`"%ss"."id"`, entityID.EntityType())).
-		QueryExpr()
-	query := s.query(WithoutSoftDeleted(ctx), Account{}).
-		Select(`"usr_memberships"."rights" AS "usr_rights", "accounts"."uid" AS "organization_id", "entity_memberships"."rights" AS "entity_rights"`).
-		Joins(`JOIN "memberships" "usr_memberships" ON "usr_memberships"."entity_type" = 'organization' AND "usr_memberships"."entity_id" = "accounts"."account_id"`).
-		Joins(`JOIN "memberships" "entity_memberships" ON "entity_memberships"."account_id" = "accounts"."id"`).
-		Where(`"usr_memberships"."account_id" = (?)`, userQuery).
-		Where(fmt.Sprintf(`"entity_memberships"."entity_type" = '%s' AND "entity_memberships"."entity_id" = (?)`, entityID.EntityType()), entityQuery)
-	var res []struct {
-		UsrRights      Rights
-		OrganizationID string
-		EntityRights   Rights
+func (m membershipChain) GetMembershipChain() *MembershipChain {
+	indirectAccountRights := ttnpb.Rights(m.IndirectAccountRights)
+	directAccountRights := ttnpb.Rights(m.DirectAccountRights)
+	c := &MembershipChain{
+		RightsOnEntity:    &directAccountRights,
+		EntityIdentifiers: buildIdentifiers(m.EntityType, m.EntityFriendlyID),
 	}
-	if err := query.Scan(&res).Error; err != nil {
+	switch m.DirectAccountType {
+	case "user":
+		c.UserIdentifiers = &ttnpb.UserIdentifiers{UserId: m.DirectAccountFriendlyID}
+	case "organization":
+		if m.IndirectAccountType == "user" {
+			c.UserIdentifiers = &ttnpb.UserIdentifiers{UserId: m.IndirectAccountFriendlyID}
+			c.RightsOnOrganization = &indirectAccountRights
+		}
+		c.OrganizationIdentifiers = &ttnpb.OrganizationIdentifiers{OrganizationId: m.DirectAccountFriendlyID}
+	}
+	return c
+}
+
+// MembershipChain is a User -> (Membership -> Organization) -> Membership -> Entity chain.
+type MembershipChain struct {
+	UserIdentifiers         *ttnpb.UserIdentifiers
+	RightsOnOrganization    *ttnpb.Rights
+	OrganizationIdentifiers *ttnpb.OrganizationIdentifiers
+	RightsOnEntity          *ttnpb.Rights
+	EntityIdentifiers       *ttnpb.EntityIdentifiers
+}
+
+// GetRights returns the intersected rights.
+func (m *MembershipChain) GetRights() *ttnpb.Rights {
+	if m.RightsOnOrganization == nil {
+		return m.RightsOnEntity.Implied()
+	}
+	return m.RightsOnEntity.Implied().Intersect(m.RightsOnOrganization.Implied())
+}
+
+// MembershipChains is a list of membership chains.
+type MembershipChains []*MembershipChain
+
+// GetRights returns the rights of the member on the entity.
+func (c MembershipChains) GetRights(member *ttnpb.OrganizationOrUserIdentifiers, entityID ttnpb.IDStringer) *ttnpb.Rights {
+	var entityRights *ttnpb.Rights
+	for _, membership := range c {
+		switch member.EntityType() {
+		case "organization":
+			if membership.OrganizationIdentifiers == nil || membership.OrganizationIdentifiers.IDString() != member.IDString() {
+				continue
+			}
+		case "user":
+			if membership.UserIdentifiers == nil || membership.UserIdentifiers.IDString() != member.IDString() {
+				continue
+			}
+		default:
+			continue
+		}
+		if membership.EntityIdentifiers.EntityType() != entityID.EntityType() || membership.EntityIdentifiers.IDString() != entityID.IDString() {
+			continue
+		}
+		entityRights = entityRights.Union(membership.GetRights())
+	}
+	return entityRights
+}
+
+func (s *membershipStore) FindAccountMembershipChains(ctx context.Context, accountID *ttnpb.OrganizationOrUserIdentifiers, entityType string, entityIDs ...string) ([]*MembershipChain, error) {
+	defer trace.StartRegion(ctx, fmt.Sprintf("find membership chains of user on %ss", entityType)).End()
+	query := s.queryMemberships(ctx, accountID, entityType, entityIDs, true)
+	var results []membershipChain
+	if err := query.Scan(&results).Error; err != nil {
 		return nil, err
 	}
-	commonOrganizations := make([]IndirectMembership, len(res))
-	for i, res := range res {
-		usrRights, entityRights := ttnpb.Rights(res.UsrRights), ttnpb.Rights(res.EntityRights)
-		commonOrganizations[i] = IndirectMembership{
-			RightsOnOrganization:    &usrRights,
-			OrganizationIdentifiers: &ttnpb.OrganizationIdentifiers{OrganizationId: res.OrganizationID},
-			OrganizationRights:      &entityRights,
-		}
+	chains := make([]*MembershipChain, len(results))
+	for i, result := range results {
+		chains[i] = result.GetMembershipChain()
 	}
-	return commonOrganizations, nil
+	return chains, nil
 }
 
 func (s *membershipStore) FindMembers(ctx context.Context, entityID *ttnpb.EntityIdentifiers) (map[*ttnpb.OrganizationOrUserIdentifiers]*ttnpb.Rights, error) {
 	defer trace.StartRegion(ctx, fmt.Sprintf("find members of %s", entityID.EntityType())).End()
-	entityQuery := s.query(ctx, modelForID(entityID), withID(entityID)).
-		Select(fmt.Sprintf(`"%ss"."id"`, entityID.EntityType())).
-		QueryExpr()
-	query := s.query(ctx, Account{}).
-		Select(`"accounts"."uid" AS "uid", "accounts"."account_type" AS "account_type", "memberships"."rights" AS "rights"`).
-		Joins(`JOIN "memberships" ON "memberships"."account_id" = "accounts"."id"`).
-		Where(fmt.Sprintf(`"memberships"."entity_type" = '%s' AND "memberships"."entity_id" = (?)`, entityID.EntityType()), entityQuery).
-		Order(`"uid"`)
+	query := s.queryWithDirectMemberships(ctx, entityID.EntityType(), entityID.IDString()).Order("direct_account_friendly_id")
 	page := query
 	if limit, offset := limitAndOffsetFromContext(ctx); limit != 0 {
 		page = query.Limit(limit).Offset(offset)
 	}
-	var results []struct {
-		UID         string
-		AccountType string
-		Rights      Rights
-	}
+	var results []membershipChain
 	if err := page.Scan(&results).Error; err != nil {
 		return nil, err
 	}
@@ -208,9 +244,14 @@ func (s *membershipStore) FindMembers(ctx context.Context, entityID *ttnpb.Entit
 	}
 	membershipRights := make(map[*ttnpb.OrganizationOrUserIdentifiers]*ttnpb.Rights, len(results))
 	for _, result := range results {
-		ids := Account{AccountType: result.AccountType, UID: result.UID}.OrganizationOrUserIdentifiers()
-		rights := ttnpb.Rights(result.Rights)
-		membershipRights[ids] = &rights
+		chain := result.GetMembershipChain()
+		var ids *ttnpb.OrganizationOrUserIdentifiers
+		if chain.OrganizationIdentifiers != nil {
+			ids = chain.OrganizationIdentifiers.GetOrganizationOrUserIdentifiers()
+		} else {
+			ids = chain.UserIdentifiers.GetOrganizationOrUserIdentifiers()
+		}
+		membershipRights[ids] = chain.RightsOnEntity
 	}
 	return membershipRights, nil
 }
@@ -222,31 +263,23 @@ var errMembershipNotFound = errors.DefineNotFound(
 
 func (s *membershipStore) GetMember(ctx context.Context, id *ttnpb.OrganizationOrUserIdentifiers, entityID *ttnpb.EntityIdentifiers) (*ttnpb.Rights, error) {
 	defer trace.StartRegion(ctx, "get membership").End()
-	accountQuery := s.query(ctx, Account{}).
-		Select(`"accounts"."id"`).
-		Where(fmt.Sprintf(`"accounts"."account_type" = '%s' AND "accounts"."uid" = ?`, id.EntityType()), id.IDString()).
-		QueryExpr()
-	entityQuery := s.query(ctx, modelForID(entityID), withID(entityID)).
-		Select(fmt.Sprintf(`"%ss"."id"`, entityID.EntityType())).
-		QueryExpr()
-	query := s.query(ctx, &Membership{}).
-		Select(`"memberships"."rights"`).
-		Where(`"memberships"."account_id" = (?)`, accountQuery).
-		Where(fmt.Sprintf(`"memberships"."entity_type" = '%s' AND "memberships"."entity_id" = (?)`, entityID.EntityType()), entityQuery)
-	var membership Membership
-	err := query.First(&membership).Error
-	if err != nil {
-		if gorm.IsRecordNotFoundError(err) {
-			return nil, errMembershipNotFound.WithAttributes(
-				"account_id", id.IDString(),
-				"entity_type", entityID.EntityType(),
-				"entity_id", entityID.IDString(),
-			)
-		}
+	query := s.queryWithDirectMemberships(ctx, entityID.EntityType(), entityID.IDString()).Where(
+		fmt.Sprintf(`"direct_accounts"."account_type" = '%s' AND "direct_accounts"."uid" = ?`, id.EntityType()),
+		id.IDString(),
+	)
+	var results []membershipChain
+	executedQuery := query.Scan(&results)
+	if err := executedQuery.Error; err != nil {
 		return nil, err
 	}
-	rights := ttnpb.Rights(membership.Rights)
-	return &rights, nil
+	if len(results) != 1 {
+		return nil, errMembershipNotFound.WithAttributes(
+			"account_id", id.IDString(),
+			"entity_type", entityID.EntityType(),
+			"entity_id", entityID.IDString(),
+		)
+	}
+	return results[0].GetMembershipChain().RightsOnEntity, nil
 }
 
 var errAccountType = errors.DefineInvalidArgument(
@@ -256,6 +289,7 @@ var errAccountType = errors.DefineInvalidArgument(
 
 func (s *membershipStore) SetMember(ctx context.Context, id *ttnpb.OrganizationOrUserIdentifiers, entityID *ttnpb.EntityIdentifiers, rights *ttnpb.Rights) error {
 	defer trace.StartRegion(ctx, "update membership").End()
+
 	var account Account
 	err := s.query(ctx, Account{}).Where(Account{
 		UID:         id.IDString(),
@@ -267,6 +301,10 @@ func (s *membershipStore) SetMember(ctx context.Context, id *ttnpb.OrganizationO
 		}
 		return err
 	}
+	if err := ctx.Err(); err != nil { // Early exit if context canceled
+		return err
+	}
+
 	entity, err := s.findEntity(ctx, entityID, "id")
 	if err != nil {
 		return err
@@ -278,19 +316,19 @@ func (s *membershipStore) SetMember(ctx context.Context, id *ttnpb.OrganizationO
 		return err
 	}
 
-	query := s.query(ctx, Membership{})
-	var membership Membership
-	err = query.Where(&Membership{
+	var (
+		membership  Membership
+		upsertQuery = s.query(ctx, Membership{})
+	)
+	err = s.query(ctx, Membership{}).Where(&Membership{
 		AccountID:  account.PrimaryKey(),
 		EntityID:   entity.PrimaryKey(),
 		EntityType: entityTypeForID(entityID),
 	}).First(&membership).Error
-	if err == nil {
-		if len(rights.Rights) == 0 {
-			return query.Delete(&membership).Error
+	if err != nil {
+		if !gorm.IsRecordNotFoundError(err) {
+			return err
 		}
-		query = query.Select("rights", "updated_at")
-	} else if gorm.IsRecordNotFoundError(err) {
 		if len(rights.Rights) == 0 {
 			return err
 		}
@@ -300,17 +338,14 @@ func (s *membershipStore) SetMember(ctx context.Context, id *ttnpb.OrganizationO
 			EntityType: entityTypeForID(entityID),
 		}
 		membership.SetContext(ctx)
-	} else if gorm.IsRecordNotFoundError(err) {
-		return errMembershipNotFound.WithAttributes(
-			"account_id", id.IDString(),
-			"entity_type", entityID.EntityType(),
-			"entity_id", entityID.IDString(),
-		)
 	} else {
-		return err
+		upsertQuery = upsertQuery.Select("updated_at", "rights")
+	}
+	if len(rights.Rights) == 0 {
+		return upsertQuery.Delete(&membership).Error
 	}
 	membership.Rights = Rights(*rights)
-	return query.Save(&membership).Error
+	return upsertQuery.Save(&membership).Error
 }
 
 func (s *membershipStore) DeleteEntityMembers(ctx context.Context, entityID *ttnpb.EntityIdentifiers) error {

--- a/pkg/identityserver/store/membership_store_test.go
+++ b/pkg/identityserver/store/membership_store_test.go
@@ -75,10 +75,18 @@ func TestFindIndirectMemberships(t *testing.T) {
 			Rights:     Rights{Rights: []ttnpb.Right{6, 7}},
 		})
 
-		common, err := store.FindIndirectMemberships(ctx, &ttnpb.UserIdentifiers{UserId: "test-user"}, (&ttnpb.ApplicationIdentifiers{ApplicationId: "test-app"}).GetEntityIdentifiers())
+		{
+			common, err := store.FindAccountMembershipChains(ctx, ttnpb.UserIdentifiers{UserId: "test-user"}.OrganizationOrUserIdentifiers(), "application", "test-app")
+			if a.So(err, should.BeNil) {
+				a.So(common, should.HaveLength, 2)
+			}
+		}
 
-		if a.So(err, should.BeNil) {
-			a.So(common, should.HaveLength, 2)
+		{
+			common, err := store.FindAccountMembershipChains(ctx, ttnpb.OrganizationIdentifiers{OrganizationId: "test-org-1"}.OrganizationOrUserIdentifiers(), "application", "test-app")
+			if a.So(err, should.BeNil) {
+				a.So(common, should.HaveLength, 1)
+			}
 		}
 	})
 }

--- a/pkg/identityserver/store/store_interfaces.go
+++ b/pkg/identityserver/store/store_interfaces.go
@@ -129,8 +129,9 @@ type UserSessionStore interface {
 type MembershipStore interface {
 	// Find direct and optionally also indirect memberships of the organization or user.
 	FindMemberships(ctx context.Context, id *ttnpb.OrganizationOrUserIdentifiers, entityType string, includeIndirect bool) ([]*ttnpb.EntityIdentifiers, error)
-	// Find indirect memberships (through organizations) between the user and entity.
-	FindIndirectMemberships(ctx context.Context, userID *ttnpb.UserIdentifiers, entityID *ttnpb.EntityIdentifiers) ([]IndirectMembership, error)
+
+	// Find memberships (through organizations) between the user and entity.
+	FindAccountMembershipChains(ctx context.Context, accountID *ttnpb.OrganizationOrUserIdentifiers, entityType string, entityIDs ...string) ([]*MembershipChain, error)
 
 	// Find direct members and rights of the given entity.
 	FindMembers(ctx context.Context, entityID *ttnpb.EntityIdentifiers) (map[*ttnpb.OrganizationOrUserIdentifiers]*ttnpb.Rights, error)

--- a/pkg/identityserver/utils.go
+++ b/pkg/identityserver/utils.go
@@ -74,3 +74,11 @@ func validateContactInfo(info []*ttnpb.ContactInfo) error {
 func setTotalHeader(ctx context.Context, total uint64) {
 	grpc.SetHeader(ctx, metadata.Pairs("x-total-count", strconv.FormatUint(total, 10)))
 }
+
+func idStrings(entityIDs ...*ttnpb.EntityIdentifiers) []string {
+	idStrings := make([]string, len(entityIDs))
+	for i, entityID := range entityIDs {
+		idStrings[i] = entityID.IDString()
+	}
+	return idStrings
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request rewrites membership queries in the Identity Server so that we can use the same (single) (sub)query in multiple places:

1. Listing all entities of a user / organization
2. Searching for all entities of a user / organization
3. Listing (indirect) rights of a user / organization on one or more entities

Closes #3304

#### Changes
<!-- What are the changes made in this pull request? -->

Exactly what the commit messages say:

- Rewrite membership lookup queries in the IS
- Find membership chains in a single query
- Execute single rights query for all results in list and search requests

#### Testing

<!-- How did you verify that this change works? -->

This should be covered by existing unit tests. Also did some testing with the Console.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Rights handling for admin users, and callers that use cluster auth is slightly different. With manual testing in the Console I verified that everything still works as expected for admin users. We should pay some extra attention to #4653 (cc: @pgalic96) because that PR adds cluster auth support to Application and EndDevice registries.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The essence of this PR is that one query. Here's what the query looks like when determining the rights of user XXX on applications YYY and ZZZ. 

```sql
SELECT
    "indirect_accounts"."account_type" "indirect_account_type",
    "indirect_accounts"."uid" "indirect_account_friendly_id",
    "indirect_memberships"."rights" "indirect_account_rights",
    "direct_accounts"."account_type" "direct_account_type",
    "direct_accounts"."uid" "direct_account_friendly_id",
    "direct_memberships"."rights" "direct_account_rights",
    "direct_memberships"."entity_type" "entity_type",
    "applications"."application_id" "entity_friendly_id"
FROM
    "applications"
    JOIN "memberships" "direct_memberships" ON "direct_memberships"."entity_id" = "applications"."id"
    AND "direct_memberships"."entity_type" = 'application'
    JOIN "accounts" "direct_accounts" ON "direct_accounts"."id" = "direct_memberships"."account_id"
    LEFT JOIN "memberships" "indirect_memberships" ON "indirect_memberships"."entity_id" = "direct_accounts"."account_id"
    AND "indirect_memberships"."entity_type" = "direct_accounts"."account_type"
    LEFT JOIN "accounts" "indirect_accounts" ON "indirect_accounts"."id" = "indirect_memberships"."account_id"
WHERE
    "applications"."deleted_at" IS NULL
    AND "direct_accounts"."deleted_at" IS NULL
    AND "indirect_accounts"."deleted_at" IS NULL
    AND "applications"."application_id" IN ( YYY, ZZZ )
    AND (
            ("direct_accounts"."account_type" = 'user' AND "direct_accounts"."uid" = XXX)
        OR 
            ("indirect_accounts"."account_type" = 'user' AND "indirect_accounts"."uid" = XXX)
        )
```

The other main functionality is in the `membershipChain`, `MembershipChain` and `MembershipChains` types.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
