### PR TITLE
Get NS address from TTJS configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ For details about compatibility between different releases, see the **Commitment
   - Automatically updating session info (no refresh necessary to schedule downlinks after a device has joined).
   - Showing session start time.
 - The Things Stack is now built with Go 1.18.
+- The Network Server Address used for End Device Claiming is fetched from the configuration instead of client input.
 
 ### Deprecated
 

--- a/config/messages.json
+++ b/config/messages.json
@@ -3509,15 +3509,6 @@
       "file": "ttjs.go"
     }
   },
-  "error:pkg/deviceclaimingserver/enddevices/ttjs:invalid_ns_address": {
-    "translations": {
-      "en": "invalid NS address `{address}`"
-    },
-    "description": {
-      "package": "pkg/deviceclaimingserver/enddevices/ttjs",
-      "file": "ttjs.go"
-    }
-  },
   "error:pkg/deviceclaimingserver/enddevices/ttjs:invalid_oui": {
     "translations": {
       "en": "invalid OUI `{oui}`"

--- a/config/messages.json
+++ b/config/messages.json
@@ -3509,6 +3509,15 @@
       "file": "ttjs.go"
     }
   },
+  "error:pkg/deviceclaimingserver/enddevices/ttjs:invalid_ns_address": {
+    "translations": {
+      "en": "invalid NS address `{address}`"
+    },
+    "description": {
+      "package": "pkg/deviceclaimingserver/enddevices/ttjs",
+      "file": "ttjs.go"
+    }
+  },
   "error:pkg/deviceclaimingserver/enddevices/ttjs:invalid_oui": {
     "translations": {
       "en": "invalid OUI `{oui}`"
@@ -3525,15 +3534,6 @@
     "description": {
       "package": "pkg/deviceclaimingserver/enddevices/ttjs",
       "file": "messages.go"
-    }
-  },
-  "error:pkg/deviceclaimingserver/enddevices/ttjs:no_home_ns_id": {
-    "translations": {
-      "en": "no HomeNSID configured for network server address `{address}`"
-    },
-    "description": {
-      "package": "pkg/deviceclaimingserver/enddevices/ttjs",
-      "file": "ttjs.go"
     }
   },
   "error:pkg/deviceclaimingserver/enddevices/ttjs:unauthorized": {

--- a/pkg/deviceclaimingserver/enddevices/config.go
+++ b/pkg/deviceclaimingserver/enddevices/config.go
@@ -26,9 +26,16 @@ import (
 // JSClientConfigurationName is the filename of Join Server client configuration.
 const JSClientConfigurationName = "config.yml"
 
+// NetworkServer contains information related to the Network Server.
+type NetworkServer struct {
+	Hostname string `name:"hostname" description:"Hostname of the Network Server. Must not contain a port"`
+	HomeNSID string `name:"home-ns-id" description:"HomeNSID of the Network Server. Must be a valid EUI"`
+}
+
 // Config contains options for end device claiming clients.
 type Config struct {
-	NetID types.NetID `name:"net-id" description:"NetID of this network to configure as home NetID when claiming"`
+	NetID         types.NetID   `name:"net-id" description:"NetID of this network to configure as home NetID when claiming"`
+	NetworkServer NetworkServer `name:"network-server" description:"Network Server of the cluster that handles claimed device traffic"`
 
 	Source    string                `name:"source" description:"Source of the file containing Join Server settings (directory, url, blob)"`
 	Directory string                `name:"directory" description:"OS filesystem directory, which contains the config.yml and the client-specific files"`

--- a/pkg/deviceclaimingserver/enddevices/config.go
+++ b/pkg/deviceclaimingserver/enddevices/config.go
@@ -28,8 +28,8 @@ const JSClientConfigurationName = "config.yml"
 
 // NetworkServer contains information related to the Network Server.
 type NetworkServer struct {
-	Hostname string `name:"hostname" description:"Hostname of the Network Server. Must not contain a port"`
-	HomeNSID string `name:"home-ns-id" description:"HomeNSID of the Network Server. Must be a valid EUI"`
+	Hostname string      `name:"hostname" description:"Hostname of the Network Server. Must not contain a port"`
+	HomeNSID types.EUI64 `name:"home-ns-id" description:"HomeNSID of the Network Server (EUI)"`
 }
 
 // Config contains options for end device claiming clients.

--- a/pkg/deviceclaimingserver/enddevices/enddevices.go
+++ b/pkg/deviceclaimingserver/enddevices/enddevices.go
@@ -41,7 +41,7 @@ type EndDeviceClaimer interface {
 	// SupportsJoinEUI returns whether the Join Server supports this JoinEUI.
 	SupportsJoinEUI(joinEUI types.EUI64) bool
 	// Claim claims an End Device.
-	Claim(ctx context.Context, joinEUI, devEUI types.EUI64, claimAuthenticationCode, networkServerAddress string) error
+	Claim(ctx context.Context, joinEUI, devEUI types.EUI64, claimAuthenticationCode string) error
 	// GetClaimStatus returns the claim status an End Device.
 	GetClaimStatus(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers) (*ttnpb.GetClaimStatusResponse, error)
 	// Unclaim releases the claim on an End Device.
@@ -161,12 +161,12 @@ func (upstream *Upstream) joinEUIClaimer(ctx context.Context, joinEUI types.EUI6
 }
 
 // Claim implements EndDeviceClaimingServer.
-func (upstream *Upstream) Claim(ctx context.Context, joinEUI, devEUI types.EUI64, claimAuthenticationCode, networkServerAddress string) error {
+func (upstream *Upstream) Claim(ctx context.Context, joinEUI, devEUI types.EUI64, claimAuthenticationCode string) error {
 	claimer := upstream.joinEUIClaimer(ctx, joinEUI)
 	if claimer == nil {
 		return errClaimingNotSupported.WithAttributes("eui", joinEUI)
 	}
-	return claimer.Claim(ctx, joinEUI, devEUI, claimAuthenticationCode, networkServerAddress)
+	return claimer.Claim(ctx, joinEUI, devEUI, claimAuthenticationCode)
 }
 
 // Unclaim implements EndDeviceClaimingServer.

--- a/pkg/deviceclaimingserver/enddevices/enddevices.go
+++ b/pkg/deviceclaimingserver/enddevices/enddevices.go
@@ -110,15 +110,12 @@ func NewUpstream(ctx context.Context, conf Config, c Component, opts ...Option) 
 			if err := yaml.UnmarshalStrict(configBytes, &ttjsConfig); err != nil {
 				return nil, err
 			}
+
 			ttjsConfig.NetID = conf.NetID
 			ttjsConfig.JoinEUIPrefixes = js.JoinEUIs
-			ttjsConfig.NetworkServer = struct {
-				Hostname string
-				HomeNSID string
-			}{
-				Hostname: conf.NetworkServer.Hostname,
-				HomeNSID: conf.NetworkServer.HomeNSID,
-			}
+			ttjsConfig.NetworkServer.HomeNSID = conf.NetworkServer.HomeNSID
+			ttjsConfig.NetworkServer.Hostname = conf.NetworkServer.Hostname
+
 			s, err = ttjsConfig.NewClient(ctx, c)
 			if err != nil {
 				return nil, err

--- a/pkg/deviceclaimingserver/enddevices/enddevices.go
+++ b/pkg/deviceclaimingserver/enddevices/enddevices.go
@@ -112,6 +112,13 @@ func NewUpstream(ctx context.Context, conf Config, c Component, opts ...Option) 
 			}
 			ttjsConfig.NetID = conf.NetID
 			ttjsConfig.JoinEUIPrefixes = js.JoinEUIs
+			ttjsConfig.NetworkServer = struct {
+				Hostname string
+				HomeNSID string
+			}{
+				Hostname: conf.NetworkServer.Hostname,
+				HomeNSID: conf.NetworkServer.HomeNSID,
+			}
 			s, err = ttjsConfig.NewClient(ctx, c)
 			if err != nil {
 				return nil, err

--- a/pkg/deviceclaimingserver/enddevices/enddevices_test.go
+++ b/pkg/deviceclaimingserver/enddevices/enddevices_test.go
@@ -47,6 +47,10 @@ func TestUpstream(t *testing.T) {
 		NetID:     test.DefaultNetID,
 		Source:    "directory",
 		Directory: "testdata",
+		NetworkServer: NetworkServer{
+			Hostname: "localhost",
+			HomeNSID: "0000000000000000",
+		},
 	}
 
 	upstream, err = NewUpstream(ctx, *conf, mock, WithDeviceRegistry(mock))

--- a/pkg/deviceclaimingserver/enddevices/enddevices_test.go
+++ b/pkg/deviceclaimingserver/enddevices/enddevices_test.go
@@ -55,7 +55,7 @@ func TestUpstream(t *testing.T) {
 	ctx = rights.NewContextWithFetcher(ctx, mock)
 
 	// Invalid JoinEUI.
-	err = upstream.Claim(ctx, *unsupportedJoinEUI, types.EUI64{0x00, 0x04, 0xA3, 0x0B, 0x00, 0x1C, 0x05, 0x30}, "secret", "")
+	err = upstream.Claim(ctx, *unsupportedJoinEUI, types.EUI64{0x00, 0x04, 0xA3, 0x0B, 0x00, 0x1C, 0x05, 0x30}, "secret")
 	a.So(errors.IsAborted(err), should.BeTrue)
 
 	_, err = upstream.Unclaim(ctx, &ttnpb.EndDeviceIdentifiers{
@@ -82,7 +82,7 @@ func TestUpstream(t *testing.T) {
 	a.So(inf.JoinEui, should.Resemble, supportedJoinEUI)
 	a.So(inf.SupportsClaiming, should.BeTrue)
 
-	err = upstream.Claim(ctx, *supportedJoinEUI, types.EUI64{0x00, 0x04, 0xA3, 0x0B, 0x00, 0x1C, 0x05, 0x30}, "secret", "")
+	err = upstream.Claim(ctx, *supportedJoinEUI, types.EUI64{0x00, 0x04, 0xA3, 0x0B, 0x00, 0x1C, 0x05, 0x30}, "secret")
 	a.So(!errors.IsUnimplemented(err), should.BeTrue)
 
 	_, err = upstream.Unclaim(ctx, &ttnpb.EndDeviceIdentifiers{

--- a/pkg/deviceclaimingserver/enddevices/enddevices_test.go
+++ b/pkg/deviceclaimingserver/enddevices/enddevices_test.go
@@ -49,7 +49,7 @@ func TestUpstream(t *testing.T) {
 		Directory: "testdata",
 		NetworkServer: NetworkServer{
 			Hostname: "localhost",
-			HomeNSID: "0000000000000000",
+			HomeNSID: types.EUI64{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
 		},
 	}
 

--- a/pkg/deviceclaimingserver/enddevices/testdata/localhost.yml
+++ b/pkg/deviceclaimingserver/enddevices/testdata/localhost.yml
@@ -4,6 +4,3 @@ tenant-id: test
 basic-auth:
   username: 'localhost'
   password: 'secret'
-ns:
-  address: localhost
-  home-ns-id: "0000000000000000"

--- a/pkg/deviceclaimingserver/enddevices/testdata/localhost.yml
+++ b/pkg/deviceclaimingserver/enddevices/testdata/localhost.yml
@@ -4,5 +4,6 @@ tenant-id: test
 basic-auth:
   username: 'localhost'
   password: 'secret'
-home-ns-ids:
-  localhost: "0000000000000000"
+ns:
+  address: localhost
+  home-ns-id: "0000000000000000"

--- a/pkg/deviceclaimingserver/enddevices/ttjs/ttjs.go
+++ b/pkg/deviceclaimingserver/enddevices/ttjs/ttjs.go
@@ -43,7 +43,7 @@ type BasicAuth struct {
 	Password string `yaml:"password"`
 }
 
-// NS contains information related to the Network Server
+// NS contains information related to the Network Server.
 type NS struct {
 	Address  string `yaml:"address"`
 	HomeNSID string `yaml:"home-ns-id"`
@@ -79,7 +79,7 @@ type TTJS struct {
 	ttiVendorID OUI
 }
 
-var nsAddressRegexp = regexp.MustCompile("^(?:(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*(?:[A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])(?::[0-9]{1,5})?$|^$")
+var nsAddressRegexp = regexp.MustCompile("^(?:(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*(?:[A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])(?::[0-9]{1,5})?$")
 
 var errInvalidNSAddress = errors.DefineInvalidArgument("invalid_ns_address", "invalid NS address `{address}`")
 

--- a/pkg/deviceclaimingserver/enddevices/ttjs/ttjs.go
+++ b/pkg/deviceclaimingserver/enddevices/ttjs/ttjs.go
@@ -41,13 +41,17 @@ type BasicAuth struct {
 	Password string `yaml:"password"`
 }
 
+// NetworkServer contains information related to the Network Server.
+type NetworkServer struct {
+	Hostname string
+	HomeNSID types.EUI64
+}
+
 // Config is the configuration to communicate with The Things Join Server End Device Claming API.
 type Config struct {
 	NetID           types.NetID         `yaml:"-"`
 	JoinEUIPrefixes []types.EUI64Prefix `yaml:"-"`
-	NetworkServer   struct {
-		Hostname, HomeNSID string
-	} `yaml:"-"`
+	NetworkServer   NetworkServer       `yaml:"-"`
 
 	BasicAuth          `yaml:"basic-auth"`
 	ClaimingAPIVersion string `yaml:"claiming-api-version"`
@@ -117,7 +121,7 @@ func (client *TTJS) Claim(ctx context.Context, joinEUI, devEUI types.EUI64, clai
 		OwnerToken: claimAuthenticationCode,
 		claimData: claimData{
 			HomeNetID: client.config.NetID.String(),
-			HomeNSID:  client.config.NetworkServer.HomeNSID,
+			HomeNSID:  client.config.NetworkServer.HomeNSID.String(),
 			VendorSpecific: VendorSpecific{
 				OUI: client.ttiVendorID,
 				Data: struct {

--- a/pkg/deviceclaimingserver/enddevices/ttjs/ttjs_test.go
+++ b/pkg/deviceclaimingserver/enddevices/ttjs/ttjs_test.go
@@ -98,33 +98,13 @@ func TestTTJS(t *testing.T) {
 		return mockTTJS.Start(ctx, apiVersion)
 	}()
 
-	// Invalid Config
-	invalidConfig := Config{
-		NS: NS{
-			Address:  "localhost:1234:34",
-			HomeNSID: "1234",
-		},
-		TenantID: tenantID,
-		NetID:    test.DefaultNetID,
-		JoinEUIPrefixes: []types.EUI64Prefix{
-			supportedJoinEUIPrefix,
-		},
-		ClaimingAPIVersion: apiVersion,
-		BasicAuth: BasicAuth{
-			Username: asID,
-			Password: "invalid",
-		},
-		URL: fmt.Sprintf("http://%s", lis.Addr().String()),
-	}
-
-	cl, err := invalidConfig.NewClient(ctx, c)
-	a.So(errors.IsInvalidArgument(err), should.BeTrue)
-	a.So(cl, should.BeNil)
-
 	// Valid Config
 	ttJSConfig := Config{
-		NS: NS{
-			Address:  "localhost",
+		NetworkServer: struct {
+			Hostname string
+			HomeNSID string
+		}{
+			Hostname: "localhost",
 			HomeNSID: homeNSID,
 		},
 		TenantID: tenantID,
@@ -222,8 +202,11 @@ func TestTTJS(t *testing.T) {
 
 	// Claim locked.
 	otherClientConfig := Config{
-		NS: NS{
-			Address:  "localhost",
+		NetworkServer: struct {
+			Hostname string
+			HomeNSID string
+		}{
+			Hostname: "localhost",
 			HomeNSID: homeNSID,
 		},
 		NetID: test.DefaultNetID,

--- a/pkg/deviceclaimingserver/enddevices/ttjs/ttjs_test.go
+++ b/pkg/deviceclaimingserver/enddevices/ttjs/ttjs_test.go
@@ -38,7 +38,7 @@ var (
 	otherClientASID         = "localhost-other"
 	claimAuthenticationCode = "SECRET"
 	nsAddress               = "localhost"
-	homeNSID                = "1122334455667788"
+	homeNSID                = types.EUI64{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88}
 	supportedJoinEUI        = types.EUI64{0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0C}
 	supportedJoinEUIPrefix  = types.EUI64Prefix{
 		EUI64:  supportedJoinEUI,
@@ -100,10 +100,7 @@ func TestTTJS(t *testing.T) {
 
 	// Valid Config
 	ttJSConfig := Config{
-		NetworkServer: struct {
-			Hostname string
-			HomeNSID string
-		}{
+		NetworkServer: NetworkServer{
 			Hostname: "localhost",
 			HomeNSID: homeNSID,
 		},
@@ -202,10 +199,7 @@ func TestTTJS(t *testing.T) {
 
 	// Claim locked.
 	otherClientConfig := Config{
-		NetworkServer: struct {
-			Hostname string
-			HomeNSID string
-		}{
+		NetworkServer: NetworkServer{
 			Hostname: "localhost",
 			HomeNSID: homeNSID,
 		},
@@ -265,7 +259,7 @@ func TestTTJS(t *testing.T) {
 	a.So(ret, should.NotBeNil)
 	a.So(ret.EndDeviceIds, should.Resemble, validEndDeviceIds)
 	a.So(*ret.HomeNetId, should.Resemble, test.DefaultNetID)
-	a.So(ret.HomeNsId.String(), should.Equal, homeNSID)
+	a.So(ret.HomeNsId.String(), should.Equal, homeNSID.String())
 	a.So(err, should.BeNil)
 	a.So(ret.VendorSpecific, should.NotBeNil)
 	a.So(ret.VendorSpecific.OrganizationUniqueIdentifier, should.Equal, 0xec656e)

--- a/pkg/deviceclaimingserver/grpc_end_devices.go
+++ b/pkg/deviceclaimingserver/grpc_end_devices.go
@@ -16,7 +16,6 @@ package deviceclaimingserver
 
 import (
 	"context"
-	"net"
 
 	pbtypes "github.com/gogo/protobuf/types"
 	"go.thethings.network/lorawan-stack/v3/pkg/auth/rights"
@@ -130,15 +129,7 @@ func (edcs *endDeviceClaimingServer) Claim(ctx context.Context, req *ttnpb.Claim
 		return nil, errNoJoinEUI.New()
 	}
 
-	// External services, including Join Servers, typically identify Network Servers by host instead of by host and port.
-	networkServerAddress, _, err := net.SplitHostPort(req.TargetNetworkServerAddress)
-	if err != nil {
-		// TargetNetworkServerAddress is already validated by the API.
-		// An error here means that it does not contain a port, so we use it directly.
-		networkServerAddress = req.TargetNetworkServerAddress
-	}
-
-	err = edcs.DCS.endDeviceClaimingUpstream.Claim(ctx, joinEUI, devEUI, claimAuthenticationCode, networkServerAddress)
+	err := edcs.DCS.endDeviceClaimingUpstream.Claim(ctx, joinEUI, devEUI, claimAuthenticationCode)
 	if err != nil {
 		if errors.IsAborted(err) {
 			log.FromContext(ctx).Warn("No upstream supports JoinEUI, use fallback")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #5404 

#### Changes
<!-- What are the changes made in this pull request? -->

- Fetch NS address and HomeNSID from config instead of ascertaining it from user input.
- Add new config and validate it.
- Update interface
- Update tests


#### Testing

<!-- How did you verify that this change works? -->

Local

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

NA

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

- This technically counts as breaking configuration but no one else currently uses the DCS for claiming with TTJS and this only exists in staging for now. So I think this is fine.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
