### PR TITLE
Fix ordering of entities with same values in the sort field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,23 @@ For details about compatibility between different releases, see the **Commitment
 ## [Unreleased]
 
 ### Added
+
 - Add `Basic Authorization` header configuration to the webhooks form in the Console.
 - Show repository formatter code in the payload formatter form in the Console and allow pasting the application and payload formatter code when using the JavaScript option.
 
 ### Changed
+
 - The custom webhook option is now shown at the top of the list in the Console when adding new webhooks.
 - Wording around webhook statuses to `Healthy`, `Requests failing` and `Pending`.
 - The uplink event preview in the Console now shows the highest SNR.
+
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- Consistent ordering of entities with equal values for the sort field.
 
 ### Security
 

--- a/pkg/identityserver/store/pagination.go
+++ b/pkg/identityserver/store/pagination.go
@@ -96,7 +96,11 @@ func OrderFromContext(ctx context.Context, table, defaultTableField, defaultOrde
 			table = "accounts"
 			opts.field = "uid"
 		}
-		return fmt.Sprintf(`"%s"."%s" %s`, table, opts.field, order)
+		tableField := fmt.Sprintf(`"%s"."%s"`, table, opts.field)
+		if tableField != defaultTableField && opts.field != defaultTableField {
+			return fmt.Sprintf(`%s %s, %s %s`, tableField, order, defaultTableField, order)
+		}
+		return fmt.Sprintf(`%s %s`, tableField, order)
 	}
 	return fmt.Sprintf("%s %s", defaultTableField, defaultOrder)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request adds a second order expression for lists with user-specified order, so that (for example) entities with equal (or without) names are still ordered by their ID.

This fixes #5133.

Also closes https://github.com/TheThingsIndustries/lorawan-stack-support/issues/707.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add secondary order expression when not sorting by the default field

#### Testing

<!-- How did you verify that this change works? -->

🐒 

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

none expected

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

nil

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
