### PR TITLE
Add default order to sortable tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Added
 
 ### Changed
-
+- Sortable tables are now sorted by default in the Console
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 - Sortable tables are now sorted by default in the Console
+
 ### Deprecated
 
 ### Removed

--- a/pkg/webui/console/containers/applications-table/index.js
+++ b/pkg/webui/console/containers/applications-table/index.js
@@ -190,6 +190,7 @@ const ApplicationsTable = props => {
   return (
     <FetchTable
       entity="applications"
+      defaultOrder="application_id"
       headers={headers}
       addMessage={sharedMessages.addApplication}
       tableTitle={<Message content={sharedMessages.applications} />}

--- a/pkg/webui/console/containers/devices-table/index.js
+++ b/pkg/webui/console/containers/devices-table/index.js
@@ -226,6 +226,7 @@ class DevicesTable extends React.Component {
     return (
       <FetchTable
         entity="devices"
+        defaultOrder="device_id"
         headers={headers}
         addMessage={sharedMessages.addDevice}
         actionItems={this.importButton}

--- a/pkg/webui/console/containers/gateways-table/index.js
+++ b/pkg/webui/console/containers/gateways-table/index.js
@@ -231,6 +231,7 @@ const GatewaysTable = props => {
   return (
     <FetchTable
       entity="gateways"
+      defaultOrder="gateway_id"
       addMessage={sharedMessages.addGateway}
       headers={headers}
       getItemsAction={getGateways}

--- a/pkg/webui/console/containers/organizations-table/index.js
+++ b/pkg/webui/console/containers/organizations-table/index.js
@@ -194,6 +194,7 @@ const OrganizationsTable = props => {
   return (
     <FetchTable
       entity="organizations"
+      defaultOrder="organization_id"
       headers={headers}
       addMessage={sharedMessages.addOrganization}
       tableTitle={<Message content={sharedMessages.organizations} />}

--- a/pkg/webui/console/containers/users-table/index.js
+++ b/pkg/webui/console/containers/users-table/index.js
@@ -149,6 +149,7 @@ export default class UsersTable extends Component {
     return (
       <FetchTable
         entity="users"
+        defaultOrder="user_id"
         headers={this.headers}
         addMessage={sharedMessages.userAdd}
         tableTitle={<Message content={sharedMessages.users} />}

--- a/pkg/webui/containers/fetch-table/index.js
+++ b/pkg/webui/containers/fetch-table/index.js
@@ -304,6 +304,7 @@ class FetchTable extends Component {
     } = this.props
     const { page, query, tab, order, initialFetch, error } = this.state
     let orderDirection, orderBy
+
     // Parse order string.
     if (typeof order === 'string') {
       orderDirection = typeof order === 'string' && order[0] === '-' ? 'desc' : 'asc'

--- a/pkg/webui/containers/fetch-table/index.js
+++ b/pkg/webui/containers/fetch-table/index.js
@@ -80,6 +80,7 @@ class FetchTable extends Component {
     actionItems: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
     addMessage: PropTypes.message,
     clickable: PropTypes.bool,
+    defaultOrder: PropTypes.string,
     dispatch: PropTypes.func.isRequired,
     entity: PropTypes.string.isRequired,
     fetching: PropTypes.bool,
@@ -148,18 +149,19 @@ class FetchTable extends Component {
     tabs: [],
     actionItems: null,
     clickable: true,
+    defaultOrder: undefined,
   }
 
   constructor(props) {
     super(props)
 
-    const { tabs } = props
+    const { tabs, defaultOrder } = props
 
     this.state = {
       query: '',
       page: 1,
       tab: tabs.length > 0 ? tabs[0].name : undefined,
-      order: undefined,
+      order: defaultOrder,
       initialFetch: true,
     }
 
@@ -302,7 +304,6 @@ class FetchTable extends Component {
     } = this.props
     const { page, query, tab, order, initialFetch, error } = this.state
     let orderDirection, orderBy
-
     // Parse order string.
     if (typeof order === 'string') {
       orderDirection = typeof order === 'string' && order[0] === '-' ? 'desc' : 'asc'


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #4886 

#### Changes
<!-- What are the changes made in this pull request? -->

- The tables that are sortable are now sorted by default with a new prop


#### Testing

<!-- How did you verify that this change works? -->

Manually


#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I could try and derive the name of the column with is initially sorted, but that seemed like a huge work around. When adding a new prop it is possible to choose with column is the table sorted by. 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
