### PR TITLE
Add GPS time to Basic Station uplink frames

### DIFF
--- a/pkg/gatewayserver/io/ws/lbslns/upstream.go
+++ b/pkg/gatewayserver/io/ws/lbslns/upstream.go
@@ -373,11 +373,13 @@ func (updf *UplinkDataFrame) toUplinkMessage(ids *ttnpb.GatewayIdentifiers, band
 	}
 
 	timestamp := TimestampFromXTime(updf.RadioMetaData.UpInfo.XTime)
+	gpsTime := TimePtrFromGPSTime(updf.UpInfo.GPSTime)
 	tm := TimePtrFromUpInfo(updf.UpInfo.GPSTime, updf.UpInfo.RxTime, receivedAt)
 	up.RxMetadata = []*ttnpb.RxMetadata{
 		{
 			GatewayIds:   ids,
 			Time:         ttnpb.ProtoTime(tm),
+			GpsTime:      ttnpb.ProtoTime(gpsTime),
 			Timestamp:    timestamp,
 			Rssi:         updf.RadioMetaData.UpInfo.RSSI,
 			ChannelRssi:  updf.RadioMetaData.UpInfo.RSSI,

--- a/pkg/gatewayserver/io/ws/ws_test.go
+++ b/pkg/gatewayserver/io/ws/ws_test.go
@@ -1151,6 +1151,7 @@ func TestTraffic(t *testing.T) {
 							md.UplinkToken = up.Message.RxMetadata[i].UplinkToken
 							md.Timestamp = timestamp
 							md.Time = ttnpb.ProtoTimePtr(now)
+							md.GpsTime = ttnpb.ProtoTimePtr(now)
 							md.ReceivedAt = expectedUp.ReceivedAt
 						}
 						expectedUp.Settings.Timestamp = timestamp


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/pull/5598

#### Changes
<!-- What are the changes made in this pull request? -->

- Fill the metadata GPS time for Basic Station uplink frames.
   - I forgot to mention this in the original issue, and realized this during testing.


#### Testing

<!-- How did you verify that this change works? -->

Discovered on `staging1`, tested locally.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A. This is new behavior.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
