### PR TITLE
Fix initStack API key serialization

### DIFF
--- a/tools/mage/dev.go
+++ b/tools/mage/dev.go
@@ -16,7 +16,6 @@ package ttnmage
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -25,6 +24,7 @@ import (
 
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
+	"go.thethings.network/lorawan-stack/v3/pkg/jsonpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 )
 
@@ -258,7 +258,7 @@ func (Dev) InitStack() error {
 	); err != nil {
 		return err
 	}
-	if err := json.Unmarshal(jsonVal, &key); err != nil {
+	if err := jsonpb.TTN().Unmarshal(jsonVal, &key); err != nil {
 		return err
 	}
 	if err := writeToFile(filepath.Join(devDir, "admin_api_key.txt"), []byte(key.Key)); err != nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/4889

#### Changes
<!-- What are the changes made in this pull request? -->

- Use `jsonpb` instead of `json` while unmarshaling the API key


#### Testing

<!-- How did you verify that this change works? -->

Before:

```
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ./mage dev:initStack
INFO	Connecting to Identity Server database...
INFO	Detected database PostgreSQL 14.0 (Debian 14.0-1.pgdg110+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit
INFO	Initializing database...
INFO	Creating tables...
DEBUG	No new version available
INFO	Successfully initialized
INFO	Connecting to Identity Server database...
INFO	Creating user...
INFO	Created user
DEBUG	No new version available
INFO	Connecting to Identity Server database...
INFO	Creating OAuth client...
INFO	Created OAuth client	{"secret": ""}
INFO	Setting owner rights...
INFO	Set owner rights
DEBUG	No new version available
INFO	Connecting to Identity Server database...
INFO	Creating OAuth client...
INFO	Created OAuth client	{"secret": "console"}
INFO	Setting owner rights...
INFO	Set owner rights
DEBUG	No new version available
INFO	Connecting to Identity Server database...
INFO	API key ID: AUDN4GOIAVVU36FEXP6W237F25J2K3KKVKSLP5A
INFO	API key value: NNSXS.AUDN4GOIAVVU36FEXP6W237F25J2K3KKVKSLP5A.XLAHE5SUKH5MQTMG7O4BIBNM73CKBZEKY6ZEWWAEYOQSMPI3FC4A
WARN	The API key value will never be shown again
WARN	Make sure to copy it to a safe place
DEBUG	No new version available
Error: json: cannot unmarshal string into Go struct field APIKey.created_at of type types.Timestamp
```

After:
```
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ./mage dev:initStack
INFO	Connecting to Identity Server database...
INFO	Detected database PostgreSQL 14.0 (Debian 14.0-1.pgdg110+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit
INFO	Initializing database...
INFO	Creating tables...
DEBUG	No new version available
INFO	Successfully initialized
INFO	Connecting to Identity Server database...
INFO	Creating user...
INFO	Created user
DEBUG	No new version available
INFO	Connecting to Identity Server database...
INFO	Creating OAuth client...
INFO	Created OAuth client	{"secret": ""}
INFO	Setting owner rights...
INFO	Set owner rights
DEBUG	No new version available
INFO	Connecting to Identity Server database...
INFO	Creating OAuth client...
INFO	Created OAuth client	{"secret": "console"}
INFO	Setting owner rights...
INFO	Set owner rights
DEBUG	No new version available
INFO	Connecting to Identity Server database...
INFO	API key ID: SEOORSRBHFV3NQLDY475WGCXMQ6DXCVTCKOWHIQ
INFO	API key value: NNSXS.SEOORSRBHFV3NQLDY475WGCXMQ6DXCVTCKOWHIQ.HFLFAZAPB45U75THNCZNFV4JLM7ZA7CKIISGFLUP3OWLNU3NUICQ
WARN	The API key value will never be shown again
WARN	Make sure to copy it to a safe place
DEBUG	No new version available
```

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I guess that the object itself does not implement `json.Marshaler`/`json.Unmarshaler` ? 
Is this the way we should be doing this ? Or does this uncover the fact that maybe we shouldn't use `json.Marshal`/`json.Unmarshal` any more for protos ?

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
