### PR TITLE
Provide better error when OIDC login is aborted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - Handling of NaN values in our JSON API.
 - Receiver metadata from more than one antenna is now available in messages received from Packet Broker.
+- Unhelpful error message when aborting the OIDC Login in the Console.
 
 ### Security
 

--- a/pkg/webui/lib/components/full-view-error/error.js
+++ b/pkg/webui/lib/components/full-view-error/error.js
@@ -34,6 +34,7 @@ import {
   isBackend as isBackendError,
   getCorrelationId,
   getBackendErrorId,
+  isOAuthClientRefusedError,
 } from '@ttn-lw/lib/errors/utils'
 import statusCodeMessages from '@ttn-lw/lib/errors/status-code-messages'
 import PropTypes from '@ttn-lw/lib/prop-types'
@@ -77,7 +78,7 @@ const FullViewErrorInner = ({ error, safe }) => {
   const isNotFound = isNotFoundError(error)
   const isFrontend = isFrontendError(error)
   const isBackend = isBackendError(error)
-  const isOAuthCallback = window.location.pathname.endsWith('/oauth/callback')
+  const isOAuthCallback = /oauth.*\/callback$/.test(window.location.pathname)
 
   const errorId = getBackendErrorId(error) || 'n/a'
   const correlationId = getCorrelationId(error) || 'n/a'
@@ -91,7 +92,11 @@ const FullViewErrorInner = ({ error, safe }) => {
     errorMessage = errorMessages.genericNotFound
   } else if (isOAuthCallback) {
     errorTitle = errorMessages.loginFailed
-    errorMessage = errorMessages.loginFailedDescription
+    if (isOAuthClientRefusedError(error)) {
+      errorMessage = errorMessages.loginFailedDescription
+    } else {
+      errorMessage = errorMessages.loginFailedAbortDescription
+    }
   } else if (isFrontend) {
     errorMessage = error.errorMessage
     if (Boolean(error.errorTitle)) {

--- a/pkg/webui/lib/errors/error-messages.js
+++ b/pkg/webui/lib/errors/error-messages.js
@@ -33,4 +33,6 @@ export default defineMessages({
   loginFailed: 'Login failed',
   loginFailedDescription:
     'There was an error causing the login to fail. This might be due to server-side misconfiguration or a browser-cookie problem. Please try logging in again.',
+  loginFailedAbortDescription:
+    'The login process was aborted during the authentication with the login provider. You can use the button below to retry logging in.',
 })

--- a/pkg/webui/lib/errors/utils.js
+++ b/pkg/webui/lib/errors/utils.js
@@ -239,6 +239,14 @@ export const isTimeoutError = error =>
   Boolean(error) && typeof error === 'object' && error.code === 'ECONNABORTED'
 
 /**
+ * Returns whether `error` is a backend error with ID: 'pkg/web/oauthclient:refused'.
+ *
+ * @param {object} error - The error to be tested.
+ * @returns {boolean} `true` if `error` is a such error, `false` otherwise.
+ */
+export const isOAuthClientRefusedError = error =>
+  isBackend(error) && getBackendErrorId(error) === 'error:pkg/web/oauthclient:refused'
+/**
  * Returns whether the error is worth being sent to Sentry.
  *
  * @param {object} error - The error to be tested.

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -731,6 +731,7 @@
   "lib.errors.error-messages.correlationId": "Correlation ID: <code>{correlationId}</code>",
   "lib.errors.error-messages.loginFailed": "Login failed",
   "lib.errors.error-messages.loginFailedDescription": "There was an error causing the login to fail. This might be due to server-side misconfiguration or a browser-cookie problem. Please try logging in again.",
+  "lib.errors.error-messages.loginFailedAbortDescription": "The login process was aborted during the authentication with the login provider. You can use the button below to retry logging in.",
   "lib.errors.status-code-messages.4××": "Client error",
   "lib.errors.status-code-messages.400": "Bad request",
   "lib.errors.status-code-messages.401": "Unauthorized",


### PR DESCRIPTION
#### Summary
Closes #4564 

#### Changes
<!-- What are the changes made in this pull request? -->

- Check for OIDC abort error and display a better error message
- Provide a login button also for errors happening during the oidc callback (was regular callback only)


#### Testing

Manual testing

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
