### PR TITLE
all: Add tls.cipher-suites config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Added
 
+- `tls.cipher-suites` config option to specify used cipher suites.
 - Support for enhanced security policies of Packet Broker services.
 - Handling of MAC and PHY versions in end device forms based on selected frequency plan in the Console.
 - Support for scheduling downlink messages as JSON in the Console.

--- a/config/messages.json
+++ b/config/messages.json
@@ -3194,6 +3194,15 @@
       "file": "config.go"
     }
   },
+  "error:pkg/config/tlsconfig:tls_cipher_suite_invalid": {
+    "translations": {
+      "en": "invalid TLS cipher suite {cipher}"
+    },
+    "description": {
+      "package": "pkg/config/tlsconfig",
+      "file": "config.go"
+    }
+  },
   "error:pkg/config/tlsconfig:tls_config_source_invalid": {
     "translations": {
       "en": "invalid TLS configuration source `{source}`"


### PR DESCRIPTION
#### Summary
Closes #3970 

#### Changes
Added an option to configure used cipher suites

#### Testing
Local tests using `openssl s_client -cipher "$cipher" -connect`

##### Regressions
None

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [X] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
