### PR TITLE
dev: Add a missing command to run tests in dev environment

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -60,7 +60,7 @@ The Things Network's development tooling uses [Mage](https://magefile.org/). Und
 - Follow [Go's installation guide](https://golang.org/doc/install) to install Go.
 - Download Node.js [from their website](https://nodejs.org) and install it.
 - Follow [Yarn's installation guide](https://yarnpkg.com/en/docs/install) to install Yarn.
-- Follow the guides to [install Docker](https://docs.docker.com/install/#supported-platforms) and to [install Docker Compose](https://docs.docker.com/compose/install/#install-compose).
+- Follow the guides to [install Docker](https://docs.docker.com/install/#supported-platforms) and to [install Docker Compose](https://docs.docker.com/compose/install/#install-compose)(only v1.x is supported for now).
 
 ## Cloning the Repository
 
@@ -787,7 +787,7 @@ We use [Cypress](https://cypress.io) for running frontend-based end-to-end tests
 
 #### Running frontend end-to-end tests locally
 
-Make sure to [build the frontend assets](#building-the-frontend), [start The Things Stack](#starting-the-things-stack) and run `tools/bin/mage dev:sqlDump` to save database dump before executing end-to-end tests.
+Make sure to [build the frontend assets](#building-the-frontend), [start The Things Stack](#starting-the-things-stack) and run it with `tools/bin/mage dev:startDevStack`, then run `tools/bin/mage dev:sqlDump` to save database dump before executing end-to-end tests.
 
 `Cypress` provides two modes for running tests: headless and interactive.
 - Headless mode - will not display any browser GUI and output test progress into your terminal instead. This is helpful when one just needs see the results of the tests.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -787,7 +787,7 @@ We use [Cypress](https://cypress.io) for running frontend-based end-to-end tests
 
 #### Running frontend end-to-end tests locally
 
-Make sure to [build the frontend assets](#building-the-frontend), [start The Things Stack](#starting-the-things-stack) and run it with `tools/bin/mage dev:startDevStack`, then run `tools/bin/mage dev:sqlDump` to save database dump before executing end-to-end tests.
+Make sure to [build the frontend assets](#building-the-frontend), [start The Things Stack](#starting-the-things-stack) and run `tools/bin/mage dev:sqlDump` after running `tools/bin/mage dev:initStack` to save database dump used as database seed when running end-to-end tests. To run the stack when working on end-to-end tests, use the `tools/bin/mage dev:startDevStack` command. This will run the stack in proper configuration for the end-to-end tests, note that this is an endless process that essentially runs the The Things Stack process so you don't have to wait for it to finish.
 
 `Cypress` provides two modes for running tests: headless and interactive.
 - Headless mode - will not display any browser GUI and output test progress into your terminal instead. This is helpful when one just needs see the results of the tests.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -60,7 +60,7 @@ The Things Network's development tooling uses [Mage](https://magefile.org/). Und
 - Follow [Go's installation guide](https://golang.org/doc/install) to install Go.
 - Download Node.js [from their website](https://nodejs.org) and install it.
 - Follow [Yarn's installation guide](https://yarnpkg.com/en/docs/install) to install Yarn.
-- Follow the guides to [install Docker](https://docs.docker.com/install/#supported-platforms) and to [install Docker Compose](https://docs.docker.com/compose/install/#install-compose)(only v1.x is supported for now).
+- Follow the guides to [install Docker](https://docs.docker.com/install/#supported-platforms) and to [install Docker Compose](https://docs.docker.com/compose/install/#install-compose).
 
 ## Cloning the Repository
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

While trying to run cypress tests for my fix of an issue, realized the documentation is lacking the fact that I need to run the stack with `tools/bin/mage dev:startDevStack` before running the tests. Also when doing my very first assignment I realized that tts only supports the v1.x of docker-compose, I don't know if that changed in the mean time. 

#### Changes
<!-- What are the changes made in this pull request? -->

- DEVELOPMENT.md: added a sentence about the command need to run tests. 


#### Testing

<!-- How did you verify that this change works? -->

Run tests without first running `tools/bin/mage dev:startDevStack` to see it not work, then run the stack with the previews command and after that run the tests to see it work.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Affects only the DEVELOPMENT.md


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
