### PR TITLE
all: Remove environmental variables from Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ For details about compatibility between different releases, see the **Commitment
 - The `gs.status.fail` and `gs.up.fail` events. `gs.status.drop` and `gs.up.drop` should be used instead, as they contain the failure cause.
 - The `data_rate_index` field in uplink message metadata. Observe the fully described data rate in the `data_rate` field instead.
 - LoRaWAN data rate index reported to LoRa Cloud DMS.
+- Dockerfile doesn't define environmental variables `TTN_LW_BLOB_LOCAL_DIRECTORY`, `TTN_LW_IS_DATABASE_URI` and `TTN_LW_REDIS_ADDRESS` anymore. They need to be set when running the container: please refer to `docker-compose.yml` for example values.
 
 ### Fixed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,10 +37,7 @@ RUN mkdir /srv/ttn-lorawan/public/blob
 
 VOLUME ["/srv/ttn-lorawan/public/blob"]
 
-ENV TTN_LW_BLOB_LOCAL_DIRECTORY=/srv/ttn-lorawan/public/blob \
-    TTN_LW_IS_DATABASE_URI=postgres://root@cockroach:26257/ttn_lorawan?sslmode=disable \
-    TTN_LW_REDIS_ADDRESS=redis:6379 \
-    TTN_LW_HEALTHCHECK_URL=http://localhost:1885/healthz/live
+ENV TTN_LW_HEALTHCHECK_URL=http://localhost:1885/healthz/live
 
 HEALTHCHECK --interval=1m --timeout=5s CMD curl -f $TTN_LW_HEALTHCHECK_URL || exit 1
 


### PR DESCRIPTION
#### Summary
Removes environmental variables from the Dockerfile.

Regarding these:

```
TTN_LW_BLOB_LOCAL_DIRECTORY
TTN_LW_IS_DATABASE_URI
TTN_LW_REDIS_ADDRESS
```

I see that we also set them in docker-compose, so no further action needed.

Regarding this:

```
TTN_LW_HEALTHCHECK_URL
```

Looks like this isn't an actual config variable, per this:

```
$ go run main.go --help | grep -i health
      --http.health.enable                                                Enable health check endpoint on HTTP server (default true)
      --http.health.password string                                       Password to protect health endpoint (username is health)
exit status 2
```

#### Changes
Removed environmental variables

#### Testing
Didn't test. If this is broken, some automatic tests should fail.

##### Regressions
AWS Cloud: we override `TTN_LW_IS_DATABASE_URI` and `TTN_LW_REDIS_ADDRESS`, so no need to change here. I don't see any mention of `blob` in the templates, so I assume we'd need to add that environmental variable, right? Or `blob` doesn't apply there?

AWS BYOL/PAYG: they build their own AMIs, so this change is irrelevant

Someone please confirm.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [X] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [X] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
