### PR TITLE
Check cluster calls based on authentication token type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Rate limiting of cluster authenticated RPCs.
+
 ### Security
 
 ## [3.17.0] - 2022-01-07


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/5011
Replaces https://github.com/TheThingsIndustries/lorawan-stack/pull/3046

#### Changes
<!-- What are the changes made in this pull request? -->

- Instead of checking the remote IP of the gRPC peer, check the cluster authentication type
  - The check is purely based on the RPC metadata, which is available before any middleware actually runs


#### Testing

<!-- How did you verify that this change works? -->

Updated unit tests.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This PR refactors the cluster detection code to be more robust.

Keep in mind that the cluster authentication key is checked _after_ the rate limitting:

https://github.com/TheThingsNetwork/lorawan-stack/blob/295590743ebf4732844838277cf191ee85cf1455/pkg/rpcserver/rpcserver.go#L174-L190

But this is fine, as we check the auth type based on the metadata, which doesn't depend on any middleware. 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
