### PR TITLE
ci: Fix release changelog

### DIFF
--- a/.goreleaser.release.yml
+++ b/.goreleaser.release.yml
@@ -1,8 +1,5 @@
 project_name: lorawan-stack
 
-changelog:
-  skip: true
-
 release:
   prerelease: auto
 


### PR DESCRIPTION
#### Summary
`changelog.skip` setting behaves differently now, effectively preventing release notes from appearing in the release on github. Previously we needed to set it to `true`, but not it needs to be `false`.

http://web.archive.org/web/20211006045029/https://goreleaser.com/customization/changelog/

https://goreleaser.com/customization/changelog/

#### Changes
Removed the changelog setting in goreleaser

#### Testing
I don't think this needs testing

##### Regressions
None

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
