### PR TITLE
util: Fix the changelog update flow

### DIFF
--- a/.github/workflows/changelog-cutoff.yml
+++ b/.github/workflows/changelog-cutoff.yml
@@ -1,0 +1,53 @@
+name: Cutoff changelog
+
+on:
+  workflow_dispatch:
+    inputs:
+      patch_version:
+        description: Patch version (integer)
+        required: true
+
+env:
+  NODE_ENV: production
+  RELEASE_VERSION: "${{ format('{0}.{1}', github.ref_name, github.event.inputs.patch_version) }}"
+
+jobs:
+  cutoff_changelog:
+    name: Cutoff changelog
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    steps:
+      - name: Check branch
+        run: echo "${{ github.ref_name }}" | grep -Pq '^v3\.\d+$'
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: Update changelog
+        run: 'cat CHANGELOG.md | tr ''\n'' ''\000'' |
+          sed ''s/## [A-Z][a-z]*\x00\x00#/\x01\x00#/g''|
+          sed ''s/## \[Unreleased\]/## \[Unreleased\]\x00\x00### Added\x00\x00### Changed\x00\x00### Deprecated\x00\x00### Removed\x00\x00### Fixed\x00\x00### Security\x00\x00''"## \\[${RELEASE_VERSION#v}\\] - unreleased"''/'' |
+          tr ''\000'' ''\n'' |
+          sed ''/\x01/d'' |
+          sed "s/\[unreleased\]: https:\/\/github.com\/$(echo "${GITHUB_REPOSITORY}" | sed ''s/\//\\\//g'')\/compare\/\(v3\.[0-9][0-9]*\.[0-9][0-9]*\)\.\.\.\(v3\.[0-9][0-9]*\)/[unreleased]: https:\/\/github.com\/$(echo "${GITHUB_REPOSITORY}" | sed ''s/\//\\\//g'')\/compare\/${RELEASE_VERSION}...${GITHUB_REF_NAME}\n[${RELEASE_VERSION#v}]: https:\/\/github.com\/$(echo "${GITHUB_REPOSITORY}" | sed ''s/\//\\\//g'')\/compare\/\1...${RELEASE_VERSION}/" > CHANGELOG2.md
+          && mv -f CHANGELOG2.md CHANGELOG.md
+          && git add CHANGELOG.md'
+      - name: Prepare a PR
+        run: |
+          git config user.name "The Things Bot"
+          git config user.email "github@thethingsindustries.com"
+          git checkout -b "changelog/${RELEASE_VERSION}"
+          git add CHANGELOG.md
+          git commit -m "all: Cut off changelog version ${RELEASE_VERSION#v}"
+          git push --set-upstream origin "changelog/${RELEASE_VERSION}"
+          gh pr create \
+              --assignee '${{ github.actor }}' \
+              --head "changelog/${RELEASE_VERSION}" \
+              --base '${{ github.ref_name }}' \
+              --body "This pull request cuts off the ${RELEASE_VERSION} changelog." \
+              --label "release" \
+              --milestone "${RELEASE_VERSION}" \
+              --title "Changelog cutoff ${RELEASE_VERSION}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -6,6 +6,9 @@ on:
       patch_version:
         description: Patch version (integer)
         required: true
+      commit_hash:
+        description: Commit hash to branch from (most likely the changelog cutoff commit)
+        required: true
 
 env:
   NODE_ENV: production
@@ -24,6 +27,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
+          ref: ${{ github.event.inputs.commit_hash }}
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
@@ -52,15 +56,6 @@ jobs:
         run: tools/bin/mage js:deps
       - name: Update version information
         run: echo "${RELEASE_VERSION}" | tools/bin/mage version:files
-      - name: Update changelog
-        run: 'cat CHANGELOG.md | tr ''\n'' ''\000'' |
-          sed ''s/## [A-Z][a-z]*\x00\x00#/\x01\x00#/g''|
-          sed ''s/## \[Unreleased\]/## \[Unreleased\]\x00\x00### Added\x00\x00### Changed\x00\x00### Deprecated\x00\x00### Removed\x00\x00### Fixed\x00\x00### Security\x00\x00''"## \\[${RELEASE_VERSION#v}\\] - $(date +%Y-%m-%d)"''/'' |
-          tr ''\000'' ''\n'' |
-          sed ''/\x01/d'' |
-          sed "s/\[unreleased\]: https:\/\/github.com\/$(echo "${GITHUB_REPOSITORY}" | sed ''s/\//\\\//g'')\/compare\/\(v3\.[0-9][0-9]*\.[0-9][0-9]*\)\.\.\.\(v3\.[0-9][0-9]*\)/[unreleased]: https:\/\/github.com\/$(echo "${GITHUB_REPOSITORY}" | sed ''s/\//\\\//g'')\/compare\/${RELEASE_VERSION}...${GITHUB_REF_NAME}\n[${RELEASE_VERSION#v}]: https:\/\/github.com\/$(echo "${GITHUB_REPOSITORY}" | sed ''s/\//\\\//g'')\/compare\/\1...${RELEASE_VERSION}/" > CHANGELOG2.md
-          && mv -f CHANGELOG2.md CHANGELOG.md
-          && git add CHANGELOG.md'
       - name: Update submodules
         id: update_submodules
         run: |

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -14,6 +14,19 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     steps:
+      - name: Get version from tag
+        id: version
+        uses: actions/github-script@v3
+        with:
+          script: |
+            const tag = context.ref.slice("refs/tags/".length);
+            const majorMinorPatchRegex = /^v([0-9]+)\.([0-9]+)\.([0-9]+)$/;
+            const majorMinorPatch = tag.match(majorMinorPatchRegex);
+            if (!majorMinorPatch) {
+              throw `invalid version tag: ${tag}`;
+            }
+            return majorMinorPatch[0].slice(1);
+          result-encoding: string
       - name: Check branch
         run: echo '${{ github.event.base_ref }}' | grep -Fxq 'refs/heads/release/${{ github.ref_name }}'
       - name: Check out code
@@ -21,6 +34,21 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
+          ref: ${{ github.event.base_ref }}
+      - name: Insert release date into the changelog
+        run: |
+          sed -i "s/^\(## \[.*\] - \)\(unreleased\)$/\1$(date +%Y-%m-%d)/" CHANGELOG.md
+          set +e
+          git diff --exit-code --quiet CHANGELOG.md
+          R=$?
+          set -e
+          git config user.name "The Things Bot"
+          git config user.email "github@thethingsindustries.com"
+          if [ $R -eq 1 ]; then
+            git add CHANGELOG.md
+            git commit -m "all: Enter release date of version ${{ steps.version.outputs.result }} into the changelog"
+            git push
+          fi
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -99,19 +127,6 @@ jobs:
           WEBPACK_GENERATE_PRODUCTION_SOURCEMAPS: "true"
       - name: Check for diff
         run: tools/bin/mage git:diff
-      - name: Get version from tag
-        id: version
-        uses: actions/github-script@v3
-        with:
-          script: |
-            const tag = context.ref.slice("refs/tags/".length);
-            const majorMinorPatchRegex = /^v([0-9]+)\.([0-9]+)\.([0-9]+)$/;
-            const majorMinorPatch = tag.match(majorMinorPatchRegex);
-            if (!majorMinorPatch) {
-              throw `invalid version tag: ${tag}`;
-            }
-            return majorMinorPatch[0].slice(1);
-          result-encoding: string
       - name: Generate Release Notes
         run: |
           awk '/^## \[${{ steps.version.outputs.result }}\]/{flag=1;next} /^## \[/{flag=0} flag' CHANGELOG.md > /tmp/release-notes.md


### PR DESCRIPTION
#### Summary
The new release flow broke the changelog. This fixes the issue.

#### Changes
The new flow is:
1. Cut-off the changelog using `changelog-cutoff.yml` with `unreleased` instead of the date. This creates a PR that should be merged.
2. `create-release-branch.yml` also takes commit hash as input to avoid race condition
3. `release-tag.yml` adds a commit that replaces `unreleased` with current date 

#### Testing
Testing on my own repo

##### Regressions
None

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
