### PR TITLE
Fix default prop for band id

### DIFF
--- a/pkg/webui/console/containers/device-freq-plans-select/index.js
+++ b/pkg/webui/console/containers/device-freq-plans-select/index.js
@@ -41,7 +41,11 @@ const FreqPlansSelect = React.memo(props => {
 })
 
 FreqPlansSelect.propTypes = {
-  bandId: PropTypes.string.isRequired,
+  bandId: PropTypes.string,
+}
+
+FreqPlansSelect.defaultProps = {
+  bandId: undefined,
 }
 
 export default FreqPlansSelect


### PR DESCRIPTION
#### Summary
Quickfix to resolve proptype warnings for end device settings when the end device has no version IDs.

#### Changes
- Remove `.isRequired` flag from the `bandId` prop


#### Testing

Manual.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
