### PR TITLE
Always queue application uplinks

### DIFF
--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -1602,7 +1602,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context, consumerID str
 		defer func() { publishEvents(ctx, queuedEvents...) }()
 
 		var queuedApplicationUplinks []*ttnpb.ApplicationUp
-		defer func() { ns.submitApplicationUplinks(ctx, queuedApplicationUplinks...) }()
+		defer func() { ns.enqueueApplicationUplinks(ctx, queuedApplicationUplinks...) }()
 
 		taskUpdateStrategy := noDownlinkTask
 		dev, ctx, err := ns.devices.SetByID(ctx, devID.ApplicationIds, devID.DeviceId,

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -882,7 +882,7 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 	}
 
 	var queuedApplicationUplinks []*ttnpb.ApplicationUp
-	defer func() { ns.submitApplicationUplinks(ctx, queuedApplicationUplinks...) }()
+	defer func() { ns.enqueueApplicationUplinks(ctx, queuedApplicationUplinks...) }()
 
 	stored, _, err := ns.devices.SetByID(ctx, matched.Device.Ids.ApplicationIds, matched.Device.Ids.DeviceId, handleDataUplinkGetPaths[:],
 		func(ctx context.Context, stored *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
@@ -1371,6 +1371,6 @@ func (ns *NetworkServer) ReportTxAcknowledgment(ctx context.Context, txAck *ttnp
 			},
 		}
 	}
-	ns.submitApplicationUplinks(ctx, appUp)
+	ns.enqueueApplicationUplinks(ctx, appUp)
 	return ttnpb.Empty, nil
 }

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -35,7 +35,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/task"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
-	"go.thethings.network/lorawan-stack/v3/pkg/workerpool"
 	"google.golang.org/grpc"
 )
 
@@ -132,8 +131,6 @@ type NetworkServer struct {
 	downlinkQueueCapacity int
 
 	scheduledDownlinkMatcher ScheduledDownlinkMatcher
-
-	uplinkSubmissionPool workerpool.WorkerPool
 }
 
 // Option configures the NetworkServer.
@@ -231,12 +228,6 @@ func New(c *component.Component, conf *Config, opts ...Option) (*NetworkServer, 
 		downlinkQueueCapacity:    conf.DownlinkQueueCapacity,
 		scheduledDownlinkMatcher: conf.ScheduledDownlinkMatcher,
 	}
-	ns.uplinkSubmissionPool = workerpool.NewWorkerPool(workerpool.Config{
-		Component: c,
-		Context:   ctx,
-		Name:      "uplink_submission",
-		Handler:   ns.handleUplinkSubmission,
-	})
 	ctx = ns.Context()
 
 	if len(opts) == 0 {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Reverts https://github.com/TheThingsNetwork/lorawan-stack/pull/4485

This short PR removes the so called 'short-path' that the Network Server uses while submitting uplinks to the Application Server. The issue with this short-path is that it encourages very high concurrency values, which adds too much overhead to the Network Server process.

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove the short-path, always enqueue the uplinks


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Should not occur. This method encourages batch processing, and was used before https://github.com/TheThingsNetwork/lorawan-stack/pull/4485 without any issues.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
