### PR TITLE
Allow application packages to register web routes

### DIFF
--- a/pkg/applicationserver/io/packages/grpc_test.go
+++ b/pkg/applicationserver/io/packages/grpc_test.go
@@ -104,7 +104,7 @@ func TestAuthentication(t *testing.T) {
 	if !a.So(err, should.BeNil) {
 		t.FailNow()
 	}
-	c.RegisterGRPC(srv)
+	c.RegisterGRPC(&grpcServiceRegistererWrapper{srv})
 	componenttest.StartComponent(t, c)
 	defer c.Close()
 
@@ -190,7 +190,7 @@ func TestAssociations(t *testing.T) {
 	if !a.So(err, should.BeNil) {
 		t.FailNow()
 	}
-	c.RegisterGRPC(srv)
+	c.RegisterGRPC(&grpcServiceRegistererWrapper{srv})
 	componenttest.StartComponent(t, c)
 	defer c.Close()
 

--- a/pkg/applicationserver/io/packages/loradms/v1/package.go
+++ b/pkg/applicationserver/io/packages/loradms/v1/package.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/types"
-	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io"
 	"go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io/packages"
 	"go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io/packages/loradms/v1/api"
@@ -31,7 +30,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	urlutil "go.thethings.network/lorawan-stack/v3/pkg/util/url"
-	"google.golang.org/grpc"
 )
 
 // PackageName defines the package name.
@@ -42,12 +40,6 @@ type DeviceManagementPackage struct {
 	server   io.Server
 	registry packages.Registry
 }
-
-// RegisterServices implements packages.ApplicationPackageHandler.
-func (p *DeviceManagementPackage) RegisterServices(s *grpc.Server) {}
-
-// RegisterHandlers implements packages.ApplicationPackageHandler.
-func (p *DeviceManagementPackage) RegisterHandlers(s *runtime.ServeMux, conn *grpc.ClientConn) {}
 
 var (
 	errDeviceEUIMissing    = errors.DefineNotFound("device_eui_missing", "device EUI `{dev_eui}` not found")

--- a/pkg/applicationserver/io/packages/loragls/v3/package.go
+++ b/pkg/applicationserver/io/packages/loragls/v3/package.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/gogo/protobuf/types"
 	"github.com/golang/protobuf/proto"
-	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io"
 	"go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io/packages"
 	"go.thethings.network/lorawan-stack/v3/pkg/applicationserver/io/packages/loragls/v3/api"
@@ -31,7 +30,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	urlutil "go.thethings.network/lorawan-stack/v3/pkg/util/url"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 )
 
@@ -43,12 +41,6 @@ type GeolocationPackage struct {
 	server   io.Server
 	registry packages.Registry
 }
-
-// RegisterServices implements packages.ApplicationPackageHandler.
-func (p *GeolocationPackage) RegisterServices(s *grpc.Server) {}
-
-// RegisterHandlers implements packages.ApplicationPackageHandler.
-func (p *GeolocationPackage) RegisterHandlers(s *runtime.ServeMux, conn *grpc.ClientConn) {}
 
 var (
 	errLocationQuery = errors.DefineInternal("location_query", "location query")

--- a/pkg/applicationserver/io/packages/registration.go
+++ b/pkg/applicationserver/io/packages/registration.go
@@ -17,20 +17,14 @@ package packages
 import (
 	"context"
 
-	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
-	"google.golang.org/grpc"
 )
 
 // ApplicationPackageHandler handles upstream traffic from the Application Server.
 type ApplicationPackageHandler interface {
 	Package() *ttnpb.ApplicationPackage
-	RegisterServices(s *grpc.Server)
-	RegisterHandlers(s *runtime.ServeMux, conn *grpc.ClientConn)
 	HandleUp(context.Context, *ttnpb.ApplicationPackageDefaultAssociation, *ttnpb.ApplicationPackageAssociation, *ttnpb.ApplicationUp) error
 }
 
-var (
-	errNotImplemented = errors.DefineUnimplemented("package_not_implemented", "package `{name}` is not implemented")
-)
+var errNotImplemented = errors.DefineUnimplemented("package_not_implemented", "package `{name}` is not implemented")

--- a/pkg/applicationserver/io/packages/util_test.go
+++ b/pkg/applicationserver/io/packages/util_test.go
@@ -112,14 +112,6 @@ type mockPackageHandler struct {
 	HandleUpFunc func(context.Context, *ttnpb.ApplicationPackageDefaultAssociation, *ttnpb.ApplicationPackageAssociation, *ttnpb.ApplicationUp) error
 }
 
-func (h *mockPackageHandler) Roles() []ttnpb.ClusterRole {
-	return nil
-}
-
-func (h *mockPackageHandler) RegisterServices(s *grpc.Server) {}
-
-func (h *mockPackageHandler) RegisterHandlers(s *runtime.ServeMux, conn *grpc.ClientConn) {}
-
 func (h *mockPackageHandler) HandleUp(ctx context.Context, defaultAssoc *ttnpb.ApplicationPackageDefaultAssociation, assoc *ttnpb.ApplicationPackageAssociation, up *ttnpb.ApplicationUp) error {
 	if h.HandleUpFunc == nil {
 		panic("HandleUp called but HandleUpFunc is nil")
@@ -147,4 +139,20 @@ func createMockPackageHandler(ch chan<- *handleUpRequest) *mockPackageHandler {
 			return nil
 		},
 	}
+}
+
+type grpcServiceRegistererWrapper struct {
+	rpcserver.ServiceRegisterer
+}
+
+func (*grpcServiceRegistererWrapper) Roles() []ttnpb.ClusterRole {
+	return nil
+}
+
+func (s *grpcServiceRegistererWrapper) RegisterServices(gs *grpc.Server) {
+	s.ServiceRegisterer.RegisterServices(gs)
+}
+
+func (s *grpcServiceRegistererWrapper) RegisterHandlers(sm *runtime.ServeMux, conn *grpc.ClientConn) {
+	s.ServiceRegisterer.RegisterHandlers(sm, conn)
 }

--- a/pkg/rpcserver/rpcserver.go
+++ b/pkg/rpcserver/rpcserver.go
@@ -263,11 +263,16 @@ func New(ctx context.Context, opts ...Option) *Server {
 	return server
 }
 
-// Registerer allows components to register their services to the gRPC server and the HTTP gateway
-type Registerer interface {
-	Roles() []ttnpb.ClusterRole
+// ServiceRegisterer allows components to register their services to the gRPC server and the HTTP gateway.
+type ServiceRegisterer interface {
 	RegisterServices(s *grpc.Server)
 	RegisterHandlers(s *runtime.ServeMux, conn *grpc.ClientConn)
+}
+
+// Registerer extends ServiceRegisterer with the cluster roles fulfilled by the component.
+type Registerer interface {
+	Roles() []ttnpb.ClusterRole
+	ServiceRegisterer
 }
 
 // Server wraps the gRPC server


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/issues/2930

#### Changes
<!-- What are the changes made in this pull request? -->

- Allow application packages to optionally implement the `web.Registerer` interface in case they want to expose HTTP endpoints
- Make the `rpcserver.Registerer` interface optional for application packages


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A. This is mainly a change in plumbing and a bit of cleanup.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
