### PR TITLE
Storage limitation for DevNonces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ For details about compatibility between different releases, see the **Commitment
 ## [Unreleased]
 
 ### Added
+- Add configurable storage limit to device's DevNonce in the JoinServer. Can be configured using the option `js.dev-nonce-limit`.
 
 ### Changed
 

--- a/cmd/internal/shared/joinserver/config.go
+++ b/cmd/internal/shared/joinserver/config.go
@@ -24,4 +24,5 @@ var DefaultJoinServerConfig = joinserver.Config{
 	JoinEUIPrefixes: []types.EUI64Prefix{
 		{},
 	},
+	DevNonceLimit: 10,
 }

--- a/config/messages.json
+++ b/config/messages.json
@@ -6083,6 +6083,15 @@
       "file": "errors.go"
     }
   },
+  "error:pkg/joinserver:dev_nonce_limit_invalid": {
+    "translations": {
+      "en": "DevNonce limit can not be less than 1"
+    },
+    "description": {
+      "package": "pkg/joinserver",
+      "file": "errors.go"
+    }
+  },
   "error:pkg/joinserver:dev_nonce_too_small": {
     "translations": {
       "en": "DevNonce is too small"

--- a/pkg/joinserver/config.go
+++ b/pkg/joinserver/config.go
@@ -24,4 +24,5 @@ type Config struct {
 	JoinEUIPrefixes               []types.EUI64Prefix                  `name:"join-eui-prefix" description:"JoinEUI prefixes handled by this Join Server"`
 	DefaultJoinEUI                types.EUI64                          `name:"default-join-eui" description:"Default JoinEUI for this Join Server"`
 	DeviceKEKLabel                string                               `name:"device-kek-label" description:"Label of KEK used to encrypt device keys at rest"`
+	DevNonceLimit                 int                                  `name:"dev-nonce-limit" description:"Amount of DevNonces stored per device"`
 }

--- a/pkg/joinserver/errors.go
+++ b/pkg/joinserver/errors.go
@@ -23,6 +23,7 @@ var (
 	errDeriveNwkSKeys                 = errors.Define("derive_nwk_s_keys", "failed to derive network session keys")
 	errDeviceNotFound                 = errors.DefineNotFound("device_not_found", "device not found")
 	errDevNonceTooSmall               = errors.DefineInvalidArgument("dev_nonce_too_small", "DevNonce is too small")
+	errDevNonceLimitInvalid           = errors.DefineInvalidArgument("dev_nonce_limit_invalid", "DevNonce limit can not be less than 1")
 	errDuplicateIdentifiers           = errors.DefineAlreadyExists("duplicate_identifiers", "a device identified by the identifiers already exists")
 	errEncodePayload                  = errors.DefineInvalidArgument("encode_payload", "failed to encode payload")
 	errEncryptPayload                 = errors.Define("encrypt_payload", "failed to encrypt JoinAccept")

--- a/pkg/joinserver/grpc_application_activation_settings_registry_test.go
+++ b/pkg/joinserver/grpc_application_activation_settings_registry_test.go
@@ -109,6 +109,7 @@ func TestApplicationActivationSettingRegistryServer(t *testing.T) {
 			&Config{
 				ApplicationActivationSettings: reg,
 				DeviceKEKLabel:                jsKEKLabel,
+				DevNonceLimit:                 defaultDevNonceLimit,
 			},
 		)).(*JoinServer)
 		js.KeyVault = keyVault

--- a/pkg/joinserver/grpc_deviceregistry_test.go
+++ b/pkg/joinserver/grpc_deviceregistry_test.go
@@ -393,6 +393,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 							return tc.GetByIDFunc(ctx, appID, devID, paths)
 						},
 					},
+					DevNonceLimit: defaultDevNonceLimit,
 				},
 			)).(*JoinServer)
 			js.KeyVault = keyVault
@@ -791,6 +792,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 							return tc.SetByIDFunc(ctx, appID, devID, paths, cb)
 						},
 					},
+					DevNonceLimit: defaultDevNonceLimit,
 				},
 			)).(*JoinServer)
 			js.KeyVault = keyVault
@@ -964,6 +966,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 							return tc.SetByIDFunc(ctx, appID, devID, paths, cb)
 						},
 					},
+					DevNonceLimit: defaultDevNonceLimit,
 				},
 			)).(*JoinServer)
 			js.KeyVault = keyVault

--- a/pkg/joinserver/grpc_test.go
+++ b/pkg/joinserver/grpc_test.go
@@ -86,6 +86,7 @@ func TestGetJoinEUIPrefixes(t *testing.T) {
 				componenttest.NewComponent(t, &component.Config{}),
 				&Config{
 					JoinEUIPrefixes: tc.JoinEUIPrefixes,
+					DevNonceLimit:   defaultDevNonceLimit,
 				})).(*JoinServer)
 			componenttest.StartComponent(t, js.Component)
 			defer js.Close()
@@ -126,6 +127,7 @@ func TestGetDefaultJoinEUI(t *testing.T) {
 				componenttest.NewComponent(t, &component.Config{}),
 				&Config{
 					DefaultJoinEUI: tc.DefaultJoinEUI,
+					DevNonceLimit:  defaultDevNonceLimit,
 				})).(*JoinServer)
 			componenttest.StartComponent(t, js.Component)
 			defer js.Close()

--- a/pkg/joinserver/joinserver.go
+++ b/pkg/joinserver/joinserver.go
@@ -333,6 +333,7 @@ func (js *JoinServer) HandleJoin(ctx context.Context, req *ttnpb.JoinRequest, au
 			if req.SelectedMacVersion.IncrementDevNonce() {
 				if (dn != 0 || dev.LastDevNonce != 0 || dev.LastJoinNonce != 0) && !dev.ResetsJoinNonces {
 					if dn <= dev.LastDevNonce {
+						registerDevNonceTooSmall(ctx, req)
 						return nil, nil, errDevNonceTooSmall.New()
 					}
 				}
@@ -354,6 +355,7 @@ func (js *JoinServer) HandleJoin(ctx context.Context, req *ttnpb.JoinRequest, au
 					}
 					paths = append(paths, "used_dev_nonces")
 				} else if !dev.ResetsJoinNonces {
+					registerDevNonceReuse(ctx, req)
 					return nil, nil, errReuseDevNonce.New()
 				}
 			}

--- a/pkg/joinserver/joinserver.go
+++ b/pkg/joinserver/joinserver.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/binary"
-	"sort"
 	"time"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
@@ -54,6 +53,7 @@ type JoinServer struct {
 
 	euiPrefixes    []types.EUI64Prefix
 	defaultJoinEUI types.EUI64
+	devNonceLimit  int
 
 	grpc struct {
 		nsJs                          nsJsServer
@@ -71,8 +71,18 @@ func (js *JoinServer) Context() context.Context {
 	return js.ctx
 }
 
+func validateConfig(conf *Config) error {
+	if conf.DevNonceLimit <= 0 {
+		return errDevNonceLimitInvalid.New()
+	}
+	return nil
+}
+
 // New returns new *JoinServer.
 func New(c *component.Component, conf *Config) (*JoinServer, error) {
+	if err := validateConfig(conf); err != nil {
+		return nil, err
+	}
 	js := &JoinServer{
 		Component: c,
 		ctx:       log.NewContextWithField(c.Context(), "namespace", "joinserver"),
@@ -83,6 +93,7 @@ func New(c *component.Component, conf *Config) (*JoinServer, error) {
 
 		euiPrefixes:    conf.JoinEUIPrefixes,
 		defaultJoinEUI: conf.DefaultJoinEUI,
+		devNonceLimit:  conf.DevNonceLimit,
 	}
 
 	js.grpc.applicationActivationSettings = applicationActivationSettingsRegistryServer{
@@ -328,11 +339,20 @@ func (js *JoinServer) HandleJoin(ctx context.Context, req *ttnpb.JoinRequest, au
 				dev.LastDevNonce = dn
 				paths = append(paths, "last_dev_nonce")
 			} else {
-				i := sort.Search(len(dev.UsedDevNonces), func(i int) bool { return dev.UsedDevNonces[i] >= dn })
-				if i >= len(dev.UsedDevNonces) || dev.UsedDevNonces[i] != dn {
-					dev.UsedDevNonces = append(dev.UsedDevNonces, 0)
-					copy(dev.UsedDevNonces[i+1:], dev.UsedDevNonces[i:])
-					dev.UsedDevNonces[i] = dn
+				isReuse := false
+				for i := len(dev.UsedDevNonces) - 1; i >= 0; i-- {
+					if dev.UsedDevNonces[i] == dn {
+						isReuse = true
+						break
+					}
+				}
+				if !isReuse {
+					if n := len(dev.UsedDevNonces) - js.devNonceLimit; n > 0 {
+						copy(dev.UsedDevNonces[:], dev.UsedDevNonces[n:])
+						dev.UsedDevNonces[js.devNonceLimit-1] = dn
+					} else {
+						dev.UsedDevNonces = append(dev.UsedDevNonces, dn)
+					}
 					paths = append(paths, "used_dev_nonces")
 				} else if !dev.ResetsJoinNonces {
 					return nil, nil, errReuseDevNonce.New()

--- a/pkg/joinserver/joinserver.go
+++ b/pkg/joinserver/joinserver.go
@@ -346,12 +346,11 @@ func (js *JoinServer) HandleJoin(ctx context.Context, req *ttnpb.JoinRequest, au
 						break
 					}
 				}
+
 				if !isReuse {
+					dev.UsedDevNonces = append(dev.UsedDevNonces, dn)
 					if n := len(dev.UsedDevNonces) - js.devNonceLimit; n > 0 {
-						copy(dev.UsedDevNonces[:], dev.UsedDevNonces[n:])
-						dev.UsedDevNonces[js.devNonceLimit-1] = dn
-					} else {
-						dev.UsedDevNonces = append(dev.UsedDevNonces, dn)
+						dev.UsedDevNonces = dev.UsedDevNonces[n:]
 					}
 					paths = append(paths, "used_dev_nonces")
 				} else if !dev.ResetsJoinNonces {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->
Closes #5069 

The idea is to limit the amount of DevNonces stored in the the device registry, leaving the size to be something configurable.

#### Changes
<!-- What are the changes made in this pull request? -->
- Add `devNonceLimit` to JS config
- Add config validation to JS
- Add limitation of DevNonces
- Add test cases confirming behaviour of the limitation process
- Update JS config for tests, added defaultDevNonceLimit to their JS config

#### Testing

<!-- How did you verify that this change works? -->
Unit tests and manually testing, the images below show a bit of the behaviour for the devNonces where the limit per device is 5.
- [DevNonce with limit of 5](https://user-images.githubusercontent.com/28912302/150012589-6fed3762-ae91-4f22-a0c7-99b26445a0ad.png)
- [Same array after two new requests](https://user-images.githubusercontent.com/28912302/150012594-7bb5c876-bb6b-48f6-ac0b-d23d6a88f2f7.png)
- [curl to metrics](https://user-images.githubusercontent.com/28912302/150148215-02f5c631-7721-4f2c-bae0-62a24ac0d1e8.png)


##### Regressions
<!-- Please indicate features that this change could affect and how that was tested. -->
This changes the amount of DevNonces stored, since its not unlimited, the configurable amount of devNonces stored have a hard cap of the maximum value of an integer. Besides this there shouldn't be any changes in other features.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->
After Johan's observations, the requests with MacVersion  <= `1.0.3` will have their devNonces treated as random, therefore the slice that stores them will not be sorted, being just a FIFO queue.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
