### PR TITLE
Fix toast styles

### DIFF
--- a/pkg/webui/lib/components/message/index.js
+++ b/pkg/webui/lib/components/message/index.js
@@ -63,6 +63,10 @@ const Message = ({
     [style.capitalize]: capitalize,
   })
 
+  if (cls) {
+    rest.className = cls
+  }
+
   const intlContext = useContext(IntlContext)
 
   if (typeof content === 'string' || typeof content === 'number') {
@@ -93,10 +97,6 @@ const Message = ({
   }
 
   const { formatMessage } = intlContext
-
-  if (cls) {
-    rest.className = cls
-  }
 
   if (convertBackticks) {
     const contentWithMarkdown = formatMessage(content, vals)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes toast title styling.

atm toast looks like this:

<img width="378" alt="Screenshot 2021-12-15 at 11 39 15" src="https://user-images.githubusercontent.com/16374166/146162053-7cd07484-4241-4047-94ef-29af9b1b1667.png">

with this PR:

<img width="378" alt="Screenshot 2021-12-15 at 11 38 58" src="https://user-images.githubusercontent.com/16374166/146162079-880ba61d-8d59-4e94-bee0-9ec2985ce59f.png">


#### Changes
<!-- What are the changes made in this pull request? -->

- Set `className` before calling `renderContent`


#### Testing

<!-- How did you verify that this change works? -->

Manual	


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
