### PR TITLE
Ensure ZREM is not called with an empty array

### DIFF
--- a/pkg/redis/lua/popTask.lua
+++ b/pkg/redis/lua/popTask.lua
@@ -65,13 +65,13 @@ local zs = redis.call('zrangebyscore', KEYS[3], '-inf', ARGV[3], 'withscores')
 if #zs > 0 then
   local members = {}
   for i=1,#zs,2 do
-    local member = zs[i]
-    members[#members+1] = member
-    redis.call('xadd', KEYS[1], 'maxlen', '~', ARGV[4],'*', 'payload', member, 'start_at', zs[i+1])
     if #members > max_unpack then
       redis.call('zrem', KEYS[3], unpack(members))
       members = {}
     end
+    local member = zs[i]
+    members[#members+1] = member
+    redis.call('xadd', KEYS[1], 'maxlen', '~', ARGV[4],'*', 'payload', member, 'start_at', zs[i+1])
   end
   redis.call('zrem', KEYS[3], unpack(members))
   return format_ready(redis.call('xreadgroup', 'group', ARGV[1], ARGV[2], 'count', 1, 'streams', KEYS[1], '>'))


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/5243

#### Changes
<!-- What are the changes made in this pull request? -->

- Flush the items from the waiting key at the beginning of the iteration, otherwise it may happen that `ZREM` is called with an empty set of members to be removed (because the flush occurred at the end of the last iteration)

#### Testing

<!-- How did you verify that this change works? -->

This occurs when the number of items to be removed is `batch_size + 1`, so I've added a test case for this.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This is a rare issue, which did not occur yet, but it's better to avoid it already.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
