### PR TITLE
Add new RP002 version pairs to the Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For details about compatibility between different releases, see the **Commitment
 - Show repository formatter code in the payload formatter form in the Console and allow pasting the application and payload formatter code when using the JavaScript option.
 - gRPC service to Gateway Configuration Server so that gateway configurations can be obtained via gRPC requests.
 - The option to configure the Redis idle connection pool timeout, using the `redis.idle-timeout` setting.
+- New RP002 regional parameters as options during device registration in the Console.
 
 ### Changed
 

--- a/pkg/webui/console/components/lorawan-version-input/index.js
+++ b/pkg/webui/console/components/lorawan-version-input/index.js
@@ -37,6 +37,10 @@ import {
   MAC_V1_0_3,
   MAC_V1_0_4,
   MAC_V1_1,
+  RP002_V1_0_0,
+  RP002_V1_0_1,
+  RP002_V1_0_2,
+  RP002_V1_0_3,
   LORAWAN_VERSIONS,
   parseLorawanMacVersion,
 } from '@console/lib/device-utils'
@@ -49,6 +53,10 @@ const phyVersionsMap = {
   [PHY_V1_0_3_REV_A.value]: [MAC_V1_0_3, MAC_V1_0_4],
   [PHY_V1_1_REV_A.value]: [MAC_V1_1, MAC_V1_0_4],
   [PHY_V1_1_REV_B.value]: [MAC_V1_1, MAC_V1_0_4],
+  [RP002_V1_0_0.value]: [MAC_V1_1, MAC_V1_0_4],
+  [RP002_V1_0_1.value]: [MAC_V1_1, MAC_V1_0_4],
+  [RP002_V1_0_2.value]: [MAC_V1_1, MAC_V1_0_4],
+  [RP002_V1_0_3.value]: [MAC_V1_1, MAC_V1_0_4],
 }
 const m = defineMessages({
   phyVersionError: 'Failed to fetch regional parameters versions',

--- a/pkg/webui/console/components/phy-version-input/index.js
+++ b/pkg/webui/console/components/phy-version-input/index.js
@@ -28,6 +28,10 @@ import {
   PHY_V1_0_3_REV_A,
   PHY_V1_1_REV_B,
   PHY_V1_1_REV_A,
+  RP002_V1_0_0,
+  RP002_V1_0_1,
+  RP002_V1_0_2,
+  RP002_V1_0_3,
 } from '@console/lib/device-utils'
 
 const lorawanVersionPairs = {
@@ -36,7 +40,7 @@ const lorawanVersionPairs = {
   102: [PHY_V1_0_2_REV_A, PHY_V1_0_2_REV_B],
   103: [PHY_V1_0_3_REV_A],
   104: LORAWAN_PHY_VERSIONS,
-  110: [PHY_V1_1_REV_A, PHY_V1_1_REV_B],
+  110: [PHY_V1_1_REV_A, PHY_V1_1_REV_B, RP002_V1_0_0, RP002_V1_0_1, RP002_V1_0_2, RP002_V1_0_3],
   0: LORAWAN_PHY_VERSIONS,
 }
 

--- a/pkg/webui/console/lib/device-utils.js
+++ b/pkg/webui/console/lib/device-utils.js
@@ -27,13 +27,32 @@ export const DEVICE_CLASSES = Object.freeze({
   CLASS_C: 'c',
 })
 
-export const PHY_V1_0 = { value: 'PHY_V1_0', label: 'PHY V1.0' }
-export const PHY_V1_0_1 = { value: 'PHY_V1_0_1', label: 'PHY V1.0.1' }
-export const PHY_V1_0_2_REV_A = { value: 'PHY_V1_0_2_REV_A', label: 'PHY V1.0.2 REV A' }
-export const PHY_V1_0_2_REV_B = { value: 'PHY_V1_0_2_REV_B', label: 'PHY V1.0.2 REV B' }
-export const PHY_V1_0_3_REV_A = { value: 'PHY_V1_0_3_REV_A', label: 'PHY V1.0.3 REV A' }
-export const PHY_V1_1_REV_A = { value: 'PHY_V1_1_REV_A', label: 'PHY V1.1 REV A' }
-export const PHY_V1_1_REV_B = { value: 'PHY_V1_1_REV_B', label: 'PHY V1.1 REV B' }
+export const PHY_V1_0 = { value: 'PHY_V1_0', label: 'TS001 Technical Specification 1.0.0' }
+export const PHY_V1_0_1 = { value: 'PHY_V1_0_1', label: 'TS001 Technical Specification 1.0.1' }
+export const PHY_V1_0_2_REV_A = {
+  value: 'PHY_V1_0_2_REV_A',
+  label: 'RP001 Regional Parameters 1.0.2',
+}
+export const PHY_V1_0_2_REV_B = {
+  value: 'PHY_V1_0_2_REV_B',
+  label: 'RP001 Regional Parameters 1.0.2 revision B',
+}
+export const PHY_V1_0_3_REV_A = {
+  value: 'PHY_V1_0_3_REV_A',
+  label: 'RP001 Regional Parameters 1.0.3 revision A',
+}
+export const PHY_V1_1_REV_A = {
+  value: 'PHY_V1_1_REV_A',
+  label: 'RP001 Regional Parameters 1.1 revision A',
+}
+export const PHY_V1_1_REV_B = {
+  value: 'PHY_V1_1_REV_B',
+  label: 'RP001 Regional Parameters 1.1 revision B',
+}
+export const RP002_V1_0_0 = { value: 'RP002_V1_0_0', label: 'RP002 Regional Parameters 1.0.0' }
+export const RP002_V1_0_1 = { value: 'RP002_V1_0_1', label: 'RP002 Regional Parameters 1.0.1' }
+export const RP002_V1_0_2 = { value: 'RP002_V1_0_2', label: 'RP002 Regional Parameters 1.0.2' }
+export const RP002_V1_0_3 = { value: 'RP002_V1_0_3', label: 'RP002 Regional Parameters 1.0.3' }
 
 export const LORAWAN_PHY_VERSIONS = Object.freeze([
   PHY_V1_0,
@@ -43,14 +62,18 @@ export const LORAWAN_PHY_VERSIONS = Object.freeze([
   PHY_V1_0_3_REV_A,
   PHY_V1_1_REV_A,
   PHY_V1_1_REV_B,
+  RP002_V1_0_0,
+  RP002_V1_0_1,
+  RP002_V1_0_2,
+  RP002_V1_0_3,
 ])
 
-export const MAC_V1_0 = { value: 'MAC_V1_0', label: 'MAC V1.0' }
-export const MAC_V1_0_1 = { value: 'MAC_V1_0_1', label: 'MAC V1.0.1' }
-export const MAC_V1_0_2 = { value: 'MAC_V1_0_2', label: 'MAC V1.0.2' }
-export const MAC_V1_0_3 = { value: 'MAC_V1_0_3', label: 'MAC V1.0.3' }
-export const MAC_V1_0_4 = { value: 'MAC_V1_0_4', label: 'MAC V1.0.4' }
-export const MAC_V1_1 = { value: 'MAC_V1_1', label: 'MAC V1.1' }
+export const MAC_V1_0 = { value: 'MAC_V1_0', label: 'LoRaWAN Specification 1.0.0' }
+export const MAC_V1_0_1 = { value: 'MAC_V1_0_1', label: 'LoRaWAN Specification 1.0.1' }
+export const MAC_V1_0_2 = { value: 'MAC_V1_0_2', label: 'LoRaWAN Specification 1.0.2' }
+export const MAC_V1_0_3 = { value: 'MAC_V1_0_3', label: 'LoRaWAN Specification 1.0.3' }
+export const MAC_V1_0_4 = { value: 'MAC_V1_0_4', label: 'LoRaWAN Specification 1.0.4' }
+export const MAC_V1_1 = { value: 'MAC_V1_1', label: 'LoRaWAN Specification 1.1.0' }
 
 export const LORAWAN_VERSIONS = Object.freeze([
   MAC_V1_0,


### PR DESCRIPTION
#### Summary
Closes #3513

#### Changes

- Add new `RP002` regional parameters to the Console so they can be selected during device onboarding

#### Testing

Manual testing.

##### Regressions

Hard for me to asses. Are there any notable side-effects of these new RPs @adriansmares, specifically with regards to retrieving and displaying MAC defaults in the Console?

#### Notes for Reviewers
This PR only adds the new versions as well as the new version pairings. There are no other changes to device onboarding or handling of MAC settings defaults.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
