### PR TITLE
Fix proto pointers in Identity Server

### DIFF
--- a/pkg/identityserver/gormstore/api_key.go
+++ b/pkg/identityserver/gormstore/api_key.go
@@ -45,7 +45,7 @@ func (k APIKey) toPB() *ttnpb.APIKey {
 		Id:        k.APIKeyID,
 		Key:       k.Key,
 		Name:      k.Name,
-		Rights:    k.Rights.Rights,
+		Rights:    k.Rights,
 		CreatedAt: ttnpb.ProtoTimePtr(cleanTime(k.CreatedAt)),
 		UpdatedAt: ttnpb.ProtoTimePtr(cleanTime(k.UpdatedAt)),
 		ExpiresAt: ttnpb.ProtoTime(cleanTimePtr(k.ExpiresAt)),

--- a/pkg/identityserver/gormstore/api_key_store.go
+++ b/pkg/identityserver/gormstore/api_key_store.go
@@ -73,7 +73,7 @@ func (s *apiKeyStore) CreateAPIKey(
 	model := &APIKey{
 		APIKeyID:   key.Id,
 		Key:        key.Key,
-		Rights:     Rights{Rights: key.Rights},
+		Rights:     key.Rights,
 		Name:       key.Name,
 		EntityID:   entity.PrimaryKey(),
 		EntityType: entityTypeForID(entityID),
@@ -194,7 +194,7 @@ func (s *apiKeyStore) UpdateAPIKey(
 	}
 	query = selectAPIKeyFields(ctx, query, fieldMask)
 	if ttnpb.HasAnyField(fieldMask, "rights") {
-		keyModel.Rights = Rights{Rights: key.Rights}
+		keyModel.Rights = key.Rights
 	}
 	if ttnpb.HasAnyField(fieldMask, "expires_at") {
 		keyModel.ExpiresAt = ttnpb.StdTime(key.ExpiresAt)

--- a/pkg/identityserver/gormstore/client.go
+++ b/pkg/identityserver/gormstore/client.go
@@ -104,7 +104,7 @@ var clientPBSetters = map[string]func(*ttnpb.Client, *Client){
 		pb.Grants = cli.Grants
 	},
 	rightsField: func(pb *ttnpb.Client, cli *Client) {
-		pb.Rights = cli.Rights.Rights
+		pb.Rights = cli.Rights
 	},
 }
 
@@ -164,7 +164,7 @@ var clientModelSetters = map[string]func(*Client, *ttnpb.Client){
 		cli.Grants = pb.Grants
 	},
 	rightsField: func(cli *Client, pb *ttnpb.Client) {
-		cli.Rights = Rights{Rights: pb.Rights}
+		cli.Rights = pb.Rights
 	},
 }
 

--- a/pkg/identityserver/gormstore/gateway.go
+++ b/pkg/identityserver/gormstore/gateway.go
@@ -374,7 +374,7 @@ var gatewayModelSetters = map[string]func(*Gateway, *ttnpb.Gateway){
 		gtw.Antennas = antennas
 		for i, pb := range pb.Antennas {
 			antenna := gtw.Antennas[i]
-			antenna.fromPB(*pb)
+			antenna.fromPB(pb)
 			antenna.Index = i
 			gtw.Antennas[i] = antenna
 		}

--- a/pkg/identityserver/gormstore/gateway_antenna.go
+++ b/pkg/identityserver/gormstore/gateway_antenna.go
@@ -56,13 +56,13 @@ func (a GatewayAntenna) toPB() *ttnpb.GatewayAntenna {
 	}
 }
 
-func (a *GatewayAntenna) fromPB(pb ttnpb.GatewayAntenna) {
+func (a *GatewayAntenna) fromPB(pb *ttnpb.GatewayAntenna) {
 	a.Gain = pb.Gain
 	a.Location = Location{
-		Latitude:  pb.Location.GetLatitude(),
-		Longitude: pb.Location.GetLongitude(),
-		Altitude:  pb.Location.GetAltitude(),
-		Accuracy:  pb.Location.GetAccuracy(),
+		Latitude:  pb.GetLocation().GetLatitude(),
+		Longitude: pb.GetLocation().GetLongitude(),
+		Altitude:  pb.GetLocation().GetAltitude(),
+		Accuracy:  pb.GetLocation().GetAccuracy(),
 	}
 	a.Attributes = attributes(a.Attributes).updateFromMap(pb.Attributes)
 	a.Placement = int(pb.Placement)

--- a/pkg/identityserver/gormstore/membership_store.go
+++ b/pkg/identityserver/gormstore/membership_store.go
@@ -185,10 +185,10 @@ type membershipChain struct {
 }
 
 func (m membershipChain) GetMembershipChain() *store.MembershipChain {
-	indirectAccountRights := ttnpb.Rights(m.IndirectAccountRights)
-	directAccountRights := ttnpb.Rights(m.DirectAccountRights)
+	indirectAccountRights := &ttnpb.Rights{Rights: m.IndirectAccountRights}
+	directAccountRights := &ttnpb.Rights{Rights: m.DirectAccountRights}
 	c := &store.MembershipChain{
-		RightsOnEntity:    &directAccountRights,
+		RightsOnEntity:    directAccountRights,
 		EntityIdentifiers: buildIdentifiers(m.EntityType, m.EntityFriendlyID),
 	}
 	switch m.DirectAccountType {
@@ -201,7 +201,7 @@ func (m membershipChain) GetMembershipChain() *store.MembershipChain {
 			c.UserIdentifiers = &ttnpb.UserIdentifiers{
 				UserId: m.IndirectAccountFriendlyID,
 			}
-			c.RightsOnOrganization = &indirectAccountRights
+			c.RightsOnOrganization = indirectAccountRights
 		}
 		c.OrganizationIdentifiers = &ttnpb.OrganizationIdentifiers{
 			OrganizationId: m.DirectAccountFriendlyID,
@@ -357,7 +357,7 @@ func (s *membershipStore) SetMember(
 	if len(rights.Rights) == 0 {
 		return upsertQuery.Delete(&membership).Error
 	}
-	membership.Rights = Rights(*rights)
+	membership.Rights = rights.Rights
 	return upsertQuery.Save(&membership).Error
 }
 

--- a/pkg/identityserver/gormstore/oauth.go
+++ b/pkg/identityserver/gormstore/oauth.go
@@ -35,7 +35,7 @@ type ClientAuthorization struct {
 
 func (a ClientAuthorization) toPB() *ttnpb.OAuthClientAuthorization {
 	pb := &ttnpb.OAuthClientAuthorization{
-		Rights:    a.Rights.Rights,
+		Rights:    a.Rights,
 		CreatedAt: ttnpb.ProtoTimePtr(cleanTime(a.CreatedAt)),
 		UpdatedAt: ttnpb.ProtoTimePtr(cleanTime(a.UpdatedAt)),
 	}
@@ -70,7 +70,7 @@ type AuthorizationCode struct {
 
 func (a AuthorizationCode) toPB() *ttnpb.OAuthAuthorizationCode {
 	pb := &ttnpb.OAuthAuthorizationCode{
-		Rights:      a.Rights.Rights,
+		Rights:      a.Rights,
 		Code:        a.Code,
 		RedirectUri: a.RedirectURI,
 		State:       a.State,
@@ -116,7 +116,7 @@ type AccessToken struct {
 
 func (a AccessToken) toPB() *ttnpb.OAuthAccessToken {
 	pb := &ttnpb.OAuthAccessToken{
-		Rights:       a.Rights.Rights,
+		Rights:       a.Rights,
 		Id:           a.TokenID,
 		AccessToken:  a.AccessToken,
 		RefreshToken: a.RefreshToken,

--- a/pkg/identityserver/gormstore/oauth_store.go
+++ b/pkg/identityserver/gormstore/oauth_store.go
@@ -124,7 +124,7 @@ func (s *oauthStore) Authorize(
 		}
 		authModel.SetContext(ctx)
 	}
-	authModel.Rights = Rights{Rights: authorization.Rights}
+	authModel.Rights = authorization.Rights
 	query := s.query(ctx, ClientAuthorization{}).Save(&authModel)
 	if query.Error != nil {
 		return nil, query.Error
@@ -215,7 +215,7 @@ func (s *oauthStore) CreateAuthorizationCode(
 	codeModel := AuthorizationCode{
 		ClientID:    client.PrimaryKey(),
 		UserID:      user.PrimaryKey(),
-		Rights:      Rights{Rights: code.Rights},
+		Rights:      code.Rights,
 		Code:        code.Code,
 		RedirectURI: code.RedirectUri,
 		State:       code.State,
@@ -285,7 +285,7 @@ func (s *oauthStore) CreateAccessToken(
 	tokenModel := AccessToken{
 		ClientID:     client.PrimaryKey(),
 		UserID:       user.PrimaryKey(),
-		Rights:       Rights{Rights: token.Rights},
+		Rights:       token.Rights,
 		TokenID:      token.Id,
 		PreviousID:   previousID,
 		AccessToken:  token.AccessToken,

--- a/pkg/identityserver/gormstore/types.go
+++ b/pkg/identityserver/gormstore/types.go
@@ -108,12 +108,12 @@ func (g *Grants) Scan(src interface{}) error {
 }
 
 // Rights adds methods on a ttnpb.Rights so that it can be stored in an SQL database.
-type Rights ttnpb.Rights
+type Rights []ttnpb.Right
 
 // Value returns the value to store in the database.
 func (r Rights) Value() (driver.Value, error) {
-	ints := make([]int64, len(r.Rights))
-	for i, right := range r.Rights {
+	ints := make([]int64, len(r))
+	for i, right := range r {
 		ints[i] = int64(right)
 	}
 	return pq.Int64Array(ints).Value()
@@ -129,7 +129,7 @@ func (r *Rights) Scan(src interface{}) error {
 	for i, right := range ints {
 		rights[i] = ttnpb.Right(right)
 	}
-	*r = Rights{Rights: rights}
+	*r = rights
 	return nil
 }
 

--- a/pkg/identityserver/gormstore/user_session_store.go
+++ b/pkg/identityserver/gormstore/user_session_store.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"runtime/trace"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/jinzhu/gorm"
 	"go.thethings.network/lorawan-stack/v3/pkg/identityserver/store"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
@@ -46,9 +47,9 @@ func (s *userSessionStore) CreateSession(ctx context.Context, sess *ttnpb.UserSe
 	if err = s.createEntity(ctx, &sessionModel); err != nil {
 		return nil, err
 	}
-	sessionProto := *sess
-	sessionModel.toPB(&sessionProto)
-	return &sessionProto, nil
+	sessionProto := proto.Clone(sess).(*ttnpb.UserSession)
+	sessionModel.toPB(sessionProto)
+	return sessionProto, nil
 }
 
 func (s *userSessionStore) FindSessions(

--- a/pkg/identityserver/storetest/population.go
+++ b/pkg/identityserver/storetest/population.go
@@ -242,7 +242,7 @@ func (p *Population) NewUserSession(user *ttnpb.UserIdentifiers) *ttnpb.UserSess
 
 // Populate creates the population in the database.
 // After calling Populate, the entities in the population should no longer be modified.
-func (p *Population) Populate(ctx context.Context, st interface{}) error {
+func (p *Population) Populate(ctx context.Context, st interface{}) error { //nolint:gocyclo
 	if len(p.Users) > 0 {
 		s, ok := st.(store.UserStore)
 		if !ok {
@@ -262,7 +262,9 @@ func (p *Population) Populate(ctx context.Context, st interface{}) error {
 			if err != nil {
 				return err
 			}
-			*usr = *created
+			if err = usr.SetFields(created, ttnpb.UserFieldPathsTopLevel...); err != nil {
+				return err
+			}
 		}
 	}
 	if len(p.Organizations) > 0 {
@@ -275,7 +277,9 @@ func (p *Population) Populate(ctx context.Context, st interface{}) error {
 			if err != nil {
 				return err
 			}
-			*org = *created
+			if err = org.SetFields(created, ttnpb.OrganizationFieldPathsTopLevel...); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -289,7 +293,9 @@ func (p *Population) Populate(ctx context.Context, st interface{}) error {
 			if err != nil {
 				return err
 			}
-			*app = *created
+			if err = app.SetFields(created, ttnpb.ApplicationFieldPathsTopLevel...); err != nil {
+				return err
+			}
 		}
 	}
 	if len(p.EndDevices) > 0 {
@@ -302,7 +308,9 @@ func (p *Population) Populate(ctx context.Context, st interface{}) error {
 			if err != nil {
 				return err
 			}
-			*dev = *created
+			if err = dev.SetFields(created, ttnpb.EndDeviceFieldPathsTopLevel...); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -316,7 +324,9 @@ func (p *Population) Populate(ctx context.Context, st interface{}) error {
 			if err != nil {
 				return err
 			}
-			*cli = *created
+			if err = cli.SetFields(created, ttnpb.ClientFieldPathsTopLevel...); err != nil {
+				return err
+			}
 		}
 	}
 	if len(p.Gateways) > 0 {
@@ -329,7 +339,9 @@ func (p *Population) Populate(ctx context.Context, st interface{}) error {
 			if err != nil {
 				return err
 			}
-			*gtw = *created
+			if err = gtw.SetFields(created, ttnpb.GatewayFieldPathsTopLevel...); err != nil {
+				return err
+			}
 		}
 	}
 	if len(p.UserSessions) > 0 {
@@ -342,7 +354,9 @@ func (p *Population) Populate(ctx context.Context, st interface{}) error {
 			if err != nil {
 				return err
 			}
-			*sess = *created
+			if err = sess.SetFields(created, ttnpb.UserSessionFieldPathsTopLevel...); err != nil {
+				return err
+			}
 		}
 	}
 	if len(p.APIKeys) > 0 {
@@ -355,7 +369,9 @@ func (p *Population) Populate(ctx context.Context, st interface{}) error {
 			if err != nil {
 				return err
 			}
-			*apiKey.APIKey = *created
+			if err = apiKey.APIKey.SetFields(created, ttnpb.APIKeyFieldPathsTopLevel...); err != nil {
+				return err
+			}
 		}
 	}
 	if len(p.Memberships) > 0 {
@@ -364,7 +380,12 @@ func (p *Population) Populate(ctx context.Context, st interface{}) error {
 			return fmt.Errorf("store of type %T does not implement MembershipStore", st)
 		}
 		for _, collaborator := range p.Memberships {
-			err := s.SetMember(ctx, collaborator.Collaborator.Ids, collaborator.EntityIdentifiers, &ttnpb.Rights{Rights: collaborator.Collaborator.GetRights()})
+			err := s.SetMember(
+				ctx,
+				collaborator.Collaborator.Ids,
+				collaborator.EntityIdentifiers,
+				&ttnpb.Rights{Rights: collaborator.Collaborator.GetRights()},
+			)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This refactors some Identity Server code to use pointers to proto messages, or not use proto messages at all, where possible.

Refs https://github.com/TheThingsIndustries/lorawan-stack/issues/3187

#### Changes
<!-- What are the changes made in this pull request? -->

- Use `SetFields` in storetest
- Refactor the `gormstore.Rights` type
- Use `proto.Clone` instead of `clone := *orig`

#### Testing

<!-- How did you verify that this change works? -->

Existing tests.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

I don't expect any.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

nil

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
