### PR TITLE
Resolve lint issues in pkg/errors

### DIFF
--- a/pkg/errors/attributes.go
+++ b/pkg/errors/attributes.go
@@ -15,6 +15,7 @@
 package errors
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 )
@@ -152,18 +153,18 @@ nextAttr:
 }
 
 // Attributes are not present in the error definition, so this just returns nil.
-func (d *Definition) Attributes() map[string]interface{} { return nil }
+func (*Definition) Attributes() map[string]interface{} { return nil }
 
 // PublicAttributes are not present in the error definition, so this just returns nil.
-func (d *Definition) PublicAttributes() map[string]interface{} { return nil }
+func (*Definition) PublicAttributes() map[string]interface{} { return nil }
 
 // Attributes returns the attributes of the errors, if they implement Attributes().
 // If more than one error is passed, subsequent error attributes will be added if not set.
 func Attributes(err ...error) map[string]interface{} {
 	attributes := make(map[string]interface{})
 	for _, err := range err {
-		if err, ok := err.(attributer); ok {
-			for k, v := range err.Attributes() {
+		if attrErr := (attributer)(nil); errors.As(err, &attrErr) {
+			for k, v := range attrErr.Attributes() {
 				if _, ok := attributes[k]; !ok {
 					attributes[k] = v
 				}
@@ -178,8 +179,8 @@ func Attributes(err ...error) map[string]interface{} {
 func PublicAttributes(err ...error) map[string]interface{} {
 	attributes := make(map[string]interface{})
 	for _, err := range err {
-		if err, ok := err.(publicAttributer); ok {
-			for k, v := range err.PublicAttributes() {
+		if attrErr := (publicAttributer)(nil); errors.As(err, &attrErr) {
+			for k, v := range attrErr.PublicAttributes() {
 				if _, ok := attributes[k]; !ok {
 					attributes[k] = v
 				}

--- a/pkg/errors/attributes_test.go
+++ b/pkg/errors/attributes_test.go
@@ -23,13 +23,14 @@ import (
 )
 
 func TestAttributesError(t *testing.T) {
+	t.Parallel()
 	a := assertions.New(t)
 
-	var errInvalidFoo = errors.DefineInvalidArgument("test_attributes_invalid_foo", "Invalid Foo: {foo}", "foo")
+	errInvalidFoo := errors.DefineInvalidArgument("test_attributes_invalid_foo", "Invalid Foo: {foo}", "foo")
 
 	a.So(errInvalidFoo.Attributes(), should.BeEmpty)
 
-	a.So(func() { errInvalidFoo.WithAttributes("only_key") }, should.Panic)
+	a.So(func() { errInvalidFoo.WithAttributes("only_key") }, should.Panic) //nolint:errcheck
 
 	err1 := errInvalidFoo.WithAttributes("foo", "bar")
 	err2 := err1.WithAttributes("bar", "baz")
@@ -45,7 +46,9 @@ func TestAttributesError(t *testing.T) {
 }
 
 func TestAttributes(t *testing.T) {
-	tt := []struct {
+	t.Parallel()
+
+	tcs := []struct {
 		Name   string
 		V      interface{}
 		Expect interface{}
@@ -59,9 +62,11 @@ func TestAttributes(t *testing.T) {
 		{"array", [5]int{1, 2, 3}, "[1 2 3 0 0]"},
 	}
 
-	for _, tt := range tt {
-		t.Run(tt.Name, func(t *testing.T) {
-			assertions.New(t).So(errors.Supported(tt.V), should.Equal, tt.Expect)
+	for _, tc := range tcs {
+		tc := tc // shadow range variable.
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			assertions.New(t).So(errors.Supported(tc.V), should.Equal, tc.Expect)
 		})
 	}
 }

--- a/pkg/errors/causes.go
+++ b/pkg/errors/causes.go
@@ -14,6 +14,8 @@
 
 package errors
 
+import "errors"
+
 type causer interface {
 	Cause() error
 }
@@ -68,11 +70,10 @@ func (*Definition) Cause() error { return nil }
 
 // Cause returns the cause of the given error, if any.
 func Cause(err error) error {
-	c, ok := err.(causer)
-	if !ok {
-		return nil
+	if causeErr := (causer)(nil); errors.As(err, &causeErr) {
+		return causeErr.Cause()
 	}
-	return c.Cause()
+	return nil
 }
 
 // RootCause walks up the "error chain" until it finds the root cause of an error.

--- a/pkg/errors/causes_test.go
+++ b/pkg/errors/causes_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestCause(t *testing.T) {
+	t.Parallel()
 	a := assertions.New(t)
 
 	cause := errors.New("cause")
@@ -34,9 +35,7 @@ func TestCause(t *testing.T) {
 
 	err1 := errInvalidFoo.WithCause(cause)
 
-	a.So(func() {
-		err1.WithCause(cause)
-	}, should.Panic)
+	a.So(func() { err1.WithCause(cause) }, should.Panic) //nolint:errcheck
 
 	a.So(err1, should.HaveSameErrorDefinitionAs, errInvalidFoo)
 	a.So(err1.Cause(), should.EqualErrorOrDefinition, cause)

--- a/pkg/errors/codes.go
+++ b/pkg/errors/codes.go
@@ -16,6 +16,7 @@ package errors
 
 import (
 	"context"
+	"errors"
 
 	"google.golang.org/grpc/codes"
 )
@@ -41,14 +42,14 @@ func (e *Error) Code() uint32 {
 }
 
 func code(err error) uint32 {
-	switch err {
-	case context.Canceled:
+	switch {
+	case errors.Is(err, context.Canceled):
 		return uint32(codes.Canceled)
-	case context.DeadlineExceeded:
+	case errors.Is(err, context.DeadlineExceeded):
 		return uint32(codes.DeadlineExceeded)
 	}
-	if c, ok := err.(coder); ok {
-		return c.Code()
+	if codeErr := (coder)(nil); errors.As(err, &codeErr) {
+		return codeErr.Code()
 	}
 	if ttnErr, ok := From(err); ok {
 		return ttnErr.Code()

--- a/pkg/errors/codes_test.go
+++ b/pkg/errors/codes_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestCodes(t *testing.T) {
+	t.Parallel()
 	a := assertions.New(t)
 
 	errStdLib := gerrors.New("go stdlib error")
@@ -34,23 +35,49 @@ func TestCodes(t *testing.T) {
 	a.So(errors.IsUnknown(errUnknown), should.BeTrue)
 	a.So(errors.IsUnknown(errUnknown.GRPCStatus().Err()), should.BeTrue)
 	a.So(errors.IsUnknown(errStdLib), should.BeFalse)
-	a.So(errors.IsUnknown(errors.DefineInternal("test_codes_not_unknown", "")), should.BeFalse)
+	a.So(errors.IsUnknown(
+		errors.DefineInternal("test_codes_not_unknown", ""),
+	), should.BeFalse)
 
 	a.So(errors.IsCanceled(context.Canceled), should.BeTrue)
 	a.So(errors.IsDeadlineExceeded(context.DeadlineExceeded), should.BeTrue)
-	a.So(errors.IsInvalidArgument(errors.DefineInvalidArgument("test_codes_invalid_argument", "")), should.BeTrue)
-	a.So(errors.IsNotFound(errors.DefineNotFound("test_codes_not_found", "")), should.BeTrue)
-	a.So(errors.IsAlreadyExists(errors.DefineAlreadyExists("test_codes_already_exists", "")), should.BeTrue)
-	a.So(errors.IsPermissionDenied(errors.DefinePermissionDenied("test_codes_permission_denied", "")), should.BeTrue)
-	a.So(errors.IsResourceExhausted(errors.DefineResourceExhausted("test_codes_resource_exhausted", "")), should.BeTrue)
-	a.So(errors.IsFailedPrecondition(errors.DefineFailedPrecondition("test_codes_failed_precondition", "")), should.BeTrue)
-	a.So(errors.IsAborted(errors.DefineAborted("test_codes_aborted", "")), should.BeTrue)
+	a.So(errors.IsInvalidArgument(
+		errors.DefineInvalidArgument("test_codes_invalid_argument", ""),
+	), should.BeTrue)
+	a.So(errors.IsNotFound(
+		errors.DefineNotFound("test_codes_not_found", ""),
+	), should.BeTrue)
+	a.So(errors.IsAlreadyExists(
+		errors.DefineAlreadyExists("test_codes_already_exists", ""),
+	), should.BeTrue)
+	a.So(errors.IsPermissionDenied(
+		errors.DefinePermissionDenied("test_codes_permission_denied", ""),
+	), should.BeTrue)
+	a.So(errors.IsResourceExhausted(
+		errors.DefineResourceExhausted("test_codes_resource_exhausted", ""),
+	), should.BeTrue)
+	a.So(errors.IsFailedPrecondition(
+		errors.DefineFailedPrecondition("test_codes_failed_precondition", ""),
+	), should.BeTrue)
+	a.So(errors.IsAborted(
+		errors.DefineAborted("test_codes_aborted", ""),
+	), should.BeTrue)
 	errInternal := errors.DefineInternal("test_codes_internal", "")
-	a.So(errors.IsInternal(errInternal), should.BeTrue)
-	a.So(errors.IsUnavailable(errors.DefineUnavailable("test_codes_unavailable", "")), should.BeTrue)
-	a.So(errors.IsDataLoss(errors.DefineDataLoss("test_codes_data_loss", "")), should.BeTrue)
-	a.So(errors.IsDataLoss(errors.DefineCorruption("test_codes_corruption", "")), should.BeTrue)
-	a.So(errors.IsUnauthenticated(errors.DefineUnauthenticated("test_codes_unauthenticated", "")), should.BeTrue)
+	a.So(errors.IsInternal(
+		errInternal,
+	), should.BeTrue)
+	a.So(errors.IsUnavailable(
+		errors.DefineUnavailable("test_codes_unavailable", ""),
+	), should.BeTrue)
+	a.So(errors.IsDataLoss(
+		errors.DefineDataLoss("test_codes_data_loss", ""),
+	), should.BeTrue)
+	a.So(errors.IsDataLoss(
+		errors.DefineCorruption("test_codes_corruption", ""),
+	), should.BeTrue)
+	a.So(errors.IsUnauthenticated(
+		errors.DefineUnauthenticated("test_codes_unauthenticated", ""),
+	), should.BeTrue)
 
 	// Unknown errors with a non-unknown cause take the cause's code
 	a.So(errors.IsInternal(errUnknown.WithCause(errInternal)), should.BeTrue)

--- a/pkg/errors/comparison_test.go
+++ b/pkg/errors/comparison_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestResembles(t *testing.T) {
+	t.Parallel()
 	a := assertions.New(t)
 
 	a.So(errors.Resemble(nil, nil), should.BeTrue)
@@ -53,6 +54,12 @@ func TestResembles(t *testing.T) {
 
 	defWrapper := errors.Define("wrapper", "something went wrong")
 
-	a.So(errors.Resemble(defWrapper.WithCause(defPermissionDenied), defWrapper), should.BeTrue)
-	a.So(errors.Resemble(defWrapper.WithCause(defPermissionDenied), defWrapper.WithCause(defInvalidArgument)), should.BeTrue)
+	a.So(errors.Resemble(
+		defWrapper.WithCause(defPermissionDenied),
+		defWrapper,
+	), should.BeTrue)
+	a.So(errors.Resemble(
+		defWrapper.WithCause(defPermissionDenied),
+		defWrapper.WithCause(defInvalidArgument),
+	), should.BeTrue)
 }

--- a/pkg/errors/definitions.go
+++ b/pkg/errors/definitions.go
@@ -152,7 +152,7 @@ func define(code uint32, name, messageFormat string, publicAttributes ...string)
 
 	parsedMessageFormat, err := formatter.Parse(messageFormat)
 	if err != nil {
-		panic(fmt.Errorf("could not parse message format `%s` for %s: %s", messageFormat, fullName, err))
+		panic(fmt.Errorf("could not parse message format `%s` for %s: %w", messageFormat, fullName, err))
 	}
 	def.parsedMessageFormat = parsedMessageFormat
 
@@ -249,7 +249,7 @@ func DefineAborted(name, messageFormat string, publicAttributes ...string) *Defi
 
 // OutOfRange - not used for now
 
-// Unimplemented defines a registered error of type Unimplemented.
+// DefineUnimplemented defines a registered error of type Unimplemented.
 func DefineUnimplemented(name, messageFormat string, publicAttributes ...string) *Definition {
 	def := define(uint32(codes.Unimplemented), name, messageFormat, publicAttributes...)
 	return def

--- a/pkg/errors/definitions_test.go
+++ b/pkg/errors/definitions_test.go
@@ -23,10 +23,11 @@ import (
 )
 
 func TestDefinitions(t *testing.T) {
+	t.Parallel()
 	a := assertions.New(t)
 
-	errors.Define("test_definitions_unknown", "")
+	errors.Define("test_definitions_unknown", "") //nolint:errcheck
 	a.So(func() {
-		errors.Define("test_definitions_unknown", "")
+		errors.Define("test_definitions_unknown", "") //nolint:errcheck
 	}, should.Panic)
 }

--- a/pkg/errors/details.go
+++ b/pkg/errors/details.go
@@ -14,7 +14,11 @@
 
 package errors
 
-import "github.com/golang/protobuf/proto"
+import (
+	"errors"
+
+	"github.com/golang/protobuf/proto"
+)
 
 type detailer interface {
 	Details() []proto.Message
@@ -68,8 +72,8 @@ func (*Definition) Details() []proto.Message { return nil }
 
 // Details gets the details of the error.
 func Details(err error) []proto.Message {
-	if c, ok := err.(detailer); ok {
-		return c.Details()
+	if detailsErr := (detailer)(nil); errors.As(err, &detailsErr) {
+		return detailsErr.Details()
 	}
 	if ttnErr, ok := From(err); ok {
 		return ttnErr.Details()

--- a/pkg/errors/details_test.go
+++ b/pkg/errors/details_test.go
@@ -35,9 +35,10 @@ func stringDetail(s string) *detail {
 }
 
 func TestDetails(t *testing.T) {
+	t.Parallel()
 	a := assertions.New(t)
 
-	var errInvalidFoo = errors.DefineInvalidArgument("test_details_invalid_foo", "Invalid Foo")
+	errInvalidFoo := errors.DefineInvalidArgument("test_details_invalid_foo", "Invalid Foo")
 
 	a.So(errInvalidFoo.Details(), should.BeEmpty)
 

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -64,6 +64,7 @@ func Example() {
 }
 
 func TestFields(t *testing.T) {
+	t.Parallel()
 	a := assertions.New(t)
 
 	errBack := stderrors.New("back")
@@ -79,6 +80,7 @@ func TestFields(t *testing.T) {
 }
 
 func TestContextCanceled(t *testing.T) {
+	t.Parallel()
 	a := assertions.New(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -92,6 +94,7 @@ func TestContextCanceled(t *testing.T) {
 }
 
 func TestContextDeadlineExceeded(t *testing.T) {
+	t.Parallel()
 	a := assertions.New(t)
 
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(5*time.Millisecond))
@@ -107,6 +110,7 @@ func TestContextDeadlineExceeded(t *testing.T) {
 }
 
 func TestNetErrors(t *testing.T) {
+	t.Parallel()
 	a := assertions.New(t)
 
 	for _, tc := range []struct {
@@ -129,7 +133,6 @@ func TestNetErrors(t *testing.T) {
 				a.So(errors.IsUnavailable(e), should.BeTrue)
 				a.So(e.PublicAttributes(), should.Resemble, map[string]interface{}{
 					"message":   err.Error(),
-					"temporary": false,
 					"timeout":   false,
 					"not_found": true,
 				})
@@ -142,9 +145,8 @@ func TestNetErrors(t *testing.T) {
 				a.So(e.FullName(), should.Equal, "pkg/errors:net_unknown_network")
 				a.So(errors.IsNotFound(e), should.BeTrue)
 				a.So(e.PublicAttributes(), should.Resemble, map[string]interface{}{
-					"message":   err.Error(),
-					"temporary": false,
-					"timeout":   false,
+					"message": err.Error(),
+					"timeout": false,
 				})
 			},
 		},
@@ -155,9 +157,8 @@ func TestNetErrors(t *testing.T) {
 				a.So(e.FullName(), should.Equal, "pkg/errors:net_invalid_addr")
 				a.So(errors.IsInvalidArgument(e), should.BeTrue)
 				a.So(e.PublicAttributes(), should.Resemble, map[string]interface{}{
-					"message":   err.Error(),
-					"temporary": false,
-					"timeout":   false,
+					"message": err.Error(),
+					"timeout": false,
 				})
 			},
 		},
@@ -171,9 +172,8 @@ func TestNetErrors(t *testing.T) {
 				a.So(e.FullName(), should.Equal, "pkg/errors:net_addr")
 				a.So(errors.IsUnavailable(e), should.BeTrue)
 				a.So(e.PublicAttributes(), should.Resemble, map[string]interface{}{
-					"message":   err.Error(),
-					"temporary": false,
-					"timeout":   false,
+					"message": err.Error(),
+					"timeout": false,
 				})
 			},
 		},
@@ -186,16 +186,15 @@ func TestNetErrors(t *testing.T) {
 				Net:    "0.0.0.0",
 				Err:    nil,
 			},
-			Validate: func(err error, e *errors.Error, a *assertions.Assertion) {
+			Validate: func(_ error, e *errors.Error, a *assertions.Assertion) {
 				a.So(e.FullName(), should.Equal, "pkg/errors:net_operation")
 				a.So(errors.IsUnavailable(e), should.BeTrue)
 				a.So(e.PublicAttributes(), should.Resemble, map[string]interface{}{
-					"temporary": false,
-					"timeout":   false,
-					"address":   "1.1.1.1",
-					"source":    "2.2.2.2",
-					"net":       "0.0.0.0",
-					"op":        "read",
+					"timeout": false,
+					"address": "1.1.1.1",
+					"source":  "2.2.2.2",
+					"net":     "0.0.0.0",
+					"op":      "read",
 				})
 			},
 		},
@@ -208,22 +207,23 @@ func TestNetErrors(t *testing.T) {
 				Net:    "0.0.0.0",
 				Err:    fmt.Errorf("dummy"),
 			},
-			Validate: func(err error, e *errors.Error, a *assertions.Assertion) {
+			Validate: func(_ error, e *errors.Error, a *assertions.Assertion) {
 				a.So(e.FullName(), should.Equal, "pkg/errors:net_operation")
 				a.So(errors.IsUnavailable(e), should.BeTrue)
 				a.So(e.PublicAttributes(), should.Resemble, map[string]interface{}{
-					"temporary": false,
-					"timeout":   false,
-					"address":   "1.1.1.1",
-					"source":    "2.2.2.2",
-					"net":       "0.0.0.0",
-					"op":        "read",
+					"timeout": false,
+					"address": "1.1.1.1",
+					"source":  "2.2.2.2",
+					"net":     "0.0.0.0",
+					"op":      "read",
 				})
 				a.So(e.Cause(), should.Resemble, fmt.Errorf("dummy"))
 			},
 		},
 	} {
+		tc := tc // shadow range variable.
 		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
 			err, ok := errors.From(tc.Error)
 			a.So(ok, should.BeTrue)
 			tc.Validate(tc.Error, err, a)

--- a/pkg/errors/grpc.go
+++ b/pkg/errors/grpc.go
@@ -24,15 +24,15 @@ import (
 )
 
 // FromGRPCStatus converts the gRPC status message into an Error.
-func FromGRPCStatus(status *status.Status) *Error {
+func FromGRPCStatus(grpcStatus *status.Status) *Error {
 	err := build(&Definition{
-		code:          uint32(status.Code()),
-		messageFormat: status.Message(),
+		code:          uint32(grpcStatus.Code()),
+		messageFormat: grpcStatus.Message(),
 	}, 0)
 	if ErrorDetailsFromProto == nil {
 		return err
 	}
-	detailMsgs := status.Details()
+	detailMsgs := grpcStatus.Details()
 	detailProtos := make([]proto.Message, 0, len(detailMsgs))
 	for _, msg := range detailMsgs { // convert to []proto.Message
 		if msg, ok := msg.(proto.Message); ok {
@@ -112,7 +112,9 @@ func (e *Error) GRPCStatus() *status.Status {
 
 // UnaryServerInterceptor makes sure that returned TTN errors contain a CorrelationID.
 func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	return func(
+		ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
+	) (interface{}, error) {
 		res, err := handler(ctx, req)
 		if ttnErr, ok := From(err); ok {
 			err = ttnErr
@@ -123,7 +125,9 @@ func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 
 // StreamServerInterceptor makes sure that returned TTN errors contain a CorrelationID.
 func StreamServerInterceptor() grpc.StreamServerInterceptor {
-	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return func(
+		srv interface{}, stream grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler,
+	) error {
 		err := handler(srv, stream)
 		if ttnErr, ok := From(err); ok {
 			err = ttnErr
@@ -134,7 +138,14 @@ func StreamServerInterceptor() grpc.StreamServerInterceptor {
 
 // UnaryClientInterceptor converts gRPC errors to regular errors.
 func UnaryClientInterceptor() grpc.UnaryClientInterceptor {
-	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	return func(
+		ctx context.Context,
+		method string,
+		req, reply interface{},
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
 		err := invoker(ctx, method, req, reply, cc, opts...)
 		if ttnErr, ok := From(err); ok {
 			return ttnErr
@@ -165,7 +176,14 @@ func (w wrappedStream) RecvMsg(m interface{}) error {
 
 // StreamClientInterceptor converts gRPC errors to regular errors.
 func StreamClientInterceptor() grpc.StreamClientInterceptor {
-	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+	return func(
+		ctx context.Context,
+		desc *grpc.StreamDesc,
+		cc *grpc.ClientConn,
+		method string,
+		streamer grpc.Streamer,
+		opts ...grpc.CallOption,
+	) (grpc.ClientStream, error) {
 		s, err := streamer(ctx, desc, cc, method, opts...)
 		if ttnErr, ok := From(err); ok {
 			return nil, ttnErr

--- a/pkg/errors/grpc_test.go
+++ b/pkg/errors/grpc_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestGRPCConversion(t *testing.T) {
+	t.Parallel()
 	a := assertions.New(t)
 
 	errCause := errors.Define("test_grpc_conversion_err_cause", "gRPC Conversion Error Cause")

--- a/pkg/errors/http_test.go
+++ b/pkg/errors/http_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestHTTP(t *testing.T) {
+	t.Parallel()
 	a := assertions.New(t)
 
 	errDef := errors.DefineInvalidArgument("test_http_conversion_err_def", "HTTP Conversion Error", "foo")
@@ -34,8 +35,9 @@ func TestHTTP(t *testing.T) {
 	errHello := errDef.WithAttributes("foo", "bar", "baz", "qux")
 	errHelloExpected := errDef.WithAttributes("foo", "bar")
 
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		errors.ToHTTP(errHello, w)
+	handler := func(w http.ResponseWriter, _ *http.Request) {
+		err := errors.ToHTTP(errHello, w)
+		a.So(err, should.BeNil)
 	}
 
 	req := httptest.NewRequest("GET", "http://example.com/err", nil)

--- a/pkg/errors/internal_test.go
+++ b/pkg/errors/internal_test.go
@@ -22,9 +22,12 @@ import (
 )
 
 func TestMessageFormat(t *testing.T) {
+	t.Parallel()
 	a := assertions.New(t)
 
-	args := messageFormatArguments("Application with ID {app_id} could not be found in namespace { ns } or namespace {   ns } does not exist")
+	args := messageFormatArguments(
+		"Application with ID {app_id} could not be found in namespace { ns } or namespace {   ns } does not exist",
+	)
 	a.So(args, should.HaveLength, 2) // no duplicates
 	a.So(args, should.Contain, "app_id")
 	a.So(args, should.Contain, "ns")

--- a/pkg/errors/json_test.go
+++ b/pkg/errors/json_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestJSONConversion(t *testing.T) {
+	t.Parallel()
 	a := assertions.New(t)
 
 	errDef := errors.Define("test_json_conversion_err_def", "JSON Conversion Error", "foo")

--- a/pkg/errors/sentry/sentry.go
+++ b/pkg/errors/sentry/sentry.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package sentry converts errors to Sentry events.
 package sentry
 
 import (
@@ -32,7 +33,7 @@ func NewEvent(err error) *sentry.Event {
 
 	errStack := errors.Stack(err)
 
-	var messages []string
+	messages := make([]string, 0, len(errStack))
 
 	for i, err := range errStack {
 		messages = append(messages, err.Error())

--- a/pkg/errors/stack_trace_test.go
+++ b/pkg/errors/stack_trace_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestStackTrace(t *testing.T) {
+	t.Parallel()
 	a := assertions.New(t)
 
 	err := errors.New("err")

--- a/pkg/errors/std.go
+++ b/pkg/errors/std.go
@@ -15,14 +15,14 @@
 package errors
 
 import (
-	stderrors "errors"
+	"errors"
 )
 
 // Alias standard library error functions.
 var (
-	As     = stderrors.As
-	Is     = stderrors.Is
-	Unwrap = stderrors.Unwrap
+	As     = errors.As
+	Is     = errors.Is
+	Unwrap = errors.Unwrap
 )
 
 // Unwrap makes the Error implement error unwrapping.
@@ -38,7 +38,14 @@ func (e *Error) Is(target error) bool {
 	if e == nil {
 		return target == nil
 	}
-	return Resemble(e, target)
+	if namedErr := (interface {
+		Namespace() string
+		Name() string
+	})(nil); errors.As(target, &namedErr) {
+		return namedErr.Namespace() == e.Namespace() &&
+			namedErr.Name() == e.Name()
+	}
+	return false
 }
 
 // Unwrap makes the Definition implement error unwrapping.
@@ -51,5 +58,12 @@ func (d *Definition) Is(target error) bool {
 	if d == nil {
 		return target == nil
 	}
-	return Resemble(d, target)
+	if namedErr := (interface {
+		Namespace() string
+		Name() string
+	})(nil); errors.As(target, &namedErr) {
+		return namedErr.Namespace() == d.Namespace() &&
+			namedErr.Name() == d.Name()
+	}
+	return false
 }

--- a/pkg/errors/std_test.go
+++ b/pkg/errors/std_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestStandardLibraryErrors(t *testing.T) {
+	t.Parallel()
 	a := assertions.New(t)
 
 	var (


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request resolves a number of lint issues in `pkg/errors`.

#### Changes
<!-- What are the changes made in this pull request? -->

- The most interesting changes are related to error conversion. Instead of checking error types, we now use `errors.Is`/`errors.As` in more places.
- Added some more `t.Parallel()`
- Removed use of deprecated `Temporary()` on errors
- Formatted long lines

#### Testing

<!-- How did you verify that this change works? -->

Existing tests

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Error conversion may be slightly different, but that shouldn't break anything, especially since those conversions were properly covered by existing unit tests.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
