### PR TITLE
Prevent crashes within message component

### DIFF
--- a/pkg/webui/lib/components/message/index.js
+++ b/pkg/webui/lib/components/message/index.js
@@ -16,6 +16,7 @@ import React, { useContext } from 'react'
 import { FormattedMessage, IntlContext } from 'react-intl'
 import classnames from 'classnames'
 import reactStringReplace from 'react-string-replace'
+import { isPlainObject } from 'lodash'
 
 import PropTypes from '@ttn-lw/lib/prop-types'
 import { warn } from '@ttn-lw/lib/log'
@@ -63,6 +64,16 @@ const Message = ({
 
   const intlContext = useContext(IntlContext)
 
+  if (typeof content === 'string' || typeof content === 'number') {
+    return renderContent(content, component, rest)
+  }
+
+  if (!isPlainObject(content)) {
+    // Better to render nothing rather than throwing an error
+    // that potentially causes the whole view to crash.
+    return renderContent(null, component, rest)
+  }
+
   let vals = values
   if (content.values && Object.keys(values).length === 0) {
     vals = content.values
@@ -84,10 +95,6 @@ const Message = ({
 
   if (cls) {
     rest.className = cls
-  }
-
-  if (typeof content === 'string' || typeof content === 'number') {
-    return renderContent(content, component, rest)
   }
 
   if (convertBackticks) {


### PR DESCRIPTION
#### Summary
This quickfix will prevent the `<Message />` component from throwing an error when using an invalid `content` prop.

#### Changes
<!-- What are the changes made in this pull request? -->

-  Render `null` when invalid `content` prop is provided

#### Testing

Manual testing.

#### Notes for Reviewers
`undefined` content props occasionally happen in production when using a faulty message property. When this happens, it is better to not render the message rather than crash the whole view. In development, this can be noticed via the prop type warning.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
