### PR TITLE
Apply styling fixes to device onboarding

### DIFF
--- a/pkg/webui/components/link/link.styl
+++ b/pkg/webui/components/link/link.styl
@@ -50,7 +50,7 @@
 
 .icon
   nudge('up', 2px)
-  margin-left: $cs.xxs
+  margin-left: .11rem
   margin-right: $cs.xxs
   font-size: 0.9rem
 

--- a/pkg/webui/console/views/device-add/repository/device-card/device-card.js
+++ b/pkg/webui/console/views/device-add/repository/device-card/device-card.js
@@ -103,12 +103,15 @@ const DeviceCard = props => {
         {hasLinks && (
           <div className={style.links}>
             {product_url && (
-              <Link.Anchor href={product_url} external>
+              <Link.Anchor secondary href={product_url} external>
                 <Message content={m.productWebsite} />
               </Link.Anchor>
             )}
+            {product_url && datasheet_url && (
+              <span className="tc-subtle-gray ml-cs-xxs mr-cs-xs">|</span>
+            )}
             {datasheet_url && (
-              <Link.Anchor href={datasheet_url} external>
+              <Link.Anchor secondary href={datasheet_url} external>
                 <Message content={m.dataSheet} />
               </Link.Anchor>
             )}

--- a/pkg/webui/console/views/device-add/repository/device-card/device-card.styl
+++ b/pkg/webui/console/views/device-add/repository/device-card/device-card.styl
@@ -18,7 +18,7 @@
 
   +media-query-min($bp.xs)
     flex-direction: row
-    max-width: 48rem
+    max-width: 52.4rem
     padding: $cs.m $cs.l $cs.m $cs.m
 
   +media-query($bp.xs)


### PR DESCRIPTION
#### Summary
This quickfix PR introduces little styling fixes to the device card that is displayed under the device repository select boxes.

<img width="833" alt="image" src="https://user-images.githubusercontent.com/5710611/165113281-34713ce4-00b3-496b-a7fa-d4c9c05df3d9.png">

#### Changes
<!-- What are the changes made in this pull request? -->

- Add a `secondary` prop to the datasheet/website links to make render them with gray color
- Improve spacing of external-link icon
- Add a seperator `|` between links
- Resize the box a bit


#### Testing

Manual testing.


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
