### PR TITLE
Protect global message descriptor with mutex

### DIFF
--- a/tools/generate_i18n.go
+++ b/tools/generate_i18n.go
@@ -36,9 +36,11 @@ func main() {
 	if err != nil && !os.IsNotExist(err) {
 		panic(err)
 	}
-	i18n.Global.Merge(messages)
 
-	updated := i18n.Global.Updated()
+	global := i18n.CloneGlobal()
+	global.Merge(messages)
+
+	updated := global.Updated()
 	if len(updated) > 0 {
 		fmt.Println("Updated the following messages:")
 		for _, updated := range updated {
@@ -46,7 +48,7 @@ func main() {
 		}
 	}
 
-	deleted := i18n.Global.Cleanup()
+	deleted := global.Cleanup()
 	if len(deleted) > 0 {
 		fmt.Println("Deleted the following messages:")
 		for _, deleted := range deleted {
@@ -55,17 +57,17 @@ func main() {
 	}
 
 	count := make(map[string]int)
-	for _, msg := range i18n.Global {
+	for _, msg := range global {
 		for lang := range msg.Translations {
 			count[lang] = count[lang] + 1
 		}
 	}
 
 	for lang, count := range count {
-		fmt.Printf("Language: %s\tTranslations: %5d\tMissing: %5d\n", lang, count, len(i18n.Global)-count)
+		fmt.Printf("Language: %s\tTranslations: %5d\tMissing: %5d\n", lang, count, len(global)-count)
 	}
 
-	err = i18n.Global.WriteFile(messagesFile)
+	err = global.WriteFile(messagesFile)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This short PR adds a mutex to `pkg/i18n` in order to avoid concurrent map writes when tests define events concurrently. This would cause a test flake every once in a blue moon.

#### Changes
<!-- What are the changes made in this pull request? -->

- Unexport the global message descriptor map.
- Use a mutex to access it.


#### Testing

<!-- How did you verify that this change works? -->

UT.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
