### PR TITLE
Fix CLI configuration field casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - Deleted users are no longer included in primary email addresses uniqueness checks. This allows a user to create a new account which uses the email address of a deleted account.
   - This requires a database schema migration (`ttn-lw-stack is-db migrate`) due to updated indices.
+- The CLI settings fields `retry-config.enable_metadata` and `retry-config.default_timeout` have been renamed to `retry.enable-metadata` and `retry.default-timeout` for consistency reasons.
 
 ### Deprecated
 

--- a/cmd/ttn-lw-cli/commands/config.go
+++ b/cmd/ttn-lw-cli/commands/config.go
@@ -31,7 +31,7 @@ var (
 	defaultOAuthServerAddress        = defaultOAuthServerBaseAddress + "/oauth"
 	defaultRetryConfig               = RetryConfig{
 		DefaultTimeout: 100 * time.Millisecond,
-		EnableMetatada: true,
+		EnableMetadata: true,
 	}
 )
 
@@ -66,8 +66,8 @@ type Config struct {
 // RetryConfig defines the values for the retry behaviour in the cli
 type RetryConfig struct {
 	Max            uint          `name:"max" yaml:"max" description:"Maximum amount of times that a request can be reattempted"`
-	DefaultTimeout time.Duration `name:"default_timeout" yaml:"default_timeout" description:"Default timeout between retry attempts"`
-	EnableMetatada bool          `name:"enable_metadata" yaml:"enable_metadata" description:"Use request response metadata to dynamically calculate timeout between retry attempts"`
+	DefaultTimeout time.Duration `name:"default-timeout" yaml:"default-timeout" description:"Default timeout between retry attempts"`
+	EnableMetadata bool          `name:"enable-metadata" yaml:"enable-metadata" description:"Use request response metadata to dynamically calculate timeout between retry attempts"`
 	Jitter         float64       `name:"jitter" yaml:"jitter" description:"Fraction that creates a deviation of the timeout used between retry attempts"`
 }
 

--- a/cmd/ttn-lw-cli/commands/config.go
+++ b/cmd/ttn-lw-cli/commands/config.go
@@ -60,10 +60,10 @@ type Config struct {
 	CA                                 string      `name:"ca" yaml:"ca" description:"CA certificate file"`
 	DumpRequests                       bool        `name:"dump-requests" yaml:"dump-requests" description:"When log level is set to debug, also dump request payload as JSON"`
 	SkipVersionCheck                   bool        `name:"skip-version-check" yaml:"skip-version-check" description:"Do not perform version checks"`
-	Retry                              RetryConfig `name:"retry-config" yaml:"retry-config"`
+	Retry                              RetryConfig `name:"retry" yaml:"retry"`
 }
 
-// RetryConfig defines the values for the retry behaviour in the cli
+// RetryConfig defines the values for the retry behavior in the CLI.
 type RetryConfig struct {
 	Max            uint          `name:"max" yaml:"max" description:"Maximum amount of times that a request can be reattempted"`
 	DefaultTimeout time.Duration `name:"default-timeout" yaml:"default-timeout" description:"Default timeout between retry attempts"`

--- a/cmd/ttn-lw-cli/commands/root.go
+++ b/cmd/ttn-lw-cli/commands/root.go
@@ -188,7 +188,7 @@ func preRun(tasks ...func() error) func(cmd *cobra.Command, args []string) error
 
 		api.SetRetryMax(config.Retry.Max)
 		api.SetRetryDefaultTimeout(config.Retry.DefaultTimeout)
-		api.SetRetryEnableMetadata(config.Retry.EnableMetatada)
+		api.SetRetryEnableMetadata(config.Retry.EnableMetadata)
 		api.SetRetryJitter(config.Retry.Jitter)
 
 		if config.CA != "" {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This PR fixes the spelling errors of the CLI request retry configuration.

#### Changes
<!-- What are the changes made in this pull request? -->

- Rename `EnableMetatada` to `EnableMetadata`
- Rename `retry-config` to `retry` (same as field name, and we do not use `config` in the field names)
- Rename `enable_metadata`  and `default_timeout` to `enable-metadata` and `default-timeout`


#### Testing

<!-- How did you verify that this change works? -->

Local testing with `ttn-lw-cli config`.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

If anyone ever used these fields, they will need to set them again.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
