### PR TITLE
Add Cache-Control headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For details about compatibility between different releases, see the **Commitment
 - Support for fine timestamps and frequency offsets sent by gateways with SX1303 concentrator using the legacy UDP protocol.
 - Support for resetting end device session context and MAC state in the Console.
 - The Content-Security-Policy header (that was previously behind the `webui.csp` feature flag) is now enabled by default.
+- Default `Cache-Control: no-store` headers.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For details about compatibility between different releases, see the **Commitment
 - Support for resetting end device session context and MAC state in the Console.
 - The Content-Security-Policy header (that was previously behind the `webui.csp` feature flag) is now enabled by default.
 - Default `Cache-Control: no-store` headers.
+- `Cache-Control: public, max-age=604800, immutable` headers for hashed static files.
 
 ### Changed
 

--- a/config/webpack.config.babel.js
+++ b/config/webpack.config.babel.js
@@ -198,6 +198,8 @@ export default {
   output: {
     filename: production ? '[name].[chunkhash].js' : '[name].js',
     chunkFilename: production ? '[name].[chunkhash].js' : '[name].js',
+    hashDigest: 'hex',
+    hashDigestLength: 20,
     path: path.resolve(context, PUBLIC_DIR),
     crossOriginLoading: 'anonymous',
     publicPath: ASSETS_ROOT,
@@ -230,7 +232,7 @@ export default {
         test: /\.(woff|woff2|ttf|eot|jpg|jpeg|png|svg)$/i,
         loader: 'file-loader',
         options: {
-          name: '[name].[hash].[ext]',
+          name: '[name].[hash:hex:20].[ext]',
         },
       },
       styleConfig,

--- a/config/webpack.dll.babel.js
+++ b/config/webpack.dll.babel.js
@@ -47,6 +47,8 @@ export default {
   entry: { libs },
   output: {
     filename: mode === 'production' ? '[name].[hash].bundle.js' : '[name].bundle.js',
+    hashDigest: 'hex',
+    hashDigestLength: 20,
     path: path.resolve(context, PUBLIC_DIR),
     library,
   },
@@ -65,7 +67,7 @@ export default {
         test: /\.(woff|woff2|ttf|eot|jpg|jpeg|png|svg)$/i,
         loader: 'file-loader',
         options: {
-          name: '[name].[hash].[ext]',
+          name: '[name].[hash:hex:20].[ext]',
         },
       },
     ],

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -177,6 +177,7 @@ func New(ctx context.Context, opts ...Option) (*Server, error) {
 		mux.MiddlewareFunc(webmiddleware.SecurityHeaders()),
 		mux.MiddlewareFunc(webmiddleware.Log(logger, options.logIgnorePaths)),
 		mux.MiddlewareFunc(webmiddleware.Cookies(hashKey, blockKey)),
+		mux.MiddlewareFunc(webmiddleware.NoCache),
 	)
 
 	var redirectConfig webmiddleware.RedirectConfiguration

--- a/pkg/webmiddleware/cache_headers.go
+++ b/pkg/webmiddleware/cache_headers.go
@@ -1,0 +1,26 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webmiddleware
+
+import "net/http"
+
+// NoCache is a middleware function that adds headers that prevent proxies from caching responses.
+func NoCache(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Pragma", "no-cache")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pkg/webmiddleware/cache_headers_test.go
+++ b/pkg/webmiddleware/cache_headers_test.go
@@ -1,0 +1,38 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webmiddleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/smartystreets/assertions"
+	"github.com/smartystreets/assertions/should"
+)
+
+func TestNoCache(t *testing.T) {
+	a := assertions.New(t)
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	rec := httptest.NewRecorder()
+	NoCache(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	})).ServeHTTP(rec, r)
+	res := rec.Result()
+
+	a.So(res.Header.Get("Cache-Control"), should.Equal, "no-store")
+	a.So(res.Header.Get("Pragma"), should.Equal, "no-cache")
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request adds `Cache-Control` headers to HTTP responses.

The default is `Cache-Control: no-store`, since most HTTP responses should not be cached.

Static files with hashes get a `Cache-Control: public, max-age=604800, immutable` header.

Refs https://github.com/TheThingsIndustries/lorawan-stack/issues/2975

#### Changes
<!-- What are the changes made in this pull request? -->

- Add default `Cache-Control: no-store` header
- Make hash configuration in Webpack explicit
- Detect requests for hashed static files, and set `Cache-Control: public, max-age=604800, immutable` on responses.

#### Testing

<!-- How did you verify that this change works? -->

- Unit test for the NoCache middleware
- Manual testing for the rest

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

In the worst case it sets the `Cache-Control: no-store` header on everything and things become slower on deployments that don't use a CDN.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

nil

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
