### PR TITLE
Improve Application Server distribution observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,19 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Added
 
+- `ttn_lw_as_subscription_sets_publish_success_total` and `ttn_lw_as_subscription_sets_publish_failed_total` metrics to track the number of subscription set publish attempts.
+- Application Server advanced distribution settings:
+  - `as.distribution.global.individual.subscription-blocks` controls if the Application Server should block while publishing traffic to individual global subscribers (such as MQTT clients).
+  - `as.distribution.global.individual.subscription-queue-size` controls how many uplinks the Application Server should buffer for an individual global subscriber. Note that when the buffer is full, the Application Server will drop the uplinks if `--as.distribution.global.individual.subscription-blocks` is not enabled. Use a negative value in order to disable the queue.
+  - `as.distribution.local.broadcast.subscription-blocks` controls if the Application Server should block while publishing traffic to broadcast local subscribers (such as webhooks and application packages matching).
+  - `as.distribution.local.broadcast.subscription-queue-size` controls how many uplinks the Application Server should buffer for an broadcast local subscriber. Has the same semantics as `--as.distribution.global.individual.subscription-queue-size`.
+  - `as.distribution.local.individual.subscription-blocks` controls if the Application Server should block while publishing traffic to individual local subscribers (such as PubSub integrations).
+  - `as.distribution.local.individual.subscription-queue-size` controls how many uplinks the Application Server should buffer for an individual local subscriber. Has the same semantics as `--as.distribution.global.individual.subscription-queue-size`.
+
 ### Changed
+
+- Gateway Server default UDP worker count has been increased to 1024, from 16.
+- Application Server webhooks and application packages default worker count has been increased to 1024, from 16.
 
 ### Deprecated
 

--- a/cmd/internal/shared/applicationserver/config.go
+++ b/cmd/internal/shared/applicationserver/config.go
@@ -43,8 +43,8 @@ var DefaultApplicationServerConfig = applicationserver.Config{
 		Templates: DefaultWebhookTemplatesConfig,
 		Target:    "direct",
 		Timeout:   5 * time.Second,
-		QueueSize: 16,
-		Workers:   16,
+		QueueSize: 1024,
+		Workers:   1024,
 		Downlinks: web.DownlinksConfig{PublicAddress: shared.DefaultPublicURL + "/api/v3"},
 	},
 	EndDeviceFetcher: applicationserver.EndDeviceFetcherConfig{
@@ -73,7 +73,7 @@ var DefaultApplicationServerConfig = applicationserver.Config{
 	},
 	Packages: applicationserver.ApplicationPackagesConfig{
 		Config: packages.Config{
-			Workers: 16,
+			Workers: 1024,
 			Timeout: 10 * time.Second,
 		},
 	},

--- a/cmd/internal/shared/applicationserver/config.go
+++ b/cmd/internal/shared/applicationserver/config.go
@@ -20,6 +20,7 @@ import (
 
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/shared"
 	"go.thethings.network/lorawan-stack/v3/pkg/applicationserver"
+	"go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io"
 	"go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io/packages"
 	"go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io/web"
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
@@ -64,6 +65,22 @@ var DefaultApplicationServerConfig = applicationserver.Config{
 	},
 	Distribution: applicationserver.DistributionConfig{
 		Timeout: time.Minute,
+		Local: applicationserver.LocalDistributorConfig{
+			Broadcast: applicationserver.DistributorConfig{
+				SubscriptionBlocks:    true,
+				SubscriptionQueueSize: -1,
+			},
+			Individual: applicationserver.DistributorConfig{
+				SubscriptionBlocks:    false,
+				SubscriptionQueueSize: io.DefaultBufferSize,
+			},
+		},
+		Global: applicationserver.GlobalDistributorConfig{
+			Individual: applicationserver.DistributorConfig{
+				SubscriptionBlocks:    false,
+				SubscriptionQueueSize: io.DefaultBufferSize,
+			},
+		},
 	},
 	PubSub: applicationserver.PubSubConfig{
 		Providers: map[string]string{

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -311,7 +311,7 @@ var startCommand = &cobra.Command{
 				Redis: redis.New(config.Redis.WithNamespace("as", "applicationups")),
 				Limit: config.AS.UplinkStorage.Limit,
 			}
-			config.AS.Distribution.PubSub = &asdistribredis.PubSub{
+			config.AS.Distribution.Global.PubSub = &asdistribredis.PubSub{
 				Redis: redis.New(config.Cache.Redis.WithNamespace("as", "traffic")),
 			}
 			pubsubRegistry := &asiopsredis.PubSubRegistry{

--- a/config/messages.json
+++ b/config/messages.json
@@ -1952,15 +1952,6 @@
       "file": "middleware.go"
     }
   },
-  "error:pkg/applicationserver/distribution/redis:channel_closed": {
-    "translations": {
-      "en": "channel closed"
-    },
-    "description": {
-      "package": "pkg/applicationserver/distribution/redis",
-      "file": "redis.go"
-    }
-  },
   "error:pkg/applicationserver/distribution:empty_set": {
     "translations": {
       "en": "empty set"

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -132,11 +132,23 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 			ttnpb.PayloadFormatter_FORMATTER_JAVASCRIPT: javascript.New(),
 			ttnpb.PayloadFormatter_FORMATTER_CAYENNELPP: cayennelpp.New(),
 		},
-		clusterDistributor: distribution.NewPubSubDistributor(ctx, c, conf.Distribution.Timeout, conf.Distribution.PubSub),
-		localDistributor:   distribution.NewLocalDistributor(ctx, c, conf.Distribution.Timeout),
-		interopClient:      interopCl,
-		interopID:          conf.Interop.ID,
-		endDeviceFetcher:   conf.EndDeviceFetcher.Fetcher,
+		clusterDistributor: distribution.NewPubSubDistributor(
+			ctx,
+			c,
+			conf.Distribution.Timeout,
+			conf.Distribution.Global.PubSub,
+			conf.Distribution.Global.Individual.SubscriptionOptions(),
+		),
+		localDistributor: distribution.NewLocalDistributor(
+			ctx,
+			c,
+			conf.Distribution.Timeout,
+			conf.Distribution.Local.Broadcast.SubscriptionOptions(),
+			conf.Distribution.Local.Individual.SubscriptionOptions(),
+		),
+		interopClient:    interopCl,
+		interopID:        conf.Interop.ID,
+		endDeviceFetcher: conf.EndDeviceFetcher.Fetcher,
 	}
 	as.formatters[ttnpb.PayloadFormatter_FORMATTER_REPOSITORY] = devicerepository.New(as.formatters, as)
 

--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -311,7 +311,9 @@ func TestApplicationServer(t *testing.T) {
 			Fetcher: &noopEndDeviceFetcher{},
 		},
 		Distribution: applicationserver.DistributionConfig{
-			PubSub: distribPubSub,
+			Global: applicationserver.GlobalDistributorConfig{
+				PubSub: distribPubSub,
+			},
 		},
 	}
 	as, err := applicationserver.New(c, config)
@@ -2351,7 +2353,9 @@ func TestSkipPayloadCrypto(t *testing.T) {
 			Fetcher: &noopEndDeviceFetcher{},
 		},
 		Distribution: applicationserver.DistributionConfig{
-			PubSub: distribPubSub,
+			Global: applicationserver.GlobalDistributorConfig{
+				PubSub: distribPubSub,
+			},
 		},
 	}
 	as, err := applicationserver.New(c, config)
@@ -2841,7 +2845,9 @@ func TestLocationFromPayload(t *testing.T) {
 			Fetcher: &noopEndDeviceFetcher{},
 		},
 		Distribution: applicationserver.DistributionConfig{
-			PubSub: distribPubSub,
+			Global: applicationserver.GlobalDistributorConfig{
+				PubSub: distribPubSub,
+			},
 		},
 	}
 	as, err := applicationserver.New(c, config)

--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -1980,7 +1980,7 @@ func TestApplicationServer(t *testing.T) {
 									t.Fatalf("Expected no upstream message but got %v", msg)
 								}
 							}
-						case <-time.After(Timeout * 2):
+						case <-time.After(Timeout):
 							if !tc.ExpectTimeout && tc.AssertUp != nil {
 								t.Fatal("Expected upstream timeout")
 							}
@@ -2397,6 +2397,8 @@ func TestSkipPayloadCrypto(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to subscribe: %v", err)
 	}
+	// Wait for connection to establish.
+	time.Sleep(2 * Timeout)
 	// Read upstream.
 	go func() {
 		for {
@@ -2627,7 +2629,7 @@ func TestSkipPayloadCrypto(t *testing.T) {
 							} else {
 								t.Fatalf("Expected no upstream message but got %v", msg)
 							}
-						case <-time.After(Timeout * 8):
+						case <-time.After(Timeout):
 							if step.AssertUp != nil {
 								step.AssertUp(t, nil)
 							} else {

--- a/pkg/applicationserver/config.go
+++ b/pkg/applicationserver/config.go
@@ -115,8 +115,41 @@ type WebhooksConfig struct {
 
 // DistributionConfig contains the upstream traffic distribution configuration of the Application Server.
 type DistributionConfig struct {
-	PubSub  distribution.PubSub `name:"-"`
-	Timeout time.Duration       `name:"timeout" description:"Wait timeout of an empty subscription set"`
+	Timeout time.Duration           `name:"timeout" description:"Wait timeout of an empty subscription set"`
+	Local   LocalDistributorConfig  `name:"local" description:"Local distributor configuration"`
+	Global  GlobalDistributorConfig `name:"global" description:"Global distributor configuration"`
+}
+
+// DistributorConfig contains the configuration of a traffic distributor of the Application Server.
+type DistributorConfig struct {
+	SubscriptionQueueSize int  `name:"subscription-queue-size" description:"Number of uplinks to queue for each subscriber"`
+	SubscriptionBlocks    bool `name:"subscription-blocks" description:"Controls if traffic should be dropped if the queue of a subscriber is full"`
+}
+
+// SubscriptionOptions generates the subscription options based on the configuration.
+func (c DistributorConfig) SubscriptionOptions() []io.SubscriptionOption {
+	if c.SubscriptionQueueSize == 0 {
+		c.SubscriptionQueueSize = io.DefaultBufferSize
+	}
+	if c.SubscriptionQueueSize < 0 {
+		c.SubscriptionQueueSize = 0
+	}
+	return []io.SubscriptionOption{
+		io.WithBlocking(c.SubscriptionBlocks),
+		io.WithBufferSize(c.SubscriptionQueueSize),
+	}
+}
+
+// LocalDistributorConfig contains the configuration of the local traffic distributor of the Application Server.
+type LocalDistributorConfig struct {
+	Broadcast  DistributorConfig `name:"broadcast" description:"Broadcast distributor configuration"`
+	Individual DistributorConfig `name:"individual" description:"Individual distributor configuration"`
+}
+
+// GlobalDistributorConfig contains the configuration of the global traffic distributor of the Application Server.
+type GlobalDistributorConfig struct {
+	PubSub     distribution.PubSub `name:"-"`
+	Individual DistributorConfig   `name:"individual" description:"Individual distributor configuration"`
 }
 
 // PubSubConfig contains go-cloud pub/sub configuration of the Application Server.

--- a/pkg/applicationserver/distribution/local_distributor.go
+++ b/pkg/applicationserver/distribution/local_distributor.go
@@ -26,10 +26,10 @@ import (
 // NewLocalDistributor creates a Distributor that routes the traffic locally.
 // The underlying subscription sets can timeout if there are no active subscribers.
 // A timeout of 0 means the underlying subscriptions never timeout.
-func NewLocalDistributor(ctx context.Context, rd RequestDecoupler, timeout time.Duration) Distributor {
+func NewLocalDistributor(ctx context.Context, rd RequestDecoupler, timeout time.Duration, broadcastOpts []io.SubscriptionOption, mapOpts []io.SubscriptionOption) Distributor {
 	return &localDistributor{
-		broadcast:     newSubscriptionSet(ctx, rd, 0, io.WithBlocking(true)),
-		subscriptions: newSubscriptionMap(ctx, rd, timeout, noSetup),
+		broadcast:     newSubscriptionSet(ctx, rd, 0, broadcastOpts...),
+		subscriptions: newSubscriptionMap(ctx, rd, timeout, noSetup, mapOpts...),
 	}
 }
 

--- a/pkg/applicationserver/distribution/pubsub_distributor.go
+++ b/pkg/applicationserver/distribution/pubsub_distributor.go
@@ -27,10 +27,10 @@ import (
 // NewPubSubDistributor creates a Distributor on top of the provided PubSub.
 // The underlying subscription sets can timeout if there are no active subscribers.
 // A timeout of 0 means the underlying subscription sets never timeout.
-func NewPubSubDistributor(ctx context.Context, rd RequestDecoupler, timeout time.Duration, pubsub PubSub) Distributor {
+func NewPubSubDistributor(ctx context.Context, rd RequestDecoupler, timeout time.Duration, pubsub PubSub, mapOpts []io.SubscriptionOption) Distributor {
 	return &pubSubDistributor{
 		pubsub:        pubsub,
-		subscriptions: newSubscriptionMap(ctx, rd, timeout, subscribeSetToPubSub(pubsub)),
+		subscriptions: newSubscriptionMap(ctx, rd, timeout, subscribeSetToPubSub(pubsub), mapOpts...),
 	}
 }
 

--- a/pkg/applicationserver/distribution/subscription_set.go
+++ b/pkg/applicationserver/distribution/subscription_set.go
@@ -155,6 +155,9 @@ func (s *subscriptionSet) run() {
 				))
 				if err := sub.Publish(ctx, up.ApplicationUp); err != nil {
 					log.FromContext(ctx).WithError(err).Warn("Failed to publish message")
+					registerPublishFailed(ctx, sub, err)
+				} else {
+					registerPublishSuccess(ctx, sub)
 				}
 			}
 		case <-tickCh:

--- a/pkg/gatewayserver/io/udp/config.go
+++ b/pkg/gatewayserver/io/udp/config.go
@@ -55,7 +55,7 @@ type Config struct {
 // We assume that the gateway sends a PULL_DATA message every 30 seconds, instead of the default of 5 seconds.
 // This behavior has been observed in the wild, and is often used by gateways which use metered connections.
 var DefaultConfig = Config{
-	PacketHandlers:         1 << 4,
+	PacketHandlers:         1024,
 	PacketBuffer:           50,
 	DownlinkPathExpires:    90 * time.Second, // Expire downlink after missing typically 3 PULL_DATA messages.
 	ConnectionExpires:      3 * time.Minute,  // Expire connection after missing typically 2 status messages.

--- a/pkg/redis/redis.go
+++ b/pkg/redis/redis.go
@@ -129,29 +129,18 @@ func (c Config) makeDialer() func(ctx context.Context, network, addr string) (ne
 		tlsConfigErr = c.TLS.Client.ApplyTo(tlsConfig)
 	}
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
-		var timeout time.Duration
-		deadline, ok := ctx.Deadline()
-		if ok {
-			timeout = time.Until(deadline)
-		}
-		var (
-			conn net.Conn
-			err  error
-		)
-		dialer := &net.Dialer{Timeout: timeout}
+		var dialer interface {
+			DialContext(ctx context.Context, network, addr string) (net.Conn, error)
+		} = &net.Dialer{}
 		if c.TLS.Require {
 			if tlsConfigErr != nil {
 				return nil, tlsConfigErr
 			}
-			conn, err = tls.DialWithDialer(dialer, network, addr, tlsConfig)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			conn, err = dialer.Dial(network, addr)
-			if err != nil {
-				return nil, err
-			}
+			dialer = &tls.Dialer{NetDialer: dialer.(*net.Dialer), Config: tlsConfig}
+		}
+		conn, err := dialer.DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
 		}
 		return &observableConn{addr: addr, Conn: conn}, nil
 	}

--- a/pkg/util/test/redis.go
+++ b/pkg/util/test/redis.go
@@ -126,7 +126,7 @@ func NewRedis(ctx context.Context, namespace ...string) (*ttnredis.Client, func(
 		q := cl.Key("*")
 		keys, err := cl.Client.Keys(ctx, q).Result()
 		if err != nil {
-			logger.WithField("query", q).Fatal("Failed to query Redis for keys")
+			logger.WithError(err).WithField("query", q).Fatal("Failed to query Redis for keys")
 			return
 		}
 

--- a/pkg/workerpool/workerpool.go
+++ b/pkg/workerpool/workerpool.go
@@ -32,7 +32,7 @@ const (
 	// defaultMinWorkers is the default number of minimum workers kept in the pool.
 	defaultMinWorkers = 4
 	// defaultMaxWorkers is the default number of maximum workers kept in the pool.
-	defaultMaxWorkers = 64
+	defaultMaxWorkers = 1024
 )
 
 // Component contains a minimal component.Component definition.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/4715

#### Changes
<!-- What are the changes made in this pull request? -->

- Change `TestSkipPayloadCrypto` to sleep _before_ starting to publish traffic, in order to allow the subscriber to actually subscribe. Previously no matter how much we would sleep the message would be lost since it would be published before the subscriber subscribed.
- Increase the default number of webhook, application packages and UDP workers to 1024
  - The workers are part of a dynamic worker pool, and are spawned on demand
- Increase the default maximum number of workers of a worker pool to 1024
  - This affects two pools currently: `webhooks_fanout` and `application_packages_fanout`, which we may move to a specific configuration option later
- Add metrics for subscription sets publishing status (success / failure)
  - The idea here is to observe basically how often `buffer_full` errors are observed, as failures can occur only on `io.Subscription.Publish`
- Allow advanced configuration of the Application Server traffic distribution
  - For each distribution level, allow the network operators to configure the buffer sizes, and if publishing should block
  - If publish blocks, the buffers no longer drop messages that arrive when the buffers are full
- The Application Server Global (PubSub based) distributor no longer buffers messages, and instead allows the underlying subscription set / subscription to do it

#### Testing

<!-- How did you verify that this change works? -->

`GOMAXPROCS=1 TEST_SLOWDOWN=8 go test -v -failfast -timeout=1h -count=1000 -run TestSkipPayloadCrypto` _many_ times

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This mainly touches piping. If CI is happy, everything should be fine.
#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
