### PR TITLE
Don't try to select indirect memberships for organizations

### DIFF
--- a/pkg/identityserver/bunstore/entity_search.go
+++ b/pkg/identityserver/bunstore/entity_search.go
@@ -133,7 +133,7 @@ func (s *entitySearch) SearchApplications(
 			attribute.String("member_type", accountID.EntityType()),
 			attribute.String("member_id", accountID.IDString()),
 		)
-		selectWithUUID, err := s.selectWithUUIDsInMemberships(ctx, accountID, "application", true)
+		selectWithUUID, err := s.selectWithUUIDsInMemberships(ctx, accountID, "application", accountID.EntityType() == "user")
 		if err != nil {
 			return nil, err
 		}
@@ -169,7 +169,7 @@ func (s *entitySearch) SearchClients(
 			attribute.String("member_type", accountID.EntityType()),
 			attribute.String("member_id", accountID.IDString()),
 		)
-		selectWithUUID, err := s.selectWithUUIDsInMemberships(ctx, accountID, "client", true)
+		selectWithUUID, err := s.selectWithUUIDsInMemberships(ctx, accountID, "client", accountID.EntityType() == "user")
 		if err != nil {
 			return nil, err
 		}
@@ -247,7 +247,7 @@ func (s *entitySearch) SearchGateways(
 			attribute.String("member_type", accountID.EntityType()),
 			attribute.String("member_id", accountID.IDString()),
 		)
-		selectWithUUID, err := s.selectWithUUIDsInMemberships(ctx, accountID, "gateway", true)
+		selectWithUUID, err := s.selectWithUUIDsInMemberships(ctx, accountID, "gateway", accountID.EntityType() == "user")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/identityserver/bunstore/membership_store.go
+++ b/pkg/identityserver/bunstore/membership_store.go
@@ -164,7 +164,9 @@ func (s *membershipStore) FindMemberships(
 	))
 	defer span.End()
 
-	selectWithUUID, err := s.selectWithUUIDsInMemberships(ctx, accountID, entityType, includeIndirect)
+	selectWithUUID, err := s.selectWithUUIDsInMemberships(
+		ctx, accountID, entityType, includeIndirect && accountID.EntityType() == "user",
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a small fix for an issue that resulted in errors when trying to list entities of organizations (if the `is.bunstore` experimental feature is enabled).

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

While it _is_ incorrect to request indirect memberships of an organization, the old gormstore implementation silently accepted and rewrote that request, so I think it's best to do the same here.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
