### PR TITLE
Use getter for session keys during downlink queue operation

### DIFF
--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -545,11 +545,11 @@ func (as *ApplicationServer) attemptDownlinkQueueOp(ctx context.Context, dev *tt
 		ctx := log.NewContextWithField(ctx, "attempt", attempt)
 
 		sessions := make([]*ttnpb.Session, 0, 2)
-		if dev.Session != nil && !op.shouldSkip(dev.Session.Keys.SessionKeyId) {
+		if dev.Session != nil && !op.shouldSkip(dev.Session.GetKeys().GetSessionKeyId()) {
 			sessions = append(sessions, dev.Session)
 			mask = ttnpb.AddFields(mask, "session.last_a_f_cnt_down")
 		}
-		if dev.PendingSession != nil && !op.shouldSkip(dev.PendingSession.Keys.SessionKeyId) {
+		if dev.PendingSession != nil && !op.shouldSkip(dev.PendingSession.GetKeys().GetSessionKeyId()) {
 			// Downlink can be encrypted with the pending session while the device first joined but not confirmed the
 			// session by sending an uplink.
 			sessions = append(sessions, dev.PendingSession)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://sentry.io/organizations/the-things-industries/issues/3128395476

#### Changes
<!-- What are the changes made in this pull request? -->

- Use getter for session key retrieval during downlink queue operations


#### Testing

<!-- How did you verify that this change works? -->

UT.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
