### PR TITLE
Add Redis connection pool idle timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ For details about compatibility between different releases, see the **Commitment
 - Add HTTP basic authentication configuration to the webhooks form in the Console.
 - Show repository formatter code in the payload formatter form in the Console and allow pasting the application and payload formatter code when using the JavaScript option.
 - gRPC service to Gateway Configuration Server so that gateway configurations can be obtained via gRPC requests.
-
+- The option to configure the Redis idle connection pool timeout, using the `redis.idle-timeout` setting.
 
 ### Changed
 

--- a/pkg/redis/redis.go
+++ b/pkg/redis/redis.go
@@ -88,6 +88,7 @@ type Config struct {
 	Database      int            `name:"database" description:"Redis database to use"`
 	RootNamespace []string       `name:"namespace" description:"Namespace for Redis keys"`
 	PoolSize      int            `name:"pool-size" description:"The maximum number of database connections"`
+	IdleTimeout   time.Duration  `name:"idle-timeout" description:"Idle connection timeout"`
 	Failover      FailoverConfig `name:"failover" description:"Redis failover configuration"`
 	TLS           struct {
 		Require          bool `name:"require" description:"Require TLS"`
@@ -115,6 +116,7 @@ func (c Config) Equals(other Config) bool {
 		c.Database == other.Database &&
 		equalsStringSlice(c.RootNamespace, other.RootNamespace) &&
 		c.PoolSize == other.PoolSize &&
+		c.IdleTimeout == other.IdleTimeout &&
 		c.Failover.Equals(other.Failover) &&
 		c.TLS.Require == other.TLS.Require &&
 		c.TLS.Client.Equals(other.TLS.Client)
@@ -197,14 +199,16 @@ func newRedisClient(conf *Config) *redis.Client {
 			Password:      conf.Password,
 			DB:            conf.Database,
 			PoolSize:      conf.PoolSize,
+			IdleTimeout:   conf.IdleTimeout,
 		})
 	}
 	return redis.NewClient(&redis.Options{
-		Dialer:   conf.makeDialer(),
-		Addr:     conf.Address,
-		Password: conf.Password,
-		DB:       conf.Database,
-		PoolSize: conf.PoolSize,
+		Dialer:      conf.makeDialer(),
+		Addr:        conf.Address,
+		Password:    conf.Password,
+		DB:          conf.Database,
+		PoolSize:    conf.PoolSize,
+		IdleTimeout: conf.IdleTimeout,
 	})
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/commit/1c520263e8680754ab26b145201572c109a48fac ( the original change )

#### Changes
<!-- What are the changes made in this pull request? -->

- Allow the Redis connection pool idle timeout to be configured.
- Increase the default maximum size of the connection pool.


#### Testing

<!-- How did you verify that this change works? -->

Local, `staging1`, and another one.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Deployments may see more connections per component, but that's not necessarily a bad thing, as the dial operation can be expensive.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
