### PR TITLE
Unset gateway location in Packet Broker when it isn't public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
+- Gateways are removed from the Packet Broker Mapper API when unsetting the location public setting. This is to remove gateways from the map. Previously, the location was still set, but it did not get updated.
+
 ### Deprecated
 
 ### Removed

--- a/pkg/gatewayserver/upstream/packetbroker/packetbroker.go
+++ b/pkg/gatewayserver/upstream/packetbroker/packetbroker.go
@@ -178,10 +178,10 @@ func (h *Handler) ConnectGateway(ctx context.Context, ids ttnpb.GatewayIdentifie
 			},
 		}
 
-		// Only update the location when it is public and when it may be updated from status messages.
-		// location_public should only be in the field mask if the location is known, so only when a location in the status.
-		// This is to avoid that the location gets reset when there is no location in the status.
 		if gtw.LocationPublic {
+			// Only update the location when it is public and when it may be updated from status messages.
+			// location_public should only be in the field mask if the location is known, so only when a location in the status.
+			// This is to avoid that the location gets reset when there is no location in the status.
 			if status, _, ok := conn.StatusStats(); ok && gtw.UpdateLocationFromStatus && len(status.GetAntennaLocations()) > 0 && status.AntennaLocations[0] != nil {
 				loc := *status.AntennaLocations[0]
 				loc.Source = ttnpb.SOURCE_GPS
@@ -193,6 +193,9 @@ func (h *Handler) ConnectGateway(ctx context.Context, ids ttnpb.GatewayIdentifie
 				}
 				req.FieldMask.Paths = append(req.FieldMask.GetPaths(), "antennas", "location_public")
 			}
+		} else {
+			// Explicitly disable location public so that the existing gateway location, if any, gets reset.
+			req.FieldMask.Paths = append(req.FieldMask.GetPaths(), "location_public")
 		}
 
 		now := time.Now()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #5079 

#### Changes
<!-- What are the changes made in this pull request? -->

Explicitly pass `location_public` when it is false, so that the location gets reset by Packet Broker Mapper. This is to remove gateways from the map after a location has been set.

#### Testing

<!-- How did you verify that this change works? -->

I didn't test this, but this is obvious enough

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None expected

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
