### PR TITLE
Event pipeline improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ For details about compatibility between different releases, see the **Commitment
 - The Network Server will now match downlink acknowledgements on the `cache` redis cluster (previously the `general` cluster was used).
 - Gateway Connection statistics updates are now debounced. The debounce period occurs before the statistics are stored, and can be configured using the `gs.update-connection-stats-debounce-time` setting (default 5 seconds).
 - Payload formatter form layout in the Console.
+- Event publication when the Redis backend is used may no longer block the hot path. Instead, the events are now asynchronously published, which may render their ordering to change.
+  - The events are queued and published using the worker pool mechanism, under the `redis_events_transactions` pool.
+  - The length of the queue used by the pool may be configured using the `events.redis.publish.queue-size` setting.
+  - The maximum worker count used by the pool may be configured using the `events.redis.publish.max-workers` setting.
 
 ### Deprecated
 

--- a/cmd/internal/shared/config.go
+++ b/cmd/internal/shared/config.go
@@ -111,6 +111,8 @@ var DefaultEventsConfig = func() config.Events {
 	c.Redis.Store.EntityCount = 100
 	c.Redis.Store.CorrelationIDCount = 100
 	c.Redis.Workers = 16
+	c.Redis.Publish.QueueSize = 8192
+	c.Redis.Publish.MaxWorkers = 1024
 	return c
 }()
 

--- a/cmd/ttn-lw-stack/commands/ns_db.go
+++ b/cmd/ttn-lw-stack/commands/ns_db.go
@@ -164,6 +164,7 @@ var (
 								return err
 							}
 							p := tx.TxPipeline()
+							defer p.Close()
 							if dev.Session != nil && dev.Session.DevAddr.Equal(devAddr) {
 								if dev.MacState == nil {
 									logger.Error("Device is missing MAC state, skip migrating current session")
@@ -267,6 +268,7 @@ var (
 					score := float64(time.Now().UnixNano())
 					if err := cl.Watch(ctx, func(tx *redis.Tx) error {
 						p := tx.TxPipeline()
+						defer p.Close()
 						if err := ttnredis.RangeRedisSet(ctx, tx, k, "*", ttnredis.DefaultRangeCount, func(uid string) (bool, error) {
 							logger := logger.WithField("uid", uid)
 							uk := nsredis.UIDKey(cl, uid)

--- a/pkg/config/shared.go
+++ b/pkg/config/shared.go
@@ -137,6 +137,10 @@ type RedisEvents struct {
 		CorrelationIDCount int           `name:"correlation-id-count" description:"How many events are indexed for a correlation ID"`
 	} `name:"store"`
 	Workers int `name:"workers"`
+	Publish struct {
+		QueueSize  int `name:"queue-size" description:"The maximum number of events which may be queued for publication"`
+		MaxWorkers int `name:"max-workers" description:"The maximum number of workers which may publish events asynchronously"`
+	} `name:"publish"`
 }
 
 // Events represents configuration for the events system.

--- a/pkg/events/basic/pubsub.go
+++ b/pkg/events/basic/pubsub.go
@@ -79,14 +79,17 @@ func (e *PubSub) RemoveSubscription(s events.Subscription) {
 }
 
 // Publish publishes an event, which will notify all matching subscriptions.
-func (e *PubSub) Publish(evt events.Event) {
-	defer trace.StartRegion(evt.Context(), "publish event").End()
+func (e *PubSub) Publish(evs ...events.Event) {
 	e.mu.RLock()
 	subscriptions := e.subscriptions
 	e.mu.RUnlock()
-	for _, sub := range subscriptions {
-		if sub.Match(evt) {
-			sub.Notify(evt)
-		}
+	for _, evt := range evs {
+		trace.WithRegion(evt.Context(), "publish event", func() {
+			for _, sub := range subscriptions {
+				if sub.Match(evt) {
+					sub.Notify(evt)
+				}
+			}
+		})
 	}
 }

--- a/pkg/events/default.go
+++ b/pkg/events/default.go
@@ -22,7 +22,7 @@ import (
 
 type noopPubSub struct{}
 
-func (noopPubSub) Publish(Event) {}
+func (noopPubSub) Publish(...Event) {}
 
 func (noopPubSub) Subscribe(context.Context, []string, []*ttnpb.EntityIdentifiers, Handler) error {
 	return nil
@@ -46,9 +46,14 @@ func Subscribe(ctx context.Context, names []string, ids []*ttnpb.EntityIdentifie
 }
 
 // Publish emits events on the default event pubsub.
-func Publish(evts ...Event) {
-	for _, evt := range evts {
-		defaultPubSub.Publish(local(evt).withCaller())
+func Publish(evs ...Event) {
+	if len(evs) == 0 {
+		return
+	}
+	evs = append(evs[:0:0], evs...)
+	for i, evt := range evs {
+		evs[i] = local(evt).withCaller()
 		publishes.WithLabelValues(evt.Name()).Inc()
 	}
+	defaultPubSub.Publish(evs...)
 }

--- a/pkg/events/internal/eventstest/events_backend.go
+++ b/pkg/events/internal/eventstest/events_backend.go
@@ -74,6 +74,9 @@ func TestBackend(ctx context.Context, t *testing.T, a *assertions.Assertion, bac
 
 	backend.Publish(events.New(ctx, "test.some.evt1", "test event 1", events.WithIdentifiers(&appID)))
 
+	runtime.Gosched()
+	time.Sleep(timeout)
+
 	if store, ok := backend.(events.Store); ok {
 		chx := make(events.Channel, 10)
 		histSubCtx, cancel := context.WithCancel(subCtx)

--- a/pkg/events/pubsub.go
+++ b/pkg/events/pubsub.go
@@ -29,7 +29,7 @@ type PubSub interface {
 // Publisher interface lets you publish events.
 type Publisher interface {
 	// Publish emits an event on the default event pubsub.
-	Publish(evt Event)
+	Publish(evs ...Event)
 }
 
 // Subscriber interface lets you subscribe to events.

--- a/pkg/events/redis/redis.go
+++ b/pkg/events/redis/redis.go
@@ -32,10 +32,11 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/task"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/unique"
+	"go.thethings.network/lorawan-stack/v3/pkg/workerpool"
 )
 
 // NewPubSub creates a new PubSub that publishes and subscribes to Redis.
-func NewPubSub(ctx context.Context, taskStarter task.Starter, conf config.RedisEvents) events.PubSub {
+func NewPubSub(ctx context.Context, component workerpool.Component, conf config.RedisEvents) events.PubSub {
 	ttnRedisClient := ttnredis.New(&conf.Config)
 	ctx = log.NewContextWithFields(ctx, log.Fields(
 		"namespace", "events/redis",
@@ -57,7 +58,7 @@ func NewPubSub(ctx context.Context, taskStarter task.Starter, conf config.RedisE
 	}
 
 	for i := 0; i < workers; i++ {
-		taskStarter.StartTask(&task.Config{
+		component.StartTask(&task.Config{
 			Context: ps.ctx,
 			ID:      fmt.Sprintf("events_redis_subscribe_%02d", i),
 			Func:    ps.subscribeTask,

--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -639,14 +639,18 @@ func TestGatewayServer(t *testing.T) {
 								upEvents[event] = make(events.Channel, 5)
 							}
 							defer test.SetDefaultEventsPubSub(&test.MockEventPubSub{
-								PublishFunc: func(ev events.Event) {
-									switch name := ev.Name(); name {
-									case "gs.gateway.connect":
-										go func() {
-											upEvents[name] <- ev
-										}()
-									default:
-										t.Logf("%s event published", name)
+								PublishFunc: func(evs ...events.Event) {
+									for _, ev := range evs {
+										ev := ev
+
+										switch name := ev.Name(); name {
+										case "gs.gateway.connect":
+											go func() {
+												upEvents[name] <- ev
+											}()
+										default:
+											t.Logf("%s event published", name)
+										}
 									}
 								},
 							})()
@@ -1302,14 +1306,18 @@ func TestGatewayServer(t *testing.T) {
 									upEvents[event] = make(events.Channel, 5)
 								}
 								defer test.SetDefaultEventsPubSub(&test.MockEventPubSub{
-									PublishFunc: func(ev events.Event) {
-										switch name := ev.Name(); name {
-										case "gs.up.receive", "gs.down.tx.success", "gs.down.tx.fail", "gs.status.receive", "gs.io.up.repeat":
-											go func() {
-												upEvents[name] <- ev
-											}()
-										default:
-											t.Logf("%s event published", name)
+									PublishFunc: func(evs ...events.Event) {
+										for _, ev := range evs {
+											ev := ev
+
+											switch name := ev.Name(); name {
+											case "gs.up.receive", "gs.down.tx.success", "gs.down.tx.fail", "gs.status.receive", "gs.io.up.repeat":
+												go func() {
+													upEvents[name] <- ev
+												}()
+											default:
+												t.Logf("%s event published", name)
+											}
 										}
 									},
 								})()

--- a/pkg/workerpool/workerpool.go
+++ b/pkg/workerpool/workerpool.go
@@ -37,7 +37,7 @@ const (
 
 // Component contains a minimal component.Component definition.
 type Component interface {
-	StartTask(*task.Config)
+	task.Starter
 	FromRequestContext(context.Context) context.Context
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack/pull/3108

#### Changes
<!-- What are the changes made in this pull request? -->

- Allow callers to publish events in batches. Mainly used by the NS, and is to be removed later (as the NS will publish less events)
- Do not block on event publishing, as it may stall the hot path. Instead, a worker pool is used which will run the transactions asynchronously. 

#### Testing

<!-- How did you verify that this change works? -->

Local testing, `staging1`.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Event ordering is no longer guaranteed. Specifically, if two events are published sequentially in the order `e1`, `e2`, the ordering guarantee before was that they are published + stored in this order. This guarantee no longer exists now, and the two events may be published in the reversed order.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This is just a backport PR, no reviews are required.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
