### PR TITLE
Fix wrong representation of time values after midnight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Fixed
 
 - End devices running on MAC versions higher or equal to 1.1 showing network downlink frame counters instead of application downlink frame counters.
+- Wrong representation of time values between midnight and 1am (eg. 24:04:11) in the Console in some cases.
 
 ### Security
 

--- a/pkg/webui/console/views/device-general-settings/network-server-form/validation-schema.js
+++ b/pkg/webui/console/views/device-general-settings/network-server-form/validation-schema.js
@@ -373,7 +373,7 @@ const validationSchema = Yup.object()
             return Yup.string()
           }),
           status_count_periodicity: Yup.lazy(value => {
-            if (!Boolean(value)) {
+            if (value === undefined || value === '') {
               return Yup.number().strip()
             }
 

--- a/pkg/webui/lib/components/date-time/index.js
+++ b/pkg/webui/lib/components/date-time/index.js
@@ -137,7 +137,6 @@ DateTime.defaultProps = {
     hour: 'numeric',
     minute: 'numeric',
     second: 'numeric',
-    hour12: false,
     hourCycle: 'h23',
   },
   noTitle: false,

--- a/pkg/webui/lib/components/date-time/index.js
+++ b/pkg/webui/lib/components/date-time/index.js
@@ -138,6 +138,7 @@ DateTime.defaultProps = {
     minute: 'numeric',
     second: 'numeric',
     hour12: false,
+    hourCycle: 'h23',
   },
   noTitle: false,
 }


### PR DESCRIPTION
#### Summary
Fixes an issue that would cause time values after midnight to be displayed as `24:xx:xx`

![image](https://user-images.githubusercontent.com/5710611/172675126-1c7a9c1c-349b-4ef2-acfb-19bfc72fb0be.png)

See also https://www.thethingsnetwork.org/forum/t/24-hour-timestamp-in-console/57422

#### Changes
- Add correct `hourCycle` option to the react intl datetime component


#### Testing

Manual.

#### Notes for Reviewers
Apparently a weird chrome quirk:
https://bugs.chromium.org/p/chromium/issues/detail?id=1045791&q=hourcycle&can=1

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
