### PR TITLE
is: Improve "already taken" errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ For details about compatibility between different releases, see the **Commitment
 ## [Unreleased]
 
 ### Added
+
 - Add configurable storage limit to device's DevNonce in the JoinServer. Can be configured using the option `js.dev-nonce-limit`.
+- Attribute `administrative_contact` on "gateway eui taken" error to help users resolve gateway EUI conflicts.
 
 ### Changed
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -4904,15 +4904,6 @@
       "file": "store.go"
     }
   },
-  "error:pkg/identityserver/gormstore:eui_taken": {
-    "translations": {
-      "en": "EUI already taken"
-    },
-    "description": {
-      "package": "pkg/identityserver/gormstore",
-      "file": "store.go"
-    }
-  },
   "error:pkg/identityserver/gormstore:gateway_not_found": {
     "translations": {
       "en": "gateway `{gateway_id}` not found"
@@ -4929,15 +4920,6 @@
     "description": {
       "package": "pkg/identityserver/gormstore",
       "file": "eui_block_store.go"
-    }
-  },
-  "error:pkg/identityserver/gormstore:id_taken": {
-    "translations": {
-      "en": "ID already taken"
-    },
-    "description": {
-      "package": "pkg/identityserver/gormstore",
-      "file": "store.go"
     }
   },
   "error:pkg/identityserver/gormstore:invitation_already_accepted": {
@@ -5109,6 +5091,24 @@
     "description": {
       "package": "pkg/identityserver/picture",
       "file": "picture.go"
+    }
+  },
+  "error:pkg/identityserver/store:eui_taken": {
+    "translations": {
+      "en": "EUI already taken"
+    },
+    "description": {
+      "package": "pkg/identityserver/store",
+      "file": "errors.go"
+    }
+  },
+  "error:pkg/identityserver/store:id_taken": {
+    "translations": {
+      "en": "ID already taken, choose a different one and try again"
+    },
+    "description": {
+      "package": "pkg/identityserver/store",
+      "file": "errors.go"
     }
   },
   "error:pkg/identityserver:access_token_mismatch": {
@@ -5320,7 +5320,7 @@
   },
   "error:pkg/identityserver:gateway_eui_taken": {
     "translations": {
-      "en": "a gateway with EUI `{gateway_eui}` is already registered as `{gateway_id}`"
+      "en": "a gateway with EUI `{gateway_eui}` is already registered (by you or someone else) as `{gateway_id}`"
     },
     "description": {
       "package": "pkg/identityserver",

--- a/pkg/identityserver/end_device_registry.go
+++ b/pkg/identityserver/end_device_registry.go
@@ -80,7 +80,7 @@ func (is *IdentityServer) createEndDevice(ctx context.Context, req *ttnpb.Create
 		return nil
 	})
 	if err != nil {
-		if errors.IsAlreadyExists(err) && errors.Resemble(err, gormstore.ErrEUITaken) {
+		if errors.IsAlreadyExists(err) && errors.Resemble(err, store.ErrEUITaken) {
 			if ids, err := is.getEndDeviceIdentifiersForEUIs(ctx, &ttnpb.GetEndDeviceIdentifiersForEUIsRequest{
 				JoinEui: *req.EndDevice.Ids.JoinEui,
 				DevEui:  *req.EndDevice.Ids.DevEui,

--- a/pkg/identityserver/gateway_registry.go
+++ b/pkg/identityserver/gateway_registry.go
@@ -66,7 +66,7 @@ var (
 
 var (
 	errAdminsCreateGateways    = errors.DefinePermissionDenied("admins_create_gateways", "gateways may only be created by admins, or in organizations")
-	errGatewayEUITaken         = errors.DefineAlreadyExists("gateway_eui_taken", "a gateway with EUI `{gateway_eui}` is already registered (by you or someone else) as `{gateway_id}`")
+	errGatewayEUITaken         = errors.DefineAlreadyExists("gateway_eui_taken", "a gateway with EUI `{gateway_eui}` is already registered (by you or someone else) as `{gateway_id}`", "administrative_contact")
 	errAdminsPurgeGateways     = errors.DefinePermissionDenied("admins_purge_gateways", "gateways may only be purged by admins")
 	errClaimAuthenticationCode = errors.DefineInvalidArgument("claim_authentication_code", "invalid claim authentication code")
 )
@@ -175,13 +175,21 @@ func (is *IdentityServer) createGateway(ctx context.Context, req *ttnpb.CreateGa
 	})
 	if err != nil {
 		if errors.IsAlreadyExists(err) && errors.Resemble(err, store.ErrEUITaken) {
-			if ids, err := is.getGatewayIdentifiersForEUI(ctx, &ttnpb.GetGatewayIdentifiersForEUIRequest{
-				Eui: reqGtw.GetIds().GetEui(),
+			var existing *ttnpb.Gateway
+			if err = is.withDatabase(ctx, func(db *gorm.DB) (err error) {
+				existing, err = gormstore.GetGatewayStore(db).GetGateway(ctx, &ttnpb.GatewayIdentifiers{
+					Eui: reqGtw.GetIds().GetEui(),
+				}, &pbtypes.FieldMask{Paths: []string{"ids.gateway_id", "ids.eui", "administrative_contact"}})
+				return err
 			}); err == nil {
-				return nil, errGatewayEUITaken.WithAttributes(
+				attributes := []interface{}{
 					"gateway_eui", reqGtw.GetIds().GetEui().String(),
-					"gateway_id", ids.GetGatewayId(),
-				)
+					"gateway_id", existing.GetIds().GetGatewayId(),
+				}
+				if existing.AdministrativeContact != nil {
+					attributes = append(attributes, "administrative_contact", existing.AdministrativeContact.IDString())
+				}
+				return nil, errGatewayEUITaken.WithAttributes(attributes...)
 			}
 		}
 		return nil, err

--- a/pkg/identityserver/gateway_registry.go
+++ b/pkg/identityserver/gateway_registry.go
@@ -66,7 +66,7 @@ var (
 
 var (
 	errAdminsCreateGateways    = errors.DefinePermissionDenied("admins_create_gateways", "gateways may only be created by admins, or in organizations")
-	errGatewayEUITaken         = errors.DefineAlreadyExists("gateway_eui_taken", "a gateway with EUI `{gateway_eui}` is already registered as `{gateway_id}`")
+	errGatewayEUITaken         = errors.DefineAlreadyExists("gateway_eui_taken", "a gateway with EUI `{gateway_eui}` is already registered (by you or someone else) as `{gateway_id}`")
 	errAdminsPurgeGateways     = errors.DefinePermissionDenied("admins_purge_gateways", "gateways may only be purged by admins")
 	errClaimAuthenticationCode = errors.DefineInvalidArgument("claim_authentication_code", "invalid claim authentication code")
 )
@@ -174,7 +174,7 @@ func (is *IdentityServer) createGateway(ctx context.Context, req *ttnpb.CreateGa
 		return nil
 	})
 	if err != nil {
-		if errors.IsAlreadyExists(err) && errors.Resemble(err, gormstore.ErrEUITaken) {
+		if errors.IsAlreadyExists(err) && errors.Resemble(err, store.ErrEUITaken) {
 			if ids, err := is.getGatewayIdentifiersForEUI(ctx, &ttnpb.GetGatewayIdentifiersForEUIRequest{
 				Eui: reqGtw.GetIds().GetEui(),
 			}); err == nil {

--- a/pkg/identityserver/gormstore/store.go
+++ b/pkg/identityserver/gormstore/store.go
@@ -150,11 +150,6 @@ func (s *baseStore) purgeEntity(ctx context.Context, entityID ttnpb.IDStringer) 
 var (
 	errDatabase      = errors.DefineInternal("database", "database error")
 	errAlreadyExists = errors.DefineAlreadyExists("already_exists", "entity already exists")
-
-	// ErrIDTaken is returned when an entity can not be created because the ID is already taken.
-	ErrIDTaken = errors.DefineAlreadyExists("id_taken", "ID already taken")
-	// ErrEUITaken is returned when an entity can not be created because the EUI is already taken.
-	ErrEUITaken = errors.DefineAlreadyExists("eui_taken", "EUI already taken")
 )
 
 var uniqueViolationRegex = regexp.MustCompile(`duplicate key value( .+)? violates unique constraint "([a-z_]+)"`)
@@ -173,9 +168,9 @@ func convertError(err error) error {
 			if match := uniqueViolationRegex.FindStringSubmatch(pqErr.Message); match != nil {
 				switch {
 				case strings.HasSuffix(match[2], "_id_index"):
-					return ErrIDTaken.WithCause(err)
+					return store.ErrIDTaken.WithCause(err)
 				case strings.HasSuffix(match[2], "_eui_index"):
-					return ErrEUITaken.WithCause(err)
+					return store.ErrEUITaken.WithCause(err)
 				default:
 					return errAlreadyExists.WithCause(err).WithAttributes("index", match[2])
 				}

--- a/pkg/identityserver/store/errors.go
+++ b/pkg/identityserver/store/errors.go
@@ -1,0 +1,24 @@
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import "go.thethings.network/lorawan-stack/v3/pkg/errors"
+
+var (
+	// ErrIDTaken is returned when an entity can not be created because the ID is already taken.
+	ErrIDTaken = errors.DefineAlreadyExists("id_taken", "ID already taken, choose a different one and try again")
+	// ErrEUITaken is returned when an entity can not be created because the EUI is already taken.
+	ErrEUITaken = errors.DefineAlreadyExists("eui_taken", "EUI already taken")
+)

--- a/pkg/ttnpb/public.go
+++ b/pkg/ttnpb/public.go
@@ -38,7 +38,10 @@ var PublicEntityFields = []string{
 }
 
 // PublicApplicationFields are the Application's fields that are public.
-var PublicApplicationFields = append(PublicEntityFields)
+var PublicApplicationFields = append(PublicEntityFields,
+	"administrative_contact",
+	"technical_contact",
+)
 
 // PublicSafe returns a copy of the application with only the fields that are
 // safe to return to any audience.
@@ -63,6 +66,8 @@ var PublicClientFields = append(PublicEntityFields,
 	"endorsed",
 	"grants",
 	"rights",
+	"administrative_contact",
+	"technical_contact",
 )
 
 // PublicSafe returns a copy of the client with only the fields that are safe to
@@ -88,6 +93,8 @@ var PublicGatewayFields = append(PublicEntityFields,
 	"location_public",
 	"antennas", // only public if location_public=true
 	"lrfhss.supported",
+	"administrative_contact",
+	"technical_contact",
 )
 
 // PublicSafe returns a copy of the gateway with only the fields that are
@@ -113,6 +120,8 @@ func (g *Gateway) PublicSafe() *Gateway {
 // PublicOrganizationFields are the Organization's fields that are public.
 var PublicOrganizationFields = append(PublicEntityFields,
 	"name",
+	"administrative_contact",
+	"technical_contact",
 )
 
 // PublicSafe returns a copy of the organization with only the fields that are


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request tries to improve the "id already taken" and "eui already taken" errors.

#### Changes
<!-- What are the changes made in this pull request? -->

- Moved error definitions from `gormstore` to `store` package so that we can re-use them in other store implementations.
- Add "choose a different one and try again" to the "id taken" error
- Add "(by you or someone else)" to "gateway eui taken" error
- Add `administrative_contact` of conflicting gateway to "gateway eui taken" error

#### Testing

<!-- How did you verify that this change works? -->

🐒 

<img width="397" alt="Screen Shot 2022-01-24 at 09 34 10" src="https://user-images.githubusercontent.com/181308/150750007-30c556c0-b489-4682-af52-c7aa22ba12a9.png">

<img width="844" alt="Screen Shot 2022-01-24 at 09 45 51" src="https://user-images.githubusercontent.com/181308/150750095-1e799132-efe2-43c2-a922-606a8226eee4.png">

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

nil

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

nil

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
