### PR TITLE
Add retry logic to bunstore transactions

### DIFF
--- a/pkg/oauth/store/interfaces.go
+++ b/pkg/oauth/store/interfaces.go
@@ -1,0 +1,38 @@
+// Copyright © 2021 The Things Network Foundation, The Things Industries B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"context"
+
+	"go.thethings.network/lorawan-stack/v3/pkg/identityserver/store"
+)
+
+// Interface is the store used by the account app.
+type Interface interface {
+	store.UserStore
+	store.UserSessionStore
+
+	store.ClientStore
+	store.OAuthStore
+}
+
+// TransactionalInterface is Interface, but with a method that uses a transaction.
+type TransactionalInterface interface {
+	Interface
+
+	// Transact runs a transaction using the store.
+	Transact(context.Context, func(context.Context, Interface) error) error
+}

--- a/pkg/oauth/store_utils_test.go
+++ b/pkg/oauth/store_utils_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"go.thethings.network/lorawan-stack/v3/pkg/identityserver/store"
+	oauth_store "go.thethings.network/lorawan-stack/v3/pkg/oauth/store"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -154,4 +155,8 @@ func (s *mockStore) DeleteAccessToken(ctx context.Context, tokenID string) error
 	}
 	s.calls = append(s.calls, "DeleteAccessToken")
 	return s.err.deleteAccessToken
+}
+
+func (s *mockStore) Transact(ctx context.Context, f func(context.Context, oauth_store.Interface) error) error {
+	return f(ctx, s)
 }

--- a/pkg/oauth/user.go
+++ b/pkg/oauth/user.go
@@ -15,12 +15,15 @@
 package oauth
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 
-	osin "github.com/openshift/osin"
+	"github.com/openshift/osin"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
+	"go.thethings.network/lorawan-stack/v3/pkg/oauth/store"
+	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 	"go.thethings.network/lorawan-stack/v3/pkg/webhandlers"
 )
 
@@ -43,57 +46,58 @@ func (s *server) ClientLogout(w http.ResponseWriter, r *http.Request) {
 		webhandlers.Error(w, r, errMissingAccessTokenIDParam.New())
 		return
 	}
-	at, err := s.store.GetAccessToken(ctx, accessTokenID)
-	if err != nil && !errors.IsNotFound(err) {
-		webhandlers.Error(w, r, err)
-		return
-	}
-	if at != nil {
-		client, err := s.store.GetClient(ctx, at.ClientIds, []string{"logout_redirect_uris"})
-		if err != nil {
-			webhandlers.Error(w, r, err)
-			return
-		}
-		if err = s.store.DeleteAccessToken(ctx, accessTokenID); err != nil {
-			webhandlers.Error(w, r, err)
-			return
-		}
-		events.Publish(evtAccessTokenDeleted.NewWithIdentifiersAndData(ctx, at.UserIds, nil))
-		err = s.store.DeleteSession(ctx, at.UserIds, at.UserSessionId)
+	err := s.store.Transact(ctx, func(ctx context.Context, st store.Interface) error {
+		at, err := st.GetAccessToken(ctx, accessTokenID)
 		if err != nil && !errors.IsNotFound(err) {
-			webhandlers.Error(w, r, err)
-			return
+			return err
 		}
-		events.Publish(EvtUserLogout.NewWithIdentifiersAndData(ctx, at.UserIds, nil))
-		redirectParam := r.URL.Query().Get("post_logout_redirect_uri")
-		if redirectParam == "" {
-			if len(client.LogoutRedirectUris) != 0 {
-				redirectURI = client.LogoutRedirectUris[0]
+		if at != nil {
+			client, err := st.GetClient(ctx, at.ClientIds, []string{"logout_redirect_uris"})
+			if err != nil {
+				return err
 			}
-		} else {
-			for _, uri := range client.LogoutRedirectUris {
-				redirectURI, err = osin.ValidateUri(uri, redirectParam)
-				if err == nil {
-					break
+			if err = st.DeleteAccessToken(ctx, accessTokenID); err != nil {
+				return err
+			}
+			events.Publish(evtAccessTokenDeleted.NewWithIdentifiersAndData(ctx, at.UserIds, nil))
+			err = st.DeleteSession(ctx, at.UserIds, at.UserSessionId)
+			if err != nil && !errors.IsNotFound(err) {
+				return err
+			}
+			events.Publish(EvtUserLogout.NewWithIdentifiersAndData(ctx, at.UserIds, nil))
+			redirectParam := r.URL.Query().Get("post_logout_redirect_uri")
+			if redirectParam == "" {
+				if len(client.LogoutRedirectUris) != 0 {
+					redirectURI = client.LogoutRedirectUris[0]
+				}
+			} else {
+				for _, uri := range client.LogoutRedirectUris {
+					redirectURI, err = osin.ValidateUri(uri, redirectParam)
+					if err == nil {
+						break
+					}
+				}
+				if err != nil {
+					return errInvalidLogoutRedirectURI.WithCause(err)
 				}
 			}
-			if err != nil {
-				webhandlers.Error(w, r, errInvalidLogoutRedirectURI.WithCause(err))
-				return
+		}
+		var session *ttnpb.UserSession
+		r, session, err = s.session.Get(w, r)
+		if err != nil && !errors.IsUnauthenticated(err) && !errors.IsNotFound(err) {
+			return err
+		}
+		if session != nil {
+			events.Publish(evtUserSessionTerminated.NewWithIdentifiersAndData(ctx, session.GetUserIds(), nil))
+			if err = st.DeleteSession(ctx, session.GetUserIds(), session.SessionId); err != nil {
+				return err
 			}
 		}
-	}
-	r, session, err := s.session.Get(w, r)
-	if err != nil && !errors.IsUnauthenticated(err) && !errors.IsNotFound(err) {
+		return nil
+	})
+	if err != nil {
 		webhandlers.Error(w, r, err)
 		return
-	}
-	if session != nil {
-		events.Publish(evtUserSessionTerminated.NewWithIdentifiersAndData(ctx, session.GetUserIds(), nil))
-		if err = s.store.DeleteSession(ctx, session.GetUserIds(), session.SessionId); err != nil {
-			webhandlers.Error(w, r, err)
-			return
-		}
 	}
 	s.session.RemoveAuthCookie(w, r)
 	url, err := url.Parse(redirectURI)

--- a/pkg/oauth/user.go
+++ b/pkg/oauth/user.go
@@ -89,8 +89,10 @@ func (s *server) ClientLogout(w http.ResponseWriter, r *http.Request) {
 		}
 		if session != nil {
 			events.Publish(evtUserSessionTerminated.NewWithIdentifiersAndData(ctx, session.GetUserIds(), nil))
-			if err = st.DeleteSession(ctx, session.GetUserIds(), session.SessionId); err != nil {
-				return err
+			if session.GetSessionId() != at.GetUserSessionId() {
+				if err = st.DeleteSession(ctx, session.GetUserIds(), session.SessionId); err != nil {
+					return err
+				}
 			}
 		}
 		return nil


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request reverts the removal of `dropdb`+`createdb` logic in CI that was actually hiding an issue where database transactions wouldn't be retried if the SQL server is (hopefully temporarily) unavailable. This pull request also fixes that issue.

#### Changes
<!-- What are the changes made in this pull request? -->

- Revert `dropdb`+`createdb` removal in e2e test
- Add simple retry logic to transactions in `bunstore`

#### Testing
<!-- How did you verify that this change works? -->

Let's see what those e2e tests do.

##### Regressions
<!-- Please indicate features that this change could affect and how that was tested. -->

...

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
