### PR TITLE
Remove additional cluster auth check

### DIFF
--- a/pkg/deviceclaimingserver/grpc_end_devices.go
+++ b/pkg/deviceclaimingserver/grpc_end_devices.go
@@ -21,6 +21,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
+	"go.thethings.network/lorawan-stack/v3/pkg/rpcmetadata"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
 	"go.thethings.network/lorawan-stack/v3/pkg/web"
@@ -115,9 +116,13 @@ func (edcs *endDeviceClaimingServer) Claim(ctx context.Context, req *ttnpb.Claim
 			return nil, err
 		}
 		qrg := ttnpb.NewEndDeviceQRCodeGeneratorClient(conn)
+		callOpt, err := rpcmetadata.WithForwardedAuth(ctx, edcs.DCS.AllowInsecureForCredentials())
+		if err != nil {
+			return nil, err
+		}
 		data, err := qrg.Parse(ctx, &ttnpb.ParseEndDeviceQRCodeRequest{
 			QrCode: qrCode,
-		}, edcs.DCS.WithClusterAuth())
+		}, callOpt)
 		dev := data.GetEndDeviceTemplate().GetEndDevice()
 		if dev == nil {
 			return nil, errParseQRCode.New()

--- a/pkg/qrcodegenerator/grpc_end_devices.go
+++ b/pkg/qrcodegenerator/grpc_end_devices.go
@@ -117,11 +117,7 @@ func (s *endDeviceQRCodeGeneratorServer) Generate(ctx context.Context, req *ttnp
 // Parse implements EndDeviceQRCodeGenerator.
 func (s *endDeviceQRCodeGeneratorServer) Parse(ctx context.Context, req *ttnpb.ParseEndDeviceQRCodeRequest) (*ttnpb.ParseEndDeviceQRCodeResponse, error) {
 	_, err := rpcmetadata.WithForwardedAuth(ctx, s.QRG.AllowInsecureForCredentials())
-	if errors.IsUnauthenticated(err) {
-		if clusterauth.Authorized(ctx) != nil {
-			return nil, errUnauthenticated.New()
-		}
-	} else if err != nil {
+	if err != nil {
 		return nil, err
 	}
 	data, err := s.QRG.endDevices.Parse(req.FormatId, req.QrCode)

--- a/pkg/qrcodegenerator/grpc_end_devices.go
+++ b/pkg/qrcodegenerator/grpc_end_devices.go
@@ -19,7 +19,6 @@ import (
 
 	pbtypes "github.com/gogo/protobuf/types"
 	qrcodegen "github.com/skip2/go-qrcode"
-	clusterauth "go.thethings.network/lorawan-stack/v3/pkg/auth/cluster"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/rpcmetadata"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -34,11 +33,7 @@ type endDeviceQRCodeGeneratorServer struct {
 // GetFormat implements EndDeviceQRCodeGenerator.
 func (s *endDeviceQRCodeGeneratorServer) GetFormat(ctx context.Context, req *ttnpb.GetQRCodeFormatRequest) (*ttnpb.QRCodeFormat, error) {
 	_, err := rpcmetadata.WithForwardedAuth(ctx, s.QRG.AllowInsecureForCredentials())
-	if errors.IsUnauthenticated(err) {
-		if clusterauth.Authorized(ctx) != nil {
-			return nil, errUnauthenticated.New()
-		}
-	} else if err != nil {
+	if err != nil {
 		return nil, err
 	}
 	format := s.QRG.endDevices.GetEndDeviceFormat(req.FormatId)
@@ -51,11 +46,7 @@ func (s *endDeviceQRCodeGeneratorServer) GetFormat(ctx context.Context, req *ttn
 // ListFormats implements EndDeviceQRCodeGenerator.
 func (s *endDeviceQRCodeGeneratorServer) ListFormats(ctx context.Context, _ *pbtypes.Empty) (*ttnpb.QRCodeFormats, error) {
 	_, err := rpcmetadata.WithForwardedAuth(ctx, s.QRG.AllowInsecureForCredentials())
-	if errors.IsUnauthenticated(err) {
-		if clusterauth.Authorized(ctx) != nil {
-			return nil, errUnauthenticated.New()
-		}
-	} else if err != nil {
+	if err != nil {
 		return nil, err
 	}
 	res := &ttnpb.QRCodeFormats{
@@ -70,11 +61,7 @@ func (s *endDeviceQRCodeGeneratorServer) ListFormats(ctx context.Context, _ *pbt
 // Generate implements EndDeviceQRCodeGenerator.
 func (s *endDeviceQRCodeGeneratorServer) Generate(ctx context.Context, req *ttnpb.GenerateEndDeviceQRCodeRequest) (*ttnpb.GenerateQRCodeResponse, error) {
 	_, err := rpcmetadata.WithForwardedAuth(ctx, s.QRG.AllowInsecureForCredentials())
-	if errors.IsUnauthenticated(err) {
-		if clusterauth.Authorized(ctx) != nil {
-			return nil, errUnauthenticated.New()
-		}
-	} else if err != nil {
+	if err != nil {
 		return nil, err
 	}
 	formatter := s.QRG.endDevices.GetEndDeviceFormat(req.FormatId)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a small quick fix to remove additional cluster auth check.
- `rpcmetadata.WithForwardedAuth` already checks for cluster auth (if the context contains a token of type `ClusterKey`)
- This additional check is unnecessary and may cause a panic for unauthenticated calls.

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove additional call.
- Make DCS forward the incoming auth.

#### Testing

<!-- How did you verify that this change works? -->

Existing UTs covers the case.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Don't expect any.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
