### PR TITLE
cli: Use cache for version check

### DIFF
--- a/pkg/version/remote_test.go
+++ b/pkg/version/remote_test.go
@@ -61,6 +61,7 @@ func TestCheckUpdate(t *testing.T) {
 
 			ctx, cancel := context.WithTimeout(ctx, timeout)
 			defer cancel()
+			version.ClearRecentCheckCache()
 			update, err := version.CheckUpdate(ctx, sourceOpt, version.WithReference(tc.Reference))
 			a.So(err, should.BeNil)
 


### PR DESCRIPTION
#### Summary
Closes #5394 

#### Changes
Made version check use cache

#### Testing
1. Run one time - information about version check. Run second time - no information.
2. Edit the cache file to an early date and run - version check gets performed.
3. Edit the cache file to make it incorrect and run - warning shows up, then version check gets performed, subsequent run doesn't show version check information.

##### Regressions
None

#### Notes for Reviewers
Maybe instead of coding the cache logic in `pkg/version/remote.go`, it'd be better to create an all-purpose caching interface?

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [ ] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
