### PR TITLE
MQTT implementation unification

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -4175,15 +4175,6 @@
       "file": "format_protobufv2.go"
     }
   },
-  "error:pkg/gatewayserver/io/mqtt:mqtt_frontend_recovered": {
-    "translations": {
-      "en": "internal server error"
-    },
-    "description": {
-      "package": "pkg/gatewayserver/io/mqtt",
-      "file": "mqtt.go"
-    }
-  },
   "error:pkg/gatewayserver/io/mqtt:not_authorized": {
     "translations": {
       "en": "not authorized"

--- a/pkg/applicationserver/io/mqtt/format.go
+++ b/pkg/applicationserver/io/mqtt/format.go
@@ -15,12 +15,45 @@
 package mqtt
 
 import (
+	"go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io"
 	"go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io/formatters"
 	"go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io/mqtt/topics"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/unique"
 )
 
 // Format represents a topic layout and message formatter.
 type Format interface {
 	topics.Layout
 	formatters.Formatter
+}
+
+// TopicParts generates the topic parts for the provided uplink.
+func TopicParts(up *io.ContextualApplicationUp, layout topics.Layout) []string {
+	var f func(string, string) []string
+	switch up.Up.(type) {
+	case *ttnpb.ApplicationUp_UplinkMessage:
+		f = layout.UplinkTopic
+	case *ttnpb.ApplicationUp_JoinAccept:
+		f = layout.JoinAcceptTopic
+	case *ttnpb.ApplicationUp_DownlinkAck:
+		f = layout.DownlinkAckTopic
+	case *ttnpb.ApplicationUp_DownlinkNack:
+		f = layout.DownlinkNackTopic
+	case *ttnpb.ApplicationUp_DownlinkSent:
+		f = layout.DownlinkSentTopic
+	case *ttnpb.ApplicationUp_DownlinkFailed:
+		f = layout.DownlinkFailedTopic
+	case *ttnpb.ApplicationUp_DownlinkQueued:
+		f = layout.DownlinkQueuedTopic
+	case *ttnpb.ApplicationUp_DownlinkQueueInvalidated:
+		f = layout.DownlinkQueueInvalidatedTopic
+	case *ttnpb.ApplicationUp_LocationSolved:
+		f = layout.LocationSolvedTopic
+	case *ttnpb.ApplicationUp_ServiceData:
+		f = layout.ServiceDataTopic
+	default:
+		panic("unreachable")
+	}
+	return f(unique.ID(up.Context, up.ApplicationIdentifiers), up.DeviceId)
 }

--- a/pkg/gatewayserver/io/mqtt/mqtt.go
+++ b/pkg/gatewayserver/io/mqtt/mqtt.go
@@ -29,7 +29,6 @@ import (
 	"github.com/TheThingsIndustries/mystique/pkg/packet"
 	"github.com/TheThingsIndustries/mystique/pkg/session"
 	"github.com/TheThingsIndustries/mystique/pkg/topic"
-	"go.thethings.network/lorawan-stack/v3/pkg/errorcontext"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
@@ -116,7 +115,6 @@ func (*connection) SupportsDownlinkClaim() bool { return false }
 
 func (c *connection) setup(ctx context.Context) (err error) {
 	ctx = auth.NewContextWithInterface(ctx, c)
-	ctx, cancel := errorcontext.New(ctx)
 	defer func() {
 		retrievedErr := recoverMQTTFrontend(ctx)
 		if retrievedErr != nil {
@@ -125,7 +123,9 @@ func (c *connection) setup(ctx context.Context) (err error) {
 	}()
 	c.session = session.New(ctx, c.mqtt, c.deliver)
 	if err := c.session.ReadConnect(); err != nil {
-		cancel(err)
+		if c.io != nil {
+			c.io.Disconnect(err)
+		}
 		return err
 	}
 	ctx = c.io.Context()
@@ -142,7 +142,7 @@ func (c *connection) setup(ctx context.Context) (err error) {
 				if err != stdio.EOF {
 					logger.WithError(err).Warn("Error when reading packet")
 				}
-				cancel(err)
+				c.io.Disconnect(err)
 				return
 			}
 			if pkt != nil {
@@ -202,7 +202,7 @@ func (c *connection) setup(ctx context.Context) (err error) {
 				err = c.mqtt.Send(pkt)
 			}
 			if err != nil {
-				cancel(err)
+				c.io.Disconnect(err)
 				return
 			}
 		}

--- a/pkg/gatewayserver/io/mqtt/mqtt.go
+++ b/pkg/gatewayserver/io/mqtt/mqtt.go
@@ -17,12 +17,10 @@ package mqtt
 import (
 	"context"
 	"fmt"
-	stdio "io"
 	"net"
 	"time"
 
 	"github.com/TheThingsIndustries/mystique/pkg/auth"
-	mqttlog "github.com/TheThingsIndustries/mystique/pkg/log"
 	mqttnet "github.com/TheThingsIndustries/mystique/pkg/net"
 	"github.com/TheThingsIndustries/mystique/pkg/packet"
 	"github.com/TheThingsIndustries/mystique/pkg/session"
@@ -39,111 +37,49 @@ import (
 
 const qosDownlink byte = 0
 
-type srv struct {
-	ctx    context.Context
-	server io.Server
-	format Format
-	lis    mqttnet.Listener
-}
-
 // Serve serves the MQTT frontend.
 func Serve(ctx context.Context, server io.Server, listener net.Listener, format Format, protocol string) error {
 	ctx = log.NewContextWithField(ctx, "namespace", "gatewayserver/io/mqtt")
-	ctx = mqttlog.NewContext(ctx, mqtt.Logger(log.FromContext(ctx)))
-	s := &srv{ctx, server, format, mqttnet.NewListener(listener, protocol)}
+	lis := mqttnet.NewListener(listener, protocol)
 	go func() {
 		<-ctx.Done()
-		s.lis.Close()
+		lis.Close()
 	}()
-	return s.accept()
-}
-
-func (s *srv) accept() error {
-	for {
-		mqttConn, err := s.lis.Accept()
-		if err != nil {
-			if s.ctx.Err() == nil {
-				log.FromContext(s.ctx).WithError(err).Warn("Accept failed")
-			}
-			return err
-		}
-
-		remoteAddr := mqttConn.RemoteAddr().String()
-		ctx := log.NewContextWithFields(s.ctx, log.Fields("remote_addr", remoteAddr))
-
-		resource := ratelimit.GatewayAcceptMQTTConnectionResource(remoteAddr)
-		if err := ratelimit.Require(s.server.RateLimiter(), resource); err != nil {
-			if err := mqttConn.Close(); err != nil {
-				log.FromContext(ctx).WithError(err).Warn("Close connection failed")
-			}
-			log.FromContext(ctx).WithError(err).Debug("Drop connection")
-			continue
-		}
-
-		go func() {
-			conn := &connection{server: s.server, mqtt: mqttConn, format: s.format}
-			if err := conn.setup(ctx); err != nil {
-				switch err {
-				case stdio.EOF, stdio.ErrUnexpectedEOF:
-				default:
-					log.FromContext(ctx).WithError(err).Warn("Failed to setup connection")
-				}
-				mqttConn.Close()
-				return
-			}
-		}()
-	}
+	return mqtt.RunListener(
+		ctx, lis, server,
+		ratelimit.GatewayAcceptMQTTConnectionResource, server.RateLimiter(),
+		func(ctx context.Context, mqttConn mqttnet.Conn) error {
+			conn := &connection{server: server, format: format}
+			return conn.setup(ctx, mqttConn)
+		},
+	)
 }
 
 type connection struct {
-	format  Format
-	server  io.Server
-	mqtt    mqttnet.Conn
-	session session.Session
-	io      *io.Connection
-	tokens  io.DownlinkTokens
-
+	format   Format
+	server   io.Server
+	io       *io.Connection
+	tokens   io.DownlinkTokens
 	resource ratelimit.Resource
 }
 
 func (*connection) Protocol() string            { return "mqtt" }
 func (*connection) SupportsDownlinkClaim() bool { return false }
 
-func (c *connection) setup(ctx context.Context) error {
+func (c *connection) setup(ctx context.Context, mqttConn mqttnet.Conn) error {
 	ctx = auth.NewContextWithInterface(ctx, c)
-	c.session = session.New(ctx, c.mqtt, c.deliver)
-	if err := c.session.ReadConnect(); err != nil {
+	session := session.New(ctx, mqttConn, c.deliver)
+	if err := session.ReadConnect(); err != nil {
 		if c.io != nil {
 			c.io.Disconnect(err)
 		}
 		return err
 	}
+
 	ctx = c.io.Context()
-
 	logger := log.FromContext(ctx)
-	controlCh := make(chan packet.ControlPacket)
 
-	// Read control packets
-	go func() {
-		for {
-			pkt, err := c.session.ReadPacket()
-			if err != nil {
-				if err != stdio.EOF {
-					logger.WithError(err).Warn("Error when reading packet")
-				}
-				c.io.Disconnect(err)
-				return
-			}
-			if pkt != nil {
-				logger.Debugf("Schedule %s packet", packet.Name[pkt.PacketType()])
-				select {
-				case <-ctx.Done():
-					return
-				case controlCh <- pkt:
-				}
-			}
-		}
-	}()
+	mqtt.RunSession(ctx, c.io.Disconnect, c.server, session, mqttConn)
 
 	// Publish downlinks
 	go func() {
@@ -162,7 +98,7 @@ func (c *connection) setup(ctx context.Context) error {
 				}
 				logger.Info("Publish downlink message")
 				topicParts := c.format.DownlinkTopic(unique.ID(c.io.Context(), c.io.Gateway().GetIds()))
-				c.session.Publish(&packet.PublishPacket{
+				session.Publish(&packet.PublishPacket{
 					TopicName:  topic.Join(topicParts),
 					TopicParts: topicParts,
 					QoS:        qosDownlink,
@@ -172,38 +108,6 @@ func (c *connection) setup(ctx context.Context) error {
 		}
 	}()
 
-	// Write packets
-	go func() {
-		for {
-			var err error
-			select {
-			case <-ctx.Done():
-				return
-			case pkt := <-controlCh:
-				err = c.mqtt.Send(pkt)
-			case pkt, ok := <-c.session.PublishChan():
-				if !ok {
-					return
-				}
-				logger.Debug("Write publish packet")
-				err = c.mqtt.Send(pkt)
-			}
-			if err != nil {
-				c.io.Disconnect(err)
-				return
-			}
-		}
-	}()
-
-	// Close connection on context closure
-	go func() {
-		<-ctx.Done()
-		logger.WithError(ctx.Err()).Info("Disconnected")
-		c.session.Close()
-		c.mqtt.Close()
-	}()
-
-	logger.Info("Connected")
 	return nil
 }
 

--- a/pkg/mqtt/mqtt.go
+++ b/pkg/mqtt/mqtt.go
@@ -14,3 +14,129 @@
 
 // Package mqtt contains MQTT-related utilities.
 package mqtt
+
+import (
+	"context"
+
+	mqttlog "github.com/TheThingsIndustries/mystique/pkg/log"
+	mqttnet "github.com/TheThingsIndustries/mystique/pkg/net"
+	"github.com/TheThingsIndustries/mystique/pkg/packet"
+	"github.com/TheThingsIndustries/mystique/pkg/session"
+	"go.thethings.network/lorawan-stack/v3/pkg/component"
+	"go.thethings.network/lorawan-stack/v3/pkg/log"
+	"go.thethings.network/lorawan-stack/v3/pkg/ratelimit"
+)
+
+// RunListener runs the MQTT accept connection loop.
+func RunListener(
+	ctx context.Context,
+	lis mqttnet.Listener,
+	ts component.TaskStarter,
+	createResource func(string) ratelimit.Resource,
+	rateLimiter ratelimit.Interface,
+	setupConnection func(context.Context, mqttnet.Conn) error,
+) error {
+	ctx = mqttlog.NewContext(ctx, Logger(log.FromContext(ctx)))
+	for {
+		mqttConn, err := lis.Accept()
+		if err != nil {
+			if ctx.Err() == nil {
+				log.FromContext(ctx).WithError(err).Warn("Accept failed")
+			}
+			return err
+		}
+
+		remoteAddr := mqttConn.RemoteAddr().String()
+		ctx := log.NewContextWithFields(ctx, log.Fields("remote_addr", remoteAddr))
+
+		resource := createResource(remoteAddr)
+		if err := ratelimit.Require(rateLimiter, resource); err != nil {
+			log.FromContext(ctx).WithError(err).Debug("Drop connection")
+			mqttConn.Close()
+			continue
+		}
+
+		f := func(ctx context.Context) (err error) {
+			defer func() {
+				if err != nil {
+					mqttConn.Close()
+				}
+			}()
+			return setupConnection(ctx, mqttConn)
+		}
+		ts.StartTask(&component.TaskConfig{
+			Context: ctx,
+			ID:      "mqtt_setup_connection",
+			Func:    f,
+			Restart: component.TaskRestartNever,
+			Backoff: component.DefaultTaskBackoffConfig,
+		})
+	}
+}
+
+// RunSession reads the control packets from the provided session and sends them to the connection.
+func RunSession(
+	ctx context.Context,
+	cancel func(error),
+	ts component.TaskStarter,
+	session session.Session,
+	mqttConn mqttnet.Conn,
+) {
+	logger := log.FromContext(ctx)
+
+	controlCh := make(chan packet.ControlPacket)
+	controlFunc := func(ctx context.Context) error {
+		for {
+			pkt, err := session.ReadPacket()
+			if err != nil {
+				cancel(err)
+				return err
+			}
+			if pkt == nil {
+				continue
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case controlCh <- pkt:
+			}
+		}
+	}
+	writeFunc := func(ctx context.Context) error {
+		for {
+			var pkt packet.ControlPacket
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case pkt = <-controlCh:
+			case pkt = <-session.PublishChan():
+			}
+			if err := mqttConn.Send(pkt); err != nil {
+				cancel(err)
+				return err
+			}
+		}
+	}
+	closeFunc := func(ctx context.Context) error {
+		logger.Info("Connected")
+		<-ctx.Done()
+		logger.WithError(ctx.Err()).Info("Disconnected")
+		session.Close()
+		mqttConn.Close()
+		return ctx.Err()
+	}
+
+	for name, f := range map[string]func(context.Context) error{
+		"mqtt_control_packets":  controlFunc,
+		"mqtt_write_packets":    writeFunc,
+		"mqtt_close_connection": closeFunc,
+	} {
+		ts.StartTask(&component.TaskConfig{
+			Context: ctx,
+			ID:      name,
+			Func:    f,
+			Restart: component.TaskRestartNever,
+			Backoff: component.DefaultTaskBackoffConfig,
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR tackles some technical debt that has been sitting on my mind for a while regarding our MQTT servers.

#### Changes
<!-- What are the changes made in this pull request? -->

- Do not create a custom context for connection setup (setup here means authentication/authorization)
  - This actually would leak previously if rate limits were hit
- Use tasks for connection routines
  - In order to avoid the custom recovery logic that we were previously duplicating through the code base
- Move MQTT connection acceptance logic to `pkg/mqtt`
- Move MQTT session management logic to `pkg/mqtt`
- Use a `sync.WaitGroup` to wait for the connection routines to finish

#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Unit tests cover most of the functionality, and I have tested if we leak subscriptions/goroutines/contexts on connection failure / disconnect.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
