### PR TITLE
Refactor ADR API usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ For details about compatibility between different releases, see the **Commitment
   - This requires a database schema migration (`ttn-lw-stack is-db migrate`) because of the added tables.
 - Add `network_server_address`, `application_server_address` and `join_server_address` to applications.
   - This requires a database schema migration (`ttn-lw-stack is-db migrate`) because of the added columns.
+- New ADR settings API, which allows stronger control over the ADR algorithm.
+  - The new settings fields can be found under `mac-settings.adr`, and are mutually exclusive with `use-adr` and `adr-margin`. The legacy settings need to be unset before the new API options may be used.
+  - `mac-settings.adr.mode.disabled` completely disables the ADR algorithm.
+  - `mac-settings.adr.mode.static.data-rate-index`, `mac-settings.adr.mode.static.nb-trans`, `mac-settings.adr.mode.static.tx-power-index` allow the user to provide static ADR parameters to be negotiated with the end device. These options persist over multiple sessions and do not require a session reset in order to be propagated to the current session.
+  - `mac-settings.adr.mode.dynamic.min-data-rate-index` and `mac-settings.adr.mode.dynamic.max-data-rate-index` control the data rate index range which the Network Server will attempt to negotiate with the end device. Note that if the provided interval is disjoint with the available data rate indices, no negotiation will take place.
+  - `mac-settings.adr.mode.dynamic.min-tx-power-index` and `mac-settings.adr.mode.dynamic.max-tx-power-index` have similar behavior, but for transmission power indices.
+  - `mac-settings.adr.mode.dynamic.min-nb-trans` and `mac-settings.adr.mode.dynamic.max-nb-trans` have similar behavior, but for NbTrans.
+  - `mac-settings.adr.mode.dynamic.margin` may be used to provide the margin of the ADR algorithm. It replaces the old `adr-margin` setting.
+  - `use-adr` and `adr-margin` are still supported, but deprecated. Any future API usage should instead use the `mac-settings.adr` settings.
 
 ### Changed
 

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -333,8 +333,12 @@ var (
 				return err
 			}
 
-			device.SetFields(res, "ids.dev_addr")
-			device.SetFields(res, append(append(nsPaths, asPaths...), jsPaths...)...)
+			if err := device.SetFields(res, "ids.dev_addr"); err != nil {
+				return err
+			}
+			if err := device.SetFields(res, append(append(nsPaths, asPaths...), jsPaths...)...); err != nil {
+				return err
+			}
 			if device.CreatedAt == nil || (res.CreatedAt != nil && ttnpb.StdTime(res.CreatedAt).Before(*ttnpb.StdTime(device.CreatedAt))) {
 				device.CreatedAt = res.CreatedAt
 			}
@@ -516,7 +520,7 @@ var (
 				paths = append(paths, "locations")
 			}
 
-			if err = util.SetFields(device, setEndDeviceFlags); err != nil {
+			if err := util.SetFields(device, setEndDeviceFlags); err != nil {
 				return err
 			}
 
@@ -625,7 +629,9 @@ var (
 			}
 			isDevice := &ttnpb.EndDevice{}
 			logger.WithField("paths", isPaths).Debug("Create end device on Identity Server")
-			isDevice.SetFields(device, append(isPaths, "ids")...)
+			if err := isDevice.SetFields(device, append(isPaths, "ids")...); err != nil {
+				return err
+			}
 			isRes, err := ttnpb.NewEndDeviceRegistryClient(is).Create(ctx, &ttnpb.CreateEndDeviceRequest{
 				EndDevice: isDevice,
 			})
@@ -633,7 +639,9 @@ var (
 				return err
 			}
 
-			device.SetFields(isRes, append(isPaths, "created_at", "updated_at")...)
+			if err := device.SetFields(isRes, append(isPaths, "created_at", "updated_at")...); err != nil {
+				return err
+			}
 
 			res, err := setEndDevice(device, nil, nsPaths, asPaths, jsPaths, nil, true, false)
 			if err != nil {
@@ -644,7 +652,9 @@ var (
 				return err
 			}
 
-			device.SetFields(res, append(append(nsPaths, asPaths...), jsPaths...)...)
+			if err := device.SetFields(res, append(append(nsPaths, asPaths...), jsPaths...)...); err != nil {
+				return err
+			}
 			if device.CreatedAt == nil || (res.CreatedAt != nil && ttnpb.StdTime(res.CreatedAt).Before(*ttnpb.StdTime(device.CreatedAt))) {
 				device.CreatedAt = res.CreatedAt
 			}
@@ -780,7 +790,9 @@ var (
 			}
 
 			if hasUpdateDeviceLocationFlags(cmd.Flags()) {
-				device.SetFields(existingDevice, "locations")
+				if err := device.SetFields(existingDevice, "locations"); err != nil {
+					return err
+				}
 				updateDeviceLocation(device, cmd.Flags())
 			}
 
@@ -929,8 +941,12 @@ var (
 			if err != nil {
 				return err
 			}
-			device.SetFields(nsDevice, "ids.dev_addr")
-			device.SetFields(nsDevice, ttnpb.AllowedBottomLevelFields(nsPaths, getEndDeviceFromNS)...)
+			if err := device.SetFields(nsDevice, "ids.dev_addr"); err != nil {
+				return err
+			}
+			if err := device.SetFields(nsDevice, ttnpb.AllowedBottomLevelFields(nsPaths, getEndDeviceFromNS)...); err != nil {
+				return err
+			}
 			if device.CreatedAt == nil || (nsDevice.CreatedAt != nil && ttnpb.StdTime(nsDevice.CreatedAt).Before(*ttnpb.StdTime(device.CreatedAt))) {
 				device.CreatedAt = nsDevice.CreatedAt
 			}
@@ -1234,7 +1250,9 @@ This command may take end device identifiers from stdin.`,
 			if err != nil {
 				return err
 			}
-			device.SetFields(dev, append(append(nsPaths, asPaths...), jsPaths...)...)
+			if err := device.SetFields(dev, append(append(nsPaths, asPaths...), jsPaths...)...); err != nil {
+				return err
+			}
 
 			size, _ := cmd.Flags().GetUint32("size")
 			res, err := client.Generate(ctx, &ttnpb.GenerateEndDeviceQRCodeRequest{

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -77,6 +77,9 @@ func addDeprecatedDeviceFlags(flagSet *pflag.FlagSet) {
 	util.DeprecateFlag(flagSet, "pending_session.keys.nwk_s_key", "pending_session.keys.f_nwk_s_int_key")
 	util.DeprecateFlag(flagSet, "session.keys.nwk_s_key.key", "session.keys.f_nwk_s_int_key.key")
 	util.DeprecateFlag(flagSet, "pending_session.keys.nwk_s_key.key", "pending_session.keys.f_nwk_s_int_key.key")
+
+	util.HideFlag(flagSet, "mac_settings.use_adr")
+	util.HideFlag(flagSet, "mac_settings.adr_margin")
 }
 
 func forwardDeprecatedDeviceFlags(flagSet *pflag.FlagSet) {

--- a/pkg/band/as_923_rp1_v1_0_2.go
+++ b/pkg/band/as_923_rp1_v1_0_2.go
@@ -22,7 +22,7 @@ import (
 var AS_923_RP1_v1_0_2 = Band{
 	ID: AS_923,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    as923DefaultChannels(as923Group1Offset),

--- a/pkg/band/as_923_rp1_v1_0_2_rev_b.go
+++ b/pkg/band/as_923_rp1_v1_0_2_rev_b.go
@@ -22,7 +22,7 @@ import (
 var AS_923_RP1_v1_0_2_RevB = Band{
 	ID: AS_923,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    as923DefaultChannels(as923Group1Offset),

--- a/pkg/band/as_923_rp1_v1_0_3_rev_a.go
+++ b/pkg/band/as_923_rp1_v1_0_3_rev_a.go
@@ -22,7 +22,7 @@ import (
 var AS_923_RP1_v1_0_3_RevA = Band{
 	ID: AS_923,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    as923DefaultChannels(as923Group1Offset),

--- a/pkg/band/as_923_rp1_v1_1_rev_a.go
+++ b/pkg/band/as_923_rp1_v1_1_rev_a.go
@@ -22,7 +22,7 @@ import (
 var AS_923_RP1_v1_1_RevA = Band{
 	ID: AS_923,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    as923DefaultChannels(as923Group1Offset),

--- a/pkg/band/as_923_rp1_v1_1_rev_b.go
+++ b/pkg/band/as_923_rp1_v1_1_rev_b.go
@@ -22,7 +22,7 @@ import (
 var AS_923_RP1_v1_1_RevB = Band{
 	ID: AS_923,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    as923DefaultChannels(as923Group1Offset),

--- a/pkg/band/as_923_rp2_v1_0_0.go
+++ b/pkg/band/as_923_rp2_v1_0_0.go
@@ -22,7 +22,7 @@ import (
 var AS_923_RP2_v1_0_0 = Band{
 	ID: AS_923,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    as923DefaultChannels(as923Group1Offset),

--- a/pkg/band/as_923_rp2_v1_0_1.go
+++ b/pkg/band/as_923_rp2_v1_0_1.go
@@ -31,7 +31,7 @@ var as923RP2101Band = func(id string, offset as923GroupOffset) Band {
 	return Band{
 		ID: id,
 
-		EnableADR: true,
+		SupportsDynamicADR: true,
 
 		MaxUplinkChannels: 16,
 		UplinkChannels:    as923DefaultChannels(offset),

--- a/pkg/band/as_923_rp2_v1_0_2.go
+++ b/pkg/band/as_923_rp2_v1_0_2.go
@@ -31,7 +31,7 @@ var as923RP2102Band = func(id string, offset as923GroupOffset) Band {
 	return Band{
 		ID: id,
 
-		EnableADR: true,
+		SupportsDynamicADR: true,
 
 		MaxUplinkChannels: 16,
 		UplinkChannels:    as923DefaultChannels(offset),

--- a/pkg/band/as_923_rp2_v1_0_3.go
+++ b/pkg/band/as_923_rp2_v1_0_3.go
@@ -33,7 +33,7 @@ var as923RP2103Band = func(id string, offset as923GroupOffset) Band {
 	return Band{
 		ID: id,
 
-		EnableADR: true,
+		SupportsDynamicADR: true,
 
 		MaxUplinkChannels: 16,
 		UplinkChannels:    as923DefaultChannels(offset),

--- a/pkg/band/au_915_928_rp1_v1_0_2.go
+++ b/pkg/band/au_915_928_rp1_v1_0_2.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var AU_915_928_RP1_v1_0_2 = Band{
 	ID: AU_915_928,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
 	UplinkChannels:    au915928UplinkChannels(-2),

--- a/pkg/band/au_915_928_rp1_v1_0_2_rev_b.go
+++ b/pkg/band/au_915_928_rp1_v1_0_2_rev_b.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var AU_915_928_RP1_v1_0_2_RevB = Band{
 	ID: AU_915_928,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
 	UplinkChannels:    au915928UplinkChannels(0),

--- a/pkg/band/au_915_928_rp1_v1_0_3_rev_a.go
+++ b/pkg/band/au_915_928_rp1_v1_0_3_rev_a.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var AU_915_928_RP1_v1_0_3_RevA = Band{
 	ID: AU_915_928,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
 	UplinkChannels:    au915928UplinkChannels(0),

--- a/pkg/band/au_915_928_rp1_v1_1_rev_a.go
+++ b/pkg/band/au_915_928_rp1_v1_1_rev_a.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var AU_915_928_RP1_v1_1_RevA = Band{
 	ID: AU_915_928,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
 	UplinkChannels:    au915928UplinkChannels(0),

--- a/pkg/band/au_915_928_rp1_v1_1_rev_b.go
+++ b/pkg/band/au_915_928_rp1_v1_1_rev_b.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var AU_915_928_RP1_v1_1_RevB = Band{
 	ID: AU_915_928,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
 	UplinkChannels:    au915928UplinkChannels(0),

--- a/pkg/band/au_915_928_rp2_v1_0_0.go
+++ b/pkg/band/au_915_928_rp2_v1_0_0.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var AU_915_928_RP2_v1_0_0 = Band{
 	ID: AU_915_928,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
 	UplinkChannels:    au915928UplinkChannels(0),

--- a/pkg/band/au_915_928_rp2_v1_0_1.go
+++ b/pkg/band/au_915_928_rp2_v1_0_1.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var AU_915_928_RP2_v1_0_1 = Band{
 	ID: AU_915_928,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
 	UplinkChannels:    au915928UplinkChannels(0),

--- a/pkg/band/au_915_928_rp2_v1_0_2.go
+++ b/pkg/band/au_915_928_rp2_v1_0_2.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var AU_915_928_RP2_v1_0_2 = Band{
 	ID: AU_915_928,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
 	UplinkChannels:    au915928UplinkChannels(0),

--- a/pkg/band/au_915_928_rp2_v1_0_3.go
+++ b/pkg/band/au_915_928_rp2_v1_0_3.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var AU_915_928_RP2_v1_0_3 = Band{
 	ID: AU_915_928,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
 	UplinkChannels:    au915928UplinkChannels(0),

--- a/pkg/band/au_915_928_ts1_v1_0_1.go
+++ b/pkg/band/au_915_928_ts1_v1_0_1.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var AU_915_928_TS1_v1_0_1 = Band{
 	ID: AU_915_928,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
 	UplinkChannels:    au915928UplinkChannels(-2),

--- a/pkg/band/band.go
+++ b/pkg/band/band.go
@@ -60,8 +60,8 @@ type Band struct {
 	// MaxFCntGap
 	MaxFCntGap uint
 
-	// EnableADR determines whether ADR should be enabled.
-	EnableADR bool
+	// SupportsDynamicADR determines whether the Adaptive Data Rate algorithm is supported.
+	SupportsDynamicADR bool
 	// ADRAckLimit
 	ADRAckLimit ttnpb.ADRAckLimitExponent
 	// ADRAckDelay

--- a/pkg/band/cn_470_510_20_a_rp2_v1_0_0.go
+++ b/pkg/band/cn_470_510_20_a_rp2_v1_0_0.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_470_510_20_A_RP2_v1_0_0 = Band{
 	ID: CN_470_510_20_A,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 64,
 	UplinkChannels:    cn47051020AUplinkChannels,

--- a/pkg/band/cn_470_510_20_a_rp2_v1_0_1.go
+++ b/pkg/band/cn_470_510_20_a_rp2_v1_0_1.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_470_510_20_A_RP2_v1_0_1 = Band{
 	ID: CN_470_510_20_A,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 64,
 	UplinkChannels:    cn47051020AUplinkChannels,

--- a/pkg/band/cn_470_510_20_a_rp2_v1_0_2.go
+++ b/pkg/band/cn_470_510_20_a_rp2_v1_0_2.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_470_510_20_A_RP2_v1_0_2 = Band{
 	ID: CN_470_510_20_A,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 64,
 	UplinkChannels:    cn47051020AUplinkChannels,

--- a/pkg/band/cn_470_510_20_a_rp2_v1_0_3.go
+++ b/pkg/band/cn_470_510_20_a_rp2_v1_0_3.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_470_510_20_A_RP2_v1_0_3 = Band{
 	ID: CN_470_510_20_A,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 64,
 	UplinkChannels:    cn47051020AUplinkChannels,

--- a/pkg/band/cn_470_510_20_b_rp2_v1_0_0.go
+++ b/pkg/band/cn_470_510_20_b_rp2_v1_0_0.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_470_510_20_B_RP2_v1_0_0 = Band{
 	ID: CN_470_510_20_B,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 64,
 	UplinkChannels:    cn47051020BUplinkChannels,

--- a/pkg/band/cn_470_510_20_b_rp2_v1_0_1.go
+++ b/pkg/band/cn_470_510_20_b_rp2_v1_0_1.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_470_510_20_B_RP2_v1_0_1 = Band{
 	ID: CN_470_510_20_B,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 64,
 	UplinkChannels:    cn47051020BUplinkChannels,

--- a/pkg/band/cn_470_510_20_b_rp2_v1_0_2.go
+++ b/pkg/band/cn_470_510_20_b_rp2_v1_0_2.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_470_510_20_B_RP2_v1_0_2 = Band{
 	ID: CN_470_510_20_B,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 64,
 	UplinkChannels:    cn47051020BUplinkChannels,

--- a/pkg/band/cn_470_510_20_b_rp2_v1_0_3.go
+++ b/pkg/band/cn_470_510_20_b_rp2_v1_0_3.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_470_510_20_B_RP2_v1_0_3 = Band{
 	ID: CN_470_510_20_B,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 64,
 	UplinkChannels:    cn47051020BUplinkChannels,

--- a/pkg/band/cn_470_510_26_a_rp2_v1_0_0.go
+++ b/pkg/band/cn_470_510_26_a_rp2_v1_0_0.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_470_510_26_A_RP2_v1_0_0 = Band{
 	ID: CN_470_510_26_A,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 48,
 	UplinkChannels:    cn47051026AUplinkChannels,

--- a/pkg/band/cn_470_510_26_a_rp2_v1_0_1.go
+++ b/pkg/band/cn_470_510_26_a_rp2_v1_0_1.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_470_510_26_A_RP2_v1_0_1 = Band{
 	ID: CN_470_510_26_A,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 48,
 	UplinkChannels:    cn47051026AUplinkChannels,

--- a/pkg/band/cn_470_510_26_a_rp2_v1_0_2.go
+++ b/pkg/band/cn_470_510_26_a_rp2_v1_0_2.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_470_510_26_A_RP2_v1_0_2 = Band{
 	ID: CN_470_510_26_A,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 48,
 	UplinkChannels:    cn47051026AUplinkChannels,

--- a/pkg/band/cn_470_510_26_a_rp2_v1_0_3.go
+++ b/pkg/band/cn_470_510_26_a_rp2_v1_0_3.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_470_510_26_A_RP2_v1_0_3 = Band{
 	ID: CN_470_510_26_A,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 48,
 	UplinkChannels:    cn47051026AUplinkChannels,

--- a/pkg/band/cn_470_510_26_b_rp2_v1_0_0.go
+++ b/pkg/band/cn_470_510_26_b_rp2_v1_0_0.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_470_510_26_B_RP2_v1_0_0 = Band{
 	ID: CN_470_510_26_B,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 48,
 	UplinkChannels:    cn47051026BUplinkChannels,

--- a/pkg/band/cn_470_510_26_b_rp2_v1_0_1.go
+++ b/pkg/band/cn_470_510_26_b_rp2_v1_0_1.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_470_510_26_B_RP2_v1_0_1 = Band{
 	ID: CN_470_510_26_B,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 48,
 	UplinkChannels:    cn47051026BUplinkChannels,

--- a/pkg/band/cn_470_510_26_b_rp2_v1_0_2.go
+++ b/pkg/band/cn_470_510_26_b_rp2_v1_0_2.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_470_510_26_B_RP2_v1_0_2 = Band{
 	ID: CN_470_510_26_B,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 48,
 	UplinkChannels:    cn47051026BUplinkChannels,

--- a/pkg/band/cn_470_510_26_b_rp2_v1_0_3.go
+++ b/pkg/band/cn_470_510_26_b_rp2_v1_0_3.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_470_510_26_B_RP2_v1_0_3 = Band{
 	ID: CN_470_510_26_B,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 48,
 	UplinkChannels:    cn47051026BUplinkChannels,

--- a/pkg/band/cn_470_510_rp1_v1_0_2.go
+++ b/pkg/band/cn_470_510_rp1_v1_0_2.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_470_510_RP1_v1_0_2 = Band{
 	ID: CN_470_510,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 96,
 	UplinkChannels:    cn470510UplinkChannels,

--- a/pkg/band/cn_470_510_rp1_v1_0_2_rev_b.go
+++ b/pkg/band/cn_470_510_rp1_v1_0_2_rev_b.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_470_510_RP1_v1_0_2_RevB = Band{
 	ID: CN_470_510,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 96,
 	UplinkChannels:    cn470510UplinkChannels,

--- a/pkg/band/cn_470_510_rp1_v1_0_3_rev_a.go
+++ b/pkg/band/cn_470_510_rp1_v1_0_3_rev_a.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_470_510_RP1_v1_0_3_RevA = Band{
 	ID: CN_470_510,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 96,
 	UplinkChannels:    cn470510UplinkChannels,

--- a/pkg/band/cn_470_510_rp1_v1_1_rev_a.go
+++ b/pkg/band/cn_470_510_rp1_v1_1_rev_a.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_470_510_RP1_v1_1_RevA = Band{
 	ID: CN_470_510,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 96,
 	UplinkChannels:    cn470510UplinkChannels,

--- a/pkg/band/cn_470_510_rp1_v1_1_rev_b.go
+++ b/pkg/band/cn_470_510_rp1_v1_1_rev_b.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_470_510_RP1_v1_1_RevB = Band{
 	ID: CN_470_510,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 96,
 	UplinkChannels:    cn470510UplinkChannels,

--- a/pkg/band/cn_470_510_ts1_v1_0_1.go
+++ b/pkg/band/cn_470_510_ts1_v1_0_1.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_470_510_TS1_v1_0_1 = Band{
 	ID: CN_470_510,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 96,
 	UplinkChannels:    cn470510UplinkChannels,

--- a/pkg/band/cn_779_787_rp1_v1_0_2.go
+++ b/pkg/band/cn_779_787_rp1_v1_0_2.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_779_787_RP1_V1_0_2 = Band{
 	ID: CN_779_787,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    cn779787DefaultChannels,

--- a/pkg/band/cn_779_787_rp1_v1_0_2_rev_b.go
+++ b/pkg/band/cn_779_787_rp1_v1_0_2_rev_b.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_779_787_RP1_V1_0_2_RevB = Band{
 	ID: CN_779_787,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    cn779787DefaultChannels,

--- a/pkg/band/cn_779_787_rp1_v1_0_3_rev_a.go
+++ b/pkg/band/cn_779_787_rp1_v1_0_3_rev_a.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_779_787_RP1_V1_0_3_RevA = Band{
 	ID: CN_779_787,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    cn779787DefaultChannels,

--- a/pkg/band/cn_779_787_rp1_v1_1_rev_a.go
+++ b/pkg/band/cn_779_787_rp1_v1_1_rev_a.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_779_787_RP1_V1_1_RevA = Band{
 	ID: CN_779_787,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    cn779787DefaultChannels,

--- a/pkg/band/cn_779_787_rp1_v1_1_rev_b.go
+++ b/pkg/band/cn_779_787_rp1_v1_1_rev_b.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_779_787_RP1_V1_1_RevB = Band{
 	ID: CN_779_787,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    cn779787DefaultChannels,

--- a/pkg/band/cn_779_787_rp2_v1_0_0.go
+++ b/pkg/band/cn_779_787_rp2_v1_0_0.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_779_787_RP2_V1_0_0 = Band{
 	ID: CN_779_787,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    cn779787DefaultChannels,

--- a/pkg/band/cn_779_787_rp2_v1_0_1.go
+++ b/pkg/band/cn_779_787_rp2_v1_0_1.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_779_787_RP2_V1_0_1 = Band{
 	ID: CN_779_787,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    cn779787DefaultChannels,

--- a/pkg/band/cn_779_787_rp2_v1_0_2.go
+++ b/pkg/band/cn_779_787_rp2_v1_0_2.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_779_787_RP2_V1_0_2 = Band{
 	ID: CN_779_787,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    cn779787DefaultChannels,

--- a/pkg/band/cn_779_787_rp2_v1_0_3.go
+++ b/pkg/band/cn_779_787_rp2_v1_0_3.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_779_787_RP2_V1_0_3 = Band{
 	ID: CN_779_787,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    cn779787DefaultChannels,

--- a/pkg/band/cn_779_787_ts1_v1_0.go
+++ b/pkg/band/cn_779_787_ts1_v1_0.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_779_787_RP1_V1_0 = Band{
 	ID: CN_779_787,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    cn779787DefaultChannels,

--- a/pkg/band/cn_779_787_ts1_v1_0_1.go
+++ b/pkg/band/cn_779_787_ts1_v1_0_1.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var CN_779_787_RP1_V1_0_1 = Band{
 	ID: CN_779_787,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    cn779787DefaultChannels,

--- a/pkg/band/eu_433_rp1_v1_0_2.go
+++ b/pkg/band/eu_433_rp1_v1_0_2.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var EU_433_RP1_V1_0_2 = Band{
 	ID: EU_433,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    eu433DefaultChannels,

--- a/pkg/band/eu_433_rp1_v1_0_2_rev_b.go
+++ b/pkg/band/eu_433_rp1_v1_0_2_rev_b.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var EU_433_RP1_V1_0_2_Rev_B = Band{
 	ID: EU_433,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    eu433DefaultChannels,

--- a/pkg/band/eu_433_rp1_v1_0_3_rev_a.go
+++ b/pkg/band/eu_433_rp1_v1_0_3_rev_a.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var EU_433_RP1_V1_0_3_Rev_A = Band{
 	ID: EU_433,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    eu433DefaultChannels,

--- a/pkg/band/eu_433_rp1_v1_1_rev_a.go
+++ b/pkg/band/eu_433_rp1_v1_1_rev_a.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var EU_433_RP1_V1_1_Rev_A = Band{
 	ID: EU_433,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    eu433DefaultChannels,

--- a/pkg/band/eu_433_rp1_v1_1_rev_b.go
+++ b/pkg/band/eu_433_rp1_v1_1_rev_b.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var EU_433_RP1_V1_1_Rev_B = Band{
 	ID: EU_433,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    eu433DefaultChannels,

--- a/pkg/band/eu_433_rp2_v1_0_0.go
+++ b/pkg/band/eu_433_rp2_v1_0_0.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var EU_433_RP2_V1_0_0 = Band{
 	ID: EU_433,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    eu433DefaultChannels,

--- a/pkg/band/eu_433_rp2_v1_0_1.go
+++ b/pkg/band/eu_433_rp2_v1_0_1.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var EU_433_RP2_V1_0_1 = Band{
 	ID: EU_433,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    eu433DefaultChannels,

--- a/pkg/band/eu_433_rp2_v1_0_2.go
+++ b/pkg/band/eu_433_rp2_v1_0_2.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var EU_433_RP2_V1_0_2 = Band{
 	ID: EU_433,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    eu433DefaultChannels,

--- a/pkg/band/eu_433_rp2_v1_0_3.go
+++ b/pkg/band/eu_433_rp2_v1_0_3.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var EU_433_RP2_V1_0_3 = Band{
 	ID: EU_433,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    eu433DefaultChannels,

--- a/pkg/band/eu_433_ts1_v1_0.go
+++ b/pkg/band/eu_433_ts1_v1_0.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var EU_433_TS1_V1_0 = Band{
 	ID: EU_433,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    eu433DefaultChannels,

--- a/pkg/band/eu_433_ts1_v1_0_1.go
+++ b/pkg/band/eu_433_ts1_v1_0_1.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var EU_433_TS1_V1_0_1 = Band{
 	ID: EU_433,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    eu433DefaultChannels,

--- a/pkg/band/eu_863_870_rp1_v1_0_2.go
+++ b/pkg/band/eu_863_870_rp1_v1_0_2.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var EU_863_870_RP1_V1_0_2 = Band{
 	ID: EU_863_870,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    eu863870DefaultChannels,

--- a/pkg/band/eu_863_870_rp1_v1_0_2_rev_b.go
+++ b/pkg/band/eu_863_870_rp1_v1_0_2_rev_b.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var EU_863_870_RP1_V1_0_2_Rev_B = Band{
 	ID: EU_863_870,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    eu863870DefaultChannels,

--- a/pkg/band/eu_863_870_rp1_v1_0_3_rev_a.go
+++ b/pkg/band/eu_863_870_rp1_v1_0_3_rev_a.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var EU_863_870_RP1_V1_0_3_Rev_A = Band{
 	ID: EU_863_870,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    eu863870DefaultChannels,

--- a/pkg/band/eu_863_870_rp1_v1_1_rev_a.go
+++ b/pkg/band/eu_863_870_rp1_v1_1_rev_a.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var EU_863_870_RP1_V1_1_Rev_A = Band{
 	ID: EU_863_870,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    eu863870DefaultChannels,

--- a/pkg/band/eu_863_870_rp1_v1_1_rev_b.go
+++ b/pkg/band/eu_863_870_rp1_v1_1_rev_b.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var EU_863_870_RP1_V1_1_Rev_B = Band{
 	ID: EU_863_870,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    eu863870DefaultChannels,

--- a/pkg/band/eu_863_870_rp2_v1_0_0.go
+++ b/pkg/band/eu_863_870_rp2_v1_0_0.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var EU_863_870_RP2_V1_0_0 = Band{
 	ID: EU_863_870,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    eu863870DefaultChannels,

--- a/pkg/band/eu_863_870_rp2_v1_0_1.go
+++ b/pkg/band/eu_863_870_rp2_v1_0_1.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var EU_863_870_RP2_V1_0_1 = Band{
 	ID: EU_863_870,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    eu863870DefaultChannels,

--- a/pkg/band/eu_863_870_rp2_v1_0_2.go
+++ b/pkg/band/eu_863_870_rp2_v1_0_2.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var EU_863_870_RP2_V1_0_2 = Band{
 	ID: EU_863_870,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    eu863870DefaultChannels,

--- a/pkg/band/eu_863_870_rp2_v1_0_3.go
+++ b/pkg/band/eu_863_870_rp2_v1_0_3.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var EU_863_870_RP2_V1_0_3 = Band{
 	ID: EU_863_870,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    eu863870DefaultChannels,

--- a/pkg/band/eu_863_870_ts1_v1_0.go
+++ b/pkg/band/eu_863_870_ts1_v1_0.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var EU_863_870_TS1_V1_0 = Band{
 	ID: EU_863_870,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    eu863870DefaultChannels,

--- a/pkg/band/eu_863_870_ts1_v1_0_1.go
+++ b/pkg/band/eu_863_870_ts1_v1_0_1.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var EU_863_870_TS1_V1_0_1 = Band{
 	ID: EU_863_870,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    eu863870DefaultChannels,

--- a/pkg/band/in_865_867_rp1_v1_0_2_rev_b.go
+++ b/pkg/band/in_865_867_rp1_v1_0_2_rev_b.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var IN_865_867_RP1_V1_0_2_Rev_B = Band{
 	ID: IN_865_867,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    in865867DefaultChannels,

--- a/pkg/band/in_865_867_rp1_v1_0_3_rev_a.go
+++ b/pkg/band/in_865_867_rp1_v1_0_3_rev_a.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var IN_865_867_RP1_V1_0_3_Rev_A = Band{
 	ID: IN_865_867,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    in865867DefaultChannels,

--- a/pkg/band/in_865_867_rp1_v1_1_rev_a.go
+++ b/pkg/band/in_865_867_rp1_v1_1_rev_a.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var IN_865_867_RP1_V1_1_Rev_A = Band{
 	ID: IN_865_867,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    in865867DefaultChannels,

--- a/pkg/band/in_865_867_rp1_v1_1_rev_b.go
+++ b/pkg/band/in_865_867_rp1_v1_1_rev_b.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var IN_865_867_RP1_V1_1_Rev_B = Band{
 	ID: IN_865_867,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    in865867DefaultChannels,

--- a/pkg/band/in_865_867_rp2_v1_0_0.go
+++ b/pkg/band/in_865_867_rp2_v1_0_0.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var IN_865_867_RP2_V1_0_0 = Band{
 	ID: IN_865_867,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    in865867DefaultChannels,

--- a/pkg/band/in_865_867_rp2_v1_0_1.go
+++ b/pkg/band/in_865_867_rp2_v1_0_1.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var IN_865_867_RP2_V1_0_1 = Band{
 	ID: IN_865_867,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    in865867DefaultChannels,

--- a/pkg/band/in_865_867_rp2_v1_0_2.go
+++ b/pkg/band/in_865_867_rp2_v1_0_2.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var IN_865_867_RP2_V1_0_2 = Band{
 	ID: IN_865_867,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    in865867DefaultChannels,

--- a/pkg/band/in_865_867_rp2_v1_0_3.go
+++ b/pkg/band/in_865_867_rp2_v1_0_3.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var IN_865_867_RP2_V1_0_3 = Band{
 	ID: IN_865_867,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    in865867DefaultChannels,

--- a/pkg/band/kr_920_923_rp1_v1_0_2.go
+++ b/pkg/band/kr_920_923_rp1_v1_0_2.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var KR_920_923_RP1_V1_0_2 = Band{
 	ID: KR_920_923,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    kr920923DefaultChannels,

--- a/pkg/band/kr_920_923_rp1_v1_0_2_rev_b.go
+++ b/pkg/band/kr_920_923_rp1_v1_0_2_rev_b.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var KR_920_923_RP1_V1_0_2_Rev_B = Band{
 	ID: KR_920_923,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    kr920923DefaultChannels,

--- a/pkg/band/kr_920_923_rp1_v1_0_3_rev_a.go
+++ b/pkg/band/kr_920_923_rp1_v1_0_3_rev_a.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var KR_920_923_RP1_V1_0_3_Rev_A = Band{
 	ID: KR_920_923,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    kr920923DefaultChannels,

--- a/pkg/band/kr_920_923_rp1_v1_1_rev_a.go
+++ b/pkg/band/kr_920_923_rp1_v1_1_rev_a.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var KR_920_923_RP1_V1_1_Rev_A = Band{
 	ID: KR_920_923,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    kr920923DefaultChannels,

--- a/pkg/band/kr_920_923_rp1_v1_1_rev_b.go
+++ b/pkg/band/kr_920_923_rp1_v1_1_rev_b.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var KR_920_923_RP1_V1_1_Rev_B = Band{
 	ID: KR_920_923,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    kr920923DefaultChannels,

--- a/pkg/band/kr_920_923_rp2_v1_0_0.go
+++ b/pkg/band/kr_920_923_rp2_v1_0_0.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var KR_920_923_RP2_V1_0_0 = Band{
 	ID: KR_920_923,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    kr920923DefaultChannels,

--- a/pkg/band/kr_920_923_rp2_v1_0_1.go
+++ b/pkg/band/kr_920_923_rp2_v1_0_1.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var KR_920_923_RP2_V1_0_1 = Band{
 	ID: KR_920_923,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    kr920923DefaultChannels,

--- a/pkg/band/kr_920_923_rp2_v1_0_2.go
+++ b/pkg/band/kr_920_923_rp2_v1_0_2.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var KR_920_923_RP2_V1_0_2 = Band{
 	ID: KR_920_923,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    kr920923DefaultChannels,

--- a/pkg/band/kr_920_923_rp2_v1_0_3.go
+++ b/pkg/band/kr_920_923_rp2_v1_0_3.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var KR_920_923_RP2_V1_0_3 = Band{
 	ID: KR_920_923,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    kr920923DefaultChannels,

--- a/pkg/band/reference_test.go
+++ b/pkg/band/reference_test.go
@@ -108,7 +108,7 @@ type serializableBand struct {
 	JoinAcceptDelay2 time.Duration
 	MaxFCntGap       uint
 
-	EnableADR            bool
+	SupportsDynamicADR   bool
 	ADRAckLimit          ttnpb.ADRAckLimitExponent
 	ADRAckDelay          ttnpb.ADRAckDelayExponent
 	MinRetransmitTimeout time.Duration
@@ -196,7 +196,7 @@ func makeBand(b band.Band) serializableBand {
 		JoinAcceptDelay2: b.JoinAcceptDelay2,
 		MaxFCntGap:       b.MaxFCntGap,
 
-		EnableADR:            b.EnableADR,
+		SupportsDynamicADR:   b.SupportsDynamicADR,
 		ADRAckLimit:          b.ADRAckLimit,
 		ADRAckDelay:          b.ADRAckDelay,
 		MinRetransmitTimeout: b.MinRetransmitTimeout,

--- a/pkg/band/ru_864_870_rp1_v1_0_3_rev_a.go
+++ b/pkg/band/ru_864_870_rp1_v1_0_3_rev_a.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var RU_864_870_RP1_V1_0_3_Rev_A = Band{
 	ID: RU_864_870,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    ru864870DefaultChannels,

--- a/pkg/band/ru_864_870_rp1_v1_1_rev_a.go
+++ b/pkg/band/ru_864_870_rp1_v1_1_rev_a.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var RU_864_870_RP1_V1_1_Rev_A = Band{
 	ID: RU_864_870,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    ru864870DefaultChannels,

--- a/pkg/band/ru_864_870_rp1_v1_1_rev_b.go
+++ b/pkg/band/ru_864_870_rp1_v1_1_rev_b.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var RU_864_870_RP1_V1_1_Rev_B = Band{
 	ID: RU_864_870,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    ru864870DefaultChannels,

--- a/pkg/band/ru_864_870_rp2_v1_0_0.go
+++ b/pkg/band/ru_864_870_rp2_v1_0_0.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var RU_864_870_RP2_V1_0_0 = Band{
 	ID: RU_864_870,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    ru864870DefaultChannels,

--- a/pkg/band/ru_864_870_rp2_v1_0_1.go
+++ b/pkg/band/ru_864_870_rp2_v1_0_1.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var RU_864_870_RP2_V1_0_1 = Band{
 	ID: RU_864_870,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    ru864870DefaultChannels,

--- a/pkg/band/ru_864_870_rp2_v1_0_2.go
+++ b/pkg/band/ru_864_870_rp2_v1_0_2.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var RU_864_870_RP2_V1_0_2 = Band{
 	ID: RU_864_870,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    ru864870DefaultChannels,

--- a/pkg/band/ru_864_870_rp2_v1_0_3.go
+++ b/pkg/band/ru_864_870_rp2_v1_0_3.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var RU_864_870_RP2_V1_0_3 = Band{
 	ID: RU_864_870,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 16,
 	UplinkChannels:    ru864870DefaultChannels,

--- a/pkg/band/testdata/AS_923_2_RP002_V1_0_1.json
+++ b/pkg/band/testdata/AS_923_2_RP002_V1_0_1.json
@@ -145,7 +145,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/AS_923_2_RP002_V1_0_2.json
+++ b/pkg/band/testdata/AS_923_2_RP002_V1_0_2.json
@@ -145,7 +145,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/AS_923_2_RP002_V1_0_3.json
+++ b/pkg/band/testdata/AS_923_2_RP002_V1_0_3.json
@@ -145,7 +145,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/AS_923_3_RP002_V1_0_1.json
+++ b/pkg/band/testdata/AS_923_3_RP002_V1_0_1.json
@@ -145,7 +145,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/AS_923_3_RP002_V1_0_2.json
+++ b/pkg/band/testdata/AS_923_3_RP002_V1_0_2.json
@@ -145,7 +145,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/AS_923_3_RP002_V1_0_3.json
+++ b/pkg/band/testdata/AS_923_3_RP002_V1_0_3.json
@@ -145,7 +145,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/AS_923_4_RP002_V1_0_3.json
+++ b/pkg/band/testdata/AS_923_4_RP002_V1_0_3.json
@@ -145,7 +145,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/AS_923_PHY_V1_0_2_REV_A.json
+++ b/pkg/band/testdata/AS_923_PHY_V1_0_2_REV_A.json
@@ -145,7 +145,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/AS_923_PHY_V1_0_2_REV_B.json
+++ b/pkg/band/testdata/AS_923_PHY_V1_0_2_REV_B.json
@@ -145,7 +145,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/AS_923_PHY_V1_0_3_REV_A.json
+++ b/pkg/band/testdata/AS_923_PHY_V1_0_3_REV_A.json
@@ -145,7 +145,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/AS_923_PHY_V1_1_REV_A.json
+++ b/pkg/band/testdata/AS_923_PHY_V1_1_REV_A.json
@@ -145,7 +145,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/AS_923_PHY_V1_1_REV_B.json
+++ b/pkg/band/testdata/AS_923_PHY_V1_1_REV_B.json
@@ -145,7 +145,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/AS_923_RP002_V1_0_0.json
+++ b/pkg/band/testdata/AS_923_RP002_V1_0_0.json
@@ -145,7 +145,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/AS_923_RP002_V1_0_1.json
+++ b/pkg/band/testdata/AS_923_RP002_V1_0_1.json
@@ -145,7 +145,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/AS_923_RP002_V1_0_2.json
+++ b/pkg/band/testdata/AS_923_RP002_V1_0_2.json
@@ -145,7 +145,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/AS_923_RP002_V1_0_3.json
+++ b/pkg/band/testdata/AS_923_RP002_V1_0_3.json
@@ -145,7 +145,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/AU_915_928_PHY_V1_0_1.json
+++ b/pkg/band/testdata/AU_915_928_PHY_V1_0_1.json
@@ -562,7 +562,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/AU_915_928_PHY_V1_0_2_REV_A.json
+++ b/pkg/band/testdata/AU_915_928_PHY_V1_0_2_REV_A.json
@@ -562,7 +562,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/AU_915_928_PHY_V1_0_2_REV_B.json
+++ b/pkg/band/testdata/AU_915_928_PHY_V1_0_2_REV_B.json
@@ -586,7 +586,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/AU_915_928_PHY_V1_0_3_REV_A.json
+++ b/pkg/band/testdata/AU_915_928_PHY_V1_0_3_REV_A.json
@@ -586,7 +586,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/AU_915_928_PHY_V1_1_REV_A.json
+++ b/pkg/band/testdata/AU_915_928_PHY_V1_1_REV_A.json
@@ -586,7 +586,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/AU_915_928_PHY_V1_1_REV_B.json
+++ b/pkg/band/testdata/AU_915_928_PHY_V1_1_REV_B.json
@@ -586,7 +586,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/AU_915_928_RP002_V1_0_0.json
+++ b/pkg/band/testdata/AU_915_928_RP002_V1_0_0.json
@@ -586,7 +586,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/AU_915_928_RP002_V1_0_1.json
+++ b/pkg/band/testdata/AU_915_928_RP002_V1_0_1.json
@@ -586,7 +586,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/AU_915_928_RP002_V1_0_2.json
+++ b/pkg/band/testdata/AU_915_928_RP002_V1_0_2.json
@@ -598,7 +598,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/AU_915_928_RP002_V1_0_3.json
+++ b/pkg/band/testdata/AU_915_928_RP002_V1_0_3.json
@@ -598,7 +598,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_470_510_20_A_RP002_V1_0_0.json
+++ b/pkg/band/testdata/CN_470_510_20_A_RP002_V1_0_0.json
@@ -742,7 +742,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_470_510_20_A_RP002_V1_0_1.json
+++ b/pkg/band/testdata/CN_470_510_20_A_RP002_V1_0_1.json
@@ -753,7 +753,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_470_510_20_A_RP002_V1_0_2.json
+++ b/pkg/band/testdata/CN_470_510_20_A_RP002_V1_0_2.json
@@ -753,7 +753,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_470_510_20_A_RP002_V1_0_3.json
+++ b/pkg/band/testdata/CN_470_510_20_A_RP002_V1_0_3.json
@@ -753,7 +753,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_470_510_20_B_RP002_V1_0_0.json
+++ b/pkg/band/testdata/CN_470_510_20_B_RP002_V1_0_0.json
@@ -742,7 +742,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_470_510_20_B_RP002_V1_0_1.json
+++ b/pkg/band/testdata/CN_470_510_20_B_RP002_V1_0_1.json
@@ -753,7 +753,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_470_510_20_B_RP002_V1_0_2.json
+++ b/pkg/band/testdata/CN_470_510_20_B_RP002_V1_0_2.json
@@ -753,7 +753,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_470_510_20_B_RP002_V1_0_3.json
+++ b/pkg/band/testdata/CN_470_510_20_B_RP002_V1_0_3.json
@@ -753,7 +753,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_470_510_26_A_RP002_V1_0_0.json
+++ b/pkg/band/testdata/CN_470_510_26_A_RP002_V1_0_0.json
@@ -462,7 +462,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_470_510_26_A_RP002_V1_0_1.json
+++ b/pkg/band/testdata/CN_470_510_26_A_RP002_V1_0_1.json
@@ -473,7 +473,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_470_510_26_A_RP002_V1_0_2.json
+++ b/pkg/band/testdata/CN_470_510_26_A_RP002_V1_0_2.json
@@ -473,7 +473,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_470_510_26_A_RP002_V1_0_3.json
+++ b/pkg/band/testdata/CN_470_510_26_A_RP002_V1_0_3.json
@@ -473,7 +473,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_470_510_26_B_RP002_V1_0_0.json
+++ b/pkg/band/testdata/CN_470_510_26_B_RP002_V1_0_0.json
@@ -462,7 +462,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_470_510_26_B_RP002_V1_0_1.json
+++ b/pkg/band/testdata/CN_470_510_26_B_RP002_V1_0_1.json
@@ -473,7 +473,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_470_510_26_B_RP002_V1_0_2.json
+++ b/pkg/band/testdata/CN_470_510_26_B_RP002_V1_0_2.json
@@ -473,7 +473,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_470_510_26_B_RP002_V1_0_3.json
+++ b/pkg/band/testdata/CN_470_510_26_B_RP002_V1_0_3.json
@@ -473,7 +473,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_470_510_PHY_V1_0_1.json
+++ b/pkg/band/testdata/CN_470_510_PHY_V1_0_1.json
@@ -822,7 +822,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_470_510_PHY_V1_0_2_REV_A.json
+++ b/pkg/band/testdata/CN_470_510_PHY_V1_0_2_REV_A.json
@@ -822,7 +822,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_470_510_PHY_V1_0_2_REV_B.json
+++ b/pkg/band/testdata/CN_470_510_PHY_V1_0_2_REV_B.json
@@ -822,7 +822,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_470_510_PHY_V1_0_3_REV_A.json
+++ b/pkg/band/testdata/CN_470_510_PHY_V1_0_3_REV_A.json
@@ -822,7 +822,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_470_510_PHY_V1_1_REV_A.json
+++ b/pkg/band/testdata/CN_470_510_PHY_V1_1_REV_A.json
@@ -822,7 +822,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_470_510_PHY_V1_1_REV_B.json
+++ b/pkg/band/testdata/CN_470_510_PHY_V1_1_REV_B.json
@@ -822,7 +822,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_779_787_PHY_V1_0.json
+++ b/pkg/band/testdata/CN_779_787_PHY_V1_0.json
@@ -185,7 +185,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_779_787_PHY_V1_0_1.json
+++ b/pkg/band/testdata/CN_779_787_PHY_V1_0_1.json
@@ -185,7 +185,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_779_787_PHY_V1_0_2_REV_A.json
+++ b/pkg/band/testdata/CN_779_787_PHY_V1_0_2_REV_A.json
@@ -185,7 +185,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_779_787_PHY_V1_0_2_REV_B.json
+++ b/pkg/band/testdata/CN_779_787_PHY_V1_0_2_REV_B.json
@@ -185,7 +185,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_779_787_PHY_V1_0_3_REV_A.json
+++ b/pkg/band/testdata/CN_779_787_PHY_V1_0_3_REV_A.json
@@ -185,7 +185,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_779_787_PHY_V1_1_REV_A.json
+++ b/pkg/band/testdata/CN_779_787_PHY_V1_1_REV_A.json
@@ -185,7 +185,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_779_787_PHY_V1_1_REV_B.json
+++ b/pkg/band/testdata/CN_779_787_PHY_V1_1_REV_B.json
@@ -185,7 +185,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_779_787_RP002_V1_0_0.json
+++ b/pkg/band/testdata/CN_779_787_RP002_V1_0_0.json
@@ -185,7 +185,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_779_787_RP002_V1_0_1.json
+++ b/pkg/band/testdata/CN_779_787_RP002_V1_0_1.json
@@ -185,7 +185,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_779_787_RP002_V1_0_2.json
+++ b/pkg/band/testdata/CN_779_787_RP002_V1_0_2.json
@@ -185,7 +185,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/CN_779_787_RP002_V1_0_3.json
+++ b/pkg/band/testdata/CN_779_787_RP002_V1_0_3.json
@@ -185,7 +185,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/EU_433_PHY_V1_0.json
+++ b/pkg/band/testdata/EU_433_PHY_V1_0.json
@@ -155,7 +155,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/EU_433_PHY_V1_0_1.json
+++ b/pkg/band/testdata/EU_433_PHY_V1_0_1.json
@@ -155,7 +155,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/EU_433_PHY_V1_0_2_REV_A.json
+++ b/pkg/band/testdata/EU_433_PHY_V1_0_2_REV_A.json
@@ -155,7 +155,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/EU_433_PHY_V1_0_2_REV_B.json
+++ b/pkg/band/testdata/EU_433_PHY_V1_0_2_REV_B.json
@@ -155,7 +155,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/EU_433_PHY_V1_0_3_REV_A.json
+++ b/pkg/band/testdata/EU_433_PHY_V1_0_3_REV_A.json
@@ -155,7 +155,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/EU_433_PHY_V1_1_REV_A.json
+++ b/pkg/band/testdata/EU_433_PHY_V1_1_REV_A.json
@@ -155,7 +155,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/EU_433_PHY_V1_1_REV_B.json
+++ b/pkg/band/testdata/EU_433_PHY_V1_1_REV_B.json
@@ -155,7 +155,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/EU_433_RP002_V1_0_0.json
+++ b/pkg/band/testdata/EU_433_RP002_V1_0_0.json
@@ -155,7 +155,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/EU_433_RP002_V1_0_1.json
+++ b/pkg/band/testdata/EU_433_RP002_V1_0_1.json
@@ -155,7 +155,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/EU_433_RP002_V1_0_2.json
+++ b/pkg/band/testdata/EU_433_RP002_V1_0_2.json
@@ -155,7 +155,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/EU_433_RP002_V1_0_3.json
+++ b/pkg/band/testdata/EU_433_RP002_V1_0_3.json
@@ -155,7 +155,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/EU_863_870_PHY_V1_0.json
+++ b/pkg/band/testdata/EU_863_870_PHY_V1_0.json
@@ -185,7 +185,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/EU_863_870_PHY_V1_0_1.json
+++ b/pkg/band/testdata/EU_863_870_PHY_V1_0_1.json
@@ -185,7 +185,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/EU_863_870_PHY_V1_0_2_REV_A.json
+++ b/pkg/band/testdata/EU_863_870_PHY_V1_0_2_REV_A.json
@@ -185,7 +185,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/EU_863_870_PHY_V1_0_2_REV_B.json
+++ b/pkg/band/testdata/EU_863_870_PHY_V1_0_2_REV_B.json
@@ -185,7 +185,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/EU_863_870_PHY_V1_0_3_REV_A.json
+++ b/pkg/band/testdata/EU_863_870_PHY_V1_0_3_REV_A.json
@@ -185,7 +185,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/EU_863_870_PHY_V1_1_REV_A.json
+++ b/pkg/band/testdata/EU_863_870_PHY_V1_1_REV_A.json
@@ -185,7 +185,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/EU_863_870_PHY_V1_1_REV_B.json
+++ b/pkg/band/testdata/EU_863_870_PHY_V1_1_REV_B.json
@@ -185,7 +185,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/EU_863_870_RP002_V1_0_0.json
+++ b/pkg/band/testdata/EU_863_870_RP002_V1_0_0.json
@@ -185,7 +185,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/EU_863_870_RP002_V1_0_1.json
+++ b/pkg/band/testdata/EU_863_870_RP002_V1_0_1.json
@@ -185,7 +185,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/EU_863_870_RP002_V1_0_2.json
+++ b/pkg/band/testdata/EU_863_870_RP002_V1_0_2.json
@@ -233,7 +233,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/EU_863_870_RP002_V1_0_3.json
+++ b/pkg/band/testdata/EU_863_870_RP002_V1_0_3.json
@@ -233,7 +233,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/IN_865_867_PHY_V1_0_2_REV_B.json
+++ b/pkg/band/testdata/IN_865_867_PHY_V1_0_2_REV_B.json
@@ -143,7 +143,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/IN_865_867_PHY_V1_0_3_REV_A.json
+++ b/pkg/band/testdata/IN_865_867_PHY_V1_0_3_REV_A.json
@@ -143,7 +143,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/IN_865_867_PHY_V1_1_REV_A.json
+++ b/pkg/band/testdata/IN_865_867_PHY_V1_1_REV_A.json
@@ -143,7 +143,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/IN_865_867_PHY_V1_1_REV_B.json
+++ b/pkg/band/testdata/IN_865_867_PHY_V1_1_REV_B.json
@@ -143,7 +143,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/IN_865_867_RP002_V1_0_0.json
+++ b/pkg/band/testdata/IN_865_867_RP002_V1_0_0.json
@@ -143,7 +143,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/IN_865_867_RP002_V1_0_1.json
+++ b/pkg/band/testdata/IN_865_867_RP002_V1_0_1.json
@@ -143,7 +143,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/IN_865_867_RP002_V1_0_2.json
+++ b/pkg/band/testdata/IN_865_867_RP002_V1_0_2.json
@@ -143,7 +143,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/IN_865_867_RP002_V1_0_3.json
+++ b/pkg/band/testdata/IN_865_867_RP002_V1_0_3.json
@@ -143,7 +143,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/ISM_2400_PHY_V1_0.json
+++ b/pkg/band/testdata/ISM_2400_PHY_V1_0.json
@@ -156,7 +156,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": false,
+  "SupportsDynamicADR": false,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/ISM_2400_PHY_V1_0_1.json
+++ b/pkg/band/testdata/ISM_2400_PHY_V1_0_1.json
@@ -156,7 +156,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": false,
+  "SupportsDynamicADR": false,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/ISM_2400_PHY_V1_0_2_REV_A.json
+++ b/pkg/band/testdata/ISM_2400_PHY_V1_0_2_REV_A.json
@@ -156,7 +156,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": false,
+  "SupportsDynamicADR": false,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/ISM_2400_PHY_V1_0_2_REV_B.json
+++ b/pkg/band/testdata/ISM_2400_PHY_V1_0_2_REV_B.json
@@ -156,7 +156,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": false,
+  "SupportsDynamicADR": false,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/ISM_2400_PHY_V1_0_3_REV_A.json
+++ b/pkg/band/testdata/ISM_2400_PHY_V1_0_3_REV_A.json
@@ -156,7 +156,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": false,
+  "SupportsDynamicADR": false,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/ISM_2400_PHY_V1_1_REV_A.json
+++ b/pkg/band/testdata/ISM_2400_PHY_V1_1_REV_A.json
@@ -156,7 +156,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": false,
+  "SupportsDynamicADR": false,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/ISM_2400_PHY_V1_1_REV_B.json
+++ b/pkg/band/testdata/ISM_2400_PHY_V1_1_REV_B.json
@@ -156,7 +156,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": false,
+  "SupportsDynamicADR": false,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/ISM_2400_RP002_V1_0_0.json
+++ b/pkg/band/testdata/ISM_2400_RP002_V1_0_0.json
@@ -156,7 +156,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": false,
+  "SupportsDynamicADR": false,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/ISM_2400_RP002_V1_0_1.json
+++ b/pkg/band/testdata/ISM_2400_RP002_V1_0_1.json
@@ -156,7 +156,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": false,
+  "SupportsDynamicADR": false,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/ISM_2400_RP002_V1_0_2.json
+++ b/pkg/band/testdata/ISM_2400_RP002_V1_0_2.json
@@ -156,7 +156,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": false,
+  "SupportsDynamicADR": false,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/ISM_2400_RP002_V1_0_3.json
+++ b/pkg/band/testdata/ISM_2400_RP002_V1_0_3.json
@@ -156,7 +156,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": false,
+  "SupportsDynamicADR": false,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/KR_920_923_PHY_V1_0_2_REV_A.json
+++ b/pkg/band/testdata/KR_920_923_PHY_V1_0_2_REV_A.json
@@ -132,7 +132,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/KR_920_923_PHY_V1_0_2_REV_B.json
+++ b/pkg/band/testdata/KR_920_923_PHY_V1_0_2_REV_B.json
@@ -132,7 +132,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/KR_920_923_PHY_V1_0_3_REV_A.json
+++ b/pkg/band/testdata/KR_920_923_PHY_V1_0_3_REV_A.json
@@ -132,7 +132,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/KR_920_923_PHY_V1_1_REV_A.json
+++ b/pkg/band/testdata/KR_920_923_PHY_V1_1_REV_A.json
@@ -132,7 +132,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/KR_920_923_PHY_V1_1_REV_B.json
+++ b/pkg/band/testdata/KR_920_923_PHY_V1_1_REV_B.json
@@ -132,7 +132,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/KR_920_923_RP002_V1_0_0.json
+++ b/pkg/band/testdata/KR_920_923_RP002_V1_0_0.json
@@ -132,7 +132,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/KR_920_923_RP002_V1_0_1.json
+++ b/pkg/band/testdata/KR_920_923_RP002_V1_0_1.json
@@ -132,7 +132,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/KR_920_923_RP002_V1_0_2.json
+++ b/pkg/band/testdata/KR_920_923_RP002_V1_0_2.json
@@ -132,7 +132,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/KR_920_923_RP002_V1_0_3.json
+++ b/pkg/band/testdata/KR_920_923_RP002_V1_0_3.json
@@ -132,7 +132,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/RU_864_870_PHY_V1_0_3_REV_A.json
+++ b/pkg/band/testdata/RU_864_870_PHY_V1_0_3_REV_A.json
@@ -145,7 +145,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/RU_864_870_PHY_V1_1_REV_A.json
+++ b/pkg/band/testdata/RU_864_870_PHY_V1_1_REV_A.json
@@ -145,7 +145,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/RU_864_870_PHY_V1_1_REV_B.json
+++ b/pkg/band/testdata/RU_864_870_PHY_V1_1_REV_B.json
@@ -145,7 +145,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/RU_864_870_RP002_V1_0_0.json
+++ b/pkg/band/testdata/RU_864_870_RP002_V1_0_0.json
@@ -145,7 +145,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/RU_864_870_RP002_V1_0_1.json
+++ b/pkg/band/testdata/RU_864_870_RP002_V1_0_1.json
@@ -145,7 +145,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/RU_864_870_RP002_V1_0_2.json
+++ b/pkg/band/testdata/RU_864_870_RP002_V1_0_2.json
@@ -145,7 +145,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/RU_864_870_RP002_V1_0_3.json
+++ b/pkg/band/testdata/RU_864_870_RP002_V1_0_3.json
@@ -145,7 +145,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/US_902_928_PHY_V1_0.json
+++ b/pkg/band/testdata/US_902_928_PHY_V1_0.json
@@ -568,7 +568,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/US_902_928_PHY_V1_0_1.json
+++ b/pkg/band/testdata/US_902_928_PHY_V1_0_1.json
@@ -568,7 +568,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/US_902_928_PHY_V1_0_2_REV_A.json
+++ b/pkg/band/testdata/US_902_928_PHY_V1_0_2_REV_A.json
@@ -568,7 +568,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/US_902_928_PHY_V1_0_2_REV_B.json
+++ b/pkg/band/testdata/US_902_928_PHY_V1_0_2_REV_B.json
@@ -568,7 +568,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/US_902_928_PHY_V1_0_3_REV_A.json
+++ b/pkg/band/testdata/US_902_928_PHY_V1_0_3_REV_A.json
@@ -568,7 +568,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/US_902_928_PHY_V1_1_REV_A.json
+++ b/pkg/band/testdata/US_902_928_PHY_V1_1_REV_A.json
@@ -568,7 +568,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/US_902_928_PHY_V1_1_REV_B.json
+++ b/pkg/band/testdata/US_902_928_PHY_V1_1_REV_B.json
@@ -568,7 +568,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/US_902_928_RP002_V1_0_0.json
+++ b/pkg/band/testdata/US_902_928_RP002_V1_0_0.json
@@ -568,7 +568,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/US_902_928_RP002_V1_0_1.json
+++ b/pkg/band/testdata/US_902_928_RP002_V1_0_1.json
@@ -568,7 +568,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/US_902_928_RP002_V1_0_2.json
+++ b/pkg/band/testdata/US_902_928_RP002_V1_0_2.json
@@ -592,7 +592,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/testdata/US_902_928_RP002_V1_0_3.json
+++ b/pkg/band/testdata/US_902_928_RP002_V1_0_3.json
@@ -592,7 +592,7 @@
   "JoinAcceptDelay1": 5000000000,
   "JoinAcceptDelay2": 6000000000,
   "MaxFCntGap": 16384,
-  "EnableADR": true,
+  "SupportsDynamicADR": true,
   "ADRAckLimit": "ADR_ACK_LIMIT_64",
   "ADRAckDelay": "ADR_ACK_DELAY_32",
   "MinRetransmitTimeout": 1000000000,

--- a/pkg/band/us_902_928_rp1_v1_0_2.go
+++ b/pkg/band/us_902_928_rp1_v1_0_2.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var US_902_928_RP1_V1_0_2 = Band{
 	ID: US_902_928,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
 	UplinkChannels:    us902928UplinkChannels,

--- a/pkg/band/us_902_928_rp1_v1_0_2_rev_b.go
+++ b/pkg/band/us_902_928_rp1_v1_0_2_rev_b.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var US_902_928_RP1_V1_0_2_Rev_B = Band{
 	ID: US_902_928,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
 	UplinkChannels:    us902928UplinkChannels,

--- a/pkg/band/us_902_928_rp1_v1_0_3_rev_a.go
+++ b/pkg/band/us_902_928_rp1_v1_0_3_rev_a.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var US_902_928_RP1_V1_0_3_Rev_A = Band{
 	ID: US_902_928,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
 	UplinkChannels:    us902928UplinkChannels,

--- a/pkg/band/us_902_928_rp1_v1_1_rev_a.go
+++ b/pkg/band/us_902_928_rp1_v1_1_rev_a.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var US_902_928_RP1_V1_1_Rev_A = Band{
 	ID: US_902_928,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
 	UplinkChannels:    us902928UplinkChannels,

--- a/pkg/band/us_902_928_rp1_v1_1_rev_b.go
+++ b/pkg/band/us_902_928_rp1_v1_1_rev_b.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var US_902_928_RP1_V1_1_Rev_B = Band{
 	ID: US_902_928,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
 	UplinkChannels:    us902928UplinkChannels,

--- a/pkg/band/us_902_928_rp2_v1_0_0.go
+++ b/pkg/band/us_902_928_rp2_v1_0_0.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var US_902_928_RP2_V1_0_0 = Band{
 	ID: US_902_928,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
 	UplinkChannels:    us902928UplinkChannels,

--- a/pkg/band/us_902_928_rp2_v1_0_1.go
+++ b/pkg/band/us_902_928_rp2_v1_0_1.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var US_902_928_RP2_V1_0_1 = Band{
 	ID: US_902_928,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
 	UplinkChannels:    us902928UplinkChannels,

--- a/pkg/band/us_902_928_rp2_v1_0_2.go
+++ b/pkg/band/us_902_928_rp2_v1_0_2.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var US_902_928_RP2_V1_0_2 = Band{
 	ID: US_902_928,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
 	UplinkChannels:    us902928UplinkChannels,

--- a/pkg/band/us_902_928_rp2_v1_0_3.go
+++ b/pkg/band/us_902_928_rp2_v1_0_3.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var US_902_928_RP2_V1_0_3 = Band{
 	ID: US_902_928,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
 	UplinkChannels:    us902928UplinkChannels,

--- a/pkg/band/us_902_928_ts1_v1_0.go
+++ b/pkg/band/us_902_928_ts1_v1_0.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var US_902_928_TS1_V1_0 = Band{
 	ID: US_902_928,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
 	UplinkChannels:    us902928UplinkChannels,

--- a/pkg/band/us_902_928_ts1_v1_0_1.go
+++ b/pkg/band/us_902_928_ts1_v1_0_1.go
@@ -20,7 +20,7 @@ import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 var US_902_928_TS1_V1_0_1 = Band{
 	ID: US_902_928,
 
-	EnableADR: true,
+	SupportsDynamicADR: true,
 
 	MaxUplinkChannels: 72,
 	UplinkChannels:    us902928UplinkChannels,

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -297,7 +297,7 @@ type setDeviceState struct {
 // in order to avoid redundant lookups.
 //
 // NOTE: If the search paths are not bottom level fields, hasAnyField may have unexpected
-// results, as ttnpb.HasAnyField does not consider lower search paths as being part of
+// results, as ttnpb.HasAnyField does not consider higher search paths as being part of
 // the requested paths - i.e ttnpb.HasAnyField([]string{"a.b"}, "a") == false.
 func hasAnyField(fs []string, cache map[string]bool, paths ...string) bool {
 	for _, p := range paths {

--- a/pkg/networkserver/grpc_deviceregistry.go
+++ b/pkg/networkserver/grpc_deviceregistry.go
@@ -1498,7 +1498,7 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 			}
 			if err := st.WithFields(func(m map[string]*ttnpb.EndDevice) error {
 				return withPHY(func(phy *band.Band, _ *frequencyplans.FrequencyPlan) error {
-					if phy.EnableADR {
+					if phy.SupportsDynamicADR {
 						return nil
 					}
 					for _, field := range fields {
@@ -1773,7 +1773,7 @@ func (ns *NetworkServer) Set(ctx context.Context, req *ttnpb.SetEndDeviceRequest
 
 		for p, isValid := range map[string]func(*ttnpb.EndDevice, *band.Band) bool{
 			"mac_settings.use_adr.value": func(dev *ttnpb.EndDevice, phy *band.Band) bool {
-				return !dev.GetMacSettings().GetUseAdr().GetValue() || phy.EnableADR
+				return !dev.GetMacSettings().GetUseAdr().GetValue() || phy.SupportsDynamicADR
 			},
 			"mac_state.current_parameters.adr_data_rate_index": func(dev *ttnpb.EndDevice, phy *band.Band) bool {
 				return dev.GetMacState().GetCurrentParameters().GetAdrDataRateIndex() <= phy.MaxADRDataRateIndex

--- a/pkg/networkserver/mac/adr.go
+++ b/pkg/networkserver/mac/adr.go
@@ -93,7 +93,7 @@ func deviceUseADR(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings, phy *band.Ba
 	case defaults.Adr.GetStatic() != nil:
 		return true
 
-	case !phy.EnableADR:
+	case !phy.SupportsDynamicADR:
 		return false
 
 	case dev.GetMacSettings().GetAdr().GetDynamic() != nil:
@@ -130,7 +130,7 @@ func deviceShouldAdaptDataRate(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings,
 	case defaults.Adr.GetStatic() != nil:
 		return false, false, defaults.Adr.GetStatic()
 
-	case !phy.EnableADR:
+	case !phy.SupportsDynamicADR:
 		return false, true, nil
 
 	case dev.GetMacSettings().GetAdr().GetDynamic() != nil:

--- a/pkg/networkserver/mac/adr.go
+++ b/pkg/networkserver/mac/adr.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -78,14 +78,99 @@ const (
 	DefaultADRMargin = 15
 )
 
+func deviceUseADR(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings, phy *band.Band) bool {
+	switch {
+	case dev.GetMulticast():
+		return false
+
+	case dev.GetMacSettings().GetAdr().GetDisabled() != nil:
+		return false
+	case dev.GetMacSettings().GetAdr().GetStatic() != nil:
+		return true
+
+	case defaults.Adr.GetDisabled() != nil:
+		return false
+	case defaults.Adr.GetStatic() != nil:
+		return true
+
+	case !phy.EnableADR:
+		return false
+
+	case dev.GetMacSettings().GetAdr().GetDynamic() != nil:
+		return true
+
+	case defaults.Adr.GetDynamic() != nil:
+		return true
+
+	default:
+		return true
+	}
+}
+
+// DeviceUseADR returns if the Network Server uses the ADR algorithm for the end device.
+func DeviceUseADR(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings, phy *band.Band) bool {
+	if dev.GetMacSettings().GetAdr() != nil {
+		return deviceUseADR(dev, defaults, phy)
+	}
+	return legacyDeviceUseADR(dev, defaults, phy)
+}
+
+func deviceShouldAdaptDataRate(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings, phy *band.Band) (adaptDataRate bool, resetDesiredParameters bool, staticSettings *ttnpb.ADRSettings_StaticMode) {
+	switch {
+	case dev.GetMulticast():
+		return false, true, nil
+
+	case dev.GetMacSettings().GetAdr().GetDisabled() != nil:
+		return false, true, nil
+	case dev.GetMacSettings().GetAdr().GetStatic() != nil:
+		return false, false, dev.MacSettings.Adr.GetStatic()
+
+	case defaults.Adr.GetDisabled() != nil:
+		return false, true, nil
+	case defaults.Adr.GetStatic() != nil:
+		return false, false, defaults.Adr.GetStatic()
+
+	case !phy.EnableADR:
+		return false, true, nil
+
+	case dev.GetMacSettings().GetAdr().GetDynamic() != nil:
+		return true, true, nil
+
+	case defaults.Adr.GetDynamic() != nil:
+		return true, true, nil
+
+	default:
+		return false, false, nil
+	}
+}
+
+// DeviceShouldAdaptDataRate returns if the ADR algorithm should be run for the end device.
+func DeviceShouldAdaptDataRate(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings, phy *band.Band) (adaptDataRate bool, resetDesiredParameters bool, staticSettings *ttnpb.ADRSettings_StaticMode) {
+	if dev.GetMacSettings().GetAdr() != nil {
+		return deviceShouldAdaptDataRate(dev, defaults, phy)
+	}
+	return legacyDeviceShouldAdaptDataRate(dev, defaults, phy)
+}
+
+func deviceADRMargin(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings) float32 {
+	switch {
+	case dev.GetMacSettings().GetAdr().GetDynamic().GetMargin() != nil:
+		return dev.MacSettings.Adr.GetDynamic().Margin.Value
+
+	case defaults.Adr.GetDynamic().GetMargin() != nil:
+		return defaults.Adr.GetDynamic().Margin.Value
+
+	default:
+		return DefaultADRMargin
+	}
+}
+
+// DeviceADRMargin returns the margin to be used by the ADR algorithm.
 func DeviceADRMargin(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings) float32 {
-	if v := dev.GetMacSettings().GetAdrMargin(); v != nil {
-		return v.Value
+	if dev.GetMacSettings().GetAdr() != nil {
+		return deviceADRMargin(dev, defaults)
 	}
-	if defaults.AdrMargin != nil {
-		return defaults.AdrMargin.Value
-	}
-	return DefaultADRMargin
+	return legacyDeviceADRMargin(dev, defaults)
 }
 
 func adrLossRate(ups ...*ttnpb.UplinkMessage) float32 {
@@ -141,35 +226,116 @@ func txPowerStep(phy *band.Band, from, to uint8) float32 {
 	return phy.TxOffset[from] - phy.TxOffset[to]
 }
 
+func clampDataRateRange(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings, minDataRateIndex, maxDataRateIndex ttnpb.DataRateIndex) (min, max ttnpb.DataRateIndex) {
+	clamp := func(dynamicSettings *ttnpb.ADRSettings_DynamicMode) (min, max ttnpb.DataRateIndex) {
+		min, max = minDataRateIndex, maxDataRateIndex
+		minSetting, maxSetting := dynamicSettings.MinDataRateIndex, dynamicSettings.MaxDataRateIndex
+		if minSetting != nil && minSetting.Value > minDataRateIndex {
+			min = minSetting.Value
+		}
+		if maxSetting != nil && maxSetting.Value < maxDataRateIndex {
+			max = maxSetting.Value
+		}
+		return min, max
+	}
+	switch {
+	case dev.GetMacSettings().GetAdr().GetDynamic() != nil:
+		return clamp(dev.MacSettings.Adr.GetDynamic())
+
+	case defaults.Adr.GetDynamic() != nil:
+		return clamp(defaults.Adr.GetDynamic())
+
+	default:
+		return minDataRateIndex, maxDataRateIndex
+	}
+}
+
+func clampTxPowerRange(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings, minTxPowerIndex, maxTxPowerIndex uint8) (min, max uint8) {
+	clamp := func(dynamicSettings *ttnpb.ADRSettings_DynamicMode) (min, max uint8) {
+		min, max = minTxPowerIndex, maxTxPowerIndex
+		minSetting, maxSetting := dynamicSettings.MinTxPowerIndex, dynamicSettings.MaxTxPowerIndex
+		if minSetting != nil && uint8(minSetting.Value) > minTxPowerIndex {
+			min = uint8(minSetting.Value)
+		}
+		if maxSetting != nil && uint8(maxSetting.Value) < maxTxPowerIndex {
+			max = uint8(maxSetting.Value)
+		}
+		return min, max
+	}
+	switch {
+	case dev.GetMacSettings().GetAdr().GetDynamic() != nil:
+		return clamp(dev.MacSettings.Adr.GetDynamic())
+
+	case defaults.Adr.GetDynamic() != nil:
+		return clamp(defaults.Adr.GetDynamic())
+
+	default:
+		return minTxPowerIndex, maxTxPowerIndex
+	}
+}
+
+func clampNbTrans(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings, nbTrans uint32) uint32 {
+	clamp := func(dynamicSettings *ttnpb.ADRSettings_DynamicMode) uint32 {
+		nbTrans := nbTrans
+		minSetting, maxSetting := dynamicSettings.MinNbTrans, dynamicSettings.MaxNbTrans
+		if minSetting != nil && minSetting.Value > nbTrans {
+			nbTrans = minSetting.Value
+		}
+		if maxSetting != nil && maxSetting.Value < nbTrans {
+			nbTrans = maxSetting.Value
+		}
+		return nbTrans
+	}
+	switch {
+	case dev.GetMacSettings().GetAdr().GetDynamic() != nil:
+		return clamp(dev.MacSettings.Adr.GetDynamic())
+
+	case defaults.Adr.GetDynamic() != nil:
+		return clamp(defaults.Adr.GetDynamic())
+
+	default:
+		return nbTrans
+	}
+}
+
+// AdaptDataRate adapts the end device desired ADR parameters based on previous transmissions and device settings.
 func AdaptDataRate(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band, defaults ttnpb.MACSettings) error {
 	if dev.MacState == nil {
 		return nil
 	}
 
+	macState := dev.MacState
+	currentParameters, desiredParameters := macState.CurrentParameters, macState.DesiredParameters
+
 	adrUplinks := func() []*ttnpb.UplinkMessage {
-		for i := len(dev.MacState.RecentUplinks) - 1; i >= 0; i-- {
-			up := dev.MacState.RecentUplinks[i]
+		for i := len(macState.RecentUplinks) - 1; i >= 0; i-- {
+			up := macState.RecentUplinks[i]
 			drIdx, _, ok := phy.FindUplinkDataRate(up.Settings.DataRate)
 			if !ok {
 				continue
 			}
 			switch {
 			case up.Payload.MHdr.MType != ttnpb.MType_UNCONFIRMED_UP && up.Payload.MHdr.MType != ttnpb.MType_CONFIRMED_UP,
-				dev.MacState.LastAdrChangeFCntUp != 0 && up.Payload.GetMacPayload().FullFCnt <= dev.MacState.LastAdrChangeFCntUp,
-				drIdx != dev.MacState.CurrentParameters.AdrDataRateIndex:
-				return dev.MacState.RecentUplinks[i+1:]
+				macState.LastAdrChangeFCntUp != 0 && up.Payload.GetMacPayload().FullFCnt <= macState.LastAdrChangeFCntUp,
+				drIdx != currentParameters.AdrDataRateIndex:
+				return macState.RecentUplinks[i+1:]
 			}
 		}
-		return dev.MacState.RecentUplinks
+		return macState.RecentUplinks
 	}()
 	if len(adrUplinks) == 0 {
 		return nil
 	}
 
-	minDataRateIndex, maxDataRateIndex, ok := channelDataRateRange(dev.MacState.CurrentParameters.Channels...)
+	minDataRateIndex, maxDataRateIndex, ok := channelDataRateRange(currentParameters.Channels...)
 	if !ok {
 		return internal.ErrCorruptedMACState.
 			WithCause(internal.ErrChannelDataRateRange)
+	}
+	minDataRateIndex, maxDataRateIndex = clampDataRateRange(dev, defaults, minDataRateIndex, maxDataRateIndex)
+	if minDataRateIndex > maxDataRateIndex {
+		log.FromContext(ctx).Debug("No common data rate index range available, avoid ADR")
+		return nil
 	}
 	if maxDataRateIndex > phy.MaxADRDataRateIndex {
 		maxDataRateIndex = phy.MaxADRDataRateIndex
@@ -189,17 +355,22 @@ func AdaptDataRate(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band, de
 		_, ok = rejectedDataRateIndexes[maxDataRateIndex]
 	}
 	if minDataRateIndex > maxDataRateIndex {
-		log.FromContext(ctx).Debug("Device has rejected all possible data rate values given the channels enabled, avoid ADR.")
+		log.FromContext(ctx).Debug("Device has rejected all possible data rate values given the channels enabled, avoid ADR")
 		return nil
 	}
-	if dev.MacState.CurrentParameters.AdrDataRateIndex > minDataRateIndex {
-		minDataRateIndex = dev.MacState.CurrentParameters.AdrDataRateIndex
+	if currentParameters.AdrDataRateIndex > minDataRateIndex {
+		minDataRateIndex = currentParameters.AdrDataRateIndex
 	}
 
 	minTxPowerIndex := uint8(0)
 	maxTxPowerIndex := phy.MaxTxPowerIndex()
-	rejectedTxPowerIndexes := make(map[uint8]struct{}, len(dev.MacState.RejectedAdrTxPowerIndexes))
-	for _, idx := range dev.MacState.RejectedAdrTxPowerIndexes {
+	minTxPowerIndex, maxTxPowerIndex = clampTxPowerRange(dev, defaults, minTxPowerIndex, maxTxPowerIndex)
+	if minTxPowerIndex > maxTxPowerIndex {
+		log.FromContext(ctx).Debug("No common TX power index range available, avoid ADR")
+		return nil
+	}
+	rejectedTxPowerIndexes := make(map[uint8]struct{}, len(macState.RejectedAdrTxPowerIndexes))
+	for _, idx := range macState.RejectedAdrTxPowerIndexes {
 		rejectedTxPowerIndexes[uint8(idx)] = struct{}{}
 	}
 	_, ok = rejectedTxPowerIndexes[minTxPowerIndex]
@@ -213,13 +384,13 @@ func AdaptDataRate(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band, de
 		_, ok = rejectedTxPowerIndexes[maxTxPowerIndex]
 	}
 	if minTxPowerIndex > maxTxPowerIndex {
-		log.FromContext(ctx).Debug("Device has rejected all possible TX output power index values, avoid ADR.")
+		log.FromContext(ctx).Debug("Device has rejected all possible TX output power index values, avoid ADR")
 		return nil
 	}
 
 	maxSNR, ok := maxSNRFromMetadata(uplinkMetadata(adrUplinks...)...)
 	if !ok {
-		log.FromContext(ctx).Debug("Failed to determine max SNR, avoid ADR.")
+		log.FromContext(ctx).Debug("Failed to determine max SNR, avoid ADR")
 		return nil
 	}
 
@@ -243,15 +414,15 @@ func AdaptDataRate(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band, de
 
 	// NOTE: Network Server may only increase the data rate index of the device.
 	// NOTE(2): TX output power is reset whenever data rate is increased.
-	dev.MacState.DesiredParameters.AdrDataRateIndex = dev.MacState.CurrentParameters.AdrDataRateIndex
-	dev.MacState.DesiredParameters.AdrTxPowerIndex = dev.MacState.CurrentParameters.AdrTxPowerIndex
-	if dev.MacState.CurrentParameters.AdrDataRateIndex < minDataRateIndex {
-		margin -= float32(minDataRateIndex-dev.MacState.CurrentParameters.AdrDataRateIndex) * drStep
-		dev.MacState.DesiredParameters.AdrDataRateIndex = minDataRateIndex
-		dev.MacState.DesiredParameters.AdrTxPowerIndex = 0
+	desiredParameters.AdrDataRateIndex = currentParameters.AdrDataRateIndex
+	desiredParameters.AdrTxPowerIndex = currentParameters.AdrTxPowerIndex
+	if currentParameters.AdrDataRateIndex < minDataRateIndex {
+		margin -= float32(minDataRateIndex-currentParameters.AdrDataRateIndex) * drStep
+		desiredParameters.AdrDataRateIndex = minDataRateIndex
+		desiredParameters.AdrTxPowerIndex = 0
 	}
-	if marginSteps := (margin - txPowerStep(phy, 0, minTxPowerIndex)) / drStep; marginSteps >= 0 && marginSteps < float32(maxDataRateIndex-dev.MacState.DesiredParameters.AdrDataRateIndex) {
-		maxDataRateIndex = dev.MacState.DesiredParameters.AdrDataRateIndex + ttnpb.DataRateIndex(marginSteps)
+	if marginSteps := (margin - txPowerStep(phy, 0, minTxPowerIndex)) / drStep; marginSteps >= 0 && marginSteps < float32(maxDataRateIndex-desiredParameters.AdrDataRateIndex) {
+		maxDataRateIndex = desiredParameters.AdrDataRateIndex + ttnpb.DataRateIndex(marginSteps)
 	} else if marginSteps < 0 {
 		maxDataRateIndex = minDataRateIndex
 	}
@@ -259,45 +430,44 @@ func AdaptDataRate(ctx context.Context, dev *ttnpb.EndDevice, phy *band.Band, de
 		if _, ok := rejectedDataRateIndexes[drIdx]; ok {
 			continue
 		}
-		margin -= float32(drIdx-dev.MacState.DesiredParameters.AdrDataRateIndex) * drStep
-		dev.MacState.DesiredParameters.AdrDataRateIndex = drIdx
-		dev.MacState.DesiredParameters.AdrTxPowerIndex = 0
+		margin -= float32(drIdx-desiredParameters.AdrDataRateIndex) * drStep
+		desiredParameters.AdrDataRateIndex = drIdx
+		desiredParameters.AdrTxPowerIndex = 0
 		break
 	}
 
-	if dev.MacState.DesiredParameters.AdrTxPowerIndex < uint32(minTxPowerIndex) {
-		margin -= txPowerStep(phy, uint8(dev.MacState.DesiredParameters.AdrTxPowerIndex), minTxPowerIndex)
-		dev.MacState.DesiredParameters.AdrTxPowerIndex = uint32(minTxPowerIndex)
+	if desiredParameters.AdrTxPowerIndex < uint32(minTxPowerIndex) {
+		margin -= txPowerStep(phy, uint8(desiredParameters.AdrTxPowerIndex), minTxPowerIndex)
+		desiredParameters.AdrTxPowerIndex = uint32(minTxPowerIndex)
 	}
-	if dev.MacState.DesiredParameters.AdrTxPowerIndex > uint32(maxTxPowerIndex) {
-		margin += txPowerStep(phy, maxTxPowerIndex, uint8(dev.MacState.DesiredParameters.AdrTxPowerIndex))
-		dev.MacState.DesiredParameters.AdrTxPowerIndex = uint32(maxTxPowerIndex)
+	if desiredParameters.AdrTxPowerIndex > uint32(maxTxPowerIndex) {
+		margin += txPowerStep(phy, maxTxPowerIndex, uint8(desiredParameters.AdrTxPowerIndex))
+		desiredParameters.AdrTxPowerIndex = uint32(maxTxPowerIndex)
 	}
 	// If we still have margin left, we decrease the TX output power (increase the index).
 	for txPowerIdx := maxTxPowerIndex; txPowerIdx > minTxPowerIndex; txPowerIdx-- {
-		diff := txPowerStep(phy, uint8(dev.MacState.DesiredParameters.AdrTxPowerIndex), txPowerIdx)
+		diff := txPowerStep(phy, uint8(desiredParameters.AdrTxPowerIndex), txPowerIdx)
 		if _, ok := rejectedTxPowerIndexes[txPowerIdx]; ok || diff > margin {
 			continue
 		}
 		margin -= diff
-		dev.MacState.DesiredParameters.AdrTxPowerIndex = uint32(txPowerIdx)
+		desiredParameters.AdrTxPowerIndex = uint32(txPowerIdx)
 		break
 	}
 
-	dev.MacState.DesiredParameters.AdrNbTrans = dev.MacState.CurrentParameters.AdrNbTrans
-	if dev.MacState.DesiredParameters.AdrNbTrans > maxNbTrans {
-		dev.MacState.DesiredParameters.AdrNbTrans = maxNbTrans
-	}
+	nbTrans := clampNbTrans(dev, defaults, currentParameters.AdrNbTrans)
 	if len(adrUplinks) >= OptimalADRUplinkCount/2 {
 		switch r := adrLossRate(adrUplinks...); {
 		case r < 0.05:
-			dev.MacState.DesiredParameters.AdrNbTrans = 1 + dev.MacState.DesiredParameters.AdrNbTrans/3
+			nbTrans = 1 + nbTrans/3
 		case r < 0.10:
 		case r < 0.30:
-			dev.MacState.DesiredParameters.AdrNbTrans = 2 + dev.MacState.DesiredParameters.AdrNbTrans/2
+			nbTrans = 2 + nbTrans/2
 		default:
-			dev.MacState.DesiredParameters.AdrNbTrans = maxNbTrans
+			nbTrans = maxNbTrans
 		}
 	}
+	desiredParameters.AdrNbTrans = clampNbTrans(dev, defaults, nbTrans)
+
 	return nil
 }

--- a/pkg/networkserver/mac/adr_internal_test.go
+++ b/pkg/networkserver/mac/adr_internal_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gogo/protobuf/types"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
@@ -209,6 +210,799 @@ func TestADRLossRate(t *testing.T) {
 			Func: func(ctx context.Context, t *testing.T, a *assertions.Assertion) {
 				a.So(adrLossRate(tc.Uplinks...), should.Equal, tc.Rate)
 			},
+		})
+	}
+}
+
+func TestClampDataRateRange(t *testing.T) {
+	for _, tc := range []struct {
+		Name     string
+		Device   *ttnpb.EndDevice
+		Defaults ttnpb.MACSettings
+
+		InputMinDataRateIndex ttnpb.DataRateIndex
+		InputMaxDataRateIndex ttnpb.DataRateIndex
+
+		ExpectedMinDataRateIndex ttnpb.DataRateIndex
+		ExpectedMaxDataRateIndex ttnpb.DataRateIndex
+	}{
+		{
+			Name: "no device",
+
+			InputMinDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_1,
+			InputMaxDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_10,
+
+			ExpectedMinDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_1,
+			ExpectedMaxDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_10,
+		},
+		{
+			Name: "minimum only;left of provided interval",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MinDataRateIndex: &ttnpb.DataRateIndexValue{
+									Value: ttnpb.DataRateIndex_DATA_RATE_3,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputMinDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_5,
+			InputMaxDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_10,
+
+			ExpectedMinDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_5,
+			ExpectedMaxDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_10,
+		},
+		{
+			Name: "minimum only;inside provided interval",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MinDataRateIndex: &ttnpb.DataRateIndexValue{
+									Value: ttnpb.DataRateIndex_DATA_RATE_5,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputMinDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_1,
+			InputMaxDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_10,
+
+			ExpectedMinDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_5,
+			ExpectedMaxDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_10,
+		},
+		{
+			Name: "minimum only;right of provided interval",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MinDataRateIndex: &ttnpb.DataRateIndexValue{
+									Value: ttnpb.DataRateIndex_DATA_RATE_12,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputMinDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_5,
+			InputMaxDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_10,
+
+			// min > max implies that no common data rate range has been found.
+			ExpectedMinDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_12,
+			ExpectedMaxDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_10,
+		},
+		{
+			Name: "maximum only;left of provided interval",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MaxDataRateIndex: &ttnpb.DataRateIndexValue{
+									Value: ttnpb.DataRateIndex_DATA_RATE_3,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputMinDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_5,
+			InputMaxDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_10,
+
+			// min > max implies that no common data rate range has been found.
+			ExpectedMinDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_5,
+			ExpectedMaxDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_3,
+		},
+		{
+			Name: "maximum only;inside provided interval",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MaxDataRateIndex: &ttnpb.DataRateIndexValue{
+									Value: ttnpb.DataRateIndex_DATA_RATE_5,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputMinDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_1,
+			InputMaxDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_10,
+
+			ExpectedMinDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_1,
+			ExpectedMaxDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_5,
+		},
+		{
+			Name: "maximum only;right of provided interval",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MaxDataRateIndex: &ttnpb.DataRateIndexValue{
+									Value: ttnpb.DataRateIndex_DATA_RATE_12,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputMinDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_5,
+			InputMaxDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_10,
+
+			ExpectedMinDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_5,
+			ExpectedMaxDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_10,
+		},
+		{
+			Name: "minimum+maximum;left of provided interval",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MinDataRateIndex: &ttnpb.DataRateIndexValue{
+									Value: ttnpb.DataRateIndex_DATA_RATE_2,
+								},
+								MaxDataRateIndex: &ttnpb.DataRateIndexValue{
+									Value: ttnpb.DataRateIndex_DATA_RATE_3,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputMinDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_5,
+			InputMaxDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_10,
+
+			// min > max implies that no common data rate range has been found.
+			ExpectedMinDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_5,
+			ExpectedMaxDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_3,
+		},
+		{
+			Name: "minimum+maximum;left-joined of provided interval",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MinDataRateIndex: &ttnpb.DataRateIndexValue{
+									Value: ttnpb.DataRateIndex_DATA_RATE_3,
+								},
+								MaxDataRateIndex: &ttnpb.DataRateIndexValue{
+									Value: ttnpb.DataRateIndex_DATA_RATE_6,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputMinDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_5,
+			InputMaxDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_10,
+
+			ExpectedMinDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_5,
+			ExpectedMaxDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_6,
+		},
+		{
+			Name: "minimum+maximum;inside of provided interval",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MinDataRateIndex: &ttnpb.DataRateIndexValue{
+									Value: ttnpb.DataRateIndex_DATA_RATE_7,
+								},
+								MaxDataRateIndex: &ttnpb.DataRateIndexValue{
+									Value: ttnpb.DataRateIndex_DATA_RATE_9,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputMinDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_5,
+			InputMaxDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_10,
+
+			ExpectedMinDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_7,
+			ExpectedMaxDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_9,
+		},
+		{
+			Name: "minimum+maximum;right-joined of provided interval",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MinDataRateIndex: &ttnpb.DataRateIndexValue{
+									Value: ttnpb.DataRateIndex_DATA_RATE_7,
+								},
+								MaxDataRateIndex: &ttnpb.DataRateIndexValue{
+									Value: ttnpb.DataRateIndex_DATA_RATE_11,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputMinDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_5,
+			InputMaxDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_10,
+
+			ExpectedMinDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_7,
+			ExpectedMaxDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_10,
+		},
+		{
+			Name: "minimum+maximum;right of provided interval",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MinDataRateIndex: &ttnpb.DataRateIndexValue{
+									Value: ttnpb.DataRateIndex_DATA_RATE_12,
+								},
+								MaxDataRateIndex: &ttnpb.DataRateIndexValue{
+									Value: ttnpb.DataRateIndex_DATA_RATE_15,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputMinDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_5,
+			InputMaxDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_10,
+
+			// min > max implies that no common data rate range has been found.
+			ExpectedMinDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_12,
+			ExpectedMaxDataRateIndex: ttnpb.DataRateIndex_DATA_RATE_10,
+		},
+	} {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			a := assertions.New(t)
+
+			min, max := clampDataRateRange(tc.Device, tc.Defaults, tc.InputMinDataRateIndex, tc.InputMaxDataRateIndex)
+			a.So(min, should.Equal, tc.ExpectedMinDataRateIndex)
+			a.So(max, should.Equal, tc.ExpectedMaxDataRateIndex)
+		})
+	}
+}
+func TestClampTxPowerRange(t *testing.T) {
+	for _, tc := range []struct {
+		Name     string
+		Device   *ttnpb.EndDevice
+		Defaults ttnpb.MACSettings
+
+		InputMinTxPowerIndex uint8
+		InputMaxTxPowerIndex uint8
+
+		ExpectedMinTxPowerIndex uint8
+		ExpectedMaxTxPowerIndex uint8
+	}{
+		{
+			Name: "no device",
+
+			InputMinTxPowerIndex: 1,
+			InputMaxTxPowerIndex: 10,
+
+			ExpectedMinTxPowerIndex: 1,
+			ExpectedMaxTxPowerIndex: 10,
+		},
+		{
+			Name: "minimum only;left of provided interval",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MinTxPowerIndex: &types.UInt32Value{
+									Value: 3,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputMinTxPowerIndex: 5,
+			InputMaxTxPowerIndex: 10,
+
+			ExpectedMinTxPowerIndex: 5,
+			ExpectedMaxTxPowerIndex: 10,
+		},
+		{
+			Name: "minimum only;inside provided interval",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MinTxPowerIndex: &types.UInt32Value{
+									Value: 5,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputMinTxPowerIndex: 1,
+			InputMaxTxPowerIndex: 10,
+
+			ExpectedMinTxPowerIndex: 5,
+			ExpectedMaxTxPowerIndex: 10,
+		},
+		{
+			Name: "minimum only;right of provided interval",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MinTxPowerIndex: &types.UInt32Value{
+									Value: 12,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputMinTxPowerIndex: 5,
+			InputMaxTxPowerIndex: 10,
+
+			// min > max implies that no common TX power range has been found.
+			ExpectedMinTxPowerIndex: 12,
+			ExpectedMaxTxPowerIndex: 10,
+		},
+		{
+			Name: "maximum only;left of provided interval",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MaxTxPowerIndex: &types.UInt32Value{
+									Value: 3,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputMinTxPowerIndex: 5,
+			InputMaxTxPowerIndex: 10,
+
+			// min > max implies that no common TX power range has been found.
+			ExpectedMinTxPowerIndex: 5,
+			ExpectedMaxTxPowerIndex: 3,
+		},
+		{
+			Name: "maximum only;inside provided interval",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MaxTxPowerIndex: &types.UInt32Value{
+									Value: 5,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputMinTxPowerIndex: 1,
+			InputMaxTxPowerIndex: 10,
+
+			ExpectedMinTxPowerIndex: 1,
+			ExpectedMaxTxPowerIndex: 5,
+		},
+		{
+			Name: "maximum only;right of provided interval",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MaxTxPowerIndex: &types.UInt32Value{
+									Value: 12,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputMinTxPowerIndex: 5,
+			InputMaxTxPowerIndex: 10,
+
+			ExpectedMinTxPowerIndex: 5,
+			ExpectedMaxTxPowerIndex: 10,
+		},
+		{
+			Name: "minimum+maximum;left of provided interval",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MinTxPowerIndex: &types.UInt32Value{
+									Value: 2,
+								},
+								MaxTxPowerIndex: &types.UInt32Value{
+									Value: 3,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputMinTxPowerIndex: 5,
+			InputMaxTxPowerIndex: 10,
+
+			// min > max implies that no common TX power range has been found.
+			ExpectedMinTxPowerIndex: 5,
+			ExpectedMaxTxPowerIndex: 3,
+		},
+		{
+			Name: "minimum+maximum;left-joined of provided interval",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MinTxPowerIndex: &types.UInt32Value{
+									Value: 3,
+								},
+								MaxTxPowerIndex: &types.UInt32Value{
+									Value: 6,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputMinTxPowerIndex: 5,
+			InputMaxTxPowerIndex: 10,
+
+			ExpectedMinTxPowerIndex: 5,
+			ExpectedMaxTxPowerIndex: 6,
+		},
+		{
+			Name: "minimum+maximum;inside of provided interval",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MinTxPowerIndex: &types.UInt32Value{
+									Value: 7,
+								},
+								MaxTxPowerIndex: &types.UInt32Value{
+									Value: 9,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputMinTxPowerIndex: 5,
+			InputMaxTxPowerIndex: 10,
+
+			ExpectedMinTxPowerIndex: 7,
+			ExpectedMaxTxPowerIndex: 9,
+		},
+		{
+			Name: "minimum+maximum;right-joined of provided interval",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MinTxPowerIndex: &types.UInt32Value{
+									Value: 7,
+								},
+								MaxTxPowerIndex: &types.UInt32Value{
+									Value: 11,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputMinTxPowerIndex: 5,
+			InputMaxTxPowerIndex: 10,
+
+			ExpectedMinTxPowerIndex: 7,
+			ExpectedMaxTxPowerIndex: 10,
+		},
+		{
+			Name: "minimum+maximum;right of provided interval",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MinTxPowerIndex: &types.UInt32Value{
+									Value: 12,
+								},
+								MaxTxPowerIndex: &types.UInt32Value{
+									Value: 15,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputMinTxPowerIndex: 5,
+			InputMaxTxPowerIndex: 10,
+
+			// min > max implies that no common TX power range has been found.
+			ExpectedMinTxPowerIndex: 12,
+			ExpectedMaxTxPowerIndex: 10,
+		},
+	} {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			a := assertions.New(t)
+
+			min, max := clampTxPowerRange(tc.Device, tc.Defaults, tc.InputMinTxPowerIndex, tc.InputMaxTxPowerIndex)
+			a.So(min, should.Equal, tc.ExpectedMinTxPowerIndex)
+			a.So(max, should.Equal, tc.ExpectedMaxTxPowerIndex)
+		})
+	}
+}
+
+func TestClampNbTrans(t *testing.T) {
+	for _, tc := range []struct {
+		Name     string
+		Device   *ttnpb.EndDevice
+		Defaults ttnpb.MACSettings
+
+		InputNbTrans uint32
+
+		ExpectedNbTrans uint32
+	}{
+		{
+			Name: "no device",
+
+			InputNbTrans: 1,
+
+			ExpectedNbTrans: 1,
+		},
+		{
+			Name: "minimum only;left of provided value",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MinNbTrans: &types.UInt32Value{
+									Value: 1,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputNbTrans: 2,
+
+			ExpectedNbTrans: 2,
+		},
+		{
+			Name: "minimum only;right of provided value",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MinNbTrans: &types.UInt32Value{
+									Value: 3,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputNbTrans: 2,
+
+			ExpectedNbTrans: 3,
+		},
+		{
+			Name: "maximum only;left of provided value",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MaxNbTrans: &types.UInt32Value{
+									Value: 3,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputNbTrans: 5,
+
+			ExpectedNbTrans: 3,
+		},
+		{
+			Name: "maximum only;right of provided value",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MaxNbTrans: &types.UInt32Value{
+									Value: 7,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputNbTrans: 5,
+
+			ExpectedNbTrans: 5,
+		},
+		{
+			Name: "minimum+maximum;left of provided value",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MinNbTrans: &types.UInt32Value{
+									Value: 2,
+								},
+								MaxNbTrans: &types.UInt32Value{
+									Value: 3,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputNbTrans: 5,
+
+			ExpectedNbTrans: 3,
+		},
+		{
+			Name: "minimum+maximum;inside of provided value",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MinNbTrans: &types.UInt32Value{
+									Value: 7,
+								},
+								MaxNbTrans: &types.UInt32Value{
+									Value: 9,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputNbTrans: 8,
+
+			ExpectedNbTrans: 8,
+		},
+		{
+			Name: "minimum+maximum;right of provided value",
+
+			Device: &ttnpb.EndDevice{
+				MacSettings: &ttnpb.MACSettings{
+					Adr: &ttnpb.ADRSettings{
+						Mode: &ttnpb.ADRSettings_Dynamic{
+							Dynamic: &ttnpb.ADRSettings_DynamicMode{
+								MinNbTrans: &types.UInt32Value{
+									Value: 12,
+								},
+								MaxNbTrans: &types.UInt32Value{
+									Value: 15,
+								},
+							},
+						},
+					},
+				},
+			},
+
+			InputNbTrans: 8,
+
+			ExpectedNbTrans: 12,
+		},
+	} {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			a := assertions.New(t)
+
+			value := clampNbTrans(tc.Device, tc.Defaults, tc.InputNbTrans)
+			a.So(value, should.Equal, tc.ExpectedNbTrans)
 		})
 	}
 }

--- a/pkg/networkserver/mac/adr_legacy.go
+++ b/pkg/networkserver/mac/adr_legacy.go
@@ -1,0 +1,51 @@
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mac
+
+import (
+	"go.thethings.network/lorawan-stack/v3/pkg/band"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+)
+
+func legacyDeviceUseADR(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings, phy *band.Band) bool {
+	switch {
+	case !phy.EnableADR:
+		return false
+	case dev.GetMulticast():
+		return false
+	case dev.GetMacSettings().GetUseAdr() != nil:
+		return dev.MacSettings.UseAdr.Value
+	case defaults.UseAdr != nil:
+		return defaults.UseAdr.Value
+	default:
+		return true
+	}
+}
+
+func legacyDeviceShouldAdaptDataRate(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings, phy *band.Band) (adaptDataRate bool, resetDesiredParameters bool, staticSettings *ttnpb.ADRSettings_StaticMode) {
+	useADR := legacyDeviceUseADR(dev, defaults, phy)
+	return useADR, useADR, nil
+}
+
+func legacyDeviceADRMargin(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings) float32 {
+	switch {
+	case dev.GetMacSettings().GetAdrMargin() != nil:
+		return dev.MacSettings.AdrMargin.Value
+	case defaults.AdrMargin != nil:
+		return defaults.AdrMargin.Value
+	default:
+		return DefaultADRMargin
+	}
+}

--- a/pkg/networkserver/mac/adr_legacy.go
+++ b/pkg/networkserver/mac/adr_legacy.go
@@ -21,7 +21,7 @@ import (
 
 func legacyDeviceUseADR(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings, phy *band.Band) bool {
 	switch {
-	case !phy.EnableADR:
+	case !phy.SupportsDynamicADR:
 		return false
 	case dev.GetMulticast():
 		return false

--- a/pkg/networkserver/mac/utils.go
+++ b/pkg/networkserver/mac/utils.go
@@ -145,22 +145,6 @@ func NextPingSlotAt(ctx context.Context, dev *ttnpb.EndDevice, earliestAt time.T
 	return time.Time{}, false
 }
 
-func DeviceUseADR(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings, phy *band.Band) bool {
-	if !phy.EnableADR {
-		return false
-	}
-	if dev.GetMulticast() {
-		return false
-	}
-	if v := dev.GetMacSettings().GetUseAdr(); v != nil {
-		return v.Value
-	}
-	if defaults.UseAdr != nil {
-		return defaults.UseAdr.Value
-	}
-	return true
-}
-
 func DeviceResetsFCnt(dev *ttnpb.EndDevice, defaults ttnpb.MACSettings) bool {
 	switch {
 	case dev.GetMacSettings().GetResetsFCnt() != nil:

--- a/pkg/ttnpb/fieldmask_utils.go
+++ b/pkg/ttnpb/fieldmask_utils.go
@@ -75,6 +75,9 @@ nextRequested:
 //
 // Note that this function may have unexpected results when non bottom search fields are used,
 // as HasAnyField([]string{"a.b"}, "a") is false.
+//
+// If all possibilities are `[a, a.b, a.c]`, and we have `[a.b]`, then requesting `[a]`
+// should be false because if it would be true, then `a.c` can be expected.
 func HasAnyField(requested []string, search ...string) bool {
 	for _, requested := range requested {
 		for _, search := range search {

--- a/pkg/ttnpb/fieldmask_utils.go
+++ b/pkg/ttnpb/fieldmask_utils.go
@@ -72,6 +72,9 @@ nextRequested:
 
 // HasAnyField returns whether the given requested paths contain any of the given fields.
 // The requested fields (i.e. `a.b`) may be of a higher level than the search path (i.e. `a.b.c`).
+//
+// Note that this function may have unexpected results when non bottom search fields are used,
+// as HasAnyField([]string{"a.b"}, "a") is false.
 func HasAnyField(requested []string, search ...string) bool {
 	for _, requested := range requested {
 		for _, search := range search {

--- a/pkg/ttnpb/fieldmask_utils.go
+++ b/pkg/ttnpb/fieldmask_utils.go
@@ -107,6 +107,17 @@ nextPath:
 	return res
 }
 
+// NonZeroFields returns the fields which are not zero in the provided message.
+func NonZeroFields(msg interface{ FieldIsZero(string) bool }, fields ...string) []string {
+	nonZeroFields := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if !msg.FieldIsZero(field) {
+			nonZeroFields = append(nonZeroFields, field)
+		}
+	}
+	return nonZeroFields
+}
+
 var errMissingField = errors.Define("missing_field", "field `{field}` is missing")
 
 // RequireFields returns nil if the given requested paths contain all of the given fields and error otherwise.
@@ -169,6 +180,20 @@ outer:
 		}
 	}
 	return selectedPaths
+}
+
+// AllowedReachableBottomLevelFields returns the reachable bottom level paths from the given paths that are in the allowed paths.
+// Reachability in this context means that all of the intermediary paths between the given paths and the bottom level paths
+// are not zero. Using only reachable paths ensures that no redundant bottom level paths are included.
+func AllowedReachableBottomLevelFields(paths, allowedPaths []string, isZero func(string) bool) []string {
+	nonZeroAllowedPaths := make([]string, 0, len(allowedPaths))
+	for _, allowedPath := range allowedPaths {
+		if isZero(allowedPath) {
+			continue
+		}
+		nonZeroAllowedPaths = append(nonZeroAllowedPaths, allowedPath)
+	}
+	return AllowedBottomLevelFields(paths, nonZeroAllowedPaths)
 }
 
 // ExcludeFields returns the given paths without the given search paths to exclude.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/3820
Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/5092
References https://github.com/TheThingsNetwork/lorawan-stack/issues/40
References https://github.com/TheThingsIndustries/protoc-gen-fieldmask/pull/43

#### Changes
<!-- What are the changes made in this pull request? -->

- Add error checking to the CLI `SetFields` calls
  - The errors would be hidden previously, which would cause weird behavior
- While retrieving an end device from multiple components in the CLI, ensure that the bottom level fields are actually reachable
  - This is relevant for `oneof` fields, as the bottom level fields could contain multiple `oneof` options
- Add ADR settings validation
  - `mac_settings.adr` is mutually exclusive with `use_adr`/`adr_margin`
  - The dynamic settings need to be well defined - both the min and the max must be valid data rates / TX power indices, and they need to be monotonic (min <= max)
  - The static settings need to be well defined - same rules
  - If the band does not allow ADR (ISM2400 does this), it is illegal to attempt to use the dynamic settings. Using static values / disabling ADR completely is still valid for those
- Refactor ADR algorithm 
  - Add aliases for the MAC state and the current/desired parameters. The `dev.MacState.*Parameters` spam is not adding any value in my opinion, but let me know your thoughts
  - For cases in which we run the algorithm (so no static settings / disabled), add parameter clamping options


#### Testing

<!-- How did you verify that this change works? -->

Unit testing and CLI testing. Unit tests have been added for the clamping logic, while the CLI has been used extensively for the validation.

<details><summary>Mutual exclusivity of the fields</summary>

```bash
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.use_adr
WARN    Using insecure connection to OAuth server
{
  "ids": {
    "device_id": "eui-1231231231231231",
    "application_ids": {
      "application_id": "app1"
    },
    "dev_eui": "1231231231231231",
    "join_eui": "0000000000000000"
  },
  "created_at": "2022-03-31T15:36:50.104Z",
  "updated_at": "2022-04-01T14:21:27.176106985Z",
  "network_server_address": "localhost",
  "mac_settings": {
    "use_adr": true
  }
}
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.dynamic
WARN    Using insecure connection to OAuth server
error:pkg/networkserver:field_value (invalid value of field `mac_settings.use_adr`)
    field=mac_settings.use_adr
    correlation_id=02f68c7580944eac993effbd1c703976
exit status 255
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.static
WARN    Using insecure connection to OAuth server
error:pkg/networkserver:field_value (invalid value of field `mac_settings.use_adr.value`)
    field=mac_settings.use_adr.value
    correlation_id=e7be3d06bcbc4ad19f459f11c6503a2c
exit status 255
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.disabled
WARN    Using insecure connection to OAuth server
error:pkg/networkserver:field_value (invalid value of field `mac_settings.use_adr`)
    field=mac_settings.use_adr
    correlation_id=ffc77bbd8e91405e9ce61e45702b4a52
exit status 255
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --unset mac-settings.use_adr
WARN    Using insecure connection to OAuth server
{
  "ids": {
    "device_id": "eui-1231231231231231",
    "application_ids": {
      "application_id": "app1"
    },
    "dev_eui": "1231231231231231",
    "join_eui": "0000000000000000"
  },
  "created_at": "2022-03-31T15:36:50.104Z",
  "updated_at": "2022-04-01T14:22:30.940208634Z",
  "network_server_address": "localhost",
  "mac_settings": {}
}
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.disabled
WARN    Using insecure connection to OAuth server
{
  "ids": {
    "device_id": "eui-1231231231231231",
    "application_ids": {
      "application_id": "app1"
    },
    "dev_eui": "1231231231231231",
    "join_eui": "0000000000000000"
  },
  "created_at": "2022-03-31T15:36:50.104Z",
  "updated_at": "2022-04-01T14:22:34.026777613Z",
  "network_server_address": "localhost",
  "mac_settings": {
    "adr": {
      "disabled": {}
    }
  }
}
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.static
WARN    Using insecure connection to OAuth server
{
  "ids": {
    "device_id": "eui-1231231231231231",
    "application_ids": {
      "application_id": "app1"
    },
    "dev_eui": "1231231231231231",
    "join_eui": "0000000000000000"
  },
  "created_at": "2022-03-31T15:36:50.104Z",
  "updated_at": "2022-04-01T14:22:37.647174521Z",
  "network_server_address": "localhost",
  "mac_settings": {
    "adr": {
      "static": {}
    }
  }
}
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.dynamic
WARN    Using insecure connection to OAuth server
{
  "ids": {
    "device_id": "eui-1231231231231231",
    "application_ids": {
      "application_id": "app1"
    },
    "dev_eui": "1231231231231231",
    "join_eui": "0000000000000000"
  },
  "created_at": "2022-03-31T15:36:50.104Z",
  "updated_at": "2022-04-01T14:22:41.545353259Z",
  "network_server_address": "localhost",
  "mac_settings": {
    "adr": {
      "dynamic": {}
    }
  }
}
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.use_adr
WARN    Using insecure connection to OAuth server
error:pkg/networkserver:field_value (invalid value of field `mac_settings.adr`)
    field=mac_settings.adr
    correlation_id=c5b488ec27d94b54a74f81590d087979
exit status 255
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr_margin 16.2
WARN    Using insecure connection to OAuth server
error:pkg/networkserver:field_value (invalid value of field `mac_settings.adr.mode.dynamic`)
    field=mac_settings.adr.mode.dynamic
    correlation_id=b05ae7f396cb4879b1b08844f1085528
exit status 255
```

</details>

<details><summary>Disallowing dynamic ADR settings when the band does not allow it</summary>

```bash
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-3123213123123123 --mac-settings.use_adr
WARN    Using insecure connection to OAuth server
error:pkg/networkserver:field_value (invalid value of field `mac_settings.use_adr.value`)
    field=mac_settings.use_adr.value
    correlation_id=d2c2b0dc867e48e2af59cc66887a09c4
exit status 255
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-3123213123123123 --mac-settings.adr.mode.dynamic
WARN    Using insecure connection to OAuth server
error:pkg/networkserver:field_value (invalid value of field `mac_settings.adr.mode.dynamic`)
    field=mac_settings.adr.mode.dynamic
    correlation_id=28b5d28c60f94043b4c5851bc5b22841
exit status 255
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-3123213123123123 --mac-settings.adr.mode.static
WARN    Using insecure connection to OAuth server
{
  "ids": {
    "device_id": "eui-3123213123123123",
    "application_ids": {
      "application_id": "app1"
    },
    "dev_eui": "3123213123123123",
    "join_eui": "0000000000000000"
  },
  "created_at": "2022-03-31T17:13:06.443Z",
  "updated_at": "2022-04-01T15:02:49.615395852Z",
  "network_server_address": "localhost",
  "mac_settings": {
    "adr": {
      "static": {}
    }
  }
}
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-3123213123123123 --mac-settings.adr.mode.disabled
WARN    Using insecure connection to OAuth server
{
  "ids": {
    "device_id": "eui-3123213123123123",
    "application_ids": {
      "application_id": "app1"
    },
    "dev_eui": "3123213123123123",
    "join_eui": "0000000000000000"
  },
  "created_at": "2022-03-31T17:13:06.443Z",
  "updated_at": "2022-04-01T15:02:54.382600251Z",
  "network_server_address": "localhost",
  "mac_settings": {
    "adr": {
      "disabled": {}
    }
  }
}
```

</details>

<details><summary>Parameter well definedness</summary>

```bash
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.dynamic.min-data-rate-index 3
WARN    Using insecure connection to OAuth server
{
  "ids": {
    "device_id": "eui-1231231231231231",
    "application_ids": {
      "application_id": "app1"
    },
    "dev_eui": "1231231231231231",
    "join_eui": "0000000000000000"
  },
  "created_at": "2022-03-31T15:36:50.104Z",
  "updated_at": "2022-04-01T16:12:48.528713620Z",
  "network_server_address": "localhost",
  "mac_settings": {
    "adr": {
      "dynamic": {
        "min_data_rate_index": 3
      }
    }
  }
}
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.dynamic.min-data-rate-index 10
WARN    Using insecure connection to OAuth server
error:pkg/networkserver:field_value (invalid value of field `mac_settings.adr.mode.dynamic.min_data_rate_index.value`)
    field=mac_settings.adr.mode.dynamic.min_data_rate_index.value
    correlation_id=6d0ad7ec95d5450bb9cac471c7ce26d2
exit status 255
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.dynamic.max-data-rate-index 5
WARN    Using insecure connection to OAuth server
{
  "ids": {
    "device_id": "eui-1231231231231231",
    "application_ids": {
      "application_id": "app1"
    },
    "dev_eui": "1231231231231231",
    "join_eui": "0000000000000000"
  },
  "created_at": "2022-03-31T15:36:50.104Z",
  "updated_at": "2022-04-01T16:13:14.361201128Z",
  "network_server_address": "localhost",
  "mac_settings": {
    "adr": {
      "dynamic": {
        "max_data_rate_index": 5
      }
    }
  }
}
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.dynamic.max-data-rate-index 2
WARN    Using insecure connection to OAuth server
error:pkg/networkserver:field_value (invalid value of field `mac_settings.adr.mode.dynamic.max_data_rate_index.value`)
    field=mac_settings.adr.mode.dynamic.max_data_rate_index.value
    correlation_id=49e425fcb04a4cefaa2af2fd6b1fbbd5
exit status 255
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.dynamic.max-data-rate-index 11
WARN    Using insecure connection to OAuth server
error:pkg/networkserver:field_value (invalid value of field `mac_settings.adr.mode.dynamic.max_data_rate_index.value`)
    field=mac_settings.adr.mode.dynamic.max_data_rate_index.value
    correlation_id=2ee504a08c004af7abb509e761f14d72
exit status 255
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.dynamic.min-tx-power-index 3
WARN    Using insecure connection to OAuth server
{
  "ids": {
    "device_id": "eui-1231231231231231",
    "application_ids": {
      "application_id": "app1"
    },
    "dev_eui": "1231231231231231",
    "join_eui": "0000000000000000"
  },
  "created_at": "2022-03-31T15:36:50.104Z",
  "updated_at": "2022-04-01T16:14:25.136783161Z",
  "network_server_address": "localhost",
  "mac_settings": {
    "adr": {
      "dynamic": {
        "min_tx_power_index": 3
      }
    }
  }
}
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.dynamic.min-tx-power-index 10
WARN    Using insecure connection to OAuth server
error:pkg/networkserver:field_value (invalid value of field `mac_settings.adr.mode.dynamic.min_tx_power_index`)
    field=mac_settings.adr.mode.dynamic.min_tx_power_index
    correlation_id=87d467e1290249d786bfb3b445168efe
exit status 255
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.dynamic.max-tx-power-index 5
WARN    Using insecure connection to OAuth server
{
  "ids": {
    "device_id": "eui-1231231231231231",
    "application_ids": {
      "application_id": "app1"
    },
    "dev_eui": "1231231231231231",
    "join_eui": "0000000000000000"
  },
  "created_at": "2022-03-31T15:36:50.104Z",
  "updated_at": "2022-04-01T16:14:39.413107444Z",
  "network_server_address": "localhost",
  "mac_settings": {
    "adr": {
      "dynamic": {
        "max_tx_power_index": 5
      }
    }
  }
}
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.dynamic.max-tx-power-index 2
WARN    Using insecure connection to OAuth server
error:pkg/networkserver:field_value (invalid value of field `mac_settings.adr.mode.dynamic.max_tx_power_index`)
    field=mac_settings.adr.mode.dynamic.max_tx_power_index
    correlation_id=75e66333b6ec49d98813a9334464ee29
exit status 255
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.dynamic.max-tx-power-index 11
WARN    Using insecure connection to OAuth server
error:pkg/networkserver:field_value (invalid value of field `mac_settings.adr.mode.dynamic.max_tx_power_index`)
    field=mac_settings.adr.mode.dynamic.max_tx_power_index
    correlation_id=b3ef7c63fb2e4018bd214017d8ffb747
exit status 255
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.dynamic.min-tx-power-index 3
WARN    Using insecure connection to OAuth server
{
  "ids": {
    "device_id": "eui-1231231231231231",
    "application_ids": {
      "application_id": "app1"
    },
    "dev_eui": "1231231231231231",
    "join_eui": "0000000000000000"
  },
  "created_at": "2022-03-31T15:36:50.104Z",
  "updated_at": "2022-04-01T16:14:25.136783161Z",
  "network_server_address": "localhost",
  "mac_settings": {
    "adr": {
      "dynamic": {
        "min_tx_power_index": 3
      }
    }
  }
}
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.dynamic.min-tx-power-index 10
WARN    Using insecure connection to OAuth server
error:pkg/networkserver:field_value (invalid value of field `mac_settings.adr.mode.dynamic.min_tx_power_index`)
    field=mac_settings.adr.mode.dynamic.min_tx_power_index
    correlation_id=87d467e1290249d786bfb3b445168efe
exit status 255
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.dynamic.max-tx-power-index 5
WARN    Using insecure connection to OAuth server
{
  "ids": {
    "device_id": "eui-1231231231231231",
    "application_ids": {
      "application_id": "app1"
    },
    "dev_eui": "1231231231231231",
    "join_eui": "0000000000000000"
  },
  "created_at": "2022-03-31T15:36:50.104Z",
  "updated_at": "2022-04-01T16:14:39.413107444Z",
  "network_server_address": "localhost",
  "mac_settings": {
    "adr": {
      "dynamic": {
        "max_tx_power_index": 5
      }
    }
  }
}
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.dynamic.max-tx-power-index 2
WARN    Using insecure connection to OAuth server
error:pkg/networkserver:field_value (invalid value of field `mac_settings.adr.mode.dynamic.max_tx_power_index`)
    field=mac_settings.adr.mode.dynamic.max_tx_power_index
    correlation_id=75e66333b6ec49d98813a9334464ee29
exit status 255
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.dynamic.max-tx-power-index 11
WARN    Using insecure connection to OAuth server
error:pkg/networkserver:field_value (invalid value of field `mac_settings.adr.mode.dynamic.max_tx_power_index`)
    field=mac_settings.adr.mode.dynamic.max_tx_power_index
    correlation_id=b3ef7c63fb2e4018bd214017d8ffb747
exit status 255
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --unset mac-settings.adr
WARN    Using insecure connection to OAuth server
{
  "ids": {
    "device_id": "eui-1231231231231231",
    "application_ids": {
      "application_id": "app1"
    },
    "dev_eui": "1231231231231231",
    "join_eui": "0000000000000000"
  },
  "created_at": "2022-03-31T15:36:50.104Z",
  "updated_at": "2022-04-01T16:16:03.222665510Z",
  "network_server_address": "localhost",
  "mac_settings": {}
}
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.dynamic.min-nb-trans 2
WARN    Using insecure connection to OAuth server
{
  "ids": {
    "device_id": "eui-1231231231231231",
    "application_ids": {
      "application_id": "app1"
    },
    "dev_eui": "1231231231231231",
    "join_eui": "0000000000000000"
  },
  "created_at": "2022-03-31T15:36:50.104Z",
  "updated_at": "2022-04-01T16:16:17.075643181Z",
  "network_server_address": "localhost",
  "mac_settings": {
    "adr": {
      "dynamic": {
        "min_nb_trans": 2
      }
    }
  }
}
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.dynamic.min-nb-trans 4
WARN    Using insecure connection to OAuth server
error:pkg/errors:validation (invalid `end_device`: embedded message failed validation)
    name=SetEndDeviceRequestValidationError
    reason=embedded message failed validation
    field=end_device
    correlation_id=75af952296fd4129863692d7d1e124dd
--- error:pkg/errors:validation (invalid `mac_settings`: embedded message failed validation)
    reason=embedded message failed validation
    field=mac_settings
    name=EndDeviceValidationError
    correlation_id=64c807380a23413595ade989fba1f42b
--- error:pkg/errors:validation (invalid `adr`: embedded message failed validation)
    field=adr
    name=MACSettingsValidationError
    reason=embedded message failed validation
    correlation_id=049cff3812cf472bb93f9da6ad2f9eaa
--- error:pkg/errors:validation (invalid `dynamic`: embedded message failed validation)
    name=ADRSettingsValidationError
    reason=embedded message failed validation
    field=dynamic
    correlation_id=5981d2dc85fb46e3a01f46f00e049920
--- error:pkg/errors:validation (invalid `min_nb_trans`: value must be inside range [1, 3])
    field=min_nb_trans
    name=ADRSettings_DynamicModeValidationError
    reason=value must be inside range [1, 3]
    correlation_id=8f1486bfa707466685497e1c8799e94b
exit status 255
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.dynamic.max-nb-trans 3
WARN    Using insecure connection to OAuth server
{
  "ids": {
    "device_id": "eui-1231231231231231",
    "application_ids": {
      "application_id": "app1"
    },
    "dev_eui": "1231231231231231",
    "join_eui": "0000000000000000"
  },
  "created_at": "2022-03-31T15:36:50.104Z",
  "updated_at": "2022-04-01T16:16:35.085298787Z",
  "network_server_address": "localhost",
  "mac_settings": {
    "adr": {
      "dynamic": {
        "max_nb_trans": 3
      }
    }
  }
}
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.dynamic.max-nb-trans 1
WARN    Using insecure connection to OAuth server
error:pkg/networkserver:field_value (invalid value of field `mac_settings.adr.mode.dynamic.max_nb_trans`)
    field=mac_settings.adr.mode.dynamic.max_nb_trans
    correlation_id=f1ea4952683b4bcc8666a3857ed44f17
exit status 255
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.static.data-rate-index 5
WARN    Using insecure connection to OAuth server
{
  "ids": {
    "device_id": "eui-1231231231231231",
    "application_ids": {
      "application_id": "app1"
    },
    "dev_eui": "1231231231231231",
    "join_eui": "0000000000000000"
  },
  "created_at": "2022-03-31T15:36:50.104Z",
  "updated_at": "2022-04-01T16:20:23.653655368Z",
  "network_server_address": "localhost",
  "mac_settings": {
    "adr": {
      "static": {
        "data_rate_index": 5
      }
    }
  }
}
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.static.data-rate-index 11WARN    Using insecure connection to OAuth server
error:pkg/networkserver:field_value (invalid value of field `mac_settings.adr.mode.static.data_rate_index`)
    field=mac_settings.adr.mode.static.data_rate_index
    correlation_id=fd74f69320c54f69a31adb418b6b77cf
exit status 255
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.static.tx-power-index 2
WARN    Using insecure connection to OAuth server
{
  "ids": {
    "device_id": "eui-1231231231231231",
    "application_ids": {
      "application_id": "app1"
    },
    "dev_eui": "1231231231231231",
    "join_eui": "0000000000000000"
  },
  "created_at": "2022-03-31T15:36:50.104Z",
  "updated_at": "2022-04-01T16:20:33.623149431Z",
  "network_server_address": "localhost",
  "mac_settings": {
    "adr": {
      "static": {
        "tx_power_index": 2
      }
    }
  }
}
adriansmares@A98BCD2222F1:~/go/src/go.thethings.network/lorawan-stack$ ttn-lw-cli dev set app1 eui-1231231231231231 --mac-settings.adr.mode.static.tx-power-index 15
WARN    Using insecure connection to OAuth server
error:pkg/networkserver:field_value (invalid value of field `mac_settings.adr.mode.static.tx_power_index`)
    field=mac_settings.adr.mode.static.tx_power_index
    correlation_id=2b22f1e722144882a3a0f1ff27430521
exit status 255
```

</details>

_I'll add these CLI only tests as unit tests in a future PR._

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

As part of this PR I've had to fix some field validation which was previously broken - you will see in the code that some extra loop variable aliases are added, since these variables are captured in certain function definitions which are called later. These checks where previously not working, so it is possible that we now reject some input that was previously accepted as valid. Depending on the reports we will need to check if validation is broken or the request is broken.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@johanstokking main reviewer.

If you would like to test this locally, regenerate the protos using https://github.com/TheThingsIndustries/protoc-gen-fieldmask/pull/43, otherwise you will have a hard time switching between modes (as currently switching the type of `oneof` field in a single roundtrip is not possible).

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
