### PR TITLE
Replace relative go mod paths

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ needs.determine-if-required.outputs.yarn-cache-dir-path }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock', 'sdk/js/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Initialize SQL dump cache
@@ -93,7 +93,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ hashFiles('go.sum', 'tools/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Download Go tool dependencies
@@ -211,7 +211,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ needs.determine-if-required.outputs.yarn-cache-dir-path }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock', 'sdk/js/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Generate certs
@@ -287,7 +287,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ needs.determine-if-required.outputs.yarn-cache-dir-path }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock', 'sdk/js/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Install FF 78 ESR


### PR DESCRIPTION
#### Summary
Replacing relative `go.mod` paths with absolute paths to fix issue related to https://github.com/actions/cache/issues/753

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix cache key path for `go.mod` files

#### Notes for Reviewers
This hopefully fixes the issue. We use the same relative paths in other workflows as well but it does not seem to cause any issues there, so I did not change any other workflow files.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
