### PR TITLE
Add generic net.Error timeout fallback

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -4060,7 +4060,16 @@
   },
   "error:pkg/errors:net_operation": {
     "translations": {
-      "en": "{message}"
+      "en": "net operation failed"
+    },
+    "description": {
+      "package": "pkg/errors",
+      "file": "conversion.go"
+    }
+  },
+  "error:pkg/errors:net_timeout": {
+    "translations": {
+      "en": "operation timed out"
     },
     "description": {
       "package": "pkg/errors",


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/745

#### Changes
<!-- What are the changes made in this pull request? -->

- Add a generic `net.Error` fallback to `pkg/errors` conversion, only for timeout errors.
- Change the description of `errNetOperation`, as we never provided a `message` attribute anyway, and using `Error()` is dubious as we cannot control the chain of contents.
- Add a generic error for `os.DeadlineExceeded`

#### Testing

<!-- How did you verify that this change works? -->

Local testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None are expected. Specifically this fallback just ensures that if a timeout error is encountered, we actually output this information to the user.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This is a very conservative implementation, since we would like to avoid outputting the error message (`Error()`) for any error that matches the interface. The original issue would require a form of type checking for the `net/http` errors, but unfortunately these are [unexported](https://github.com/golang/go/blob/690ac4071fa3e07113bf371c9e74394ab54d6749/src/net/http/transport.go#L2503).

Let me know if you think that we can actually always expose the message.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
