### PR TITLE
Fix webhook encoding and decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ For details about compatibility between different releases, see the **Commitment
 ### Fixed
 
 - Join-accept scheduling if it took more than ~1.2 seconds to process the device activation with default configuration. These slow device activations can be observed when using external Join Servers.
+- Fix issues in the webhook forms causing webhooks to be created with all message types enabled and no way of deactivating message types.
+- Fix validation issue in the webhook form not detecting message type paths with more than 64 characters.
 
 ### Security
 

--- a/cypress/integration/console/integrations/webhooks/create-with-template.spec.js
+++ b/cypress/integration/console/integrations/webhooks/create-with-template.spec.js
@@ -103,6 +103,8 @@ describe('Application Webhook create', () => {
 
     cy.findByTestId('error-notification').should('not.exist')
     cy.findByTestId('full-error-view').should('not.exist')
-    cy.findByText('my-new-akenza-webhook').should('be.visible')
+    cy.findByText('my-new-akenza-webhook').should('be.visible').click()
+
+    cy.findByLabelText('Webhook ID').should('have.attr', 'value', webhook.id)
   })
 })

--- a/cypress/integration/console/integrations/webhooks/create-without-template.spec.js
+++ b/cypress/integration/console/integrations/webhooks/create-without-template.spec.js
@@ -121,10 +121,13 @@ describe('Application Webhook create without template', () => {
       id: 'my-new-webhook',
       format: 'JSON',
       baseUrl: 'https://example.com/webhooks',
+      path: '/path/to/webhook',
     }
     cy.findByLabelText('Webhook ID').type(webhook.id)
     cy.findByLabelText('Webhook format').selectOption(webhook.format)
     cy.findByLabelText('Base URL').type(webhook.baseUrl)
+    cy.get('#uplink_message_checkbox').check()
+    cy.findByLabelText('Uplink message').type(webhook.path)
 
     cy.findByRole('button', { name: 'Add webhook' }).click()
 
@@ -150,5 +153,7 @@ describe('Application Webhook create without template', () => {
       .and('have.attr', 'value')
       .and('eq', webhook.id)
     cy.findByLabelText('Base URL').and('have.attr', 'value').and('eq', webhook.baseUrl)
+    cy.findByLabelText('Uplink message').should('have.attr', 'value', webhook.path)
+    cy.get('#uplink_message_checkbox').should('be.checked')
   })
 })

--- a/cypress/integration/console/integrations/webhooks/edit.spec.js
+++ b/cypress/integration/console/integrations/webhooks/edit.spec.js
@@ -70,19 +70,27 @@ describe('Application Webhook', () => {
     cy.findByRole('button', { name: 'Save changes' }).click()
 
     cy.findByTestId('error-notification').should('not.exist')
-    cy.findByTestId('toast-notification')
-      .should('be.visible')
-      .findByText(`Webhook updated`)
-      .should('be.visible')
-    cy.findByLabelText('Base URL')
-      .should('be.visible')
-      .and('have.attr', 'value')
-      .and('eq', webhook.url)
-    cy.get('#uplink_message_checkbox').should('have.attr', 'value', 'true')
-    cy.findByLabelText('Uplink message')
-      .should('be.visible')
-      .and('have.attr', 'value')
-      .and('eq', webhook.path)
+    cy.findByTestId('toast-notification').findByText(`Webhook updated`).should('be.visible')
+
+    cy.reload()
+    cy.findByLabelText('Base URL').should('have.attr', 'value', webhook.url)
+    cy.findByLabelText('Uplink message').should('have.attr', 'value', webhook.path)
+    cy.get('#join_accept_checkbox').should('not.be.checked')
+    cy.findByLabelText('Uplink message').clear()
+    cy.findByRole('button', { name: 'Save changes' }).click()
+    cy.findByTestId('error-notification').should('not.exist')
+    cy.findByTestId('toast-notification').findByText(`Webhook updated`).should('be.visible')
+
+    cy.reload()
+    cy.findByLabelText('Uplink message').should('have.attr', 'value', '')
+    cy.get('#uplink_message_checkbox').should('be.checked')
+    cy.get('#uplink_message_checkbox').uncheck()
+    cy.findByRole('button', { name: 'Save changes' }).click()
+    cy.findByTestId('error-notification').should('not.exist')
+    cy.findByTestId('toast-notification').findByText(`Webhook updated`).should('be.visible')
+
+    cy.reload()
+    cy.get('#uplink_message_checkbox').should('not.be.checked')
   })
 
   it('succeeds adding headers', () => {
@@ -98,6 +106,8 @@ describe('Application Webhook', () => {
       .should('be.visible')
       .findByText(`Webhook updated`)
       .should('be.visible')
+
+    cy.reload()
 
     cy.findByTestId('_headers[0].key')
       .should('be.visible')
@@ -129,6 +139,8 @@ describe('Application Webhook', () => {
       .should('be.visible')
       .findByText(`Webhook updated`)
       .should('be.visible')
+
+    cy.reload()
 
     cy.findByLabelText('Request authentication').should('have.attr', 'value', 'true')
     cy.findByTestId('basic-auth-username')

--- a/pkg/webui/console/components/webhook-form/index.js
+++ b/pkg/webui/console/components/webhook-form/index.js
@@ -87,12 +87,12 @@ const m = defineMessages({
 const isReadOnly = value => value.readOnly
 
 const messageCheck = message => {
-  if (message && message.enabled) {
-    const { value } = message
-
-    return value ? value.length <= 64 : true
+  if (message && 'path' in message) {
+    if (message.path === undefined) {
+      return true
+    }
+    return message.path.length <= 64
   }
-
   return true
 }
 
@@ -143,64 +143,64 @@ const validationSchema = Yup.object().shape({
   ),
   uplink_message: Yup.object()
     .shape({
-      enabled: Yup.boolean(),
       path: Yup.string(),
     })
-    .test('has path length at most 64 characters', m.messagePathValidateTooLong, messageCheck),
+    .test('has path length at most 64 characters', m.messagePathValidateTooLong, messageCheck)
+    .nullable(),
   join_accept: Yup.object()
     .shape({
-      enabled: Yup.boolean(),
-      value: Yup.string(),
+      path: Yup.string(),
     })
-    .test('has path length at most 64 characters', m.messagePathValidateTooLong, messageCheck),
+    .test('has path length at most 64 characters', m.messagePathValidateTooLong, messageCheck)
+    .nullable(),
   downlink_ack: Yup.object()
     .shape({
-      enabled: Yup.boolean(),
-      value: Yup.string(),
+      path: Yup.string(),
     })
-    .test('has path length at most 64 characters', m.messagePathValidateTooLong, messageCheck),
+    .test('has path length at most 64 characters', m.messagePathValidateTooLong, messageCheck)
+    .nullable(),
   downlink_nack: Yup.object()
     .shape({
-      enabled: Yup.boolean(),
-      value: Yup.string(),
+      path: Yup.string(),
     })
-    .test('has path length at most 64 characters', m.messagePathValidateTooLong, messageCheck),
+    .test('has path length at most 64 characters', m.messagePathValidateTooLong, messageCheck)
+    .nullable(),
   downlink_sent: Yup.object()
     .shape({
-      enabled: Yup.boolean(),
-      value: Yup.string(),
+      path: Yup.string(),
     })
-    .test('has path length at most 64 characters', m.messagePathValidateTooLong, messageCheck),
+    .test('has path length at most 64 characters', m.messagePathValidateTooLong, messageCheck)
+    .nullable(),
   downlink_failed: Yup.object()
     .shape({
-      enabled: Yup.boolean(),
-      value: Yup.string(),
+      path: Yup.string(),
     })
-    .test('has path length at most 64 characters', m.messagePathValidateTooLong, messageCheck),
+    .test('has path length at most 64 characters', m.messagePathValidateTooLong, messageCheck)
+    .nullable(),
   downlink_queued: Yup.object()
     .shape({
-      enabled: Yup.boolean(),
-      value: Yup.string(),
+      path: Yup.string(),
     })
-    .test('has path length at most 64 characters', m.messagePathValidateTooLong, messageCheck),
+    .test('has path length at most 64 characters', m.messagePathValidateTooLong, messageCheck)
+    .nullable(),
   downlink_queue_invalidated: Yup.object()
     .shape({
-      enabled: Yup.boolean(),
-      value: Yup.string(),
+      path: Yup.string(),
     })
-    .test('has path length at most 64 characters', m.messagePathValidateTooLong, messageCheck),
+    .test('has path length at most 64 characters', m.messagePathValidateTooLong, messageCheck)
+    .nullable(),
   location_solved: Yup.object()
     .shape({
-      enabled: Yup.boolean(),
-      value: Yup.string(),
+      path: Yup.string(),
     })
-    .test('has path length at most 64 characters', m.messagePathValidateTooLong, messageCheck),
+    .test('has path length at most 64 characters', m.messagePathValidateTooLong, messageCheck)
+    .nullable(),
   service_data: Yup.object()
     .shape({
-      enabled: Yup.boolean(),
-      value: Yup.string(),
+      path: Yup.string(),
     })
-    .test('has path length at most 64 characters', m.messagePathValidateTooLong, messageCheck),
+    .test('has path length at most 64 characters', m.messagePathValidateTooLong, messageCheck)
+    .nullable(),
 })
 
 export default class WebhookForm extends Component {
@@ -351,7 +351,7 @@ export default class WebhookForm extends Component {
     const { error, displayOverwriteModal, existingId } = this.state
     let initialValues = blankValues
     if (update && initialWebhookValue) {
-      initialValues = decodeValues(initialWebhookValue)
+      initialValues = decodeValues({ ...blankValues, ...initialWebhookValue })
     }
 
     const mayReactivate =

--- a/pkg/webui/console/components/webhook-form/mapping.js
+++ b/pkg/webui/console/components/webhook-form/mapping.js
@@ -19,8 +19,12 @@ const isBasicAuth = header =>
 const hasBasicAuth = headers => headers instanceof Array && headers.findIndex(isBasicAuth) !== -1
 
 export const decodeMessageType = messageType => {
-  if (messageType && (messageType.enabled || messageType.path)) {
-    return { enabled: true, value: messageType.path }
+  if (isPlainObject(messageType)) {
+    if ('path' in messageType) {
+      return { enabled: true, value: messageType.path }
+    }
+
+    return { enabled: true, value: '' }
   }
 
   return { enabled: false, value: '' }
@@ -28,10 +32,10 @@ export const decodeMessageType = messageType => {
 
 export const encodeMessageType = formValue => {
   if (formValue && formValue.enabled) {
-    return { enabled: true, path: formValue.value }
+    return { path: formValue.value }
   }
 
-  return { enabled: false, path: '' }
+  return null
 }
 
 const decodeHeaders = headersType =>
@@ -109,16 +113,16 @@ export const blankValues = {
   base_url: undefined,
   format: undefined,
   downlink_api_key: '',
-  uplink_message: { enabled: false, value: '' },
-  join_accept: { enabled: false, value: '' },
-  downlink_ack: { enabled: false, value: '' },
-  downlink_nack: { enabled: false, value: '' },
-  downlink_sent: { enabled: false, value: '' },
-  downlink_failed: { enabled: false, value: '' },
-  downlink_queued: { enabled: false, value: '' },
-  downlink_queue_invalidated: { enabled: false, value: '' },
-  location_solved: { enabled: false, value: '' },
-  service_data: { enabled: false, value: '' },
+  uplink_message: null,
+  join_accept: null,
+  downlink_ack: null,
+  downlink_nack: null,
+  downlink_sent: null,
+  downlink_failed: null,
+  downlink_queued: null,
+  downlink_queue_invalidated: null,
+  location_solved: null,
+  service_data: null,
   _basic_auth_enabled: false,
   _basic_auth_username: '',
   _basic_auth_password: '',

--- a/pkg/webui/lib/errors/utils.js
+++ b/pkg/webui/lib/errors/utils.js
@@ -409,7 +409,7 @@ export const getBackendErrorRootCause = error => {
  * @returns {string} The attributes or undefined.
  */
 export const getBackendErrorMessageAttributes = error =>
-  isBackend(error) ? error.details[0].attributes : undefined
+  hasValidDetails(error) ? error.details[0].attributes : undefined
 
 /**
  * Returns the correlation ID of the backend error message if present,
@@ -419,7 +419,7 @@ export const getBackendErrorMessageAttributes = error =>
  * @returns {string} The correlation ID.
  */
 export const getCorrelationId = error =>
-  isBackend(error) ? error.details[0].correlation_id : undefined
+  hasValidDetails(error) ? error.details[0].correlation_id : undefined
 
 /**
  * Adapts the error object to props of message object, if possible.


### PR DESCRIPTION
#### Summary
This quickfix fixes a critical issue within webhooks that caused webhooks being created with all message types enabled as well as made it impossible to deactivate message types.


#### Changes
<!-- What are the changes made in this pull request? -->

- Fix the decode and encode function for message type fields
- Update cypress webhook tests to prevent false positives in the future
- Fix a small issue causing errors when extracting info from the details of a backend error object


#### Testing

Manual and e2e

#### Notes for Reviewers
This also affected field validation for message types causing the form [to not warn on paths that were longer than 64](https://sentry.io/organizations/the-things-industries/issues/2015318983/events/e170b971330744349f65ca97daaf1923/?project=2682566&query=frontendOrigin%3ATrue+is%3Aunresolved&statsPeriod=14d) characters before submitting.

We need to make sure that we don't solely rely on the success toast when doing end-to-end tests but actually check whether fields are set as expected after refreshing the page.

We'll hotfix and deploy this fix tomorrow once this PR is merged.

cc @adriansmares 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
