### PR TITLE
is: Add varchar data type in end device registry placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ For details about compatibility between different releases, see the **Commitment
 
 - Console showing `404 Not Found` errors for pages containing user IDs in the path, when the user ID has a length of two.
 - CLI no longer panics when deleting a device without JoinEUI, this scenario only occurred when deleting a device that uses ABP.
+- The batch update query for `EndDevice.LastSeenAt` field now specifies the data type of the placeholders.
 
 ### Security
 

--- a/pkg/identityserver/gormstore/end_device_store.go
+++ b/pkg/identityserver/gormstore/end_device_store.go
@@ -271,7 +271,7 @@ func (s *deviceStore) BatchUpdateEndDeviceLastSeen(
 	valueArgs := []interface{}{}
 
 	for _, dev := range devsLastSeen {
-		valueStrings = append(valueStrings, "(?, ?, ?::timestamptz)")
+		valueStrings = append(valueStrings, "(?::varchar, ?::varchar, ?::timestamptz)")
 		valueArgs = append(valueArgs,
 			dev.Ids.ApplicationIds.ApplicationId,
 			dev.Ids.DeviceId,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Closes #5576

#### Changes
<!-- What are the changes made in this pull request? -->

- Specified data type for place holders on gorm implementation of `end_device_store`.

#### Testing

<!-- How did you verify that this change works? -->

I tried to replicate the exact same setup using cockroachDB since this doesn't happen on `postgres:14` but ended up entangling myself in the setup. Since is just specifying the data type for two placeholders on a single query I believe this fine without the manual testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

I can't think of any in this case, just specifying the data type of the place holder.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

This change doesn't have to be applied to the bunstore, [doc reference:](https://bun.uptrace.dev/guide/models.html#column-types) 
>Bun generates column types from the struct field types. For example, Go type string is translated to SQL type varchar.



#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
