### PR TITLE
Fix CLI flags usage for End Device commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Fixed
 
 - Support `app_eui` as alias for `join_eui` in CSV file import, per documentation.
+- CLI not allowing devices to be created or updated.
 
 ### Security
 

--- a/cmd/ttn-lw-cli/commands/applications.go
+++ b/cmd/ttn-lw-cli/commands/applications.go
@@ -30,7 +30,7 @@ import (
 )
 
 var (
-	selectApplicationFlags = &pflag.FlagSet{}
+	selectApplicationFlags = util.NormalizedFlagSet()
 
 	selectAllApplicationFlags = util.SelectAllFlagSet("application")
 )

--- a/cmd/ttn-lw-cli/commands/applications_activation_settings.go
+++ b/cmd/ttn-lw-cli/commands/applications_activation_settings.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	selectApplicationActivationSettingsFlags = &pflag.FlagSet{}
+	selectApplicationActivationSettingsFlags = util.NormalizedFlagSet()
 
 	selectAllApplicationActivationSettingsFlags = util.SelectAllFlagSet("application activation settings")
 )

--- a/cmd/ttn-lw-cli/commands/applications_link.go
+++ b/cmd/ttn-lw-cli/commands/applications_link.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	selectApplicationLinkFlags = &pflag.FlagSet{}
+	selectApplicationLinkFlags = util.NormalizedFlagSet()
 
 	selectAllApplicationLinkFlags = util.SelectAllFlagSet("application link")
 )

--- a/cmd/ttn-lw-cli/commands/applications_packages.go
+++ b/cmd/ttn-lw-cli/commands/applications_packages.go
@@ -32,8 +32,8 @@ import (
 )
 
 var (
-	selectApplicationPackageAssociationsFlags        = &pflag.FlagSet{}
-	selectApplicationPackageDefaultAssociationsFlags = &pflag.FlagSet{}
+	selectApplicationPackageAssociationsFlags        = util.NormalizedFlagSet()
+	selectApplicationPackageDefaultAssociationsFlags = util.NormalizedFlagSet()
 
 	selectAllApplicationPackageAssociationsFlags        = util.SelectAllFlagSet("application package association")
 	selectAllApplicationPackageDefaultAssociationsFlags = util.SelectAllFlagSet("application package default association")

--- a/cmd/ttn-lw-cli/commands/applications_pubsub.go
+++ b/cmd/ttn-lw-cli/commands/applications_pubsub.go
@@ -30,13 +30,13 @@ import (
 )
 
 var (
-	selectApplicationPubSubFlags = &pflag.FlagSet{}
-	setApplicationPubSubFlags    = &pflag.FlagSet{}
+	selectApplicationPubSubFlags = util.NormalizedFlagSet()
+	setApplicationPubSubFlags    = util.NormalizedFlagSet()
 
-	natsProviderApplicationPubSubFlags   = &pflag.FlagSet{}
-	mqttProviderApplicationPubSubFlags   = &pflag.FlagSet{}
-	awsiotProviderApplicationPubSubFlags = &pflag.FlagSet{}
-	awsiotDefaultIntegrationPubSubFlags  = &pflag.FlagSet{}
+	natsProviderApplicationPubSubFlags   = util.NormalizedFlagSet()
+	mqttProviderApplicationPubSubFlags   = util.NormalizedFlagSet()
+	awsiotProviderApplicationPubSubFlags = util.NormalizedFlagSet()
+	awsiotDefaultIntegrationPubSubFlags  = util.NormalizedFlagSet()
 
 	selectAllApplicationPubSubFlags = util.SelectAllFlagSet("application pub/sub")
 )

--- a/cmd/ttn-lw-cli/commands/applications_webhooks.go
+++ b/cmd/ttn-lw-cli/commands/applications_webhooks.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	selectApplicationWebhookFlags = &pflag.FlagSet{}
+	selectApplicationWebhookFlags = util.NormalizedFlagSet()
 
 	selectAllApplicationWebhookFlags = util.SelectAllFlagSet("application webhook")
 )

--- a/cmd/ttn-lw-cli/commands/clients.go
+++ b/cmd/ttn-lw-cli/commands/clients.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	selectClientFlags = &pflag.FlagSet{}
+	selectClientFlags = util.NormalizedFlagSet()
 
 	selectAllClientFlags = util.SelectAllFlagSet("client")
 )

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -1369,13 +1369,15 @@ func init() {
 
 	allEndDeviceSelectFlags.VisitAll(func(flag *pflag.Flag) {
 		fieldName := toUnderscore.Replace(flag.Name)
-		if ttnpb.ContainsField(fieldName, getEndDeviceFromIS) {
-			selectEndDeviceListFlags.AddFlag(flag)
-			selectEndDeviceFlags.AddFlag(flag)
-		} else if ttnpb.ContainsField(fieldName, getEndDeviceFromNS) ||
-			ttnpb.ContainsField(fieldName, getEndDeviceFromAS) ||
-			ttnpb.ContainsField(fieldName, getEndDeviceFromJS) {
-			selectEndDeviceFlags.AddFlag(flag)
+		selectEndDeviceListFlags.AddFlag(flag)
+		selectEndDeviceFlags.AddFlag(flag)
+		if !ttnpb.ContainsField(fieldName, getEndDeviceFromIS) {
+			util.HideFlag(selectEndDeviceListFlags, flag.Name)
+			if !ttnpb.ContainsField(fieldName, getEndDeviceFromNS) &&
+				!ttnpb.ContainsField(fieldName, getEndDeviceFromAS) &&
+				!ttnpb.ContainsField(fieldName, getEndDeviceFromJS) {
+				util.HideFlag(selectEndDeviceFlags, flag.Name)
+			}
 		}
 	})
 
@@ -1384,11 +1386,12 @@ func init() {
 
 	allEndDeviceSetFlags.VisitAll(func(flag *pflag.Flag) {
 		fieldName := toUnderscore.Replace(flag.Name)
-		if ttnpb.ContainsField(fieldName, setEndDeviceToIS) ||
-			ttnpb.ContainsField(fieldName, setEndDeviceToNS) ||
-			ttnpb.ContainsField(fieldName, setEndDeviceToAS) ||
-			ttnpb.ContainsField(fieldName, setEndDeviceToJS) {
-			setEndDeviceFlags.AddFlag(flag)
+		setEndDeviceFlags.AddFlag(flag)
+		if !ttnpb.ContainsField(fieldName, setEndDeviceToIS) &&
+			!ttnpb.ContainsField(fieldName, setEndDeviceToNS) &&
+			!ttnpb.ContainsField(fieldName, setEndDeviceToAS) &&
+			!ttnpb.ContainsField(fieldName, setEndDeviceToJS) {
+			util.HideFlag(setEndDeviceFlags, flag.Name)
 		}
 	})
 

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -39,15 +39,15 @@ import (
 )
 
 var (
-	selectEndDeviceListFlags   = &pflag.FlagSet{}
-	selectEndDeviceFlags       = &pflag.FlagSet{}
-	setEndDeviceFlags          = &pflag.FlagSet{}
+	selectEndDeviceListFlags   = util.NormalizedFlagSet()
+	selectEndDeviceFlags       = util.NormalizedFlagSet()
+	setEndDeviceFlags          = util.NormalizedFlagSet()
 	endDeviceFlattenPaths      = []string{"provisioning_data"}
-	endDevicePictureFlags      = &pflag.FlagSet{}
-	endDeviceLocationFlags     = &pflag.FlagSet{}
-	getDefaultMACSettingsFlags = &pflag.FlagSet{}
-	allEndDeviceSetFlags       = &pflag.FlagSet{}
-	allEndDeviceSelectFlags    = &pflag.FlagSet{}
+	endDevicePictureFlags      = util.NormalizedFlagSet()
+	endDeviceLocationFlags     = util.NormalizedFlagSet()
+	getDefaultMACSettingsFlags = util.NormalizedFlagSet()
+	allEndDeviceSetFlags       = util.NormalizedFlagSet()
+	allEndDeviceSelectFlags    = util.NormalizedFlagSet()
 
 	selectAllEndDeviceFlags = util.SelectAllFlagSet("end devices")
 	toUnderscore            = strings.NewReplacer("-", "_")

--- a/cmd/ttn-lw-cli/commands/gateways.go
+++ b/cmd/ttn-lw-cli/commands/gateways.go
@@ -31,7 +31,7 @@ import (
 )
 
 var (
-	selectGatewayFlags    = &pflag.FlagSet{}
+	selectGatewayFlags    = util.NormalizedFlagSet()
 	selectAllGatewayFlags = util.SelectAllFlagSet("gateway")
 
 	gatewayFlattenPaths = []string{"lbs_lns_secret", "claim_authentication_code", "target_cups_key"}

--- a/cmd/ttn-lw-cli/commands/organizations.go
+++ b/cmd/ttn-lw-cli/commands/organizations.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	selectOrganizationFlags = &pflag.FlagSet{}
+	selectOrganizationFlags = util.NormalizedFlagSet()
 
 	selectAllOrganizationFlags = util.SelectAllFlagSet("organization")
 )

--- a/cmd/ttn-lw-cli/commands/storage_integration_util.go
+++ b/cmd/ttn-lw-cli/commands/storage_integration_util.go
@@ -25,7 +25,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 )
 
-var applicationUpFlags = &pflag.FlagSet{}
+var applicationUpFlags = util.NormalizedFlagSet()
 
 func getStoredUpFlags() *pflag.FlagSet {
 	flags := &pflag.FlagSet{}

--- a/cmd/ttn-lw-cli/commands/users.go
+++ b/cmd/ttn-lw-cli/commands/users.go
@@ -30,8 +30,8 @@ import (
 )
 
 var (
-	selectUserFlags     = &pflag.FlagSet{}
-	profilePictureFlags = &pflag.FlagSet{}
+	selectUserFlags     = util.NormalizedFlagSet()
+	profilePictureFlags = util.NormalizedFlagSet()
 
 	selectAllUserFlags = util.SelectAllFlagSet("user")
 )

--- a/cmd/ttn-lw-cli/internal/util/flags.go
+++ b/cmd/ttn-lw-cli/internal/util/flags.go
@@ -30,6 +30,13 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 )
 
+// NormalizedFlagSet returns a flagset with a NormalizeFunc that replaces underscores to dashes.
+func NormalizedFlagSet() *pflag.FlagSet {
+	fs := &pflag.FlagSet{}
+	fs.SetNormalizeFunc(NormalizeFlags)
+	return fs
+}
+
 // DeprecateFlag deprecates a CLI flag.
 func DeprecateFlag(flagSet *pflag.FlagSet, old string, new string) {
 	if newFlag := flagSet.Lookup(new); newFlag != nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Refs; https://github.com/TheThingsIndustries/lorawan-stack-support/issues/778

#### Changes
<!-- What are the changes made in this pull request? -->

1. Make sure that any independent use of `&pflag.Flagset{}` uses the variant with the `toDash` normalizer.
2. Update `{set|select}EndDeviceFlags` logic to hide unused flags instead of not adding them.
3. Update all **exposed var flagsets** to use the normalized version.

#### Testing

<!-- How did you verify that this change works? -->

Locally:
```
Devices
-------

~/go/src/go.thethings.network/lorawan-stack (fix/flags*) » ./ttn-lw-cli end-devices create test-app test-cli-10  \
  --dev-eui 70B3D57ED8000884 \
  --join-eui 0000000000000003 \
  --frequency-plan-id EU_863_870 \
  --root-keys.app-key.key 752BAEC23EAE7964AF27C325F4C23C9A \
  --lorawan-version 1.0.3 \
  --lorawan-phy-version 1.0.3-a
WARN	Using insecure connection to OAuth server
WARN	Using insecure connection to API
{
  "ids": {
    "device_id": "test-cli-10",
    "application_ids": {
      "application_id": "test-app"
    },
    "dev_eui": "70B3D57ED8000884",
    "join_eui": "0000000000000003"
  },
  "created_at": "2022-05-06T11:13:11.849Z",
  "updated_at": "2022-05-06T11:13:11.924928Z",
  "attributes": {},
  "network_server_address": "localhost",
  "application_server_address": "localhost",
  "join_server_address": "localhost",
  "lorawan_version": "MAC_V1_0_3",
  "lorawan_phy_version": "PHY_V1_0_3_REV_A",
  "frequency_plan_id": "EU_863_870",
  "supports_join": true,
  "root_keys": {
    "app_key": {
      "key": "752BAEC23EAE7964AF27C325F4C23C9A"
    }
  }
}
----------------------------------------------------------------------------------------------------------------------
~/go/src/go.thethings.network/lorawan-stack (fix/flags*) » gs              krishnaiyereaswaran@Krishnas-MacBook-Pro-2
----------------------------------------------------------------------------------------------------------------------
~/go/src/go.thethings.network/lorawan-stack (fix/flags*) » ./ttn-lw-cli end-devices get test-app test-cli-10 --root-keys
WARN	Using insecure connection to OAuth server
WARN	Using insecure connection to API
{
  "ids": {
    "device_id": "test-cli-10",
    "application_ids": {
      "application_id": "test-app"
    },
    "dev_eui": "70B3D57ED8000884",
    "join_eui": "0000000000000003"
  },
  "created_at": "2022-05-06T11:13:11.849Z",
  "updated_at": "2022-05-06T11:13:11.879473Z",
  "join_server_address": "localhost",
  "root_keys": {
    "app_key": {
      "key": "752BAEC23EAE7964AF27C325F4C23C9A"
    }
  }
}
----------------------------------------------------------------------------------------------------------------------
~/go/src/go.thethings.network/lorawan-stack (fix/flags*) » ./ttn-lw-cli end-devices set test-app test-cli-10 --root-keys.app-key.key 752BAEC23EAE7964AF27C325F4C23C9B
WARN	Using insecure connection to OAuth server
WARN	Using insecure connection to API
{
  "ids": {
    "device_id": "test-cli-10",
    "application_ids": {
      "application_id": "test-app"
    },
    "dev_eui": "70B3D57ED8000884",
    "join_eui": "0000000000000003"
  },
  "created_at": "2022-05-06T11:13:11.849Z",
  "updated_at": "2022-05-06T11:13:57.897814Z",
  "join_server_address": "localhost",
  "root_keys": {
    "app_key": {
      "key": "752BAEC23EAE7964AF27C325F4C23C9B"
    }
  }
}
----------------------------------------------------------------------------------------------------------------------
~/go/src/go.thethings.network/lorawan-stack (fix/flags*) » ./ttn-lw-cli end-devices delete test-app test-cli-10
WARN	Using insecure connection to OAuth server
WARN	Using insecure connection to API


NET ID

~/go/src/go.thethings.network/lorawan-stack (fix/flags*) » ./ttn-lw-cli end-devices set test-app test-cli-10 --net-id
000013
WARN	Using insecure connection to OAuth server
WARN	Using insecure connection to API
{
  "ids": {
    "device_id": "test-cli-10",
    "application_ids": {
      "application_id": "test-app"
    },
    "dev_eui": "70B3D57ED8000884",
    "join_eui": "0000000000000003"
  },
  "created_at": "2022-05-06T11:18:48.748Z",
  "updated_at": "2022-05-06T11:19:04.089256Z",
  "join_server_address": "localhost",
  "net_id": "000013"
}
```

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This was pretty broken but I've done a few regression tests on users.

```
Users
-----

Create a user

Usage:
  ttn-lw-cli users create [user-id] [flags]

Aliases:
  create, add, register

Flags:
      --admin
      --attributes stringToString
      --description string
  -h, --help                                           help for create
      --invitation-token string
      --name string
      --password string
      --primary-email-address string
      --primary-email-address-validated-at timestamp
      --profile-picture string                         upload the profile picture from this file
      --require-password-update
      --state string                                   allowed values: STATE_REQUESTED, STATE_APPROVED, STATE_REJECTED, STATE_FLAGGED, STATE_SUSPENDED
      --state-description string
      --temporary-password string
      --user-id string

Global Flags:
      --allow-unknown-hosts                             Allow sending credentials to unknown hosts
      --application-server-enabled                      Application Server enabled (default true)
      --application-server-grpc-address string          Application Server address (default "localhost:8884")
      --ca string                                       CA certificate file
  -c, --config strings                                  Location of the config files
      --credentials-id string                           Credentials ID (if using multiple configurations)
      --device-claiming-server-grpc-address string      Device Claiming Server address (default "localhost:8884")
      --device-template-converter-grpc-address string   Device Template Converter address (default "localhost:8884")
      --dump-requests                                   When log level is set to debug, also dump request payload as JSON
      --experimental.features strings                   Experimental features to activate
      --gateway-server-enabled                          Gateway Server enabled (default true)
      --gateway-server-grpc-address string              Gateway Server address (default "localhost:8884")
      --identity-server-grpc-address string             Identity Server address (default "localhost:8884")
      --input-format string                             Input format (default "json")
      --insecure                                        Connect without TLS
      --join-server-enabled                             Join Server enabled (default true)
      --join-server-grpc-address string                 Join Server address (default "localhost:8884")
      --log.format string                               Log format to write (console, json) (default "console")
      --log.level string                                The minimum level log messages must have to be shown (default "info")
      --network-server-enabled                          Network Server enabled (default true)
      --network-server-grpc-address string              Network Server address (default "localhost:8884")
      --oauth-server-address string                     OAuth Server address (default "https://localhost/oauth")
      --output-format string                            Output format (default "json")
      --packet-broker-agent-grpc-address string         Packet Broker Agent address (default "localhost:8884")
      --qr-code-generator-grpc-address string           QR Code Generator address (default "localhost:8884")
      --retry-config.default-timeout duration           Default timeout between retry attempts (default 100ms)
      --retry-config.enable-metadata                    Use request response metadata to dynamically calculate timeout between retry attempts (default true)
      --retry-config.jitter float                       Fraction that creates a deviation of the timeout used between retry attempts
      --retry-config.max uint                           Maximum amount of times that a request can be reattempted
      --skip-version-check                              Do not perform version checks

~/go/src/go.thethings.network/lorawan-stack (fix/flags*) » ./ttn-lw-cli users create --user-id test-user-1 --primary-email-address test1@test.com
WARN  Using insecure connection to OAuth server
WARN  Using insecure connection to API
INFO  Password Requirements:
INFO  Minimum length: 8
INFO  Maximum length: 1000
INFO  Minimum uppercase: 1
INFO  Minimum digits: 1
Please enter password:**********
Please confirm password:**********
{
  "ids": {
    "user_id": "test-user-1"
  },
  "created_at": "2022-05-06T10:55:33.296Z",
  "updated_at": "2022-05-06T10:55:33.296Z",
  "contact_info": [
    {
      "contact_method": "CONTACT_METHOD_EMAIL",
      "value": "test1@test.com"
    }
  ],
  "primary_email_address": "test1@test.com",
  "password_updated_at": "2022-05-06T10:55:33.294Z",
  "state": "STATE_APPROVED"
}


~/go/src/go.thethings.network/lorawan-stack (fix/flags*) » ./ttn-lw-cli users list
WARN  Using insecure connection to OAuth server
WARN  Using insecure connection to API
INFO  Use the flags "--limit=0 --page=1" to get the next page of results  {"total": 3}
[{
  "ids": {
    "user_id": "admin"
  },
  "created_at": "2022-05-05T16:40:52.159Z",
  "updated_at": "2022-05-05T16:40:52.159Z"
}, {
  "ids": {
    "user_id": "test-user"
  },
  "created_at": "2022-05-06T10:51:27.392Z",
  "updated_at": "2022-05-06T10:51:27.392Z"
}, {
  "ids": {
    "user_id": "test-user-1"
  },
  "created_at": "2022-05-06T10:55:33.296Z",
  "updated_at": "2022-05-06T10:55:33.296Z"
}]


~/go/src/go.thethings.network/lorawan-stack (fix/flags*) » ./ttn-lw-cli users get --user-id test-user-1 --primary-emai
l-address
WARN  Using insecure connection to OAuth server
WARN  Using insecure connection to API
{
  "ids": {
    "user_id": "test-user-1"
  },
  "created_at": "2022-05-06T10:55:33.296Z",
  "updated_at": "2022-05-06T10:55:33.296Z",
  "primary_email_address": "test1@test.com"
}


~/go/src/go.thethings.network/lorawan-stack (fix/flags*) » ./ttn-lw-cli users set --user-id test-user-1 --primary-email-address a@b.com
WARN  Using insecure connection to OAuth server
WARN  Using insecure connection to API
{
  "ids": {
    "user_id": "test-user-1"
  },
  "created_at": "2022-05-06T10:55:33.296Z",
  "updated_at": "2022-05-06T10:57:34.785Z",
  "primary_email_address": "a@b.com"
}

~/go/src/go.thethings.network/lorawan-stack (fix/flags*) » ./ttn-lw-cli users get --user-id test-user-1 --primary-email-address
WARN  Using insecure connection to OAuth server
WARN  Using insecure connection to API
{
  "ids": {
    "user_id": "test-user-1"
  },
  "created_at": "2022-05-06T10:55:33.296Z",
  "updated_at": "2022-05-06T10:57:34.785Z",
  "primary_email_address": "a@b.com"
}


~/go/src/go.thethings.network/lorawan-stack (fix/flags*) » ./ttn-lw-cli users delete --user-id test-user-1
WARN  Using insecure connection to OAuth server
WARN  Using insecure connection to API


~/go/src/go.thethings.network/lorawan-stack (fix/flags*) » ./ttn-lw-cli users list
WARN  Using insecure connection to OAuth server
WARN  Using insecure connection to API
INFO  Use the flags "--limit=0 --page=1" to get the next page of results  {"total": 2}
[{
  "ids": {
    "user_id": "admin"
  },
  "created_at": "2022-05-05T16:40:52.159Z",
  "updated_at": "2022-05-05T16:40:52.159Z"
}, {
  "ids": {
    "user_id": "test-user"
  },
  "created_at": "2022-05-06T10:51:27.392Z",
  "updated_at": "2022-05-06T10:51:27.392Z"
}]
```

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
