### PR TITLE
JavaScript ahead of time compilation support

### DIFF
--- a/pkg/messageprocessors/cayennelpp/cayennelpp.go
+++ b/pkg/messageprocessors/cayennelpp/cayennelpp.go
@@ -32,7 +32,7 @@ type host struct{}
 type decodedMap map[string]interface{}
 
 // New creates and returns a new CayenneLPP payload encoder and decoder.
-func New() messageprocessors.PayloadEncodeDecoder {
+func New() messageprocessors.PayloadEncoderDecoder {
 	return &host{}
 }
 

--- a/pkg/messageprocessors/devicerepository/devicerepository.go
+++ b/pkg/messageprocessors/devicerepository/devicerepository.go
@@ -41,7 +41,7 @@ const (
 	// cacheErrorTTL is the TTL for cached payload formatters, when there was an error retrieving them.
 	cacheErrorTTL = 5 * time.Minute
 	// cacheSize is the cache size.
-	cacheSize = 500
+	cacheSize = 4096
 )
 
 type PayloadFormatter interface {

--- a/pkg/messageprocessors/devicerepository/devicerepository.go
+++ b/pkg/messageprocessors/devicerepository/devicerepository.go
@@ -44,39 +44,46 @@ const (
 	cacheSize = 4096
 )
 
-type PayloadFormatter interface {
-	GetFormatter() ttnpb.PayloadFormatter
-	GetFormatterParameter() string
-}
-
 // Cluster represents the interface the cluster.
 type Cluster interface {
 	GetPeerConn(ctx context.Context, role ttnpb.ClusterRole, ids cluster.EntityIdentifiers) (*grpc.ClientConn, error)
 	WithClusterAuth() grpc.CallOption
 }
 
-// cacheItem stores the payload formatter as well as the error response.
+// PayloadEncoderDecoderProvider provides a messageprocessors.PayloadEncoderDecoder
+// for the provided formatter.
+type PayloadEncoderDecoderProvider interface {
+	GetPayloadEncoderDecoder(ctx context.Context, formatter ttnpb.PayloadFormatter) (messageprocessors.PayloadEncoderDecoder, error)
+}
+
+// cacheProcessors stores the payload processors.
+type cacheProcessors struct {
+	uplinkProcessor   func(context.Context, *ttnpb.EndDeviceIdentifiers, *ttnpb.EndDeviceVersionIdentifiers, *ttnpb.ApplicationUplink) error
+	downlinkProcessor func(context.Context, *ttnpb.EndDeviceIdentifiers, *ttnpb.EndDeviceVersionIdentifiers, *ttnpb.ApplicationDownlink) error
+}
+
+// cacheItem stores the payload processors as well as the error response.
 type cacheItem struct {
-	formatter PayloadFormatter
-	err       error
+	processors *cacheProcessors
+	err        error
 }
 
 type host struct {
 	ctx context.Context
 
-	cluster   Cluster
-	processor messageprocessors.PayloadProcessor
+	cluster  Cluster
+	provider PayloadEncoderDecoderProvider
 
 	singleflight singleflight.Group
 	cache        gcache.Cache
 }
 
-// New creates a new PayloadEncodeDecoder that retrieves codecs from the Device Repository
-// and uses an underlying PayloadEncodeDecoder to execute them.
-func New(processor messageprocessors.PayloadProcessor, cluster Cluster) messageprocessors.PayloadEncodeDecoder {
+// New creates a new PayloadEncoderDecoder that retrieves codecs from the Device Repository
+// and uses an underlying PayloadEncoderDecoder to execute them.
+func New(provider PayloadEncoderDecoderProvider, cluster Cluster) messageprocessors.PayloadEncoderDecoder {
 	return &host{
-		cluster:   cluster,
-		processor: processor,
+		cluster:  cluster,
+		provider: provider,
 
 		cache: gcache.New(cacheSize).LFU().Build(),
 	}
@@ -88,14 +95,14 @@ func cacheKey(codec codecType, version *ttnpb.EndDeviceVersionIdentifiers) strin
 
 var errNoVersionIdentifiers = errors.DefineInvalidArgument("no_version_identifiers", "no version identifiers for device")
 
-func (h *host) retrieve(ctx context.Context, codec codecType, ids *ttnpb.ApplicationIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers) (PayloadFormatter, error) {
+func (h *host) retrieve(ctx context.Context, codec codecType, ids *ttnpb.ApplicationIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers) (*cacheProcessors, error) {
 	if version == nil {
 		return nil, errNoVersionIdentifiers.New()
 	}
 	key := cacheKey(codec, version)
 	if cachedInterface, err := h.cache.Get(key); err == nil {
-		cached := cachedInterface.(cacheItem)
-		return cached.formatter, cached.err
+		cached := cachedInterface.(*cacheItem)
+		return cached.processors, cached.err
 	}
 	cc, err := h.cluster.GetPeerConn(ctx, ttnpb.ClusterRole_DEVICE_REPOSITORY, nil)
 	if err != nil {
@@ -103,8 +110,11 @@ func (h *host) retrieve(ctx context.Context, codec codecType, ids *ttnpb.Applica
 	}
 	result, err, _ := h.singleflight.Do(key, func() (interface{}, error) {
 		var (
-			formatter PayloadFormatter
-			err       error
+			formatter interface {
+				GetFormatter() ttnpb.PayloadFormatter
+				GetFormatterParameter() string
+			}
+			err error
 		)
 		req := &ttnpb.GetPayloadFormatterRequest{
 			ApplicationIds: ids,
@@ -121,20 +131,84 @@ func (h *host) retrieve(ctx context.Context, codec codecType, ids *ttnpb.Applica
 		default:
 			panic(fmt.Sprintf("Invalid codec type: %v", codec))
 		}
-
+		var cachedProcessors *cacheProcessors
+		if err == nil {
+			cachedProcessors, err = h.compileProcessor(ctx, codec, formatter.GetFormatter(), formatter.GetFormatterParameter())
+		}
 		expire := cacheTTL
 		if err != nil {
 			expire = cacheErrorTTL
 		}
-		if err := h.cache.SetWithExpire(key, cacheItem{formatter, err}, expire); err != nil {
+		if err := h.cache.SetWithExpire(key, &cacheItem{cachedProcessors, err}, expire); err != nil {
 			log.FromContext(h.ctx).WithError(err).Error("Failed to cache payload formatter")
 		}
-		return formatter, err
+		return cachedProcessors, err
 	})
 	if err != nil {
 		return nil, err
 	}
-	return result.(PayloadFormatter), nil
+	return result.(*cacheProcessors), nil
+}
+
+func (h *host) compileProcessor(ctx context.Context, codec codecType, formatter ttnpb.PayloadFormatter, parameter string) (*cacheProcessors, error) {
+	encoderDecoder, err := h.provider.GetPayloadEncoderDecoder(ctx, formatter)
+	if err != nil {
+		return nil, err
+	}
+
+	if compilableEncoderDecoder, canCompile := encoderDecoder.(messageprocessors.CompilablePayloadEncoderDecoder); canCompile {
+		switch codec {
+		case downlinkDecoder:
+			run, err := compilableEncoderDecoder.CompileDownlinkDecoder(ctx, parameter)
+			if err != nil {
+				return nil, err
+			}
+			return &cacheProcessors{
+				downlinkProcessor: run,
+			}, nil
+		case downlinkEncoder:
+			run, err := compilableEncoderDecoder.CompileDownlinkEncoder(ctx, parameter)
+			if err != nil {
+				return nil, err
+			}
+			return &cacheProcessors{
+				downlinkProcessor: run,
+			}, nil
+		case uplinkDecoder:
+			run, err := compilableEncoderDecoder.CompileUplinkDecoder(ctx, parameter)
+			if err != nil {
+				return nil, err
+			}
+			return &cacheProcessors{
+				uplinkProcessor: run,
+			}, nil
+		default:
+			panic(fmt.Sprintf("Invalid codec type: %v", codec))
+		}
+	}
+
+	switch codec {
+	case downlinkDecoder:
+		return &cacheProcessors{
+			downlinkProcessor: func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationDownlink) error {
+				return encoderDecoder.DecodeDownlink(ctx, ids, version, message, parameter)
+			},
+		}, nil
+	case downlinkEncoder:
+		return &cacheProcessors{
+			downlinkProcessor: func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationDownlink) error {
+				return encoderDecoder.EncodeDownlink(ctx, ids, version, message, parameter)
+			},
+		}, nil
+	case uplinkDecoder:
+		return &cacheProcessors{
+			uplinkProcessor: func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationUplink) error {
+				return encoderDecoder.DecodeUplink(ctx, ids, version, message, parameter)
+			},
+		}, nil
+	default:
+		panic(fmt.Sprintf("Invalid codec type: %v", codec))
+	}
 }
 
 // EncodeDownlink encodes a downlink message.
@@ -143,7 +217,7 @@ func (h *host) EncodeDownlink(ctx context.Context, ids *ttnpb.EndDeviceIdentifie
 	if err != nil {
 		return err
 	}
-	return h.processor.EncodeDownlink(ctx, ids, version, message, res.GetFormatter(), res.GetFormatterParameter())
+	return res.downlinkProcessor(ctx, ids, version, message)
 }
 
 // DecodeUplink decodes an uplink message.
@@ -152,7 +226,7 @@ func (h *host) DecodeUplink(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers
 	if err != nil {
 		return err
 	}
-	return h.processor.DecodeUplink(ctx, ids, version, message, res.GetFormatter(), res.GetFormatterParameter())
+	return res.uplinkProcessor(ctx, ids, version, message)
 }
 
 // DecodeDownlink decodes a downlink message.
@@ -161,5 +235,5 @@ func (h *host) DecodeDownlink(ctx context.Context, ids *ttnpb.EndDeviceIdentifie
 	if err != nil {
 		return err
 	}
-	return h.processor.DecodeDownlink(ctx, ids, version, message, res.GetFormatter(), res.GetFormatterParameter())
+	return res.downlinkProcessor(ctx, ids, version, message)
 }

--- a/pkg/messageprocessors/devicerepository/devicerepository_test.go
+++ b/pkg/messageprocessors/devicerepository/devicerepository_test.go
@@ -27,6 +27,7 @@ import (
 	componenttest "go.thethings.network/lorawan-stack/v3/pkg/component/test"
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/messageprocessors"
 	dr_processor "go.thethings.network/lorawan-stack/v3/pkg/messageprocessors/devicerepository"
 	"go.thethings.network/lorawan-stack/v3/pkg/rpcserver"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -34,41 +35,55 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
 )
 
-// mockProcessor is a mock messageprocessors.PayloadEncodeDecoder
-type mockProcessor struct {
-	ch chan dr_processor.PayloadFormatter
+type mockEncoderDecoder struct {
+	encodeDownlink func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationDownlink, parameter string) error
+	decodeUplink   func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationUplink, parameter string) error
+	decodeDownlink func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationDownlink, parameter string) error
+}
+
+func (m mockEncoderDecoder) EncodeDownlink(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationDownlink, parameter string) error {
+	return m.encodeDownlink(ctx, ids, version, message, parameter)
+}
+
+func (m mockEncoderDecoder) DecodeUplink(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationUplink, parameter string) error {
+	return m.decodeUplink(ctx, ids, version, message, parameter)
+}
+
+func (m mockEncoderDecoder) DecodeDownlink(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationDownlink, parameter string) error {
+	return m.decodeDownlink(ctx, ids, version, message, parameter)
+}
+
+type mockCompilableEncoderDecoder struct {
+	mockEncoderDecoder
+
+	compileDownlinkEncoder func(ctx context.Context, parameter string) (func(context.Context, *ttnpb.EndDeviceIdentifiers, *ttnpb.EndDeviceVersionIdentifiers, *ttnpb.ApplicationDownlink) error, error)
+	compileUplinkDecoder   func(ctx context.Context, parameter string) (func(context.Context, *ttnpb.EndDeviceIdentifiers, *ttnpb.EndDeviceVersionIdentifiers, *ttnpb.ApplicationUplink) error, error)
+	compileDownlinkDecoder func(ctx context.Context, parameter string) (func(context.Context, *ttnpb.EndDeviceIdentifiers, *ttnpb.EndDeviceVersionIdentifiers, *ttnpb.ApplicationDownlink) error, error)
+}
+
+func (m mockCompilableEncoderDecoder) CompileDownlinkEncoder(ctx context.Context, parameter string) (func(context.Context, *ttnpb.EndDeviceIdentifiers, *ttnpb.EndDeviceVersionIdentifiers, *ttnpb.ApplicationDownlink) error, error) {
+	return m.compileDownlinkEncoder(ctx, parameter)
+}
+
+func (m mockCompilableEncoderDecoder) CompileUplinkDecoder(ctx context.Context, parameter string) (func(context.Context, *ttnpb.EndDeviceIdentifiers, *ttnpb.EndDeviceVersionIdentifiers, *ttnpb.ApplicationUplink) error, error) {
+	return m.compileUplinkDecoder(ctx, parameter)
+}
+
+func (m mockCompilableEncoderDecoder) CompileDownlinkDecoder(ctx context.Context, parameter string) (func(context.Context, *ttnpb.EndDeviceIdentifiers, *ttnpb.EndDeviceVersionIdentifiers, *ttnpb.ApplicationDownlink) error, error) {
+	return m.compileDownlinkDecoder(ctx, parameter)
+}
+
+type mockProvider struct {
+	processor messageprocessors.PayloadEncoderDecoder
 
 	err error
 }
 
-func (p *mockProcessor) EncodeDownlink(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationDownlink, formatter ttnpb.PayloadFormatter, parameter string) error {
-	if p.err == nil {
-		p.ch <- &ttnpb.MessagePayloadEncoder{
-			Formatter:          formatter,
-			FormatterParameter: parameter,
-		}
+func (m mockProvider) GetPayloadEncoderDecoder(ctx context.Context, formatter ttnpb.PayloadFormatter) (messageprocessors.PayloadEncoderDecoder, error) {
+	if m.err != nil {
+		return nil, m.err
 	}
-	return p.err
-}
-
-func (p *mockProcessor) DecodeUplink(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationUplink, formatter ttnpb.PayloadFormatter, parameter string) error {
-	if p.err == nil {
-		p.ch <- &ttnpb.MessagePayloadDecoder{
-			Formatter:          formatter,
-			FormatterParameter: parameter,
-		}
-	}
-	return p.err
-}
-
-func (p *mockProcessor) DecodeDownlink(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationDownlink, formatter ttnpb.PayloadFormatter, parameter string) error {
-	if p.err == nil {
-		p.ch <- &ttnpb.MessagePayloadDecoder{
-			Formatter:          formatter,
-			FormatterParameter: parameter,
-		}
-	}
-	return p.err
+	return m.processor, nil
 }
 
 type mockDR struct {
@@ -150,7 +165,7 @@ func mustHavePeer(ctx context.Context, c *component.Component, role ttnpb.Cluste
 }
 
 func TestDeviceRepository(t *testing.T) {
-	ids := &ttnpb.EndDeviceVersionIdentifiers{
+	versionIDs := &ttnpb.EndDeviceVersionIdentifiers{
 		BrandId:         "brand",
 		ModelId:         "model",
 		FirmwareVersion: "1.0",
@@ -164,7 +179,7 @@ func TestDeviceRepository(t *testing.T) {
 		HardwareVersion: "1.1",
 		BandId:          "band",
 	}
-	devID := &ttnpb.EndDeviceIdentifiers{
+	devIDs := &ttnpb.EndDeviceIdentifiers{
 		DeviceId: "dev1",
 		ApplicationIds: &ttnpb.ApplicationIdentifiers{
 			ApplicationId: "app1",
@@ -176,25 +191,21 @@ func TestDeviceRepository(t *testing.T) {
 		downlinkDecoders: make(map[string]*ttnpb.MessagePayloadDecoder),
 		downlinkEncoders: make(map[string]*ttnpb.MessagePayloadEncoder),
 	}
-	dr.uplinkDecoders[dr.key(ids)] = &ttnpb.MessagePayloadDecoder{
+	dr.uplinkDecoders[dr.key(versionIDs)] = &ttnpb.MessagePayloadDecoder{
 		Formatter:          ttnpb.PayloadFormatter_FORMATTER_JAVASCRIPT,
 		FormatterParameter: "uplink decoder",
 	}
-	dr.downlinkDecoders[dr.key(ids)] = &ttnpb.MessagePayloadDecoder{
+	dr.downlinkDecoders[dr.key(versionIDs)] = &ttnpb.MessagePayloadDecoder{
 		Formatter:          ttnpb.PayloadFormatter_FORMATTER_JAVASCRIPT,
 		FormatterParameter: "downlink decoder",
 	}
-	dr.downlinkEncoders[dr.key(ids)] = &ttnpb.MessagePayloadEncoder{
+	dr.downlinkEncoders[dr.key(versionIDs)] = &ttnpb.MessagePayloadEncoder{
 		Formatter:          ttnpb.PayloadFormatter_FORMATTER_JAVASCRIPT,
 		FormatterParameter: "downlink encoder",
 	}
 	drAddr := dr.start(test.Context())
 
 	ctx := test.Context()
-	mockProcessor := &mockProcessor{
-		ch:  make(chan dr_processor.PayloadFormatter, 1),
-		err: nil,
-	}
 
 	// start mock device repository
 	c := componenttest.NewComponent(t, &component.Config{
@@ -213,94 +224,226 @@ func TestDeviceRepository(t *testing.T) {
 
 	mustHavePeer(ctx, c, ttnpb.ClusterRole_DEVICE_REPOSITORY)
 
-	p := dr_processor.New(mockProcessor, c)
-
 	t.Run("NilDeviceIdentifiers", func(t *testing.T) {
-		err := p.DecodeDownlink(test.Context(), devID, nil, nil, "")
-		assertions.New(t).So(errors.IsInvalidArgument(err), should.BeTrue)
+		p := dr_processor.New(&mockProvider{}, c)
 
-		select {
-		case <-mockProcessor.ch:
-			t.Error("Expected timeout but processor was called instead")
-			t.FailNow()
-		case <-time.After(30 * time.Millisecond):
-		}
+		err := p.DecodeDownlink(test.Context(), devIDs, nil, nil, "")
+		assertions.New(t).So(errors.IsInvalidArgument(err), should.BeTrue)
 	})
 
 	t.Run("DeviceNotFound", func(t *testing.T) {
-		err := p.DecodeDownlink(test.Context(), devID, idsNotFound, nil, "")
+		p := dr_processor.New(&mockProvider{}, c)
+
+		err := p.DecodeDownlink(test.Context(), devIDs, idsNotFound, nil, "")
 		a := assertions.New(t)
 		a.So(err.Error(), should.ContainSubstring, errMock.Error())
-
-		select {
-		case <-mockProcessor.ch:
-			t.Error("Expected timeout but processor was called instead")
-			t.FailNow()
-		case <-time.After(30 * time.Millisecond):
-		}
 	})
 
-	t.Run("UplinkDecoder", func(t *testing.T) {
-		err := p.DecodeUplink(test.Context(), devID, ids, nil, "")
+	t.Run("UplinkDecoder-Simple", func(t *testing.T) {
 		a := assertions.New(t)
+
+		called := false
+		mockProvider := &mockProvider{
+			processor: mockEncoderDecoder{
+				decodeUplink: func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationUplink, parameter string) error {
+					a.So(ids, should.Resemble, devIDs)
+					a.So(version, should.Resemble, versionIDs)
+					a.So(message, should.BeNil)
+					a.So(parameter, should.Equal, "uplink decoder")
+
+					called = true
+
+					return nil
+				},
+			},
+		}
+		p := dr_processor.New(mockProvider, c)
+
+		err := p.DecodeUplink(test.Context(), devIDs, versionIDs, nil, "")
 		a.So(err, should.BeNil)
 
-		select {
-		case f := <-mockProcessor.ch:
-			a.So(f, should.Resemble, &ttnpb.MessagePayloadDecoder{
-				Formatter:          ttnpb.PayloadFormatter_FORMATTER_JAVASCRIPT,
-				FormatterParameter: "uplink decoder",
-			})
-		case <-time.After(time.Second):
-			t.Error("Timed out waiting for message processor")
-			t.FailNow()
-		}
+		a.So(called, should.BeTrue)
 	})
-
-	t.Run("DownlinkDecoder", func(t *testing.T) {
-		err := p.DecodeDownlink(test.Context(), devID, ids, nil, "")
+	t.Run("UplinkDecoder-Compile", func(t *testing.T) {
 		a := assertions.New(t)
+
+		calledCompile := false
+		calledRun := false
+		mockProvider := mockProvider{
+			processor: mockCompilableEncoderDecoder{
+				mockEncoderDecoder: mockEncoderDecoder{
+					decodeUplink: func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationUplink, parameter string) error {
+						t.Error("Direct uplink decoder should not be called")
+						return nil
+					},
+				},
+				compileUplinkDecoder: func(ctx context.Context, parameter string) (func(context.Context, *ttnpb.EndDeviceIdentifiers, *ttnpb.EndDeviceVersionIdentifiers, *ttnpb.ApplicationUplink) error, error) {
+					a.So(parameter, should.Equal, "uplink decoder")
+
+					calledCompile = true
+
+					return func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationUplink) error {
+						a.So(ids, should.Resemble, devIDs)
+						a.So(version, should.Resemble, versionIDs)
+						a.So(message, should.BeNil)
+
+						calledRun = true
+
+						return nil
+					}, nil
+				},
+			},
+		}
+		p := dr_processor.New(mockProvider, c)
+
+		err := p.DecodeUplink(test.Context(), devIDs, versionIDs, nil, "")
 		a.So(err, should.BeNil)
 
-		select {
-		case f := <-mockProcessor.ch:
-			a.So(f, should.Resemble, &ttnpb.MessagePayloadDecoder{
-				Formatter:          ttnpb.PayloadFormatter_FORMATTER_JAVASCRIPT,
-				FormatterParameter: "downlink decoder",
-			})
-		case <-time.After(time.Second):
-			t.Error("Timed out waiting for message processor")
-			t.FailNow()
-		}
+		a.So(calledCompile, should.BeTrue)
+		a.So(calledRun, should.BeTrue)
 	})
-	t.Run("DownlinkEncoder", func(t *testing.T) {
-		err := p.EncodeDownlink(test.Context(), devID, ids, nil, "")
+
+	t.Run("DownlinkDecoder-Simple", func(t *testing.T) {
 		a := assertions.New(t)
+
+		called := false
+		mockProvider := &mockProvider{
+			processor: mockEncoderDecoder{
+				decodeDownlink: func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationDownlink, parameter string) error {
+					a.So(ids, should.Resemble, devIDs)
+					a.So(version, should.Resemble, versionIDs)
+					a.So(message, should.BeNil)
+					a.So(parameter, should.Equal, "downlink decoder")
+
+					called = true
+
+					return nil
+				},
+			},
+		}
+		p := dr_processor.New(mockProvider, c)
+
+		err := p.DecodeDownlink(test.Context(), devIDs, versionIDs, nil, "")
 		a.So(err, should.BeNil)
 
-		select {
-		case f := <-mockProcessor.ch:
-			a.So(f, should.Resemble, &ttnpb.MessagePayloadEncoder{
-				Formatter:          ttnpb.PayloadFormatter_FORMATTER_JAVASCRIPT,
-				FormatterParameter: "downlink encoder",
-			})
-		case <-time.After(time.Second):
-			t.Error("Timed out waiting for message processor")
-			t.FailNow()
-		}
+		a.So(called, should.BeTrue)
 	})
-
-	t.Run("ProcessorError", func(t *testing.T) {
-		mockProcessor.err = errMock
+	t.Run("DownlinkDecoder-Compile", func(t *testing.T) {
 		a := assertions.New(t)
 
-		err := p.DecodeDownlink(test.Context(), devID, ids, nil, "")
-		a.So(err.Error(), should.ContainSubstring, errMock.Error())
-		err = p.DecodeUplink(test.Context(), devID, ids, nil, "")
-		a.So(err.Error(), should.ContainSubstring, errMock.Error())
-		err = p.EncodeDownlink(test.Context(), devID, ids, nil, "")
-		a.So(err.Error(), should.ContainSubstring, errMock.Error())
+		calledCompile := false
+		calledRun := false
+		mockProvider := mockProvider{
+			processor: mockCompilableEncoderDecoder{
+				mockEncoderDecoder: mockEncoderDecoder{
+					decodeDownlink: func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationDownlink, parameter string) error {
+						t.Error("Direct downlink decoder should not be called")
+						return nil
+					},
+				},
+				compileDownlinkDecoder: func(ctx context.Context, parameter string) (func(context.Context, *ttnpb.EndDeviceIdentifiers, *ttnpb.EndDeviceVersionIdentifiers, *ttnpb.ApplicationDownlink) error, error) {
+					a.So(parameter, should.Equal, "downlink decoder")
 
-		mockProcessor.err = nil
+					calledCompile = true
+
+					return func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationDownlink) error {
+						a.So(ids, should.Resemble, devIDs)
+						a.So(version, should.Resemble, versionIDs)
+						a.So(message, should.BeNil)
+
+						calledRun = true
+
+						return nil
+					}, nil
+				},
+			},
+		}
+		p := dr_processor.New(mockProvider, c)
+
+		err := p.DecodeDownlink(test.Context(), devIDs, versionIDs, nil, "")
+		a.So(err, should.BeNil)
+
+		a.So(calledCompile, should.BeTrue)
+		a.So(calledRun, should.BeTrue)
+	})
+
+	t.Run("DownlinkEncoder-Simple", func(t *testing.T) {
+		a := assertions.New(t)
+
+		called := false
+		mockProvider := &mockProvider{
+			processor: mockEncoderDecoder{
+				encodeDownlink: func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationDownlink, parameter string) error {
+					a.So(ids, should.Resemble, devIDs)
+					a.So(version, should.Resemble, versionIDs)
+					a.So(message, should.BeNil)
+					a.So(parameter, should.Equal, "downlink encoder")
+
+					called = true
+
+					return nil
+				},
+			},
+		}
+		p := dr_processor.New(mockProvider, c)
+
+		err := p.EncodeDownlink(test.Context(), devIDs, versionIDs, nil, "")
+		a.So(err, should.BeNil)
+
+		a.So(called, should.BeTrue)
+	})
+	t.Run("DownlinkEncoder-Compile", func(t *testing.T) {
+		a := assertions.New(t)
+
+		calledCompile := false
+		calledRun := false
+		mockProvider := mockProvider{
+			processor: mockCompilableEncoderDecoder{
+				mockEncoderDecoder: mockEncoderDecoder{
+					encodeDownlink: func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationDownlink, parameter string) error {
+						t.Error("Direct downlink encoder should not be called")
+						return nil
+					},
+				},
+				compileDownlinkEncoder: func(ctx context.Context, parameter string) (func(context.Context, *ttnpb.EndDeviceIdentifiers, *ttnpb.EndDeviceVersionIdentifiers, *ttnpb.ApplicationDownlink) error, error) {
+					a.So(parameter, should.Equal, "downlink encoder")
+
+					calledCompile = true
+
+					return func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationDownlink) error {
+						a.So(ids, should.Resemble, devIDs)
+						a.So(version, should.Resemble, versionIDs)
+						a.So(message, should.BeNil)
+
+						calledRun = true
+
+						return nil
+					}, nil
+				},
+			},
+		}
+		p := dr_processor.New(mockProvider, c)
+
+		err := p.EncodeDownlink(test.Context(), devIDs, versionIDs, nil, "")
+		a.So(err, should.BeNil)
+
+		a.So(calledCompile, should.BeTrue)
+		a.So(calledRun, should.BeTrue)
+	})
+
+	t.Run("ProviderError", func(t *testing.T) {
+		mockProvider := mockProvider{
+			err: errMock,
+		}
+		p := dr_processor.New(mockProvider, c)
+
+		a := assertions.New(t)
+
+		err := p.DecodeDownlink(test.Context(), devIDs, versionIDs, nil, "")
+		a.So(err.Error(), should.ContainSubstring, errMock.Error())
+		err = p.DecodeUplink(test.Context(), devIDs, versionIDs, nil, "")
+		a.So(err.Error(), should.ContainSubstring, errMock.Error())
+		err = p.EncodeDownlink(test.Context(), devIDs, versionIDs, nil, "")
+		a.So(err.Error(), should.ContainSubstring, errMock.Error())
 	})
 }

--- a/pkg/messageprocessors/payload.go
+++ b/pkg/messageprocessors/payload.go
@@ -28,6 +28,16 @@ type PayloadEncodeDecoder interface {
 	DecodeDownlink(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationDownlink, parameter string) error
 }
 
+// CompilablePayloadEncoderDecoder extends PayloadEncodeDecoder with the ability
+// to compile the parameters ahead of time.
+type CompilablePayloadEncoderDecoder interface {
+	PayloadEncodeDecoder
+
+	CompileDownlinkEncoder(ctx context.Context, parameter string) (func(context.Context, *ttnpb.EndDeviceIdentifiers, *ttnpb.EndDeviceVersionIdentifiers, *ttnpb.ApplicationDownlink) error, error)
+	CompileUplinkDecoder(ctx context.Context, parameter string) (func(context.Context, *ttnpb.EndDeviceIdentifiers, *ttnpb.EndDeviceVersionIdentifiers, *ttnpb.ApplicationUplink) error, error)
+	CompileDownlinkDecoder(ctx context.Context, parameter string) (func(context.Context, *ttnpb.EndDeviceIdentifiers, *ttnpb.EndDeviceVersionIdentifiers, *ttnpb.ApplicationDownlink) error, error)
+}
+
 // PayloadProcessor provides an interface to processing payloads of multiple formats.
 type PayloadProcessor interface {
 	EncodeDownlink(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationDownlink, formatter ttnpb.PayloadFormatter, parameter string) error

--- a/pkg/messageprocessors/payload.go
+++ b/pkg/messageprocessors/payload.go
@@ -21,17 +21,17 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 )
 
-// PayloadEncodeDecoder provides an interface to encoding and decoding messages.
-type PayloadEncodeDecoder interface {
+// PayloadEncoderDecoder provides an interface to encoding and decoding messages.
+type PayloadEncoderDecoder interface {
 	EncodeDownlink(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationDownlink, parameter string) error
 	DecodeUplink(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationUplink, parameter string) error
 	DecodeDownlink(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationDownlink, parameter string) error
 }
 
-// CompilablePayloadEncoderDecoder extends PayloadEncodeDecoder with the ability
+// CompilablePayloadEncoderDecoder extends PayloadEncoderDecoder with the ability
 // to compile the parameters ahead of time.
 type CompilablePayloadEncoderDecoder interface {
-	PayloadEncodeDecoder
+	PayloadEncoderDecoder
 
 	CompileDownlinkEncoder(ctx context.Context, parameter string) (func(context.Context, *ttnpb.EndDeviceIdentifiers, *ttnpb.EndDeviceVersionIdentifiers, *ttnpb.ApplicationDownlink) error, error)
 	CompileUplinkDecoder(ctx context.Context, parameter string) (func(context.Context, *ttnpb.EndDeviceIdentifiers, *ttnpb.EndDeviceVersionIdentifiers, *ttnpb.ApplicationUplink) error, error)
@@ -45,8 +45,8 @@ type PayloadProcessor interface {
 	DecodeDownlink(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, version *ttnpb.EndDeviceVersionIdentifiers, message *ttnpb.ApplicationDownlink, formatter ttnpb.PayloadFormatter, parameter string) error
 }
 
-// MapPayloadProcessor implements PayloadProcessor using a mapping between ttnpb.PayloadFormatter and PayloadEncodeDecoder.
-type MapPayloadProcessor map[ttnpb.PayloadFormatter]PayloadEncodeDecoder
+// MapPayloadProcessor implements PayloadProcessor using a mapping between ttnpb.PayloadFormatter and PayloadEncoderDecoder.
+type MapPayloadProcessor map[ttnpb.PayloadFormatter]PayloadEncoderDecoder
 
 var errFormatterNotConfigured = errors.DefineFailedPrecondition("formatter_not_configured", "formatter `{formatter}` is not configured")
 
@@ -84,4 +84,13 @@ func (p MapPayloadProcessor) DecodeDownlink(ctx context.Context, ids *ttnpb.EndD
 		return err
 	}
 	return nil
+}
+
+// GetPayloadEncoderDecoder returns the underlying PayloadEncoderDecoder for the provided format.
+func (p MapPayloadProcessor) GetPayloadEncoderDecoder(ctx context.Context, formatter ttnpb.PayloadFormatter) (PayloadEncoderDecoder, error) {
+	mp, ok := p[formatter]
+	if !ok {
+		return nil, errFormatterNotConfigured.WithAttributes("formatter", formatter)
+	}
+	return mp, nil
 }

--- a/pkg/scripting/engine.go
+++ b/pkg/scripting/engine.go
@@ -22,3 +22,10 @@ import (
 type Engine interface {
 	Run(ctx context.Context, script, fn string, params ...interface{}) (func(target interface{}) error, error)
 }
+
+// AheadOfTimeEngine extends Engine with the capability of compiling the script ahead of time.
+type AheadOfTimeEngine interface {
+	Engine
+
+	Compile(ctx context.Context, script string) (run func(context.Context, string, ...interface{}) (func(interface{}) error, error), err error)
+}

--- a/pkg/scripting/javascript/metrics.go
+++ b/pkg/scripting/javascript/metrics.go
@@ -21,23 +21,44 @@ import (
 
 const subsystem = "javascript"
 
-var runs = metrics.NewCounterVec(
-	prometheus.CounterOpts{
-		Subsystem: subsystem,
-		Name:      "runs_total",
-		Help:      "JavaScript runs",
-	},
-	[]string{"result"},
-)
-
-var runLatency = metrics.NewHistogram(
-	prometheus.HistogramOpts{
-		Subsystem: subsystem,
-		Name:      "run_latency_seconds",
-		Help:      "Histogram of latency (seconds) of JavaScript runs",
-	},
+var (
+	compilations = metrics.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "compilations_total",
+			Help:      "JavaScript compilations",
+		},
+		[]string{"result"},
+	)
+	compilationsLatency = metrics.NewHistogram(
+		prometheus.HistogramOpts{
+			Subsystem: subsystem,
+			Name:      "compilations_latency_seconds",
+			Help:      "Histogram of latency (seconds) of JavaScript compilations",
+		},
+	)
+	runs = metrics.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "runs_total",
+			Help:      "JavaScript runs",
+		},
+		[]string{"result"},
+	)
+	runLatency = metrics.NewHistogram(
+		prometheus.HistogramOpts{
+			Subsystem: subsystem,
+			Name:      "run_latency_seconds",
+			Help:      "Histogram of latency (seconds) of JavaScript runs",
+		},
+	)
 )
 
 func init() {
-	metrics.MustRegister(runs, runLatency)
+	metrics.MustRegister(
+		compilations,
+		compilationsLatency,
+		runs,
+		runLatency,
+	)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/722

#### Changes
<!-- What are the changes made in this pull request? -->

- Add support for ahead of time compilation of JavaScript scripts in the JavaScript scripting engine
- Introduce the concept of _compilable_ payload encoder/decoders
  - The JavaScript payload encoder/decoders implement this concept, using the JS engine support
- Device Repository payload encoding / decoding now supports compiling the scripts ahead of time
  - The scripts are compiled upon retrieval, then the compiled program is cached - the parsing cost is paid only once

#### Testing

<!-- How did you verify that this change works? -->

Unit testing. Reworked the device repository payload encoding / decoding tests.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This affects the payload encoding / decoding chain, and unit tests and local testing should cover this.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- Why isn't running a script just a compile + run ? Why are there two different paths ?
  - In order to enforce the execution time limit of 100ms of compile + run. Otherwise, the 100ms would apply only to the run part, not the compilation, which would be a regression from the previous behavior.
  - Note that it is impossible to actually interrupt the compilation of a script, even when using `RunString`, because the compilation part of `RunString` is not affected by the fact that the VM was interrupted. Our current semantics are that if the compilation takes more than 100ms, we won't run the resulting compiled script, but the time per uplink still has the compilation time as an upper bound, not 100ms.
- What about JavaScript that is not coming from the Device Repository ?
  - I have a plan here, but it is outside the scope of this issue (timeouts for Device Repository scripts)
  - Basically, if we store the hash for the parameter, we could cache by hash. In this way, we don't have to pay the hashing cost each uplink, because we know the hash and update it in the store. We only need some minimal changes in order to achieve this, such as generating the hash on `Set`, and having a migration that generates the hash for existing entries.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
