### PR TITLE
Update json decoder to comport array input via stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ For details about compatibility between different releases, see the **Commitment
   - Join Servers using Backend Interfaces 1.1 (protocol `BI1.1`) must be configured with a `sender-ns-id` containing the EUI of the Network Server.
 - Fix `time.Duration` flags in CLI.
 - Gateway Server will no longer leave permanent gateway connection stats data on the registry when crashing.
+- CLI operations in bulk no longer provide an error message regarding invalid character `]`.
 
 ### Security
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #5228 

In short when using cli commands to create end-devices, users etc in bulk, there was an error of invalid character `]`. This happened due to the custom `JSONDecoder` of the `io` pkg, which always excluded the `[`.


#### Changes
<!-- What are the changes made in this pull request? -->

- Update `JSONDecoder` to read all the content if need the object passed is an array.


#### Testing

<!-- How did you verify that this change works? -->
All unit tests pass and manual testing. The second consists of creating users and end-devices by passing a json file with an array of objects and a file with just one object.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->
N/A

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I wrote the main reasons for this in the issue but the main problem is that running bulk operations in the cli integration tests will always fail. 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
