### PR TITLE
Initialize zero locations for end devices with stored locations

### DIFF
--- a/pkg/identityserver/bunstore/end_device_store.go
+++ b/pkg/identityserver/bunstore/end_device_store.go
@@ -141,6 +141,11 @@ func endDeviceToPB(m *EndDevice, fieldMask ...string) (*ttnpb.EndDevice, error) 
 		pb.Locations = make(map[string]*ttnpb.Location, len(m.Locations))
 		for _, location := range m.Locations {
 			locationPB := locationToPB(location.Location)
+			if locationPB == nil {
+				// Unfortunately it's relatively common to have nil or zero locations in the database.
+				// If that's the case, we still need to set the source on a zero location.
+				locationPB = &ttnpb.Location{}
+			}
 			locationPB.Source = ttnpb.LocationSource(location.Source)
 			pb.Locations[location.Service] = locationPB
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This is a small fix for an issue where end devices wouldn't be loaded because they would have a `nil` location, but still a source set, which resulted in a panic.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

nil

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
