### PR TITLE
Return context on error

### DIFF
--- a/pkg/gatewayserver/io/ws/lbslns/upstream.go
+++ b/pkg/gatewayserver/io/ws/lbslns/upstream.go
@@ -550,11 +550,11 @@ func (f *lbsLNS) HandleUp(ctx context.Context, raw []byte, ids *ttnpb.GatewayIde
 			antennaGain = int(antennas[0].Gain)
 		}
 		ctx, msg, stat, err := f.GetRouterConfig(ctx, raw, conn.BandID(), conn.FrequencyPlans(), antennaGain, receivedAt)
-		logger = log.FromContext(ctx)
 		if err != nil {
 			logger.WithError(err).Warn("Failed to generate router configuration")
 			return nil, err
 		}
+		logger = log.FromContext(ctx)
 		if err := conn.HandleStatus(stat); err != nil {
 			logger.WithError(err).Warn("Failed to handle status message")
 			return nil, err

--- a/pkg/gatewayserver/io/ws/lbslns/version.go
+++ b/pkg/gatewayserver/io/ws/lbslns/version.go
@@ -67,7 +67,7 @@ func (v Version) IsProduction() bool {
 func (f *lbsLNS) GetRouterConfig(ctx context.Context, msg []byte, bandID string, fps map[string]*frequencyplans.FrequencyPlan, antennaGain int, receivedAt time.Time) (context.Context, []byte, *ttnpb.GatewayStatus, error) {
 	var version Version
 	if err := json.Unmarshal(msg, &version); err != nil {
-		return nil, nil, nil, err
+		return ctx, nil, nil, err
 	}
 	// We attempt to transfer time to all gateways by default.
 	// In the future, we should disable time transfers permanently
@@ -76,7 +76,7 @@ func (f *lbsLNS) GetRouterConfig(ctx context.Context, msg []byte, bandID string,
 	updateSessionTimeSync(ctx, true)
 	cfg, err := pfconfig.GetRouterConfig(bandID, fps, version.IsProduction(), time.Now(), antennaGain)
 	if err != nil {
-		return nil, nil, nil, err
+		return ctx, nil, nil, err
 	}
 	// The SX1301 configuration object should not specify a bandwidth field for the FSK channel.
 	// See https://doc.sm.tc/station/tcproto.html#router-config-message under the SX1301CONF section.
@@ -87,7 +87,7 @@ func (f *lbsLNS) GetRouterConfig(ctx context.Context, msg []byte, bandID string,
 	}
 	routerCfg, err := cfg.MarshalJSON()
 	if err != nil {
-		return nil, nil, nil, err
+		return ctx, nil, nil, err
 	}
 	// TODO: Revisit these fields for v3 events (https://github.com/TheThingsNetwork/lorawan-stack/issues/2629)
 	stat := &ttnpb.GatewayStatus{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://sentry.io/organizations/the-things-industries/issues/3332073809

#### Changes
<!-- What are the changes made in this pull request? -->

- Return the original context on error in the LBSLNS frontend
  - The panic referenced above occurs because we attempt to obtain the logger from the context even when an error occurs.
https://github.com/TheThingsNetwork/lorawan-stack/blob/1e9fb3a9a96d393957b631579b4eb62bf9efc677/pkg/gatewayserver/io/ws/lbslns/upstream.go#L552-L557
  - In most places where this kind of operation occurs (we take some parameters, then return them in a modified form), even on error we return the original value in order to avoid making the life too hard for the caller.


#### Testing

<!-- How did you verify that this change works? -->

N/A

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
