### PR TITLE
Unset session `started_at` in Application Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,15 @@ For details about compatibility between different releases, see the **Commitment
   - `as.distribution.local.individual.subscription-queue-size` controls how many uplinks the Application Server should buffer for an individual local subscriber. Has the same semantics as `--as.distribution.global.individual.subscription-queue-size`.
 - `ttn_lw_gs_txack_received_total`, `ttn_lw_gs_txack_forwarded_total` and `ttn_lw_gs_txack_dropped_total` metrics, which track the transmission acknowledgements from gateways.
 - `gs.txack.receive`, `gs.txack.drop` and `gs.txack.forward` events, which track the transmission acknowledgements from gateways.
+- `ttn-lw-stack as-db migrate` command to migrate the Application Server database. This command records the schema version and only performs migrations if on a newer version.
+  - Use the `--force` flag to force perform migrations.
 
 ### Changed
 
 - Gateway Server default UDP worker count has been increased to 1024, from 16.
 - Application Server webhooks and application packages default worker count has been increased to 1024, from 16.
+- Application Server no longer sets the end device's `session.started_at` and `pending_session.started_at`. The session start time should be retrieved from the Network Server, per API specification.
+  - This requires an Application Server database migration (`ttn-lw-stack as-db migrate`) to clear the `started_at` field in existing (pending) sessions.
 
 ### Deprecated
 

--- a/cmd/ttn-lw-stack/commands/as_db.go
+++ b/cmd/ttn-lw-stack/commands/as_db.go
@@ -42,7 +42,7 @@ var (
 			}
 
 			logger.Info("Connecting to Redis database...")
-			cl := NewApplicationServerDeviceRegistryRedis(*config)
+			cl := ttnredis.New(config.Redis.WithNamespace("as"))
 
 			if force, _ := cmd.Flags().GetBool("force"); !force {
 				needMigration, err := checkLatestSchemaVersion(cl, asredis.SchemaVersion)
@@ -63,7 +63,7 @@ var (
 				uidRegexpStr = idRegexpStr + `\.` + idRegexpStr
 			)
 
-			uidRegexp := regexp.MustCompile(cl.Key("uid", uidRegexpStr+"$"))
+			uidRegexp := regexp.MustCompile(cl.Key("devices", "uid", uidRegexpStr+"$"))
 
 			lockerID, err := ttnredis.GenerateLockerID()
 			if err != nil {

--- a/cmd/ttn-lw-stack/commands/as_db.go
+++ b/cmd/ttn-lw-stack/commands/as_db.go
@@ -15,11 +15,15 @@
 package commands
 
 import (
+	"regexp"
 	"time"
 
+	"github.com/go-redis/redis/v8"
 	"github.com/spf13/cobra"
 	"go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io/web"
+	asredis "go.thethings.network/lorawan-stack/v3/pkg/applicationserver/redis"
 	"go.thethings.network/lorawan-stack/v3/pkg/cleanup"
+	ttnredis "go.thethings.network/lorawan-stack/v3/pkg/redis"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/unique"
 )
@@ -28,6 +32,76 @@ var (
 	asDBCommand = &cobra.Command{
 		Use:   "as-db",
 		Short: "Manage Application Server database",
+	}
+	asDBMigrateCommand = &cobra.Command{
+		Use:   "migrate",
+		Short: "Migrate Application Server data",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if config.Redis.IsZero() {
+				panic("Only Redis is supported by this command")
+			}
+
+			logger.Info("Connecting to Redis database...")
+			cl := NewApplicationServerDeviceRegistryRedis(*config)
+
+			if force, _ := cmd.Flags().GetBool("force"); !force {
+				needMigration, err := checkLatestSchemaVersion(cl, asredis.SchemaVersion)
+				if err != nil {
+					return err
+				}
+				if !needMigration {
+					logger.Info("Database schema version is already in latest version")
+					return nil
+				}
+			}
+
+			var migrated uint64
+			defer func() { logger.Debugf("%d keys migrated", migrated) }()
+
+			const (
+				idRegexpStr  = `([a-z0-9](?:[-]?[a-z0-9]){2,}){1,36}?`
+				uidRegexpStr = idRegexpStr + `\.` + idRegexpStr
+			)
+
+			uidRegexp := regexp.MustCompile(cl.Key("uid", uidRegexpStr+"$"))
+
+			if err := ttnredis.RangeRedisKeys(ctx, cl, cl.Key("*"), 1, func(k string) (bool, error) {
+				logger := logger.WithField("key", k)
+				switch {
+				case uidRegexp.MatchString(k):
+					if err := cl.Watch(ctx, func(tx *redis.Tx) error {
+						dev := &ttnpb.EndDevice{}
+						if err := ttnredis.GetProto(ctx, tx, k).ScanProto(dev); err != nil {
+							logger.WithError(err).Error("Failed to get device proto")
+							return err
+						}
+						var any bool
+						for _, sess := range []*ttnpb.Session{dev.Session, dev.PendingSession} {
+							if sess == nil || sess.StartedAt.IsZero() {
+								continue
+							}
+							sess.StartedAt = time.Time{}
+							any = true
+						}
+						_, err := ttnredis.SetProto(ctx, tx, k, dev, 0)
+						if err != nil {
+							return err
+						}
+						if any {
+							migrated++
+						}
+						return nil
+					}, k); err != nil {
+						logger.WithError(err).Error("Transaction failed")
+					}
+				}
+				return true, nil
+			}); err != nil {
+				return err
+			}
+
+			return recordSchemaVersion(cl, asredis.SchemaVersion)
+		},
 	}
 	asDBCleanupCommand = &cobra.Command{
 		Use:   "cleanup",
@@ -152,6 +226,7 @@ var (
 
 func init() {
 	Root.AddCommand(asDBCommand)
+	asDBCommand.AddCommand(asDBMigrateCommand)
 	asDBCleanupCommand.Flags().Bool("dry-run", false, "Dry run")
 	asDBCleanupCommand.Flags().Duration("pagination-delay", 100, "Delay between batch requests")
 	asDBCommand.AddCommand(asDBCleanupCommand)

--- a/cmd/ttn-lw-stack/commands/is_db.go
+++ b/cmd/ttn-lw-stack/commands/is_db.go
@@ -189,6 +189,9 @@ var (
 					return err
 				}
 				err = appStore.PurgeApplication(ctx, ids.GetIds())
+				if err != nil {
+					return err
+				}
 			}
 
 			logger.Info("Purging expired users")

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -68,6 +68,10 @@ func NewNetworkServerDownlinkTaskRedis(conf Config) *redis.Client {
 	return redis.New(conf.Redis.WithNamespace("ns", "tasks"))
 }
 
+func NewApplicationServerDeviceRegistryRedis(conf Config) *redis.Client {
+	return NewComponentDeviceRegistryRedis(conf, "as")
+}
+
 var errUnknownComponent = errors.DefineInvalidArgument("unknown_component", "unknown component `{component}`")
 
 var startCommand = &cobra.Command{
@@ -300,7 +304,7 @@ var startCommand = &cobra.Command{
 			}
 			config.AS.Links = linkRegistry
 			deviceRegistry := &asredis.DeviceRegistry{
-				Redis:   NewComponentDeviceRegistryRedis(*config, "as"),
+				Redis:   NewApplicationServerDeviceRegistryRedis(*config),
 				LockTTL: defaultLockTTL,
 			}
 			if err := deviceRegistry.Init(ctx); err != nil {

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -400,7 +400,6 @@ func (as *ApplicationServer) buildSessionsFromError(ctx context.Context, dev *tt
 				AppSKey:      &appSKey,
 			},
 			LastAFCntDown: lastAFCntDownFromMinFCnt(minFCntDown),
-			StartedAt:     time.Now().UTC(),
 		}, nil
 	}
 
@@ -781,7 +780,6 @@ func (as *ApplicationServer) handleJoinAccept(ctx context.Context, ids ttnpb.End
 					SessionKeyId: joinAccept.SessionKeyId,
 					AppSKey:      joinAccept.AppSKey,
 				},
-				StartedAt: time.Now().UTC(),
 			}
 			mask = ttnpb.AddFields(mask, "pending_session")
 			if as.skipPayloadCrypto(ctx, link, dev, dev.PendingSession) {
@@ -862,7 +860,6 @@ func (as *ApplicationServer) matchSession(ctx context.Context, ids ttnpb.EndDevi
 				SessionKeyId: sessionKeyID,
 				AppSKey:      &appSKey,
 			},
-			StartedAt: time.Now().UTC(),
 		}
 		dev.PendingSession = nil
 		dev.DevAddr = ids.DevAddr

--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -967,7 +967,6 @@ func TestApplicationServer(t *testing.T) {
 									},
 								},
 								LastAFCntDown: 0,
-								StartedAt:     dev.PendingSession.StartedAt,
 							})
 							a.So(queue, should.BeEmpty)
 						},
@@ -1014,7 +1013,6 @@ func TestApplicationServer(t *testing.T) {
 									},
 								},
 								LastAFCntDown: 0,
-								StartedAt:     dev.PendingSession.StartedAt,
 							})
 							a.So(queue, should.BeEmpty)
 						},
@@ -1133,7 +1131,6 @@ func TestApplicationServer(t *testing.T) {
 									},
 								},
 								LastAFCntDown: 0,
-								StartedAt:     dev.Session.StartedAt,
 							})
 							a.So(dev.PendingSession, should.Resemble, &ttnpb.Session{
 								DevAddr: types.DevAddr{0x33, 0x33, 0x33, 0x33},
@@ -1145,7 +1142,6 @@ func TestApplicationServer(t *testing.T) {
 									},
 								},
 								LastAFCntDown: 2,
-								StartedAt:     dev.PendingSession.StartedAt,
 							})
 							a.So(queue, should.Resemble, []*ttnpb.ApplicationDownlink{
 								{
@@ -1567,7 +1563,6 @@ func TestApplicationServer(t *testing.T) {
 									},
 								},
 								LastAFCntDown: 44,
-								StartedAt:     dev.Session.StartedAt,
 							})
 							a.So(dev.PendingSession, should.Resemble, &ttnpb.Session{
 								DevAddr: types.DevAddr{0x44, 0x44, 0x44, 0x44},
@@ -1579,7 +1574,6 @@ func TestApplicationServer(t *testing.T) {
 									},
 								},
 								LastAFCntDown: 2,
-								StartedAt:     dev.PendingSession.StartedAt,
 							})
 							a.So(queue, should.Resemble, []*ttnpb.ApplicationDownlink{
 								{
@@ -1671,7 +1665,6 @@ func TestApplicationServer(t *testing.T) {
 									},
 								},
 								LastAFCntDown: 2,
-								StartedAt:     dev.Session.StartedAt,
 							})
 							a.So(dev.PendingSession, should.BeNil)
 							a.So(queue, should.Resemble, []*ttnpb.ApplicationDownlink{
@@ -1917,7 +1910,6 @@ func TestApplicationServer(t *testing.T) {
 									},
 								},
 								LastAFCntDown: 0,
-								StartedAt:     dev.Session.StartedAt,
 							})
 							a.So(dev.PendingSession, should.BeNil)
 							a.So(queue, should.Resemble, []*ttnpb.ApplicationDownlink{})
@@ -2517,7 +2509,6 @@ func TestSkipPayloadCrypto(t *testing.T) {
 									},
 								},
 								LastAFCntDown: 0,
-								StartedAt:     dev.PendingSession.StartedAt,
 							})
 						},
 					},

--- a/pkg/applicationserver/redis/registry.go
+++ b/pkg/applicationserver/redis/registry.go
@@ -34,6 +34,9 @@ var (
 	errReadOnlyField        = errors.DefineInvalidArgument("read_only_field", "read-only field `{field}`")
 )
 
+// SchemaVersion is the Application Server database schema version. Bump when a migration is required.
+const SchemaVersion = 1
+
 // DeviceRegistry is a Redis device registry.
 type DeviceRegistry struct {
 	Redis   *ttnredis.Client


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Unset session `started_at`

Addresses #4766

#### Changes
<!-- What are the changes made in this pull request? -->

- Do not set session `started_at` in AS
- Unset `started_at` as part of `as-db cleanup`

#### Testing

<!-- How did you verify that this change works? -->

1. Made local device
2. Temporarily allowed setting `session.started_at` in AS (by allowing field mask validation, not part of this PR)
3. Set the started at to a value: 
```
TTN_LW_NETWORK_SERVER_ENABLED=false ttn-lw-cli dev set app1 dev1 --session.started_at "2021-01-01T12:00:00Z" --session.dev_addr ABCDABCD
```
4. Decode the value from the database:
```json
{"ids":{"device_id":"dev1","application_ids":{"application_id":"app1"},"dev_eui":"1122334455667788","join_eui":"0000000000000000","dev_addr":"ABCDABCD"},"created_at":"2021-10-27T08:34:35.761063Z","updated_at":"2021-10-27T08:37:21.740897Z","session":{"dev_addr":"ABCDABCD","keys":{},"started_at":"2021-01-01T12:00:00Z"}}
```
5. Run `as-db cleanup`
6. Decode the value from the database:
```json
{"ids":{"device_id":"dev1","application_ids":{"application_id":"app1"},"dev_eui":"1122334455667788","join_eui":"0000000000000000","dev_addr":"ABCDABCD"},"created_at":"2021-10-27T08:34:35.761063Z","updated_at":"2021-10-27T08:44:47.863279Z","session":{"dev_addr":"ABCDABCD","keys":{},"started_at":"0001-01-01T00:00:00Z"}}
```
Notice that it's reset to an empty value, the best we can do now

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None, unless clients were relying on faulty behavior

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@kschiffer I'm leaving the target issue open and will provide some additional information on what the Console should do when merging sessions.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
