### PR TITLE
Check if dev SQL database is running after starting it

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -787,7 +787,7 @@ We use [Cypress](https://cypress.io) for running frontend-based end-to-end tests
 
 #### Running frontend end-to-end tests locally
 
-Make sure to [build the frontend assets](#building-the-frontend), [start The Things Stack](#starting-the-things-stack) and run `tools/bin/mage dev:sqlDump` after running `tools/bin/mage dev:initStack` to save database dump used as database seed when running end-to-end tests. To run the stack when working on end-to-end tests, use the `tools/bin/mage dev:startDevStack` command. This will run the stack in proper configuration for the end-to-end tests, note that this is an endless process that essentially runs the The Things Stack process so you don't have to wait for it to finish.
+Make sure to [build the frontend assets](#building-the-frontend), [start The Things Stack](#starting-the-things-stack) and run `tools/bin/mage dev:initStack dev:sqlDump dev:sqlCreateSeedDb` to create a seed database which the tests can reset the database to in between runs. To run the stack when working on end-to-end tests, use the `tools/bin/mage dev:startDevStack` command. This will run the stack in proper configuration for the end-to-end tests, note that this is an endless process that essentially runs the The Things Stack process in the background so you don't have to wait for it to finish.
 
 `Cypress` provides two modes for running tests: headless and interactive.
 - Headless mode - will not display any browser GUI and output test progress into your terminal instead. This is helpful when one just needs see the results of the tests.

--- a/tools/mage/scripts/recreate-db-from-dump.sh
+++ b/tools/mage/scripts/recreate-db-from-dump.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-docker-compose -p lorawan-stack-dev exec -T postgres /bin/bash -c "dropdb --if-exists --force $1; createdb $1; psql $1 --quiet" < $2
+docker-compose -p lorawan-stack-dev exec -T postgres /bin/bash -c "dropdb --if-exists --force $1 2> /dev/null; createdb $1; psql $1 --quiet" < $2


### PR DESCRIPTION
#### Summary
This quickfix PR will ensure that the database is running after running `tools/bin/mage dev:dbStart`, so that other targets that depend on the database can run right after it.

Closes #4911

#### Changes
- Add a connection check to `tools/bin/mage dev:dbStart` using `pg_isready`
- Mute `dropdb` output
- Update documentation accordingly to clarify usage of `dev:sqlCreateSeedDb`


#### Testing

Manual and CI

#### Notes for Reviewers
For reasons that I wasn't able to figure out, `pg_isready` does not run in CI but will always return an error code 1. Additionally, the problem of the postgres server not running immediately after the `dev:dbStart` target seem to be only present in local environments, not the CI. If anyone has an idea why this is, we might be able to avoid having to distinguish between CI in the mage target.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
