### PR TITLE
Account for implementation errors while parsing GPS timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ For details about compatibility between different releases, see the **Commitment
 - The Content-Security-Policy header (that was previously behind the `webui.csp` feature flag) is now enabled by default.
 - Default `Cache-Control: no-store` headers.
 - `Cache-Control: public, max-age=604800, immutable` headers for hashed static files.
+- Experimental support for BasicStation GPS timestamps which use the wrong precision (milliseconds instead of microseconds).
+  - The Gateway Server will attempt to determine the correct GPS timestamp from the provided `gpstime` based on the time at which the upstream message has been received.
+  - This workaround will be available until the related gateway vendors will release patches for this issue.
 
 ### Changed
 

--- a/pkg/gatewayserver/io/ws/lbslns/time.go
+++ b/pkg/gatewayserver/io/ws/lbslns/time.go
@@ -25,7 +25,7 @@ import (
 // TimeFromUnixSeconds constructs a time.Time from the provided UNIX fractional timestamp.
 func TimeFromUnixSeconds(tf float64) time.Time {
 	sec, nsec := math.Modf(tf)
-	return time.Unix(int64(sec), int64(nsec*1e9))
+	return time.Unix(int64(sec), int64(nsec*1e9)).UTC()
 }
 
 // TimeFromUnixSeconds constructs a *time.Time from the provided UNIX fractional timestamp.
@@ -63,13 +63,50 @@ func TimeToGPSTime(t time.Time) int64 {
 	return int64(gpstime.ToGPS(t) / time.Microsecond)
 }
 
+func absoluteDuration(d time.Duration) time.Duration {
+	if d > 0 {
+		return d
+	}
+	return -d
+}
+
+func absoluteTimeDifference(a time.Time, b time.Time) time.Duration {
+	return absoluteDuration(a.Sub(b))
+}
+
+func closestTimestamp(referenceTime time.Time, ds ...time.Time) *time.Time {
+	if len(ds) == 0 {
+		return nil
+	}
+	minTime, minDifference := ds[0], absoluteTimeDifference(referenceTime, ds[0])
+	for _, t := range ds[1:] {
+		if diff := absoluteTimeDifference(referenceTime, t); diff < minDifference {
+			minTime, minDifference = t, diff
+		}
+	}
+	return &minTime
+}
+
 // TimePtrFromUpInfo contructs a *time.Time from the provided uplink metadata information.
 // The GPS timestamp is used if present, then the RxTime. The function returns nil if both
 // timestamps are unavailable.
-func TimePtrFromUpInfo(gpsTime int64, rxTime float64) *time.Time {
+// The implementation will attempt to correct GPS time precision errors caused by faulty
+// implementations. In cases in which such errors occur, the timestamp which is closer to
+// the provided reference time is considered correct.
+func TimePtrFromUpInfo(gpsTime int64, rxTime float64, referenceTime time.Time) *time.Time {
 	switch {
 	case gpsTime != 0:
-		return TimePtrFromGPSTime(gpsTime)
+		// Certain gateways report GPS timestamps using millisecond precision, instead of microsecond precision.
+		// This causes the messages to appear as if they originate from ~1980 - very close to the GPS epoch.
+		// In order to account for such errors, we compute the *time.Time associated with the provided timestamp
+		// and the *time.Time associated with the timestamp multiplied by 1000 (the ratio between millisecond
+		// and microsecond). The timestamp which is closer to the reference time is considered to be the correct
+		// timestamp.
+		return closestTimestamp(
+			referenceTime,
+			TimeFromGPSTime(gpsTime),
+			TimeFromGPSTime(gpsTime*int64(time.Millisecond/time.Microsecond)),
+		)
 	case rxTime != 0.0:
 		return TimePtrFromUnixSeconds(rxTime)
 	default:

--- a/pkg/gatewayserver/io/ws/lbslns/time.go
+++ b/pkg/gatewayserver/io/ws/lbslns/time.go
@@ -93,6 +93,8 @@ func closestTimestamp(referenceTime time.Time, ds ...time.Time) *time.Time {
 // The implementation will attempt to correct GPS time precision errors caused by faulty
 // implementations. In cases in which such errors occur, the timestamp which is closer to
 // the provided reference time is considered correct.
+// TODO: Remove precision errors accounting (use TimePtrFromGPSTime directly).
+// https://github.com/TheThingsNetwork/lorawan-stack/issues/4907
 func TimePtrFromUpInfo(gpsTime int64, rxTime float64, referenceTime time.Time) *time.Time {
 	switch {
 	case gpsTime != 0:

--- a/pkg/gatewayserver/io/ws/lbslns/time_test.go
+++ b/pkg/gatewayserver/io/ws/lbslns/time_test.go
@@ -1,0 +1,75 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lbslns
+
+import (
+	"testing"
+	"time"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+)
+
+func timePtr(t time.Time) *time.Time { return &t }
+
+func TestTimePtrFromUpInfo(t *testing.T) {
+	for _, tc := range []struct {
+		Name          string
+		GPSTime       int64
+		RxTime        float64
+		ReferenceTime time.Time
+		ExpectedTime  *time.Time
+	}{
+		{
+			Name:          "NoTimestamps",
+			ReferenceTime: time.Unix(0, 456),
+		},
+		{
+			Name:          "OnlyRxTime",
+			RxTime:        123.456,
+			ReferenceTime: time.Unix(0, 456),
+
+			ExpectedTime: timePtr(time.Unix(123, 456000000).UTC()),
+		},
+		{
+			Name:          "EqualGPSTimeAndRxTime",
+			GPSTime:       -315964676544, // The timestamp is negative as the UTC epoch precedes the GPS epoch.
+			RxTime:        123.456,
+			ReferenceTime: time.Unix(123, 456),
+
+			ExpectedTime: timePtr(time.Unix(123, 456000000).UTC()),
+		},
+		{
+			Name:          "OnlyGPSTime",
+			GPSTime:       -315964676544, // The timestamp is negative as the UTC epoch precedes the GPS epoch.
+			ReferenceTime: time.Unix(0, 456),
+
+			ExpectedTime: timePtr(time.Unix(123, 456000000).UTC()),
+		},
+		{
+			Name:          "MillisecondGPSTime",
+			GPSTime:       1321619791991, // This timestamp is in milliseconds, instead of microseconds.
+			RxTime:        1637584573,
+			ReferenceTime: time.Unix(1637584483, 999974502), // 2021-11-22T12:34:43.999974502Z
+
+			ExpectedTime: timePtr(time.Unix(1637584573, 991000000).UTC()),
+		},
+	} {
+		t.Run(tc.Name, func(t *testing.T) {
+			a, _ := test.New(t)
+			a.So(TimePtrFromUpInfo(tc.GPSTime, tc.RxTime, tc.ReferenceTime), should.Resemble, tc.ExpectedTime)
+		})
+	}
+}

--- a/pkg/gatewayserver/io/ws/lbslns/upstream.go
+++ b/pkg/gatewayserver/io/ws/lbslns/upstream.go
@@ -213,7 +213,7 @@ func (req *JoinRequest) toUplinkMessage(ids ttnpb.GatewayIdentifiers, bandID str
 	}
 
 	timestamp := TimestampFromXTime(req.RadioMetaData.UpInfo.XTime)
-	tm := TimePtrFromUpInfo(req.UpInfo.GPSTime, req.UpInfo.RxTime)
+	tm := TimePtrFromUpInfo(req.UpInfo.GPSTime, req.UpInfo.RxTime, receivedAt)
 	up.RxMetadata = []*ttnpb.RxMetadata{
 		{
 			GatewayIds:   &ids,
@@ -371,7 +371,7 @@ func (updf *UplinkDataFrame) toUplinkMessage(ids ttnpb.GatewayIdentifiers, bandI
 	}
 
 	timestamp := TimestampFromXTime(updf.RadioMetaData.UpInfo.XTime)
-	tm := TimePtrFromUpInfo(updf.UpInfo.GPSTime, updf.UpInfo.RxTime)
+	tm := TimePtrFromUpInfo(updf.UpInfo.GPSTime, updf.UpInfo.RxTime, receivedAt)
 	up.RxMetadata = []*ttnpb.RxMetadata{
 		{
 			GatewayIds:   &ids,
@@ -527,7 +527,7 @@ func (f *lbsLNS) HandleUp(ctx context.Context, raw []byte, ids ttnpb.GatewayIden
 		return &io.FrontendClockSynchronization{
 			Timestamp:        TimestampFromXTime(xTime),
 			ServerTime:       receivedAt,
-			GatewayTime:      TimePtrFromUpInfo(gpsTime, rxTime),
+			GatewayTime:      TimePtrFromUpInfo(gpsTime, rxTime, receivedAt),
 			ConcentratorTime: ConcentratorTimeFromXTime(xTime),
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/638

#### Changes
<!-- What are the changes made in this pull request? -->

- Account for the fact that certain BasicStation implementations use millisecond precision instead of microsecond precision for GPS timestamps
   - The [standard](https://doc.sm.tc/station/tcproto.html#radio-metadata) explicitly says that microsecond precision must be used
   - This is probably caused by the fact that the UDP packet forwarder was using [millisecond precision](https://github.com/Lora-net/packet_forwarder/blob/d0226eae6e7b6bbaec6117d0d2372bf17819c438/PROTOCOL.TXT#L134), and bridges/implementations just thought that the field has the same meaning

Logs from a particular bridge that show this error (observe that `tmms` and `gpstime` are equal, even though they should not be):
```
Nov 22 12:36:13 kona-micro-outdoor tek_bstn[2110]: [DEBUG ] bridge_data_conv.c:437 PUSH_DATA message body: {"rxpk":[{"tmst":137070715,"tmms":1321619791991,"chan":4,"rfch":0,"freq":867.300000,"stat":1,"modu":"LORA","datr":"SF7BW125","codr":"4/5","lsnr":11.0,"rssi":-42,"size":20,"data":"QOAHACeAVi0FhAfwk3ryro2909A="}]}
Nov 22 12:36:13 kona-micro-outdoor tek_bstn[2110]: [DEBUG ] bridge_bstn_lns.c:1728 DR index found: [5]
Nov 22 12:36:13 kona-micro-outdoor tek_bstn[2110]: [DEBUG ] bridge_bstn_lns.c:448 sending [353] bytes to WS stream
Nov 22 12:36:13 kona-micro-outdoor tek_bstn[2110]: [DEBUG ] bridge_bstn_lns.c:449 payload:
{ "DR": 5, "Freq": 867300000, "upinfo": { "rctx": 0, "rxtime": 1637584573, "xtime": 24769944116496507, "gpstime": 1321619791991, "rssi": -42, "snr": 11.0, "chan": 4 }, "msgtype": "updf", "MHdr": 64, "DevAddr": 654313440, "FCtrl": 128, "FCnt": 11606, "FOpts": "", "FPort": 5, "FRMPayload": "8407f0937af2ae", "MIC": -791429747, "RefTime": 1637584573.983 }
```

#### Testing

<!-- How did you verify that this change works? -->

Wrote a unit test based on the log.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

New unit tests for `TimePtrFromUpInfo` should cover the old and new behavior.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
