### PR TITLE
Revert to Redis PubSub channel

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -1952,6 +1952,15 @@
       "file": "middleware.go"
     }
   },
+  "error:pkg/applicationserver/distribution/redis:channel_closed": {
+    "translations": {
+      "en": "channel closed"
+    },
+    "description": {
+      "package": "pkg/applicationserver/distribution/redis",
+      "file": "redis.go"
+    }
+  },
   "error:pkg/applicationserver/distribution:empty_set": {
     "translations": {
       "en": "empty set"

--- a/pkg/applicationserver/distribution/redis/redis.go
+++ b/pkg/applicationserver/distribution/redis/redis.go
@@ -17,6 +17,7 @@ package redis
 import (
 	"context"
 
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	ttnredis "go.thethings.network/lorawan-stack/v3/pkg/redis"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/unique"
@@ -33,39 +34,49 @@ func (ps PubSub) uidUplinkKey(uid string) string {
 
 // Publish publishes the uplink to Pub/Sub.
 func (ps PubSub) Publish(ctx context.Context, up *ttnpb.ApplicationUp) error {
-	s, err := ttnredis.MarshalProto(up)
+	msg, err := ttnredis.MarshalProto(up)
 	if err != nil {
 		return err
 	}
 	uid := unique.ID(ctx, up.ApplicationIdentifiers)
-	ch := ps.uidUplinkKey(uid)
-	if err = ps.Redis.Publish(ctx, ch, s).Err(); err != nil {
+	if err = ps.Redis.Publish(ctx, ps.uidUplinkKey(uid), msg).Err(); err != nil {
 		return ttnredis.ConvertError(err)
 	}
 	return nil
 }
 
+var errChannelClosed = errors.DefineAborted("channel_closed", "channel closed")
+
 // Subscribe subscribes to the traffic of the provided application and processes it using the handler.
 func (ps PubSub) Subscribe(ctx context.Context, ids ttnpb.ApplicationIdentifiers, handler func(context.Context, *ttnpb.ApplicationUp) error) error {
 	uid := unique.ID(ctx, ids)
-	ch := ps.uidUplinkKey(uid)
-
-	sub := ps.Redis.Subscribe(ctx, ch)
+	sub := ps.Redis.Subscribe(ctx, ps.uidUplinkKey(uid))
 	defer sub.Close()
 
+	// sub.Receive(.*) will not respect the asynchronous context
+	// cancelation, only a context deadline, if present.
+	// As such, we use the buffered channel instead and do the
+	// asynchronous select here. This allows us to close the
+	// subscription on context cancellation.
+	ch := sub.Channel()
 	for {
-		msg, err := sub.ReceiveMessage(ctx)
-		if err != nil {
-			return ttnredis.ConvertError(err)
-		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
 
-		up := &ttnpb.ApplicationUp{}
-		if err := ttnredis.UnmarshalProto(msg.Payload, up); err != nil {
-			return err
-		}
+		case msg, ok := <-ch:
+			if !ok {
+				return errChannelClosed.New()
+			}
 
-		if err := handler(ctx, up); err != nil {
-			return err
+			up := &ttnpb.ApplicationUp{}
+			if err := ttnredis.UnmarshalProto(msg.Payload, up); err != nil {
+				return err
+			}
+
+			if err := handler(ctx, up); err != nil {
+				return err
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes the following leak in the Application Server distribution mechanism:

![image](https://user-images.githubusercontent.com/36161392/141770375-64376393-e027-4ece-948a-fb92a5a6612f.png)

#### Changes
<!-- What are the changes made in this pull request? -->

- Use the buffered channel of the Redis subscription, instead of the `ReceiveMessage` API
   - See code comments for reasoning

#### Testing

<!-- How did you verify that this change works? -->

Tested on an affected cluster.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None are expected. I wanted to use `ReceiveMessage` in order to reduce buffering, but this is not possible because the context `Done` cancellation is not respected.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
