### PR TITLE
Decode downlink when scheduling binary payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
+- Application Server now decodes downlink if a downlink decoder is present and binary payload is scheduled.
+
 ### Deprecated
 
 ### Removed

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -787,8 +787,6 @@ func (as *ApplicationServer) handleUp(ctx context.Context, up *ttnpb.Application
 		return true, as.handleUplink(ctx, up.EndDeviceIds, p.UplinkMessage, link)
 	case *ttnpb.ApplicationUp_DownlinkQueueInvalidated:
 		return as.handleDownlinkQueueInvalidated(ctx, up.EndDeviceIds, p.DownlinkQueueInvalidated, link)
-	case *ttnpb.ApplicationUp_DownlinkQueued:
-		return true, as.decryptDownlinkMessage(ctx, up.EndDeviceIds, p.DownlinkQueued, link)
 	case *ttnpb.ApplicationUp_DownlinkSent:
 		return true, as.decryptDownlinkMessage(ctx, up.EndDeviceIds, p.DownlinkSent, link)
 	case *ttnpb.ApplicationUp_DownlinkFailed:

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -638,8 +638,17 @@ func (as *ApplicationServer) downlinkQueueOp(ctx context.Context, ids *ttnpb.End
 			if dev == nil {
 				return nil, nil, errDeviceNotFound.WithAttributes("device_uid", unique.ID(ctx, ids))
 			}
-			if err := as.encodeDownlinks(ctx, dev, link, items); err != nil {
-				return nil, nil, err
+			for _, item := range items {
+				var err error
+				if item.FrmPayload != nil && item.DecodedPayload == nil {
+					err = as.decodeDownlink(ctx, dev, item, link.DefaultFormatters)
+				} else {
+					err = as.encodeDownlink(ctx, dev, item, link.DefaultFormatters)
+				}
+				if err != nil {
+					log.FromContext(ctx).WithError(err).Warn("Encoding or decoding downlink message failed")
+					return nil, nil, err
+				}
 			}
 			registerReceiveDownlinks(ctx, ids, items)
 			mask, err := as.attemptDownlinkQueueOp(ctx, dev, link, peer, downlinkQueueOperation{

--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -1234,46 +1234,6 @@ func TestApplicationServer(t *testing.T) {
 						},
 					},
 					{
-						Name: "RegisteredDevice/DownlinkMessage/Queued",
-						IDs:  registeredDevice.Ids,
-						Message: &ttnpb.ApplicationUp{
-							EndDeviceIds: withDevAddr(registeredDevice.Ids, types.DevAddr{0x33, 0x33, 0x33, 0x33}),
-							Up: &ttnpb.ApplicationUp_DownlinkQueued{
-								DownlinkQueued: &ttnpb.ApplicationDownlink{
-									SessionKeyId: []byte{0x33},
-									FPort:        42,
-									FCnt:         42,
-									FrmPayload:   []byte{0x50, 0xd, 0x40, 0xd5},
-								},
-							},
-						},
-						AssertUp: func(t *testing.T, up *ttnpb.ApplicationUp) {
-							a := assertions.New(t)
-							a.So(up, should.Resemble, &ttnpb.ApplicationUp{
-								EndDeviceIds: withDevAddr(registeredDevice.Ids, types.DevAddr{0x33, 0x33, 0x33, 0x33}),
-								Up: &ttnpb.ApplicationUp_DownlinkQueued{
-									DownlinkQueued: &ttnpb.ApplicationDownlink{
-										SessionKeyId: []byte{0x33},
-										FPort:        42,
-										FCnt:         42,
-										FrmPayload:   []byte{0x1, 0x1, 0x1, 0x1},
-										DecodedPayload: &pbtypes.Struct{
-											Fields: map[string]*pbtypes.Value{
-												"sum": {
-													Kind: &pbtypes.Value_NumberValue{
-														NumberValue: 4, // Payload formatter sums the bytes in FRMPayload.
-													},
-												},
-											},
-										},
-									},
-								},
-								CorrelationIds: up.CorrelationIds,
-								ReceivedAt:     up.ReceivedAt,
-							})
-						},
-					},
-					{
 						Name: "RegisteredDevice/DownlinkMessage/QueueInvalidated",
 						IDs:  registeredDevice.Ids,
 						Message: &ttnpb.ApplicationUp{

--- a/pkg/applicationserver/payload.go
+++ b/pkg/applicationserver/payload.go
@@ -33,16 +33,6 @@ var (
 	errNoFPort   = errors.DefineInvalidArgument("no_f_port", "no FPort")
 )
 
-func (as *ApplicationServer) encodeDownlinks(ctx context.Context, dev *ttnpb.EndDevice, link *ttnpb.ApplicationLink, items []*ttnpb.ApplicationDownlink) error {
-	for _, item := range items {
-		if err := as.encodeDownlink(ctx, dev, item, link.DefaultFormatters); err != nil {
-			log.FromContext(ctx).WithError(err).Warn("Encoding and encryption of downlink message failed; drop item")
-			return err
-		}
-	}
-	return nil
-}
-
 func (as *ApplicationServer) encodeDownlink(ctx context.Context, dev *ttnpb.EndDevice, downlink *ttnpb.ApplicationDownlink, defaultFormatters *ttnpb.MessagePayloadFormatters) error {
 	if downlink.FrmPayload == nil && downlink.DecodedPayload == nil {
 		return errNoPayload.New()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #5260 

#### Changes
<!-- What are the changes made in this pull request? -->

- Decode downlink when binary payload gets scheduled
- Remove processing downlink queued event from NS as it's never sent

#### Testing

<!-- How did you verify that this change works? -->

Seeing the downlink being decoded is a bit hard to test with unit tests, as tests currently don't observe the "downlink queued" event when queuing downlink; the tests observe the entire downlink queue and then the downlink was also decoded.

So ran locally:

```bash
$ ttn-lw-cli dev downlink push app1 dragino1 --frm-payload DEADBEEF --f-port 42
```

The downlink queued event has the result of the downlink decoder (which sums the bytes):

<img width="1072" alt="Screen Shot 2022-04-26 at 10 45 17" src="https://user-images.githubusercontent.com/13334001/165261180-c33bc6b3-eb74-47bc-ab53-b0dbe6a8ff5b.png">

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None expected

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
