### PR TITLE
Add content-security policy to console,account,oauth

### DIFF
--- a/pkg/account/server_test.go
+++ b/pkg/account/server_test.go
@@ -98,6 +98,7 @@ func TestAuthentication(t *testing.T) {
 			},
 		},
 	})
+	csp := make(map[string][]string)
 	s := account.NewServer(c, store, oauth.Config{
 		Mount:       "/oauth",
 		CSRFAuthKey: []byte("12345678123456781234567812345678"),
@@ -108,7 +109,7 @@ func TestAuthentication(t *testing.T) {
 				CanonicalURL: "https://example.com/oauth",
 			},
 		},
-	})
+	}, csp)
 	c.RegisterWeb(s)
 	componenttest.StartComponent(t, c)
 

--- a/pkg/oauth/server_test.go
+++ b/pkg/oauth/server_test.go
@@ -134,6 +134,7 @@ func TestOAuthFlow(t *testing.T) {
 			},
 		},
 	})
+	csp := make(map[string][]string)
 	s, err := oauth.NewServer(c, store, oauth.Config{
 		Mount:       "/oauth",
 		CSRFAuthKey: []byte("12345678123456781234567812345678"),
@@ -144,7 +145,7 @@ func TestOAuthFlow(t *testing.T) {
 				CanonicalURL: "https://example.com/oauth",
 			},
 		},
-	})
+	}, csp)
 	if err != nil {
 		panic(err)
 	}
@@ -549,6 +550,7 @@ func TestTokenExchange(t *testing.T) {
 			},
 		},
 	})
+	csp := make(map[string][]string)
 	s, err := oauth.NewServer(c, store, oauth.Config{
 		Mount: "/oauth",
 		UI: oauth.UIConfig{
@@ -557,7 +559,7 @@ func TestTokenExchange(t *testing.T) {
 				Title:    "OAuth",
 			},
 		},
-	})
+	}, csp)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/webui/csp.go
+++ b/pkg/webui/csp.go
@@ -1,0 +1,59 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webui
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"strings"
+)
+
+// GenerateNonce returns a nonce used for inline scripts.
+func GenerateNonce() string {
+	var b [20]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		panic(err)
+	}
+	return base64.StdEncoding.EncodeToString(b[:])
+}
+
+// CleanCSP de-duplicates and removes empty entries from the CSP directive map.
+func CleanCSP(csp map[string][]string) map[string][]string {
+	for directive, entries := range csp {
+		occurred := map[string]bool{}
+		cleanedDirective := []string{}
+		for i := range entries {
+			if !occurred[entries[i]] && entries[i] != "" {
+				occurred[entries[i]] = true
+				cleanedDirective = append(cleanedDirective, entries[i])
+			}
+		}
+		csp[directive] = cleanedDirective
+	}
+	return csp
+}
+
+// GenerateCSPNonce returns a final csp string from map of directives.
+func GenerateCSPString(csp map[string][]string, nonce string) string {
+	resultList := make([]string, 0)
+	for key, value := range csp {
+		if key == "default-src" {
+			value = append(value, fmt.Sprintf("'nonce-%s'", nonce))
+		}
+		resultList = append(resultList, fmt.Sprintf("%s %s;", key, strings.Join(value, " ")))
+	}
+	return strings.Join(resultList, " ")
+}

--- a/pkg/webui/template.go
+++ b/pkg/webui/template.go
@@ -32,6 +32,7 @@ type Data struct {
 	AppConfig            interface{}
 	ExperimentalFeatures map[string]bool
 	PageData             interface{}
+	CSPNonce             string
 }
 
 // TemplateData contains data to use in the App template.
@@ -91,7 +92,7 @@ const appHTML = `
   </head>
   <body>
     <div id="app"></div>
-		<script>
+		<script nonce="{{.CSPNonce}}">
 		(function (win) {
 			var config = {
 				APP_ROOT:{{.MountPath}},
@@ -151,6 +152,7 @@ func RegisterHashedFile(original, hashed string) {
 // Render is the echo.Renderer that renders the web UI.
 func (t *AppTemplate) Render(w io.Writer, _ string, pageData interface{}, c echo.Context) error {
 	templateData := c.Get("template_data").(TemplateData)
+	cspNonce := c.Get("csp_nonce").(string)
 	cssFiles := make([]string, len(templateData.CSSFiles))
 	for i, cssFile := range templateData.CSSFiles {
 		if hashedFile, ok := hashedFiles[cssFile]; ok {
@@ -174,6 +176,7 @@ func (t *AppTemplate) Render(w io.Writer, _ string, pageData interface{}, c echo
 		AppConfig:            c.Get("app_config"),
 		ExperimentalFeatures: experimental.AllFeatures(c.Request().Context()),
 		PageData:             pageData,
+		CSPNonce:             cspNonce,
 	})
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #4212 

#### Changes
<!-- What are the changes made in this pull request? -->

- Add middleware that adds `Content-Security-Policy` header
- Generate and pass nonce to the application

#### Testing

<!-- How did you verify that this change works? -->

Manual

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

If CSP is set too strict, our scripts and assets won't load which will break UI or functionality.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

As discussed with some of you, in the bundled console/account file there are many expressions `Function("return this")` which need `unsafe-eval` policy in `default-src` or `script-src` to be set to work. The `unsafe-eval` is not recommended but I don't think there are immediate security concerns regarding this. However we should figure out why are these expressions necessary and how can we replace them. I will file an issue for this.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
