### PR TITLE
Fix reading base64-encoded (formerly) custom types from JSON

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -128,7 +128,8 @@ func unmarshalNBytes(s *jsonplugin.UnmarshalState, n int) []byte {
 	if s.Err() != nil {
 		return nil
 	}
-	trimmed := strings.TrimSuffix(enc, "=")
+	trimmed := strings.TrimRight(enc, "=")
+
 	switch len(trimmed) {
 	case 0:
 		b := make([]byte, n)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a quick fix for an issue where formerly custom types were not correctly decoded from JSON if they were passed as base64.

#### Testing

<!-- How did you verify that this change works? -->

Decode DevAddr `AYLeTA==`.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

We never really supported decoding these former customtypes from anything other than hex, so I don't think we need to mention this as a bugfix in the CHANGELOG.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
