### PR TITLE
Fix packet broker network policy page being unaccessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ For details about compatibility between different releases, see the **Commitment
 
 - Console showing `404 Not Found` errors for pages containing user IDs in the path, when the user ID has a length of two.
 - CLI no longer panics when deleting a device without JoinEUI, this scenario only occurred when deleting a device that uses ABP.
+- Console crashing when navigating to certain Packet Broker network configuration pages.
+- Packet Broker network pages becoming inaccessible until refreshing after a user navigates to a non-existing network.
 
 ### Security
 

--- a/cypress/integration/console/packet-broker/default-gateway-visibility.spec.js
+++ b/cypress/integration/console/packet-broker/default-gateway-visibility.spec.js
@@ -26,6 +26,7 @@ describe('Packet Broker routing policies', () => {
   })
 
   it('succeeds setting default gateway visibility configuration', () => {
+    cy.intercept('GET', '/api/v3/pba/home-networks/policies/default', { statusCode: 404 })
     cy.intercept('PUT', '/api/v3/pba/home-networks/gateway-visibilities/default', {}).as('putCall')
     cy.visit(`${Cypress.config('consoleRootPath')}/admin/packet-broker/default-gateway-visibility`)
 
@@ -44,6 +45,7 @@ describe('Packet Broker routing policies', () => {
   })
 
   it('succeeds unsetting default gateway visibility configuration', () => {
+    cy.intercept('GET', '/api/v3/pba/home-networks/policies/default', { statusCode: 404 })
     cy.intercept('GET', '/api/v3/pba/home-networks/gateway-visibilities/default', {
       fixture: 'console/packet-broker/default-gateway-visibility.json',
     })

--- a/cypress/integration/console/packet-broker/networks.spec.js
+++ b/cypress/integration/console/packet-broker/networks.spec.js
@@ -30,6 +30,9 @@ describe('Packet Broker networks', () => {
     cy.intercept('GET', '/api/v3/pba/home-networks/policies/default', {
       fixture: 'console/packet-broker/default-policy.json',
     })
+    cy.intercept('GET', '/api/v3/pba/home-networks/gateway-visibilities/default', {
+      statusCode: 404,
+    })
     cy.intercept('GET', '/api/v3/pba/home-networks/policies/19/johan', {
       statusCode: 404,
       fixture: '404-body.json',

--- a/cypress/integration/console/packet-broker/registration.spec.js
+++ b/cypress/integration/console/packet-broker/registration.spec.js
@@ -79,11 +79,15 @@ describe('Packet Broker registration', () => {
   })
 
   it('succeeds registering with Packet Broker', () => {
-    cy.loginConsole({ user_id: 'admin', password: 'admin' })
-    cy.visit(`${Cypress.config('consoleRootPath')}/admin/packet-broker`)
-
+    cy.intercept('GET', '/api/v3/pba/home-networks/gateway-visibilities/default', {
+      statusCode: 404,
+    })
+    cy.intercept('GET', '/api/v3/pba/home-networks/policies/default', { statusCode: 404 })
     cy.intercept('/api/v3/pba/registration', { fixture: 'console/packet-broker/registration.json' })
     cy.intercept('/api/v3/pba/info', { fixture: 'console/packet-broker/info.json' })
+
+    cy.loginConsole({ user_id: 'admin', password: 'admin' })
+    cy.visit(`${Cypress.config('consoleRootPath')}/admin/packet-broker`)
 
     cy.findByText('Register network').click().next().findByTestId('switch').should('be.checked')
     cy.findByText('List network publicly')

--- a/cypress/integration/console/packet-broker/routing-policies.spec.js
+++ b/cypress/integration/console/packet-broker/routing-policies.spec.js
@@ -30,6 +30,10 @@ describe('Packet Broker routing policies', () => {
   })
 
   it('succeeds setting a default routing policy', () => {
+    cy.intercept('GET', '/api/v3/pba/home-networks/gateway-visibilities/default', {
+      statusCode: 404,
+    })
+    cy.intercept('GET', '/api/v3/pba/home-networks/policies/default', { statusCode: 404 })
     cy.intercept('PUT', '/api/v3/pba/home-networks/policies/default', {})
     cy.visit(`${Cypress.config('consoleRootPath')}/admin/packet-broker`)
 
@@ -62,6 +66,9 @@ describe('Packet Broker routing policies', () => {
   })
 
   it('succeeds unsetting a default routing policy', () => {
+    cy.intercept('GET', '/api/v3/pba/home-networks/gateway-visibilities/default', {
+      statusCode: 404,
+    })
     cy.intercept('GET', '/api/v3/pba/home-networks/policies/default', {
       fixture: 'console/packet-broker/default-policy.json',
     })

--- a/pkg/webui/console/store/middleware/logics/packet-broker.js
+++ b/pkg/webui/console/store/middleware/logics/packet-broker.js
@@ -42,12 +42,12 @@ const unauthenticatedError = createFrontendError(
 
 const fetchThroughPagination = async (endpoint, additionalArgs, process, shouldStop) => {
   let page = 1
-  const limit = 1000
+  const limit = 100
   let totalCount = Infinity
   let stop = false
   let acc
 
-  while (page * limit <= totalCount && !stop) {
+  while ((page - 1) * limit < totalCount && !stop) {
     // eslint-disable-next-line no-await-in-loop
     const result = await endpoint({ page, limit, ...additionalArgs })
 

--- a/pkg/webui/console/views/admin-packet-broker/admin-packet-broker.js
+++ b/pkg/webui/console/views/admin-packet-broker/admin-packet-broker.js
@@ -33,6 +33,8 @@ import Message from '@ttn-lw/lib/components/message'
 import RequireRequest from '@ttn-lw/lib/components/require-request'
 import NotFoundRoute from '@ttn-lw/lib/components/not-found-route'
 
+import SubViewErrorComponent from '@console/views/sub-view-error'
+
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 import PropTypes from '@ttn-lw/lib/prop-types'
 
@@ -288,6 +290,7 @@ const PacketBroker = ({ match }) => {
                   getHomeNetworkDefaultRoutingPolicy(),
                   getHomeNetworkDefaultGatewayVisibility(),
                 ]}
+                errorRenderFunction={SubViewErrorComponent}
               >
                 <RouteSwitch>
                   <Route path={url} exact component={DefaultRoutingPolicyView} />

--- a/pkg/webui/console/views/admin-packet-broker/network-routing-policy.js
+++ b/pkg/webui/console/views/admin-packet-broker/network-routing-policy.js
@@ -27,7 +27,6 @@ import Link from '@ttn-lw/components/link'
 import Message from '@ttn-lw/lib/components/message'
 import DateTime from '@ttn-lw/lib/components/date-time'
 import RequireRequest from '@ttn-lw/lib/components/require-request'
-import { FullViewErrorInner } from '@ttn-lw/lib/components/full-view-error'
 
 import RoutingPolicy from '@console/components/routing-policy'
 import RoutingPolicyForm from '@console/components/routing-policy-form'
@@ -53,7 +52,6 @@ import {
   selectPacketBrokerNetworkById,
   selectHomeNetworkDefaultRoutingPolicy,
   selectRegistered,
-  selectPacketBrokerNetworkError,
 } from '@console/store/selectors/packet-broker'
 
 import m from './messages'
@@ -236,11 +234,6 @@ const NetworkRoutingPolicyView = props => {
   const tenantId = props.match.params.tenantId
   const combinedId = tenantId ? `${netId}/${tenantId}` : netId
   const registered = useSelector(selectRegistered)
-  const networkError = useSelector(selectPacketBrokerNetworkError)
-
-  if (networkError) {
-    return <FullViewErrorInner error={networkError} />
-  }
 
   return (
     <Require condition={registered} otherwise={{ redirect: '/admin/packet-broker' }}>

--- a/pkg/webui/lib/components/require-request.js
+++ b/pkg/webui/lib/components/require-request.js
@@ -22,11 +22,18 @@ import useRequest from '@ttn-lw/lib/hooks/use-request'
 import PropTypes from '@ttn-lw/lib/prop-types'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 
+import { FullViewErrorInner } from './full-view-error'
+
 // `<RequireRequest />` is a utility component that can wrap a component tree
 // and dispatch a request action, rendering a loading spinner until the request
-// has been resolved.
-const RequireRequest = ({ requestAction, children }) => {
-  const [fetching] = useRequest(requestAction)
+// has been resolved. It also takes care of rendering possible errors if wished.
+const RequireRequest = ({
+  requestAction,
+  children,
+  handleErrors,
+  errorRenderFunction: ErrorRenderFunction,
+}) => {
+  const [fetching, error] = useRequest(requestAction)
   if (fetching) {
     return (
       <Spinner inline center>
@@ -35,13 +42,24 @@ const RequireRequest = ({ requestAction, children }) => {
     )
   }
 
+  if (error && handleErrors) {
+    return <ErrorRenderFunction error={error} />
+  }
+
   return children
 }
 
 RequireRequest.propTypes = {
   children: PropTypes.node.isRequired,
+  errorRenderFunction: PropTypes.func,
+  handleErrors: PropTypes.bool,
   requestAction: PropTypes.oneOfType([PropTypes.shape({}), PropTypes.arrayOf(PropTypes.shape({}))])
     .isRequired,
+}
+
+RequireRequest.defaultProps = {
+  errorRenderFunction: FullViewErrorInner,
+  handleErrors: true,
 }
 
 export default RequireRequest


### PR DESCRIPTION
#### Summary
Closes https://github.com/TheThingsIndustries/lorawan-stack/issues/3301

This PR fixes an issue that caused some packet broker network pages to be unaccessible due to a bug in how the frontend paginates through the list of available networks.

#### Changes
- Fix missing zero-index when paginating through List RPCs
- Change the pagination limit from `1000` to `100`, which appears to be the maximum. Using 1000 then messes with the pagination calculation.
- Fix errors persisting until a refresh when a packet broker network error occurred

#### Testing
Manual testing on the staging environment.

#### Notes for Reviewers
The Console has to paginate through the list of available networks, since the network information can only be obtained through a paginated RPC. The while loop that cycled through the list had a faulty break condition causing the networks on the last page to not be retrievable and hence causing the 404.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
