### PR TITLE
Improve PBA subscription streams

### DIFF
--- a/pkg/packetbrokeragent/agent.go
+++ b/pkg/packetbrokeragent/agent.go
@@ -43,7 +43,7 @@ import (
 
 const (
 	// subscribeStreamCount is the number of subscription streams that are used by the Forwarder and Home Network roles.
-	subscribeStreamCount = 8
+	subscribeStreamCount = 4
 
 	// publishMessageTimeout defines the timeout for publishing messages.
 	publishMessageTimeout = 3 * time.Second

--- a/pkg/packetbrokeragent/agent.go
+++ b/pkg/packetbrokeragent/agent.go
@@ -89,7 +89,8 @@ type Agent struct {
 	netID            types.NetID
 	subscriptionTenantID,
 	clusterID,
-	homeNetworkClusterID string
+	homeNetworkClusterID,
+	subscriptionGroup string
 	authenticator     authenticator
 	forwarderConfig   ForwarderConfig
 	homeNetworkConfig HomeNetworkConfig
@@ -180,6 +181,10 @@ func New(c *component.Component, conf *Config, opts ...Option) (*Agent, error) {
 	if homeNetworkClusterID == "" {
 		homeNetworkClusterID = conf.ClusterID
 	}
+	subscriptionGroup := conf.ClusterID
+	if subscriptionGroup == "" {
+		subscriptionGroup = "default"
+	}
 	a := &Agent{
 		Component:            c,
 		ctx:                  ctx,
@@ -188,6 +193,7 @@ func New(c *component.Component, conf *Config, opts ...Option) (*Agent, error) {
 		subscriptionTenantID: conf.TenantID,
 		clusterID:            conf.ClusterID,
 		homeNetworkClusterID: homeNetworkClusterID,
+		subscriptionGroup:    subscriptionGroup,
 		authenticator:        authenticator,
 		forwarderConfig:      conf.Forwarder,
 		homeNetworkConfig:    conf.HomeNetwork,
@@ -506,7 +512,7 @@ func (a *Agent) subscribeDownlinkStream(client routingpb.ForwarderDataClient, do
 			ForwarderNetId:     a.netID.MarshalNumber(),
 			ForwarderTenantId:  a.subscriptionTenantID,
 			ForwarderClusterId: a.clusterID,
-			Group:              a.clusterID,
+			Group:              a.subscriptionGroup,
 		})
 		if err != nil {
 			return err
@@ -820,7 +826,7 @@ func (a *Agent) subscribeUplinkStream(client routingpb.HomeNetworkDataClient, up
 			HomeNetworkTenantId:  a.subscriptionTenantID,
 			HomeNetworkClusterId: a.homeNetworkClusterID,
 			Filters:              filters,
-			Group:                a.clusterID,
+			Group:                a.subscriptionGroup,
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION

<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This small PR improves the subscription streams between Packet Broker Agent and Packet Broker.

#### Changes
<!-- What are the changes made in this pull request? -->

- Decrease default number of subscription streams; 4 is good enough for load balancing and more only adds overhead
- Always use a subscription group; otherwise, with multiple streams, data is delivered at each stream

#### Testing

<!-- How did you verify that this change works? -->

Local integration testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
