### PR TITLE
Support LR-FHSS uplinks

### DIFF
--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -632,7 +632,12 @@ macLoop:
 			return nil, false, nil
 		}
 	}
-	dev.MacState.RxWindowsAvailable = true
+	if isLRFHSS := up.GetSettings().GetDataRate().GetLrfhss() != nil; isLRFHSS {
+		dev.MacState.RxWindowsAvailable = false
+		dev.MacState.QueuedResponses = nil
+	} else {
+		dev.MacState.RxWindowsAvailable = true
+	}
 	dev.Session.LastFCntUp = cmacFMatchResult.FullFCnt
 
 	var queuedApplicationUplinks []*ttnpb.ApplicationUp
@@ -1294,6 +1299,12 @@ func (ns *NetworkServer) HandleUplink(ctx context.Context, up *ttnpb.UplinkMessa
 		logger = logger.WithFields(log.Fields(
 			"bandwidth", dr.Lora.GetBandwidth(),
 			"spreading_factor", dr.Lora.GetSpreadingFactor(),
+		))
+	case *ttnpb.DataRate_Lrfhss:
+		logger = logger.WithFields(log.Fields(
+			"modulation_type", dr.Lrfhss.GetModulationType(),
+			"coding_rate", dr.Lrfhss.GetCodingRate(),
+			"ocw", dr.Lrfhss.GetOperatingChannelWidth(),
 		))
 	default:
 		return nil, errDataRateNotFound.New()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #3806 
Replaces #4193

#### Changes
<!-- What are the changes made in this pull request? -->

- Do not open the RX1/RX2 windows if the datarate of the uplink is an LR-FHSS data rate
- Support (i.e. recognize) LR-FHSS datarates 


#### Testing

<!-- How did you verify that this change works? -->

Local testing with simulated uplink traffic.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
