### PR TITLE
Add pagination test to IS store tests

### DIFF
--- a/pkg/identityserver/gormstore/store_test.go
+++ b/pkg/identityserver/gormstore/store_test.go
@@ -141,6 +141,7 @@ func TestAPIKeyStore(t *testing.T) {
 
 	st := storetest.New(t, newTestStore)
 	st.TestAPIKeyStoreCRUD(t)
+	st.TestAPIKeyStorePagination(t)
 }
 
 func TestMembershipStore(t *testing.T) {

--- a/pkg/identityserver/gormstore/store_test.go
+++ b/pkg/identityserver/gormstore/store_test.go
@@ -134,6 +134,7 @@ func TestUserSessionStore(t *testing.T) {
 
 	st := storetest.New(t, newTestStore)
 	st.TestUserSessionStore(t)
+	st.TestUserSessionStorePagination(t)
 }
 
 func TestAPIKeyStore(t *testing.T) {

--- a/pkg/identityserver/gormstore/store_test.go
+++ b/pkg/identityserver/gormstore/store_test.go
@@ -86,6 +86,7 @@ func TestApplicationStore(t *testing.T) {
 
 	st := storetest.New(t, newTestStore)
 	st.TestApplicationStoreCRUD(t)
+	st.TestApplicationStorePagination(t)
 }
 
 func TestClientStore(t *testing.T) {
@@ -93,6 +94,7 @@ func TestClientStore(t *testing.T) {
 
 	st := storetest.New(t, newTestStore)
 	st.TestClientStoreCRUD(t)
+	st.TestClientStorePagination(t)
 }
 
 func TestEndDeviceStore(t *testing.T) {
@@ -107,6 +109,7 @@ func TestGatewayStore(t *testing.T) {
 
 	st := storetest.New(t, newTestStore)
 	st.TestGatewayStoreCRUD(t)
+	st.TestGatewayStorePagination(t)
 }
 
 func TestOrganizationStore(t *testing.T) {
@@ -114,6 +117,7 @@ func TestOrganizationStore(t *testing.T) {
 
 	st := storetest.New(t, newTestStore)
 	st.TestOrganizationStoreCRUD(t)
+	st.TestOrganizationStorePagination(t)
 }
 
 func TestUserStore(t *testing.T) {
@@ -121,6 +125,7 @@ func TestUserStore(t *testing.T) {
 
 	st := storetest.New(t, newTestStore)
 	st.TestUserStoreCRUD(t)
+	st.TestUserStorePagination(t)
 }
 
 func TestUserSessionStore(t *testing.T) {

--- a/pkg/identityserver/gormstore/store_test.go
+++ b/pkg/identityserver/gormstore/store_test.go
@@ -197,4 +197,5 @@ func TestEntitySearch(t *testing.T) {
 
 	st := storetest.New(t, newTestStore)
 	st.TestEntitySearch(t)
+	st.TestEntitySearchPagination(t)
 }

--- a/pkg/identityserver/gormstore/store_test.go
+++ b/pkg/identityserver/gormstore/store_test.go
@@ -102,6 +102,7 @@ func TestEndDeviceStore(t *testing.T) {
 
 	st := storetest.New(t, newTestStore)
 	st.TestEndDeviceStoreCRUD(t)
+	st.TestEndDeviceStorePagination(t)
 }
 
 func TestGatewayStore(t *testing.T) {

--- a/pkg/identityserver/gormstore/store_test.go
+++ b/pkg/identityserver/gormstore/store_test.go
@@ -164,6 +164,7 @@ func TestInvitationStore(t *testing.T) {
 
 	st := storetest.New(t, newTestStore)
 	st.TestInvitationStore(t)
+	st.TestInvitationStorePagination(t)
 }
 
 func TestLoginTokenStore(t *testing.T) {

--- a/pkg/identityserver/gormstore/store_test.go
+++ b/pkg/identityserver/gormstore/store_test.go
@@ -180,6 +180,7 @@ func TestOAuthStore(t *testing.T) {
 
 	st := storetest.New(t, newTestStore)
 	st.TestOAuthStore(t)
+	st.TestOAuthStorePagination(t)
 }
 
 func TestEUIStore(t *testing.T) {

--- a/pkg/identityserver/gormstore/store_test.go
+++ b/pkg/identityserver/gormstore/store_test.go
@@ -149,6 +149,7 @@ func TestMembershipStore(t *testing.T) {
 
 	st := storetest.New(t, newTestStore)
 	st.TestMembershipStoreCRUD(t)
+	st.TestMembershipStorePagination(t)
 }
 
 func TestContactInfoStore(t *testing.T) {

--- a/pkg/identityserver/storetest/application_store.go
+++ b/pkg/identityserver/storetest/application_store.go
@@ -267,4 +267,44 @@ func (st *StoreTest) TestApplicationStoreCRUD(t *T) {
 	})
 }
 
-// TODO: Test Pagination (https://github.com/TheThingsNetwork/lorawan-stack/issues/5047).
+func (st *StoreTest) TestApplicationStorePagination(t *T) {
+	usr1 := st.population.NewUser()
+
+	var all []*ttnpb.Application
+	for i := 0; i < 7; i++ {
+		all = append(all, st.population.NewApplication(usr1.GetOrganizationOrUserIdentifiers()))
+	}
+
+	s, ok := st.PrepareDB(t).(interface {
+		Store
+		is.ApplicationStore
+	})
+	defer st.DestroyDB(t, false)
+	defer s.Close()
+	if !ok {
+		t.Fatal("Store does not implement ApplicationStore")
+	}
+
+	t.Run("FindApplications_Paginated", func(t *T) {
+		a, ctx := test.New(t)
+
+		var total uint64
+		for _, page := range []uint32{1, 2, 3, 4} {
+			paginateCtx := store.WithPagination(ctx, 2, page, &total)
+
+			got, err := s.FindApplications(paginateCtx, nil, fieldMask(ttnpb.ApplicationFieldPathsTopLevel...))
+			if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
+				if page == 4 {
+					a.So(got, should.HaveLength, 1)
+				} else {
+					a.So(got, should.HaveLength, 2)
+				}
+				for i, e := range got {
+					a.So(e, should.Resemble, all[i+2*int(page-1)])
+				}
+			}
+
+			a.So(total, should.Equal, 7)
+		}
+	})
+}

--- a/pkg/identityserver/storetest/contact_info_store.go
+++ b/pkg/identityserver/storetest/contact_info_store.go
@@ -239,5 +239,3 @@ func (st *StoreTest) TestContactInfoStoreCRUD(t *T) {
 		})
 	}
 }
-
-// TODO: Test Pagination (https://github.com/TheThingsNetwork/lorawan-stack/issues/5047).

--- a/pkg/identityserver/storetest/gateway_store.go
+++ b/pkg/identityserver/storetest/gateway_store.go
@@ -422,4 +422,44 @@ func (st *StoreTest) TestGatewayStoreCRUD(t *T) {
 	})
 }
 
-// TODO: Test Pagination (https://github.com/TheThingsNetwork/lorawan-stack/issues/5047).
+func (st *StoreTest) TestGatewayStorePagination(t *T) {
+	usr1 := st.population.NewUser()
+
+	var all []*ttnpb.Gateway
+	for i := 0; i < 7; i++ {
+		all = append(all, st.population.NewGateway(usr1.GetOrganizationOrUserIdentifiers()))
+	}
+
+	s, ok := st.PrepareDB(t).(interface {
+		Store
+		is.GatewayStore
+	})
+	defer st.DestroyDB(t, false)
+	defer s.Close()
+	if !ok {
+		t.Fatal("Store does not implement GatewayStore")
+	}
+
+	t.Run("FindGateways_Paginated", func(t *T) {
+		a, ctx := test.New(t)
+
+		var total uint64
+		for _, page := range []uint32{1, 2, 3, 4} {
+			paginateCtx := store.WithPagination(ctx, 2, page, &total)
+
+			got, err := s.FindGateways(paginateCtx, nil, fieldMask(ttnpb.GatewayFieldPathsTopLevel...))
+			if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
+				if page == 4 {
+					a.So(got, should.HaveLength, 1)
+				} else {
+					a.So(got, should.HaveLength, 2)
+				}
+				for i, e := range got {
+					a.So(e, should.Resemble, all[i+2*int(page-1)])
+				}
+			}
+
+			a.So(total, should.Equal, 7)
+		}
+	})
+}

--- a/pkg/identityserver/storetest/oauth_store.go
+++ b/pkg/identityserver/storetest/oauth_store.go
@@ -15,10 +15,12 @@
 package storetest
 
 import (
+	"fmt"
 	. "testing"
 	"time"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/identityserver/store"
 	is "go.thethings.network/lorawan-stack/v3/pkg/identityserver/store"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
@@ -353,4 +355,98 @@ func (st *StoreTest) TestOAuthStore(t *T) {
 	})
 }
 
-// TODO: Test Pagination (https://github.com/TheThingsNetwork/lorawan-stack/issues/5047).
+func (st *StoreTest) TestOAuthStorePagination(t *T) {
+	a, ctx := test.New(t)
+
+	usr1 := st.population.NewUser()
+
+	var clients []*ttnpb.Client
+	for i := 0; i < 7; i++ {
+		clients = append(clients, st.population.NewClient(usr1.GetOrganizationOrUserIdentifiers()))
+	}
+
+	s, ok := st.PrepareDB(t).(interface {
+		Store
+		is.OAuthStore
+	})
+	defer st.DestroyDB(t, false)
+	defer s.Close()
+	if !ok {
+		t.Fatal("Store does not implement OAuthStore")
+	}
+
+	var authorizations []*ttnpb.OAuthClientAuthorization
+	for i := 0; i < 7; i++ {
+		created, err := s.Authorize(ctx, &ttnpb.OAuthClientAuthorization{
+			UserIds:   usr1.GetIds(),
+			ClientIds: clients[i].GetIds(),
+		})
+		if !a.So(err, should.BeNil) {
+			t.FailNow()
+		}
+		authorizations = append(authorizations, created)
+
+		time.Sleep(test.Delay) // The tests depend on sorting by created_at, so we don't want multiple authorizations with the same time.
+	}
+
+	var accessTokens []*ttnpb.OAuthAccessToken
+	for i := 0; i < 7; i++ {
+		created, err := s.CreateAccessToken(ctx, &ttnpb.OAuthAccessToken{
+			UserIds:   usr1.GetIds(),
+			ClientIds: clients[0].GetIds(),
+			Id:        fmt.Sprintf("TOKEN%d", i+1),
+		}, "")
+		if !a.So(err, should.BeNil) {
+			t.FailNow()
+		}
+		accessTokens = append(accessTokens, created)
+
+		time.Sleep(test.Delay) // The tests depend on sorting by created_at, so we don't want multiple tokens with the same time.
+	}
+
+	t.Run("ListAuthorizations_Paginated", func(t *T) {
+		a, ctx := test.New(t)
+
+		var total uint64
+		for _, page := range []uint32{1, 2, 3, 4} {
+			paginateCtx := store.WithPagination(store.WithOrder(ctx, "created_at"), 2, page, &total)
+
+			got, err := s.ListAuthorizations(paginateCtx, usr1.GetIds())
+			if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
+				if page == 4 {
+					a.So(got, should.HaveLength, 1)
+				} else {
+					a.So(got, should.HaveLength, 2)
+				}
+				for i, e := range got {
+					a.So(e, should.Resemble, authorizations[i+2*int(page-1)])
+				}
+			}
+
+			a.So(total, should.Equal, 7)
+		}
+	})
+
+	t.Run("ListAccessTokens_Paginated", func(t *T) {
+		a, ctx := test.New(t)
+
+		var total uint64
+		for _, page := range []uint32{1, 2, 3, 4} {
+			paginateCtx := store.WithPagination(store.WithOrder(ctx, "created_at"), 2, page, &total)
+
+			got, err := s.ListAccessTokens(paginateCtx, usr1.GetIds(), clients[0].GetIds())
+			if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
+				if page == 4 {
+					a.So(got, should.HaveLength, 1)
+				} else {
+					a.So(got, should.HaveLength, 2)
+				}
+				for i, e := range got {
+					a.So(e, should.Resemble, accessTokens[i+2*int(page-1)])
+				}
+			}
+
+			a.So(total, should.Equal, 7)
+		}
+	})
+}

--- a/pkg/identityserver/storetest/organization_store.go
+++ b/pkg/identityserver/storetest/organization_store.go
@@ -267,4 +267,44 @@ func (st *StoreTest) TestOrganizationStoreCRUD(t *T) {
 	})
 }
 
-// TODO: Test Pagination (https://github.com/TheThingsNetwork/lorawan-stack/issues/5047).
+func (st *StoreTest) TestOrganizationStorePagination(t *T) {
+	usr1 := st.population.NewUser()
+
+	var all []*ttnpb.Organization
+	for i := 0; i < 7; i++ {
+		all = append(all, st.population.NewOrganization(usr1.GetOrganizationOrUserIdentifiers()))
+	}
+
+	s, ok := st.PrepareDB(t).(interface {
+		Store
+		is.OrganizationStore
+	})
+	defer st.DestroyDB(t, false)
+	defer s.Close()
+	if !ok {
+		t.Fatal("Store does not implement OrganizationStore")
+	}
+
+	t.Run("FindOrganizations_Paginated", func(t *T) {
+		a, ctx := test.New(t)
+
+		var total uint64
+		for _, page := range []uint32{1, 2, 3, 4} {
+			paginateCtx := store.WithPagination(ctx, 2, page, &total)
+
+			got, err := s.FindOrganizations(paginateCtx, nil, fieldMask(ttnpb.OrganizationFieldPathsTopLevel...))
+			if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
+				if page == 4 {
+					a.So(got, should.HaveLength, 1)
+				} else {
+					a.So(got, should.HaveLength, 2)
+				}
+				for i, e := range got {
+					a.So(e, should.Resemble, all[i+2*int(page-1)])
+				}
+			}
+
+			a.So(total, should.Equal, 7)
+		}
+	})
+}

--- a/pkg/identityserver/storetest/storetest.go
+++ b/pkg/identityserver/storetest/storetest.go
@@ -179,4 +179,6 @@ func (s *StoreTest) DestroyDB(t *testing.T, assertClean bool, exceptions ...stri
 	}
 
 	t.Logf("Destroyed schema %s in %s", schemaName, time.Since(start))
+
+	s.population = &Population{}
 }

--- a/pkg/identityserver/storetest/user_store.go
+++ b/pkg/identityserver/storetest/user_store.go
@@ -355,4 +355,42 @@ func (st *StoreTest) TestUserStoreCRUD(t *T) {
 	})
 }
 
-// TODO: Test Pagination (https://github.com/TheThingsNetwork/lorawan-stack/issues/5047).
+func (st *StoreTest) TestUserStorePagination(t *T) {
+	var all []*ttnpb.User
+	for i := 0; i < 7; i++ {
+		all = append(all, st.population.NewUser())
+	}
+
+	s, ok := st.PrepareDB(t).(interface {
+		Store
+		is.UserStore
+	})
+	defer st.DestroyDB(t, false)
+	defer s.Close()
+	if !ok {
+		t.Fatal("Store does not implement UserStore")
+	}
+
+	t.Run("FindUsers_Paginated", func(t *T) {
+		a, ctx := test.New(t)
+
+		var total uint64
+		for _, page := range []uint32{1, 2, 3, 4} {
+			paginateCtx := store.WithPagination(ctx, 2, page, &total)
+
+			got, err := s.FindUsers(paginateCtx, nil, fieldMask(ttnpb.UserFieldPathsTopLevel...))
+			if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
+				if page == 4 {
+					a.So(got, should.HaveLength, 1)
+				} else {
+					a.So(got, should.HaveLength, 2)
+				}
+				for i, e := range got {
+					a.So(e, should.Resemble, all[i+2*int(page-1)])
+				}
+			}
+
+			a.So(total, should.Equal, 7)
+		}
+	})
+}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request adds a number of unit tests to the Identity Server to test that pagination in the stores works as expected.

Closes #5047

#### Changes
<!-- What are the changes made in this pull request? -->

- Added a bunch of tests
- Couple of small changes in population tooling

#### Testing

<!-- How did you verify that this change works? -->

`go test`

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None expected. This only touches test code.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- Removed the TODO from ContactInfoStore (which currently doesn't have pagination).

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
