### PR TITLE
Handle RP1-1.0.2B data rate index remapping

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -3050,6 +3050,15 @@
       "file": "errors.go"
     }
   },
+  "error:pkg/band:data_rate_not_found": {
+    "translations": {
+      "en": "data rate `{data_rate_index}` not found"
+    },
+    "description": {
+      "package": "pkg/band",
+      "file": "mapping.go"
+    }
+  },
   "error:pkg/band:data_rate_offset_too_high": {
     "translations": {
       "en": "data rate offset must be lower or equal to {max}"

--- a/pkg/band/mapping.go
+++ b/pkg/band/mapping.go
@@ -1,0 +1,52 @@
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package band
+
+import (
+	"github.com/gogo/protobuf/proto"
+	"go.thethings.network/lorawan-stack/v3/pkg/errors"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
+)
+
+var errDataRateNotFound = errors.DefineNotFound(
+	"data_rate_not_found", "data rate `{data_rate_index}` not found",
+)
+
+// MapDataRateIndex maps a data rate index between two bands.
+// Note that if multiple data rate indices may map to the provided
+// data rate index, the lowest one is returned, except when
+// the data rate index is equivalent between the two bands.
+// See Band.FindUplinkDataRate for more details on why this matters.
+func MapDataRateIndex(
+	sourceBand *Band, sourceDataRateIndex ttnpb.DataRateIndex, targetBand *Band,
+) (targetDataRateIndex ttnpb.DataRateIndex, err error) {
+	sourceDataRate, ok := sourceBand.DataRates[sourceDataRateIndex]
+	if !ok {
+		return 0, errDataRateNotFound.WithAttributes("data_rate_index", sourceDataRateIndex)
+	}
+	// Fast path: check if the index is equivalent between the two bands.
+	targetDataRate, ok := targetBand.DataRates[sourceDataRateIndex]
+	if ok && proto.Equal(sourceDataRate.Rate, targetDataRate.Rate) {
+		return sourceDataRateIndex, nil
+	}
+	// Slow path: scan the target band for the indices.
+	for i := ttnpb.DataRateIndex_DATA_RATE_0; i <= ttnpb.DataRateIndex_DATA_RATE_15; i++ {
+		targetDataRate, ok := targetBand.DataRates[i]
+		if ok && proto.Equal(sourceDataRate.Rate, targetDataRate.Rate) {
+			return i, nil
+		}
+	}
+	return 0, errDataRateNotFound.WithAttributes("data_rate_index", sourceDataRateIndex)
+}

--- a/pkg/networkserver/networkserver_util_internal_test.go
+++ b/pkg/networkserver/networkserver_util_internal_test.go
@@ -1617,7 +1617,7 @@ func (env TestEnvironment) AssertJoin(ctx context.Context, conf JoinAssertionCon
 					RejoinCountPeriodicity:     ttnpb.RejoinCountExponent_REJOIN_COUNT_16,
 					PingSlotFrequency:          mac.DeviceDesiredPingSlotFrequency(dev, phy, fp, defaultMACSettings),
 					BeaconFrequency:            mac.DeviceDesiredBeaconFrequency(dev, defaultMACSettings),
-					Channels:                   mac.DeviceDesiredChannels(dev, phy, fp, defaultMACSettings),
+					Channels:                   test.Must(mac.DeviceDesiredChannels(dev, phy, fp, defaultMACSettings)).([]*ttnpb.MACParameters_Channel),
 					UplinkDwellTime:            mac.DeviceDesiredUplinkDwellTime(phy, fp),
 					DownlinkDwellTime:          mac.DeviceDesiredDownlinkDwellTime(phy, fp),
 					AdrAckLimitExponent:        mac.DeviceDesiredADRAckLimitExponent(dev, phy, defaultMACSettings),

--- a/pkg/util/test/frequencyplans.go
+++ b/pkg/util/test/frequencyplans.go
@@ -36,6 +36,10 @@ const (
   name: Australia 923-925 MHz (AS923)
   base-frequency: 915
   file: AS_923_925_AU.yml
+- id: AU_915_928_FSB_2
+  name: Australia 915-928 MHz, FSB 2 (used by TTN)
+  base-frequency: 915
+  file: AU_915_928_FSB_2.yml
 - id: EXAMPLE
   name: Example 866.1 MHz
   base-frequency: 868
@@ -352,6 +356,60 @@ radios:
   rssi-offset: -166
 clock-source: 1`
 
+	// AUFrequencyPlanID is the identifier of the Australia 915-928 FSB 2 frequency plan.
+	AUFrequencyPlanID = "AU_915_928_FSB_2"
+	auFrequencyPlan   = `band-id: AU_915_928
+uplink-channels:
+- frequency: 916800000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 917000000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 917200000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 917400000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 0
+- frequency: 917600000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 917800000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 918000000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+- frequency: 918200000
+  min-data-rate: 0
+  max-data-rate: 5
+  radio: 1
+lora-standard-channel:
+  frequency: 917500000
+  data-rate: 12
+  radio: 0
+radios:
+- enable: true
+  chip-type: SX1257
+  frequency: 917200000
+  rssi-offset: -166
+  tx:
+    min-frequency: 915000000
+    max-frequency: 928000000
+- enable: true
+  chip-type: SX1257
+  frequency: 917900000
+  rssi-offset: -166
+clock-source: 1`
+
 	// ExampleFrequencyPlanID is an example frequency plan.
 	ExampleFrequencyPlanID = "EXAMPLE"
 	exampleFrequencyPlan   = `band-id: EU_863_870
@@ -416,6 +474,7 @@ var (
 		"KR_920_923.yml":       []byte(krFrequencyPlan),
 		"US_902_928_FSB_2.yml": []byte(usFrequencyPlan),
 		"AS_923_925_AU.yml":    []byte(asAUFrequencyPlan),
+		"AU_915_928_FSB_2.yml": []byte(auFrequencyPlan),
 		"EXAMPLE.yml":          []byte(exampleFrequencyPlan),
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #4196 

#### Changes
<!-- What are the changes made in this pull request? -->

- Add to `pkg/band` a data rate index translation function (between two bands)
- Translate the max data rate index of the factory preset frequency channels
- Translate the min and max data rate index of the frequency plan channels


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This was already broken. Existing unit tests ensure that other bands are not affected by this change.
The `pkg/band` translation function has a fast path that ensures that we don't need to scan the bands if this data rate remapping does not exist.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

In the future we may want to completely deprecate the `factory_preset_frequencies` and to instead provide a full `factory_channels` structure instead. As it stands right now, `factory_preset_frequencies` lacks data rate indices and cannot handle bands where the uplink and downlink frequency differs - it is a simple but flawed abstraction.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
