### PR TITLE
Fix EUI blocks index migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ For details about compatibility between different releases, see the **Commitment
 - Console determining gateways as "Other cluster" even though using the same host if server addresses not matching exactly (e.g. due to using different host or scheme).
 - CLI no longer informs the user that is using the default JoinEUI when passing its value via flags.
 - Generating device ID from a DevEUI when importing a CSV file.
+- The `is-db migrate` command that failed when running on databases created by `v3.18`.
 
 ### Security
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request fixes #5378. The migration tried to drop an index that didn't exist.

#### Changes
<!-- What are the changes made in this pull request? -->

- Rewrite migration

#### Testing

<!-- How did you verify that this change works? -->

Running the migration

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Can't get more broken than it already is...

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
