### PR TITLE
Show correct downlink frame counts for < MAC1.1 devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- End devices running on MAC versions lower than 1.1 showing network downlink frame counters instead of application downlink frame counters.
+
 ### Security
 
 ## [3.19.2] - unreleased

--- a/pkg/webui/console/store/reducers/devices.js
+++ b/pkg/webui/console/store/reducers/devices.js
@@ -70,7 +70,7 @@ const devices = (state = defaultState, { type, payload, event }) => {
     case GET_DEV_SUCCESS:
       const updatedState = { ...state }
       const id = getCombinedDeviceId(payload)
-      const lorawanVersion = getByPath(state.entities, `${id}.lorawan_version`)
+      const lorawanVersion = payload.lorawan_version
 
       const mergedDevice = mergeWith({}, state.entities[id], payload, (_, __, key, ___, source) => {
         // Always set location from the payload.


### PR DESCRIPTION
#### Summary
Quickfix PR to make sure end devices running on LoRaWAN versions lower than 1.1 are showing the correct network downlink frame counter.

#### Changes
- Fix lorawan version resolution that is used to determine the source for the downlink frame counts


#### Testing

Manual

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
