### PR TITLE
Make CLI retry when it fails due to rate limitations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For details about compatibility between different releases, see the **Commitment
 - Fix copy button in API key modal in the Console.
 - Enable copying and format transformations of byte values in the event previews in the Console.
 - Attribute `administrative_contact` on "gateway eui taken" error to help users resolve gateway EUI conflicts.
+- Add retry capability for cli requests. Can be configured with the options found in `retry-config`, some of the configuration options are `retry-config.max` and `retry-config.default-timeout`.
 
 ### Changed
 

--- a/cmd/ttn-lw-cli/commands/config.go
+++ b/cmd/ttn-lw-cli/commands/config.go
@@ -15,6 +15,8 @@
 package commands
 
 import (
+	"time"
+
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/commands"
 	conf "go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
@@ -27,33 +29,44 @@ var (
 	defaultGRPCAddress, _            = discover.DefaultPort(defaultClusterHost, discover.DefaultPorts[!defaultInsecure])
 	defaultOAuthServerBaseAddress, _ = discover.DefaultURL(defaultClusterHost, discover.DefaultHTTPPorts[!defaultInsecure], !defaultInsecure)
 	defaultOAuthServerAddress        = defaultOAuthServerBaseAddress + "/oauth"
+	defaultRetryConfig               = RetryConfig{
+		Max:     5,
+		Timeout: 50 * time.Millisecond,
+	}
 )
 
 // Config for the ttn-lw-cli binary.
 type Config struct {
 	conf.Base                          `name:",squash"`
-	CredentialsID                      string `name:"credentials-id" yaml:"credentials-id" description:"Credentials ID (if using multiple configurations)"`
-	InputFormat                        string `name:"input-format" yaml:"input-format" description:"Input format"`
-	OutputFormat                       string `name:"output-format" yaml:"output-format" description:"Output format"`
-	AllowUnknownHosts                  bool   `name:"allow-unknown-hosts" yaml:"allow-unknown-hosts" description:"Allow sending credentials to unknown hosts"`
-	OAuthServerAddress                 string `name:"oauth-server-address" yaml:"oauth-server-address" description:"OAuth Server address"`
-	IdentityServerGRPCAddress          string `name:"identity-server-grpc-address" yaml:"identity-server-grpc-address" description:"Identity Server address"`
-	GatewayServerEnabled               bool   `name:"gateway-server-enabled" yaml:"gateway-server-enabled" description:"Gateway Server enabled"`
-	GatewayServerGRPCAddress           string `name:"gateway-server-grpc-address" yaml:"gateway-server-grpc-address" description:"Gateway Server address"`
-	NetworkServerEnabled               bool   `name:"network-server-enabled" yaml:"network-server-enabled" description:"Network Server enabled"`
-	NetworkServerGRPCAddress           string `name:"network-server-grpc-address" yaml:"network-server-grpc-address" description:"Network Server address"`
-	ApplicationServerEnabled           bool   `name:"application-server-enabled" yaml:"application-server-enabled" description:"Application Server enabled"`
-	ApplicationServerGRPCAddress       string `name:"application-server-grpc-address" yaml:"application-server-grpc-address" description:"Application Server address"`
-	JoinServerEnabled                  bool   `name:"join-server-enabled" yaml:"join-server-enabled" description:"Join Server enabled"`
-	JoinServerGRPCAddress              string `name:"join-server-grpc-address" yaml:"join-server-grpc-address" description:"Join Server address"`
-	DeviceTemplateConverterGRPCAddress string `name:"device-template-converter-grpc-address" yaml:"device-template-converter-grpc-address" description:"Device Template Converter address"`
-	DeviceClaimingServerGRPCAddress    string `name:"device-claiming-server-grpc-address" yaml:"device-claiming-server-grpc-address" description:"Device Claiming Server address"`
-	QRCodeGeneratorGRPCAddress         string `name:"qr-code-generator-grpc-address" yaml:"qr-code-generator-grpc-address" description:"QR Code Generator address"`
-	PacketBrokerAgentGRPCAddress       string `name:"packet-broker-agent-grpc-address" yaml:"packet-broker-agent-grpc-address" description:"Packet Broker Agent address"`
-	Insecure                           bool   `name:"insecure" yaml:"insecure" description:"Connect without TLS"`
-	CA                                 string `name:"ca" yaml:"ca" description:"CA certificate file"`
-	DumpRequests                       bool   `name:"dump-requests" yaml:"dump-requests" description:"When log level is set to debug, also dump request payload as JSON"`
-	SkipVersionCheck                   bool   `name:"skip-version-check" yaml:"skip-version-check" description:"Do not perform version checks"`
+	CredentialsID                      string      `name:"credentials-id" yaml:"credentials-id" description:"Credentials ID (if using multiple configurations)"`
+	InputFormat                        string      `name:"input-format" yaml:"input-format" description:"Input format"`
+	OutputFormat                       string      `name:"output-format" yaml:"output-format" description:"Output format"`
+	AllowUnknownHosts                  bool        `name:"allow-unknown-hosts" yaml:"allow-unknown-hosts" description:"Allow sending credentials to unknown hosts"`
+	OAuthServerAddress                 string      `name:"oauth-server-address" yaml:"oauth-server-address" description:"OAuth Server address"`
+	IdentityServerGRPCAddress          string      `name:"identity-server-grpc-address" yaml:"identity-server-grpc-address" description:"Identity Server address"`
+	GatewayServerEnabled               bool        `name:"gateway-server-enabled" yaml:"gateway-server-enabled" description:"Gateway Server enabled"`
+	GatewayServerGRPCAddress           string      `name:"gateway-server-grpc-address" yaml:"gateway-server-grpc-address" description:"Gateway Server address"`
+	NetworkServerEnabled               bool        `name:"network-server-enabled" yaml:"network-server-enabled" description:"Network Server enabled"`
+	NetworkServerGRPCAddress           string      `name:"network-server-grpc-address" yaml:"network-server-grpc-address" description:"Network Server address"`
+	ApplicationServerEnabled           bool        `name:"application-server-enabled" yaml:"application-server-enabled" description:"Application Server enabled"`
+	ApplicationServerGRPCAddress       string      `name:"application-server-grpc-address" yaml:"application-server-grpc-address" description:"Application Server address"`
+	JoinServerEnabled                  bool        `name:"join-server-enabled" yaml:"join-server-enabled" description:"Join Server enabled"`
+	JoinServerGRPCAddress              string      `name:"join-server-grpc-address" yaml:"join-server-grpc-address" description:"Join Server address"`
+	DeviceTemplateConverterGRPCAddress string      `name:"device-template-converter-grpc-address" yaml:"device-template-converter-grpc-address" description:"Device Template Converter address"`
+	DeviceClaimingServerGRPCAddress    string      `name:"device-claiming-server-grpc-address" yaml:"device-claiming-server-grpc-address" description:"Device Claiming Server address"`
+	QRCodeGeneratorGRPCAddress         string      `name:"qr-code-generator-grpc-address" yaml:"qr-code-generator-grpc-address" description:"QR Code Generator address"`
+	PacketBrokerAgentGRPCAddress       string      `name:"packet-broker-agent-grpc-address" yaml:"packet-broker-agent-grpc-address" description:"Packet Broker Agent address"`
+	Insecure                           bool        `name:"insecure" yaml:"insecure" description:"Connect without TLS"`
+	CA                                 string      `name:"ca" yaml:"ca" description:"CA certificate file"`
+	DumpRequests                       bool        `name:"dump-requests" yaml:"dump-requests" description:"When log level is set to debug, also dump request payload as JSON"`
+	SkipVersionCheck                   bool        `name:"skip-version-check" yaml:"skip-version-check" description:"Do not perform version checks"`
+	Retry                              RetryConfig `name:"retry-config" yaml:"retry-config" description:"group of settings that describe the behaviour of the retry interceptor of the cli. If not specified the retry will only happen on the ResourceExhausted and Unavailable status codes"`
+}
+
+// RetryConfig defines the values for the retry behaviour in the cli
+type RetryConfig struct {
+	Max     uint          `name:"max" yaml:"max" description:"defines the amount of retries to be attempted when "`
+	Timeout time.Duration `name:"timeout" yaml:"timeout" description:"determines the default amount of time that the client will wait in between retry requests, the value will be used when the rate limit headers cannot be found in the request response"`
 }
 
 func (c Config) getHosts() []string {
@@ -105,6 +118,7 @@ func MakeDefaultConfig(clusterGRPCAddress string, oauthServerAddress string, ins
 		QRCodeGeneratorGRPCAddress:         clusterGRPCAddress,
 		PacketBrokerAgentGRPCAddress:       clusterGRPCAddress,
 		Insecure:                           insecure,
+		Retry:                              defaultRetryConfig,
 	}
 }
 

--- a/cmd/ttn-lw-cli/commands/config.go
+++ b/cmd/ttn-lw-cli/commands/config.go
@@ -30,8 +30,8 @@ var (
 	defaultOAuthServerBaseAddress, _ = discover.DefaultURL(defaultClusterHost, discover.DefaultHTTPPorts[!defaultInsecure], !defaultInsecure)
 	defaultOAuthServerAddress        = defaultOAuthServerBaseAddress + "/oauth"
 	defaultRetryConfig               = RetryConfig{
-		Max:     5,
-		Timeout: 50 * time.Millisecond,
+		DefaultTimeout: 100 * time.Millisecond,
+		EnableMetatada: true,
 	}
 )
 
@@ -60,13 +60,15 @@ type Config struct {
 	CA                                 string      `name:"ca" yaml:"ca" description:"CA certificate file"`
 	DumpRequests                       bool        `name:"dump-requests" yaml:"dump-requests" description:"When log level is set to debug, also dump request payload as JSON"`
 	SkipVersionCheck                   bool        `name:"skip-version-check" yaml:"skip-version-check" description:"Do not perform version checks"`
-	Retry                              RetryConfig `name:"retry-config" yaml:"retry-config" description:"group of settings that describe the behaviour of the retry interceptor of the cli. If not specified the retry will only happen on the ResourceExhausted and Unavailable status codes"`
+	Retry                              RetryConfig `name:"retry-config" yaml:"retry-config"`
 }
 
 // RetryConfig defines the values for the retry behaviour in the cli
 type RetryConfig struct {
-	Max     uint          `name:"max" yaml:"max" description:"defines the amount of retries to be attempted when "`
-	Timeout time.Duration `name:"timeout" yaml:"timeout" description:"determines the default amount of time that the client will wait in between retry requests, the value will be used when the rate limit headers cannot be found in the request response"`
+	Max            uint          `name:"max" yaml:"max" description:"Maximum amount of times that a request can be reattempted"`
+	DefaultTimeout time.Duration `name:"default_timeout" yaml:"default_timeout" description:"Default timeout between retry attempts"`
+	EnableMetatada bool          `name:"enable_metadata" ymal:"enable_metadata" description:"Use request response metadata to dynamically calculate timeout between retry attempts"`
+	Jitter         float64       `name:"jitter" yaml:"jitter" description:"Fraction that creates a deviation of the timeout used between retry attempts"`
 }
 
 func (c Config) getHosts() []string {

--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -181,6 +181,10 @@ func preRun(tasks ...func() error) func(cmd *cobra.Command, args []string) error
 		if config.DumpRequests {
 			api.SetDumpRequests(true)
 		}
+
+		api.SetRetryMax(config.Retry.Max)
+		api.SetRetryTimeout(config.Retry.Timeout)
+
 		if config.CA != "" {
 			pemBytes, err := os.ReadFile(config.CA)
 			if err != nil {

--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"os"
@@ -182,8 +183,13 @@ func preRun(tasks ...func() error) func(cmd *cobra.Command, args []string) error
 			api.SetDumpRequests(true)
 		}
 
+		// initializes seed for random related operations
+		rand.Seed(time.Now().UnixNano())
+
 		api.SetRetryMax(config.Retry.Max)
-		api.SetRetryTimeout(config.Retry.Timeout)
+		api.SetRetryDefaultTimeout(config.Retry.DefaultTimeout)
+		api.SetRetryEnableMetadata(config.Retry.EnableMetatada)
+		api.SetRetryJitter(config.Retry.Jitter)
 
 		if config.CA != "" {
 			pemBytes, err := os.ReadFile(config.CA)

--- a/cmd/ttn-lw-cli/internal/api/grpc.go
+++ b/cmd/ttn-lw-cli/internal/api/grpc.go
@@ -26,7 +26,9 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/rpcclient"
 	"go.thethings.network/lorawan-stack/v3/pkg/rpcmetadata"
 	"go.thethings.network/lorawan-stack/v3/pkg/rpcmiddleware/rpclog"
+	"go.thethings.network/lorawan-stack/v3/pkg/rpcmiddleware/rpcretry"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 )
@@ -36,6 +38,9 @@ var (
 	tlsConfig    *tls.Config
 	auth         *rpcmetadata.MD
 	withDump     bool
+	retryMax     uint
+	retryTimeout time.Duration
+	retryCodes   []codes.Code
 )
 
 // SetLogger sets the default API logger
@@ -51,6 +56,21 @@ func SetInsecure(insecure bool) {
 // SetDumpRequests configures the API options to dump gRPC requests.
 func SetDumpRequests(dump bool) {
 	withDump = dump
+}
+
+// SetRetryMax configures the amount of time the client will retry the request
+func SetRetryMax(rm uint) {
+	retryMax = rm
+}
+
+// SetRetryTimeout configures the default timeout before making a retry in a failed request
+func SetRetryTimeout(rt time.Duration) {
+	retryTimeout = rt
+}
+
+// SetRetryCodes configures which response codes will trigger the retry
+func SetRetryCodes(rc ...codes.Code) {
+	retryCodes = rc
 }
 
 // AddCA adds the CA certificate file.
@@ -107,6 +127,12 @@ func GetDialOptions() (opts []grpc.DialOption) {
 	if withDump {
 		opts = append(opts, grpc.WithChainUnaryInterceptor(requestInterceptor))
 	}
+
+	opts = append(opts, grpc.WithChainUnaryInterceptor(
+		rpcretry.UnaryClientInterceptor(
+			rpcretry.WithMax(retryMax),
+			rpcretry.WithDefaultTimeout(retryTimeout),
+		)))
 	return
 }
 

--- a/pkg/rpcmiddleware/rpcretry/client_interceptors.go
+++ b/pkg/rpcmiddleware/rpcretry/client_interceptors.go
@@ -1,0 +1,120 @@
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpcretry
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/util/backoffutils"
+	"go.thethings.network/lorawan-stack/v3/pkg/log"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// UnaryClientInterceptor returns a new unary client interceptor that retries the execution of external gRPC calls, the
+// retry attempt will only occur if any of the validators define the error as a trigger.
+func UnaryClientInterceptor(opts ...Option) grpc.UnaryClientInterceptor {
+	callOpts := evaluateClientOpt(opts...)
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		var md metadata.MD
+		var err error
+		logger := log.FromContext(ctx)
+
+		for attempt := uint(0); attempt <= callOpts.max; attempt++ {
+			retryTimeout := callOpts.timeout
+			if callOpts.enableMetadata {
+				if headerTimeout := getHeaderLimiterTimeout(ctx, md, callOpts); headerTimeout > 0 {
+					retryTimeout = headerTimeout
+				}
+			}
+
+			err = waitRetryBackoff(ctx, retryTimeout, attempt)
+			if err != nil {
+				logger.WithError(err).Error("An unexpected error occurred while in the timeout for the next request retry")
+				return err
+			}
+
+			err = invoker(ctx, method, req, reply, cc, append(opts, grpc.Header(&md))...)
+			if err == nil {
+				return nil
+			}
+
+			if !isRetriable(err, callOpts) {
+				return err
+			}
+		}
+
+		return err
+	}
+}
+
+func evaluateClientOpt(opts ...Option) *options {
+	optCopy := &options{}
+	*optCopy = *defaultOptions
+
+	for _, f := range opts {
+		f(optCopy)
+	}
+	return optCopy
+}
+
+func isRetriable(err error, opt *options) bool {
+	if err == nil {
+		return false
+	}
+	for _, check := range opt.validators {
+		if check(err) {
+			return true
+		}
+	}
+	return false
+}
+
+func waitRetryBackoff(ctx context.Context, timeout time.Duration, attempt uint) error {
+	if attempt == 0 {
+		return nil
+	}
+	log.FromContext(ctx).WithFields(log.Fields(
+		"attempt", attempt,
+		"timeout", timeout,
+	)).Debug("Failed request, waiting until next attempt")
+	timer := time.NewTicker(timeout)
+	select {
+	case <-ctx.Done():
+		timer.Stop()
+		return ctx.Err()
+	case <-timer.C:
+	}
+	return nil
+}
+
+func getHeaderLimiterTimeout(ctx context.Context, md metadata.MD, opt *options) time.Duration {
+	if len(md.Get("x-rate-limit-reset")) <= 0 {
+		return -1
+	}
+	var reset int
+	reset, err := strconv.Atoi(md.Get("x-rate-limit-reset")[0])
+	if err != nil {
+		return -1
+	}
+
+	timeout := time.Duration(reset) * time.Second
+	if opt.jitter > 0 {
+		timeout = backoffutils.JitterUp(timeout, opt.jitter)
+	}
+	return timeout
+}

--- a/pkg/rpcmiddleware/rpcretry/client_interceptors_test.go
+++ b/pkg/rpcmiddleware/rpcretry/client_interceptors_test.go
@@ -1,0 +1,174 @@
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpcretry_test
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/smartystreets/assertions"
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/ratelimit"
+	"go.thethings.network/lorawan-stack/v3/pkg/rpcmiddleware/rpcretry"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/rpctest"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
+	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+var (
+	exhaustedErr = errors.DefineResourceExhausted("rpcretry_unary_resource_exhausted", "mock error of a resource exhausted scenario")
+	internalErr  = errors.DefineInternal("rpcretry_unary_internal", "mock error that represents an error that should not be retried")
+)
+
+type unaryService struct {
+	rpctest.FooBarServer
+	md metadata.MD
+
+	counter uint
+	err     error
+	sleep   time.Duration
+}
+
+func (fs *unaryService) Unary(ctx context.Context, foo *rpctest.Foo) (*rpctest.Bar, error) {
+	fs.counter++
+	time.Sleep(fs.sleep)
+
+	if err := grpc.SendHeader(ctx, fs.md); err != nil {
+		return nil, err
+	}
+	return &rpctest.Bar{Message: "bar"}, fs.err
+}
+
+func Test_UnaryClientInterceptor(t *testing.T) {
+	type Service struct {
+		err   error
+		sleep time.Duration
+		md    metadata.MD
+	}
+	type Client struct {
+		retries       uint
+		retryTimeout  time.Duration
+		useMetadata   bool
+		jitter        float64
+		contextFiller func(ctx context.Context) context.Context
+	}
+
+	for _, tt := range []struct {
+		name              string
+		service           Service
+		client            Client
+		errAssertion      func(error) bool
+		expectedReqAmount int
+	}{
+		{
+			name:              "no error",
+			client:            Client{retries: 5, retryTimeout: 3 * test.Delay},
+			service:           Service{sleep: 0},
+			expectedReqAmount: 1,
+		},
+		{
+			name:              "unretriable error",
+			client:            Client{retries: 5, retryTimeout: 3 * test.Delay},
+			service:           Service{err: internalErr.New()},
+			errAssertion:      errors.IsInternal,
+			expectedReqAmount: 1,
+		},
+		{
+			name:              "retriable error",
+			client:            Client{retries: 5, retryTimeout: 3 * test.Delay},
+			service:           Service{err: exhaustedErr.New()},
+			errAssertion:      errors.IsResourceExhausted,
+			expectedReqAmount: 6,
+		},
+		{
+			name: "timeout error",
+			client: Client{
+				retries:      5,
+				retryTimeout: 10 * test.Delay,
+				contextFiller: func(ctx context.Context) context.Context {
+					ctx, _ = context.WithTimeout(ctx, 5*test.Delay)
+					return ctx
+				},
+			},
+			service:           Service{sleep: 5 * test.Delay},
+			errAssertion:      errors.IsDeadlineExceeded,
+			expectedReqAmount: 1,
+		},
+		{
+			name: "timeout from metadata rate-limiter",
+			client: Client{
+				retries:     1,
+				useMetadata: true,
+			},
+			service: Service{
+				err: exhaustedErr.New(),
+				md:  ratelimit.Result{Limit: 10, Remaining: 8, RetryAfter: time.Second, ResetAfter: time.Second}.GRPCHeaders(),
+			},
+			errAssertion:      errors.IsResourceExhausted,
+			expectedReqAmount: 2,
+		},
+	} {
+		lis, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			panic(err)
+		}
+
+		server := grpc.NewServer()
+		testService := &unaryService{
+			err:   tt.service.err,
+			sleep: tt.service.sleep,
+			md:    tt.service.md,
+		}
+		rpctest.RegisterFooBarServer(server, testService)
+		go server.Serve(lis)
+
+		cc, err := grpc.DialContext(
+			test.Context(), lis.Addr().String(), grpc.WithInsecure(),
+			grpc.WithUnaryInterceptor(rpcretry.UnaryClientInterceptor(
+				rpcretry.WithMax(tt.client.retries),
+				rpcretry.WithDefaultTimeout(tt.client.retryTimeout),
+				rpcretry.UseMetadata(tt.client.useMetadata),
+				rpcretry.WithJitter(tt.client.jitter),
+			)),
+		)
+		if err != nil {
+			t.Fail()
+		}
+		defer cc.Close()
+
+		client := rpctest.NewFooBarClient(cc)
+		t.Run(tt.name, func(t *testing.T) {
+			a := assertions.New(t)
+
+			ctx := test.Context()
+			if tt.client.contextFiller != nil {
+				ctx = tt.client.contextFiller(ctx)
+			}
+
+			resp, err := client.Unary(ctx, &rpctest.Foo{Message: "foo"})
+			if tt.errAssertion != nil {
+				a.So(tt.errAssertion(err), should.BeTrue)
+			} else {
+				a.So(err, should.BeNil)
+				a.So(resp.Message, should.Equal, "bar")
+			}
+			a.So(testService.counter, should.Equal, tt.expectedReqAmount)
+		})
+	}
+}

--- a/pkg/rpcmiddleware/rpcretry/options.go
+++ b/pkg/rpcmiddleware/rpcretry/options.go
@@ -1,0 +1,85 @@
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpcretry
+
+import (
+	"time"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+)
+
+// Validator is a method that validates if an error should trigger the request retry.
+type Validator func(error) bool
+
+type options struct {
+	max            uint
+	timeout        time.Duration
+	validators     []Validator
+	enableMetadata bool
+	jitter         float64
+}
+
+// Options is an option for the rpcretry clients.
+type Option func(*options)
+
+var (
+	// Default Validators is a set of functions that validate errors that should trigger a retry of the request.
+	DefaultValidators = []Validator{
+		Validator(errors.IsResourceExhausted),
+		Validator(errors.IsUnavailable),
+	}
+
+	defaultOptions = &options{
+		max:            0,
+		timeout:        100 * time.Millisecond,
+		validators:     DefaultValidators,
+		enableMetadata: true,
+	}
+)
+
+// WithMax sets the value of the maximum amount of times a request will be retried.
+func WithMax(m uint) Option {
+	return func(opt *options) {
+		opt.max = m
+	}
+}
+
+// WithDefaultTimeout sets the default timeout between request retries.
+func WithDefaultTimeout(t time.Duration) Option {
+	return func(opt *options) {
+		opt.timeout = t
+	}
+}
+
+// WithValidator sets validators that will be evaluated when validating if a request should be retried.
+func WithValidator(validators ...Validator) Option {
+	return func(opt *options) {
+		opt.validators = validators
+	}
+}
+
+// UseMetadata establishes if the x-rate-limit headers will be used to dinamically calculate the timeout between requests.
+func UseMetadata(b bool) Option {
+	return func(opt *options) {
+		opt.enableMetadata = b
+	}
+}
+
+// WithJitter determines the value of the fraciton used to create the deviation in the timeout between the requests.
+func WithJitter(f float64) Option {
+	return func(opt *options) {
+		opt.jitter = f
+	}
+}

--- a/pkg/rpcmiddleware/rpcretry/options.go
+++ b/pkg/rpcmiddleware/rpcretry/options.go
@@ -46,6 +46,7 @@ var (
 		timeout:        100 * time.Millisecond,
 		validators:     DefaultValidators,
 		enableMetadata: true,
+		jitter:         0.0,
 	}
 )
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->
Closes #4902 

#### Changes
<!-- What are the changes made in this pull request? -->

- Add unary interceptor for retry request
- Add unary interceptor test cases
- Add interceptor to CLI, disabled by default

#### Testing

<!-- How did you verify that this change works? -->
Unit testing and local tests

Config and prints:
- [Print of concurrent unary requests with jitter](https://user-images.githubusercontent.com/28912302/150571680-d933fa3c-9b6f-4afb-ae1e-53d9dd815d8b.png)
- cli:
```yml
retry-config:
  max: 5
  jitter: 0.2
  enable_metadata: true
```
- stack
```yml
tls:
  source: file
  root-ca: ./ca.pem
  certificate: ./cert.pem
  key: ./key.pem

rate-limiting:
 profiles:
   - name: gRPC API
     max-per-min: 5
     max-burst: 7
     associations:
       - grpc:method
       - grpc:stream:accept
```
##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->
Might increase the amount of requests made to services that usually return `resourceExhausted`, concurrent request could receive the same timeout but this can be mitigated with the jitter.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->
The implementation takes as a base the implementation that can be found [here](https://github.com/grpc-ecosystem/go-grpc-middleware/blob/master/retry/retry.go), however there are a few small decisions made in this PR that changes some of the behaviours, all of these are welcomed to be discussed and changed. 

A few things that were changed:
- The validator that trigger the retry are determined by `func (error) bool`, this by default englobes `resourceExhausted` and `unavailable`. While it can be changed through grpcretry Option functions, there isn't any CLI settings to set which errors trigger the retry.
- In the `getHeaderLimiterTimeout` the reason for only using the `reset` header is due to its value being a incremental value. From the discussion that occured [here](https://github.com/TheThingsNetwork/lorawan-stack/issues/5080), the retry header will only contain a positive value when there are no available request to be made but to have a more dynamic timeout between requests the `reset` header is, in my opinion, ideal.
- After some discussion it was agreed that a stream interceptor is inappropriate for most of the requests that exist, therefore this PR only adds the unary interceptor.

Documentation PR - [here](https://github.com/TheThingsIndustries/lorawan-stack-docs/pull/741).
Will make the PR ready for review after everything here is approved, its just to have it as a reference until then.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
