### PR TITLE
Add additional Gateway Server transmission metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For details about compatibility between different releases, see the **Commitment
   - `as.distribution.local.broadcast.subscription-queue-size` controls how many uplinks the Application Server should buffer for an broadcast local subscriber. Has the same semantics as `--as.distribution.global.individual.subscription-queue-size`.
   - `as.distribution.local.individual.subscription-blocks` controls if the Application Server should block while publishing traffic to individual local subscribers (such as PubSub integrations).
   - `as.distribution.local.individual.subscription-queue-size` controls how many uplinks the Application Server should buffer for an individual local subscriber. Has the same semantics as `--as.distribution.global.individual.subscription-queue-size`.
+- `ttn_lw_gs_txack_received_total`, `ttn_lw_gs_txack_forwarded_total` and `ttn_lw_gs_txack_dropped_total` metrics, which track the transmission acknowledgements from gateways.
+- `gs.txack.receive`, `gs.txack.drop` and `gs.txack.forward` events, which track the transmission acknowledgements from gateways.
 
 ### Changed
 
@@ -28,6 +30,9 @@ For details about compatibility between different releases, see the **Commitment
 ### Deprecated
 
 ### Removed
+
+- The `ttn_lw_gs_status_failed_total`, `ttn_lw_gs_uplink_failed_total` metrics. `ttn_lw_gs_status_dropped_total` and `ttn_lw_gs_uplink_dropped_total` should be used instead, as they contain the failure cause.
+- The `gs.status.fail` and `gs.up.fail` events. `gs.status.drop` and `gs.up.drop` should be used instead, as they contain the failure cause.
 
 ### Fixed
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -9278,15 +9278,6 @@
       "file": "observability.go"
     }
   },
-  "event:gs.status.fail": {
-    "translations": {
-      "en": "fail to handle gateway status"
-    },
-    "description": {
-      "package": "pkg/gatewayserver",
-      "file": "observability.go"
-    }
-  },
   "event:gs.status.receive": {
     "translations": {
       "en": "receive gateway status"
@@ -9299,15 +9290,6 @@
   "event:gs.txack.drop": {
     "translations": {
       "en": "drop transmission acknowledgement"
-    },
-    "description": {
-      "package": "pkg/gatewayserver",
-      "file": "observability.go"
-    }
-  },
-  "event:gs.txack.fail": {
-    "translations": {
-      "en": "fail to handle transmission acknowledgement"
     },
     "description": {
       "package": "pkg/gatewayserver",
@@ -9335,15 +9317,6 @@
   "event:gs.up.drop": {
     "translations": {
       "en": "drop uplink message"
-    },
-    "description": {
-      "package": "pkg/gatewayserver",
-      "file": "observability.go"
-    }
-  },
-  "event:gs.up.fail": {
-    "translations": {
-      "en": "fail to handle uplink message"
     },
     "description": {
       "package": "pkg/gatewayserver",

--- a/config/messages.json
+++ b/config/messages.json
@@ -9296,6 +9296,42 @@
       "file": "observability.go"
     }
   },
+  "event:gs.txack.drop": {
+    "translations": {
+      "en": "drop transmission acknowledgement"
+    },
+    "description": {
+      "package": "pkg/gatewayserver",
+      "file": "observability.go"
+    }
+  },
+  "event:gs.txack.fail": {
+    "translations": {
+      "en": "fail to handle transmission acknowledgement"
+    },
+    "description": {
+      "package": "pkg/gatewayserver",
+      "file": "observability.go"
+    }
+  },
+  "event:gs.txack.forward": {
+    "translations": {
+      "en": "forward transmission acknowledgement"
+    },
+    "description": {
+      "package": "pkg/gatewayserver",
+      "file": "observability.go"
+    }
+  },
+  "event:gs.txack.receive": {
+    "translations": {
+      "en": "receive transmission acknowledgement"
+    },
+    "description": {
+      "package": "pkg/gatewayserver",
+      "file": "observability.go"
+    }
+  },
   "event:gs.up.drop": {
     "translations": {
       "en": "drop uplink message"

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -663,7 +663,7 @@ func (host *upstreamHost) handlePacket(ctx context.Context, item interface{}) {
 				logger = logger.WithField("dev_addr", *ids.DevAddr)
 			}
 			logger.Debug("Drop message")
-			registerDropUplink(ctx, gtw, msg.UplinkMessage, host.name, err)
+			registerDropUplink(ctx, gtw, msg, host.name, err)
 		}
 		ids, err := lorawan.GetUplinkMessageIdentifiers(msg.RawPayload)
 		if err != nil {
@@ -793,11 +793,11 @@ func (gs *GatewayServer) handleUpstream(conn connectionEntry) {
 			logger.WithField("name", host.name).WithError(err).Warn("Upstream handler publish failed")
 			switch msg := val.(type) {
 			case *ttnpb.GatewayUplinkMessage:
-				registerFailUplink(ctx, gtw, msg, host.name, err)
+				registerDropUplink(ctx, gtw, msg, host.name, err)
 			case *ttnpb.GatewayStatus:
-				registerFailStatus(ctx, gtw, msg, host.name, err)
+				registerDropStatus(ctx, gtw, msg, host.name, err)
 			case *ttnpb.TxAcknowledgment:
-				registerFailTxAck(ctx, gtw, msg, host.name, err)
+				registerDropTxAck(ctx, gtw, msg, host.name, err)
 			default:
 				panic("unreachable")
 			}

--- a/pkg/gatewayserver/io/observability.go
+++ b/pkg/gatewayserver/io/observability.go
@@ -101,11 +101,11 @@ func registerDropMessage(ctx context.Context, gtw *ttnpb.Gateway, typ string, er
 	case "txack":
 		events.Publish(evtDropTxAck.NewWithIdentifiersAndData(ctx, gtw, err))
 	}
+	errorLabel := "unknown"
 	if ttnErr, ok := errors.From(err); ok {
-		ioMetrics.droppedMessages.WithLabelValues(ctx, typ, ttnErr.FullName()).Inc()
-	} else {
-		ioMetrics.droppedMessages.WithLabelValues(ctx, typ, "unknown").Inc()
+		errorLabel = ttnErr.FullName()
 	}
+	ioMetrics.droppedMessages.WithLabelValues(ctx, typ, errorLabel).Inc()
 }
 
 func init() {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This short PR fixes a number of issues with GS traffic metrics, and adds extra metrics.

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix the events and metrics related to dropped uplinks when the upstream handlers are full
  - The type of the message is `GatewayUplinkMessage`, not `UplinkMessage`
- Dropped (rejected by upstream handlers) uplink messages and status messages now have the error cause attached to the metric
  - It's only one error for now, don't be afraid of high cardinality
- Remove the 'failed' events/metrics related to uplinks/status messages
  - These events were used when the upstream handlers were full
  - We now have a reason (error) attached to the dropped metrics, which should suffice
  - The old equilibrium equation was `received = forwarded + dropped + failed`, now it is `received = forwarded + dropped`
- Add transmission acknowledgements received/forwarded/dropped metrics/events

#### Testing

<!-- How did you verify that this change works? -->

:monkey: 

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

It was already broken. We can only go up from here.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
