### PR TITLE
Fix payload formatter issues

### DIFF
--- a/cypress/integration/console/shared/payload-formatters/edit.spec.js
+++ b/cypress/integration/console/shared/payload-formatters/edit.spec.js
@@ -82,6 +82,7 @@ describe('Payload formatters', () => {
     cy.dropAndSeedDatabase()
     cy.createUser(user)
     cy.createApplication(application, userId)
+    cy.setApplicationPayloadFormatter(applicationId)
     cy.createMockDeviceAllComponents(applicationId, undefined, { ns, is }).then(body => {
       endDeviceId = body.end_device.ids.device_id
     })
@@ -460,7 +461,7 @@ describe('Payload formatters', () => {
         cy.visit(
           `${Cypress.config(
             'consoleRootPath',
-          )}/applications/${applicationId}/devices/${endDeviceId}/payload-formatters/uplink`,
+          )}/applications/${applicationId}/devices/${endDeviceId}/payload-formatters/downlink`,
         )
 
         cy.findByLabelText('Formatter type').selectOption('javascript')
@@ -474,7 +475,7 @@ describe('Payload formatters', () => {
         cy.visit(
           `${Cypress.config(
             'consoleRootPath',
-          )}/applications/${applicationId}/devices/${endDeviceId}/payload-formatters/uplink`,
+          )}/applications/${applicationId}/devices/${endDeviceId}/payload-formatters/downlink`,
         )
 
         cy.findByTestId('code-editor-javascript-formatter').should('be.visible')

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -214,6 +214,39 @@ Cypress.Commands.add('setApplicationCollaborator', (applicationId, collaboratorI
   })
 })
 
+// Helper function to create a new application payload formatter programmatically.
+Cypress.Commands.add('setApplicationPayloadFormatter', (appId, formatter) => {
+  const baseUrl = Cypress.config('baseUrl')
+  const adminApiKey = Cypress.config('adminApiKey')
+  cy.request({
+    url: `${baseUrl}/api/v3/as/applications/${appId}/link`,
+    method: 'PUT',
+    body: {
+      link: {
+        default_formatters: {
+          down_formatter: 'FORMATTER_JAVASCRIPT',
+          down_formatter_parameter:
+            formatter ||
+            'function encodeDownlink(input) {\n  return {\n    bytes: [],\n    fPort: 1,\n    warnings: [],\n    errors: []\n  };\n}\n\nfunction decodeDownlink(input) {\n  return {\n    data: {\n      bytes: input.bytes\n    },\n    warnings: [],\n    errors: []\n  }\n}',
+          up_formatter: 'FORMATTER_JAVASCRIPT',
+          up_formatter_parameter:
+            formatter ||
+            'function decodeUplink(input) {\n  return {\n    data: {\n      bytes: input.bytes\n    },\n    warnings: [],\n    errors: []\n  };\n}',
+        },
+      },
+      field_mask: {
+        paths: [
+          'default_formatters.down_formatter',
+          'default_formatters.down_formatter_parameter',
+          'default_formatters.up_formatter',
+          'default_formatters.up_formatter_parameter',
+        ],
+      },
+    },
+    headers: { Authorization: `Bearer ${adminApiKey}` },
+  })
+})
+
 // Helper function to create a new gateway programmatically.
 Cypress.Commands.add('createGateway', (gateway, userId) => {
   const baseUrl = Cypress.config('baseUrl')

--- a/pkg/webui/console/components/payload-formatters-form/index.js
+++ b/pkg/webui/console/components/payload-formatters-form/index.js
@@ -63,6 +63,8 @@ const m = defineMessages({
   learnMoreAboutDeviceRepo: 'What is the Device Repository formatter option?',
   learnMoreAboutPayloadFormatters: 'Learn more about payload formatters',
   learnMoreAboutCayenne: 'What is CayenneLPP?',
+  noRepositoryWarning:
+    'The application formatter is set to `Repository` but this device does not have an associated formatter in the LoRaWAN Device repository. Messages for this end device will hence not be formatted.',
 })
 
 const FIELD_NAMES = {
@@ -294,6 +296,9 @@ class PayloadFormattersForm extends React.Component {
         </Link.DocLink>
       )
     } else if (showRepositoryParameter) {
+      if (!hasRepoFormatter) {
+        return <Notification warning content={m.noRepositoryWarning} small />
+      }
       return (
         <>
           <Form.Field
@@ -385,9 +390,7 @@ class PayloadFormattersForm extends React.Component {
                 component={Select}
                 options={options}
                 onChange={this.onTypeChange}
-                warning={
-                  type === TYPES.DEFAULT || type === TYPES.NONE ? m.appFormatterWarning : undefined
-                }
+                warning={type === TYPES.DEFAULT ? m.appFormatterWarning : undefined}
                 inputWidth="m"
                 required
               />

--- a/pkg/webui/console/containers/device-payload-formatters/downlink.js
+++ b/pkg/webui/console/containers/device-payload-formatters/downlink.js
@@ -60,11 +60,10 @@ import { selectDeviceRepoPayloadFromatters } from '@console/store/selectors/devi
       repositoryPayloadFormatters: selectDeviceRepoPayloadFromatters(state),
     }
   },
-  dispatch => ({
+  {
     updateDevice: attachPromise(updateDevice),
-    getRepositoryPayloadFormatters: (appId, versionIds) =>
-      dispatch(getRepositoryPayloadFormatters(appId, versionIds)),
-  }),
+    getRepositoryPayloadFormatters,
+  },
 )
 @withRequest(({ appId, device, getRepositoryPayloadFormatters }) =>
   getRepositoryPayloadFormatters(appId, device.version_ids),

--- a/pkg/webui/console/containers/device-payload-formatters/uplink.js
+++ b/pkg/webui/console/containers/device-payload-formatters/uplink.js
@@ -58,11 +58,10 @@ import { selectDeviceRepoPayloadFromatters } from '@console/store/selectors/devi
     decodeUplink: tts.As.decodeUplink,
     repositoryPayloadFormatters: selectDeviceRepoPayloadFromatters(state),
   }),
-  dispatch => ({
+  {
     updateDevice: attachPromise(updateDevice),
-    getRepositoryPayloadFormatters: (appId, versionIds) =>
-      dispatch(getRepositoryPayloadFormatters(appId, versionIds)),
-  }),
+    getRepositoryPayloadFormatters,
+  },
 )
 @withRequest(({ appId, device, getRepositoryPayloadFormatters }) =>
   getRepositoryPayloadFormatters(appId, device.version_ids),

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -255,6 +255,7 @@
   "console.components.payload-formatters-form.index.learnMoreAboutDeviceRepo": "What is the Device Repository formatter option?",
   "console.components.payload-formatters-form.index.learnMoreAboutPayloadFormatters": "Learn more about payload formatters",
   "console.components.payload-formatters-form.index.learnMoreAboutCayenne": "What is CayenneLPP?",
+  "console.components.payload-formatters-form.index.noRepositoryWarning": "The application formatter is set to `Repository` but this device does not have an associated formatter in the LoRaWAN Device repository. Messages for this end device will hence not be formatted.",
   "console.components.payload-formatters-form.test-form.index.validResult": "Payload is valid",
   "console.components.payload-formatters-form.test-form.index.noResult": "No test result generated yet",
   "console.components.payload-formatters-form.test-form.index.testDecoder": "Test decoder",


### PR DESCRIPTION
#### Summary
This PR fixes an issue where payload formatters were not saved when clicking on 'Save changes'. It also adds a warning when an end device uses the repository formatter (via application default) when it does not have an associated formatter.

Closes #5206

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix faulty dispatch in the PF form
- Add warning for end devices without repository PF
- Remove false warnings stating that setting the formatter to `None` will affect both uplink and downlink formatter


#### Testing

Manual and e2e

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
