### PR TITLE
console: Show data reveive messages for downlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
+- Replace `as.down.data.forward` to `as.down.data.receive` in default event filter, so that decrypted and decoded dowlink payload can be examined in the Console.
+
 ### Deprecated
 
 ### Removed

--- a/pkg/applicationserver/observability.go
+++ b/pkg/applicationserver/observability.go
@@ -88,6 +88,7 @@ var (
 		events.WithDataType(&ttnpb.ApplicationDownlink{}),
 		events.WithAuthFromContext(),
 		events.WithClientInfoFromContext(),
+		events.WithPropagateToParent(),
 	)
 	evtDropDataDown = events.Define(
 		"as.down.data.drop", "drop downlink data message",
@@ -101,7 +102,6 @@ var (
 		events.WithDataType(&ttnpb.ApplicationDownlink{}),
 		events.WithAuthFromContext(),
 		events.WithClientInfoFromContext(),
-		events.WithPropagateToParent(),
 	)
 	evtEncodeFailDataDown = events.Define(
 		"as.down.data.encode.fail", "encode downlink data message failure",

--- a/pkg/webui/console/constants/event-filters.js
+++ b/pkg/webui/console/constants/event-filters.js
@@ -16,7 +16,7 @@ import { APPLICATION, END_DEVICE, GATEWAY } from '@console/constants/entities'
 
 export const END_DEVICE_EVENTS_VERBOSE_FILTERS = [
   'as.*.drop',
-  'as.down.data.forward',
+  'as.down.data.receive',
   'as.up.*.forward',
   'js.join.accept',
   'js.join.reject',


### PR DESCRIPTION
#### Summary
Quickfix PR to change the application and end device event filter in the Console to use downlink data receive events rather than downlink data forward events, which only contain the encrypted payload.

Closes #5304 

#### Changes
- Replace `as.down.data.forward` to `as.down.data.receive` in Console event default filter
- Propagate `as.down.data.receive` instead of `as.down.data.forward` to the application event stream

#### Testing

Manual testing.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
