### PR TITLE
Fix resolution of last activity value for end devices and applications

### DIFF
--- a/pkg/webui/console/constants/event-filters.js
+++ b/pkg/webui/console/constants/event-filters.js
@@ -17,9 +17,7 @@ import { APPLICATION, END_DEVICE, GATEWAY } from '@console/constants/entities'
 export const END_DEVICE_EVENTS_VERBOSE_FILTERS = [
   'as.*.drop',
   'as.down.data.forward',
-  'as.up.location.forward',
-  'as.up.data.forward',
-  'as.up.service.forward',
+  'as.up.*.forward',
   'js.join.accept',
   'js.join.reject',
   'ns.mac.*.answer.reject',
@@ -44,20 +42,14 @@ export const GATEWAY_EVENTS_VERBOSE_FILTERS = [
   'gateway.*',
 ]
 
-export const EVENT_END_DEVICE_HEARTBEAT_FILTERS = [
-  'ns.up.data.receive',
-  'ns.up.join.receive',
-  'ns.up.rejoin.receive',
-]
+// Regex for matching heartbeat events that trigger an update of the
+// last activity display.
+export const EVENT_END_DEVICE_HEARTBEAT_FILTERS_REGEXP = /^as.up\..*\.forward$/
 
 // Utility function to convert filter arrays to Regular Expressions strings
 // that the backend accepts for applying filters.
 const filterListToRegExpList = array =>
   array.map(f => `/^${f.replace(/\./g, '\\.').replace(/\*/g, '.*')}$/`)
-
-export const EVENT_END_DEVICE_HEARTBEAT_FILTERS_REGEXP = filterListToRegExpList(
-  EVENT_END_DEVICE_HEARTBEAT_FILTERS,
-)
 
 export const EVENT_FILTERS = {
   [APPLICATION]: [

--- a/pkg/webui/console/store/reducers/applications.js
+++ b/pkg/webui/console/store/reducers/applications.js
@@ -28,8 +28,6 @@ import {
   GET_APP_EVENT_MESSAGE_SUCCESS,
 } from '@console/store/actions/applications'
 
-const heartbeatFilterRegExp = new RegExp(EVENT_END_DEVICE_HEARTBEAT_FILTERS_REGEXP)
-
 const application = (state = {}, application) => ({
   ...state,
   ...application,
@@ -99,7 +97,7 @@ const applications = (state = defaultState, { type, payload, event }) => {
         entities: rest,
       }
     case GET_APP_EVENT_MESSAGE_SUCCESS:
-      if (heartbeatFilterRegExp.test(event.name)) {
+      if (EVENT_END_DEVICE_HEARTBEAT_FILTERS_REGEXP.test(event.name)) {
         const lastSeen = getByPath(event, 'data.received_at') || event.time
         const id = getApplicationId(event.identifiers[0].device_ids)
 


### PR DESCRIPTION
#### Summary
This quickfix PR fixes the "Last activity" value not being updated for end devices and applications.

Closes #4871
Closes #4870 

cc @adriansmares 

#### Changes
- Fix wrong RegExp format for the "heartbeat" filter for end devices.
- Use `as.up.*.forward` events only to determine activity.
- Use `as.up.*.forward` for the verbose filters (instead of listing them one by one)

#### Testing

Mnaual using the staging environment.

#### Notes for Reviewers
The issue was two-fold

1. Since we are using backend filtering now, we cannot use any filtered events to determine heartbeats anymore
2. The backend needs a different RegExp string format than the JS parser, which lead to the frontend being unable to use the heartbeat filter regexp that was composed for golang.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
