### PR TITLE
Fix `last activity` bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Fix `last activity` not updating bug in the Console.
+
 ### Security
 
 ## [3.20.0] - unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
-- Fix `last activity` not updating bug in the Console.
+- Fix `last activity` not updating when an end device joins for the first time in the Console.
 
 ### Security
 

--- a/pkg/webui/console/store/reducers/devices.js
+++ b/pkg/webui/console/store/reducers/devices.js
@@ -190,7 +190,10 @@ const devices = (state = defaultState, { type, payload, event }) => {
           const currentEndDevice = state.entities[id]
           if (currentEndDevice) {
             // Only update if the event was actually more recent than the current value.
-            if (currentEndDevice.last_seen_at && currentEndDevice.last_seen_at < receivedAt) {
+            if (
+              (currentEndDevice.last_seen_at && currentEndDevice.last_seen_at < receivedAt) ||
+              !currentEndDevice.last_seen_at
+            ) {
               currentEndDevice.last_seen_at = receivedAt
             }
           }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #5513 

#### Changes
<!-- What are the changes made in this pull request? -->

- Update `last_seen_at` when it's undefined.


#### Testing

<!-- How did you verify that this change works? -->

Manually

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

The `currentDevice.last_seen_at` is `undefined` until the page is refreshed. 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
