### PR TITLE
Filter end device events that propagate to application event streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Changed
 
 - Webhook maximum header value length extended to 4096 characters.
+- Limited the end device event types that are included in application event streams to only application layer events, errors and warnings. Other end device events can still be received when subscribing to end device device events.
 
 ### Deprecated
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -6983,15 +6983,6 @@
       "file": "grpc_asns.go"
     }
   },
-  "error:pkg/networkserver:duplicate": {
-    "translations": {
-      "en": "uplink is a duplicate"
-    },
-    "description": {
-      "package": "pkg/networkserver",
-      "file": "errors.go"
-    }
-  },
   "error:pkg/networkserver:empty_session": {
     "translations": {
       "en": "session in empty"

--- a/pkg/applicationserver/grpc_deviceregistry.go
+++ b/pkg/applicationserver/grpc_deviceregistry.go
@@ -34,6 +34,7 @@ var (
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ),
 		events.WithAuthFromContext(),
 		events.WithClientInfoFromContext(),
+		events.WithPropagateToParent(),
 	)
 	evtUpdateEndDevice = events.Define(
 		"as.end_device.update", "update end device",
@@ -41,12 +42,14 @@ var (
 		events.WithUpdatedFieldsDataType(),
 		events.WithAuthFromContext(),
 		events.WithClientInfoFromContext(),
+		events.WithPropagateToParent(),
 	)
 	evtDeleteEndDevice = events.Define(
 		"as.end_device.delete", "delete end device",
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ),
 		events.WithAuthFromContext(),
 		events.WithClientInfoFromContext(),
+		events.WithPropagateToParent(),
 	)
 )
 

--- a/pkg/applicationserver/io/packages/loradms/v1/observability.go
+++ b/pkg/applicationserver/io/packages/loradms/v1/observability.go
@@ -25,6 +25,7 @@ var evtPackageFail = events.Define(
 	"as.packages.loraclouddmsv1.fail", "fail to process upstream message",
 	events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
 	events.WithErrorDataType(),
+	events.WithPropagateToParent(),
 )
 
 func registerPackageFail(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, err error) {

--- a/pkg/applicationserver/io/packages/loragls/v3/observability.go
+++ b/pkg/applicationserver/io/packages/loragls/v3/observability.go
@@ -25,6 +25,7 @@ var evtPackageFail = events.Define(
 	"as.packages.loracloudglsv3.fail", "fail to process upstream message",
 	events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
 	events.WithErrorDataType(),
+	events.WithPropagateToParent(),
 )
 
 func registerPackageFail(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, err error) {

--- a/pkg/applicationserver/io/web/observability.go
+++ b/pkg/applicationserver/io/web/observability.go
@@ -28,6 +28,7 @@ var evtWebhookFail = events.Define(
 	"as.webhook.fail", "fail to send webhook",
 	events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
 	events.WithErrorDataType(),
+	events.WithPropagateToParent(),
 )
 
 const (

--- a/pkg/applicationserver/observability.go
+++ b/pkg/applicationserver/observability.go
@@ -36,21 +36,25 @@ var (
 		"as.up.data.drop", "drop uplink data message",
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
 		events.WithErrorDataType(),
+		events.WithPropagateToParent(),
 	)
 	evtForwardDataUp = events.Define(
 		"as.up.data.forward", "forward uplink data message",
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
 		events.WithDataType(&ttnpb.ApplicationUp{}),
+		events.WithPropagateToParent(),
 	)
 	evtDecodeFailDataUp = events.Define(
 		"as.up.data.decode.fail", "decode uplink data message failure",
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
 		events.WithErrorDataType(),
+		events.WithPropagateToParent(),
 	)
 	evtDecodeWarningDataUp = events.Define(
 		"as.up.data.decode.warning", "decode uplink data message warning",
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
 		events.WithDataType(&ttnpb.ApplicationUplink{}),
+		events.WithPropagateToParent(),
 	)
 	evtReceiveJoinAccept = events.Define(
 		"as.up.join.receive", "receive join-accept message",
@@ -60,11 +64,13 @@ var (
 		"as.up.join.drop", "drop join-accept message",
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
 		events.WithErrorDataType(),
+		events.WithPropagateToParent(),
 	)
 	evtForwardJoinAccept = events.Define(
 		"as.up.join.forward", "forward join-accept message",
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
 		events.WithDataType(&ttnpb.ApplicationUp{}),
+		events.WithPropagateToParent(),
 	)
 	evtForwardLocationSolved = events.Define(
 		"as.up.location.forward", "forward location solved message",
@@ -87,6 +93,7 @@ var (
 		"as.down.data.drop", "drop downlink data message",
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
 		events.WithErrorDataType(),
+		events.WithPropagateToParent(),
 	)
 	evtForwardDataDown = events.Define(
 		"as.down.data.forward", "forward downlink data message",
@@ -94,26 +101,31 @@ var (
 		events.WithDataType(&ttnpb.ApplicationDownlink{}),
 		events.WithAuthFromContext(),
 		events.WithClientInfoFromContext(),
+		events.WithPropagateToParent(),
 	)
 	evtEncodeFailDataDown = events.Define(
 		"as.down.data.encode.fail", "encode downlink data message failure",
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
 		events.WithErrorDataType(),
+		events.WithPropagateToParent(),
 	)
 	evtEncodeWarningDataDown = events.Define(
 		"as.down.data.encode.warning", "encode downlink data message warning",
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
 		events.WithDataType(&ttnpb.ApplicationDownlink{}),
+		events.WithPropagateToParent(),
 	)
 	evtDecodeFailDataDown = events.Define(
 		"as.down.data.decode.fail", "decode downlink data message failure",
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
 		events.WithErrorDataType(),
+		events.WithPropagateToParent(),
 	)
 	evtDecodeWarningDataDown = events.Define(
 		"as.down.data.decode.warning", "decode downlink data message warning",
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
 		events.WithDataType(&ttnpb.ApplicationDownlink{}),
+		events.WithPropagateToParent(),
 	)
 )
 

--- a/pkg/events/basic/subscription.go
+++ b/pkg/events/basic/subscription.go
@@ -57,6 +57,7 @@ func (s *Subscription) matchIdentifiers(evt events.Event) bool {
 	if len(s.identifiers) == 0 {
 		return true
 	}
+	definition := events.GetDefinition(evt)
 	for _, evtIDs := range evt.Identifiers() {
 		evtEntityType := evtIDs.EntityType()
 		for _, subIDs := range s.identifiers {
@@ -65,7 +66,8 @@ func (s *Subscription) matchIdentifiers(evt events.Event) bool {
 				return true
 			}
 			if evtEntityType == "end device" && subEntityType == "application" &&
-				unique.ID(evt.Context(), evtIDs.GetDeviceIds().ApplicationIds) == unique.ID(s.ctx, subIDs) {
+				unique.ID(evt.Context(), evtIDs.GetDeviceIds().ApplicationIds) == unique.ID(s.ctx, subIDs) &&
+				definition != nil && definition.PropagateToParent() {
 				return true
 			}
 		}

--- a/pkg/events/definitions.go
+++ b/pkg/events/definitions.go
@@ -27,9 +27,10 @@ import (
 const i18nPrefix = "event"
 
 type definition struct {
-	name        string
-	description string
-	dataType    proto.Message
+	name              string
+	description       string
+	dataType          proto.Message
+	propagateToParent bool
 }
 
 // Definition describes an event definition.
@@ -37,6 +38,7 @@ type Definition interface {
 	Name() string
 	Description() string
 	DataType() proto.Message
+	PropagateToParent() bool
 }
 
 func (d *definition) Definition() Definition { return d }
@@ -44,6 +46,7 @@ func (d *definition) Definition() Definition { return d }
 func (d definition) Name() string            { return d.name }
 func (d definition) Description() string     { return d.description }
 func (d definition) DataType() proto.Message { return d.dataType }
+func (d definition) PropagateToParent() bool { return d.propagateToParent }
 
 func (d *definition) With(options ...Option) Builder {
 	extended := &builder{
@@ -134,4 +137,12 @@ func DefineFunc(name, description string, opts ...Option) func() Builder {
 	return func() Builder {
 		return defineSkip(name, description, 1, opts...)
 	}
+}
+
+// GetDefinition gets the definition for an event.
+func GetDefinition(evt Event) Definition {
+	if def, ok := definitions[evt.Name()]; ok {
+		return def
+	}
+	return nil
 }

--- a/pkg/events/options.go
+++ b/pkg/events/options.go
@@ -164,3 +164,11 @@ func WithUpdatedFieldsDataType() DefinitionOption {
 		d.dataType = updatedFieldsDataType
 	})
 }
+
+// WithPropagateToParent returns an option that propagate the event to its parent.
+// Typically used to propagate end device events to applications.
+func WithPropagateToParent() DefinitionOption {
+	return definitionOptionFunc(func(d *definition) {
+		d.propagateToParent = true
+	})
+}

--- a/pkg/events/redis/redis.go
+++ b/pkg/events/redis/redis.go
@@ -202,11 +202,14 @@ func (ps *PubSub) Subscribe(ctx context.Context, names []string, ids []*ttnpb.En
 	ps.mu.Lock()
 	defer ps.mu.Unlock()
 
+	basicSub, err := basic.NewSubscription(ctx, names, ids, hdl)
+	if err != nil {
+		return err
+	}
+
 	sub := &subscription{
-		names:    names,
-		ids:      ids,
+		basicSub: basicSub,
 		patterns: ps.eventChannelPatterns(ctx, names, ids),
-		hdl:      hdl,
 	}
 
 	ps.PubSub.AddSubscription(sub)

--- a/pkg/events/redis/subscription.go
+++ b/pkg/events/redis/subscription.go
@@ -16,17 +16,15 @@ package redis
 
 import (
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
-	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/events/basic"
 )
 
 type subscription struct {
-	names    []string
-	ids      []*ttnpb.EntityIdentifiers
+	basicSub *basic.Subscription
 	patterns []string
-	hdl      events.Handler
 }
 
-func (s *subscription) Match(evt events.Event) bool {
+func (s *subscription) matchPattern(evt events.Event) bool {
 	if evt, ok := evt.(*patternEvent); ok {
 		for _, pattern := range s.patterns {
 			if pattern == evt.pattern {
@@ -37,9 +35,19 @@ func (s *subscription) Match(evt events.Event) bool {
 	return false
 }
 
+func (s *subscription) Match(evt events.Event) bool {
+	if s == nil {
+		return false
+	}
+	if !s.matchPattern(evt) {
+		return false
+	}
+	return s.basicSub.Match(evt)
+}
+
 func (s *subscription) Notify(evt events.Event) {
 	if s == nil {
 		return
 	}
-	s.hdl.Notify(evt)
+	s.basicSub.Notify(evt)
 }

--- a/pkg/identityserver/end_device_registry.go
+++ b/pkg/identityserver/end_device_registry.go
@@ -36,6 +36,7 @@ var (
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ),
 		events.WithAuthFromContext(),
 		events.WithClientInfoFromContext(),
+		events.WithPropagateToParent(),
 	)
 	evtUpdateEndDevice = events.Define(
 		"end_device.update", "update end device",
@@ -43,12 +44,14 @@ var (
 		events.WithUpdatedFieldsDataType(),
 		events.WithAuthFromContext(),
 		events.WithClientInfoFromContext(),
+		events.WithPropagateToParent(),
 	)
 	evtDeleteEndDevice = events.Define(
 		"end_device.delete", "delete end device",
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ),
 		events.WithAuthFromContext(),
 		events.WithClientInfoFromContext(),
+		events.WithPropagateToParent(),
 	)
 )
 

--- a/pkg/joinserver/grpc_deviceregistry.go
+++ b/pkg/joinserver/grpc_deviceregistry.go
@@ -34,6 +34,7 @@ var (
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ),
 		events.WithAuthFromContext(),
 		events.WithClientInfoFromContext(),
+		events.WithPropagateToParent(),
 	)
 	evtUpdateEndDevice = events.Define(
 		"js.end_device.update", "update end device",
@@ -41,12 +42,14 @@ var (
 		events.WithUpdatedFieldsDataType(),
 		events.WithAuthFromContext(),
 		events.WithClientInfoFromContext(),
+		events.WithPropagateToParent(),
 	)
 	evtDeleteEndDevice = events.Define(
 		"js.end_device.delete", "delete end device",
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ),
 		events.WithAuthFromContext(),
 		events.WithClientInfoFromContext(),
+		events.WithPropagateToParent(),
 	)
 )
 

--- a/pkg/joinserver/observability.go
+++ b/pkg/joinserver/observability.go
@@ -29,10 +29,12 @@ var (
 		"js.join.reject", "reject join-request",
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
 		events.WithErrorDataType(),
+		events.WithPropagateToParent(),
 	)
 	evtAcceptJoin = events.Define(
 		"js.join.accept", "accept join-request",
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
+		events.WithPropagateToParent(),
 	)
 )
 

--- a/pkg/networkserver/errors.go
+++ b/pkg/networkserver/errors.go
@@ -29,7 +29,6 @@ var (
 	errDataRateIndexNotFound              = errors.DefineNotFound("data_rate_index_not_found", "data rate with index `{index}` not found")
 	errDecodePayload                      = errors.DefineInvalidArgument("decode_payload", "failed to decode payload")
 	errDeviceNotFound                     = errors.DefineNotFound("device_not_found", "device not found")
-	errDuplicate                          = errors.DefineFailedPrecondition("duplicate", "uplink is a duplicate")
 	errEmptySession                       = errors.DefineFailedPrecondition("empty_session", "session in empty")
 	errEncodeMAC                          = errors.DefineInternal("encode_mac", "failed to encode MAC commands")
 	errEncodePayload                      = errors.Define("encode_payload", "failed to encode payload")

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -43,6 +43,7 @@ var (
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ),
 		events.WithAuthFromContext(),
 		events.WithClientInfoFromContext(),
+		events.WithPropagateToParent(),
 	)
 	evtUpdateEndDevice = events.Define(
 		"ns.end_device.update", "update end device",
@@ -50,12 +51,14 @@ var (
 		events.WithUpdatedFieldsDataType(),
 		events.WithAuthFromContext(),
 		events.WithClientInfoFromContext(),
+		events.WithPropagateToParent(),
 	)
 	evtDeleteEndDevice = events.Define(
 		"ns.end_device.delete", "delete end device",
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_DEVICES_READ),
 		events.WithAuthFromContext(),
 		events.WithClientInfoFromContext(),
+		events.WithPropagateToParent(),
 	)
 )
 

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -852,7 +852,6 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 		return err
 	}
 	if !ok {
-		queuedEvents = append(queuedEvents, evtDropDataUplink.NewWithIdentifiersAndData(ctx, matched.Device.Ids, errDuplicate))
 		registerReceiveDuplicateUplink(ctx, up)
 		return nil
 	}
@@ -1121,7 +1120,6 @@ func (ns *NetworkServer) handleJoinRequest(ctx context.Context, up *ttnpb.Uplink
 		return err
 	}
 	if !ok {
-		queuedEvents = append(queuedEvents, evtDropJoinRequest.NewWithIdentifiersAndData(ctx, matched.Ids, errDuplicate))
 		registerReceiveDuplicateUplink(ctx, up)
 		return nil
 	}

--- a/pkg/networkserver/mac/observability.go
+++ b/pkg/networkserver/mac/observability.go
@@ -86,6 +86,7 @@ func defineClassSwitchEvent(class rune) func() events.Builder {
 	return events.DefineFunc(
 		fmt.Sprintf("ns.class.switch.%c", class), fmt.Sprintf("switched to class %c", unicode.ToUpper(class)),
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
+		events.WithPropagateToParent(),
 	)
 }
 

--- a/pkg/networkserver/networkserver_util_internal_test.go
+++ b/pkg/networkserver/networkserver_util_internal_test.go
@@ -69,7 +69,6 @@ var (
 	ErrApplicationDownlinkTooLong = errApplicationDownlinkTooLong
 	ErrDecodePayload              = errDecodePayload
 	ErrDeviceNotFound             = errDeviceNotFound
-	ErrDuplicate                  = errDuplicate
 	ErrInvalidAbsoluteTime        = errInvalidAbsoluteTime
 	ErrOutdatedData               = errOutdatedData
 	ErrRejoinRequest              = errRejoinRequest
@@ -1657,7 +1656,6 @@ func (env TestEnvironment) AssertJoin(ctx context.Context, conf JoinAssertionCon
 				for range ups[1:] {
 					evBuilders = append(evBuilders,
 						EvtReceiveJoinRequest,
-						EvtDropJoinRequest.With(events.WithData(ErrDuplicate)),
 					)
 				}
 				if conf.ClusterResponse != nil {
@@ -1805,7 +1803,6 @@ func (env TestEnvironment) AssertHandleDataUplink(ctx context.Context, conf Data
 					for range ups[1:] {
 						evBuilders = append(evBuilders,
 							EvtReceiveDataUplink,
-							EvtDropDataUplink.With(events.WithData(ErrDuplicate)),
 						)
 					}
 					return append(

--- a/pkg/networkserver/observability.go
+++ b/pkg/networkserver/observability.go
@@ -65,6 +65,7 @@ var (
 		"ns.down.data.schedule.fail", "failed to schedule data downlink for transmission on Gateway Server",
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
 		events.WithErrorDataType(),
+		events.WithPropagateToParent(),
 	)
 	evtReceiveJoinRequest = events.Define(
 		"ns.up.join.receive", "receive join-request",
@@ -95,6 +96,7 @@ var (
 		"ns.up.join.cluster.fail", "join-request to cluster-local Join Server failed",
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
 		events.WithErrorDataType(),
+		events.WithPropagateToParent(),
 	)
 	evtInteropJoinAttempt = events.Define(
 		"ns.up.join.interop.attempt", "forward join-request to interoperability Join Server",
@@ -110,6 +112,7 @@ var (
 		"ns.up.join.interop.fail", "join-request to interoperability Join Server failed",
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
 		events.WithErrorDataType(),
+		events.WithPropagateToParent(),
 	)
 	evtForwardJoinAccept = events.Define(
 		"ns.up.join.accept.forward", "forward join-accept to Application Server",
@@ -132,6 +135,7 @@ var (
 		"ns.down.join.schedule.fail", "failed to schedule join-accept for transmission on Gateway Server",
 		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
 		events.WithErrorDataType(),
+		events.WithPropagateToParent(),
 	)
 )
 

--- a/pkg/webui/console/store/actions/devices.js
+++ b/pkg/webui/console/store/actions/devices.js
@@ -36,6 +36,7 @@ import {
   clearEvents,
   createClearEventsActionType,
   createSetEventsFilterActionType,
+  createGetEventMessageSuccessActionType,
   setEventsFilter,
 } from './events'
 
@@ -91,6 +92,8 @@ export const RESUME_DEVICE_EVENT_STREAM = createResumeEventsStreamActionType(SHA
 export const CLEAR_DEVICE_EVENTS = createClearEventsActionType(SHARED_NAME)
 
 export const SET_DEVICE_EVENTS_FILTER = createSetEventsFilterActionType(SHARED_NAME)
+
+export const GET_DEVICE_EVENT_MESSAGE_SUCCESS = createGetEventMessageSuccessActionType(SHARED_NAME)
 
 export const startDeviceEventsStream = startEventsStream(SHARED_NAME)
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request adds additional filtering to the functionality that propagates end device events to the application event streams.

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/4834

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove (very chatty) "duplicate dropped" event from NS completely
- Add options to end device events that need to get forwarded to application streams

#### Testing

<!-- How did you verify that this change works? -->

Existing unit tests, manual testing in the Console.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

@kschiffer to confirm that the Console doesn't rely on events that are no longer in the application stream.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

nil

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
