### PR TITLE
Fix duration value assignment from reflect.Value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Fixed
 
 - Device activation flow with a LoRaWAN Backend Interfaces 1.1 capable Join Server.
+- Fix `time.Duration` flags in CLI.
 
 ### Security
 

--- a/cmd/ttn-lw-cli/internal/util/flags.go
+++ b/cmd/ttn-lw-cli/internal/util/flags.go
@@ -627,10 +627,7 @@ func setField(rv reflect.Value, path []string, v reflect.Value) error {
 						}
 						field.Set(reflect.ValueOf(*ttnpb.ProtoTimePtr(t)))
 					case "Duration":
-						d, err := time.ParseDuration(v.String())
-						if err != nil {
-							return err
-						}
+						d := v.Interface().(time.Duration)
 						field.Set(reflect.ValueOf(*ttnpb.ProtoDurationPtr(d)))
 					}
 				case ft.PkgPath() == "go.thethings.network/lorawan-stack/v3/pkg/ttnpb":


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #5156 

Calling `String()` on non-string values in `reflect.Value` will return `"<T value>"` string instead of what `(T) String()` would return. Duration is set directly to `time.Duration` unlike the `time.Time` for which we use string flag. We can use `Interface()` method directly because the `Value` field of the flag struct is exported so it won't panic.

#### Changes
<!-- What are the changes made in this pull request? -->

- Change how `time.Duration` is handled in `setField` for struct fields.


#### Testing

<!-- How did you verify that this change works? -->

🐒 

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Can't be worse than now.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This is an example of how messy the current flag - struct setting is. I've pushed to the branch the new generated flags where most of the `FieldFlags`and `FieldMaskFlags` references are removed --> https://github.com/TheThingsNetwork/lorawan-stack/tree/feature/protoc-gen-go-flags .

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
