### PR TITLE
Add typing to pkg/workerpool

### DIFF
--- a/pkg/applicationserver/io/io.go
+++ b/pkg/applicationserver/io/io.go
@@ -219,7 +219,12 @@ func (s *Subscription) Up() <-chan *ContextualApplicationUp {
 }
 
 // Pipe pipes the output of the Subscription to the provided handler.
-func (s *Subscription) Pipe(ctx context.Context, ts task.Starter, name string, submit func(context.Context, interface{}) error) {
+func (s *Subscription) Pipe(
+	ctx context.Context,
+	ts task.Starter,
+	name string,
+	submit func(context.Context, *ttnpb.ApplicationUp) error,
+) {
 	f := func(ctx context.Context) error {
 		for {
 			select {

--- a/pkg/applicationserver/metadata/location_registry.go
+++ b/pkg/applicationserver/metadata/location_registry.go
@@ -161,7 +161,7 @@ type cachedEndDeviceLocationRegistry struct {
 	maxRefreshInterval time.Duration
 	ttl                time.Duration
 
-	replicationPool workerpool.WorkerPool
+	replicationPool workerpool.WorkerPool[*ttnpb.EndDeviceIdentifiers]
 }
 
 // Get implements EndDeviceLocationRegistry.
@@ -221,12 +221,11 @@ func NewCachedEndDeviceLocationRegistry(ctx context.Context, c workerpool.Compon
 		maxRefreshInterval: maxRefreshInterval,
 		ttl:                ttl,
 
-		replicationPool: workerpool.NewWorkerPool(workerpool.Config{
+		replicationPool: workerpool.NewWorkerPool(workerpool.Config[*ttnpb.EndDeviceIdentifiers]{
 			Component: c,
 			Context:   ctx,
 			Name:      "replicate_end_device_locations",
-			Handler: func(ctx context.Context, item interface{}) {
-				ids := item.(*ttnpb.EndDeviceIdentifiers)
+			Handler: func(ctx context.Context, ids *ttnpb.EndDeviceIdentifiers) {
 				locations, err := registry.Get(ctx, ids)
 				if err != nil {
 					log.FromContext(ctx).WithError(err).Warn("Failed to retrieve end device locations")

--- a/pkg/gatewayserver/io/udp/udp.go
+++ b/pkg/gatewayserver/io/udp/udp.go
@@ -80,7 +80,7 @@ func Serve(ctx context.Context, server io.Server, conn *net.UDPConn, config Conf
 
 		limitLogs: limitLogs,
 	}
-	wp := workerpool.NewWorkerPool(workerpool.Config{
+	wp := workerpool.NewWorkerPool(workerpool.Config[encoding.Packet]{
 		Component:  server,
 		Context:    ctx,
 		Name:       "udp",
@@ -96,7 +96,7 @@ func Serve(ctx context.Context, server io.Server, conn *net.UDPConn, config Conf
 	return s.read(wp)
 }
 
-func (s *srv) read(wp workerpool.WorkerPool) error {
+func (s *srv) read(wp workerpool.WorkerPool[encoding.Packet]) error {
 	var buf [65507]byte
 	for {
 		n, addr, err := s.conn.ReadFromUDP(buf[:])
@@ -145,9 +145,7 @@ func (s *srv) read(wp workerpool.WorkerPool) error {
 	}
 }
 
-func (s *srv) handlePacket(ctx context.Context, pkt interface{}) {
-	packet := pkt.(encoding.Packet)
-
+func (s *srv) handlePacket(ctx context.Context, packet encoding.Packet) {
 	eui := *packet.GatewayEUI
 	ctx = log.NewContextWithField(ctx, "gateway_eui", eui)
 	logger := log.FromContext(ctx)

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -132,7 +132,7 @@ type NetworkServer struct {
 
 	scheduledDownlinkMatcher ScheduledDownlinkMatcher
 
-	uplinkSubmissionPool workerpool.WorkerPool
+	uplinkSubmissionPool workerpool.WorkerPool[[]*ttnpb.ApplicationUp]
 }
 
 // Option configures the NetworkServer.
@@ -232,7 +232,7 @@ func New(c *component.Component, conf *Config, opts ...Option) (*NetworkServer, 
 		downlinkQueueCapacity:    conf.DownlinkQueueCapacity,
 		scheduledDownlinkMatcher: conf.ScheduledDownlinkMatcher,
 	}
-	ns.uplinkSubmissionPool = workerpool.NewWorkerPool(workerpool.Config{
+	ns.uplinkSubmissionPool = workerpool.NewWorkerPool(workerpool.Config[[]*ttnpb.ApplicationUp]{
 		Component:  c,
 		Context:    ctx,
 		Name:       "uplink_submission",

--- a/pkg/networkserver/utils.go
+++ b/pkg/networkserver/utils.go
@@ -401,8 +401,7 @@ func (ns *NetworkServer) submitApplicationUplinks(ctx context.Context, ups ...*t
 	}
 }
 
-func (ns *NetworkServer) handleUplinkSubmission(ctx context.Context, item interface{}) {
-	ups := item.([]*ttnpb.ApplicationUp)
+func (ns *NetworkServer) handleUplinkSubmission(ctx context.Context, ups []*ttnpb.ApplicationUp) {
 	conn, err := ns.GetPeerConn(ctx, ttnpb.ClusterRole_APPLICATION_SERVER, nil)
 	if err != nil {
 		log.FromContext(ctx).WithError(err).Warn("Failed to get Application Server peer")

--- a/pkg/workerpool/utils.go
+++ b/pkg/workerpool/utils.go
@@ -22,10 +22,10 @@ import (
 )
 
 // HandlerFromUplinkHandler converts a static uplink handler to a Handler.
-func HandlerFromUplinkHandler(handler func(context.Context, *ttnpb.ApplicationUp) error) Handler {
-	h := func(ctx context.Context, item interface{}) {
-		up := item.(*ttnpb.ApplicationUp)
-
+func HandlerFromUplinkHandler(
+	handler func(context.Context, *ttnpb.ApplicationUp) error,
+) Handler[*ttnpb.ApplicationUp] {
+	h := func(ctx context.Context, up *ttnpb.ApplicationUp) {
 		if err := handler(ctx, up); err != nil {
 			log.FromContext(ctx).WithError(err).Warn("Failed to submit message")
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR adds type information to `pkg/workerpool`, in order to avoid type conversions to and from `interface{}`.

#### Changes
<!-- What are the changes made in this pull request? -->

- Make worker pools typed, with the worker item type being carried to the handler
  - This works very well for pools that have a singular item type, even if it is an interface.
  - There is a pool in `pkg/gatewayserver` which still requires `any` because it may carry 3 different work items. There are no sum types in Go yet (only type set constrains, which cannot be used here), so for now it will have to stay as is.


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

No new functionality has been added or changed - this is just a tech debt change that moves away from the unsafe `interface{}` to a stronger typing. As such, existing unit tests should cover all of the uses.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
