### PR TITLE
Isolate FrequencyPlans from Component definition

### DIFF
--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -84,7 +84,7 @@ type Component struct {
 
 	fillers []fillcontext.Filler
 
-	FrequencyPlans *frequencyplans.Store
+	frequencyPlans *frequencyplans.Store
 	KeyVault       crypto.KeyVault
 
 	rightsFetcher rights.Fetcher
@@ -178,7 +178,7 @@ func New(logger log.Stack, config *Config, opts ...Option) (c *Component, err er
 	if err != nil {
 		return nil, err
 	}
-	c.FrequencyPlans = frequencyplans.NewStore(fpsFetcher)
+	c.frequencyPlans = frequencyplans.NewStore(fpsFetcher)
 
 	if c.clusterNew == nil {
 		c.clusterNew = cluster.New
@@ -263,6 +263,11 @@ func (c *Component) FromRequestContext(ctx context.Context) context.Context {
 		valueCtx:  ctx,
 		cancelCtx: c.ctx,
 	}
+}
+
+// FrequencyPlansStore returns the component's frequencyPlans Store
+func (c *Component) FrequencyPlansStore(ctx context.Context) (*frequencyplans.Store, error) {
+	return c.frequencyPlans, nil
 }
 
 // Start starts the component.

--- a/pkg/component/configuration_grpc.go
+++ b/pkg/component/configuration_grpc.go
@@ -49,7 +49,11 @@ func (c *ConfigurationServer) RegisterHandlers(s *runtime.ServeMux, conn *grpc.C
 
 // ListFrequencyPlans implements the Configuration service's ListFrequencyPlans RPC.
 func (c *ConfigurationServer) ListFrequencyPlans(ctx context.Context, req *ttnpb.ListFrequencyPlansRequest) (*ttnpb.ListFrequencyPlansResponse, error) {
-	return frequencyplans.NewRPCServer(c.component.FrequencyPlans).ListFrequencyPlans(ctx, req)
+	fps, err := c.component.FrequencyPlansStore(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return frequencyplans.NewRPCServer(fps).ListFrequencyPlans(ctx, req)
 }
 
 // GetPhyVersions implements the Configuration service's GetPhyVersions RPC.

--- a/pkg/gatewayconfigurationserver/server.go
+++ b/pkg/gatewayconfigurationserver/server.go
@@ -128,13 +128,21 @@ func (s *Server) RegisterRoutes(server *web.Server) {
 
 	router.Handle("/semtechudp/global_conf.json",
 		s.makeJSONHandler(func(ctx context.Context, gtw *ttnpb.Gateway) (interface{}, error) {
-			return semtechudp.Build(gtw, s.FrequencyPlans)
+			fps, err := s.FrequencyPlansStore(ctx)
+			if err != nil {
+				return nil, err
+			}
+			return semtechudp.Build(gtw, fps)
 		}),
 	).Methods(http.MethodGet)
 
 	router.Handle("/kerlink-cpf/lorad/lorad.json",
 		s.makeJSONHandler(func(ctx context.Context, gtw *ttnpb.Gateway) (interface{}, error) {
-			return cpf.BuildLorad(gtw, s.FrequencyPlans)
+			fps, err := s.FrequencyPlansStore(ctx)
+			if err != nil {
+				return nil, err
+			}
+			return cpf.BuildLorad(gtw, fps)
 		}),
 	).Methods(http.MethodGet)
 

--- a/pkg/gatewayconfigurationserver/v2/http_frequency_plan.go
+++ b/pkg/gatewayconfigurationserver/v2/http_frequency_plan.go
@@ -24,8 +24,14 @@ import (
 )
 
 func (s *Server) handleGetFrequencyPlan(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	frequencyPlanID := mux.Vars(r)["frequency_plan_id"]
-	plan, err := s.component.FrequencyPlans.GetByID(frequencyPlanID)
+	fps, err := s.component.FrequencyPlansStore(ctx)
+	if err != nil {
+		webhandlers.Error(w, r, err)
+		return
+	}
+	plan, err := fps.GetByID(frequencyPlanID)
 	if err != nil {
 		webhandlers.Error(w, r, err)
 		return

--- a/pkg/gatewayconfigurationserver/v2/server_test.go
+++ b/pkg/gatewayconfigurationserver/v2/server_test.go
@@ -239,10 +239,13 @@ func TestGetFrequencyPlan(t *testing.T) {
 					HTTP: config.HTTP{
 						Listen: ":0",
 					},
+					FrequencyPlans: config.FrequencyPlansConfig{
+						ConfigSource: "static",
+						Static:       test.StaticFrequencyPlans,
+					},
 				},
 			}
 			c := componenttest.NewComponent(t, conf)
-			c.FrequencyPlans.Fetcher = test.FrequencyPlansFetcher
 			New(c)
 			componenttest.StartComponent(t, c)
 			defer c.Close()

--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -40,7 +40,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/errorcontext"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
-	"go.thethings.network/lorawan-stack/v3/pkg/frequencyplans"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/udp"
@@ -91,6 +90,10 @@ func TestGatewayServer(t *testing.T) {
 						Cluster: cluster.Config{
 							IdentityServer: isAddr,
 							NetworkServer:  nsAddr,
+						},
+						FrequencyPlans: config.FrequencyPlansConfig{
+							ConfigSource: "static",
+							Static:       test.StaticFrequencyPlans,
 						},
 					},
 				})
@@ -162,8 +165,6 @@ func TestGatewayServer(t *testing.T) {
 			roles := gs.Roles()
 			a.So(len(roles), should.Equal, 1)
 			a.So(roles[0], should.Equal, ttnpb.ClusterRole_GATEWAY_SERVER)
-
-			c.FrequencyPlans = frequencyplans.NewStore(test.FrequencyPlansFetcher)
 
 			config, err := gs.GetConfig(ctx)
 			a.So(err, should.BeNil)
@@ -1779,6 +1780,10 @@ func TestUpdateVersionInfo(t *testing.T) {
 			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
+			FrequencyPlans: config.FrequencyPlansConfig{
+				ConfigSource: "static",
+				Static:       test.StaticFrequencyPlans,
+			},
 		},
 	})
 
@@ -1803,8 +1808,6 @@ func TestUpdateVersionInfo(t *testing.T) {
 	roles := gs.Roles()
 	a.So(len(roles), should.Equal, 1)
 	a.So(roles[0], should.Equal, ttnpb.ClusterRole_GATEWAY_SERVER)
-
-	c.FrequencyPlans = frequencyplans.NewStore(test.FrequencyPlansFetcher)
 	a.So(err, should.BeNil)
 
 	componenttest.StartComponent(t, c)

--- a/pkg/gatewayserver/io/grpc/grpc_test.go
+++ b/pkg/gatewayserver/io/grpc/grpc_test.go
@@ -28,7 +28,6 @@ import (
 	componenttest "go.thethings.network/lorawan-stack/v3/pkg/component/test"
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
-	"go.thethings.network/lorawan-stack/v3/pkg/frequencyplans"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io"
 	. "go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/grpc"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/mock"
@@ -67,9 +66,12 @@ func TestAuthentication(t *testing.T) {
 			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
+			FrequencyPlans: config.FrequencyPlansConfig{
+				ConfigSource: "static",
+				Static:       test.StaticFrequencyPlans,
+			},
 		},
 	})
-	c.FrequencyPlans = frequencyplans.NewStore(test.FrequencyPlansFetcher)
 	gs := mock.NewServer(c)
 	srv := New(gs)
 	c.RegisterGRPC(&mockRegisterer{ctx, srv})
@@ -165,9 +167,12 @@ func TestTraffic(t *testing.T) {
 			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
+			FrequencyPlans: config.FrequencyPlansConfig{
+				ConfigSource: "static",
+				Static:       test.StaticFrequencyPlans,
+			},
 		},
 	})
-	c.FrequencyPlans = frequencyplans.NewStore(test.FrequencyPlansFetcher)
 	gs := mock.NewServer(c)
 	srv := New(gs)
 	c.RegisterGRPC(&mockRegisterer{ctx, srv})
@@ -600,9 +605,12 @@ func TestConcentratorConfig(t *testing.T) {
 			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
+			FrequencyPlans: config.FrequencyPlansConfig{
+				ConfigSource: "static",
+				Static:       test.StaticFrequencyPlans,
+			},
 		},
 	})
-	c.FrequencyPlans = frequencyplans.NewStore(test.FrequencyPlansFetcher)
 	gs := mock.NewServer(c)
 	srv := New(gs)
 	c.RegisterGRPC(&mockRegisterer{ctx, srv})
@@ -653,9 +661,12 @@ func TestMQTTConfig(t *testing.T) {
 			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
+			FrequencyPlans: config.FrequencyPlansConfig{
+				ConfigSource: "static",
+				Static:       test.StaticFrequencyPlans,
+			},
 		},
 	})
-	c.FrequencyPlans = frequencyplans.NewStore(test.FrequencyPlansFetcher)
 	gs := mock.NewServer(c)
 	srv := New(gs,
 		WithMQTTConfigProvider(&mockMQTTConfigProvider{

--- a/pkg/gatewayserver/io/io_test.go
+++ b/pkg/gatewayserver/io/io_test.go
@@ -23,8 +23,8 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/v3/pkg/component"
 	componenttest "go.thethings.network/lorawan-stack/v3/pkg/component/test"
+	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
-	"go.thethings.network/lorawan-stack/v3/pkg/frequencyplans"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/mock"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
@@ -47,8 +47,14 @@ func TestFlow(t *testing.T) {
 	a := assertions.New(t)
 	ctx := log.NewContext(test.Context(), test.GetLogger(t))
 
-	c := componenttest.NewComponent(t, &component.Config{})
-	c.FrequencyPlans = frequencyplans.NewStore(test.FrequencyPlansFetcher)
+	c := componenttest.NewComponent(t, &component.Config{
+		ServiceBase: config.ServiceBase{
+			FrequencyPlans: config.FrequencyPlansConfig{
+				ConfigSource: "static",
+				Static:       test.StaticFrequencyPlans,
+			},
+		},
+	})
 	gs := mock.NewServer(c)
 
 	ids := ttnpb.GatewayIdentifiers{GatewayId: "foo-gateway"}
@@ -522,8 +528,14 @@ func TestSubBandEIRPOverride(t *testing.T) {
 	a := assertions.New(t)
 	ctx := log.NewContext(test.Context(), test.GetLogger(t))
 
-	c := componenttest.NewComponent(t, &component.Config{})
-	c.FrequencyPlans = frequencyplans.NewStore(test.FrequencyPlansFetcher)
+	c := componenttest.NewComponent(t, &component.Config{
+		ServiceBase: config.ServiceBase{
+			FrequencyPlans: config.FrequencyPlansConfig{
+				ConfigSource: "static",
+				Static:       test.StaticFrequencyPlans,
+			},
+		},
+	})
 	gs := mock.NewServer(c)
 
 	ids := ttnpb.GatewayIdentifiers{GatewayId: "bar-gateway"}

--- a/pkg/gatewayserver/io/mock/server.go
+++ b/pkg/gatewayserver/io/mock/server.go
@@ -86,7 +86,11 @@ func (s *server) Connect(ctx context.Context, frontend io.Frontend, ids ttnpb.Ga
 			FrequencyPlanId: test.EUFrequencyPlanID,
 		}
 	}
-	conn, err := io.NewConnection(ctx, frontend, gtw, s.FrequencyPlans, true, nil)
+	fps, err := s.FrequencyPlansStore(ctx)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := io.NewConnection(ctx, frontend, gtw, fps, true, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gatewayserver/io/mqtt/mqtt_test.go
+++ b/pkg/gatewayserver/io/mqtt/mqtt_test.go
@@ -29,7 +29,6 @@ import (
 	componenttest "go.thethings.network/lorawan-stack/v3/pkg/component/test"
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
-	"go.thethings.network/lorawan-stack/v3/pkg/frequencyplans"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/mock"
 	. "go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/mqtt"
@@ -67,9 +66,12 @@ func TestAuthentication(t *testing.T) {
 			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
+			FrequencyPlans: config.FrequencyPlansConfig{
+				ConfigSource: "static",
+				Static:       test.StaticFrequencyPlans,
+			},
 		},
 	})
-	c.FrequencyPlans = frequencyplans.NewStore(test.FrequencyPlansFetcher)
 	componenttest.StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
@@ -145,9 +147,12 @@ func TestTraffic(t *testing.T) {
 			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
+			FrequencyPlans: config.FrequencyPlansConfig{
+				ConfigSource: "static",
+				Static:       test.StaticFrequencyPlans,
+			},
 		},
 	})
-	c.FrequencyPlans = frequencyplans.NewStore(test.FrequencyPlansFetcher)
 	componenttest.StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)

--- a/pkg/gatewayserver/io/udp/udp_test.go
+++ b/pkg/gatewayserver/io/udp/udp_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/component"
 	componenttest "go.thethings.network/lorawan-stack/v3/pkg/component/test"
-	"go.thethings.network/lorawan-stack/v3/pkg/frequencyplans"
+	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/mock"
 	. "go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/udp"
@@ -60,8 +60,14 @@ func TestConnection(t *testing.T) {
 	ctx, cancelCtx := context.WithCancel(ctx)
 	defer cancelCtx()
 
-	c := componenttest.NewComponent(t, &component.Config{})
-	c.FrequencyPlans = frequencyplans.NewStore(test.FrequencyPlansFetcher)
+	c := componenttest.NewComponent(t, &component.Config{
+		ServiceBase: config.ServiceBase{
+			FrequencyPlans: config.FrequencyPlansConfig{
+				ConfigSource: "static",
+				Static:       test.StaticFrequencyPlans,
+			},
+		},
+	})
 	componenttest.StartComponent(t, c)
 	defer c.Close()
 
@@ -200,8 +206,14 @@ func TestTraffic(t *testing.T) {
 	ctx, cancelCtx := context.WithCancel(ctx)
 	defer cancelCtx()
 
-	c := componenttest.NewComponent(t, &component.Config{})
-	c.FrequencyPlans = frequencyplans.NewStore(test.FrequencyPlansFetcher)
+	c := componenttest.NewComponent(t, &component.Config{
+		ServiceBase: config.ServiceBase{
+			FrequencyPlans: config.FrequencyPlansConfig{
+				ConfigSource: "static",
+				Static:       test.StaticFrequencyPlans,
+			},
+		},
+	})
 	componenttest.StartComponent(t, c)
 	defer c.Close()
 

--- a/pkg/gatewayserver/io/ws/ws_test.go
+++ b/pkg/gatewayserver/io/ws/ws_test.go
@@ -35,7 +35,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/encoding/lorawan"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
-	"go.thethings.network/lorawan-stack/v3/pkg/frequencyplans"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/mock"
 	. "go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/ws"
@@ -91,9 +90,12 @@ func TestClientTokenAuth(t *testing.T) {
 			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
+			FrequencyPlans: config.FrequencyPlansConfig{
+				ConfigSource: "static",
+				Static:       test.StaticFrequencyPlans,
+			},
 		},
 	})
-	c.FrequencyPlans = frequencyplans.NewStore(test.FrequencyPlansFetcher)
 	componenttest.StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
@@ -224,9 +226,12 @@ func TestDiscover(t *testing.T) {
 			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
+			FrequencyPlans: config.FrequencyPlansConfig{
+				ConfigSource: "static",
+				Static:       test.StaticFrequencyPlans,
+			},
 		},
 	})
-	c.FrequencyPlans = frequencyplans.NewStore(test.FrequencyPlansFetcher)
 	componenttest.StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
@@ -479,10 +484,12 @@ func TestVersion(t *testing.T) {
 				Listen:                      ":0",
 				AllowInsecureForCredentials: true,
 			},
+			FrequencyPlans: config.FrequencyPlansConfig{
+				ConfigSource: "static",
+				Static:       test.StaticFrequencyPlans,
+			},
 		},
 	})
-
-	c.FrequencyPlans = frequencyplans.NewStore(test.FrequencyPlansFetcher)
 	componenttest.StartComponent(t, c)
 	defer c.Close()
 	gs := mock.NewServer(c)
@@ -749,9 +756,12 @@ func TestTraffic(t *testing.T) {
 			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
+			FrequencyPlans: config.FrequencyPlansConfig{
+				ConfigSource: "static",
+				Static:       test.StaticFrequencyPlans,
+			},
 		},
 	})
-	c.FrequencyPlans = frequencyplans.NewStore(test.FrequencyPlansFetcher)
 	componenttest.StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
@@ -1209,9 +1219,12 @@ func TestRTT(t *testing.T) {
 			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
+			FrequencyPlans: config.FrequencyPlansConfig{
+				ConfigSource: "static",
+				Static:       test.StaticFrequencyPlans,
+			},
 		},
 	})
-	c.FrequencyPlans = frequencyplans.NewStore(test.FrequencyPlansFetcher)
 	componenttest.StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)
@@ -1532,9 +1545,12 @@ func TestPingPong(t *testing.T) {
 			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
+			FrequencyPlans: config.FrequencyPlansConfig{
+				ConfigSource: "static",
+				Static:       test.StaticFrequencyPlans,
+			},
 		},
 	})
-	c.FrequencyPlans = frequencyplans.NewStore(test.FrequencyPlansFetcher)
 	componenttest.StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)

--- a/pkg/gatewayserver/io/ws/ws_util_test.go
+++ b/pkg/gatewayserver/io/ws/ws_util_test.go
@@ -29,7 +29,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/component"
 	componenttest "go.thethings.network/lorawan-stack/v3/pkg/component/test"
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
-	"go.thethings.network/lorawan-stack/v3/pkg/frequencyplans"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/mock"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/ws"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/ws/lbslns"
@@ -63,10 +62,13 @@ func withServer(t *testing.T, wsConfig ws.Config, rateLimitConf config.RateLimit
 			Cluster: cluster.Config{
 				IdentityServer: isAddr,
 			},
+			FrequencyPlans: config.FrequencyPlansConfig{
+				ConfigSource: "static",
+				Static:       test.StaticFrequencyPlans,
+			},
 			RateLimiting: rateLimitConf,
 		},
 	})
-	c.FrequencyPlans = frequencyplans.NewStore(test.FrequencyPlansFetcher)
 	componenttest.StartComponent(t, c)
 	defer c.Close()
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_ENTITY_REGISTRY)

--- a/pkg/gatewayserver/redis/registry_test.go
+++ b/pkg/gatewayserver/redis/registry_test.go
@@ -127,7 +127,7 @@ func TestRegistry(t *testing.T) {
 		a.So(err, should.BeNil)
 		a.So(retrieved, should.Resemble, stats)
 
-		time.Sleep(Timeout)
+		time.Sleep(2 * Timeout)
 
 		// shouldn't be found after ttl has passed
 		retrieved, err = registry.Get(ctx, ids)

--- a/pkg/networkserver/downlink_test.go
+++ b/pkg/networkserver/downlink_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/band"
+	"go.thethings.network/lorawan-stack/v3/pkg/component"
+	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/crypto"
 	"go.thethings.network/lorawan-stack/v3/pkg/encoding/lorawan"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
@@ -2546,6 +2548,14 @@ func TestProcessDownlinkTask(t *testing.T) {
 							errCh <- conf.Func(conf.Context)
 						}()
 					}),
+					Component: component.Config{
+						ServiceBase: config.ServiceBase{
+							FrequencyPlans: config.FrequencyPlansConfig{
+								ConfigSource: "static",
+								Static:       test.StaticFrequencyPlans,
+							},
+						},
+					},
 				})
 				defer stop()
 

--- a/pkg/networkserver/grpc.go
+++ b/pkg/networkserver/grpc.go
@@ -32,7 +32,11 @@ func (ns *NetworkServer) GenerateDevAddr(ctx context.Context, req *pbtypes.Empty
 }
 
 func (ns *NetworkServer) GetDefaultMACSettings(ctx context.Context, req *ttnpb.GetDefaultMACSettingsRequest) (*ttnpb.MACSettings, error) {
-	fp, phy, err := FrequencyPlanAndBand(req.FrequencyPlanId, req.LorawanPhyVersion, ns.FrequencyPlans)
+	fps, err := ns.FrequencyPlansStore(ctx)
+	if err != nil {
+		return nil, err
+	}
+	fp, phy, err := FrequencyPlanAndBand(req.FrequencyPlanId, req.LorawanPhyVersion, fps)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/networkserver/grpc_asns.go
+++ b/pkg/networkserver/grpc_asns.go
@@ -305,7 +305,11 @@ func (ns *NetworkServer) DownlinkQueueReplace(ctx context.Context, req *ttnpb.Do
 			if dev.PendingSession != nil {
 				dev.PendingSession.QueuedApplicationDownlinks = nil
 			}
-			if err := matchQueuedApplicationDownlinks(ctx, dev, ns.FrequencyPlans, req.Downlinks...); err != nil {
+			fps, err := ns.FrequencyPlansStore(ctx)
+			if err != nil {
+				return nil, nil, err
+			}
+			if err := matchQueuedApplicationDownlinks(ctx, dev, fps, req.Downlinks...); err != nil {
 				return nil, nil, err
 			}
 			if len(dev.Session.GetQueuedApplicationDownlinks()) > ns.downlinkQueueCapacity || len(dev.PendingSession.GetQueuedApplicationDownlinks()) > ns.downlinkQueueCapacity {
@@ -365,7 +369,11 @@ func (ns *NetworkServer) DownlinkQueuePush(ctx context.Context, req *ttnpb.Downl
 			if dev == nil {
 				return nil, nil, errDeviceNotFound.New()
 			}
-			if err := matchQueuedApplicationDownlinks(ctx, dev, ns.FrequencyPlans, req.Downlinks...); err != nil {
+			fps, err := ns.FrequencyPlansStore(ctx)
+			if err != nil {
+				return nil, nil, err
+			}
+			if err := matchQueuedApplicationDownlinks(ctx, dev, fps, req.Downlinks...); err != nil {
 				return nil, nil, err
 			}
 			if len(dev.Session.GetQueuedApplicationDownlinks()) > ns.downlinkQueueCapacity || len(dev.PendingSession.GetQueuedApplicationDownlinks()) > ns.downlinkQueueCapacity {

--- a/pkg/networkserver/grpc_asns_test.go
+++ b/pkg/networkserver/grpc_asns_test.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/v3/pkg/component"
+	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	. "go.thethings.network/lorawan-stack/v3/pkg/networkserver"
 	. "go.thethings.network/lorawan-stack/v3/pkg/networkserver/internal"
@@ -705,6 +707,14 @@ func TestDownlinkQueueReplace(t *testing.T) {
 						TaskStarter: StartTaskExclude(
 							DownlinkProcessTaskName,
 						),
+						Component: component.Config{
+							ServiceBase: config.ServiceBase{
+								FrequencyPlans: config.FrequencyPlansConfig{
+									ConfigSource: "static",
+									Static:       test.StaticFrequencyPlans,
+								},
+							},
+						},
 					},
 				)
 				defer stop()
@@ -1276,6 +1286,14 @@ func TestDownlinkQueuePush(t *testing.T) {
 						TaskStarter: StartTaskExclude(
 							DownlinkProcessTaskName,
 						),
+						Component: component.Config{
+							ServiceBase: config.ServiceBase{
+								FrequencyPlans: config.FrequencyPlansConfig{
+									ConfigSource: "static",
+									Static:       test.StaticFrequencyPlans,
+								},
+							},
+						},
 					},
 				)
 				defer stop()
@@ -1497,6 +1515,14 @@ func TestDownlinkQueueList(t *testing.T) {
 						TaskStarter: StartTaskExclude(
 							DownlinkProcessTaskName,
 						),
+						Component: component.Config{
+							ServiceBase: config.ServiceBase{
+								FrequencyPlans: config.FrequencyPlansConfig{
+									ConfigSource: "static",
+									Static:       test.StaticFrequencyPlans,
+								},
+							},
+						},
 					},
 				)
 				defer stop()

--- a/pkg/networkserver/grpc_deviceregistry_test.go
+++ b/pkg/networkserver/grpc_deviceregistry_test.go
@@ -853,6 +853,10 @@ func TestDeviceRegistrySet(t *testing.T) {
 									},
 								},
 								KeyVault: test.DefaultKeyVault,
+								FrequencyPlans: config.FrequencyPlansConfig{
+									ConfigSource: "static",
+									Static:       test.StaticFrequencyPlans,
+								},
 							},
 						},
 						NetworkServer: nsConf,
@@ -1107,6 +1111,10 @@ func TestDeviceRegistryResetFactoryDefaults(t *testing.T) {
 									},
 								},
 								KeyVault: test.DefaultKeyVault,
+								FrequencyPlans: config.FrequencyPlansConfig{
+									ConfigSource: "static",
+									Static:       test.StaticFrequencyPlans,
+								},
 							},
 						},
 						NetworkServer: nsConf,
@@ -1175,8 +1183,13 @@ func TestDeviceRegistryResetFactoryDefaults(t *testing.T) {
 							return
 						}
 
+						fps, err := ns.FrequencyPlansStore(ctx)
+						if !a.So(err, should.BeNil) {
+							t.Fail()
+							return
+						}
 						var newErr error
-						macState, newErr = mac.NewState(created, ns.FrequencyPlans, DefaultConfig.DefaultMACSettings.Parse())
+						macState, newErr = mac.NewState(created, fps, DefaultConfig.DefaultMACSettings.Parse())
 						if newErr != nil {
 							a.So(err, should.NotBeNil)
 							a.So(err, should.HaveSameErrorDefinitionAs, newErr)

--- a/pkg/networkserver/grpc_test.go
+++ b/pkg/networkserver/grpc_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/v3/pkg/component"
+	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	. "go.thethings.network/lorawan-stack/v3/pkg/networkserver"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -70,6 +72,14 @@ func TestGenerateDevAddr(t *testing.T) {
 					TaskStarter: StartTaskExclude(
 						DownlinkProcessTaskName,
 					),
+					Component: component.Config{
+						ServiceBase: config.ServiceBase{
+							FrequencyPlans: config.FrequencyPlansConfig{
+								ConfigSource: "static",
+								Static:       test.StaticFrequencyPlans,
+							},
+						},
+					},
 				})
 				defer stop()
 
@@ -149,6 +159,14 @@ func TestGenerateDevAddr(t *testing.T) {
 					TaskStarter: StartTaskExclude(
 						DownlinkProcessTaskName,
 					),
+					Component: component.Config{
+						ServiceBase: config.ServiceBase{
+							FrequencyPlans: config.FrequencyPlansConfig{
+								ConfigSource: "static",
+								Static:       test.StaticFrequencyPlans,
+							},
+						},
+					},
 				})
 				defer stop()
 
@@ -209,7 +227,16 @@ func TestGetDefaultMACSettings(t *testing.T) {
 			Name:     tc.name,
 			Parallel: true,
 			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
-				ns, _, _, stop := StartTest(ctx, TestConfig{})
+				ns, _, _, stop := StartTest(ctx, TestConfig{
+					Component: component.Config{
+						ServiceBase: config.ServiceBase{
+							FrequencyPlans: config.FrequencyPlansConfig{
+								ConfigSource: "static",
+								Static:       test.StaticFrequencyPlans,
+							},
+						},
+					},
+				})
 				defer stop()
 				settings, err := ttnpb.NewNsClient(ns.LoopbackConn()).GetDefaultMACSettings(test.Context(), tc.req)
 				if tc.assertion != nil {

--- a/pkg/networkserver/networkserver_flow_test.go
+++ b/pkg/networkserver/networkserver_flow_test.go
@@ -25,6 +25,8 @@ import (
 	pbtypes "github.com/gogo/protobuf/types"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/band"
+	"go.thethings.network/lorawan-stack/v3/pkg/component"
+	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/frequencyplans"
 	. "go.thethings.network/lorawan-stack/v3/pkg/networkserver"
@@ -416,6 +418,14 @@ func TestFlow(t *testing.T) {
 
 					_, ctx, env, stop := StartTest(ctx, TestConfig{
 						NetworkServer: nsConf,
+						Component: component.Config{
+							ServiceBase: config.ServiceBase{
+								FrequencyPlans: config.FrequencyPlansConfig{
+									ConfigSource: "static",
+									Static:       test.StaticFrequencyPlans,
+								},
+							},
+						},
 					})
 					defer stop()
 					handleFlowTest(ctx, env)

--- a/pkg/networkserver/networkserver_internal_test.go
+++ b/pkg/networkserver/networkserver_internal_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/v3/pkg/component"
+	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
@@ -38,6 +40,14 @@ func TestNewDevAddr(t *testing.T) {
 					TaskStarter: StartTaskExclude(
 						DownlinkProcessTaskName,
 					),
+					Component: component.Config{
+						ServiceBase: config.ServiceBase{
+							FrequencyPlans: config.FrequencyPlansConfig{
+								ConfigSource: "static",
+								Static:       test.StaticFrequencyPlans,
+							},
+						},
+					},
 				},
 			)
 			defer stop()
@@ -77,6 +87,14 @@ func TestNewDevAddr(t *testing.T) {
 					TaskStarter: StartTaskExclude(
 						DownlinkProcessTaskName,
 					),
+					Component: component.Config{
+						ServiceBase: config.ServiceBase{
+							FrequencyPlans: config.FrequencyPlansConfig{
+								ConfigSource: "static",
+								Static:       test.StaticFrequencyPlans,
+							},
+						},
+					},
 				},
 			)
 			defer stop()

--- a/pkg/networkserver/networkserver_util_internal_test.go
+++ b/pkg/networkserver/networkserver_util_internal_test.go
@@ -2003,7 +2003,6 @@ func StartTest(ctx context.Context, conf TestConfig) (*NetworkServer, context.Co
 		&conf.NetworkServer,
 		conf.NetworkServerOptions...,
 	)).(*NetworkServer)
-	ns.Component.FrequencyPlans = frequencyplans.NewStore(test.FrequencyPlansFetcher)
 
 	env := TestEnvironment{
 		Config: conf.NetworkServer,

--- a/pkg/packetbrokeragent/agent.go
+++ b/pkg/packetbrokeragent/agent.go
@@ -291,6 +291,11 @@ func New(c *component.Component, conf *Config, opts ...Option) (*Agent, error) {
 	} else {
 		a.grpc.pba = &disabledServer{}
 	}
+
+	getFrequencyPlanStore := func(ctx context.Context) (frequencyPlansStore, error) {
+		return a.FrequencyPlansStore(ctx)
+	}
+
 	if a.forwarderConfig.Enable {
 		mapperConn, err := a.dialContext(ctx, conf.MapperAddress)
 		if err != nil {
@@ -303,7 +308,7 @@ func New(c *component.Component, conf *Config, opts ...Option) (*Agent, error) {
 			messageEncrypter:    a,
 			contextDecoupler:    a,
 			tenantIDExtractor:   a.tenantIDExtractor,
-			frequencyPlansStore: a.FrequencyPlans,
+			frequencyPlansStore: getFrequencyPlanStore,
 			upstreamCh:          a.upstreamCh,
 			mapperConn:          mapperConn,
 		}
@@ -314,7 +319,7 @@ func New(c *component.Component, conf *Config, opts ...Option) (*Agent, error) {
 		a.grpc.nsPba = &nsPbaServer{
 			contextDecoupler: a,
 			downstreamCh:     a.downstreamCh,
-			frequencyPlans:   a.FrequencyPlans,
+			frequencyPlans:   getFrequencyPlanStore,
 		}
 	} else {
 		a.grpc.nsPba = &disabledServer{}

--- a/pkg/packetbrokeragent/agent_test.go
+++ b/pkg/packetbrokeragent/agent_test.go
@@ -74,9 +74,13 @@ func TestForwarder(t *testing.T) {
 	defer cancel()
 
 	c := componenttest.NewComponent(t, &component.Config{
-		ServiceBase: config.ServiceBase{},
+		ServiceBase: config.ServiceBase{
+			FrequencyPlans: config.FrequencyPlansConfig{
+				ConfigSource: "static",
+				Static:       test.StaticFrequencyPlans,
+			},
+		},
 	})
-	c.FrequencyPlans = test.FrequencyPlanStore
 
 	dp, dpAddr := mustServePBDataPlane(ctx, t)
 	mp, mpAddr := mustServePBMapper(ctx, t)
@@ -520,8 +524,14 @@ func TestHomeNetwork(t *testing.T) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	c := componenttest.NewComponent(t, &component.Config{})
-	c.FrequencyPlans = test.FrequencyPlanStore
+	c := componenttest.NewComponent(t, &component.Config{
+		ServiceBase: config.ServiceBase{
+			FrequencyPlans: config.FrequencyPlansConfig{
+				ConfigSource: "static",
+				Static:       test.StaticFrequencyPlans,
+			},
+		},
+	})
 
 	dp, addr := mustServePBDataPlane(ctx, t)
 

--- a/pkg/util/test/frequencyplans.go
+++ b/pkg/util/test/frequencyplans.go
@@ -401,15 +401,19 @@ max-eirp: 27`
 )
 
 var (
-	// FrequencyPlansFetcher fetches frequency plans from memory.
-	FrequencyPlansFetcher = fetch.NewMemFetcher(map[string][]byte{
+	// StaticFrequencyPlans contains the values used to mock a static
+	// frequencyStore in most tests component related
+	StaticFrequencyPlans = map[string][]byte{
 		"frequency-plans.yml":  []byte(frequencyPlansDescription),
 		"EU_863_870.yml":       []byte(euFrequencyPlan),
 		"KR_920_923.yml":       []byte(krFrequencyPlan),
 		"US_902_928_FSB_2.yml": []byte(usFrequencyPlan),
 		"AS_923_925_AU.yml":    []byte(asAUFrequencyPlan),
 		"EXAMPLE.yml":          []byte(exampleFrequencyPlan),
-	})
+	}
+
+	// FrequencyPlansFetcher fetches frequency plans from memory.
+	FrequencyPlansFetcher = fetch.NewMemFetcher(StaticFrequencyPlans)
 
 	FrequencyPlanStore = frequencyplans.NewStore(FrequencyPlansFetcher)
 )


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/issues/3005

#### Changes
<!-- What are the changes made in this pull request? -->

- Update `FrequencyPlans` variable from Component struct, not exported anymore
- Add `FrequencyPlans(ctx)` method to Component

#### Testing

<!-- How did you verify that this change works? -->
Local testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->
N/A

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->
The objective of this PR is to make way for the implementation of custom frequency plans in the enterprise version

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
