### PR TITLE
Add BasicStation time sync protocol

### DIFF
--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -264,11 +264,7 @@ func New(c *component.Component, conf *Config, opts ...Option) (gs *GatewayServe
 				fallbackFreqPlanID: conf.BasicStation.FallbackFrequencyPlanID,
 				listen:             conf.BasicStation.Listen,
 				listenTLS:          conf.BasicStation.ListenTLS,
-				frontend: ws.Config{
-					UseTrafficTLSAddress: conf.BasicStation.UseTrafficTLSAddress,
-					WSPingInterval:       conf.BasicStation.WSPingInterval,
-					AllowUnauthenticated: conf.BasicStation.AllowUnauthenticated,
-				},
+				frontend:           conf.BasicStation.Config,
 			},
 		},
 	} {

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -711,6 +711,12 @@ func (c *Connection) TimeFromTimestampTime(timestamp uint32) (scheduling.Concent
 	return c.scheduler.TimeFromTimestampTime(timestamp)
 }
 
+// TimeFromServerTime returns the concentrator time by the given server time.
+// This method returns false if the clock is not synced with the server.
+func (c *Connection) TimeFromServerTime(t time.Time) (scheduling.ConcentratorTime, bool) {
+	return c.scheduler.TimeFromServerTime(t)
+}
+
 func (c *Connection) notifyStatsChanged() {
 	select {
 	case c.statsChangedCh <- struct{}{}:

--- a/pkg/gatewayserver/io/ws/config.go
+++ b/pkg/gatewayserver/io/ws/config.go
@@ -20,6 +20,7 @@ import "time"
 type Config struct {
 	UseTrafficTLSAddress bool          `name:"use-traffic-tls-address" description:"Use WSS for the traffic address regardless of the TLS setting"`
 	WSPingInterval       time.Duration `name:"ws-ping-interval" description:"Interval to send WS ping messages"`
+	TimeSyncInterval     time.Duration `name:"time-sync-interval" description:"Interval to send time transfer messages"`
 	AllowUnauthenticated bool          `name:"allow-unauthenticated" description:"Allow unauthenticated connections"`
 }
 
@@ -27,5 +28,6 @@ type Config struct {
 var DefaultConfig = Config{
 	UseTrafficTLSAddress: false,
 	WSPingInterval:       30 * time.Second,
+	TimeSyncInterval:     30 * time.Minute,
 	AllowUnauthenticated: false,
 }

--- a/pkg/gatewayserver/io/ws/format.go
+++ b/pkg/gatewayserver/io/ws/format.go
@@ -47,4 +47,6 @@ type Formatter interface {
 	HandleUp(ctx context.Context, raw []byte, ids ttnpb.GatewayIdentifiers, conn *io.Connection, receivedAt time.Time) ([]byte, error)
 	// FromDownlink generates a downlink byte stream that can be sent over the WS connection.
 	FromDownlink(ctx context.Context, uid string, down ttnpb.DownlinkMessage, bandID string, concentratorTime scheduling.ConcentratorTime, dlTime time.Time) ([]byte, error)
+	// TransferTime generates a spurious time transfer message for a particular server time.
+	TransferTime(ctx context.Context, t time.Time, conn *io.Connection) ([]byte, error)
 }

--- a/pkg/gatewayserver/io/ws/format.go
+++ b/pkg/gatewayserver/io/ws/format.go
@@ -46,7 +46,7 @@ type Formatter interface {
 	// This function optionally returns a byte stream to be sent as response to the upstream message.
 	HandleUp(ctx context.Context, raw []byte, ids ttnpb.GatewayIdentifiers, conn *io.Connection, receivedAt time.Time) ([]byte, error)
 	// FromDownlink generates a downlink byte stream that can be sent over the WS connection.
-	FromDownlink(ctx context.Context, uid string, down ttnpb.DownlinkMessage, bandID string, concentratorTime scheduling.ConcentratorTime, dlTime time.Time) ([]byte, error)
+	FromDownlink(ctx context.Context, down ttnpb.DownlinkMessage, bandID string, concentratorTime scheduling.ConcentratorTime, dlTime time.Time) ([]byte, error)
 	// TransferTime generates a spurious time transfer message for a particular server time.
 	TransferTime(ctx context.Context, t time.Time, conn *io.Connection) ([]byte, error)
 }

--- a/pkg/gatewayserver/io/ws/lbslns/downstream.go
+++ b/pkg/gatewayserver/io/ws/lbslns/downstream.go
@@ -78,8 +78,8 @@ func (f *lbsLNS) FromDownlink(ctx context.Context, uid string, down ttnpb.Downli
 		ok    bool
 	)
 	session := ws.SessionFromContext(ctx)
-	session.DataMu.Lock()
-	defer session.DataMu.Unlock()
+	session.DataMu.RLock()
+	defer session.DataMu.RUnlock()
 	if state, ok = session.Data.(State); !ok {
 		return nil, errSessionStateNotFound.New()
 	}

--- a/pkg/gatewayserver/io/ws/lbslns/downstream.go
+++ b/pkg/gatewayserver/io/ws/lbslns/downstream.go
@@ -137,6 +137,10 @@ func (dnmsg *DownlinkMessage) ToDownlinkMessage(bandID string) (*ttnpb.DownlinkM
 
 // TransferTime implements Formatter.
 func (*lbsLNS) TransferTime(ctx context.Context, t time.Time, conn *io.Connection) ([]byte, error) {
+	if enabled, ok := getSessionTimeSync(ctx); !ok || !enabled {
+		return nil, nil
+	}
+
 	concentratorTime, ok := conn.TimeFromServerTime(t)
 	if !ok {
 		return nil, nil

--- a/pkg/gatewayserver/io/ws/lbslns/downstream.go
+++ b/pkg/gatewayserver/io/ws/lbslns/downstream.go
@@ -61,7 +61,7 @@ func (dnmsg *DownlinkMessage) unmarshalJSON(data []byte) error {
 }
 
 // FromDownlink implements Formatter.
-func (f *lbsLNS) FromDownlink(ctx context.Context, uid string, down ttnpb.DownlinkMessage, bandID string, concentratorTime scheduling.ConcentratorTime, dlTime time.Time) ([]byte, error) {
+func (f *lbsLNS) FromDownlink(ctx context.Context, down ttnpb.DownlinkMessage, bandID string, concentratorTime scheduling.ConcentratorTime, dlTime time.Time) ([]byte, error) {
 	var dnmsg DownlinkMessage
 	settings := down.GetScheduled()
 	dnmsg.Pdu = hex.EncodeToString(down.GetRawPayload())
@@ -109,7 +109,7 @@ func (f *lbsLNS) FromDownlink(ctx context.Context, uid string, down ttnpb.Downli
 	dnmsg.Rx1Freq = int(settings.Frequency)
 
 	// Add the MuxTime for RTT measurement
-	dnmsg.MuxTime = float64(dlTime.UnixNano()) / float64(time.Second)
+	dnmsg.MuxTime = TimeToUnixSeconds(dlTime)
 
 	// The GS controls the scheduling and hence for the gateway, its always Class A.
 	dnmsg.DeviceClass = uint(ttnpb.CLASS_A)
@@ -160,5 +160,6 @@ func (*lbsLNS) TransferTime(ctx context.Context, t time.Time, conn *io.Connectio
 	return TimeSyncResponse{
 		XTime:   ConcentratorTimeToXTime(state.ID, concentratorTime),
 		GPSTime: TimeToGPSTime(t),
+		MuxTime: TimeToUnixSeconds(t),
 	}.MarshalJSON()
 }

--- a/pkg/gatewayserver/io/ws/lbslns/downstream_test.go
+++ b/pkg/gatewayserver/io/ws/lbslns/downstream_test.go
@@ -25,18 +25,14 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/ws"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/scheduling"
-	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
-	"go.thethings.network/lorawan-stack/v3/pkg/unique"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
 )
 
 func TestFromDownlinkMessage(t *testing.T) {
 	var lbsLNS lbsLNS
-	ctx := log.NewContext(test.Context(), test.GetLogger(t))
-	uid := unique.ID(ctx, ttnpb.GatewayIdentifiers{GatewayId: "test-gateway"})
 	session := ws.Session{
 		Data: State{
 			ID: 0x11,
@@ -132,7 +128,7 @@ func TestFromDownlinkMessage(t *testing.T) {
 			a := assertions.New(t)
 			ctx := context.Background()
 			sessionCtx := ws.NewContextWithSession(ctx, &session)
-			raw, err := lbsLNS.FromDownlink(sessionCtx, uid, tc.DownlinkMessage, tc.BandID, 1554300787, time.Unix(1554300787, 123456000))
+			raw, err := lbsLNS.FromDownlink(sessionCtx, tc.DownlinkMessage, tc.BandID, 1554300787, time.Unix(1554300787, 123456000))
 			if !a.So(err, should.BeNil) {
 				t.FailNow()
 			}
@@ -300,5 +296,6 @@ func TestTransferTime(t *testing.T) {
 		a.So(res.XTime>>48, should.Equal, 42)
 		a.So(res.XTime&0xFFFFFFFFFF, should.Equal, int64(xTime)+timeNow.Sub(timeAtSync).Microseconds())
 		a.So(res.GPSTime, should.Equal, TimeToGPSTime(timeNow))
+		a.So(res.MuxTime, should.Equal, TimeToUnixSeconds(timeNow))
 	}
 }

--- a/pkg/gatewayserver/io/ws/lbslns/downstream_test.go
+++ b/pkg/gatewayserver/io/ws/lbslns/downstream_test.go
@@ -230,8 +230,7 @@ func TestToDownlinkMessage(t *testing.T) {
 func TestTransferTime(t *testing.T) {
 	a, ctx := test.New(t)
 
-	session := &ws.Session{}
-	ctx = ws.NewContextWithSession(ctx, session)
+	ctx = ws.NewContextWithSession(ctx, &ws.Session{})
 
 	gtw := &ttnpb.Gateway{
 		Ids: &ttnpb.GatewayIdentifiers{
@@ -248,8 +247,18 @@ func TestTransferTime(t *testing.T) {
 
 	f := (*lbsLNS)(nil)
 
-	// No time sync available.
+	// No timesync settings available in the session.
 	b, err := f.TransferTime(ctx, time.Now(), conn)
+	if !a.So(err, should.BeNil) {
+		t.FailNow()
+	}
+	a.So(b, should.BeNil)
+
+	// Enable timesync for the session.
+	updateSessionTimeSync(ctx, true)
+
+	// No time sync available.
+	b, err = f.TransferTime(ctx, time.Now(), conn)
 	if !a.So(err, should.BeNil) {
 		t.FailNow()
 	}

--- a/pkg/gatewayserver/io/ws/lbslns/format.go
+++ b/pkg/gatewayserver/io/ws/lbslns/format.go
@@ -28,11 +28,6 @@ var (
 	trafficEndPointPrefix   = "/traffic"
 )
 
-// State represents the LBS Session state.
-type State struct {
-	ID int32
-}
-
 type lbsLNS struct {
 	maxRoundTripDelay time.Duration
 	tokens            io.DownlinkTokens

--- a/pkg/gatewayserver/io/ws/lbslns/state.go
+++ b/pkg/gatewayserver/io/ws/lbslns/state.go
@@ -1,0 +1,65 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lbslns
+
+import (
+	"context"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/ws"
+)
+
+// state represents the LBS session state.
+type state struct {
+	ID *int32
+}
+
+func updateState(ctx context.Context, f func(*state)) {
+	session := ws.SessionFromContext(ctx)
+	session.DataMu.Lock()
+	defer session.DataMu.Unlock()
+	st, ok := session.Data.(*state)
+	if !ok {
+		st = &state{}
+		session.Data = st
+	}
+	f(st)
+}
+
+func updateSessionID(ctx context.Context, id int32) {
+	updateState(ctx, func(st *state) {
+		st.ID = &id
+	})
+}
+
+func getState(ctx context.Context, f func(*state) interface{}) interface{} {
+	session := ws.SessionFromContext(ctx)
+	session.DataMu.RLock()
+	defer session.DataMu.RUnlock()
+	st, ok := session.Data.(*state)
+	if !ok {
+		return nil
+	}
+	return f(st)
+}
+
+func getSessionID(ctx context.Context) (int32, bool) {
+	i, ok := getState(ctx, func(st *state) interface{} {
+		if st.ID != nil {
+			return *st.ID
+		}
+		return nil
+	}).(int32)
+	return i, ok
+}

--- a/pkg/gatewayserver/io/ws/lbslns/state.go
+++ b/pkg/gatewayserver/io/ws/lbslns/state.go
@@ -22,7 +22,8 @@ import (
 
 // state represents the LBS session state.
 type state struct {
-	ID *int32
+	ID       *int32
+	TimeSync *bool
 }
 
 func updateState(ctx context.Context, f func(*state)) {
@@ -40,6 +41,12 @@ func updateState(ctx context.Context, f func(*state)) {
 func updateSessionID(ctx context.Context, id int32) {
 	updateState(ctx, func(st *state) {
 		st.ID = &id
+	})
+}
+
+func updateSessionTimeSync(ctx context.Context, b bool) {
+	updateState(ctx, func(st *state) {
+		st.TimeSync = &b
 	})
 }
 
@@ -62,4 +69,14 @@ func getSessionID(ctx context.Context) (int32, bool) {
 		return nil
 	}).(int32)
 	return i, ok
+}
+
+func getSessionTimeSync(ctx context.Context) (bool, bool) {
+	d, ok := getState(ctx, func(st *state) interface{} {
+		if st.TimeSync != nil {
+			return *st.TimeSync
+		}
+		return nil
+	}).(bool)
+	return d, ok
 }

--- a/pkg/gatewayserver/io/ws/lbslns/time.go
+++ b/pkg/gatewayserver/io/ws/lbslns/time.go
@@ -1,0 +1,38 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lbslns
+
+import (
+	"math"
+	"time"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/gpstime"
+)
+
+// TimeFromUnixSeconds constructs a time.Time from the provided UNIX fractional timestamp.
+func TimeFromUnixSeconds(tf float64) time.Time {
+	sec, nsec := math.Modf(tf)
+	return time.Unix(int64(sec), int64(nsec*1e9))
+}
+
+// TimeToUnixSeconds constructs a UNIX fractional timestamp from the provided time.Time.
+func TimeToUnixSeconds(t time.Time) float64 {
+	return float64(t.UnixNano()) / float64(1e9)
+}
+
+// TimeToGPSTime contructs a GPS timestamp from the provided time.Time.
+func TimeToGPSTime(t time.Time) int64 {
+	return int64(gpstime.ToGPS(t) / time.Microsecond)
+}

--- a/pkg/gatewayserver/io/ws/lbslns/time.go
+++ b/pkg/gatewayserver/io/ws/lbslns/time.go
@@ -18,6 +18,7 @@ import (
 	"math"
 	"time"
 
+	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/scheduling"
 	"go.thethings.network/lorawan-stack/v3/pkg/gpstime"
 )
 
@@ -35,4 +36,10 @@ func TimeToUnixSeconds(t time.Time) float64 {
 // TimeToGPSTime contructs a GPS timestamp from the provided time.Time.
 func TimeToGPSTime(t time.Time) int64 {
 	return int64(gpstime.ToGPS(t) / time.Microsecond)
+}
+
+// ConcentratorTimeToXTime contructs the XTime associated with the provided
+// session ID and concentrator timestamp.
+func ConcentratorTimeToXTime(id int32, t scheduling.ConcentratorTime) int64 {
+	return int64(id)<<48 | (int64(t) / int64(time.Microsecond) & 0xFFFFFFFFFF)
 }

--- a/pkg/gatewayserver/io/ws/lbslns/upstream.go
+++ b/pkg/gatewayserver/io/ws/lbslns/upstream.go
@@ -162,6 +162,7 @@ func (tsr TimeSyncRequest) Response(t time.Time) TimeSyncResponse {
 	return TimeSyncResponse{
 		TxTime:  tsr.TxTime,
 		GPSTime: TimeToGPSTime(t),
+		MuxTime: TimeToUnixSeconds(t),
 	}
 }
 
@@ -170,6 +171,7 @@ type TimeSyncResponse struct {
 	TxTime  float64 `json:"txtime,omitempty"`
 	XTime   int64   `json:"xtime,omitempty"`
 	GPSTime int64   `json:"gpstime"`
+	MuxTime float64 `json:"MuxTime,omitempty"`
 }
 
 // MarshalJSON implements json.Marshaler.

--- a/pkg/gatewayserver/io/ws/lbslns/upstream.go
+++ b/pkg/gatewayserver/io/ws/lbslns/upstream.go
@@ -28,7 +28,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/encoding/lorawan"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io"
-	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/ws"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/scheduling"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -582,12 +581,7 @@ func (f *lbsLNS) HandleUp(ctx context.Context, raw []byte, ids ttnpb.GatewayIden
 			logger.WithError(err).Warn("Failed to handle upstream message")
 			return nil, err
 		}
-		session := ws.SessionFromContext(ctx)
-		session.DataMu.Lock()
-		session.Data = State{
-			ID: int32(jreq.UpInfo.XTime >> 48),
-		}
-		session.DataMu.Unlock()
+		updateSessionID(ctx, int32(jreq.UpInfo.XTime>>48))
 		recordTime(jreq.RefTime, jreq.UpInfo.XTime)
 
 	case TypeUpstreamUplinkDataFrame:
@@ -609,12 +603,7 @@ func (f *lbsLNS) HandleUp(ctx context.Context, raw []byte, ids ttnpb.GatewayIden
 			logger.WithError(err).Warn("Failed to handle upstream message")
 			return nil, err
 		}
-		session := ws.SessionFromContext(ctx)
-		session.DataMu.Lock()
-		session.Data = State{
-			ID: int32(updf.UpInfo.XTime >> 48),
-		}
-		session.DataMu.Unlock()
+		updateSessionID(ctx, int32(updf.UpInfo.XTime>>48))
 		recordTime(updf.RefTime, updf.UpInfo.XTime)
 
 	case TypeUpstreamTxConfirmation:
@@ -630,12 +619,7 @@ func (f *lbsLNS) HandleUp(ctx context.Context, raw []byte, ids ttnpb.GatewayIden
 			logger.WithError(err).Warn("Failed to handle tx ack message")
 			return nil, err
 		}
-		session := ws.SessionFromContext(ctx)
-		session.DataMu.Lock()
-		session.Data = State{
-			ID: int32(txConf.XTime >> 48),
-		}
-		session.DataMu.Unlock()
+		updateSessionID(ctx, int32(txConf.XTime>>48))
 		recordTime(0.0, txConf.XTime)
 
 	case TypeUpstreamTimeSync:

--- a/pkg/gatewayserver/io/ws/lbslns/upstream_test.go
+++ b/pkg/gatewayserver/io/ws/lbslns/upstream_test.go
@@ -623,8 +623,7 @@ func TestJreqFromUplinkDataFrame(t *testing.T) {
 func TestTxAck(t *testing.T) {
 	a := assertions.New(t)
 	txConf := TxConfirmation{
-		Diid:    1,
-		RefTime: 0,
+		Diid: 1,
 	}
 	msg := &ttnpb.DownlinkMessage{
 		RawPayload:     []byte{0x00, 0x00},

--- a/pkg/gatewayserver/io/ws/lbslns/upstream_test.go
+++ b/pkg/gatewayserver/io/ws/lbslns/upstream_test.go
@@ -95,6 +95,13 @@ func TestMarshalJSON(t *testing.T) {
 			},
 			Expected: []byte(`{"msgtype":"dntxed","diid":35,"DevEui":"1111:1111:1111:1111","rctx":0,"xtime":1552906698,"txtime":1552906698,"gpstime":1552906698}`),
 		},
+		{
+			Name: "TimeSyncRequest",
+			Message: TimeSyncRequest{
+				TxTime: 123.456,
+			},
+			Expected: []byte(`{"msgtype":"timesync","txtime":123.456}`),
+		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			a := assertions.New(t)

--- a/pkg/gatewayserver/io/ws/lbslns/version.go
+++ b/pkg/gatewayserver/io/ws/lbslns/version.go
@@ -69,6 +69,7 @@ func (f *lbsLNS) GetRouterConfig(ctx context.Context, msg []byte, bandID string,
 	if err := json.Unmarshal(msg, &version); err != nil {
 		return nil, nil, nil, err
 	}
+	updateSessionTimeSync(ctx, true)
 	cfg, err := pfconfig.GetRouterConfig(bandID, fps, version.IsProduction(), time.Now())
 	if err != nil {
 		return nil, nil, nil, err

--- a/pkg/gatewayserver/io/ws/sessions.go
+++ b/pkg/gatewayserver/io/ws/sessions.go
@@ -25,7 +25,7 @@ var sessionKey sessionKeyType
 
 // Session contains the session state for a single gateway.
 type Session struct {
-	DataMu sync.Mutex
+	DataMu sync.RWMutex
 	Data   interface{}
 }
 

--- a/pkg/gatewayserver/io/ws/ws.go
+++ b/pkg/gatewayserver/io/ws/ws.go
@@ -293,7 +293,7 @@ func (s *srv) handleTraffic(c echo.Context) (err error) {
 					logger.Warn("No clock synchronization")
 					continue
 				}
-				dnmsg, err := s.formatter.FromDownlink(ctx, uid, *down, conn.BandID(), concentratorTime, time.Now())
+				dnmsg, err := s.formatter.FromDownlink(ctx, *down, conn.BandID(), concentratorTime, time.Now())
 				if err != nil {
 					logger.WithError(err).Warn("Failed to marshal downlink message")
 					continue

--- a/pkg/gatewayserver/scheduling/scheduler.go
+++ b/pkg/gatewayserver/scheduling/scheduler.go
@@ -488,6 +488,17 @@ func (s *Scheduler) TimeFromTimestampTime(t uint32) (ConcentratorTime, bool) {
 	return s.clock.FromTimestampTime(t), true
 }
 
+// TimeFromServerTime returns an indication of the provided timestamp in concentrator time.
+// This method returns false if the clock is not synced with the server.
+func (s *Scheduler) TimeFromServerTime(t time.Time) (ConcentratorTime, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if !s.clock.IsSynced() {
+		return 0, false
+	}
+	return s.clock.FromServerTime(t)
+}
+
 // SubBandStats returns a map with the usage stats of each sub band.
 func (s *Scheduler) SubBandStats() []*ttnpb.GatewayConnectionStats_SubBand {
 	var res []*ttnpb.GatewayConnectionStats_SubBand


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/3546
References https://github.com/TheThingsNetwork/lorawan-stack/issues/4804

#### Changes
<!-- What are the changes made in this pull request? -->

- Use `RefTime` for RTT calculations iff it is not `0.0`, and within the configured bound
- Add PPS based `TimeSync` support (based on the request-response format)
- Add transfer based `TimeSync` support (based on the time transfer format)
- Send `MuxTime` also during `TimeSync` ([supported as well](https://github.com/lorabasics/basicstation/blob/bd17e53ab1137de6abb5ae48d6f3d52f6c268299/src/s2e.c#L1616))

#### Testing

<!-- How did you verify that this change works? -->

Local testing with TTIGs/Laird/Tektelic `2.0.4`-based forwarders, and unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

It seems that the Tektelic Basic Station bridge does not support the transfer-based `timesync` message:

```
Oct 29 23:42:31 kona-micro tek_bstn[14117]: [DEBUG ] bridge_bstn_lns.c:389 data received from WS stream:
{"msgtype":"timesync","xtime":32651101339486062,"gpstime":1319586169418490}
Oct 29 23:42:31 kona-micro tek_bstn[14117]: [WARN  ] bridge_json_helpers.c:35 unable to retrieve field
Oct 29 23:42:31 kona-micro tek_bstn[14117]: [DEBUG ] bridge_bstn_lns.c:1469 stopping LWS main loop...
Oct 29 23:42:31 kona-micro tek_bstn[14117]: [DEBUG ] bridge_bstn_lns.c:711 disconnecting WS stream
Oct 29 23:42:31 kona-micro tek_bstn[14117]: [DEBUG ] bridge_bstn_lns.c:572 WS connection closed
Oct 29 23:42:31 kona-micro tek_bstn[14117]: [DEBUG ] bridge_bstn_lns.c:576 WSI destroyed, notifying outer loop to stop processing
Oct 29 23:42:31 kona-micro tek_bstn[14117]: [DEBUG ] bridge_data_conv.c:1093 UDP bridge is deinitialized
Oct 29 23:42:31 kona-micro tek_bstn[14117]: [WARN  ] main_bstn.c:162 non-critical error raised: [-1]
Oct 29 23:42:31 kona-micro tek_bstn[14117]: [WARN  ] main_bstn.c:163 restarting Basic Station in 20 seconds...
```

So this is an open problem - do we put the transfer-based `timesync` behind a feature flag ? I would be surprised if the PPS-style handshake would be used that much in the wild.

Other native gateways (TTIG / Laird) seem to handle this correctly, and RTTs are realistic.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
