### PR TITLE
Move from io/ioutil to io and os packages

### DIFF
--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -18,13 +18,11 @@ import (
 	"bufio"
 	"context"
 	"encoding/hex"
-	"io/ioutil"
+	stdio "io"
 	"mime"
 	"os"
 	"path"
 	"strings"
-
-	stdio "io"
 
 	pbtypes "github.com/gogo/protobuf/types"
 	"github.com/spf13/cobra"
@@ -1132,7 +1130,7 @@ This command may take end device identifiers from stdin.`,
 				ext = exts[0]
 			}
 			filename := path.Join(folder, device.DeviceId+ext)
-			if err := ioutil.WriteFile(filename, res.Image.Embedded.Data, 0o644); err != nil {
+			if err := os.WriteFile(filename, res.Image.Embedded.Data, 0o644); err != nil {
 				return err
 			}
 

--- a/cmd/ttn-lw-cli/commands/flags.go
+++ b/cmd/ttn-lw-cli/commands/flags.go
@@ -17,7 +17,6 @@ package commands
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -273,7 +272,7 @@ func getDataBytes(name string, flagSet *pflag.FlagSet) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadAll(r)
+	return io.ReadAll(r)
 }
 
 func getDataReader(name string, flagSet *pflag.FlagSet) (io.Reader, error) {

--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -171,7 +170,7 @@ func preRun(tasks ...func() error) func(cmd *cobra.Command, args []string) error
 			api.SetDumpRequests(true)
 		}
 		if config.CA != "" {
-			pemBytes, err := ioutil.ReadFile(config.CA)
+			pemBytes, err := os.ReadFile(config.CA)
 			if err != nil {
 				return err
 			}

--- a/cmd/ttn-lw-cli/commands/use.go
+++ b/cmd/ttn-lw-cli/commands/use.go
@@ -22,7 +22,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -154,7 +153,7 @@ var (
 						logger.Warnf("Could not retrieve certificate: %s", err)
 					}
 				}
-				if err = ioutil.WriteFile(caFile, buf.Bytes(), 0644); err != nil {
+				if err = os.WriteFile(caFile, buf.Bytes(), 0644); err != nil {
 					return errFailWrite.WithCause(err).WithAttributes("file", caFile)
 				}
 				logger.Infof("CA file for %s written in %s", host, caFile)
@@ -173,7 +172,7 @@ var (
 			if err != nil {
 				return err
 			}
-			if err = ioutil.WriteFile(configFile, b, 0644); err != nil {
+			if err = os.WriteFile(configFile, b, 0644); err != nil {
 				return errFailWrite.WithCause(err).WithAttributes("file", configFile)
 			}
 			logger.Infof("Config file for %s written in %s", host, configFile)

--- a/cmd/ttn-lw-cli/commands/utils.go
+++ b/cmd/ttn-lw-cli/commands/utils.go
@@ -17,7 +17,6 @@ package commands
 import (
 	"fmt"
 	stdio "io"
-	"io/ioutil"
 	"net"
 	"net/url"
 	"strings"
@@ -87,7 +86,7 @@ func parsePayloadFormatterParameterFlags(prefix string, formatters *ttnpb.Messag
 	r, err := getDataReader(prefix+".up-formatter-parameter", flags)
 	switch err {
 	case nil:
-		b, err := ioutil.ReadAll(r)
+		b, err := stdio.ReadAll(r)
 		if err != nil {
 			return nil, err
 		}
@@ -102,7 +101,7 @@ func parsePayloadFormatterParameterFlags(prefix string, formatters *ttnpb.Messag
 	r, err = getDataReader(prefix+".down-formatter-parameter", flags)
 	switch err {
 	case nil:
-		b, err := ioutil.ReadAll(r)
+		b, err := stdio.ReadAll(r)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/account/server_test.go
+++ b/pkg/account/server_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
@@ -370,7 +370,7 @@ func TestAuthentication(t *testing.T) {
 				req.Header.Set("Content-Type", contentType)
 			}
 			if body != nil {
-				req.Body = ioutil.NopCloser(body)
+				req.Body = io.NopCloser(body)
 				req.ContentLength = int64(body.Len())
 			}
 

--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -759,7 +759,7 @@ func TestApplicationServer(t *testing.T) {
 			Connect: func(ctx context.Context, t *testing.T, ids ttnpb.ApplicationIdentifiers, key string, chs *connChannels) error {
 				// Start web server to read upstream.
 				webhookTarget := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-					buf, err := ioutil.ReadAll(req.Body)
+					buf, err := io.ReadAll(req.Body)
 					if !a.So(err, should.BeNil) {
 						t.FailNow()
 					}

--- a/pkg/applicationserver/io/packages/loradms/v1/api/client_test.go
+++ b/pkg/applicationserver/io/packages/loradms/v1/api/client_test.go
@@ -17,7 +17,7 @@ package api_test
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -61,7 +61,7 @@ func TestNoAuth(t *testing.T) {
 			a := assertions.New(t)
 
 			respChan <- &http.Response{
-				Body: ioutil.NopCloser(bytes.NewBufferString("")),
+				Body: io.NopCloser(bytes.NewBufferString("")),
 			}
 			errChan <- nil
 
@@ -79,7 +79,7 @@ func TestAuth(t *testing.T) {
 			a := assertions.New(t)
 
 			respChan <- &http.Response{
-				Body: ioutil.NopCloser(bytes.NewBufferString("")),
+				Body: io.NopCloser(bytes.NewBufferString("")),
 			}
 			errChan <- nil
 

--- a/pkg/applicationserver/io/packages/loradms/v1/api/uplinks_test.go
+++ b/pkg/applicationserver/io/packages/loradms/v1/api/uplinks_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -93,7 +93,7 @@ func TestUplinks(t *testing.T) {
 					a := assertions.New(t)
 
 					respChan <- &http.Response{
-						Body:       ioutil.NopCloser(bytes.NewBufferString(tc.body)),
+						Body:       io.NopCloser(bytes.NewBufferString(tc.body)),
 						StatusCode: http.StatusOK,
 					}
 					errChan <- tc.err

--- a/pkg/applicationserver/io/packages/loragls/v3/api/client_test.go
+++ b/pkg/applicationserver/io/packages/loragls/v3/api/client_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -63,7 +63,7 @@ func TestNoAuth(t *testing.T) {
 			a := assertions.New(t)
 
 			respChan <- &http.Response{
-				Body: ioutil.NopCloser(bytes.NewBufferString("")),
+				Body: io.NopCloser(bytes.NewBufferString("")),
 			}
 			errChan <- nil
 
@@ -81,7 +81,7 @@ func TestAuth(t *testing.T) {
 			a := assertions.New(t)
 
 			respChan <- &http.Response{
-				Body: ioutil.NopCloser(bytes.NewBufferString("")),
+				Body: io.NopCloser(bytes.NewBufferString("")),
 			}
 			errChan <- nil
 
@@ -355,7 +355,7 @@ func TestClient(t *testing.T) {
 
 					respChan <- &http.Response{
 						StatusCode: http.StatusOK,
-						Body:       ioutil.NopCloser(b),
+						Body:       io.NopCloser(b),
 					}
 					errChan <- nil
 

--- a/pkg/applicationserver/io/pubsub/provider/mqtt/provider_test.go
+++ b/pkg/applicationserver/io/pubsub/provider/mqtt/provider_test.go
@@ -17,7 +17,7 @@ package mqtt
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -42,15 +42,15 @@ func TestOpenConnection(t *testing.T) {
 	a := assertions.New(t)
 	ctx := test.Context()
 
-	ca, err := ioutil.ReadFile("testdata/rootCA.pem")
+	ca, err := os.ReadFile("testdata/rootCA.pem")
 	a.So(err, should.BeNil)
-	clientCert, err := ioutil.ReadFile("testdata/clientcert.pem")
+	clientCert, err := os.ReadFile("testdata/clientcert.pem")
 	a.So(err, should.BeNil)
-	clientKey, err := ioutil.ReadFile("testdata/clientkey.pem")
+	clientKey, err := os.ReadFile("testdata/clientkey.pem")
 	a.So(err, should.BeNil)
-	serverCert, err := ioutil.ReadFile("testdata/servercert.pem")
+	serverCert, err := os.ReadFile("testdata/servercert.pem")
 	a.So(err, should.BeNil)
-	serverKey, err := ioutil.ReadFile("testdata/serverkey.pem")
+	serverKey, err := os.ReadFile("testdata/serverkey.pem")
 	a.So(err, should.BeNil)
 
 	clientTLSConfig, err := createTLSConfig(ca, clientCert, clientKey)

--- a/pkg/applicationserver/io/web/webhooks.go
+++ b/pkg/applicationserver/io/web/webhooks.go
@@ -18,13 +18,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	stdio "io"
 	"net/http"
 	"net/url"
 	"strings"
 	"sync"
-
-	stdio "io"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/gorilla/mux"
@@ -387,7 +385,7 @@ func (w *webhooks) handleDown(op func(io.Server, context.Context, ttnpb.EndDevic
 			webhandlers.Error(res, req, errFormatNotFound.WithAttributes("format", hook.Format))
 			return
 		}
-		body, err := ioutil.ReadAll(req.Body)
+		body, err := stdio.ReadAll(req.Body)
 		if err != nil {
 			webhandlers.Error(res, req, errReadBody.WithCause(err))
 			return

--- a/pkg/applicationserver/io/web/webhooks_test.go
+++ b/pkg/applicationserver/io/web/webhooks_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	stdio "io"
 	"net/http"
 	"testing"
 	"time"
@@ -405,7 +405,7 @@ func TestWebhooks(t *testing.T) {
 								a.So(req.Header.Get("X-Downlink-Replace"), should.Equal,
 									"https://example.com/api/v3/as/applications/foo-app/webhooks/foo-hook/devices/foo-device/down/replace")
 								a.So(req.Header.Get("X-Tts-Domain"), should.Equal, "example.com")
-								actualBody, err := ioutil.ReadAll(req.Body)
+								actualBody, err := stdio.ReadAll(req.Body)
 								if !a.So(err, should.BeNil) {
 									t.FailNow()
 								}

--- a/pkg/band/reference_test.go
+++ b/pkg/band/reference_test.go
@@ -17,7 +17,6 @@ package band_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -228,11 +227,11 @@ func testBand(t *testing.T, band serializableBand, version ttnpb.PHYVersion) {
 			t.Fatal(err)
 		}
 
-		if err := ioutil.WriteFile(reference, b, 0600); err != nil {
+		if err := os.WriteFile(reference, b, 0600); err != nil {
 			t.Fatal(err)
 		}
 	} else {
-		b, err := ioutil.ReadFile(reference)
+		b, err := os.ReadFile(reference)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/component/component_test.go
+++ b/pkg/component/component_test.go
@@ -19,8 +19,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -144,7 +144,7 @@ func TestHTTP(t *testing.T) {
 		a.So(err, should.BeNil)
 
 		certPool := x509.NewCertPool()
-		certContent, err := ioutil.ReadFile("testdata/serverca.pem")
+		certContent, err := os.ReadFile("testdata/serverca.pem")
 		a.So(err, should.BeNil)
 		certPool.AppendCertsFromPEM(certContent)
 		client := http.Client{

--- a/pkg/component/interop.go
+++ b/pkg/component/interop.go
@@ -16,7 +16,7 @@ package component
 
 import (
 	"crypto/tls"
-	"io/ioutil"
+	"io"
 	stdlog "log"
 	"net"
 	"net/http"
@@ -35,7 +35,7 @@ func (c *Component) serveInterop(lis net.Listener) error {
 		Handler:           c.interop,
 		ReadTimeout:       120 * time.Second,
 		ReadHeaderTimeout: 5 * time.Second,
-		ErrorLog:          stdlog.New(ioutil.Discard, "", 0),
+		ErrorLog:          stdlog.New(io.Discard, "", 0),
 	}
 	go func() {
 		<-c.Context().Done()

--- a/pkg/component/interop_test.go
+++ b/pkg/component/interop_test.go
@@ -20,8 +20,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/smartystreets/assertions"
@@ -126,7 +126,7 @@ func TestInteropTLS(t *testing.T) {
 	defer c.Close()
 
 	certPool := x509.NewCertPool()
-	certContent, err := ioutil.ReadFile("testdata/serverca.pem")
+	certContent, err := os.ReadFile("testdata/serverca.pem")
 	a.So(err, should.BeNil)
 	certPool.AppendCertsFromPEM(certContent)
 	client := http.Client{

--- a/pkg/component/web.go
+++ b/pkg/component/web.go
@@ -15,7 +15,7 @@
 package component
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -139,7 +139,7 @@ func (c *Component) serveWeb(lis net.Listener) error {
 		Handler:           handler,
 		ReadTimeout:       120 * time.Second,
 		ReadHeaderTimeout: 5 * time.Second,
-		ErrorLog:          log.New(ioutil.Discard, "", 0),
+		ErrorLog:          log.New(io.Discard, "", 0),
 	}
 	go func() {
 		<-c.Context().Done()

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -17,7 +17,6 @@ package config
 import (
 	"context"
 	"crypto/tls"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"time"
@@ -254,7 +253,7 @@ func (c BlobConfig) Bucket(ctx context.Context, bucket string) (*blob.Bucket, er
 			jsonCreds = []byte(c.GCP.Credentials)
 		} else if c.GCP.CredentialsFile != "" {
 			var err error
-			jsonCreds, err = ioutil.ReadFile(c.GCP.CredentialsFile)
+			jsonCreds, err = os.ReadFile(c.GCP.CredentialsFile)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/config/tlsconfig/config.go
+++ b/pkg/config/tlsconfig/config.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
+	"os"
 	"sync"
 	"sync/atomic"
 
@@ -123,7 +123,7 @@ func (c *Client) ApplyTo(tlsConfig *tls.Config) error {
 	}
 	c.loadRootCA.Do(func() {
 		if c.RootCA != "" {
-			readFile := ioutil.ReadFile
+			readFile := os.ReadFile
 			if c.FileReader != nil {
 				readFile = c.FileReader.ReadFile
 			}
@@ -148,7 +148,7 @@ func (c *Client) ApplyTo(tlsConfig *tls.Config) error {
 }
 
 func readCert(fileReader FileReader, certFile, keyFile string) (*tls.Certificate, error) {
-	readFile := ioutil.ReadFile
+	readFile := os.ReadFile
 	if fileReader != nil {
 		readFile = fileReader.ReadFile
 	}

--- a/pkg/devicerepository/store/bleve/init.go
+++ b/pkg/devicerepository/store/bleve/init.go
@@ -17,7 +17,6 @@ package bleve
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -195,11 +194,11 @@ func prepareWorkingDirectory(ctx context.Context, workingDirectory, lorawanDevic
 		if err := os.MkdirAll(path.Dir(destination), 0755); err != nil {
 			return err
 		}
-		b, err := ioutil.ReadFile(fullPath)
+		b, err := os.ReadFile(fullPath)
 		if err != nil {
 			return err
 		}
 		logger.WithField("filename", destination).Debug("Copying file to working directory")
-		return ioutil.WriteFile(destination, b, info.Mode())
+		return os.WriteFile(destination, b, info.Mode())
 	})
 }

--- a/pkg/devicerepository/store/remote/schema_test.go
+++ b/pkg/devicerepository/store/remote/schema_test.go
@@ -15,7 +15,7 @@
 package remote
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -203,7 +203,7 @@ func TestProfile(t *testing.T) {
 	} {
 		t.Run(tc.profile, func(t *testing.T) {
 			a := assertions.New(t)
-			b, err := ioutil.ReadFile(filepath.Join("testdata", "vendor", "full-vendor", tc.profile+".yaml"))
+			b, err := os.ReadFile(filepath.Join("testdata", "vendor", "full-vendor", tc.profile+".yaml"))
 			if !a.So(err, should.BeNil) {
 				t.FailNow()
 			}

--- a/pkg/email/smtp/smtp_util_test.go
+++ b/pkg/email/smtp/smtp_util_test.go
@@ -16,7 +16,6 @@ package smtp
 
 import (
 	"io"
-	"io/ioutil"
 
 	"github.com/emersion/go-smtp"
 )
@@ -65,7 +64,7 @@ func (s *session) Rcpt(to string) error {
 }
 
 func (s *session) Data(r io.Reader) error {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/pkg/encoding/lorawan/mac.go
+++ b/pkg/encoding/lorawan/mac.go
@@ -17,7 +17,6 @@ package lorawan
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"time"
 
@@ -924,7 +923,7 @@ func (spec MACCommandSpec) read(phy band.Band, r io.Reader, isUplink bool, cmd *
 
 	desc, ok := spec[ret.Cid]
 	if !ok || desc == nil {
-		b, err := ioutil.ReadAll(r)
+		b, err := io.ReadAll(r)
 		if err != nil {
 			return err
 		}

--- a/pkg/errors/web/middleware_test.go
+++ b/pkg/errors/web/middleware_test.go
@@ -15,7 +15,7 @@
 package web_test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -104,7 +104,7 @@ func TestErrorHandling(t *testing.T) {
 			}
 
 			res := rec.Result()
-			b, err := ioutil.ReadAll(res.Body)
+			b, err := io.ReadAll(res.Body)
 			if !a.So(err, should.BeNil) {
 				t.FailNow()
 			}

--- a/pkg/fetch/bucket_test.go
+++ b/pkg/fetch/bucket_test.go
@@ -15,8 +15,6 @@
 package fetch_test
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/smartystreets/assertions"
@@ -30,14 +28,8 @@ func TestBucket(t *testing.T) {
 	a := assertions.New(t)
 	ctx := test.Context()
 
-	tmpDir, err := ioutil.TempDir("", "FetchTestBucket")
-	if err != nil {
-		t.Fatalf("Failed to create temporary directory: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
 	conf := config.BlobConfig{Provider: "local"}
-	conf.Local.Directory = tmpDir
+	conf.Local.Directory = t.TempDir()
 
 	filename := "file"
 	content := []byte("Hello world")

--- a/pkg/fetch/fs.go
+++ b/pkg/fetch/fs.go
@@ -15,7 +15,6 @@
 package fetch
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -38,7 +37,7 @@ func (f fsFetcher) File(pathElements ...string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	content, err := ioutil.ReadFile(rp)
+	content, err := os.ReadFile(rp)
 	if err == nil {
 		f.observeLatency(time.Since(start))
 		return content, nil

--- a/pkg/fetch/fs_test.go
+++ b/pkg/fetch/fs_test.go
@@ -15,7 +15,6 @@
 package fetch_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,7 +27,7 @@ import (
 type frequencyPlansFileSystem string
 
 func createMockFileSystem() (frequencyPlansFileSystem, error) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/fetch/http.go
+++ b/pkg/fetch/http.go
@@ -15,7 +15,7 @@
 package fetch
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -53,7 +53,7 @@ func (f httpFetcher) File(pathElements ...string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	result, err := ioutil.ReadAll(resp.Body)
+	result, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errCouldNotReadFile.WithCause(err).WithAttributes("filename", p)
 	}

--- a/pkg/gatewayconfigurationserver/server_test.go
+++ b/pkg/gatewayconfigurationserver/server_test.go
@@ -20,7 +20,7 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -171,7 +171,7 @@ func TestWeb(t *testing.T) {
 						if !a.So(res.Header.Get("Content-Type"), should.Equal, "application/json") {
 							t.FailNow()
 						}
-						b, err := ioutil.ReadAll(res.Body)
+						b, err := io.ReadAll(res.Body)
 						if err != nil {
 							t.Fatalf("Failed to read response body: %s", err)
 						}
@@ -197,7 +197,7 @@ func TestWeb(t *testing.T) {
 						if !a.So(res.Header.Get("Content-Type"), should.Equal, "application/json") {
 							t.FailNow()
 						}
-						b, err := ioutil.ReadAll(res.Body)
+						b, err := io.ReadAll(res.Body)
 						if err != nil {
 							t.Fatalf("Failed to read response body: %s", err)
 						}
@@ -223,7 +223,7 @@ func TestWeb(t *testing.T) {
 						if !a.So(res.Header.Get("Content-Type"), should.Equal, "application/toml") {
 							t.FailNow()
 						}
-						b, err := ioutil.ReadAll(res.Body)
+						b, err := io.ReadAll(res.Body)
 						if err != nil {
 							t.Fatalf("Failed to read response body: %s", err)
 						}

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -18,7 +18,7 @@ package gatewayserver
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	stdio "io"
 	stdlog "log"
 	"math"
 	"net"
@@ -305,7 +305,7 @@ func New(c *component.Component, conf *Config, opts ...Option) (gs *GatewayServe
 						Handler:           webServer,
 						ReadTimeout:       120 * time.Second,
 						ReadHeaderTimeout: 5 * time.Second,
-						ErrorLog:          stdlog.New(ioutil.Discard, "", 0),
+						ErrorLog:          stdlog.New(stdio.Discard, "", 0),
 					}
 					go func() {
 						<-ctx.Done()

--- a/pkg/i18n/i18n.go
+++ b/pkg/i18n/i18n.go
@@ -19,7 +19,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -130,7 +130,7 @@ var Global = make(MessageDescriptorMap)
 
 // ReadFile reads the descriptors from a file.
 func ReadFile(filename string) (MessageDescriptorMap, error) {
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +192,7 @@ func (m MessageDescriptorMap) WriteFile(filename string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filename, append(bytes, '\n'), 0644)
+	return os.WriteFile(filename, append(bytes, '\n'), 0644)
 }
 
 // Define a message.

--- a/pkg/interop/client.go
+++ b/pkg/interop/client.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"path/filepath"
 	"sort"
@@ -128,7 +127,7 @@ func httpExchange(ctx context.Context, httpReq *http.Request, res interface{}, d
 	logger = logger.WithField("http_code", httpRes.StatusCode)
 	logger.Debug("Receive interop HTTP response")
 
-	b, err := ioutil.ReadAll(httpRes.Body)
+	b, err := io.ReadAll(httpRes.Body)
 	if err != nil {
 		if err == io.EOF && res == nil {
 			return nil

--- a/pkg/interop/client_test.go
+++ b/pkg/interop/client_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -79,7 +79,7 @@ func TestGetAppSKey(t *testing.T) {
 					a := assertions.New(t)
 					a.So(r.Method, should.Equal, http.MethodPost)
 
-					b, err := ioutil.ReadAll(r.Body)
+					b, err := io.ReadAll(r.Body)
 					a.So(err, should.BeNil)
 					a.So(string(b), should.Equal, `{"ProtocolVersion":"1.0","TransactionID":0,"MessageType":"AppSKeyReq","SenderID":"test-as","ReceiverID":"70B3D57ED0000000","DevEUI":"0102030405060708","SessionKeyID":"016BFA7BAD4756346A674981E75CDBDC"}
 `)
@@ -94,24 +94,24 @@ func TestGetAppSKey(t *testing.T) {
 				}))
 			},
 			NewClientConfig: func(fqdn string, port uint32) (config.InteropClient, func() error) {
-				confDir := test.Must(ioutil.TempDir("", "lorawan-stack-js-interop-test")).(string)
+				confDir := test.Must(os.MkdirTemp("", "lorawan-stack-js-interop-test")).(string)
 				confPath := filepath.Join(confDir, InteropClientConfigurationName)
 				js1Path := filepath.Join(confDir, "test-js-1.yml")
 				js2Path := filepath.Join(confDir, "foo", "test-js-2.yml")
 				js3Path := filepath.Join(confDir, "test-js-3.yml")
 
 				test.MustMultiple(os.Mkdir(filepath.Join(confDir, "testdata"), 0755))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ClientCertPath), ClientCert, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ClientKeyPath), ClientKey, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ServerCertPath), ServerCert, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ServerKeyPath), ServerKey, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, RootCAPath), RootCA, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ClientCertPath), ClientCert, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ClientKeyPath), ClientKey, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ServerCertPath), ServerCert, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ServerKeyPath), ServerKey, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, RootCAPath), RootCA, 0644))
 
 				rel := func(path string) string {
 					return test.Must(filepath.Rel(confDir, path)).(string)
 				}
 
-				test.MustMultiple(ioutil.WriteFile(confPath, []byte(fmt.Sprintf(`join-servers:
+				test.MustMultiple(os.WriteFile(confPath, []byte(fmt.Sprintf(`join-servers:
    - file: %s
      join-euis:
         - 0000000000000000/0
@@ -130,7 +130,7 @@ func TestGetAppSKey(t *testing.T) {
 					rel(js3Path),
 				)), 0644))
 
-				test.MustMultiple(ioutil.WriteFile(js1Path, []byte(fmt.Sprintf(`fqdn: test-js.fqdn
+				test.MustMultiple(os.WriteFile(js1Path, []byte(fmt.Sprintf(`fqdn: test-js.fqdn
 port: 12345
 protocol: BI1.1
 tls:
@@ -146,7 +146,7 @@ headers:
 				)), 0644))
 
 				test.MustMultiple(os.Mkdir(filepath.Join(confDir, "foo"), 0755))
-				test.MustMultiple(ioutil.WriteFile(js2Path, []byte(fmt.Sprintf(`fqdn: %s
+				test.MustMultiple(os.WriteFile(js2Path, []byte(fmt.Sprintf(`fqdn: %s
 port: %d
 protocol: BI1.0
 paths:
@@ -166,7 +166,7 @@ headers:
 					filepath.Join("..", ClientKeyPath),
 				)), 0644))
 
-				test.MustMultiple(ioutil.WriteFile(js3Path, []byte(`dns: invalid.dns
+				test.MustMultiple(os.WriteFile(js3Path, []byte(`dns: invalid.dns
 protocol: BI1.1
 paths:
    join: test-join-path
@@ -198,7 +198,7 @@ paths:
 					a := assertions.New(t)
 					a.So(r.Method, should.Equal, http.MethodPost)
 
-					b, err := ioutil.ReadAll(r.Body)
+					b, err := io.ReadAll(r.Body)
 					a.So(err, should.BeNil)
 					a.So(string(b), should.Equal, `{"ProtocolVersion":"1.1","TransactionID":0,"MessageType":"AppSKeyReq","SenderID":"test-as","ReceiverID":"70B3D57ED0000000","DevEUI":"0102030405060708","SessionKeyID":"016BFA7BAD4756346A674981E75CDBDC"}
 `)
@@ -213,24 +213,24 @@ paths:
 				}))
 			},
 			NewClientConfig: func(fqdn string, port uint32) (config.InteropClient, func() error) {
-				confDir := test.Must(ioutil.TempDir("", "lorawan-stack-js-interop-test")).(string)
+				confDir := test.Must(os.MkdirTemp("", "lorawan-stack-js-interop-test")).(string)
 				confPath := filepath.Join(confDir, InteropClientConfigurationName)
 				js1Path := filepath.Join(confDir, "test-js-1.yml")
 				js2Path := filepath.Join(confDir, "foo", "test-js-2.yml")
 				js3Path := filepath.Join(confDir, "test-js-3.yml")
 
 				test.MustMultiple(os.Mkdir(filepath.Join(confDir, "testdata"), 0755))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ClientCertPath), ClientCert, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ClientKeyPath), ClientKey, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ServerCertPath), ServerCert, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ServerKeyPath), ServerKey, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, RootCAPath), RootCA, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ClientCertPath), ClientCert, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ClientKeyPath), ClientKey, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ServerCertPath), ServerCert, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ServerKeyPath), ServerKey, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, RootCAPath), RootCA, 0644))
 
 				rel := func(path string) string {
 					return test.Must(filepath.Rel(confDir, path)).(string)
 				}
 
-				test.MustMultiple(ioutil.WriteFile(confPath, []byte(fmt.Sprintf(`join-servers:
+				test.MustMultiple(os.WriteFile(confPath, []byte(fmt.Sprintf(`join-servers:
    - file: %s
      join-euis:
         - 0000000000000000/0
@@ -249,7 +249,7 @@ paths:
 					rel(js3Path),
 				)), 0644))
 
-				test.MustMultiple(ioutil.WriteFile(js1Path, []byte(fmt.Sprintf(`fqdn: test-js.fqdn
+				test.MustMultiple(os.WriteFile(js1Path, []byte(fmt.Sprintf(`fqdn: test-js.fqdn
 port: 12345
 protocol: BI1.0
 tls:
@@ -265,7 +265,7 @@ headers:
 				)), 0644))
 
 				test.MustMultiple(os.Mkdir(filepath.Join(confDir, "foo"), 0755))
-				test.MustMultiple(ioutil.WriteFile(js2Path, []byte(fmt.Sprintf(`fqdn: %s
+				test.MustMultiple(os.WriteFile(js2Path, []byte(fmt.Sprintf(`fqdn: %s
 port: %d
 protocol: BI1.1
 paths:
@@ -285,7 +285,7 @@ headers:
 					filepath.Join("..", ClientKeyPath),
 				)), 0644))
 
-				test.MustMultiple(ioutil.WriteFile(js3Path, []byte(`dns: invalid.dns
+				test.MustMultiple(os.WriteFile(js3Path, []byte(`dns: invalid.dns
 protocol: BI1.0
 paths:
    join: test-join-path
@@ -317,7 +317,7 @@ paths:
 					a := assertions.New(t)
 					a.So(r.Method, should.Equal, http.MethodPost)
 
-					b, err := ioutil.ReadAll(r.Body)
+					b, err := io.ReadAll(r.Body)
 					a.So(err, should.BeNil)
 					a.So(string(b), should.Equal, `{"ProtocolVersion":"1.0","TransactionID":0,"MessageType":"AppSKeyReq","SenderID":"test-as","ReceiverID":"70B3D57ED0000000","DevEUI":"0102030405060708","SessionKeyID":"016BFA7BAD4756346A674981E75CDBDC"}
 `)
@@ -344,24 +344,24 @@ paths:
 				}))
 			},
 			NewClientConfig: func(fqdn string, port uint32) (config.InteropClient, func() error) {
-				confDir := test.Must(ioutil.TempDir("", "lorawan-stack-js-interop-test")).(string)
+				confDir := test.Must(os.MkdirTemp("", "lorawan-stack-js-interop-test")).(string)
 				confPath := filepath.Join(confDir, InteropClientConfigurationName)
 				js1Path := filepath.Join(confDir, "test-js-1.yml")
 				js2Path := filepath.Join(confDir, "foo", "test-js-2.yml")
 				js3Path := filepath.Join(confDir, "test-js-3.yml")
 
 				test.MustMultiple(os.Mkdir(filepath.Join(confDir, "testdata"), 0755))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ClientCertPath), ClientCert, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ClientKeyPath), ClientKey, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ServerCertPath), ServerCert, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ServerKeyPath), ServerKey, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, RootCAPath), RootCA, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ClientCertPath), ClientCert, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ClientKeyPath), ClientKey, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ServerCertPath), ServerCert, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ServerKeyPath), ServerKey, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, RootCAPath), RootCA, 0644))
 
 				rel := func(path string) string {
 					return test.Must(filepath.Rel(confDir, path)).(string)
 				}
 
-				test.MustMultiple(ioutil.WriteFile(confPath, []byte(fmt.Sprintf(`join-servers:
+				test.MustMultiple(os.WriteFile(confPath, []byte(fmt.Sprintf(`join-servers:
    - file: %s
      join-euis:
         - 0000000000000000/0
@@ -380,7 +380,7 @@ paths:
 					rel(js3Path),
 				)), 0644))
 
-				test.MustMultiple(ioutil.WriteFile(js1Path, []byte(fmt.Sprintf(`fqdn: test-js.fqdn
+				test.MustMultiple(os.WriteFile(js1Path, []byte(fmt.Sprintf(`fqdn: test-js.fqdn
 port: 12345
 protocol: BI1.1
 tls:
@@ -396,7 +396,7 @@ headers:
 				)), 0644))
 
 				test.MustMultiple(os.Mkdir(filepath.Join(confDir, "foo"), 0755))
-				test.MustMultiple(ioutil.WriteFile(js2Path, []byte(fmt.Sprintf(`fqdn: %s
+				test.MustMultiple(os.WriteFile(js2Path, []byte(fmt.Sprintf(`fqdn: %s
 port: %d
 protocol: BI1.0
 paths:
@@ -416,7 +416,7 @@ headers:
 					filepath.Join("..", ClientKeyPath),
 				)), 0644))
 
-				test.MustMultiple(ioutil.WriteFile(js3Path, []byte(`dns: invalid.dns
+				test.MustMultiple(os.WriteFile(js3Path, []byte(`dns: invalid.dns
 protocol: BI1.1
 paths:
    join: test-join-path
@@ -453,7 +453,7 @@ paths:
 					a := assertions.New(t)
 					a.So(r.Method, should.Equal, http.MethodPost)
 
-					b, err := ioutil.ReadAll(r.Body)
+					b, err := io.ReadAll(r.Body)
 					a.So(err, should.BeNil)
 					a.So(string(b), should.Equal, `{"ProtocolVersion":"1.1","TransactionID":0,"MessageType":"AppSKeyReq","SenderID":"test-as","ReceiverID":"70B3D57ED0000000","DevEUI":"0102030405060708","SessionKeyID":"016BFA7BAD4756346A674981E75CDBDC"}
 `)
@@ -480,24 +480,24 @@ paths:
 				}))
 			},
 			NewClientConfig: func(fqdn string, port uint32) (config.InteropClient, func() error) {
-				confDir := test.Must(ioutil.TempDir("", "lorawan-stack-js-interop-test")).(string)
+				confDir := test.Must(os.MkdirTemp("", "lorawan-stack-js-interop-test")).(string)
 				confPath := filepath.Join(confDir, InteropClientConfigurationName)
 				js1Path := filepath.Join(confDir, "test-js-1.yml")
 				js2Path := filepath.Join(confDir, "foo", "test-js-2.yml")
 				js3Path := filepath.Join(confDir, "test-js-3.yml")
 
 				test.MustMultiple(os.Mkdir(filepath.Join(confDir, "testdata"), 0755))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ClientCertPath), ClientCert, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ClientKeyPath), ClientKey, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ServerCertPath), ServerCert, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ServerKeyPath), ServerKey, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, RootCAPath), RootCA, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ClientCertPath), ClientCert, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ClientKeyPath), ClientKey, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ServerCertPath), ServerCert, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ServerKeyPath), ServerKey, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, RootCAPath), RootCA, 0644))
 
 				rel := func(path string) string {
 					return test.Must(filepath.Rel(confDir, path)).(string)
 				}
 
-				test.MustMultiple(ioutil.WriteFile(confPath, []byte(fmt.Sprintf(`join-servers:
+				test.MustMultiple(os.WriteFile(confPath, []byte(fmt.Sprintf(`join-servers:
    - file: %s
      join-euis:
         - 0000000000000000/0
@@ -516,7 +516,7 @@ paths:
 					rel(js3Path),
 				)), 0644))
 
-				test.MustMultiple(ioutil.WriteFile(js1Path, []byte(fmt.Sprintf(`fqdn: test-js.fqdn
+				test.MustMultiple(os.WriteFile(js1Path, []byte(fmt.Sprintf(`fqdn: test-js.fqdn
 port: 12345
 protocol: BI1.0
 tls:
@@ -532,7 +532,7 @@ headers:
 				)), 0644))
 
 				test.MustMultiple(os.Mkdir(filepath.Join(confDir, "foo"), 0755))
-				test.MustMultiple(ioutil.WriteFile(js2Path, []byte(fmt.Sprintf(`fqdn: %s
+				test.MustMultiple(os.WriteFile(js2Path, []byte(fmt.Sprintf(`fqdn: %s
 port: %d
 protocol: BI1.1
 paths:
@@ -552,7 +552,7 @@ headers:
 					filepath.Join("..", ClientKeyPath),
 				)), 0644))
 
-				test.MustMultiple(ioutil.WriteFile(js3Path, []byte(`dns: invalid.dns
+				test.MustMultiple(os.WriteFile(js3Path, []byte(`dns: invalid.dns
 protocol: BI1.0
 paths:
    join: test-join-path
@@ -648,7 +648,7 @@ func TestHandleJoinRequest(t *testing.T) {
 					a := assertions.New(t)
 					a.So(r.Method, should.Equal, http.MethodPost)
 
-					b, err := ioutil.ReadAll(r.Body)
+					b, err := io.ReadAll(r.Body)
 					a.So(err, should.BeNil)
 					a.So(string(b), should.Equal, `{"ProtocolVersion":"1.0","TransactionID":0,"MessageType":"JoinReq","SenderID":"42FFFF","ReceiverID":"70B3D57ED0000000","MACVersion":"1.0.3","PHYPayload":"00000000D07ED5B370080706050403020100003851F0B6","DevEUI":"0102030405060708","DevAddr":"01020304","DLSettings":"00","RxDelay":5,"CFList":""}
 `)
@@ -663,24 +663,24 @@ func TestHandleJoinRequest(t *testing.T) {
 				}))
 			},
 			NewClientConfig: func(fqdn string, port uint32) (config.InteropClient, func() error) {
-				confDir := test.Must(ioutil.TempDir("", "lorawan-stack-js-interop-test")).(string)
+				confDir := test.Must(os.MkdirTemp("", "lorawan-stack-js-interop-test")).(string)
 				confPath := filepath.Join(confDir, InteropClientConfigurationName)
 				js1Path := filepath.Join(confDir, "test-js-1.yml")
 				js2Path := filepath.Join(confDir, "foo", "test-js-2.yml")
 				js3Path := filepath.Join(confDir, "test-js-3.yml")
 
 				test.MustMultiple(os.Mkdir(filepath.Join(confDir, "testdata"), 0755))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ClientCertPath), ClientCert, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ClientKeyPath), ClientKey, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ServerCertPath), ServerCert, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ServerKeyPath), ServerKey, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, RootCAPath), RootCA, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ClientCertPath), ClientCert, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ClientKeyPath), ClientKey, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ServerCertPath), ServerCert, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ServerKeyPath), ServerKey, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, RootCAPath), RootCA, 0644))
 
 				rel := func(path string) string {
 					return test.Must(filepath.Rel(confDir, path)).(string)
 				}
 
-				test.MustMultiple(ioutil.WriteFile(confPath, []byte(fmt.Sprintf(`join-servers:
+				test.MustMultiple(os.WriteFile(confPath, []byte(fmt.Sprintf(`join-servers:
    - file: %s
      join-euis:
         - 0000000000000000/0
@@ -699,7 +699,7 @@ func TestHandleJoinRequest(t *testing.T) {
 					rel(js3Path),
 				)), 0644))
 
-				test.MustMultiple(ioutil.WriteFile(js1Path, []byte(fmt.Sprintf(`fqdn: test-js.fqdn
+				test.MustMultiple(os.WriteFile(js1Path, []byte(fmt.Sprintf(`fqdn: test-js.fqdn
 port: 12345
 protocol: BI1.1
 tls:
@@ -715,7 +715,7 @@ headers:
 				)), 0644))
 
 				test.MustMultiple(os.Mkdir(filepath.Join(confDir, "foo"), 0755))
-				test.MustMultiple(ioutil.WriteFile(js2Path, []byte(fmt.Sprintf(`fqdn: %s
+				test.MustMultiple(os.WriteFile(js2Path, []byte(fmt.Sprintf(`fqdn: %s
 port: %d
 protocol: BI1.0
 paths:
@@ -735,7 +735,7 @@ headers:
 					filepath.Join("..", ClientKeyPath),
 				)), 0644))
 
-				test.MustMultiple(ioutil.WriteFile(js3Path, []byte(`dns: invalid.dns
+				test.MustMultiple(os.WriteFile(js3Path, []byte(`dns: invalid.dns
 protocol: BI1.1
 paths:
    join: test-join-path
@@ -767,7 +767,7 @@ paths:
 					a := assertions.New(t)
 					a.So(r.Method, should.Equal, http.MethodPost)
 
-					b, err := ioutil.ReadAll(r.Body)
+					b, err := io.ReadAll(r.Body)
 					a.So(err, should.BeNil)
 					a.So(string(b), should.Equal, `{"ProtocolVersion":"1.1","TransactionID":0,"MessageType":"JoinReq","SenderID":"42FFFF","ReceiverID":"70B3D57ED0000000","MACVersion":"1.0.3","PHYPayload":"00000000D07ED5B370080706050403020100003851F0B6","DevEUI":"0102030405060708","DevAddr":"01020304","DLSettings":"00","RxDelay":5,"CFList":""}
 `)
@@ -782,24 +782,24 @@ paths:
 				}))
 			},
 			NewClientConfig: func(fqdn string, port uint32) (config.InteropClient, func() error) {
-				confDir := test.Must(ioutil.TempDir("", "lorawan-stack-js-interop-test")).(string)
+				confDir := test.Must(os.MkdirTemp("", "lorawan-stack-js-interop-test")).(string)
 				confPath := filepath.Join(confDir, InteropClientConfigurationName)
 				js1Path := filepath.Join(confDir, "test-js-1.yml")
 				js2Path := filepath.Join(confDir, "foo", "test-js-2.yml")
 				js3Path := filepath.Join(confDir, "test-js-3.yml")
 
 				test.MustMultiple(os.Mkdir(filepath.Join(confDir, "testdata"), 0755))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ClientCertPath), ClientCert, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ClientKeyPath), ClientKey, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ServerCertPath), ServerCert, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ServerKeyPath), ServerKey, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, RootCAPath), RootCA, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ClientCertPath), ClientCert, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ClientKeyPath), ClientKey, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ServerCertPath), ServerCert, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ServerKeyPath), ServerKey, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, RootCAPath), RootCA, 0644))
 
 				rel := func(path string) string {
 					return test.Must(filepath.Rel(confDir, path)).(string)
 				}
 
-				test.MustMultiple(ioutil.WriteFile(confPath, []byte(fmt.Sprintf(`join-servers:
+				test.MustMultiple(os.WriteFile(confPath, []byte(fmt.Sprintf(`join-servers:
    - file: %s
      join-euis:
         - 0000000000000000/0
@@ -818,7 +818,7 @@ paths:
 					rel(js3Path),
 				)), 0644))
 
-				test.MustMultiple(ioutil.WriteFile(js1Path, []byte(fmt.Sprintf(`fqdn: test-js.fqdn
+				test.MustMultiple(os.WriteFile(js1Path, []byte(fmt.Sprintf(`fqdn: test-js.fqdn
 port: 12345
 protocol: BI1.0
 tls:
@@ -834,7 +834,7 @@ headers:
 				)), 0644))
 
 				test.MustMultiple(os.Mkdir(filepath.Join(confDir, "foo"), 0755))
-				test.MustMultiple(ioutil.WriteFile(js2Path, []byte(fmt.Sprintf(`fqdn: %s
+				test.MustMultiple(os.WriteFile(js2Path, []byte(fmt.Sprintf(`fqdn: %s
 port: %d
 protocol: BI1.1
 paths:
@@ -854,7 +854,7 @@ headers:
 					filepath.Join("..", ClientKeyPath),
 				)), 0644))
 
-				test.MustMultiple(ioutil.WriteFile(js3Path, []byte(`dns: invalid.dns
+				test.MustMultiple(os.WriteFile(js3Path, []byte(`dns: invalid.dns
 protocol: BI1.0
 paths:
    join: test-join-path
@@ -886,7 +886,7 @@ paths:
 					a := assertions.New(t)
 					a.So(r.Method, should.Equal, http.MethodPost)
 
-					b, err := ioutil.ReadAll(r.Body)
+					b, err := io.ReadAll(r.Body)
 					a.So(err, should.BeNil)
 					a.So(string(b), should.Equal, `{"ProtocolVersion":"1.0","TransactionID":0,"MessageType":"JoinReq","SenderID":"42FFFF","ReceiverID":"70B3D57ED0000000","MACVersion":"1.0.3","PHYPayload":"00000000D07ED5B370080706050403020100003851F0B6","DevEUI":"0102030405060708","DevAddr":"01020304","DLSettings":"00","RxDelay":5,"CFList":""}
 `)
@@ -918,24 +918,24 @@ paths:
 				}))
 			},
 			NewClientConfig: func(fqdn string, port uint32) (config.InteropClient, func() error) {
-				confDir := test.Must(ioutil.TempDir("", "lorawan-stack-js-interop-test")).(string)
+				confDir := test.Must(os.MkdirTemp("", "lorawan-stack-js-interop-test")).(string)
 				confPath := filepath.Join(confDir, InteropClientConfigurationName)
 				js1Path := filepath.Join(confDir, "test-js-1.yml")
 				js2Path := filepath.Join(confDir, "foo", "test-js-2.yml")
 				js3Path := filepath.Join(confDir, "test-js-3.yml")
 
 				test.MustMultiple(os.Mkdir(filepath.Join(confDir, "testdata"), 0755))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ClientCertPath), ClientCert, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ClientKeyPath), ClientKey, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ServerCertPath), ServerCert, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ServerKeyPath), ServerKey, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, RootCAPath), RootCA, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ClientCertPath), ClientCert, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ClientKeyPath), ClientKey, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ServerCertPath), ServerCert, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ServerKeyPath), ServerKey, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, RootCAPath), RootCA, 0644))
 
 				rel := func(path string) string {
 					return test.Must(filepath.Rel(confDir, path)).(string)
 				}
 
-				test.MustMultiple(ioutil.WriteFile(confPath, []byte(fmt.Sprintf(`join-servers:
+				test.MustMultiple(os.WriteFile(confPath, []byte(fmt.Sprintf(`join-servers:
    - file: %s
      join-euis:
         - 0000000000000000/0
@@ -954,7 +954,7 @@ paths:
 					rel(js3Path),
 				)), 0644))
 
-				test.MustMultiple(ioutil.WriteFile(js1Path, []byte(fmt.Sprintf(`fqdn: test-js.fqdn
+				test.MustMultiple(os.WriteFile(js1Path, []byte(fmt.Sprintf(`fqdn: test-js.fqdn
 port: 12345
 protocol: BI1.1
 tls:
@@ -970,7 +970,7 @@ headers:
 				)), 0644))
 
 				test.MustMultiple(os.Mkdir(filepath.Join(confDir, "foo"), 0755))
-				test.MustMultiple(ioutil.WriteFile(js2Path, []byte(fmt.Sprintf(`fqdn: %s
+				test.MustMultiple(os.WriteFile(js2Path, []byte(fmt.Sprintf(`fqdn: %s
 port: %d
 protocol: BI1.0
 paths:
@@ -990,7 +990,7 @@ headers:
 					filepath.Join("..", ClientKeyPath),
 				)), 0644))
 
-				test.MustMultiple(ioutil.WriteFile(js3Path, []byte(`dns: invalid.dns
+				test.MustMultiple(os.WriteFile(js3Path, []byte(`dns: invalid.dns
 protocol: BI1.1
 paths:
    join: test-join-path
@@ -1035,7 +1035,7 @@ paths:
 					a := assertions.New(t)
 					a.So(r.Method, should.Equal, http.MethodPost)
 
-					b, err := ioutil.ReadAll(r.Body)
+					b, err := io.ReadAll(r.Body)
 					a.So(err, should.BeNil)
 					a.So(string(b), should.Equal, `{"ProtocolVersion":"1.1","TransactionID":0,"MessageType":"JoinReq","SenderID":"42FFFF","ReceiverID":"70B3D57ED0000000","MACVersion":"1.0.3","PHYPayload":"00000000D07ED5B370080706050403020100003851F0B6","DevEUI":"0102030405060708","DevAddr":"01020304","DLSettings":"00","RxDelay":5,"CFList":""}
 `)
@@ -1067,24 +1067,24 @@ paths:
 				}))
 			},
 			NewClientConfig: func(fqdn string, port uint32) (config.InteropClient, func() error) {
-				confDir := test.Must(ioutil.TempDir("", "lorawan-stack-js-interop-test")).(string)
+				confDir := test.Must(os.MkdirTemp("", "lorawan-stack-js-interop-test")).(string)
 				confPath := filepath.Join(confDir, InteropClientConfigurationName)
 				js1Path := filepath.Join(confDir, "test-js-1.yml")
 				js2Path := filepath.Join(confDir, "foo", "test-js-2.yml")
 				js3Path := filepath.Join(confDir, "test-js-3.yml")
 
 				test.MustMultiple(os.Mkdir(filepath.Join(confDir, "testdata"), 0755))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ClientCertPath), ClientCert, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ClientKeyPath), ClientKey, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ServerCertPath), ServerCert, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ServerKeyPath), ServerKey, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, RootCAPath), RootCA, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ClientCertPath), ClientCert, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ClientKeyPath), ClientKey, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ServerCertPath), ServerCert, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ServerKeyPath), ServerKey, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, RootCAPath), RootCA, 0644))
 
 				rel := func(path string) string {
 					return test.Must(filepath.Rel(confDir, path)).(string)
 				}
 
-				test.MustMultiple(ioutil.WriteFile(confPath, []byte(fmt.Sprintf(`join-servers:
+				test.MustMultiple(os.WriteFile(confPath, []byte(fmt.Sprintf(`join-servers:
    - file: %s
      join-euis:
         - 0000000000000000/0
@@ -1103,7 +1103,7 @@ paths:
 					rel(js3Path),
 				)), 0644))
 
-				test.MustMultiple(ioutil.WriteFile(js1Path, []byte(fmt.Sprintf(`fqdn: test-js.fqdn
+				test.MustMultiple(os.WriteFile(js1Path, []byte(fmt.Sprintf(`fqdn: test-js.fqdn
 port: 12345
 protocol: BI1.0
 tls:
@@ -1119,7 +1119,7 @@ headers:
 				)), 0644))
 
 				test.MustMultiple(os.Mkdir(filepath.Join(confDir, "foo"), 0755))
-				test.MustMultiple(ioutil.WriteFile(js2Path, []byte(fmt.Sprintf(`fqdn: %s
+				test.MustMultiple(os.WriteFile(js2Path, []byte(fmt.Sprintf(`fqdn: %s
 port: %d
 protocol: BI1.1
 paths:
@@ -1139,7 +1139,7 @@ headers:
 					filepath.Join("..", ClientKeyPath),
 				)), 0644))
 
-				test.MustMultiple(ioutil.WriteFile(js3Path, []byte(`dns: invalid.dns
+				test.MustMultiple(os.WriteFile(js3Path, []byte(`dns: invalid.dns
 protocol: BI1.0
 paths:
    join: test-join-path
@@ -1184,7 +1184,7 @@ paths:
 					a := assertions.New(t)
 					a.So(r.Method, should.Equal, http.MethodPost)
 
-					b, err := ioutil.ReadAll(r.Body)
+					b, err := io.ReadAll(r.Body)
 					a.So(err, should.BeNil)
 					a.So(string(b), should.Equal, `{"ProtocolVersion":"1.1","TransactionID":0,"MessageType":"JoinReq","SenderID":"42FFFF","ReceiverID":"70B3D57ED0000000","MACVersion":"1.0.3","PHYPayload":"00000000D07ED5B370080706050403020100003851F0B6","DevEUI":"0102030405060708","DevAddr":"01020304","DLSettings":"00","RxDelay":5,"CFList":""}
 `)
@@ -1215,24 +1215,24 @@ paths:
 				}))
 			},
 			NewClientConfig: func(fqdn string, port uint32) (config.InteropClient, func() error) {
-				confDir := test.Must(ioutil.TempDir("", "lorawan-stack-js-interop-test")).(string)
+				confDir := test.Must(os.MkdirTemp("", "lorawan-stack-js-interop-test")).(string)
 				confPath := filepath.Join(confDir, InteropClientConfigurationName)
 				js1Path := filepath.Join(confDir, "test-js-1.yml")
 				js2Path := filepath.Join(confDir, "foo", "test-js-2.yml")
 				js3Path := filepath.Join(confDir, "test-js-3.yml")
 
 				test.MustMultiple(os.Mkdir(filepath.Join(confDir, "testdata"), 0755))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ClientCertPath), ClientCert, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ClientKeyPath), ClientKey, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ServerCertPath), ServerCert, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, ServerKeyPath), ServerKey, 0644))
-				test.MustMultiple(ioutil.WriteFile(filepath.Join(confDir, RootCAPath), RootCA, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ClientCertPath), ClientCert, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ClientKeyPath), ClientKey, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ServerCertPath), ServerCert, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, ServerKeyPath), ServerKey, 0644))
+				test.MustMultiple(os.WriteFile(filepath.Join(confDir, RootCAPath), RootCA, 0644))
 
 				rel := func(path string) string {
 					return test.Must(filepath.Rel(confDir, path)).(string)
 				}
 
-				test.MustMultiple(ioutil.WriteFile(confPath, []byte(fmt.Sprintf(`join-servers:
+				test.MustMultiple(os.WriteFile(confPath, []byte(fmt.Sprintf(`join-servers:
    - file: %s
      join-euis:
         - 0000000000000000/0
@@ -1251,7 +1251,7 @@ paths:
 					rel(js3Path),
 				)), 0644))
 
-				test.MustMultiple(ioutil.WriteFile(js1Path, []byte(fmt.Sprintf(`fqdn: test-js.fqdn
+				test.MustMultiple(os.WriteFile(js1Path, []byte(fmt.Sprintf(`fqdn: test-js.fqdn
 port: 12345
 protocol: BI1.0
 tls:
@@ -1267,7 +1267,7 @@ headers:
 				)), 0644))
 
 				test.MustMultiple(os.Mkdir(filepath.Join(confDir, "foo"), 0755))
-				test.MustMultiple(ioutil.WriteFile(js2Path, []byte(fmt.Sprintf(`fqdn: %s
+				test.MustMultiple(os.WriteFile(js2Path, []byte(fmt.Sprintf(`fqdn: %s
 port: %d
 protocol: BI1.1
 paths:
@@ -1287,7 +1287,7 @@ headers:
 					filepath.Join("..", ClientKeyPath),
 				)), 0644))
 
-				test.MustMultiple(ioutil.WriteFile(js3Path, []byte(`dns: invalid.dns
+				test.MustMultiple(os.WriteFile(js3Path, []byte(`dns: invalid.dns
 protocol: BI1.0
 paths:
    join: test-join-path

--- a/pkg/interop/config.go
+++ b/pkg/interop/config.go
@@ -19,7 +19,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
+	"os"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/config/tlsconfig"
@@ -104,7 +104,7 @@ func fetchSenderClientCAs(ctx context.Context, conf config.InteropServer) (map[s
 	if len(conf.SenderClientCADeprecated) > 0 {
 		senderClientCAs = make(map[string][]*x509.Certificate, len(conf.SenderClientCA.Static))
 		for id, filename := range conf.SenderClientCADeprecated {
-			b, err := ioutil.ReadFile(filename)
+			b, err := os.ReadFile(filename)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/interop/server.go
+++ b/pkg/interop/server.go
@@ -19,7 +19,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -185,7 +185,7 @@ func (s *Server) handle() http.Handler {
 		ctx := events.ContextWithCorrelationID(r.Context(), cid)
 		logger := log.FromContext(ctx)
 
-		data, err := ioutil.ReadAll(r.Body)
+		data, err := io.ReadAll(r.Body)
 		if err != nil {
 			logger.WithError(err).Debug("Failed to read body")
 			w.WriteHeader(http.StatusBadRequest)

--- a/pkg/interop/util_test.go
+++ b/pkg/interop/util_test.go
@@ -20,9 +20,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 
 	"github.com/gorilla/mux"
@@ -34,19 +34,19 @@ import (
 
 var (
 	RootCAPath = filepath.Join("testdata", "rootCA.pem")
-	RootCA     = test.Must(ioutil.ReadFile(RootCAPath)).([]byte)
+	RootCA     = test.Must(os.ReadFile(RootCAPath)).([]byte)
 
 	ClientCertPath = filepath.Join("testdata", "clientcert.pem")
-	ClientCert     = test.Must(ioutil.ReadFile(ClientCertPath)).([]byte)
+	ClientCert     = test.Must(os.ReadFile(ClientCertPath)).([]byte)
 
 	ClientKeyPath = filepath.Join("testdata", "clientkey.pem")
-	ClientKey     = test.Must(ioutil.ReadFile(ClientKeyPath)).([]byte)
+	ClientKey     = test.Must(os.ReadFile(ClientKeyPath)).([]byte)
 
 	ServerCertPath = filepath.Join("testdata", "servercert.pem")
-	ServerCert     = test.Must(ioutil.ReadFile(ServerCertPath)).([]byte)
+	ServerCert     = test.Must(os.ReadFile(ServerCertPath)).([]byte)
 
 	ServerKeyPath = filepath.Join("testdata", "serverkey.pem")
-	ServerKey     = test.Must(ioutil.ReadFile(ServerKeyPath)).([]byte)
+	ServerKey     = test.Must(os.ReadFile(ServerKeyPath)).([]byte)
 )
 
 func makeCertPool() *x509.CertPool {

--- a/pkg/oauth/server_test.go
+++ b/pkg/oauth/server_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
@@ -516,7 +516,7 @@ func TestOAuthFlow(t *testing.T) {
 				req.Header.Set("Content-Type", contentType)
 			}
 			if body != nil {
-				req.Body = ioutil.NopCloser(body)
+				req.Body = io.NopCloser(body)
 				req.ContentLength = int64(body.Len())
 			}
 

--- a/pkg/packetbroker/token.go
+++ b/pkg/packetbroker/token.go
@@ -17,7 +17,7 @@ package packetbroker
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -237,7 +237,7 @@ func PublicKeyFromURL(client *http.Client, url string) PublicKeyProvider {
 			return nil, errFetchToken.WithCause(err)
 		}
 		defer res.Body.Close()
-		buf, err := ioutil.ReadAll(res.Body)
+		buf, err := io.ReadAll(res.Body)
 		if err != nil {
 			return nil, errFetchToken.WithCause(err)
 		}

--- a/pkg/redis/codec/main.go
+++ b/pkg/redis/codec/main.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 
@@ -74,7 +74,7 @@ func main() {
 		}
 		return
 	}
-	b, err := ioutil.ReadAll(os.Stdin)
+	b, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		log.Fatalf("Failed to read from stdin: %v", err)
 	}

--- a/pkg/rpcmiddleware/discover/discover_test.go
+++ b/pkg/rpcmiddleware/discover/discover_test.go
@@ -19,8 +19,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"testing"
 
 	"github.com/smartystreets/assertions"
@@ -186,7 +186,7 @@ func TestDialContext(t *testing.T) {
 			clientTLSConfig := &tls.Config{
 				RootCAs: x509.NewCertPool(),
 			}
-			serverCA := test.Must(ioutil.ReadFile("testdata/serverca.pem")).([]byte)
+			serverCA := test.Must(os.ReadFile("testdata/serverca.pem")).([]byte)
 			clientTLSConfig.RootCAs.AppendCertsFromPEM(serverCA)
 
 			var dialAddresses []string

--- a/pkg/ttnpb/ttnpb_encoding_test.go
+++ b/pkg/ttnpb/ttnpb_encoding_test.go
@@ -18,7 +18,6 @@ import (
 	"encoding"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -508,11 +507,11 @@ func TestMarshalers(t *testing.T) {
 	)
 	goldenPath := filepath.Join("testdata", "ttnpb_encoding_golden.md")
 	if os.Getenv("TEST_WRITE_GOLDEN") == "1" {
-		if err := ioutil.WriteFile(goldenPath, []byte(out), 0o644); err != nil {
+		if err := os.WriteFile(goldenPath, []byte(out), 0o644); err != nil {
 			t.Fatalf("Failed to write golden file: %s", err)
 		}
 	} else {
-		prevOut, err := ioutil.ReadFile(goldenPath)
+		prevOut, err := os.ReadFile(goldenPath)
 		if err != nil {
 			t.Fatalf("Failed to read golden file: %s", err)
 		}

--- a/pkg/util/test/generate_constructors.go
+++ b/pkg/util/test/generate_constructors.go
@@ -20,7 +20,6 @@ package main
 import (
 	"bytes"
 	"go/format"
-	"io/ioutil"
 	"log"
 	"os"
 	"reflect"
@@ -170,7 +169,7 @@ func Make{{ $type.Name }}(opts ...{{ $optionType }}) *{{ $typeString }} {
 	if err != nil {
 		log.Fatalf("Failed to format source: %s", err)
 	}
-	if err := ioutil.WriteFile("constructors_generated.go", b, 0o644); err != nil {
+	if err := os.WriteFile("constructors_generated.go", b, 0o644); err != nil {
 		log.Fatalf("Failed to write output: %s", err)
 	}
 }

--- a/pkg/web/error_handler_test.go
+++ b/pkg/web/error_handler_test.go
@@ -15,7 +15,7 @@
 package web
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -47,7 +47,7 @@ func TestErrorHandler(t *testing.T) {
 
 		resp := rec.Result()
 
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		a.So(string(body), should.ContainSubstring, "This handler throws an error")
 	}
 
@@ -59,7 +59,7 @@ func TestErrorHandler(t *testing.T) {
 
 		resp := rec.Result()
 
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		a.So(resp.StatusCode, should.Equal, http.StatusNotImplemented)
 		a.So(string(body), should.ContainSubstring, "Not Implemented")
 	}
@@ -72,7 +72,7 @@ func TestErrorHandler(t *testing.T) {
 
 		resp := rec.Result()
 
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		a.So(resp.StatusCode, should.Equal, http.StatusNotFound)
 		a.So(string(body), should.ContainSubstring, "route `/not_found` not found")
 	}

--- a/pkg/web/logger.go
+++ b/pkg/web/logger.go
@@ -16,7 +16,6 @@ package web
 
 import (
 	"io"
-	"io/ioutil"
 
 	echo "github.com/labstack/echo/v4"
 	"github.com/labstack/gommon/log"
@@ -29,7 +28,7 @@ func NewNoopLogger() echo.Logger {
 
 type noopLogger struct{}
 
-func (n *noopLogger) Output() io.Writer                         { return ioutil.Discard }
+func (n *noopLogger) Output() io.Writer                         { return io.Discard }
 func (n *noopLogger) SetOutput(w io.Writer)                     {}
 func (n *noopLogger) Prefix() string                            { return "" }
 func (n *noopLogger) SetPrefix(p string)                        {}

--- a/pkg/web/web.go
+++ b/pkg/web/web.go
@@ -17,7 +17,6 @@ package web
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -268,7 +267,7 @@ func New(ctx context.Context, opts ...Option) (*Server, error) {
 		s.Static(options.staticMount, staticDir)
 
 		// register hashed filenames
-		manifest, err := ioutil.ReadFile(filepath.Join(staticPath, "manifest.yaml"))
+		manifest, err := os.ReadFile(filepath.Join(staticPath, "manifest.yaml"))
 		if err != nil {
 			logger.WithError(err).Warn("Failed to load manifest.yaml")
 			return s, nil

--- a/pkg/web/web_test.go
+++ b/pkg/web/web_test.go
@@ -15,7 +15,7 @@
 package web
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -114,7 +114,7 @@ func TestStatic(t *testing.T) {
 		s.ServeHTTP(rec, req)
 
 		resp := rec.Result()
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 
 		a.So(resp.StatusCode, should.Equal, http.StatusOK)
 		a.So(strings.HasPrefix(string(body), "//"), should.BeTrue)

--- a/pkg/webhandlers/error_test.go
+++ b/pkg/webhandlers/error_test.go
@@ -15,7 +15,7 @@
 package webhandlers_test
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -42,7 +42,7 @@ func TestErrorHandler(t *testing.T) {
 	res := rec.Result()
 	a.So(res.StatusCode, should.Equal, http.StatusInternalServerError)
 
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 	a.So(string(body), should.ContainSubstring, "some_error")
 
 	a.So(getError(), should.EqualErrorOrDefinition, err)

--- a/pkg/webmiddleware/basic_auth_test.go
+++ b/pkg/webmiddleware/basic_auth_test.go
@@ -15,7 +15,7 @@
 package webmiddleware
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -101,7 +101,7 @@ func TestBasicAuth(t *testing.T) {
 		})).ServeHTTP(rec, r)
 		res := rec.Result()
 		a.So(res.StatusCode, should.Equal, http.StatusOK)
-		body, _ := ioutil.ReadAll(res.Body)
+		body, _ := io.ReadAll(res.Body)
 		a.So(string(body), should.Equal, "Secret")
 	})
 }

--- a/pkg/webmiddleware/cors_test.go
+++ b/pkg/webmiddleware/cors_test.go
@@ -15,7 +15,7 @@
 package webmiddleware
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -52,7 +52,7 @@ func TestCORS(t *testing.T) {
 		a.So(res.Header.Get("Access-Control-Expose-Headers"), should.ContainSubstring, "X-Exposed-Header")
 		a.So(res.Header.Get("Access-Control-Allow-Credentials"), should.Equal, "true")
 
-		body, _ := ioutil.ReadAll(res.Body)
+		body, _ := io.ReadAll(res.Body)
 		a.So(string(body), should.Equal, "CORS-Enabled")
 	})
 
@@ -74,7 +74,7 @@ func TestCORS(t *testing.T) {
 		a.So(res.Header.Get("Access-Control-Max-Age"), should.Equal, "600")
 		a.So(res.Header.Get("Access-Control-Allow-Credentials"), should.Equal, "true")
 
-		body, _ := ioutil.ReadAll(res.Body)
+		body, _ := io.ReadAll(res.Body)
 		a.So(body, should.BeEmpty)
 	})
 
@@ -92,7 +92,7 @@ func TestCORS(t *testing.T) {
 		a.So(res.StatusCode, should.BeBetweenOrEqual, 200, 299)
 		a.So(res.Header.Get("Access-Control-Allow-Origin"), should.BeEmpty)
 
-		body, _ := ioutil.ReadAll(res.Body)
+		body, _ := io.ReadAll(res.Body)
 		a.So(body, should.BeEmpty)
 	})
 
@@ -113,7 +113,7 @@ func TestCORS(t *testing.T) {
 		a.So(res.StatusCode, should.Equal, http.StatusMethodNotAllowed)
 		a.So(res.Header.Get("Access-Control-Allow-Origin"), should.BeEmpty)
 
-		body, _ := ioutil.ReadAll(res.Body)
+		body, _ := io.ReadAll(res.Body)
 		a.So(body, should.BeEmpty)
 	})
 
@@ -134,7 +134,7 @@ func TestCORS(t *testing.T) {
 		a.So(res.StatusCode, should.Equal, http.StatusForbidden)
 		a.So(res.Header.Get("Access-Control-Allow-Origin"), should.BeEmpty)
 
-		body, _ := ioutil.ReadAll(res.Body)
+		body, _ := io.ReadAll(res.Body)
 		a.So(body, should.BeEmpty)
 	})
 }

--- a/pkg/webmiddleware/max_body_test.go
+++ b/pkg/webmiddleware/max_body_test.go
@@ -16,7 +16,7 @@ package webmiddleware_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -48,14 +48,14 @@ func TestMaxBody(t *testing.T) {
 		)
 		rec := httptest.NewRecorder()
 		m(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_, err := ioutil.ReadAll(r.Body)
+			_, err := io.ReadAll(r.Body)
 			a.So(err, should.HaveSameErrorDefinitionAs, ErrRequestBodyTooLarge)
 			webhandlers.Error(w, r, err)
 		})).ServeHTTP(rec, r)
 		res := rec.Result()
 		a.So(res.StatusCode, should.Equal, http.StatusBadRequest)
 
-		body, _ := ioutil.ReadAll(res.Body)
+		body, _ := io.ReadAll(res.Body)
 		a.So(string(body), should.ContainSubstring, "request_body_too_large")
 	})
 }

--- a/pkg/webmiddleware/recover_test.go
+++ b/pkg/webmiddleware/recover_test.go
@@ -15,7 +15,7 @@
 package webmiddleware
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -38,6 +38,6 @@ func TestRecover(t *testing.T) {
 
 	a.So(res.StatusCode, should.Equal, http.StatusInternalServerError)
 
-	body, _ := ioutil.ReadAll(res.Body)
+	body, _ := io.ReadAll(res.Body)
 	a.So(string(body), should.ContainSubstring, "http_recovered")
 }

--- a/pkg/webmiddleware/redirect_test.go
+++ b/pkg/webmiddleware/redirect_test.go
@@ -15,7 +15,7 @@
 package webmiddleware
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -55,7 +55,7 @@ func TestRedirect(t *testing.T) {
 		})).ServeHTTP(rec, r)
 		res := rec.Result()
 		a.So(res.StatusCode, should.Equal, http.StatusOK)
-		body, _ := ioutil.ReadAll(res.Body)
+		body, _ := io.ReadAll(res.Body)
 		a.So(string(body), should.Equal, "OK")
 	})
 

--- a/tools/generate_allowed_field_mask_paths.go
+++ b/tools/generate_allowed_field_mask_paths.go
@@ -19,7 +19,6 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -42,7 +41,7 @@ func main() {
 		panic(err)
 	}
 
-	if err = ioutil.WriteFile(messagesFile, data, 0o644); err != nil {
+	if err = os.WriteFile(messagesFile, data, 0o644); err != nil {
 		panic(err)
 	}
 }

--- a/tools/mage/certificates.go
+++ b/tools/mage/certificates.go
@@ -15,7 +15,7 @@
 package ttnmage
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/csr"
@@ -36,10 +36,10 @@ func (Dev) Certificates() error {
 	if err != nil {
 		return err
 	}
-	if err = ioutil.WriteFile("ca.pem", caCert, 0644); err != nil {
+	if err = os.WriteFile("ca.pem", caCert, 0644); err != nil {
 		return err
 	}
-	if err = ioutil.WriteFile("ca-key.pem", caKey, 0644); err != nil {
+	if err = os.WriteFile("ca-key.pem", caKey, 0644); err != nil {
 		return err
 	}
 	certReq := csr.CertificateRequest{
@@ -75,10 +75,10 @@ func (Dev) Certificates() error {
 	if err != nil {
 		return err
 	}
-	if err = ioutil.WriteFile("cert.pem", cert, 0644); err != nil {
+	if err = os.WriteFile("cert.pem", cert, 0644); err != nil {
 		return err
 	}
-	if err = ioutil.WriteFile("key.pem", key, 0644); err != nil {
+	if err = os.WriteFile("key.pem", key, 0644); err != nil {
 		return err
 	}
 	return nil

--- a/tools/mage/dev.go
+++ b/tools/mage/dev.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -113,7 +112,7 @@ func (Dev) SQLDump() error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filepath.Join(".cache", "sqldump.sql"), []byte(output), 0644)
+	return os.WriteFile(filepath.Join(".cache", "sqldump.sql"), []byte(output), 0644)
 }
 
 // SQLCreateSeedDB creates a database template from the current dump.

--- a/tools/mage/git.go
+++ b/tools/mage/git.go
@@ -18,7 +18,6 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -36,7 +35,7 @@ func (Git) installHook(name string) (err error) {
 	if mg.Verbose() {
 		fmt.Printf("Installing %s hook\n", name)
 	}
-	return ioutil.WriteFile(
+	return os.WriteFile(
 		filepath.Join(".git", "hooks", name),
 		[]byte(fmt.Sprintf(
 			`STDIN="$(cat /dev/stdin)" ARGS="$@" make git.%s`,

--- a/tools/mage/go.go
+++ b/tools/mage/go.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -65,7 +64,7 @@ func runGoFrom(dir string, args ...string) error {
 }
 
 func writeToFile(filename string, value []byte) error {
-	return ioutil.WriteFile(filename, value, 0644)
+	return os.WriteFile(filename, value, 0644)
 }
 
 func outputGo(cmd string, args ...string) (string, error) {

--- a/tools/mage/headers.go
+++ b/tools/mage/headers.go
@@ -18,7 +18,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -108,7 +107,7 @@ func init() {
 }
 
 func (Headers) loadFile() error {
-	headerBytes, err := ioutil.ReadFile(headerFile)
+	headerBytes, err := os.ReadFile(headerFile)
 	if err != nil {
 		return err
 	}

--- a/tools/mage/version.go
+++ b/tools/mage/version.go
@@ -16,7 +16,7 @@ package ttnmage
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -67,7 +67,7 @@ func (Version) Files() error {
 	}
 	mg.Deps(Version.getCurrent, Js.Deps)
 	version := strings.TrimPrefix(currentVersion, "v")
-	err := ioutil.WriteFile(goVersionFilePath, []byte(fmt.Sprintf(goVersionFile, version)), 0644)
+	err := os.WriteFile(goVersionFilePath, []byte(fmt.Sprintf(goVersionFile, version)), 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

#### Changes
<!-- What are the changes made in this pull request? -->
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.WriteFile` => `os.WriteFile`

#### Testing
Manual

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This change does not affect the end users.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

While the `io/ioutil` package is still usable under the Go 1 compatibility promise, we shall start using the new definitions in `io` and `os` packages for code consistency in the future.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
