### PR TITLE
Unpack members early on popTask

### DIFF
--- a/pkg/redis/redis_test.go
+++ b/pkg/redis/redis_test.go
@@ -328,7 +328,7 @@ func TestTaskQueue(t *testing.T) {
 
 	q := &TaskQueue{
 		Redis:  cl,
-		MaxLen: 42,
+		MaxLen: 16384,
 		Group:  "testGroup",
 		Key:    cl.Key("test"),
 	}
@@ -392,6 +392,40 @@ func TestTaskQueue(t *testing.T) {
 		!a.So(q.Add(ctx, nil, "test2", time.Unix(0, 41), true), should.BeNil),
 		!a.So(assertPop(ctx, nil, "test2", time.Unix(0, 43).UTC()), should.BeTrue),
 		!a.So(assertPop(ctx, nil, "test2", time.Unix(0, 41).UTC()), should.BeTrue):
+	}
+
+	// The Lua stack limit is 8000. See https://www.lua.org/source/5.1/luaconf.h.html
+	// specifically LUAI_MAXCSTACK.
+	const batchSize = 8192
+
+	p = cl.Pipeline()
+	for i := 0; i < batchSize; i++ {
+		a.So(q.Add(ctx, p, fmt.Sprintf("test%d", i), time.Unix(int64(i), 0), false), should.BeNil)
+	}
+	a.So(func() error {
+		_, err := p.Exec(ctx)
+		return err
+	}(), should.BeNil)
+
+	times := make(map[string]time.Time)
+	for i := 0; i < batchSize; i++ {
+		a.So(q.Pop(ctx, "testID", cl, func(p redis.Pipeliner, payload string, startAt time.Time) error {
+			p.Ping(ctx)
+
+			_, ok := times[payload]
+			a.So(ok, should.BeFalse)
+			times[payload] = startAt
+
+			return nil
+		}), should.BeNil)
+	}
+	a.So(times, should.HaveLength, batchSize)
+	for i := 0; i < batchSize; i++ {
+		k := fmt.Sprintf("test%d", i)
+
+		t, ok := times[k]
+		a.So(ok, should.BeTrue)
+		a.So(t, should.Equal, time.Unix(int64(i), 0).UTC())
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://sentry.io/organizations/the-things-industries/issues/3003795580/?project=2682566&query=is%3Aunresolved&statsPeriod=24h

#### Changes
<!-- What are the changes made in this pull request? -->

- Flush waiting keys early, in order to avoid running into the 8k limitation of unpack

@onizmx you may replace https://github.com/halter-corp/lorawan-stack/commit/cb4d236e9c44d57c4c0e68dbe339e8229733e6bb with this PR in order to lower your diff with our head.

#### Testing

<!-- How did you verify that this change works? -->

Unit testing with more than 8k tasks. If the Lua code addition is commented out, the new test addition fails.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Not expected.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
