### PR TITLE
Fix tag typo in cli-retry metadata config

### DIFF
--- a/cmd/ttn-lw-cli/commands/config.go
+++ b/cmd/ttn-lw-cli/commands/config.go
@@ -67,7 +67,7 @@ type Config struct {
 type RetryConfig struct {
 	Max            uint          `name:"max" yaml:"max" description:"Maximum amount of times that a request can be reattempted"`
 	DefaultTimeout time.Duration `name:"default_timeout" yaml:"default_timeout" description:"Default timeout between retry attempts"`
-	EnableMetatada bool          `name:"enable_metadata" ymal:"enable_metadata" description:"Use request response metadata to dynamically calculate timeout between retry attempts"`
+	EnableMetatada bool          `name:"enable_metadata" yaml:"enable_metadata" description:"Use request response metadata to dynamically calculate timeout between retry attempts"`
 	Jitter         float64       `name:"jitter" yaml:"jitter" description:"Fraction that creates a deviation of the timeout used between retry attempts"`
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Didn't create a issue for it but the change is simply replacing a single `ymal` tag with `yaml`.  Mistake done in the `cli-retry` PR which was added on the `v3.17.2`. I thought it would implicate in the `yaml` parsing of the config from that version until now but from testing locally the content is still parsed, in short, this is just a typo fix.

#### Changes
<!-- What are the changes made in this pull request? -->

- fix `--retry-config.enable_metadata` tag typo.


#### Testing

<!-- How did you verify that this change works? -->
Content is parsed correctly when passing a yml file.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->
It should not imply in changes since the content was still being parsed correctly before this fix.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I was thinking of changing the naming to replace `_` to `-` but that would break the compatibility with the change added on `v3.17.2`.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
