### PR TITLE
Set timeouts on all workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,5 @@
 name: End-to-end Tests
-concurrency: 
+concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: true
 on:
@@ -32,6 +32,7 @@ jobs:
       needs-to-run: ${{ steps.check-result.outputs.passed != 'true' }}
       hash: ${{ steps.get-hash.outputs.hash }}
       yarn-cache-dir-path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+    timeout-minutes: 5
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -61,6 +62,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: determine-if-required
     if: needs.determine-if-required.outputs.needs-to-run == 'true'
+    timeout-minutes: 30
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -175,6 +177,7 @@ jobs:
         machines: [1, 2, 3, 4]
     needs: [determine-if-required, preparation]
     if: needs.determine-if-required.outputs.needs-to-run == 'true'
+    timeout-minutes: 15
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -266,6 +269,7 @@ jobs:
       NODE_ENV: development
     needs: [determine-if-required, preparation]
     if: needs.determine-if-required.outputs.needs-to-run == 'true'
+    timeout-minutes: 15
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -322,6 +326,7 @@ jobs:
     name: Write result cache
     runs-on: ubuntu-20.04
     needs: [preparation, end-to-end, cross-browser-smoke, determine-if-required]
+    timeout-minutes: 5
     steps:
       - name: Setup result cache to skip redundant runs
         id: run-cache

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -6,6 +6,7 @@ jobs:
   quality:
     name: Code Quality
     runs-on: ubuntu-20.04
+    timeout-minutes: 5
     steps:
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,6 +19,7 @@ jobs:
   quality:
     name: Code Quality
     runs-on: ubuntu-20.04
+    timeout-minutes: 15
     steps:
     - name: Check out code
       uses: actions/checkout@v2
@@ -73,6 +74,7 @@ jobs:
         image: redis
         ports:
           - '6379/tcp'
+    timeout-minutes: 15
     steps:
     - name: Create ttn_lorawan_is_test DB
       uses: docker://postgres

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -7,6 +7,7 @@ jobs:
   triage:
     name: Triage New Issues
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Add "needs/triage" label
         uses: actions/github-script@v3

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -18,6 +18,7 @@ jobs:
   quality:
     name: Code Quality
     runs-on: ubuntu-20.04
+    timeout-minutes: 15
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -68,7 +69,6 @@ jobs:
         run: tools/bin/mage jsSDK:clean jsSDK:build
       - name: Install JS dependencies
         run: tools/bin/mage js:deps
-        timeout-minutes: 5
       - name: Generate JS translations
         run: tools/bin/mage js:translations js:backendTranslations
       - name: Lint JS SDK code
@@ -81,6 +81,7 @@ jobs:
   test:
     name: Tests
     runs-on: ubuntu-20.04
+    timeout-minutes: 15
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -133,7 +134,6 @@ jobs:
         run: tools/bin/mage jsSDK:deps
       - name: Install JS dependencies
         run: tools/bin/mage js:deps
-        timeout-minutes: 5
       - name: Test JS SDK code
         run: tools/bin/mage jsSDK:test
       - name: Test frontend code

--- a/.github/workflows/mergeability.yml
+++ b/.github/workflows/mergeability.yml
@@ -23,6 +23,7 @@ jobs:
         tools/go.mod
         tools/go.sum
         yarn.lock
+    timeout-minutes: 5
     steps:
       - name: Configure Git
         run: |

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -4,6 +4,7 @@ on: pull_request
 jobs:
   triage:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/labeler@v2
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !startsWith(github.actor, 'dependabot') }}

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -11,6 +11,7 @@ jobs:
   protos:
     name: Generate protos
     runs-on: ubuntu-20.04
+    timeout-minutes: 5
     steps:
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -12,6 +12,7 @@ jobs:
   release:
     name: Snapshot release
     runs-on: ubuntu-20.04
+    timeout-minutes: 30
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -12,6 +12,7 @@ jobs:
   release:
     name: Tag release
     runs-on: ubuntu-20.04
+    timeout-minutes: 60
     steps:
     - name: Check out code
       uses: actions/checkout@v2


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request sets timeouts on all CI workflows. For every job I added a timeout of 5 minutes (small tasks), 15 minutes (most tasks), 30 minutes (things that should take 15 minutes but don't) or 60 minutes (releases).

#### Testing

<!-- How did you verify that this change works? -->

CI 🤷 

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Only development experience, not production.

We may start seeing more timeouts in CI, but I really think 15 minutes should be the upper limit. In my opinion anything that takes longer than 10 minutes is useless for my development workflow.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
