### PR TITLE
Fix happens-before relation in location cache test

### DIFF
--- a/pkg/applicationserver/metadata/redis/location_cache_test.go
+++ b/pkg/applicationserver/metadata/redis/location_cache_test.go
@@ -73,7 +73,7 @@ func TestLocationCache(t *testing.T) {
 	locations, storedAt, err := cache.Get(ctx, registeredEndDeviceIDs)
 	if a.So(err, should.BeNil) {
 		if a.So(storedAt, should.NotBeNil) {
-			a.So(*storedAt, should.HappenAfter, storeTime)
+			a.So(*storedAt, should.HappenOnOrAfter, storeTime)
 		}
 		a.So(len(locations), should.Equal, len(locationA))
 		for k, v := range locations {
@@ -88,7 +88,7 @@ func TestLocationCache(t *testing.T) {
 	locations, storedAt, err = cache.Get(ctx, registeredEndDeviceIDs)
 	if a.So(err, should.BeNil) {
 		if a.So(storedAt, should.NotBeNil) {
-			a.So(*storedAt, should.HappenAfter, storeTime)
+			a.So(*storedAt, should.HappenOnOrAfter, storeTime)
 		}
 		a.So(len(locations), should.Equal, len(locationB))
 		for k, v := range locations {
@@ -110,7 +110,7 @@ func TestLocationCache(t *testing.T) {
 	locations, storedAt, err = cache.Get(ctx, registeredEndDeviceIDs)
 	if a.So(err, should.BeNil) {
 		if a.So(storedAt, should.NotBeNil) {
-			a.So(*storedAt, should.HappenAfter, storeTime)
+			a.So(*storedAt, should.HappenOnOrAfter, storeTime)
 		}
 		a.So(len(locations), should.Equal, len(locationA))
 		for k, v := range locations {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes test failures on M1 laptops which occur due to lowered clock accuracy.

```
--- FAIL: TestLocationCache (4.17s)
    doc.go:66: 
        /Users/adriansmares/projects/lorawan-stack/pkg/applicationserver/metadata/redis/location_cache_test.go:76
        Expected '2022-06-30 14:56:11.575882 +0200 CEST' to happen after '2022-06-30 14:56:11.575882 +0200 CEST m=+0.049152501' (it happened '0s' before)!
    doc.go:66: 
        /Users/adriansmares/projects/lorawan-stack/pkg/applicationserver/metadata/redis/location_cache_test.go:91
        Expected '2022-06-30 14:56:11.580202 +0200 CEST' to happen after '2022-06-30 14:56:11.580202 +0200 CEST m=+0.053472501' (it happened '0s' before)!
    doc.go:66: 
        /Users/adriansmares/projects/lorawan-stack/pkg/applicationserver/metadata/redis/location_cache_test.go:113
        Expected '2022-06-30 14:56:11.587794 +0200 CEST' to happen after '2022-06-30 14:56:11.587794 +0200 CEST m=+0.061064751' (it happened '0s' before)!
FAIL
FAIL	go.thethings.network/lorawan-stack/v3/pkg/applicationserver/metadata/redis	5.643s
```

On M1 `time.Time()` has millisecond accuracy, so it is possible that basically the `updated_at` timestamp is really the timestamp just before the `Set` call occurs.

#### Changes
<!-- What are the changes made in this pull request? -->

- Change `HappenAfter` to `HappenOnOrAfter`


#### Testing

<!-- How did you verify that this change works? -->

Local testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This is purely testing changes.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
