### PR TITLE
Remove false leap second

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Fixed
 
 - Encoding of DevAddr, EUI and similar fields in `text/event-stream` responses.
+- GPS time leap second calculations taking a new leap second into consideration for 6th of July 2022.
 
 ### Security
 

--- a/pkg/gpstime/gpstime.go
+++ b/pkg/gpstime/gpstime.go
@@ -41,7 +41,6 @@ var leaps = [...]int64{
 	1025136015,
 	1119744016,
 	1167264017,
-	1341118800,
 }
 
 func seconds(d time.Duration) int64 {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes https://github.com/TheThingsNetwork/lorawan-stack/issues/5591

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove the false `1341118800` leap second
  - I cannot tell how we came up with this one in https://github.com/TheThingsIndustries/lorawan-stack/pull/210
  - It would correspond to `2022-07-06 04:59:42 +0000 UTC`, which makes no real sense - leap seconds are added either on the 1st of January (well, 31st of December but let's not get into that) or 1st of July.


#### Testing

<!-- How did you verify that this change works? -->

Local testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This is already broken and affecting any time sensitive (class B / C) behavior.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

I've subscribed our ops email to the IERS subscription for leap second announcements. 

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
