### PR TITLE
Upgrade dependencies in Github Actions workflows

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -29,7 +29,7 @@ jobs:
           submodules: true
           ref: ${{ github.event.inputs.commit_hash }}
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "~1.17"
       - name: Download Go tool dependencies

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -86,7 +86,7 @@ jobs:
             .env/admin_api_key.txt
           key: db-cache-${{ hashFiles('pkg/identityserver/store/**/*.go', 'cmd/ttn-lw-stack/commands/is-db.go', '.github/workflows/e2e.yml') }}
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "~1.17"
       - name: Initialize Go module cache

--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -11,9 +11,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Set up Node
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v3
         with:
-          node-version: "~14"
+          node-version: "~16"
       - name: Get Yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(npx yarn cache dir)"
@@ -26,7 +26,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "~1.17"
       - name: Initialize Go module cache

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "~1.17"
       - name: Initialize Go module cache
@@ -93,7 +93,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "~1.17"
       - name: Initialize Go module cache

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -10,11 +10,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Add "needs/triage" label
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            github.issues.addLabels({
+            github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -24,9 +24,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Set up Node
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v3
         with:
-          node-version: "~14"
+          node-version: "~16"
       - name: Get Yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(npx yarn cache dir)"
@@ -39,7 +39,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "~1.17"
       - name: Initialize Go module cache
@@ -87,9 +87,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Set up Node
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "~16"
       - name: Get Yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(npx yarn cache dir)"
@@ -102,7 +102,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "~1.17"
       - name: Initialize public folder cache

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/labeler@v2
+      - uses: actions/labeler@v3
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && !startsWith(github.actor, 'dependabot') }}
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "~1.17"
       - name: Initialize Go module cache

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -33,9 +33,9 @@ jobs:
           username: "${{ secrets.DOCKERHUB_USERNAME }}"
           password: "${{ secrets.DOCKERHUB_PASSWORD }}"
       - name: Set up Node
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v3
         with:
-          node-version: "~14"
+          node-version: "~16"
       - name: Get Yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(npx yarn cache dir)"
@@ -48,7 +48,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "~1.17"
       - name: Initialize Go module cache

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -29,9 +29,9 @@ jobs:
           username: "${{ secrets.DOCKERHUB_USERNAME }}"
           password: "${{ secrets.DOCKERHUB_PASSWORD }}"
       - name: Set up Node
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v3
         with:
-          node-version: "~14"
+          node-version: "~16"
       - name: Get Yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(npx yarn cache dir)"
@@ -44,7 +44,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "~1.17"
       - name: Initialize Go module cache

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Get version from tag
         id: version
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           script: |
             const tag = context.ref.slice("refs/tags/".length);
@@ -73,11 +73,11 @@ jobs:
           SNAPCRAFT_LOGIN: ${{ secrets.SNAPCRAFT_LOGIN }}
         run: snapcraft login --with <(printf "$SNAPCRAFT_LOGIN")
       - name: Set up Node
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v3
         with:
-          node-version: "~14"
+          node-version: "~16"
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "~1.17"
       - name: Initialize Go module cache


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request upgrades dependencies of our GitHub Actions workflows.

#### Changes
<!-- What are the changes made in this pull request? -->

- Upgrade `actions/setup-go` from `v2` to `v3`
- Upgrade `actions/setup-node` from `v2` to `v3`
	- And upgraded `node-version` from `~14` to `~16`
- Upgrade `actions/github-script` from `v3` to `v6`
	- And patched scripts to use `rest`, since REST API is no longer on the `github` object directly.

#### Testing

<!-- How did you verify that this change works? -->

Impossible to test in isolation, so let's see what the workflows do when CI runs.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

I went over the release notes of each action to see if we needed to make any additional changes and did so where necessary.

I don't know what will happen with Node v16.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

nil

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
