### PR TITLE
Increase the buffer time used for absolute time scheduling

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -4582,7 +4582,7 @@
   },
   "error:pkg/gatewayserver/scheduling:too_late": {
     "translations": {
-      "en": "too late to transmission scheduled time (delta is `{delta}`)"
+      "en": "too late to transmission scheduled time (delta is `{delta}`, min is `{min}`)"
     },
     "description": {
       "package": "pkg/gatewayserver/scheduling",

--- a/pkg/gatewayserver/scheduling/scheduler.go
+++ b/pkg/gatewayserver/scheduling/scheduler.go
@@ -263,7 +263,7 @@ func (s *Scheduler) syncWithUplinkToken(token *ttnpb.UplinkToken) bool {
 
 var (
 	errConflict              = errors.DefineAlreadyExists("conflict", "scheduling conflict")
-	errTooLate               = errors.DefineFailedPrecondition("too_late", "too late to transmission scheduled time (delta is `{delta}`)")
+	errTooLate               = errors.DefineFailedPrecondition("too_late", "too late to transmission scheduled time (delta is `{delta}`, min is `{min}`)")
 	errNoClockSync           = errors.DefineUnavailable("no_clock_sync", "no clock sync")
 	errNoAbsoluteGatewayTime = errors.DefineAborted("no_absolute_gateway_time", "no absolute gateway time")
 	errNoServerTime          = errors.DefineAborted("no_server_time", "no server time")
@@ -326,7 +326,10 @@ func (s *Scheduler) ScheduleAt(ctx context.Context, opts Options) (Emission, err
 	}
 	if ok {
 		if delta := time.Duration(starts - now); delta < minScheduleTime {
-			return Emission{}, errTooLate.WithAttributes("delta", delta)
+			return Emission{}, errTooLate.WithAttributes(
+				"delta", delta,
+				"min", minScheduleTime,
+			)
 		}
 	}
 	sb, err := s.findSubBand(opts.Frequency)

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -65,7 +65,7 @@ func loggerWithApplicationDownlinkFields(logger log.Interface, down *ttnpb.Appli
 	if down.GetClassBC() != nil {
 		pairs = append(pairs, "class_b_c", true)
 		if down.ClassBC.GetAbsoluteTime() != nil {
-			pairs = append(pairs, "absolute_time", *down.ClassBC.AbsoluteTime)
+			pairs = append(pairs, "absolute_time", ttnpb.StdTime(down.ClassBC.AbsoluteTime))
 		}
 		if len(down.ClassBC.GetGateways()) > 0 {
 			pairs = append(pairs, "fixed_gateway_count", len(down.ClassBC.Gateways))
@@ -131,7 +131,7 @@ func (ns *NetworkServer) nextDataDownlinkTaskAt(ctx context.Context, dev *ttnpb.
 
 	case !from.IsZero():
 		// Absolute time downlink slot, enqueue in advance to allow for scheduling.
-		taskAt = from.Add(-dev.MacState.CurrentParameters.Rx1Delay.Duration() - nsScheduleWindow())
+		taskAt = from.Add(-absoluteTimeSchedulingDelay - nsScheduleWindow())
 	}
 	if taskAt.Before(earliestAt) {
 		taskAt = earliestAt

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -45,8 +45,13 @@ const (
 	// fOptsCapacity is the maximum length of FOpts in bytes.
 	fOptsCapacity = 15
 
-	// infrastructureDelay represents a time interval Network Server uses as a buffer to account for infrastructure delay.
+	// infrastructureDelay represents a time interval that the Network Server uses as a buffer to account for infrastructure delay.
 	infrastructureDelay = time.Second
+
+	// absoluteTimeSchedulingDelay represents a time interval that the Network Server uses as a buffer to account for the transmission
+	// time while scheduling absolute time downlinks, since absolute time scheduling considers the absolute time to be the timestamp
+	// for the arrival, not start, of the transmission.
+	absoluteTimeSchedulingDelay = 5 * time.Second
 
 	// peeringScheduleDelay is the schedule delay used for scheduling downlink via peering.
 	// The schedule delay is used to estimate the transmission time, which is used as the minimum time for a subsequent transmission.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/634
References https://github.com/TheThingsNetwork/lorawan-stack/pull/635

#### Changes
<!-- What are the changes made in this pull request? -->

- Use a fixed 5 second buffer, instead of the RX1 duration, while deciding when to start the schedule attempt (not the transmission) of an absolute time downlink
  - For devices that have RX1 = 1 (multicast perhaps, or migrated devices), the 1 second RX1 + 200ms scheduling delay is not sufficient in order to transmit even 1 byte in near perfect conditions - the TOA of such a downlink is 1155.1 ms - the scheduling attempt needs to start earlier
  - I've used 5 seconds to be on the 'very safe' side, but in theory ~2.8 seconds would have sufficed for 51 bytes at SF12
  - Using the actual TOA is not really possible - we don't know how the actual physical frame will look like (downlink commands have not been decided yet)
 
#### Testing

<!-- How did you verify that this change works? -->

Local testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This was already quite broken.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
