### PR TITLE
Update connection timeout defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ For details about compatibility between different releases, see the **Commitment
 - Searching for entity IDs is now case insensitive.
 - Renamed entitie's "Last seen" to "Last activity" in the Console.
 - The database queries for determining the rights of users on entities have been rewritten to reduce the number of round-trips to the database.
+- The default downlink path expiration timeout for UDP gateway connections has been increased to 90 seconds, and the default connection timeout has been increased to 3 minutes.
+  - The original downlink path expiration timeout was based on the fact that the default `PULL_DATA` interval is 5 seconds. In practice we have observed that most gateways actually send a `PULL_DATA` message every 30 seconds instead in order to preserve data transfer costs.
 
 ### Deprecated
 

--- a/pkg/gatewayserver/io/udp/config.go
+++ b/pkg/gatewayserver/io/udp/config.go
@@ -52,11 +52,13 @@ type Config struct {
 }
 
 // DefaultConfig contains the default configuration.
+// We assume that the gateway sends a PULL_DATA message every 30 seconds, instead of the default of 5 seconds.
+// This behavior has been observed in the wild, and is often used by gateways which use metered connections.
 var DefaultConfig = Config{
 	PacketHandlers:         1 << 4,
 	PacketBuffer:           50,
-	DownlinkPathExpires:    15 * time.Second, // Expire downlink after missing typically 3 PULL_DATA messages.
-	ConnectionExpires:      1 * time.Minute,  // Expire connection after missing typically 2 status messages.
+	DownlinkPathExpires:    90 * time.Second, // Expire downlink after missing typically 3 PULL_DATA messages.
+	ConnectionExpires:      3 * time.Minute,  // Expire connection after missing typically 2 status messages.
 	ConnectionErrorExpires: 5 * time.Minute,
 	ScheduleLateTime:       800 * time.Millisecond,
 	AddrChangeBlock:        0, // Release address when the connection expires.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-aws/pull/527

#### Changes
<!-- What are the changes made in this pull request? -->

- Update the UDP downlink path expiration timeout to 90 seconds (under the assumption that the gateway actually sends a `PULL_DATA` every 30 seconds instead of the default 5 seconds)
- Update the UDP connection timeout to 3 minutes


#### Testing

<!-- How did you verify that this change works? -->

This is mainly about defaults, and has been tested with very good results in our production environment. We've observed massive decreases in downlink path flip flops (claim-unclaim cycles) after this update.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
