### PR TITLE
Fix full-text search query parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ For details about compatibility between different releases, see the **Commitment
 - Handling of NaN values in our JSON API.
 - Receiver metadata from more than one antenna is now available in messages received from Packet Broker.
 - Unhelpful error message when aborting the OIDC Login in the Console.
+- Parsing of multi-word description search queries.
 
 ### Security
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This fixes query parsing for searching on `description` fields, and makes searching on `name` fields more intuitive.

#### Changes
<!-- What are the changes made in this pull request? -->

- Use `ILIKE` for name queries, so that you can search for partial names
- Use `websearch_to_tsquery` for description queries, so that you can put multiple words in the query

#### Testing

<!-- How did you verify that this change works? -->

Existing tests

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
