### PR TITLE
Fix frontend build cache in CI

### DIFF
--- a/.github/actions/build-frontend/action.yml
+++ b/.github/actions/build-frontend/action.yml
@@ -9,27 +9,21 @@ runs:
   using: composite
   steps:
     - name: Initialize public folder cache
-      id: public-cache
+      id: cache
       uses: actions/cache@v3
       with:
-        path: public
-        key: ${{ runner.os }}-public-${{ hashFiles('pkg/webui/**', 'sdk/js/**/*.js', 'sdk/js/generated/*.json', 'config/babel.config.json', 'config/webpack.config.babel.js', 'package.json', 'yarn.lock', 'sdk/js/yarn.lock')}}
-    - name: Initialize Babel cache
-      if: steps.public-cache.outputs.cache-hit != 'true'
-      uses: actions/cache@v3
-      with:
-        path: .cache/babel
-        key: ${{ runner.os }}-babel-cache-${{ hashFiles('pkg/webui/**', 'sdk/js/**/*.js', 'sdk/js/generated/*.json', 'config/babel.config.json', 'config/webpack.config.babel.js', 'package.json', 'yarn.lock', 'sdk/js/yarn.lock')}}
-        restore-keys: |
-          ${{ runner.os }}-babel-cache-
+        path: |
+          public
+          .cache/babel
+        key: ${{ runner.os }}-build-frontend-${{ hashFiles('pkg/webui/**', 'sdk/js/**/*.js', 'sdk/js/generated/*.json', 'config/babel.config.json', 'config/webpack.config.babel.js', 'package.json', 'yarn.lock', 'sdk/js/yarn.lock')}}
     - name: Build DLLs
-      if: steps.public-cache.outputs.cache-hit != 'true'
+      if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
       run: tools/bin/mage js:buildDll
       env:
         WEBPACK_GENERATE_PRODUCTION_SOURCEMAPS: ${{ inputs.production-sourcemaps }}
     - name: Build Frontend
-      if: steps.public-cache.outputs.cache-hit != 'true'
+      if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
       run: tools/bin/mage js:build
       env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            .cache/database.pgdump
+            .env/cache/database.pgdump
             .env/admin_api_key.txt
           key: db-cache-${{ hashFiles('pkg/identityserver/store/**/*.go', 'cmd/ttn-lw-stack/commands/is-db.go', '.github/workflows/e2e.yml', 'docker-compose.yml') }}
       - name: Initialize device repository index cache
@@ -105,7 +105,7 @@ jobs:
         if: steps.build-cache.outputs.cache-hit != 'true'
         run: go build ./cmd/ttn-lw-stack
       - name: Zip build artifacts
-        run: zip -r build.zip .cache/database.pgdump .env/admin_api_key.txt data/lorawan-devices-index public ttn-lw-stack tools/bin/mage
+        run: zip -r build.zip .env/cache/database.pgdump .env/admin_api_key.txt data/lorawan-devices-index public ttn-lw-stack tools/bin/mage
       - name: Upload build artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - POSTGRES_DB=ttn_lorawan_dev
     volumes:
       - ${DEV_DATA_DIR:-.env/data}/postgres:/var/lib/postgresql/data
-      - .cache:/var/lib/ttn-lorawan/cache
+      - .env/cache:/var/lib/ttn-lorawan/cache
     ports:
       - "127.0.0.1:5432:5432"
 

--- a/tools/mage/dev.go
+++ b/tools/mage/dev.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -105,7 +106,7 @@ func (Dev) SQLDump() error {
 	if mg.Verbose() {
 		fmt.Println("Saving sql database dump")
 	}
-	if err := os.MkdirAll(".cache", 0o755); err != nil {
+	if err := os.MkdirAll(path.Join(".env", "cache"), 0o755); err != nil {
 		return err
 	}
 	return execDockerCompose("exec", "-T", "postgres",
@@ -118,7 +119,7 @@ func (Dev) SQLRestore() error {
 	if mg.Verbose() {
 		fmt.Println("Restoring database from dump")
 	}
-	d := filepath.Join(".cache", "database.pgdump")
+	d := filepath.Join(".env", "cache", "database.pgdump")
 	if _, err := os.Stat(d); errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("Dumpfile does not exist: %w", d)
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This should fix issues with CI with the frontend build cache.

#### Changes
<!-- What are the changes made in this pull request? -->

Dump the database to `.env/cache` and keep `.cache` clean of Docker volumes.

#### Testing

<!-- How did you verify that this change works? -->

CI

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None expected

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@kschiffer either the cache was corrupt or the `.cache` folder gets cursed by the Docker volume mount for the database.
I think it's pretty clean to use `.env/cache` for the database cache as it's more environment (like tenant admin key etc) than build cache.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
