### PR TITLE
Lock based concurrency

### DIFF
--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -294,9 +294,14 @@ var startCommand = &cobra.Command{
 			config.AS.Links = &asredis.LinkRegistry{
 				Redis: redis.New(config.Redis.WithNamespace("as", "links")),
 			}
-			config.AS.Devices = &asredis.DeviceRegistry{
-				Redis: NewComponentDeviceRegistryRedis(*config, "as"),
+			deviceRegistry := &asredis.DeviceRegistry{
+				Redis:   NewComponentDeviceRegistryRedis(*config, "as"),
+				LockTTL: defaultLockTTL,
 			}
+			if err := deviceRegistry.Init(ctx); err != nil {
+				return shared.ErrInitializeApplicationServer.WithCause(err)
+			}
+			config.AS.Devices = deviceRegistry
 			config.AS.UplinkStorage.Registry = &asredis.ApplicationUplinkRegistry{
 				Redis: redis.New(config.Redis.WithNamespace("as", "applicationups")),
 				Limit: config.AS.UplinkStorage.Limit,

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -291,9 +291,14 @@ var startCommand = &cobra.Command{
 
 		if start.ApplicationServer {
 			logger.Info("Setting up Application Server")
-			config.AS.Links = &asredis.LinkRegistry{
-				Redis: redis.New(config.Redis.WithNamespace("as", "links")),
+			linkRegistry := &asredis.LinkRegistry{
+				Redis:   redis.New(config.Redis.WithNamespace("as", "links")),
+				LockTTL: defaultLockTTL,
 			}
+			if err := linkRegistry.Init(ctx); err != nil {
+				return shared.ErrInitializeApplicationServer.WithCause(err)
+			}
+			config.AS.Links = linkRegistry
 			deviceRegistry := &asredis.DeviceRegistry{
 				Redis:   NewComponentDeviceRegistryRedis(*config, "as"),
 				LockTTL: defaultLockTTL,

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -337,9 +337,14 @@ var startCommand = &cobra.Command{
 				return shared.ErrInitializeJoinServer.WithCause(err)
 			}
 			config.JS.Devices = deviceRegistry
-			config.JS.Keys = &jsredis.KeyRegistry{
-				Redis: redis.New(config.Redis.WithNamespace("js", "keys")),
+			keyRegistry := &jsredis.KeyRegistry{
+				Redis:   redis.New(config.Redis.WithNamespace("js", "keys")),
+				LockTTL: defaultLockTTL,
 			}
+			if err := keyRegistry.Init(ctx); err != nil {
+				return shared.ErrInitializeJoinServer.WithCause(err)
+			}
+			config.JS.Keys = keyRegistry
 			config.JS.ApplicationActivationSettings = &jsredis.ApplicationActivationSettingRegistry{
 				Redis: redis.New(config.Redis.WithNamespace("js", "application-activation-settings")),
 			}

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -329,9 +329,14 @@ var startCommand = &cobra.Command{
 
 		if start.JoinServer {
 			logger.Info("Setting up Join Server")
-			config.JS.Devices = &jsredis.DeviceRegistry{
-				Redis: NewComponentDeviceRegistryRedis(*config, "js"),
+			deviceRegistry := &jsredis.DeviceRegistry{
+				Redis:   NewComponentDeviceRegistryRedis(*config, "js"),
+				LockTTL: defaultLockTTL,
 			}
+			if err := deviceRegistry.Init(ctx); err != nil {
+				return shared.ErrInitializeJoinServer.WithCause(err)
+			}
+			config.JS.Devices = deviceRegistry
 			config.JS.Keys = &jsredis.KeyRegistry{
 				Redis: redis.New(config.Redis.WithNamespace("js", "keys")),
 			}

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -345,9 +345,14 @@ var startCommand = &cobra.Command{
 				return shared.ErrInitializeJoinServer.WithCause(err)
 			}
 			config.JS.Keys = keyRegistry
-			config.JS.ApplicationActivationSettings = &jsredis.ApplicationActivationSettingRegistry{
-				Redis: redis.New(config.Redis.WithNamespace("js", "application-activation-settings")),
+			applicationActivationSettingRegistry := &jsredis.ApplicationActivationSettingRegistry{
+				Redis:   redis.New(config.Redis.WithNamespace("js", "application-activation-settings")),
+				LockTTL: defaultLockTTL,
 			}
+			if err := applicationActivationSettingRegistry.Init(ctx); err != nil {
+				return shared.ErrInitializeJoinServer.WithCause(err)
+			}
+			config.JS.ApplicationActivationSettings = applicationActivationSettingRegistry
 			js, err := joinserver.New(c, &config.JS)
 			if err != nil {
 				return shared.ErrInitializeJoinServer.WithCause(err)

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -225,9 +225,14 @@ var startCommand = &cobra.Command{
 			logger.Info("Setting up Gateway Server")
 			switch config.Cache.Service {
 			case "redis":
-				config.GS.Stats = &gsredis.GatewayConnectionStatsRegistry{
-					Redis: redis.New(config.Cache.Redis.WithNamespace("gs", "cache", "connstats")),
+				gatewayConnectionStatsRegistry := &gsredis.GatewayConnectionStatsRegistry{
+					Redis:   redis.New(config.Cache.Redis.WithNamespace("gs", "cache", "connstats")),
+					LockTTL: defaultLockTTL,
 				}
+				if err := gatewayConnectionStatsRegistry.Init(ctx); err != nil {
+					return shared.ErrInitializeGatewayServer.WithCause(err)
+				}
+				config.GS.Stats = gatewayConnectionStatsRegistry
 			}
 			gs, err := gatewayserver.New(c, &config.GS)
 			if err != nil {

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -50,6 +50,8 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/web"
 )
 
+const defaultLockTTL = 10 * time.Second
+
 func NewComponentDeviceRegistryRedis(conf Config, name string) *redis.Client {
 	return redis.New(conf.Redis.WithNamespace(name, "devices"))
 }
@@ -254,7 +256,7 @@ var startCommand = &cobra.Command{
 			config.NS.ApplicationUplinkQueue.Queue = applicationUplinkQueue
 			devices := &nsredis.DeviceRegistry{
 				Redis:   NewNetworkServerDeviceRegistryRedis(*config),
-				LockTTL: time.Second,
+				LockTTL: defaultLockTTL,
 			}
 			if err := devices.Init(ctx); err != nil {
 				return shared.ErrInitializeNetworkServer.WithCause(err)
@@ -302,7 +304,7 @@ var startCommand = &cobra.Command{
 			}
 			applicationPackagesRegistry := &asioapredis.ApplicationPackagesRegistry{
 				Redis:   redis.New(config.Redis.WithNamespace("as", "io", "applicationpackages")),
-				LockTTL: 10 * time.Second,
+				LockTTL: defaultLockTTL,
 			}
 			if err := applicationPackagesRegistry.Init(ctx); err != nil {
 				return shared.ErrInitializeApplicationServer.WithCause(err)

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -314,9 +314,14 @@ var startCommand = &cobra.Command{
 			config.AS.Distribution.PubSub = &asdistribredis.PubSub{
 				Redis: redis.New(config.Cache.Redis.WithNamespace("as", "traffic")),
 			}
-			config.AS.PubSub.Registry = &asiopsredis.PubSubRegistry{
-				Redis: redis.New(config.Redis.WithNamespace("as", "io", "pubsub")),
+			pubsubRegistry := &asiopsredis.PubSubRegistry{
+				Redis:   redis.New(config.Redis.WithNamespace("as", "io", "pubsub")),
+				LockTTL: defaultLockTTL,
 			}
+			if err := pubsubRegistry.Init(ctx); err != nil {
+				return shared.ErrInitializeApplicationServer.WithCause(err)
+			}
+			config.AS.PubSub.Registry = pubsubRegistry
 			applicationPackagesRegistry := &asioapredis.ApplicationPackagesRegistry{
 				Redis:   redis.New(config.Redis.WithNamespace("as", "io", "applicationpackages")),
 				LockTTL: defaultLockTTL,

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -326,9 +326,14 @@ var startCommand = &cobra.Command{
 			}
 			config.AS.Packages.Registry = applicationPackagesRegistry
 			if config.AS.Webhooks.Target != "" {
-				config.AS.Webhooks.Registry = &asiowebredis.WebhookRegistry{
-					Redis: redis.New(config.Redis.WithNamespace("as", "io", "webhooks")),
+				webhookRegistry := &asiowebredis.WebhookRegistry{
+					Redis:   redis.New(config.Redis.WithNamespace("as", "io", "webhooks")),
+					LockTTL: defaultLockTTL,
 				}
+				if err := webhookRegistry.Init(ctx); err != nil {
+					return shared.ErrInitializeApplicationServer.WithCause(err)
+				}
+				config.AS.Webhooks.Registry = webhookRegistry
 			}
 			fetcher, err := config.AS.EndDeviceFetcher.NewFetcher(c)
 			if err != nil {

--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -190,7 +190,10 @@ func TestApplicationServer(t *testing.T) {
 	linksRedisClient, linksFlush := test.NewRedis(ctx, "applicationserver_test", "links")
 	defer linksFlush()
 	defer linksRedisClient.Close()
-	linkRegistry := &redis.LinkRegistry{Redis: linksRedisClient}
+	linkRegistry := &redis.LinkRegistry{Redis: linksRedisClient, LockTTL: test.Delay << 10}
+	if err := linkRegistry.Init(ctx); !a.So(err, should.BeNil) {
+		t.FailNow()
+	}
 	_, err := linkRegistry.Set(ctx, registeredApplicationID, nil, func(_ *ttnpb.ApplicationLink) (*ttnpb.ApplicationLink, []string, error) {
 		return &ttnpb.ApplicationLink{
 			DefaultFormatters: &ttnpb.MessagePayloadFormatters{
@@ -2282,7 +2285,10 @@ func TestSkipPayloadCrypto(t *testing.T) {
 	linksRedisClient, linksFlush := test.NewRedis(ctx, "applicationserver_test", "links")
 	defer linksFlush()
 	defer linksRedisClient.Close()
-	linkRegistry := &redis.LinkRegistry{Redis: linksRedisClient}
+	linkRegistry := &redis.LinkRegistry{Redis: linksRedisClient, LockTTL: test.Delay << 10}
+	if err := linkRegistry.Init(ctx); !a.So(err, should.BeNil) {
+		t.FailNow()
+	}
 	_, err := linkRegistry.Set(ctx, registeredApplicationID, nil, func(_ *ttnpb.ApplicationLink) (*ttnpb.ApplicationLink, []string, error) {
 		return &ttnpb.ApplicationLink{
 			SkipPayloadCrypto: &pbtypes.BoolValue{Value: true},
@@ -2774,7 +2780,10 @@ func TestLocationFromPayload(t *testing.T) {
 	linksRedisClient, linksFlush := test.NewRedis(ctx, "applicationserver_test", "links")
 	defer linksFlush()
 	defer linksRedisClient.Close()
-	linkRegistry := &redis.LinkRegistry{Redis: linksRedisClient}
+	linkRegistry := &redis.LinkRegistry{Redis: linksRedisClient, LockTTL: test.Delay << 10}
+	if err := linkRegistry.Init(ctx); !a.So(err, should.BeNil) {
+		t.FailNow()
+	}
 	_, err = linkRegistry.Set(ctx, registeredApplicationID, nil, func(_ *ttnpb.ApplicationLink) (*ttnpb.ApplicationLink, []string, error) {
 		return &ttnpb.ApplicationLink{}, nil, nil
 	})

--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -182,7 +182,10 @@ func TestApplicationServer(t *testing.T) {
 	devsRedisClient, devsFlush := test.NewRedis(ctx, "applicationserver_test", "devices")
 	defer devsFlush()
 	defer devsRedisClient.Close()
-	deviceRegistry := &redis.DeviceRegistry{Redis: devsRedisClient}
+	deviceRegistry := &redis.DeviceRegistry{Redis: devsRedisClient, LockTTL: test.Delay << 10}
+	if err := deviceRegistry.Init(ctx); !a.So(err, should.BeNil) {
+		t.FailNow()
+	}
 
 	linksRedisClient, linksFlush := test.NewRedis(ctx, "applicationserver_test", "links")
 	defer linksFlush()
@@ -2271,7 +2274,10 @@ func TestSkipPayloadCrypto(t *testing.T) {
 	devsRedisClient, devsFlush := test.NewRedis(ctx, "applicationserver_test", "devices")
 	defer devsFlush()
 	defer devsRedisClient.Close()
-	deviceRegistry := &redis.DeviceRegistry{Redis: devsRedisClient}
+	deviceRegistry := &redis.DeviceRegistry{Redis: devsRedisClient, LockTTL: test.Delay << 10}
+	if err := deviceRegistry.Init(ctx); !a.So(err, should.BeNil) {
+		t.FailNow()
+	}
 
 	linksRedisClient, linksFlush := test.NewRedis(ctx, "applicationserver_test", "links")
 	defer linksFlush()
@@ -2754,7 +2760,10 @@ func TestLocationFromPayload(t *testing.T) {
 	devsRedisClient, devsFlush := test.NewRedis(ctx, "applicationserver_test", "devices")
 	defer devsFlush()
 	defer devsRedisClient.Close()
-	deviceRegistry := &redis.DeviceRegistry{Redis: devsRedisClient}
+	deviceRegistry := &redis.DeviceRegistry{Redis: devsRedisClient, LockTTL: test.Delay << 10}
+	if err := deviceRegistry.Init(ctx); !a.So(err, should.BeNil) {
+		t.FailNow()
+	}
 	_, err := deviceRegistry.Set(ctx, registeredDevice.EndDeviceIdentifiers, nil, func(ed *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
 		return registeredDevice, []string{"ids", "session", "formatters"}, nil
 	})

--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -225,7 +225,10 @@ func TestApplicationServer(t *testing.T) {
 	pubsubRedisClient, pubsubFlush := test.NewRedis(ctx, "applicationserver_test", "pubsub")
 	defer pubsubFlush()
 	defer pubsubRedisClient.Close()
-	pubsubRegistry := iopubsubredis.PubSubRegistry{Redis: pubsubRedisClient}
+	pubsubRegistry := iopubsubredis.PubSubRegistry{Redis: pubsubRedisClient, LockTTL: test.Delay << 10}
+	if err := pubsubRegistry.Init(ctx); !a.So(err, should.BeNil) {
+		t.FailNow()
+	}
 
 	distribRedisClient, distribFlush := test.NewRedis(ctx, "applicationserver_test", "traffic")
 	defer distribFlush()

--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -217,7 +217,10 @@ func TestApplicationServer(t *testing.T) {
 	webhooksRedisClient, webhooksFlush := test.NewRedis(ctx, "applicationserver_test", "webhooks")
 	defer webhooksFlush()
 	defer webhooksRedisClient.Close()
-	webhookRegistry := iowebredis.WebhookRegistry{Redis: webhooksRedisClient}
+	webhookRegistry := iowebredis.WebhookRegistry{Redis: webhooksRedisClient, LockTTL: test.Delay << 10}
+	if err := webhookRegistry.Init(ctx); !a.So(err, should.BeNil) {
+		t.FailNow()
+	}
 
 	pubsubRedisClient, pubsubFlush := test.NewRedis(ctx, "applicationserver_test", "pubsub")
 	defer pubsubFlush()

--- a/pkg/applicationserver/io/packages/redis/registry.go
+++ b/pkg/applicationserver/io/packages/redis/registry.go
@@ -461,7 +461,7 @@ func (r ApplicationPackagesRegistry) SetDefaultAssociation(ctx context.Context, 
 				return err
 			}
 		}
-		_, err = tx.Pipelined(ctx, pipelined)
+		_, err = tx.TxPipelined(ctx, pipelined)
 		if err != nil {
 			return err
 		}

--- a/pkg/applicationserver/io/pubsub/integrate_test.go
+++ b/pkg/applicationserver/io/pubsub/integrate_test.go
@@ -66,7 +66,11 @@ func TestIntegrate(t *testing.T) {
 	redisClient, flush := test.NewRedis(ctx, "applicationserver_test")
 	defer flush()
 	defer redisClient.Close()
-	pubsubRegistry := &redis.PubSubRegistry{Redis: redisClient}
+	pubsubRegistry := &redis.PubSubRegistry{Redis: redisClient, LockTTL: test.Delay << 10}
+	if err := pubsubRegistry.Init(ctx); !a.So(err, should.BeNil) {
+		t.FailNow()
+	}
+
 	_, err = pubsubRegistry.Set(ctx, ps1, paths, func(_ *ttnpb.ApplicationPubSub) (*ttnpb.ApplicationPubSub, []string, error) {
 		return &ttnpb.ApplicationPubSub{
 			ApplicationPubSubIdentifiers: ps1,

--- a/pkg/applicationserver/io/pubsub/pubsub_test.go
+++ b/pkg/applicationserver/io/pubsub/pubsub_test.go
@@ -47,7 +47,11 @@ func TestPubSub(t *testing.T) {
 	defer flush()
 	defer redisClient.Close()
 	registry := &redis.PubSubRegistry{
-		Redis: redisClient,
+		Redis:   redisClient,
+		LockTTL: test.Delay << 10,
+	}
+	if err := registry.Init(ctx); !a.So(err, should.BeNil) {
+		t.FailNow()
 	}
 	ids := ttnpb.ApplicationPubSubIdentifiers{
 		ApplicationIdentifiers: registeredApplicationID,

--- a/pkg/applicationserver/io/pubsub/redis/registry.go
+++ b/pkg/applicationserver/io/pubsub/redis/registry.go
@@ -16,10 +16,14 @@ package redis
 
 import (
 	"context"
+	"io"
+	"math/rand"
+	"sync"
 	"time"
 
 	"github.com/go-redis/redis/v8"
 	"github.com/gogo/protobuf/proto"
+	"github.com/oklog/ulid/v2"
 	"go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io/pubsub"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	ttnredis "go.thethings.network/lorawan-stack/v3/pkg/redis"
@@ -52,7 +56,21 @@ func applyPubSubFieldMask(dst, src *ttnpb.ApplicationPubSub, paths ...string) (*
 
 // PubSubRegistry is a Redis pub/sub registry.
 type PubSubRegistry struct {
-	Redis *ttnredis.Client
+	Redis   *ttnredis.Client
+	LockTTL time.Duration
+
+	entropyMu *sync.Mutex
+	entropy   io.Reader
+}
+
+// Init initializes the PubSubRegistry.
+func (r *PubSubRegistry) Init(ctx context.Context) error {
+	if err := ttnredis.InitMutex(ctx, r.Redis); err != nil {
+		return err
+	}
+	r.entropyMu = &sync.Mutex{}
+	r.entropy = ulid.Monotonic(rand.New(rand.NewSource(time.Now().UnixNano())), 1000)
+	return nil
 }
 
 func (r *PubSubRegistry) allKey(ctx context.Context) string {
@@ -144,8 +162,13 @@ func (r PubSubRegistry) Set(ctx context.Context, ids ttnpb.ApplicationPubSubIden
 	appUID := unique.ID(ctx, ids.ApplicationIdentifiers)
 	ik := r.uidKey(appUID, ids.PubSubId)
 
+	lockerID, err := ttnredis.GenerateLockerID(r.entropy, r.entropyMu)
+	if err != nil {
+		return nil, err
+	}
+
 	var pb *ttnpb.ApplicationPubSub
-	err := r.Redis.Watch(ctx, func(tx *redis.Tx) error {
+	err = ttnredis.LockedWatch(ctx, r.Redis, ik, lockerID, r.LockTTL, func(tx *redis.Tx) error {
 		cmd := ttnredis.GetProto(ctx, tx, ik)
 		stored := &ttnpb.ApplicationPubSub{}
 		if err := cmd.ScanProto(stored); errors.IsNotFound(err) {
@@ -262,7 +285,7 @@ func (r PubSubRegistry) Set(ctx context.Context, ids ttnpb.ApplicationPubSubIden
 			return err
 		}
 		return nil
-	}, ik)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/applicationserver/io/web/grpc_webhooks_test.go
+++ b/pkg/applicationserver/io/web/grpc_webhooks_test.go
@@ -55,7 +55,10 @@ func TestWebhookRegistryRPC(t *testing.T) {
 	redisClient, flush := test.NewRedis(ctx, "applicationserver_test")
 	defer flush()
 	defer redisClient.Close()
-	webhookReg := &redis.WebhookRegistry{Redis: redisClient}
+	webhookReg := &redis.WebhookRegistry{Redis: redisClient, LockTTL: test.Delay << 10}
+	if err := webhookReg.Init(ctx); !a.So(err, should.BeNil) {
+		t.FailNow()
+	}
 	srv := web.NewWebhookRegistryRPC(webhookReg, nil)
 	c.RegisterGRPC(&mockRegisterer{ctx, srv})
 	componenttest.StartComponent(t, c)

--- a/pkg/applicationserver/io/web/redis/registry.go
+++ b/pkg/applicationserver/io/web/redis/registry.go
@@ -16,10 +16,14 @@ package redis
 
 import (
 	"context"
+	"io"
+	"math/rand"
+	"sync"
 	"time"
 
 	"github.com/go-redis/redis/v8"
 	"github.com/gogo/protobuf/proto"
+	"github.com/oklog/ulid/v2"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	ttnredis "go.thethings.network/lorawan-stack/v3/pkg/redis"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -50,7 +54,21 @@ func applyWebhookFieldMask(dst, src *ttnpb.ApplicationWebhook, paths ...string) 
 
 // WebhookRegistry is a Redis webhook registry.
 type WebhookRegistry struct {
-	Redis *ttnredis.Client
+	Redis   *ttnredis.Client
+	LockTTL time.Duration
+
+	entropyMu *sync.Mutex
+	entropy   io.Reader
+}
+
+// Init initializes the WebhookRegistry.
+func (r *WebhookRegistry) Init(ctx context.Context) error {
+	if err := ttnredis.InitMutex(ctx, r.Redis); err != nil {
+		return err
+	}
+	r.entropyMu = &sync.Mutex{}
+	r.entropy = ulid.Monotonic(rand.New(rand.NewSource(time.Now().UnixNano())), 1000)
+	return nil
 }
 
 func (r *WebhookRegistry) appKey(uid string) string {
@@ -102,8 +120,13 @@ func (r WebhookRegistry) Set(ctx context.Context, ids ttnpb.ApplicationWebhookId
 	appUID := unique.ID(ctx, ids.ApplicationIdentifiers)
 	ik := r.idKey(appUID, ids.WebhookId)
 
+	lockerID, err := ttnredis.GenerateLockerID(r.entropy, r.entropyMu)
+	if err != nil {
+		return nil, err
+	}
+
 	var pb *ttnpb.ApplicationWebhook
-	err := r.Redis.Watch(ctx, func(tx *redis.Tx) error {
+	err = ttnredis.LockedWatch(ctx, r.Redis, ik, lockerID, r.LockTTL, func(tx *redis.Tx) error {
 		cmd := ttnredis.GetProto(ctx, tx, ik)
 		stored := &ttnpb.ApplicationWebhook{}
 		if err := cmd.ScanProto(stored); errors.IsNotFound(err) {
@@ -212,7 +235,7 @@ func (r WebhookRegistry) Set(ctx context.Context, ids ttnpb.ApplicationWebhookId
 			return err
 		}
 		return nil
-	}, ik)
+	})
 	if err != nil {
 		return nil, ttnredis.ConvertError(err)
 	}

--- a/pkg/applicationserver/io/web/webhooks_test.go
+++ b/pkg/applicationserver/io/web/webhooks_test.go
@@ -54,7 +54,7 @@ func createdPooledSink(ctx context.Context, t *testing.T, sink web.Sink) web.Sin
 }
 
 func TestWebhooks(t *testing.T) {
-	_, ctx := test.New(t)
+	a, ctx := test.New(t)
 
 	redisClient, flush := test.NewRedis(ctx, "web_test")
 	defer flush()
@@ -63,7 +63,11 @@ func TestWebhooks(t *testing.T) {
 		PublicAddress: "https://example.com/api/v3",
 	}
 	registry := &redis.WebhookRegistry{
-		Redis: redisClient,
+		Redis:   redisClient,
+		LockTTL: test.Delay << 10,
+	}
+	if err := registry.Init(ctx); !a.So(err, should.BeNil) {
+		t.FailNow()
 	}
 	ids := ttnpb.ApplicationWebhookIdentifiers{
 		ApplicationIdentifiers: registeredApplicationID,

--- a/pkg/applicationserver/redis/registry.go
+++ b/pkg/applicationserver/redis/registry.go
@@ -473,7 +473,7 @@ func (r *ApplicationUplinkRegistry) Push(ctx context.Context, ids ttnpb.EndDevic
 	}
 
 	uidKey := r.uidKey(unique.ID(ctx, ids))
-	_, err = r.Redis.Pipelined(ctx, func(p redis.Pipeliner) error {
+	_, err = r.Redis.TxPipelined(ctx, func(p redis.Pipeliner) error {
 		p.LPush(ctx, uidKey, s)
 		p.LTrim(ctx, uidKey, 0, r.Limit-1)
 		return nil

--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -177,7 +177,11 @@ func TestGatewayServer(t *testing.T) {
 				defer statsFlush()
 				defer statsRedisClient.Close()
 				statsRegistry := &gsredis.GatewayConnectionStatsRegistry{
-					Redis: statsRedisClient,
+					Redis:   statsRedisClient,
+					LockTTL: test.Delay << 10,
+				}
+				if err := statsRegistry.Init(ctx); !a.So(err, should.BeNil) {
+					t.FailNow()
 				}
 				config.Stats = statsRegistry
 			}

--- a/pkg/gatewayserver/redis/registry.go
+++ b/pkg/gatewayserver/redis/registry.go
@@ -16,9 +16,14 @@ package redis
 
 import (
 	"context"
+	"io"
+	"math/rand"
 	"runtime/trace"
+	"sync"
+	"time"
 
 	"github.com/go-redis/redis/v8"
+	"github.com/oklog/ulid/v2"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	ttnredis "go.thethings.network/lorawan-stack/v3/pkg/redis"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -27,7 +32,21 @@ import (
 
 // GatewayConnectionStatsRegistry implements the GatewayConnectionStatsRegistry interface.
 type GatewayConnectionStatsRegistry struct {
-	Redis *ttnredis.Client
+	Redis   *ttnredis.Client
+	LockTTL time.Duration
+
+	entropyMu *sync.Mutex
+	entropy   io.Reader
+}
+
+// Init initializes the GatewayConnectionStatsRegistry.
+func (r *GatewayConnectionStatsRegistry) Init(ctx context.Context) error {
+	if err := ttnredis.InitMutex(ctx, r.Redis); err != nil {
+		return err
+	}
+	r.entropyMu = &sync.Mutex{}
+	r.entropy = ulid.Monotonic(rand.New(rand.NewSource(time.Now().UnixNano())), 1000)
+	return nil
 }
 
 func (r *GatewayConnectionStatsRegistry) key(uid string) string {
@@ -38,25 +57,28 @@ func (r *GatewayConnectionStatsRegistry) key(uid string) string {
 func (r *GatewayConnectionStatsRegistry) Set(ctx context.Context, ids ttnpb.GatewayIdentifiers, stats *ttnpb.GatewayConnectionStats, paths []string) error {
 	uid := unique.ID(ctx, ids)
 
+	lockerID, err := ttnredis.GenerateLockerID(r.entropy, r.entropyMu)
+	if err != nil {
+		return err
+	}
+
 	defer trace.StartRegion(ctx, "set gateway connection stats").End()
 
 	uk := r.key(uid)
-	var err error
 	if stats == nil {
 		err = r.Redis.Del(ctx, uk).Err()
 	} else {
-		err = r.Redis.Watch(ctx, func(tx *redis.Tx) error {
+		err = ttnredis.LockedWatch(ctx, r.Redis, uk, lockerID, r.LockTTL, func(tx *redis.Tx) error {
 			pb := &ttnpb.GatewayConnectionStats{}
 			if err := ttnredis.GetProto(ctx, tx, uk).ScanProto(pb); err != nil && !errors.IsNotFound(err) {
 				return err
 			}
-
 			if err := pb.SetFields(stats, paths...); err != nil {
 				return err
 			}
 			_, err := ttnredis.SetProto(ctx, tx, uk, pb, 0)
 			return err
-		}, uk)
+		})
 	}
 	if err != nil {
 		return ttnredis.ConvertError(err)

--- a/pkg/gatewayserver/redis/registry_test.go
+++ b/pkg/gatewayserver/redis/registry_test.go
@@ -28,7 +28,7 @@ import (
 var Timeout = 10 * test.Delay
 
 func TestRegistry(t *testing.T) {
-	_, ctx := test.New(t)
+	a, ctx := test.New(t)
 	cl, flush := test.NewRedis(ctx, "redis_test")
 	defer flush()
 	defer cl.Close()
@@ -46,7 +46,11 @@ func TestRegistry(t *testing.T) {
 		Eui:       &types.EUI64{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02},
 	}
 	registry := &GatewayConnectionStatsRegistry{
-		Redis: cl,
+		Redis:   cl,
+		LockTTL: test.Delay << 10,
+	}
+	if err := registry.Init(ctx); !a.So(err, should.BeNil) {
+		t.FailNow()
 	}
 
 	now := time.Now().UTC()

--- a/pkg/joinserver/grpc_application_activation_settings_registry_test.go
+++ b/pkg/joinserver/grpc_application_activation_settings_registry_test.go
@@ -40,7 +40,11 @@ func NewRedisApplicationActivationSettingRegistry(ctx context.Context) (Applicat
 	tb := test.MustTBFromContext(ctx)
 	cl, flush := test.NewRedis(ctx, "application-activation-settings")
 	reg := &redis.ApplicationActivationSettingRegistry{
-		Redis: cl,
+		Redis:   cl,
+		LockTTL: test.Delay << 10,
+	}
+	if err := reg.Init(ctx); !assertions.New(tb).So(err, should.BeNil) {
+		tb.FailNow()
 	}
 	return reg,
 		func() {

--- a/pkg/joinserver/joinserver_test.go
+++ b/pkg/joinserver/joinserver_test.go
@@ -145,7 +145,10 @@ func TestInvalidJoinRequests(t *testing.T) {
 				redisClient, flush := test.NewRedis(ctx, "joinserver_test")
 				defer flush()
 				defer redisClient.Close()
-				devReg := &redis.DeviceRegistry{Redis: redisClient}
+				devReg := &redis.DeviceRegistry{Redis: redisClient, LockTTL: test.Delay << 10}
+				if err := devReg.Init(ctx); !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
 				keyReg := &redis.KeyRegistry{Redis: redisClient}
 				aasReg, aasRegCloseFn := NewRedisApplicationActivationSettingRegistry(ctx)
 				defer aasRegCloseFn()
@@ -2042,7 +2045,10 @@ func TestHandleJoin(t *testing.T) {
 				redisClient, flush := test.NewRedis(ctx, "joinserver_test")
 				defer flush()
 				defer redisClient.Close()
-				devReg := &redis.DeviceRegistry{Redis: redisClient}
+				devReg := &redis.DeviceRegistry{Redis: redisClient, LockTTL: test.Delay << 10}
+				if err := devReg.Init(ctx); !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
 				keyReg := &redis.KeyRegistry{Redis: redisClient}
 				aasReg, aasRegCloseFn := NewRedisApplicationActivationSettingRegistry(ctx)
 				defer aasRegCloseFn()

--- a/pkg/joinserver/joinserver_test.go
+++ b/pkg/joinserver/joinserver_test.go
@@ -149,7 +149,10 @@ func TestInvalidJoinRequests(t *testing.T) {
 				if err := devReg.Init(ctx); !a.So(err, should.BeNil) {
 					t.FailNow()
 				}
-				keyReg := &redis.KeyRegistry{Redis: redisClient}
+				keyReg := &redis.KeyRegistry{Redis: redisClient, LockTTL: test.Delay << 10}
+				if err := keyReg.Init(ctx); !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
 				aasReg, aasRegCloseFn := NewRedisApplicationActivationSettingRegistry(ctx)
 				defer aasRegCloseFn()
 
@@ -2049,7 +2052,10 @@ func TestHandleJoin(t *testing.T) {
 				if err := devReg.Init(ctx); !a.So(err, should.BeNil) {
 					t.FailNow()
 				}
-				keyReg := &redis.KeyRegistry{Redis: redisClient}
+				keyReg := &redis.KeyRegistry{Redis: redisClient, LockTTL: test.Delay << 10}
+				if err := keyReg.Init(ctx); !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
 				aasReg, aasRegCloseFn := NewRedisApplicationActivationSettingRegistry(ctx)
 				defer aasRegCloseFn()
 

--- a/pkg/joinserver/redis/registry.go
+++ b/pkg/joinserver/redis/registry.go
@@ -18,14 +18,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"io"
-	"math/rand"
 	"runtime/trace"
-	"sync"
 	"time"
 
 	"github.com/go-redis/redis/v8"
-	"github.com/oklog/ulid/v2"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/provisioning"
 	ttnredis "go.thethings.network/lorawan-stack/v3/pkg/redis"
@@ -47,9 +43,6 @@ var (
 type DeviceRegistry struct {
 	Redis   *ttnredis.Client
 	LockTTL time.Duration
-
-	entropyMu *sync.Mutex
-	entropy   io.Reader
 }
 
 // Init initializes the DeviceRegistry.
@@ -57,8 +50,6 @@ func (r *DeviceRegistry) Init(ctx context.Context) error {
 	if err := ttnredis.InitMutex(ctx, r.Redis); err != nil {
 		return err
 	}
-	r.entropyMu = &sync.Mutex{}
-	r.entropy = ulid.Monotonic(rand.New(rand.NewSource(time.Now().UnixNano())), 1000)
 	return nil
 }
 
@@ -331,7 +322,7 @@ func (r *DeviceRegistry) SetByEUI(ctx context.Context, joinEUI types.EUI64, devE
 	}
 	ek := r.euiKey(joinEUI, devEUI)
 
-	lockerID, err := ttnredis.GenerateLockerID(r.entropy, r.entropyMu)
+	lockerID, err := ttnredis.GenerateLockerID()
 	if err != nil {
 		return nil, err
 	}
@@ -394,9 +385,6 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIde
 type KeyRegistry struct {
 	Redis   *ttnredis.Client
 	LockTTL time.Duration
-
-	entropyMu *sync.Mutex
-	entropy   io.Reader
 }
 
 // Init initializes the KeyRegistry.
@@ -404,8 +392,6 @@ func (r *KeyRegistry) Init(ctx context.Context) error {
 	if err := ttnredis.InitMutex(ctx, r.Redis); err != nil {
 		return err
 	}
-	r.entropyMu = &sync.Mutex{}
-	r.entropy = ulid.Monotonic(rand.New(rand.NewSource(time.Now().UnixNano())), 1000)
 	return nil
 }
 
@@ -435,7 +421,7 @@ func (r *KeyRegistry) SetByID(ctx context.Context, joinEUI, devEUI types.EUI64, 
 	}
 	ik := r.idKey(joinEUI, devEUI, id)
 
-	lockerID, err := ttnredis.GenerateLockerID(r.entropy, r.entropyMu)
+	lockerID, err := ttnredis.GenerateLockerID()
 	if err != nil {
 		return nil, err
 	}
@@ -562,9 +548,6 @@ func filterGetApplicationActivationSettings(pb *ttnpb.ApplicationActivationSetti
 type ApplicationActivationSettingRegistry struct {
 	Redis   *ttnredis.Client
 	LockTTL time.Duration
-
-	entropyMu *sync.Mutex
-	entropy   io.Reader
 }
 
 // Init initializes the ApplicationActivationSettingRegistry.
@@ -572,8 +555,6 @@ func (r *ApplicationActivationSettingRegistry) Init(ctx context.Context) error {
 	if err := ttnredis.InitMutex(ctx, r.Redis); err != nil {
 		return err
 	}
-	r.entropyMu = &sync.Mutex{}
-	r.entropy = ulid.Monotonic(rand.New(rand.NewSource(time.Now().UnixNano())), 1000)
 	return nil
 }
 
@@ -603,7 +584,7 @@ func (r *ApplicationActivationSettingRegistry) SetByID(ctx context.Context, appI
 	}
 	uk := r.uidKey(unique.ID(ctx, appID))
 
-	lockerID, err := ttnredis.GenerateLockerID(r.entropy, r.entropyMu)
+	lockerID, err := ttnredis.GenerateLockerID()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/joinserver/registry_test.go
+++ b/pkg/joinserver/registry_test.go
@@ -379,19 +379,24 @@ func TestSessionKeyRegistries(t *testing.T) {
 
 	for _, tc := range []struct {
 		Name string
-		New  func(ctx context.Context) (reg KeyRegistry, closeFn func() error)
+		New  func(ctx context.Context) (KeyRegistry, func() error, error)
 		N    uint16
 	}{
 		{
 			Name: "Redis",
-			New: func(ctx context.Context) (KeyRegistry, func() error) {
+			New: func(ctx context.Context) (KeyRegistry, func() error, error) {
 				cl, flush := test.NewRedis(ctx, namespace[:]...)
-				return &redis.KeyRegistry{
-						Redis: cl,
-					}, func() error {
-						flush()
-						return cl.Close()
-					}
+				keyReg := &redis.KeyRegistry{
+					Redis:   cl,
+					LockTTL: test.Delay << 10,
+				}
+				if err := keyReg.Init(ctx); err != nil {
+					return nil, nil, err
+				}
+				return keyReg, func() error {
+					flush()
+					return cl.Close()
+				}, nil
 			},
 			N: 8,
 		},
@@ -401,8 +406,11 @@ func TestSessionKeyRegistries(t *testing.T) {
 			test.RunSubtest(t, test.SubtestConfig{
 				Name:     fmt.Sprintf("%s/%d", tc.Name, i),
 				Parallel: true,
-				Func: func(ctx context.Context, t *testing.T, _ *assertions.Assertion) {
-					reg, closeFn := tc.New(ctx)
+				Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+					reg, closeFn, err := tc.New(ctx)
+					if !a.So(err, should.BeNil) {
+						t.FailNow()
+					}
 					if closeFn != nil {
 						defer func() {
 							if err := closeFn(); err != nil {

--- a/pkg/joinserver/registry_test.go
+++ b/pkg/joinserver/registry_test.go
@@ -207,19 +207,24 @@ func TestDeviceRegistries(t *testing.T) {
 
 	for _, tc := range []struct {
 		Name string
-		New  func(ctx context.Context) (reg DeviceRegistry, closeFn func() error)
+		New  func(ctx context.Context) (DeviceRegistry, func() error, error)
 		N    uint16
 	}{
 		{
 			Name: "Redis",
-			New: func(ctx context.Context) (DeviceRegistry, func() error) {
+			New: func(ctx context.Context) (DeviceRegistry, func() error, error) {
 				cl, flush := test.NewRedis(ctx, namespace[:]...)
-				return &redis.DeviceRegistry{
-						Redis: cl,
-					}, func() error {
-						flush()
-						return cl.Close()
-					}
+				devReg := &redis.DeviceRegistry{
+					Redis:   cl,
+					LockTTL: test.Delay << 10,
+				}
+				if err := devReg.Init(ctx); err != nil {
+					return nil, nil, err
+				}
+				return devReg, func() error {
+					flush()
+					return cl.Close()
+				}, nil
 			},
 			N: 8,
 		},
@@ -229,8 +234,11 @@ func TestDeviceRegistries(t *testing.T) {
 			test.RunSubtest(t, test.SubtestConfig{
 				Name:     fmt.Sprintf("%s/%d", tc.Name, i),
 				Parallel: true,
-				Func: func(ctx context.Context, t *testing.T, _ *assertions.Assertion) {
-					reg, closeFn := tc.New(ctx)
+				Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
+					reg, closeFn, err := tc.New(ctx)
+					if !a.So(err, should.BeNil) {
+						t.FailNow()
+					}
 					if closeFn != nil {
 						defer func() {
 							if err := closeFn(); err != nil {

--- a/pkg/redis/redis.go
+++ b/pkg/redis/redis.go
@@ -17,10 +17,10 @@ package redis
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
-	"io"
 	"net"
 	"strconv"
 	"strings"
@@ -985,12 +985,9 @@ outer:
 	}
 }
 
-// GenerateLockerID generates a unique locker ID from the provided entropy source.
-// The mutex is acquired and held during entropy extraction.
-func GenerateLockerID(entropy io.Reader, mu *sync.Mutex) (string, error) {
-	mu.Lock()
-	defer mu.Unlock()
-	lockID, err := ulid.New(ulid.Timestamp(time.Now()), entropy)
+// GenerateLockerID generates a unique locker ID to be used with a Redis mutex.
+func GenerateLockerID() (string, error) {
+	lockID, err := ulid.New(ulid.Timestamp(time.Now()), rand.Reader)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #2696 

#### Changes
<!-- What are the changes made in this pull request? -->

- Add lock based concurrency to registries where optimistic concurrency was used
  - What this means in general is that we moved from `Watch` to `LockedWatch`, which wraps `Watch` with a mutex 
  - This has the same pattern:
    - Add `LockTTL` and mutex / entropy source
    - Ensure `Init` is called before the registry is used
    - Use `ttnredis.LockedWatch` instead of simple `Watch`
- Lock (mutex) TTL has been standardized to 10 seconds
  - The previous 1 second TTL has been a bit too optimistic for high load environments


#### Testing

<!-- How did you verify that this change works? -->

Unit testing covers this.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

If I did something wrong, this may deadlock. With that being said, I'm pretty optimistic.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
