### PR TITLE
Use component selectors for Join Server interop config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Added
 
+- Component selector for Join Server interoperability configuration. This allows administrators to declare separate Network Server and Application Server configuration for the same JoinEUI ranges in the same interoperability configuration. See [documentation](https://www.thethingsindustries.com/docs/reference/interop-repository/).
+
 ### Changed
 
 - Deleted users are no longer included in primary email addresses uniqueness checks. This allows a user to create a new account which uses the email address of a deleted account.

--- a/pkg/applicationserver/applicationserver.go
+++ b/pkg/applicationserver/applicationserver.go
@@ -110,7 +110,7 @@ func New(c *component.Component, conf *Config) (as *ApplicationServer, err error
 		interopConf := conf.Interop.InteropClient
 		interopConf.BlobConfig = baseConf.Blob
 
-		interopCl, err = interop.NewClient(ctx, interopConf, c)
+		interopCl, err = interop.NewClient(ctx, interopConf, c, interop.SelectorApplicationServer)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/interop/client_test.go
+++ b/pkg/interop/client_test.go
@@ -248,7 +248,7 @@ func TestGetAppSKey(t *testing.T) { //nolint:paralleltest
 			cl, err := NewClient(ctx, config.InteropClient{
 				ConfigSource: "directory",
 				Directory:    "testdata/client",
-			}, test.HTTPClientProvider)
+			}, test.HTTPClientProvider, SelectorApplicationServer)
 			if !a.So(err, should.BeNil) {
 				t.Fatalf("Failed to create new client: %s", err)
 			}
@@ -662,7 +662,7 @@ func TestHandleJoinRequest(t *testing.T) { //nolint:paralleltest
 			cl, err := NewClient(ctx, config.InteropClient{
 				ConfigSource: "directory",
 				Directory:    "testdata/client",
-			}, test.HTTPClientProvider)
+			}, test.HTTPClientProvider, SelectorNetworkServer)
 			if !a.So(err, should.BeNil) {
 				t.Fatalf("Failed to create new client: %s", err)
 			}

--- a/pkg/interop/client_test.go
+++ b/pkg/interop/client_test.go
@@ -32,20 +32,19 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
 )
 
-func TestGetAppSKey(t *testing.T) {
-	for _, tc := range []struct {
+func TestGetAppSKey(t *testing.T) { //nolint:paralleltest
+	for _, tc := range []struct { //nolint:paralleltest
 		Name              string
-		NewServer         func(*testing.T) *httptest.Server
+		NewServer         func(*assertions.Assertion) *httptest.Server
 		AsID              string
 		Request           *ttnpb.SessionKeyRequest
-		ResponseAssertion func(*testing.T, *ttnpb.AppSKeyResponse) bool
-		ErrorAssertion    func(*testing.T, error) bool
+		ResponseAssertion func(*assertions.Assertion, *ttnpb.AppSKeyResponse) bool
+		ErrorAssertion    func(*assertions.Assertion, error) bool
 	}{
 		{
 			Name: "Backend Interfaces 1.0/UnknownDevEUI",
-			NewServer: func(t *testing.T) *httptest.Server {
+			NewServer: func(a *assertions.Assertion) *httptest.Server {
 				return newTLSServer(9183, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					a := assertions.New(t)
 					a.So(r.Method, should.Equal, http.MethodPost)
 					b := test.Must(io.ReadAll(r.Body)).([]byte)
 					var req map[string]interface{}
@@ -75,20 +74,20 @@ func TestGetAppSKey(t *testing.T) {
 			Request: &ttnpb.SessionKeyRequest{
 				JoinEui:      types.EUI64{0x70, 0xb3, 0xd5, 0x7e, 0xd0, 0x00, 0x00, 0x00}.Bytes(),
 				DevEui:       types.EUI64{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}.Bytes(),
-				SessionKeyId: []byte{0x01, 0x6b, 0xfa, 0x7b, 0xad, 0x47, 0x56, 0x34, 0x6a, 0x67, 0x49, 0x81, 0xe7, 0x5c, 0xdb, 0xdc},
+				SessionKeyId: []byte{0x01, 0x6b, 0xfa, 0x7b, 0xad, 0x47, 0x56, 0x34, 0x6a, 0x67, 0x49, 0x81, 0xe7, 0x5c, 0xdb, 0xdc}, //nolint:lll
 			},
-			ResponseAssertion: func(t *testing.T, resp *ttnpb.AppSKeyResponse) bool {
-				return assertions.New(t).So(resp, should.BeNil)
+			ResponseAssertion: func(a *assertions.Assertion, resp *ttnpb.AppSKeyResponse) bool {
+				return a.So(resp, should.BeNil)
 			},
-			ErrorAssertion: func(t *testing.T, err error) bool {
-				return assertions.New(t).So(err, should.HaveSameErrorDefinitionAs, ErrUnknownDevEUI)
+			ErrorAssertion: func(a *assertions.Assertion, err error) bool {
+				return a.So(err, should.HaveSameErrorDefinitionAs, ErrUnknownDevEUI)
 			},
 		},
 		{
 			Name: "Backend Interfaces 1.1/UnknownDevEUI",
-			NewServer: func(t *testing.T) *httptest.Server {
+			NewServer: func(a *assertions.Assertion) *httptest.Server {
 				return newTLSServer(9183, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					a := assertions.New(t)
+					a := a
 					a.So(r.Method, should.Equal, http.MethodPost)
 					b := test.Must(io.ReadAll(r.Body)).([]byte)
 					var req map[string]interface{}
@@ -118,20 +117,20 @@ func TestGetAppSKey(t *testing.T) {
 			Request: &ttnpb.SessionKeyRequest{
 				JoinEui:      types.EUI64{0xec, 0x65, 0x6e, 0x00, 0x00, 0x00, 0x00, 0x00}.Bytes(),
 				DevEui:       types.EUI64{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}.Bytes(),
-				SessionKeyId: []byte{0x01, 0x6b, 0xfa, 0x7b, 0xad, 0x47, 0x56, 0x34, 0x6a, 0x67, 0x49, 0x81, 0xe7, 0x5c, 0xdb, 0xdc},
+				SessionKeyId: []byte{0x01, 0x6b, 0xfa, 0x7b, 0xad, 0x47, 0x56, 0x34, 0x6a, 0x67, 0x49, 0x81, 0xe7, 0x5c, 0xdb, 0xdc}, //nolint:lll
 			},
-			ResponseAssertion: func(t *testing.T, resp *ttnpb.AppSKeyResponse) bool {
-				return assertions.New(t).So(resp, should.BeNil)
+			ResponseAssertion: func(a *assertions.Assertion, resp *ttnpb.AppSKeyResponse) bool {
+				return a.So(resp, should.BeNil)
 			},
-			ErrorAssertion: func(t *testing.T, err error) bool {
-				return assertions.New(t).So(err, should.HaveSameErrorDefinitionAs, ErrUnknownDevEUI)
+			ErrorAssertion: func(a *assertions.Assertion, err error) bool {
+				return a.So(err, should.HaveSameErrorDefinitionAs, ErrUnknownDevEUI)
 			},
 		},
 		{
 			Name: "Backend Interfaces 1.0/Success",
-			NewServer: func(t *testing.T) *httptest.Server {
+			NewServer: func(a *assertions.Assertion) *httptest.Server {
 				return newTLSServer(9183, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					a := assertions.New(t)
+					a := a
 					a.So(r.Method, should.Equal, http.MethodPost)
 					b := test.Must(io.ReadAll(r.Body)).([]byte)
 					var req map[string]interface{}
@@ -167,25 +166,25 @@ func TestGetAppSKey(t *testing.T) {
 			Request: &ttnpb.SessionKeyRequest{
 				JoinEui:      types.EUI64{0x70, 0xb3, 0xd5, 0x7e, 0xd0, 0x00, 0x00, 0x00}.Bytes(),
 				DevEui:       types.EUI64{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}.Bytes(),
-				SessionKeyId: []byte{0x01, 0x6b, 0xfa, 0x7b, 0xad, 0x47, 0x56, 0x34, 0x6a, 0x67, 0x49, 0x81, 0xe7, 0x5c, 0xdb, 0xdc},
+				SessionKeyId: []byte{0x01, 0x6b, 0xfa, 0x7b, 0xad, 0x47, 0x56, 0x34, 0x6a, 0x67, 0x49, 0x81, 0xe7, 0x5c, 0xdb, 0xdc}, //nolint:lll
 			},
-			ResponseAssertion: func(t *testing.T, resp *ttnpb.AppSKeyResponse) bool {
-				return assertions.New(t).So(resp, should.Resemble, &ttnpb.AppSKeyResponse{
+			ResponseAssertion: func(a *assertions.Assertion, resp *ttnpb.AppSKeyResponse) bool {
+				return a.So(resp, should.Resemble, &ttnpb.AppSKeyResponse{
 					AppSKey: &ttnpb.KeyEnvelope{
 						KekLabel:     "as:010042",
-						EncryptedKey: []byte{0x2a, 0x19, 0x5c, 0xc9, 0x3c, 0xa5, 0x4a, 0xd8, 0x2c, 0xfb, 0x36, 0xc8, 0x3d, 0x91, 0x45, 0x0f, 0x3d, 0x2d, 0x52, 0x35, 0x56, 0xf1, 0x3e, 0x69},
+						EncryptedKey: []byte{0x2a, 0x19, 0x5c, 0xc9, 0x3c, 0xa5, 0x4a, 0xd8, 0x2c, 0xfb, 0x36, 0xc8, 0x3d, 0x91, 0x45, 0x0f, 0x3d, 0x2d, 0x52, 0x35, 0x56, 0xf1, 0x3e, 0x69}, //nolint:lll
 					},
 				})
 			},
-			ErrorAssertion: func(t *testing.T, err error) bool {
-				return assertions.New(t).So(err, should.BeNil)
+			ErrorAssertion: func(a *assertions.Assertion, err error) bool {
+				return a.So(err, should.BeNil)
 			},
 		},
 		{
 			Name: "Backend Interfaces 1.1/Success",
-			NewServer: func(t *testing.T) *httptest.Server {
+			NewServer: func(a *assertions.Assertion) *httptest.Server {
 				return newTLSServer(9183, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					a := assertions.New(t)
+					a := a
 					a.So(r.Method, should.Equal, http.MethodPost)
 					b := test.Must(io.ReadAll(r.Body)).([]byte)
 					var req map[string]interface{}
@@ -221,28 +220,29 @@ func TestGetAppSKey(t *testing.T) {
 			Request: &ttnpb.SessionKeyRequest{
 				JoinEui:      types.EUI64{0xec, 0x65, 0x6e, 0x00, 0x00, 0x00, 0x00, 0x00}.Bytes(),
 				DevEui:       types.EUI64{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}.Bytes(),
-				SessionKeyId: []byte{0x01, 0x6b, 0xfa, 0x7b, 0xad, 0x47, 0x56, 0x34, 0x6a, 0x67, 0x49, 0x81, 0xe7, 0x5c, 0xdb, 0xdc},
+				SessionKeyId: []byte{0x01, 0x6b, 0xfa, 0x7b, 0xad, 0x47, 0x56, 0x34, 0x6a, 0x67, 0x49, 0x81, 0xe7, 0x5c, 0xdb, 0xdc}, //nolint:lll
 			},
-			ResponseAssertion: func(t *testing.T, resp *ttnpb.AppSKeyResponse) bool {
-				return assertions.New(t).So(resp, should.Resemble, &ttnpb.AppSKeyResponse{
+			ResponseAssertion: func(a *assertions.Assertion, resp *ttnpb.AppSKeyResponse) bool {
+				return a.So(resp, should.Resemble, &ttnpb.AppSKeyResponse{
 					AppSKey: &ttnpb.KeyEnvelope{
 						KekLabel:     "as:010042",
-						EncryptedKey: []byte{0x2a, 0x19, 0x5c, 0xc9, 0x3c, 0xa5, 0x4a, 0xd8, 0x2c, 0xfb, 0x36, 0xc8, 0x3d, 0x91, 0x45, 0x0f, 0x3d, 0x2d, 0x52, 0x35, 0x56, 0xf1, 0x3e, 0x69},
+						EncryptedKey: []byte{0x2a, 0x19, 0x5c, 0xc9, 0x3c, 0xa5, 0x4a, 0xd8, 0x2c, 0xfb, 0x36, 0xc8, 0x3d, 0x91, 0x45, 0x0f, 0x3d, 0x2d, 0x52, 0x35, 0x56, 0xf1, 0x3e, 0x69}, //nolint:lll
 					},
 				})
 			},
-			ErrorAssertion: func(t *testing.T, err error) bool {
-				return assertions.New(t).So(err, should.BeNil)
+			ErrorAssertion: func(a *assertions.Assertion, err error) bool {
+				return a.So(err, should.BeNil)
 			},
 		},
 	} {
+		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			a := assertions.New(t)
 
 			ctx := test.Context()
 			ctx = log.NewContext(ctx, test.GetLogger(t))
 
-			srv := tc.NewServer(t)
+			srv := tc.NewServer(a)
 			defer srv.Close()
 
 			cl, err := NewClient(ctx, config.InteropClient{
@@ -254,8 +254,8 @@ func TestGetAppSKey(t *testing.T) {
 			}
 
 			res, err := cl.GetAppSKey(ctx, tc.AsID, tc.Request)
-			if a.So(tc.ErrorAssertion(t, err), should.BeTrue) {
-				a.So(tc.ResponseAssertion(t, res), should.BeTrue)
+			if a.So(tc.ErrorAssertion(a, err), should.BeTrue) {
+				a.So(tc.ResponseAssertion(a, res), should.BeTrue)
 			} else if err != nil {
 				t.Errorf("Received unexpected error: %v", errors.Stack(err))
 			}
@@ -263,20 +263,20 @@ func TestGetAppSKey(t *testing.T) {
 	}
 }
 
-func TestHandleJoinRequest(t *testing.T) {
-	for _, tc := range []struct {
+func TestHandleJoinRequest(t *testing.T) { //nolint:paralleltest
+	for _, tc := range []struct { //nolint:paralleltest
 		Name              string
-		NewServer         func(*testing.T) *httptest.Server
+		NewServer         func(*assertions.Assertion) *httptest.Server
 		NetID             types.NetID
 		Request           *ttnpb.JoinRequest
-		ResponseAssertion func(*testing.T, *ttnpb.JoinResponse) bool
-		ErrorAssertion    func(*testing.T, error) bool
+		ResponseAssertion func(*assertions.Assertion, *ttnpb.JoinResponse) bool
+		ErrorAssertion    func(*assertions.Assertion, error) bool
 	}{
 		{
 			Name: "Backend Interfaces 1.0/MICFailed",
-			NewServer: func(t *testing.T) *httptest.Server {
+			NewServer: func(a *assertions.Assertion) *httptest.Server {
 				return newTLSServer(9183, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					a := assertions.New(t)
+					a := a
 					a.So(r.Method, should.Equal, http.MethodPost)
 					b := test.Must(io.ReadAll(r.Body)).([]byte)
 					var req map[string]interface{}
@@ -321,20 +321,20 @@ func TestHandleJoinRequest(t *testing.T) {
 						},
 					},
 				},
-				RawPayload: []byte{0x00, 0x00, 0x00, 0x00, 0xd0, 0x7e, 0xd5, 0xb3, 0x70, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00, 0x00, 0x38, 0x51, 0xf0, 0xb6},
+				RawPayload: []byte{0x00, 0x00, 0x00, 0x00, 0xd0, 0x7e, 0xd5, 0xb3, 0x70, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00, 0x00, 0x38, 0x51, 0xf0, 0xb6}, //nolint:lll
 			},
-			ResponseAssertion: func(t *testing.T, resp *ttnpb.JoinResponse) bool {
-				return assertions.New(t).So(resp, should.BeNil)
+			ResponseAssertion: func(a *assertions.Assertion, resp *ttnpb.JoinResponse) bool {
+				return a.So(resp, should.BeNil)
 			},
-			ErrorAssertion: func(t *testing.T, err error) bool {
-				return assertions.New(t).So(err, should.HaveSameErrorDefinitionAs, ErrMIC)
+			ErrorAssertion: func(a *assertions.Assertion, err error) bool {
+				return a.So(err, should.HaveSameErrorDefinitionAs, ErrMIC)
 			},
 		},
 		{
 			Name: "Backend Interfaces 1.1/MICFailed",
-			NewServer: func(t *testing.T) *httptest.Server {
+			NewServer: func(a *assertions.Assertion) *httptest.Server {
 				return newTLSServer(9183, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					a := assertions.New(t)
+					a := a
 					a.So(r.Method, should.Equal, http.MethodPost)
 					b := test.Must(io.ReadAll(r.Body)).([]byte)
 					var req map[string]interface{}
@@ -381,20 +381,20 @@ func TestHandleJoinRequest(t *testing.T) {
 						},
 					},
 				},
-				RawPayload: []byte{0x00, 0x00, 0x00, 0x00, 0xd0, 0x7e, 0xd5, 0xb3, 0x70, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00, 0x00, 0x38, 0x51, 0xf0, 0xb6},
+				RawPayload: []byte{0x00, 0x00, 0x00, 0x00, 0xd0, 0x7e, 0xd5, 0xb3, 0x70, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00, 0x00, 0x38, 0x51, 0xf0, 0xb6}, //nolint:lll
 			},
-			ResponseAssertion: func(t *testing.T, resp *ttnpb.JoinResponse) bool {
-				return assertions.New(t).So(resp, should.BeNil)
+			ResponseAssertion: func(a *assertions.Assertion, resp *ttnpb.JoinResponse) bool {
+				return a.So(resp, should.BeNil)
 			},
-			ErrorAssertion: func(t *testing.T, err error) bool {
-				return assertions.New(t).So(err, should.HaveSameErrorDefinitionAs, ErrMIC)
+			ErrorAssertion: func(a *assertions.Assertion, err error) bool {
+				return a.So(err, should.HaveSameErrorDefinitionAs, ErrMIC)
 			},
 		},
 		{
 			Name: "Backend Interfaces 1.0/Success",
-			NewServer: func(t *testing.T) *httptest.Server {
+			NewServer: func(a *assertions.Assertion) *httptest.Server {
 				return newTLSServer(9183, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					a := assertions.New(t)
+					a := a
 					a.So(r.Method, should.Equal, http.MethodPost)
 					b := test.Must(io.ReadAll(r.Body)).([]byte)
 					var req map[string]interface{}
@@ -451,34 +451,34 @@ func TestHandleJoinRequest(t *testing.T) {
 						},
 					},
 				},
-				RawPayload: []byte{0x00, 0x00, 0x00, 0x00, 0xd0, 0x7e, 0xd5, 0xb3, 0x70, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00, 0x00, 0x38, 0x51, 0xf0, 0xb6},
+				RawPayload: []byte{0x00, 0x00, 0x00, 0x00, 0xd0, 0x7e, 0xd5, 0xb3, 0x70, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00, 0x00, 0x38, 0x51, 0xf0, 0xb6}, //nolint:lll
 			},
-			ResponseAssertion: func(t *testing.T, resp *ttnpb.JoinResponse) bool {
-				return assertions.New(t).So(resp, should.Resemble, &ttnpb.JoinResponse{
-					RawPayload: []byte{0x20, 0x4d, 0x67, 0x50, 0x73, 0xbb, 0x41, 0x53, 0xb2, 0x36, 0x53, 0xef, 0xa8, 0x2c, 0x1f, 0x3a, 0x49, 0xe1, 0x9c, 0x2a, 0x86, 0x96, 0xc9, 0xa3, 0x4b, 0xf4, 0x92, 0x67, 0x47, 0x79, 0xe4, 0xbe, 0xfa},
+			ResponseAssertion: func(a *assertions.Assertion, resp *ttnpb.JoinResponse) bool {
+				return a.So(resp, should.Resemble, &ttnpb.JoinResponse{
+					RawPayload: []byte{0x20, 0x4d, 0x67, 0x50, 0x73, 0xbb, 0x41, 0x53, 0xb2, 0x36, 0x53, 0xef, 0xa8, 0x2c, 0x1f, 0x3a, 0x49, 0xe1, 0x9c, 0x2a, 0x86, 0x96, 0xc9, 0xa3, 0x4b, 0xf4, 0x92, 0x67, 0x47, 0x79, 0xe4, 0xbe, 0xfa}, //nolint:lll
 					SessionKeys: &ttnpb.SessionKeys{
-						SessionKeyId: []byte{0x01, 0x6b, 0xfa, 0x7b, 0xad, 0x47, 0x56, 0x34, 0x6a, 0x67, 0x49, 0x81, 0xe7, 0x5c, 0xdb, 0xdc},
+						SessionKeyId: []byte{0x01, 0x6b, 0xfa, 0x7b, 0xad, 0x47, 0x56, 0x34, 0x6a, 0x67, 0x49, 0x81, 0xe7, 0x5c, 0xdb, 0xdc}, //nolint:lll
 						FNwkSIntKey: &ttnpb.KeyEnvelope{
 							KekLabel:     "ns:42ffff",
-							EncryptedKey: []byte{0xeb, 0x56, 0xfe, 0x66, 0x81, 0x99, 0x9f, 0x25, 0xd5, 0x48, 0xcf, 0xed, 0xd4, 0xa6, 0x52, 0x8b, 0x33, 0x1b, 0xb5, 0xad, 0xe1, 0xca, 0xf1, 0x7f},
+							EncryptedKey: []byte{0xeb, 0x56, 0xfe, 0x66, 0x81, 0x99, 0x9f, 0x25, 0xd5, 0x48, 0xcf, 0xed, 0xd4, 0xa6, 0x52, 0x8b, 0x33, 0x1b, 0xb5, 0xad, 0xe1, 0xca, 0xf1, 0x7f}, //nolint:lll
 						},
 						AppSKey: &ttnpb.KeyEnvelope{
 							KekLabel:     "as:010042",
-							EncryptedKey: []byte{0x2a, 0x19, 0x5c, 0xc9, 0x3c, 0xa5, 0x4a, 0xd8, 0x2c, 0xfb, 0x36, 0xc8, 0x3d, 0x91, 0x45, 0x0f, 0x3d, 0x2d, 0x52, 0x35, 0x56, 0xf1, 0x3e, 0x69},
+							EncryptedKey: []byte{0x2a, 0x19, 0x5c, 0xc9, 0x3c, 0xa5, 0x4a, 0xd8, 0x2c, 0xfb, 0x36, 0xc8, 0x3d, 0x91, 0x45, 0x0f, 0x3d, 0x2d, 0x52, 0x35, 0x56, 0xf1, 0x3e, 0x69}, //nolint:lll
 						},
 					},
 					Lifetime: ttnpb.ProtoDurationPtr(0),
 				})
 			},
-			ErrorAssertion: func(t *testing.T, err error) bool {
-				return assertions.New(t).So(err, should.BeNil)
+			ErrorAssertion: func(a *assertions.Assertion, err error) bool {
+				return a.So(err, should.BeNil)
 			},
 		},
 		{
 			Name: "Backend Interfaces 1.1/Success/With Session Key ID",
-			NewServer: func(t *testing.T) *httptest.Server {
+			NewServer: func(a *assertions.Assertion) *httptest.Server {
 				return newTLSServer(9183, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					a := assertions.New(t)
+					a := a
 					a.So(r.Method, should.Equal, http.MethodPost)
 					b := test.Must(io.ReadAll(r.Body)).([]byte)
 					var req map[string]interface{}
@@ -537,34 +537,34 @@ func TestHandleJoinRequest(t *testing.T) {
 						},
 					},
 				},
-				RawPayload: []byte{0x00, 0x00, 0x00, 0x00, 0xd0, 0x7e, 0xd5, 0xb3, 0x70, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00, 0x00, 0x38, 0x51, 0xf0, 0xb6},
+				RawPayload: []byte{0x00, 0x00, 0x00, 0x00, 0xd0, 0x7e, 0xd5, 0xb3, 0x70, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00, 0x00, 0x38, 0x51, 0xf0, 0xb6}, //nolint:lll
 			},
-			ResponseAssertion: func(t *testing.T, resp *ttnpb.JoinResponse) bool {
-				return assertions.New(t).So(resp, should.Resemble, &ttnpb.JoinResponse{
-					RawPayload: []byte{0x20, 0x4d, 0x67, 0x50, 0x73, 0xbb, 0x41, 0x53, 0xb2, 0x36, 0x53, 0xef, 0xa8, 0x2c, 0x1f, 0x3a, 0x49, 0xe1, 0x9c, 0x2a, 0x86, 0x96, 0xc9, 0xa3, 0x4b, 0xf4, 0x92, 0x67, 0x47, 0x79, 0xe4, 0xbe, 0xfa},
+			ResponseAssertion: func(a *assertions.Assertion, resp *ttnpb.JoinResponse) bool {
+				return a.So(resp, should.Resemble, &ttnpb.JoinResponse{
+					RawPayload: []byte{0x20, 0x4d, 0x67, 0x50, 0x73, 0xbb, 0x41, 0x53, 0xb2, 0x36, 0x53, 0xef, 0xa8, 0x2c, 0x1f, 0x3a, 0x49, 0xe1, 0x9c, 0x2a, 0x86, 0x96, 0xc9, 0xa3, 0x4b, 0xf4, 0x92, 0x67, 0x47, 0x79, 0xe4, 0xbe, 0xfa}, //nolint:lll
 					SessionKeys: &ttnpb.SessionKeys{
-						SessionKeyId: []byte{0x01, 0x6b, 0xfa, 0x7b, 0xad, 0x47, 0x56, 0x34, 0x6a, 0x67, 0x49, 0x81, 0xe7, 0x5c, 0xdb, 0xdc},
+						SessionKeyId: []byte{0x01, 0x6b, 0xfa, 0x7b, 0xad, 0x47, 0x56, 0x34, 0x6a, 0x67, 0x49, 0x81, 0xe7, 0x5c, 0xdb, 0xdc}, //nolint:lll
 						FNwkSIntKey: &ttnpb.KeyEnvelope{
 							KekLabel:     "ns:42ffff",
-							EncryptedKey: []byte{0xeb, 0x56, 0xfe, 0x66, 0x81, 0x99, 0x9f, 0x25, 0xd5, 0x48, 0xcf, 0xed, 0xd4, 0xa6, 0x52, 0x8b, 0x33, 0x1b, 0xb5, 0xad, 0xe1, 0xca, 0xf1, 0x7f},
+							EncryptedKey: []byte{0xeb, 0x56, 0xfe, 0x66, 0x81, 0x99, 0x9f, 0x25, 0xd5, 0x48, 0xcf, 0xed, 0xd4, 0xa6, 0x52, 0x8b, 0x33, 0x1b, 0xb5, 0xad, 0xe1, 0xca, 0xf1, 0x7f}, //nolint:lll
 						},
 						AppSKey: &ttnpb.KeyEnvelope{
 							KekLabel:     "as:010042",
-							EncryptedKey: []byte{0x2a, 0x19, 0x5c, 0xc9, 0x3c, 0xa5, 0x4a, 0xd8, 0x2c, 0xfb, 0x36, 0xc8, 0x3d, 0x91, 0x45, 0x0f, 0x3d, 0x2d, 0x52, 0x35, 0x56, 0xf1, 0x3e, 0x69},
+							EncryptedKey: []byte{0x2a, 0x19, 0x5c, 0xc9, 0x3c, 0xa5, 0x4a, 0xd8, 0x2c, 0xfb, 0x36, 0xc8, 0x3d, 0x91, 0x45, 0x0f, 0x3d, 0x2d, 0x52, 0x35, 0x56, 0xf1, 0x3e, 0x69}, //nolint:lll
 						},
 					},
 					Lifetime: ttnpb.ProtoDurationPtr(0),
 				})
 			},
-			ErrorAssertion: func(t *testing.T, err error) bool {
-				return assertions.New(t).So(err, should.BeNil)
+			ErrorAssertion: func(a *assertions.Assertion, err error) bool {
+				return a.So(err, should.BeNil)
 			},
 		},
 		{
 			Name: "Backend Interfaces 1.1/Success/Without Session Key ID",
-			NewServer: func(t *testing.T) *httptest.Server {
+			NewServer: func(a *assertions.Assertion) *httptest.Server {
 				return newTLSServer(9183, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					a := assertions.New(t)
+					a := a
 					a.So(r.Method, should.Equal, http.MethodPost)
 					b := test.Must(io.ReadAll(r.Body)).([]byte)
 					var req map[string]interface{}
@@ -622,41 +622,41 @@ func TestHandleJoinRequest(t *testing.T) {
 						},
 					},
 				},
-				RawPayload: []byte{0x00, 0x00, 0x00, 0x00, 0xd0, 0x7e, 0xd5, 0xb3, 0x70, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00, 0x00, 0x38, 0x51, 0xf0, 0xb6},
+				RawPayload: []byte{0x00, 0x00, 0x00, 0x00, 0xd0, 0x7e, 0xd5, 0xb3, 0x70, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00, 0x00, 0x38, 0x51, 0xf0, 0xb6}, //nolint:lll
 			},
-			ResponseAssertion: func(t *testing.T, resp *ttnpb.JoinResponse) bool {
-				a := assertions.New(t)
+			ResponseAssertion: func(a *assertions.Assertion, resp *ttnpb.JoinResponse) bool {
 				if !a.So(GeneratedSessionKeyID(resp.SessionKeys.SessionKeyId), should.BeTrue) {
 					return false
 				}
 				return a.So(resp, should.Resemble, &ttnpb.JoinResponse{
-					RawPayload: []byte{0x20, 0x4d, 0x67, 0x50, 0x73, 0xbb, 0x41, 0x53, 0xb2, 0x36, 0x53, 0xef, 0xa8, 0x2c, 0x1f, 0x3a, 0x49, 0xe1, 0x9c, 0x2a, 0x86, 0x96, 0xc9, 0xa3, 0x4b, 0xf4, 0x92, 0x67, 0x47, 0x79, 0xe4, 0xbe, 0xfa},
+					RawPayload: []byte{0x20, 0x4d, 0x67, 0x50, 0x73, 0xbb, 0x41, 0x53, 0xb2, 0x36, 0x53, 0xef, 0xa8, 0x2c, 0x1f, 0x3a, 0x49, 0xe1, 0x9c, 0x2a, 0x86, 0x96, 0xc9, 0xa3, 0x4b, 0xf4, 0x92, 0x67, 0x47, 0x79, 0xe4, 0xbe, 0xfa}, //nolint:lll
 					SessionKeys: &ttnpb.SessionKeys{
 						SessionKeyId: resp.SessionKeys.SessionKeyId,
 						FNwkSIntKey: &ttnpb.KeyEnvelope{
 							KekLabel:     "ns:42ffff",
-							EncryptedKey: []byte{0xeb, 0x56, 0xfe, 0x66, 0x81, 0x99, 0x9f, 0x25, 0xd5, 0x48, 0xcf, 0xed, 0xd4, 0xa6, 0x52, 0x8b, 0x33, 0x1b, 0xb5, 0xad, 0xe1, 0xca, 0xf1, 0x7f},
+							EncryptedKey: []byte{0xeb, 0x56, 0xfe, 0x66, 0x81, 0x99, 0x9f, 0x25, 0xd5, 0x48, 0xcf, 0xed, 0xd4, 0xa6, 0x52, 0x8b, 0x33, 0x1b, 0xb5, 0xad, 0xe1, 0xca, 0xf1, 0x7f}, //nolint:lll
 						},
 						AppSKey: &ttnpb.KeyEnvelope{
 							KekLabel:     "as:010042",
-							EncryptedKey: []byte{0x2a, 0x19, 0x5c, 0xc9, 0x3c, 0xa5, 0x4a, 0xd8, 0x2c, 0xfb, 0x36, 0xc8, 0x3d, 0x91, 0x45, 0x0f, 0x3d, 0x2d, 0x52, 0x35, 0x56, 0xf1, 0x3e, 0x69},
+							EncryptedKey: []byte{0x2a, 0x19, 0x5c, 0xc9, 0x3c, 0xa5, 0x4a, 0xd8, 0x2c, 0xfb, 0x36, 0xc8, 0x3d, 0x91, 0x45, 0x0f, 0x3d, 0x2d, 0x52, 0x35, 0x56, 0xf1, 0x3e, 0x69}, //nolint:lll
 						},
 					},
 					Lifetime: ttnpb.ProtoDurationPtr(0),
 				})
 			},
-			ErrorAssertion: func(t *testing.T, err error) bool {
-				return assertions.New(t).So(err, should.BeNil)
+			ErrorAssertion: func(a *assertions.Assertion, err error) bool {
+				return a.So(err, should.BeNil)
 			},
 		},
 	} {
+		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			a := assertions.New(t)
 
 			ctx := test.Context()
 			ctx = log.NewContext(ctx, test.GetLogger(t))
 
-			srv := tc.NewServer(t)
+			srv := tc.NewServer(a)
 			defer srv.Close()
 
 			cl, err := NewClient(ctx, config.InteropClient{
@@ -668,8 +668,8 @@ func TestHandleJoinRequest(t *testing.T) {
 			}
 
 			res, err := cl.HandleJoinRequest(ctx, tc.NetID, tc.Request)
-			if a.So(tc.ErrorAssertion(t, err), should.BeTrue) {
-				a.So(tc.ResponseAssertion(t, res), should.BeTrue)
+			if a.So(tc.ErrorAssertion(a, err), should.BeTrue) {
+				a.So(tc.ResponseAssertion(a, res), should.BeTrue)
 			} else if err != nil {
 				t.Errorf("Received unexpected error: %v", errors.Stack(err))
 			}

--- a/pkg/interop/config.go
+++ b/pkg/interop/config.go
@@ -81,7 +81,9 @@ const (
 	SenderClientCAsConfigurationName = "config.yml"
 )
 
-func fetchSenderClientCAs(ctx context.Context, conf config.InteropServer, httpClientProvider httpclient.Provider) (map[string][]*x509.Certificate, error) {
+func fetchSenderClientCAs( //nolint:gocyclo
+	ctx context.Context, conf config.InteropServer, httpClientProvider httpclient.Provider,
+) (map[string][]*x509.Certificate, error) {
 	decodeCerts := func(b []byte) (res []*x509.Certificate, err error) {
 		for len(b) > 0 {
 			var block *pem.Block

--- a/pkg/interop/errors.go
+++ b/pkg/interop/errors.go
@@ -19,35 +19,54 @@ import (
 )
 
 var (
-	errNoPublicTLSAddress  = errors.DefineFailedPrecondition("no_public_tls_address", "no public TLS address configured for interop")
-	errUnknownMACVersion   = errors.DefineInvalidArgument("unknown_mac_version", "unknown MAC version")
-	errInvalidLength       = errors.DefineInvalidArgument("invalid_length", "invalid length")
-	errInvalidRequestType  = errors.DefineInvalidArgument("invalid_request_type", "invalid request type `{type}`")
-	errNotRegistered       = errors.DefineNotFound("not_registered", "not registered")
-	errUnexpectedResult    = errors.Define("unexpected_result", "unexpected result code `{result_code}`", "result_description")
-	errCallerNotAuthorized = errors.DefinePermissionDenied("caller_not_authorized", "caller is not authorized for `{target}`")
-	errUnauthenticated     = errors.DefineUnauthenticated("unauthenticated", "unauthenticated")
-	errInvalidVendorID     = errors.DefineInvalidArgument("invalid_vendor_id", "invalid vendor ID")
+	errNoPublicTLSAddress = errors.DefineFailedPrecondition("no_public_tls_address",
+		"no public TLS address configured for interop",
+	)
+	errUnknownMACVersion  = errors.DefineInvalidArgument("unknown_mac_version", "unknown MAC version")
+	errInvalidLength      = errors.DefineInvalidArgument("invalid_length", "invalid length")
+	errInvalidRequestType = errors.DefineInvalidArgument("invalid_request_type", "invalid request type `{type}`")
+	errNotRegistered      = errors.DefineNotFound("not_registered", "not registered")
+	errUnexpectedResult   = errors.Define("unexpected_result",
+		"unexpected result code `{result_code}`", "result_description",
+	)
+	errCallerNotAuthorized = errors.DefinePermissionDenied("caller_not_authorized",
+		"caller is not authorized for `{target}`",
+	)
+	errUnauthenticated = errors.DefineUnauthenticated("unauthenticated", "unauthenticated")
+	errInvalidVendorID = errors.DefineInvalidArgument("invalid_vendor_id", "invalid vendor ID")
+)
 
+// LoRaWAN Backend Interfaces 1.0 errors.
+var (
 	ErrNoAction           = errors.DefineAborted("no_action", "no action", "result_description")
 	ErrMIC                = errors.DefineInvalidArgument("mic", "MIC failed", "result_description")
 	ErrFrameReplayed      = errors.DefineAborted("frame_replayed", "frame replayed", "result_description")
 	ErrJoinReq            = errors.DefineAborted("join_req", "join-request failed", "result_description")
-	ErrNoRoamingAgreement = errors.DefineFailedPrecondition("no_roaming_agreement", "no roaming agreement", "result_description")
-	ErrDeviceRoaming      = errors.DefineFailedPrecondition("device_roaming", "device roaming disallowed", "result_description")
-	ErrRoamingActivation  = errors.DefineFailedPrecondition("roaming_activation", "roaming activation disallowed", "result_description")
-	ErrActivation         = errors.DefineFailedPrecondition("activation", "activation disallowed", "result_description")
-	ErrUnknownDevEUI      = errors.DefineNotFound("unknown_dev_eui", "unknown DevEUI", "result_description")
-	ErrUnknownDevAddr     = errors.DefineNotFound("unknown_dev_addr", "unknown DevAddr", "result_description")
-	ErrUnknownSender      = errors.DefineNotFound("unknown_sender", "unknown sender", "result_description")
-	ErrUnknownReceiver    = errors.DefineNotFound("unknown_receiver", "unknown receiver", "result_description")
-	ErrDeferred           = errors.DefineAborted("deferred", "deferred", "result_description")
-	ErrTransmitFailed     = errors.DefineAborted("transmit_failed", "transmit failed", "result_description")
-	ErrFPort              = errors.DefineInvalidArgument("f_port", "invalid FPort", "result_description")
-	ErrProtocolVersion    = errors.DefineInvalidArgument("protocol_version", "invalid protocol version", "result_description")
-	ErrStaleDeviceProfile = errors.DefineFailedPrecondition("stale_device_profile", "stale device profile", "result_description")
-	ErrMalformedMessage   = errors.DefineInvalidArgument("malformed_message", "malformed message", "result_description")
-	ErrFrameSize          = errors.DefineInvalidArgument("frame_size", "frame size error", "result_description")
+	ErrNoRoamingAgreement = errors.DefineFailedPrecondition("no_roaming_agreement", "no roaming agreement",
+		"result_description",
+	)
+	ErrDeviceRoaming = errors.DefineFailedPrecondition("device_roaming", "device roaming disallowed",
+		"result_description",
+	)
+	ErrRoamingActivation = errors.DefineFailedPrecondition("roaming_activation", "roaming activation disallowed",
+		"result_description",
+	)
+	ErrActivation      = errors.DefineFailedPrecondition("activation", "activation disallowed", "result_description")
+	ErrUnknownDevEUI   = errors.DefineNotFound("unknown_dev_eui", "unknown DevEUI", "result_description")
+	ErrUnknownDevAddr  = errors.DefineNotFound("unknown_dev_addr", "unknown DevAddr", "result_description")
+	ErrUnknownSender   = errors.DefineNotFound("unknown_sender", "unknown sender", "result_description")
+	ErrUnknownReceiver = errors.DefineNotFound("unknown_receiver", "unknown receiver", "result_description")
+	ErrDeferred        = errors.DefineAborted("deferred", "deferred", "result_description")
+	ErrTransmitFailed  = errors.DefineAborted("transmit_failed", "transmit failed", "result_description")
+	ErrFPort           = errors.DefineInvalidArgument("f_port", "invalid FPort", "result_description")
+	ErrProtocolVersion = errors.DefineInvalidArgument("protocol_version", "invalid protocol version",
+		"result_description",
+	)
+	ErrStaleDeviceProfile = errors.DefineFailedPrecondition("stale_device_profile", "stale device profile",
+		"result_description",
+	)
+	ErrMalformedMessage = errors.DefineInvalidArgument("malformed_message", "malformed message", "result_description")
+	ErrFrameSize        = errors.DefineInvalidArgument("frame_size", "frame size error", "result_description")
 
 	resultErrors = map[ResultCode]*errors.Definition{
 		ResultNoAction:               ErrNoAction,

--- a/pkg/interop/extensions.go
+++ b/pkg/interop/extensions.go
@@ -26,7 +26,7 @@ var TTIVendorID = VendorID{0xec, 0x65, 0x6e}
 type TTIVendorIDType VendorID
 
 // MarshalText returns the vendor ID of The Things Industries.
-func (v TTIVendorIDType) MarshalText() ([]byte, error) {
+func (TTIVendorIDType) MarshalText() ([]byte, error) {
 	return TTIVendorID.MarshalText()
 }
 

--- a/pkg/interop/extensions_test.go
+++ b/pkg/interop/extensions_test.go
@@ -23,7 +23,7 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
 )
 
-func TestExtensions(t *testing.T) {
+func TestExtensions(t *testing.T) { //nolint:paralleltest
 	a := assertions.New(t)
 
 	actual := TTIHomeNSAns{

--- a/pkg/interop/interop.go
+++ b/pkg/interop/interop.go
@@ -1,0 +1,16 @@
+// Copyright © 2022 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package interop implements a LoRaWAN Backend Interfaces server and client.
+package interop

--- a/pkg/interop/server.go
+++ b/pkg/interop/server.go
@@ -167,8 +167,9 @@ func (s *Server) ClientCAPool() *x509.CertPool {
 }
 
 // SenderClientCAs returns the client certificate authorities that are trusted for the given SenderID.
-// The SenderID is typically a NetID, but an AS-ID or JoinEUI can also be used to trust Application Servers and Join Servers respectively.
-func (s *Server) SenderClientCAs(ctx context.Context, senderID string) ([]*x509.Certificate, error) {
+// The SenderID is typically a NetID, but an AS-ID or JoinEUI can also be used to trust Application Servers
+// and Join Servers respectively.
+func (s *Server) SenderClientCAs(_ context.Context, senderID string) ([]*x509.Certificate, error) {
 	// TODO: Lookup partner CA by SenderID with DNS (https://github.com/TheThingsNetwork/lorawan-stack/issues/718).
 	return s.senderClientCAs[senderID], nil
 }
@@ -267,6 +268,6 @@ func (s *Server) handle() http.Handler {
 			return
 		}
 
-		json.NewEncoder(w).Encode(ans)
+		json.NewEncoder(w).Encode(ans) //nolint:errcheck
 	})
 }

--- a/pkg/interop/server_authn.go
+++ b/pkg/interop/server_authn.go
@@ -38,7 +38,7 @@ type NetworkServerAuthInfo struct {
 func (n NetworkServerAuthInfo) addressPatterns() []string { return n.Addresses }
 
 // Require returns an error if the given NetID or NSID does not match.
-func (n NetworkServerAuthInfo) Require(netID types.NetID, nsID *EUI64) error {
+func (n NetworkServerAuthInfo) Require(netID types.NetID, _ *EUI64) error {
 	if !n.NetID.Equal(netID) {
 		return errUnauthenticated.New()
 	}
@@ -76,7 +76,9 @@ var asAuthInfoKey asAuthInfoKeyType
 
 // NewContextWithApplicationServerAuthInfo returns a derived context with the given authentication information of the
 // Application Server.
-func NewContextWithApplicationServerAuthInfo(parent context.Context, authInfo *ApplicationServerAuthInfo) context.Context {
+func NewContextWithApplicationServerAuthInfo(
+	parent context.Context, authInfo *ApplicationServerAuthInfo,
+) context.Context {
 	return context.WithValue(parent, asAuthInfoKey, authInfo)
 }
 
@@ -114,7 +116,7 @@ func (s *Server) authenticateNS(ctx context.Context, r *http.Request, data []byt
 		// Verify TLS client certificate.
 		func(ctx context.Context) (*NetworkServerAuthInfo, error) {
 			if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
-				return nil, nil
+				return nil, nil //nolint:nilnil
 			}
 			addrs, err := s.verifySenderCertificate(ctx, types.NetID(header.SenderID).String(), r.TLS)
 			if err != nil {
@@ -130,18 +132,18 @@ func (s *Server) authenticateNS(ctx context.Context, r *http.Request, data []byt
 			logger := log.FromContext(ctx).WithField("authenticator", "packetbroker")
 			authz := strings.SplitN(r.Header.Get("Authorization"), " ", 2)
 			if len(authz) < 2 || strings.ToLower(authz[0]) != "bearer" {
-				return nil, nil
+				return nil, nil //nolint:nilnil
 			}
 			token, err := jwt.ParseSigned(authz[1])
 			if err != nil {
 				logger.WithError(err).Debug("Failed to parse token")
-				return nil, nil
+				return nil, nil //nolint:nilnil
 			}
 			var claims jwt.Claims
 			err = token.UnsafeClaimsWithoutVerification(&claims)
 			if err != nil {
 				logger.WithError(err).Debug("Failed to parse claims")
-				return nil, nil
+				return nil, nil //nolint:nilnil
 			}
 			if tokenVerifier, ok := s.tokenVerifiers[claims.Issuer]; ok {
 				authInfo, err := tokenVerifier.VerifyNetworkServer(ctx, token)
@@ -151,7 +153,7 @@ func (s *Server) authenticateNS(ctx context.Context, r *http.Request, data []byt
 				return authInfo, nil
 			}
 			logger.WithError(err).WithField("issuer", claims.Issuer).Debug("Unknown token issuer")
-			return nil, nil
+			return nil, nil //nolint:nilnil
 		},
 	} {
 		authInfo, err := authFunc(ctx)
@@ -191,7 +193,9 @@ func (s *Server) authenticateAS(ctx context.Context, r *http.Request, data []byt
 
 type senderAuthenticatorFunc func(ctx context.Context, r *http.Request, data []byte) (context.Context, error)
 
-func (f senderAuthenticatorFunc) Authenticate(ctx context.Context, r *http.Request, data []byte) (context.Context, error) {
+func (f senderAuthenticatorFunc) Authenticate(
+	ctx context.Context, r *http.Request, data []byte,
+) (context.Context, error) {
 	return f(ctx, r, data)
 }
 

--- a/pkg/interop/server_authn_mtls.go
+++ b/pkg/interop/server_authn_mtls.go
@@ -19,8 +19,11 @@ import (
 	"crypto/tls"
 )
 
-func (s *Server) verifySenderCertificate(ctx context.Context, senderID string, state *tls.ConnectionState) (addrs []string, err error) {
-	// TODO: Support reading TLS client certificate from proxy headers (https://github.com/TheThingsNetwork/lorawan-stack/issues/717).
+func (s *Server) verifySenderCertificate(
+	ctx context.Context, senderID string, state *tls.ConnectionState,
+) (addrs []string, err error) {
+	// TODO: Support reading TLS client certificate from proxy header.
+	// (https://github.com/TheThingsNetwork/lorawan-stack/issues/717)
 	senderClientCAs, err := s.SenderClientCAs(ctx, senderID)
 	if err != nil {
 		return nil, err
@@ -29,7 +32,8 @@ func (s *Server) verifySenderCertificate(ctx context.Context, senderID string, s
 		peerCert, clientCA := chain[0], chain[len(chain)-1]
 		for _, senderClientCA := range senderClientCAs {
 			if clientCA.Equal(senderClientCA) {
-				// If the TLS client certificate contains DNS addresses, use those. Otherwise, fallback to using CommonName as address.
+				// If the TLS client certificate contains DNS addresses, use those.
+				// Otherwise, fallback to using CommonName as address.
 				if len(peerCert.DNSNames) > 0 {
 					addrs = append([]string(nil), peerCert.DNSNames...)
 				} else {
@@ -39,7 +43,7 @@ func (s *Server) verifySenderCertificate(ctx context.Context, senderID string, s
 			}
 		}
 	}
-	// TODO: Verify state.PeerCertificates[0] with senderClientCAs as Roots and state.PeerCertificates[1:] as Intermediates.
-	// (https://github.com/TheThingsNetwork/lorawan-stack/issues/718).
+	// TODO: Verify state.PeerCertificates[0] with senderClientCAs as Roots
+	// and state.PeerCertificates[1:] as Intermediates (https://github.com/TheThingsNetwork/lorawan-stack/issues/718).
 	return nil, errUnauthenticated.New()
 }

--- a/pkg/interop/server_authn_token.go
+++ b/pkg/interop/server_authn_token.go
@@ -29,7 +29,9 @@ type packetBrokerTokenVerifier struct {
 	issuer, audience  string
 }
 
-func newPacketBrokerTokenVerifier(ctx context.Context, issuer, audience string, httpClient httpclient.Provider) (tokenVerifier, error) {
+func newPacketBrokerTokenVerifier(
+	ctx context.Context, issuer, audience string, httpClient httpclient.Provider,
+) (tokenVerifier, error) {
 	client, err := httpClient.HTTPClient(ctx)
 	if err != nil {
 		return nil, err
@@ -44,12 +46,16 @@ func newPacketBrokerTokenVerifier(ctx context.Context, issuer, audience string, 
 	}, nil
 }
 
-var errNotPacketBrokerCluster = errors.DefinePermissionDenied("not_packet_broker_cluster", "caller not authenticated as Packet Broker cluster")
+var errNotPacketBrokerCluster = errors.DefinePermissionDenied("not_packet_broker_cluster",
+	"caller not authenticated as Packet Broker cluster",
+)
 
 // VerifyNetworkServer verifies the token as Packet Broker cluster token; only Packet Broker clusters can authenticate.
 // Packet Broker clusters are authenticated as NetID 000000 and the cluster ID as NSID.
 // Packet Broker networks are not allowed to authenticate through LoRaWAN Backend Interfaces.
-func (v packetBrokerTokenVerifier) VerifyNetworkServer(ctx context.Context, token *jwt.JSONWebToken) (*NetworkServerAuthInfo, error) {
+func (v packetBrokerTokenVerifier) VerifyNetworkServer(
+	ctx context.Context, token *jwt.JSONWebToken,
+) (*NetworkServerAuthInfo, error) {
 	claims, err := packetbroker.Verify(ctx, token, v.publicKeyProvider, v.issuer, v.audience)
 	if err != nil {
 		return nil, err
@@ -64,6 +70,8 @@ func (v packetBrokerTokenVerifier) VerifyNetworkServer(ctx context.Context, toke
 }
 
 // VerifyApplicationServer returns an Unauthenticated error; Packet Broker never authenticates as Application Server.
-func (v packetBrokerTokenVerifier) VerifyApplicationServer(context.Context, *jwt.JSONWebToken) (*ApplicationServerAuthInfo, error) {
+func (packetBrokerTokenVerifier) VerifyApplicationServer(
+	context.Context, *jwt.JSONWebToken,
+) (*ApplicationServerAuthInfo, error) {
 	return nil, errUnauthenticated.New()
 }

--- a/pkg/interop/server_authz.go
+++ b/pkg/interop/server_authz.go
@@ -26,8 +26,9 @@ import (
 // Authorizer authorizes requests handled by the interop server.
 type Authorizer struct{}
 
-// RequireAuthorized returns an error if the given context is not authorized as neither Network Server nor Application Server.
-func (a Authorizer) RequireAuthorized(ctx context.Context) error {
+// RequireAuthorized returns an error if the given context is not authorized as neither Network Server
+// nor Application Server.
+func (Authorizer) RequireAuthorized(ctx context.Context) error {
 	if ctx.Value(nsAuthInfoKey) != nil || ctx.Value(asAuthInfoKey) != nil {
 		return nil
 	}
@@ -35,14 +36,14 @@ func (a Authorizer) RequireAuthorized(ctx context.Context) error {
 }
 
 // RequireAddress returns an error if the given address is not authorized in the context.
-func (a Authorizer) RequireAddress(ctx context.Context, addr string) error {
+func (Authorizer) RequireAddress(ctx context.Context, addr string) error {
 	var authInfo authInfo
 	if nsAuthInfo, ok := NetworkServerAuthInfoFromContext(ctx); ok {
 		authInfo = nsAuthInfo
-	} else if asAuthInfo, ok := ApplicationServerAuthInfoFromContext(ctx); ok {
-		authInfo = asAuthInfo
-	} else {
+	} else if asAuthInfo, ok := ApplicationServerAuthInfoFromContext(ctx); !ok {
 		return errUnauthenticated.New()
+	} else {
+		authInfo = asAuthInfo
 	}
 
 	patterns := authInfo.addressPatterns()
@@ -51,8 +52,8 @@ func (a Authorizer) RequireAddress(ctx context.Context, addr string) error {
 	}
 
 	host := addr
-	if url, err := url.Parse(addr); err == nil && url.Host != "" {
-		host = url.Host
+	if hostURL, err := url.Parse(addr); err == nil && hostURL.Host != "" {
+		host = hostURL.Host
 	}
 	if h, _, err := net.SplitHostPort(addr); err == nil {
 		host = h
@@ -81,8 +82,8 @@ nextPattern:
 	return errCallerNotAuthorized.WithAttributes("target", addr)
 }
 
-// RequireID returns an error if the given NetID is not authorized in the context.
-func (a Authorizer) RequireNetID(ctx context.Context, netID types.NetID) error {
+// RequireNetID returns an error if the given NetID is not authorized in the context.
+func (Authorizer) RequireNetID(ctx context.Context, netID types.NetID) error {
 	nsAuthInfo, ok := NetworkServerAuthInfoFromContext(ctx)
 	if !ok {
 		return errCallerNotAuthorized.WithAttributes("target", netID.String())
@@ -93,8 +94,8 @@ func (a Authorizer) RequireNetID(ctx context.Context, netID types.NetID) error {
 	return nil
 }
 
-// RequireID returns an error if the given AS-ID is not authorized in the context.
-func (a Authorizer) RequireASID(ctx context.Context, id string) error {
+// RequireASID returns an error if the given AS-ID is not authorized in the context.
+func (Authorizer) RequireASID(ctx context.Context, id string) error {
 	asAuthInfo, ok := ApplicationServerAuthInfoFromContext(ctx)
 	if !ok {
 		return errCallerNotAuthorized.WithAttributes("target", id)

--- a/pkg/interop/server_errors.go
+++ b/pkg/interop/server_errors.go
@@ -21,7 +21,7 @@ import (
 	ttnerrors "go.thethings.network/lorawan-stack/v3/pkg/errors"
 )
 
-func writeError(w http.ResponseWriter, r *http.Request, header MessageHeader, err error) {
+func writeError(w http.ResponseWriter, _ *http.Request, header MessageHeader, err error) {
 	answerHeader, headerErr := header.AnswerHeader()
 	if headerErr != nil {
 		w.WriteHeader(http.StatusBadRequest)
@@ -50,5 +50,5 @@ func writeError(w http.ResponseWriter, r *http.Request, header MessageHeader, er
 			Description: desc,
 		},
 	}
-	json.NewEncoder(w).Encode(msg)
+	json.NewEncoder(w).Encode(msg) //nolint:errcheck
 }

--- a/pkg/interop/testdata/client/config.yml
+++ b/pkg/interop/testdata/client/config.yml
@@ -14,5 +14,6 @@ join-servers:
       - 70b3d83ed0000000/30
 
   - file: test-js-4.yml
+    components: [ns, as]
     join-euis:
       - ec656e0000000000/24

--- a/pkg/interop/types.go
+++ b/pkg/interop/types.go
@@ -193,6 +193,7 @@ func (m MessageType) ToJoinServer() bool {
 // ResultCode is the result of an answer message.
 type ResultCode string
 
+// LoRaWAN Backend Interfaces 1.0 result codes.
 const (
 	ResultSuccess              ResultCode = "Success"
 	ResultNoAction             ResultCode = "NoAction"
@@ -360,7 +361,7 @@ func (k *KeyEnvelope) UnmarshalJSON(data []byte) error {
 // NetID is a LoRaWAN NetID.
 type NetID types.NetID
 
-// MarshalJSON marshals the NetID to text.
+// MarshalText marshals the NetID to text.
 func (n NetID) MarshalText() ([]byte, error) {
 	return Buffer(n[:]).MarshalText()
 }

--- a/pkg/interop/types_test.go
+++ b/pkg/interop/types_test.go
@@ -35,7 +35,7 @@ func aes128KeyPtr(key types.AES128Key) *types.AES128Key {
 	return &key
 }
 
-func TestMarshalTypes(t *testing.T) {
+func TestMarshalTypes(t *testing.T) { //nolint:paralleltest
 	a := assertions.New(t)
 
 	{
@@ -44,12 +44,12 @@ func TestMarshalTypes(t *testing.T) {
 			Buffer:     interop.Buffer([]byte{0x1, 0x2, 0x3}),
 			Key: interop.KeyEnvelope{
 				KekLabel: "",
-				Key:      aes128KeyPtr(types.AES128Key{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf}),
+				Key:      aes128KeyPtr(types.AES128Key{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf}), //nolint:lll
 			},
 		}
 		data, err := json.Marshal(msg)
 		if a.So(err, should.BeNil) {
-			a.So(string(data), should.Equal, `{"MACVersion":"1.0.2","Buffer":"010203","Key":{"KEKLabel":"","AESKey":"000102030405060708090A0B0C0D0E0F"}}`)
+			a.So(string(data), should.Equal, `{"MACVersion":"1.0.2","Buffer":"010203","Key":{"KEKLabel":"","AESKey":"000102030405060708090A0B0C0D0E0F"}}`) //nolint:lll
 		}
 	}
 
@@ -63,12 +63,12 @@ func TestMarshalTypes(t *testing.T) {
 		}
 		data, err := json.Marshal(msg)
 		if a.So(err, should.BeNil) {
-			a.So(string(data), should.Equal, `{"MACVersion":"1.1","Key":{"KEKLabel":"test","AESKey":"000102030405060708090A0B0C0D0E0F"}}`)
+			a.So(string(data), should.Equal, `{"MACVersion":"1.1","Key":{"KEKLabel":"test","AESKey":"000102030405060708090A0B0C0D0E0F"}}`) //nolint:lll
 		}
 	}
 }
 
-func TestUnmarshalTypes(t *testing.T) {
+func TestUnmarshalTypes(t *testing.T) { //nolint:paralleltest
 	a := assertions.New(t)
 
 	{

--- a/pkg/interop/util_test.go
+++ b/pkg/interop/util_test.go
@@ -77,6 +77,7 @@ func makeServerCertificates() []tls.Certificate {
 
 func makeClientTLSConfig() *tls.Config {
 	return &tls.Config{
+		MinVersion:   tls.VersionTLS12,
 		Certificates: makeClientCertificates(),
 		RootCAs:      makeCertPool(),
 	}
@@ -84,6 +85,7 @@ func makeClientTLSConfig() *tls.Config {
 
 func makeServerTLSConfig() *tls.Config {
 	return &tls.Config{
+		MinVersion:   tls.VersionTLS12,
 		Certificates: makeServerCertificates(),
 		ClientAuth:   tls.VerifyClientCertIfGiven,
 		ClientCAs:    makeCertPool(),
@@ -127,7 +129,7 @@ func makePacketBrokerTokenIssuer(ctx context.Context, subject string) (iss strin
 	router := mux.NewRouter()
 	router.Handle("/.well-known/jwks.json", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(&jose.JSONWebKeySet{
+		json.NewEncoder(w).Encode(&jose.JSONWebKeySet{ //nolint:errcheck
 			Keys: []jose.JSONWebKey{publicJWK},
 		})
 	}))

--- a/pkg/networkserver/networkserver.go
+++ b/pkg/networkserver/networkserver.go
@@ -206,7 +206,7 @@ func New(c *component.Component, conf *Config, opts ...Option) (*NetworkServer, 
 		interopConf := conf.Interop
 		interopConf.BlobConfig = c.GetBaseConfig(ctx).Blob
 
-		interopCl, err = interop.NewClient(ctx, interopConf, c)
+		interopCl, err = interop.NewClient(ctx, interopConf, c, interop.SelectorNetworkServer)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Use component selectors for Join Server interop client configuration

#### Changes
<!-- What are the changes made in this pull request? -->

- With selectors for NS and AS, the same interop configuration can be used by both NS and AS. Should they have separate credentials for the same JS, the configuration can contain a component selector
- Removed all lint warnings in `pkg/interop`

#### Testing

<!-- How did you verify that this change works? -->

CI

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

None

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Only material change is 0e664dd7d, the rest is lint warning removal and changelog.

Documentation comes in a separate PR.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
