### PR TITLE
Fix NetID derivation from DevAddr

### DIFF
--- a/pkg/networkserver/networkserver_flow_test.go
+++ b/pkg/networkserver/networkserver_flow_test.go
@@ -437,7 +437,7 @@ func TestFlow(t *testing.T) {
 						}
 						return &d
 					}()
-					nsConf.NetID = test.Must(types.NewNetID(2, []byte{1, 2, 3})).(types.NetID)
+					nsConf.NetID = test.Must(types.NewNetID(2, []byte{3})).(types.NetID)
 					nsConf.ClusterID = "test-cluster"
 					nsConf.DeduplicationWindow = (1 << 8) * test.Delay
 					nsConf.CooldownWindow = (1 << 11) * test.Delay

--- a/pkg/networkserver/networkserver_util_internal_test.go
+++ b/pkg/networkserver/networkserver_util_internal_test.go
@@ -1540,11 +1540,12 @@ func (env TestEnvironment) AssertJoin(ctx context.Context, conf JoinAssertionCon
 					},
 					func(ctx, reqCtx context.Context, req *ttnpb.JoinRequest) bool {
 						joinReq = req
+						netID, netIDOK := req.DevAddr.NetID()
 						return test.AllTrue(
 							a.So(events.CorrelationIDsFromContext(reqCtx), should.NotBeEmpty),
 							a.So(req.DevAddr, should.NotBeEmpty),
-							a.So(req.DevAddr.NwkID(), should.Resemble, env.Config.NetID.ID()),
-							a.So(req.DevAddr.NetIDType(), should.Equal, env.Config.NetID.Type()),
+							a.So(netIDOK, should.BeTrue),
+							a.So(netID, should.Resemble, env.Config.NetID),
 							a.So(req.CorrelationIds, should.BeProperSupersetOfElementsFunc, test.StringEqual, ups[0].CorrelationIds),
 							a.So(req, should.Resemble, MakeNsJsJoinRequest(NsJsJoinRequestConfig{
 								JoinEUI:            *conf.Device.Ids.JoinEui,

--- a/pkg/types/netid.go
+++ b/pkg/types/netid.go
@@ -23,8 +23,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 )
 
-const unmatchedNetID = "unmatched NetID type"
-
 var errInvalidNetID = errors.DefineInvalidArgument("invalid_net_id", "invalid NetID")
 
 // NetID is issued by the LoRa Alliance.
@@ -151,7 +149,7 @@ func (id NetID) ID() []byte {
 		// 21 LSB
 		return []byte{id[0] & 0x1f, id[1], id[2]}
 	default:
-		panic(unmatchedNetID)
+		panic("unreachable")
 	}
 }
 
@@ -165,7 +163,7 @@ func (id NetID) IDBits() uint {
 	case 3, 4, 5, 6, 7:
 		return 21
 	}
-	panic(unmatchedNetID)
+	panic("unreachable")
 }
 
 // Copy stores a copy of id in x and returns it.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a fix for NetID derivation from a DevAddr.

I'm not aware of any current issues with this because this code was merely unused. It's now needed for https://github.com/TheThingsIndustries/lorawan-stack/issues/3161.

#### Changes
<!-- What are the changes made in this pull request? -->

There were some serious issues with the previous and I'm honestly surprised this hasn't cause any issues so far.

First, `NetIDType()` was using a `for i := uint(7); i >= 0; i--` loop, while `i--` on a `uint` will always return a positive value, always resulting NetID type 0 I guess (if 1 shifted right with the underflowed `uint` would work at all).

Second, `NetIDType()` did not take the prefix into account, but would just return the highest NetID type that had the signaling `0` set, regardless of the prefix:

<img width="440" alt="Screen Shot 2022-04-19 at 14 23 44" src="https://user-images.githubusercontent.com/13334001/164003419-290ccb01-1201-4edf-bcee-7fa649988392.png">

Third, there was a tedious way to actually determine the NetID from the DevAddr.

#### Testing

<!-- How did you verify that this change works? -->

UT

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None expected

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
