### PR TITLE
Allow frontends to retrieve end devices from local registry

### DIFF
--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -1225,3 +1225,8 @@ func (as *ApplicationServer) GetMQTTConfig(ctx context.Context) (*config.MQTT, e
 func (as *ApplicationServer) RangeUplinks(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, paths []string, f func(ctx context.Context, up *ttnpb.ApplicationUplink) bool) error {
 	return as.appUpsRegistry.Range(ctx, ids, paths, f)
 }
+
+// GetEndDevice retrieves the end device associated with the provided identifiers from the end device registry.
+func (as *ApplicationServer) GetEndDevice(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, paths []string) (*ttnpb.EndDevice, error) {
+	return as.deviceRegistry.Get(ctx, ids, paths)
+}

--- a/pkg/applicationserver/applicationserver_util_test.go
+++ b/pkg/applicationserver/applicationserver_util_test.go
@@ -53,14 +53,6 @@ func (r MockDeviceRegistry) Range(ctx context.Context, paths []string, f func(co
 	return nil
 }
 
-// noopEndDeviceFetcher is a no-op.
-type noopEndDeviceFetcher struct{}
-
-// Get implements the EndDeviceFetcher interface.
-func (noopEndDeviceFetcher) Get(ctx context.Context, ids ttnpb.EndDeviceIdentifiers, fieldMaskPaths ...string) (*ttnpb.EndDevice, error) {
-	return nil, errNotFound.New()
-}
-
 // MockLinkRegistry is a mock LinkRegistry used for testing.
 type MockLinkRegistry struct {
 	GetFunc   func(ctx context.Context, ids *ttnpb.ApplicationIdentifiers, paths []string) (*ttnpb.ApplicationLink, error)

--- a/pkg/applicationserver/io/io.go
+++ b/pkg/applicationserver/io/io.go
@@ -72,6 +72,14 @@ type Cluster interface {
 	GetPeerConn(ctx context.Context, role ttnpb.ClusterRole, ids cluster.EntityIdentifiers) (*grpc.ClientConn, error)
 }
 
+// EndDeviceRegistry represents the Application Server end device registry to application frontends.
+type EndDeviceRegistry interface {
+	// GetEndDevice retrieves the end device from the Application Server end device registry.
+	// This call will be delegated to the underlying end device registry, and should not be
+	// used on the hot path. It exists for provisioning purposes.
+	GetEndDevice(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, paths []string) (*ttnpb.EndDevice, error)
+}
+
 // Server represents the Application Server to application frontends.
 type Server interface {
 	task.Starter
@@ -80,6 +88,7 @@ type Server interface {
 	DownlinkQueueOperator
 	UplinkStorage
 	Cluster
+	EndDeviceRegistry
 	// FromRequestContext decouples the lifetime of the provided context from the values found in the context.
 	FromRequestContext(context.Context) context.Context
 	// GetBaseConfig returns the component configuration.

--- a/pkg/applicationserver/io/mock/server.go
+++ b/pkg/applicationserver/io/mock/server.go
@@ -34,7 +34,6 @@ type server struct {
 	downlinkQueueMu sync.RWMutex
 	downlinkQueue   map[string][]*ttnpb.ApplicationDownlink
 	subscribeError  error
-	applicationUps  map[string][]*ttnpb.ApplicationUplink
 }
 
 // Server represents a mock io.Server.
@@ -43,8 +42,6 @@ type Server interface {
 
 	SetSubscribeError(error)
 	Subscriptions() <-chan *io.Subscription
-
-	SetUplinks(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, ups ...*ttnpb.ApplicationUplink)
 }
 
 // NewServer instantiates a new Server.
@@ -139,19 +136,10 @@ func (s *server) RateLimiter() ratelimit.Interface {
 	return &ratelimit.NoopRateLimiter{}
 }
 
-func (s *server) SetUplinks(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, ups ...*ttnpb.ApplicationUplink) {
-	s.applicationUps[unique.ID(ctx, ids)] = ups
+func (s *server) RangeUplinks(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, paths []string, f func(ctx context.Context, up *ttnpb.ApplicationUplink) bool) error {
+	panic("unimplemented")
 }
 
-func (s *server) RangeUplinks(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, paths []string, f func(ctx context.Context, up *ttnpb.ApplicationUplink) bool) error {
-	for _, up := range s.applicationUps[unique.ID(ctx, ids)] {
-		dst := &ttnpb.ApplicationUplink{}
-		if err := dst.SetFields(up, paths...); err != nil {
-			return err
-		}
-		if !f(ctx, dst) {
-			break
-		}
-	}
-	return nil
+func (s *server) GetEndDevice(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, paths []string) (*ttnpb.EndDevice, error) {
+	panic("unimplemented")
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/issues/2930

#### Changes
<!-- What are the changes made in this pull request? -->

- Add the `EndDeviceRegistry` interface to `io.Server`


#### Testing

<!-- How did you verify that this change works? -->

N/A

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The [original comment](https://github.com/TheThingsIndustries/lorawan-stack/issues/2930#issuecomment-938903037) is a great example of my ability to over-engineer designs. We don't really need to bother with caching, since this call is meant to be used only during provisioning, not on the hot path. As such, we can endure an extra one-time call to the underlying end device registry without dealing with field mask subsets and cloning. 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
