### PR TITLE
Add additional getter usage for session keys

### DIFF
--- a/pkg/crypto/cryptoutil/cryptoutil.go
+++ b/pkg/crypto/cryptoutil/cryptoutil.go
@@ -148,7 +148,7 @@ func UnwrapSelectedSessionKeys(ctx context.Context, keyVault crypto.KeyVault, sk
 		}
 	}
 	return &ttnpb.SessionKeys{
-		SessionKeyId: sk.SessionKeyId,
+		SessionKeyId: sk.GetSessionKeyId(),
 		FNwkSIntKey:  fNwkSIntKeyEnvelope,
 		NwkSEncKey:   nwkSEncKeyEnvelope,
 		SNwkSIntKey:  sNwkSIntKeyEnvelope,

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -1687,10 +1687,10 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 			"session.dev_addr":                 st.Device.Session.DevAddr.IsZero,
 			"session.keys.f_nwk_s_int_key.key": st.Device.Session.Keys.GetFNwkSIntKey().IsZero,
 			"session.keys.nwk_s_enc_key.key": func() bool {
-				return st.Device.Session.Keys.NwkSEncKey != nil && st.Device.Session.Keys.NwkSEncKey.IsZero()
+				return st.Device.Session.Keys.GetNwkSEncKey() != nil && st.Device.Session.Keys.NwkSEncKey.IsZero()
 			},
 			"session.keys.s_nwk_s_int_key.key": func() bool {
-				return st.Device.Session.Keys.SNwkSIntKey != nil && st.Device.Session.Keys.SNwkSIntKey.IsZero()
+				return st.Device.Session.Keys.GetSNwkSIntKey() != nil && st.Device.Session.Keys.SNwkSIntKey.IsZero()
 			},
 		} {
 			if err := st.ValidateSetField(func() bool { return !isZero() }, p); err != nil {
@@ -1714,7 +1714,7 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 				}
 			})
 		}
-		if k := st.Device.Session.Keys.NwkSEncKey.GetKey(); k != nil && st.HasSetField("session.keys.nwk_s_enc_key.key") {
+		if k := st.Device.Session.Keys.GetNwkSEncKey().GetKey(); k != nil && st.HasSetField("session.keys.nwk_s_enc_key.key") {
 			nwkSEncKey, err := cryptoutil.WrapAES128Key(ctx, *k, ns.deviceKEKLabel, ns.KeyVault)
 			if err != nil {
 				return nil, err
@@ -1730,7 +1730,7 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 				}
 			})
 		}
-		if k := st.Device.Session.Keys.SNwkSIntKey.GetKey(); k != nil && st.HasSetField("session.keys.s_nwk_s_int_key.key") {
+		if k := st.Device.Session.Keys.GetSNwkSIntKey().GetKey(); k != nil && st.HasSetField("session.keys.s_nwk_s_int_key.key") {
 			sNwkSIntKey, err := cryptoutil.WrapAES128Key(ctx, *k, ns.deviceKEKLabel, ns.KeyVault)
 			if err != nil {
 				return nil, err
@@ -1750,11 +1750,11 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 	if st.Device.PendingSession != nil {
 		for p, isZero := range map[string]func() bool{
 			"pending_session.dev_addr":                 st.Device.PendingSession.DevAddr.IsZero,
-			"pending_session.keys.f_nwk_s_int_key.key": st.Device.PendingSession.Keys.FNwkSIntKey.IsZero,
-			"pending_session.keys.nwk_s_enc_key.key":   st.Device.PendingSession.Keys.NwkSEncKey.IsZero,
-			"pending_session.keys.s_nwk_s_int_key.key": st.Device.PendingSession.Keys.SNwkSIntKey.IsZero,
+			"pending_session.keys.f_nwk_s_int_key.key": st.Device.PendingSession.Keys.GetFNwkSIntKey().IsZero,
+			"pending_session.keys.nwk_s_enc_key.key":   st.Device.PendingSession.Keys.GetNwkSEncKey().IsZero,
+			"pending_session.keys.s_nwk_s_int_key.key": st.Device.PendingSession.Keys.GetSNwkSIntKey().IsZero,
 			"pending_session.keys.session_key_id": func() bool {
-				return len(st.Device.PendingSession.Keys.SessionKeyId) == 0
+				return len(st.Device.PendingSession.Keys.GetSessionKeyId()) == 0
 			},
 		} {
 			if err := st.ValidateSetField(func() bool { return !isZero() }, p); err != nil {
@@ -1815,10 +1815,10 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 	}
 	if st.Device.PendingMacState.GetQueuedJoinAccept() != nil {
 		for p, isZero := range map[string]func() bool{
-			"pending_mac_state.queued_join_accept.keys.f_nwk_s_int_key.key": st.Device.PendingMacState.QueuedJoinAccept.Keys.FNwkSIntKey.IsZero,
-			"pending_mac_state.queued_join_accept.keys.nwk_s_enc_key.key":   st.Device.PendingMacState.QueuedJoinAccept.Keys.NwkSEncKey.IsZero,
-			"pending_mac_state.queued_join_accept.keys.s_nwk_s_int_key.key": st.Device.PendingMacState.QueuedJoinAccept.Keys.SNwkSIntKey.IsZero,
-			"pending_mac_state.queued_join_accept.keys.session_key_id":      func() bool { return len(st.Device.PendingMacState.QueuedJoinAccept.Keys.SessionKeyId) == 0 },
+			"pending_mac_state.queued_join_accept.keys.f_nwk_s_int_key.key": st.Device.PendingMacState.QueuedJoinAccept.Keys.GetFNwkSIntKey().IsZero,
+			"pending_mac_state.queued_join_accept.keys.nwk_s_enc_key.key":   st.Device.PendingMacState.QueuedJoinAccept.Keys.GetNwkSEncKey().IsZero,
+			"pending_mac_state.queued_join_accept.keys.s_nwk_s_int_key.key": st.Device.PendingMacState.QueuedJoinAccept.Keys.GetSNwkSIntKey().IsZero,
+			"pending_mac_state.queued_join_accept.keys.session_key_id":      func() bool { return len(st.Device.PendingMacState.QueuedJoinAccept.Keys.GetSessionKeyId()) == 0 },
 			"pending_mac_state.queued_join_accept.payload":                  func() bool { return len(st.Device.PendingMacState.QueuedJoinAccept.Payload) == 0 },
 			"pending_mac_state.queued_join_accept.dev_addr":                 st.Device.PendingMacState.QueuedJoinAccept.DevAddr.IsZero,
 		} {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://sentry.io/organizations/the-things-industries/issues/2879498040/?project=2682566&referrer=regression-activity-email
References https://sentry.io/organizations/the-things-industries/issues/2875750127/?project=2682566&referrer=regression-activity-email

#### Changes
<!-- What are the changes made in this pull request? -->

- Use getter for session key ID
- Use getters for certain session keys related operations


#### Testing

<!-- How did you verify that this change works? -->

:monkey: 

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
