### PR TITLE
Include user defined antenna gain in LBS router config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Added
 
+- User defined antenna gain for LBS gateways.
+
 ### Changed
 
 ### Deprecated

--- a/cmd/ttn-lw-cli/commands/gateways.go
+++ b/cmd/ttn-lw-cli/commands/gateways.go
@@ -368,7 +368,7 @@ var (
 				if antennaRemove {
 					gateway.Antennas = append(res.Antennas[:antennaIndex], res.Antennas[antennaIndex+1:]...)
 				} else { // create or update
-					if err = util.SetFields(&res.Antennas[antennaIndex], setGatewayAntennaFlags, "antenna"); err != nil {
+					if err = util.SetFields(res.Antennas[antennaIndex], setGatewayAntennaFlags, "antenna"); err != nil {
 						return err
 					}
 					gateway.Antennas = res.Antennas

--- a/pkg/gatewayserver/io/ws/lbslns/version.go
+++ b/pkg/gatewayserver/io/ws/lbslns/version.go
@@ -64,7 +64,7 @@ func (v Version) IsProduction() bool {
 }
 
 // GetRouterConfig gets router config for the particular version message.
-func (f *lbsLNS) GetRouterConfig(ctx context.Context, msg []byte, bandID string, fps map[string]*frequencyplans.FrequencyPlan, receivedAt time.Time) (context.Context, []byte, *ttnpb.GatewayStatus, error) {
+func (f *lbsLNS) GetRouterConfig(ctx context.Context, msg []byte, bandID string, fps map[string]*frequencyplans.FrequencyPlan, antennaGain int, receivedAt time.Time) (context.Context, []byte, *ttnpb.GatewayStatus, error) {
 	var version Version
 	if err := json.Unmarshal(msg, &version); err != nil {
 		return nil, nil, nil, err
@@ -74,7 +74,7 @@ func (f *lbsLNS) GetRouterConfig(ctx context.Context, msg []byte, bandID string,
 	// to gateways that signal the presence of a PPS.
 	// References https://github.com/lorabasics/basicstation/issues/135.
 	updateSessionTimeSync(ctx, true)
-	cfg, err := pfconfig.GetRouterConfig(bandID, fps, version.IsProduction(), time.Now())
+	cfg, err := pfconfig.GetRouterConfig(bandID, fps, version.IsProduction(), time.Now(), antennaGain)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/gatewayserver/io/ws/ws_test.go
+++ b/pkg/gatewayserver/io/ws/ws_test.go
@@ -473,24 +473,29 @@ func TestVersion(t *testing.T) {
 	ctx, cancelCtx := context.WithCancel(ctx)
 	defer cancelCtx()
 
-	is, isAddr := mock.NewIS(ctx)
-	is.Add(ctx, registeredGatewayID, registeredGatewayToken)
 	c := componenttest.NewComponent(t, &component.Config{
 		ServiceBase: config.ServiceBase{
 			GRPC: config.GRPC{
 				Listen:                      ":0",
 				AllowInsecureForCredentials: true,
 			},
-			Cluster: cluster.Config{
-				IdentityServer: isAddr,
-			},
 		},
 	})
+
 	c.FrequencyPlans = frequencyplans.NewStore(test.FrequencyPlansFetcher)
 	componenttest.StartComponent(t, c)
 	defer c.Close()
-	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
 	gs := mock.NewServer(c)
+
+	gs.RegisterGateway(ctx, registeredGatewayID, &ttnpb.Gateway{
+		Ids:             &registeredGatewayID,
+		FrequencyPlanId: test.EUFrequencyPlanID,
+		Antennas: []*ttnpb.GatewayAntenna{
+			{
+				Gain: 3,
+			},
+		},
+	})
 
 	web, err := New(ctx, gs, lbslns.NewFormatter(maxValidRoundTripDelay), defaultConfig)
 	if !a.So(err, should.BeNil) {
@@ -555,12 +560,14 @@ func TestVersion(t *testing.T) {
 					{
 						Radios: []pfconfig.LBSRFConfig{
 							{
-								Enable:    true,
-								Frequency: 867500000,
+								Enable:      true,
+								Frequency:   867500000,
+								AntennaGain: 3,
 							},
 							{
-								Enable:    true,
-								Frequency: 868500000,
+								Enable:      true,
+								Frequency:   868500000,
+								AntennaGain: 3,
 							},
 						},
 						Channels: []shared.IFConfig{
@@ -628,12 +635,14 @@ func TestVersion(t *testing.T) {
 					{
 						Radios: []pfconfig.LBSRFConfig{
 							{
-								Enable:    true,
-								Frequency: 867500000,
+								Enable:      true,
+								Frequency:   867500000,
+								AntennaGain: 3,
 							},
 							{
-								Enable:    true,
-								Frequency: 868500000,
+								Enable:      true,
+								Frequency:   868500000,
+								AntennaGain: 3,
 							},
 						},
 						Channels: []shared.IFConfig{

--- a/pkg/pfconfig/lbslns/lbslbs_test.go
+++ b/pkg/pfconfig/lbslns/lbslbs_test.go
@@ -203,7 +203,7 @@ func TestGetRouterConfig(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			a := assertions.New(t)
 			fps := map[string]*frequencyplans.FrequencyPlan{tc.FrequencyPlanID: &tc.FrequencyPlan}
-			cfg, err := GetRouterConfig(tc.FrequencyPlan.BandID, fps, tc.IsProd, time.Now())
+			cfg, err := GetRouterConfig(tc.FrequencyPlan.BandID, fps, tc.IsProd, time.Now(), 0)
 			if err != nil {
 				if tc.ErrorAssertion == nil || !a.So(tc.ErrorAssertion(err), should.BeTrue) {
 					t.Fatalf("Unexpected error: %v", err)
@@ -297,12 +297,14 @@ func TestGetRouterConfigWithMultipleFP(t *testing.T) {
 					{
 						Radios: []LBSRFConfig{
 							{
-								Enable:    true,
-								Frequency: 924300000,
+								Enable:      true,
+								Frequency:   924300000,
+								AntennaGain: 3,
 							},
 							{
-								Enable:    false,
-								Frequency: 925000000,
+								Enable:      false,
+								Frequency:   925000000,
+								AntennaGain: 3,
 							},
 						},
 						Channels: []shared.IFConfig{
@@ -321,12 +323,14 @@ func TestGetRouterConfigWithMultipleFP(t *testing.T) {
 					{
 						Radios: []LBSRFConfig{
 							{
-								Enable:    true,
-								Frequency: 924300000,
+								Enable:      true,
+								Frequency:   924300000,
+								AntennaGain: 3,
 							},
 							{
-								Enable:    false,
-								Frequency: 925000000,
+								Enable:      false,
+								Frequency:   925000000,
+								AntennaGain: 3,
 							},
 						},
 						Channels: []shared.IFConfig{
@@ -348,7 +352,7 @@ func TestGetRouterConfigWithMultipleFP(t *testing.T) {
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			a := assertions.New(t)
-			cfg, err := GetRouterConfig(tc.BandID, tc.FrequencyPlans, tc.IsProd, time.Now())
+			cfg, err := GetRouterConfig(tc.BandID, tc.FrequencyPlans, tc.IsProd, time.Now(), 3)
 			if err != nil {
 				if tc.ErrorAssertion == nil || !a.So(tc.ErrorAssertion(err), should.BeTrue) {
 					t.Fatalf("Unexpected error: %v", err)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #4191 

#### Changes
<!-- What are the changes made in this pull request? -->

- Add `AntennaGain` to `RFCONF` object; https://doc.sm.tc/station/gw_v1.5.html#rfconf-object
- Update code and tests
- Also fix a small bug in the CLI while setting Gateway Antennas


#### Testing

<!-- How did you verify that this change works? -->

- [x] UT 
- [x] Stack Test
   - [x] Check that LBS doesn't fail parsing
<img width="1920" alt="TTIG Parsing" src="https://user-images.githubusercontent.com/13186113/144237597-fd27aaa3-c033-4ee7-8224-99ce3c34eecc.png">

   - [x] Check that Antenna Gain reflects in the RouterConfig   
<img width="1918" alt="RC" src="https://user-images.githubusercontent.com/13186113/144237489-2b60ecd8-081f-4078-8af9-677eb20861f9.png">
<img width="1919" alt="RC2" src="https://user-images.githubusercontent.com/13186113/144237510-8114275b-1a2c-4960-b454-3e878eba8e4e.png">
   
- [x] Test downlinks work
  
<img width="1920" alt="Downlink" src="https://user-images.githubusercontent.com/13186113/144237663-5d0694c8-8cbd-4338-af99-48a8844c68b3.png">

<img width="1920" alt="join" src="https://user-images.githubusercontent.com/13186113/144238276-9b23588a-5940-4e55-a7db-d891b774cc12.png">

- [ ] Check with Tektelic gateway ⚠️ 

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

I don't expect any but depends on the gateway.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

1. I can't really verify if the gateway is offsetting the Tx power since I'll need a spectrum analyzer. I assume that if there are no errors in the logs, this should be ok. I've checked the LBS source code and this is a logical assumption.
   - LBS [stores](https://github.com/lorabasics/basicstation/blob/60fd9788763ea11ec80ec1b1f683c0374792f71e/src/sx130xconf.c#L119) the gain value from config.
   - It's [offset](https://github.com/lorabasics/basicstation/blob/60fd9788763ea11ec80ec1b1f683c0374792f71e/src/ral_lgw.c#L211) during a downlink.
   - But when printing the Tx Ack, it prints the [absolute Pow value](https://github.com/lorabasics/basicstation/blob/60fd9788763ea11ec80ec1b1f683c0374792f71e/src/s2e.c#L294) and not the offset one.
2. The AntennaGain is an INT value for LBS so this will truncate fractional gain values.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.

