### PR TITLE
Return sink error instead of registry error

### DIFF
--- a/pkg/applicationserver/io/web/health_sink.go
+++ b/pkg/applicationserver/io/web/health_sink.go
@@ -196,7 +196,10 @@ func (hcs *healthCheckSink) executeAndRecord(r *http.Request, healthy bool) erro
 			},
 		}, nil
 	}
-	return hcs.registry.Set(r, f)
+	if err := hcs.registry.Set(r, f); err != nil {
+		return err
+	}
+	return sinkErr
 }
 
 // NewHealthCheckSink creates a Sink that records the health status of the webhooks and stops them from executing if


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This short PR ensures that sink (i.e. HTTP errors) are not hidden away while webhooks health checks occur. 
The previous behavior was that the sink error was hidden away, and as a result an error event was not generated.

#### Changes
<!-- What are the changes made in this pull request? -->

- Return the sink error instead of the store error, in order to avoid accidentally hiding the error


#### Testing

<!-- How did you verify that this change works? -->

Local testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
