### PR TITLE
Remove cockroach from development tooling

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -166,7 +166,6 @@ jobs:
     runs-on: ubuntu-18.04
     env:
       TTN_LW_LOG_LEVEL: debug
-      COCKROACHDB_COCKROACH_TAG: v19.2.12
       CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
@@ -197,7 +196,7 @@ jobs:
       - name: Generate certs
         run: tools/bin/mage dev:certificates
       - name: Restore initialized sql db
-        run: tools/bin/mage dev:dbStart dev:sqlRestore
+        run: tools/bin/mage dev:dbStart dev:sqlRestore dev:sqlCreateSeedDb
       - name: Run stack
         run: tools/bin/mage dev:startDevStack &
       - name: Run frontend end-to-end tests
@@ -259,7 +258,7 @@ jobs:
       - name: Generate certs
         run: tools/bin/mage dev:certificates
       - name: Restore initialized sql db
-        run: tools/bin/mage dev:dbStart dev:sqlRestore
+        run: tools/bin/mage dev:dbStart dev:SQLRestore dev:SQLCreateSeedDB
       - name: Run stack
         run: tools/bin/mage dev:startDevStack &
       - name: Run end-to-end smoke tests (Firefox)

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,9 +56,6 @@ jobs:
     if: needs.determine-if-required.outputs.needs-to-run == 'true'
     env:
       TTN_LW_LOG_LEVEL: debug
-      # TODO: Remove this after we no longer depend on cockroach dump command
-      # (https://github.com/TheThingsNetwork/lorawan-stack/issues/4184)
-      COCKROACHDB_COCKROACH_TAG: v19.2.12
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Check out code
@@ -169,8 +166,6 @@ jobs:
     runs-on: ubuntu-18.04
     env:
       TTN_LW_LOG_LEVEL: debug
-      # TODO: Remove this after we no longer depend on cockroach dump command
-      # (https://github.com/TheThingsNetwork/lorawan-stack/issues/4184)
       COCKROACHDB_COCKROACH_TAG: v19.2.12
       CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -230,8 +225,6 @@ jobs:
     runs-on: ubuntu-18.04
     env:
       TTN_LW_LOG_LEVEL: debug
-      # TODO: Remove this after we no longer depend on cockroach dump command
-      # (https://github.com/TheThingsNetwork/lorawan-stack/issues/4184)
       COCKROACHDB_COCKROACH_TAG: v19.2.12
       CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.release.yml
+++ b/.goreleaser.release.yml
@@ -89,7 +89,7 @@ nfpms:
       - rpm
     recommends:
       - redis
-      - cockroach
+      - postgresql
     contents:
       - src: 'public/**'
         dst: '/srv/ttn-lorawan/public'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ For details about compatibility between different releases, see the **Commitment
 - The `data_rate_index` field in uplink message metadata. Observe the fully described data rate in the `data_rate` field instead.
 - LoRaWAN data rate index reported to LoRa Cloud DMS.
 - Dockerfile doesn't define environmental variables `TTN_LW_BLOB_LOCAL_DIRECTORY`, `TTN_LW_IS_DATABASE_URI` and `TTN_LW_REDIS_ADDRESS` anymore. They need to be set when running the container: please refer to `docker-compose.yml` for example values.
+- `CockroachDB` from development tooling as well as config option within `docker-compose.yml`.
+  - This also changes the default value of the `--is.database-uri` option, so it can connect to the development Postgres database by default.
 
 ### Fixed
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,7 +12,7 @@ The Things Stack components are primarily built in Go, we use React for web fron
   - [Steps](#steps)
 - [Using the CLI with the Development Environment](#using-the-cli-with-the-development-environment)
 - [Managing the Development Databases](#managing-the-development-databases)
-  - [CockroachDB](#cockroachdb)
+  - [PostgreSQL](#PostgreSQL)
   - [Redis](#redis)
 - [Building the Frontend](#building-the-frontend)
 - [Starting The Things Stack](#starting-the-things-stack)
@@ -109,7 +109,7 @@ This will build the frontend assets and place it in the `public` folder.
 $ tools/bin/mage dev:dbStart # This requires Docker to be running.
 ```
 
-This will start one instance each of `CockroachDB` and `Redis` as Docker containers. To verify this, you can run
+This will start one instance each of `postgres` and `Redis` as Docker containers. To verify this, you can run
 
 ```bash
 $ docker ps
@@ -167,9 +167,9 @@ $ tools/bin/mage dev:dbStop  # Stops all databases.
 $ tools/bin/mage dev:dbErase # Stops all databases and erase storage.
 ```
 
-### CockroachDB
+### PostgreSQL
 
-CockroachDB is a distributed SQL database that we use in the Identity Server.
+PostgreSQL is a SQL database that we use in the Identity Server.
 
 You can use `tools/bin/mage dev:dbSQL` to enter an SQL shell.
 

--- a/cmd/internal/shared/identityserver/config.go
+++ b/cmd/internal/shared/identityserver/config.go
@@ -26,7 +26,7 @@ import (
 
 // DefaultIdentityServerConfig is the default configuration for the Identity Server.
 var DefaultIdentityServerConfig = identityserver.Config{
-	DatabaseURI: "postgresql://root@localhost:26257/ttn_lorawan_dev?sslmode=disable",
+	DatabaseURI: "postgresql://root:root@localhost:5432/ttn_lorawan_dev?sslmode=disable",
 	OAuth: oauth.Config{
 		Mount: "/oauth",
 		UI: oauth.UIConfig{

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,29 +1,16 @@
-version: '3.7'
+version: "3.7"
 services:
-
-  # If using CockroachDB:
-  cockroach:
-    image: cockroachdb/cockroach:${COCKROACHDB_COCKROACH_TAG:-latest}
-    command: start-single-node --http-port 26256 --insecure
+  postgres:
+    image: postgres
     restart: unless-stopped
+    environment:
+      - POSTGRES_PASSWORD=root
+      - POSTGRES_USER=root
+      - POSTGRES_DB=ttn_lorawan_dev
     volumes:
-      - ${DEV_DATA_DIR:-.env/data}/cockroach:/cockroach/cockroach-data
+      - ${DEV_DATA_DIR:-.env/data}/postgres:/var/lib/postgresql/data
     ports:
-      - "127.0.0.1:26257:26257" # Cockroach
-      - "127.0.0.1:26256:26256" # WebUI
-
-  # If using PostgreSQL:
-  # postgres:
-  #   image: postgres
-  #   restart: unless-stopped
-  #   environment:
-  #     - POSTGRES_PASSWORD=root
-  #     - POSTGRES_USER=root
-  #     - POSTGRES_DB=ttn_lorawan
-  #   volumes:
-  #     - ${DEV_DATA_DIR:-.env/data}/postgres:/var/lib/postgresql/data
-  #   ports:
-  #     - "127.0.0.1:5432:5432"
+      - "127.0.0.1:5432:5432"
 
   redis:
     image: redis
@@ -41,10 +28,7 @@ services:
     restart: unless-stopped
     depends_on:
       - redis
-      # If using CockroachDB:
-      - cockroach
-      # If using PostgreSQL:
-      # - postgres
+      - postgres
     volumes:
       - ./blob:/srv/ttn-lorawan/public/blob
       - ./config/stack:/config:ro
@@ -53,10 +37,7 @@ services:
     environment:
       TTN_LW_BLOB_LOCAL_DIRECTORY: /srv/ttn-lorawan/public/blob
       TTN_LW_REDIS_ADDRESS: redis:6379
-      # If using CockroachDB:
-      TTN_LW_IS_DATABASE_URI: postgres://root@cockroach:26257/ttn_lorawan?sslmode=disable
-      # # If using PostgreSQL:
-      # TTN_LW_IS_DATABASE_URI: postgres://root:root@postgres:5432/ttn_lorawan?sslmode=disable
+      TTN_LW_IS_DATABASE_URI: postgres://root:root@postgres:5432/ttn_lorawan?sslmode=disable
 
     ports:
       # If deploying on a public server:

--- a/tools/mage/scripts/recreate-db-from-dump.sh
+++ b/tools/mage/scripts/recreate-db-from-dump.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+docker-compose -p lorawan-stack-dev exec -T postgres /bin/bash -c "dropdb --if-exists --force $1; createdb $1; psql $1 --quiet" < $2


### PR DESCRIPTION
#### Summary

This PR removes CockroachDB from the development tooling, as well as `docker-compose.yml` and fixes running local end-to-end tests on macs with M1 chip.

Closes #4184 

#### Changes
- Remove cockroach from `docker-compose.yml`
- Use PostgreSQL by default
- Change default config for the DB connection
- Change cypress' `dropAndSeedDB` task to work with PostgreSQL
- Change mage tooling to work with PostgreSQL
- Remove occurrences of cockroach in `DEVELOPMENT.md` and other files
- Update `e2e` GitHub action slightly to initialize the seed DB

#### Testing

CI is working and I can run the end-to-end tests on my M1 mac again.

##### Regressions

I don't have a complete oversight of all implications of removing cockroach from `docker-compose.yml` so @htdvisser @adriansmares please double check this.

#### Notes for Reviewers
I'm using PostgreSQL templating feature for seeding the database during the e2es, which is faster. Due to the way PosgreSQL works, I could no longer drop and seed the database using the SQL connection itself but have to run a couple of commands within the container. I'm doing this with a bash session within the postgres container that I keep open while the cypress is running. This saves a couple of seconds when seeding the DB.

This also breaks config compatibility since I had to update the `is.database-uri` default.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
