### PR TITLE
Fix panic when determining latest updated at

### DIFF
--- a/cmd/ttn-lw-cli/commands/end_devices_split.go
+++ b/cmd/ttn-lw-cli/commands/end_devices_split.go
@@ -227,7 +227,7 @@ func setEndDevice(device *ttnpb.EndDevice, isPaths, nsPaths, asPaths, jsPaths, u
 		if res.CreatedAt == nil || (jsRes.CreatedAt != nil && ttnpb.StdTime(jsRes.CreatedAt).Before(*ttnpb.StdTime(res.CreatedAt))) {
 			res.CreatedAt = jsRes.CreatedAt
 		}
-		if ttnpb.StdTime(jsRes.UpdatedAt).After(*ttnpb.StdTime(res.UpdatedAt)) {
+		if res.UpdatedAt == nil || (jsRes.UpdatedAt != nil && ttnpb.StdTime(jsRes.UpdatedAt).After(*ttnpb.StdTime(res.UpdatedAt))) {
 			res.UpdatedAt = jsRes.UpdatedAt
 		}
 	}
@@ -253,7 +253,7 @@ func setEndDevice(device *ttnpb.EndDevice, isPaths, nsPaths, asPaths, jsPaths, u
 		if res.CreatedAt == nil || (nsRes.CreatedAt != nil && ttnpb.StdTime(nsRes.CreatedAt).Before(*ttnpb.StdTime(res.CreatedAt))) {
 			res.CreatedAt = nsRes.CreatedAt
 		}
-		if ttnpb.StdTime(nsRes.UpdatedAt).After(*ttnpb.StdTime(res.UpdatedAt)) {
+		if res.UpdatedAt == nil || (nsRes.UpdatedAt != nil && ttnpb.StdTime(nsRes.UpdatedAt).After(*ttnpb.StdTime(res.UpdatedAt))) {
 			res.UpdatedAt = nsRes.UpdatedAt
 		}
 	}
@@ -279,7 +279,7 @@ func setEndDevice(device *ttnpb.EndDevice, isPaths, nsPaths, asPaths, jsPaths, u
 		if res.CreatedAt == nil || (asRes.CreatedAt != nil && ttnpb.StdTime(asRes.CreatedAt).Before(*ttnpb.StdTime(res.CreatedAt))) {
 			res.CreatedAt = asRes.CreatedAt
 		}
-		if ttnpb.StdTime(asRes.UpdatedAt).After(*ttnpb.StdTime(res.UpdatedAt)) {
+		if res.UpdatedAt == nil || (asRes.UpdatedAt != nil && ttnpb.StdTime(asRes.UpdatedAt).After(*ttnpb.StdTime(res.UpdatedAt))) {
 			res.UpdatedAt = asRes.UpdatedAt
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Follow up on #5033 

#### Changes
<!-- What are the changes made in this pull request? -->

Same as other PR, but not also for setting the latest updated at.

#### Testing

<!-- How did you verify that this change works? -->

Local testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
