### PR TITLE
 Remove sorting on rights in API keys table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,14 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Removed
 
+- Sorting on associated rights in the API keys table.
+
 ### Fixed
 
-- Fix `last activity` not updating when an end device joins for the first time in the Console.
-- Fix a bug that would show the "Status count periodicity"-field in the Console as `200` when actually set to `0`.
-- Fix location bug in the Console.
+- `last activity` not updating when an end device joins for the first time in the Console.
+- A bug that would show the "Status count periodicity"-field in the Console as `200` when actually set to `0`.
+- A bug causing map viewports to be set in odd locations when setting end device/gateway locations.
+- Console crashing when sorting by associated rights in the API keys table.
 
 ### Security
 

--- a/pkg/webui/console/containers/api-keys-table/index.js
+++ b/pkg/webui/console/containers/api-keys-table/index.js
@@ -58,7 +58,6 @@ const ApiKeysTable = props => {
       name: 'rights',
       displayName: m.grantedRights,
       width: 50,
-      sortable: true,
       render: (rights = []) => {
         if (rights.length === 0) {
           return <Message className={style.none} content={sharedMessages.none} lowercase />


### PR DESCRIPTION
#### Summary
Closes #5541 

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove option to sort on rights
- Improve some changelog entries

#### Testing

- Manual testing

#### Notes for Reviewers
- Forgot to remove the option after we enabled API key sorting via the backend

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
