### PR TITLE
Do not attempt to use RX1 window if data rate is ambiguous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
+- In AS923 frequency plans, the Network Server will skip the RX1 window if the data rate is ambiguous.
+  - This change occurs in old Regional Parameters versions in which the initial downlink dwell time setting of the end device is not specified. The end device may have the downlink dwell time setting either enabled or disabled, and due to this the data rate of the RX1 window is ambiguous.
+  - This ambiguity exists until the Network Server is successful in negotiating the dwell time limitations using the TxParamSetupReq MAC command. This will occur automatically and does not require any external input.
+  - If you already know the boot dwell time settings of your end device, you may provide them via the `--mac-settings.downlink-dwell-time` and `--mac-settings.uplink-dwell-time` MAC settings. This will ensure that RX1 transmissions are available from the first uplink of the session.
+
 ### Deprecated
 
 ### Removed

--- a/pkg/networkserver/networkserver_flow_test.go
+++ b/pkg/networkserver/networkserver_flow_test.go
@@ -282,7 +282,7 @@ func makeOTAAFlowTest(conf OTAAFlowTestConfig) func(context.Context, TestEnviron
 			SessionKeys: dev.Session.Keys,
 		})
 		dev, ok = env.AssertScheduleDataDownlink(ctx, DataDownlinkAssertionConfig{
-			SetRX1:      true,
+			SetRX1:      !SkipRX1Window(ttnpb.DataRateIndex_DATA_RATE_1, dev.MacState, phy),
 			SetRX2:      true,
 			Device:      dev,
 			Class:       ttnpb.Class_CLASS_A,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsIndustries/lorawan-stack-support/issues/796

#### Changes
<!-- What are the changes made in this pull request? -->

- If both the RX1 and RX2 windows may be used for downlink transmission, and the downlink dwell time is ambiguous for the end device, we will attempt to schedule the downlink only in RX2.


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

We will skip the RX1 window for these particular cases in which the data rate is ambiguous. Before this change, we would still try it, and for some end devices it would succeed. I'm far more confident that we will be more successful by using RX2 only however.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
