### PR TITLE
Fix NS panic due to nil session

### DIFF
--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -1013,7 +1013,7 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 	if st.HasSetField("ids.dev_addr") {
 		if err := st.ValidateField(func(dev *ttnpb.EndDevice) bool {
 			if st.Device.DevAddr == nil {
-				return dev.Session == nil
+				return dev.GetSession() == nil
 			}
 			return dev.GetSession() != nil && dev.Session.DevAddr.Equal(*st.Device.DevAddr)
 		}, "session.dev_addr"); err != nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/4731

#### Changes
<!-- What are the changes made in this pull request? -->

- Use `GetSession` instead of direct access to the session field


#### Testing

<!-- How did you verify that this change works? -->

Use reproduction in issue.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This ensures that the validator still works if the device is not updated, but instead created. No regressions expected.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
