### PR TITLE
Deprecate contact-info commands in CLI

### DIFF
--- a/cmd/ttn-lw-cli/commands/contact_info.go
+++ b/cmd/ttn-lw-cli/commands/contact_info.go
@@ -147,11 +147,13 @@ var (
 func contactInfoCommands(entity string, getID func(cmd *cobra.Command, args []string) (*ttnpb.EntityIdentifiers, error)) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "contact-info",
-		Short: fmt.Sprintf("Manage %s contact info", entity),
+		Short: fmt.Sprintf("Manage %[1]s contact info (DEPRECATED. Instead, use administrative_contact and technical_contact fields of %[1]s)", entity),
 	}
 	list := &cobra.Command{
 		Use:     fmt.Sprintf("list [%s-id]", entity),
 		Aliases: []string{"ls", "get"},
+		Short:   fmt.Sprintf("List %[1]s contact info (DEPRECATED. Instead, select administrative_contact and technical_contact fields of %[1]s)", entity),
+		Hidden:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := getID(cmd, args)
 			if err != nil {
@@ -167,6 +169,8 @@ func contactInfoCommands(entity string, getID func(cmd *cobra.Command, args []st
 	add := &cobra.Command{
 		Use:     fmt.Sprintf("create [%s-id]", entity),
 		Aliases: []string{"add", "register"},
+		Short:   fmt.Sprintf("Add %[1]s contact info (DEPRECATED. Instead, set administrative_contact and technical_contact fields of %[1]s)", entity),
+		Hidden:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := getID(cmd, args)
 			if err != nil {
@@ -193,6 +197,8 @@ func contactInfoCommands(entity string, getID func(cmd *cobra.Command, args []st
 	remove := &cobra.Command{
 		Use:     fmt.Sprintf("delete [%s-id]", entity),
 		Aliases: []string{"del", "remove", "rm"},
+		Short:   fmt.Sprintf("Remove %[1]s contact info (DEPRECATED. Instead, unset administrative_contact and technical_contact fields of %[1]s)", entity),
+		Hidden:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := getID(cmd, args)
 			if err != nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Refs #4930

#### Changes
<!-- What are the changes made in this pull request? -->

- Mark commands as deprecated and hide them.

#### Testing

<!-- How did you verify that this change works? -->

Using the `--help` flag.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

nil

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

nil

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
