### PR TITLE
Publish encoded and encrypted downlink in forwarded event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Added
 
-- Add `Basic Authorization` header configuration to the webhooks form in the Console.
+- Add HTTP basic authentication configuration to the webhooks form in the Console.
 - Show repository formatter code in the payload formatter form in the Console and allow pasting the application and payload formatter code when using the JavaScript option.
 
 ### Changed
@@ -19,6 +19,8 @@ For details about compatibility between different releases, see the **Commitment
 - The custom webhook option is now shown at the top of the list in the Console when adding new webhooks.
 - Wording around webhook statuses to `Healthy`, `Requests failing` and `Pending`.
 - The uplink event preview in the Console now shows the highest SNR.
+- When scheduling downlink messages with decoded payload, the downlink queued event now contains the encoded, plain binary payload.
+- When Application Server forwards downlink messages to Network Server, the event payload now contains the encrypted LoRaWAN `FRMPayload`.
 
 ### Deprecated
 

--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -2050,12 +2050,6 @@ func TestApplicationServer(t *testing.T) {
 					default:
 						t.Fatal("Expected downlink error")
 					}
-					select {
-					case up := <-chs.up:
-						a.So(up.Up, should.HaveSameTypeAs, &ttnpb.ApplicationUp_DownlinkFailed{})
-					default:
-						t.Fatal("Expected upstream event")
-					}
 				})
 				t.Run("RegisteredDevice/Push", func(t *testing.T) {
 					a := assertions.New(t)

--- a/pkg/applicationserver/observability.go
+++ b/pkg/applicationserver/observability.go
@@ -347,8 +347,8 @@ func (as *ApplicationServer) registerDropDownlinks(ctx context.Context, ids *ttn
 	}
 }
 
-func (as *ApplicationServer) registerForwardDownlinks(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, items []*ttnpb.ApplicationDownlink, peerName string) {
-	for _, item := range items {
+func (as *ApplicationServer) registerForwardDownlinks(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers, decrypted, encrypted []*ttnpb.ApplicationDownlink, peerName string) {
+	for _, item := range decrypted {
 		if err := as.publishUp(ctx, &ttnpb.ApplicationUp{
 			EndDeviceIds:   ids,
 			CorrelationIds: item.CorrelationIds,
@@ -358,6 +358,8 @@ func (as *ApplicationServer) registerForwardDownlinks(ctx context.Context, ids *
 		}); err != nil {
 			log.FromContext(ctx).WithError(err).Warn("Failed to send upstream message")
 		}
+	}
+	for _, item := range encrypted {
 		registerForwardDownlink(ctx, ids, item, peerName)
 	}
 }

--- a/pkg/applicationserver/payload.go
+++ b/pkg/applicationserver/payload.go
@@ -30,49 +30,17 @@ import (
 
 var errNoPayload = errors.DefineInvalidArgument("no_payload", "no payload")
 
-func (as *ApplicationServer) encodeAndEncryptDownlinks(ctx context.Context, dev *ttnpb.EndDevice, link *ttnpb.ApplicationLink, items []*ttnpb.ApplicationDownlink, sessions []*ttnpb.Session) ([]*ttnpb.ApplicationDownlink, error) {
-	var encryptedItems []*ttnpb.ApplicationDownlink
-	for _, session := range sessions {
-		skipPayloadCrypto := as.skipPayloadCrypto(ctx, link, dev, session)
-		for _, item := range items {
-			fCnt := session.LastAFCntDown + 1
-			sessionKeyID := session.Keys.SessionKeyId
-			if skipPayloadCrypto {
-				fCnt = item.FCnt
-
-				if len(item.SessionKeyId) > 0 {
-					sessionKeyID = item.SessionKeyId
-				}
-			}
-			encryptedItem := &ttnpb.ApplicationDownlink{
-				SessionKeyId:   sessionKeyID,
-				FPort:          item.FPort,
-				FCnt:           fCnt,
-				FrmPayload:     item.FrmPayload,
-				DecodedPayload: item.DecodedPayload,
-				Confirmed:      item.Confirmed,
-				ClassBC:        item.ClassBC,
-				Priority:       item.Priority,
-				CorrelationIds: item.CorrelationIds,
-			}
-			if !skipPayloadCrypto {
-				if err := as.encodeAndEncryptDownlink(ctx, dev, session, encryptedItem, link.DefaultFormatters); err != nil {
-					log.FromContext(ctx).WithError(err).Warn("Encoding and encryption of downlink message failed; drop item")
-					return nil, err
-				}
-			}
-			encryptedItem.DecodedPayload = nil
-			session.LastAFCntDown = encryptedItem.FCnt
-			encryptedItems = append(encryptedItems, encryptedItem)
+func (as *ApplicationServer) encodeDownlinks(ctx context.Context, dev *ttnpb.EndDevice, link *ttnpb.ApplicationLink, items []*ttnpb.ApplicationDownlink) error {
+	for _, item := range items {
+		if err := as.encodeDownlink(ctx, dev, item, link.DefaultFormatters); err != nil {
+			log.FromContext(ctx).WithError(err).Warn("Encoding and encryption of downlink message failed; drop item")
+			return err
 		}
 	}
-	return encryptedItems, nil
+	return nil
 }
 
-func (as *ApplicationServer) encodeAndEncryptDownlink(ctx context.Context, dev *ttnpb.EndDevice, session *ttnpb.Session, downlink *ttnpb.ApplicationDownlink, defaultFormatters *ttnpb.MessagePayloadFormatters) error {
-	if session.GetKeys().GetAppSKey() == nil {
-		return errNoAppSKey.New()
-	}
+func (as *ApplicationServer) encodeDownlink(ctx context.Context, dev *ttnpb.EndDevice, downlink *ttnpb.ApplicationDownlink, defaultFormatters *ttnpb.MessagePayloadFormatters) error {
 	if downlink.FrmPayload == nil && downlink.DecodedPayload == nil {
 		return errNoPayload.New()
 	}
@@ -93,6 +61,51 @@ func (as *ApplicationServer) encodeAndEncryptDownlink(ctx context.Context, dev *
 				events.Publish(evtEncodeWarningDataDown.NewWithIdentifiersAndData(ctx, dev.Ids, downlink))
 			}
 		}
+	}
+	return nil
+}
+
+func (as *ApplicationServer) encryptDownlinks(ctx context.Context, dev *ttnpb.EndDevice, link *ttnpb.ApplicationLink, items []*ttnpb.ApplicationDownlink, sessions []*ttnpb.Session) ([]*ttnpb.ApplicationDownlink, error) {
+	var encryptedItems []*ttnpb.ApplicationDownlink
+	for _, session := range sessions {
+		skipPayloadCrypto := as.skipPayloadCrypto(ctx, link, dev, session)
+		for _, item := range items {
+			fCnt := session.LastAFCntDown + 1
+			sessionKeyID := session.Keys.SessionKeyId
+			if skipPayloadCrypto {
+				fCnt = item.FCnt
+				if len(item.SessionKeyId) > 0 {
+					sessionKeyID = item.SessionKeyId
+				}
+			}
+			encryptedItem := &ttnpb.ApplicationDownlink{
+				SessionKeyId:   sessionKeyID,
+				FPort:          item.FPort,
+				FCnt:           fCnt,
+				FrmPayload:     item.FrmPayload,
+				DecodedPayload: item.DecodedPayload,
+				Confirmed:      item.Confirmed,
+				ClassBC:        item.ClassBC,
+				Priority:       item.Priority,
+				CorrelationIds: item.CorrelationIds,
+			}
+			if !skipPayloadCrypto {
+				if err := as.encryptDownlink(ctx, dev, session, encryptedItem, link.DefaultFormatters); err != nil {
+					log.FromContext(ctx).WithError(err).Warn("Encoding and encryption of downlink message failed; drop item")
+					return nil, err
+				}
+			}
+			encryptedItem.DecodedPayload = nil
+			session.LastAFCntDown = encryptedItem.FCnt
+			encryptedItems = append(encryptedItems, encryptedItem)
+		}
+	}
+	return encryptedItems, nil
+}
+
+func (as *ApplicationServer) encryptDownlink(ctx context.Context, dev *ttnpb.EndDevice, session *ttnpb.Session, downlink *ttnpb.ApplicationDownlink, defaultFormatters *ttnpb.MessagePayloadFormatters) error {
+	if session.GetKeys().GetAppSKey() == nil {
+		return errNoAppSKey.New()
 	}
 	appSKey, err := cryptoutil.UnwrapAES128Key(ctx, session.Keys.AppSKey, as.KeyVault)
 	if err != nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-docs/issues/710#issuecomment-1042783544

#### Changes
<!-- What are the changes made in this pull request? -->

The downlink forwarded event now contains the FPort and FRMPayload output from the encoding and encryption steps.

#### Testing

<!-- How did you verify that this change works? -->

Tested locally:

<img width="744" alt="Screen Shot 2022-02-22 at 16 16 50" src="https://user-images.githubusercontent.com/13334001/155163873-868f836b-aeea-4d88-99e9-8bf8af220d2f.png">

In the second instance (here on top), I scheduled a downlink message that was encoded by the encoder. It appears that the JSON is not shown in the Console.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

If applications rely on the content of the `as.down.data.forward` payload or the contents of the `DownlinkQueued` payload, they may break. However, I think that it is acceptable that what AS forwards to NS is encrypted and encoded.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
