### PR TITLE
Add pagination to invitation listing

### DIFF
--- a/pkg/identityserver/invitation_registry.go
+++ b/pkg/identityserver/invitation_registry.go
@@ -86,6 +86,13 @@ func (is *IdentityServer) listInvitations(ctx context.Context, req *ttnpb.ListIn
 	if !authInfo.GetUniversalRights().IncludesAll(ttnpb.Right_RIGHT_SEND_INVITES) {
 		return nil, errNoInviteRights.New()
 	}
+	var total uint64
+	ctx = store.WithPagination(ctx, req.Limit, req.Page, &total)
+	defer func() {
+		if err == nil {
+			setTotalHeader(ctx, total)
+		}
+	}()
 	invitations = &ttnpb.Invitations{}
 	err = is.store.Transact(ctx, func(ctx context.Context, st store.Store) (err error) {
 		invitations.Invitations, err = st.FindInvitations(ctx)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes the pagination of the `ListInvitations` RPC. It is supported at store level, but not at RPC level.

This bug has been detected on TTSCE - you can reproduce it at the moment on https://eu1.cloud.thethings.network/console/admin/user-management by switching pages - the content will stay the same and the backend returns the all of the records, irrespective of the count per page / page itself.

The `gormstore` does support this:
https://github.com/TheThingsNetwork/lorawan-stack/blob/b0b8c21c4f24b8e1051bc8349aed08cc133d2781/pkg/identityserver/gormstore/invitation_store.go#L63-L68

#### Changes
<!-- What are the changes made in this pull request? -->

- Inject the pagination context filler in this RPC.


#### Testing

<!-- How did you verify that this change works? -->

🐒 

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None are expected. Both the CLI and the frontend support this functionality already, but the backend was not respecting the `limit`/`page`.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
