### PR TITLE
Allow for multiple block creation for the same eui block type

### DIFF
--- a/pkg/identityserver/gormstore/eui_block.go
+++ b/pkg/identityserver/gormstore/eui_block.go
@@ -18,7 +18,7 @@ package store
 type EUIBlock struct {
 	Model
 
-	Type           string `gorm:"unique_index:eui_block_index;type:VARCHAR(10);"`
+	Type           string `gorm:"type:VARCHAR(10);"`
 	StartEUI       EUI64  `gorm:"type:VARCHAR(16);column:start_eui"`
 	MaxCounter     int64  `gorm:"type:BIGINT;column:end_counter"`
 	CurrentCounter int64  `gorm:"type:BIGINT;column:current_counter"`

--- a/pkg/identityserver/gormstore/migrations/entity_contacts.go
+++ b/pkg/identityserver/gormstore/migrations/entity_contacts.go
@@ -93,7 +93,3 @@ func (m EntityContacts) Apply(ctx context.Context, db *gorm.DB) error {
 func (m EntityContacts) Rollback(ctx context.Context, db *gorm.DB) error {
 	return nil
 }
-
-func init() {
-	All = append(All, EntityContacts{})
-}

--- a/pkg/identityserver/gormstore/migrations/eui_blocks_index.go
+++ b/pkg/identityserver/gormstore/migrations/eui_blocks_index.go
@@ -38,7 +38,3 @@ func (m EUIBlocksIndex) Apply(ctx context.Context, db *gorm.DB) error {
 func (m EUIBlocksIndex) Rollback(ctx context.Context, db *gorm.DB) error {
 	return db.Model(store.EUIBlock{}).AddUniqueIndex("eui_block_index", "type").Error
 }
-
-func init() {
-	All = append(All, EUIBlocksIndex{})
-}

--- a/pkg/identityserver/gormstore/migrations/eui_blocks_index.go
+++ b/pkg/identityserver/gormstore/migrations/eui_blocks_index.go
@@ -1,0 +1,44 @@
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/jinzhu/gorm"
+	store "go.thethings.network/lorawan-stack/v3/pkg/identityserver/gormstore"
+)
+
+// EUIBlocksIndex removes the unique index constraint from `type` field.
+type EUIBlocksIndex struct{}
+
+// Name implements Migration.
+func (EUIBlocksIndex) Name() string {
+	return "eui_blocks_index"
+}
+
+// Apply implements Migration.
+func (m EUIBlocksIndex) Apply(ctx context.Context, db *gorm.DB) error {
+	return db.Model(store.EUIBlock{}).RemoveIndex("eui_block_index").Error
+}
+
+// Rollback implements migration. It recreates the removed "eui_block_index".
+func (m EUIBlocksIndex) Rollback(ctx context.Context, db *gorm.DB) error {
+	return db.Model(store.EUIBlock{}).AddUniqueIndex("eui_block_index", "type").Error
+}
+
+func init() {
+	All = append(All, EUIBlocksIndex{})
+}

--- a/pkg/identityserver/gormstore/migrations/migration.go
+++ b/pkg/identityserver/gormstore/migrations/migration.go
@@ -60,3 +60,10 @@ func Apply(ctx context.Context, transact func(context.Context, func(*gorm.DB) er
 
 // All is a list of all database migrations.
 var All []Migration
+
+func init() {
+	All = append(All,
+		EntityContacts{},
+		EUIBlocksIndex{},
+	)
+}

--- a/pkg/identityserver/gormstore/populate.go
+++ b/pkg/identityserver/gormstore/populate.go
@@ -253,6 +253,9 @@ func (p *Populator) Populate(ctx context.Context, db *gorm.DB) (err error) {
 	if err = p.populateEndDevices(ctx, tx); err != nil {
 		return fmt.Errorf("failed to populate end devices: %w", err)
 	}
+	if err = p.populateDevEUIBlock(ctx, tx); err != nil {
+		return fmt.Errorf("failed to populate DevEUI block: %w", err)
+	}
 	return nil
 }
 
@@ -374,5 +377,12 @@ func (p *Populator) populateEndDevices(ctx context.Context, db *gorm.DB) (err er
 			return err
 		}
 	}
+	return nil
+}
+
+func (p *Populator) populateDevEUIBlock(ctx context.Context, db *gorm.DB) (err error) {
+	var euiBlock types.EUI64Prefix
+	euiBlock.UnmarshalConfigString("70B3D57ED0000000/36")
+	GetEUIStore(db).CreateEUIBlock(ctx, euiBlock, 0, "dev_eui")
 	return nil
 }

--- a/pkg/identityserver/identityserver.go
+++ b/pkg/identityserver/identityserver.go
@@ -171,19 +171,6 @@ func New(c *component.Component, config *Config) (is *IdentityServer, err error)
 		return nil, err
 	}
 
-	if is.config.DevEUIBlock.Enabled {
-		err := gormstore.Transact(is.Context(), is.db, func(db *gorm.DB) error {
-			err = gormstore.GetEUIStore(db).CreateEUIBlock(is.Context(), "dev_eui", is.config.DevEUIBlock.Prefix, is.config.DevEUIBlock.InitCounter)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	is.config.OAuth.CSRFAuthKey = is.GetBaseConfig(is.Context()).HTTP.Cookie.HashKey
 	is.config.OAuth.UI.FrontendConfig.EnableUserRegistration = is.config.UserRegistration.Enabled
 	is.oauth, err = oauth.NewServer(c, struct {

--- a/pkg/identityserver/identityserver_test.go
+++ b/pkg/identityserver/identityserver_test.go
@@ -28,7 +28,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/rpcmetadata"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
-	"go.thethings.network/lorawan-stack/v3/pkg/types"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
 	"google.golang.org/grpc"
 )
@@ -344,10 +343,7 @@ func getIdentityServer(t *testing.T) (*IdentityServer, *grpc.ClientConn) {
 	conf.UserRights.CreateGateways = true
 	conf.UserRights.CreateOrganizations = true
 	conf.AdminRights.All = true
-	var euiBlock types.EUI64Prefix
-	euiBlock.UnmarshalConfigString("70B3D57ED0000000/36")
 	conf.DevEUIBlock.Enabled = true
-	conf.DevEUIBlock.Prefix = euiBlock
 	conf.DevEUIBlock.ApplicationLimit = 3
 	conf.Network.NetID = test.DefaultNetID
 	conf.Network.TenantID = "test"

--- a/pkg/identityserver/store/store_interfaces.go
+++ b/pkg/identityserver/store/store_interfaces.go
@@ -19,6 +19,7 @@ import (
 
 	pbtypes "github.com/gogo/protobuf/types"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/types"
 	ttntypes "go.thethings.network/lorawan-stack/v3/pkg/types"
 )
 
@@ -219,6 +220,6 @@ type ContactInfoStore interface {
 
 // EUIStore interface for assigning DevEUI blocks and addresses
 type EUIStore interface {
-	CreateEUIBlock(ctx context.Context, euiType string, block ttntypes.EUI64Prefix, initCounterValue int64) (err error)
+	CreateEUIBlock(ctx context.Context, configPrefix types.EUI64Prefix, initCounter int64, euiType string) error
 	IssueDevEUIForApplication(ctx context.Context, id *ttnpb.ApplicationIdentifiers, applicationLimit int) (*ttntypes.EUI64, error)
 }

--- a/pkg/identityserver/storetest/eui_store.go
+++ b/pkg/identityserver/storetest/eui_store.go
@@ -15,6 +15,7 @@
 package storetest
 
 import (
+	"log"
 	. "testing"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
@@ -38,12 +39,12 @@ func (st *StoreTest) TestEUIStore(t *T) {
 		t.Fatal("Store does not implement EUIStore")
 	}
 
-	t.Run("CreateEUIBlock", func(t *T) {
+	t.Run("InitializeDevEUIBlock", func(t *T) {
 		a, ctx := test.New(t)
-		err := s.CreateEUIBlock(ctx, "dev_eui", types.EUI64Prefix{
+		err := s.CreateEUIBlock(ctx, types.EUI64Prefix{
 			EUI64:  types.EUI64{1, 1, 1, 1, 1, 1, 0, 0},
 			Length: 62,
-		}, 1)
+		}, 1, "dev_eui")
 		a.So(err, should.BeNil)
 	})
 
@@ -79,28 +80,26 @@ func (st *StoreTest) TestEUIStore(t *T) {
 		}
 		_, err = s.IssueDevEUIForApplication(ctx, app1.GetIds(), 3)
 		if a.So(err, should.NotBeNil) {
+			log.Println(err)
 			a.So(errors.IsInvalidArgument(err), should.BeTrue)
 		}
 	})
 
-	t.Run("CreateEUIBlock_Extra", func(t *T) {
-		// FIXME: CreateEUIBlock updates an EUI block instead of creating a new one (https://github.com/TheThingsNetwork/lorawan-stack/issues/5045).
-		t.Skip("CreateEUIBlock updates an EUI block instead of creating a new one")
-		// a, ctx := test.New(t)
-		// err := s.CreateEUIBlock(ctx, "dev_eui", types.EUI64Prefix{
-		// 	EUI64:  types.EUI64{1, 1, 1, 1, 1, 1, 1, 0},
-		// 	Length: 62,
-		// }, 0)
-		// a.So(err, should.BeNil)
+	t.Run("InitializeDevEUIBlock_Extra", func(t *T) {
+		a, ctx := test.New(t)
+		err := s.CreateEUIBlock(ctx, types.EUI64Prefix{
+			EUI64:  types.EUI64{1, 1, 1, 1, 0, 0, 0, 0},
+			Length: 32,
+		}, 0, "dev_eui")
+		a.So(err, should.BeNil)
 	})
 
-	t.Run("IssueDevEUIForApplication_ExtraBlock", func(t *T) {
-		// TODO: See CreateEUIBlock_Extra.
-		t.Skip("See CreateEUIBlock_Extra")
-		// a, ctx := test.New(t)
-		// eui, err := s.IssueDevEUIForApplication(ctx, app1.GetIds(), 3)
-		// if a.So(err, should.BeNil) && a.So(eui, should.NotBeNil) {
-		// 	a.So(*eui, should.Equal, types.EUI64{1, 1, 1, 1, 1, 1, 1, 0})
-		// }
+	t.Run("IssueDevEUIForApplication_Other", func(t *T) {
+		a, ctx := test.New(t)
+		eui, err := s.IssueDevEUIForApplication(ctx, app1.GetIds(), 5)
+		if a.So(err, should.BeNil) && a.So(eui, should.NotBeNil) {
+			a.So(*eui, should.Equal, types.EUI64{1, 1, 1, 1, 0, 0, 0, 0})
+		}
+		a.So(err, should.BeNil)
 	})
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #5045 

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove unique constraint and index for the `eui_type` field
- Updating config creates a new block, not overwriting the old one
- Issuing a dev block now selects all blocks that did not reach the limit, and picks a first one to issue DevEUI from


#### Testing

<!-- How did you verify that this change works? -->

unit

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

should be covered by tests

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This will require a migration because the `type` was unique

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
