### PR TITLE
Fix duplicated identifiers and visibility items in events

### DIFF
--- a/pkg/events/cloud/cloud.go
+++ b/pkg/events/cloud/cloud.go
@@ -169,7 +169,7 @@ func (ps *PubSub) getMetadata(evt events.Event) map[string]string {
 	md := make(map[string]string, len(ids)+3)
 	md["content-type"] = ps.contentType
 	md["event"] = evt.Name()
-	md["correlation_ids"] = strings.Join(evt.CorrelationIDs(), ",")
+	md["correlation_ids"] = strings.Join(evt.CorrelationIds(), ",")
 	for k, v := range ids {
 		md[k] = strings.Join(v, ",")
 	}

--- a/pkg/events/correlation_context.go
+++ b/pkg/events/correlation_context.go
@@ -25,10 +25,10 @@ import (
 type correlationKey struct{}
 
 // ContextWithCorrelationID returns a derived context with the correlation IDs if they were not already in there.
-// NOTE: This function assumes that the provided correlation IDs do not contain any duplicates.
 func ContextWithCorrelationID(ctx context.Context, cids ...string) context.Context {
 	cids = append(cids[:0:0], cids...)
 	sort.Strings(cids)
+	cids = uniqueStrings(cids)
 
 	existing, ok := ctx.Value(correlationKey{}).([]string)
 	if !ok {
@@ -49,6 +49,26 @@ func CorrelationIDsFromContext(ctx context.Context) []string {
 // NewCorrelationID returns a new random correlation ID.
 func NewCorrelationID() string {
 	return ulid.MustNew(ulid.Now(), rand.Reader).String()
+}
+
+// uniqueStrings returns a slice with the unique elements of
+// the provided slice. The provided slice must be sorted,
+// and the returning slice will be sorted as well.
+// The provided slice will be modified in place, so it must
+// not be reused after uniqueStrings has been called.
+func uniqueStrings(s []string) []string {
+	if len(s) < 2 {
+		return s
+	}
+	u := 1
+	for i := 1; i < len(s); i++ {
+		if s[i] == s[i-1] {
+			continue
+		}
+		s[u] = s[i]
+		u++
+	}
+	return s[:u]
 }
 
 // mergeStrings merges 2 sorted string slices and returns the resulting slice

--- a/pkg/events/correlation_context.go
+++ b/pkg/events/correlation_context.go
@@ -25,6 +25,7 @@ import (
 type correlationKey struct{}
 
 // ContextWithCorrelationID returns a derived context with the correlation IDs if they were not already in there.
+// NOTE: This function assumes that the provided correlation IDs do not contain any duplicates.
 func ContextWithCorrelationID(ctx context.Context, cids ...string) context.Context {
 	cids = append(cids[:0:0], cids...)
 	sort.Strings(cids)

--- a/pkg/events/correlation_context_internal_test.go
+++ b/pkg/events/correlation_context_internal_test.go
@@ -1,0 +1,50 @@
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"testing"
+
+	"github.com/smartystreets/assertions"
+)
+
+func TestUniqueStrings(t *testing.T) {
+	t.Parallel()
+	a := assertions.New(t)
+
+	a.So(uniqueStrings([]string{
+		"aaa", "bbb", "ccc",
+	}), assertions.ShouldResemble, []string{
+		"aaa", "bbb", "ccc",
+	})
+
+	a.So(uniqueStrings([]string{
+		"aaa", "aaa", "bbb", "ccc",
+	}), assertions.ShouldResemble, []string{
+		"aaa", "bbb", "ccc",
+	})
+
+	a.So(uniqueStrings([]string{
+		"aaa", "aaa", "bbb", "bbb", "bbb", "ccc",
+	}), assertions.ShouldResemble, []string{
+		"aaa", "bbb", "ccc",
+	})
+
+	a.So(uniqueStrings([]string{
+		"aaa", "aaa", "bbb", "bbb", "bbb", "ccc", "ccc", "ccc", "ccc",
+	}), assertions.ShouldResemble, []string{
+		"aaa", "bbb", "ccc",
+	})
+}

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -41,7 +41,7 @@ type Event interface {
 	Time() time.Time
 	Identifiers() []*ttnpb.EntityIdentifiers
 	Data() interface{}
-	CorrelationIDs() []string
+	CorrelationIds() []string
 	Origin() string
 	Caller() string
 	Visibility() *ttnpb.Rights
@@ -63,7 +63,7 @@ func local(evt Event) *event {
 				Name:           evt.Name(),
 				Time:           ttnpb.ProtoTimePtr(t),
 				Identifiers:    evt.Identifiers(),
-				CorrelationIds: evt.CorrelationIDs(),
+				CorrelationIds: evt.CorrelationIds(),
 				Origin:         evt.Origin(),
 				Visibility:     evt.Visibility(),
 				UserAgent:      evt.UserAgent(),
@@ -150,7 +150,7 @@ func (e event) Time() time.Time {
 }
 func (e event) Identifiers() []*ttnpb.EntityIdentifiers { return e.innerEvent.Identifiers }
 func (e event) Data() interface{}                       { return e.data }
-func (e event) CorrelationIDs() []string                { return e.innerEvent.CorrelationIds }
+func (e event) CorrelationIds() []string                { return e.innerEvent.CorrelationIds }
 func (e event) Origin() string                          { return e.innerEvent.Origin }
 func (e event) Caller() string                          { return e.caller }
 func (e event) Visibility() *ttnpb.Rights               { return e.innerEvent.Visibility }

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -37,7 +37,7 @@ func TestNew(t *testing.T) {
 	a := assertions.New(t)
 	ctx := events.ContextWithCorrelationID(test.Context(), t.Name())
 	evt := events.New(ctx, "test.evt", "test event", events.WithAuthFromContext())
-	a.So(evt.CorrelationIDs(), should.Resemble, []string{"TestNew"})
+	a.So(evt.CorrelationIds(), should.Resemble, []string{"TestNew"})
 	a.So(evt.Visibility().GetRights(), should.Contain, ttnpb.Right_RIGHT_ALL)
 	a.So(evt.AuthType(), should.Equal, "")
 	a.So(evt.AuthTokenType(), should.Equal, "")

--- a/pkg/events/options.go
+++ b/pkg/events/options.go
@@ -49,13 +49,6 @@ func WithIdentifiers(identifiers ...EntityIdentifiers) Option {
 func WithData(data interface{}) Option {
 	return optionFunc(func(e *event) {
 		e.data = data
-		if data, ok := data.(interface{ GetCorrelationIDs() []string }); ok {
-			if cids := data.GetCorrelationIDs(); len(cids) > 0 {
-				cids = append(cids[:0:0], cids...)
-				sort.Strings(cids)
-				e.innerEvent.CorrelationIds = mergeStrings(e.innerEvent.CorrelationIds, cids)
-			}
-		}
 		if data, ok := data.(interface{ GetCorrelationIds() []string }); ok {
 			if cids := data.GetCorrelationIds(); len(cids) > 0 {
 				cids = append(cids[:0:0], cids...)

--- a/pkg/events/redis/codec.go
+++ b/pkg/events/redis/codec.go
@@ -47,8 +47,11 @@ func decodeEventData(enc string, evt *ttnpb.Event) error {
 	if err != nil {
 		return err
 	}
-	// NOTE: We're merging additional event data into an event that may already contain fields.
-	return proto.UnmarshalMerge(bpb, evt)
+	// NOTE: We override the contents of `evt` with the contents `enc` explicitly.
+	// proto.UnmarshalMerge has append semantics for slices, and as such identifiers
+	// and event visibility will be duplicated, as `evt` most likely contains them
+	// from the sparse event representation.
+	return proto.Unmarshal(bpb, evt)
 }
 
 const (

--- a/pkg/events/redis/store.go
+++ b/pkg/events/redis/store.go
@@ -67,7 +67,7 @@ func (ps *PubSubStore) storeEvent(ctx context.Context, tx redis.Cmdable, evt eve
 		return err
 	}
 	tx.Set(ctx, ps.eventDataKey(evt.Context(), evt.UniqueID()), b, ps.historyTTL)
-	for _, cid := range evt.CorrelationIDs() {
+	for _, cid := range evt.CorrelationIds() {
 		key := ps.eventIndexKey(evt.Context(), cid)
 		tx.LPush(ctx, key, evt.UniqueID())
 		tx.LTrim(ctx, key, 0, int64(ps.correlationIDHistoryCount))

--- a/pkg/events/redis/store.go
+++ b/pkg/events/redis/store.go
@@ -113,11 +113,11 @@ func (ps *PubSubStore) LoadEvent(ctx context.Context, uid string) (*ttnpb.Event,
 	if err != nil {
 		return nil, ttnredis.ConvertError(err)
 	}
-	var evtPB ttnpb.Event
-	if err = decodeEventData(data, &evtPB); err != nil {
+	evtPB := &ttnpb.Event{}
+	if err = decodeEventData(data, evtPB); err != nil {
 		return nil, err
 	}
-	return &evtPB, nil
+	return evtPB, nil
 }
 
 func xMessageHasEventName(names ...string) func(msg redis.XMessage) bool {

--- a/pkg/networkserver/networkserver_util_internal_test.go
+++ b/pkg/networkserver/networkserver_util_internal_test.go
@@ -600,7 +600,7 @@ func (env TestEnvironment) AssertSetDevice(ctx context.Context, create bool, req
 
 	case ev := <-env.Events:
 		if !a.So(ev.Event, should.ResembleEvent, expectedEvent.New(
-			events.ContextWithCorrelationID(reqCtx, ev.Event.CorrelationIDs()...),
+			events.ContextWithCorrelationID(reqCtx, ev.Event.CorrelationIds()...),
 			events.WithIdentifiers(req.EndDevice.Ids),
 		)) {
 			t.Errorf("Failed to assert device %s event", action)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes a bug that caused certain slices in events to be duplicated.

<img width="589" alt="image" src="https://user-images.githubusercontent.com/36161392/172687524-6417932e-b33e-4f27-b89b-f9cff2c7d741.png">
<img width="521" alt="image" src="https://user-images.githubusercontent.com/36161392/172687620-823260d4-726a-44ed-a92d-4e6e2e594f70.png">


#### Changes
<!-- What are the changes made in this pull request? -->

1. When using the Redis events store, always unmarshal the event data completely, instead of merging the representations.
   - As mentioned in the code comment, `proto.UnmarshalMerge` has append semantics for slices, and as such duplicates the identifiers. The first identifiers come from the event sparse representation found in the streams, while the full identifiers (with EUIs) come from the actual event data.
2. Remove the deprecated `GetCorrelationIDs` getter syntax.
   - This is a bit of debt from the transitory period in which we had both custom names and non-custom names fields.

#### Testing

<!-- How did you verify that this change works? -->

Local testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

1. I've looked everywhere and I couldn't find a case in which the merging behavior was actually useful. `encodeEventData` will always store a full representation of the event, so merging cannot add any missing information.
2. This is just debt and we don't have any code that actually uses `GetCorrelationIDs` (case sensitive !)

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
