### PR TITLE
Include entity IDs in API key query if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Security
 
+- Security fix for an issue where the description and list of rights of arbitrary API keys could be retrieved by any logged-in user if the 24-bit random API key ID was known.
+
 ## [3.19.1] - 2022-05-04
 
 ### Changed

--- a/pkg/identityserver/application_access.go
+++ b/pkg/identityserver/application_access.go
@@ -139,7 +139,7 @@ func (is *IdentityServer) getApplicationAPIKey(ctx context.Context, req *ttnpb.G
 	}
 
 	err = is.store.Transact(ctx, func(ctx context.Context, st store.Store) (err error) {
-		_, key, err = st.GetAPIKey(ctx, req.KeyId)
+		key, err = st.GetAPIKey(ctx, req.GetApplicationIds().GetEntityIdentifiers(), req.KeyId)
 		if err != nil {
 			return err
 		}
@@ -166,7 +166,7 @@ func (is *IdentityServer) updateApplicationAPIKey(ctx context.Context, req *ttnp
 
 	err = is.store.Transact(ctx, func(ctx context.Context, st store.Store) (err error) {
 		if len(req.ApiKey.Rights) > 0 {
-			_, key, err := st.GetAPIKey(ctx, req.ApiKey.Id)
+			key, err := st.GetAPIKey(ctx, req.GetApplicationIds().GetEntityIdentifiers(), req.ApiKey.Id)
 			if err != nil {
 				return err
 			}

--- a/pkg/identityserver/entity_access.go
+++ b/pkg/identityserver/entity_access.go
@@ -105,7 +105,7 @@ func (is *IdentityServer) authInfo(ctx context.Context) (info *ttnpb.AuthInfoRes
 	switch tokenType {
 	case auth.APIKey:
 		fetch = func(ctx context.Context, st store.Store) error {
-			ids, apiKey, err := st.GetAPIKey(ctx, tokenID)
+			ids, apiKey, err := st.GetAPIKeyByID(ctx, tokenID)
 			if err != nil {
 				if errors.IsNotFound(err) {
 					return errAPIKeyNotFound.WithCause(err)

--- a/pkg/identityserver/gateway_access.go
+++ b/pkg/identityserver/gateway_access.go
@@ -139,7 +139,7 @@ func (is *IdentityServer) getGatewayAPIKey(ctx context.Context, req *ttnpb.GetGa
 	}
 
 	err = is.store.Transact(ctx, func(ctx context.Context, st store.Store) (err error) {
-		_, key, err = st.GetAPIKey(ctx, req.KeyId)
+		key, err = st.GetAPIKey(ctx, req.GetGatewayIds().GetEntityIdentifiers(), req.KeyId)
 		if err != nil {
 			return err
 		}
@@ -167,7 +167,7 @@ func (is *IdentityServer) updateGatewayAPIKey(ctx context.Context, req *ttnpb.Up
 	apiKey := req.GetApiKey()
 	err = is.store.Transact(ctx, func(ctx context.Context, st store.Store) (err error) {
 		if len(apiKey.Rights) > 0 {
-			_, key, err := st.GetAPIKey(ctx, apiKey.Id)
+			key, err := st.GetAPIKey(ctx, req.GetGatewayIds().GetEntityIdentifiers(), apiKey.Id)
 			if err != nil {
 				return err
 			}

--- a/pkg/identityserver/organization_access.go
+++ b/pkg/identityserver/organization_access.go
@@ -139,7 +139,7 @@ func (is *IdentityServer) getOrganizationAPIKey(ctx context.Context, req *ttnpb.
 	}
 
 	err = is.store.Transact(ctx, func(ctx context.Context, st store.Store) (err error) {
-		_, key, err = st.GetAPIKey(ctx, req.KeyId)
+		key, err = st.GetAPIKey(ctx, req.GetOrganizationIds().GetEntityIdentifiers(), req.KeyId)
 		if err != nil {
 			return err
 		}
@@ -166,7 +166,7 @@ func (is *IdentityServer) updateOrganizationAPIKey(ctx context.Context, req *ttn
 
 	err = is.store.Transact(ctx, func(ctx context.Context, st store.Store) (err error) {
 		if len(req.ApiKey.Rights) > 0 {
-			_, key, err := st.GetAPIKey(ctx, req.ApiKey.Id)
+			key, err := st.GetAPIKey(ctx, req.GetOrganizationIds().GetEntityIdentifiers(), req.ApiKey.Id)
 			if err != nil {
 				return err
 			}

--- a/pkg/identityserver/store/store_interfaces.go
+++ b/pkg/identityserver/store/store_interfaces.go
@@ -156,8 +156,10 @@ type APIKeyStore interface {
 	CreateAPIKey(ctx context.Context, entityID *ttnpb.EntityIdentifiers, key *ttnpb.APIKey) (*ttnpb.APIKey, error)
 	// Find API keys of the given entity.
 	FindAPIKeys(ctx context.Context, entityID *ttnpb.EntityIdentifiers) ([]*ttnpb.APIKey, error)
+	// Get an API key.
+	GetAPIKey(ctx context.Context, entityID *ttnpb.EntityIdentifiers, id string) (*ttnpb.APIKey, error)
 	// Get an API key by its ID.
-	GetAPIKey(ctx context.Context, id string) (*ttnpb.EntityIdentifiers, *ttnpb.APIKey, error)
+	GetAPIKeyByID(ctx context.Context, id string) (*ttnpb.EntityIdentifiers, *ttnpb.APIKey, error)
 	// Update key rights on an entity. Rights can be deleted by not passing any rights, in which case the returned API key will be nil.
 	UpdateAPIKey(ctx context.Context, entityID *ttnpb.EntityIdentifiers, key *ttnpb.APIKey, fieldMask FieldMask) (*ttnpb.APIKey, error)
 	// Delete api keys deletes all api keys tied to an entity. Used when purging entities.

--- a/pkg/identityserver/storetest/api_key_store.go
+++ b/pkg/identityserver/storetest/api_key_store.go
@@ -106,16 +106,32 @@ func (st *StoreTest) TestAPIKeyStoreCRUD(t *T) {
 
 			t.Run("GetAPIKey", func(t *T) {
 				a, ctx := test.New(t)
-				gotIDs, got, err := s.GetAPIKey(ctx, id)
-				if a.So(err, should.BeNil) && a.So(gotIDs, should.NotBeNil) && a.So(got, should.NotBeNil) {
-					a.So(gotIDs, should.Resemble, ids)
+				got, err := s.GetAPIKey(ctx, ids, id)
+				if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
 					a.So(got, should.Resemble, created)
 				}
 			})
 
 			t.Run("GetAPIKey_Other", func(t *T) {
 				a, ctx := test.New(t)
-				_, _, err := s.GetAPIKey(ctx, "OTHER")
+				_, err := s.GetAPIKey(ctx, ids, "OTHER")
+				if a.So(err, should.NotBeNil) {
+					a.So(errors.IsNotFound(err), should.BeTrue)
+				}
+			})
+
+			t.Run("GetAPIKeyByID", func(t *T) {
+				a, ctx := test.New(t)
+				gotIDs, got, err := s.GetAPIKeyByID(ctx, id)
+				if a.So(err, should.BeNil) && a.So(gotIDs, should.NotBeNil) && a.So(got, should.NotBeNil) {
+					a.So(gotIDs, should.Resemble, ids)
+					a.So(got, should.Resemble, created)
+				}
+			})
+
+			t.Run("GetAPIKeyByID_Other", func(t *T) {
+				a, ctx := test.New(t)
+				_, _, err := s.GetAPIKeyByID(ctx, "OTHER")
 				if a.So(err, should.NotBeNil) {
 					a.So(errors.IsNotFound(err), should.BeTrue)
 				}
@@ -169,9 +185,9 @@ func (st *StoreTest) TestAPIKeyStoreCRUD(t *T) {
 				a.So(err, should.BeNil)
 			})
 
-			t.Run("GetAPIKey_AfterDelete", func(t *T) {
+			t.Run("GetAPIKeyByID_AfterDelete", func(t *T) {
 				a, ctx := test.New(t)
-				_, _, err := s.GetAPIKey(ctx, id)
+				_, _, err := s.GetAPIKeyByID(ctx, id)
 				if a.So(err, should.NotBeNil) {
 					a.So(errors.IsNotFound(err), should.BeTrue)
 				}

--- a/pkg/identityserver/user_access.go
+++ b/pkg/identityserver/user_access.go
@@ -121,7 +121,7 @@ func (is *IdentityServer) getUserAPIKey(ctx context.Context, req *ttnpb.GetUserA
 	}
 
 	err = is.store.Transact(ctx, func(ctx context.Context, st store.Store) (err error) {
-		_, key, err = st.GetAPIKey(ctx, req.KeyId)
+		key, err = st.GetAPIKey(ctx, req.GetUserIds().GetEntityIdentifiers(), req.KeyId)
 		if err != nil {
 			return err
 		}
@@ -148,7 +148,7 @@ func (is *IdentityServer) updateUserAPIKey(ctx context.Context, req *ttnpb.Updat
 
 	err = is.store.Transact(ctx, func(ctx context.Context, st store.Store) (err error) {
 		if len(req.ApiKey.Rights) > 0 {
-			_, key, err := st.GetAPIKey(ctx, req.ApiKey.Id)
+			key, err := st.GetAPIKey(ctx, req.GetUserIds().GetEntityIdentifiers(), req.ApiKey.Id)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This updates the IS EndDevice store interface to add a method for getting an API key by _both_ entity ID and API key ID. In most places where we get the API key, we have both available, so we should query by both.

Refs https://github.com/TheThingsIndustries/lorawan-stack-support/issues/783

#### Changes
<!-- What are the changes made in this pull request? -->

- Duplicate `GetAPIKey` into `GetAPIKey` and `GetAPIKeyByID`, and only use `GetAPIKeyByID` when no entity IDs available.

#### Testing

<!-- How did you verify that this change works? -->

Updated unit tests

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

nil

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

While this is a security issue, I don't think it's severe enough to require a patch release before the next scheduled one. @johanstokking ACK?

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
