### PR TITLE
Ignore some common and easy to fix merge conflicts

### DIFF
--- a/.github/workflows/mergeability.yml
+++ b/.github/workflows/mergeability.yml
@@ -13,6 +13,16 @@ jobs:
     name: Check Mergeability
     if: ${{ github.repository == 'TheThingsNetwork/lorawan-stack' }}
     runs-on: ubuntu-20.04
+    env:
+      MERGE_CONFLICTS_IGNORE: |
+        CHANGELOG.md
+        config/messages.json
+        go.mod
+        go.sum
+        package.json
+        tools/go.mod
+        tools/go.sum
+        yarn.lock
     steps:
       - name: Configure Git
         run: |
@@ -25,10 +35,28 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - name: Merge TheThingsNetwork/lorawan-stack:${{ github.event.pull_request.base.ref }}
+        continue-on-error: true
         run: |
           git fetch origin ${{ github.event.pull_request.base.ref }}
           git merge FETCH_HEAD -m "Merge ${{ github.event.pull_request.base.ref }} into #${{ github.event.inputs.pull_request_number }}"
+      - name: Check for conflicts with TheThingsNetwork/lorawan-stack:${{ github.event.pull_request.base.ref }}
+        run: |
+          conflicts=$(comm -23 <(git diff --name-only --diff-filter=U | sort) <(echo "$MERGE_CONFLICTS_IGNORE" | sort))
+          if [[ ! -z "$conflicts" ]]; then
+            echo "Merge conflicts in the following files:"
+            echo "$conflicts"
+            false
+          fi
       - name: Merge TheThingsIndustries/lorawan-stack:${{ github.event.pull_request.base.ref }}
+        continue-on-error: true
         run: |
           git fetch https://github.com/TheThingsIndustries/lorawan-stack ${{ github.event.pull_request.base.ref }}
           git merge FETCH_HEAD -m "Merge remote/${{ github.event.pull_request.base.ref }} into #${{ github.event.inputs.pull_request_number }}"
+      - name: Check for conflicts with TheThingsIndustries/lorawan-stack:${{ github.event.pull_request.base.ref }}
+        run: |
+          conflicts=$(comm -23 <(git diff --name-only --diff-filter=U | sort) <(echo "$MERGE_CONFLICTS_IGNORE" | sort))
+          if [[ ! -z "$conflicts" ]]; then
+            echo "Merge conflicts in the following files:"
+            echo "$conflicts"
+            false
+          fi


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request updates the mergeability check workflow to ignore some common conflicts in `go.mod`, `go.sum`, `messages.json`, etc. which are easy to fix.

This hopefully makes the check less "noisy" and more useful.