### PR TITLE
Check Join EUI from flags before using JS default 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Fixed
 
 - Console determining gateways as "Other cluster" even though using the same host if server addresses not matching exactly (e.g. due to using different host or scheme).
+- CLI no longer informs the user that is using the default JoinEUI when passing its value via flags.
 
 ### Security
 

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -458,7 +458,7 @@ var (
 						paths = append(paths,
 							"join_server_address",
 						)
-						if device.Ids.JoinEui == nil {
+						if device.Ids.JoinEui == nil && (devID == nil || devID.JoinEui == nil) {
 							// Get the default JoinEUI for Join Server.
 							logger.WithField("join_server_address", config.JoinServerGRPCAddress).Info("JoinEUI empty but defaults flag is set, fetch default JoinEUI of the Join Server")
 							js, err := api.Dial(ctx, config.JoinServerGRPCAddress)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

From the discussion in #5340, we confirmed that the bug found in #5140 is happening again.

#### Changes
<!-- What are the changes made in this pull request? -->

- Check Join EUI from flags before using JS default
- Update changelog


#### Testing

<!-- How did you verify that this change works? -->

The same testing done in #5140 but with the addition of creating an end-device through a json file.

**before:**
```
go run ./cmd/ttn-lw-cli end-devices create test-app dev1   --join-eui 1234567812345678 --dev-eui 1234567812345678 --root-keys.app-key.key 12345678765432121234567898765432

INFO    JoinEUI empty but defaults flag is set, fetch default JoinEUI of the Join Server        {"join_server_address": "localhost:8884"}
INFO    Successfully obtained Join Server's default JoinEUI     {"default_join_eui": "0000000000000000"}
{
  "ids": {
    "device_id": "dev1",
    "application_ids": {
      "application_id": "test-app"
    },
    "dev_eui": "1234567812345678",
    "join_eui": "1234567812345678"
  },
  "created_at": "2022-03-30T19:44:35.645Z",
  "updated_at": "2022-03-30T19:44:35.768226Z",
  "attributes": {},
  "network_server_address": "localhost",
  "applicationserver_address": "localhost",
  "join_server_address": "localhost",
  "supports_join": true,
  "root_keys": {
    "app_key": {
      "key": "12345678765432121234567898765432"
    }
  }
}
```
**after:**
```
go run ./cmd/ttn-lw-cli end-devices create test-app dev2   --join-eui 1234567812345679 --dev-eui 1234567812345679 --root-keys.app-key.key 12345678765432121234567898765432
{
  "ids": {
    "device_id": "dev2",
    "application_ids": {
      "application_id": "test-app"
    },
    "dev_eui": "1234567812345679",
    "join_eui": "1234567812345679"
  },
  "created_at": "2022-03-30T19:45:25.710Z",
  "updated_at": "2022-03-30T19:45:25.786095Z",
  "attributes": {},
  "network_server_address": "localhost",
  "application_server_address": "localhost",
  "join_server_address": "localhost",
  "supports_join": true,
  "root_keys": {
    "app_key": {
      "key": "12345678765432121234567898765432"
    }
  }
}
```
**fetching default Join EUI**
```
go run ./cmd/ttn-lw-cli end-devices create test-app dev3  --dev-eui 1134567812345679 --root-keys.app-key.key 12345678765432121234567898765432
INFO    JoinEUI empty but defaults flag is set, fetch default JoinEUI of the Join Server        {"join_server_address": "localhost:8884"}
INFO    Successfully obtained Join Server's default JoinEUI     {"default_join_eui": "0000000000000000"}
{
  "ids": {
    "device_id": "dev3",
    "application_ids": {
      "application_id": "test-app"
    },
    "dev_eui": "1134567812345679",
    "join_eui": "0000000000000000"
  },
  "created_at": "2022-03-30T19:46:02.057Z",
  "updated_at": "2022-03-30T19:46:02.136273Z",
  "attributes": {},
  "network_server_address": "localhost",
  "application_server_address": "localhost",
  "join_server_address": "localhost",
  "supports_join": true,
  "root_keys": {
    "app_key": {
      "key": "12345678765432121234567898765432"
    }
  }
}
```
**defining end-device via json (dev4)**

```
go run ./cmd/ttn-lw-cli device create < device_info.json --application-id test-app
{
  "ids": {
    "device_id": "dev4",
    "application_ids": {
      "application_id": "test-app"
    },
    "dev_eui": "AAAA567812345678",
    "join_eui": "1288867812345678"
  },
  "created_at": "2022-03-30T19:52:13.140Z",
  "updated_at": "2022-03-30T19:52:13.237977Z",
  "attributes": {},
  "network_server_address": "localhost",
  "application_server_address": "localhost",
  "join_server_address": "localhost",
  "supports_join": true,
  "root_keys": {
    "app_key": {
      "key": "23445678765432121234567898765432"
    }
  }
}
```

![image](https://user-images.githubusercontent.com/28912302/160919632-ddc94d31-0586-46af-ae4e-af8bb5734025.png)


##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None that I know

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->



#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
