### PR TITLE
Don't Copy Lock value

### DIFF
--- a/cmd/ttn-lw-stack/commands/as_db.go
+++ b/cmd/ttn-lw-stack/commands/as_db.go
@@ -142,7 +142,7 @@ var (
 			// Define retry delay for obtaining cluster peer connection.
 			retryDelay := time.Duration(500) * time.Millisecond
 			// Create cluster and grpc connection with identity server.
-			conn, cl, err := NewClusterComponentConnection(ctx, *config, retryDelay, 5, ttnpb.ClusterRole_ENTITY_REGISTRY)
+			conn, cl, err := NewClusterComponentConnection(ctx, config, retryDelay, 5, ttnpb.ClusterRole_ENTITY_REGISTRY)
 			if err != nil {
 				return err
 			}

--- a/cmd/ttn-lw-stack/commands/js_db.go
+++ b/cmd/ttn-lw-stack/commands/js_db.go
@@ -78,8 +78,8 @@ var (
 			}
 
 			logger.Info("Connecting to Redis database...")
-			devicesCl := NewJoinServerDeviceRegistryRedis(*config)
-			keysCl := NewJoinServerSessionKeyRegistryRedis(*config)
+			devicesCl := NewJoinServerDeviceRegistryRedis(config)
+			keysCl := NewJoinServerSessionKeyRegistryRedis(config)
 
 			schemaVersion, err := getSchemaVersion(keysCl)
 			if err != nil {
@@ -209,7 +209,7 @@ var (
 			// Define retry delay for obtaining cluster peer connection.
 			retryDelay := time.Duration(500) * time.Millisecond
 			// Create cluster and grpc connection with identity server.
-			conn, cl, err := NewClusterComponentConnection(ctx, *config, retryDelay, 5, ttnpb.ClusterRole_ENTITY_REGISTRY)
+			conn, cl, err := NewClusterComponentConnection(ctx, config, retryDelay, 5, ttnpb.ClusterRole_ENTITY_REGISTRY)
 			if err != nil {
 				return err
 			}

--- a/cmd/ttn-lw-stack/commands/ns_db.go
+++ b/cmd/ttn-lw-stack/commands/ns_db.go
@@ -43,7 +43,7 @@ var (
 			}
 
 			logger.Info("Connecting to Redis database...")
-			cl := NewNetworkServerApplicationUplinkQueueRedis(*config)
+			cl := NewNetworkServerApplicationUplinkQueueRedis(config)
 			var deleted uint64
 			defer func() { logger.Debugf("%d processed stream entries deleted", deleted) }()
 			return ttnredis.RangeRedisKeys(ctx, cl, nsredis.ApplicationUplinkQueueUIDGenericUplinkKey(cl, "*"), ttnredis.DefaultRangeCount, func(k string) (bool, error) {
@@ -93,7 +93,7 @@ var (
 			}
 
 			logger.Info("Connecting to Redis database...")
-			cl := NewNetworkServerDeviceRegistryRedis(*config)
+			cl := NewNetworkServerDeviceRegistryRedis(config)
 
 			if force, _ := cmd.Flags().GetBool("force"); !force {
 				schemaVersion, err := getSchemaVersion(cl)
@@ -477,7 +477,7 @@ var (
 			// Define retry delay for obtaining cluster peer connection.
 			retryDelay := time.Duration(500) * time.Millisecond
 			// Create cluster and grpc connection with identity server.
-			conn, cl, err := NewClusterComponentConnection(ctx, *config, retryDelay, 5, ttnpb.ClusterRole_ENTITY_REGISTRY)
+			conn, cl, err := NewClusterComponentConnection(ctx, config, retryDelay, 5, ttnpb.ClusterRole_ENTITY_REGISTRY)
 			if err != nil {
 				return err
 			}

--- a/cmd/ttn-lw-stack/commands/root.go
+++ b/cmd/ttn-lw-stack/commands/root.go
@@ -48,7 +48,7 @@ var (
 	versionUpdate       chan pkgversion.Update
 	versionCheckTimeout = 500 * time.Millisecond
 
-	// Root command is the entrypoint of the program
+	// Root command is the entrypoint of the program.
 	Root = &cobra.Command{
 		Use:           name,
 		SilenceErrors: true,

--- a/cmd/ttn-lw-stack/commands/start.go
+++ b/cmd/ttn-lw-stack/commands/start.go
@@ -54,30 +54,43 @@ import (
 
 const defaultLockTTL = 10 * time.Second
 
+// NewComponentDeviceRegistryRedis instantiates a new redis client with the Component Device Registry namespace.
 func NewComponentDeviceRegistryRedis(conf *Config, name string) *redis.Client {
 	return redis.New(conf.Redis.WithNamespace(name, "devices"))
 }
 
+// NewNetworkServerDeviceRegistryRedis instantiates a new redis client
+// with the Network Server Device Registry namespace.
 func NewNetworkServerDeviceRegistryRedis(conf *Config) *redis.Client {
 	return NewComponentDeviceRegistryRedis(conf, "ns")
 }
 
+// NewNetworkServerApplicationUplinkQueueRedis instantiates a new redis client
+// with the Network Server Application Uplink Queue namespace.
 func NewNetworkServerApplicationUplinkQueueRedis(conf *Config) *redis.Client {
 	return redis.New(conf.Redis.WithNamespace("ns", "application-uplinks"))
 }
 
+// NewNetworkServerDownlinkTaskRedis instantiates a new redis client
+// with the Network Server Downlink Task namespace.
 func NewNetworkServerDownlinkTaskRedis(conf *Config) *redis.Client {
 	return redis.New(conf.Redis.WithNamespace("ns", "tasks"))
 }
 
+// NewApplicationServerDeviceRegistryRedis instantiates a new redis client
+// with the Application Server Device Registry namespace.
 func NewApplicationServerDeviceRegistryRedis(conf *Config) *redis.Client {
 	return NewComponentDeviceRegistryRedis(conf, "as")
 }
 
+// NewJoinServerDeviceRegistryRedis instantiates a new redis client
+// with the Join Server Device Registry namespace.
 func NewJoinServerDeviceRegistryRedis(conf *Config) *redis.Client {
 	return NewComponentDeviceRegistryRedis(conf, "js")
 }
 
+// NewJoinServerSessionKeyRegistryRedis instantiates a new redis client
+// with the Join Server Session Key Registry namespace.
 func NewJoinServerSessionKeyRegistryRedis(conf *Config) *redis.Client {
 	return redis.New(conf.Redis.WithNamespace("js", "keys"))
 }

--- a/cmd/ttn-lw-stack/commands/utils.go
+++ b/cmd/ttn-lw-stack/commands/utils.go
@@ -32,7 +32,7 @@ const defaultPaginationLimit = 1000
 // NewClusterComponentConnection connects returns a new cluster instance and a connection to a specified peer.
 // The connection to a cluster peer is retried specified number of times before returning an error in case
 // of connection not being ready.
-func NewClusterComponentConnection(ctx context.Context, config Config, delay time.Duration, maxRetries int, role ttnpb.ClusterRole) (*grpc.ClientConn, cluster.Cluster, error) {
+func NewClusterComponentConnection(ctx context.Context, config *Config, delay time.Duration, maxRetries int, role ttnpb.ClusterRole) (*grpc.ClientConn, cluster.Cluster, error) {
 	clusterOpts := []cluster.Option{}
 	if config.Cluster.TLS {
 		tlsConf := config.TLS

--- a/cmd/ttn-lw-stack/commands/utils.go
+++ b/cmd/ttn-lw-stack/commands/utils.go
@@ -32,7 +32,12 @@ const defaultPaginationLimit = 1000
 // NewClusterComponentConnection connects returns a new cluster instance and a connection to a specified peer.
 // The connection to a cluster peer is retried specified number of times before returning an error in case
 // of connection not being ready.
-func NewClusterComponentConnection(ctx context.Context, config *Config, delay time.Duration, maxRetries int, role ttnpb.ClusterRole) (*grpc.ClientConn, cluster.Cluster, error) {
+func NewClusterComponentConnection(ctx context.Context,
+	config *Config,
+	delay time.Duration,
+	maxRetries int,
+	role ttnpb.ClusterRole,
+) (*grpc.ClientConn, cluster.Cluster, error) {
 	clusterOpts := []cluster.Option{}
 	if config.Cluster.TLS {
 		tlsConf := config.TLS


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a small fix for a linter warning.
```
copylocks: call of NewClusterComponentConnection copies lock value: go.thethings.network/lorawan-stack/v3/cmd/ttn-lw-stack/commands.Config contains go.thethings.network/lorawan-stack/v3/pkg/config.ServiceBase contains go.thethings.network/lorawan-stack/v3/pkg/config.Cache contains go.thethings.network/lorawan-stack/v3/pkg/redis.Config contains struct{Require bool "name:\"require\" description:\"Require TLS\""; go.thethings.network/lorawan-stack/v3/pkg/config/tlsconfig.Client "name:\",squash\""} contains go.thethings.network/lorawan-stack/v3/pkg/config/tlsconfig.Client contains sync.Once contains sync.Mutex (govet)go-golangci-lint
```

#### Changes
<!-- What are the changes made in this pull request? -->

- Change methods to accept pointer to config instead of value.

#### Testing

<!-- How did you verify that this change works? -->

NA

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

NA

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
