### PR TITLE
Allow absolute time scheduling downlink tasks to fire early

### DIFF
--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -616,6 +616,7 @@ func (c *Connection) ScheduleDown(path *ttnpb.DownlinkPath, msg *ttnpb.DownlinkM
 			"rx_window", i+1,
 			"starts", em.Starts(),
 			"duration", em.Duration(),
+			"delay", delay,
 		)).Debug("Scheduled downlink")
 		break
 	}

--- a/pkg/gatewayserver/scheduling/scheduler.go
+++ b/pkg/gatewayserver/scheduling/scheduler.go
@@ -299,6 +299,10 @@ func (s *Scheduler) ScheduleAt(ctx context.Context, opts Options) (Emission, err
 			medianRTT = &median
 		}
 	}
+	log.FromContext(ctx).WithFields(log.Fields(
+		"median_rtt", medianRTT,
+		"min_schedule_time", minScheduleTime,
+	)).Debug("Computed scheduling delays")
 	var starts ConcentratorTime
 	now, ok := s.clock.FromServerTime(s.timeSource.Now())
 	if opts.Time != nil {
@@ -320,6 +324,10 @@ func (s *Scheduler) ScheduleAt(ctx context.Context, opts Options) (Emission, err
 		if err != nil {
 			return Emission{}, err
 		}
+		log.FromContext(ctx).WithFields(log.Fields(
+			"toa", toa,
+			"time", opts.Time,
+		)).Debug("Computed downlink time-on-air")
 		starts -= ConcentratorTime(toa)
 	} else {
 		starts = s.clock.FromTimestampTime(opts.Timestamp)
@@ -330,6 +338,12 @@ func (s *Scheduler) ScheduleAt(ctx context.Context, opts Options) (Emission, err
 				"delta", delta,
 				"min", minScheduleTime,
 			)
+		} else {
+			log.FromContext(ctx).WithFields(log.Fields(
+				"now", now,
+				"starts", starts,
+				"delta", delta,
+			)).Debug("Computed downlink start timestamp")
 		}
 	}
 	sb, err := s.findSubBand(opts.Frequency)

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -986,6 +986,7 @@ func (ns *NetworkServer) scheduleDownlinkByPaths(ctx context.Context, req *sched
 		logger.WithFields(log.Fields(
 			"transmission_delay", delay,
 			"transmit_at", transmitAt,
+			"absolute_time", ttnpb.StdTime(req.TxRequest.AbsoluteTime),
 		)).Debug("Scheduled downlink")
 		queuedEvents = append(queuedEvents, events.Builders(append([]events.Builder{
 			successEvent.With(

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -1871,15 +1871,15 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context, consumerID str
 							taskUpdateStrategy = nextDownlinkTask
 							return dev, nil, nil
 
-						case time.Until(slot.Time) > dev.MacState.CurrentParameters.Rx1Delay.Duration()+2*nsScheduleWindow():
+						case time.Until(slot.Time) > absoluteTimeSchedulingDelay+2*nsScheduleWindow():
 							logger.WithFields(log.Fields(
 								"slot_start", slot.Time,
 							)).Info("Class B/C downlink scheduling attempt performed too soon, retry attempt")
 							taskUpdateStrategy = nextDownlinkTask
 							return dev, nil, nil
 
-						case !slot.IsApplicationTime && slot.Class == ttnpb.Class_CLASS_B && time.Until(slot.Time) < dev.MacState.CurrentParameters.Rx1Delay.Duration()/2:
-							earliestAt = time.Now().Add(dev.MacState.CurrentParameters.Rx1Delay.Duration() / 2)
+						case !slot.IsApplicationTime && slot.Class == ttnpb.Class_CLASS_B && time.Until(slot.Time) < absoluteTimeSchedulingDelay/2:
+							earliestAt = time.Now().Add(absoluteTimeSchedulingDelay / 2)
 							continue
 						}
 						a := ns.attemptNetworkInitiatedDataDownlink(ctx, dev, phy, fp, slot, maxUpLength)

--- a/pkg/networkserver/downlink_test.go
+++ b/pkg/networkserver/downlink_test.go
@@ -257,7 +257,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 	if !ok {
 		t.Fatal("Failed to compute ping slot")
 	}
-	now := pingAt.Add(-DefaultEU868RX1Delay.Duration()/2 - 2*NSScheduleWindow())
+	now := pingAt.Add(-AbsoluteTimeSchedulingDelay/2 - 2*NSScheduleWindow())
 	clock := test.NewMockClock(now)
 	defer SetMockClock(clock)()
 
@@ -1988,7 +1988,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 							Priority:       ttnpb.TxSchedulePriority_HIGHEST,
 							SessionKeyId:   []byte{0x11, 0x22, 0x33, 0x44},
 							ClassBC: &ttnpb.ApplicationDownlink_ClassBC{
-								AbsoluteTime: ttnpb.ProtoTimePtr(now.Add(DefaultEU868RX1Delay.Duration())),
+								AbsoluteTime: ttnpb.ProtoTimePtr(now.Add(AbsoluteTimeSchedulingDelay)),
 							},
 						},
 					},
@@ -2036,7 +2036,7 @@ func TestProcessDownlinkTask(t *testing.T) {
 							Class:           ttnpb.Class_CLASS_C,
 							DownlinkPaths:   paths,
 							Priority:        ttnpb.TxSchedulePriority_HIGH,
-							AbsoluteTime:    ttnpb.ProtoTimePtr(now.Add(DefaultEU868RX1Delay.Duration())),
+							AbsoluteTime:    ttnpb.ProtoTimePtr(now.Add(AbsoluteTimeSchedulingDelay)),
 							Rx2DataRate:     rx2DataRateFromIndex(dev, a, t),
 							Rx2Frequency:    dev.MacState.CurrentParameters.Rx2Frequency,
 							FrequencyPlanId: dev.FrequencyPlanId,

--- a/pkg/networkserver/grpc_asns.go
+++ b/pkg/networkserver/grpc_asns.go
@@ -190,7 +190,7 @@ func matchApplicationDownlinks(session *ttnpb.Session, macState *ttnpb.MACState,
 		case multicast && len(down.GetClassBC().GetGateways()) == 0:
 			return unmatched, errNoPath.New()
 
-		case down.GetClassBC().GetAbsoluteTime() != nil && ttnpb.StdTime(down.GetClassBC().GetAbsoluteTime()).Before(time.Now().Add(macState.CurrentParameters.Rx1Delay.Duration()/2)):
+		case down.GetClassBC().GetAbsoluteTime() != nil && ttnpb.StdTime(down.GetClassBC().GetAbsoluteTime()).Before(time.Now().Add(absoluteTimeSchedulingDelay/2)):
 			return unmatched, errExpiredDownlink.New()
 		}
 		minFCnt = down.FCnt + 1

--- a/pkg/networkserver/networkserver_util_internal_test.go
+++ b/pkg/networkserver/networkserver_util_internal_test.go
@@ -49,11 +49,12 @@ import (
 )
 
 const (
-	DownlinkProcessTaskName = downlinkProcessTaskName
-	DownlinkRetryInterval   = downlinkRetryInterval
-	InfrastructureDelay     = infrastructureDelay
-	RecentDownlinkCount     = recentDownlinkCount
-	RecentUplinkCount       = recentUplinkCount
+	DownlinkProcessTaskName     = downlinkProcessTaskName
+	DownlinkRetryInterval       = downlinkRetryInterval
+	AbsoluteTimeSchedulingDelay = absoluteTimeSchedulingDelay
+	InfrastructureDelay         = infrastructureDelay
+	RecentDownlinkCount         = recentDownlinkCount
+	RecentUplinkCount           = recentUplinkCount
 )
 
 var (


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/4933
References https://github.com/TheThingsNetwork/lorawan-stack/issues/4990

#### Changes
<!-- What are the changes made in this pull request? -->

- Allow absolute time downlink tasks to fire earlier than `now-Rx1`
  - The original fix in #4933 allowed the task to be scheduled earlier, but an additional condition did not allow the task to actually run
  - Tested as part of the ongoing https://github.com/TheThingsIndustries/lorawan-stack-support/issues/714 issue
- Add additional logging statements for debugging purposes for https://github.com/TheThingsNetwork/lorawan-stack/issues/4990 / https://github.com/TheThingsIndustries/lorawan-stack-support/issues/714


#### Testing

<!-- How did you verify that this change works? -->

Unit testing + integration testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

As before, this is quite broken already for multicast on high SF due to the fact that absolute time scheduling uses the absolute time as the end of transmission.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@KrishnaIyer this is the same patch that we've tested with CE, with some extra debugging statements added. 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
