### PR TITLE
Fix webhook configuration selector

### DIFF
--- a/pkg/webui/console/store/selectors/application-server.js
+++ b/pkg/webui/console/store/selectors/application-server.js
@@ -36,6 +36,10 @@ export const selectWebhooksConfiguration = state => selectAsConfiguration(state)
 export const selectWebhooksHealthStatusEnabled = state => {
   const webhooksConfig = selectWebhooksConfiguration(state)
 
+  if (!webhooksConfig) {
+    return false
+  }
+
   return (
     webhooksConfig.unhealthy_retry_interval !== '0s' ||
     'unhealthy_attempts_threshold' in webhooksConfig


### PR DESCRIPTION
#### Summary
This quickfix PR fixes the webhook config selector throwing an exception when no webhook configuration is available.

#### Changes
<!-- What are the changes made in this pull request? -->

- Check whether the `webhooks` prop exists before trying to extract information from it

#### Testing

Manual.

#### Notes for Reviewers

via https://sentry.io/organizations/the-things-industries/issues/3205138974/?project=2682566&query=is%3Aunresolved+frontendOrigin%3ATrue&statsPeriod=14d

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
