### PR TITLE
Network Server device registry cleanup

### DIFF
--- a/cmd/ttn-lw-stack/commands/ns_utils.go
+++ b/cmd/ttn-lw-stack/commands/ns_utils.go
@@ -1,0 +1,44 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"context"
+
+	"go.thethings.network/lorawan-stack/v3/cmd/internal/shared"
+	ns "go.thethings.network/lorawan-stack/v3/pkg/networkserver"
+	nsredis "go.thethings.network/lorawan-stack/v3/pkg/networkserver/redis"
+	"go.thethings.network/lorawan-stack/v3/pkg/redis"
+)
+
+// NewNSDeviceRegistryCleaner returns a new instance of Network Server RegistryCleaner with a local set
+// of devices.
+func NewNSDeviceRegistryCleaner(ctx context.Context, config *redis.Config) (*ns.RegistryCleaner, error) {
+	deviceRegistry := &nsredis.DeviceRegistry{
+		Redis:   redis.New(config.WithNamespace("ns", "devices")),
+		LockTTL: defaultLockTTL,
+	}
+	if err := deviceRegistry.Init(ctx); err != nil {
+		return nil, shared.ErrInitializeApplicationServer.WithCause(err)
+	}
+	cleaner := &ns.RegistryCleaner{
+		DevRegistry: deviceRegistry,
+	}
+	err := cleaner.RangeToLocalSet(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return cleaner, nil
+}

--- a/pkg/applicationserver/redis/registry.go
+++ b/pkg/applicationserver/redis/registry.go
@@ -16,9 +16,7 @@ package redis
 
 import (
 	"context"
-	"regexp"
 	"runtime/trace"
-	"strings"
 	"time"
 
 	"github.com/go-redis/redis/v8"
@@ -56,13 +54,6 @@ func (r *DeviceRegistry) uidKey(uid string) string {
 
 func (r *DeviceRegistry) euiKey(joinEUI, devEUI types.EUI64) string {
 	return r.Redis.Key("eui", devEUI.String(), joinEUI.String())
-}
-
-func deviceRegex(key string) (*regexp.Regexp, error) {
-	keyRegex := strings.ReplaceAll(key, ":", "\\:")
-	keyRegex = strings.ReplaceAll(keyRegex, "*", ".[^\\:]*")
-	keyRegex = keyRegex + "$"
-	return regexp.Compile(keyRegex)
 }
 
 // Get returns the end device by its identifiers.
@@ -250,7 +241,7 @@ func (r *DeviceRegistry) Set(ctx context.Context, ids ttnpb.EndDeviceIdentifiers
 }
 
 func (r *DeviceRegistry) Range(ctx context.Context, paths []string, f func(context.Context, ttnpb.EndDeviceIdentifiers, *ttnpb.EndDevice) bool) error {
-	deviceEntityRegex, err := deviceRegex(r.uidKey(unique.GenericID(ctx, "*")))
+	deviceEntityRegex, err := ttnredis.DeviceRegex((r.uidKey(unique.GenericID(ctx, "*"))))
 	if err != nil {
 		return err
 	}

--- a/pkg/networkserver/cleanup.go
+++ b/pkg/networkserver/cleanup.go
@@ -1,0 +1,79 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkserver
+
+import (
+	"context"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/cleanup"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/unique"
+)
+
+// RegistryCleaner is a service responsible for cleanup of the device registry.
+type RegistryCleaner struct {
+	DevRegistry DeviceRegistry
+	LocalSet    map[string]struct{}
+}
+
+// RangeToLocalSet returns a set of devices that have data in the registry.
+func (cleaner *RegistryCleaner) RangeToLocalSet(ctx context.Context) error {
+	cleaner.LocalSet = make(map[string]struct{})
+	err := cleaner.DevRegistry.Range(ctx, []string{"ids"}, func(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, dev *ttnpb.EndDevice) bool {
+		cleaner.LocalSet[unique.ID(ctx, ids)] = struct{}{}
+		return true
+	})
+	return err
+}
+
+// DeleteComplement deletes registry application data of all devices in the device id list.
+func (cleaner *RegistryCleaner) DeleteDeviceData(ctx context.Context, devSet []string) error {
+	for _, ids := range devSet {
+		devIds, err := unique.ToDeviceID(ids)
+		if err != nil {
+			return err
+		}
+		ctx, err = unique.WithContext(ctx, ids)
+		if err != nil {
+			return err
+		}
+		_, _, err = cleaner.DevRegistry.SetByID(ctx, devIds.ApplicationIdentifiers, devIds.DeviceId, nil, func(ctx context.Context, dev *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
+			if dev == nil {
+				return nil, nil, errDeviceNotFound.New()
+			}
+			return nil, nil, nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CleanData cleans registry device data.
+func (cleaner *RegistryCleaner) CleanData(ctx context.Context, isSet map[string]struct{}) error {
+	complement := cleanup.ComputeSetComplement(isSet, cleaner.LocalSet)
+	devIds := make([]string, len(complement))
+	i := 0
+	for id := range complement {
+		devIds[i] = id
+		i++
+	}
+	err := cleaner.DeleteDeviceData(ctx, devIds)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/networkserver/networkserver_util_internal_test.go
+++ b/pkg/networkserver/networkserver_util_internal_test.go
@@ -2426,3 +2426,8 @@ func (m MockDeviceRegistry) SetByID(ctx context.Context, appID ttnpb.Application
 func (m MockDeviceRegistry) RangeByUplinkMatches(context.Context, *ttnpb.UplinkMessage, time.Duration, func(context.Context, *UplinkMatch) (bool, error)) error {
 	panic("RangeByUplinkMatches must not be called")
 }
+
+// Range panics.
+func (m MockDeviceRegistry) Range(ctx context.Context, paths []string, f func(context.Context, ttnpb.EndDeviceIdentifiers, *ttnpb.EndDevice) bool) error {
+	panic("Range must not be called")
+}

--- a/pkg/networkserver/redis/registry.go
+++ b/pkg/networkserver/redis/registry.go
@@ -1027,3 +1027,27 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID ttnpb.ApplicationIde
 	}
 	return pb, ctx, nil
 }
+
+func (r *DeviceRegistry) Range(ctx context.Context, paths []string, f func(context.Context, ttnpb.EndDeviceIdentifiers, *ttnpb.EndDevice) bool) error {
+	deviceEntityRegex, err := ttnredis.DeviceRegex((r.uidKey(unique.GenericID(ctx, "*"))))
+	if err != nil {
+		return err
+	}
+	return ttnredis.RangeRedisKeys(ctx, r.Redis, r.uidKey(unique.GenericID(ctx, "*")), 1, func(key string) (bool, error) {
+		if !deviceEntityRegex.MatchString(key) {
+			return true, nil
+		}
+		dev := &ttnpb.EndDevice{}
+		if err := ttnredis.GetProto(ctx, r.Redis, key).ScanProto(dev); err != nil {
+			return false, err
+		}
+		dev, err := ttnpb.FilterGetEndDevice(dev, paths...)
+		if err != nil {
+			return false, err
+		}
+		if !f(ctx, dev.EndDeviceIdentifiers, dev) {
+			return false, nil
+		}
+		return true, nil
+	})
+}

--- a/pkg/redis/utils.go
+++ b/pkg/redis/utils.go
@@ -1,0 +1,27 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redis
+
+import (
+	"regexp"
+	"strings"
+)
+
+func DeviceRegex(key string) (*regexp.Regexp, error) {
+	keyRegex := strings.ReplaceAll(key, ":", "\\:")
+	keyRegex = strings.ReplaceAll(keyRegex, "*", ".[^\\:]*")
+	keyRegex = keyRegex + "$"
+	return regexp.Compile(keyRegex)
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References #14 

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `Range` to `DeviceRegistry` in network server.
- Add `ns-db cleanup` command.


#### Testing

<!-- How did you verify that this change works? -->

Manual

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

New functionality

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Do we need tests, since the functionality is pretty much the same as for AS and that is pretty well covered by the tests.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
