### PR TITLE
Fix status count periodicity validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Fix a bug that would show the "Status count periodicity"-field in the Console as `200` when actually set to `0`.
+
 ### Security
 
 ## [3.20.0] - unreleased

--- a/pkg/webui/console/views/device-general-settings/network-server-form/validation-schema.js
+++ b/pkg/webui/console/views/device-general-settings/network-server-form/validation-schema.js
@@ -373,7 +373,7 @@ const validationSchema = Yup.object()
             return Yup.string()
           }),
           status_count_periodicity: Yup.lazy(value => {
-            if (!Boolean(value)) {
+            if (value === undefined || value === '') {
               return Yup.number().strip()
             }
 


### PR DESCRIPTION
#### Summary
This PR fixes a bug in the Console that caused "Status count periodicity" being displayed as `200` when actually set to `0`.

Closes #5522 

#### Changes
- Fix validation for the `status_count_periodicity` field.

#### Testing

Manual testing.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
