### PR TITLE
Provide detailed scheduling details in scheduling event

### DIFF
--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -110,7 +110,7 @@ func TestCluster(t *testing.T) {
 	a.So(err, should.BeNil)
 
 	// Test Packet Broker Agent override; Packet Broker Agent is not in the cluster.
-	pba, err := c.GetPeer(ctx, ttnpb.ClusterRole_GATEWAY_SERVER, &PacketBrokerGatewayID)
+	pba, err := c.GetPeer(ctx, ttnpb.ClusterRole_GATEWAY_SERVER, PacketBrokerGatewayID)
 	a.So(pba, should.BeNil)
 	a.So(err, should.NotBeNil)
 

--- a/pkg/cluster/ids.go
+++ b/pkg/cluster/ids.go
@@ -17,4 +17,4 @@ package cluster
 import "go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 
 // PacketBrokerGatewayID is the proxy gateway identifier of gateways connected through Packet Broker.
-var PacketBrokerGatewayID = ttnpb.GatewayIdentifiers{GatewayId: "packetbroker"}
+var PacketBrokerGatewayID = &ttnpb.GatewayIdentifiers{GatewayId: "packetbroker"}

--- a/pkg/networkserver/mac/link_check_test.go
+++ b/pkg/networkserver/mac/link_check_test.go
@@ -294,7 +294,7 @@ func TestHandleLinkCheckReq(t *testing.T) {
 						Snr: 25,
 					},
 					{
-						GatewayIds: &cluster.PacketBrokerGatewayID,
+						GatewayIds: cluster.PacketBrokerGatewayID,
 						PacketBroker: &ttnpb.PacketBrokerMetadata{
 							ForwarderNetId:     types.NetID{0x0, 0x0, 0x42},
 							ForwarderTenantId:  "test",

--- a/pkg/networkserver/networkserver_util_internal_test.go
+++ b/pkg/networkserver/networkserver_util_internal_test.go
@@ -1207,9 +1207,7 @@ func (env TestEnvironment) AssertScheduleJoinAccept(ctx context.Context, dev *tt
 					events.WithIdentifiers(dev.Ids),
 				).New(ctx),
 				EvtScheduleJoinAcceptSuccess.With(
-					events.WithData(&ttnpb.ScheduleDownlinkResponse{
-						Delay: ttnpb.ProtoDurationPtr(0),
-					}),
+					events.WithData(&ttnpb.ScheduleDownlinkResponse{}),
 					events.WithIdentifiers(dev.Ids),
 				).New(events.ContextWithCorrelationID(ctx, scheduledDown.CorrelationIds...)),
 			)
@@ -1276,9 +1274,7 @@ func (env TestEnvironment) AssertScheduleDataDownlink(ctx context.Context, conf 
 					events.WithIdentifiers(dev.Ids),
 				).New(ctx),
 				EvtScheduleDataDownlinkSuccess.With(
-					events.WithData(&ttnpb.ScheduleDownlinkResponse{
-						Delay: ttnpb.ProtoDurationPtr(0),
-					}),
+					events.WithData(&ttnpb.ScheduleDownlinkResponse{}),
 					events.WithIdentifiers(dev.Ids),
 				).New(events.ContextWithCorrelationID(ctx, scheduledDown.CorrelationIds...)),
 			)

--- a/pkg/packetbrokeragent/agent_test.go
+++ b/pkg/packetbrokeragent/agent_test.go
@@ -661,7 +661,7 @@ func TestHomeNetwork(t *testing.T) {
 					RawPayload: []byte{0x40, 0x44, 0x33, 0x22, 0x11, 0x01, 0x01, 0x00, 0x42, 0x1, 0x42, 0x1, 0x2, 0x3, 0x4},
 					RxMetadata: []*ttnpb.RxMetadata{
 						{
-							GatewayIds:   &cluster.PacketBrokerGatewayID,
+							GatewayIds:   cluster.PacketBrokerGatewayID,
 							AntennaIndex: 0,
 							PacketBroker: &ttnpb.PacketBrokerMetadata{
 								MessageId:           "test",
@@ -691,7 +691,7 @@ func TestHomeNetwork(t *testing.T) {
 							})).([]byte),
 						},
 						{
-							GatewayIds:   &cluster.PacketBrokerGatewayID,
+							GatewayIds:   cluster.PacketBrokerGatewayID,
 							AntennaIndex: 1,
 							PacketBroker: &ttnpb.PacketBrokerMetadata{
 								MessageId:           "test",
@@ -804,7 +804,7 @@ func TestHomeNetwork(t *testing.T) {
 					RawPayload: []byte{0x40, 0x44, 0x33, 0x22, 0x11, 0x01, 0x01, 0x00, 0x42, 0x1, 0x42, 0x1, 0x2, 0x3, 0x4},
 					RxMetadata: []*ttnpb.RxMetadata{
 						{
-							GatewayIds: &cluster.PacketBrokerGatewayID,
+							GatewayIds: cluster.PacketBrokerGatewayID,
 							PacketBroker: &ttnpb.PacketBrokerMetadata{
 								MessageId:           "test",
 								ForwarderNetId:      [3]byte{0x0, 0x0, 0x42},

--- a/pkg/packetbrokeragent/translation.go
+++ b/pkg/packetbrokeragent/translation.go
@@ -523,7 +523,7 @@ func fromPBUplink(ctx context.Context, msg *packetbroker.RoutedUplinkMessage, re
 		if md := gtwMd.GetPlainLocalization().GetTerrestrial(); md != nil {
 			for _, ant := range md.Antennas {
 				up.RxMetadata = append(up.RxMetadata, &ttnpb.RxMetadata{
-					GatewayIds:             &cluster.PacketBrokerGatewayID,
+					GatewayIds:             cluster.PacketBrokerGatewayID,
 					PacketBroker:           pbMD,
 					AntennaIndex:           ant.Index,
 					Time:                   receiveTime,
@@ -551,7 +551,7 @@ func fromPBUplink(ctx context.Context, msg *packetbroker.RoutedUplinkMessage, re
 				}
 				if md == nil {
 					md = &ttnpb.RxMetadata{
-						GatewayIds:             &cluster.PacketBrokerGatewayID,
+						GatewayIds:             cluster.PacketBrokerGatewayID,
 						PacketBroker:           pbMD,
 						AntennaIndex:           ant.Index,
 						Time:                   receiveTime,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR makes the NS `ns.down.data.schedule.success` event contain more information about the scheduling itself.

#### Changes
<!-- What are the changes made in this pull request? -->

- Provide the full scheduling response from the scheduling targets in the Network Server.
  - The reasoning is that this event is not that helpful. Before the change it would only say the scheduling delay and nothing else.
  - For GS this means that the path (gateway ID identifier and antenna) + RX window becomes available. This is privacy safe, as the identifiers were already available in the metadata - so one could trace back a token to a set of identifiers based on the contents of the uplink - it was just very annoying to do.
  - For PBA targets at least it shows that the downlink has been scheduled via PB.
- Provide the real (i.e. unwrapped) downlink path in the Gateway Server.
  - The local Network Server already knew the gateway antenna identifiers as part of the metadata.
  - The local Packet Broker Agent does not transmit these identifiers forward (only the RX1/RX2 window usage for the downlink).

#### Testing

<!-- How did you verify that this change works? -->

Local testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A. This change inherently provides more information to the event, which consumers may use.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
