### PR TITLE
Fix CLI context cancellation

### DIFF
--- a/cmd/ttn-lw-cli/commands/context.go
+++ b/cmd/ttn-lw-cli/commands/context.go
@@ -24,17 +24,6 @@ import (
 var cancelSignals = []os.Signal{syscall.SIGHUP, os.Interrupt, syscall.SIGTERM}
 
 func newContext(parent context.Context) context.Context {
-	ctx, cancel := context.WithCancel(parent)
-	sig := make(chan os.Signal)
-	signal.Notify(sig, cancelSignals...)
-	go func() {
-		select {
-		case <-ctx.Done():
-		case sig := <-sig:
-			logger.WithField("signal", sig).Debug("Command interrupted")
-			cancel()
-		}
-		signal.Stop(sig)
-	}()
+	ctx, _ := signal.NotifyContext(parent, cancelSignals...)
 	return ctx
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Since Go 1.17 `go vet` complains about incorrect use of `signal.Notify`:

```
cmd/ttn-lw-cli/commands/context.go:29:2: misuse of unbuffered os.Signal channel as argument to signal.Notify
```

So this is a small PR that fixes context cancellation in the CLI. Instead of our custom implementation, we now use `signal.NotifyContext` that was added in Go 1.16. 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
