### PR TITLE
Avoid extracting frame counts from retained events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- End devices frame counts being displayed as `n/a` when event stream contained historical data message events.
+
 ### Security
 
 ## [3.19.0] - unreleased

--- a/pkg/webui/console/store/reducers/devices.js
+++ b/pkg/webui/console/store/reducers/devices.js
@@ -167,26 +167,35 @@ const devices = (state = defaultState, { type, payload, event }) => {
     case GET_DEVICE_EVENT_MESSAGE_SUCCESS:
       // Detect uplink/downlink process events to update uplink/downlink frame count state.
       if (event.name === uplinkFrameCountEvent) {
-        return mergeDerived(state, getCombinedDeviceId(event.identifiers[0].device_ids), {
-          uplinkFrameCount: getByPath(event, 'data.payload.mac_payload.full_f_cnt'),
-        })
+        const uplinkFrameCount = getByPath(event, 'data.payload.mac_payload.full_f_cnt')
+        if (typeof uplinkFrameCount === 'number') {
+          return mergeDerived(state, getCombinedDeviceId(event.identifiers[0].device_ids), {
+            uplinkFrameCount,
+          })
+        }
       } else if (event.name === downlinkFrameCountEvent) {
         const combinedDeviceId = getCombinedDeviceId(event.identifiers[0].device_ids)
         const lorawanVersion = getByPath(state.entities, `${combinedDeviceId}.lorawan_version`)
 
         if (parseLorawanMacVersion(lorawanVersion) < 110) {
-          return mergeDerived(state, combinedDeviceId, {
-            downlinkFrameCount: getByPath(event, 'data.payload.mac_payload.full_f_cnt'),
-          })
+          const downlinkFrameCount = getByPath(event, 'data.payload.mac_payload.full_f_cnt')
+          if (typeof downlinkFrameCount === 'number') {
+            return mergeDerived(state, combinedDeviceId, {
+              downlinkFrameCount,
+            })
+          }
         }
 
         // For 1.1+ end devices there are two frame counters. If `f_port` is equal to 0 - then it's the "network" frame counter,
         // otherwise it's the "application" frame counter. Currently, we display only the application counter.
         // Also, see https://github.com/TheThingsNetwork/lorawan-stack/issues/2740.
         if (getByPath(event, 'data.payload.f_port') > 0) {
-          return mergeDerived(state, combinedDeviceId, {
-            downlinkFrameCount: getByPath(event, 'data.payload.mac_payload.full_f_cnt'),
-          })
+          const downlinkFrameCount = getByPath(event, 'data.payload.mac_payload.full_f_cnt')
+          if (typeof downlinkFrameCount === 'number') {
+            return mergeDerived(state, combinedDeviceId, {
+              downlinkFrameCount,
+            })
+          }
         }
       }
 


### PR DESCRIPTION
#### Summary
This quickfix will address frame counts of devices being displayed as `n/a` when historical events are loaded.

Closes https://github.com/TheThingsIndustries/lorawan-stack-support/issues/750

#### Changes
<!-- What are the changes made in this pull request? -->

- Check whether frame count information is present in the event before applying

#### Testing

Manual testing on staging

#### Notes for Reviewers
Historical events in some cases don't store the event data (based on event retention config of the deployment). The Console would store the uplink/downlink value anyways, even when it was resolved to `undefined`. With the change the values are only updated if they are present in the event data.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
