### PR TITLE
Parse frame payload only once

### DIFF
--- a/pkg/encoding/lorawan/messages.go
+++ b/pkg/encoding/lorawan/messages.go
@@ -581,7 +581,7 @@ func UnmarshalMessage(b []byte, msg *ttnpb.Message) error {
 	return nil
 }
 
-// GetUplinkMessageIdentifiers parses the PHYPayload and retrieves the EndDeviceIdentifers (except DeviceID).
+// GetUplinkMessageIdentifiers parses the PHYPayload and retrieves the EndDeviceIdentifiers (except DeviceID).
 func GetUplinkMessageIdentifiers(phyPayload []byte) (ttnpb.EndDeviceIdentifiers, error) {
 	n := len(phyPayload)
 	if n == 0 {

--- a/pkg/gatewayserver/upstream/ns/ns.go
+++ b/pkg/gatewayserver/upstream/ns/ns.go
@@ -95,8 +95,8 @@ func (h *Handler) ConnectGateway(ctx context.Context, ids ttnpb.GatewayIdentifie
 var errNetworkServerNotFound = errors.DefineNotFound("network_server_not_found", "Network Server not found")
 
 // HandleUplink implements upstream.Handler.
-func (h *Handler) HandleUplink(ctx context.Context, _ ttnpb.GatewayIdentifiers, ids ttnpb.EndDeviceIdentifiers, msg *ttnpb.GatewayUplinkMessage) error {
-	nsConn, err := h.cluster.GetPeerConn(ctx, ttnpb.ClusterRole_NETWORK_SERVER, &ids)
+func (h *Handler) HandleUplink(ctx context.Context, _ ttnpb.GatewayIdentifiers, ids *ttnpb.EndDeviceIdentifiers, msg *ttnpb.GatewayUplinkMessage) error {
+	nsConn, err := h.cluster.GetPeerConn(ctx, ttnpb.ClusterRole_NETWORK_SERVER, ids)
 	if err != nil {
 		return errNetworkServerNotFound.WithCause(err)
 	}

--- a/pkg/gatewayserver/upstream/ns/ns_test.go
+++ b/pkg/gatewayserver/upstream/ns/ns_test.go
@@ -60,7 +60,7 @@ func TestNSHandler(t *testing.T) {
 	for _, tc := range []struct {
 		Name                 string
 		Message              *ttnpb.GatewayUplinkMessage
-		EndDeviceIdentifiers ttnpb.EndDeviceIdentifiers
+		EndDeviceIdentifiers *ttnpb.EndDeviceIdentifiers
 	}{
 		{
 			Name: "OneUplink",
@@ -92,7 +92,7 @@ func TestNSHandler(t *testing.T) {
 					},
 				},
 			},
-			EndDeviceIdentifiers: ttnpb.EndDeviceIdentifiers{
+			EndDeviceIdentifiers: &ttnpb.EndDeviceIdentifiers{
 				DeviceId: "test-device",
 			},
 		},

--- a/pkg/gatewayserver/upstream/packetbroker/packetbroker.go
+++ b/pkg/gatewayserver/upstream/packetbroker/packetbroker.go
@@ -234,8 +234,8 @@ func (h *Handler) ConnectGateway(ctx context.Context, ids ttnpb.GatewayIdentifie
 var errPacketBrokerAgentNotFound = errors.DefineNotFound("packet_broker_agent_not_found", "Packet Broker Agent not found")
 
 // HandleUplink implements upstream.Handler.
-func (h *Handler) HandleUplink(ctx context.Context, _ ttnpb.GatewayIdentifiers, ids ttnpb.EndDeviceIdentifiers, msg *ttnpb.GatewayUplinkMessage) error {
-	pbaConn, err := h.Cluster.GetPeerConn(ctx, ttnpb.ClusterRole_PACKET_BROKER_AGENT, &ids)
+func (h *Handler) HandleUplink(ctx context.Context, _ ttnpb.GatewayIdentifiers, ids *ttnpb.EndDeviceIdentifiers, msg *ttnpb.GatewayUplinkMessage) error {
+	pbaConn, err := h.Cluster.GetPeerConn(ctx, ttnpb.ClusterRole_PACKET_BROKER_AGENT, ids)
 	if err != nil {
 		return errPacketBrokerAgentNotFound.WithCause(err)
 	}

--- a/pkg/gatewayserver/upstream/upstream.go
+++ b/pkg/gatewayserver/upstream/upstream.go
@@ -31,7 +31,7 @@ type Handler interface {
 	// ConnectGateway informs the upstream handler that a particular gateway is connected to the frontend.
 	ConnectGateway(context.Context, ttnpb.GatewayIdentifiers, *io.Connection) error
 	// HandleUp handles ttnpb.GatewayUplinkMessage. It must not mutate the gateway uplink message.
-	HandleUplink(context.Context, ttnpb.GatewayIdentifiers, ttnpb.EndDeviceIdentifiers, *ttnpb.GatewayUplinkMessage) error
+	HandleUplink(context.Context, ttnpb.GatewayIdentifiers, *ttnpb.EndDeviceIdentifiers, *ttnpb.GatewayUplinkMessage) error
 	// HandleStatus handles ttnpb.GatewayStatus.
 	HandleStatus(context.Context, ttnpb.GatewayIdentifiers, *ttnpb.GatewayStatus) error
 	// HandleTxAck handles ttnpb.TxAcknowledgment.

--- a/pkg/ttnpb/lorawan.go
+++ b/pkg/ttnpb/lorawan.go
@@ -2409,3 +2409,31 @@ func (v *DeviceEIRPValue) FieldIsZero(p string) bool {
 	}
 	panic(fmt.Sprintf("unknown path '%s'", p))
 }
+
+// EndDeviceIdentifiers returns the end device identifiers (DevEUI/JoinEUI/DevAddr) available for the message payload.
+// Note that if the payload is nil, the end device identifiers will be nil.
+func (m *Message) EndDeviceIdentifiers() *EndDeviceIdentifiers {
+	if p := m.GetMacPayload(); p != nil {
+		return &EndDeviceIdentifiers{
+			DevAddr: &p.DevAddr,
+		}
+	}
+	if p := m.GetJoinRequestPayload(); p != nil {
+		return &EndDeviceIdentifiers{
+			DevEui:  &p.DevEui,
+			JoinEui: &p.JoinEui,
+		}
+	}
+	if p := m.GetJoinAcceptPayload(); p != nil {
+		return &EndDeviceIdentifiers{
+			DevAddr: &p.DevAddr,
+		}
+	}
+	if p := m.GetRejoinRequestPayload(); p != nil {
+		return &EndDeviceIdentifiers{
+			DevEui:  &p.DevEui,
+			JoinEui: &p.JoinEui,
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This short PR changes the Gateway Server to parse the frame payload only once in order to build the end device identifiers

#### Changes
<!-- What are the changes made in this pull request? -->

- Extract the device identifiers from the parsed payload
  - We are always parsing the payload, but previously if parsing failed we would just let the message reach the backends (NS/PBA/`ttnv2`) where it would be dropped because the parsing would fail
- Use component tasks for gateway tasks (connection stats updates, location updates etc.)
  - Mainly in order to have a recovery mechanism in place, for panics

#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This is just plumbing.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This optimization should lower our load, since in production we have a pretty large amount of non-LoRaWAN frames that we receive, and parse at least 3 times for no reason.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
