### PR TITLE
Match downlinks on cache Redis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ For details about compatibility between different releases, see the **Commitment
 - The uplink event preview in the Console now shows the highest SNR.
 - When scheduling downlink messages with decoded payload, the downlink queued event now contains the encoded, plain binary payload.
 - When Application Server forwards downlink messages to Network Server, the event payload now contains the encrypted LoRaWAN `FRMPayload`.
+- The Network Server will now match downlink acknowledgements on the `cache` redis cluster (previously the `general` cluster was used).
 
 ### Deprecated
 

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -280,7 +280,7 @@ var startCommand = &cobra.Command{
 			defer downlinkTasks.Close(ctx)
 			config.NS.DownlinkTaskQueue.Queue = downlinkTasks
 			config.NS.ScheduledDownlinkMatcher = &nsredis.ScheduledDownlinkMatcher{
-				Redis: redis.New(config.Redis.WithNamespace("ns", "scheduled-downlinks")),
+				Redis: redis.New(config.Cache.Redis.WithNamespace("ns", "scheduled-downlinks")),
 			}
 			ns, err := networkserver.New(c, &config.NS)
 			if err != nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/commit/be5a17da702be835fc9cc49ec267f1e6032df4a3 (original commit)

#### Changes
<!-- What are the changes made in this pull request? -->

- The NS downlink matching process (which recovers the downlink associated with a downlink transmission acknowledgement) is now done on the `cache` Redis.

#### Testing

<!-- How did you verify that this change works? -->

Local testing, `staging1`, and more.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

During the upgrade some transmission acknowledgement will be lost. This is fine.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
