### PR TITLE
Move custom webhook option to top of the list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Changed
 
 - The minimum required Redis version is now 6.2.
+- The custom webhook option is now shown at the top of the list in the Console when adding new webhooks.
 
 ### Deprecated
 - Gateway Server setting `gs.update-connection-stats-debounce-time` is no longer valid.

--- a/pkg/webui/console/views/application-integrations-webhook-add-choose/application-integrations-webhook-add-choose.js
+++ b/pkg/webui/console/views/application-integrations-webhook-add-choose/application-integrations-webhook-add-choose.js
@@ -70,13 +70,13 @@ const WebhookChooser = props => {
         </Col>
       </Row>
       <Row gutterWidth={15} className={style.tileRow}>
-        {webhookTemplates.map(WebhookTile)}
         <WebhookTile
           ids={{ template_id: 'custom' }}
           name="Custom webhook"
           description={m.customTileDescription}
           logo_url={BlankWebhookImg}
         />
+        {webhookTemplates.map(WebhookTile)}
       </Row>
     </Container>
   )


### PR DESCRIPTION
#### Summary
Quickfix PR to move the custom webhook option to the top of the list.

#### Changes
- Move custom webhook option to the top of the list when adding a new webhook


#### Testing
Manual

#### Notes for Reviewers
Doing this since the custom option is likely the most commonly used option and it got quite buried with all the templates that have been added in the last months.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
