### PR TITLE
BasicStation timesync fixes

### DIFF
--- a/pkg/gatewayserver/io/ws/config.go
+++ b/pkg/gatewayserver/io/ws/config.go
@@ -28,6 +28,8 @@ type Config struct {
 var DefaultConfig = Config{
 	UseTrafficTLSAddress: false,
 	WSPingInterval:       30 * time.Second,
-	TimeSyncInterval:     30 * time.Minute,
+	// Assuming 5ppm of drift, this means a drift of 5 microseconds in one second.
+	// A drift of 1 millisecond would occur every 200 seconds in such a situation.
+	TimeSyncInterval:     200 * time.Second,
 	AllowUnauthenticated: false,
 }

--- a/pkg/gatewayserver/io/ws/lbslns/downstream.go
+++ b/pkg/gatewayserver/io/ws/lbslns/downstream.go
@@ -136,8 +136,6 @@ func (dnmsg *DownlinkMessage) ToDownlinkMessage(bandID string) (*ttnpb.DownlinkM
 }
 
 const (
-	// transferTimeRTTPercentile is the percentile of round-trip times that is considered for determining the gateway GPS time.
-	transferTimeRTTPercentile = 90
 	// transferTimeMinRTTCount is the minimum number of observed round-trip times that are taken into account before using
 	// their statistics to determine the gateway GPS time.
 	transferTimeMinRTTCount = 5
@@ -154,7 +152,7 @@ func (*lbsLNS) TransferTime(ctx context.Context, serverTime time.Time, conn *io.
 		return nil, nil
 	}
 
-	_, _, _, np, n := conn.RTTStats(transferTimeRTTPercentile, serverTime)
+	_, _, median, _, n := conn.RTTStats(100, serverTime)
 	if n < transferTimeMinRTTCount {
 		return nil, nil
 	}
@@ -162,7 +160,7 @@ func (*lbsLNS) TransferTime(ctx context.Context, serverTime time.Time, conn *io.
 	// The concentrator time is based on the current server time plus
 	// half a round trip. The timestamp is relative to the server
 	// time in order to avoid aggregating gateway time errors.
-	concentratorTime, ok := conn.TimeFromServerTime(serverTime.Add(np / 2))
+	concentratorTime, ok := conn.TimeFromServerTime(serverTime.Add(median / 2))
 	if !ok {
 		return nil, nil
 	}

--- a/pkg/gatewayserver/io/ws/lbslns/upstream.go
+++ b/pkg/gatewayserver/io/ws/lbslns/upstream.go
@@ -611,9 +611,14 @@ func (f *lbsLNS) HandleUp(ctx context.Context, raw []byte, ids ttnpb.GatewayIden
 		// Transmission confirmation messages do not contain a RefTime, and cannot be used for
 		// RTT computations. The GPS timestamp is present only if the downlink is a class
 		// B downlink. We allow clock synchronization to occur only if GPSTime is present.
+		// References https://github.com/lorabasics/basicstation/issues/134.
 		syncClock(txConf.XTime, txConf.GPSTime, true)
 
 	case TypeUpstreamTimeSync:
+		// If the gateway sends a `timesync` request, it means that it has access to a PPS
+		// source. As such, there is no point in doing time transfers with this particular
+		// gateway.
+		updateSessionTimeSync(ctx, false)
 		var req TimeSyncRequest
 		if err := json.Unmarshal(raw, &req); err != nil {
 			return nil, err

--- a/pkg/gatewayserver/io/ws/lbslns/version.go
+++ b/pkg/gatewayserver/io/ws/lbslns/version.go
@@ -69,6 +69,10 @@ func (f *lbsLNS) GetRouterConfig(ctx context.Context, msg []byte, bandID string,
 	if err := json.Unmarshal(msg, &version); err != nil {
 		return nil, nil, nil, err
 	}
+	// We attempt to transfer time to all gateways by default.
+	// In the future, we should disable time transfers permanently
+	// to gateways that signal the presence of a PPS.
+	// References https://github.com/lorabasics/basicstation/issues/135.
 	updateSessionTimeSync(ctx, true)
 	cfg, err := pfconfig.GetRouterConfig(bandID, fps, version.IsProduction(), time.Now())
 	if err != nil {

--- a/pkg/gatewayserver/io/ws/ws.go
+++ b/pkg/gatewayserver/io/ws/ws.go
@@ -32,6 +32,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/frequencyplans"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
+	"go.thethings.network/lorawan-stack/v3/pkg/random"
 	"go.thethings.network/lorawan-stack/v3/pkg/ratelimit"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
@@ -226,7 +227,7 @@ func (s *srv) handleTraffic(c echo.Context) (err error) {
 		err = nil // Errors are sent over the websocket connection that is established by this point.
 	}()
 
-	pingTicker := time.NewTicker(s.cfg.WSPingInterval)
+	pingTicker := time.NewTicker(random.Jitter(s.cfg.WSPingInterval, 0.1))
 	defer pingTicker.Stop()
 
 	ws.SetPingHandler(func(data string) error {
@@ -248,7 +249,7 @@ func (s *srv) handleTraffic(c echo.Context) (err error) {
 
 	var timeSyncTickerC <-chan time.Time
 	if s.cfg.TimeSyncInterval > 0 {
-		ticker := time.NewTicker(s.cfg.TimeSyncInterval)
+		ticker := time.NewTicker(random.Jitter(s.cfg.TimeSyncInterval, 0.1))
 		timeSyncTickerC = ticker.C
 		defer ticker.Stop()
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/4805
References https://github.com/TheThingsNetwork/lorawan-stack/pull/4828

#### Changes
<!-- What are the changes made in this pull request? -->

- Lower the `timesync` interval to 200 seconds, from 30 minutes
  - This ensures that both the `gpstime`, and the `MuxTime` are fresh
- Disable time transfer to gateways that requested a `timesync` round with the Gateway Server
  - This ensures that we don't push time synchronization messages to gateways that do not require them
- Add a 10% jitter to `ping-pong` and `timesync` tickers.
  - This should lower the pressure on the Gateway Server when multiple gateways reconnect at the same time.

#### Testing

<!-- How did you verify that this change works? -->

Local testing + `staging1`.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

These changes have been made in the presence of a PPS-enabled gateway, and have been tested both with PPS enabled, and disabled.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
