### PR TITLE
Set default port if it doesn't exist in LBS discover message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ For details about compatibility between different releases, see the **Commitment
 - Fix issues in the webhook forms causing webhooks to be created with all message types enabled and no way of deactivating message types.
 - Fix validation issue in the webhook form not detecting message type paths with more than 64 characters.
 - Fix "reactivate"-webhook button in the Console.
+- Port returned by the LBS LNS discovery message if standard 80/443 ports are used.
 
 ### Security
 

--- a/pkg/gatewayserver/io/ws/ws.go
+++ b/pkg/gatewayserver/io/ws/ws.go
@@ -119,14 +119,24 @@ func (s *srv) handleConnectionInfo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	scheme := "ws"
+	var (
+		scheme = "ws"
+		port   = "80"
+	)
 	if r.TLS != nil || s.cfg.UseTrafficTLSAddress {
 		scheme = "wss"
+		port = "443"
+	}
+
+	// If port is retrievable from the host, use it.
+	address := strings.Split(r.Host, ":")
+	if len(address) == 2 {
+		port = address[1]
 	}
 
 	info := ServerInfo{
 		Scheme:  scheme,
-		Address: r.Host,
+		Address: fmt.Sprintf("%s:%s", address[0], port),
 	}
 
 	resp := s.formatter.HandleConnectionInfo(ctx, data, s.server, info, time.Now())


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #5197 

The reasoning is in the issue
> Looking at the docs for Request.Host (https://pkg.go.dev/net/http#Request), it seems that this only returns the port if the port is non-default for the scheme that was used, so for example if you're connecting via wss:// and you're connected via 443, it will omit the port, but if you use the scheme wss:// but you're connected via 8887, the port will be included. The issue is that TTS currently assumes that it always returns the port.

#### Changes
<!-- What are the changes made in this pull request? -->

- Use default port values and set ports only if present in `r.Host`.

#### Testing

<!-- How did you verify that this change works? -->

Locally 
```
» wscat -c ws://localhost:80/router-info
Connected (press CTRL+C to quit)
> {"router":"11-11-11-11-11-11-11-11"}
< {"router":"1111:1111:1111:1111","muxs":"muxs-::0","uri":"ws://localhost:80/traffic/eui-1111111111111111"}
Disconnected (code: 1006, reason: "")
```

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Tested
```
 » wscat -c ws://localhost:1887/router-info
Connected (press CTRL+C to quit)
> {"router":"11-11-11-11-11-11-11-11"}
< {"router":"1111:1111:1111:1111","muxs":"muxs-::0","uri":"ws://localhost:1887/traffic/eui-1111111111111111"}
Disconnected (code: 1006, reason: "")
```

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This is quite difficult to UT since the tests need to bind port 80/443 and it's not easy to locally test since I need to setup a proxy. But I think the current tests are sufficient.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
