### PR TITLE
Fix Redis namespace for non-general Redis instances

### DIFF
--- a/cmd/internal/shared/config.go
+++ b/cmd/internal/shared/config.go
@@ -95,11 +95,17 @@ var DefaultRedisConfig = redis.Config{
 	RootNamespace: []string{"ttn", "v3"},
 }
 
+// DefaultCacheConfig is the default cache configuration.
+var DefaultCacheConfig = config.Cache{
+	Redis: DefaultRedisConfig,
+}
+
 // DefaultEventsConfig is the default config for Events.
 var DefaultEventsConfig = func() config.Events {
 	c := config.Events{
 		Backend: "internal",
 	}
+	c.Redis.Config = DefaultRedisConfig
 	c.Redis.Store.TTL = 10 * time.Minute
 	c.Redis.Store.EntityTTL = 24 * time.Hour
 	c.Redis.Store.EntityCount = 100
@@ -136,6 +142,7 @@ var DefaultKeyVaultConfig = config.KeyVault{
 var DefaultServiceBase = config.ServiceBase{
 	Base:           DefaultBaseConfig,
 	Cluster:        DefaultClusterConfig,
+	Cache:          DefaultCacheConfig,
 	Redis:          DefaultRedisConfig,
 	Events:         DefaultEventsConfig,
 	GRPC:           DefaultGRPCConfig,

--- a/cmd/internal/shared/init.go
+++ b/cmd/internal/shared/init.go
@@ -31,6 +31,16 @@ func InitializeFallbacks(conf *config.ServiceBase) error {
 	if conf.Events.Redis.Config.IsZero() {
 		conf.Events.Redis.Config = conf.Redis
 	}
+	if !conf.Redis.Equals(DefaultRedisConfig) {
+		// Fallback to the default Redis configuration for the cache system
+		if conf.Cache.Redis.Equals(DefaultRedisConfig) {
+			conf.Cache.Redis = conf.Redis
+		}
+		// Fallback to the default Redis configuration for the events system
+		if conf.Events.Redis.Config.Equals(DefaultRedisConfig) {
+			conf.Events.Redis.Config = conf.Redis
+		}
+	}
 	return nil
 }
 

--- a/pkg/config/tlsconfig/config.go
+++ b/pkg/config/tlsconfig/config.go
@@ -115,6 +115,12 @@ type Client struct {
 	InsecureSkipVerify bool   `name:"insecure-skip-verify" description:"Skip verification of certificate chains (insecure)"`
 }
 
+// Equals checks if the other configuration is equivalent to this.
+func (c Client) Equals(other Client) bool {
+	return c.RootCA == other.RootCA &&
+		c.InsecureSkipVerify == other.InsecureSkipVerify
+}
+
 // ApplyTo applies the client configuration options to the given TLS configuration.
 // If tlsConfig is nil, this is a no-op.
 func (c *Client) ApplyTo(tlsConfig *tls.Config) error {

--- a/pkg/redis/redis.go
+++ b/pkg/redis/redis.go
@@ -96,6 +96,30 @@ type Config struct {
 	namespace []string
 }
 
+func equalsStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Equals checks if the other configuration is equivalent to this.
+func (c Config) Equals(other Config) bool {
+	return c.Address == other.Address &&
+		c.Password == other.Password &&
+		c.Database == other.Database &&
+		equalsStringSlice(c.RootNamespace, other.RootNamespace) &&
+		c.PoolSize == other.PoolSize &&
+		c.Failover.Equals(other.Failover) &&
+		c.TLS.Require == other.TLS.Require &&
+		c.TLS.Client.Equals(other.TLS.Client)
+}
+
 func (c Config) WithNamespace(namespace ...string) *Config {
 	deriv := c
 	deriv.namespace = namespace
@@ -115,6 +139,13 @@ type FailoverConfig struct {
 	Enable     bool     `name:"enable" description:"Enable failover using Redis Sentinel"`
 	Addresses  []string `name:"addresses" description:"Redis Sentinel server addresses"`
 	MasterName string   `name:"master-name" description:"Redis Sentinel master name"`
+}
+
+// Equals checks if the other configuration is equivalent to this.
+func (c FailoverConfig) Equals(other FailoverConfig) bool {
+	return c.Enable == other.Enable &&
+		equalsStringSlice(c.Addresses, other.Addresses) &&
+		c.MasterName == other.MasterName
 }
 
 func (c Config) makeDialer() func(ctx context.Context, network, addr string) (net.Conn, error) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes the way fallbacks are handled for Redis settings, specifically namespacing: the events and caching Redis instances do not have a `RootNamespace` set, so the keys look as follows:

![image](https://user-images.githubusercontent.com/36161392/145059004-dd8bca4e-dadf-4af3-a13a-54d2e9546dec.png)

This happens because the fallback occurs only when the configuration is empty, but if the address is provided, then the `RootNamespace` is not copied, and the keys have an empty one.

#### Changes
<!-- What are the changes made in this pull request? -->

- Introduce a default cache configuration. This will backfill the Redis configuration, including the root namespace, but the cache backend won't be set - the administrators need to manually set this to `redis` for caching to occur.
- Use the default Redis configuration for the events storage.


#### Testing

<!-- How did you verify that this change works? -->

Local testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This is a pretty breaking change. Specifically, since the root namespace won't be empty anymore, the old events won't be visible anymore when this occurs. I'm opening up this PR to ask if we want to fix this for a minor.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
