### PR TITLE
Fix device repository form prop-types warning in the Console

### DIFF
--- a/pkg/webui/lib/prop-types.js
+++ b/pkg/webui/lib/prop-types.js
@@ -221,9 +221,7 @@ PropTypes.deviceTemplate = PropTypes.shape({
     lorawan_version: PropTypes.string.isRequired,
     lorawan_phy_version: PropTypes.string.isRequired,
   }),
-  field_mask: PropTypes.shape({
-    paths: PropTypes.arrayOf(PropTypes.string).isRequired,
-  }).isRequired,
+  field_mask: PropTypes.string.isRequired,
 })
 
 PropTypes.organization = PropTypes.shape({


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Resolve 
```
Failed prop type: Invalid prop `template.field_mask` of type `string` supplied to `DeviceCard`, expected `object`.
    at DeviceCard
```

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
