### PR TITLE
Limit Network Server uplink submission concurrency per instance

### DIFF
--- a/pkg/networkserver/config.go
+++ b/pkg/networkserver/config.go
@@ -29,6 +29,9 @@ type ApplicationUplinkQueueConfig struct {
 	Queue        ApplicationUplinkQueue `name:"-"`
 	BufferSize   uint64                 `name:"buffer-size"`
 	NumConsumers uint64                 `name:"num-consumers"`
+
+	FastBufferSize   uint64 `name:"fast-buffer-size"`
+	FastNumConsumers uint64 `name:"fast-num-consumers"`
 }
 
 // ApplicationUplinkQueueConfig defines downlink task queue configuration.
@@ -143,6 +146,9 @@ var DefaultConfig = Config{
 	ApplicationUplinkQueue: ApplicationUplinkQueueConfig{
 		BufferSize:   1000,
 		NumConsumers: 1,
+
+		FastBufferSize:   16384,
+		FastNumConsumers: 16,
 	},
 	DownlinkTaskQueue: DownlinkTaskQueueConfig{
 		NumConsumers: 1,

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -1602,7 +1602,7 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context, consumerID str
 		defer func() { publishEvents(ctx, queuedEvents...) }()
 
 		var queuedApplicationUplinks []*ttnpb.ApplicationUp
-		defer func() { ns.enqueueApplicationUplinks(ctx, queuedApplicationUplinks...) }()
+		defer func() { ns.submitApplicationUplinks(ctx, queuedApplicationUplinks...) }()
 
 		taskUpdateStrategy := noDownlinkTask
 		dev, ctx, err := ns.devices.SetByID(ctx, devID.ApplicationIds, devID.DeviceId,

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -882,7 +882,7 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 	}
 
 	var queuedApplicationUplinks []*ttnpb.ApplicationUp
-	defer func() { ns.enqueueApplicationUplinks(ctx, queuedApplicationUplinks...) }()
+	defer func() { ns.submitApplicationUplinks(ctx, queuedApplicationUplinks...) }()
 
 	stored, _, err := ns.devices.SetByID(ctx, matched.Device.Ids.ApplicationIds, matched.Device.Ids.DeviceId, handleDataUplinkGetPaths[:],
 		func(ctx context.Context, stored *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
@@ -1371,6 +1371,6 @@ func (ns *NetworkServer) ReportTxAcknowledgment(ctx context.Context, txAck *ttnp
 			},
 		}
 	}
-	ns.enqueueApplicationUplinks(ctx, appUp)
+	ns.submitApplicationUplinks(ctx, appUp)
 	return ttnpb.Empty, nil
 }

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -232,10 +232,13 @@ func New(c *component.Component, conf *Config, opts ...Option) (*NetworkServer, 
 		scheduledDownlinkMatcher: conf.ScheduledDownlinkMatcher,
 	}
 	ns.uplinkSubmissionPool = workerpool.NewWorkerPool(workerpool.Config{
-		Component: c,
-		Context:   ctx,
-		Name:      "uplink_submission",
-		Handler:   ns.handleUplinkSubmission,
+		Component:  c,
+		Context:    ctx,
+		Name:       "uplink_submission",
+		Handler:    ns.handleUplinkSubmission,
+		QueueSize:  int(conf.ApplicationUplinkQueue.FastBufferSize),
+		MinWorkers: int(conf.ApplicationUplinkQueue.FastNumConsumers),
+		MaxWorkers: int(conf.ApplicationUplinkQueue.FastNumConsumers),
 	})
 	ctx = ns.Context()
 

--- a/pkg/networkserver/utils.go
+++ b/pkg/networkserver/utils.go
@@ -25,6 +25,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/networkserver/internal/time"
 	"go.thethings.network/lorawan-stack/v3/pkg/networkserver/mac"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+	"go.thethings.network/lorawan-stack/v3/pkg/unique"
 )
 
 // nsScheduleWindow returns minimum time.Duration between downlink being added to the queue and it being sent to GS for transmission.
@@ -378,13 +379,39 @@ func publishEvents(ctx context.Context, evs ...events.Event) {
 }
 
 func (ns *NetworkServer) enqueueApplicationUplinks(ctx context.Context, ups ...*ttnpb.ApplicationUp) {
+	log.FromContext(ctx).Debug("Enqueue application uplinks for sending to Application Server")
+	if err := ns.applicationUplinks.Add(ctx, ups...); err != nil {
+		log.FromContext(ctx).WithError(err).Warn("Failed to enqueue application uplinks for sending to Application Server")
+	}
+}
+
+func (ns *NetworkServer) submitApplicationUplinks(ctx context.Context, ups ...*ttnpb.ApplicationUp) {
 	n := len(ups)
 	if n == 0 {
 		return
 	}
-	ctx = log.NewContextWithField(ctx, "uplink_count", n)
-	log.FromContext(ctx).Debug("Enqueue application uplinks for sending to Application Server")
-	if err := ns.applicationUplinks.Add(ctx, ups...); err != nil {
-		log.FromContext(ctx).WithError(err).Warn("Failed to enqueue application uplinks for sending to Application Server")
+	ctx = log.NewContextWithFields(ctx, log.Fields(
+		"device_uid", unique.ID(ctx, ups[0].EndDeviceIds),
+		"uplink_count", n,
+	))
+	if err := ns.uplinkSubmissionPool.Publish(ctx, ups); err != nil {
+		log.FromContext(ctx).WithError(err).Warn("Failed to enqueue application uplinks in submission pool")
+		ns.enqueueApplicationUplinks(ctx, ups...)
+		return
+	}
+}
+
+func (ns *NetworkServer) handleUplinkSubmission(ctx context.Context, item interface{}) {
+	ups := item.([]*ttnpb.ApplicationUp)
+	conn, err := ns.GetPeerConn(ctx, ttnpb.ClusterRole_APPLICATION_SERVER, nil)
+	if err != nil {
+		log.FromContext(ctx).WithError(err).Warn("Failed to get Application Server peer")
+		ns.enqueueApplicationUplinks(ctx, ups...)
+		return
+	}
+	if err := ns.sendApplicationUplinks(ctx, ttnpb.NewNsAsClient(conn), ups...); err != nil {
+		log.FromContext(ctx).WithError(err).Warn("Failed to send application uplinks to Application Server")
+		ns.enqueueApplicationUplinks(ctx, ups...)
+		return
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Reverts https://github.com/TheThingsNetwork/lorawan-stack/pull/5219

#### Changes
<!-- What are the changes made in this pull request? -->

- Reintroduce the uplink fast path, which was removed in #5219 in order to rule out the fact that we're choking the Application Server with concurrent uplink processing requests
- Limit the concurrency of the submission pool to a lower value

#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Only 531b420907317176c3d868cc3c5d3af6e0dcb349 should require review - the first commit just adds already reviewed code.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
