### PR TITLE
Add warning for gateway creation without Frequency Plan

### DIFF
--- a/cmd/ttn-lw-cli/commands/gateways.go
+++ b/cmd/ttn-lw-cli/commands/gateways.go
@@ -300,6 +300,11 @@ var (
 			if !proto.Equal(antenna, &ttnpb.GatewayAntenna{}) {
 				gateway.Antennas = []*ttnpb.GatewayAntenna{antenna}
 			}
+
+			if gateway.FrequencyPlanId == "" && len(gateway.FrequencyPlanIds) == 0 {
+				logger.Warn("Frequency plan not set. Without choosing a frequency plan, packets from the gateway will not be correctly processed")
+			}
+
 			is, err := api.Dial(ctx, config.IdentityServerGRPCAddress)
 			if err != nil {
 				return err


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #5292 

#### Changes
<!-- What are the changes made in this pull request? -->

- Add warning for gateway creation without Frequency Plan

#### Testing

<!-- How did you verify that this change works? -->

Local
```bash
./ttn-lw-cli gateway create testgtw --user-id admin
WARN    Using insecure connection to OAuth server
WARN    Using insecure connection to API
WARN    Frequency plan not set. Without choosing a frequency plan, packets from the gateway will not be correctly processed
{
  "ids": {
    "gateway_id": "testgtw"
  },
  "created_at": "2022-03-16T14:40:00.039Z",
  "updated_at": "2022-03-16T14:40:00.039Z",
  "administrative_contact": {
    "user_ids": {
      "user_id": "admin"
    }
  },
  "technical_contact": {
    "user_ids": {
      "user_id": "admin"
    }
  },
  "version_ids": {},
  "gateway_server_address": "localhost",
  "auto_update": true,
  "status_public": true,
  "location_public": true,
  "enforce_duty_cycle": true,
  "schedule_anytime_delay": "0s",
  "claim_authentication_code": {},
  "lrfhss": {}
}
```

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

NA


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
