### PR TITLE
ops: Add tag release prepare action

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -15,80 +15,12 @@ This is a checklist for releases. This is filled in by both the releaser and the
 #### Preparation
 
 - [ ] Create a [documentation release issue](https://github.com/TheThingsIndustries/lorawan-stack-docs/issues/new?title=Release+v3.x.x&labels=release&template=release.md).
-
-- [ ] Create a `release/v3.${minor}.${patch}` branch off the `v3.${minor}` branch.
-  ```bash
-  $ git checkout v3.${minor}
-  $ git checkout -b release/v3.${minor}.${patch}
-  ```
-
-- [ ] Update submodules
-  ```bash
-  $ mage git:pullSubmodules
-  $ git add data
-  $ git commit -m "data: Update external repositories" # if any changes.
-  ```
-
-- [ ] Update the `CHANGELOG.md` file
-  - [ ] Change the **Unreleased** section to the new version and add date obtained via `date +%Y-%m-%d` (e.g. `## [3.2.1] - 2019-10-11`)
-  - [ ] Check if we didn't forget anything important
-  - [ ] Remove empty subsections
-  - [ ] Update the list of links in the bottom of the file
-  - [ ] Add new **Unreleased** section:
-    ```md
-    ## [Unreleased]
-
-    ### Added
-
-    ### Changed
-
-    ### Deprecated
-
-    ### Removed
-
-    ### Fixed
-
-    ### Security
-    ```
-
-- [ ] Once complete, you can add the file to staging
-  ```bash
-  $ git add CHANGELOG.md
-  ```
-
-
-- [ ] If releasing a new minor version, update the `SECURITY.md` file and stage it for commit.
-  ```bash
-  $ git add SECURITY.md
-  ```
-
-- [ ] Bump version
-  - [ ] Run the necessary `mage` bump commands based on the type of release
-    ```bash
-    $ tools/bin/mage version:bumpMajor   # bumps a major version (from 3.4.5 -> 4.0.0).
-    $ tools/bin/mage version:bumpMinor   # bumps a minor version (from 3.4.5 -> 3.5.0).
-    $ tools/bin/mage version:bumpPatch   # bumps a patch version (from 3.4.5 -> 3.4.6).
-    $ tools/bin/mage version:bumpRC      # bumps a release candidate version (from 3.4.5-rc1 -> 3.4.5-rc2).
-    $ tools/bin/mage version:bumpRelease # bumps a pre-release to a release version (from 3.4.5-rc1 -> 3.4.5).
-    # These bumps can be combined (i.e. `version:bumpMinor version:bumpRC` bumps 3.4.5 -> 3.5.0-rc1).
-    ```
-
-  - [ ] Write the version files
-    ```bash
-    $ tools/bin/mage version:files
-    ```
-
-  - [ ] Commit the version bump
-    ```bash
-    $ tools/bin/mage version:commitBump
-    ```
-
-- [ ] Create a pull request targeting `v3.${minor}`.
+- [ ] Run `tools/bin/prepare_release minor` or `tools/bin/prepare_release patch`, depending on the kind of release.
+- [ ] Follow the instructions.
 
 #### Check 1 (for reviewers)
 
 - [ ] The Changelog is complete i.e., contains only the changes that are in the release (not more/less).
-- [ ] `SECURITY.md` is updated.
 - [ ] The version files are correctly updated.
 
 #### Release
@@ -99,7 +31,6 @@ This is a checklist for releases. This is filled in by both the releaser and the
   $ tools/bin/mage version:bumpXXX version:tag
   # For RCs, make sure to use the same bumping combination (ex: `version:bumpXXX version:bumpYYY`) as used in the bump step above.
   ```
-
 - [ ] Push the version tag. Once this is done, CI automatically starts building and pushing to package managers. When this is done, you'll find a new release on the [releases page](https://github.com/TheThingsNetwork/lorawan-stack/releases).
   ```bash
   $ git push origin ${version}
@@ -109,9 +40,9 @@ This is a checklist for releases. This is filled in by both the releaser and the
 
 - [ ] For non RC releases, push the Docker latest tag.
     ```bash
-    $ versionDockerTag=${version#"v"} # v3.6.1 -> 3.6.1
+    $ versionDockerTag=${$(tools/bin/mage version:current)#"v"}
     $ docker pull thethingsnetwork/lorawan-stack:${versionDockerTag}
-    $ docker tag thethingsnetwork/lorawan-stack:{versionDockerTag} thethingsnetwork/lorawan-stack:latest
+    $ docker tag thethingsnetwork/lorawan-stack:${versionDockerTag} thethingsnetwork/lorawan-stack:latest
     $ docker push thethingsnetwork/lorawan-stack:latest
     ```
 

--- a/.github/workflows/release-tag-pre.yml
+++ b/.github/workflows/release-tag-pre.yml
@@ -1,0 +1,36 @@
+name: Prepare tag release
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch
+        required: true
+      minor_patch:
+        description: minor/patch
+        required: true
+
+jobs:
+  release:
+    name: Prepare tag release
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        submodules: true
+        ref: ${{ github.event.inputs.branch }}
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '~1.17'
+    - name: Prepare dev environment
+      run: |
+        make init
+    - name: Prepare release
+      run: |
+        git config user.name "The Things Bot"
+        git config user.email "github@thethingsindustries.com"
+        tools/bin/prepare_release ${{ github.event.inputs.minor_patch }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tools/bin/prepare_release
+++ b/tools/bin/prepare_release
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -e
+
+case "$1" in
+minor|Minor ) BUMP="Minor" ;;
+patch|Patch ) BUMP="Patch" ;;
+* ) echo "Missing release type [minor|patch]"; exit 1;;
+esac
+MAGE_BUMP="version:bump$BUMP"
+
+export MAGEFILE_VERSBOSE=0
+
+MAGE=${MAGE:-tools/bin/mage}
+ORIGIN=${ORIGIN:-origin}
+
+MINOR_BRANCH=$($MAGE "$MAGE_BUMP" version:majorMinor)
+RELEASE_TAG=$($MAGE "$MAGE_BUMP" version:current)
+RELEASE_DATE=$(date +%Y-%m-%d)
+RELEASE_BRANCH=release/$RELEASE_TAG
+
+echo "Current Version: $($MAGE version:current)"
+echo "$BUMP bump branch $MINOR_BRANCH to $RELEASE_TAG"
+
+echo "Checking out $RELEASE_BRANCH"
+git checkout -b "$RELEASE_BRANCH"
+
+echo "Pulling latest changes for submodules"
+$MAGE git:pullSubmodules
+
+if [[ ! -z "$(git diff --name-only data)" ]]; then
+  echo "Committing changes for updated submodules"
+  git add data
+  git commit -m "data: Update external repositories"
+fi
+
+echo "Updating CHANGELOG.md"
+
+# Take care of the [3.x.y] section
+cat CHANGELOG.md | tr '\n' '\000' `# First change newlines to \x00 so that sed can treat whole file as a stream of text` | \
+    sed 's/## [A-Z][a-z]*\x00\x00#/\x01\x00#/g' `# Then replace empty sections with \x01, we mark them for deletion later` | \
+    # The reason why we mark for deletion and then delete later is because otherwise there are issues when two consecutive sections are empty
+    sed 's/## \[Unreleased\]/## \[Unreleased\]\x00\x00### Added\x00\x00### Changed\x00\x00### Deprecated\x00\x00### Removed\x00\x00### Fixed\x00\x00### Security\x00\x00'"## \\[${RELEASE_TAG:1}\\] - ${RELEASE_DATE}"'/' `# Rename the "Unreleased" section to "Tag - Date", and add a new, empty one` | \
+    tr '\000' '\n' `# Change \x00 back to newlines` | \
+    sed '/\x01/d' `# Remove lines with \x01 (previously marked for deletion)` | \
+    sed "s/\[unreleased\]: https:\/\/github.com\/$(echo "${GITHUB_REPOSITORY}" | sed 's/\//\\\//g')\/compare\/\(v3\.[0-9][0-9]*\.[0-9][0-9]*\)\.\.\.\(v3\.[0-9][0-9]*\)/[unreleased]: https:\/\/github.com\/$(echo "${GITHUB_REPOSITORY}" | sed 's/\//\\\//g')\/compare\/${RELEASE_TAG}...${MINOR_BRANCH}\n[${RELEASE_TAG}]: https:\/\/github.com\/$(echo "${GITHUB_REPOSITORY}" | sed 's/\//\\\//g')\/compare\/\1...${RELEASE_TAG}/" > CHANGELOG2.md # Add new github diff link
+mv -f CHANGELOG2.md CHANGELOG.md
+git add CHANGELOG.md
+
+echo "Generating version files"
+$MAGE "$MAGE_BUMP" version:files
+
+echo "Committing version bump"
+$MAGE "$MAGE_BUMP" version:commitBump
+
+echo "Pushing ${RELEASE_BRANCH} to ${ORIGIN}"
+git push -u "$ORIGIN" "${RELEASE_BRANCH}:${RELEASE_BRANCH}"
+
+echo "Creating pull request for ${RELEASE_TAG} release"
+gh pr create \
+    --assignee "${GITHUB_ACTOR}" \
+    --base "${MINOR_BRANCH}" \
+    --body "This pull request prepares for the ${RELEASE_TAG} release." \
+    --head "${RELEASE_BRANCH}" \
+    --label "release" \
+    --milestone "${RELEASE_TAG}" \
+    --title "Release ${RELEASE_TAG}" \
+    --repo "${GITHUB_REPOSITORY}"

--- a/tools/mage/version.go
+++ b/tools/mage/version.go
@@ -54,6 +54,17 @@ func (Version) Current() error {
 	return nil
 }
 
+// MajorMinor returns the current major.minor version.
+func (Version) MajorMinor() error {
+	mg.Deps(Version.getCurrent)
+	version, err := semver.Parse(strings.TrimPrefix(currentVersion, "v"))
+	if err != nil {
+		return err
+	}
+	fmt.Printf("v%d.%d\n", version.Major, version.Minor)
+	return nil
+}
+
 const (
 	goVersionFilePath = "pkg/version/ttn.go"
 )


### PR DESCRIPTION
#### Summary
References https://github.com/TheThingsNetwork/lorawan-stack/issues/4982

Based on @htdvisser work in commit https://github.com/TheThingsNetwork/lorawan-stack/commit/86141a66a6410cc581e6925b43d0be4a6da353e3

This PR adds a github action that simplifies the release process.

Question to @htdvisser :

`mage version:commitBump` implies the option `-S` to `git commit`. I'm now sure how this is supposed to work in this scenario, and I suggest we remove the `-S`. I removed that for testing, but it's still present in this PR.

#### Changes
Added a github action that simplifies the release process.

#### Testing
Called the github action in my own repo. See this PR that has been created:

https://github.com/michalborkowski96/lorawan-stack/pull/2

##### Regressions
We never use the "release candidate" flow, so I skipped it.
#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
