### PR TITLE
Validate MAC settings data rate indices

### DIFF
--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -1176,6 +1176,10 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 		"mac_settings.factory_preset_frequencies",
 		"mac_settings.ping_slot_frequency.value",
 		"mac_settings.use_adr.value",
+		"mac_settings.rx2_data_rate_index.value",
+		"mac_settings.desired_rx2_data_rate_index.value",
+		"mac_settings.ping_slot_data_rate_index.value",
+		"mac_settings.desired_ping_slot_data_rate_index.value",
 		"mac_state.current_parameters.adr_data_rate_index",
 		"mac_state.current_parameters.adr_tx_power_index",
 		"mac_state.current_parameters.channels",
@@ -1244,6 +1248,94 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 					return nil
 				})
 			}, "version_ids.band_id"); err != nil {
+				return nil, err
+			}
+		}
+		if st.HasSetField(
+			"frequency_plan_id",
+			"lorawan_phy_version",
+			"mac_settings.rx2_data_rate_index.value",
+		) {
+			if err := st.WithField(func(dev *ttnpb.EndDevice) error {
+				return withPHY(func(phy *band.Band, fp *frequencyplans.FrequencyPlan) error {
+					if dev.GetMacSettings().GetRx2DataRateIndex() == nil {
+						return nil
+					}
+					_, ok := phy.DataRates[dev.MacSettings.Rx2DataRateIndex.Value]
+					if !ok {
+						return newInvalidFieldValueError("mac_settings.rx2_data_rate_index.value")
+					}
+					return nil
+				})
+			},
+				"mac_settings.rx2_data_rate_index.value",
+			); err != nil {
+				return nil, err
+			}
+		}
+		if st.HasSetField(
+			"frequency_plan_id",
+			"lorawan_phy_version",
+			"mac_settings.desired_rx2_data_rate_index.value",
+		) {
+			if err := st.WithField(func(dev *ttnpb.EndDevice) error {
+				return withPHY(func(phy *band.Band, fp *frequencyplans.FrequencyPlan) error {
+					if dev.GetMacSettings().GetDesiredRx2DataRateIndex() == nil {
+						return nil
+					}
+					_, ok := phy.DataRates[dev.MacSettings.DesiredRx2DataRateIndex.Value]
+					if !ok {
+						return newInvalidFieldValueError("mac_settings.desired_rx2_data_rate_index.value")
+					}
+					return nil
+				})
+			},
+				"mac_settings.desired_rx2_data_rate_index.value",
+			); err != nil {
+				return nil, err
+			}
+		}
+		if st.HasSetField(
+			"frequency_plan_id",
+			"lorawan_phy_version",
+			"mac_settings.ping_slot_data_rate_index.value",
+		) {
+			if err := st.WithField(func(dev *ttnpb.EndDevice) error {
+				return withPHY(func(phy *band.Band, fp *frequencyplans.FrequencyPlan) error {
+					if dev.GetMacSettings().GetPingSlotDataRateIndex() == nil {
+						return nil
+					}
+					_, ok := phy.DataRates[dev.MacSettings.PingSlotDataRateIndex.Value]
+					if !ok {
+						return newInvalidFieldValueError("mac_settings.ping_slot_data_rate_index.value")
+					}
+					return nil
+				})
+			},
+				"mac_settings.ping_slot_data_rate_index.value",
+			); err != nil {
+				return nil, err
+			}
+		}
+		if st.HasSetField(
+			"frequency_plan_id",
+			"lorawan_phy_version",
+			"mac_settings.desired_ping_slot_data_rate_index.value",
+		) {
+			if err := st.WithField(func(dev *ttnpb.EndDevice) error {
+				return withPHY(func(phy *band.Band, fp *frequencyplans.FrequencyPlan) error {
+					if dev.GetMacSettings().GetDesiredPingSlotDataRateIndex() == nil {
+						return nil
+					}
+					_, ok := phy.DataRates[dev.MacSettings.DesiredPingSlotDataRateIndex.Value]
+					if !ok {
+						return newInvalidFieldValueError("mac_settings.desired_ping_slot_data_rate_index.value")
+					}
+					return nil
+				})
+			},
+				"mac_settings.desired_ping_slot_data_rate_index.value",
+			); err != nil {
 				return nil, err
 			}
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://sentry.io/organizations/the-things-industries/issues/2662530577/events/c6d23bda96d246cf9fca3e30090af200/?project=2682566&statsPeriod=14d

#### Changes
<!-- What are the changes made in this pull request? -->

- Validate data rate indices present in the device MAC settings


#### Testing

<!-- How did you verify that this change works? -->

Local testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

I've tested locally by moving between bands. The simplest example is to try to move to AU915 from AS923 (Australia 923-25 FP). RX2 data rate index is default to 8 on AU915, but does not exist on AS923.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Existing end devices will continue to throw errors. I'd rather fix the individual end devices (not that many of them, but they do push a bit of traffic over time) than create a migration.

@bafonins do we need extra end to end tests for this ?

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
