### PR TITLE
Allow frontends to manually synchronize gateway clocks

### DIFF
--- a/pkg/gatewayserver/io/grpc/grpc.go
+++ b/pkg/gatewayserver/io/grpc/grpc.go
@@ -132,7 +132,7 @@ func (s *impl) LinkGateway(link ttnpb.GtwGs_LinkGatewayServer) error {
 
 			for _, up := range io.UniqueUplinkMessagesByRSSI(msg.UplinkMessages) {
 				up.ReceivedAt = now
-				if err := conn.HandleUp(up); err != nil {
+				if err := conn.HandleUp(up, nil); err != nil {
 					logger.WithError(err).Warn("Failed to handle uplink message")
 				}
 			}

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -201,9 +201,9 @@ var errBufferFull = errors.DefineInternal("buffer_full", "buffer is full")
 // Interval between emitting consecutive gs.up.repeat events for the same gateway connection.
 const consecutiveRepeatUpEventsInterval = time.Minute
 
-// ManualClockSynchronization contains the clock synchronization
+// FrontendClockSynchronization contains the clock synchronization
 // timestamps provided by a frontend for manual synchronization.
-type ManualClockSynchronization struct {
+type FrontendClockSynchronization struct {
 	Timestamp        uint32
 	ServerTime       time.Time
 	GatewayTime      *time.Time
@@ -211,20 +211,20 @@ type ManualClockSynchronization struct {
 }
 
 // HandleUp updates the uplink stats and sends the message to the upstream channel.
-func (c *Connection) HandleUp(up *ttnpb.UplinkMessage, manualSync *ManualClockSynchronization) error {
+func (c *Connection) HandleUp(up *ttnpb.UplinkMessage, frontendSync *FrontendClockSynchronization) error {
 	if c.discardRepeatedUplink(up) {
 		return nil
 	}
 
 	var ct scheduling.ConcentratorTime
 	switch {
-	case manualSync != nil:
-		ct = c.scheduler.SyncWithGatewayConcentrator(manualSync.Timestamp, manualSync.ServerTime, manualSync.GatewayTime, manualSync.ConcentratorTime)
+	case frontendSync != nil:
+		ct = c.scheduler.SyncWithGatewayConcentrator(frontendSync.Timestamp, frontendSync.ServerTime, frontendSync.GatewayTime, frontendSync.ConcentratorTime)
 		log.FromContext(c.ctx).WithFields(log.Fields(
-			"timestamp", manualSync.Timestamp,
-			"concentrator_time", manualSync.ConcentratorTime,
-			"server_time", manualSync.ServerTime,
-			"gateway_time", manualSync.GatewayTime,
+			"timestamp", frontendSync.Timestamp,
+			"concentrator_time", frontendSync.ConcentratorTime,
+			"server_time", frontendSync.ServerTime,
+			"gateway_time", frontendSync.GatewayTime,
 		)).Info("Gateway clocks have been synchronized by the frontend")
 	case up.Settings.Time != nil:
 		ct = c.scheduler.SyncWithGatewayAbsolute(up.Settings.Timestamp, up.ReceivedAt, *up.Settings.Time)

--- a/pkg/gatewayserver/io/mock/frontend.go
+++ b/pkg/gatewayserver/io/mock/frontend.go
@@ -56,7 +56,7 @@ func ConnectFrontend(ctx context.Context, ids ttnpb.GatewayIdentifiers, server i
 				gatewayTime := time.Unix(0, 0).Add(time.Since(started))
 				up.ReceivedAt = time.Now()
 				up.Settings.Time = &gatewayTime
-				conn.HandleUp(up)
+				conn.HandleUp(up, nil)
 			case status := <-f.Status:
 				conn.HandleStatus(status)
 			case txAck := <-f.TxAck:

--- a/pkg/gatewayserver/io/mqtt/mqtt.go
+++ b/pkg/gatewayserver/io/mqtt/mqtt.go
@@ -326,7 +326,7 @@ func (c *connection) deliver(pkt *packet.PublishPacket) {
 			return
 		}
 		up.ReceivedAt = pkt.Received
-		if err := c.io.HandleUp(up); err != nil {
+		if err := c.io.HandleUp(up, nil); err != nil {
 			logger.WithError(err).Warn("Failed to handle uplink message")
 		}
 	case c.format.IsStatusTopic(pkt.TopicParts):

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -290,7 +290,7 @@ func (s *srv) handleUp(ctx context.Context, state *state, packet encoding.Packet
 		}
 		for _, up := range io.UniqueUplinkMessagesByRSSI(msg.UplinkMessages) {
 			up.ReceivedAt = packet.ReceivedAt
-			if err := state.io.HandleUp(up); err != nil {
+			if err := state.io.HandleUp(up, nil); err != nil {
 				logger.WithError(err).Warn("Failed to handle uplink message")
 			}
 		}

--- a/pkg/gatewayserver/io/ws/format.go
+++ b/pkg/gatewayserver/io/ws/format.go
@@ -48,5 +48,5 @@ type Formatter interface {
 	// FromDownlink generates a downlink byte stream that can be sent over the WS connection.
 	FromDownlink(ctx context.Context, down ttnpb.DownlinkMessage, bandID string, concentratorTime scheduling.ConcentratorTime, dlTime time.Time) ([]byte, error)
 	// TransferTime generates a spurious time transfer message for a particular server time.
-	TransferTime(ctx context.Context, t time.Time, conn *io.Connection) ([]byte, error)
+	TransferTime(ctx context.Context, serverTime time.Time, gpsTime *time.Time, concentratorTime *scheduling.ConcentratorTime) ([]byte, error)
 }

--- a/pkg/gatewayserver/io/ws/lbslns/upstream.go
+++ b/pkg/gatewayserver/io/ws/lbslns/upstream.go
@@ -520,20 +520,20 @@ func (f *lbsLNS) HandleUp(ctx context.Context, raw []byte, ids ttnpb.GatewayIden
 			conn.RecordRTT(delta, receivedAt)
 		}
 	}
-	syncClock := func(xTime int64, gpsTime int64, onlyWithGPS bool) {
+	syncClock := func(xTime int64, gpsTime int64, rxTime float64, onlyWithGPS bool) *io.ManualClockSynchronization {
 		if onlyWithGPS && gpsTime == 0 {
-			return
+			return nil
 		}
-		conn.SyncWithGatewayConcentrator(
-			TimestampFromXTime(xTime),
-			receivedAt,
-			TimePtrFromGPSTime(gpsTime),
-			ConcentratorTimeFromXTime(xTime),
-		)
+		return &io.ManualClockSynchronization{
+			Timestamp:        TimestampFromXTime(xTime),
+			ServerTime:       receivedAt,
+			GatewayTime:      TimePtrFromUpInfo(gpsTime, rxTime),
+			ConcentratorTime: ConcentratorTimeFromXTime(xTime),
+		}
 	}
-	recordTime := func(refTimeUnix float64, xTime int64, gpsTime int64) {
+	recordTime := func(refTimeUnix float64, xTime int64, gpsTime int64, rxTime float64) *io.ManualClockSynchronization {
 		recordRTT(refTimeUnix)
-		syncClock(xTime, gpsTime, false)
+		return syncClock(xTime, gpsTime, rxTime, false)
 	}
 
 	switch typ {
@@ -565,12 +565,12 @@ func (f *lbsLNS) HandleUp(ctx context.Context, raw []byte, ids ttnpb.GatewayIden
 			logger.WithError(err).Warn("Failed to parse join request")
 			return nil, err
 		}
-		if err := conn.HandleUp(up); err != nil {
+		updateSessionID(ctx, SessionIDFromXTime(jreq.UpInfo.XTime))
+		ct := recordTime(jreq.RefTime, jreq.UpInfo.XTime, jreq.UpInfo.GPSTime, jreq.UpInfo.RxTime)
+		if err := conn.HandleUp(up, ct); err != nil {
 			logger.WithError(err).Warn("Failed to handle upstream message")
 			return nil, err
 		}
-		updateSessionID(ctx, SessionIDFromXTime(jreq.UpInfo.XTime))
-		recordTime(jreq.RefTime, jreq.UpInfo.XTime, jreq.UpInfo.GPSTime)
 
 	case TypeUpstreamUplinkDataFrame:
 		var updf UplinkDataFrame
@@ -587,12 +587,12 @@ func (f *lbsLNS) HandleUp(ctx context.Context, raw []byte, ids ttnpb.GatewayIden
 			logger.WithError(err).Warn("Failed to parse uplink message")
 			return nil, err
 		}
-		if err := conn.HandleUp(up); err != nil {
+		updateSessionID(ctx, SessionIDFromXTime(updf.UpInfo.XTime))
+		ct := recordTime(updf.RefTime, updf.UpInfo.XTime, updf.UpInfo.GPSTime, updf.UpInfo.RxTime)
+		if err := conn.HandleUp(up, ct); err != nil {
 			logger.WithError(err).Warn("Failed to handle upstream message")
 			return nil, err
 		}
-		updateSessionID(ctx, SessionIDFromXTime(updf.UpInfo.XTime))
-		recordTime(updf.RefTime, updf.UpInfo.XTime, updf.UpInfo.GPSTime)
 
 	case TypeUpstreamTxConfirmation:
 		var txConf TxConfirmation
@@ -612,7 +612,7 @@ func (f *lbsLNS) HandleUp(ctx context.Context, raw []byte, ids ttnpb.GatewayIden
 		// RTT computations. The GPS timestamp is present only if the downlink is a class
 		// B downlink. We allow clock synchronization to occur only if GPSTime is present.
 		// References https://github.com/lorabasics/basicstation/issues/134.
-		syncClock(txConf.XTime, txConf.GPSTime, true)
+		syncClock(txConf.XTime, txConf.GPSTime, 0.0, true)
 
 	case TypeUpstreamTimeSync:
 		// If the gateway sends a `timesync` request, it means that it has access to a PPS

--- a/pkg/gatewayserver/io/ws/lbslns/upstream.go
+++ b/pkg/gatewayserver/io/ws/lbslns/upstream.go
@@ -520,18 +520,18 @@ func (f *lbsLNS) HandleUp(ctx context.Context, raw []byte, ids ttnpb.GatewayIden
 			conn.RecordRTT(delta, receivedAt)
 		}
 	}
-	syncClock := func(xTime int64, gpsTime int64, rxTime float64, onlyWithGPS bool) *io.ManualClockSynchronization {
+	syncClock := func(xTime int64, gpsTime int64, rxTime float64, onlyWithGPS bool) *io.FrontendClockSynchronization {
 		if onlyWithGPS && gpsTime == 0 {
 			return nil
 		}
-		return &io.ManualClockSynchronization{
+		return &io.FrontendClockSynchronization{
 			Timestamp:        TimestampFromXTime(xTime),
 			ServerTime:       receivedAt,
 			GatewayTime:      TimePtrFromUpInfo(gpsTime, rxTime),
 			ConcentratorTime: ConcentratorTimeFromXTime(xTime),
 		}
 	}
-	recordTime := func(refTimeUnix float64, xTime int64, gpsTime int64, rxTime float64) *io.ManualClockSynchronization {
+	recordTime := func(refTimeUnix float64, xTime int64, gpsTime int64, rxTime float64) *io.FrontendClockSynchronization {
 		recordRTT(refTimeUnix)
 		return syncClock(xTime, gpsTime, rxTime, false)
 	}

--- a/pkg/gatewayserver/io/ws/ws.go
+++ b/pkg/gatewayserver/io/ws/ws.go
@@ -270,7 +270,9 @@ func (s *srv) handleTraffic(c echo.Context) (err error) {
 					return
 				}
 			case <-timeSyncTickerC:
-				b, err := s.formatter.TransferTime(ctx, time.Now(), conn)
+				// TODO: Use GPS timestamp from a overlapping frames.
+				// https://github.com/TheThingsNetwork/lorawan-stack/issues/4852
+				b, err := s.formatter.TransferTime(ctx, time.Now(), nil, nil)
 				if err != nil {
 					logger.WithError(err).Warn("Failed to generate time transfer")
 					conn.Disconnect(err)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #4853

#### Changes
<!-- What are the changes made in this pull request? -->

- Gateway Server frontends may now manually provide clock synchronization information
  - We no longer sync the Basic Station frontend twice (once in the frontend, once in `io.HandleUp`)
- BasicStation `timetransfer` is now used only to transfer `MuxTime`
  - See https://github.com/TheThingsNetwork/lorawan-stack/issues/4852 for how GPS time transfer should actually work
  - Synchronizing `MuxTime` is enough in order to actually have accurate `RxTime` and `RefTime` (modulo RTT variations), which is enough for our usage


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Not expected.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

We already didn't include `TxSettings.Time` for the MQTT v2 protocol, so the granularity mentioned in the original issue is not a huge problem. For the rest of the frontends, they are in the order of milliseconds, which is enough for absolute time downlinks.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
