### PR TITLE
Avoid using an uplink message after passing ownership

### DIFF
--- a/pkg/gatewayserver/io/grpc/grpc_test.go
+++ b/pkg/gatewayserver/io/grpc/grpc_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/cluster"
 	"go.thethings.network/lorawan-stack/v3/pkg/component"
@@ -366,9 +367,9 @@ func TestTraffic(t *testing.T) {
 				for ups != len(tc.UplinkMessages) || needStatus || needTxAck {
 					select {
 					case up := <-conn.Up():
-						expected := tc.UplinkMessages[ups]
-						up.Message.ReceivedAt = expected.ReceivedAt
-						up.Message.RxMetadata[0].UplinkToken = expected.RxMetadata[0].UplinkToken
+						expected := deepcopy.Copy(tc.UplinkMessages[ups]).(*ttnpb.UplinkMessage)
+						expected.ReceivedAt = up.Message.ReceivedAt
+						expected.RxMetadata[0].UplinkToken = up.Message.RxMetadata[0].UplinkToken
 						a.So(up.Message, should.Resemble, expected)
 						ups++
 					case status := <-conn.Status():

--- a/pkg/gatewayserver/io/mqtt/mqtt_test.go
+++ b/pkg/gatewayserver/io/mqtt/mqtt_test.go
@@ -23,6 +23,7 @@ import (
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/gogo/protobuf/proto"
+	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/cluster"
 	"go.thethings.network/lorawan-stack/v3/pkg/component"
@@ -270,8 +271,9 @@ func TestTraffic(t *testing.T) {
 				case up := <-conn.Up():
 					if tc.OK {
 						a.So(time.Since(*ttnpb.StdTime(up.Message.ReceivedAt)), should.BeLessThan, timeout)
-						up.Message.ReceivedAt = nil
-						a.So(up.Message, should.Resemble, tc.Message)
+						expected := deepcopy.Copy(tc.Message).(*ttnpb.UplinkMessage)
+						expected.ReceivedAt = up.Message.ReceivedAt
+						a.So(up.Message, should.Resemble, expected)
 					} else {
 						t.Fatalf("Did not expect uplink message, but have %v", up)
 					}

--- a/pkg/gatewayserver/io/ws/lbslns/upstream_test.go
+++ b/pkg/gatewayserver/io/ws/lbslns/upstream_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/band"
 	"go.thethings.network/lorawan-stack/v3/pkg/basicstation"
@@ -249,9 +250,10 @@ func TestJoinRequest(t *testing.T) {
 				if !a.So(&payload, should.Resemble, msg.Payload) {
 					t.Fatalf("Invalid RawPayload: %v", msg.RawPayload)
 				}
-				msg.RawPayload = nil
-				msg.ReceivedAt = nil
-				if !a.So(*msg, should.Resemble, tc.ExpectedUplinkMessage) {
+				expected := deepcopy.Copy(tc.ExpectedUplinkMessage).(ttnpb.UplinkMessage)
+				expected.RawPayload = msg.RawPayload
+				expected.ReceivedAt = msg.ReceivedAt
+				if !a.So(*msg, should.Resemble, expected) {
 					t.Fatalf("Invalid UplinkMessage: %s", msg.RawPayload)
 				}
 			}
@@ -422,9 +424,10 @@ func TestUplinkDataFrame(t *testing.T) {
 			} else if tc.ErrorAssertion != nil {
 				t.Fatalf("Expected error")
 			} else {
-				msg.RawPayload = nil
-				msg.ReceivedAt = nil
-				if !a.So(*msg, should.Resemble, tc.ExpectedUplinkMessage) {
+				expected := deepcopy.Copy(tc.ExpectedUplinkMessage).(ttnpb.UplinkMessage)
+				expected.RawPayload = msg.RawPayload
+				expected.ReceivedAt = msg.ReceivedAt
+				if !a.So(*msg, should.Resemble, expected) {
 					t.Fatalf("Invalid UplinkMessage: %s", msg.RawPayload)
 				}
 			}

--- a/pkg/gatewayserver/io/ws/ws_test.go
+++ b/pkg/gatewayserver/io/ws/ws_test.go
@@ -27,6 +27,7 @@ import (
 
 	pbtypes "github.com/gogo/protobuf/types"
 	"github.com/gorilla/websocket"
+	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/basicstation"
 	"go.thethings.network/lorawan-stack/v3/pkg/cluster"
@@ -1135,15 +1136,16 @@ func TestTraffic(t *testing.T) {
 					select {
 					case up := <-gsConn.Up():
 						a.So(time.Since(*ttnpb.StdTime(up.Message.ReceivedAt)), should.BeLessThan, timeout)
-						up.Message.ReceivedAt = nil
 						var payload ttnpb.Message
 						a.So(lorawan.UnmarshalMessage(up.Message.RawPayload, &payload), should.BeNil)
 						if !a.So(&payload, should.Resemble, up.Message.Payload) {
 							t.Fatalf("Invalid RawPayload: %v", up.Message.RawPayload)
 						}
-						up.Message.RawPayload = nil
-						up.Message.RxMetadata[0].UplinkToken = nil
-						expectedUp := tc.ExpectedNetworkUpstream.(ttnpb.UplinkMessage)
+
+						expectedUp := deepcopy.Copy(tc.ExpectedNetworkUpstream).(ttnpb.UplinkMessage)
+						expectedUp.ReceivedAt = up.Message.ReceivedAt
+						expectedUp.RawPayload = up.Message.RawPayload
+						expectedUp.RxMetadata[0].UplinkToken = up.Message.RxMetadata[0].UplinkToken
 
 						// Set the correct xtime and timestamps for the assertion.
 						expectedUp.RxMetadata[0].Timestamp = timestamp
@@ -1169,15 +1171,16 @@ func TestTraffic(t *testing.T) {
 					select {
 					case up := <-gsConn.Up():
 						a.So(time.Since(*ttnpb.StdTime(up.Message.ReceivedAt)), should.BeLessThan, timeout)
-						up.Message.ReceivedAt = nil
 						var payload ttnpb.Message
 						a.So(lorawan.UnmarshalMessage(up.Message.RawPayload, &payload), should.BeNil)
 						if !a.So(&payload, should.Resemble, up.Message.Payload) {
 							t.Fatalf("Invalid RawPayload: %v", up.Message.RawPayload)
 						}
-						up.Message.RawPayload = nil
-						up.Message.RxMetadata[0].UplinkToken = nil
-						expectedUp := tc.ExpectedNetworkUpstream.(ttnpb.UplinkMessage)
+
+						expectedUp := deepcopy.Copy(tc.ExpectedNetworkUpstream).(ttnpb.UplinkMessage)
+						expectedUp.ReceivedAt = up.Message.ReceivedAt
+						expectedUp.RawPayload = up.Message.RawPayload
+						expectedUp.RxMetadata[0].UplinkToken = up.Message.RxMetadata[0].UplinkToken
 
 						// Set the correct xtime and timestamps for the assertion.
 						expectedUp.RxMetadata[0].Timestamp = timestamp

--- a/pkg/packetbrokeragent/agent_test.go
+++ b/pkg/packetbrokeragent/agent_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	pbtypes "github.com/gogo/protobuf/types"
+	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	mappingpb "go.packetbroker.org/api/mapping/v2"
 	packetbroker "go.packetbroker.org/api/v3"
@@ -857,10 +858,13 @@ func TestHomeNetwork(t *testing.T) {
 					t.Fatal("Expected uplink message from Forwarder")
 				}
 				a.So(nsMsg.CorrelationIds, should.HaveLength, 2)
-				nsMsg.CorrelationIds = nil
 				a.So(*ttnpb.StdTime(nsMsg.ReceivedAt), should.HappenBetween, before, time.Now()) // Packet Broker Agent sets local time on receive.
-				nsMsg.ReceivedAt = nil
-				a.So(nsMsg, should.Resemble, tc.UplinkMessage)
+
+				expected := deepcopy.Copy(tc.UplinkMessage).(*ttnpb.UplinkMessage)
+				expected.CorrelationIds = nsMsg.CorrelationIds
+				expected.ReceivedAt = nsMsg.ReceivedAt
+
+				a.So(nsMsg, should.Resemble, expected)
 
 				var stateChange *packetbroker.UplinkMessageDeliveryStateChange
 				select {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/runs/6353425551?check_suite_focus=true

#### Changes
<!-- What are the changes made in this pull request? -->

- Ensure that `up.ReceivedAt` is not accessed after the uplink has been sent via channel
- Ensure that we don't edit the uplink message we received via these channels, but instead adapt the expected value


#### Testing

<!-- How did you verify that this change works? -->

CI

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
