### PR TITLE
Fix broken docs Markdown link in `DEVELOPMENT.md`

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -265,7 +265,7 @@ $ tools/bin/mage proto:clean proto:all jsSDK:definitions
 
 ### Documentation
 
-The documentation site for The Things Stack is built from the [`lorawan-stack-docs`(https://github.com/TheThingsIndustries/lorawan-stack-docs) repository.
+The documentation site for The Things Stack is built from the [`lorawan-stack-docs`](https://github.com/TheThingsIndustries/lorawan-stack-docs) repository.
 
 ### Web UI
 


### PR DESCRIPTION
#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes the docs Markdown link in `DEVELOPMENT.md`.