### PR TITLE
Fix application lookup on device validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - Support `app_eui` as alias for `join_eui` in CSV file import, per documentation.
 - CLI not allowing devices to be created or updated.
+- End device creation no longer errors on missing application info rights.
 
 ### Security
 

--- a/pkg/identityserver/end_device_registry.go
+++ b/pkg/identityserver/end_device_registry.go
@@ -95,13 +95,14 @@ func (is *IdentityServer) validateEndDeviceServerAddressMatch(ctx context.Contex
 	if dev.NetworkServerAddress == "" && dev.ApplicationServerAddress == "" && dev.JoinServerAddress == "" {
 		return nil
 	}
-	app, err := is.getApplication(ctx, &ttnpb.GetApplicationRequest{
-		ApplicationIds: dev.Ids.ApplicationIds,
-		FieldMask: ttnpb.FieldMask(
+	var app *ttnpb.Application
+	err := is.store.Transact(ctx, func(ctx context.Context, st store.Store) (err error) {
+		app, err = st.GetApplication(ctx, dev.GetIds().GetApplicationIds(), store.FieldMask{
 			"network_server_address",
 			"application_server_address",
 			"join_server_address",
-		),
+		})
+		return err
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request fixes an issue where end device create suddenly required application rights that it didn't need before (and doesn't actually need).

Refs https://github.com/TheThingsIndustries/lorawan-stack-support/issues/780

#### Changes
<!-- What are the changes made in this pull request? -->

- Instead of forwarding to another RPC, we just check the database directly.

#### Testing

<!-- How did you verify that this change works? -->

Covered by existing tests.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
