### PR TITLE
ci: Add arm64 images to snapshot release workflow

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -134,8 +134,10 @@ jobs:
       - name: Tag and Push Docker images
         run: |
           docker tag lorawan-stack-dev:${{ github.sha }}-amd64 thethingsnetwork/lorawan-stack-dev:${{ github.sha }}-amd64
+          docker tag lorawan-stack-dev:${{ github.sha }}-arm64 thethingsnetwork/lorawan-stack-dev:${{ github.sha }}-arm64
           docker push thethingsnetwork/lorawan-stack-dev:${{ github.sha }}-amd64
-          docker manifest create thethingsnetwork/lorawan-stack-dev:${{ github.sha }} thethingsnetwork/lorawan-stack-dev:${{ github.sha }}-amd64
+          docker push thethingsnetwork/lorawan-stack-dev:${{ github.sha }}-arm64
+          docker manifest create thethingsnetwork/lorawan-stack-dev:${{ github.sha }} thethingsnetwork/lorawan-stack-dev:${{ github.sha }}-amd64 thethingsnetwork/lorawan-stack-dev:${{ github.sha }}-arm64
           docker manifest push thethingsnetwork/lorawan-stack-dev:${{ github.sha }}
         env:
           DOCKER_CLI_EXPERIMENTAL: enabled

--- a/.goreleaser.snapshot.yml
+++ b/.goreleaser.snapshot.yml
@@ -19,7 +19,7 @@ builds:
     env:
       - CGO_ENABLED=0
     goos: [linux]
-    goarch: [amd64]
+    goarch: [amd64, arm64]
 
   - id: cli
     main: ./cmd/ttn-lw-cli
@@ -33,7 +33,7 @@ builds:
     env:
       - CGO_ENABLED=0
     goos: [linux]
-    goarch: [amd64]
+    goarch: [amd64, arm64]
 
 dockers:
   - goos: linux
@@ -52,6 +52,26 @@ dockers:
       - '--label=org.opencontainers.image.revision={{.FullCommit}}'
     image_templates:
       - 'lorawan-stack-dev:{{ .FullCommit }}-amd64'
+    skip_push: true
+    extra_files:
+      - data
+      - public
+  - goos: linux
+    goarch: arm64
+    dockerfile: Dockerfile
+    use: buildx
+    ids:
+      - cli
+      - stack
+    build_flag_templates:
+      - --platform=linux/arm64
+      - '--label=org.opencontainers.image.created={{.Date}}'
+      - '--label=org.opencontainers.image.vendor=The Things Network Foundation'
+      - '--label=org.opencontainers.image.title=The Things Stack'
+      - '--label=org.opencontainers.image.url=https://www.thethingsindustries.com/docs'
+      - '--label=org.opencontainers.image.revision={{.FullCommit}}'
+    image_templates:
+      - 'lorawan-stack-dev:{{ .FullCommit }}-arm64'
     skip_push: true
     extra_files:
       - data


### PR DESCRIPTION
#### Summary
References https://github.com/TheThingsIndustries/lorawan-stack-aws/issues/563

#### Changes
Added arm64 docker image generation for snaphsot release.

#### Testing
The CI action completes successfully https://github.com/TheThingsNetwork/lorawan-stack/actions/runs/1573320323

Did not test if the image actually works, but I guess it's safe to assume it does.

##### Regressions
None

#### Notes for Reviewers
I will submit a similar PR to the enterprise repository.

On AWS we often deploy snapshots, so we want arm64 generation for snapshots. And we want enterprise and open-source repos to be similar, so I start with adding a PR here.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [X] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
