### PR TITLE
Check updated_at value for end device before using it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- CLI panic when getting devices.
+
 ### Security
 
 ## [3.16.2] - 2021-12-17

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -335,7 +335,7 @@ var (
 			if device.CreatedAt == nil || (res.CreatedAt != nil && ttnpb.StdTime(res.CreatedAt).Before(*ttnpb.StdTime(device.CreatedAt))) {
 				device.CreatedAt = res.CreatedAt
 			}
-			if ttnpb.StdTime(res.UpdatedAt).After(*ttnpb.StdTime(device.UpdatedAt)) {
+			if res.UpdatedAt != nil && ttnpb.StdTime(res.UpdatedAt).After(*ttnpb.StdTime(device.UpdatedAt)) {
 				device.UpdatedAt = res.UpdatedAt
 			}
 
@@ -561,7 +561,7 @@ var (
 			if device.CreatedAt == nil || (res.CreatedAt != nil && ttnpb.StdTime(res.CreatedAt).Before(*ttnpb.StdTime(device.CreatedAt))) {
 				device.CreatedAt = res.CreatedAt
 			}
-			if ttnpb.StdTime(res.UpdatedAt).After(*ttnpb.StdTime(device.UpdatedAt)) {
+			if res.UpdatedAt != nil && ttnpb.StdTime(res.UpdatedAt).After(*ttnpb.StdTime(device.UpdatedAt)) {
 				device.UpdatedAt = res.UpdatedAt
 			}
 
@@ -832,7 +832,7 @@ var (
 			if device.CreatedAt == nil || (nsDevice.CreatedAt != nil && ttnpb.StdTime(nsDevice.CreatedAt).Before(*ttnpb.StdTime(device.CreatedAt))) {
 				device.CreatedAt = nsDevice.CreatedAt
 			}
-			if ttnpb.StdTime(nsDevice.UpdatedAt).After(*ttnpb.StdTime(device.UpdatedAt)) {
+			if nsDevice.UpdatedAt != nil && ttnpb.StdTime(nsDevice.UpdatedAt).After(*ttnpb.StdTime(device.UpdatedAt)) {
 				device.UpdatedAt = nsDevice.UpdatedAt
 			}
 			return io.Write(os.Stdout, config.OutputFormat, device)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fixes; https://github.com/TheThingsIndustries/lorawan-stack-support/issues/672

#### Changes
<!-- What are the changes made in this pull request? -->

- Check if the returned `UpdatedAt` field is nil before using it for asserting time.

#### Testing

<!-- How did you verify that this change works? -->

Local CLI
```
 ./ttn-lw-cli end-devices get --application-id my-test-app --device-id eui-1111111111111111
WARN	Using insecure connection to OAuth server
WARN	Using insecure connection to API
{
  "ids": {
    "device_id": "eui-1111111111111111",
    "application_ids": {
      "application_id": "my-test-app"
    },
    "dev_eui": "1111111111111111",
    "join_eui": "1111111111111111"
  },
  "created_at": "2021-12-20T12:38:31.758Z",
  "updated_at": "2021-12-20T12:38:31.758Z"
}
```

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

I don't think there's any.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
