### PR TITLE
Switch protoc-gen-fieldmask image

### DIFF
--- a/tools/mage/proto.go
+++ b/tools/mage/proto.go
@@ -172,7 +172,7 @@ func (p Proto) GoClean(context.Context) error {
 		if err != nil {
 			return err
 		}
-		for _, ext := range []string{".pb.go", ".pb.gw.go", ".pb.fm.go", ".pb.util.go"} {
+		for _, ext := range []string{".pb.go", ".pb.gw.go", ".pb.paths.fm.go", ".pb.setters.fm.go", ".pb.validate.go", ".pb.util.fm.go"} {
 			if strings.HasSuffix(path, ext) {
 				if err := sh.Rm(path); err != nil {
 					return err

--- a/tools/mage/proto.go
+++ b/tools/mage/proto.go
@@ -32,7 +32,7 @@ const (
 	protocOut             = "/out"
 	gogoProtoImage        = "ghcr.io/thethingsindustries/protoc:gen-gogo-1.3.1"
 	jsonProtoImage        = "ghcr.io/thethingsindustries/protoc:3.9.1-gen-go-json-1.1.0"
-	fieldMaskProtoImage   = "thethingsindustries/protoc:3.1.28-dev-tts"
+	fieldMaskProtoImage   = "ghcr.io/thethingsindustries/protoc:3.9.1-gen-fieldmask-0.5.0"
 	grpcGatewayProtoImage = "ghcr.io/thethingsindustries/protoc:gen-grpc-gateway-1.16.0"
 	swaggerProtoImage     = "ghcr.io/thethingsindustries/protoc:gen-grpc-gateway-1.16.0"
 	docProtoImage         = "ghcr.io/thethingsindustries/protoc:gen-doc-1.4.1"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request switches the Docker image we use to run protoc-gen-fieldmask from `thethingsindustries/protoc` to `ghcr.io/thethingsindustries/protoc`, which also supports `arm64`.

#### Changes
<!-- What are the changes made in this pull request? -->

- Switch Docker image
- Fix missing file patterns in `tools/bin/mage proto:clean`

#### Testing

<!-- How did you verify that this change works? -->

- `tools/bin/mage proto:clean proto:all` and observe no diff.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This also includes updated versions of [protoc-gen-validate](https://github.com/TheThingsIndustries/protoc-gen-validate) and [protoc-gen-fieldmask](https://github.com/TheThingsIndustries/protoc-gen-fieldmask).

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
