### PR TITLE
Increase amount of elements scanned

### DIFF
--- a/cmd/ttn-lw-stack/commands/as_db.go
+++ b/cmd/ttn-lw-stack/commands/as_db.go
@@ -70,7 +70,7 @@ var (
 			if err != nil {
 				return err
 			}
-			if err := ttnredis.RangeRedisKeys(ctx, cl, cl.Key("*"), 1, func(k string) (bool, error) {
+			if err := ttnredis.RangeRedisKeys(ctx, cl, cl.Key("*"), ttnredis.DefaultRangeCount, func(k string) (bool, error) {
 				logger := logger.WithField("key", k)
 				switch {
 				case deviceUIDRegexp.MatchString(k):

--- a/cmd/ttn-lw-stack/commands/ns_db.go
+++ b/cmd/ttn-lw-stack/commands/ns_db.go
@@ -46,7 +46,7 @@ var (
 			cl := NewNetworkServerApplicationUplinkQueueRedis(*config)
 			var deleted uint64
 			defer func() { logger.Debugf("%d processed stream entries deleted", deleted) }()
-			return ttnredis.RangeRedisKeys(ctx, cl, nsredis.ApplicationUplinkQueueUIDGenericUplinkKey(cl, "*"), 1, func(k string) (bool, error) {
+			return ttnredis.RangeRedisKeys(ctx, cl, nsredis.ApplicationUplinkQueueUIDGenericUplinkKey(cl, "*"), ttnredis.DefaultRangeCount, func(k string) (bool, error) {
 				gs, err := cl.XInfoGroups(ctx, k).Result()
 				if err != nil {
 					logger.WithError(err).Errorf("Failed to query groups of stream %q", k)
@@ -134,7 +134,7 @@ var (
 			addrRegexp3_11_Current := regexp.MustCompile(cl.Key("addr", devAddrRegexpStr, "current$"))
 			addrRegexp3_11_CurrentFields := regexp.MustCompile(cl.Key("addr", devAddrRegexpStr, "current", "fields$"))
 			addrRegexp3_11_PendingFields := regexp.MustCompile(cl.Key("addr", devAddrRegexpStr, "pending", "fields$"))
-			err := ttnredis.RangeRedisKeys(ctx, cl, cl.Key("*"), 1, func(k string) (bool, error) {
+			err := ttnredis.RangeRedisKeys(ctx, cl, cl.Key("*"), ttnredis.DefaultRangeCount, func(k string) (bool, error) {
 				logger := logger.WithField("key", k)
 				switch {
 				case uidRegexp3_10_Fields.MatchString(k):
@@ -154,7 +154,7 @@ var (
 					pendingKey := nsredis.PendingAddrKey(k)
 					pendingFieldKey := nsredis.FieldKey(pendingKey)
 					pendingScore := float64(time.Now().UnixNano())
-					if err := ttnredis.RangeRedisSet(ctx, cl, k, "*", 1, func(uid string) (bool, error) {
+					if err := ttnredis.RangeRedisSet(ctx, cl, k, "*", ttnredis.DefaultRangeCount, func(uid string) (bool, error) {
 						logger := logger.WithField("uid", uid)
 						uk := nsredis.UIDKey(cl, uid)
 						if err := cl.Watch(ctx, func(tx *redis.Tx) error {
@@ -213,7 +213,7 @@ var (
 				case addrRegexp3_10_16Bit.MatchString(k), addrRegexp3_10_32Bit.MatchString(k):
 					currentKey := nsredis.CurrentAddrKey(k[:len(k)-6])
 					fieldKey := nsredis.FieldKey(currentKey)
-					if err := ttnredis.RangeRedisZSet(ctx, cl, k, "*", 1, func(uid string, v float64) (bool, error) {
+					if err := ttnredis.RangeRedisZSet(ctx, cl, k, "*", ttnredis.DefaultRangeCount, func(uid string, v float64) (bool, error) {
 						logger := logger.WithField("uid", uid)
 						uk := nsredis.UIDKey(cl, uid)
 						if err := cl.Watch(ctx, func(tx *redis.Tx) error {
@@ -267,7 +267,7 @@ var (
 					score := float64(time.Now().UnixNano())
 					if err := cl.Watch(ctx, func(tx *redis.Tx) error {
 						p := tx.TxPipeline()
-						if err := ttnredis.RangeRedisSet(ctx, tx, k, "*", 1, func(uid string) (bool, error) {
+						if err := ttnredis.RangeRedisSet(ctx, tx, k, "*", ttnredis.DefaultRangeCount, func(uid string) (bool, error) {
 							logger := logger.WithField("uid", uid)
 							uk := nsredis.UIDKey(cl, uid)
 							if err := tx.Watch(ctx, uk).Err(); err != nil {

--- a/pkg/applicationserver/io/packages/redis/registry.go
+++ b/pkg/applicationserver/io/packages/redis/registry.go
@@ -532,7 +532,7 @@ func (r ApplicationPackagesRegistry) Range(
 	if err != nil {
 		return err
 	}
-	return ttnredis.RangeRedisKeys(ctx, r.Redis, r.associationKey(unique.GenericID(ctx, "*"), "*"), 1, func(key string) (bool, error) {
+	return ttnredis.RangeRedisKeys(ctx, r.Redis, r.associationKey(unique.GenericID(ctx, "*"), "*"), ttnredis.DefaultRangeCount, func(key string) (bool, error) {
 		if !associationEntityRegex.MatchString(key) {
 			return true, nil
 		}

--- a/pkg/applicationserver/io/web/redis/registry.go
+++ b/pkg/applicationserver/io/web/redis/registry.go
@@ -249,7 +249,7 @@ func (r WebhookRegistry) Range(ctx context.Context, paths []string, f func(conte
 	if err != nil {
 		return err
 	}
-	return ttnredis.RangeRedisKeys(ctx, r.Redis, r.idKey(unique.GenericID(ctx, "*"), "*"), 1, func(key string) (bool, error) {
+	return ttnredis.RangeRedisKeys(ctx, r.Redis, r.idKey(unique.GenericID(ctx, "*"), "*"), ttnredis.DefaultRangeCount, func(key string) (bool, error) {
 		if !webhookEntityRegex.MatchString(key) {
 			return true, nil
 		}

--- a/pkg/applicationserver/redis/registry.go
+++ b/pkg/applicationserver/redis/registry.go
@@ -249,7 +249,7 @@ func (r *DeviceRegistry) Range(ctx context.Context, paths []string, f func(conte
 	if err != nil {
 		return err
 	}
-	return ttnredis.RangeRedisKeys(ctx, r.Redis, r.uidKey(unique.GenericID(ctx, "*")), 1, func(key string) (bool, error) {
+	return ttnredis.RangeRedisKeys(ctx, r.Redis, r.uidKey(unique.GenericID(ctx, "*")), ttnredis.DefaultRangeCount, func(key string) (bool, error) {
 		if !deviceEntityRegex.MatchString(key) {
 			return true, nil
 		}

--- a/pkg/joinserver/redis/registry.go
+++ b/pkg/joinserver/redis/registry.go
@@ -392,7 +392,7 @@ func (r *DeviceRegistry) RangeByID(ctx context.Context, paths []string, f func(c
 	if err != nil {
 		return err
 	}
-	return ttnredis.RangeRedisKeys(ctx, r.Redis, r.uidKey(unique.GenericID(ctx, "*")), 1, func(key string) (bool, error) {
+	return ttnredis.RangeRedisKeys(ctx, r.Redis, r.uidKey(unique.GenericID(ctx, "*")), ttnredis.DefaultRangeCount, func(key string) (bool, error) {
 		if !deviceEntityRegex.MatchString(key) {
 			return true, nil
 		}
@@ -717,7 +717,7 @@ func (r *ApplicationActivationSettingRegistry) Range(ctx context.Context, paths 
 	if err != nil {
 		return err
 	}
-	return ttnredis.RangeRedisKeys(ctx, r.Redis, r.uidKey(unique.GenericID(ctx, "*")), 1, func(key string) (bool, error) {
+	return ttnredis.RangeRedisKeys(ctx, r.Redis, r.uidKey(unique.GenericID(ctx, "*")), ttnredis.DefaultRangeCount, func(key string) (bool, error) {
 		if !appKeyRegex.MatchString(key) {
 			return true, nil
 		}

--- a/pkg/networkserver/redis/registry.go
+++ b/pkg/networkserver/redis/registry.go
@@ -1034,7 +1034,7 @@ func (r *DeviceRegistry) Range(ctx context.Context, paths []string, f func(conte
 	if err != nil {
 		return err
 	}
-	return ttnredis.RangeRedisKeys(ctx, r.Redis, r.uidKey(unique.GenericID(ctx, "*")), 1, func(key string) (bool, error) {
+	return ttnredis.RangeRedisKeys(ctx, r.Redis, r.uidKey(unique.GenericID(ctx, "*")), ttnredis.DefaultRangeCount, func(key string) (bool, error) {
 		if !deviceEntityRegex.MatchString(key) {
 			return true, nil
 		}

--- a/pkg/redis/range.go
+++ b/pkg/redis/range.go
@@ -70,6 +70,9 @@ func rangeStringsBindFunc(f func(string) (bool, error)) func(ss ...string) (bool
 	}
 }
 
+// DefaultRangeCount is the default number of elements to be returned by a SCAN-family operation.
+const DefaultRangeCount = 1024
+
 func RangeRedisKeys(ctx context.Context, r redis.Cmdable, match string, count int64, f func(k string) (bool, error)) error {
 	return rangeScan(func(cursor uint64) *redis.ScanCmd {
 		return r.Scan(ctx, cursor, match, count)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Increase the number of elements returned in a singular `SCAN`/`ZSCAN`/`SSCAN` to 1024 by default

#### Changes
<!-- What are the changes made in this pull request? -->

- Increase the number of elements returned in a singular `SCAN`/`ZSCAN`/`SSCAN` to 1024 by default
   - Introduce `ttnredis.DefaultRangeCount` = `1024`
   - Change all `SCAN` call sites to `ttnredis.DefaultRangeCount` instead of `1` (!)

#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Not expected.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

We were previously returning at most (not even guaranteed) one key per round trip. This means that for 1M keys (keys in general, not even matching the `MATCH`) we had to do at least 1M round trips (in reality this is a lot higher, probably 5-6M) - a very efficient and scalable design. 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
