### PR TITLE
is: Add non-TLS interop listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Added
 
 - User defined antenna gain for LBS gateways.
+- Non-TLS interop listener. Default port is 1886.
 
 ### Changed
 

--- a/cmd/internal/shared/config.go
+++ b/cmd/internal/shared/config.go
@@ -73,6 +73,7 @@ var DefaultHTTPConfig = config.HTTP{
 
 // DefaultInteropServerConfig is the default interop server config.
 var DefaultInteropServerConfig = config.InteropServer{
+	Listen:    ":1886",
 	ListenTLS: ":8886",
 	PacketBroker: config.PacketBrokerInteropAuth{
 		Enabled:     false,

--- a/pkg/component/interop.go
+++ b/pkg/component/interop.go
@@ -46,7 +46,7 @@ func (c *Component) serveInterop(lis net.Listener) error {
 
 func (c *Component) interopEndpoints() []Endpoint {
 	return []Endpoint{
-		// TODO: Enable TCP endpoint (https://github.com/TheThingsNetwork/lorawan-stack/issues/717)
+		NewTCPEndpoint(c.config.Interop.Listen, "Interop"),
 		NewTLSEndpoint(c.config.Interop.ListenTLS, "Interop",
 			WithTLSClientAuth(tls.VerifyClientCertIfGiven, c.interop.ClientCAPool(), nil),
 			WithNextProtos("h2", "http/1.1"),

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -420,7 +420,8 @@ type PacketBrokerInteropAuth struct {
 
 // InteropServer represents the server-side interoperability through LoRaWAN Backend Interfaces configuration.
 type InteropServer struct {
-	ListenTLS        string `name:"listen-tls" description:"Address for the interop server for LoRaWAN Backend Interfaces to listen on"`
+	Listen           string `name:"listen" description:"Address for the interop server for LoRaWAN Backend Interfaces to listen on"`
+	ListenTLS        string `name:"listen-tls" description:"TLS address for the interop server for LoRaWAN Backend Interfaces to listen on"`
 	PublicTLSAddress string `name:"public-tls-address" description:"Public address of the interop server for LoRaWAN Backend Interfaces"`
 
 	SenderClientCA           SenderClientCA    `name:"sender-client-ca"`


### PR DESCRIPTION
#### Summary
References https://github.com/TheThingsNetwork/lorawan-stack/issues/4924

#### Changes
Added non-TLS interop listener

#### Testing
I don't know how to test this. When I run the stack locally, both TLS and non-TLS listeners report `route_not_found` when sending an example request.

##### Regressions
None

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
