### PR TITLE
Remove old session keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Added
 
+- Retain at most 10 recent session keys in the Join Server. This avoids a slowly growing number of session keys in the Join Server's database.
+  - This requires a database migration (`ttn-lw-stack js-db migrate`).
+
 ### Changed
 
 ### Deprecated

--- a/cmd/internal/shared/joinserver/config.go
+++ b/cmd/internal/shared/joinserver/config.go
@@ -24,5 +24,6 @@ var DefaultJoinServerConfig = joinserver.Config{
 	JoinEUIPrefixes: []types.EUI64Prefix{
 		{},
 	},
-	DevNonceLimit: 10,
+	DevNonceLimit:   10,
+	SessionKeyLimit: 10,
 }

--- a/cmd/ttn-lw-stack/commands/as_db.go
+++ b/cmd/ttn-lw-stack/commands/as_db.go
@@ -45,11 +45,11 @@ var (
 			cl := ttnredis.New(config.Redis.WithNamespace("as"))
 
 			if force, _ := cmd.Flags().GetBool("force"); !force {
-				needMigration, err := checkLatestSchemaVersion(cl, asredis.SchemaVersion)
+				schemaVersion, err := getSchemaVersion(cl)
 				if err != nil {
 					return err
 				}
-				if !needMigration {
+				if schemaVersion >= asredis.SchemaVersion {
 					logger.Info("Database schema version is already in latest version")
 					return nil
 				}

--- a/cmd/ttn-lw-stack/commands/js_db.go
+++ b/cmd/ttn-lw-stack/commands/js_db.go
@@ -78,12 +78,12 @@ var (
 			devicesCl := NewJoinServerDeviceRegistryRedis(*config)
 			keysCl := NewJoinServerSessionKeyRegistryRedis(*config)
 
+			schemaVersion, err := getSchemaVersion(keysCl)
+			if err != nil {
+				return err
+			}
 			if force, _ := cmd.Flags().GetBool("force"); !force {
-				needMigration, err := checkLatestSchemaVersion(keysCl, jsredis.SchemaVersion)
-				if err != nil {
-					return err
-				}
-				if !needMigration {
+				if schemaVersion >= jsredis.SchemaVersion {
 					logger.Info("Database schema version is already in latest version")
 					return nil
 				}

--- a/cmd/ttn-lw-stack/commands/js_db.go
+++ b/cmd/ttn-lw-stack/commands/js_db.go
@@ -15,7 +15,11 @@
 package commands
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
+	"regexp"
+	"sort"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -23,23 +27,24 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/cleanup"
 	js "go.thethings.network/lorawan-stack/v3/pkg/joinserver"
 	jsredis "go.thethings.network/lorawan-stack/v3/pkg/joinserver/redis"
-	"go.thethings.network/lorawan-stack/v3/pkg/redis"
+	ttnredis "go.thethings.network/lorawan-stack/v3/pkg/redis"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/types"
 	"go.thethings.network/lorawan-stack/v3/pkg/unique"
 )
 
 // NewJSRegistryCleaner returns a new instance of Join Server RegistryCleaner with a local set
 // of devices and applications.
-func NewJSRegistryCleaner(ctx context.Context, config *redis.Config) (*js.RegistryCleaner, error) {
+func NewJSRegistryCleaner(ctx context.Context, config *ttnredis.Config) (*js.RegistryCleaner, error) {
 	deviceRegistry := &jsredis.DeviceRegistry{
-		Redis:   redis.New(config.WithNamespace("js", "devices")),
+		Redis:   ttnredis.New(config.WithNamespace("js", "devices")),
 		LockTTL: defaultLockTTL,
 	}
 	if err := deviceRegistry.Init(ctx); err != nil {
 		return nil, shared.ErrInitializeApplicationServer.WithCause(err)
 	}
 	applicationActivationSettingRegistry := &jsredis.ApplicationActivationSettingRegistry{
-		Redis:   redis.New(config.WithNamespace("js", "application-activation-settings")),
+		Redis:   ttnredis.New(config.WithNamespace("js", "application-activation-settings")),
 		LockTTL: defaultLockTTL,
 	}
 	if err := applicationActivationSettingRegistry.Init(ctx); err != nil {
@@ -60,6 +65,112 @@ var (
 	jsDBCommand = &cobra.Command{
 		Use:   "js-db",
 		Short: "Manage Join Server database",
+	}
+	jsDBMigrateCommand = &cobra.Command{
+		Use:   "migrate",
+		Short: "Migrate Join Server data",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if config.Redis.IsZero() {
+				panic("Only Redis is supported by this command")
+			}
+
+			logger.Info("Connecting to Redis database...")
+			devicesCl := NewJoinServerDeviceRegistryRedis(*config)
+			keysCl := NewJoinServerSessionKeyRegistryRedis(*config)
+
+			if force, _ := cmd.Flags().GetBool("force"); !force {
+				needMigration, err := checkLatestSchemaVersion(keysCl, jsredis.SchemaVersion)
+				if err != nil {
+					return err
+				}
+				if !needMigration {
+					logger.Info("Database schema version is already in latest version")
+					return nil
+				}
+			}
+
+			var migrated uint64
+			defer func() { logger.Debugf("%d keys migrated", migrated) }()
+
+			const (
+				euiRegexpStr    = "([[:xdigit:]]{16})"
+				sessionKeyIDStr = "([A-Za-z0-9+/]+)"
+			)
+
+			euiRegexp := regexp.MustCompile(devicesCl.Key("eui", euiRegexpStr, euiRegexpStr+"$"))
+			sessionKeyIDRegexp := regexp.MustCompile(keysCl.Key("id", euiRegexpStr, euiRegexpStr, sessionKeyIDStr+"$"))
+
+			err := ttnredis.RangeRedisKeys(ctx, devicesCl, devicesCl.Key("*"), ttnredis.DefaultRangeCount, func(k string) (bool, error) {
+				logger := logger.WithField("key", k)
+				if match := euiRegexp.FindSubmatch([]byte(k)); len(match) > 0 && config.JS.SessionKeyLimit > 0 {
+					var joinEUI, devEUI types.EUI64
+					if err := joinEUI.UnmarshalText(match[1]); err != nil {
+						logger.WithError(err).Error("Failed to parse JoinEUI")
+						return true, nil
+					}
+					if err := devEUI.UnmarshalText(match[2]); err != nil {
+						logger.WithError(err).Error("Failed to parse DevEUI")
+						return true, nil
+					}
+					var sids [][]byte
+					err := ttnredis.RangeRedisKeys(ctx, keysCl, keysCl.Key("id", joinEUI.String(), devEUI.String(), "*"), ttnredis.DefaultRangeCount, func(k string) (bool, error) {
+						match := sessionKeyIDRegexp.FindStringSubmatch(k)
+						if len(match) == 0 {
+							logger.WithField("key", k).Error("Failed to parse session key ID key")
+							return true, nil
+						}
+						sid, err := base64.RawStdEncoding.DecodeString(match[3])
+						if err != nil {
+							logger.WithError(err).Error("Failed to parse base64 session key ID")
+							return true, nil
+						}
+						sids = append(sids, sid)
+						return true, nil
+					})
+					if err != nil {
+						logger.WithError(err).Error("Failed to range session keys")
+						return true, nil
+					}
+					logger.WithField("count", len(sids)).Debug("Retrieved session keys")
+					sort.Slice(sids, func(i, j int) bool { return bytes.Compare(sids[i], sids[j]) < 0 })
+					if d := len(sids) - config.JS.SessionKeyLimit; d > 0 {
+						for _, sid := range sids[:d] {
+							sidKey := keysCl.Key("id", joinEUI.String(), devEUI.String(), base64.RawStdEncoding.EncodeToString(sid))
+							logger := logger.WithField("key", sidKey)
+							if err := keysCl.Del(ctx, sidKey).Err(); err != nil {
+								logger.WithError(err).Error("Failed to delete session key")
+								continue
+							}
+							logger.Debug("Deleted old session key")
+						}
+						sids = sids[d:]
+					}
+					sidVals := make([]interface{}, len(sids))
+					for i := range sids {
+						sidVals[i] = base64.RawStdEncoding.EncodeToString(sids[i])
+					}
+					sidsKey := keysCl.Key("ids", joinEUI.String(), devEUI.String())
+					if err := keysCl.Del(ctx, sidsKey).Err(); err != nil {
+						logger.WithError(err).Error("Failed to delete existing recent session key IDs")
+						return true, nil
+					}
+					if err := keysCl.RPush(ctx, sidsKey, sidVals...).Err(); err != nil {
+						logger.WithError(err).Error("Failed to store recent session key IDs")
+						return true, nil
+					}
+				} else {
+					logger.Debug("Skip unmatched key")
+					return true, nil
+				}
+				migrated++
+				return true, nil
+			})
+			if err != nil {
+				return err
+			}
+
+			return recordSchemaVersion(keysCl, jsredis.SchemaVersion)
+		},
 	}
 	jsDBCleanupCommand = &cobra.Command{
 		Use:   "cleanup",
@@ -132,6 +243,8 @@ var (
 
 func init() {
 	Root.AddCommand(jsDBCommand)
+	jsDBMigrateCommand.Flags().Bool("force", false, "Force perform database migrations")
+	jsDBCommand.AddCommand(jsDBMigrateCommand)
 	jsDBCleanupCommand.Flags().Bool("dry-run", false, "Dry run")
 	jsDBCleanupCommand.Flags().Duration("pagination-delay", 100, "Delay between batch requests")
 	jsDBCommand.AddCommand(jsDBCleanupCommand)

--- a/cmd/ttn-lw-stack/commands/ns_db.go
+++ b/cmd/ttn-lw-stack/commands/ns_db.go
@@ -524,9 +524,9 @@ var (
 func init() {
 	Root.AddCommand(nsDBCommand)
 	nsDBCommand.AddCommand(nsDBPruneCommand)
+	nsDBMigrateCommand.Flags().Bool("force", false, "Force perform database migrations")
 	nsDBCommand.AddCommand(nsDBMigrateCommand)
 	nsDBCleanupCommand.Flags().Bool("dry-run", false, "Dry run")
 	nsDBCleanupCommand.Flags().Duration("pagination-delay", 100, "Delay between batch requests")
 	nsDBCommand.AddCommand(nsDBCleanupCommand)
-	nsDBMigrateCommand.Flags().Bool("force", false, "Force perform database migrations")
 }

--- a/cmd/ttn-lw-stack/commands/ns_db.go
+++ b/cmd/ttn-lw-stack/commands/ns_db.go
@@ -96,11 +96,11 @@ var (
 			cl := NewNetworkServerDeviceRegistryRedis(*config)
 
 			if force, _ := cmd.Flags().GetBool("force"); !force {
-				needMigration, err := checkLatestSchemaVersion(cl, nsredis.SchemaVersion)
+				schemaVersion, err := getSchemaVersion(cl)
 				if err != nil {
 					return err
 				}
-				if !needMigration {
+				if schemaVersion >= nsredis.SchemaVersion {
 					logger.Info("Database schema version is already in latest version")
 					return nil
 				}

--- a/cmd/ttn-lw-stack/commands/utils.go
+++ b/cmd/ttn-lw-stack/commands/utils.go
@@ -132,18 +132,18 @@ func recordSchemaVersion(cl *ttnredis.Client, version int) error {
 	return cl.Set(ctx, schemaVersionKey(cl), version, 0).Err()
 }
 
-func checkLatestSchemaVersion(cl *ttnredis.Client, latestVersion int) (bool, error) {
+func getSchemaVersion(cl *ttnredis.Client) (int, error) {
 	schemaVersionString, err := cl.Get(ctx, schemaVersionKey(cl)).Result()
 	if err != nil {
 		if errors.IsNotFound(ttnredis.ConvertError(err)) {
-			return true, nil
+			return 0, nil
 		}
-		return true, err
+		return 0, err
 	}
 	schemaVersion, err := strconv.ParseInt(schemaVersionString, 10, 32)
 	if err != nil {
-		return true, err
+		return 0, err
 	}
 	logger.WithField("version", schemaVersion).Info("Existing database schema version")
-	return int(schemaVersion) < latestVersion, nil
+	return int(schemaVersion), nil
 }

--- a/pkg/joinserver/config.go
+++ b/pkg/joinserver/config.go
@@ -25,4 +25,5 @@ type Config struct {
 	DefaultJoinEUI                types.EUI64                          `name:"default-join-eui" description:"Default JoinEUI for this Join Server"`
 	DeviceKEKLabel                string                               `name:"device-kek-label" description:"Label of KEK used to encrypt device keys at rest"`
 	DevNonceLimit                 int                                  `name:"dev-nonce-limit" description:"Amount of DevNonces stored per device"`
+	SessionKeyLimit               int                                  `name:"session-key-limit" description:"Amount of session keys stored per device"`
 }

--- a/pkg/joinserver/joinserver_internal_test.go
+++ b/pkg/joinserver/joinserver_internal_test.go
@@ -86,6 +86,7 @@ func (m MockDeviceRegistry) RangeByID(ctx context.Context, paths []string, f fun
 type MockKeyRegistry struct {
 	GetByIDFunc func(context.Context, types.EUI64, types.EUI64, []byte, []string) (*ttnpb.SessionKeys, error)
 	SetByIDFunc func(context.Context, types.EUI64, types.EUI64, []byte, []string, func(*ttnpb.SessionKeys) (*ttnpb.SessionKeys, []string, error)) (*ttnpb.SessionKeys, error)
+	DeleteFunc  func(context.Context, types.EUI64, types.EUI64) error
 }
 
 // GetByID calls GetByIDFunc if set and panics otherwise.
@@ -102,4 +103,11 @@ func (m MockKeyRegistry) SetByID(ctx context.Context, joinEUI, devEUI types.EUI6
 		panic("SetByID called, but not set")
 	}
 	return m.SetByIDFunc(ctx, joinEUI, devEUI, id, paths, f)
+}
+
+func (m MockKeyRegistry) Delete(ctx context.Context, joinEUI, devEUI types.EUI64) error {
+	if m.DeleteFunc == nil {
+		panic("Delete called, but not set")
+	}
+	return m.DeleteFunc(ctx, joinEUI, devEUI)
 }

--- a/pkg/joinserver/registry.go
+++ b/pkg/joinserver/registry.go
@@ -42,6 +42,7 @@ func DeleteDevice(ctx context.Context, r DeviceRegistry, appID *ttnpb.Applicatio
 type KeyRegistry interface {
 	GetByID(ctx context.Context, joinEUI, devEUI types.EUI64, id []byte, paths []string) (*ttnpb.SessionKeys, error)
 	SetByID(ctx context.Context, joinEUI, devEUI types.EUI64, id []byte, paths []string, f func(*ttnpb.SessionKeys) (*ttnpb.SessionKeys, []string, error)) (*ttnpb.SessionKeys, error)
+	Delete(ctx context.Context, joinEUI, devEUI types.EUI64) error
 }
 
 // DeleteKeys deletes session keys identified by devEUI, id pair from r.

--- a/pkg/joinserver/registry_test.go
+++ b/pkg/joinserver/registry_test.go
@@ -413,6 +413,18 @@ func handleKeyRegistryTest(t *testing.T, reg KeyRegistry) {
 			}
 		}
 	}
+
+	// Delete all the session keys of the given device.
+	err = reg.Delete(ctx, joinEUI, devEUI)
+	if !a.So(err, should.BeNil) {
+		t.Fatalf("Error received: %v", err)
+	}
+	for i := byte(0); i < 20; i++ {
+		_, err := reg.GetByID(ctx, joinEUI, devEUI, bytes.Repeat([]byte{i}, 4), ttnpb.SessionKeysFieldPathsTopLevel)
+		if !a.So(err, should.NotBeNil) || !a.So(errors.IsNotFound(err), should.BeTrue) {
+			t.Fatalf("Error received: %v", err)
+		}
+	}
 }
 
 func TestSessionKeyRegistries(t *testing.T) {

--- a/pkg/joinserver/registry_test.go
+++ b/pkg/joinserver/registry_test.go
@@ -15,6 +15,7 @@
 package joinserver_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"testing"
@@ -368,6 +369,50 @@ func handleKeyRegistryTest(t *testing.T, reg KeyRegistry) {
 		t.Fatalf("Error received: %v", err)
 	}
 	a.So(ret, should.BeNil)
+
+	// Check number of retained session keys. Only the last 10 should be kept.
+	for i := byte(0); i < 20; i++ {
+		sid := bytes.Repeat([]byte{i}, 4)
+		_, err := reg.SetByID(ctx, joinEUI, devEUI, sid, []string{
+			"app_s_key",
+			"f_nwk_s_int_key",
+			"nwk_s_enc_key",
+			"s_nwk_s_int_key",
+		},
+			func(stored *ttnpb.SessionKeys) (*ttnpb.SessionKeys, []string, error) {
+				if !a.So(stored, should.BeNil) {
+					t.Fatal("Registry is not empty")
+				}
+				return &ttnpb.SessionKeys{
+						SessionKeyId: sid,
+						FNwkSIntKey:  test.DefaultFNwkSIntKeyEnvelope,
+						SNwkSIntKey:  test.DefaultSNwkSIntKeyEnvelope,
+						NwkSEncKey:   test.DefaultNwkSEncKeyEnvelope,
+						AppSKey:      test.DefaultAppSKeyEnvelope,
+					}, []string{
+						"app_s_key",
+						"f_nwk_s_int_key",
+						"nwk_s_enc_key",
+						"s_nwk_s_int_key",
+						"session_key_id",
+					}, nil
+			})
+		if !a.So(err, should.BeNil) {
+			t.Fatalf("Error received: %v", err)
+		}
+	}
+	for i := byte(0); i < 20; i++ {
+		_, err := reg.GetByID(ctx, joinEUI, devEUI, bytes.Repeat([]byte{i}, 4), ttnpb.SessionKeysFieldPathsTopLevel)
+		if i < 10 {
+			if !a.So(err, should.NotBeNil) || !a.So(errors.IsNotFound(err), should.BeTrue) {
+				t.Fatalf("Error received: %v", err)
+			}
+		} else {
+			if !a.So(err, should.BeNil) {
+				t.FailNow()
+			}
+		}
+	}
 }
 
 func TestSessionKeyRegistries(t *testing.T) {
@@ -389,6 +434,7 @@ func TestSessionKeyRegistries(t *testing.T) {
 				keyReg := &redis.KeyRegistry{
 					Redis:   cl,
 					LockTTL: test.Delay << 10,
+					Limit:   10,
 				}
 				if err := keyReg.Init(ctx); err != nil {
 					return nil, nil, err


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #5086 

#### Changes
<!-- What are the changes made in this pull request? -->

- Record the last N (default 10) session keys in a Redis list. New key that are pushed lead to pruning the oldest ones
- Add `js-db migrate` to enumerate session key IDs for end devices and puts them in the list. Old session key IDs are pruned

#### Testing

<!-- How did you verify that this change works? -->

Local testing of the migration and unit testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None expected

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@adriansmares the JS session keys Redis implementation is likely not the fastest one as it does some reading and writing that can't be pipelined. We could work with a Lua script but this join flow isn't time critical enough for that in my opinion.

What is currently not being pruned are session keys of devices that are deleted or that are being deleted. Automatic deletion of session keys on device delete is a bit trickier because the JS device registry isn't configured with the key namespace of the session keys. We could do this with a separate `js-db prune` or `cleanup` analog to NS, but I don't see that in the scope of closing this issue.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
