### PR TITLE
Fix miscellaneous panics

### DIFF
--- a/pkg/crypto/cryptoutil/cryptoutil.go
+++ b/pkg/crypto/cryptoutil/cryptoutil.go
@@ -123,25 +123,25 @@ func UnwrapSelectedSessionKeys(ctx context.Context, keyVault crypto.KeyVault, sk
 
 		err error
 	)
-	if ttnpb.HasAnyField(paths, pathWithPrefix(prefix, "app_s_key.key")) && sk.AppSKey != nil {
+	if ttnpb.HasAnyField(paths, pathWithPrefix(prefix, "app_s_key.key")) && sk.GetAppSKey() != nil {
 		appSKeyEnvelope, err = UnwrapKeyEnvelope(ctx, sk.AppSKey, keyVault)
 		if err != nil {
 			return nil, err
 		}
 	}
-	if ttnpb.HasAnyField(paths, pathWithPrefix(prefix, "f_nwk_s_int_key.key")) && sk.FNwkSIntKey != nil {
+	if ttnpb.HasAnyField(paths, pathWithPrefix(prefix, "f_nwk_s_int_key.key")) && sk.GetFNwkSIntKey() != nil {
 		fNwkSIntKeyEnvelope, err = UnwrapKeyEnvelope(ctx, sk.FNwkSIntKey, keyVault)
 		if err != nil {
 			return nil, err
 		}
 	}
-	if ttnpb.HasAnyField(paths, pathWithPrefix(prefix, "nwk_s_enc_key.key")) && sk.NwkSEncKey != nil {
+	if ttnpb.HasAnyField(paths, pathWithPrefix(prefix, "nwk_s_enc_key.key")) && sk.GetNwkSEncKey() != nil {
 		nwkSEncKeyEnvelope, err = UnwrapKeyEnvelope(ctx, sk.NwkSEncKey, keyVault)
 		if err != nil {
 			return nil, err
 		}
 	}
-	if ttnpb.HasAnyField(paths, pathWithPrefix(prefix, "s_nwk_s_int_key.key")) && sk.SNwkSIntKey != nil {
+	if ttnpb.HasAnyField(paths, pathWithPrefix(prefix, "s_nwk_s_int_key.key")) && sk.GetSNwkSIntKey() != nil {
 		sNwkSIntKeyEnvelope, err = UnwrapKeyEnvelope(ctx, sk.SNwkSIntKey, keyVault)
 		if err != nil {
 			return nil, err

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -1641,7 +1641,7 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 	if st.Device.Session != nil {
 		for p, isZero := range map[string]func() bool{
 			"session.dev_addr":                 st.Device.Session.DevAddr.IsZero,
-			"session.keys.f_nwk_s_int_key.key": st.Device.Session.Keys.FNwkSIntKey.IsZero,
+			"session.keys.f_nwk_s_int_key.key": st.Device.Session.Keys.GetFNwkSIntKey().IsZero,
 			"session.keys.nwk_s_enc_key.key": func() bool {
 				return st.Device.Session.Keys.NwkSEncKey != nil && st.Device.Session.Keys.NwkSEncKey.IsZero()
 			},

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -130,7 +130,7 @@ func makeDeferredMACHandler(dev *ttnpb.EndDevice, f macHandler) macHandler {
 		case n == queuedLength:
 			return f(ctx, dev, up)
 		default:
-			tail := append(dev.MacState.QueuedResponses[queuedLength:0:0], dev.MacState.QueuedResponses[queuedLength:]...)
+			tail := append(dev.MacState.QueuedResponses[:0:0], dev.MacState.QueuedResponses[queuedLength:]...)
 			dev.MacState.QueuedResponses = dev.MacState.QueuedResponses[:queuedLength]
 			evs, err := f(ctx, dev, up)
 			dev.MacState.QueuedResponses = append(dev.MacState.QueuedResponses, tail...)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://sentry.io/organizations/the-things-industries/issues/2879498040/?environment=ttn-prod-eu1&project=2682566&query=is%3Aunresolved&statsPeriod=7d
Closes https://sentry.io/organizations/the-things-industries/issues/2875750127/?environment=ttn-prod-eu1&project=2682566&query=is%3Aunresolved&statsPeriod=7d
Closes https://sentry.io/organizations/the-things-industries/issues/2651934591/?environment=ttn-prod-eu1&project=2682566&query=is%3Aunresolved&statsPeriod=7d

#### Changes
<!-- What are the changes made in this pull request? -->

- Use getters for session keys retrieval (since `*ttnpb.SessionKeys` can be `nil` now)
- Fix a slice expression that has been broken for 3 years


#### Testing

<!-- How did you verify that this change works? -->

N/A

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
