### PR TITLE
Fix getting end device by EUI in bunstore implementation

### DIFF
--- a/cypress/integration/console/devices/import.spec.js
+++ b/cypress/integration/console/devices/import.spec.js
@@ -83,7 +83,7 @@ describe('End device messaging', () => {
       .closest('div')
       .within(() => {
         cy.findByText(/ID already taken/).should('be.visible')
-        cy.findByText(/EUI already taken/).should('be.visible')
+        cy.findByText(/an end device with/, /is already registered/).should('be.visible')
       })
     cy.visit(`${Cypress.config('consoleRootPath')}/applications/${appId}/devices`)
     cy.findByText(/End devices \(\d+\)/).should('be.visible')

--- a/pkg/identityserver/storetest/end_device_store.go
+++ b/pkg/identityserver/storetest/end_device_store.go
@@ -163,6 +163,17 @@ func (st *StoreTest) TestEndDeviceStoreCRUD(t *T) {
 		}
 	})
 
+	t.Run("GetEndDevice_ByEUIs", func(t *T) {
+		a, ctx := test.New(t)
+		got, err := s.GetEndDevice(ctx, &ttnpb.EndDeviceIdentifiers{
+			DevEui:  &types.EUI64{1, 2, 3, 4, 5, 6, 7, 8},
+			JoinEui: &types.EUI64{1, 2, 3, 4, 5, 6, 7, 8},
+		}, endDeviceMask)
+		if a.So(err, should.BeNil) && a.So(got, should.NotBeNil) {
+			a.So(got, should.Resemble, created)
+		}
+	})
+
 	t.Run("GetEndDevice_Other", func(t *T) {
 		a, ctx := test.New(t)
 		_, err := s.GetEndDevice(ctx, &ttnpb.EndDeviceIdentifiers{


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a fix for the `identityserver/bunstore` implementation where selecting end devices by EUI always resulted in NotFound errors because we always selected on IDs.

#### Changes
<!-- What are the changes made in this pull request? -->

- Add test and fix query

#### Testing

<!-- How did you verify that this change works? -->

Added test

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

nil

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

nil

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
