### PR TITLE
Use peer IP for rate-limiting if x-real-ip is not set

### DIFF
--- a/pkg/ratelimit/grpc.go
+++ b/pkg/ratelimit/grpc.go
@@ -25,6 +25,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/unique"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 )
 
 // grpcRemoteIP retrieves the remote IP address by the X-Real-IP header. The header is set by rpcmiddleware.ProxyHeaders
@@ -32,6 +33,9 @@ func grpcRemoteIP(ctx context.Context) string {
 	md, _ := metadata.FromIncomingContext(ctx)
 	if v := md.Get("x-real-ip"); len(v) > 0 {
 		return v[0]
+	}
+	if p, ok := peer.FromContext(ctx); ok {
+		return p.Addr.String()
 	}
 	return ""
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Currently, we just assume that all requests coming in from "trusted IP" ranges are from proxies and we get the `x-real-ip` from `x-forwarded-for`.
However, when running the stack locally, requests from the cli are from `127.0.0.1` which is a trusted IP but is not from a proxy. Without this header, rate-limiting doesn't work.
This PR checks that x-real-ip is always set by the proxy interceptor.

#### Changes
<!-- What are the changes made in this pull request? -->

- Check that x-real-ip is always set by the proxy interceptor.

#### Testing

<!-- How did you verify that this change works? -->

local

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

I don't expect any.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
