### PR TITLE
Fix render issues of spinner

### DIFF
--- a/pkg/webui/components/spinner/index.js
+++ b/pkg/webui/components/spinner/index.js
@@ -104,9 +104,15 @@ export default class Spinner extends React.PureComponent {
             </linearGradient>
           </defs>
           <g transform="translate(50, 50)">
-            <circle cx="0" cy="0" r="40" className={style.bar} stroke={`url(#${this.id})`} />
+            <circle
+              cx="0"
+              cy="0"
+              r={micro ? 35 : 40}
+              className={style.bar}
+              stroke={`url(#${this.id})`}
+            />
           </g>
-          <circle cx="50" cy="50" r="40" className={style.circle} />
+          <circle cx="50" cy="50" r={micro ? 35 : 40} className={style.circle} />
         </svg>
         <div className={style.message}>{children}</div>
       </div>

--- a/pkg/webui/components/spinner/spinner.styl
+++ b/pkg/webui/components/spinner/spinner.styl
@@ -33,9 +33,6 @@ $xs = $cs.m
     justify-content: flex-start
     align-items: center
 
-    .spinner
-      margin-right: $cs.xs
-
 .spinner
   width: $l
   height: $l
@@ -70,6 +67,7 @@ $xs = $cs.m
 
 .message
   color: $tc-subtle-gray
+  margin-left: $cs.xs
 
 .center
   &:not(.inline)
@@ -101,4 +99,4 @@ $xs = $cs.m
 
   .bar,
   .circle
-    stroke-width: 3.5
+    stroke-width: 3


### PR DESCRIPTION
#### Summary
This quickfix fixes the rendering of the spinner when using the `micro` prop.

The small spinner was cutoff on the sides of the bounding box.
Before
<img width="164" alt="image" src="https://user-images.githubusercontent.com/5710611/169314618-d1fda6bc-a6b4-4b8c-a700-bf3e7ce0ca20.png">

After
<img width="160" alt="image" src="https://user-images.githubusercontent.com/5710611/169314219-7b850497-e88a-4c6f-bfe2-a1802420c299.png">


#### Changes

- Fix spinner styling

#### Testing

Manual

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
