### PR TITLE
Increase NS fast path consumers

### DIFF
--- a/pkg/networkserver/config.go
+++ b/pkg/networkserver/config.go
@@ -148,7 +148,7 @@ var DefaultConfig = Config{
 		NumConsumers: 1,
 
 		FastBufferSize:   16384,
-		FastNumConsumers: 16,
+		FastNumConsumers: 128,
 	},
 	DownlinkTaskQueue: DownlinkTaskQueueConfig{
 		NumConsumers: 1,

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -237,7 +237,6 @@ func New(c *component.Component, conf *Config, opts ...Option) (*NetworkServer, 
 		Name:       "uplink_submission",
 		Handler:    ns.handleUplinkSubmission,
 		QueueSize:  int(conf.ApplicationUplinkQueue.FastBufferSize),
-		MinWorkers: int(conf.ApplicationUplinkQueue.FastNumConsumers),
 		MaxWorkers: int(conf.ApplicationUplinkQueue.FastNumConsumers),
 	})
 	ctx = ns.Context()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/commit/add69d6753800d7a762a48573d3e3cd51977d5bd (original change)
References https://github.com/TheThingsNetwork/lorawan-stack/pull/5249

#### Changes
<!-- What are the changes made in this pull request? -->

- Increase the number of consumers per NS instance to 128 from 16
- Do not set a minimum amount of consumers in the worker pool


#### Testing

<!-- How did you verify that this change works? -->

Local testing, `staging1`, and more.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
