### PR TITLE
Fix dll loading in development builds

### DIFF
--- a/config/webpack.config.babel.js
+++ b/config/webpack.config.babel.js
@@ -276,7 +276,7 @@ export default {
       new CleanWebpackPlugin({
         dry: WEBPACK_IS_DEV_SERVER_BUILD,
         verbose: false,
-        cleanOnceBeforeBuildPatterns: ['**/*', '!libs.*.bundle.js', '!libs.*.bundle.js.map'],
+        cleanOnceBeforeBuildPatterns: ['**/*', '!libs*bundle.js', '!libs*bundle.js.map'],
       }),
       // Copy static assets to output directory.
       new CopyWebpackPlugin({ patterns: [{ from: `${src}/assets/static` }] }),
@@ -285,7 +285,7 @@ export default {
         manifest: path.resolve(context, CACHE_DIR, 'dll.json'),
       }),
       new AddAssetHtmlPlugin({
-        filepath: path.resolve(context, PUBLIC_DIR, 'libs.*.bundle.js'),
+        filepath: path.resolve(context, PUBLIC_DIR, 'libs*bundle.js'),
       }),
     ],
     production: [

--- a/config/webpack.dll.babel.js
+++ b/config/webpack.dll.babel.js
@@ -46,7 +46,7 @@ export default {
   recordsPath: path.resolve(context, CACHE_DIR, '_libs_records'),
   entry: { libs },
   output: {
-    filename: '[name].[hash].bundle.js',
+    filename: mode === 'production' ? '[name].[hash].bundle.js' : '[name].bundle.js',
     path: path.resolve(context, PUBLIC_DIR),
     library,
   },


### PR DESCRIPTION
#### Summary
Quickfix to fix a bug in development builds introduced via #4824, which made development builds show blank pages due to the DLL bundle not being found.

#### Changes
- Fix DLL bundle naming in development builds
- Fix DLL bundle asset resolution in development builds


#### Testing

Manual.


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
