### PR TITLE
Use most recent timestamp for calculating "Last activity" for gateways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - The reported sub-band's `downlink_utilization` in gateway connection stats now represents the utilization of the available duty-cycle time.
 - Missing fields when admins list non-owned entities.
+- Using the correct timestamp when retreiving the "Last activity" data point for Gateways on initial page loads in the Console.
 
 ### Security
 

--- a/pkg/webui/console/containers/gateway-connection/gateway-connection.js
+++ b/pkg/webui/console/containers/gateway-connection/gateway-connection.js
@@ -50,7 +50,11 @@ class GatewayConnection extends React.PureComponent {
     error: PropTypes.oneOfType([PropTypes.error, PropTypes.shape({ message: PropTypes.message })]),
     fetching: PropTypes.bool,
     isOtherCluster: PropTypes.bool.isRequired,
-    lastSeen: PropTypes.instanceOf(Date),
+    lastSeen: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number, // Support timestamps.
+      PropTypes.instanceOf(Date),
+    ]),
     startStatistics: PropTypes.func.isRequired,
     statistics: PropTypes.gatewayStats,
     stopStatistics: PropTypes.func.isRequired,

--- a/pkg/webui/console/store/reducers/gateway-status.js
+++ b/pkg/webui/console/store/reducers/gateway-status.js
@@ -23,24 +23,25 @@ import {
 } from '@console/store/actions/gateways'
 
 const handleStatsUpdate = (state, { stats = {} }) => {
-  const status = stats && (stats.last_status_received_at || stats.last_uplink_received_at)
-
-  if (status) {
-    let lastSeen = new Date(status)
-
-    if (state.lastSeen) {
-      lastSeen = lastSeen > state.lastSeen ? lastSeen : state.lastSeen
-    }
-
-    return { ...state, lastSeen }
+  if (
+    state.lastSeen &&
+    (!stats.last_status_received_at || state.lastSeen > stats.last_status_received_at) &&
+    (!stats.last_uplink_received_at || state.lastSeen > stats.last_uplink_received_at)
+  ) {
+    return state
   }
 
-  return state
+  const lastSeen =
+    stats.last_status_received_at > stats.last_uplink_received_at
+      ? stats.last_status_received_at
+      : stats.last_uplink_received_at
+
+  return { ...state, lastSeen }
 }
 
 const handleEventUpdate = (state, event) => {
   if (isGsStatusReceiveEvent(event.name) || isGsUplinkReceiveEvent(event.name)) {
-    let lastSeen = new Date(event.time)
+    let lastSeen = event.time
 
     if (state.lastSeen) {
       lastSeen = lastSeen > state.lastSeen ? lastSeen : state.lastSeen

--- a/pkg/webui/console/store/reducers/tests/gateway-status_test.js
+++ b/pkg/webui/console/store/reducers/tests/gateway-status_test.js
@@ -37,23 +37,23 @@ describe('Gateway-status reducer', () => {
 
       expect(newState !== defaultState).toBe(true)
       expect(newState.lastSeen).toBeDefined()
-      expect(newState.lastSeen).toStrictEqual(new Date(stats.last_status_received_at))
+      expect(newState.lastSeen).toEqual(stats.last_status_received_at)
     })
 
     it('sets `lastSeen` from `last_status_received_at` if have more recent value', () => {
       const stats = {
-        last_status_received_at: '2019-09-24T13:35:30.033728431Z',
-        last_uplink_received_at: '2019-09-24T13:35:10.536603866Z',
+        last_status_received_at: '2019-09-24T13:35:10.033728431Z',
+        last_uplink_received_at: '2019-09-24T13:35:30.536603866Z',
       }
 
       newState = reducer(newState, updateGatewayStatisticsSuccess({ stats }))
 
       expect(newState !== defaultState).toBe(true)
       expect(newState.lastSeen).toBeDefined()
-      expect(newState.lastSeen).not.toStrictEqual(new Date(stats.last_status_received_at))
+      expect(newState.lastSeen).not.toEqual(stats.last_uplink_received_at)
     })
 
-    it('updates `lastSeen` from `last_status_received_at` with most recent value', () => {
+    it("updates `lastSeen` from `last_uplink_received_at` if it's the most recent value", () => {
       const stats = {
         last_status_received_at: '2019-09-24T13:45:30.033728431Z',
         last_uplink_received_at: '2019-09-24T13:40:10.536603866Z',
@@ -63,7 +63,7 @@ describe('Gateway-status reducer', () => {
 
       expect(newState !== defaultState).toBe(true)
       expect(newState.lastSeen).toBeDefined()
-      expect(newState.lastSeen).toStrictEqual(new Date(stats.last_status_received_at))
+      expect(newState.lastSeen).toEqual(stats.last_status_received_at)
     })
 
     it('sets `lastSeen` from `last_uplink_received_at` if `last_status_received_at` not present', () => {
@@ -75,7 +75,7 @@ describe('Gateway-status reducer', () => {
 
       expect(newState !== defaultState).toBe(true)
       expect(newState.lastSeen).toBeDefined()
-      expect(newState.lastSeen).toStrictEqual(new Date(stats.last_uplink_received_at))
+      expect(newState.lastSeen).toEqual(stats.last_uplink_received_at)
     })
 
     it('sets `lastSeen` from `last_uplink_received_at` with most recent value if `last_status_received_at` not present', () => {
@@ -87,7 +87,7 @@ describe('Gateway-status reducer', () => {
 
       expect(newState !== defaultState).toBe(true)
       expect(newState.lastSeen).toBeDefined()
-      expect(newState.lastSeen).toStrictEqual(new Date(stats.last_uplink_received_at))
+      expect(newState.lastSeen).toEqual(stats.last_uplink_received_at)
     })
 
     it('does not set `lastSeen` from `last_uplink_received_at` if have more recent value', () => {
@@ -99,7 +99,7 @@ describe('Gateway-status reducer', () => {
 
       expect(newState !== defaultState).toBe(true)
       expect(newState.lastSeen).toBeDefined()
-      expect(newState.lastSeen).not.toStrictEqual(new Date(stats.last_uplink_received_at))
+      expect(newState.lastSeen).not.toEqual(stats.last_uplink_received_at)
     })
 
     it('resets state on gateway request', () => {
@@ -121,7 +121,7 @@ describe('Gateway-status reducer', () => {
       newState = reducer(defaultState, getGatewayEventMessageSuccess('test-gtw-id', event))
       expect(newState !== defaultState).toBe(true)
       expect(newState.lastSeen).toBeDefined()
-      expect(newState.lastSeen).toStrictEqual(new Date(event.time))
+      expect(newState.lastSeen).toStrictEqual(event.time)
     })
 
     it('updates `lastSeen` on most recent uplink event', () => {
@@ -133,7 +133,7 @@ describe('Gateway-status reducer', () => {
       newState = reducer(newState, getGatewayEventMessageSuccess('test-gtw-id', event))
       expect(newState !== defaultState).toBe(true)
       expect(newState.lastSeen).toBeDefined()
-      expect(newState.lastSeen).toStrictEqual(new Date(event.time))
+      expect(newState.lastSeen).toStrictEqual(event.time)
     })
 
     it('does not set `lastSeen` on uplink event if have more recent value', () => {
@@ -145,7 +145,7 @@ describe('Gateway-status reducer', () => {
       newState = reducer(newState, getGatewayEventMessageSuccess('test-gtw-id', event))
       expect(newState !== defaultState).toBe(true)
       expect(newState.lastSeen).toBeDefined()
-      expect(newState.lastSeen).not.toStrictEqual(new Date(event.time))
+      expect(newState.lastSeen).not.toStrictEqual(event.time)
     })
 
     it('updates `lastSeen` on status event', () => {
@@ -157,7 +157,7 @@ describe('Gateway-status reducer', () => {
       newState = reducer(newState, getGatewayEventMessageSuccess('test-gtw-id', event))
       expect(newState !== defaultState).toBe(true)
       expect(newState.lastSeen).toBeDefined()
-      expect(newState.lastSeen).toStrictEqual(new Date(event.time))
+      expect(newState.lastSeen).toStrictEqual(event.time)
     })
 
     it('updates `lastSeen` on most recent status event', () => {
@@ -169,7 +169,7 @@ describe('Gateway-status reducer', () => {
       newState = reducer(newState, getGatewayEventMessageSuccess('test-gtw-id', event))
       expect(newState !== defaultState).toBe(true)
       expect(newState.lastSeen).toBeDefined()
-      expect(newState.lastSeen).toStrictEqual(new Date(event.time))
+      expect(newState.lastSeen).toStrictEqual(event.time)
     })
 
     it('does not set `lastSeen` on status event if have more recent value', () => {
@@ -181,7 +181,7 @@ describe('Gateway-status reducer', () => {
       newState = reducer(newState, getGatewayEventMessageSuccess('test-gtw-id', event))
       expect(newState !== defaultState).toBe(true)
       expect(newState.lastSeen).toBeDefined()
-      expect(newState.lastSeen).not.toStrictEqual(new Date(event.time))
+      expect(newState.lastSeen).not.toStrictEqual(event.time)
     })
 
     it('resets state on gateway request', () => {


### PR DESCRIPTION
#### Summary
This quickfix will ensure that the most recent timestamp is considered for the "Last activity" data point in the Console for gateways. Currently, on initial page loads, the Console uses the `last_status_received_at` timestamp only, which in most cases is less recent than `last_uplink_received_at`.

#### Changes
- When receiving a gateway status, compare `last_status_received_at` and `last_uplink_received_at` to determine the most recent of the two and use this as `lastSeen`
- Store a ISO date string instead of a `Date` instance for easier comparison

#### Testing

Manual testing using the staging environment

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
