### PR TITLE
Check for nil UpdatedAt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Fixed
 
 - Rate limiting of cluster authenticated RPCs.
+- CLI panic when setting end devices.
 
 ### Security
 

--- a/cmd/ttn-lw-cli/commands/end_devices_split.go
+++ b/cmd/ttn-lw-cli/commands/end_devices_split.go
@@ -201,7 +201,7 @@ func setEndDevice(device *ttnpb.EndDevice, isPaths, nsPaths, asPaths, jsPaths, u
 		if res.CreatedAt == nil || (isRes.CreatedAt != nil && ttnpb.StdTime(isRes.CreatedAt).Before(*ttnpb.StdTime(res.CreatedAt))) {
 			res.CreatedAt = isRes.CreatedAt
 		}
-		if ttnpb.StdTime(isRes.UpdatedAt).After(*ttnpb.StdTime(res.UpdatedAt)) {
+		if res.UpdatedAt == nil || ttnpb.StdTime(isRes.UpdatedAt).After(*ttnpb.StdTime(res.UpdatedAt)) {
 			res.UpdatedAt = isRes.UpdatedAt
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

 Refs https://github.com/TheThingsIndustries/lorawan-stack-support/issues/672#issuecomment-1010048696

This is quite annoying that we are messing this up. Hopefully this is the last of such fixes for the ED.

#### Changes
<!-- What are the changes made in this pull request? -->

- Check for nil UpdatedAt.


#### Testing

<!-- How did you verify that this change works? -->

Locally tested

Before
```
~/go/src/go.thethings.network/lorawan-stack (fix/cli-again*) » ./ttn-lw-cli dev set test-app test-device  --mac-settings.desired-rx1-delay 6
WARN	Using insecure connection to OAuth server
WARN	Using insecure connection to API
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x10346b938]

goroutine 1 [running]:
go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/commands.setEndDevice(0x14000b38a00, {0x14000b65ea0, 0x1, 0x1}, {0x14000b65eb0, 0x1, 0x1}, {0x14000b65ec0, 0x0, 0x1}, ...)
	/Users/krishnaiyereaswaran/go/src/go.thethings.network/lorawan-stack/cmd/ttn-lw-cli/commands/end_devices_split.go:204 +0x508
go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-cli/commands.glob..func85(0x104aaf900, {0x14000af6b00, 0x2, 0x4})
	/Users/krishnaiyereaswaran/go/src/go.thethings.network/lorawan-stack/cmd/ttn-lw-cli/commands/end_devices.go:705 +0x1218
github.com/spf13/cobra.(*Command).execute(0x104aaf900, {0x14000af6ac0, 0x4, 0x4})
	/Users/krishnaiyereaswaran/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:856 +0x668
github.com/spf13/cobra.(*Command).ExecuteC(0x104abc880)
	/Users/krishnaiyereaswaran/go/pkg/mod/github.com/spf13/cobra@v1.2.1/command.go:974 +0x410
main.main()
	/Users/krishnaiyereaswaran/go/src/go.thethings.network/lorawan-stack/cmd/ttn-lw-cli/main.go:27 +0x30
```

After
```
~/go/src/go.thethings.network/lorawan-stack (fix/cli-again*) » ./ttn-lw-cli dev set test-app test-device  --mac-settings.desired-rx1-delay 6
WARN	Using insecure connection to OAuth server
WARN	Using insecure connection to API
{
  "ids": {
    "device_id": "test-device",
    "application_ids": {
      "application_id": "test-app"
    },
    "dev_eui": "1111111111111111",
    "join_eui": "1111111111111111"
  },
  "created_at": "2022-01-12T08:04:46.649Z",
  "updated_at": "2022-01-12T08:08:49.238710Z",
  "network_server_address": "localhost",
  "mac_settings": {
    "desired_rx1_delay": 6
  }
```
##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
