### PR TITLE
Merge multiple antenna signal qualities with location information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Fixed
 
 - Handling of NaN values in our JSON API.
+- Receiver metadata from more than one antenna is now available in messages received from Packet Broker.
 
 ### Security
 

--- a/pkg/packetbrokeragent/agent_test.go
+++ b/pkg/packetbrokeragent/agent_test.go
@@ -588,6 +588,14 @@ func TestHomeNetwork(t *testing.T) {
 														FrequencyOffset: 0,
 													},
 												},
+												{
+													Index: 1,
+													Value: &packetbroker.TerrestrialGatewayAntennaSignalQuality{
+														ChannelRssi:     -43,
+														Snr:             10.6,
+														FrequencyOffset: 1,
+													},
+												},
 											},
 										},
 									},
@@ -642,7 +650,8 @@ func TestHomeNetwork(t *testing.T) {
 					RawPayload: []byte{0x40, 0x44, 0x33, 0x22, 0x11, 0x01, 0x01, 0x00, 0x42, 0x1, 0x42, 0x1, 0x2, 0x3, 0x4},
 					RxMetadata: []*ttnpb.RxMetadata{
 						{
-							GatewayIds: &cluster.PacketBrokerGatewayID,
+							GatewayIds:   &cluster.PacketBrokerGatewayID,
+							AntennaIndex: 0,
 							PacketBroker: &ttnpb.PacketBrokerMetadata{
 								MessageId:           "test",
 								ForwarderNetId:      [3]byte{0x0, 0x0, 0x42},
@@ -664,6 +673,32 @@ func TestHomeNetwork(t *testing.T) {
 								Longitude: 4.8,
 								Altitude:  2,
 							},
+							UplinkToken: test.Must(WrapUplinkTokens([]byte("test-token"), nil, &AgentUplinkToken{
+								ForwarderNetID:     [3]byte{0x0, 0x0, 0x42},
+								ForwarderTenantID:  "foo-tenant",
+								ForwarderClusterID: "test",
+							})).([]byte),
+						},
+						{
+							GatewayIds:   &cluster.PacketBrokerGatewayID,
+							AntennaIndex: 1,
+							PacketBroker: &ttnpb.PacketBrokerMetadata{
+								MessageId:           "test",
+								ForwarderNetId:      [3]byte{0x0, 0x0, 0x42},
+								ForwarderTenantId:   "foo-tenant",
+								ForwarderClusterId:  "test",
+								ForwarderGatewayEui: eui64Ptr(types.EUI64{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88}),
+								ForwarderGatewayId: &pbtypes.StringValue{
+									Value: "foo-gateway",
+								},
+								HomeNetworkNetId:     [3]byte{0x0, 0x0, 0x13},
+								HomeNetworkTenantId:  "foo-tenant",
+								HomeNetworkClusterId: "test",
+							},
+							ChannelRssi:     -43,
+							Rssi:            -43,
+							Snr:             10.6,
+							FrequencyOffset: 1,
 							UplinkToken: test.Must(WrapUplinkTokens([]byte("test-token"), nil, &AgentUplinkToken{
 								ForwarderNetID:     [3]byte{0x0, 0x0, 0x42},
 								ForwarderTenantID:  "foo-tenant",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #4709 

#### Changes
<!-- What are the changes made in this pull request? -->

When location information is present in uplink metadata received from Packet Broker, still loop through the signal quality metadata as there might be RF metadata from other antennas.

#### Testing

<!-- How did you verify that this change works? -->

Unit testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
