### PR TITLE
Use FNV-1a for payload hashing

### DIFF
--- a/pkg/networkserver/redis/redis.go
+++ b/pkg/networkserver/redis/redis.go
@@ -17,10 +17,10 @@ package redis
 
 import (
 	"encoding/base64"
+	"hash/fnv"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	ttnredis "go.thethings.network/lorawan-stack/v3/pkg/redis"
-	"golang.org/x/crypto/sha3"
 )
 
 type keyer interface {
@@ -38,7 +38,7 @@ func uidLastInvalidationKey(r keyer, uid string) string {
 var keyEncoding = base64.RawStdEncoding
 
 func uplinkPayloadHash(b []byte) string {
-	h := sha3.New224()
+	h := fnv.New64a()
 	_, _ = h.Write(b)
 	return keyEncoding.EncodeToString(h.Sum(nil))
 }

--- a/pkg/ttnpb/applicationserver_integrations_storage.go
+++ b/pkg/ttnpb/applicationserver_integrations_storage.go
@@ -14,6 +14,17 @@
 
 package ttnpb
 
+var (
+	_ interface {
+		IDStringer
+		ExtractRequestFields(dst map[string]interface{})
+	} = (*GetStoredApplicationUpRequest)(nil)
+	_ interface {
+		IDStringer
+		ExtractRequestFields(dst map[string]interface{})
+	} = (*GetStoredApplicationUpCountRequest)(nil)
+)
+
 // StoredApplicationUpTypes is a list of available ApplicationUp message types.
 var StoredApplicationUpTypes = map[string]struct{}{
 	"":                           {},
@@ -41,6 +52,31 @@ func (m *GetStoredApplicationUpRequest) WithApplicationIds(ids *ApplicationIdent
 	return m
 }
 
+// EntityType implements IDStringer.
+func (m *GetStoredApplicationUpRequest) EntityType() string {
+	if ids := m.GetEndDeviceIds(); !ids.IsZero() {
+		return ids.EntityType()
+	}
+	return m.GetApplicationIds().EntityType()
+}
+
+// IDString implements IDStringer.
+func (m *GetStoredApplicationUpRequest) IDString() string {
+	if ids := m.GetEndDeviceIds(); !ids.IsZero() {
+		return ids.IDString()
+	}
+	return m.GetApplicationIds().IDString()
+}
+
+// ExtractRequestFields is used by github.com/grpc-ecosystem/go-grpc-middleware/tags.
+func (m *GetStoredApplicationUpRequest) ExtractRequestFields(dst map[string]interface{}) {
+	if ids := m.GetEndDeviceIds(); !ids.IsZero() {
+		ids.ExtractRequestFields(dst)
+		return
+	}
+	m.GetApplicationIds().ExtractRequestFields(dst)
+}
+
 // WithEndDeviceIds returns the request with set EndDeviceIdentifiers.
 func (m *GetStoredApplicationUpCountRequest) WithEndDeviceIds(ids *EndDeviceIdentifiers) *GetStoredApplicationUpCountRequest {
 	m.EndDeviceIds = ids
@@ -51,4 +87,29 @@ func (m *GetStoredApplicationUpCountRequest) WithEndDeviceIds(ids *EndDeviceIden
 func (m *GetStoredApplicationUpCountRequest) WithApplicationIds(ids *ApplicationIdentifiers) *GetStoredApplicationUpCountRequest {
 	m.ApplicationIds = ids
 	return m
+}
+
+// EntityType implements IDStringer.
+func (m *GetStoredApplicationUpCountRequest) EntityType() string {
+	if ids := m.GetEndDeviceIds(); !ids.IsZero() {
+		return ids.EntityType()
+	}
+	return m.GetApplicationIds().EntityType()
+}
+
+// IDString implements IDStringer.
+func (m *GetStoredApplicationUpCountRequest) IDString() string {
+	if ids := m.GetEndDeviceIds(); !ids.IsZero() {
+		return ids.IDString()
+	}
+	return m.GetApplicationIds().IDString()
+}
+
+// ExtractRequestFields is used by github.com/grpc-ecosystem/go-grpc-middleware/tags.
+func (m *GetStoredApplicationUpCountRequest) ExtractRequestFields(dst map[string]interface{}) {
+	if ids := m.GetEndDeviceIds(); !ids.IsZero() {
+		ids.ExtractRequestFields(dst)
+		return
+	}
+	m.GetApplicationIds().ExtractRequestFields(dst)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Partially reverts https://github.com/TheThingsNetwork/lorawan-stack/pull/4574

#### Changes
<!-- What are the changes made in this pull request? -->

- Revert back to FNV-1a from SHA3-224
  - At the time when this change was introduced, the line of thought was that perhaps we encounter hash collisions for the payloads. This proved to be false - https://github.com/TheThingsIndustries/lorawan-stack/pull/2925 .
  - This change should raise the uplink throughput per NS instance, as SHA3 is an expensive hash function to use due to its cryptographic properties. Expected raw hashing throughput is 6-7x (per https://github.com/rurban/smhasher , not 100% applicable but gives a raw idea).
- Explicitly implement and check that the `ttnpb.IDStringer` interface is implemented by the storage integration requests
  - This is required for rate limiting per entity


#### Testing

<!-- How did you verify that this change works? -->

The old hash function has been battle tested for a year before the change, and the interface checks verify that the message explicitly implements the interface.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
