### PR TITLE
Support claiming deleted tasks

### DIFF
--- a/pkg/redis/lua/dispatchTask.lua
+++ b/pkg/redis/lua/dispatchTask.lua
@@ -40,14 +40,14 @@ if #streams > 0 then
     for i, xs in ipairs(streams) do
         for j, x in ipairs(xs[2]) do
             local start_at, payload, replace
-            for j = 1, #x[2], 2 do
-                local name = x[2][j]
+            for k = 1, #x[2], 2 do
+                local name = x[2][k]
                 if name == 'start_at' then
-                    start_at = x[2][j + 1]
+                    start_at = x[2][k + 1]
                 elseif name == 'payload' then
-                    payload = x[2][j + 1]
+                    payload = x[2][k + 1]
                 elseif name == 'replace' then
-                    replace = x[2][j + 1]
+                    replace = x[2][k + 1]
                 end
             end
             if replace then


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/5308
References https://github.com/redis/redis/pull/10227

#### Changes
<!-- What are the changes made in this pull request? -->

- Explicitly check if the message actually has fields (is not deleted)

This bug was a pain to debug. It occurs due to the fact that the input task stream has a fixed size, so older messages are deleted as the time goes on. This normally is not an issue, but references to these messages remain in the pending entries list of the consumers (in Redis, deleting a message from the stream, either manually or automatically, does not remove it from the pending entries list of the consumers in the consumer group). 
#5308 added an `XAUTOCLAIM` call in order to ensure that even if a dispatcher goes down, we can pickup the message and prepare it in another dispatcher. The problem is that this `XAUTOCLAIM` call may pickup these 'deleted-but-still-referenced-by-dead-consumers' messages, which we must explicitly check now until we have Redis 7.0 compatibility.


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Unit testing covers this.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
