### PR TITLE
Initialize obsevation vector on cache hit or miss

### DIFF
--- a/pkg/applicationserver/metadata/observability.go
+++ b/pkg/applicationserver/metadata/observability.go
@@ -89,9 +89,11 @@ func (m metadataMetrics) Collect(ch chan<- prometheus.Metric) {
 
 func registerMetadataCacheHit(ctx context.Context, metadata string) {
 	metaMetrics.cacheHits.WithLabelValues(ctx, metadata).Inc()
+	metaMetrics.cacheMisses.WithLabelValues(ctx, metadata)
 }
 
 func registerMetadataCacheMiss(ctx context.Context, metadata string) {
+	metaMetrics.cacheHits.WithLabelValues(ctx, metadata)
 	metaMetrics.cacheMisses.WithLabelValues(ctx, metadata).Inc()
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/4970

#### Changes
<!-- What are the changes made in this pull request? -->

- Initialize the AS metadata observation vectors on both cache hits and misses, in order to have both vectors available for rate calculations

#### Testing

<!-- How did you verify that this change works? -->

Local

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
