### PR TITLE
Do not lock List calls on the Application Server hot path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Fixed
 
 - CLI panic when getting devices.
+- Application uplink processing serialization behavior in the Application Server.
 
 ### Security
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/2696

This PR ensures that application packages registry `List*` calls are not locked on the hot path (when a limit does not exist).

We lock for correctness reasons during a `List*` call in order to ensure that the total number of protos that we return is consistent with the pagination numbers (the total number of associations). This lock however would serialize uplink processing of a singular application due to the application packages fanout (as the distributed lock has `sync.Mutex` semantics, not `sync.RWMutex` semantics).

#### Changes
<!-- What are the changes made in this pull request? -->

- Do not lock the unique ID key if we don't need to be consistent.


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This is a regression introduced by https://github.com/TheThingsNetwork/lorawan-stack/pull/4734 .  

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
