### PR TITLE
Treat NSID as EUI64 and use VSExtension to convey tenant + NS address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ For details about compatibility between different releases, see the **Commitment
 - Support for enhanced security policies of Packet Broker services.
 - Handling of MAC and PHY versions in end device forms based on selected frequency plan in the Console.
 - Support for scheduling downlink messages as JSON in the Console.
-- Backend Interfaces middleware to extract proxy headers from trusted proxies. This adds a configuration `interop.trusted-proxies` that is similar to the existing `http.trusted-proxies` option.
 - Support for Packet Broker authentication through LoRaWAN Backend Interfaces. This adds the following configuration options:
   - `interop.public-tls-address`: public address of the interop server. The audience in the incoming OAuth 2.0 token from Packet Broker is verified against this address to ensure that other networks cannot impersonate as Packet Broker;
   - `interop.packet-broker.enabled`: enable Packet Broker to authenticate;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,16 +18,15 @@ For details about compatibility between different releases, see the **Commitment
   - `interop.public-tls-address`: public address of the interop server. The audience in the incoming OAuth 2.0 token from Packet Broker is verified against this address to ensure that other networks cannot impersonate as Packet Broker;
   - `interop.packet-broker.enabled`: enable Packet Broker to authenticate;
   - `interop.packet-broker.token-issuer`: the issuer of the incoming OAuth 2.0 token from Packet Broker is verified against this value.
-- Support for LoRaWAN Backend Interfaces in Identity Server to obtain an end device's NetID and NSID (Network Server address). This adds the following configuration options:
+- Support for LoRaWAN Backend Interfaces in Identity Server to obtain an end device's NetID, tenant ID and Network Server address. This adds the following configuration options:
   - `is.network.net-id`: the NetID of the network. When running a Network Server, make sure that this is the same value as `ns.net-id`.
-  - `is.network.tenant-id`: the Tenant ID in the host NetID. Leave blank if you the NetID that you use is dedicated for the Identity Server.
+  - `is.network.tenant-id`: the Tenant ID in the host NetID. Leave blank if the NetID that you use is dedicated for this Identity Server.
 - Configuration option `experimental.features` to enable experimental features.
 - Tooltip descriptions for "Last activity" values (formerly "Last seen") and uplink/downlink counts in the Console.
 - Status pulses being triggered by incoming data in the Console.
 
 ### Changed
 
-- The NSID field of LoRaWAN Backend Interfaces 1.1 is now interpreted as Network Server address. Clients authenticating with `SenderNSID` must be authenticated as a Network Server with that address (see Security below).
 - Searching for entity IDs is now case insensitive.
 - Renamed entitie's "Last seen" to "Last activity" in the Console.
 - The database queries for determining the rights of users on entities have been rewritten to reduce the number of round-trips to the database.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ For details about compatibility between different releases, see the **Commitment
   - `interop.public-tls-address`: public address of the interop server. The audience in the incoming OAuth 2.0 token from Packet Broker is verified against this address to ensure that other networks cannot impersonate as Packet Broker;
   - `interop.packet-broker.enabled`: enable Packet Broker to authenticate;
   - `interop.packet-broker.token-issuer`: the issuer of the incoming OAuth 2.0 token from Packet Broker is verified against this value.
-- Support for LoRaWAN Backend Interfaces in Identity Server to obtain an end device's NetID, tenant ID and Network Server address. This adds the following configuration options:
+- Support for LoRaWAN Backend Interfaces in Identity Server to obtain an end device's NetID, tenant ID and Network Server address with the use of a vendor-specifc extension (`VSExtension`). This adds the following configuration options:
   - `is.network.net-id`: the NetID of the network. When running a Network Server, make sure that this is the same value as `ns.net-id`.
   - `is.network.tenant-id`: the Tenant ID in the host NetID. Leave blank if the NetID that you use is dedicated for this Identity Server.
 - Configuration option `experimental.features` to enable experimental features.

--- a/config/messages.json
+++ b/config/messages.json
@@ -5768,6 +5768,15 @@
       "file": "errors.go"
     }
   },
+  "error:pkg/interop:invalid_vendor_id": {
+    "translations": {
+      "en": "invalid vendor ID"
+    },
+    "description": {
+      "package": "pkg/interop",
+      "file": "errors.go"
+    }
+  },
   "error:pkg/interop:join_req": {
     "translations": {
       "en": "join-request failed"

--- a/pkg/component/interop_test.go
+++ b/pkg/component/interop_test.go
@@ -75,19 +75,21 @@ func (m mockInterop) AppSKeyRequest(ctx context.Context, req *interop.AppSKeyReq
 	}, nil
 }
 
-func (m mockInterop) HomeNSRequest(ctx context.Context, req *interop.HomeNSReq) (*interop.HomeNSAns, error) {
+func (m mockInterop) HomeNSRequest(ctx context.Context, req *interop.HomeNSReq) (*interop.TTIHomeNSAns, error) {
 	ansHeader, err := req.AnswerHeader()
 	if err != nil {
 		return nil, err
 	}
-	return &interop.HomeNSAns{
-		JsNsMessageHeader: interop.JsNsMessageHeader{
-			MessageHeader: ansHeader,
-			SenderID:      req.ReceiverID,
-			ReceiverID:    req.SenderID,
-		},
-		Result: interop.Result{
-			ResultCode: interop.ResultSuccess,
+	return &interop.TTIHomeNSAns{
+		HomeNSAns: interop.HomeNSAns{
+			JsNsMessageHeader: interop.JsNsMessageHeader{
+				MessageHeader: ansHeader,
+				SenderID:      req.ReceiverID,
+				ReceiverID:    req.SenderID,
+			},
+			Result: interop.Result{
+				ResultCode: interop.ResultSuccess,
+			},
 		},
 	}, nil
 }

--- a/pkg/identityserver/http_interop_test.go
+++ b/pkg/identityserver/http_interop_test.go
@@ -97,9 +97,7 @@ func TestInteropServer(t *testing.T) {
 			t.FailNow()
 		}
 		a.So(ans.HNetID, should.Equal, interop.NetID(test.DefaultNetID))
-		if a.So(ans.HNSID, should.NotBeNil) {
-			a.So(*ans.HNSID, should.Equal, "test@thethings.example.com")
-		}
+		a.So(ans.HNSID, should.BeNil) // TODO: Return HNSID (https://github.com/TheThingsNetwork/lorawan-stack/issues/4741).
 
 		// Test an unknown device
 		_, err = srv.HomeNSRequest(ctx, &interop.HomeNSReq{

--- a/pkg/interop/errors.go
+++ b/pkg/interop/errors.go
@@ -27,6 +27,7 @@ var (
 	errUnexpectedResult    = errors.Define("unexpected_result", "unexpected result code {code}", "code")
 	errCallerNotAuthorized = errors.DefinePermissionDenied("caller_not_authorized", "caller is not authorized for `{target}`")
 	errUnauthenticated     = errors.DefineUnauthenticated("unauthenticated", "unauthenticated")
+	errInvalidVendorID     = errors.DefineInvalidArgument("invalid_vendor_id", "invalid vendor ID")
 
 	ErrNoAction           = errors.DefineAborted("no_action", "no action")
 	ErrMIC                = errors.DefineCorruption("mic", "MIC failed")

--- a/pkg/interop/extensions.go
+++ b/pkg/interop/extensions.go
@@ -1,0 +1,100 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interop
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+var tti = VendorID{0xec, 0x65, 0x6e}
+
+// IsTheThingsIndustries returns true if the vendor ID is The Things Industries.
+func (v VendorID) IsTheThingsIndustries() bool {
+	return bytes.Equal(v[:], tti[:])
+}
+
+type TTIVendorID VendorID
+
+// MarshalText returns the vendor ID of The Things Industries.
+func (v TTIVendorID) MarshalText() ([]byte, error) {
+	return tti.MarshalText()
+}
+
+// UnmarshalText returns an error if the vendor ID is not of The Things Industries.
+func (v *TTIVendorID) UnmarshalText(data []byte) error {
+	var vid VendorID
+	if err := vid.UnmarshalText(data); err != nil {
+		return err
+	}
+	if !vid.IsTheThingsIndustries() {
+		return errInvalidVendorID.New()
+	}
+	*v = TTIVendorID(vid)
+	return nil
+}
+
+// TTIHomeNSAns is HomeNSAns with vendor extension of The Things Industries.
+type TTIHomeNSAns struct {
+	HomeNSAns
+	// HTenantID is the Tenant ID within a host HNetID.
+	HTenantID string
+	// HNSAddress is the Home Network Server address.
+	HNSAddress string
+}
+
+func (m TTIHomeNSAns) MarshalJSON() ([]byte, error) {
+	aux := struct {
+		HomeNSAns
+		VSExtension struct {
+			VendorID TTIVendorID
+			Object   struct {
+				TTSV3 struct {
+					HTenantID  string `json:",omitempty"`
+					HNSAddress string `json:",omitempty"`
+				}
+			}
+		}
+	}{
+		HomeNSAns: m.HomeNSAns,
+	}
+	aux.VSExtension.Object.TTSV3.HTenantID = m.HTenantID
+	aux.VSExtension.Object.TTSV3.HNSAddress = m.HNSAddress
+	return json.Marshal(aux)
+}
+
+func (m *TTIHomeNSAns) UnmarshalJSON(data []byte) error {
+	var aux struct {
+		HomeNSAns
+		VSExtension struct {
+			VendorID TTIVendorID
+			Object   struct {
+				TTSV3 struct {
+					HTenantID  string `json:",omitempty"`
+					HNSAddress string `json:",omitempty"`
+				}
+			}
+		}
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	*m = TTIHomeNSAns{
+		HomeNSAns:  aux.HomeNSAns,
+		HTenantID:  aux.VSExtension.Object.TTSV3.HTenantID,
+		HNSAddress: aux.VSExtension.Object.TTSV3.HNSAddress,
+	}
+	return nil
+}

--- a/pkg/interop/extensions_test.go
+++ b/pkg/interop/extensions_test.go
@@ -1,0 +1,90 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interop
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+)
+
+func TestExtensions(t *testing.T) {
+	a := assertions.New(t)
+
+	actual := TTIHomeNSAns{
+		HomeNSAns: HomeNSAns{
+			JsNsMessageHeader: JsNsMessageHeader{
+				MessageHeader: MessageHeader{
+					ProtocolVersion: ProtocolV1_1,
+					TransactionID:   42,
+					MessageType:     MessageTypeHomeNSAns,
+				},
+				SenderID:     EUI64{0x42, 0x42, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+				ReceiverID:   NetID{0x42, 0x0, 0x0},
+				ReceiverNSID: &EUI64{0x42, 0x42, 0x42, 0x0, 0x0, 0x0, 0x0, 0x0},
+			},
+			Result: Result{
+				ResultCode: ResultSuccess,
+			},
+			HNSID:  &EUI64{0x42, 0x42, 0x42, 0x42, 0x0, 0x0, 0x0, 0x0},
+			HNetID: NetID{0x42, 0x42, 0x0},
+		},
+		HTenantID:  "foo-tenant",
+		HNSAddress: "thethings.example.com",
+	}
+
+	buf := bytes.NewBuffer(nil)
+	enc := json.NewEncoder(buf)
+	enc.SetIndent("", "\t")
+	err := enc.Encode(actual)
+	if !a.So(err, should.BeNil) {
+		t.FailNow()
+	}
+	data := buf.Bytes()
+	a.So(string(data), should.Equal, `{
+	"ProtocolVersion": "1.1",
+	"TransactionID": 42,
+	"MessageType": "HomeNSAns",
+	"SenderID": "4242000000000000",
+	"ReceiverID": "420000",
+	"ReceiverNSID": "4242420000000000",
+	"Result": {
+		"ResultCode": "Success"
+	},
+	"HNSID": "4242424200000000",
+	"HNetID": "424200",
+	"VSExtension": {
+		"VendorID": "EC656E",
+		"Object": {
+			"TTSV3": {
+				"HTenantID": "foo-tenant",
+				"HNSAddress": "thethings.example.com"
+			}
+		}
+	}
+}
+`)
+
+	var expected TTIHomeNSAns
+	err = json.Unmarshal(data, &expected)
+	if !a.So(err, should.BeNil) {
+		t.FailNow()
+	}
+
+	a.So(actual, should.Resemble, expected)
+}

--- a/pkg/interop/messages.go
+++ b/pkg/interop/messages.go
@@ -25,10 +25,10 @@ type MessageHeader struct {
 	MessageType     MessageType
 	SenderID,
 	ReceiverID string
-	SenderNSID    *string `json:",omitempty"`
-	ReceiverNSID  *string `json:",omitempty"`
-	SenderToken   Buffer  `json:",omitempty"`
-	ReceiverToken Buffer  `json:",omitempty"`
+	SenderNSID    *EUI64 `json:",omitempty"`
+	ReceiverNSID  *EUI64 `json:",omitempty"`
+	SenderToken   Buffer `json:",omitempty"`
+	ReceiverToken Buffer `json:",omitempty"`
 }
 
 // AnswerHeader returns the header of the answer message.
@@ -66,7 +66,7 @@ type ErrorMessage struct {
 type NsMessageHeader struct {
 	MessageHeader
 	SenderID   NetID
-	SenderNSID *string `json:",omitempty"`
+	SenderNSID *EUI64 `json:",omitempty"`
 }
 
 // AsMessageHeader contains the message header for AS messages.
@@ -80,7 +80,7 @@ type NsJsMessageHeader struct {
 	SenderID NetID
 	// ReceiverID is a JoinEUI.
 	ReceiverID EUI64
-	SenderNSID *string `json:",omitempty"`
+	SenderNSID *EUI64 `json:",omitempty"`
 }
 
 // JsNsMessageHeader contains the message header for JS to NS messages.
@@ -89,7 +89,7 @@ type JsNsMessageHeader struct {
 	// SenderID is a JoinEUI.
 	SenderID     EUI64
 	ReceiverID   NetID
-	ReceiverNSID *string `json:",omitempty"`
+	ReceiverNSID *EUI64 `json:",omitempty"`
 }
 
 // AsJsMessageHeader contains the message header for AS to JS messages.
@@ -160,6 +160,6 @@ type HomeNSReq struct {
 type HomeNSAns struct {
 	JsNsMessageHeader
 	Result Result
-	HNSID  *string `json:",omitempty"`
+	HNSID  *EUI64 `json:",omitempty"`
 	HNetID NetID
 }

--- a/pkg/interop/messages.go
+++ b/pkg/interop/messages.go
@@ -25,10 +25,11 @@ type MessageHeader struct {
 	MessageType     MessageType
 	SenderID,
 	ReceiverID string
-	SenderNSID    *EUI64 `json:",omitempty"`
-	ReceiverNSID  *EUI64 `json:",omitempty"`
-	SenderToken   Buffer `json:",omitempty"`
-	ReceiverToken Buffer `json:",omitempty"`
+	SenderNSID    *EUI64       `json:",omitempty"`
+	ReceiverNSID  *EUI64       `json:",omitempty"`
+	SenderToken   Buffer       `json:",omitempty"`
+	ReceiverToken Buffer       `json:",omitempty"`
+	VSExtension   *VSExtension `json:",omitempty"`
 }
 
 // AnswerHeader returns the header of the answer message.
@@ -48,6 +49,11 @@ func (h MessageHeader) AnswerHeader() (MessageHeader, error) {
 		SenderToken:     h.ReceiverToken,
 		SenderNSID:      h.ReceiverNSID,
 	}, nil
+}
+
+// VSExtension is a vendor-specific extension.
+type VSExtension struct {
+	VendorID VendorID
 }
 
 // Result contains the result of an operation.

--- a/pkg/interop/server.go
+++ b/pkg/interop/server.go
@@ -39,14 +39,14 @@ type Registerer interface {
 
 // IdentityServer represents an Identity Server.
 type IdentityServer interface {
-	HomeNSRequest(context.Context, *HomeNSReq) (*HomeNSAns, error)
+	HomeNSRequest(context.Context, *HomeNSReq) (*TTIHomeNSAns, error)
 }
 
 // JoinServer represents a Join Server as specified in LoRaWAN Backend Interfaces.
 type JoinServer interface {
 	JoinRequest(context.Context, *JoinReq) (*JoinAns, error)
 	AppSKeyRequest(context.Context, *AppSKeyReq) (*AppSKeyAns, error)
-	HomeNSRequest(context.Context, *HomeNSReq) (*HomeNSAns, error)
+	HomeNSRequest(context.Context, *HomeNSReq) (*TTIHomeNSAns, error)
 }
 
 type noopServer struct{}
@@ -59,7 +59,7 @@ func (noopServer) AppSKeyRequest(context.Context, *AppSKeyReq) (*AppSKeyAns, err
 	return nil, ErrMalformedMessage.New()
 }
 
-func (noopServer) HomeNSRequest(context.Context, *HomeNSReq) (*HomeNSAns, error) {
+func (noopServer) HomeNSRequest(context.Context, *HomeNSReq) (*TTIHomeNSAns, error) {
 	return nil, ErrMalformedMessage.New()
 }
 

--- a/pkg/interop/server_test.go
+++ b/pkg/interop/server_test.go
@@ -185,42 +185,6 @@ func TestServer(t *testing.T) {
 			},
 		},
 		{
-			Name: "ClientTLS/JoinReq/Unauthenticated NSID",
-			JS: mockTarget{
-				JoinRequestFunc: func(ctx context.Context, req *interop.JoinReq) (*interop.JoinAns, error) {
-					if err := authorizer.RequireAuthorized(ctx); err != nil {
-						return nil, err
-					}
-					return nil, interop.ErrUnknownDevEUI.New()
-				},
-			},
-			ClientTLSConfig: makeClientTLSConfig(),
-			RequestBody: &interop.JoinReq{
-				NsJsMessageHeader: interop.NsJsMessageHeader{
-					MessageHeader: interop.MessageHeader{
-						MessageType:     interop.MessageTypeJoinReq,
-						ProtocolVersion: interop.ProtocolV1_1,
-					},
-					SenderID:   interop.NetID{0x0, 0x0, 0x01},
-					SenderNSID: stringPtr("example.com"), // The client is authenticated with NSID localhost and *.localhost only
-					ReceiverID: interop.EUI64{0x42, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
-				},
-				MACVersion: interop.MACVersion(ttnpb.MAC_V1_0_3),
-			},
-			ResponseAssertion: func(t *testing.T, res *http.Response) bool {
-				a := assertions.New(t)
-				if !a.So(res.StatusCode, should.Equal, http.StatusOK) {
-					return false
-				}
-				var msg interop.ErrorMessage
-				err := json.NewDecoder(res.Body).Decode(&msg)
-				if !a.So(err, should.BeNil) {
-					return false
-				}
-				return a.So(msg.Result.ResultCode, should.Equal, interop.ResultUnknownSender)
-			},
-		},
-		{
 			Name: "ClientTLS/JoinReq/Success",
 			JS: mockTarget{
 				JoinRequestFunc: func(ctx context.Context, req *interop.JoinReq) (*interop.JoinAns, error) {
@@ -310,7 +274,7 @@ func TestServer(t *testing.T) {
 							ResultCode: interop.ResultSuccess,
 						},
 						HNetID: interop.NetID{0x0, 0x0, 0x1},
-						HNSID:  stringPtr("localhost:4242"),
+						HNSID:  &interop.EUI64{0x42, 0x42, 0x42, 0x0, 0x0, 0x0, 0x0, 0x0},
 					}, nil
 				},
 			},
@@ -322,7 +286,6 @@ func TestServer(t *testing.T) {
 						ProtocolVersion: interop.ProtocolV1_1,
 					},
 					SenderID:   interop.NetID{0x0, 0x0, 0x0},
-					SenderNSID: stringPtr("test.packetbroker.io"),
 					ReceiverID: interop.EUI64{0x42, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
 				},
 				DevEUI: interop.EUI64{0x42, 0xff, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
@@ -338,9 +301,8 @@ func TestServer(t *testing.T) {
 					a.So(msg.Result.ResultCode, should.Equal, interop.ResultSuccess) &&
 					a.So(msg.SenderID, should.Resemble, interop.EUI64{0x42, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}) &&
 					a.So(msg.ReceiverID, should.Resemble, interop.NetID{0x0, 0x0, 0x0}) &&
-					a.So(msg.ReceiverNSID, should.Resemble, stringPtr("test.packetbroker.io")) &&
 					a.So(msg.HNetID, should.Resemble, interop.NetID{0x0, 0x0, 0x1}) &&
-					a.So(msg.HNSID, should.Resemble, stringPtr("localhost:4242"))
+					a.So(msg.HNSID, should.Resemble, &interop.EUI64{0x42, 0x42, 0x42, 0x0, 0x0, 0x0, 0x0, 0x0})
 			},
 		},
 	} {

--- a/pkg/interop/types.go
+++ b/pkg/interop/types.go
@@ -286,6 +286,27 @@ func (b *Buffer) UnmarshalText(data []byte) error {
 	return nil
 }
 
+// VendorID is an IEEE MAC-L (OUI) assignment to indicate the vendor.
+type VendorID [3]byte
+
+// MarshalText implements encoding.TextMarshaler.
+func (v VendorID) MarshalText() ([]byte, error) {
+	return Buffer(v[:]).MarshalText()
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (v *VendorID) UnmarshalText(data []byte) error {
+	var buf Buffer
+	if err := buf.UnmarshalText(data); err != nil {
+		return errInvalidVendorID.WithCause(err)
+	}
+	if len(buf) != 3 {
+		return errInvalidVendorID.WithCause(errInvalidLength.New())
+	}
+	copy(v[:], buf)
+	return nil
+}
+
 // KeyEnvelope contains a (encrypted) key.
 type KeyEnvelope ttnpb.KeyEnvelope
 
@@ -336,8 +357,7 @@ type NetID types.NetID
 
 // MarshalJSON marshals the NetID to text.
 func (n NetID) MarshalText() ([]byte, error) {
-	buf := Buffer(n[:])
-	return buf.MarshalText()
+	return Buffer(n[:]).MarshalText()
 }
 
 // UnmarshalText unmarshals the NetID from text.
@@ -358,8 +378,7 @@ type EUI64 types.EUI64
 
 // MarshalText implements encoding.TextMarshaler.
 func (n EUI64) MarshalText() ([]byte, error) {
-	buf := Buffer(n[:])
-	return buf.MarshalText()
+	return Buffer(n[:]).MarshalText()
 }
 
 // UnmarshalText implements encoding.TextUnmarshaler.
@@ -380,8 +399,7 @@ type DevAddr types.DevAddr
 
 // MarshalText implements encoding.TextMarshaler.
 func (n DevAddr) MarshalText() ([]byte, error) {
-	buf := Buffer(n[:])
-	return buf.MarshalText()
+	return Buffer(n[:]).MarshalText()
 }
 
 // UnmarshalText implements encoding.TextUnmarshaler.

--- a/pkg/interop/util_test.go
+++ b/pkg/interop/util_test.go
@@ -49,8 +49,6 @@ var (
 	ServerKey     = test.Must(ioutil.ReadFile(ServerKeyPath)).([]byte)
 )
 
-func stringPtr(s string) *string { return &s }
-
 func makeCertPool() *x509.CertPool {
 	certpool := x509.NewCertPool()
 	certpool.AppendCertsFromPEM(RootCA)

--- a/pkg/joinserver/http_interop.go
+++ b/pkg/joinserver/http_interop.go
@@ -28,7 +28,7 @@ import (
 
 type interopHandler interface {
 	HandleJoin(context.Context, *ttnpb.JoinRequest, Authorizer) (*ttnpb.JoinResponse, error)
-	GetHomeNetID(context.Context, types.EUI64, types.EUI64, Authorizer) (netID *types.NetID, nsID string, err error)
+	GetHomeNetID(context.Context, types.EUI64, types.EUI64, Authorizer) (netID *types.NetID, nsID *types.EUI64, err error)
 	GetAppSKey(context.Context, *ttnpb.SessionKeyRequest, Authorizer) (*ttnpb.AppSKeyResponse, error)
 }
 
@@ -149,8 +149,8 @@ func (srv interopServer) HomeNSRequest(ctx context.Context, in *interop.HomeNSRe
 		},
 		HNetID: interop.NetID(*netID),
 	}
-	if nsID != "" && in.ProtocolVersion.SupportsNSID() {
-		ans.HNSID = &nsID
+	if nsID != nil && in.ProtocolVersion.SupportsNSID() {
+		ans.HNSID = (*interop.EUI64)(nsID)
 	}
 	return ans, nil
 }

--- a/pkg/joinserver/http_interop_internal_test.go
+++ b/pkg/joinserver/http_interop_internal_test.go
@@ -30,9 +30,9 @@ import (
 )
 
 type mockInteropHandler struct {
-	HandleJoinFunc   func(context.Context, *ttnpb.JoinRequest) (*ttnpb.JoinResponse, error)
-	GetHomeNetIDFunc func(context.Context, types.EUI64, types.EUI64) (netID *types.NetID, nsID *types.EUI64, err error)
-	GetAppSKeyFunc   func(context.Context, *ttnpb.SessionKeyRequest) (*ttnpb.AppSKeyResponse, error)
+	HandleJoinFunc     func(context.Context, *ttnpb.JoinRequest) (*ttnpb.JoinResponse, error)
+	GetHomeNetworkFunc func(context.Context, types.EUI64, types.EUI64) (*EndDeviceHomeNetwork, error)
+	GetAppSKeyFunc     func(context.Context, *ttnpb.SessionKeyRequest) (*ttnpb.AppSKeyResponse, error)
 }
 
 func (h mockInteropHandler) HandleJoin(ctx context.Context, req *ttnpb.JoinRequest, authorizer Authorizer) (*ttnpb.JoinResponse, error) {
@@ -42,11 +42,11 @@ func (h mockInteropHandler) HandleJoin(ctx context.Context, req *ttnpb.JoinReque
 	return h.HandleJoinFunc(ctx, req)
 }
 
-func (h mockInteropHandler) GetHomeNetID(ctx context.Context, joinEUI, devEUI types.EUI64, authorizer Authorizer) (*types.NetID, *types.EUI64, error) {
-	if h.GetHomeNetIDFunc == nil {
-		panic("GetHomeNetID should not be called")
+func (h mockInteropHandler) GetHomeNetwork(ctx context.Context, joinEUI, devEUI types.EUI64, authorizer Authorizer) (*EndDeviceHomeNetwork, error) {
+	if h.GetHomeNetworkFunc == nil {
+		panic("GetHomeNetwork should not be called")
 	}
-	return h.GetHomeNetIDFunc(ctx, joinEUI, devEUI)
+	return h.GetHomeNetworkFunc(ctx, joinEUI, devEUI)
 }
 
 func (h mockInteropHandler) GetAppSKey(ctx context.Context, req *ttnpb.SessionKeyRequest, authorizer Authorizer) (*ttnpb.AppSKeyResponse, error) {
@@ -445,13 +445,13 @@ func TestInteropJoinRequest(t *testing.T) {
 
 func TestInteropHomeNSRequest(t *testing.T) {
 	for _, tc := range []struct {
-		Name              string
-		HomeNSReq         *interop.HomeNSReq
-		ExpectedJoinEUI   types.EUI64
-		ExpectedDevEUI    types.EUI64
-		ErrorAssertion    func(*testing.T, error) bool
-		GetNetIDFunc      func() (*types.NetID, *types.EUI64, error)
-		ExpectedHomeNSAns *interop.HomeNSAns
+		Name               string
+		HomeNSReq          *interop.HomeNSReq
+		ExpectedJoinEUI    types.EUI64
+		ExpectedDevEUI     types.EUI64
+		ErrorAssertion     func(*testing.T, error) bool
+		GetHomeNetworkFunc func() (*EndDeviceHomeNetwork, error)
+		ExpectedHomeNSAns  *interop.TTIHomeNSAns
 	}{
 		{
 			Name: "Normal/TS002-1.0",
@@ -468,23 +468,32 @@ func TestInteropHomeNSRequest(t *testing.T) {
 			},
 			ExpectedJoinEUI: types.EUI64{0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 			ExpectedDevEUI:  types.EUI64{0x42, 0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
-			GetNetIDFunc: func() (*types.NetID, *types.EUI64, error) {
-				return &types.NetID{0x42, 0xff, 0xff}, &types.EUI64{0x42, 0x42, 0x42, 0x0, 0x0, 0x0, 0x0, 0x0}, nil
+			GetHomeNetworkFunc: func() (*EndDeviceHomeNetwork, error) {
+				return &EndDeviceHomeNetwork{
+					NetID:                &types.NetID{0x42, 0xff, 0xff},
+					NSID:                 &types.EUI64{0x42, 0x42, 0x42, 0x0, 0x0, 0x0, 0x0, 0x0},
+					TenantID:             "foo-tenant",
+					NetworkServerAddress: "thethings.example.com",
+				}, nil
 			},
-			ExpectedHomeNSAns: &interop.HomeNSAns{
-				JsNsMessageHeader: interop.JsNsMessageHeader{
-					MessageHeader: interop.MessageHeader{
-						ProtocolVersion: interop.ProtocolV1_0,
-						MessageType:     interop.MessageTypeJoinAns,
+			ExpectedHomeNSAns: &interop.TTIHomeNSAns{
+				HomeNSAns: interop.HomeNSAns{
+					JsNsMessageHeader: interop.JsNsMessageHeader{
+						MessageHeader: interop.MessageHeader{
+							ProtocolVersion: interop.ProtocolV1_0,
+							MessageType:     interop.MessageTypeJoinAns,
+						},
+						SenderID:   interop.EUI64{0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+						ReceiverID: interop.NetID{0x0, 0x0, 0x13},
 					},
-					SenderID:   interop.EUI64{0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
-					ReceiverID: interop.NetID{0x0, 0x0, 0x13},
+					Result: interop.Result{
+						ResultCode: interop.ResultSuccess,
+					},
+					HNetID: interop.NetID{0x42, 0xff, 0xff},
+					// NOTE: HNSID is not returned as the field is not supported in LoRaWAN Backend Interfaces 1.0.
 				},
-				Result: interop.Result{
-					ResultCode: interop.ResultSuccess,
-				},
-				HNetID: interop.NetID{0x42, 0xff, 0xff},
-				// NOTE: HNSID is not returned as the field is not supported in LoRaWAN Backend Interfaces 1.0.
+				HTenantID:  "foo-tenant",
+				HNSAddress: "thethings.example.com",
 			},
 		},
 		{
@@ -503,24 +512,29 @@ func TestInteropHomeNSRequest(t *testing.T) {
 			},
 			ExpectedJoinEUI: types.EUI64{0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 			ExpectedDevEUI:  types.EUI64{0x42, 0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
-			GetNetIDFunc: func() (*types.NetID, *types.EUI64, error) {
-				return &types.NetID{0x42, 0xff, 0xff}, &types.EUI64{0x42, 0x42, 0x42, 0x0, 0x0, 0x0, 0x0, 0x0}, nil
+			GetHomeNetworkFunc: func() (*EndDeviceHomeNetwork, error) {
+				return &EndDeviceHomeNetwork{
+					NetID: &types.NetID{0x42, 0xff, 0xff},
+					NSID:  &types.EUI64{0x42, 0x42, 0x42, 0x0, 0x0, 0x0, 0x0, 0x0},
+				}, nil
 			},
-			ExpectedHomeNSAns: &interop.HomeNSAns{
-				JsNsMessageHeader: interop.JsNsMessageHeader{
-					MessageHeader: interop.MessageHeader{
-						ProtocolVersion: interop.ProtocolV1_1,
-						MessageType:     interop.MessageTypeJoinAns,
+			ExpectedHomeNSAns: &interop.TTIHomeNSAns{
+				HomeNSAns: interop.HomeNSAns{
+					JsNsMessageHeader: interop.JsNsMessageHeader{
+						MessageHeader: interop.MessageHeader{
+							ProtocolVersion: interop.ProtocolV1_1,
+							MessageType:     interop.MessageTypeJoinAns,
+						},
+						SenderID:     interop.EUI64{0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+						ReceiverID:   interop.NetID{0x0, 0x0, 0x13},
+						ReceiverNSID: &interop.EUI64{0x42, 0x42, 0x42, 0x0, 0x0, 0x0, 0x0, 0xff},
 					},
-					SenderID:     interop.EUI64{0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
-					ReceiverID:   interop.NetID{0x0, 0x0, 0x13},
-					ReceiverNSID: &interop.EUI64{0x42, 0x42, 0x42, 0x0, 0x0, 0x0, 0x0, 0xff},
+					Result: interop.Result{
+						ResultCode: interop.ResultSuccess,
+					},
+					HNetID: interop.NetID{0x42, 0xff, 0xff},
+					HNSID:  &interop.EUI64{0x42, 0x42, 0x42, 0x0, 0x0, 0x0, 0x0, 0x0},
 				},
-				Result: interop.Result{
-					ResultCode: interop.ResultSuccess,
-				},
-				HNetID: interop.NetID{0x42, 0xff, 0xff},
-				HNSID:  &interop.EUI64{0x42, 0x42, 0x42, 0x0, 0x0, 0x0, 0x0, 0x0},
 			},
 		},
 		{
@@ -538,8 +552,8 @@ func TestInteropHomeNSRequest(t *testing.T) {
 			},
 			ExpectedJoinEUI: types.EUI64{0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 			ExpectedDevEUI:  types.EUI64{0x42, 0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
-			GetNetIDFunc: func() (*types.NetID, *types.EUI64, error) {
-				return nil, nil, nil
+			GetHomeNetworkFunc: func() (*EndDeviceHomeNetwork, error) {
+				return &EndDeviceHomeNetwork{}, nil
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
 				a := assertions.New(t)
@@ -553,11 +567,11 @@ func TestInteropHomeNSRequest(t *testing.T) {
 
 			srv := interopServer{
 				JS: &mockInteropHandler{
-					GetHomeNetIDFunc: func(ctx context.Context, joinEUI, devEUI types.EUI64) (*types.NetID, *types.EUI64, error) {
+					GetHomeNetworkFunc: func(ctx context.Context, joinEUI, devEUI types.EUI64) (*EndDeviceHomeNetwork, error) {
 						if !a.So(joinEUI, should.Resemble, tc.ExpectedJoinEUI) || !a.So(devEUI, should.Resemble, tc.ExpectedDevEUI) {
 							t.FailNow()
 						}
-						return tc.GetNetIDFunc()
+						return tc.GetHomeNetworkFunc()
 					},
 				},
 			}

--- a/pkg/joinserver/joinserver.go
+++ b/pkg/joinserver/joinserver.go
@@ -702,9 +702,9 @@ func (js *JoinServer) GetAppSKey(ctx context.Context, req *ttnpb.SessionKeyReque
 }
 
 // GetHomeNetID returns the requested NetID.
-func (js *JoinServer) GetHomeNetID(ctx context.Context, joinEUI, devEUI types.EUI64, authorizer Authorizer) (netID *types.NetID, nsID string, err error) {
+func (js *JoinServer) GetHomeNetID(ctx context.Context, joinEUI, devEUI types.EUI64, authorizer Authorizer) (netID *types.NetID, nsID *types.EUI64, err error) {
 	if err := authorizer.RequireAuthorized(ctx); err != nil {
-		return nil, "", err
+		return nil, nil, err
 	}
 
 	dev, err := js.devices.GetByEUI(ctx, joinEUI, devEUI,
@@ -714,19 +714,21 @@ func (js *JoinServer) GetHomeNetID(ctx context.Context, joinEUI, devEUI types.EU
 		},
 	)
 	if err != nil {
-		return nil, "", errRegistryOperation.WithCause(err)
+		return nil, nil, errRegistryOperation.WithCause(err)
 	}
 	if dev.NetId != nil {
-		return dev.NetId, dev.NetworkServerAddress, nil
+		// TODO: Return NSID (https://github.com/TheThingsNetwork/lorawan-stack/issues/4741).
+		return dev.NetId, nil, nil
 	}
 	sets, err := js.applicationActivationSettings.GetByID(ctx, dev.ApplicationIdentifiers, []string{
 		"home_net_id",
 	})
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			return nil, "", errGetApplicationActivationSettings.WithCause(err)
+			return nil, nil, errGetApplicationActivationSettings.WithCause(err)
 		}
-		return nil, "", nil
+		return nil, nil, nil
 	}
-	return sets.HomeNetId, dev.NetworkServerAddress, nil
+	// TODO: Return NSID (https://github.com/TheThingsNetwork/lorawan-stack/issues/4741).
+	return sets.HomeNetId, nil, nil
 }

--- a/pkg/joinserver/joinserver_internal_test.go
+++ b/pkg/joinserver/joinserver_internal_test.go
@@ -31,8 +31,6 @@ var (
 	ErrReuseDevNonce     = errReuseDevNonce
 )
 
-func stringPtr(s string) *string { return &s }
-
 type AsJsServer = asJsServer
 type NsJsServer = nsJsServer
 type JsDeviceServer = jsEndDeviceRegistryServer

--- a/pkg/joinserver/joinserver_test.go
+++ b/pkg/joinserver/joinserver_test.go
@@ -2909,21 +2909,21 @@ func TestGetHomeNetID(t *testing.T) {
 						},
 					},
 				)).(*JoinServer)
-				netID, nsID, err := js.GetHomeNetID(ctx, tc.JoinEUI, tc.DevEUI, tc.Authorizer)
+				homeNetwork, err := js.GetHomeNetwork(ctx, tc.JoinEUI, tc.DevEUI, tc.Authorizer)
 
 				if tc.ErrorAssertion != nil {
 					if !tc.ErrorAssertion(t, err) {
 						t.Fatalf("Received unexpected error: %s", err)
 					}
-					a.So(netID, should.BeNil)
+					a.So(homeNetwork, should.BeNil)
 					return
 				}
 
 				if !a.So(err, should.BeNil) {
 					t.FailNow()
 				}
-				a.So(netID, should.Resemble, tc.ResponseNetID)
-				a.So(nsID, should.Equal, tc.ResponseNSID)
+				a.So(homeNetwork.NetID, should.Resemble, tc.ResponseNetID)
+				a.So(homeNetwork.NSID, should.Equal, tc.ResponseNSID)
 			},
 		})
 	}

--- a/pkg/joinserver/joinserver_test.go
+++ b/pkg/joinserver/joinserver_test.go
@@ -2841,7 +2841,7 @@ func TestGetHomeNetID(t *testing.T) {
 		JoinEUI       types.EUI64
 		DevEUI        types.EUI64
 		ResponseNetID *types.NetID
-		ResponseNSID  string
+		ResponseNSID  *types.EUI64
 
 		ErrorAssertion func(*testing.T, error) bool
 	}{
@@ -2892,7 +2892,6 @@ func TestGetHomeNetID(t *testing.T) {
 			JoinEUI:       types.EUI64{0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 			DevEUI:        types.EUI64{0x42, 0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
 			ResponseNetID: &types.NetID{0x42, 0xff, 0xff},
-			ResponseNSID:  nsAddr,
 		},
 	} {
 		tc := tc


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsIndustries/lorawan-stack/issues/2935

#### Changes
<!-- What are the changes made in this pull request? -->

- Treat NSID as EUI64 as specified in TS002 1.1
- Return the Home Network Server address and tenant ID as part of a new VSExtension that's carried over the `HomeNSAns`

#### Testing

<!-- How did you verify that this change works? -->

CI

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None expected

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

See referenced issue for reasoning

@adriansmares is the main reviewer

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
