### PR TITLE
Remove CSP feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - Support for fine timestamps and frequency offsets sent by gateways with SX1303 concentrator using the legacy UDP protocol.
 - Support for resetting end device session context and MAC state in the Console.
+- The Content-Security-Policy header (that was previously behind the `webui.csp` feature flag) is now enabled by default.
 
 ### Changed
 

--- a/pkg/account/server.go
+++ b/pkg/account/server.go
@@ -91,12 +91,10 @@ func (s *server) RegisterRoutes(server *web.Server) {
 		s.config.Mount,
 		func(next echo.HandlerFunc) echo.HandlerFunc {
 			return func(c echo.Context) error {
-				if webui.CSPFeatureFlag.GetValue(c.Request().Context()) {
-					nonce := webui.GenerateNonce()
-					c.Set("csp_nonce", nonce)
-					cspString := s.generateCSP(s.configFromContext(c.Request().Context()), nonce)
-					c.Response().Header().Set("Content-Security-Policy", cspString)
-				}
+				nonce := webui.GenerateNonce()
+				c.Set("csp_nonce", nonce)
+				cspString := s.generateCSP(s.configFromContext(c.Request().Context()), nonce)
+				c.Response().Header().Set("Content-Security-Policy", cspString)
 				return next(c)
 			}
 		},

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -132,12 +132,10 @@ func (console *Console) RegisterRoutes(server *web.Server) {
 		console.config.Mount,
 		func(next echo.HandlerFunc) echo.HandlerFunc {
 			return func(c echo.Context) error {
-				if webui.CSPFeatureFlag.GetValue(c.Request().Context()) {
-					nonce := webui.GenerateNonce()
-					c.Set("csp_nonce", nonce)
-					cspString := generateConsoleCSPString(console.configFromContext(c.Request().Context()), nonce)
-					c.Response().Header().Set("Content-Security-Policy", cspString)
-				}
+				nonce := webui.GenerateNonce()
+				c.Set("csp_nonce", nonce)
+				cspString := generateConsoleCSPString(console.configFromContext(c.Request().Context()), nonce)
+				c.Response().Header().Set("Content-Security-Policy", cspString)
 				return next(c)
 			}
 		},

--- a/pkg/webui/csp.go
+++ b/pkg/webui/csp.go
@@ -20,12 +20,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
-
-	"go.thethings.network/lorawan-stack/v3/pkg/experimental"
 )
-
-// CSPFeatureFlag is the feature flag that enables the Content-Security-Policy header.
-var CSPFeatureFlag = experimental.DefineFeature("webui.csp", false)
 
 // GenerateNonce returns a nonce used for inline scripts.
 func GenerateNonce() string {

--- a/pkg/webui/template.go
+++ b/pkg/webui/template.go
@@ -154,10 +154,8 @@ func RegisterHashedFile(original, hashed string) {
 func (t *AppTemplate) Render(w io.Writer, _ string, pageData interface{}, c echo.Context) error {
 	templateData := c.Get("template_data").(TemplateData)
 	var cspNonce string
-	if CSPFeatureFlag.GetValue(c.Request().Context()) {
-		if v, ok := c.Get("csp_nonce").(string); ok {
-			cspNonce = v
-		}
+	if v, ok := c.Get("csp_nonce").(string); ok {
+		cspNonce = v
 	}
 	cssFiles := make([]string, len(templateData.CSSFiles))
 	for i, cssFile := range templateData.CSSFiles {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This removes the `webui.csp` feature flag, hence enabling the `Content-Security-Policy` header by default.

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove the feature flag

#### Testing

<!-- How did you verify that this change works? -->

We've had the feature flag enabled in production for some time now.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This may break some (exotic) deployment models that we (@pgalic96, me) didn't think of when initially building this functionality.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
