### PR TITLE
Fix both `disconnect_at` and `connected_at` present in gateway status json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - CLI Completion and Documentation commands no longer try to make a server connection.
 - When an end device has both `NwkKey` and `AppKey` provisioned in the Join Server, `NwkKey` is used for MIC and session key derivation when activating the device in LoRaWAN 1.0.x. This is per LoRaWAN 1.1 specification.
+- Gateway Server will no longer report the gateways as being both connected and disconnected at the same time.
 
 ### Security
 

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -712,7 +712,7 @@ func (c *Connection) Stats() (*ttnpb.GatewayConnectionStats, []string) {
 		Protocol:    c.Frontend().Protocol(),
 	}
 	paths := make([]string, 0, len(ttnpb.GatewayConnectionStatsFieldPathsTopLevel))
-	paths = append(paths, "connected_at", "protocol")
+	paths = append(paths, "connected_at", "disconnected_at", "protocol")
 
 	if s, t, ok := c.StatusStats(); ok {
 		stats.LastStatusReceivedAt = ttnpb.ProtoTimePtr(t)

--- a/pkg/gatewayserver/io/io_test.go
+++ b/pkg/gatewayserver/io/io_test.go
@@ -89,7 +89,7 @@ func TestFlow(t *testing.T) {
 	a.So(conn.PrimaryFrequencyPlan().BandID, should.Equal, "EU_863_870")
 
 	_, paths := conn.Stats()
-	a.So(paths, should.Resemble, []string{"connected_at", "protocol"})
+	a.So(paths, should.Resemble, []string{"connected_at", "disconnected_at", "protocol"})
 
 	{
 		frontend.Up <- &ttnpb.UplinkMessage{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->
Closes #5052

#### Changes
<!-- What are the changes made in this pull request? -->
- Add `disconnected_at` path to the fieldmask in connection stats method


#### Testing

<!-- How did you verify that this change works? -->

The change was created according to the problem reported in the issue. 
The verification for this PR are the existent tests.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->
N/A



#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
