### PR TITLE
Fix discarding consecutive toasts notifications

### DIFF
--- a/pkg/webui/account/api/tts.js
+++ b/pkg/webui/account/api/tts.js
@@ -42,6 +42,7 @@ tts.subscribe('warning', payload => {
     type: toast.types.WARNING,
     message: payload,
     preventConsecutive: true,
+    messageGroup: 'header-warning',
   })
 })
 

--- a/pkg/webui/components/toast/toast.js
+++ b/pkg/webui/components/toast/toast.js
@@ -101,7 +101,7 @@ const createToast = () => {
       })
     } else {
       show({ autoClose, ...toastOptions })
-      lastMessage = toastOptions
+      lastMessage = options
       lastMessageGroup = messageGroup
     }
   }

--- a/pkg/webui/console/api/tts.js
+++ b/pkg/webui/console/api/tts.js
@@ -53,6 +53,7 @@ tts.subscribe('warning', payload => {
     type: toast.types.WARNING,
     message: payload,
     preventConsecutive: true,
+    messageGroup: 'header-warning',
   })
 })
 


### PR DESCRIPTION
#### Summary
Quickfix PR to fix consecutive toast messages not being discarded when using `preventConsecutive`.

#### Changes
- Add `messageGroup` to SDK warnings
- Fix message comparison when discarding repeated messages


#### Testing

Manual.


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
