### PR TITLE
Fix handling of dropped events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ For details about compatibility between different releases, see the **Commitment
 - Missing success notification when successfully deleting an application in the Console.
 - CLI create commands for applications, gateways and clients no longer have their decoded ID emptied when using the `--user-id` flag.
 - Metric `ttn_lw_events_channel_dropped_total` not getting updated.
+- Dropped events when calling the Stream RPC with a long tail.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ For details about compatibility between different releases, see the **Commitment
 - End device creation no longer errors on missing application info rights.
 - Missing success notification when successfully deleting an application in the Console.
 - CLI create commands for applications, gateways and clients no longer have their decoded ID emptied when using the `--user-id` flag.
+- Metric `ttn_lw_events_channel_dropped_total` not getting updated.
 
 ### Security
 

--- a/pkg/events/grpc/grpc.go
+++ b/pkg/events/grpc/grpc.go
@@ -135,7 +135,14 @@ func (srv *EventsServer) Stream(req *ttnpb.StreamEventsRequest, stream ttnpb.Eve
 		return err
 	}
 
-	ch := make(events.Channel, 8)
+	chSize := int(req.Tail)
+	if chSize < 8 {
+		chSize = 8
+	}
+	if chSize > 1024 {
+		chSize = 1024
+	}
+	ch := make(events.Channel, chSize)
 	handler := events.ContextHandler(ctx, ch)
 
 	store, hasStore := srv.pubsub.(events.Store)

--- a/pkg/events/handler.go
+++ b/pkg/events/handler.go
@@ -46,7 +46,7 @@ func (ch Channel) Notify(evt Event) {
 	select {
 	case ch <- evt:
 	default:
-		channelDropped.WithLabelValues(evt.Name())
+		channelDropped.WithLabelValues(evt.Name()).Inc()
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This should fix an issue where events would be silently dropped. With these changes is should get less likely that events get dropped from the Stream RPC, and if they do get dropped, we'll be able to see that in telemetry.

#### Changes
<!-- What are the changes made in this pull request? -->

- Fix metric that wasn't incrementing
- Use larger event channels in Stream RPC

#### Testing

<!-- How did you verify that this change works? -->

I couldn't reliably reproduce the problem locally, but I think this should fix the issue.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

none expected

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Let's try to still get this in with v3.19.2

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
