### PR TITLE
Gateway Server connection stats event and event type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Added
 
+- New event type `gs.gateway.connection.stats` with connection statistics. A new event is sent at most every `gs.update-connection-stats-debounce-time` time.
+
 ### Changed
+
+- Event type for `gs.up.receive` event to `GatewayUplinkMessage`.
+- Default debounce time for updating connection stats in de Gateway Server (configuration setting `gs.update-connection-stats-debounce-time`) is now 30 seconds.
 
 ### Deprecated
 

--- a/cmd/internal/shared/gatewayserver/config.go
+++ b/cmd/internal/shared/gatewayserver/config.go
@@ -32,7 +32,7 @@ var DefaultGatewayServerConfig = gatewayserver.Config{
 	FetchGatewayInterval:              10 * time.Minute,
 	FetchGatewayJitter:                0.2,
 	UpdateGatewayLocationDebounceTime: time.Hour,
-	UpdateConnectionStatsDebounceTime: 5 * time.Second,
+	UpdateConnectionStatsDebounceTime: 30 * time.Second,
 	ConnectionStatsTTL:                12 * time.Hour,
 	ConnectionStatsDisconnectTTL:      48 * time.Hour,
 	UpdateVersionInfoDelay:            5 * time.Second,

--- a/config/messages.json
+++ b/config/messages.json
@@ -9404,6 +9404,15 @@
       "file": "observability.go"
     }
   },
+  "event:gs.gateway.connection.stats": {
+    "translations": {
+      "en": "gateway connection statistics"
+    },
+    "description": {
+      "package": "pkg/gatewayserver",
+      "file": "observability.go"
+    }
+  },
   "event:gs.gateway.disconnect": {
     "translations": {
       "en": "disconnect gateway"

--- a/pkg/gatewayserver/config.go
+++ b/pkg/gatewayserver/config.go
@@ -56,7 +56,7 @@ type Config struct {
 
 	UpdateGatewayLocationDebounceTime time.Duration `name:"update-gateway-location-debounce-time" description:"Debounce time for gateway location updates from status messages"`
 	UpdateConnectionStatsDebounceTime time.Duration `name:"update-connection-stats-debounce-time" description:"Time before repeated refresh of the gateway connection stats"`
-	ConnectionStatsTTL                time.Duration `name:"connection-stats-ttl" description:"Time to live of the gateway connection stats. Periodically refreshed by the GatewayServer but works as an expiration date on the data in case of crashes"`
+	ConnectionStatsTTL                time.Duration `name:"connection-stats-ttl" description:"Time to live of the gateway connection stats that are periodically updated by Gateway Server"`
 	ConnectionStatsDisconnectTTL      time.Duration `name:"connection-stats-disconnect-ttl" description:"Time to live of the gateway connection stats after disconnecting"`
 
 	UpdateVersionInfoDelay time.Duration `name:"update-version-info-delay" description:"Maximum time to wait to update version information. A Jitter of 25% is applied for randomization"`

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -755,7 +755,7 @@ func (host *upstreamHost) handlePacket(ctx context.Context, item interface{}) {
 			codes.Unimplemented, codes.Unavailable:
 			drop(ids, errHostHandle.WithCause(err).WithAttributes("host", host.name))
 		default:
-			registerForwardUplink(ctx, gtw, msg.Message, host.name)
+			registerForwardUplink(ctx, gtw, msg, host.name)
 		}
 	case *ttnpb.GatewayStatus:
 		if err := host.handler.HandleStatus(ctx, *gtw.Ids, msg); err != nil {
@@ -832,7 +832,7 @@ func (gs *GatewayServer) handleUpstream(ctx context.Context, conn connectionEntr
 				continue
 			}
 			val = msg
-			registerReceiveUplink(ctx, gtw, msg.Message, protocol)
+			registerReceiveUplink(ctx, gtw, msg, protocol)
 		case msg := <-conn.Status():
 			ctx = events.ContextWithCorrelationID(ctx, fmt.Sprintf("gs:status:%s", events.NewCorrelationID()))
 			val = msg

--- a/pkg/gatewayserver/observability.go
+++ b/pkg/gatewayserver/observability.go
@@ -63,7 +63,7 @@ var (
 	evtReceiveUp = events.Define(
 		"gs.up.receive", "receive uplink message",
 		events.WithVisibility(ttnpb.Right_RIGHT_GATEWAY_TRAFFIC_READ),
-		events.WithDataType(&ttnpb.UplinkMessage{}),
+		events.WithDataType(&ttnpb.GatewayUplinkMessage{}),
 	)
 	evtDropUp = events.Define(
 		"gs.up.drop", "drop uplink message",
@@ -303,12 +303,12 @@ func registerDropStatus(ctx context.Context, gtw *ttnpb.Gateway, status *ttnpb.G
 	gsMetrics.statusDropped.WithLabelValues(ctx, host, errorLabel).Inc()
 }
 
-func registerReceiveUplink(ctx context.Context, gtw *ttnpb.Gateway, msg *ttnpb.UplinkMessage, protocol string) {
+func registerReceiveUplink(ctx context.Context, gtw *ttnpb.Gateway, msg *ttnpb.GatewayUplinkMessage, protocol string) {
 	events.Publish(evtReceiveUp.NewWithIdentifiersAndData(ctx, gtw, msg))
 	gsMetrics.uplinkReceived.WithLabelValues(ctx, protocol).Inc()
 }
 
-func registerForwardUplink(ctx context.Context, gtw *ttnpb.Gateway, msg *ttnpb.UplinkMessage, host string) {
+func registerForwardUplink(ctx context.Context, gtw *ttnpb.Gateway, msg *ttnpb.GatewayUplinkMessage, host string) {
 	events.Publish(evtForwardUp.NewWithIdentifiersAndData(ctx, gtw, host))
 	gsMetrics.uplinkForwarded.WithLabelValues(ctx, host).Inc()
 }

--- a/pkg/gatewayserver/observability.go
+++ b/pkg/gatewayserver/observability.go
@@ -42,6 +42,14 @@ var (
 		),
 		events.WithErrorDataType(),
 	)
+	evtGatewayConnectionStats = events.Define(
+		"gs.gateway.connection.stats", "gateway connection statistics",
+		events.WithVisibility(
+			ttnpb.Right_RIGHT_GATEWAY_LINK,
+			ttnpb.Right_RIGHT_GATEWAY_STATUS_READ,
+		),
+		events.WithDataType(&ttnpb.GatewayConnectionStats{}),
+	)
 	evtReceiveStatus = events.Define(
 		"gs.status.receive", "receive gateway status",
 		events.WithVisibility(ttnpb.Right_RIGHT_GATEWAY_STATUS_READ),
@@ -271,6 +279,10 @@ func registerGatewayConnect(ctx context.Context, ids ttnpb.GatewayIdentifiers, p
 func registerGatewayDisconnect(ctx context.Context, ids ttnpb.GatewayIdentifiers, protocol string, err error) {
 	events.Publish(evtGatewayDisconnect.NewWithIdentifiersAndData(ctx, &ids, err))
 	gsMetrics.gatewaysConnected.WithLabelValues(ctx, protocol).Dec()
+}
+
+func registerGatewayConnectionStats(ctx context.Context, ids ttnpb.GatewayIdentifiers, stats *ttnpb.GatewayConnectionStats) {
+	events.Publish(evtGatewayConnectionStats.NewWithIdentifiersAndData(ctx, &ids, stats))
 }
 
 func registerReceiveStatus(ctx context.Context, gtw *ttnpb.Gateway, status *ttnpb.GatewayStatus, protocol string) {

--- a/pkg/webui/console/components/events/utils/definitions.js
+++ b/pkg/webui/console/components/events/utils/definitions.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import DownlinkMessage from '../previews/downlink-message'
-import UplinkMessage from '../previews/uplink-message'
+import GatewayUplinkMessage from '../previews/gateway-uplink-message'
 import ApplicationDownlink from '../previews/application-downlink'
 import ApplicationUplink from '../previews/application-uplink'
 import ApplicationUp from '../previews/application-up'
@@ -101,7 +101,7 @@ export const dataTypeMap = {
   ApplicationUp,
   ApplicationLocation,
   DownlinkMessage,
-  UplinkMessage,
+  GatewayUplinkMessage,
   JoinRequest,
   JoinResponse,
   ErrorDetails,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Gateway Server groundwork for https://github.com/TheThingsIndustries/lorawan-stack/issues/3161

#### Changes
<!-- What are the changes made in this pull request? -->

- Add new `gs.gateway.connection.stats` event that publishes connection stats changes, besides being persisted in the stats registry
- Increased the debounce time; writing and publishing stats every 5 seconds is too often
- Change event data type of `gs.up.receive` to `GatewayUplinkMessage` instead of `UplinkMessage`

#### Testing

<!-- How did you verify that this change works? -->

Local testing

Console event row:

<img width="1194" alt="Screen Shot 2022-04-29 at 18 09 30" src="https://user-images.githubusercontent.com/13334001/165982649-f484f4a8-9e90-4965-bd63-e96e56fb607c.png">


##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None expected, unless clients rely on the data type of `gs.up.receive`.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@htdvisser @kschiffer  @adriansmares @pgalic96 no need to review

@KrishnaIyer @nicholaspcr  please review GS
@ryaplots please review Console

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
