### PR TITLE
Protect error definitions with a mutex

### DIFF
--- a/pkg/errors/definitions.go
+++ b/pkg/errors/definitions.go
@@ -16,6 +16,7 @@ package errors
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 
 	"github.com/gotnospirit/messageformat"
@@ -119,15 +120,15 @@ func messageFormatArguments(messageFormat string) (args []string) {
 			args = append(args, matches[1])
 		}
 	}
-	m := make(map[string]struct{}, len(args))
+	unique := make([]string, 0, len(args))
+	seen := make(map[string]struct{}, len(args))
 	for _, arg := range args {
-		m[arg] = struct{}{}
+		if _, ok := seen[arg]; !ok {
+			unique = append(unique, arg)
+			seen[arg] = struct{}{}
+		}
 	}
-	args = make([]string, 0, len(m))
-	for arg := range m {
-		args = append(args, arg)
-	}
-	return
+	return unique
 }
 
 func define(code uint32, name, messageFormat string, publicAttributes ...string) *Definition {
@@ -146,9 +147,6 @@ func define(code uint32, name, messageFormat string, publicAttributes ...string)
 	}
 
 	fullName := def.FullName()
-	if Definitions[fullName] != nil {
-		panic(fmt.Errorf("error %s already defined", fullName))
-	}
 
 	parsedMessageFormat, err := formatter.Parse(messageFormat)
 	if err != nil {
@@ -168,6 +166,28 @@ nextArg:
 	}
 
 	def.setGRPCStatus() // store the (marshaled) gRPC status message.
+
+	if existing := Definitions[fullName]; existing != nil {
+		if existing.code != def.code {
+			panic(fmt.Errorf(
+				"error %s with code %d already defined with code %d",
+				fullName, def.code, existing.code,
+			))
+		}
+		if existing.messageFormat != def.messageFormat {
+			panic(fmt.Errorf(
+				"error %s with message format %q already defined with message format %q",
+				fullName, def.messageFormat, existing.messageFormat,
+			))
+		}
+		if !reflect.DeepEqual(existing.publicAttributes, def.publicAttributes) {
+			panic(fmt.Errorf(
+				"error %s with public attributes %q already defined with public attributes %q",
+				fullName, def.publicAttributes, existing.publicAttributes,
+			))
+		}
+		return existing
+	}
 
 	Definitions[fullName] = &def
 

--- a/pkg/errors/definitions.go
+++ b/pkg/errors/definitions.go
@@ -138,7 +138,7 @@ func define(code uint32, name, messageFormat string, publicAttributes ...string)
 		code = uint32(codes.Unknown)
 	}
 
-	def := Definition{
+	def := &Definition{
 		namespace:              ns,
 		name:                   name,
 		messageFormat:          messageFormat,
@@ -168,46 +168,49 @@ nextArg:
 
 	def.setGRPCStatus() // store the (marshaled) gRPC status message.
 
-	definitionsMu.Lock()
-	if existing := definitions[fullName]; existing != nil {
-		if existing.code != def.code {
-			definitionsMu.Unlock()
-			panic(fmt.Errorf(
-				"error %s with code %d already defined with code %d",
-				fullName, def.code, existing.code,
-			))
-		}
-		if existing.messageFormat != def.messageFormat {
-			definitionsMu.Unlock()
-			panic(fmt.Errorf(
-				"error %s with message format %q already defined with message format %q",
-				fullName, def.messageFormat, existing.messageFormat,
-			))
-		}
-		if !reflect.DeepEqual(existing.publicAttributes, def.publicAttributes) {
-			definitionsMu.Unlock()
-			panic(fmt.Errorf(
-				"error %s with public attributes %q already defined with public attributes %q",
-				fullName, def.publicAttributes, existing.publicAttributes,
-			))
-		}
-		definitionsMu.Unlock()
-		return existing
+	if registered := registerDefinition(def); registered != def {
+		return registered
 	}
-
-	definitions[fullName] = &def
-	definitionsMu.Unlock()
 
 	desc := i18n.Define(fmt.Sprintf("error:%s", fullName), def.messageFormat)
 	desc.SetSource(2)
 
-	return &def
+	return def
 }
 
 var (
 	definitions   = make(map[string]*Definition)
 	definitionsMu sync.Mutex
 )
+
+func registerDefinition(def *Definition) *Definition {
+	definitionsMu.Lock()
+	defer definitionsMu.Unlock()
+	fullName := def.FullName()
+	if existing := definitions[fullName]; existing != nil {
+		if existing.code != def.code {
+			panic(fmt.Errorf(
+				"error %s with code %d already defined with code %d",
+				fullName, def.code, existing.code,
+			))
+		}
+		if existing.messageFormat != def.messageFormat {
+			panic(fmt.Errorf(
+				"error %s with message format %q already defined with message format %q",
+				fullName, def.messageFormat, existing.messageFormat,
+			))
+		}
+		if !reflect.DeepEqual(existing.publicAttributes, def.publicAttributes) {
+			panic(fmt.Errorf(
+				"error %s with public attributes %q already defined with public attributes %q",
+				fullName, def.publicAttributes, existing.publicAttributes,
+			))
+		}
+		return existing
+	}
+	definitions[fullName] = def
+	return def
+}
 
 // Define defines a registered error of type Unknown.
 func Define(name, messageFormat string, publicAttributes ...string) *Definition {

--- a/pkg/errors/definitions_test.go
+++ b/pkg/errors/definitions_test.go
@@ -26,8 +26,6 @@ func TestDefinitions(t *testing.T) {
 	t.Parallel()
 	a := assertions.New(t)
 
-	errors.Define("test_definitions_unknown", "") //nolint:errcheck
-	a.So(func() {
-		errors.Define("test_definitions_unknown", "") //nolint:errcheck
-	}, should.Panic)
+	def := errors.Define("test_definitions_unknown", "")
+	a.So(errors.Define("test_definitions_unknown", ""), should.Equal, def)
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a fix for issues where (parallel) tests would panic because either (1) they would register error definitions concurrently or (2) they would re-register error definitions if `-count` is greater than one. 

#### Changes
<!-- What are the changes made in this pull request? -->

- Allow re-registering error definitions if they're the same
- Protect error definitions with a mutex

#### Testing

<!-- How did you verify that this change works? -->

It's all about testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None expected

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

None

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
