### PR TITLE
Fix DeviceTimeAns timestamp not corresponding to the specification

### DIFF
--- a/pkg/networkserver/grpc_gsns.go
+++ b/pkg/networkserver/grpc_gsns.go
@@ -560,6 +560,11 @@ macLoop:
 		case ttnpb.MACCommandIdentifier_CID_ADR_PARAM_SETUP:
 			evs, err = mac.HandleADRParamSetupAns(ctx, dev)
 		case ttnpb.MACCommandIdentifier_CID_DEVICE_TIME:
+			if !deduplicated {
+				m := makeDeferredMACHandler(dev, mac.HandleDeviceTimeReq)
+				deferredMACHandlers = append(deferredMACHandlers, m)
+				continue macLoop
+			}
 			evs, err = mac.HandleDeviceTimeReq(ctx, dev, up)
 		case ttnpb.MACCommandIdentifier_CID_REJOIN_PARAM_SETUP:
 			evs, err = mac.HandleRejoinParamSetupAns(ctx, dev, cmd.GetRejoinParamSetupAns())

--- a/pkg/networkserver/mac/device_time.go
+++ b/pkg/networkserver/mac/device_time.go
@@ -17,6 +17,8 @@ package mac
 import (
 	"context"
 
+	pbtypes "github.com/gogo/protobuf/types"
+
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 )
@@ -33,11 +35,27 @@ var (
 
 func HandleDeviceTimeReq(ctx context.Context, dev *ttnpb.EndDevice, msg *ttnpb.UplinkMessage) (events.Builders, error) {
 	ans := &ttnpb.MACCommand_DeviceTimeAns{
-		Time: msg.ReceivedAt,
+		Time: messageTimestamp(msg),
 	}
 	dev.MacState.QueuedResponses = append(dev.MacState.QueuedResponses, ans.MACCommand())
 	return events.Builders{
 		EvtReceiveDeviceTimeRequest,
 		EvtEnqueueDeviceTimeAnswer.With(events.WithData(ans)),
 	}, nil
+}
+
+func messageTimestamp(msg *ttnpb.UplinkMessage) *pbtypes.Timestamp {
+	var ts *pbtypes.Timestamp
+	for _, md := range msg.RxMetadata {
+		if t := md.GpsTime; t != nil {
+			return t
+		}
+		if ts == nil && md.ReceivedAt != nil {
+			ts = md.ReceivedAt
+		}
+	}
+	if ts != nil {
+		return ts
+	}
+	return msg.ReceivedAt
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #5586 

#### Changes
<!-- What are the changes made in this pull request? -->

- Improved [HandleDeviceTimeReq](https://github.com/TheThingsNetwork/lorawan-stack/blob/70d88dd86a9b17bf8faf1bbea6961d6c5d3f2ae7/pkg/networkserver/mac/device_time.go#L34-L43) timestamp
- Reverted the change that made the MAC handler run before the deduplication occurred


#### Testing

<!-- How did you verify that this change works? -->

- Added test cases regarding the improvement

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

n/a

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

nil

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
