### PR TITLE
Add query field to search flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ For details about compatibility between different releases, see the **Commitment
 - CLI no longer informs the user that is using the default JoinEUI when passing its value via flags.
 - Generating device ID from a DevEUI when importing a CSV file.
 - The `is-db migrate` command that failed when running on databases created by `v3.18`.
+- Missing `query` flag on CLI search commands.
 
 ### Security
 

--- a/cmd/ttn-lw-cli/commands/flags.go
+++ b/cmd/ttn-lw-cli/commands/flags.go
@@ -182,6 +182,7 @@ func getAPIKeyFields(flagSet *pflag.FlagSet) ([]ttnpb.Right, *time.Time, []strin
 var searchFlags = func() *pflag.FlagSet {
 	flagSet := &pflag.FlagSet{}
 	// NOTE: These flags need to be named with underscores, not dashes!
+	flagSet.String("query", "", "")
 	flagSet.String("id_contains", "", "")
 	flagSet.String("name_contains", "", "")
 	flagSet.String("description_contains", "", "")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request fixes the missing `--query` flag in CLI search commands. The API field was added in https://github.com/TheThingsNetwork/lorawan-stack/pull/5232, but I assumed that the CLI would derive the flags from the API messages, which wasn't the case. This pull request fixes that.

#### Changes
<!-- What are the changes made in this pull request? -->

- Define `query` flag (setting it into the request messages is done automagically)

#### Testing

<!-- How did you verify that this change works? -->

- 🐒

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

nil

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

nil

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
