### PR TITLE
Fix error messages for errors with unknown `details` structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ For details about compatibility between different releases, see the **Commitment
 - CLI no longer informs the user that is using the default JoinEUI when passing its value via flags.
 - Generating device ID from a DevEUI when importing a CSV file.
 - The `is-db migrate` command that failed when running on databases created by `v3.18`.
+- Some error messages being displayed as `error:undefined:undefined` in the Console, e.g. in the live data view.
 
 ### Security
 

--- a/pkg/webui/lib/errors/utils_test.js
+++ b/pkg/webui/lib/errors/utils_test.js
@@ -117,6 +117,24 @@ const backendErrorDetailsWithPathErrors = {
   ],
 }
 
+const backendErrorWithUnknownDetailStructure = {
+  '@type': 'type.googleapis.com/ttn.lorawan.v3.ErrorDetails',
+  namespace: 'pkg/applicationserver/io/packages/loradms/v1/api',
+  name: 'request',
+  message_format: 'LoRaCloud DMS request',
+  correlation_id: 'b0de67a448334364a53df8cbd9f9b429',
+  code: 14,
+  details: [
+    {
+      '@type': 'type.googleapis.com/google.protobuf.Struct',
+      value: {
+        body: 'Unauthorized status',
+        status_code: 401,
+      },
+    },
+  ],
+}
+
 const conflictBackendError = {
   code: 6,
   message: 'error:pkg/identityserver/store:id_taken (ID already taken)',
@@ -405,6 +423,18 @@ describe('Converting errors to message props', () => {
       values: {
         message:
           '`` is not a valid ID. Must be at least 2 and at most 36 characters long and may consist of only letters, numbers and dashes. It may not start or end with a dash',
+      },
+    })
+  })
+
+  it('correctly extracts from error details with unknown detail structure', () => {
+    const messageProps = toMessageProps(backendErrorWithUnknownDetailStructure, true)
+    expect(messageProps).toBeInstanceOf(Array)
+    expect(messageProps).toHaveLength(1)
+    expect(messageProps[0]).toMatchObject({
+      content: {
+        id: 'error:pkg/applicationserver/io/packages/loradms/v1/api:request',
+        defaultMessage: 'LoRaCloud DMS request',
       },
     })
   })


### PR DESCRIPTION
#### Summary
This quickfix fixes error messages being displayed as `error:undefined:undefined` in the Console.
<img width="528" alt="image" src="https://user-images.githubusercontent.com/5710611/163010631-118ec629-1b77-441b-8048-8a5339e29921.png">

#### Changes
- Do not compose the error title using the error details, when its structure is unknown.

#### Testing

Manual testing and updated the unit test for error utils.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
