### PR TITLE
Do not store correlation IDs for recent messages

### DIFF
--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -679,9 +679,12 @@ macLoop:
 }
 
 func appendRecentUplink(recent []*ttnpb.UplinkMessage, up *ttnpb.UplinkMessage, window int) []*ttnpb.UplinkMessage {
+	if n := len(recent); n > 0 {
+		recent[n-1].CorrelationIds = nil
+	}
 	recent = append(recent, up)
-	if len(recent) > window {
-		recent = recent[len(recent)-window:]
+	if extra := len(recent) - window; extra > 0 {
+		recent = recent[extra:]
 	}
 	return recent
 }

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -41,7 +41,7 @@ import (
 
 const (
 	// recentDownlinkCount is the maximum amount of recent downlinks stored per device.
-	recentDownlinkCount = 20
+	recentDownlinkCount = 5
 
 	// fOptsCapacity is the maximum length of FOpts in bytes.
 	fOptsCapacity = 15


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This short PR disables the storage of correlation IDs for recent uplinks and downlinks, except for the last message.

#### Changes
<!-- What are the changes made in this pull request? -->

- Clear the correlation IDs of the previous latest recent message on recent message storage
- Store only the latest 5 recent downlinks
   - Uplinks are used for ADR, so we cannot go lower than 20 without affecting ADR

#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
