### PR TITLE
Ingest unhandled exceptions during form submit to Sentry

### DIFF
--- a/pkg/webui/components/form/index.js
+++ b/pkg/webui/components/form/index.js
@@ -23,6 +23,7 @@ import Notification from '@ttn-lw/components/notification'
 import ErrorNotification from '@ttn-lw/components/error-notification'
 
 import PropTypes from '@ttn-lw/lib/prop-types'
+import { ingestError } from '@ttn-lw/lib/errors/utils'
 
 import FormContext from './context'
 import FormField from './field'
@@ -171,6 +172,20 @@ class Form extends React.PureComponent {
   }
 
   @bind
+  async handleSubmit(...args) {
+    const { onSubmit } = this.props
+
+    try {
+      return await onSubmit(...args)
+    } catch (error) {
+      // Make sure all unhandled exceptions during submit are ingested.
+      ingestError(error, { ingestedBy: 'FormSubmit' })
+
+      throw error
+    }
+  }
+
+  @bind
   validate(values) {
     const { validationSchema, validationContext, validateSync } = this.props
 
@@ -212,7 +227,6 @@ class Form extends React.PureComponent {
 
   render() {
     const {
-      onSubmit,
       onReset,
       initialValues,
       validateOnBlur,
@@ -229,7 +243,7 @@ class Form extends React.PureComponent {
       <Formik
         innerRef={formikRef}
         validate={this.validate}
-        onSubmit={onSubmit}
+        onSubmit={this.handleSubmit}
         onReset={onReset}
         validateOnMount={validateOnMount}
         initialValues={initialValues}


### PR DESCRIPTION
#### Summary
This quickfix PR makes sure that unhandled exceptions that are thrown during the form submit are sent to sentry. Currently they are automatically caught by `formik` and passed to a `console.warn()` only.

#### Changes
- Add a middleware to the form submit handler that catches errors and ingests them.


#### Testing

Manual and existing e2e.

#### Notes for Reviewers
This was the reason that #5405 was not visible in sentry. Unhandled exceptions that occur in the submit handler were only logged via `console.warn()` via formik and not rethrown.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
