### PR TITLE
Disconnect WS gateways that stop sending WS pong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
+- Gateway server disconnects LoRa Basics Station gateways that stop sending pongs to server pings. This does not apply to gateways that don't support pongs.
+
 ### Deprecated
 
 ### Removed

--- a/config/messages.json
+++ b/config/messages.json
@@ -4346,6 +4346,15 @@
       "file": "ws.go"
     }
   },
+  "error:pkg/gatewayserver/io/ws:missed_too_many_pongs": {
+    "translations": {
+      "en": "gateway missed too many pongs"
+    },
+    "description": {
+      "package": "pkg/gatewayserver/io/ws",
+      "file": "ws.go"
+    }
+  },
   "error:pkg/gatewayserver/io/ws:no_auth_provided": {
     "translations": {
       "en": "no auth provided `{uid}`"

--- a/pkg/gatewayserver/io/ws/config.go
+++ b/pkg/gatewayserver/io/ws/config.go
@@ -20,6 +20,7 @@ import "time"
 type Config struct {
 	UseTrafficTLSAddress bool          `name:"use-traffic-tls-address" description:"Use WSS for the traffic address regardless of the TLS setting"`
 	WSPingInterval       time.Duration `name:"ws-ping-interval" description:"Interval to send WS ping messages"`
+	MissedPongThreshold  int           `name:"missed-pong-threshold" description:"Number of consecutive missed pongs before disconnection. This value is used only if the gateway sends at least one pong."`
 	TimeSyncInterval     time.Duration `name:"time-sync-interval" description:"Interval to send time transfer messages"`
 	AllowUnauthenticated bool          `name:"allow-unauthenticated" description:"Allow unauthenticated connections"`
 }
@@ -30,6 +31,7 @@ var DefaultConfig = Config{
 	WSPingInterval:       30 * time.Second,
 	// Assuming 5ppm of drift, this means a drift of 5 microseconds in one second.
 	// A drift of 1 millisecond would occur every 200 seconds in such a situation.
+	MissedPongThreshold:  2,
 	TimeSyncInterval:     200 * time.Second,
 	AllowUnauthenticated: false,
 }

--- a/pkg/gatewayserver/io/ws/ws.go
+++ b/pkg/gatewayserver/io/ws/ws.go
@@ -283,12 +283,12 @@ func (s *srv) handleTraffic(c echo.Context) (err error) {
 				if gatewayCanSendPong {
 					missedPongsMu.Lock()
 					missedPongs++
+					missedPongsMu.Unlock()
 					if missedPongs == s.cfg.MissedPongThreshold {
 						logger.WithError(errMissedTooManyPongs).Warn("Disconnect gateway")
-						conn.Disconnect(errMissedTooManyPongs)
+						conn.Disconnect(errMissedTooManyPongs.New())
 						return
 					}
-					missedPongsMu.Unlock()
 				}
 			case <-timeSyncTickerC:
 				b, err := s.formatter.TransferTime(ctx, time.Now(), conn)

--- a/pkg/gatewayserver/io/ws/ws_util_test.go
+++ b/pkg/gatewayserver/io/ws/ws_util_test.go
@@ -17,11 +17,14 @@ package ws_test
 import (
 	"context"
 	"fmt"
+	"math"
 	"net"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"go.thethings.network/lorawan-stack/v3/pkg/cluster"
 	"go.thethings.network/lorawan-stack/v3/pkg/component"
 	componenttest "go.thethings.network/lorawan-stack/v3/pkg/component/test"
@@ -81,4 +84,43 @@ func withServer(t *testing.T, wsConfig ws.Config, rateLimitConf config.RateLimit
 	servAddr := fmt.Sprintf("ws://%s", lis.Addr().String())
 
 	f(t, is, servAddr)
+}
+
+// PingPongHandler handles WS Ping Pong.
+type PingPongHandler struct {
+	errCh         chan error
+	wsConn        *websocket.Conn
+	wsConnMu      sync.RWMutex
+	disablePong   bool
+	numberOfPongs int
+}
+
+// New returns a new PingPongHandler.
+func NewPingPongHandler(wsConn *websocket.Conn, disablePong bool, numberOfPongs int) *PingPongHandler {
+	if !disablePong && numberOfPongs == 0 {
+		numberOfPongs = math.MaxInt // allow unlimited
+	}
+	return &PingPongHandler{
+		wsConn:        wsConn,
+		errCh:         make(chan error),
+		disablePong:   disablePong,
+		numberOfPongs: numberOfPongs,
+	}
+}
+
+func (h *PingPongHandler) HandlePing(data string) error {
+	if h.disablePong || h.numberOfPongs == 0 {
+		return nil
+	}
+	h.wsConnMu.Lock()
+	defer h.wsConnMu.Unlock()
+	if err := h.wsConn.WriteMessage(websocket.PongMessage, nil); err != nil {
+		h.errCh <- err
+	}
+	h.numberOfPongs--
+	return nil
+}
+
+func (h *PingPongHandler) ErrCh() <-chan error {
+	return h.errCh
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Disconnect WS gateways that stop sending WS pong. Closes #4783.

#### Background of the issue and the solution

- This issue only occurs with unclean TCP disconnects, for ex yanking the power cable of the gateway.
- This is not visible with `wscat` which does a clean disconnect.
- With local testing, I found that the gateway connection exists for about 2-3 mins after I've removed the power.
- In addition [AWS ELB's keep alive](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#connection-idle-timeout ) is 350 seconds (5.8 mins) and that cannot be changed. The end result being that the connection is kept alive for 10-12 mins. On one test, I even got 18 mins. I'm not sure how to account for that.
>  Elastic Load Balancing sets the idle timeout value for TCP flows to 350 seconds. You cannot modify this value. Clients or targets can use TCP keepalive packets to reset the idle timeout. Keepalive packets sent to maintain TLS connections cannot contain data or payload. 
- So logically, we disconnect the gateway based on WS ping-pong.
  - Many gateways don't send ping to the server. We cannot use gateway pings as the reference.
  - A few of them don't even respond with pong to server ping.
  - So I've designed the logic to disconnect only if the gateway is capable of sending pongs but doesn't at some point in the connection.

#### Changes
<!-- What are the changes made in this pull request? -->

- Use a new ticker to wait for pongs after a ping. If the gateway doesn't send pongs, disconnect.
- Here are the cases
  - Gateway doesn't send pong; don't do anything. Such gateways will continue to have the issue and we can't do anything. We should reach out to those gateway vendors to support WS pong.
  - Gateway sends pongs but stops sending at some point. At least allow 2 failed pings before disconnecting.
- Add UT.


#### Testing

<!-- How did you verify that this change works? -->

UT and tested locally with my TTIG.
- I've also tested that this does not interfere with the reconnection.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Covered by UT. Let's test this in staging.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

We should do some extended testing for a few days in staging (and TTN) since we don't want to be randomly disconnecting gateways.
Should we put this under a flag so that we can get some feedback from TTS CE? Or should can move this to the next milestone and test on TTS CE first and update TTSC in `v3.16.1`.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
