### PR TITLE
Clean up error for admin-only field updates

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -5921,6 +5921,15 @@
       "file": "entity_access.go"
     }
   },
+  "error:pkg/identityserver:update_admin_field": {
+    "translations": {
+      "en": "only admins can update the `{field}` field"
+    },
+    "description": {
+      "package": "pkg/identityserver",
+      "file": "entity_access.go"
+    }
+  },
   "error:pkg/identityserver:user_registration_disabled": {
     "translations": {
       "en": "user registration disabled"
@@ -5955,15 +5964,6 @@
     "description": {
       "package": "pkg/identityserver",
       "file": "entity_access.go"
-    }
-  },
-  "error:pkg/identityserver:user_update_admin_field": {
-    "translations": {
-      "en": "only admins can update the `{field}` field"
-    },
-    "description": {
-      "package": "pkg/identityserver",
-      "file": "user_registry.go"
     }
   },
   "error:pkg/identityserver:validations_already_sent": {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a small PR that cleans up the error that's returned when a user tries to update admin-only fields.

Refs https://github.com/TheThingsIndustries/lorawan-stack/pull/3296

#### Changes
<!-- What are the changes made in this pull request? -->

- Introduce new `RequireAdminForFieldUpdate` method
- Replace existing logic

#### Testing

<!-- How did you verify that this change works? -->

N/A

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

N/A

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
