### PR TITLE
Update tenant DevAddr blocks only when authenticated as host NetID"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ For details about compatibility between different releases, see the **Commitment
 - End device mac settings handling in the Console.
 - Uplink and downlink counters display on end device activity in the Console.
 - Join settings handling in JS-only deployments in the Console.
+- Configuring Packet Broker listed option when Packet Broker Agent is configured with a Packet Broker tenant API key.
 
 ### Security
 

--- a/pkg/packetbrokeragent/grpc_pba_test.go
+++ b/pkg/packetbrokeragent/grpc_pba_test.go
@@ -232,17 +232,7 @@ func TestPba(t *testing.T) {
 						Name: &pbtypes.StringValue{
 							Value: "Test Network",
 						},
-						DevAddrBlocks: &iampb.DevAddrBlocksValue{
-							Value: []*packetbroker.DevAddrBlock{
-								{
-									Prefix: &packetbroker.DevAddrPrefix{
-										Value:  0x26000000,
-										Length: 24,
-									},
-									HomeNetworkClusterId: "test-cluster",
-								},
-							},
-						},
+						// NOTE: DevAddrBlocks are not updated here, as the tenant cannot change their own DevAddr blocks.
 						AdministrativeContact: &packetbroker.ContactInfoValue{
 							Value: &packetbroker.ContactInfo{
 								Email: "admin@example.com",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsIndustries/lorawan-stack-support/issues/655

#### Changes
<!-- What are the changes made in this pull request? -->

If PBA uses an Packet Broker API key that has access to a tenant only, do not update DevAddr blocks. These can only be updated by the host NetID.

#### Testing

<!-- How did you verify that this change works? -->

CI

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
