### PR TITLE
Increase default TTL for sparse entity events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ For details about compatibility between different releases, see the **Commitment
 - The database queries for determining the rights of users on entities have been rewritten to reduce the number of round-trips to the database.
 - The default downlink path expiration timeout for UDP gateway connections has been increased to 90 seconds, and the default connection timeout has been increased to 3 minutes.
   - The original downlink path expiration timeout was based on the fact that the default `PULL_DATA` interval is 5 seconds. In practice we have observed that most gateways actually send a `PULL_DATA` message every 30 seconds instead in order to preserve data transfer costs.
+- The default duration for storing (sparse) entity events has been increased to 24 hours.
 
 ### Deprecated
 

--- a/cmd/internal/shared/config.go
+++ b/cmd/internal/shared/config.go
@@ -100,7 +100,7 @@ var DefaultEventsConfig = func() config.Events {
 		Backend: "internal",
 	}
 	c.Redis.Store.TTL = 10 * time.Minute
-	c.Redis.Store.EntityTTL = time.Hour
+	c.Redis.Store.EntityTTL = 24 * time.Hour
 	c.Redis.Store.EntityCount = 100
 	c.Redis.Store.CorrelationIDCount = 100
 	c.Redis.Workers = 16


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a small PR that increases the default TTL for storage of sparse entity events. Storing sparse events doesn't cost a lot of resources, but can provide useful information about devices that only send a few uplinks per day. Since entity events are also capped at 100, it will not make a difference for active applications or gateways.