### PR TITLE
Cleanup HTTP clients usage

### DIFF
--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -200,7 +200,9 @@ var startCommand = &cobra.Command{
 			if *httpClient != nil {
 				continue
 			}
-			*httpClient, err = c.HTTPClient(ctx)
+			*httpClient, err = c.HTTPClient(ctx, component.WithTransportOptions(
+				component.WithCache(true),
+			))
 			if err != nil {
 				return err
 			}

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -39,7 +39,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayconfigurationserver"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver"
 	gsredis "go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/redis"
-	"go.thethings.network/lorawan-stack/v3/pkg/httpclient"
 	"go.thethings.network/lorawan-stack/v3/pkg/identityserver"
 	"go.thethings.network/lorawan-stack/v3/pkg/joinserver"
 	jsredis "go.thethings.network/lorawan-stack/v3/pkg/joinserver/redis"
@@ -188,28 +187,6 @@ var startCommand = &cobra.Command{
 
 		c.RegisterGRPC(events_grpc.NewEventsServer(c.Context(), events.DefaultPubSub()))
 		c.RegisterGRPC(component.NewConfigurationServer(c))
-
-		for _, httpClient := range []**http.Client{
-			&config.ServiceBase.FrequencyPlans.HTTPClient,
-			&config.ServiceBase.Interop.SenderClientCA.HTTPClient,
-			&config.ServiceBase.KeyVault.HTTPClient,
-			&config.ServiceBase.RateLimiting.HTTPClient,
-			&config.ServiceBase.Blob.HTTPClient,
-			&config.AS.Interop.InteropClient.BlobConfig.HTTPClient,
-			&config.NS.Interop.BlobConfig.HTTPClient,
-		} {
-			if *httpClient != nil {
-				continue
-			}
-			*httpClient, err = c.HTTPClient(ctx,
-				httpclient.WithTransportOptions(
-					httpclient.WithCache(true),
-				),
-			)
-			if err != nil {
-				return err
-			}
-		}
 
 		if start.IdentityServer {
 			logger.Info("Setting up Identity Server")

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -39,6 +39,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayconfigurationserver"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver"
 	gsredis "go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/redis"
+	"go.thethings.network/lorawan-stack/v3/pkg/httpclient"
 	"go.thethings.network/lorawan-stack/v3/pkg/identityserver"
 	"go.thethings.network/lorawan-stack/v3/pkg/joinserver"
 	jsredis "go.thethings.network/lorawan-stack/v3/pkg/joinserver/redis"
@@ -200,9 +201,11 @@ var startCommand = &cobra.Command{
 			if *httpClient != nil {
 				continue
 			}
-			*httpClient, err = c.HTTPClient(ctx, component.WithTransportOptions(
-				component.WithCache(true),
-			))
+			*httpClient, err = c.HTTPClient(ctx,
+				httpclient.WithTransportOptions(
+					httpclient.WithCache(true),
+				),
+			)
 			if err != nil {
 				return err
 			}

--- a/pkg/applicationserver/io/io.go
+++ b/pkg/applicationserver/io/io.go
@@ -23,6 +23,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/errorcontext"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/httpclient"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/ratelimit"
 	"go.thethings.network/lorawan-stack/v3/pkg/task"
@@ -87,7 +88,7 @@ type Server interface {
 	// This method should only be used for request contexts.
 	FillContext(ctx context.Context) context.Context
 	// HTTPClient returns a configured *http.Client.
-	HTTPClient(context.Context) (*http.Client, error)
+	HTTPClient(context.Context, ...httpclient.Option) (*http.Client, error)
 	// RateLimiter returns the rate limiter instance.
 	RateLimiter() ratelimit.Interface
 }

--- a/pkg/applicationserver/io/io.go
+++ b/pkg/applicationserver/io/io.go
@@ -17,7 +17,6 @@ package io
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/cluster"
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
@@ -76,6 +75,7 @@ type Cluster interface {
 // Server represents the Application Server to application frontends.
 type Server interface {
 	task.Starter
+	httpclient.Provider
 	PubSub
 	DownlinkQueueOperator
 	UplinkStorage
@@ -87,8 +87,6 @@ type Server interface {
 	// FillContext fills the given context.
 	// This method should only be used for request contexts.
 	FillContext(ctx context.Context) context.Context
-	// HTTPClient returns a configured *http.Client.
-	HTTPClient(context.Context, ...httpclient.Option) (*http.Client, error)
 	// RateLimiter returns the rate limiter instance.
 	RateLimiter() ratelimit.Interface
 }

--- a/pkg/applicationserver/io/web/config.go
+++ b/pkg/applicationserver/io/web/config.go
@@ -54,7 +54,7 @@ func (c TemplatesConfig) NewTemplateStore(ctx context.Context, httpClientProvide
 		fallthrough
 	case c.URL != "":
 		var err error
-		httpClient, err := httpClientProvider.HTTPClient(ctx)
+		httpClient, err := httpClientProvider.HTTPClient(ctx, httpclient.WithCache(true))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/applicationserver/io/web/config.go
+++ b/pkg/applicationserver/io/web/config.go
@@ -58,7 +58,7 @@ func (c TemplatesConfig) NewTemplateStore(ctx context.Context, httpClientProvide
 		if err != nil {
 			return nil, err
 		}
-		fetcher, err = fetch.FromHTTP(httpClient, c.URL, true)
+		fetcher, err = fetch.FromHTTP(httpClient, c.URL)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/applicationserver/io/web/config.go
+++ b/pkg/applicationserver/io/web/config.go
@@ -16,11 +16,11 @@ package web
 
 import (
 	"context"
-	"net/http"
 	"net/url"
 	"os"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/fetch"
+	"go.thethings.network/lorawan-stack/v3/pkg/httpclient"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 )
 
@@ -30,8 +30,6 @@ type TemplatesConfig struct {
 	Directory   string            `name:"directory" description:"Retrieve the webhook templates from the filesystem"`
 	URL         string            `name:"url" description:"Retrieve the webhook templates from a web server"`
 	LogoBaseURL string            `name:"logo-base-url" description:"The base URL for the logo storage"`
-
-	HTTPClient *http.Client `name:"-"`
 }
 
 // TemplateStore contains the webhook templates.
@@ -43,7 +41,7 @@ type TemplateStore interface {
 }
 
 // NewTemplateStore returns a TemplateStore based on the configuration.
-func (c TemplatesConfig) NewTemplateStore() (TemplateStore, error) {
+func (c TemplatesConfig) NewTemplateStore(ctx context.Context, httpClientProvider httpclient.Provider) (TemplateStore, error) {
 	var fetcher fetch.Interface
 	switch {
 	case c.Static != nil:
@@ -56,7 +54,11 @@ func (c TemplatesConfig) NewTemplateStore() (TemplateStore, error) {
 		fallthrough
 	case c.URL != "":
 		var err error
-		fetcher, err = fetch.FromHTTP(c.HTTPClient, c.URL, true)
+		httpClient, err := httpClientProvider.HTTPClient(ctx)
+		if err != nil {
+			return nil, err
+		}
+		fetcher, err = fetch.FromHTTP(httpClient, c.URL, true)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/applicationserver/io/web/grpc_webhooks_test.go
+++ b/pkg/applicationserver/io/web/grpc_webhooks_test.go
@@ -16,7 +16,6 @@ package web_test
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
 	"github.com/gogo/protobuf/types"
@@ -231,14 +230,14 @@ description: Bar`),
 
 			a := assertions.New(t)
 
+			c := componenttest.NewComponent(t, &component.Config{})
+
 			config := web.TemplatesConfig{
-				Static:     tc.contents,
-				HTTPClient: http.DefaultClient,
+				Static: tc.contents,
 			}
-			store, err := config.NewTemplateStore()
+			store, err := config.NewTemplateStore(ctx, c)
 			a.So(err, should.BeNil)
 
-			c := componenttest.NewComponent(t, &component.Config{})
 			c.RegisterGRPC(&mockRegisterer{ctx, web.NewWebhookRegistryRPC(nil, store)})
 			componenttest.StartComponent(t, c)
 			defer c.Close()

--- a/pkg/blob/bucket_test.go
+++ b/pkg/blob/bucket_test.go
@@ -16,7 +16,6 @@ package blob_test
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,7 +39,7 @@ func testBucket(t *testing.T, conf config.BlobConfig) {
 	a := assertions.New(t)
 	ctx := test.Context()
 
-	bucket, err := conf.Bucket(ctx, bucketName())
+	bucket, err := conf.Bucket(ctx, bucketName(), test.HTTPClientProvider)
 	if !a.So(err, should.BeNil) {
 		t.Errorf("Failed to create bucket: %v", err)
 		return
@@ -84,7 +83,6 @@ func TestAWS(t *testing.T) {
 	conf.AWS.Region = os.Getenv("AWS_REGION")
 	conf.AWS.AccessKeyID = os.Getenv("AWS_ACCESS_KEY_ID")
 	conf.AWS.SecretAccessKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
-	conf.HTTPClient = http.DefaultClient
 
 	if conf.AWS.Region == "" || conf.AWS.AccessKeyID == "" || conf.AWS.SecretAccessKey == "" {
 		t.Skip("Missing AWS credentials")

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -165,7 +165,7 @@ func New(logger log.Stack, config *Config, opts ...Option) (c *Component, err er
 		taskStarter: task.StartTaskFunc(task.DefaultStartTask),
 	}
 
-	c.limiter, err = ratelimit.New(ctx, config.RateLimiting, config.Blob)
+	c.limiter, err = ratelimit.New(ctx, config.RateLimiting, config.Blob, c)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +174,7 @@ func New(logger log.Stack, config *Config, opts ...Option) (c *Component, err er
 		opt(c)
 	}
 
-	fpsFetcher, err := config.FrequencyPlansFetcher(ctx)
+	fpsFetcher, err := config.FrequencyPlansFetcher(ctx, c)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/component/grpc.go
+++ b/pkg/component/grpc.go
@@ -19,6 +19,7 @@ import (
 	"net"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	"go.thethings.network/lorawan-stack/v3/pkg/config/tlsconfig"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/metrics"
@@ -80,7 +81,7 @@ func (c *Component) serveGRPC(lis net.Listener) error {
 func (c *Component) grpcEndpoints() []Endpoint {
 	return []Endpoint{
 		NewTCPEndpoint(c.config.GRPC.Listen, "gRPC"),
-		NewTLSEndpoint(c.config.GRPC.ListenTLS, "gRPC", WithNextProtos("h2", "http/1.1")),
+		NewTLSEndpoint(c.config.GRPC.ListenTLS, "gRPC", tlsconfig.WithNextProtos("h2", "http/1.1")),
 	}
 }
 

--- a/pkg/component/http.go
+++ b/pkg/component/http.go
@@ -16,102 +16,12 @@ package component
 
 import (
 	"context"
-	"fmt"
 	"net/http"
-	"runtime"
-	"time"
 
-	"github.com/gregjones/httpcache"
-	"go.thethings.network/lorawan-stack/v3/pkg/version"
+	"go.thethings.network/lorawan-stack/v3/pkg/httpclient"
 )
 
-// defaultHTTPClientTimeout is the default timeout for the HTTP client.
-const defaultHTTPClientTimeout = 10 * time.Second
-
-type httpClientOptions struct {
-	transportOptions []HTTPTransportOption
-}
-
-// HTTPClientOption is an option for HTTP clients.
-type HTTPClientOption func(*httpClientOptions)
-
-// WithTransportOptions constructs a transport with the provided options.
-func WithTransportOptions(opts ...HTTPTransportOption) HTTPClientOption {
-	return HTTPClientOption(func(o *httpClientOptions) {
-		o.transportOptions = opts
-	})
-}
-
 // HTTPClient returns a new *http.Client with a default timeout and a configured transport.
-func (c *Component) HTTPClient(ctx context.Context, opts ...HTTPClientOption) (*http.Client, error) {
-	options := &httpClientOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
-
-	tr, err := c.HTTPTransport(ctx, options.transportOptions...)
-	if err != nil {
-		return nil, err
-	}
-
-	return &http.Client{
-		Timeout:   defaultHTTPClientTimeout,
-		Transport: tr,
-	}, nil
-}
-
-type httpTransportOptions struct {
-	cache bool
-}
-
-// HTTPTransportOption is an option for HTTP transports.
-type HTTPTransportOption func(*httpTransportOptions)
-
-// WithCache enables caching at transport level.
-func WithCache(b bool) HTTPTransportOption {
-	return HTTPTransportOption(func(o *httpTransportOptions) {
-		o.cache = b
-	})
-}
-
-// HTTPTransport returns a new http.RoundTripper with TLS client configuration.
-func (c *Component) HTTPTransport(ctx context.Context, opts ...HTTPTransportOption) (http.RoundTripper, error) {
-	tlsConfig, err := c.GetTLSClientConfig(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.TLSClientConfig = tlsConfig
-
-	options := &httpTransportOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
-
-	rt := http.RoundTripper(transport)
-	if options.cache {
-		rt = &httpcache.Transport{
-			Transport:           rt,
-			Cache:               httpcache.NewMemoryCache(),
-			MarkCachedResponses: true,
-		}
-	}
-
-	return &roundTripperWithUserAgent{
-		RoundTripper: rt,
-		UserAgent:    fmt.Sprintf("TheThingsStack/%s (%s/%s)", version.TTN, runtime.GOOS, runtime.GOARCH),
-	}, nil
-}
-
-type roundTripperWithUserAgent struct {
-	http.RoundTripper
-	UserAgent string
-}
-
-func (rt *roundTripperWithUserAgent) RoundTrip(r *http.Request) (*http.Response, error) {
-	if r.Header.Get("User-Agent") == "" {
-		r.Header.Set("User-Agent", rt.UserAgent)
-	}
-	return rt.RoundTripper.RoundTrip(r)
+func (c *Component) HTTPClient(ctx context.Context, opts ...httpclient.Option) (*http.Client, error) {
+	return httpclient.NewProvider(c).HTTPClient(ctx, opts...)
 }

--- a/pkg/component/interop.go
+++ b/pkg/component/interop.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"time"
 
+	"go.thethings.network/lorawan-stack/v3/pkg/config/tlsconfig"
 	"go.thethings.network/lorawan-stack/v3/pkg/interop"
 )
 
@@ -48,8 +49,8 @@ func (c *Component) interopEndpoints() []Endpoint {
 	return []Endpoint{
 		NewTCPEndpoint(c.config.Interop.Listen, "Interop"),
 		NewTLSEndpoint(c.config.Interop.ListenTLS, "Interop",
-			WithTLSClientAuth(tls.VerifyClientCertIfGiven, c.interop.ClientCAPool(), nil),
-			WithNextProtos("h2", "http/1.1"),
+			tlsconfig.WithTLSClientAuth(tls.VerifyClientCertIfGiven, c.interop.ClientCAPool(), nil),
+			tlsconfig.WithNextProtos("h2", "http/1.1"),
 		),
 	}
 }

--- a/pkg/component/listeners.go
+++ b/pkg/component/listeners.go
@@ -18,6 +18,7 @@ import (
 	"crypto/tls"
 	"net"
 
+	"go.thethings.network/lorawan-stack/v3/pkg/config/tlsconfig"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 )
@@ -29,7 +30,7 @@ var (
 
 // Listener that accepts multiple protocols on the same port
 type Listener interface {
-	TLS(opts ...TLSConfigOption) (net.Listener, error)
+	TLS(opts ...tlsconfig.Option) (net.Listener, error)
 	TCP() (net.Listener, error)
 	Addr() net.Addr
 	Close() error
@@ -48,7 +49,7 @@ func (l *listener) Addr() net.Addr {
 	return l.tcp.Addr()
 }
 
-func (l *listener) TLS(opts ...TLSConfigOption) (net.Listener, error) {
+func (l *listener) TLS(opts ...tlsconfig.Option) (net.Listener, error) {
 	if l.tcpUsed || l.tlsUsed {
 		return nil, errors.New("listener already in use")
 	}
@@ -129,11 +130,11 @@ func (tcpEndpoint) Listen(l Listener) (net.Listener, error) { return l.TCP() }
 type tlsEndpoint struct {
 	address    string
 	protocol   string
-	configOpts []TLSConfigOption
+	configOpts []tlsconfig.Option
 }
 
 // NewTLSEndpoint returns a new TLS endpoint.
-func NewTLSEndpoint(address, protocol string, configOpts ...TLSConfigOption) Endpoint {
+func NewTLSEndpoint(address, protocol string, configOpts ...tlsconfig.Option) Endpoint {
 	return &tlsEndpoint{address, protocol, configOpts}
 }
 

--- a/pkg/component/version_check.go
+++ b/pkg/component/version_check.go
@@ -16,7 +16,6 @@ package component
 
 import (
 	"context"
-	"net/http"
 	"time"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/httpclient"
@@ -29,12 +28,8 @@ const (
 	versionCheckTimeout = 10 * time.Second
 )
 
-type httpClientProvider interface {
-	HTTPClient(context.Context, ...httpclient.Option) (*http.Client, error)
-}
-
 // versionCheckTask returns the task configuration for a periodic version check.
-func versionCheckTask(ctx context.Context, clientProvider httpClientProvider) *task.Config {
+func versionCheckTask(ctx context.Context, clientProvider httpclient.Provider) *task.Config {
 	taskConfig := task.Config{
 		Context: ctx,
 		ID:      "version_check",

--- a/pkg/component/version_check.go
+++ b/pkg/component/version_check.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"time"
 
+	"go.thethings.network/lorawan-stack/v3/pkg/httpclient"
 	"go.thethings.network/lorawan-stack/v3/pkg/task"
 	"go.thethings.network/lorawan-stack/v3/pkg/version"
 )
@@ -29,7 +30,7 @@ const (
 )
 
 type httpClientProvider interface {
-	HTTPClient(context.Context) (*http.Client, error)
+	HTTPClient(context.Context, ...httpclient.Option) (*http.Client, error)
 }
 
 // versionCheckTask returns the task configuration for a periodic version check.

--- a/pkg/component/web.go
+++ b/pkg/component/web.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/heptiolabs/healthcheck"
+	"go.thethings.network/lorawan-stack/v3/pkg/config/tlsconfig"
 	"go.thethings.network/lorawan-stack/v3/pkg/metrics"
 	"go.thethings.network/lorawan-stack/v3/pkg/ratelimit"
 	"go.thethings.network/lorawan-stack/v3/pkg/web"
@@ -151,7 +152,7 @@ func (c *Component) serveWeb(lis net.Listener) error {
 func (c *Component) webEndpoints() []Endpoint {
 	return []Endpoint{
 		NewTCPEndpoint(c.config.HTTP.Listen, "Web"),
-		NewTLSEndpoint(c.config.HTTP.ListenTLS, "Web", WithNextProtos("h2", "http/1.1")),
+		NewTLSEndpoint(c.config.HTTP.ListenTLS, "Web", tlsconfig.WithNextProtos("h2", "http/1.1")),
 	}
 }
 

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -236,7 +236,7 @@ func (c BlobConfig) Bucket(ctx context.Context, bucket string, httpClientProvide
 	case "local":
 		return ttnblob.Local(ctx, bucket, c.Local.Directory)
 	case "aws":
-		httpClient, err := httpClientProvider.HTTPClient(ctx)
+		httpClient, err := httpClientProvider.HTTPClient(ctx, httpclient.WithCache(true))
 		if err != nil {
 			return nil, err
 		}
@@ -321,7 +321,7 @@ func (c FrequencyPlansConfig) Fetcher(ctx context.Context, blobConf BlobConfig, 
 	case "directory":
 		return fetch.FromFilesystem(c.Directory), nil
 	case "url":
-		httpClient, err := httpClientProvider.HTTPClient(ctx)
+		httpClient, err := httpClientProvider.HTTPClient(ctx, httpclient.WithCache(true))
 		if err != nil {
 			return nil, err
 		}
@@ -378,7 +378,7 @@ func (c InteropClient) Fetcher(ctx context.Context, httpClientProvider httpclien
 	case "directory":
 		return fetch.FromFilesystem(c.Directory), nil
 	case "url":
-		httpClient, err := httpClientProvider.HTTPClient(ctx)
+		httpClient, err := httpClientProvider.HTTPClient(ctx, httpclient.WithCache(true))
 		if err != nil {
 			return nil, err
 		}
@@ -411,7 +411,7 @@ func (c SenderClientCA) Fetcher(ctx context.Context, httpClientProvider httpclie
 	case "directory":
 		return fetch.FromFilesystem(c.Directory), nil
 	case "url":
-		httpClient, err := httpClientProvider.HTTPClient(ctx)
+		httpClient, err := httpClientProvider.HTTPClient(ctx, httpclient.WithCache(true))
 		if err != nil {
 			return nil, err
 		}
@@ -523,7 +523,7 @@ func (c RateLimiting) Fetcher(ctx context.Context, blobConf BlobConfig, httpClie
 	case "directory":
 		return fetch.FromFilesystem(c.Directory), nil
 	case "url":
-		httpClient, err := httpClientProvider.HTTPClient(ctx)
+		httpClient, err := httpClientProvider.HTTPClient(ctx, httpclient.WithCache(true))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -236,7 +236,7 @@ func (c BlobConfig) Bucket(ctx context.Context, bucket string, httpClientProvide
 	case "local":
 		return ttnblob.Local(ctx, bucket, c.Local.Directory)
 	case "aws":
-		httpClient, err := httpClientProvider.HTTPClient(ctx, httpclient.WithCache(true))
+		httpClient, err := httpClientProvider.HTTPClient(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -325,7 +325,7 @@ func (c FrequencyPlansConfig) Fetcher(ctx context.Context, blobConf BlobConfig, 
 		if err != nil {
 			return nil, err
 		}
-		return fetch.FromHTTP(httpClient, c.URL, true)
+		return fetch.FromHTTP(httpClient, c.URL)
 	case "blob":
 		b, err := blobConf.Bucket(ctx, c.Blob.Bucket, httpClientProvider)
 		if err != nil {
@@ -382,7 +382,7 @@ func (c InteropClient) Fetcher(ctx context.Context, httpClientProvider httpclien
 		if err != nil {
 			return nil, err
 		}
-		return fetch.FromHTTP(httpClient, c.URL, true)
+		return fetch.FromHTTP(httpClient, c.URL)
 	case "blob":
 		b, err := c.BlobConfig.Bucket(ctx, c.Blob.Bucket, httpClientProvider)
 		if err != nil {
@@ -415,7 +415,7 @@ func (c SenderClientCA) Fetcher(ctx context.Context, httpClientProvider httpclie
 		if err != nil {
 			return nil, err
 		}
-		return fetch.FromHTTP(httpClient, c.URL, true)
+		return fetch.FromHTTP(httpClient, c.URL)
 	case "blob":
 		b, err := c.BlobConfig.Bucket(ctx, c.Blob.Bucket, httpClientProvider)
 		if err != nil {
@@ -527,7 +527,7 @@ func (c RateLimiting) Fetcher(ctx context.Context, blobConf BlobConfig, httpClie
 		if err != nil {
 			return nil, err
 		}
-		return fetch.FromHTTP(httpClient, c.URL, true)
+		return fetch.FromHTTP(httpClient, c.URL)
 	case "blob":
 		b, err := blobConf.Bucket(ctx, c.Blob.Bucket, httpClientProvider)
 		if err != nil {

--- a/pkg/config/tlsconfig/provider.go
+++ b/pkg/config/tlsconfig/provider.go
@@ -1,0 +1,100 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tlsconfig
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/log"
+)
+
+// Option provides customization for TLS configuration.
+type Option interface {
+	apply(*tls.Config)
+}
+
+// ConfigOptionFunc is a Option.
+type ConfigOptionFunc func(*tls.Config)
+
+func (fn ConfigOptionFunc) apply(c *tls.Config) {
+	fn(c)
+}
+
+// WithTLSClientAuth sets TLS client authentication options.
+func WithTLSClientAuth(auth tls.ClientAuthType, cas *x509.CertPool, verify func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error) Option {
+	return ConfigOptionFunc(func(c *tls.Config) {
+		c.ClientAuth = auth
+		c.ClientCAs = cas
+		c.VerifyPeerCertificate = verify
+	})
+}
+
+// WithTLSCertificates sets TLS certificates.
+func WithTLSCertificates(certificates ...tls.Certificate) Option {
+	return ConfigOptionFunc(func(c *tls.Config) {
+		c.Certificates = certificates
+	})
+}
+
+// WithNextProtos appends the given protocols to NextProtos.
+func WithNextProtos(protos ...string) Option {
+	return ConfigOptionFunc(func(c *tls.Config) {
+		c.NextProtos = append(c.NextProtos, protos...)
+	})
+}
+
+// ConfigurationProvider generates a Config from the provided context.
+type ConfigurationProvider func(context.Context) Config
+
+// GetTLSServerConfig gets the component's server TLS config and applies the given options.
+func (p ConfigurationProvider) GetTLSServerConfig(ctx context.Context, opts ...Option) (*tls.Config, error) {
+	conf := p(ctx)
+	cipherSuites, err := conf.GetCipherSuites()
+	if err != nil {
+		return nil, err
+	}
+	if cipherSuites != nil {
+		log.FromContext(ctx).Warn("TLS is configured to use a custom set of cipher suites. Make sure that your list is up to date, or disable the custom cipher suites")
+	}
+	res := &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		CipherSuites: cipherSuites,
+	}
+	if err := conf.ServerAuth.ApplyTo(res); err != nil {
+		return nil, err
+	}
+	for _, opt := range opts {
+		opt.apply(res)
+	}
+	return res, nil
+}
+
+// GetTLSClientConfig gets the component's client TLS config and applies the given options.
+func (p ConfigurationProvider) GetTLSClientConfig(ctx context.Context, opts ...Option) (*tls.Config, error) {
+	conf := p(ctx)
+	res := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: conf.InsecureSkipVerify,
+	}
+	if err := conf.Client.ApplyTo(res); err != nil {
+		return nil, err
+	}
+	for _, opt := range opts {
+		opt.apply(res)
+	}
+	return res, nil
+}

--- a/pkg/devicerepository/store/remote/repository_test.go
+++ b/pkg/devicerepository/store/remote/repository_test.go
@@ -47,7 +47,7 @@ const (
 // Run test with `$ go test -tags=slowtests ./pkg/devicerepository/store/remote`.
 func TestGithubDeviceRepository(t *testing.T) {
 	a := assertions.New(t)
-	f, err := fetch.FromHTTP(http.DefaultClient, githubRepository, true)
+	f, err := fetch.FromHTTP(http.DefaultClient, githubRepository)
 	a.So(err, should.BeNil)
 	s := remote.NewRemoteStore(f)
 	brands, err := s.GetBrands(store.GetBrandsRequest{Limit: 0, Paths: []string{"brand_id"}})

--- a/pkg/fetch/bucket_test.go
+++ b/pkg/fetch/bucket_test.go
@@ -34,7 +34,7 @@ func TestBucket(t *testing.T) {
 	filename := "file"
 	content := []byte("Hello world")
 
-	bucket, err := conf.Bucket(ctx, "bucket")
+	bucket, err := conf.Bucket(ctx, "bucket", test.HTTPClientProvider)
 	a.So(err, should.BeNil)
 
 	err = bucket.WriteAll(ctx, filename, content, nil)

--- a/pkg/fetch/fetch_test.go
+++ b/pkg/fetch/fetch_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func Example() {
-	fetcher, err := fetch.FromHTTP(http.DefaultClient, "http://webserver.thethings.network/repository", true)
+	fetcher, err := fetch.FromHTTP(http.DefaultClient, "http://webserver.thethings.network/repository")
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/fetch/http.go
+++ b/pkg/fetch/http.go
@@ -21,7 +21,6 @@ import (
 	"path"
 	"time"
 
-	"github.com/gregjones/httpcache"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 )
 
@@ -62,19 +61,7 @@ func (f httpFetcher) File(pathElements ...string) ([]byte, error) {
 }
 
 // FromHTTP returns an object to fetch files from a webserver.
-func FromHTTP(client *http.Client, rootURL string, cache bool) (Interface, error) {
-	if client == nil {
-		client = http.DefaultClient
-	}
-	if cache {
-		cp := *client
-		client = &cp
-		client.Transport = &httpcache.Transport{
-			Transport:           client.Transport,
-			Cache:               httpcache.NewMemoryCache(),
-			MarkCachedResponses: true,
-		}
-	}
+func FromHTTP(client *http.Client, rootURL string) (Interface, error) {
 	var root *url.URL
 	if rootURL != "" {
 		var err error

--- a/pkg/frequencyplans/frequencyplans_test.go
+++ b/pkg/frequencyplans/frequencyplans_test.go
@@ -32,7 +32,7 @@ import (
 func uint64Ptr(v uint64) *uint64 { return &v }
 
 func Example() {
-	fetcher, err := fetch.FromHTTP(http.DefaultClient, "https://raw.githubusercontent.com/TheThingsNetwork/lorawan-frequency-plans", true)
+	fetcher, err := fetch.FromHTTP(http.DefaultClient, "https://raw.githubusercontent.com/TheThingsNetwork/lorawan-frequency-plans")
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/gatewayconfigurationserver/server_test.go
+++ b/pkg/gatewayconfigurationserver/server_test.go
@@ -81,7 +81,7 @@ func TestWeb(t *testing.T) {
 	fpConf := config.FrequencyPlansConfig{
 		URL: "https://raw.githubusercontent.com/TheThingsNetwork/lorawan-frequency-plans/master",
 	}
-	fps := frequencyplans.NewStore(test.Must(fpConf.Fetcher(ctx, config.BlobConfig{})).(fetch.Interface))
+	fps := frequencyplans.NewStore(test.Must(fpConf.Fetcher(ctx, config.BlobConfig{}, test.HTTPClientProvider)).(fetch.Interface))
 
 	conf := &component.Config{
 		ServiceBase: config.ServiceBase{

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -32,6 +32,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/cluster"
 	"go.thethings.network/lorawan-stack/v3/pkg/component"
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
+	"go.thethings.network/lorawan-stack/v3/pkg/config/tlsconfig"
 	"go.thethings.network/lorawan-stack/v3/pkg/encoding/lorawan"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
@@ -282,7 +283,7 @@ func New(c *component.Component, conf *Config, opts ...Option) (gs *GatewayServe
 		}
 		for _, endpoint := range []component.Endpoint{
 			component.NewTCPEndpoint(version.listenerConfig.listen, version.Name),
-			component.NewTLSEndpoint(version.listenerConfig.listenTLS, version.Name, component.WithNextProtos("h2", "http/1.1")),
+			component.NewTLSEndpoint(version.listenerConfig.listenTLS, version.Name, tlsconfig.WithNextProtos("h2", "http/1.1")),
 		} {
 			endpoint := endpoint
 			if endpoint.Address() == "" {

--- a/pkg/httpclient/http.go
+++ b/pkg/httpclient/http.go
@@ -1,0 +1,146 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpclient
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"runtime"
+	"time"
+
+	"github.com/gregjones/httpcache"
+	"go.thethings.network/lorawan-stack/v3/pkg/config/tlsconfig"
+	"go.thethings.network/lorawan-stack/v3/pkg/version"
+)
+
+// TLSClientConfigurationProvider provides a *tls.Config to be used by TLS clients.
+type TLSClientConfigurationProvider interface {
+	GetTLSClientConfig(context.Context, ...tlsconfig.Option) (*tls.Config, error)
+}
+
+// Provider constructs *http.Clients.
+type Provider interface {
+	HTTPClient(context.Context, ...Option) (*http.Client, error)
+}
+
+type provider struct {
+	tlsConfigProvider TLSClientConfigurationProvider
+}
+
+// NewProvider constructs a Provider on top of the provided TLS configuration provider.
+func NewProvider(tlsConfigProvider TLSClientConfigurationProvider) Provider {
+	return &provider{tlsConfigProvider: tlsConfigProvider}
+}
+
+// defaultHTTPClientTimeout is the default timeout for the HTTP client.
+const defaultHTTPClientTimeout = 10 * time.Second
+
+type httpClientOptions struct {
+	transportOptions []TransportOption
+}
+
+// Option is an option for HTTP clients.
+type Option func(*httpClientOptions)
+
+// WithTransportOptions constructs a transport with the provided options.
+func WithTransportOptions(opts ...TransportOption) Option {
+	return Option(func(o *httpClientOptions) {
+		o.transportOptions = opts
+	})
+}
+
+// HTTPClient returns a new *http.Client with a default timeout and a configured transport.
+func (p *provider) HTTPClient(ctx context.Context, opts ...Option) (*http.Client, error) {
+	options := &httpClientOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	tr, err := p.HTTPTransport(ctx, options.transportOptions...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &http.Client{
+		Timeout:   defaultHTTPClientTimeout,
+		Transport: tr,
+	}, nil
+}
+
+type httpTransportOptions struct {
+	cache            bool
+	tlsConfigOptions []tlsconfig.Option
+}
+
+// TransportOption is an option for HTTP transports.
+type TransportOption func(*httpTransportOptions)
+
+// WithCache enables caching at transport level.
+func WithCache(b bool) TransportOption {
+	return TransportOption(func(o *httpTransportOptions) {
+		o.cache = b
+	})
+}
+
+// WithTLSConfigurationOptions provides the given tlsconfig.ConfigOption to the underlying TLS configuration provider.
+func WithTLSConfigurationOptions(opts ...tlsconfig.Option) TransportOption {
+	return TransportOption(func(o *httpTransportOptions) {
+		o.tlsConfigOptions = opts
+	})
+}
+
+// HTTPTransport returns a new http.RoundTripper with TLS client configuration.
+func (p *provider) HTTPTransport(ctx context.Context, opts ...TransportOption) (http.RoundTripper, error) {
+	options := &httpTransportOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	tlsConfig, err := p.tlsConfigProvider.GetTLSClientConfig(ctx, options.tlsConfigOptions...)
+	if err != nil {
+		return nil, err
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
+
+	rt := http.RoundTripper(transport)
+	if options.cache {
+		rt = &httpcache.Transport{
+			Transport:           rt,
+			Cache:               httpcache.NewMemoryCache(),
+			MarkCachedResponses: true,
+		}
+	}
+
+	return &roundTripperWithUserAgent{
+		RoundTripper: rt,
+		UserAgent:    fmt.Sprintf("TheThingsStack/%s (%s/%s)", version.TTN, runtime.GOOS, runtime.GOARCH),
+	}, nil
+}
+
+type roundTripperWithUserAgent struct {
+	http.RoundTripper
+	UserAgent string
+}
+
+func (rt *roundTripperWithUserAgent) RoundTrip(r *http.Request) (*http.Response, error) {
+	if r.Header.Get("User-Agent") == "" {
+		r.Header.Set("User-Agent", rt.UserAgent)
+	}
+	return rt.RoundTripper.RoundTrip(r)
+}

--- a/pkg/identityserver/config.go
+++ b/pkg/identityserver/config.go
@@ -149,7 +149,7 @@ func (c emailTemplatesConfig) Fetcher(ctx context.Context, blobConf config.BlobC
 		if err != nil {
 			return nil, err
 		}
-		return fetch.FromHTTP(httpClient, c.URL, true)
+		return fetch.FromHTTP(httpClient, c.URL)
 	case "blob":
 		b, err := blobConf.Bucket(ctx, c.Blob.Bucket, httpClientProvider)
 		if err != nil {

--- a/pkg/identityserver/config.go
+++ b/pkg/identityserver/config.go
@@ -145,7 +145,7 @@ func (c emailTemplatesConfig) Fetcher(ctx context.Context, blobConf config.BlobC
 	case "directory":
 		return fetch.FromFilesystem(c.Directory), nil
 	case "url":
-		httpClient, err := httpClientProvider.HTTPClient(ctx)
+		httpClient, err := httpClientProvider.HTTPClient(ctx, httpclient.WithCache(true))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/identityserver/email.go
+++ b/pkg/identityserver/email.go
@@ -30,14 +30,7 @@ import (
 
 func (is *IdentityServer) initEmailTemplates(ctx context.Context) (*email.TemplateRegistry, error) {
 	config := is.configFromContext(ctx).Email.Templates
-	if config.HTTPClient == nil {
-		httpClient, err := is.HTTPClient(ctx)
-		if err != nil {
-			return nil, err
-		}
-		config.HTTPClient = httpClient
-	}
-	fetcher, err := config.Fetcher(ctx, is.Component.GetBaseConfig(ctx).Blob)
+	fetcher, err := config.Fetcher(ctx, is.Component.GetBaseConfig(ctx).Blob, is)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/identityserver/picture.go
+++ b/pkg/identityserver/picture.go
@@ -93,7 +93,7 @@ func (is *IdentityServer) processUserProfilePicture(ctx context.Context, usr *tt
 	}
 
 	// Store picture to bucket.
-	bucket, err := is.Component.GetBaseConfig(ctx).Blob.Bucket(ctx, config.ProfilePicture.Bucket)
+	bucket, err := is.Component.GetBaseConfig(ctx).Blob.Bucket(ctx, config.ProfilePicture.Bucket, is)
 	if err != nil {
 		return err
 	}
@@ -146,7 +146,7 @@ func (is *IdentityServer) processEndDevicePicture(ctx context.Context, dev *ttnp
 	}
 
 	// Store picture to bucket.
-	bucket, err := is.Component.GetBaseConfig(ctx).Blob.Bucket(ctx, config.EndDevicePicture.Bucket)
+	bucket, err := is.Component.GetBaseConfig(ctx).Blob.Bucket(ctx, config.EndDevicePicture.Bucket, is)
 	if err != nil {
 		return err
 	}

--- a/pkg/identityserver/picture/picture_test.go
+++ b/pkg/identityserver/picture/picture_test.go
@@ -104,7 +104,7 @@ func TestStore(t *testing.T) {
 	ctx := test.Context()
 	var blobConfig config.BlobConfig
 	blobConfig.Provider, blobConfig.Local.Directory = "local", "."
-	bucket, _ := blobConfig.Bucket(ctx, "testdata")
+	bucket, _ := blobConfig.Bucket(ctx, "testdata", test.HTTPClientProvider)
 
 	pic, err := picture.Store(ctx, bucket, "picture", &ttnpb.Picture{
 		Sizes: map[uint32]string{

--- a/pkg/interop/client.go
+++ b/pkg/interop/client.go
@@ -368,7 +368,7 @@ func NewClient(ctx context.Context, conf config.InteropClient, httpClientProvide
 				if err != nil {
 					return nil, err
 				}
-				opts = append(opts, httpclient.WithTransportOptions(httpclient.WithTLSConfig(tlsConf)))
+				opts = append(opts, httpclient.WithTLSConfig(tlsConf))
 			}
 
 			httpClient, err := httpClientProvider.HTTPClient(ctx, opts...)

--- a/pkg/interop/client.go
+++ b/pkg/interop/client.go
@@ -308,7 +308,6 @@ type Client struct {
 var errUnknownConfig = errors.DefineNotFound("unknown_config", "configuration is unknown")
 
 // NewClient return new interop client.
-// fallbackTLS is optional.
 func NewClient(ctx context.Context, conf config.InteropClient, httpClientProvider httpclient.Provider) (*Client, error) {
 	fetcher, err := conf.Fetcher(ctx, httpClientProvider)
 	if err != nil {

--- a/pkg/interop/client_test.go
+++ b/pkg/interop/client_test.go
@@ -15,8 +15,6 @@
 package interop_test
 
 import (
-	"context"
-	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -174,9 +172,7 @@ paths:
 				), 0644))
 
 				return config.InteropClient{
-						Directory:            confDir,
-						GetFallbackTLSConfig: func(context.Context) (*tls.Config, error) { return nil, nil },
-						HTTPClient:           http.DefaultClient,
+						Directory: confDir,
 					}, func() error {
 						return os.RemoveAll(confDir)
 					}
@@ -293,9 +289,7 @@ paths:
 				), 0644))
 
 				return config.InteropClient{
-						Directory:            confDir,
-						GetFallbackTLSConfig: func(context.Context) (*tls.Config, error) { return nil, nil },
-						HTTPClient:           http.DefaultClient,
+						Directory: confDir,
 					}, func() error {
 						return os.RemoveAll(confDir)
 					}
@@ -424,9 +418,7 @@ paths:
 				), 0644))
 
 				return config.InteropClient{
-						Directory:            confDir,
-						GetFallbackTLSConfig: func(context.Context) (*tls.Config, error) { return nil, nil },
-						HTTPClient:           http.DefaultClient,
+						Directory: confDir,
 					}, func() error {
 						return os.RemoveAll(confDir)
 					}
@@ -560,9 +552,7 @@ paths:
 				), 0644))
 
 				return config.InteropClient{
-						Directory:            confDir,
-						GetFallbackTLSConfig: func(context.Context) (*tls.Config, error) { return nil, nil },
-						HTTPClient:           http.DefaultClient,
+						Directory: confDir,
 					}, func() error {
 						return os.RemoveAll(confDir)
 					}
@@ -599,7 +589,7 @@ paths:
 			conf, flush := tc.NewClientConfig(host[0], uint32(test.Must(strconv.ParseUint(host[1], 10, 32)).(uint64)))
 			defer flush()
 
-			cl, err := NewClient(ctx, conf)
+			cl, err := NewClient(ctx, conf, test.HTTPClientProvider)
 			if !a.So(err, should.BeNil) {
 				t.Fatalf("Failed to create new client: %s", err)
 			}
@@ -744,9 +734,7 @@ paths:
 				), 0644))
 
 				return config.InteropClient{
-						Directory:            confDir,
-						GetFallbackTLSConfig: func(context.Context) (*tls.Config, error) { return nil, nil },
-						HTTPClient:           http.DefaultClient,
+						Directory: confDir,
 					}, func() error {
 						return os.RemoveAll(confDir)
 					}
@@ -863,9 +851,7 @@ paths:
 				), 0644))
 
 				return config.InteropClient{
-						Directory:            confDir,
-						GetFallbackTLSConfig: func(context.Context) (*tls.Config, error) { return nil, nil },
-						HTTPClient:           http.DefaultClient,
+						Directory: confDir,
 					}, func() error {
 						return os.RemoveAll(confDir)
 					}
@@ -999,9 +985,7 @@ paths:
 				), 0644))
 
 				return config.InteropClient{
-						Directory:            confDir,
-						GetFallbackTLSConfig: func(context.Context) (*tls.Config, error) { return nil, nil },
-						HTTPClient:           http.DefaultClient,
+						Directory: confDir,
 					}, func() error {
 						return os.RemoveAll(confDir)
 					}
@@ -1149,9 +1133,7 @@ paths:
 				), 0644))
 
 				return config.InteropClient{
-						Directory:            confDir,
-						GetFallbackTLSConfig: func(context.Context) (*tls.Config, error) { return nil, nil },
-						HTTPClient:           http.DefaultClient,
+						Directory: confDir,
 					}, func() error {
 						return os.RemoveAll(confDir)
 					}
@@ -1298,9 +1280,7 @@ paths:
 				), 0644))
 
 				return config.InteropClient{
-						Directory:            confDir,
-						GetFallbackTLSConfig: func(context.Context) (*tls.Config, error) { return nil, nil },
-						HTTPClient:           http.DefaultClient,
+						Directory: confDir,
 					}, func() error {
 						return os.RemoveAll(confDir)
 					}
@@ -1350,7 +1330,7 @@ paths:
 			conf, flush := tc.NewClientConfig(host[0], uint32(test.Must(strconv.ParseUint(host[1], 10, 32)).(uint64)))
 			defer flush()
 
-			cl, err := NewClient(ctx, conf)
+			cl, err := NewClient(ctx, conf, test.HTTPClientProvider)
 			if !a.So(err, should.BeNil) {
 				t.Fatalf("Failed to create new client: %s", err)
 			}

--- a/pkg/interop/config.go
+++ b/pkg/interop/config.go
@@ -25,6 +25,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/config/tlsconfig"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/fetch"
+	"go.thethings.network/lorawan-stack/v3/pkg/httpclient"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -80,7 +81,7 @@ const (
 	SenderClientCAsConfigurationName = "config.yml"
 )
 
-func fetchSenderClientCAs(ctx context.Context, conf config.InteropServer) (map[string][]*x509.Certificate, error) {
+func fetchSenderClientCAs(ctx context.Context, conf config.InteropServer, httpClientProvider httpclient.Provider) (map[string][]*x509.Certificate, error) {
 	decodeCerts := func(b []byte) (res []*x509.Certificate, err error) {
 		for len(b) > 0 {
 			var block *pem.Block
@@ -128,7 +129,7 @@ func fetchSenderClientCAs(ctx context.Context, conf config.InteropServer) (map[s
 			}
 		}
 	} else {
-		fetcher, err := conf.SenderClientCA.Fetcher(ctx)
+		fetcher, err := conf.SenderClientCA.Fetcher(ctx, httpClientProvider)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/interop/server.go
+++ b/pkg/interop/server.go
@@ -26,6 +26,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/fillcontext"
+	"go.thethings.network/lorawan-stack/v3/pkg/httpclient"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/ratelimit"
 	"go.thethings.network/lorawan-stack/v3/pkg/webhandlers"
@@ -78,11 +79,11 @@ type Server struct {
 	js JoinServer
 }
 
-// Components represents the Component to the Interop Server.
+// Component represents the Component to the Interop Server.
 type Component interface {
 	Context() context.Context
 	RateLimiter() ratelimit.Interface
-	HTTPClient(context.Context) (*http.Client, error)
+	HTTPClient(context.Context, ...httpclient.Option) (*http.Client, error)
 }
 
 // NewServer builds a new server.

--- a/pkg/interop/server.go
+++ b/pkg/interop/server.go
@@ -91,7 +91,7 @@ func NewServer(c Component, contextFillers []fillcontext.Filler, conf config.Int
 	ctx := log.NewContextWithField(c.Context(), "namespace", "interop")
 	logger := log.FromContext(ctx)
 
-	senderClientCAs, err := fetchSenderClientCAs(ctx, conf)
+	senderClientCAs, err := fetchSenderClientCAs(ctx, conf, c)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/interop/server.go
+++ b/pkg/interop/server.go
@@ -81,9 +81,9 @@ type Server struct {
 
 // Component represents the Component to the Interop Server.
 type Component interface {
+	httpclient.Provider
 	Context() context.Context
 	RateLimiter() ratelimit.Interface
-	HTTPClient(context.Context, ...httpclient.Option) (*http.Client, error)
 }
 
 // NewServer builds a new server.

--- a/pkg/interop/server_authn_token.go
+++ b/pkg/interop/server_authn_token.go
@@ -16,7 +16,6 @@ package interop
 
 import (
 	"context"
-	"net/http"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/httpclient"
@@ -30,11 +29,7 @@ type packetBrokerTokenVerifier struct {
 	issuer, audience  string
 }
 
-type httpClientProvider interface {
-	HTTPClient(context.Context, ...httpclient.Option) (*http.Client, error)
-}
-
-func newPacketBrokerTokenVerifier(ctx context.Context, issuer, audience string, httpClient httpClientProvider) (tokenVerifier, error) {
+func newPacketBrokerTokenVerifier(ctx context.Context, issuer, audience string, httpClient httpclient.Provider) (tokenVerifier, error) {
 	client, err := httpClient.HTTPClient(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/interop/server_authn_token.go
+++ b/pkg/interop/server_authn_token.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/httpclient"
 	"go.thethings.network/lorawan-stack/v3/pkg/packetbroker"
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
 	"gopkg.in/square/go-jose.v2/jwt"
@@ -30,7 +31,7 @@ type packetBrokerTokenVerifier struct {
 }
 
 type httpClientProvider interface {
-	HTTPClient(context.Context) (*http.Client, error)
+	HTTPClient(context.Context, ...httpclient.Option) (*http.Client, error)
 }
 
 func newPacketBrokerTokenVerifier(ctx context.Context, issuer, audience string, httpClient httpClientProvider) (tokenVerifier, error) {

--- a/pkg/interop/server_test.go
+++ b/pkg/interop/server_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
+	"go.thethings.network/lorawan-stack/v3/pkg/httpclient"
 	"go.thethings.network/lorawan-stack/v3/pkg/interop"
 	"go.thethings.network/lorawan-stack/v3/pkg/ratelimit"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -45,7 +46,7 @@ func (c *mockComponent) RateLimiter() ratelimit.Interface {
 	return &ratelimit.NoopRateLimiter{}
 }
 
-func (c *mockComponent) HTTPClient(context.Context) (*http.Client, error) {
+func (c *mockComponent) HTTPClient(context.Context, ...httpclient.Option) (*http.Client, error) {
 	return http.DefaultClient, nil
 }
 

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -18,7 +18,6 @@ package networkserver
 import (
 	"context"
 	"crypto/rand"
-	"crypto/tls"
 	"fmt"
 	"os"
 	"sync"
@@ -204,19 +203,9 @@ func New(c *component.Component, conf *Config, opts ...Option) (*NetworkServer, 
 	var interopCl InteropClient
 	if !conf.Interop.IsZero() {
 		interopConf := conf.Interop
-		interopConf.GetFallbackTLSConfig = func(ctx context.Context) (*tls.Config, error) {
-			return c.GetTLSClientConfig(ctx)
-		}
 		interopConf.BlobConfig = c.GetBaseConfig(ctx).Blob
-		if interopConf.HTTPClient == nil {
-			httpClient, err := c.HTTPClient(ctx)
-			if err != nil {
-				return nil, err
-			}
-			interopConf.HTTPClient = httpClient
-		}
 
-		interopCl, err = interop.NewClient(ctx, interopConf)
+		interopCl, err = interop.NewClient(ctx, interopConf, c)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/packetbrokeragent/authenticator.go
+++ b/pkg/packetbrokeragent/authenticator.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"crypto/tls"
 
-	"go.thethings.network/lorawan-stack/v3/pkg/component"
+	"go.thethings.network/lorawan-stack/v3/pkg/config/tlsconfig"
 	"go.thethings.network/lorawan-stack/v3/pkg/packetbroker"
 	"go.thethings.network/lorawan-stack/v3/pkg/rpcclient"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -28,7 +28,7 @@ import (
 )
 
 type tlsConfigurator interface {
-	GetTLSClientConfig(context.Context, ...component.TLSConfigOption) (*tls.Config, error)
+	GetTLSClientConfig(context.Context, ...tlsconfig.Option) (*tls.Config, error)
 }
 
 type authenticator interface {

--- a/pkg/pfconfig/semtechudp/semtechudp_test.go
+++ b/pkg/pfconfig/semtechudp/semtechudp_test.go
@@ -36,7 +36,7 @@ func TestBuild(t *testing.T) {
 		fetcher = fetch.FromFilesystem(localPath)
 	} else {
 		var err error
-		fetcher, err = fetch.FromHTTP(http.DefaultClient, "https://raw.githubusercontent.com/TheThingsNetwork/lorawan-frequency-plans/master", true)
+		fetcher, err = fetch.FromHTTP(http.DefaultClient, "https://raw.githubusercontent.com/TheThingsNetwork/lorawan-frequency-plans/master")
 		if err != nil {
 			t.Fatalf("Failed to construct HTTP fetcher: %v", err)
 		}
@@ -49,7 +49,7 @@ func TestBuild(t *testing.T) {
 		referenceFetcher = fetch.FromFilesystem(referenceLocalPath)
 	} else {
 		var err error
-		referenceFetcher, err = fetch.FromHTTP(http.DefaultClient, "https://raw.githubusercontent.com/TheThingsNetwork/gateway-conf/master", true)
+		referenceFetcher, err = fetch.FromHTTP(http.DefaultClient, "https://raw.githubusercontent.com/TheThingsNetwork/gateway-conf/master")
 		if err != nil {
 			t.Fatalf("Failed to construct HTTP fetcher: %v", err)
 		}

--- a/pkg/ratelimit/config.go
+++ b/pkg/ratelimit/config.go
@@ -21,6 +21,7 @@ import (
 	"github.com/throttled/throttled/v2/store/memstore"
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/httpclient"
 	"gopkg.in/yaml.v2"
 )
 
@@ -30,11 +31,11 @@ const defaultMaxSize = 1 << 12
 var errRateLimitExceeded = errors.DefineResourceExhausted("rate_limit_exceeded", "rate limit of `{rate}` accesses per minute exceeded for resource `{key}`")
 
 // New creates a new ratelimit.Interface from configuration.
-func New(ctx context.Context, conf config.RateLimiting, blobConf config.BlobConfig) (Interface, error) {
+func New(ctx context.Context, conf config.RateLimiting, blobConf config.BlobConfig, httpClientProvider httpclient.Provider) (Interface, error) {
 	defaultLimiter := &NoopRateLimiter{}
 	profiles := conf.Profiles
 
-	fetcher, err := conf.Fetcher(ctx, blobConf)
+	fetcher, err := conf.Fetcher(ctx, blobConf, httpClientProvider)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ratelimit/rate_limit_test.go
+++ b/pkg/ratelimit/rate_limit_test.go
@@ -57,7 +57,7 @@ func TestRateLimit(t *testing.T) {
 				Associations: []string{"override"},
 			},
 		},
-	}, config.BlobConfig{})
+	}, config.BlobConfig{}, nil)
 	if !a.So(err, should.BeNil) {
 		t.FailNow()
 	}
@@ -163,7 +163,7 @@ func TestRateLimit(t *testing.T) {
 		}
 
 		a := assertions.New(t)
-		limiter, err := ratelimit.New(test.Context(), conf, config.BlobConfig{})
+		limiter, err := ratelimit.New(test.Context(), conf, config.BlobConfig{}, nil)
 		a.So(err, should.BeNil)
 
 		resource := &mockResource{key: "key", classes: []string{"assoc1"}}

--- a/pkg/util/test/httpclient.go
+++ b/pkg/util/test/httpclient.go
@@ -1,0 +1,29 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"context"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/config/tlsconfig"
+	"go.thethings.network/lorawan-stack/v3/pkg/httpclient"
+)
+
+// HTTPClientProvider is a valid httpclient.Provider.
+var HTTPClientProvider = httpclient.NewProvider(
+	tlsconfig.ConfigurationProvider(func(context.Context) tlsconfig.Config {
+		return tlsconfig.Config{}
+	}),
+)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/issues/3005

#### Changes
<!-- What are the changes made in this pull request? -->

- Extract the component TLS configuration generators (`GetTLSServerConfig` / `GetTLSClientConfig`) to `pkg/config/tlsconfig`
   - This allows other packages to use TLS configuration options without creating a cycle with the `component` package
- Extract the component HTTP client generators (`HTTPClient` / `HTTPTransport`) to `pkg/httpclient`
   - Same rationale
- Remove the custom `*http.Client` that we've been adding to configs over time. We just propagate a `httpclient.Provider` down to the call site now.


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Shouldn't occur.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
