### PR TITLE
Prevent events from reappearing after event stream was cleared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - The reported sub-band's `downlink_utilization` in gateway connection stats now represents the utilization of the available duty-cycle time.
 - Missing fields when admins list non-owned entities.
+- Events reappearing in the end device data view after clearing them when navigating back and forth.
 
 ### Security
 

--- a/pkg/webui/console/store/selectors/events.js
+++ b/pkg/webui/console/store/selectors/events.js
@@ -14,6 +14,8 @@
 
 import CONNECTION_STATUS from '@console/constants/connection-status'
 
+import { EVENT_STATUS_CLEARED } from '@console/lib/events/definitions'
+
 const selectEventsStore = (state, entityId) => state[entityId] || {}
 
 export const createEventsSelector = entity => (state, entityId) => {
@@ -62,6 +64,18 @@ export const createLatestEventSelector = entity => {
   }
 
   return selectLatestEvent
+}
+
+export const createLatestClearedEventSelector = entity => {
+  const eventsSelector = createEventsSelector(entity)
+
+  const selectLatestClearedEvent = (state, entityId) => {
+    const events = eventsSelector(state, entityId)
+
+    return events.find(e => e.name === EVENT_STATUS_CLEARED)
+  }
+
+  return selectLatestClearedEvent
 }
 
 export const createInterruptedStreamsSelector = entity => state => {


### PR DESCRIPTION
#### Summary
This is a quickfix PR to fix an issue that would cause events from reappearing and duplicating when navigating back and forth from the entity after the event stream was cleared.

#### Changes
- Do not load historical events that were emitted before the event stream was cleared by the user
- Use correct ID string when selecting the last end device event

#### Testing

- Manual using staging environment

#### Notes for Reviewers
This happened due to the console loading historical events from points in time before the event stream was cleared, causing events to reappear if they were emitted before the event stream was cleared. Additionally, the calculation of the `after` prop for end device event stream could not succeed due to a logic issue, which caused events to be added again when the event stream was restarted.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.