### PR TITLE
Upgrade GoReleaser to v0.184.0

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Run Goreleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: 'v0.161.1'
+          version: 'v0.184.0'
           args: release --config .goreleaser.snapshot.yml --snapshot --timeout 60m
         env:
           SIGN_KEY_NAME: ${{ secrets.SIGN_KEY_NAME }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -128,7 +128,7 @@ jobs:
     - name: Run Goreleaser
       uses: goreleaser/goreleaser-action@v2
       with:
-        version: 'v0.161.1'
+        version: 'v0.184.0'
         args: release --config .goreleaser.release.yml --release-notes /tmp/release-notes.md --timeout 120m
       env:
         AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/.goreleaser.release.yml
+++ b/.goreleaser.release.yml
@@ -11,59 +11,43 @@ builds:
     main: ./cmd/ttn-lw-stack
     binary: ttn-lw-stack
     ldflags:
-    - -s
-    - -w
-    - -X go.thethings.network/lorawan-stack/v3/pkg/version.BuildDate={{.Date}}
-    - -X go.thethings.network/lorawan-stack/v3/pkg/version.GitCommit={{.ShortCommit}}
-    - -X go.thethings.network/lorawan-stack/v3/pkg/version.TTN={{.Version}}
+      - -s
+      - -w
+      - -X go.thethings.network/lorawan-stack/v3/pkg/version.BuildDate={{.Date}}
+      - -X go.thethings.network/lorawan-stack/v3/pkg/version.GitCommit={{.ShortCommit}}
+      - -X go.thethings.network/lorawan-stack/v3/pkg/version.TTN={{.Version}}
     env:
       - CGO_ENABLED=0
-    goos:
-      - darwin
-      - linux
-      - windows
-    goarch:
-      - 386
-      - amd64
-      - arm
-      - arm64
-    goarm:
-      - 6
-      - 7
+    goos: [darwin, linux, windows]
+    goarch: [386, amd64, arm, arm64]
+    goarm: [6, 7]
     ignore:
-      - goos: darwin
-        goarch: 386
+      - { goos: darwin, goarch: 386 }
+      - { goos: windows, goarch: arm, goarm: 6 }
+      - { goos: windows, goarch: arm, goarm: 7 }
 
   - id: cli
     main: ./cmd/ttn-lw-cli
     binary: ttn-lw-cli
     ldflags:
-    - -s
-    - -w
-    - -X go.thethings.network/lorawan-stack/v3/pkg/version.BuildDate={{.Date}}
-    - -X go.thethings.network/lorawan-stack/v3/pkg/version.GitCommit={{.ShortCommit}}
-    - -X go.thethings.network/lorawan-stack/v3/pkg/version.TTN={{.Version}}
+      - -s
+      - -w
+      - -X go.thethings.network/lorawan-stack/v3/pkg/version.BuildDate={{.Date}}
+      - -X go.thethings.network/lorawan-stack/v3/pkg/version.GitCommit={{.ShortCommit}}
+      - -X go.thethings.network/lorawan-stack/v3/pkg/version.TTN={{.Version}}
     env:
       - CGO_ENABLED=0
-    goos:
-      - darwin
-      - linux
-      - windows
-    goarch:
-      - 386
-      - amd64
-      - arm
-      - arm64
-    goarm:
-      - 6
-      - 7
+    goos: [darwin, linux, windows]
+    goarch: [386, amd64, arm, arm64]
+    goarm: [6, 7]
     ignore:
-      - goos: darwin
-        goarch: 386
+      - { goos: darwin, goarch: 386 }
+      - { goos: windows, goarch: arm, goarm: 6 }
+      - { goos: windows, goarch: arm, goarm: 7 }
 
 archives:
   - id: stack
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     builds:
       - cli
       - stack
@@ -78,7 +62,7 @@ archives:
         format: zip
 
   - id: cli
-    name_template: "{{ .ProjectName }}-cli_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    name_template: '{{ .ProjectName }}-cli_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     builds:
       - cli
     files:
@@ -107,14 +91,14 @@ nfpms:
       - redis
       - cockroach
     contents:
-      - src: "public/**"
-        dst: "/srv/ttn-lorawan/public"
-      - src: "config/completion/bash/*"
-        dst: "/usr/share/bash-completion/completions"
-      - src: "config/completion/fish/*"
-        dst: "/usr/share/fish/vendor_completions.d"
-      - src: "config/completion/zsh/*"
-        dst: "/usr/share/zsh/vendor-completions"
+      - src: 'public/**'
+        dst: '/srv/ttn-lorawan/public'
+      - src: 'config/completion/bash/*'
+        dst: '/usr/share/bash-completion/completions'
+      - src: 'config/completion/fish/*'
+        dst: '/usr/share/fish/vendor_completions.d'
+      - src: 'config/completion/zsh/*'
+        dst: '/usr/share/zsh/vendor-completions'
 
 snapcrafts:
   - id: stack
@@ -136,11 +120,11 @@ snapcrafts:
         mode: 0755
     apps:
       ttn-lw-stack:
-        plugs: [ home, network, network-bind ]
+        plugs: [home, network, network-bind]
         command: ttn-lw-stack.wrapper
         completer: config/completion/bash/ttn-lw-stack
       ttn-lw-cli:
-        plugs: [ home, network, network-bind ]
+        plugs: [home, network, network-bind]
         command: ttn-lw-cli.wrapper
         completer: config/completion/bash/ttn-lw-cli-snap
 
@@ -198,28 +182,28 @@ blobs:
     # NOTE: GoReleaser documentation says that bucket is a template, but it's not.
     bucket: the-things-stack-releases
     ids:
-    - stack
-    - cli
-    folder: "{{ .Version }}"
+      - stack
+      - cli
+    folder: '{{ .Version }}'
     extra_files:
-    - glob: ./CHANGELOG.md
+      - glob: ./CHANGELOG.md
 
 dockers:
   - goos: linux
     goarch: amd64
     dockerfile: Dockerfile
-    binaries:
-      - ttn-lw-cli
-      - ttn-lw-stack
-    use_buildx: true
+    ids:
+      - cli
+      - stack
+    use: buildx
     build_flag_templates:
       - --platform=linux/amd64
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.vendor=The Things Network Foundation"
-      - "--label=org.opencontainers.image.title=The Things Stack"
-      - "--label=org.opencontainers.image.url=https://www.thethingsindustries.com/docs"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - '--label=org.opencontainers.image.created={{.Date}}'
+      - '--label=org.opencontainers.image.vendor=The Things Network Foundation'
+      - '--label=org.opencontainers.image.title=The Things Stack'
+      - '--label=org.opencontainers.image.url=https://www.thethingsindustries.com/docs'
+      - '--label=org.opencontainers.image.version={{.Version}}'
+      - '--label=org.opencontainers.image.revision={{.FullCommit}}'
     image_templates:
       - 'thethingsnetwork/lorawan-stack:{{ .Major }}.{{ .Minor }}-amd64'
       - 'thethingsnetwork/lorawan-stack:{{ .Version }}-amd64'
@@ -232,18 +216,18 @@ dockers:
   - goos: linux
     goarch: arm64
     dockerfile: Dockerfile
-    binaries:
-      - ttn-lw-cli
-      - ttn-lw-stack
-    use_buildx: true
+    ids:
+      - cli
+      - stack
+    use: buildx
     build_flag_templates:
       - --platform=linux/arm64/v8
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.vendor=The Things Network Foundation"
-      - "--label=org.opencontainers.image.title=The Things Stack"
-      - "--label=org.opencontainers.image.url=https://www.thethingsindustries.com/docs"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - '--label=org.opencontainers.image.created={{.Date}}'
+      - '--label=org.opencontainers.image.vendor=The Things Network Foundation'
+      - '--label=org.opencontainers.image.title=The Things Stack'
+      - '--label=org.opencontainers.image.url=https://www.thethingsindustries.com/docs'
+      - '--label=org.opencontainers.image.version={{.Version}}'
+      - '--label=org.opencontainers.image.revision={{.FullCommit}}'
     image_templates:
       - 'thethingsnetwork/lorawan-stack:{{ .Major }}.{{ .Minor }}-arm64'
       - 'thethingsnetwork/lorawan-stack:{{ .Version }}-arm64'
@@ -257,18 +241,18 @@ dockers:
     goarch: arm
     goarm: 7
     dockerfile: Dockerfile
-    binaries:
-      - ttn-lw-cli
-      - ttn-lw-stack
-    use_buildx: true
+    ids:
+      - cli
+      - stack
+    use: buildx
     build_flag_templates:
       - --platform=linux/arm/v7
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.vendor=The Things Network Foundation"
-      - "--label=org.opencontainers.image.title=The Things Stack"
-      - "--label=org.opencontainers.image.url=https://www.thethingsindustries.com/docs"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - '--label=org.opencontainers.image.created={{.Date}}'
+      - '--label=org.opencontainers.image.vendor=The Things Network Foundation'
+      - '--label=org.opencontainers.image.title=The Things Stack'
+      - '--label=org.opencontainers.image.url=https://www.thethingsindustries.com/docs'
+      - '--label=org.opencontainers.image.version={{.Version}}'
+      - '--label=org.opencontainers.image.revision={{.FullCommit}}'
     image_templates:
       - 'thethingsnetwork/lorawan-stack:{{ .Major }}.{{ .Minor }}-armv7'
       - 'thethingsnetwork/lorawan-stack:{{ .Version }}-armv7'
@@ -302,5 +286,16 @@ docker_manifests:
 
 signs:
   - artifacts: checksum
-    args: ["--pinentry-mode=loopback", "--no-tty", "--passphrase-fd", "0", "--batch", "--output", "${signature}", "--detach-sign", "-u", "{{ .Env.SIGN_KEY_NAME }}", "${artifact}"]
+    args:
+      - '--pinentry-mode=loopback'
+      - '--no-tty'
+      - '--passphrase-fd'
+      - '0'
+      - '--batch'
+      - '--output'
+      - '${signature}'
+      - '--detach-sign'
+      - '-u'
+      - '{{ .Env.SIGN_KEY_NAME }}'
+      - '${artifact}'
     stdin_file: /tmp/gpg_passphrase

--- a/.goreleaser.snapshot.yml
+++ b/.goreleaser.snapshot.yml
@@ -18,10 +18,8 @@ builds:
       - -X go.thethings.network/lorawan-stack/v3/pkg/version.TTN={{ trimprefix .Version "v" }}
     env:
       - CGO_ENABLED=0
-    goos:
-      - linux
-    goarch:
-      - amd64
+    goos: [linux]
+    goarch: [amd64]
 
   - id: cli
     main: ./cmd/ttn-lw-cli
@@ -34,26 +32,24 @@ builds:
       - -X go.thethings.network/lorawan-stack/v3/pkg/version.TTN={{ trimprefix .Version "v" }}
     env:
       - CGO_ENABLED=0
-    goos:
-      - linux
-    goarch:
-      - amd64
+    goos: [linux]
+    goarch: [amd64]
 
 dockers:
   - goos: linux
     goarch: amd64
     dockerfile: Dockerfile
-    use_buildx: true
-    binaries:
-      - ttn-lw-cli
-      - ttn-lw-stack
+    use: buildx
+    ids:
+      - cli
+      - stack
     build_flag_templates:
       - --platform=linux/amd64
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.vendor=The Things Network Foundation"
-      - "--label=org.opencontainers.image.title=The Things Stack"
-      - "--label=org.opencontainers.image.url=https://www.thethingsindustries.com/docs"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - '--label=org.opencontainers.image.created={{.Date}}'
+      - '--label=org.opencontainers.image.vendor=The Things Network Foundation'
+      - '--label=org.opencontainers.image.title=The Things Stack'
+      - '--label=org.opencontainers.image.url=https://www.thethingsindustries.com/docs'
+      - '--label=org.opencontainers.image.revision={{.FullCommit}}'
     image_templates:
       - 'lorawan-stack-dev:{{ .FullCommit }}-amd64'
     skip_push: true
@@ -63,5 +59,16 @@ dockers:
 
 signs:
   - artifacts: checksum
-    args: ["--pinentry-mode=loopback", "--no-tty", "--passphrase-fd", "0", "--batch", "--output", "${signature}", "--detach-sign", "-u", "{{ .Env.SIGN_KEY_NAME }}", "${artifact}"]
+    args:
+      - '--pinentry-mode=loopback'
+      - '--no-tty'
+      - '--passphrase-fd'
+      - '0'
+      - '--batch'
+      - '--output'
+      - '${signature}'
+      - '--detach-sign'
+      - '-u'
+      - '{{ .Env.SIGN_KEY_NAME }}'
+      - '${artifact}'
     stdin_file: /tmp/gpg_passphrase

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1102,7 +1102,7 @@ It is also possible to use `go build`, or release snapshots, as described below.
 The Things Stack uses [GoReleaser](https://goreleaser.com/) for releases. If you want to build a release (snapshot), you first need to install GoReleaser:
 
 ```bash
-$ go install github.com/goreleaser/goreleaser@v0.161.1
+$ go install github.com/goreleaser/goreleaser@v0.184.0
 ```
 
 The command for building a release snapshot is:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request upgrades GoReleaser to v0.184.0 and updates the configuration files accordingly.

This should fix Homebrew's complaints about our Formulae.

#### Changes
<!-- What are the changes made in this pull request? -->

- Upgrade GoReleaser
- Add ignores for `windows/armv6` and `windows/armv7` which we don't support (but GoReleaser does now)
- Change `docker.binaries: [ttn-lw-cli, ttn-lw-stack]` to `ids: [cli, stack]`
- Change `docker.use_buildx: true` to `docker.use: buildx`
- Format YAML files

#### Testing

<!-- How did you verify that this change works? -->

Difficult to test, but I ran both snapshot and tag release workflows locally with `--skip-push`.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Not in The Things Stack itself, but in the worst case, release builds may fail.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
