### PR TITLE
Use legacy search query on Postgres below version 11

### DIFF
--- a/pkg/identityserver/gormstore/entity_search.go
+++ b/pkg/identityserver/gormstore/entity_search.go
@@ -44,7 +44,10 @@ func likePattern(v string) string { return "%" + v + "%" }
 
 func ftsQuery(query *gorm.DB, field string) string {
 	if dbKind, ok := query.Get("db:kind"); ok && dbKind == "PostgreSQL" {
-		return fmt.Sprintf("to_tsvector('english', %s) @@ websearch_to_tsquery('english', ?)", field)
+		if dbMajor, ok := query.Get("db:version:major"); ok && dbMajor.(int) >= 11 {
+			return fmt.Sprintf("to_tsvector('english', %s) @@ websearch_to_tsquery('english', ?)", field)
+		}
+		return fmt.Sprintf("to_tsvector('english', %s) @@ to_tsquery('english', ?)", field)
 	}
 	return fmt.Sprintf("%s ILIKE '%%' || ? || '%%'", field)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request changes the full-text-search query used by #5232 on PostgreSQL 10 and below, which don't support the `websearch_to_tsquery` function yet.

#### Changes
<!-- What are the changes made in this pull request? -->

- Read the database version on start
- Only use `websearch_to_tsquery` on PostgreSQL 11 and later

#### Testing

<!-- How did you verify that this change works? -->

Locally

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

none expected

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

nil

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
