### PR TITLE
Take into account GPS time for uplink timestamps

### DIFF
--- a/pkg/ttnpb/udp/translation.go
+++ b/pkg/ttnpb/udp/translation.go
@@ -193,8 +193,14 @@ func convertUplink(rx RxPacket, md UpstreamMetadata) (ttnpb.UplinkMessage, error
 		}
 	}
 
-	if rx.Time != nil {
-		goTime := time.Time(*rx.Time)
+	var goTime time.Time
+	switch {
+	case rx.Tmms != nil:
+		goTime = gpstime.Parse(time.Duration(*rx.Tmms) * time.Millisecond)
+	case rx.Time != nil:
+		goTime = time.Time(*rx.Time)
+	}
+	if !goTime.IsZero() {
 		for _, md := range up.RxMetadata {
 			md.Time = &goTime
 		}

--- a/pkg/ttnpb/udp/translation_test.go
+++ b/pkg/ttnpb/udp/translation_test.go
@@ -23,6 +23,7 @@ import (
 	pbtypes "github.com/gogo/protobuf/types"
 	"github.com/kr/pretty"
 	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/v3/pkg/gpstime"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb/udp"
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
@@ -89,6 +90,9 @@ func TestStatusRaw(t *testing.T) {
 func TestToGatewayUp(t *testing.T) {
 	a := assertions.New(t)
 
+	absoluteTime := time.Now().UTC().Truncate(time.Millisecond)
+	gpsTime := uint64(gpstime.ToGPS(absoluteTime) / time.Millisecond)
+
 	p := udp.Packet{
 		GatewayEUI:      &types.EUI64{0xAA, 0xEE, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 		ProtocolVersion: udp.Version1,
@@ -104,6 +108,7 @@ func TestToGatewayUp(t *testing.T) {
 					Data: "QCkuASaAAAAByFaF53Iu+vzmwQ==",
 					Size: 19,
 					Tmst: 1000,
+					Tmms: &gpsTime,
 				},
 			},
 		},
@@ -121,7 +126,9 @@ func TestToGatewayUp(t *testing.T) {
 	a.So(msg.Settings.CodingRate, should.Equal, "4/7")
 	a.So(msg.Settings.Frequency, should.Equal, 868000000)
 	a.So(msg.Settings.Timestamp, should.Equal, 1000)
+	a.So(msg.Settings.Time, should.Resemble, &absoluteTime)
 	a.So(msg.RxMetadata[0].Timestamp, should.Equal, 1000)
+	a.So(msg.RxMetadata[0].Time, should.Resemble, &absoluteTime)
 	a.So(msg.RawPayload, should.Resemble, []byte{0x40, 0x29, 0x2e, 0x01, 0x26, 0x80, 0x00, 0x00, 0x01, 0xc8, 0x56, 0x85, 0xe7, 0x72, 0x2e, 0xfa, 0xfc, 0xe6, 0xc1})
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/4816

#### Changes
<!-- What are the changes made in this pull request? -->

- Give preference to `tmms` over `time` when deciding the absolute gateway timestamp for an uplink


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Shouldn't occur, unless somehow there are gateways in the wild that send bogus `tmms`.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
