### PR TITLE
Validate complete entity on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,16 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
+- Entities are now fully validated when updated in the stores.
+  - Previously only the updated paths where validated. This lead to situations in which a partial update could cause the entity as a whole to reach an invalid state.
+
 ### Deprecated
 
 ### Removed
 
 ### Fixed
 
-- End devices running on MAC versions lower than 1.1 showing network downlink frame counters instead of application downlink frame counters.
+- End devices running on MAC versions higher or equal to 1.1 showing network downlink frame counters instead of application downlink frame counters.
 
 ### Security
 

--- a/cypress/integration/console/integrations/webhooks/edit.spec.js
+++ b/cypress/integration/console/integrations/webhooks/edit.spec.js
@@ -36,7 +36,9 @@ describe('Application Webhook', () => {
         webhook_id: webhookId,
       },
     },
-    fieldMasks: ['base_url', 'format', 'ids', 'ids.application_ids', 'ids.webhook_id'],
+    field_mask: {
+      paths: ['base_url', 'format', 'ids', 'ids.application_ids', 'ids.webhook_id'],
+    },
   }
 
   before(() => {
@@ -63,7 +65,7 @@ describe('Application Webhook', () => {
     }
 
     cy.findByLabelText('Webhook format').selectOption(webhook.format)
-    cy.findByLabelText('Base URL').type(webhook.url)
+    cy.findByLabelText('Base URL').clear().type(webhook.url)
     cy.findByLabelText('Uplink message')
       .check()
       .parents('[data-test-id="form-field"]')

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -574,11 +574,11 @@ func (as *ApplicationServer) attemptDownlinkQueueOp(ctx context.Context, dev *tt
 		ctx := log.NewContextWithField(ctx, "attempt", attempt)
 
 		sessions := make([]*ttnpb.Session, 0, 2)
-		if dev.Session != nil && !op.shouldSkip(dev.Session.GetKeys().GetSessionKeyId()) {
+		if dev.Session != nil && !op.shouldSkip(dev.Session.Keys.SessionKeyId) {
 			sessions = append(sessions, dev.Session)
 			mask = ttnpb.AddFields(mask, "session.last_a_f_cnt_down")
 		}
-		if dev.PendingSession != nil && !op.shouldSkip(dev.PendingSession.GetKeys().GetSessionKeyId()) {
+		if dev.PendingSession != nil && !op.shouldSkip(dev.PendingSession.Keys.SessionKeyId) {
 			// Downlink can be encrypted with the pending session while the device first joined but not confirmed the
 			// session by sending an uplink.
 			sessions = append(sessions, dev.PendingSession)

--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -3090,11 +3090,15 @@ func TestApplicationServerCleanup(t *testing.T) {
 			},
 			func(web *ttnpb.ApplicationWebhook) (*ttnpb.ApplicationWebhook, []string, error) {
 				return &ttnpb.ApplicationWebhook{
-						Ids: webID,
+						Ids:     webID,
+						BaseUrl: "https://example.com",
+						Format:  "json",
 					},
 					[]string{
 						"ids.application_ids",
 						"ids.webhook_id",
+						"base_url",
+						"format",
 					}, nil
 			})
 		a.So(err, should.BeNil)
@@ -3109,10 +3113,18 @@ func TestApplicationServerCleanup(t *testing.T) {
 			func(ps *ttnpb.ApplicationPubSub) (*ttnpb.ApplicationPubSub, []string, error) {
 				return &ttnpb.ApplicationPubSub{
 						Ids: pubsubID,
+						Provider: &ttnpb.ApplicationPubSub_Mqtt{
+							Mqtt: &ttnpb.ApplicationPubSub_MQTTProvider{
+								ServerUrl: "mqtt://example.com",
+							},
+						},
+						Format: "json",
 					},
 					[]string{
 						"ids.application_ids",
 						"ids.pub_sub_id",
+						"provider",
+						"format",
 					},
 					nil
 			})
@@ -3128,12 +3140,14 @@ func TestApplicationServerCleanup(t *testing.T) {
 			},
 			func(as *ttnpb.ApplicationPackageAssociation) (*ttnpb.ApplicationPackageAssociation, []string, error) {
 				return &ttnpb.ApplicationPackageAssociation{
-						Ids: associationID,
+						Ids:         associationID,
+						PackageName: "example",
 					},
 					[]string{
 						"ids.end_device_ids.application_ids",
 						"ids.end_device_ids.device_id",
 						"ids.f_port",
+						"package_name",
 					},
 					nil
 			})
@@ -3148,11 +3162,13 @@ func TestApplicationServerCleanup(t *testing.T) {
 			},
 			func(as *ttnpb.ApplicationPackageDefaultAssociation) (*ttnpb.ApplicationPackageDefaultAssociation, []string, error) {
 				return &ttnpb.ApplicationPackageDefaultAssociation{
-						Ids: defaultAssociationID,
+						Ids:         defaultAssociationID,
+						PackageName: "example",
 					},
 					[]string{
 						"ids.application_ids",
 						"ids.f_port",
+						"package_name",
 					},
 					nil
 			})

--- a/pkg/applicationserver/io/packages/redis/registry.go
+++ b/pkg/applicationserver/io/packages/redis/registry.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -284,7 +284,7 @@ func (r ApplicationPackagesRegistry) SetAssociation(ctx context.Context, ids *tt
 					return err
 				}
 			}
-			if err := updated.ValidateFields(sets...); err != nil {
+			if err := updated.ValidateFields(); err != nil {
 				return err
 			}
 
@@ -486,7 +486,7 @@ func (r ApplicationPackagesRegistry) SetDefaultAssociation(ctx context.Context, 
 					return err
 				}
 			}
-			if err := updated.ValidateFields(sets...); err != nil {
+			if err := updated.ValidateFields(); err != nil {
 				return err
 			}
 

--- a/pkg/applicationserver/io/pubsub/redis/registry.go
+++ b/pkg/applicationserver/io/pubsub/redis/registry.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -253,7 +253,7 @@ func (r PubSubRegistry) Set(ctx context.Context, ids *ttnpb.ApplicationPubSubIde
 					return err
 				}
 			}
-			if err := updated.ValidateFields(sets...); err != nil {
+			if err := updated.ValidateFields(); err != nil {
 				return err
 			}
 

--- a/pkg/applicationserver/io/web/grpc_webhooks_test.go
+++ b/pkg/applicationserver/io/web/grpc_webhooks_test.go
@@ -106,8 +106,9 @@ func TestWebhookRegistryRPC(t *testing.T) {
 					WebhookId:      registeredWebhookID,
 				},
 				BaseUrl: "http://localhost/test",
+				Format:  "json",
 			},
-			FieldMask: ttnpb.FieldMask("base_url"),
+			FieldMask: ttnpb.FieldMask("base_url", "format"),
 		}, creds)
 		a.So(err, should.BeNil)
 	}

--- a/pkg/applicationserver/io/web/health_sink_test.go
+++ b/pkg/applicationserver/io/web/health_sink_test.go
@@ -49,8 +49,10 @@ func TestHealthStatusRegistry(t *testing.T) {
 
 	_, err := webhookRegistry.Set(ctx, registeredWebhookIDs, nil, func(wh *ttnpb.ApplicationWebhook) (*ttnpb.ApplicationWebhook, []string, error) {
 		return &ttnpb.ApplicationWebhook{
-			Ids: registeredWebhookIDs,
-		}, []string{"ids"}, nil
+			Ids:     registeredWebhookIDs,
+			BaseUrl: "http://example.com",
+			Format:  "json",
+		}, []string{"ids", "base_url", "format"}, nil
 	})
 	if !a.So(err, should.BeNil) {
 		t.FailNow()
@@ -206,8 +208,10 @@ func TestHealthCheckSink(t *testing.T) {
 
 	_, err := webhookRegistry.Set(ctx, registeredWebhookIDs, nil, func(wh *ttnpb.ApplicationWebhook) (*ttnpb.ApplicationWebhook, []string, error) {
 		return &ttnpb.ApplicationWebhook{
-			Ids: registeredWebhookIDs,
-		}, []string{"ids"}, nil
+			Ids:     registeredWebhookIDs,
+			BaseUrl: "http://example.com",
+			Format:  "json",
+		}, []string{"ids", "base_url", "format"}, nil
 	})
 	if !a.So(err, should.BeNil) {
 		t.FailNow()

--- a/pkg/applicationserver/io/web/redis/registry.go
+++ b/pkg/applicationserver/io/web/redis/registry.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -213,7 +213,7 @@ func (r WebhookRegistry) Set(ctx context.Context, ids *ttnpb.ApplicationWebhookI
 					return err
 				}
 			}
-			if err := updated.ValidateFields(sets...); err != nil {
+			if err := updated.ValidateFields(); err != nil {
 				return err
 			}
 

--- a/pkg/applicationserver/redis/registry.go
+++ b/pkg/applicationserver/redis/registry.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -201,7 +201,7 @@ func (r *DeviceRegistry) Set(ctx context.Context, ids *ttnpb.EndDeviceIdentifier
 					return err
 				}
 			}
-			if err := updated.ValidateFields(sets...); err != nil {
+			if err := updated.ValidateFields(); err != nil {
 				return err
 			}
 
@@ -412,7 +412,7 @@ func (r *LinkRegistry) Set(ctx context.Context, ids *ttnpb.ApplicationIdentifier
 				return err
 			}
 
-			if err := updated.ValidateFields(sets...); err != nil {
+			if err := updated.ValidateFields(); err != nil {
 				return err
 			}
 

--- a/pkg/devicerepository/store/remote/repository_test.go
+++ b/pkg/devicerepository/store/remote/repository_test.go
@@ -67,7 +67,7 @@ func TestGithubDeviceRepository(t *testing.T) {
 		go func() {
 			for model := range modelCh {
 				atomic.AddUint32(&totalModels, 1)
-				if err := model.ValidateFields(ttnpb.EndDeviceModelFieldPathsNested...); err != nil {
+				if err := model.ValidateFields(); err != nil {
 					fmt.Printf("Failed to validate model %s/%s: %v -- %v\n", model.BrandId, model.ModelId, err, model.DatasheetUrl)
 					atomic.AddUint32(&failures, 1)
 				}
@@ -91,7 +91,7 @@ func TestGithubDeviceRepository(t *testing.T) {
 								fmt.Printf("Failed to retrieve uplink decoder for %v: %v\n", ids, err)
 								atomic.AddUint32(&failures, 1)
 							}
-							if err := d.ValidateFields(ttnpb.MessagePayloadDecoderFieldPathsNested...); err != nil {
+							if err := d.ValidateFields(); err != nil {
 								fmt.Printf("Failed to validate uplink encoder for %v: %v\n", ids, err)
 								atomic.AddUint32(&failures, 1)
 							}
@@ -102,7 +102,7 @@ func TestGithubDeviceRepository(t *testing.T) {
 								fmt.Printf("Failed to retrieve downlink decoder for %v: %v\n", ids, err)
 								atomic.AddUint32(&failures, 1)
 							}
-							if err := d.ValidateFields(ttnpb.MessagePayloadDecoderFieldPathsNested...); err != nil {
+							if err := d.ValidateFields(); err != nil {
 								fmt.Printf("Failed to validate downlink decoder for %v: %v\n", ids, err)
 								atomic.AddUint32(&failures, 1)
 							}
@@ -113,7 +113,7 @@ func TestGithubDeviceRepository(t *testing.T) {
 								fmt.Printf("Failed to retrieve downlink encoder for %v: %v\n", ids, err)
 								atomic.AddUint32(&failures, 1)
 							}
-							if err := d.ValidateFields(ttnpb.MessagePayloadEncoderFieldPathsNested...); err != nil {
+							if err := d.ValidateFields(); err != nil {
 								fmt.Printf("Failed to validate downlink encoder for %v: %v\n", ids, err)
 								atomic.AddUint32(&failures, 1)
 							}
@@ -129,7 +129,7 @@ func TestGithubDeviceRepository(t *testing.T) {
 		brandWg.Add(1)
 		go func() {
 			for brand := range brandCh {
-				if err := brand.ValidateFields(ttnpb.EndDeviceBrandFieldPathsNested...); err != nil {
+				if err := brand.ValidateFields(); err != nil {
 					fmt.Printf("Failed to validate brand %s: %v\n", brand.BrandId, err)
 					atomic.AddUint32(&failures, 1)
 				}

--- a/pkg/joinserver/redis/registry.go
+++ b/pkg/joinserver/redis/registry.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -267,7 +267,7 @@ func (r *DeviceRegistry) set(ctx context.Context, tx *redis.Tx, uid string, gets
 				return nil, err
 			}
 		}
-		if err := updated.ValidateFields(sets...); err != nil {
+		if err := updated.ValidateFields(); err != nil {
 			return nil, err
 		}
 
@@ -570,7 +570,7 @@ func (r *KeyRegistry) SetByID(ctx context.Context, joinEUI, devEUI types.EUI64, 
 				return err
 			}
 		}
-		if err := updated.ValidateFields(sets...); err != nil {
+		if err := updated.ValidateFields(); err != nil {
 			return err
 		}
 
@@ -745,7 +745,7 @@ func (r *ApplicationActivationSettingRegistry) SetByID(ctx context.Context, appI
 					return err
 				}
 			}
-			if err := updated.ValidateFields(sets...); err != nil {
+			if err := updated.ValidateFields(); err != nil {
 				return err
 			}
 

--- a/pkg/networkserver/redis/registry.go
+++ b/pkg/networkserver/redis/registry.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 The Things Network Foundation, The Things Industries B.V.
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -749,9 +749,6 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID *ttnpb.ApplicationId
 				return nil
 			}
 
-			if err = pb.ValidateFields(sets...); err != nil {
-				return err
-			}
 			if stored == nil {
 				trace.Log(ctx, "ns:redis", "create end device")
 				if err := ttnpb.RequireFields(sets,
@@ -810,6 +807,9 @@ func (r *DeviceRegistry) SetByID(ctx context.Context, appID *ttnpb.ApplicationId
 			if updated.Session != nil && updated.MacState == nil ||
 				updated.PendingSession != nil && updated.PendingMacState == nil {
 				return errInvalidDevice.New()
+			}
+			if err := updated.ValidateFields(); err != nil {
+				return err
 			}
 
 			storedPendingSession := stored.GetPendingSession()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://sentry.io/organizations/the-things-industries/issues/3288249317/?project=2682566
References https://sentry.io/organizations/the-things-industries/issues/3128395476/?project=2682566

I've started with the above mentioned issues while looking into how `ttnpb.EndDevice.Session.Keys` could be `nil`, given that the field is marked as `required`. The rabbit whole led to this PR.

#### Changes
<!-- What are the changes made in this pull request? -->

- The Redis registry implementations now validate the complete object upon updates, instead of just the updated paths.
  - The reasoning is that a `SetFields` operation may create previously `nil` fields. Consider the following situation:
    1. You create an end device entity by providing a valid entity. You don't set any `session` or `pending_session`.
    2. You update the entity by setting `session.dev_addr`. This creates both the `session` and the `session.dev_addr`.
    3. At this point, the registry code will validate only `session.dev_addr`. `session.keys` is `nil`, even though it is a field marked as `required` - no error occurs !
  - In general it doesn't seem like we can avoid having to do a full object validation round. Possible proposals include doing the full object check only for user facing operations (coming from user-facing RPCs).
  - Validation itself is quite light on most entities, but the Network Server end device registry contains rather large entities (specifically due to traffic history). ~Since the performance hit may be too high, the change here is guarded by the experimental flag `ns.registry.redis.full_validation`.~

#### Testing

<!-- How did you verify that this change works? -->

Local testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

There are two kinds of regressions that we may encounter here:
- The performance regression because we validate the complete object instead of just the updated fields.
  - The expectation here is that the this will come mainly from the Network Server end device registry, which is why this is guarded by a feature flag.
  - The other registries are light as is, and should not cause issues.
- Previously valid entity updates and creation requests will now result in errors.
  - The result object is invalid, so this is covered by the compatibility agreement.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
