### PR TITLE
Increase frontend build speed

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -124,6 +124,15 @@ jobs:
         with:
           path: public
           key: public-cache-${{ hashFiles('pkg/webui/**', 'sdk/js/**/*.js', 'sdk/js/generated/*.json', 'config/webpack.config.babel.js', 'yarn.lock', 'sdk/js/yarn.lock')}}
+      - name: Initialize dll cache
+        if: steps.public-cache.outputs.cache-hit != 'true'
+        id: dll-cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            public/libs.*.bundle.js
+            .cache/dll.json
+          key: dll-cache-${{ hashFiles('yarn.lock', 'sdk/js/yarn.lock')}}
       - name: Initialize babel cache
         id: babel-cache
         uses: actions/cache@v2
@@ -133,6 +142,9 @@ jobs:
           key: ${{ runner.os }}-babel-cache-${{ hashFiles('config/babel.config.json', 'config/webpack.config.babel.js') }}
           restore-keys: |
             ${{ runner.os }}-babel-cache-
+      - name: Build DLLs
+        if: steps.dll-cache.outputs.cache-hit != 'true'
+        run: tools/bin/mage js:buildDll
       - name: Build frontend
         if: steps.public-cache.outputs.cache-hit != 'true'
         run: tools/bin/mage js:build

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -53,10 +53,6 @@ jobs:
       # TODO: Fix EditorConfig errors and remove
       # https://github.com/TheThingsNetwork/lorawan-stack/issues/2723
       continue-on-error: true
-    - name: Install JS dependencies
-      if: steps.yarn-cache.outputs.cache-hit != 'true'
-      run: tools/bin/mage js:deps
-      timeout-minutes: 5
     - name: Check headers
       run: tools/bin/mage headers:check
     - name: Fix common spelling mistakes

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -138,6 +138,9 @@ jobs:
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: tools/bin/mage js:deps
         timeout-minutes: 5
+      - name: Build DLLs
+        if: steps.dll-cache.outputs.cache-hit != 'true'
+        run: tools/bin/mage js:buildDll
       - name: Build frontend
         if: steps.public-cache.outputs.cache-hit != 'true'
         run: tools/bin/mage js:build

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -67,7 +67,6 @@ jobs:
       - name: Build JS SDK
         run: tools/bin/mage jsSDK:clean jsSDK:build
       - name: Install JS dependencies
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: tools/bin/mage js:deps
         timeout-minutes: 5
       - name: Generate JS translations
@@ -132,18 +131,9 @@ jobs:
         if: steps.tools-cache.outputs.cache-hit != 'true'
       - name: Install JS SDK dependencies
         run: tools/bin/mage jsSDK:deps
-      - name: Build JS SDK
-        run: tools/bin/mage jsSDK:clean jsSDK:build
       - name: Install JS dependencies
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: tools/bin/mage js:deps
         timeout-minutes: 5
-      - name: Build DLLs
-        if: steps.dll-cache.outputs.cache-hit != 'true'
-        run: tools/bin/mage js:buildDll
-      - name: Build frontend
-        if: steps.public-cache.outputs.cache-hit != 'true'
-        run: tools/bin/mage js:build
       - name: Test JS SDK code
         run: tools/bin/mage jsSDK:test
       - name: Test frontend code

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -90,6 +90,15 @@ jobs:
         with:
           path: public
           key: public-cache-${{ hashFiles('pkg/webui/**', 'sdk/js/**/*.js', 'sdk/js/generated/*.json', 'config/webpack.config.babel.js', 'yarn.lock', 'sdk/js/yarn.lock')}}
+      - name: Initialize dll cache
+        if: steps.public-cache.outputs.cache-hit != 'true'
+        id: dll-cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            public/libs.*.bundle.js
+            .cache/dll.json
+          key: dll-cache-${{ hashFiles('yarn.lock', 'sdk/js/yarn.lock')}}
       - name: Initialize babel cache
         id: babel-cache
         uses: actions/cache@v2
@@ -99,9 +108,16 @@ jobs:
           key: ${{ runner.os }}-babel-cache-${{ hashFiles('config/babel.config.json', 'config/webpack.config.babel.js') }}
           restore-keys: |
             ${{ runner.os }}-babel-cache-
+      - name: Build DLLs
+        if: steps.dll-cache.outputs.cache-hit != 'true'
+        run: tools/bin/mage js:buildDll
+        env:
+          WEBPACK_GENERATE_PRODUCTION_SOURCEMAPS: 'true'
       - name: Build frontend
         run: tools/bin/mage js:build
         if: steps.public-cache.outputs.cache-hit != 'true'
+        env:
+          WEBPACK_GENERATE_PRODUCTION_SOURCEMAPS: 'true'
       - name: Check for diff
         run: tools/bin/mage git:diff
       - name: Import the signing key

--- a/cmd/internal/shared/console/config.go
+++ b/cmd/internal/shared/console/config.go
@@ -41,7 +41,7 @@ var DefaultConsoleConfig = console.Config{
 			AssetsBaseURL: shared.DefaultAssetsBaseURL,
 			IconPrefix:    "console-",
 			CSSFiles:      []string{"console.css"},
-			JSFiles:       []string{"console.js"},
+			JSFiles:       []string{"libs.bundle.js", "console.js"},
 		},
 		FrontendConfig: console.FrontendConfig{
 			DocumentationBaseURL: "https://thethingsindustries.com/docs",

--- a/cmd/internal/shared/identityserver/config.go
+++ b/cmd/internal/shared/identityserver/config.go
@@ -38,7 +38,7 @@ var DefaultIdentityServerConfig = identityserver.Config{
 				AssetsBaseURL: shared.DefaultAssetsBaseURL,
 				IconPrefix:    "oauth-",
 				CSSFiles:      []string{"account.css"},
-				JSFiles:       []string{"account.js"},
+				JSFiles:       []string{"libs.bundle.js", "account.js"},
 			},
 			FrontendConfig: oauth.FrontendConfig{
 				DocumentationBaseURL: "https://thethingsindustries.com/docs",

--- a/config/webpack.dll.babel.js
+++ b/config/webpack.dll.babel.js
@@ -18,6 +18,9 @@ import path from 'path'
 import webpack from 'webpack'
 
 const { CONTEXT = '.', CACHE_DIR = '.cache', PUBLIC_DIR = 'public' } = process.env
+const mode = process.env.NODE_ENV === 'production' ? 'production' : 'development'
+const WEBPACK_GENERATE_PRODUCTION_SOURCEMAPS =
+  process.env.WEBPACK_GENERATE_PRODUCTION_SOURCEMAPS === 'true'
 
 const context = path.resolve(CONTEXT)
 const library = '[name]_[hash]'
@@ -25,21 +28,25 @@ const library = '[name]_[hash]'
 const pkg = require(path.resolve(context, 'package.json'))
 const excludeLibs = ['react-hot-loader', 'ttn-lw']
 const libs = Object.keys(pkg.dependencies || {}).filter(lib => !excludeLibs.includes(lib))
+const devtool =
+  (mode === 'production' && WEBPACK_GENERATE_PRODUCTION_SOURCEMAPS) || mode === 'development'
+    ? 'module-source-map'
+    : false
 
 export default {
   context,
-  mode: 'development',
+  mode,
   target: 'web',
   node: {
     fs: 'empty',
     module: 'empty',
   },
   stats: 'minimal',
-  devtool: 'module-source-map',
+  devtool,
   recordsPath: path.resolve(context, CACHE_DIR, '_libs_records'),
   entry: { libs },
   output: {
-    filename: '[name].bundle.js',
+    filename: '[name].[hash].bundle.js',
     path: path.resolve(context, PUBLIC_DIR),
     library,
   },

--- a/tools/mage/js.go
+++ b/tools/mage/js.go
@@ -150,11 +150,6 @@ func (js Js) Deps() error {
 
 // BuildDll runs the webpack command to build the DLL bundle
 func (js Js) BuildDll() error {
-	if js.isProductionMode() {
-		fmt.Println("Skipping DLL building (production mode)")
-		return nil
-	}
-
 	ok, err := target.Path(
 		filepath.Join("public", "libs.bundle.js"),
 		"yarn.lock",
@@ -174,7 +169,11 @@ func (js Js) BuildDll() error {
 
 // Build runs the webpack command with the project config.
 func (js Js) Build() error {
-	mg.Deps(js.Deps, js.Translations, js.BackendTranslations, js.BuildDll)
+	mg.Deps(js.Deps, js.BackendTranslations)
+	ci := os.Getenv("CI")
+	if ci != "true" {
+		mg.Deps(js.BuildDll)
+	}
 	if mg.Verbose() {
 		fmt.Println("Running Webpack")
 	}


### PR DESCRIPTION
#### Summary
This PR will increase the frontend build speed by making use of webpacks DLL feature in production, as well as removing a calculation heavy file hashing plugin.

References #2661

```
Before ---
time mage js:clean js:cleanDeps jsSdk:Clean jsSdk:cleanDeps js:build
351.66s user 57.73s system 169% cpu 4:01.81 total

time mage js:build
91.81s user 12.12s system 119% cpu 1:27.14 total

After ---
time mage js:clean js:cleanDeps jsSdk:Clean jsSdk:cleanDeps js:build
230.47s user 33.66s system 198% cpu 2:12.87 total

time mage js:build
28.38s user 3.05s system 141% cpu 22.191 total
```
Note that these are measures from my M1 Mac, so the times on the CI machines will be significantly slower, however, the relative delta is about the same.

#### Changes
- Enable DLL referencing in production as well (currently development only)
- Enable caching of DLL module in GitHub action
- Remove `webpack-plugin-hash-output`
- Enable source map generation for release builds only
- Remove some unnecessary GitHub action job steps

#### Testing
Tested this in a separate PR #4769 

##### Regressions

In production we will now, additionally to the app bundle, also include a bundle that includes external libraries. It is possible that this leads to issues. I could however not find any when running this locally and also end-to-end tests work properly.

#### Notes for Reviewers
Note that this includes a config update, where the default values for the `js-files` config has to be updated to include the additional `libs.*.bundle.js` file that includes the external modules.

There is more speed up potential which I cannot work on currently and includes: 
- Removing number of modules (e.g. stylus files that use a lot of duplicate styles)
- Improving the mage tooling to avoid running the `yarn install` command multiple times during build
  - This could e.g. be done using yarn workspaces, so that the dependencies for webui and SDK can be installed in one go
- Treeshaking and sharing external dependencies
- Migrating to webpack 5, which (seemingly) has better build caching capabilities

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
