### PR TITLE
Filter end device frequency plans based on band ID in the Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For details about compatibility between different releases, see the **Commitment
 - Support reading the Join Server's default JoinEUI and using this in the CLI for end device creation.
  - The Join Server has a new API `GetDefaultJoinEUI`.
  - The default JoinEUI can be configured on the Join Server using the option `--js.default-join-eui`.
+- Filtering of end device frequency plans in end device forms based on band id in the Console.
 
 ### Changed
 

--- a/pkg/webui/console/containers/device-freq-plans-select/index.js
+++ b/pkg/webui/console/containers/device-freq-plans-select/index.js
@@ -18,13 +18,15 @@ import { CreateFrequencyPlansSelect } from '@console/containers/freq-plans-selec
 
 import PropTypes from '@ttn-lw/lib/prop-types'
 
+const getRegionFromBandId = (bandId = '') => bandId.split('_')[0]
+
 const FreqPlansSelect = React.memo(props => {
   const { bandId, ...rest } = props
 
   return React.createElement(
     CreateFrequencyPlansSelect('ns', {
       optionsFormatter: plans => {
-        const region = bandId.split('_')[0]
+        const region = getRegionFromBandId(bandId)
         if (!Boolean(region)) {
           return plans.map(plan => ({ value: plan.id, label: plan.name }))
         }

--- a/pkg/webui/console/views/device-add/repository/device-registration/index.js
+++ b/pkg/webui/console/views/device-add/repository/device-registration/index.js
@@ -27,6 +27,7 @@ import Message from '@ttn-lw/lib/components/message'
 import JoinEUIPRefixesInput from '@console/components/join-eui-prefixes-input'
 
 import DevAddrInput from '@console/containers/dev-addr-input'
+import FreqPlansSelect from '@console/containers/device-freq-plans-select'
 
 import tooltipIds from '@ttn-lw/lib/constants/tooltip-ids'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
@@ -40,8 +41,6 @@ import { selectBand } from '../reducer'
 import { REGISTRATION_TYPES } from '../../utils'
 import messages from '../../messages'
 import style from '../../device-add.styl'
-
-import FreqPlansSelect from './freq-plans-select'
 
 const m = defineMessages({
   fetching: 'Fetching template…',

--- a/pkg/webui/console/views/device-general-settings/network-server-form/index.js
+++ b/pkg/webui/console/views/device-general-settings/network-server-form/index.js
@@ -32,7 +32,7 @@ import PhyVersionInput from '@console/components/phy-version-input'
 import LorawanVersionInput from '@console/components/lorawan-version-input'
 import MacSettingsSection from '@console/components/mac-settings-section'
 
-import { NsFrequencyPlansSelect } from '@console/containers/freq-plans-select'
+import FreqPlansSelect from '@console/containers/device-freq-plans-select'
 import DevAddrInput from '@console/containers/dev-addr-input'
 
 import tooltipIds from '@ttn-lw/lib/constants/tooltip-ids'
@@ -89,11 +89,13 @@ const NetworkServerForm = React.memo(props => {
     supports_class_b = false,
     supports_class_c = false,
     mac_settings = {},
+    version_ids = {},
   } = device
 
   const isABP = isDeviceABP(device)
   const isMulticast = isDeviceMulticast(device)
   const isJoinedOTAA = isDeviceOTAA(device) && isDeviceJoined(device)
+  const bandId = version_ids.band_id
 
   const validationContext = React.useMemo(
     () => ({
@@ -369,11 +371,12 @@ const NetworkServerForm = React.memo(props => {
       error={error}
       formikRef={formRef}
     >
-      <NsFrequencyPlansSelect
+      <FreqPlansSelect
         name="frequency_plan_id"
         required
         tooltipId={tooltipIds.FREQUENCY_PLAN}
         onChange={handleFreqPlanChange}
+        bandId={bandId}
       />
       <Form.Field
         title={sharedMessages.macVersion}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://sentry.io/organizations/the-things-industries/issues/2298261705/events/90dca272eca54ffeb7007d4766630f28/?project=2682566

#### Changes
<!-- What are the changes made in this pull request? -->

- Use `<FreqPlansSelect />` in device general settings


#### Testing

<!-- How did you verify that this change works? -->

Manual

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
