### PR TITLE
Fix panic on deletion of ABP devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Fixed
 
 - Console showing `404 Not Found` errors for pages containing user IDs in the path, when the user ID has a length of two.
+- CLI no longer panics when deleting a device without JoinEUI, this scenario only occurred when deleting a device that uses ABP.
 
 ### Security
 

--- a/cmd/ttn-lw-cli/commands/end_devices.go
+++ b/cmd/ttn-lw-cli/commands/end_devices.go
@@ -1004,7 +1004,7 @@ var (
 				return errAddressMismatchEndDevice.New()
 			}
 
-			if existingDevice.JoinServerAddress == "" {
+			if existingDevice.JoinServerAddress == "" && devID.GetJoinEui() != nil {
 				// Attempt to unclaim device via the DCS.
 				dcs, err := api.Dial(ctx, config.DeviceClaimingServerGRPCAddress)
 				if err != nil {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #5560

Effectively what happened is that when creating an end-device that uses ABP the `JoinEUI` field was set as nil and the `.Bytes()` method caused it to panic. I tried looking at other places in which this would happen but couldn't find any that aren't validated through a `joinEui != nil`.

#### Changes
<!-- What are the changes made in this pull request? -->

- Added `OrZero()` to generate an empty `EUI64` variable instead of `nil`


#### Testing

<!-- How did you verify that this change works? -->

Manual testing

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Bug fix, there should be none.


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
