### PR TITLE
Add MQTT connection failure event

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -8675,6 +8675,15 @@
       "file": "grpc_deviceregistry.go"
     }
   },
+  "event:as.mqtt.connect.fail": {
+    "translations": {
+      "en": "fail to connect to MQTT"
+    },
+    "description": {
+      "package": "pkg/applicationserver/io/mqtt",
+      "file": "observability.go"
+    }
+  },
   "event:as.packages.loraclouddmsv1.fail": {
     "translations": {
       "en": "fail to process upstream message"

--- a/pkg/applicationserver/io/mqtt/observability.go
+++ b/pkg/applicationserver/io/mqtt/observability.go
@@ -1,0 +1,32 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mqtt
+
+import (
+	"context"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/events"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+)
+
+var evtConnectFail = events.Define(
+	"as.mqtt.connect.fail", "fail to connect to MQTT",
+	events.WithVisibility(ttnpb.RIGHT_APPLICATION_TRAFFIC_READ),
+	events.WithErrorDataType(),
+)
+
+func registerConnectFail(ctx context.Context, ids ttnpb.ApplicationIdentifiers, err error) {
+	events.Publish(evtConnectFail.NewWithIdentifiersAndData(ctx, &ids, err))
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://www.thethingsnetwork.org/forum/t/what-are-unsubscribe-application-and-subscribe-application-events-in-console-live-data/53073/6

#### Changes
<!-- What are the changes made in this pull request? -->

- Add an MQTT connect failure event, to be used when authentication fails

#### Testing

<!-- How did you verify that this change works? -->

Local testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None are expected.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
