### PR TITLE
Support `ftime` and `foff` for SX1303 using V1 UDP protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Added
 
+- Support for fine timestamps and frequency offsets sent by gateways with SX1303 concentrator using the legacy UDP protocol.
+
 ### Changed
 
 ### Deprecated

--- a/config/messages.json
+++ b/config/messages.json
@@ -7982,15 +7982,6 @@
       "file": "toa.go"
     }
   },
-  "error:pkg/ttnpb/udp:bandwidth": {
-    "translations": {
-      "en": "failed to parse bandwidth"
-    },
-    "description": {
-      "package": "pkg/ttnpb/udp",
-      "file": "errors.go"
-    }
-  },
   "error:pkg/ttnpb/udp:eui": {
     "translations": {
       "en": "failed to parse EUI"
@@ -8039,15 +8030,6 @@
   "error:pkg/ttnpb/udp:payload": {
     "translations": {
       "en": "failed to parse binary payload"
-    },
-    "description": {
-      "package": "pkg/ttnpb/udp",
-      "file": "errors.go"
-    }
-  },
-  "error:pkg/ttnpb/udp:spreading_factor": {
-    "translations": {
-      "en": "failed to parse spreading factor"
     },
     "description": {
       "package": "pkg/ttnpb/udp",

--- a/pkg/ttnpb/udp/errors.go
+++ b/pkg/ttnpb/udp/errors.go
@@ -19,12 +19,10 @@ import (
 )
 
 var (
-	errNoEUI           = errors.DefineInvalidArgument("no_eui", "packet is not long enough to contain the EUI")
-	errPayload         = errors.DefineInvalidArgument("payload", "failed to parse binary payload")
-	errBandwidth       = errors.DefineInvalidArgument("bandwidth", "failed to parse bandwidth")
-	errSpreadingFactor = errors.DefineInvalidArgument("spreading_factor", "failed to parse spreading factor")
-	errEUI             = errors.DefineInvalidArgument("eui", "failed to parse EUI")
-	errTimestamp       = errors.DefineInvalidArgument("timestamp", "failed to parse timestamp")
-	errModulation      = errors.DefineInvalidArgument("modulation", "invalid modulation `{modulation}`")
-	errNotScheduled    = errors.DefineInvalidArgument("not_scheduled", "downlink message not scheduled")
+	errNoEUI        = errors.DefineInvalidArgument("no_eui", "packet is not long enough to contain the EUI")
+	errPayload      = errors.DefineInvalidArgument("payload", "failed to parse binary payload")
+	errEUI          = errors.DefineInvalidArgument("eui", "failed to parse EUI")
+	errTimestamp    = errors.DefineInvalidArgument("timestamp", "failed to parse timestamp")
+	errModulation   = errors.DefineInvalidArgument("modulation", "invalid modulation `{modulation}`")
+	errNotScheduled = errors.DefineInvalidArgument("not_scheduled", "downlink message not scheduled")
 )

--- a/pkg/ttnpb/udp/packet_data.go
+++ b/pkg/ttnpb/udp/packet_data.go
@@ -31,24 +31,26 @@ type Data struct {
 
 // RxPacket contains a Rx message
 type RxPacket struct {
-	Time *CompactTime `json:"time,omitempty"` // UTC time of pkt Rx, us precision, ISO 8601 'compact' format
-	Tmms *uint64      `json:"tmms,omitempty"` // GPS time of pkt Rx, number of milliseconds since 06.Jan.1980
-	Tmst uint32       `json:"tmst"`           // Internal timestamp of "Rx finished" event (32b unsigned)
-	Freq float64      `json:"freq"`           // Rx central frequency in MHz (unsigned float, Hz precision)
-	Chan uint8        `json:"chan"`           // Concentrator "IF" channel used for Rx (unsigned integer)
-	RFCh uint8        `json:"rfch"`           // Concentrator "RF chain" used for Rx (unsigned integer)
-	Stat int8         `json:"stat"`           // CRC status: 1 = OK, -1 = fail, 0 = no CRC
-	Modu string       `json:"modu"`           // Modulation identifier "LORA", "FSK" or "LR-FHSS"
-	DatR datarate.DR  `json:"datr"`           // LoRa datarate, FSK datarate or LR-FHSS datarate
-	CodR string       `json:"codr"`           // LoRa or LR-FHSS ECC coding rate identifier
-	Hpw  uint32       `json:"hpw,omitempty"`  // Hopping width; a number describing the number of steps of the LR-FHSS grid
-	RSSI int16        `json:"rssi"`           // RSSI in dBm (signed integer, 1 dB precision)
-	LSNR float64      `json:"lsnr"`           // Lora SNR ratio in dB (signed float, 0.1 dB precision)
-	Size uint16       `json:"size"`           // RF packet payload size in bytes (unsigned integer)
-	Data string       `json:"data"`           // Base64 encoded RF packet payload, padded
-	RSig []RSig       `json:"rsig"`           // Received signal information, per antenna (Optional)
-	Brd  uint         `json:"brd"`            // Concentrator board used for Rx (unsigned integer)
-	Aesk uint         `json:"aesk"`           // AES key index used for encrypting fine timestamps (unsigned integer)
+	Time  *CompactTime `json:"time,omitempty"`  // UTC time of pkt Rx, us precision, ISO 8601 'compact' format
+	Tmms  *uint64      `json:"tmms,omitempty"`  // GPS time of pkt Rx, number of milliseconds since 06.Jan.1980
+	Tmst  uint32       `json:"tmst"`            // Internal timestamp of "Rx finished" event (32b unsigned)
+	FTime *uint32      `json:"ftime,omitempty"` // Fine timestamp, ns precision [0..999999999] (Optional)
+	Freq  float64      `json:"freq"`            // Rx central frequency in MHz (unsigned float, Hz precision)
+	Chan  uint8        `json:"chan"`            // Concentrator "IF" channel used for Rx (unsigned integer)
+	RFCh  uint8        `json:"rfch"`            // Concentrator "RF chain" used for Rx (unsigned integer)
+	Stat  int8         `json:"stat"`            // CRC status: 1 = OK, -1 = fail, 0 = no CRC
+	Modu  string       `json:"modu"`            // Modulation identifier "LORA", "FSK" or "LR-FHSS"
+	DatR  datarate.DR  `json:"datr"`            // LoRa datarate, FSK datarate or LR-FHSS datarate
+	CodR  string       `json:"codr"`            // LoRa or LR-FHSS ECC coding rate identifier
+	Hpw   uint32       `json:"hpw,omitempty"`   // Hopping width; a number describing the number of steps of the LR-FHSS grid
+	RSSI  int16        `json:"rssi"`            // RSSI in dBm (signed integer, 1 dB precision)
+	LSNR  float64      `json:"lsnr"`            // Lora SNR ratio in dB (signed float, 0.1 dB precision)
+	FOff  *int32       `json:"foff,omitempty"`  // Frequency offset in Hz [-125kHz..+125Khz] (Optional)
+	Size  uint16       `json:"size"`            // RF packet payload size in bytes (unsigned integer)
+	Data  string       `json:"data"`            // Base64 encoded RF packet payload, padded
+	RSig  []RSig       `json:"rsig"`            // Received signal information, per antenna (Optional)
+	Brd   uint         `json:"brd"`             // Concentrator board used for Rx (unsigned integer)
+	Aesk  uint         `json:"aesk"`            // AES key index used for encrypting fine timestamps (unsigned integer)
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/pkg/ttnpb/udp/packet_test.go
+++ b/pkg/ttnpb/udp/packet_test.go
@@ -16,7 +16,6 @@ package udp
 
 import (
 	"bytes"
-	"math"
 	"testing"
 
 	"github.com/smartystreets/assertions"
@@ -80,35 +79,4 @@ func TestFailedPackets(t *testing.T) {
 		a.So(err, should.BeNil)
 		a.So(p.Data, should.NotBeNil)
 	}
-}
-
-func TestPacketType(t *testing.T) {
-	a := assertions.New(t)
-
-	eui := new(types.EUI64)
-	data := new(Data)
-
-	pTypes := []PacketType{PushAck, PushData, PullData, PullResp, PullAck, TxAck}
-	for _, pType := range pTypes {
-		a.So(pType.String(), should.NotEqual, "?")
-
-		pType.HasGatewayEUI()
-		pType.HasData()
-
-		p := Packet{
-			ProtocolVersion: Version1,
-			Token:           [2]byte{},
-			PacketType:      pType,
-			GatewayEUI:      eui,
-			Data:            data,
-		}
-		switch pType {
-		case PushData, PullData:
-			_, err := p.BuildAck()
-			a.So(err, should.BeNil)
-		}
-	}
-
-	inexistantPacketType := PacketType(math.MaxUint8)
-	a.So(inexistantPacketType.String(), should.Equal, "?")
 }

--- a/pkg/ttnpb/udp/translation_test.go
+++ b/pkg/ttnpb/udp/translation_test.go
@@ -35,6 +35,8 @@ import (
 var ids = ttnpb.GatewayIdentifiers{GatewayId: "test-gateway"}
 
 func timePtr(t time.Time) *time.Time { return &t }
+func uint32Ptr(v uint32) *uint32     { return &v }
+func int32Ptr(v int32) *int32        { return &v }
 
 func TestStatusRaw(t *testing.T) {
 	a := assertions.New(t)
@@ -100,15 +102,17 @@ func TestToGatewayUp(t *testing.T) {
 		Data: &udp.Data{
 			RxPacket: []*udp.RxPacket{
 				{
-					Freq: 868.0,
-					Chan: 2,
-					Modu: "LORA",
-					DatR: datarate.DR{DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_Lora{Lora: &ttnpb.LoRaDataRate{SpreadingFactor: 10, Bandwidth: 125000}}}},
-					CodR: "4/7",
-					Data: "QCkuASaAAAAByFaF53Iu+vzmwQ==",
-					Size: 19,
-					Tmst: 1000,
-					Tmms: &gpsTime,
+					Freq:  868.0,
+					Chan:  2,
+					Modu:  "LORA",
+					DatR:  datarate.DR{DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_Lora{Lora: &ttnpb.LoRaDataRate{SpreadingFactor: 10, Bandwidth: 125000}}}},
+					CodR:  "4/7",
+					Data:  "QCkuASaAAAAByFaF53Iu+vzmwQ==",
+					Size:  19,
+					Tmst:  1000,
+					Tmms:  &gpsTime,
+					FTime: uint32Ptr(12345678),
+					FOff:  int32Ptr(-42),
 				},
 			},
 		},
@@ -129,6 +133,8 @@ func TestToGatewayUp(t *testing.T) {
 	a.So(msg.Settings.Time, should.Resemble, &absoluteTime)
 	a.So(msg.RxMetadata[0].Timestamp, should.Equal, 1000)
 	a.So(msg.RxMetadata[0].Time, should.Resemble, &absoluteTime)
+	a.So(msg.RxMetadata[0].FineTimestamp, should.Equal, 12345678)
+	a.So(msg.RxMetadata[0].FrequencyOffset, should.Equal, -42)
 	a.So(msg.RawPayload, should.Resemble, []byte{0x40, 0x29, 0x2e, 0x01, 0x26, 0x80, 0x00, 0x00, 0x01, 0xc8, 0x56, 0x85, 0xe7, 0x72, 0x2e, 0xfa, 0xfc, 0xe6, 0xc1})
 }
 
@@ -198,14 +204,16 @@ func TestToGatewayUpRoundtrip(t *testing.T) {
 			Data: &udp.Data{
 				RxPacket: []*udp.RxPacket{
 					{
-						Freq: 868.0,
-						Chan: 2,
-						Modu: "LORA",
-						DatR: datarate.DR{DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_Lora{Lora: &ttnpb.LoRaDataRate{SpreadingFactor: 10, Bandwidth: 125000}}}},
-						CodR: "4/7",
-						Data: "QCkuASaAAAAByFaF53Iu+vzmwQ==",
-						Size: 19,
-						Tmst: 1000,
+						Freq:  868.0,
+						Chan:  2,
+						Modu:  "LORA",
+						DatR:  datarate.DR{DataRate: ttnpb.DataRate{Modulation: &ttnpb.DataRate_Lora{Lora: &ttnpb.LoRaDataRate{SpreadingFactor: 10, Bandwidth: 125000}}}},
+						CodR:  "4/7",
+						Data:  "QCkuASaAAAAByFaF53Iu+vzmwQ==",
+						Size:  19,
+						Tmst:  1000,
+						FTime: uint32Ptr(12345678),
+						FOff:  int32Ptr(-42),
 					},
 				},
 			},


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

The SX1303 produces fine timestamps and frequency offset, yet may use the legacy UDP protocol version 1. See https://github.com/Lora-net/sx1302_hal/blob/4b42025d1751e04632c0b04160e0d29dbbb222a5/packet_forwarder/PROTOCOL.md?plain=1#L129-L147

#### Changes
<!-- What are the changes made in this pull request? -->

- This adds support to reading `ftime` and `foff` if they are set
- The V2 format (`rsig` set) still takes precedence for these values
- Few bugfixes along the way; coding rate wasn't reset properly in the loop and coding rate is taken for LR-FHSS

#### Testing

<!-- How did you verify that this change works? -->

Unit testing should do it.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

We don't send `rxpk` to the gateway so there's no compatibility issue expected.

... unless, of course, some gateways are already sending values with these fields and they don't use the `uint32` and `int32` types respectively.

#### Notes for Reviewers

@htdvisser no need for review
@adriansmares please review instead

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
