### PR TITLE
Disregard session start time as "Last activity" for ABP devices

### DIFF
--- a/pkg/webui/console/lib/device-utils.js
+++ b/pkg/webui/console/lib/device-utils.js
@@ -151,6 +151,7 @@ export const getLastSeen = device => {
   }
   let lastUplinkReceivedAt
   let relevantSessionStart
+  const supportsJoin = Boolean(device.supports_join)
   const relevantSession = device.session || device.pending_session
   const relevantMacState = device.mac_state || device.pending_mac_state
   if (relevantMacState) {
@@ -164,7 +165,8 @@ export const getLastSeen = device => {
       }
     }
   }
-  if (relevantSession) {
+  if (supportsJoin && relevantSession) {
+    // TODO: Remove this once https://github.com/TheThingsNetwork/lorawan-stack/issues/4766 is resolved.
     relevantSessionStart =
       relevantSession.started_at !== '0001-01-01T00:00:00Z' ? relevantSession.started_at : undefined
   }
@@ -177,7 +179,10 @@ export const getLastSeen = device => {
   }
 
   // Return whichever timestamp is more recent.
-  return [relevantSessionStart, lastUplinkReceivedAt].sort().reverse()[0]
+  if (relevantSessionStart > lastUplinkReceivedAt) {
+    return relevantSessionStart
+  }
+  return lastUplinkReceivedAt
 }
 
 /**

--- a/sdk/js/src/service/devices/merge.js
+++ b/sdk/js/src/service/devices/merge.js
@@ -65,6 +65,10 @@ export default (parts, base = {}, minimum = [['ids'], ['created_at'], ['updated_
             }
 
             if (this.isLeaf) {
+              // TODO: Remove this once https://github.com/TheThingsNetwork/lorawan-stack/issues/4766 is resolved.
+              if (this.key.endsWith('_at') && e === '0001-01-01T00:00:00Z') {
+                return
+              }
               // Write the sub object leaf into the result.
               traverse(result).set([...path, ...this.path], e)
             }


### PR DESCRIPTION
#### Summary
This PR will fix the Console regarding session start times as activity for ABP devices. It will also disregard zero date values when merging the end device object in the JS SDK.

Closes #4761

#### Changes
- Disregard session start time of ABP devices when calculating a device's "Last activity" value
- Disregard `0001-01-01T00:00:00Z` date values when merging the device object in the JS SDK, so that it also does not overwrite legitimate values of other components.


#### Testing

Manual testing locally and on the staging environment.

#### Notes for Reviewers
The inconsistencies between the list and the single view came from the the different ways of retrieving the session object when listing devices (querying the NS only with the correct value) and the single device (querying AS with wrong value, and NS, then merging).

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
