### PR TITLE
Update uplink/downlink counters on end device activity in the Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - Access to application payload formatters for users with `RIGHT_APPLICATION_SETTINGS_BASIC` right.
 - End device mac settings handling in the Console.
+- Uplink and downlink counters display on end device activity in the Console.
 
 ### Security
 

--- a/pkg/webui/console/constants/event-filters.js
+++ b/pkg/webui/console/constants/event-filters.js
@@ -20,6 +20,8 @@ export const END_DEVICE_EVENTS_VERBOSE_FILTERS = [
   'as.up.*.forward',
   'js.join.accept',
   'js.join.reject',
+  'ns.up.data.process',
+  'ns.down.data.schedule.attempt',
   'ns.mac.*.answer.reject',
   '*.warning',
   '*.fail',


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/4912

#### Changes
<!-- What are the changes made in this pull request? -->

- Include `ns.up.data.process` and `ns.down.data.schedule.attempt` in events filter.


#### Testing

<!-- How did you verify that this change works? -->

Manual on staging with both otaa and abp end devices


#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The issue is that both events we use to determine uplink and downlink counters are dispatched only when in verbose mode.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
