### PR TITLE
More form updates

### DIFF
--- a/pkg/webui/components/form/field/index.js
+++ b/pkg/webui/components/form/field/index.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React, { useCallback } from 'react'
+import React, { useCallback, useEffect } from 'react'
 import classnames from 'classnames'
 import { useField } from 'formik'
 import { isPlainObject } from 'lodash'
@@ -79,6 +79,7 @@ const FormField = props => {
     encode,
     fieldWidth,
     name,
+    connectedFields,
     readOnly,
     required,
     title,
@@ -95,6 +96,8 @@ const FormField = props => {
     validateOnBlur,
     setFieldValue,
     setFieldTouched,
+    addToFieldRegistry,
+    removeFromFieldRegistry,
   } = useFormContext()
 
   // Initialize field, which also takes care of registering fields in formik's internal registry.
@@ -102,6 +105,19 @@ const FormField = props => {
     name,
     validate,
   })
+
+  // Apply any connected names to the field registry.
+  useEffect(() => {
+    if (connectedFields) {
+      addToFieldRegistry(connectedFields)
+      return () => {
+        removeFromFieldRegistry(connectedFields)
+      }
+    }
+    // Using a custom comparator for the array to avoid infinite render loops.
+    // Solution as per https://github.com/facebook/react/issues/14476#issuecomment-471199055
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [addToFieldRegistry, JSON.stringify(connectedFields), removeFromFieldRegistry])
 
   const handleChange = useCallback(
     async (value, enforceValidation = false) => {
@@ -232,6 +248,7 @@ FormField.propTypes = {
       render: PropTypes.func.isRequired,
     }),
   ]).isRequired,
+  connectedFields: PropTypes.arrayOf(PropTypes.string),
   decode: PropTypes.func,
   description: PropTypes.message,
   disabled: PropTypes.bool,
@@ -263,6 +280,7 @@ FormField.propTypes = {
 
 FormField.defaultProps = {
   className: undefined,
+  connectedFields: undefined,
   decode: value => value,
   description: '',
   disabled: false,

--- a/pkg/webui/components/form/field/index.js
+++ b/pkg/webui/components/form/field/index.js
@@ -121,7 +121,8 @@ const FormField = props => {
 
   const handleChange = useCallback(
     async (value, enforceValidation = false) => {
-      const newValue = encode(extractValue(value))
+      const oldValue = encodedValue
+      const newValue = encode(extractValue(value), oldValue)
       let isSyntheticEvent = false
 
       if (isPlainObject(value)) {
@@ -141,9 +142,9 @@ const FormField = props => {
         setFieldTouched(name, true, true)
       }
 
-      onChange(isSyntheticEvent ? value : encode(value))
+      onChange(isSyntheticEvent ? value : encode(value, oldValue))
     },
-    [encode, name, onChange, setFieldTouched, setFieldValue],
+    [encode, encodedValue, name, onChange, setFieldTouched, setFieldValue],
   )
 
   const handleBlur = useCallback(

--- a/pkg/webui/components/form/field/index.js
+++ b/pkg/webui/components/form/field/index.js
@@ -87,6 +87,7 @@ const FormField = props => {
     tooltipId,
     warning,
     validate,
+    valueSetter,
     onChange,
     onBlur,
   } = props
@@ -96,6 +97,7 @@ const FormField = props => {
     validateOnBlur,
     setFieldValue,
     setFieldTouched,
+    setValues,
     addToFieldRegistry,
     removeFromFieldRegistry,
   } = useFormContext()
@@ -136,7 +138,13 @@ const FormField = props => {
         }
       }
 
-      await setFieldValue(name, newValue)
+      // This middleware takes care of updating the form values  and allows for more control
+      // over how the form values are changed if needed. See the default prop to understand
+      // how the value is set by default.
+      await valueSetter(
+        { setFieldValue, setValues, setFieldTouched },
+        { name, value: newValue, oldValue },
+      )
 
       if (enforceValidation) {
         setFieldTouched(name, true, true)
@@ -144,7 +152,7 @@ const FormField = props => {
 
       onChange(isSyntheticEvent ? value : encode(value, oldValue))
     },
-    [encode, encodedValue, name, onChange, setFieldTouched, setFieldValue],
+    [encode, encodedValue, name, onChange, setFieldTouched, setFieldValue, setValues, valueSetter],
   )
 
   const handleBlur = useCallback(
@@ -276,6 +284,7 @@ FormField.propTypes = {
   titleChildren: PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
   tooltipId: PropTypes.string,
   validate: PropTypes.func,
+  valueSetter: PropTypes.func,
   warning: PropTypes.message,
 }
 
@@ -295,6 +304,7 @@ FormField.defaultProps = {
   titleChildren: null,
   tooltipId: '',
   validate: undefined,
+  valueSetter: ({ setFieldValue }, { name, value }) => setFieldValue(name, value),
   warning: '',
 }
 


### PR DESCRIPTION
#### Summary
This PR extends the `<Form />` and `<Form.Field />` components more to enable advanced use cases that we require for implementing new end device onboarding (#4847)

#### Changes
- Add support for "composite fields". Composite fields can map to multiple form values, allowing complex modifications with the help of encoders/decoders without the need for intermediate logic (like using `_` fields).
- Add a `valueSetter` prop to fields which allows for full control over how a field updates form values. This is useful when a field can modify values of other independent fields, e.g. to change a value that would otherwise become invalid due to value constraints. What is important here is that this allows values to change in one single update rather than consecutively like when using `useEffect()` to hook into form value changes.
- Allow passing a `hiddenFields` prop, to avoid stripping such fields when cleaning the form values during submit.
- Compose cleaned values and provide the to the submit handler
  - Cleaned values have been stripped from all values corresponding to unmounted (but not hidden) fields, as well as intermediate fields (that we mark with `_`)
  - To make the validation run against the cleaned values, the `validateAgainstCleanedValues` needs to be used. This is only done for backwards compatibility until we refactored fields to always work with cleaned values.
- Pass the old value to the encoder to allow composing new values based on the old one. This is useful when using object-values.

#### Testing
I tested this heavily on the device onboarding branch. The existing e2e should verify that there are no issues with backward compatibility.

##### Regressions

Possible since this touches on forms.

#### Notes for Reviewers
Composite fields are a really nice and idiomatic way to enable complex form value modifications without the need of intermediate logic:

```js
const initialValues = { foo: 'one', bar: 'two', baz: 'three' }
const foobarEncoder = inputValue => { foo: inputValue.split(',')[0], bar: inputValue.split(',')[1] }
const foobarDecoder = ({ foo, bar }) => [foo, bar].join(',')

<Form
  initialValues={initialValues}
  …
>
  <Form.Field
    name="foo,bar"
    component={Input}
    encode={foobarEncoder}
    decode={foobarDecoder}
    …
  />
  …
</Form>
```

Observe the following:
- The encoders get an object containing (only) the desired fields, as defined in the `name` prop
- The form will automatically spread the encoded result over the existing form values
- Both `error`'s and `touched`-state is automatically mapped back to the corresponding field
- This allows updating multiple form values at the same time without intermediate steps or logic

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
