### PR TITLE
Expose disconnect reason in gateway disconnect event

### DIFF
--- a/pkg/gatewayserver/observability.go
+++ b/pkg/gatewayserver/observability.go
@@ -40,6 +40,7 @@ var (
 			ttnpb.RIGHT_GATEWAY_LINK,
 			ttnpb.RIGHT_GATEWAY_STATUS_READ,
 		),
+		events.WithErrorDataType(),
 	)
 	evtReceiveStatus = events.Define(
 		"gs.status.receive", "receive gateway status",
@@ -267,8 +268,8 @@ func registerGatewayConnect(ctx context.Context, ids ttnpb.GatewayIdentifiers, p
 	gsMetrics.gatewaysConnected.WithLabelValues(ctx, protocol).Inc()
 }
 
-func registerGatewayDisconnect(ctx context.Context, ids ttnpb.GatewayIdentifiers, protocol string) {
-	events.Publish(evtGatewayDisconnect.NewWithIdentifiersAndData(ctx, &ids, nil))
+func registerGatewayDisconnect(ctx context.Context, ids ttnpb.GatewayIdentifiers, protocol string, err error) {
+	events.Publish(evtGatewayDisconnect.NewWithIdentifiersAndData(ctx, &ids, err))
 	gsMetrics.gatewaysConnected.WithLabelValues(ctx, protocol).Dec()
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This short PR adds the disconnect reason to the gateway disconnect events. This allows users to track _why_ the gateway disconnected.

#### Changes
<!-- What are the changes made in this pull request? -->

- Expose the connection context error as data in the gateway disconnect event
- Remove old channel synchronization - we have been using the `*sync.WaitGroup` for a while

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
