### PR TITLE
Fix interop client validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Fixed
 
 - Device activation flow with a LoRaWAN Backend Interfaces 1.1 capable Join Server.
+  - Join Servers using Backend Interfaces 1.1 (protocol `BI1.1`) must be configured with a `sender-ns-id` containing the EUI of the Network Server.
 - Fix `time.Duration` flags in CLI.
 
 ### Security

--- a/config/messages.json
+++ b/config/messages.json
@@ -5858,7 +5858,7 @@
       "file": "errors.go"
     }
   },
-  "error:pkg/interop:missing_nsid": {
+  "error:pkg/interop:missing_ns_id": {
     "translations": {
       "en": "missing NSID"
     },
@@ -5921,7 +5921,7 @@
       "file": "errors.go"
     }
   },
-  "error:pkg/interop:nsid_not_supported": {
+  "error:pkg/interop:ns_id_not_supported": {
     "translations": {
       "en": "NSID not supported"
     },

--- a/pkg/interop/testdata/client/test-js-1.yml
+++ b/pkg/interop/testdata/client/test-js-1.yml
@@ -1,6 +1,7 @@
 fqdn: test-js.fqdn
 port: 12345
 protocol: BI1.1
+sender-ns-id: '1122334455667788'
 tls:
   root-ca: ../rootCA.pem
   certificate: ../clientcert.pem

--- a/pkg/interop/testdata/client/test-js-3.yml
+++ b/pkg/interop/testdata/client/test-js-3.yml
@@ -1,4 +1,4 @@
-dns: invalid.dns
+fqdn: localhost
 protocol: BI1.0
 paths:
   join: test-join-path

--- a/pkg/interop/testdata/client/test-js-4.yml
+++ b/pkg/interop/testdata/client/test-js-4.yml
@@ -1,7 +1,7 @@
 fqdn: localhost
 port: 9183
 protocol: BI1.1
-sender-nsid: 70B3D57ED0000001
+sender-ns-id: '70B3D57ED0000001'
 paths:
   app-s-key: test-app-s-key-path
   home-ns: test-home-ns-path


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Fixes interop client configuration

#### Changes
<!-- What are the changes made in this pull request? -->

- Rename `sender-nsid` to `sender-ns-id` to harmonize with upcoming DCS configuration cc @KrishnaIyer 
- Validate configuration when initializing a client. This stops TTS from starting if the config is invalid. This is a behavioral change. We believe it is better to see immediately why the interop client configuration is broken, than to find out at runtime

#### Testing

<!-- How did you verify that this change works? -->

Local testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

TTS deployments using wrong interop client configuration will fail on start with an error.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
