### PR TITLE
Upgrade protoc-gen-fieldmask to 0.6.0

### DIFF
--- a/pkg/ttnpb/applicationserver_pubsub.pb.setters.fm.go
+++ b/pkg/ttnpb/applicationserver_pubsub.pb.setters.fm.go
@@ -433,99 +433,105 @@ func (dst *ApplicationPubSub) SetFields(src *ApplicationPubSub, paths ...string)
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "nats":
-					_, srcOk := src.Provider.(*ApplicationPubSub_Nats)
-					if !srcOk && src.Provider != nil {
+					_, srcTypeOk := src.Provider.(*ApplicationPubSub_Nats)
+					srcValid := srcTypeOk || src.Provider == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'nats', while different oneof is set in source")
 					}
-					_, dstOk := dst.Provider.(*ApplicationPubSub_Nats)
-					if !dstOk && dst.Provider != nil {
+					_, dstTypeOk := dst.Provider.(*ApplicationPubSub_Nats)
+					dstValid := dstTypeOk || dst.Provider == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'nats', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *ApplicationPubSub_NATSProvider
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Provider.(*ApplicationPubSub_Nats).Nats
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Provider.(*ApplicationPubSub_Nats).Nats
-						} else {
+						} else if srcTypeOk {
 							newDst = &ApplicationPubSub_NATSProvider{}
 							dst.Provider = &ApplicationPubSub_Nats{Nats: newDst}
+						} else {
+							dst.Provider = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Provider = src.Provider
 						} else {
 							dst.Provider = nil
 						}
 					}
 				case "mqtt":
-					_, srcOk := src.Provider.(*ApplicationPubSub_Mqtt)
-					if !srcOk && src.Provider != nil {
+					_, srcTypeOk := src.Provider.(*ApplicationPubSub_Mqtt)
+					srcValid := srcTypeOk || src.Provider == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'mqtt', while different oneof is set in source")
 					}
-					_, dstOk := dst.Provider.(*ApplicationPubSub_Mqtt)
-					if !dstOk && dst.Provider != nil {
+					_, dstTypeOk := dst.Provider.(*ApplicationPubSub_Mqtt)
+					dstValid := dstTypeOk || dst.Provider == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'mqtt', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *ApplicationPubSub_MQTTProvider
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Provider.(*ApplicationPubSub_Mqtt).Mqtt
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Provider.(*ApplicationPubSub_Mqtt).Mqtt
-						} else {
+						} else if srcTypeOk {
 							newDst = &ApplicationPubSub_MQTTProvider{}
 							dst.Provider = &ApplicationPubSub_Mqtt{Mqtt: newDst}
+						} else {
+							dst.Provider = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Provider = src.Provider
 						} else {
 							dst.Provider = nil
 						}
 					}
 				case "aws_iot":
-					_, srcOk := src.Provider.(*ApplicationPubSub_AwsIot)
-					if !srcOk && src.Provider != nil {
+					_, srcTypeOk := src.Provider.(*ApplicationPubSub_AwsIot)
+					srcValid := srcTypeOk || src.Provider == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'aws_iot', while different oneof is set in source")
 					}
-					_, dstOk := dst.Provider.(*ApplicationPubSub_AwsIot)
-					if !dstOk && dst.Provider != nil {
+					_, dstTypeOk := dst.Provider.(*ApplicationPubSub_AwsIot)
+					dstValid := dstTypeOk || dst.Provider == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'aws_iot', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *ApplicationPubSub_AWSIoTProvider
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Provider.(*ApplicationPubSub_AwsIot).AwsIot
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Provider.(*ApplicationPubSub_AwsIot).AwsIot
-						} else {
+						} else if srcTypeOk {
 							newDst = &ApplicationPubSub_AWSIoTProvider{}
 							dst.Provider = &ApplicationPubSub_AwsIot{AwsIot: newDst}
+						} else {
+							dst.Provider = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Provider = src.Provider
 						} else {
 							dst.Provider = nil
@@ -947,33 +953,35 @@ func (dst *ApplicationPubSub_AWSIoTProvider) SetFields(src *ApplicationPubSub_AW
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "default":
-					_, srcOk := src.Deployment.(*ApplicationPubSub_AWSIoTProvider_Default)
-					if !srcOk && src.Deployment != nil {
+					_, srcTypeOk := src.Deployment.(*ApplicationPubSub_AWSIoTProvider_Default)
+					srcValid := srcTypeOk || src.Deployment == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'default', while different oneof is set in source")
 					}
-					_, dstOk := dst.Deployment.(*ApplicationPubSub_AWSIoTProvider_Default)
-					if !dstOk && dst.Deployment != nil {
+					_, dstTypeOk := dst.Deployment.(*ApplicationPubSub_AWSIoTProvider_Default)
+					dstValid := dstTypeOk || dst.Deployment == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'default', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *ApplicationPubSub_AWSIoTProvider_DefaultIntegration
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Deployment.(*ApplicationPubSub_AWSIoTProvider_Default).Default
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Deployment.(*ApplicationPubSub_AWSIoTProvider_Default).Default
-						} else {
+						} else if srcTypeOk {
 							newDst = &ApplicationPubSub_AWSIoTProvider_DefaultIntegration{}
 							dst.Deployment = &ApplicationPubSub_AWSIoTProvider_Default{Default: newDst}
+						} else {
+							dst.Deployment = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Deployment = src.Deployment
 						} else {
 							dst.Deployment = nil

--- a/pkg/ttnpb/applicationserver_web.pb.setters.fm.go
+++ b/pkg/ttnpb/applicationserver_web.pb.setters.fm.go
@@ -566,66 +566,70 @@ func (dst *ApplicationWebhookHealth) SetFields(src *ApplicationWebhookHealth, pa
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "healthy":
-					_, srcOk := src.Status.(*ApplicationWebhookHealth_Healthy)
-					if !srcOk && src.Status != nil {
+					_, srcTypeOk := src.Status.(*ApplicationWebhookHealth_Healthy)
+					srcValid := srcTypeOk || src.Status == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'healthy', while different oneof is set in source")
 					}
-					_, dstOk := dst.Status.(*ApplicationWebhookHealth_Healthy)
-					if !dstOk && dst.Status != nil {
+					_, dstTypeOk := dst.Status.(*ApplicationWebhookHealth_Healthy)
+					dstValid := dstTypeOk || dst.Status == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'healthy', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *ApplicationWebhookHealth_WebhookHealthStatusHealthy
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Status.(*ApplicationWebhookHealth_Healthy).Healthy
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Status.(*ApplicationWebhookHealth_Healthy).Healthy
-						} else {
+						} else if srcTypeOk {
 							newDst = &ApplicationWebhookHealth_WebhookHealthStatusHealthy{}
 							dst.Status = &ApplicationWebhookHealth_Healthy{Healthy: newDst}
+						} else {
+							dst.Status = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Status = src.Status
 						} else {
 							dst.Status = nil
 						}
 					}
 				case "unhealthy":
-					_, srcOk := src.Status.(*ApplicationWebhookHealth_Unhealthy)
-					if !srcOk && src.Status != nil {
+					_, srcTypeOk := src.Status.(*ApplicationWebhookHealth_Unhealthy)
+					srcValid := srcTypeOk || src.Status == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'unhealthy', while different oneof is set in source")
 					}
-					_, dstOk := dst.Status.(*ApplicationWebhookHealth_Unhealthy)
-					if !dstOk && dst.Status != nil {
+					_, dstTypeOk := dst.Status.(*ApplicationWebhookHealth_Unhealthy)
+					dstValid := dstTypeOk || dst.Status == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'unhealthy', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *ApplicationWebhookHealth_WebhookHealthStatusUnhealthy
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Status.(*ApplicationWebhookHealth_Unhealthy).Unhealthy
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Status.(*ApplicationWebhookHealth_Unhealthy).Unhealthy
-						} else {
+						} else if srcTypeOk {
 							newDst = &ApplicationWebhookHealth_WebhookHealthStatusUnhealthy{}
 							dst.Status = &ApplicationWebhookHealth_Unhealthy{Unhealthy: newDst}
+						} else {
+							dst.Status = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Status = src.Status
 						} else {
 							dst.Status = nil

--- a/pkg/ttnpb/deviceclaimingserver.pb.setters.fm.go
+++ b/pkg/ttnpb/deviceclaimingserver.pb.setters.fm.go
@@ -131,51 +131,55 @@ func (dst *ClaimEndDeviceRequest) SetFields(src *ClaimEndDeviceRequest, paths ..
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "authenticated_identifiers":
-					_, srcOk := src.SourceDevice.(*ClaimEndDeviceRequest_AuthenticatedIdentifiers_)
-					if !srcOk && src.SourceDevice != nil {
+					_, srcTypeOk := src.SourceDevice.(*ClaimEndDeviceRequest_AuthenticatedIdentifiers_)
+					srcValid := srcTypeOk || src.SourceDevice == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'authenticated_identifiers', while different oneof is set in source")
 					}
-					_, dstOk := dst.SourceDevice.(*ClaimEndDeviceRequest_AuthenticatedIdentifiers_)
-					if !dstOk && dst.SourceDevice != nil {
+					_, dstTypeOk := dst.SourceDevice.(*ClaimEndDeviceRequest_AuthenticatedIdentifiers_)
+					dstValid := dstTypeOk || dst.SourceDevice == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'authenticated_identifiers', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *ClaimEndDeviceRequest_AuthenticatedIdentifiers
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.SourceDevice.(*ClaimEndDeviceRequest_AuthenticatedIdentifiers_).AuthenticatedIdentifiers
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.SourceDevice.(*ClaimEndDeviceRequest_AuthenticatedIdentifiers_).AuthenticatedIdentifiers
-						} else {
+						} else if srcTypeOk {
 							newDst = &ClaimEndDeviceRequest_AuthenticatedIdentifiers{}
 							dst.SourceDevice = &ClaimEndDeviceRequest_AuthenticatedIdentifiers_{AuthenticatedIdentifiers: newDst}
+						} else {
+							dst.SourceDevice = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.SourceDevice = src.SourceDevice
 						} else {
 							dst.SourceDevice = nil
 						}
 					}
 				case "qr_code":
-					_, srcOk := src.SourceDevice.(*ClaimEndDeviceRequest_QrCode)
-					if !srcOk && src.SourceDevice != nil {
+					_, srcTypeOk := src.SourceDevice.(*ClaimEndDeviceRequest_QrCode)
+					srcValid := srcTypeOk || src.SourceDevice == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'qr_code', while different oneof is set in source")
 					}
-					_, dstOk := dst.SourceDevice.(*ClaimEndDeviceRequest_QrCode)
-					if !dstOk && dst.SourceDevice != nil {
+					_, dstTypeOk := dst.SourceDevice.(*ClaimEndDeviceRequest_QrCode)
+					dstValid := dstTypeOk || dst.SourceDevice == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'qr_code', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						return fmt.Errorf("'qr_code' has no subfields, but %s were specified", oneofSubs)
 					}
-					if src != nil {
+					if srcTypeOk {
 						dst.SourceDevice = src.SourceDevice
 					} else {
 						dst.SourceDevice = nil
@@ -417,54 +421,58 @@ func (dst *CUPSRedirection) SetFields(src *CUPSRedirection, paths ...string) err
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "client_tls":
-					_, srcOk := src.GatewayCredentials.(*CUPSRedirection_ClientTls)
-					if !srcOk && src.GatewayCredentials != nil {
+					_, srcTypeOk := src.GatewayCredentials.(*CUPSRedirection_ClientTls)
+					srcValid := srcTypeOk || src.GatewayCredentials == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'client_tls', while different oneof is set in source")
 					}
-					_, dstOk := dst.GatewayCredentials.(*CUPSRedirection_ClientTls)
-					if !dstOk && dst.GatewayCredentials != nil {
+					_, dstTypeOk := dst.GatewayCredentials.(*CUPSRedirection_ClientTls)
+					dstValid := dstTypeOk || dst.GatewayCredentials == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'client_tls', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *CUPSRedirection_ClientTLS
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.GatewayCredentials.(*CUPSRedirection_ClientTls).ClientTls
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.GatewayCredentials.(*CUPSRedirection_ClientTls).ClientTls
-						} else {
+						} else if srcTypeOk {
 							newDst = &CUPSRedirection_ClientTLS{}
 							dst.GatewayCredentials = &CUPSRedirection_ClientTls{ClientTls: newDst}
+						} else {
+							dst.GatewayCredentials = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.GatewayCredentials = src.GatewayCredentials
 						} else {
 							dst.GatewayCredentials = nil
 						}
 					}
 				case "auth_token":
-					_, srcOk := src.GatewayCredentials.(*CUPSRedirection_AuthToken)
-					if !srcOk && src.GatewayCredentials != nil {
+					_, srcTypeOk := src.GatewayCredentials.(*CUPSRedirection_AuthToken)
+					srcValid := srcTypeOk || src.GatewayCredentials == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'auth_token', while different oneof is set in source")
 					}
-					_, dstOk := dst.GatewayCredentials.(*CUPSRedirection_AuthToken)
-					if !dstOk && dst.GatewayCredentials != nil {
+					_, dstTypeOk := dst.GatewayCredentials.(*CUPSRedirection_AuthToken)
+					dstValid := dstTypeOk || dst.GatewayCredentials == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'auth_token', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						return fmt.Errorf("'auth_token' has no subfields, but %s were specified", oneofSubs)
 					}
-					if src != nil {
+					if srcTypeOk {
 						dst.GatewayCredentials = src.GatewayCredentials
 					} else {
-						dst.GatewayCredentials = &CUPSRedirection_AuthToken{}
+						dst.GatewayCredentials = nil
 					}
 
 				default:
@@ -579,51 +587,55 @@ func (dst *ClaimGatewayRequest) SetFields(src *ClaimGatewayRequest, paths ...str
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "authenticated_identifiers":
-					_, srcOk := src.SourceGateway.(*ClaimGatewayRequest_AuthenticatedIdentifiers_)
-					if !srcOk && src.SourceGateway != nil {
+					_, srcTypeOk := src.SourceGateway.(*ClaimGatewayRequest_AuthenticatedIdentifiers_)
+					srcValid := srcTypeOk || src.SourceGateway == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'authenticated_identifiers', while different oneof is set in source")
 					}
-					_, dstOk := dst.SourceGateway.(*ClaimGatewayRequest_AuthenticatedIdentifiers_)
-					if !dstOk && dst.SourceGateway != nil {
+					_, dstTypeOk := dst.SourceGateway.(*ClaimGatewayRequest_AuthenticatedIdentifiers_)
+					dstValid := dstTypeOk || dst.SourceGateway == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'authenticated_identifiers', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *ClaimGatewayRequest_AuthenticatedIdentifiers
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.SourceGateway.(*ClaimGatewayRequest_AuthenticatedIdentifiers_).AuthenticatedIdentifiers
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.SourceGateway.(*ClaimGatewayRequest_AuthenticatedIdentifiers_).AuthenticatedIdentifiers
-						} else {
+						} else if srcTypeOk {
 							newDst = &ClaimGatewayRequest_AuthenticatedIdentifiers{}
 							dst.SourceGateway = &ClaimGatewayRequest_AuthenticatedIdentifiers_{AuthenticatedIdentifiers: newDst}
+						} else {
+							dst.SourceGateway = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.SourceGateway = src.SourceGateway
 						} else {
 							dst.SourceGateway = nil
 						}
 					}
 				case "qr_code":
-					_, srcOk := src.SourceGateway.(*ClaimGatewayRequest_QrCode)
-					if !srcOk && src.SourceGateway != nil {
+					_, srcTypeOk := src.SourceGateway.(*ClaimGatewayRequest_QrCode)
+					srcValid := srcTypeOk || src.SourceGateway == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'qr_code', while different oneof is set in source")
 					}
-					_, dstOk := dst.SourceGateway.(*ClaimGatewayRequest_QrCode)
-					if !dstOk && dst.SourceGateway != nil {
+					_, dstTypeOk := dst.SourceGateway.(*ClaimGatewayRequest_QrCode)
+					dstValid := dstTypeOk || dst.SourceGateway == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'qr_code', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						return fmt.Errorf("'qr_code' has no subfields, but %s were specified", oneofSubs)
 					}
-					if src != nil {
+					if srcTypeOk {
 						dst.SourceGateway = src.SourceGateway
 					} else {
 						dst.SourceGateway = nil

--- a/pkg/ttnpb/end_device.pb.setters.fm.go
+++ b/pkg/ttnpb/end_device.pb.setters.fm.go
@@ -642,99 +642,105 @@ func (dst *ADRSettings) SetFields(src *ADRSettings, paths ...string) error {
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "static":
-					_, srcOk := src.Mode.(*ADRSettings_Static)
-					if !srcOk && src.Mode != nil {
+					_, srcTypeOk := src.Mode.(*ADRSettings_Static)
+					srcValid := srcTypeOk || src.Mode == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'static', while different oneof is set in source")
 					}
-					_, dstOk := dst.Mode.(*ADRSettings_Static)
-					if !dstOk && dst.Mode != nil {
+					_, dstTypeOk := dst.Mode.(*ADRSettings_Static)
+					dstValid := dstTypeOk || dst.Mode == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'static', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *ADRSettings_StaticMode
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Mode.(*ADRSettings_Static).Static
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Mode.(*ADRSettings_Static).Static
-						} else {
+						} else if srcTypeOk {
 							newDst = &ADRSettings_StaticMode{}
 							dst.Mode = &ADRSettings_Static{Static: newDst}
+						} else {
+							dst.Mode = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Mode = src.Mode
 						} else {
 							dst.Mode = nil
 						}
 					}
 				case "dynamic":
-					_, srcOk := src.Mode.(*ADRSettings_Dynamic)
-					if !srcOk && src.Mode != nil {
+					_, srcTypeOk := src.Mode.(*ADRSettings_Dynamic)
+					srcValid := srcTypeOk || src.Mode == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'dynamic', while different oneof is set in source")
 					}
-					_, dstOk := dst.Mode.(*ADRSettings_Dynamic)
-					if !dstOk && dst.Mode != nil {
+					_, dstTypeOk := dst.Mode.(*ADRSettings_Dynamic)
+					dstValid := dstTypeOk || dst.Mode == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'dynamic', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *ADRSettings_DynamicMode
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Mode.(*ADRSettings_Dynamic).Dynamic
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Mode.(*ADRSettings_Dynamic).Dynamic
-						} else {
+						} else if srcTypeOk {
 							newDst = &ADRSettings_DynamicMode{}
 							dst.Mode = &ADRSettings_Dynamic{Dynamic: newDst}
+						} else {
+							dst.Mode = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Mode = src.Mode
 						} else {
 							dst.Mode = nil
 						}
 					}
 				case "disabled":
-					_, srcOk := src.Mode.(*ADRSettings_Disabled)
-					if !srcOk && src.Mode != nil {
+					_, srcTypeOk := src.Mode.(*ADRSettings_Disabled)
+					srcValid := srcTypeOk || src.Mode == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'disabled', while different oneof is set in source")
 					}
-					_, dstOk := dst.Mode.(*ADRSettings_Disabled)
-					if !dstOk && dst.Mode != nil {
+					_, dstTypeOk := dst.Mode.(*ADRSettings_Disabled)
+					dstValid := dstTypeOk || dst.Mode == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'disabled', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *ADRSettings_DisabledMode
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Mode.(*ADRSettings_Disabled).Disabled
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Mode.(*ADRSettings_Disabled).Disabled
-						} else {
+						} else if srcTypeOk {
 							newDst = &ADRSettings_DisabledMode{}
 							dst.Mode = &ADRSettings_Disabled{Disabled: newDst}
+						} else {
+							dst.Mode = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Mode = src.Mode
 						} else {
 							dst.Mode = nil

--- a/pkg/ttnpb/identifiers.pb.setters.fm.go
+++ b/pkg/ttnpb/identifiers.pb.setters.fm.go
@@ -221,66 +221,70 @@ func (dst *OrganizationOrUserIdentifiers) SetFields(src *OrganizationOrUserIdent
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "organization_ids":
-					_, srcOk := src.Ids.(*OrganizationOrUserIdentifiers_OrganizationIds)
-					if !srcOk && src.Ids != nil {
+					_, srcTypeOk := src.Ids.(*OrganizationOrUserIdentifiers_OrganizationIds)
+					srcValid := srcTypeOk || src.Ids == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'organization_ids', while different oneof is set in source")
 					}
-					_, dstOk := dst.Ids.(*OrganizationOrUserIdentifiers_OrganizationIds)
-					if !dstOk && dst.Ids != nil {
+					_, dstTypeOk := dst.Ids.(*OrganizationOrUserIdentifiers_OrganizationIds)
+					dstValid := dstTypeOk || dst.Ids == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'organization_ids', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *OrganizationIdentifiers
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Ids.(*OrganizationOrUserIdentifiers_OrganizationIds).OrganizationIds
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Ids.(*OrganizationOrUserIdentifiers_OrganizationIds).OrganizationIds
-						} else {
+						} else if srcTypeOk {
 							newDst = &OrganizationIdentifiers{}
 							dst.Ids = &OrganizationOrUserIdentifiers_OrganizationIds{OrganizationIds: newDst}
+						} else {
+							dst.Ids = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Ids = src.Ids
 						} else {
 							dst.Ids = nil
 						}
 					}
 				case "user_ids":
-					_, srcOk := src.Ids.(*OrganizationOrUserIdentifiers_UserIds)
-					if !srcOk && src.Ids != nil {
+					_, srcTypeOk := src.Ids.(*OrganizationOrUserIdentifiers_UserIds)
+					srcValid := srcTypeOk || src.Ids == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'user_ids', while different oneof is set in source")
 					}
-					_, dstOk := dst.Ids.(*OrganizationOrUserIdentifiers_UserIds)
-					if !dstOk && dst.Ids != nil {
+					_, dstTypeOk := dst.Ids.(*OrganizationOrUserIdentifiers_UserIds)
+					dstValid := dstTypeOk || dst.Ids == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'user_ids', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *UserIdentifiers
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Ids.(*OrganizationOrUserIdentifiers_UserIds).UserIds
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Ids.(*OrganizationOrUserIdentifiers_UserIds).UserIds
-						} else {
+						} else if srcTypeOk {
 							newDst = &UserIdentifiers{}
 							dst.Ids = &OrganizationOrUserIdentifiers_UserIds{UserIds: newDst}
+						} else {
+							dst.Ids = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Ids = src.Ids
 						} else {
 							dst.Ids = nil
@@ -319,198 +323,210 @@ func (dst *EntityIdentifiers) SetFields(src *EntityIdentifiers, paths ...string)
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "application_ids":
-					_, srcOk := src.Ids.(*EntityIdentifiers_ApplicationIds)
-					if !srcOk && src.Ids != nil {
+					_, srcTypeOk := src.Ids.(*EntityIdentifiers_ApplicationIds)
+					srcValid := srcTypeOk || src.Ids == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'application_ids', while different oneof is set in source")
 					}
-					_, dstOk := dst.Ids.(*EntityIdentifiers_ApplicationIds)
-					if !dstOk && dst.Ids != nil {
+					_, dstTypeOk := dst.Ids.(*EntityIdentifiers_ApplicationIds)
+					dstValid := dstTypeOk || dst.Ids == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'application_ids', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *ApplicationIdentifiers
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Ids.(*EntityIdentifiers_ApplicationIds).ApplicationIds
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Ids.(*EntityIdentifiers_ApplicationIds).ApplicationIds
-						} else {
+						} else if srcTypeOk {
 							newDst = &ApplicationIdentifiers{}
 							dst.Ids = &EntityIdentifiers_ApplicationIds{ApplicationIds: newDst}
+						} else {
+							dst.Ids = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Ids = src.Ids
 						} else {
 							dst.Ids = nil
 						}
 					}
 				case "client_ids":
-					_, srcOk := src.Ids.(*EntityIdentifiers_ClientIds)
-					if !srcOk && src.Ids != nil {
+					_, srcTypeOk := src.Ids.(*EntityIdentifiers_ClientIds)
+					srcValid := srcTypeOk || src.Ids == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'client_ids', while different oneof is set in source")
 					}
-					_, dstOk := dst.Ids.(*EntityIdentifiers_ClientIds)
-					if !dstOk && dst.Ids != nil {
+					_, dstTypeOk := dst.Ids.(*EntityIdentifiers_ClientIds)
+					dstValid := dstTypeOk || dst.Ids == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'client_ids', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *ClientIdentifiers
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Ids.(*EntityIdentifiers_ClientIds).ClientIds
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Ids.(*EntityIdentifiers_ClientIds).ClientIds
-						} else {
+						} else if srcTypeOk {
 							newDst = &ClientIdentifiers{}
 							dst.Ids = &EntityIdentifiers_ClientIds{ClientIds: newDst}
+						} else {
+							dst.Ids = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Ids = src.Ids
 						} else {
 							dst.Ids = nil
 						}
 					}
 				case "device_ids":
-					_, srcOk := src.Ids.(*EntityIdentifiers_DeviceIds)
-					if !srcOk && src.Ids != nil {
+					_, srcTypeOk := src.Ids.(*EntityIdentifiers_DeviceIds)
+					srcValid := srcTypeOk || src.Ids == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'device_ids', while different oneof is set in source")
 					}
-					_, dstOk := dst.Ids.(*EntityIdentifiers_DeviceIds)
-					if !dstOk && dst.Ids != nil {
+					_, dstTypeOk := dst.Ids.(*EntityIdentifiers_DeviceIds)
+					dstValid := dstTypeOk || dst.Ids == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'device_ids', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *EndDeviceIdentifiers
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Ids.(*EntityIdentifiers_DeviceIds).DeviceIds
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Ids.(*EntityIdentifiers_DeviceIds).DeviceIds
-						} else {
+						} else if srcTypeOk {
 							newDst = &EndDeviceIdentifiers{}
 							dst.Ids = &EntityIdentifiers_DeviceIds{DeviceIds: newDst}
+						} else {
+							dst.Ids = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Ids = src.Ids
 						} else {
 							dst.Ids = nil
 						}
 					}
 				case "gateway_ids":
-					_, srcOk := src.Ids.(*EntityIdentifiers_GatewayIds)
-					if !srcOk && src.Ids != nil {
+					_, srcTypeOk := src.Ids.(*EntityIdentifiers_GatewayIds)
+					srcValid := srcTypeOk || src.Ids == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'gateway_ids', while different oneof is set in source")
 					}
-					_, dstOk := dst.Ids.(*EntityIdentifiers_GatewayIds)
-					if !dstOk && dst.Ids != nil {
+					_, dstTypeOk := dst.Ids.(*EntityIdentifiers_GatewayIds)
+					dstValid := dstTypeOk || dst.Ids == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'gateway_ids', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *GatewayIdentifiers
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Ids.(*EntityIdentifiers_GatewayIds).GatewayIds
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Ids.(*EntityIdentifiers_GatewayIds).GatewayIds
-						} else {
+						} else if srcTypeOk {
 							newDst = &GatewayIdentifiers{}
 							dst.Ids = &EntityIdentifiers_GatewayIds{GatewayIds: newDst}
+						} else {
+							dst.Ids = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Ids = src.Ids
 						} else {
 							dst.Ids = nil
 						}
 					}
 				case "organization_ids":
-					_, srcOk := src.Ids.(*EntityIdentifiers_OrganizationIds)
-					if !srcOk && src.Ids != nil {
+					_, srcTypeOk := src.Ids.(*EntityIdentifiers_OrganizationIds)
+					srcValid := srcTypeOk || src.Ids == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'organization_ids', while different oneof is set in source")
 					}
-					_, dstOk := dst.Ids.(*EntityIdentifiers_OrganizationIds)
-					if !dstOk && dst.Ids != nil {
+					_, dstTypeOk := dst.Ids.(*EntityIdentifiers_OrganizationIds)
+					dstValid := dstTypeOk || dst.Ids == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'organization_ids', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *OrganizationIdentifiers
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Ids.(*EntityIdentifiers_OrganizationIds).OrganizationIds
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Ids.(*EntityIdentifiers_OrganizationIds).OrganizationIds
-						} else {
+						} else if srcTypeOk {
 							newDst = &OrganizationIdentifiers{}
 							dst.Ids = &EntityIdentifiers_OrganizationIds{OrganizationIds: newDst}
+						} else {
+							dst.Ids = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Ids = src.Ids
 						} else {
 							dst.Ids = nil
 						}
 					}
 				case "user_ids":
-					_, srcOk := src.Ids.(*EntityIdentifiers_UserIds)
-					if !srcOk && src.Ids != nil {
+					_, srcTypeOk := src.Ids.(*EntityIdentifiers_UserIds)
+					srcValid := srcTypeOk || src.Ids == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'user_ids', while different oneof is set in source")
 					}
-					_, dstOk := dst.Ids.(*EntityIdentifiers_UserIds)
-					if !dstOk && dst.Ids != nil {
+					_, dstTypeOk := dst.Ids.(*EntityIdentifiers_UserIds)
+					dstValid := dstTypeOk || dst.Ids == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'user_ids', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *UserIdentifiers
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Ids.(*EntityIdentifiers_UserIds).UserIds
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Ids.(*EntityIdentifiers_UserIds).UserIds
-						} else {
+						} else if srcTypeOk {
 							newDst = &UserIdentifiers{}
 							dst.Ids = &EntityIdentifiers_UserIds{UserIds: newDst}
+						} else {
+							dst.Ids = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Ids = src.Ids
 						} else {
 							dst.Ids = nil

--- a/pkg/ttnpb/identityserver.pb.setters.fm.go
+++ b/pkg/ttnpb/identityserver.pb.setters.fm.go
@@ -59,99 +59,105 @@ func (dst *AuthInfoResponse) SetFields(src *AuthInfoResponse, paths ...string) e
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "api_key":
-					_, srcOk := src.AccessMethod.(*AuthInfoResponse_ApiKey)
-					if !srcOk && src.AccessMethod != nil {
+					_, srcTypeOk := src.AccessMethod.(*AuthInfoResponse_ApiKey)
+					srcValid := srcTypeOk || src.AccessMethod == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'api_key', while different oneof is set in source")
 					}
-					_, dstOk := dst.AccessMethod.(*AuthInfoResponse_ApiKey)
-					if !dstOk && dst.AccessMethod != nil {
+					_, dstTypeOk := dst.AccessMethod.(*AuthInfoResponse_ApiKey)
+					dstValid := dstTypeOk || dst.AccessMethod == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'api_key', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *AuthInfoResponse_APIKeyAccess
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.AccessMethod.(*AuthInfoResponse_ApiKey).ApiKey
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.AccessMethod.(*AuthInfoResponse_ApiKey).ApiKey
-						} else {
+						} else if srcTypeOk {
 							newDst = &AuthInfoResponse_APIKeyAccess{}
 							dst.AccessMethod = &AuthInfoResponse_ApiKey{ApiKey: newDst}
+						} else {
+							dst.AccessMethod = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.AccessMethod = src.AccessMethod
 						} else {
 							dst.AccessMethod = nil
 						}
 					}
 				case "oauth_access_token":
-					_, srcOk := src.AccessMethod.(*AuthInfoResponse_OauthAccessToken)
-					if !srcOk && src.AccessMethod != nil {
+					_, srcTypeOk := src.AccessMethod.(*AuthInfoResponse_OauthAccessToken)
+					srcValid := srcTypeOk || src.AccessMethod == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'oauth_access_token', while different oneof is set in source")
 					}
-					_, dstOk := dst.AccessMethod.(*AuthInfoResponse_OauthAccessToken)
-					if !dstOk && dst.AccessMethod != nil {
+					_, dstTypeOk := dst.AccessMethod.(*AuthInfoResponse_OauthAccessToken)
+					dstValid := dstTypeOk || dst.AccessMethod == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'oauth_access_token', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *OAuthAccessToken
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.AccessMethod.(*AuthInfoResponse_OauthAccessToken).OauthAccessToken
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.AccessMethod.(*AuthInfoResponse_OauthAccessToken).OauthAccessToken
-						} else {
+						} else if srcTypeOk {
 							newDst = &OAuthAccessToken{}
 							dst.AccessMethod = &AuthInfoResponse_OauthAccessToken{OauthAccessToken: newDst}
+						} else {
+							dst.AccessMethod = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.AccessMethod = src.AccessMethod
 						} else {
 							dst.AccessMethod = nil
 						}
 					}
 				case "user_session":
-					_, srcOk := src.AccessMethod.(*AuthInfoResponse_UserSession)
-					if !srcOk && src.AccessMethod != nil {
+					_, srcTypeOk := src.AccessMethod.(*AuthInfoResponse_UserSession)
+					srcValid := srcTypeOk || src.AccessMethod == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'user_session', while different oneof is set in source")
 					}
-					_, dstOk := dst.AccessMethod.(*AuthInfoResponse_UserSession)
-					if !dstOk && dst.AccessMethod != nil {
+					_, dstTypeOk := dst.AccessMethod.(*AuthInfoResponse_UserSession)
+					dstValid := dstTypeOk || dst.AccessMethod == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'user_session', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *UserSession
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.AccessMethod.(*AuthInfoResponse_UserSession).UserSession
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.AccessMethod.(*AuthInfoResponse_UserSession).UserSession
-						} else {
+						} else if srcTypeOk {
 							newDst = &UserSession{}
 							dst.AccessMethod = &AuthInfoResponse_UserSession{UserSession: newDst}
+						} else {
+							dst.AccessMethod = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.AccessMethod = src.AccessMethod
 						} else {
 							dst.AccessMethod = nil

--- a/pkg/ttnpb/joinserver.pb.setters.fm.go
+++ b/pkg/ttnpb/joinserver.pb.setters.fm.go
@@ -533,99 +533,105 @@ func (dst *ProvisionEndDevicesRequest) SetFields(src *ProvisionEndDevicesRequest
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "list":
-					_, srcOk := src.EndDevices.(*ProvisionEndDevicesRequest_List)
-					if !srcOk && src.EndDevices != nil {
+					_, srcTypeOk := src.EndDevices.(*ProvisionEndDevicesRequest_List)
+					srcValid := srcTypeOk || src.EndDevices == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'list', while different oneof is set in source")
 					}
-					_, dstOk := dst.EndDevices.(*ProvisionEndDevicesRequest_List)
-					if !dstOk && dst.EndDevices != nil {
+					_, dstTypeOk := dst.EndDevices.(*ProvisionEndDevicesRequest_List)
+					dstValid := dstTypeOk || dst.EndDevices == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'list', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *ProvisionEndDevicesRequest_IdentifiersList
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.EndDevices.(*ProvisionEndDevicesRequest_List).List
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.EndDevices.(*ProvisionEndDevicesRequest_List).List
-						} else {
+						} else if srcTypeOk {
 							newDst = &ProvisionEndDevicesRequest_IdentifiersList{}
 							dst.EndDevices = &ProvisionEndDevicesRequest_List{List: newDst}
+						} else {
+							dst.EndDevices = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.EndDevices = src.EndDevices
 						} else {
 							dst.EndDevices = nil
 						}
 					}
 				case "range":
-					_, srcOk := src.EndDevices.(*ProvisionEndDevicesRequest_Range)
-					if !srcOk && src.EndDevices != nil {
+					_, srcTypeOk := src.EndDevices.(*ProvisionEndDevicesRequest_Range)
+					srcValid := srcTypeOk || src.EndDevices == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'range', while different oneof is set in source")
 					}
-					_, dstOk := dst.EndDevices.(*ProvisionEndDevicesRequest_Range)
-					if !dstOk && dst.EndDevices != nil {
+					_, dstTypeOk := dst.EndDevices.(*ProvisionEndDevicesRequest_Range)
+					dstValid := dstTypeOk || dst.EndDevices == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'range', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *ProvisionEndDevicesRequest_IdentifiersRange
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.EndDevices.(*ProvisionEndDevicesRequest_Range).Range
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.EndDevices.(*ProvisionEndDevicesRequest_Range).Range
-						} else {
+						} else if srcTypeOk {
 							newDst = &ProvisionEndDevicesRequest_IdentifiersRange{}
 							dst.EndDevices = &ProvisionEndDevicesRequest_Range{Range: newDst}
+						} else {
+							dst.EndDevices = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.EndDevices = src.EndDevices
 						} else {
 							dst.EndDevices = nil
 						}
 					}
 				case "from_data":
-					_, srcOk := src.EndDevices.(*ProvisionEndDevicesRequest_FromData)
-					if !srcOk && src.EndDevices != nil {
+					_, srcTypeOk := src.EndDevices.(*ProvisionEndDevicesRequest_FromData)
+					srcValid := srcTypeOk || src.EndDevices == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'from_data', while different oneof is set in source")
 					}
-					_, dstOk := dst.EndDevices.(*ProvisionEndDevicesRequest_FromData)
-					if !dstOk && dst.EndDevices != nil {
+					_, dstTypeOk := dst.EndDevices.(*ProvisionEndDevicesRequest_FromData)
+					dstValid := dstTypeOk || dst.EndDevices == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'from_data', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *ProvisionEndDevicesRequest_IdentifiersFromData
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.EndDevices.(*ProvisionEndDevicesRequest_FromData).FromData
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.EndDevices.(*ProvisionEndDevicesRequest_FromData).FromData
-						} else {
+						} else if srcTypeOk {
 							newDst = &ProvisionEndDevicesRequest_IdentifiersFromData{}
 							dst.EndDevices = &ProvisionEndDevicesRequest_FromData{FromData: newDst}
+						} else {
+							dst.EndDevices = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.EndDevices = src.EndDevices
 						} else {
 							dst.EndDevices = nil

--- a/pkg/ttnpb/lorawan.pb.setters.fm.go
+++ b/pkg/ttnpb/lorawan.pb.setters.fm.go
@@ -61,132 +61,140 @@ func (dst *Message) SetFields(src *Message, paths ...string) error {
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "mac_payload":
-					_, srcOk := src.Payload.(*Message_MacPayload)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*Message_MacPayload)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'mac_payload', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*Message_MacPayload)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*Message_MacPayload)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'mac_payload', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACPayload
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*Message_MacPayload).MacPayload
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*Message_MacPayload).MacPayload
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACPayload{}
 							dst.Payload = &Message_MacPayload{MacPayload: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "join_request_payload":
-					_, srcOk := src.Payload.(*Message_JoinRequestPayload)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*Message_JoinRequestPayload)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'join_request_payload', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*Message_JoinRequestPayload)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*Message_JoinRequestPayload)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'join_request_payload', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *JoinRequestPayload
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*Message_JoinRequestPayload).JoinRequestPayload
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*Message_JoinRequestPayload).JoinRequestPayload
-						} else {
+						} else if srcTypeOk {
 							newDst = &JoinRequestPayload{}
 							dst.Payload = &Message_JoinRequestPayload{JoinRequestPayload: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "join_accept_payload":
-					_, srcOk := src.Payload.(*Message_JoinAcceptPayload)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*Message_JoinAcceptPayload)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'join_accept_payload', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*Message_JoinAcceptPayload)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*Message_JoinAcceptPayload)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'join_accept_payload', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *JoinAcceptPayload
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*Message_JoinAcceptPayload).JoinAcceptPayload
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*Message_JoinAcceptPayload).JoinAcceptPayload
-						} else {
+						} else if srcTypeOk {
 							newDst = &JoinAcceptPayload{}
 							dst.Payload = &Message_JoinAcceptPayload{JoinAcceptPayload: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "rejoin_request_payload":
-					_, srcOk := src.Payload.(*Message_RejoinRequestPayload)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*Message_RejoinRequestPayload)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'rejoin_request_payload', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*Message_RejoinRequestPayload)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*Message_RejoinRequestPayload)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'rejoin_request_payload', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *RejoinRequestPayload
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*Message_RejoinRequestPayload).RejoinRequestPayload
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*Message_RejoinRequestPayload).RejoinRequestPayload
-						} else {
+						} else if srcTypeOk {
 							newDst = &RejoinRequestPayload{}
 							dst.Payload = &Message_RejoinRequestPayload{RejoinRequestPayload: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
@@ -841,99 +849,105 @@ func (dst *DataRate) SetFields(src *DataRate, paths ...string) error {
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "lora":
-					_, srcOk := src.Modulation.(*DataRate_Lora)
-					if !srcOk && src.Modulation != nil {
+					_, srcTypeOk := src.Modulation.(*DataRate_Lora)
+					srcValid := srcTypeOk || src.Modulation == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'lora', while different oneof is set in source")
 					}
-					_, dstOk := dst.Modulation.(*DataRate_Lora)
-					if !dstOk && dst.Modulation != nil {
+					_, dstTypeOk := dst.Modulation.(*DataRate_Lora)
+					dstValid := dstTypeOk || dst.Modulation == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'lora', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *LoRaDataRate
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Modulation.(*DataRate_Lora).Lora
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Modulation.(*DataRate_Lora).Lora
-						} else {
+						} else if srcTypeOk {
 							newDst = &LoRaDataRate{}
 							dst.Modulation = &DataRate_Lora{Lora: newDst}
+						} else {
+							dst.Modulation = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Modulation = src.Modulation
 						} else {
 							dst.Modulation = nil
 						}
 					}
 				case "fsk":
-					_, srcOk := src.Modulation.(*DataRate_Fsk)
-					if !srcOk && src.Modulation != nil {
+					_, srcTypeOk := src.Modulation.(*DataRate_Fsk)
+					srcValid := srcTypeOk || src.Modulation == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'fsk', while different oneof is set in source")
 					}
-					_, dstOk := dst.Modulation.(*DataRate_Fsk)
-					if !dstOk && dst.Modulation != nil {
+					_, dstTypeOk := dst.Modulation.(*DataRate_Fsk)
+					dstValid := dstTypeOk || dst.Modulation == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'fsk', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *FSKDataRate
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Modulation.(*DataRate_Fsk).Fsk
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Modulation.(*DataRate_Fsk).Fsk
-						} else {
+						} else if srcTypeOk {
 							newDst = &FSKDataRate{}
 							dst.Modulation = &DataRate_Fsk{Fsk: newDst}
+						} else {
+							dst.Modulation = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Modulation = src.Modulation
 						} else {
 							dst.Modulation = nil
 						}
 					}
 				case "lrfhss":
-					_, srcOk := src.Modulation.(*DataRate_Lrfhss)
-					if !srcOk && src.Modulation != nil {
+					_, srcTypeOk := src.Modulation.(*DataRate_Lrfhss)
+					srcValid := srcTypeOk || src.Modulation == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'lrfhss', while different oneof is set in source")
 					}
-					_, dstOk := dst.Modulation.(*DataRate_Lrfhss)
-					if !dstOk && dst.Modulation != nil {
+					_, dstTypeOk := dst.Modulation.(*DataRate_Lrfhss)
+					dstValid := dstTypeOk || dst.Modulation == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'lrfhss', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *LRFHSSDataRate
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Modulation.(*DataRate_Lrfhss).Lrfhss
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Modulation.(*DataRate_Lrfhss).Lrfhss
-						} else {
+						} else if srcTypeOk {
 							newDst = &LRFHSSDataRate{}
 							dst.Modulation = &DataRate_Lrfhss{Lrfhss: newDst}
+						} else {
+							dst.Modulation = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Modulation = src.Modulation
 						} else {
 							dst.Modulation = nil
@@ -1212,50 +1226,54 @@ func (dst *DownlinkPath) SetFields(src *DownlinkPath, paths ...string) error {
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "uplink_token":
-					_, srcOk := src.Path.(*DownlinkPath_UplinkToken)
-					if !srcOk && src.Path != nil {
+					_, srcTypeOk := src.Path.(*DownlinkPath_UplinkToken)
+					srcValid := srcTypeOk || src.Path == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'uplink_token', while different oneof is set in source")
 					}
-					_, dstOk := dst.Path.(*DownlinkPath_UplinkToken)
-					if !dstOk && dst.Path != nil {
+					_, dstTypeOk := dst.Path.(*DownlinkPath_UplinkToken)
+					dstValid := dstTypeOk || dst.Path == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'uplink_token', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						return fmt.Errorf("'uplink_token' has no subfields, but %s were specified", oneofSubs)
 					}
-					if src != nil {
+					if srcTypeOk {
 						dst.Path = src.Path
 					} else {
 						dst.Path = nil
 					}
 				case "fixed":
-					_, srcOk := src.Path.(*DownlinkPath_Fixed)
-					if !srcOk && src.Path != nil {
+					_, srcTypeOk := src.Path.(*DownlinkPath_Fixed)
+					srcValid := srcTypeOk || src.Path == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'fixed', while different oneof is set in source")
 					}
-					_, dstOk := dst.Path.(*DownlinkPath_Fixed)
-					if !dstOk && dst.Path != nil {
+					_, dstTypeOk := dst.Path.(*DownlinkPath_Fixed)
+					dstValid := dstTypeOk || dst.Path == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'fixed', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *GatewayAntennaIdentifiers
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Path.(*DownlinkPath_Fixed).Fixed
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Path.(*DownlinkPath_Fixed).Fixed
-						} else {
+						} else if srcTypeOk {
 							newDst = &GatewayAntennaIdentifiers{}
 							dst.Path = &DownlinkPath_Fixed{Fixed: newDst}
+						} else {
+							dst.Path = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Path = src.Path
 						} else {
 							dst.Path = nil
@@ -1452,1007 +1470,1069 @@ func (dst *MACCommand) SetFields(src *MACCommand, paths ...string) error {
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "raw_payload":
-					_, srcOk := src.Payload.(*MACCommand_RawPayload)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_RawPayload)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'raw_payload', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_RawPayload)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_RawPayload)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'raw_payload', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						return fmt.Errorf("'raw_payload' has no subfields, but %s were specified", oneofSubs)
 					}
-					if src != nil {
+					if srcTypeOk {
 						dst.Payload = src.Payload
 					} else {
 						dst.Payload = nil
 					}
 				case "reset_ind":
-					_, srcOk := src.Payload.(*MACCommand_ResetInd_)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_ResetInd_)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'reset_ind', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_ResetInd_)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_ResetInd_)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'reset_ind', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_ResetInd
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_ResetInd_).ResetInd
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_ResetInd_).ResetInd
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_ResetInd{}
 							dst.Payload = &MACCommand_ResetInd_{ResetInd: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "reset_conf":
-					_, srcOk := src.Payload.(*MACCommand_ResetConf_)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_ResetConf_)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'reset_conf', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_ResetConf_)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_ResetConf_)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'reset_conf', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_ResetConf
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_ResetConf_).ResetConf
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_ResetConf_).ResetConf
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_ResetConf{}
 							dst.Payload = &MACCommand_ResetConf_{ResetConf: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "link_check_ans":
-					_, srcOk := src.Payload.(*MACCommand_LinkCheckAns_)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_LinkCheckAns_)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'link_check_ans', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_LinkCheckAns_)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_LinkCheckAns_)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'link_check_ans', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_LinkCheckAns
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_LinkCheckAns_).LinkCheckAns
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_LinkCheckAns_).LinkCheckAns
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_LinkCheckAns{}
 							dst.Payload = &MACCommand_LinkCheckAns_{LinkCheckAns: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "link_adr_req":
-					_, srcOk := src.Payload.(*MACCommand_LinkAdrReq)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_LinkAdrReq)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'link_adr_req', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_LinkAdrReq)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_LinkAdrReq)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'link_adr_req', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_LinkADRReq
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_LinkAdrReq).LinkAdrReq
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_LinkAdrReq).LinkAdrReq
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_LinkADRReq{}
 							dst.Payload = &MACCommand_LinkAdrReq{LinkAdrReq: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "link_adr_ans":
-					_, srcOk := src.Payload.(*MACCommand_LinkAdrAns)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_LinkAdrAns)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'link_adr_ans', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_LinkAdrAns)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_LinkAdrAns)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'link_adr_ans', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_LinkADRAns
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_LinkAdrAns).LinkAdrAns
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_LinkAdrAns).LinkAdrAns
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_LinkADRAns{}
 							dst.Payload = &MACCommand_LinkAdrAns{LinkAdrAns: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "duty_cycle_req":
-					_, srcOk := src.Payload.(*MACCommand_DutyCycleReq_)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_DutyCycleReq_)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'duty_cycle_req', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_DutyCycleReq_)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_DutyCycleReq_)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'duty_cycle_req', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_DutyCycleReq
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_DutyCycleReq_).DutyCycleReq
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_DutyCycleReq_).DutyCycleReq
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_DutyCycleReq{}
 							dst.Payload = &MACCommand_DutyCycleReq_{DutyCycleReq: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "rx_param_setup_req":
-					_, srcOk := src.Payload.(*MACCommand_RxParamSetupReq_)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_RxParamSetupReq_)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'rx_param_setup_req', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_RxParamSetupReq_)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_RxParamSetupReq_)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'rx_param_setup_req', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_RxParamSetupReq
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_RxParamSetupReq_).RxParamSetupReq
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_RxParamSetupReq_).RxParamSetupReq
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_RxParamSetupReq{}
 							dst.Payload = &MACCommand_RxParamSetupReq_{RxParamSetupReq: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "rx_param_setup_ans":
-					_, srcOk := src.Payload.(*MACCommand_RxParamSetupAns_)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_RxParamSetupAns_)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'rx_param_setup_ans', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_RxParamSetupAns_)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_RxParamSetupAns_)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'rx_param_setup_ans', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_RxParamSetupAns
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_RxParamSetupAns_).RxParamSetupAns
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_RxParamSetupAns_).RxParamSetupAns
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_RxParamSetupAns{}
 							dst.Payload = &MACCommand_RxParamSetupAns_{RxParamSetupAns: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "dev_status_ans":
-					_, srcOk := src.Payload.(*MACCommand_DevStatusAns_)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_DevStatusAns_)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'dev_status_ans', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_DevStatusAns_)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_DevStatusAns_)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'dev_status_ans', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_DevStatusAns
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_DevStatusAns_).DevStatusAns
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_DevStatusAns_).DevStatusAns
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_DevStatusAns{}
 							dst.Payload = &MACCommand_DevStatusAns_{DevStatusAns: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "new_channel_req":
-					_, srcOk := src.Payload.(*MACCommand_NewChannelReq_)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_NewChannelReq_)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'new_channel_req', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_NewChannelReq_)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_NewChannelReq_)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'new_channel_req', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_NewChannelReq
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_NewChannelReq_).NewChannelReq
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_NewChannelReq_).NewChannelReq
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_NewChannelReq{}
 							dst.Payload = &MACCommand_NewChannelReq_{NewChannelReq: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "new_channel_ans":
-					_, srcOk := src.Payload.(*MACCommand_NewChannelAns_)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_NewChannelAns_)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'new_channel_ans', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_NewChannelAns_)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_NewChannelAns_)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'new_channel_ans', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_NewChannelAns
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_NewChannelAns_).NewChannelAns
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_NewChannelAns_).NewChannelAns
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_NewChannelAns{}
 							dst.Payload = &MACCommand_NewChannelAns_{NewChannelAns: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "dl_channel_req":
-					_, srcOk := src.Payload.(*MACCommand_DlChannelReq)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_DlChannelReq)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'dl_channel_req', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_DlChannelReq)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_DlChannelReq)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'dl_channel_req', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_DLChannelReq
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_DlChannelReq).DlChannelReq
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_DlChannelReq).DlChannelReq
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_DLChannelReq{}
 							dst.Payload = &MACCommand_DlChannelReq{DlChannelReq: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "dl_channel_ans":
-					_, srcOk := src.Payload.(*MACCommand_DlChannelAns)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_DlChannelAns)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'dl_channel_ans', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_DlChannelAns)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_DlChannelAns)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'dl_channel_ans', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_DLChannelAns
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_DlChannelAns).DlChannelAns
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_DlChannelAns).DlChannelAns
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_DLChannelAns{}
 							dst.Payload = &MACCommand_DlChannelAns{DlChannelAns: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "rx_timing_setup_req":
-					_, srcOk := src.Payload.(*MACCommand_RxTimingSetupReq_)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_RxTimingSetupReq_)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'rx_timing_setup_req', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_RxTimingSetupReq_)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_RxTimingSetupReq_)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'rx_timing_setup_req', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_RxTimingSetupReq
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_RxTimingSetupReq_).RxTimingSetupReq
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_RxTimingSetupReq_).RxTimingSetupReq
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_RxTimingSetupReq{}
 							dst.Payload = &MACCommand_RxTimingSetupReq_{RxTimingSetupReq: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "tx_param_setup_req":
-					_, srcOk := src.Payload.(*MACCommand_TxParamSetupReq_)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_TxParamSetupReq_)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'tx_param_setup_req', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_TxParamSetupReq_)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_TxParamSetupReq_)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'tx_param_setup_req', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_TxParamSetupReq
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_TxParamSetupReq_).TxParamSetupReq
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_TxParamSetupReq_).TxParamSetupReq
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_TxParamSetupReq{}
 							dst.Payload = &MACCommand_TxParamSetupReq_{TxParamSetupReq: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "rekey_ind":
-					_, srcOk := src.Payload.(*MACCommand_RekeyInd_)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_RekeyInd_)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'rekey_ind', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_RekeyInd_)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_RekeyInd_)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'rekey_ind', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_RekeyInd
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_RekeyInd_).RekeyInd
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_RekeyInd_).RekeyInd
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_RekeyInd{}
 							dst.Payload = &MACCommand_RekeyInd_{RekeyInd: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "rekey_conf":
-					_, srcOk := src.Payload.(*MACCommand_RekeyConf_)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_RekeyConf_)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'rekey_conf', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_RekeyConf_)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_RekeyConf_)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'rekey_conf', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_RekeyConf
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_RekeyConf_).RekeyConf
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_RekeyConf_).RekeyConf
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_RekeyConf{}
 							dst.Payload = &MACCommand_RekeyConf_{RekeyConf: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "adr_param_setup_req":
-					_, srcOk := src.Payload.(*MACCommand_AdrParamSetupReq)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_AdrParamSetupReq)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'adr_param_setup_req', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_AdrParamSetupReq)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_AdrParamSetupReq)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'adr_param_setup_req', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_ADRParamSetupReq
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_AdrParamSetupReq).AdrParamSetupReq
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_AdrParamSetupReq).AdrParamSetupReq
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_ADRParamSetupReq{}
 							dst.Payload = &MACCommand_AdrParamSetupReq{AdrParamSetupReq: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "device_time_ans":
-					_, srcOk := src.Payload.(*MACCommand_DeviceTimeAns_)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_DeviceTimeAns_)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'device_time_ans', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_DeviceTimeAns_)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_DeviceTimeAns_)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'device_time_ans', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_DeviceTimeAns
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_DeviceTimeAns_).DeviceTimeAns
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_DeviceTimeAns_).DeviceTimeAns
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_DeviceTimeAns{}
 							dst.Payload = &MACCommand_DeviceTimeAns_{DeviceTimeAns: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "force_rejoin_req":
-					_, srcOk := src.Payload.(*MACCommand_ForceRejoinReq_)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_ForceRejoinReq_)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'force_rejoin_req', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_ForceRejoinReq_)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_ForceRejoinReq_)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'force_rejoin_req', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_ForceRejoinReq
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_ForceRejoinReq_).ForceRejoinReq
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_ForceRejoinReq_).ForceRejoinReq
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_ForceRejoinReq{}
 							dst.Payload = &MACCommand_ForceRejoinReq_{ForceRejoinReq: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "rejoin_param_setup_req":
-					_, srcOk := src.Payload.(*MACCommand_RejoinParamSetupReq_)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_RejoinParamSetupReq_)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'rejoin_param_setup_req', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_RejoinParamSetupReq_)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_RejoinParamSetupReq_)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'rejoin_param_setup_req', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_RejoinParamSetupReq
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_RejoinParamSetupReq_).RejoinParamSetupReq
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_RejoinParamSetupReq_).RejoinParamSetupReq
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_RejoinParamSetupReq{}
 							dst.Payload = &MACCommand_RejoinParamSetupReq_{RejoinParamSetupReq: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "rejoin_param_setup_ans":
-					_, srcOk := src.Payload.(*MACCommand_RejoinParamSetupAns_)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_RejoinParamSetupAns_)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'rejoin_param_setup_ans', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_RejoinParamSetupAns_)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_RejoinParamSetupAns_)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'rejoin_param_setup_ans', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_RejoinParamSetupAns
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_RejoinParamSetupAns_).RejoinParamSetupAns
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_RejoinParamSetupAns_).RejoinParamSetupAns
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_RejoinParamSetupAns{}
 							dst.Payload = &MACCommand_RejoinParamSetupAns_{RejoinParamSetupAns: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "ping_slot_info_req":
-					_, srcOk := src.Payload.(*MACCommand_PingSlotInfoReq_)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_PingSlotInfoReq_)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'ping_slot_info_req', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_PingSlotInfoReq_)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_PingSlotInfoReq_)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'ping_slot_info_req', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_PingSlotInfoReq
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_PingSlotInfoReq_).PingSlotInfoReq
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_PingSlotInfoReq_).PingSlotInfoReq
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_PingSlotInfoReq{}
 							dst.Payload = &MACCommand_PingSlotInfoReq_{PingSlotInfoReq: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "ping_slot_channel_req":
-					_, srcOk := src.Payload.(*MACCommand_PingSlotChannelReq_)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_PingSlotChannelReq_)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'ping_slot_channel_req', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_PingSlotChannelReq_)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_PingSlotChannelReq_)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'ping_slot_channel_req', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_PingSlotChannelReq
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_PingSlotChannelReq_).PingSlotChannelReq
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_PingSlotChannelReq_).PingSlotChannelReq
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_PingSlotChannelReq{}
 							dst.Payload = &MACCommand_PingSlotChannelReq_{PingSlotChannelReq: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "ping_slot_channel_ans":
-					_, srcOk := src.Payload.(*MACCommand_PingSlotChannelAns_)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_PingSlotChannelAns_)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'ping_slot_channel_ans', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_PingSlotChannelAns_)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_PingSlotChannelAns_)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'ping_slot_channel_ans', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_PingSlotChannelAns
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_PingSlotChannelAns_).PingSlotChannelAns
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_PingSlotChannelAns_).PingSlotChannelAns
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_PingSlotChannelAns{}
 							dst.Payload = &MACCommand_PingSlotChannelAns_{PingSlotChannelAns: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "beacon_timing_ans":
-					_, srcOk := src.Payload.(*MACCommand_BeaconTimingAns_)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_BeaconTimingAns_)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'beacon_timing_ans', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_BeaconTimingAns_)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_BeaconTimingAns_)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'beacon_timing_ans', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_BeaconTimingAns
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_BeaconTimingAns_).BeaconTimingAns
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_BeaconTimingAns_).BeaconTimingAns
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_BeaconTimingAns{}
 							dst.Payload = &MACCommand_BeaconTimingAns_{BeaconTimingAns: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "beacon_freq_req":
-					_, srcOk := src.Payload.(*MACCommand_BeaconFreqReq_)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_BeaconFreqReq_)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'beacon_freq_req', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_BeaconFreqReq_)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_BeaconFreqReq_)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'beacon_freq_req', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_BeaconFreqReq
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_BeaconFreqReq_).BeaconFreqReq
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_BeaconFreqReq_).BeaconFreqReq
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_BeaconFreqReq{}
 							dst.Payload = &MACCommand_BeaconFreqReq_{BeaconFreqReq: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "beacon_freq_ans":
-					_, srcOk := src.Payload.(*MACCommand_BeaconFreqAns_)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_BeaconFreqAns_)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'beacon_freq_ans', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_BeaconFreqAns_)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_BeaconFreqAns_)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'beacon_freq_ans', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_BeaconFreqAns
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_BeaconFreqAns_).BeaconFreqAns
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_BeaconFreqAns_).BeaconFreqAns
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_BeaconFreqAns{}
 							dst.Payload = &MACCommand_BeaconFreqAns_{BeaconFreqAns: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "device_mode_ind":
-					_, srcOk := src.Payload.(*MACCommand_DeviceModeInd_)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_DeviceModeInd_)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'device_mode_ind', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_DeviceModeInd_)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_DeviceModeInd_)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'device_mode_ind', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_DeviceModeInd
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_DeviceModeInd_).DeviceModeInd
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_DeviceModeInd_).DeviceModeInd
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_DeviceModeInd{}
 							dst.Payload = &MACCommand_DeviceModeInd_{DeviceModeInd: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil
 						}
 					}
 				case "device_mode_conf":
-					_, srcOk := src.Payload.(*MACCommand_DeviceModeConf_)
-					if !srcOk && src.Payload != nil {
+					_, srcTypeOk := src.Payload.(*MACCommand_DeviceModeConf_)
+					srcValid := srcTypeOk || src.Payload == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'device_mode_conf', while different oneof is set in source")
 					}
-					_, dstOk := dst.Payload.(*MACCommand_DeviceModeConf_)
-					if !dstOk && dst.Payload != nil {
+					_, dstTypeOk := dst.Payload.(*MACCommand_DeviceModeConf_)
+					dstValid := dstTypeOk || dst.Payload == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'device_mode_conf', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *MACCommand_DeviceModeConf
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Payload.(*MACCommand_DeviceModeConf_).DeviceModeConf
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Payload.(*MACCommand_DeviceModeConf_).DeviceModeConf
-						} else {
+						} else if srcTypeOk {
 							newDst = &MACCommand_DeviceModeConf{}
 							dst.Payload = &MACCommand_DeviceModeConf_{DeviceModeConf: newDst}
+						} else {
+							dst.Payload = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Payload = src.Payload
 						} else {
 							dst.Payload = nil

--- a/pkg/ttnpb/messages.pb.setters.fm.go
+++ b/pkg/ttnpb/messages.pb.setters.fm.go
@@ -217,66 +217,70 @@ func (dst *DownlinkMessage) SetFields(src *DownlinkMessage, paths ...string) err
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "request":
-					_, srcOk := src.Settings.(*DownlinkMessage_Request)
-					if !srcOk && src.Settings != nil {
+					_, srcTypeOk := src.Settings.(*DownlinkMessage_Request)
+					srcValid := srcTypeOk || src.Settings == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'request', while different oneof is set in source")
 					}
-					_, dstOk := dst.Settings.(*DownlinkMessage_Request)
-					if !dstOk && dst.Settings != nil {
+					_, dstTypeOk := dst.Settings.(*DownlinkMessage_Request)
+					dstValid := dstTypeOk || dst.Settings == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'request', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *TxRequest
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Settings.(*DownlinkMessage_Request).Request
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Settings.(*DownlinkMessage_Request).Request
-						} else {
+						} else if srcTypeOk {
 							newDst = &TxRequest{}
 							dst.Settings = &DownlinkMessage_Request{Request: newDst}
+						} else {
+							dst.Settings = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Settings = src.Settings
 						} else {
 							dst.Settings = nil
 						}
 					}
 				case "scheduled":
-					_, srcOk := src.Settings.(*DownlinkMessage_Scheduled)
-					if !srcOk && src.Settings != nil {
+					_, srcTypeOk := src.Settings.(*DownlinkMessage_Scheduled)
+					srcValid := srcTypeOk || src.Settings == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'scheduled', while different oneof is set in source")
 					}
-					_, dstOk := dst.Settings.(*DownlinkMessage_Scheduled)
-					if !dstOk && dst.Settings != nil {
+					_, dstTypeOk := dst.Settings.(*DownlinkMessage_Scheduled)
+					dstValid := dstTypeOk || dst.Settings == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'scheduled', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *TxSettings
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Settings.(*DownlinkMessage_Scheduled).Scheduled
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Settings.(*DownlinkMessage_Scheduled).Scheduled
-						} else {
+						} else if srcTypeOk {
 							newDst = &TxSettings{}
 							dst.Settings = &DownlinkMessage_Scheduled{Scheduled: newDst}
+						} else {
+							dst.Settings = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Settings = src.Settings
 						} else {
 							dst.Settings = nil
@@ -1219,330 +1223,350 @@ func (dst *ApplicationUp) SetFields(src *ApplicationUp, paths ...string) error {
 			for oneofName, oneofSubs := range subPathMap {
 				switch oneofName {
 				case "uplink_message":
-					_, srcOk := src.Up.(*ApplicationUp_UplinkMessage)
-					if !srcOk && src.Up != nil {
+					_, srcTypeOk := src.Up.(*ApplicationUp_UplinkMessage)
+					srcValid := srcTypeOk || src.Up == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'uplink_message', while different oneof is set in source")
 					}
-					_, dstOk := dst.Up.(*ApplicationUp_UplinkMessage)
-					if !dstOk && dst.Up != nil {
+					_, dstTypeOk := dst.Up.(*ApplicationUp_UplinkMessage)
+					dstValid := dstTypeOk || dst.Up == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'uplink_message', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *ApplicationUplink
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Up.(*ApplicationUp_UplinkMessage).UplinkMessage
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Up.(*ApplicationUp_UplinkMessage).UplinkMessage
-						} else {
+						} else if srcTypeOk {
 							newDst = &ApplicationUplink{}
 							dst.Up = &ApplicationUp_UplinkMessage{UplinkMessage: newDst}
+						} else {
+							dst.Up = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Up = src.Up
 						} else {
 							dst.Up = nil
 						}
 					}
 				case "join_accept":
-					_, srcOk := src.Up.(*ApplicationUp_JoinAccept)
-					if !srcOk && src.Up != nil {
+					_, srcTypeOk := src.Up.(*ApplicationUp_JoinAccept)
+					srcValid := srcTypeOk || src.Up == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'join_accept', while different oneof is set in source")
 					}
-					_, dstOk := dst.Up.(*ApplicationUp_JoinAccept)
-					if !dstOk && dst.Up != nil {
+					_, dstTypeOk := dst.Up.(*ApplicationUp_JoinAccept)
+					dstValid := dstTypeOk || dst.Up == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'join_accept', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *ApplicationJoinAccept
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Up.(*ApplicationUp_JoinAccept).JoinAccept
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Up.(*ApplicationUp_JoinAccept).JoinAccept
-						} else {
+						} else if srcTypeOk {
 							newDst = &ApplicationJoinAccept{}
 							dst.Up = &ApplicationUp_JoinAccept{JoinAccept: newDst}
+						} else {
+							dst.Up = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Up = src.Up
 						} else {
 							dst.Up = nil
 						}
 					}
 				case "downlink_ack":
-					_, srcOk := src.Up.(*ApplicationUp_DownlinkAck)
-					if !srcOk && src.Up != nil {
+					_, srcTypeOk := src.Up.(*ApplicationUp_DownlinkAck)
+					srcValid := srcTypeOk || src.Up == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'downlink_ack', while different oneof is set in source")
 					}
-					_, dstOk := dst.Up.(*ApplicationUp_DownlinkAck)
-					if !dstOk && dst.Up != nil {
+					_, dstTypeOk := dst.Up.(*ApplicationUp_DownlinkAck)
+					dstValid := dstTypeOk || dst.Up == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'downlink_ack', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *ApplicationDownlink
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Up.(*ApplicationUp_DownlinkAck).DownlinkAck
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Up.(*ApplicationUp_DownlinkAck).DownlinkAck
-						} else {
+						} else if srcTypeOk {
 							newDst = &ApplicationDownlink{}
 							dst.Up = &ApplicationUp_DownlinkAck{DownlinkAck: newDst}
+						} else {
+							dst.Up = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Up = src.Up
 						} else {
 							dst.Up = nil
 						}
 					}
 				case "downlink_nack":
-					_, srcOk := src.Up.(*ApplicationUp_DownlinkNack)
-					if !srcOk && src.Up != nil {
+					_, srcTypeOk := src.Up.(*ApplicationUp_DownlinkNack)
+					srcValid := srcTypeOk || src.Up == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'downlink_nack', while different oneof is set in source")
 					}
-					_, dstOk := dst.Up.(*ApplicationUp_DownlinkNack)
-					if !dstOk && dst.Up != nil {
+					_, dstTypeOk := dst.Up.(*ApplicationUp_DownlinkNack)
+					dstValid := dstTypeOk || dst.Up == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'downlink_nack', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *ApplicationDownlink
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Up.(*ApplicationUp_DownlinkNack).DownlinkNack
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Up.(*ApplicationUp_DownlinkNack).DownlinkNack
-						} else {
+						} else if srcTypeOk {
 							newDst = &ApplicationDownlink{}
 							dst.Up = &ApplicationUp_DownlinkNack{DownlinkNack: newDst}
+						} else {
+							dst.Up = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Up = src.Up
 						} else {
 							dst.Up = nil
 						}
 					}
 				case "downlink_sent":
-					_, srcOk := src.Up.(*ApplicationUp_DownlinkSent)
-					if !srcOk && src.Up != nil {
+					_, srcTypeOk := src.Up.(*ApplicationUp_DownlinkSent)
+					srcValid := srcTypeOk || src.Up == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'downlink_sent', while different oneof is set in source")
 					}
-					_, dstOk := dst.Up.(*ApplicationUp_DownlinkSent)
-					if !dstOk && dst.Up != nil {
+					_, dstTypeOk := dst.Up.(*ApplicationUp_DownlinkSent)
+					dstValid := dstTypeOk || dst.Up == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'downlink_sent', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *ApplicationDownlink
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Up.(*ApplicationUp_DownlinkSent).DownlinkSent
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Up.(*ApplicationUp_DownlinkSent).DownlinkSent
-						} else {
+						} else if srcTypeOk {
 							newDst = &ApplicationDownlink{}
 							dst.Up = &ApplicationUp_DownlinkSent{DownlinkSent: newDst}
+						} else {
+							dst.Up = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Up = src.Up
 						} else {
 							dst.Up = nil
 						}
 					}
 				case "downlink_failed":
-					_, srcOk := src.Up.(*ApplicationUp_DownlinkFailed)
-					if !srcOk && src.Up != nil {
+					_, srcTypeOk := src.Up.(*ApplicationUp_DownlinkFailed)
+					srcValid := srcTypeOk || src.Up == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'downlink_failed', while different oneof is set in source")
 					}
-					_, dstOk := dst.Up.(*ApplicationUp_DownlinkFailed)
-					if !dstOk && dst.Up != nil {
+					_, dstTypeOk := dst.Up.(*ApplicationUp_DownlinkFailed)
+					dstValid := dstTypeOk || dst.Up == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'downlink_failed', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *ApplicationDownlinkFailed
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Up.(*ApplicationUp_DownlinkFailed).DownlinkFailed
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Up.(*ApplicationUp_DownlinkFailed).DownlinkFailed
-						} else {
+						} else if srcTypeOk {
 							newDst = &ApplicationDownlinkFailed{}
 							dst.Up = &ApplicationUp_DownlinkFailed{DownlinkFailed: newDst}
+						} else {
+							dst.Up = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Up = src.Up
 						} else {
 							dst.Up = nil
 						}
 					}
 				case "downlink_queued":
-					_, srcOk := src.Up.(*ApplicationUp_DownlinkQueued)
-					if !srcOk && src.Up != nil {
+					_, srcTypeOk := src.Up.(*ApplicationUp_DownlinkQueued)
+					srcValid := srcTypeOk || src.Up == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'downlink_queued', while different oneof is set in source")
 					}
-					_, dstOk := dst.Up.(*ApplicationUp_DownlinkQueued)
-					if !dstOk && dst.Up != nil {
+					_, dstTypeOk := dst.Up.(*ApplicationUp_DownlinkQueued)
+					dstValid := dstTypeOk || dst.Up == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'downlink_queued', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *ApplicationDownlink
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Up.(*ApplicationUp_DownlinkQueued).DownlinkQueued
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Up.(*ApplicationUp_DownlinkQueued).DownlinkQueued
-						} else {
+						} else if srcTypeOk {
 							newDst = &ApplicationDownlink{}
 							dst.Up = &ApplicationUp_DownlinkQueued{DownlinkQueued: newDst}
+						} else {
+							dst.Up = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Up = src.Up
 						} else {
 							dst.Up = nil
 						}
 					}
 				case "downlink_queue_invalidated":
-					_, srcOk := src.Up.(*ApplicationUp_DownlinkQueueInvalidated)
-					if !srcOk && src.Up != nil {
+					_, srcTypeOk := src.Up.(*ApplicationUp_DownlinkQueueInvalidated)
+					srcValid := srcTypeOk || src.Up == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'downlink_queue_invalidated', while different oneof is set in source")
 					}
-					_, dstOk := dst.Up.(*ApplicationUp_DownlinkQueueInvalidated)
-					if !dstOk && dst.Up != nil {
+					_, dstTypeOk := dst.Up.(*ApplicationUp_DownlinkQueueInvalidated)
+					dstValid := dstTypeOk || dst.Up == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'downlink_queue_invalidated', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *ApplicationInvalidatedDownlinks
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Up.(*ApplicationUp_DownlinkQueueInvalidated).DownlinkQueueInvalidated
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Up.(*ApplicationUp_DownlinkQueueInvalidated).DownlinkQueueInvalidated
-						} else {
+						} else if srcTypeOk {
 							newDst = &ApplicationInvalidatedDownlinks{}
 							dst.Up = &ApplicationUp_DownlinkQueueInvalidated{DownlinkQueueInvalidated: newDst}
+						} else {
+							dst.Up = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Up = src.Up
 						} else {
 							dst.Up = nil
 						}
 					}
 				case "location_solved":
-					_, srcOk := src.Up.(*ApplicationUp_LocationSolved)
-					if !srcOk && src.Up != nil {
+					_, srcTypeOk := src.Up.(*ApplicationUp_LocationSolved)
+					srcValid := srcTypeOk || src.Up == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'location_solved', while different oneof is set in source")
 					}
-					_, dstOk := dst.Up.(*ApplicationUp_LocationSolved)
-					if !dstOk && dst.Up != nil {
+					_, dstTypeOk := dst.Up.(*ApplicationUp_LocationSolved)
+					dstValid := dstTypeOk || dst.Up == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'location_solved', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *ApplicationLocation
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Up.(*ApplicationUp_LocationSolved).LocationSolved
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Up.(*ApplicationUp_LocationSolved).LocationSolved
-						} else {
+						} else if srcTypeOk {
 							newDst = &ApplicationLocation{}
 							dst.Up = &ApplicationUp_LocationSolved{LocationSolved: newDst}
+						} else {
+							dst.Up = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Up = src.Up
 						} else {
 							dst.Up = nil
 						}
 					}
 				case "service_data":
-					_, srcOk := src.Up.(*ApplicationUp_ServiceData)
-					if !srcOk && src.Up != nil {
+					_, srcTypeOk := src.Up.(*ApplicationUp_ServiceData)
+					srcValid := srcTypeOk || src.Up == nil || len(oneofSubs) == 0
+					if !srcValid {
 						return fmt.Errorf("attempt to set oneof 'service_data', while different oneof is set in source")
 					}
-					_, dstOk := dst.Up.(*ApplicationUp_ServiceData)
-					if !dstOk && dst.Up != nil {
+					_, dstTypeOk := dst.Up.(*ApplicationUp_ServiceData)
+					dstValid := dstTypeOk || dst.Up == nil || len(oneofSubs) == 0
+					if !dstValid {
 						return fmt.Errorf("attempt to set oneof 'service_data', while different oneof is set in destination")
 					}
 					if len(oneofSubs) > 0 {
 						var newDst, newSrc *ApplicationServiceData
-						if !srcOk && !dstOk {
-							continue
-						}
-						if srcOk {
+						if srcTypeOk {
 							newSrc = src.Up.(*ApplicationUp_ServiceData).ServiceData
 						}
-						if dstOk {
+						if dstTypeOk {
 							newDst = dst.Up.(*ApplicationUp_ServiceData).ServiceData
-						} else {
+						} else if srcTypeOk {
 							newDst = &ApplicationServiceData{}
 							dst.Up = &ApplicationUp_ServiceData{ServiceData: newDst}
+						} else {
+							dst.Up = nil
+							continue
 						}
 						if err := newDst.SetFields(newSrc, oneofSubs...); err != nil {
 							return err
 						}
 					} else {
-						if src != nil {
+						if srcTypeOk {
 							dst.Up = src.Up
 						} else {
 							dst.Up = nil

--- a/tools/mage/proto.go
+++ b/tools/mage/proto.go
@@ -32,7 +32,7 @@ const (
 	protocOut             = "/out"
 	gogoProtoImage        = "ghcr.io/thethingsindustries/protoc:gen-gogo-1.3.1"
 	jsonProtoImage        = "ghcr.io/thethingsindustries/protoc:3.9.1-gen-go-json-1.3.1"
-	fieldMaskProtoImage   = "ghcr.io/thethingsindustries/protoc:3.9.1-gen-fieldmask-0.5.0"
+	fieldMaskProtoImage   = "ghcr.io/thethingsindustries/protoc:3.9.1-gen-fieldmask-0.6.0"
 	grpcGatewayProtoImage = "ghcr.io/thethingsindustries/protoc:gen-grpc-gateway-1.16.0"
 	swaggerProtoImage     = "ghcr.io/thethingsindustries/protoc:gen-grpc-gateway-1.16.0"
 	docProtoImage         = "ghcr.io/thethingsindustries/protoc:gen-doc-1.4.1"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/protoc-gen-fieldmask/pull/43

#### Changes
<!-- What are the changes made in this pull request? -->

- Upgrade `protoc-gen-fieldmask` to `0.6.0`
  - See the referenced PR for the changes.


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

We now allow that the type of an `oneof` is changed under specific circumstances. This has been tested in the appropriate PRs (https://github.com/TheThingsNetwork/lorawan-stack/pull/5353)

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
