### PR TITLE
Render merge conflicts as warnings

### DIFF
--- a/.github/workflows/mergeability.yml
+++ b/.github/workflows/mergeability.yml
@@ -44,8 +44,9 @@ jobs:
         run: |
           conflicts=$(comm -23 <(git diff --name-only --diff-filter=U | sort) <(echo "$MERGE_CONFLICTS_IGNORE" | sort))
           if [[ ! -z "$conflicts" ]]; then
-            echo "Merge conflicts in the following files:"
-            echo "$conflicts"
+            echo "Merge conflicts detected."
+            echo ""
+            echo "$conflicts" | awk '{ print "::warning file=" $0 "::" $0 " has a conflict when merging TheThingsNetwork/lorawan-stack:${{ github.event.pull_request.base.ref }}."}'
             false
           fi
       - name: Merge TheThingsIndustries/lorawan-stack:${{ github.event.pull_request.base.ref }}
@@ -57,7 +58,8 @@ jobs:
         run: |
           conflicts=$(comm -23 <(git diff --name-only --diff-filter=U | sort) <(echo "$MERGE_CONFLICTS_IGNORE" | sort))
           if [[ ! -z "$conflicts" ]]; then
-            echo "Merge conflicts in the following files:"
-            echo "$conflicts"
+            echo "Merge conflicts detected."
+            echo ""
+            echo "$conflicts" | awk '{ print "::warning file=" $0 "::" $0 " has a conflict when merging TheThingsIndustries/lorawan-stack:${{ github.event.pull_request.base.ref }}."}'
             false
           fi


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request makes a small change to the Mergeability workflow that should render merge conflict warnings in a more GitHub-friendly way.

#### Changes
<!-- What are the changes made in this pull request? -->

- Write warnings (https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-warning-message) for each conflicting file.

#### Testing

<!-- How did you verify that this change works? -->

I've added a second commit so that this can be tested in this PR. That commit is removed now.

The result of testing can be seen here:

<img width="840" alt="Screen Shot 2022-02-21 at 10 18 20" src="https://user-images.githubusercontent.com/181308/154925163-9e948a44-09f4-442d-a2de-827cf7a98e90.png">

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

nil

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

nil

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
