### PR TITLE
Fix lint issue and extend trigger of the JS github action

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -12,6 +12,7 @@ on:
       - '!pkg/webui/**.go'
       - 'sdk/js/**'
       - 'tools/**'
+      - 'cypress/**'
       - 'yarn.lock'
 
 jobs:

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -12,13 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const fs = require('fs')
-
 const tasks = require('./tasks')
-
-const failedSpecsFilename = `./.cache/.failed-specs-${
-  process.env.CYPRESS_MACHINE_NUMBER || '0'
-}.txt`
 
 module.exports = (on, config) => {
   tasks.stackConfigTask(on, config)


### PR DESCRIPTION
#### Summary
This quickfix PR fixes a lint issue and makes sure that the JS github action also runs for changes to the `cypress` folder.

#### Changes
- Fix lint issue in cypress code
- Extend the `on.pull_request.paths` prop of the `js.yml` github action so that the action runs also for changes to the `cypress` files.


#### Testing
Manual

#### Notes for Reviewers
The lint error sneaked in because the JS action would not run for changes to cypress files.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
