### PR TITLE
Avoid ingesting timeout errors to sentry

### DIFF
--- a/pkg/webui/lib/errors/utils.js
+++ b/pkg/webui/lib/errors/utils.js
@@ -42,11 +42,10 @@ export const hasValidDetails = object =>
  * @returns {boolean} `true` if `error` is a well known backend error object.
  */
 export const isBackend = error =>
-  Boolean(error) &&
-  typeof error === 'object' &&
+  isPlainObject(error) &&
   !('id' in error) &&
   error.message &&
-  (error.code || error.grpc_code)
+  (typeof error.code === 'number' || typeof error.grpc_code === 'number')
 
 /**
  * Returns whether the error is a frontend defined error object.

--- a/pkg/webui/lib/errors/utils_test.js
+++ b/pkg/webui/lib/errors/utils_test.js
@@ -171,6 +171,45 @@ const frontendError = createFrontendError(
   undefined,
   500,
 )
+
+const timeoutError = {
+  code: 'ECONNABORTED',
+  columnNumber: '[undefined]',
+  config: {
+    adapter: '[Function: <anonymous>]',
+    baseURL: 'https://au1.cloud.thethings.network/api/v3',
+    data: '[undefined]',
+    headers: {
+      Accept: 'application/json, text/plain, */*',
+      Authorization: '[Filtered]',
+    },
+    maxBodyLength: -1,
+    maxContentLength: -1,
+    method: 'get',
+    timeout: 10000,
+    transformRequest: ['[Function: <anonymous>]'],
+    transformResponse: ['[Function: <anonymous>]'],
+    transitional: {
+      clarifyTimeoutError: false,
+      forcedJSONParsing: true,
+      silentJSONParsing: true,
+    },
+    url: '/edtc/formats',
+    validateStatus: '[Function: validateStatus]',
+    xsrfCookieName: 'XSRF-TOKEN',
+    xsrfHeaderName: 'X-XSRF-TOKEN',
+  },
+  description: '[undefined]',
+  fileName: '[undefined]',
+  lineNumber: '[undefined]',
+  message: 'timeout of 10000ms exceeded',
+  name: 'Error',
+  number: '[undefined]',
+  stack:
+    'Error: timeout of 10000ms exceeded\n    at e.exports (https://assets.cloud.thethings.network/console.57b1ac5a73941623bdf2.js:1:1709004)',
+  status: null,
+}
+
 const plainFrontendError = createFrontendError(errorMessages.unknownErrorTitle)
 const codeError = { code: 'ECONNABORTED' }
 const statusCodeError = { statusCode: 404 }
@@ -178,7 +217,6 @@ const emptyError = {}
 const undefinedError = undefined
 const errorInstance = new Error('There was an unknown error')
 const networkError = new Error('Network Error')
-const timeoutError = { code: 'ECONNABORTED' }
 const tokenTimeoutError = new TokenError('Could not fetch token', timeoutError)
 const tokenNetworkError = new TokenError('Could not fetch token', networkError)
 const tokenError = new TokenError('Token error', backendErrorWithDetails)


### PR DESCRIPTION
#### Summary
This quickfix PR fixes an issue prevented timeout errors from being ignored for sentry logging.

#### Changes
- Improve precision of our logic that determines whether an error object is originating from the backend

#### Testing

Unit tests.

#### Notes for Reviewers
Timeout errors are typically client related. Or related to server outages during version updates. Having those errors reported to Sentry generates a lot of noise.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
