### PR TITLE
Update CODEOWNERS catch all expression

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Root
-/ @johanstokking @htdvisser
+/** @johanstokking @htdvisser
 /CODEOWNERS @johanstokking
 /LICENSE @johanstokking
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This short PR fixes the `CODEOWNERS` catch all expression - `/` doesn't actually match anything.