### PR TITLE
Fix faulty length constraint in routes with user IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ For details about compatibility between different releases, see the **Commitment
 
 ### Fixed
 
+- Console showing `404 Not Found` errors for pages containing user IDs in the path, when the user ID has a length of two.
+
 ### Security
 
 ## [3.20.2] - unreleased

--- a/pkg/webui/console/views/admin-user-management/index.js
+++ b/pkg/webui/console/views/admin-user-management/index.js
@@ -30,7 +30,7 @@ import InvitationSend from '@console/views/invitation-send'
 
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 import PropTypes from '@ttn-lw/lib/prop-types'
-import { pathId as pathIdRegexp } from '@ttn-lw/lib/regexp'
+import { userPathId as userPathIdRegexp } from '@ttn-lw/lib/regexp'
 
 import { mayManageUsers } from '@console/lib/feature-checks'
 
@@ -54,7 +54,7 @@ export default class UserManagementRouter extends Component {
           <Route exact path={`${match.path}`} component={UserManagement} />
           <Route path={`${match.path}/add`} component={UserAdd} />
           <Route path={`${match.path}/invitations/add`} component={InvitationSend} />
-          <Route path={`${match.path}/:userId${pathIdRegexp}`} component={UserEdit} sensitive />
+          <Route path={`${match.path}/:userId${userPathIdRegexp}`} component={UserEdit} sensitive />
           <NotFoundRoute />
         </Switch>
       </React.Fragment>

--- a/pkg/webui/console/views/application-collaborators/application-collaborators.js
+++ b/pkg/webui/console/views/application-collaborators/application-collaborators.js
@@ -28,7 +28,7 @@ import ApplicationCollaboratorAdd from '@console/views/application-collaborator-
 
 import PropTypes from '@ttn-lw/lib/prop-types'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
-import { pathId as pathIdRegexp } from '@ttn-lw/lib/regexp'
+import { userPathId as userPathIdRegexp } from '@ttn-lw/lib/regexp'
 
 const ApplicationCollaborators = props => {
   const { appId, match } = props
@@ -47,7 +47,7 @@ const ApplicationCollaborators = props => {
         <Route exact path={`${match.path}`} component={ApplicationCollaboratorsList} />
         <Route exact path={`${match.path}/add`} component={ApplicationCollaboratorAdd} />
         <Route
-          path={`${match.path}/:collaboratorType(user|organization)/:collaboratorId${pathIdRegexp}`}
+          path={`${match.path}/:collaboratorType(user|organization)/:collaboratorId${userPathIdRegexp}`}
           component={ApplicationCollaboratorEdit}
           sensitive
         />

--- a/pkg/webui/console/views/gateway-collaborators/gateway-collaborators.js
+++ b/pkg/webui/console/views/gateway-collaborators/gateway-collaborators.js
@@ -28,7 +28,7 @@ import SubViewError from '@console/views/sub-view-error'
 
 import PropTypes from '@ttn-lw/lib/prop-types'
 import sharedMessages from '@ttn-lw/lib/shared-messages'
-import { pathId as pathIdRegexp } from '@ttn-lw/lib/regexp'
+import { userPathId as userPathIdRegexp } from '@ttn-lw/lib/regexp'
 
 const GatewayCollaborators = props => {
   const { match, gtwId } = props
@@ -44,7 +44,7 @@ const GatewayCollaborators = props => {
         <Route exact path={`${match.path}`} component={GatewayCollaboratorsList} />
         <Route exact path={`${match.path}/add`} component={GatewayCollaboratorAdd} />
         <Route
-          path={`${match.path}/:collaboratorType(user|organization)/:collaboratorId${pathIdRegexp}`}
+          path={`${match.path}/:collaboratorType(user|organization)/:collaboratorId${userPathIdRegexp}`}
           component={GatewayCollaboratorEdit}
         />
         <NotFoundRoute />

--- a/pkg/webui/console/views/organization-collaborators/organization-collaborators.js
+++ b/pkg/webui/console/views/organization-collaborators/organization-collaborators.js
@@ -28,7 +28,7 @@ import OrganizationCollaboratorEdit from '@console/views/organization-collaborat
 
 import sharedMessages from '@ttn-lw/lib/shared-messages'
 import PropTypes from '@ttn-lw/lib/prop-types'
-import { pathId as pathIdRegexp } from '@ttn-lw/lib/regexp'
+import { userPathId as userPathIdRegexp } from '@ttn-lw/lib/regexp'
 
 const OrganizationCollaborators = props => {
   const { orgId, match } = props
@@ -47,7 +47,7 @@ const OrganizationCollaborators = props => {
         <Route exact path={`${match.path}`} component={OrganizationCollaboratorsList} />
         <Route exact path={`${match.path}/add`} component={OrganizationCollaboratorAdd} />
         <Route
-          path={`${match.path}/:collaboratorType(user|organization)/:collaboratorId${pathIdRegexp}`}
+          path={`${match.path}/:collaboratorType(user|organization)/:collaboratorId${userPathIdRegexp}`}
           component={OrganizationCollaboratorEdit}
         />
         <NotFoundRoute />

--- a/pkg/webui/lib/regexp.js
+++ b/pkg/webui/lib/regexp.js
@@ -18,3 +18,4 @@ export const url = /^\b((http|https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]
 export const id = /^[a-z0-9](?:[-]?[a-z0-9]){2,}$/
 export const userId = /^[a-z0-9](?:[-]?[a-z0-9]){1,}$/
 export const pathId = '([a-z0-9-]{3,})' // To be used within router paths.
+export const userPathId = '([a-z0-9-]{2,})' // To be used within router paths.


### PR DESCRIPTION
#### Summary

Closes #5607

#### Changes
Allow user IDs in paths with length of 2

#### Testing

Manual testing.

#### Notes for Reviewers
The issue was not the user ID being numeric, but the length of 2.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
