### PR TITLE
Fix Application Server subscription leak

### DIFF
--- a/pkg/applicationserver/distribution/subscription_set.go
+++ b/pkg/applicationserver/distribution/subscription_set.go
@@ -42,8 +42,8 @@ func newSubscriptionSet(ctx context.Context, rd RequestDecoupler, timeout time.D
 		cancel:        cancel,
 		rd:            rd,
 		timeout:       timeout,
-		subscribeCh:   make(chan *io.Subscription, 1),
-		unsubscribeCh: make(chan *io.Subscription, 1),
+		subscribeCh:   make(chan *io.Subscription),
+		unsubscribeCh: make(chan *io.Subscription),
 		upCh:          make(chan *io.ContextualApplicationUp, subscriptionSetBufferSize),
 		subOpts:       opts,
 	}
@@ -145,6 +145,8 @@ func (s *subscriptionSet) run() {
 			if correlationID, ok := subscribers[sub]; ok {
 				delete(subscribers, sub)
 				s.observeUnsubscribe(correlationID, sub)
+			} else {
+				panic("unknown subscription")
 			}
 			lastAction = time.Now()
 		case up := <-s.upCh:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes a leak that occurs when a user connects and disconnects repeatedly. The leak occurs because the subscription cancellation is observed by the subscription set before the subscription itself. This causes the subscription set to ignore the unsubscribe, and then the subscription becomes part of `subscribers` map permanently, until the process OOMs.

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove the buffering of the subscription set subscribed/unsubscribed channels
   - This ensures that the subscription sets always perceives the subscribe event before the unsubscribed event


#### Testing

<!-- How did you verify that this change works? -->

The script at https://github.com/TheThingsIndustries/lorawan-stack-aws/pull/501#issuecomment-928960300 triggers the `panic` immediately if the channels are buffered.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None are expected. Specifically, there should be no performance penalties for removing buffering, as subscriptions sets exist on a per application basis.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
