### PR TITLE
Allow partial key updates for pre-1.1 devices

### DIFF
--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -1915,10 +1915,12 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 				return false, "session.keys.s_nwk_s_int_key.key"
 			}
 		} else {
-			if !isZero.NwkSEncKey && !setKeyEqual(m, getFNwkSIntKey, getNwkSEncKey, "session.keys.f_nwk_s_int_key", "session.keys.nwk_s_enc_key") {
+			if st.HasSetField("session.keys.nwk_s_enc_key.key") &&
+				!setKeyEqual(m, getFNwkSIntKey, getNwkSEncKey, "session.keys.f_nwk_s_int_key", "session.keys.nwk_s_enc_key") {
 				return false, "session.keys.nwk_s_enc_key.key"
 			}
-			if !isZero.SNwkSIntKey && !setKeyEqual(m, getFNwkSIntKey, getSNwkSIntKey, "session.keys.f_nwk_s_int_key", "session.keys.s_nwk_s_int_key") {
+			if st.HasSetField("session.keys.s_nwk_s_int_key.key") &&
+				!setKeyEqual(m, getFNwkSIntKey, getSNwkSIntKey, "session.keys.f_nwk_s_int_key", "session.keys.s_nwk_s_int_key") {
 				return false, "session.keys.s_nwk_s_int_key.key"
 			}
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes an issue that LoRaWAN 1.0.x devices encounter while attempting to change their network session key. Specifically, the NS allows the device to be _created_ while specifying only the `FNwkSIntKey`, but not to update it later (as all 3 keys had to specified for validation purposes).

#### Changes
<!-- What are the changes made in this pull request? -->

- Check if `SNwkSIntKey` and `NwkSEncKey` are actually updated by the RPC caller during validation. If not, just skip their validation, since they will be overridden anyway.


#### Testing

<!-- How did you verify that this change works? -->

Local testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This relaxes the validation, but it should be fine.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
