### PR TITLE
Fix occasionally failing end-to-end tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -123,14 +123,13 @@ jobs:
           path: public
           key: public-cache-${{ hashFiles('pkg/webui/**', 'sdk/js/**/*.js', 'sdk/js/generated/*.json', 'config/webpack.config.babel.js', 'yarn.lock', 'sdk/js/yarn.lock')}}
       - name: Initialize dll cache
-        if: steps.public-cache.outputs.cache-hit != 'true'
         id: dll-cache
         uses: actions/cache@v2
         with:
           path: |
             public/libs.*.bundle.js
             .cache/dll.json
-          key: dll-cache-${{ hashFiles('yarn.lock', 'sdk/js/yarn.lock')}}
+          key: dll-cache-${{ hashFiles('yarn.lock') }}
       - name: Initialize babel cache
         id: babel-cache
         uses: actions/cache@v2
@@ -141,9 +140,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-babel-cache-
       - name: Build DLLs
-        if: |
-          steps.dll-cache.outputs.cache-hit != 'true' ||
-          steps.public-cache.outputs.cache-hit != 'true'
+        if: steps.dll-cache.outputs.cache-hit != 'true'
         run: tools/bin/mage js:buildDll
       - name: Build frontend
         if: steps.public-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,6 +57,7 @@ jobs:
     env:
       TTN_LW_LOG_LEVEL: debug
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NODE_ENV: production
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -140,7 +141,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-babel-cache-
       - name: Build DLLs
-        if: steps.dll-cache.outputs.cache-hit != 'true'
+        if: |
+          steps.dll-cache.outputs.cache-hit != 'true' ||
+          steps.public-cache.outputs.cache-hit != 'true'
         run: tools/bin/mage js:buildDll
       - name: Build frontend
         if: steps.public-cache.outputs.cache-hit != 'true'
@@ -168,6 +171,7 @@ jobs:
       TTN_LW_LOG_LEVEL: debug
       CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NODE_ENV: development
     strategy:
       matrix:
         machines: [1, 2, 3, 4]
@@ -227,6 +231,7 @@ jobs:
       COCKROACHDB_COCKROACH_TAG: v19.2.12
       CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NODE_ENV: development
     needs: [determine-if-required, preparation]
     if: needs.determine-if-required.outputs.needs-to-run == 'true'
     steps:

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -98,7 +98,7 @@ jobs:
           path: |
             public/libs.*.bundle.js
             .cache/dll.json
-          key: dll-cache-${{ hashFiles('yarn.lock', 'sdk/js/yarn.lock')}}
+          key: dll-cache-${{ hashFiles('yarn.lock') }}
       - name: Initialize babel cache
         id: babel-cache
         uses: actions/cache@v2

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -89,12 +89,6 @@ jobs:
       if: steps.dr-index-cache.outputs.cache-hit != 'true'
     - name: Auto-completion scripts
       run: tools/bin/mage cli:autocomplete
-    - name: Install JS SDK dependencies
-      run: tools/bin/mage jsSDK:deps
-    - name: Build JS SDK
-      run: tools/bin/mage jsSDK:clean jsSDK:build
-    - name: Install JS dependencies
-      run: tools/bin/mage js:deps
       timeout-minutes: 5
     - name: Build frontend
       run: tools/bin/mage js:clean js:buildDll js:build

--- a/config/webpack.config.babel.js
+++ b/config/webpack.config.babel.js
@@ -276,7 +276,11 @@ export default {
       new CleanWebpackPlugin({
         dry: WEBPACK_IS_DEV_SERVER_BUILD,
         verbose: false,
-        cleanOnceBeforeBuildPatterns: ['**/*', '!libs*bundle.js', '!libs*bundle.js.map'],
+        cleanOnceBeforeBuildPatterns: env({
+          all: ['**/*'],
+          development: ['!libs.bundle.js', '!libs.bundle.js.map'],
+          production: ['!libs.*.bundle.js', '!libs.*.bundle.js.map'],
+        }),
       }),
       // Copy static assets to output directory.
       new CopyWebpackPlugin({ patterns: [{ from: `${src}/assets/static` }] }),

--- a/config/webpack.dll.babel.js
+++ b/config/webpack.dll.babel.js
@@ -18,7 +18,7 @@ import path from 'path'
 import webpack from 'webpack'
 
 const { CONTEXT = '.', CACHE_DIR = '.cache', PUBLIC_DIR = 'public' } = process.env
-const mode = process.env.NODE_ENV === 'production' ? 'production' : 'development'
+const mode = process.env.NODE_ENV === 'development' ? 'development' : 'production'
 const WEBPACK_GENERATE_PRODUCTION_SOURCEMAPS =
   process.env.WEBPACK_GENERATE_PRODUCTION_SOURCEMAPS === 'true'
 


### PR DESCRIPTION
#### Summary
This quickfix PR will fix crashing end-to-end test workflows in some caching scenarios.

#### Changes
- Ensure proper caching of the DLL files
- Fix irregularities wrt how the tooling determines the production or development environments
- Simplify the tag release workflow

#### Testing

CI

#### Notes for Reviewers
This was caused by DLLs being built-in development mode in CI

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
