### PR TITLE
Make primary email address index take into account account state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Changed
 
+- Deleted users are no longer included in primary email addresses uniqueness checks. This allows a user to create a new account which uses the email address of a deleted account.
+  - This requires a database schema migration (`ttn-lw-stack is-db migrate`) due to updated indices.
+
 ### Deprecated
 
 ### Removed

--- a/pkg/identityserver/gormstore/scope.go
+++ b/pkg/identityserver/gormstore/scope.go
@@ -186,9 +186,14 @@ func withPrimaryEmailAddress(emails ...string) func(*gorm.DB) *gorm.DB {
 		case 0:
 			return db
 		case 1:
-			return db.Where("users.primary_email_address = ?", emails[0])
+			email := strings.ToLower(emails[0])
+			return db.Where("LOWER(users.primary_email_address) = ?", email)
 		default:
-			return db.Where("users.primary_email_address IN (?)", emails)
+			emails := append(make([]string, 0, len(emails)), emails...)
+			for i := range emails {
+				emails[i] = strings.ToLower(emails[i])
+			}
+			return db.Where("LOWER(users.primary_email_address) IN (?)", emails)
 		}
 	}
 }

--- a/pkg/identityserver/store/migrations/20220701140000_update_email_index.tx.down.sql
+++ b/pkg/identityserver/store/migrations/20220701140000_update_email_index.tx.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX uix_users_primary_email_address;
+CREATE UNIQUE INDEX uix_users_primary_email_address ON users USING btree (primary_email_address);

--- a/pkg/identityserver/store/migrations/20220701140000_update_email_index.tx.up.sql
+++ b/pkg/identityserver/store/migrations/20220701140000_update_email_index.tx.up.sql
@@ -1,0 +1,5 @@
+-- The primary email address of a user should be unique only amount the active accounts, otherwise
+-- this will prevent the registration of new users with the same email address as the deleted account.
+
+DROP INDEX uix_users_primary_email_address;
+CREATE UNIQUE INDEX uix_users_primary_email_address ON users USING btree ((LOWER(primary_email_address))) WHERE deleted_at IS NULL;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsIndustries/lorawan-stack/issues/2932

#### Changes
<!-- What are the changes made in this pull request? -->

- Make the primary email address index take into account the `deleted_at` status and convert the email address to lower case.

#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This migration is potentially irreversible - if the deleted accounts with duplicate primary email addresses are not purged, it is not possible to roll back the unique index.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

@htdvisser main reviewer.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
