### PR TITLE
Return ctx.Error instead of ErrTxDone on canceled database transactions

### DIFF
--- a/pkg/identityserver/bunstore/store.go
+++ b/pkg/identityserver/bunstore/store.go
@@ -104,6 +104,10 @@ func (s *baseStore) transact(ctx context.Context, fc func(context.Context, bun.I
 	done = true
 	err = tx.Commit()
 	if err != nil {
+		// tx.Commit returns an error if the context provided to BeginTx is canceled.
+		if ctxErr := ctx.Err(); ctxErr != nil && errors.Is(err, sql.ErrTxDone) {
+			return ctxErr
+		}
 		return wrapDriverError(err)
 	}
 	return nil


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request makes IS DB transaction logic return `ctx.Error` instead of `sql.ErrTxDone` ("sql: transaction has already been committed or rolled back") on canceled transactions.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

nil

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
