### PR TITLE
Report utilization rate of duty-cycle window in sub-band's `downlink_utilization`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- The reported sub-band's `downlink_utilization` in gateway connection stats now represents the utilization of the available duty-cycle time.
+
 ### Security
 
 ## [3.16.0] - 2021-11-12

--- a/api/api.md
+++ b/api/api.md
@@ -3890,8 +3890,8 @@ Connection stats as monitored by the Gateway Server.
 | ----- | ---- | ----- | ----------- |
 | `min_frequency` | [`uint64`](#uint64) |  |  |
 | `max_frequency` | [`uint64`](#uint64) |  |  |
-| `downlink_utilization_limit` | [`float`](#float) |  |  |
-| `downlink_utilization` | [`float`](#float) |  |  |
+| `downlink_utilization_limit` | [`float`](#float) |  | Duty-cycle limit of the sub-band as a fraction of time. |
+| `downlink_utilization` | [`float`](#float) |  | Utilization rate of the available duty-cycle. This value should not exceed downlink_utilization_limit. |
 
 ### <a name="ttn.lorawan.v3.GatewayModel">Message `GatewayModel`</a>
 

--- a/api/api.swagger.json
+++ b/api/api.swagger.json
@@ -10967,11 +10967,13 @@
         },
         "downlink_utilization_limit": {
           "type": "number",
-          "format": "float"
+          "format": "float",
+          "description": "Duty-cycle limit of the sub-band as a fraction of time."
         },
         "downlink_utilization": {
           "type": "number",
-          "format": "float"
+          "format": "float",
+          "description": "Utilization rate of the available duty-cycle. This value should not exceed downlink_utilization_limit."
         }
       }
     },

--- a/api/gateway.proto
+++ b/api/gateway.proto
@@ -384,7 +384,9 @@ message GatewayConnectionStats {
   message SubBand {
     uint64 min_frequency = 1;
     uint64 max_frequency = 2;
+    // Duty-cycle limit of the sub-band as a fraction of time.
     float downlink_utilization_limit = 3;
+    // Utilization rate of the available duty-cycle. This value should not exceed downlink_utilization_limit.
     float downlink_utilization = 4;
   }
   // Statistics for each sub band.

--- a/pkg/gatewayserver/scheduling/sub_band.go
+++ b/pkg/gatewayserver/scheduling/sub_band.go
@@ -104,7 +104,7 @@ func (sb *SubBand) DutyCycleUtilization() float32 {
 	sb.mu.RLock()
 	val := sb.sum(now-ConcentratorTime(DutyCycleWindow), now)
 	sb.mu.RUnlock()
-	return float32(val) / float32(DutyCycleWindow) / sb.DutyCycle
+	return float32(val) / float32(DutyCycleWindow)
 }
 
 // prioritizedDutyCycle returns the duty-cycle given the scheduling priority.

--- a/pkg/gatewayserver/scheduling/sub_band_test.go
+++ b/pkg/gatewayserver/scheduling/sub_band_test.go
@@ -113,7 +113,7 @@ func TestSubBandScheduleRestricted(t *testing.T) {
 			Starts:            scheduling.ConcentratorTime(6 * time.Second),
 			Duration:          1 * time.Second,
 			Priority:          ttnpb.TxSchedulePriority_NORMAL,
-			ExpectUtilization: 0.1 / 0.5,
+			ExpectUtilization: float32(1*time.Second) / float32(scheduling.DutyCycleWindow),
 			// [     1              ]
 			//  ^^^^^^
 		},
@@ -121,7 +121,7 @@ func TestSubBandScheduleRestricted(t *testing.T) {
 			Starts:            scheduling.ConcentratorTime(14 * time.Second),
 			Duration:          1 * time.Second,
 			Priority:          ttnpb.TxSchedulePriority_NORMAL,
-			ExpectUtilization: 0.2 / 0.5,
+			ExpectUtilization: float32(2*time.Second) / float32(scheduling.DutyCycleWindow),
 			// [     1       2      ]
 			//      ^^^^^^^^^^
 		},
@@ -129,7 +129,7 @@ func TestSubBandScheduleRestricted(t *testing.T) {
 			Starts:            scheduling.ConcentratorTime(18 * time.Second),
 			Duration:          1 * time.Second,
 			Priority:          ttnpb.TxSchedulePriority_NORMAL,
-			ExpectUtilization: 0.2 / 0.5,
+			ExpectUtilization: float32(2*time.Second) / float32(scheduling.DutyCycleWindow),
 			// [     1       2   3  ]
 			//          ^^^^^^^^^^
 		},
@@ -138,7 +138,7 @@ func TestSubBandScheduleRestricted(t *testing.T) {
 			Duration:          1 * time.Second,
 			Priority:          ttnpb.TxSchedulePriority_NORMAL,
 			ExpectError:       errors.IsResourceExhausted,
-			ExpectUtilization: 0.1 / 0.5,
+			ExpectUtilization: float32(1*time.Second) / float32(scheduling.DutyCycleWindow),
 			// [     1    X  2   3  ]
 			//   ^^^^^^^^^^
 			//            ^^^^^^^^^^
@@ -147,7 +147,7 @@ func TestSubBandScheduleRestricted(t *testing.T) {
 			Starts:            scheduling.ConcentratorTime(11 * time.Second),
 			Duration:          1 * time.Second,
 			Priority:          ttnpb.TxSchedulePriority_HIGHEST,
-			ExpectUtilization: 0.2 / 0.5,
+			ExpectUtilization: float32(2*time.Second) / float32(scheduling.DutyCycleWindow),
 			// [     1    4  2   3  ]
 			//   ^^^^^^^^^^
 			//            ^^^^^^^^^^

--- a/pkg/ttnpb/gateway.pb.go
+++ b/pkg/ttnpb/gateway.pb.go
@@ -1727,12 +1727,14 @@ func (m *GatewayConnectionStats_RoundTripTimes) GetCount() uint32 {
 }
 
 type GatewayConnectionStats_SubBand struct {
-	MinFrequency             uint64   `protobuf:"varint,1,opt,name=min_frequency,json=minFrequency,proto3" json:"min_frequency,omitempty"`
-	MaxFrequency             uint64   `protobuf:"varint,2,opt,name=max_frequency,json=maxFrequency,proto3" json:"max_frequency,omitempty"`
-	DownlinkUtilizationLimit float32  `protobuf:"fixed32,3,opt,name=downlink_utilization_limit,json=downlinkUtilizationLimit,proto3" json:"downlink_utilization_limit,omitempty"`
-	DownlinkUtilization      float32  `protobuf:"fixed32,4,opt,name=downlink_utilization,json=downlinkUtilization,proto3" json:"downlink_utilization,omitempty"`
-	XXX_NoUnkeyedLiteral     struct{} `json:"-"`
-	XXX_sizecache            int32    `json:"-"`
+	MinFrequency uint64 `protobuf:"varint,1,opt,name=min_frequency,json=minFrequency,proto3" json:"min_frequency,omitempty"`
+	MaxFrequency uint64 `protobuf:"varint,2,opt,name=max_frequency,json=maxFrequency,proto3" json:"max_frequency,omitempty"`
+	// Duty-cycle limit of the sub-band as a fraction of time.
+	DownlinkUtilizationLimit float32 `protobuf:"fixed32,3,opt,name=downlink_utilization_limit,json=downlinkUtilizationLimit,proto3" json:"downlink_utilization_limit,omitempty"`
+	// Utilization rate of the available duty-cycle. This value should not exceed downlink_utilization_limit.
+	DownlinkUtilization  float32  `protobuf:"fixed32,4,opt,name=downlink_utilization,json=downlinkUtilization,proto3" json:"downlink_utilization,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
 }
 
 func (m *GatewayConnectionStats_SubBand) Reset()      { *m = GatewayConnectionStats_SubBand{} }

--- a/sdk/js/generated/api.json
+++ b/sdk/js/generated/api.json
@@ -17555,7 +17555,7 @@
             },
             {
               "name": "downlink_utilization_limit",
-              "description": "",
+              "description": "Duty-cycle limit of the sub-band as a fraction of time.",
               "label": "",
               "type": "float",
               "longType": "float",
@@ -17567,7 +17567,7 @@
             },
             {
               "name": "downlink_utilization",
-              "description": "",
+              "description": "Utilization rate of the available duty-cycle. This value should not exceed downlink_utilization_limit.",
               "label": "",
               "type": "float",
               "longType": "float",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Addresses https://www.thethingsnetwork.org/forum/t/misbehaving-nodes-revisited-rogue-end-device/53163

#### Changes
<!-- What are the changes made in this pull request? -->

This changes the calculation of the sub-band's `downlink_utilization` to a utilization rate of the limit to the utilization rate of the duty-cycle window. This means that `downlink_utilization` is now always smaller or equal to `downlink_utilization_limit`.

#### Testing

<!-- How did you verify that this change works? -->

CI

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This breaks applications depending on the old, undocumented and reportedly unclear behavior.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
