### PR TITLE
Improve efficiency of cypress runs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,7 @@
 name: End-to-end Tests
+concurrency: 
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
 on:
   pull_request:
     paths:
@@ -16,7 +19,11 @@ on:
       - 'cypress/**'
       - 'docker-compose.yml'
       - '.github/workflows/e2e.yml'
-
+env:
+  TTN_LW_LOG_LEVEL: debug
+  CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+  CYPRESS_FAIL_FAST: true
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   determine-if-required:
     name: Determine if run is required
@@ -54,10 +61,6 @@ jobs:
     runs-on: ubuntu-20.04
     needs: determine-if-required
     if: needs.determine-if-required.outputs.needs-to-run == 'true'
-    env:
-      TTN_LW_LOG_LEVEL: debug
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      NODE_ENV: production
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -165,10 +168,8 @@ jobs:
     name: Main frontend end-to-end tests (Chrome)
     runs-on: ubuntu-20.04
     env:
-      TTN_LW_LOG_LEVEL: debug
-      CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       NODE_ENV: development
+      CYPRESS_MACHINE_NUMBER: ${{ matrix.machines }}
     strategy:
       matrix:
         machines: [1, 2, 3, 4]
@@ -184,6 +185,22 @@ jobs:
         name: Download build artifacts
         with:
           name: 'build-files'
+      - name: Download last failed spec
+        uses: dawidd6/action-download-artifact@v2
+        continue-on-error: true
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: e2e.yml
+          branch: ${{ github.head_ref }}
+          workflow_conclusion: completed
+          name: cypress-failed-test-spec
+          search_artifacts: true
+      - name: Read failed spec file
+        id: get-failed-spec
+        continue-on-error: true
+        run: |
+          echo "::set-output name=failed-test::$(paste -d , .failed-specs-*.txt)"
+          echo "::set-output name=neg-failed-test::!$(paste -d ',!' .failed-specs-*.txt)"
       - name: Unzip build artifacts
         run: unzip -o build.zip
       - name: Initialize Yarn module cache
@@ -200,6 +217,17 @@ jobs:
         run: tools/bin/mage dev:dbStart dev:sqlRestore dev:sqlCreateSeedDb
       - name: Run stack
         run: tools/bin/mage dev:startDevStack &
+      - name: Run previously failed test first
+        uses: cypress-io/github-action@v2
+        if: steps.get-failed-spec.outputs.failed-test != ''
+        with:
+          config-file: config/cypress.json
+          config: baseUrl=https://localhost:8885
+          record: true
+          parallel: true
+          browser: chrome
+          group: previously-failed-${{ needs.determine-if-required.outputs.hash }}
+          spec: ${{ steps.get-failed-spec.outputs.failed-test }}
       - name: Run frontend end-to-end tests
         uses: cypress-io/github-action@v2
         with:
@@ -209,6 +237,10 @@ jobs:
           parallel: true
           browser: chrome
           group: main-${{ needs.determine-if-required.outputs.hash }}
+          spec: |
+            **/*
+            !cypress/integration/smoke/smoke.spec.js
+            ${{ steps.get-failed-spec.outputs.neg-failed-test }}
       - name: Upload logs
         uses: actions/upload-artifact@v2
         if: failure()
@@ -221,14 +253,16 @@ jobs:
         with:
           name: cypress-screenshots
           path: cypress/screenshots
+      - name: Upload name of failing test
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: cypress-failed-test-spec
+          path: .cache/.failed-specs-*.txt
   cross-browser-smoke:
     name: Cross-browser smoke tests (Firefox 78 ESR)
     runs-on: ubuntu-20.04
     env:
-      TTN_LW_LOG_LEVEL: debug
-      COCKROACHDB_COCKROACH_TAG: v19.2.12
-      CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       NODE_ENV: development
     needs: [determine-if-required, preparation]
     if: needs.determine-if-required.outputs.needs-to-run == 'true'

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -12,12 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+const fs = require('fs')
+
 const tasks = require('./tasks')
+
+const failedSpecsFilename = `./.cache/.failed-specs-${
+  process.env.CYPRESS_MACHINE_NUMBER || '0'
+}.txt`
 
 module.exports = (on, config) => {
   tasks.stackConfigTask(on, config)
   tasks.sqlTask(on, config)
   tasks.stackLogTask(on, config)
+  tasks.fileExistsTask(on, config)
 
   if (process.env.NODE_ENV === 'development') {
     tasks.codeCoverageTask(on, config)

--- a/cypress/plugins/tasks.js
+++ b/cypress/plugins/tasks.js
@@ -143,9 +143,22 @@ const stackLogTask = on => {
   })
 }
 
+const fileExistsTask = on => {
+  on('task', {
+    fileExists: filename => {
+      if (fs.existsSync(filename)) {
+        return fs.readFileSync(filename)
+      }
+
+      return false
+    },
+  })
+}
+
 module.exports = {
   stackConfigTask,
   codeCoverageTask,
   sqlTask,
   stackLogTask,
+  fileExistsTask,
 }

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -12,12 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/* eslint-disable no-invalid-this */
+
 import '@cypress/code-coverage/support'
 import '@testing-library/cypress/add-commands'
 import { configure } from '@testing-library/cypress'
 import './commands'
 
+const failedSpecsFilename = `./.cache/.failed-specs-${Cypress.env('MACHINE_NUMBER') || '0'}.txt`
+
 configure({ testIdAttribute: 'data-test-id' })
 Cypress.SelectorPlayground.defaults({
   selectorPriority: ['data-test-id', 'id', 'class', 'tag', 'attributes', 'nth-child'],
 })
+
+// Enable fail early if set.
+afterEach(function () {
+  if (this.currentTest.state === 'failed' && Cypress.env('FAIL_FAST')) {
+    cy.log('Skipping rest of run due to test failure (fail fast)')
+    cy.writeFile(failedSpecsFilename, this.currentTest.invocationDetails.relativeFile)
+  }
+})
+
+// Skip remaining runs if fail early is set.
+const skipIfNecessary = function () {
+  cy.task('fileExists', failedSpecsFilename).then(content => {
+    if (content !== '' && content !== false && Cypress.env('FAIL_FAST')) {
+      this.currentTest.pending = true
+      Cypress.runner.stop()
+    }
+  })
+}
+
+before(skipIfNecessary)
+beforeEach(skipIfNecessary)


### PR DESCRIPTION
#### Summary
This PR will reduce unnecessary cypress runs in several ways.

#### Changes
<!-- What are the changes made in this pull request? -->

- Use `concurrency` option for the end-to-end workflow to enable newer runs canceling out earlier ones
- Add logic to skip subsequent tests after a test failed (fail early)
- Add logic to run previously failed test specs first in subsequent workflow runs
- Run smoke tests only once in Firefox ESR (and not additionally on latest chrome)

#### Testing

Manually using this draft PR.

#### Notes for Reviewers

The goal here is to decrease the overages that we currently pay to cypress.

Things to note:
- Fail fast currently skips the subsequent test of the current runner. However, other parallel runners will keep going until the failed runner has consumed and skipped all remaining tests. There might be ways to build this more efficiently but it would likely necessitate quite some hacking, which is why I avoided it for now. There is no simple way to cancel a run from within cypress.
- When testing previously failed tests first, the smoke tests will still run in parallel but will cancel out if the previously failing test still fails.
- I was not 100% sure about running the smoke tests in Firefox ESR only but ultimately decided for it since it will cause a significant decrease in test results and hence in costs and because I believe it is safe to assume that things that run in Firefox ESR (Extended Support Range) will run in a current Chrome version as well.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
