### PR TITLE
Debounce stats updates with jitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ For details about compatibility between different releases, see the **Commitment
 - When scheduling downlink messages with decoded payload, the downlink queued event now contains the encoded, plain binary payload.
 - When Application Server forwards downlink messages to Network Server, the event payload now contains the encrypted LoRaWAN `FRMPayload`.
 - The Network Server will now match downlink acknowledgements on the `cache` redis cluster (previously the `general` cluster was used).
+- Gateway Connection statistics updates are now debounced. The debounce period occurs before the statistics are stored, and can be configured using the `gs.update-connection-stats-debounce-time` setting (default 5 seconds).
 
 ### Deprecated
 

--- a/cmd/internal/shared/gatewayserver/config.go
+++ b/cmd/internal/shared/gatewayserver/config.go
@@ -32,6 +32,7 @@ var DefaultGatewayServerConfig = gatewayserver.Config{
 	FetchGatewayInterval:              10 * time.Minute,
 	FetchGatewayJitter:                0.2,
 	UpdateGatewayLocationDebounceTime: time.Hour,
+	UpdateConnectionStatsDebounceTime: 5 * time.Second,
 	ConnectionStatsTTL:                12 * time.Hour,
 	ConnectionStatsDisconnectTTL:      48 * time.Hour,
 	UpdateVersionInfoDelay:            5 * time.Second,

--- a/pkg/gatewayserver/config.go
+++ b/pkg/gatewayserver/config.go
@@ -55,7 +55,7 @@ type Config struct {
 	FetchGatewayJitter   float64       `name:"fetch-gateway-jitter" description:"Jitter (fraction) to apply to the get interval to randomize intervals"`
 
 	UpdateGatewayLocationDebounceTime time.Duration `name:"update-gateway-location-debounce-time" description:"Debounce time for gateway location updates from status messages"`
-	UpdateConnectionStatsDebounceTime time.Duration `name:"update-connection-stats-debounce-time" description:"DEPRECATED: Time before repeated refresh of the gateway connection stats"`
+	UpdateConnectionStatsDebounceTime time.Duration `name:"update-connection-stats-debounce-time" description:"Time before repeated refresh of the gateway connection stats"`
 	ConnectionStatsTTL                time.Duration `name:"connection-stats-ttl" description:"Time to live of the gateway connection stats. Periodically refreshed by the GatewayServer but works as an expiration date on the data in case of crashes"`
 	ConnectionStatsDisconnectTTL      time.Duration `name:"connection-stats-disconnect-ttl" description:"Time to live of the gateway connection stats after disconnecting"`
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/commit/336777c6fb6ffaa9c1646a01e2ce677a5f84dfae (original change)

#### Changes
<!-- What are the changes made in this pull request? -->

- Reintroduce stat updates debouncing, with a different strategy - the debounce period occurs before the write, in order to de-correlate writes.
- Add jitter to the gateway location writes debouncing.


#### Testing

<!-- How did you verify that this change works? -->

Local testing, `staging1`, and more.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Stat updates will be slightly delayed, but this is fine.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
