### PR TITLE
console: Fix join settings handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For details about compatibility between different releases, see the **Commitment
 - Access to application payload formatters for users with `RIGHT_APPLICATION_SETTINGS_BASIC` right.
 - End device mac settings handling in the Console.
 - Uplink and downlink counters display on end device activity in the Console.
+- Join settings handling in JS-only deployments in the Console.
 
 ### Security
 

--- a/sdk/js/src/service/devices/index.js
+++ b/sdk/js/src/service/devices/index.js
@@ -361,7 +361,7 @@ class Devices {
     }
 
     if (
-      !assembledValues.supports_join ||
+      (this._stackConfig.isComponentAvailable(NS) && !assembledValues.supports_join) ||
       assembledValues.join_server_address !== this._stackConfig.jsHost
     ) {
       delete requestTree.js


### PR DESCRIPTION
Check if NS is available before fetching 'supports_join' value when updating join settings

<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/4941

#### Changes
<!-- What are the changes made in this pull request? -->

- Check if NS is available when fetching `supports_join` value

#### Testing

<!-- How did you verify that this change works? -->

Manual


#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

In JS-only deployments we cant fetch `supports_join` value from NS because it is not available. This caused the `js` entry to be deleted from the `requestTree` resulting in no update request to JS.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
