### PR TITLE
Wrap JSON unmarshaling errors

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -3023,6 +3023,15 @@
       "file": "server.go"
     }
   },
+  "error:pkg/basicstation/cups:parse": {
+    "translations": {
+      "en": "request body parsing"
+    },
+    "description": {
+      "package": "pkg/basicstation/cups",
+      "file": "update_info.go"
+    }
+  },
   "error:pkg/basicstation/cups:server_trust": {
     "translations": {
       "en": "failed to fetch server trust for address `{address}`"

--- a/pkg/basicstation/cups/update_info.go
+++ b/pkg/basicstation/cups/update_info.go
@@ -153,12 +153,14 @@ func (s *Server) UpdateInfo(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+var errParse = errors.DefineAborted("parse", "request body parsing")
+
 func (s *Server) updateInfo(w http.ResponseWriter, r *http.Request) (err error) {
 	ctx := r.Context()
 
 	var req UpdateInfoRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		return err
+		return errParse.WithCause(err)
 	}
 
 	if err := req.ValidateContext(ctx); err != nil {

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -236,7 +236,7 @@ func (c *Connection) HandleUp(up *ttnpb.UplinkMessage, frontendSync *FrontendClo
 			"concentrator_time", frontendSync.ConcentratorTime,
 			"server_time", frontendSync.ServerTime,
 			"gateway_time", frontendSync.GatewayTime,
-		)).Info("Gateway clocks have been synchronized by the frontend")
+		)).Debug("Gateway clocks have been synchronized by the frontend")
 	case up.Settings.Time != nil:
 		ct = c.scheduler.SyncWithGatewayAbsolute(up.Settings.Timestamp, *ttnpb.StdTime(up.ReceivedAt), *ttnpb.StdTime(up.Settings.Time))
 		log.FromContext(c.ctx).WithFields(log.Fields(
@@ -244,14 +244,14 @@ func (c *Connection) HandleUp(up *ttnpb.UplinkMessage, frontendSync *FrontendClo
 			"concentrator_time", ct,
 			"server_time", up.ReceivedAt,
 			"gateway_time", *up.Settings.Time,
-		)).Info("Synchronized server and gateway absolute time")
+		)).Debug("Synchronized server and gateway absolute time")
 	case up.Settings.Time == nil:
 		ct = c.scheduler.Sync(up.Settings.Timestamp, *ttnpb.StdTime(up.ReceivedAt))
 		log.FromContext(c.ctx).WithFields(log.Fields(
 			"timestamp", up.Settings.Timestamp,
 			"concentrator_time", ct,
 			"server_time", up.ReceivedAt,
-		)).Info("Synchronized server absolute time only")
+		)).Debug("Synchronized server absolute time only")
 	default:
 		panic("unreachable")
 	}

--- a/pkg/ttnpb/udp/translation.go
+++ b/pkg/ttnpb/udp/translation.go
@@ -54,8 +54,7 @@ func validLocation(loc ttnpb.Location) bool {
 			return false
 		}
 	}
-
-	return true
+	return loc.ValidateFields() == nil
 }
 
 // UpstreamMetadata related to an uplink.
@@ -264,7 +263,7 @@ func convertStatus(stat Stat, md UpstreamMetadata) *ttnpb.GatewayStatus {
 	}
 
 	if stat.Lati != nil && stat.Long != nil {
-		loc := &ttnpb.Location{Latitude: *stat.Lati, Longitude: *stat.Long}
+		loc := &ttnpb.Location{Latitude: *stat.Lati, Longitude: *stat.Long, Source: ttnpb.SOURCE_GPS}
 		if stat.Alti != nil {
 			loc.Altitude = *stat.Alti
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://sentry.io/organizations/the-things-industries/issues/2822581377/?environment=ttn-prod-au1&project=2682566&referrer=alert_email

#### Changes
<!-- What are the changes made in this pull request? -->

- Wrap the errors returned by `json.NewDecoder.Unmarshal`, in order to avoid causing Internal Server Errors when EOF is returned
- Validate the location returned by a gateway status message before attempting to append it to the frontend status message, otherwise the `ttnpb.GatewayStatus` validation will fail
```
{
    "level": "warn",
    "msg": "Failed to handle status message",
    "error": "invalid GatewayStatus.antenna_locations[0]: embedded message failed validation | caused by: invalid Location.latitude: value must be inside range [-90, 90]",
    "gateway_eui": "edited",
    "gateway_uid": "eui-edited@ttn",
    "namespace": "gatewayserver/io/udp",
    "protocol": "udp",
    "remote_addr": "edited",
    "tenant_id": "edited"
}
```
- Add `op` to `errURL` / `errRequest` for debugging reasons - I have reports of some cause-less errors and I want to find out which code path lead there


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This should reject invalid locations earlier than the whole status validation. This is fine.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
