### PR TITLE
console: Counting the body stream error as network error

### DIFF
--- a/pkg/webui/console/lib/events/utils.js
+++ b/pkg/webui/console/lib/events/utils.js
@@ -26,7 +26,7 @@ export const defineSyntheticEvent = name => data => ({
 export const createSyntheticEventFromError = error => {
   if (error instanceof Error) {
     const errorString = error.toString()
-    if (error.message === 'network error') {
+    if (error.message === 'network error' || error.message === 'Error in body stream') {
       return createNetworkErrorEvent({ error: errorString })
     }
 


### PR DESCRIPTION
#### Summary

While working on issue #4685 found out that on Firefox the loss of network connection throws an "Error in body stream" instead of a "network error", showing on the live data of the application, in the console, an "unknown error" event.

#### Changes

- in pkg/webui/console/lib/events/utils.js added an OR, so that the body stream error counts as network error


#### Testing

Disconnect and reconnect your Wi-fi/Ethernet while running the console in Firefox. The Live Data in the application shows a "Network Error" event instead of a "Unknown Error" event 


##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

I think it won't affect any other features.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
