### PR TITLE
Small fixes for a slow Join Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Join-accept scheduling if it took more than ~1.2 seconds to process the device activation with default configuration. These slow device activations can be observed when using external Join Servers.
+
 ### Security
 
 ## [3.18.1] - 2022-03-09

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -60,8 +60,8 @@ type UplinkDeduplicator interface {
 	AccumulatedMetadata(context.Context, *ttnpb.UplinkMessage) ([]*ttnpb.RxMetadata, error)
 }
 
-func (ns *NetworkServer) deduplicateUplink(ctx context.Context, up *ttnpb.UplinkMessage) (bool, error) {
-	ok, err := ns.uplinkDeduplicator.DeduplicateUplink(ctx, up, ns.collectionWindow(ctx))
+func (ns *NetworkServer) deduplicateUplink(ctx context.Context, up *ttnpb.UplinkMessage, window time.Duration) (bool, error) {
+	ok, err := ns.uplinkDeduplicator.DeduplicateUplink(ctx, up, window)
 	if err != nil {
 		log.FromContext(ctx).WithError(err).Error("Failed to deduplicate uplink")
 		return false, err
@@ -781,7 +781,7 @@ func (ns *NetworkServer) handleDataUplink(ctx context.Context, up *ttnpb.UplinkM
 		"uplink_f_cnt", pld.FHdr.FCnt,
 	))
 
-	ok, err := ns.deduplicateUplink(ctx, up)
+	ok, err := ns.deduplicateUplink(ctx, up, ns.collectionWindow(ctx))
 	if err != nil {
 		return err
 	}
@@ -1140,7 +1140,7 @@ func (ns *NetworkServer) handleJoinRequest(ctx context.Context, up *ttnpb.Uplink
 		"device_channel_index", chIdx,
 	)
 
-	ok, err := ns.deduplicateUplink(ctx, up)
+	ok, err := ns.deduplicateUplink(ctx, up, phy.JoinAcceptDelay2)
 	if err != nil {
 		return err
 	}

--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -733,6 +733,10 @@ func (ns *NetworkServer) mergeMetadata(ctx context.Context, up *ttnpb.UplinkMess
 		log.FromContext(ctx).WithError(err).Error("Failed to merge metadata")
 		return
 	}
+	if len(mds) == 0 {
+		log.FromContext(ctx).Warn("No metadata to merge, keep uplink message metadata")
+		return
+	}
 	up.RxMetadata = mds
 	log.FromContext(ctx).WithField("metadata_count", len(up.RxMetadata)).Debug("Merged metadata")
 	registerMergeMetadata(ctx, up)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

As discussed offline, a few fixes for a slow Join Server.

#### Changes
<!-- What are the changes made in this pull request? -->

1. Metadata could expire before the interop Join Server came back with a join-accept. This resulted in metadata being reset, so that the downlink path was gone and the join-accept couldn't be scheduled. This is now fixed: the metadata is kept for a longer time (max join-accept delay 2). Also, if there's no accumulated metadata anymore, NS doesn't reset the deduplicated uplink message's metadata with empty metadata
2. Another small fix for the interop client validation. This partially reverts a previous fix that landed in https://github.com/TheThingsNetwork/lorawan-stack/pull/5176. The thing is that AS uses the same code path (`interop.NewClient()`), and AS obviously doesn't have an NSID but may use BI 1.1. So the validation is now again "late". Alternatively, there would be a different validation for NS vs AS

#### Testing

<!-- How did you verify that this change works? -->

🐒

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None expected

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
