### PR TITLE
Establish the usage of TTL for all gateway connection stats operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@ For details about compatibility between different releases, see the **Commitment
 
 - Retain at most 10 recent session keys in the Join Server. This avoids a slowly growing number of session keys in the Join Server's database.
   - This requires a database migration (`ttn-lw-stack js-db migrate`).
+- Add TTL for gateway connection stats. Can be configured with the option `gs.connection-stats-ttl`.
 
 ### Changed
 
 ### Deprecated
+- Gateway Server setting `gs.update-connection-stats-debounce-time` is no longer valid.
 
 ### Removed
 
@@ -25,6 +27,7 @@ For details about compatibility between different releases, see the **Commitment
 - Device activation flow with a LoRaWAN Backend Interfaces 1.1 capable Join Server.
   - Join Servers using Backend Interfaces 1.1 (protocol `BI1.1`) must be configured with a `sender-ns-id` containing the EUI of the Network Server.
 - Fix `time.Duration` flags in CLI.
+- Gateway Server will no longer leave permanent gateway connection stats data on the registry when crashing.
 
 ### Security
 

--- a/cmd/internal/shared/gatewayserver/config.go
+++ b/cmd/internal/shared/gatewayserver/config.go
@@ -32,7 +32,6 @@ var DefaultGatewayServerConfig = gatewayserver.Config{
 	FetchGatewayInterval:              10 * time.Minute,
 	FetchGatewayJitter:                0.2,
 	UpdateGatewayLocationDebounceTime: time.Hour,
-	UpdateConnectionStatsDebounceTime: 3 * time.Second,
 	ConnectionStatsDisconnectTTL:      48 * time.Hour,
 	UpdateVersionInfoDelay:            5 * time.Second,
 	Forward: map[string][]string{

--- a/cmd/internal/shared/gatewayserver/config.go
+++ b/cmd/internal/shared/gatewayserver/config.go
@@ -32,6 +32,7 @@ var DefaultGatewayServerConfig = gatewayserver.Config{
 	FetchGatewayInterval:              10 * time.Minute,
 	FetchGatewayJitter:                0.2,
 	UpdateGatewayLocationDebounceTime: time.Hour,
+	ConnectionStatsTTL:                12 * time.Hour,
 	ConnectionStatsDisconnectTTL:      48 * time.Hour,
 	UpdateVersionInfoDelay:            5 * time.Second,
 	Forward: map[string][]string{

--- a/pkg/gatewayserver/config.go
+++ b/pkg/gatewayserver/config.go
@@ -55,7 +55,7 @@ type Config struct {
 	FetchGatewayJitter   float64       `name:"fetch-gateway-jitter" description:"Jitter (fraction) to apply to the get interval to randomize intervals"`
 
 	UpdateGatewayLocationDebounceTime time.Duration `name:"update-gateway-location-debounce-time" description:"Debounce time for gateway location updates from status messages"`
-	UpdateConnectionStatsDebounceTime time.Duration `name:"update-connection-stats-debounce-time" description:"Time before repeated refresh of the gateway connection stats"`
+	UpdateConnectionStatsDebounceTime time.Duration `name:"update-connection-stats-debounce-time" description:"DEPRECATED: Time before repeated refresh of the gateway connection stats"`
 	ConnectionStatsDisconnectTTL      time.Duration `name:"connection-stats-disconnect-ttl" description:"Time to live of the gateway connection stats after disconnecting"`
 
 	UpdateVersionInfoDelay time.Duration `name:"update-version-info-delay" description:"Maximum time to wait to update version information. A Jitter of 25% is applied for randomization"`

--- a/pkg/gatewayserver/config.go
+++ b/pkg/gatewayserver/config.go
@@ -56,6 +56,7 @@ type Config struct {
 
 	UpdateGatewayLocationDebounceTime time.Duration `name:"update-gateway-location-debounce-time" description:"Debounce time for gateway location updates from status messages"`
 	UpdateConnectionStatsDebounceTime time.Duration `name:"update-connection-stats-debounce-time" description:"DEPRECATED: Time before repeated refresh of the gateway connection stats"`
+	ConnectionStatsTTL                time.Duration `name:"connection-stats-ttl" description:"Time to live of the gateway connection stats. Periodically refreshed by the GatewayServer but works as an expiration date on the data in case of crashes"`
 	ConnectionStatsDisconnectTTL      time.Duration `name:"connection-stats-disconnect-ttl" description:"Time to live of the gateway connection stats after disconnecting"`
 
 	UpdateVersionInfoDelay time.Duration `name:"update-version-info-delay" description:"Maximum time to wait to update version information. A Jitter of 25% is applied for randomization"`

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -890,11 +890,11 @@ func (gs *GatewayServer) updateConnStats(ctx context.Context, conn connectionEnt
 
 	defer func() {
 		logger.Debug("Delete connection stats")
-		stats.ConnectedAt = nil
-		stats.DisconnectedAt = ttnpb.ProtoTimePtr(time.Now())
-
 		if err := gs.statsRegistry.Set(
-			decoupledCtx, *ids, stats,
+			decoupledCtx, *ids, &ttnpb.GatewayConnectionStats{
+				ConnectedAt:    nil,
+				DisconnectedAt: ttnpb.ProtoTimePtr(time.Now()),
+			},
 			[]string{"connected_at", "disconnected_at"},
 			gs.config.ConnectionStatsDisconnectTTL,
 		); err != nil {

--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -126,7 +126,6 @@ func TestGatewayServer(t *testing.T) {
 							AllowUnauthenticated: true,
 						},
 					},
-					UpdateConnectionStatsDebounceTime: 0,
 				}
 
 				er := gatewayserver.NewIS(c)

--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -74,14 +74,14 @@ var (
 func TestGatewayServer(t *testing.T) {
 	for _, rtc := range []struct {
 		Name                   string
-		Setup                  func(context.Context, string, string) (*component.Component, *gatewayserver.GatewayServer, error)
+		Setup                  func(context.Context, string, string, gatewayserver.GatewayConnectionStatsRegistry) (*component.Component, *gatewayserver.GatewayServer, error)
 		PostSetup              func(context.Context, *component.Component, *mockis.MockDefinition)
 		SkipProtocols          func(string) bool
 		SupportsLocationUpdate bool
 	}{
 		{
 			Name: "IdentityServer",
-			Setup: func(ctx context.Context, isAddr string, nsAddr string) (*component.Component, *gatewayserver.GatewayServer, error) {
+			Setup: func(ctx context.Context, isAddr string, nsAddr string, statsRegistry gatewayserver.GatewayConnectionStatsRegistry) (*component.Component, *gatewayserver.GatewayServer, error) {
 				c := componenttest.NewComponent(t, &component.Config{
 					ServiceBase: config.ServiceBase{
 						GRPC: config.GRPC{
@@ -101,6 +101,9 @@ func TestGatewayServer(t *testing.T) {
 				gsConfig := &gatewayserver.Config{
 					RequireRegisteredGateways:         false,
 					UpdateGatewayLocationDebounceTime: 0,
+					ConnectionStatsTTL:                (1 << 3) * test.Delay,
+					ConnectionStatsDisconnectTTL:      (1 << 3) * test.Delay,
+					Stats:                             statsRegistry,
 					FetchGatewayInterval:              time.Minute,
 					FetchGatewayJitter:                1,
 					MQTT: config.MQTT{
@@ -159,7 +162,22 @@ func TestGatewayServer(t *testing.T) {
 			defer closeIS()
 			ns, nsAddr := mock.StartNS(ctx)
 
-			c, gs, err := rtc.Setup(ctx, isAddr, nsAddr)
+			var statsRegistry gatewayserver.GatewayConnectionStatsRegistry
+			if os.Getenv("TEST_REDIS") == "1" {
+				statsRedisClient, statsFlush := test.NewRedis(ctx, "gatewayserver_test")
+				defer statsFlush()
+				defer statsRedisClient.Close()
+				registry := &gsredis.GatewayConnectionStatsRegistry{
+					Redis:   statsRedisClient,
+					LockTTL: test.Delay << 10,
+				}
+				if err := registry.Init(ctx); !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
+				statsRegistry = registry
+			}
+
+			c, gs, err := rtc.Setup(ctx, isAddr, nsAddr, statsRegistry)
 			if !a.So(err, should.BeNil) {
 				t.Fatalf("Failed to setup server :%v", err)
 			}
@@ -168,20 +186,8 @@ func TestGatewayServer(t *testing.T) {
 			a.So(roles[0], should.Equal, ttnpb.ClusterRole_GATEWAY_SERVER)
 
 			config, err := gs.GetConfig(ctx)
-			a.So(err, should.BeNil)
-
-			if os.Getenv("TEST_REDIS") == "1" {
-				statsRedisClient, statsFlush := test.NewRedis(ctx, "gatewayserver_test")
-				defer statsFlush()
-				defer statsRedisClient.Close()
-				statsRegistry := &gsredis.GatewayConnectionStatsRegistry{
-					Redis:   statsRedisClient,
-					LockTTL: test.Delay << 10,
-				}
-				if err := statsRegistry.Init(ctx); !a.So(err, should.BeNil) {
-					t.FailNow()
-				}
-				config.Stats = statsRegistry
+			if !a.So(err, should.BeNil) {
+				t.FailNow()
 			}
 
 			componenttest.StartComponent(t, c)
@@ -1402,8 +1408,8 @@ func TestGatewayServer(t *testing.T) {
 
 								stats, paths := conn.Stats()
 								a.So(stats, should.NotBeNil)
-								if config.Stats != nil {
-									a.So(config.Stats.Set(conn.Context(), ids, stats, paths, 0), should.BeNil)
+								if statsRegistry != nil {
+									a.So(statsRegistry.Set(conn.Context(), ids, stats, paths, 0), should.BeNil)
 								}
 
 								stats, err := statsClient.GetGatewayConnectionStats(statsCtx, &ids)
@@ -1748,7 +1754,7 @@ func TestGatewayServer(t *testing.T) {
 					}
 
 					// Wait for disconnection to be processed.
-					time.Sleep(timeout)
+					time.Sleep(2 * config.ConnectionStatsDisconnectTTL)
 
 					// After canceling the context and awaiting the link, the connection should be gone.
 					t.Run("Disconnected", func(t *testing.T) {
@@ -1759,7 +1765,39 @@ func TestGatewayServer(t *testing.T) {
 					})
 				})
 			}
-			c.Close()
+
+			t.Run("Shutdown", func(t *testing.T) {
+				if statsRegistry == nil {
+					t.Skip("Stats registry disabled")
+				}
+
+				ids := &ttnpb.GatewayIdentifiers{
+					GatewayId: registeredGatewayID,
+					Eui:       &registeredGatewayEUI,
+				}
+
+				conn, err := grpc.Dial(":9187", append(rpcclient.DefaultDialOptions(ctx), grpc.WithInsecure(), grpc.WithBlock())...)
+				if !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
+				defer conn.Close()
+				md := rpcmetadata.MD{
+					ID:            ids.GatewayId,
+					AuthType:      "Bearer",
+					AuthValue:     registeredGatewayKey,
+					AllowInsecure: true,
+				}
+				_, err = ttnpb.NewGtwGsClient(conn).LinkGateway(ctx, grpc.PerRPCCredentials(md))
+				if !a.So(err, should.BeNil) {
+					t.FailNow()
+				}
+
+				gs.Close()
+				time.Sleep(2 * config.ConnectionStatsTTL)
+
+				_, err = statsRegistry.Get(ctx, *ids)
+				a.So(errors.IsNotFound(err), should.BeTrue)
+			})
 		})
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->
Closes #5129 
By enforcing the TTL for all the gtw conn stats it avoids leftovers inside redis, that previously only happened when a server instance was destroyed before a gtw disconnected.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add  `ConnectionStatsTTL` to GS config
- Add ticker that refreshes the gateway connection stats
- Add a test case for the gs closing before gtw disconnects


#### Testing

<!-- How did you verify that this change works? -->
Local test and unit test

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

No other affect besides setting a time to live for gtw connection stats in the redis registry.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Will open the documentation PR for the new gateway config option in a bit.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
