### PR TITLE
Sentry error fixes

### DIFF
--- a/pkg/gatewayserver/upstream/ns/ns.go
+++ b/pkg/gatewayserver/upstream/ns/ns.go
@@ -74,15 +74,15 @@ func (h *Handler) ConnectGateway(ctx context.Context, ids ttnpb.GatewayIdentifie
 	if conn.Frontend().SupportsDownlinkClaim() {
 		return nil
 	}
+	decoupledCtx := h.contextDecoupler.FromRequestContext(ctx)
 	logger := log.FromContext(ctx)
-	if err := h.cluster.ClaimIDs(ctx, &ids); err != nil {
+	if err := h.cluster.ClaimIDs(decoupledCtx, &ids); err != nil {
 		logger.WithError(err).Error("Failed to claim downlink path")
 		return err
 	}
 	logger.Info("Downlink path claimed")
 	defer func() {
-		ctx := h.contextDecoupler.FromRequestContext(ctx)
-		if err := h.cluster.UnclaimIDs(ctx, &ids); err != nil {
+		if err := h.cluster.UnclaimIDs(decoupledCtx, &ids); err != nil {
 			logger.WithError(err).Error("Failed to unclaim downlink path")
 			return
 		}

--- a/pkg/interop/errors.go
+++ b/pkg/interop/errors.go
@@ -30,7 +30,7 @@ var (
 	errInvalidVendorID     = errors.DefineInvalidArgument("invalid_vendor_id", "invalid vendor ID")
 
 	ErrNoAction           = errors.DefineAborted("no_action", "no action")
-	ErrMIC                = errors.DefineCorruption("mic", "MIC failed")
+	ErrMIC                = errors.DefineInvalidArgument("mic", "MIC failed")
 	ErrFrameReplayed      = errors.DefineAborted("frame_replayed", "frame replayed")
 	ErrJoinReq            = errors.DefineAborted("join_req", "join-request failed")
 	ErrNoRoamingAgreement = errors.DefineFailedPrecondition("no_roaming_agreement", "no roaming agreement")

--- a/pkg/messageprocessors/cayennelpp/cayennelpp.go
+++ b/pkg/messageprocessors/cayennelpp/cayennelpp.go
@@ -38,7 +38,7 @@ func New() messageprocessors.PayloadEncodeDecoder {
 
 var (
 	errInput  = errors.DefineInvalidArgument("input", "invalid input")
-	errOutput = errors.Define("output", "invalid output")
+	errOutput = errors.DefineInvalidArgument("output", "invalid output")
 )
 
 // EncodeDownlink encodes the message's DecodedPayload to FRMPayload using CayenneLPP encoding.

--- a/pkg/networkserver/mac/utils.go
+++ b/pkg/networkserver/mac/utils.go
@@ -37,7 +37,7 @@ func channelDataRateRange(chs ...*ttnpb.MACParameters_Channel) (min, max ttnpb.D
 		if i >= len(chs) {
 			return 0, 0, false
 		}
-		if chs[i].EnableUplink {
+		if chs[i].GetEnableUplink() {
 			break
 		}
 		i++
@@ -46,7 +46,7 @@ func channelDataRateRange(chs ...*ttnpb.MACParameters_Channel) (min, max ttnpb.D
 	min = chs[i].MinDataRateIndex
 	max = chs[i].MaxDataRateIndex
 	for _, ch := range chs[i+1:] {
-		if !ch.EnableUplink {
+		if !ch.GetEnableUplink() {
 			continue
 		}
 		if ch.MaxDataRateIndex > max {

--- a/pkg/networkserver/utils.go
+++ b/pkg/networkserver/utils.go
@@ -37,7 +37,7 @@ func nsScheduleWindow() time.Duration {
 
 func searchUplinkChannel(freq uint64, macState *ttnpb.MACState) (uint8, error) {
 	for i, ch := range macState.CurrentParameters.Channels {
-		if ch.UplinkFrequency == freq {
+		if ch.GetUplinkFrequency() == freq {
 			return uint8(i), nil
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://sentry.io/organizations/the-things-industries/issues/2780300004/?project=2682566
References https://sentry.io/organizations/the-things-industries/issues/2406140221/?project=2682566
References https://sentry.io/organizations/the-things-industries/issues/2474217529/?project=2682566
References https://sentry.io/organizations/the-things-industries/issues/2828875503/?project=2682566
References https://sentry.io/organizations/the-things-industries/issues/2232797687/?project=2682566

#### Changes
<!-- What are the changes made in this pull request? -->

- Disable `nil` channels via validation of the MAC state
  - This was possible due to missing validation
  - Existing devices are to be found and edited on demand unfortunately, I'll think of a way of doing this systematically perhaps via a migration
  - We may want to add this kind of validation to other `repeated` messages too - please let me know if you want this to be done systematically.
- Adjust some error codes that were unknown / corruption
- Gateways are now claimed using a decoupled context, in order to avoid spurious errors because the gateway disconnected sporadically. Keep in mind that we don't actually know if the claim succeeded, if the gateway disconnects while `ClaimIDs` is running, so we may actually miss an unclaim if we don't use an 'uncancellable context'. 


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
