### PR TITLE
Fix transmission acknowledgement correlation IDs

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -7390,7 +7390,7 @@
   },
   "error:pkg/networkserver:transmission": {
     "translations": {
-      "en": "downlink transsmission failed with result `{result}`"
+      "en": "downlink transmission failed with result `{result}`"
     },
     "description": {
       "package": "pkg/networkserver",
@@ -9668,6 +9668,24 @@
   "event:ns.down.join.schedule.success": {
     "translations": {
       "en": "successfully scheduled join-accept for transmission on Gateway Server"
+    },
+    "description": {
+      "package": "pkg/networkserver",
+      "file": "observability.go"
+    }
+  },
+  "event:ns.down.transmission.fail": {
+    "translations": {
+      "en": "failed to transmit downlink"
+    },
+    "description": {
+      "package": "pkg/networkserver",
+      "file": "observability.go"
+    }
+  },
+  "event:ns.down.transmission.success": {
+    "translations": {
+      "en": "downlink successfully transmitted"
     },
     "description": {
       "package": "pkg/networkserver",

--- a/pkg/gatewayserver/gatewayserver_test.go
+++ b/pkg/gatewayserver/gatewayserver_test.go
@@ -1392,8 +1392,9 @@ func TestGatewayServer(t *testing.T) {
 									}
 									select {
 									case ack := <-ns.TxAck():
-										if a.So(ack, should.NotBeNil) {
-											a.So(ack.TxAck, should.Resemble, expected)
+										if txAck := ack.GetTxAck(); a.So(txAck, should.NotBeNil) {
+											a.So(txAck.Result, should.Resemble, expected.Result)
+											a.So(txAck.DownlinkMessage, should.Resemble, expected.DownlinkMessage)
 										}
 									case <-time.After(timeout):
 										t.Fatal("Expected Tx acknowledgment event timeout")

--- a/pkg/networkserver/observability.go
+++ b/pkg/networkserver/observability.go
@@ -137,6 +137,17 @@ var (
 		events.WithErrorDataType(),
 		events.WithPropagateToParent(),
 	)
+	evtTransmissionSuccess = events.Define(
+		"ns.down.transmission.success", "downlink successfully transmitted",
+		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
+		events.WithDataType(&ttnpb.DownlinkMessage{}),
+	)
+	evtTransmissionFail = events.Define(
+		"ns.down.transmission.fail", "failed to transmit downlink",
+		events.WithVisibility(ttnpb.Right_RIGHT_APPLICATION_TRAFFIC_READ),
+		events.WithErrorDataType(),
+		events.WithPropagateToParent(),
+	)
 )
 
 const (

--- a/pkg/util/test/assertions/proto.go
+++ b/pkg/util/test/assertions/proto.go
@@ -48,6 +48,9 @@ const shouldHaveEmptyProtoDiff = "Expected:\n%v\nActual:\n%v\nDiff:\n%s\n(should
 
 // indentBlock indents a block of text with an indent string.
 func indentBlock(text, indent string) string {
+	if text == "" {
+		return indent
+	}
 	if text[len(text)-1:] == "\n" {
 		result := ""
 		for _, j := range strings.Split(text[:len(text)-1], "\n") {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes some inconsistencies related to transmission acknowledgement correlation IDs.

#### Changes
<!-- What are the changes made in this pull request? -->

- At Gateway Server level, populate the context correlation IDs with the correlation IDs from the message.
  - This is done in other components, but not in the Gateway Server.
  - This is most likely caused by the fact that we didn't propagate the context in the past, when this correlation IDs filling was added. This occurs now as the `workerpool.WorkerPool` carries the context.
- Ensure that the `*ttnpb.TxAcknowldgement` and `*ttnpb.DownlinkMessage` carry the same correlation IDs.
  - Previously this was inconsistent - the top level message would not have some correlation IDs that the downlink message would do. See example below.
- Emit events in the Network Server for such transmission acknowledgements / failures.


#### Testing

<!-- How did you verify that this change works? -->

Local testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

The only user facing changes are the clarifications related to correlation IDs, and these have been tested locally.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Before the change, this is how a `gx.txack.receive` event would look like:
```json
{
  "name": "gs.txack.receive",
  "time": "2022-05-30T14:15:18.812178588Z",
  "identifiers": [
    {
      "gateway_ids": {
        "gateway_id": "dragino-lps8-adrian-2"
      }
    },
    {
      "gateway_ids": {
        "gateway_id": "dragino-lps8-adrian-2",
        "eui": "A84041218C3C4150"
      }
    }
  ],
  "data": {
    "@type": "type.googleapis.com/ttn.lorawan.v3.TxAcknowledgment",
    "correlation_ids": [
      "as:downlink:01G4AN49DQBRZSJGMJ7M66WYWM",
      "gs:conn:01G4AMZYFW0E415W3SP9WQ5C6D",
      "gs:up:host:01G4AMZYG61QB9NVKA2Q9ZWQ9S",
      "gs:up:host:01G4AMZYG65GJ3KS1Z3RZXF46F",
      "gs:uplink:01G4AN494PXWSNBX40YH10MDJ3",
      "ns:downlink:01G4AN49Q09XCEBEVNQZSP1R99",
      "ns:uplink:01G4AN494RTS2H2PH9YBR6T1V2",
      "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01G4AN494RD1QBM585F9J7Z5NX",
      "gs:conn:01G4AMZYFW0E415W3SP9WQ5C6D"
    ],
    "downlink_message": {
      "raw_payload": "oJ0AACeAFEkBXVIFLnk=",
      "scheduled": {
        "data_rate": {
          "lora": {
            "bandwidth": 500000,
            "spreading_factor": 7
          }
        },
        "coding_rate": "4/5",
        "frequency": "923900000",
        "timestamp": 140284779,
        "downlink": {
          "tx_power": 28.15,
          "invert_polarization": true
        },
        "concentrator_timestamp": "140284779000"
      },
      "correlation_ids": [
        "as:downlink:01G4AN49DQBRZSJGMJ7M66WYWM",
        "gs:conn:01G4AMZYFW0E415W3SP9WQ5C6D",
        "gs:up:host:01G4AMZYG61QB9NVKA2Q9ZWQ9S",
        "gs:up:host:01G4AMZYG65GJ3KS1Z3RZXF46F",
        "gs:uplink:01G4AN494PXWSNBX40YH10MDJ3",
        "ns:downlink:01G4AN49Q09XCEBEVNQZSP1R99",
        "ns:uplink:01G4AN494RTS2H2PH9YBR6T1V2",
        "rpc:/ttn.lorawan.v3.GsNs/HandleUplink:01G4AN494RD1QBM585F9J7Z5NX",
        "gs:conn:01G4AMZYFW0E415W3SP9WQ5C6D",
        "gs:conn:01G4AMZYFW0E415W3SP9WQ5C6D",
        "gs:tx_ack:01G4AN4E0WYNFPTJ6GFXA7B884"
      ]
    }
  },
  "correlation_ids": [
    "gs:conn:01G4AMZYFW0E415W3SP9WQ5C6D",
    "gs:tx_ack:01G4AN4E0WYNFPTJ6GFXA7B884"
  ],
  "origin": "ip-10-20-6-86.eu-west-1.compute.internal",
  "context": {
    "tenant-id": "CgN0dGk="
  },
  "visibility": {
    "rights": [
      "RIGHT_GATEWAY_TRAFFIC_READ",
      "RIGHT_GATEWAY_TRAFFIC_READ"
    ]
  },
  "unique_id": "01G4AN4E0WVRH51S01FEQX884F"
}
```
You can see that the last two correlation IDs in the downlink message are not found in the upper level transmission acknowledgement message, and that the event itself lacks some correlation ids. The `gs:conn:01G4AMZYFW0E415W3SP9WQ5C6D` ID is also duplicated.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
