### PR TITLE
Check Join EUI from flags before using JS default

### DIFF
--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -455,7 +455,7 @@ var (
 						paths = append(paths,
 							"join_server_address",
 						)
-						if device.Ids.JoinEui == nil {
+						if devID.JoinEui == nil {
 							// Get the default JoinEUI for JS.
 							logger.WithField("join_server_address", config.JoinServerGRPCAddress).Info("JoinEUI empty but defaults flag is set, fetch default JoinEUI of the Join Server")
 							js, err := api.Dial(ctx, config.JoinServerGRPCAddress)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #5140 

#### Changes
<!-- What are the changes made in this pull request? -->

- Check Join EUI from flags before using JS default

#### Testing

<!-- How did you verify that this change works? -->

**Before:**
```bash
tti-lw-cli end-devices create test-app dev1   --join-eui 1234567812345678 --dev-eui 1234567812345678 --root-keys.app-key.key 12345678765432121234567898765432
WARN	Using insecure connection to OAuth server
WARN	Using insecure connection to API
INFO	JoinEUI empty but defaults flag is set, fetch default JoinEUI of the Join Server	{"join_server_address": "localhost:1884"}
INFO	Successfully obtained Join Server's default JoinEUI	{"default_join_eui": "1122334455667788"}
{
  "ids": {
    "device_id": "dev1",
    "application_ids": {
      "application_id": "test-app"
    },
    "dev_eui": "1234567812345678",
    "join_eui": "1234567812345678"
  },
  "created_at": "2022-02-10T09:33:16.155Z",
  "updated_at": "2022-02-10T09:33:16.328061Z",
  "attributes": {},
  "network_server_address": "localhost",
  "application_server_address": "localhost",
  "join_server_address": "localhost",
  "supports_join": true,
  "root_keys": {
    "app_key": {
      "key": "12345678765432121234567898765432"
    }
  }
}
```

**After:**
```bash
./ttn-lw-cli end-devices create test-app dev2   --join-eui 1234567812345679 --dev-eui 1234567812345679 --root-keys.app-key.key 12345678765432121234567898765432
WARN	Using insecure connection to OAuth server
WARN	Using insecure connection to API
{
  "ids": {
    "device_id": "dev2",
    "application_ids": {
      "application_id": "test-app"
    },
    "dev_eui": "1234567812345679",
    "join_eui": "1234567812345679"
  },
  "created_at": "2022-02-10T09:36:07.550Z",
  "updated_at": "2022-02-10T09:36:07.707582Z",
  "attributes": {},
  "network_server_address": "localhost",
  "application_server_address": "localhost",
  "join_server_address": "localhost",
  "supports_join": true,
  "root_keys": {
    "app_key": {
      "key": "12345678765432121234567898765432"
    }
  }
}
```

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Test for fetching default Join EUI
```bash
 ./ttn-lw-cli end-devices create test-app dev3  --dev-eui 1134567812345679 --root-keys.app-key.key 12345678765432121234567898765432
WARN	Using insecure connection to OAuth server
WARN	Using insecure connection to API
INFO	JoinEUI empty but defaults flag is set, fetch default JoinEUI of the Join Server	{"join_server_address": "localhost:1884"}
INFO	Successfully obtained Join Server's default JoinEUI	{"default_join_eui": "1122334455667788"}
{
  "ids": {
    "device_id": "dev3",
    "application_ids": {
      "application_id": "test-app"
    },
    "dev_eui": "1134567812345679",
    "join_eui": "1122334455667788"
  },
  "created_at": "2022-02-10T09:38:35.322Z",
  "updated_at": "2022-02-10T09:38:35.517143Z",
  "attributes": {},
  "network_server_address": "localhost",
  "application_server_address": "localhost",
  "join_server_address": "localhost",
  "supports_join": true,
  "root_keys": {
    "app_key": {
      "key": "12345678765432121234567898765432"
    }
  }
}
```

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
