### PR TITLE
Fix correlation IDs race in the Gateway Server

### DIFF
--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -622,7 +622,8 @@ func (as *ApplicationServer) downlinkQueueOp(ctx context.Context, ids *ttnpb.End
 		return err
 	}
 	for _, item := range items {
-		item.CorrelationIds = append(item.CorrelationIds, events.CorrelationIDsFromContext(ctx)...)
+		ctx := events.ContextWithCorrelationID(ctx, item.CorrelationIds...)
+		item.CorrelationIds = events.CorrelationIDsFromContext(ctx)
 	}
 	_, err = as.deviceRegistry.Set(ctx, ids,
 		[]string{

--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -705,15 +705,25 @@ func (host *upstreamHost) handlePacket(ctx context.Context, item any) {
 	ctx = events.ContextWithCorrelationID(ctx, host.correlationID)
 	logger := log.FromContext(ctx)
 	gtw := host.gtw
+	// Each concurrent upstream host will receive the message and edit it in order
+	// to append the correlation IDs. This would be a concurrent write, so we are
+	// creating a shallow message copy in order to safely edit the correlation IDs.
 	switch msg := item.(type) {
 	case *ttnpb.GatewayUplinkMessage:
-		up := msg.Message
+		ctx := events.ContextWithCorrelationID(ctx, msg.Message.CorrelationIds...)
 		msg = &ttnpb.GatewayUplinkMessage{
-			BandId:  msg.BandId,
-			Message: up,
+			BandId: msg.BandId,
+			Message: &ttnpb.UplinkMessage{
+				RawPayload:         msg.Message.RawPayload,
+				Payload:            msg.Message.Payload,
+				Settings:           msg.Message.Settings,
+				RxMetadata:         msg.Message.RxMetadata,
+				ReceivedAt:         msg.Message.ReceivedAt,
+				CorrelationIds:     events.CorrelationIDsFromContext(ctx),
+				DeviceChannelIndex: msg.Message.DeviceChannelIndex,
+				ConsumedAirtime:    msg.Message.ConsumedAirtime,
+			},
 		}
-		msg.Message.CorrelationIds = append(make([]string, 0, len(msg.Message.CorrelationIds)+1), msg.Message.CorrelationIds...)
-		msg.Message.CorrelationIds = append(msg.Message.CorrelationIds, host.correlationID)
 		drop := func(ids *ttnpb.EndDeviceIdentifiers, err error) {
 			logger := logger.WithError(err)
 			if ids.JoinEui != nil {
@@ -728,7 +738,7 @@ func (host *upstreamHost) handlePacket(ctx context.Context, item any) {
 			logger.Debug("Drop message")
 			registerDropUplink(ctx, gtw, msg, host.name, err)
 		}
-		ids := up.Payload.EndDeviceIdentifiers()
+		ids := msg.Message.Payload.EndDeviceIdentifiers()
 		var pass bool
 		switch {
 		case ids.DevAddr != nil:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/5471
References https://sentry.io/organizations/the-things-industries/issues/3346136069
References https://sentry.io/organizations/the-things-industries/issues/3345934395

#### Changes
<!-- What are the changes made in this pull request? -->

- Ensure that we actually shallow clone the uplink message in the Gateway Server upstream handler
  - The context here is that each upstream handler needs to edit the uplink message in order to add its correlation IDs. Since this would be a concurrent write, we used to do a shallow clone of the uplink message.
  - Doing shallow clones is no longer supported in the new protobuf library, so we have to manually copy each fields.
  - If we do not do the shallow clone, bad things happen during marshalling (the library pre-allocates space for the contents of the message, the message is concurrently modified, panic ensues)
- Do not append correlation IDs using `append`, but use the `events` package function instead
  - This is mostly cosmetical, but it ensures that appended entries are sorted correctly. 
  - We were and still are a bit inconsistent here. I will do some small fixes in the future, but this should suffice for now.


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This was already broken.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
