### PR TITLE
Fix `session` field mask handling in Network Layer form in the Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ For details about compatibility between different releases, see the **Commitment
 - Profile settings link not being present in the mobile menu in the Console.
 - Calculation of "Last activity" values not using all available data in the Console.
 - Layout jumps due to length of "Last activity" text.
+- Invalid `session` handling in Network Layer settings form in the Console.
 
 ### Security
 

--- a/pkg/webui/console/views/device-general-settings/network-server-form/index.js
+++ b/pkg/webui/console/views/device-general-settings/network-server-form/index.js
@@ -132,12 +132,15 @@ const NetworkServerForm = React.memo(props => {
         'app_s_key',
       ])
 
+      const patch = updatedValues
+      // Always submit current `mac_settings` values to avoid overwriting nested entries.
+      patch.mac_settings = castedValues.mac_settings
+
       const isOTAA = values._activation_mode === ACTIVATION_MODES.OTAA
-      const mac_settings = castedValues.mac_settings
-      let session
+      // Do not update session for joined OTAA end devices.
       if (!isOTAA && castedValues.session && castedValues.session.keys) {
         const { app_s_key, ...keys } = castedValues.session.keys
-        session = {
+        patch.session = {
           ...updatedValues.session,
           keys,
         }
@@ -145,12 +148,7 @@ const NetworkServerForm = React.memo(props => {
 
       setError('')
       try {
-        // Always submit current `mac_settings` values to avoid overwriting nested entries.
-        await onSubmit({
-          ...updatedValues,
-          mac_settings,
-          session,
-        })
+        await onSubmit(patch)
         resetForm({ values: castedValues })
         onSubmitSuccess()
       } catch (err) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/581

#### Changes
<!-- What are the changes made in this pull request? -->

- Do not set `session` on OTAA and joined OTAA devices even if it is `undefined`


#### Testing

<!-- How did you verify that this change works? -->

Manual testing on `staging1` with real joined OTAA end device


#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The issue was caused by the js sdk still adding the `session` field mask even when the actual `session` object is set `undefined`

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
