### PR TITLE
Improve payload formatter link handling

### DIFF
--- a/pkg/webui/console/containers/device-payload-formatters/messages.js
+++ b/pkg/webui/console/containers/device-payload-formatters/messages.js
@@ -17,6 +17,8 @@ import { defineMessages } from 'react-intl'
 const m = defineMessages({
   defaultFormatter:
     'Click <Link>here</Link> to modify the default payload formatter for this application',
+  mayNotViewLink:
+    'You are not allowed to view link information of this application. This includes seeing the default payload formatter of this application.',
 })
 
 export default m

--- a/pkg/webui/console/views/application-payload-formatters/application-payload-formatters.js
+++ b/pkg/webui/console/views/application-payload-formatters/application-payload-formatters.js
@@ -33,10 +33,8 @@ const ApplicationPayloadFormatters = props => {
   const {
     appId,
     fetching,
-    getLink,
     match,
     match: { url },
-    mayViewLink,
   } = props
 
   useBreadcrumbs(
@@ -46,12 +44,6 @@ const ApplicationPayloadFormatters = props => {
       content={sharedMessages.payloadFormatters}
     />,
   )
-
-  React.useEffect(() => {
-    if (mayViewLink) {
-      getLink(appId, ['default_formatters'])
-    }
-  }, [appId, getLink, mayViewLink])
 
   if (fetching) {
     return (
@@ -83,9 +75,7 @@ const ApplicationPayloadFormatters = props => {
 ApplicationPayloadFormatters.propTypes = {
   appId: PropTypes.string.isRequired,
   fetching: PropTypes.bool.isRequired,
-  getLink: PropTypes.func.isRequired,
   match: PropTypes.match.isRequired,
-  mayViewLink: PropTypes.bool.isRequired,
 }
 
 export default ApplicationPayloadFormatters

--- a/pkg/webui/console/views/application-payload-formatters/connect.js
+++ b/pkg/webui/console/views/application-payload-formatters/connect.js
@@ -14,6 +14,8 @@
 
 import { connect as withConnect } from 'react-redux'
 
+import withRequest from '@ttn-lw/lib/components/with-request'
+
 import withFeatureRequirement from '@console/lib/components/with-feature-requirement'
 
 import pipe from '@ttn-lw/lib/pipe'
@@ -52,6 +54,11 @@ const addHocs = pipe(
   withConnect(mapStateToProps, mapDispatchToProps),
   withFeatureRequirement(maySetApplicationPayloadFormatters, {
     redirect: ({ appId }) => `/applications/${appId}`,
+  }),
+  withRequest(({ appId, getLink, mayViewLink }) => {
+    if (mayViewLink) {
+      getLink(appId, ['default_formatters'])
+    }
   }),
 )
 

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -405,6 +405,7 @@
   "console.containers.device-importer.index.abortWarningMessage": "The end device import was aborted and the remaining {count} {count, plural, one {end device} other {end devices}} have not been imported",
   "console.containers.device-importer.index.largeFileWarningMessage": "Providing files larger than {warningThreshold} can cause issues during the import process. We recommend you to split such files up into multiple smaller files and importing them one by one.",
   "console.containers.device-payload-formatters.messages.defaultFormatter": "Click <Link>here</Link> to modify the default payload formatter for this application",
+  "console.containers.device-payload-formatters.messages.mayNotViewLink": "You are not allowed to view link information of this application. This includes seeing the default payload formatter of this application.",
   "console.containers.device-template-format-select.index.title": "File format",
   "console.containers.device-template-format-select.index.warning": "End device template formats unavailable",
   "console.containers.device-title-section.device-title-section.uplinkDownlinkTooltip": "The number of sent uplinks and received downlinks of this end device since the last frame counter reset.",


### PR DESCRIPTION
#### Summary
This quickfix PR will fix and improve payload formatter logic when the application has no link or link info.

#### Changes
<!-- What are the changes made in this pull request? -->
- Catch link errors and display them in the app payload formatter view
- Handle missing link in application and end device payload formatters

#### Testing

Manual.

#### Notes for Reviewers
See https://sentry.io/organizations/the-things-industries/issues/2801479339/?project=2682566&query=default_formatters&statsPeriod=14d

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
