### PR TITLE
Optimize membership views and queries

### DIFF
--- a/pkg/identityserver/bunstore/membership_store.go
+++ b/pkg/identityserver/bunstore/membership_store.go
@@ -119,7 +119,7 @@ func (s *membershipStore) selectWithUUIDsInMemberships(
 	if includeIndirect {
 		return func(q *bun.SelectQuery) *bun.SelectQuery {
 			return q.Where(
-				"?TableAlias.id IN (?) OR ?TableAlias.id IN (?)",
+				"?TableAlias.id IN (? UNION ?)",
 				directMembershipSelectQuery,
 				indirectMembershipSelectQuery,
 			)

--- a/pkg/identityserver/store/migrations/20220808000000_optimize_membership_views.down.sql
+++ b/pkg/identityserver/store/migrations/20220808000000_optimize_membership_views.down.sql
@@ -1,0 +1,91 @@
+DROP VIEW IF EXISTS direct_entity_memberships CASCADE;
+DROP VIEW IF EXISTS indirect_entity_memberships CASCADE;
+DROP VIEW IF EXISTS entity_friendly_ids CASCADE;
+
+--bun:split
+
+CREATE VIEW entity_friendly_ids AS
+SELECT
+  'application' AS entity_type,
+  id AS entity_id,
+  application_id AS friendly_id
+FROM
+  applications
+UNION
+SELECT
+  'client' AS entity_type,
+  id AS entity_id,
+  client_id AS friendly_id
+FROM
+  clients
+UNION
+SELECT
+  'gateway' AS entity_type,
+  id AS entity_id,
+  gateway_id AS friendly_id
+FROM
+  gateways
+UNION
+SELECT
+  'organization' AS entity_type,
+  account_id AS entity_id,
+  uid AS friendly_id
+FROM
+  accounts
+WHERE
+  account_type = 'organization'
+UNION
+SELECT
+  'user' AS entity_type,
+  account_id AS entity_id,
+  uid AS friendly_id
+FROM
+  accounts
+WHERE
+  account_type = 'user';
+
+--bun:split
+
+CREATE VIEW direct_entity_memberships AS
+SELECT
+  acc.account_type AS account_type,
+  acc.id AS account_id,
+  acc.uid AS account_friendly_id,
+  mem.rights AS rights,
+  mem.entity_type AS entity_type,
+  mem.entity_id AS entity_id,
+  ids.friendly_id AS entity_friendly_id
+FROM
+  accounts AS acc
+  JOIN memberships AS mem ON mem.account_id = acc.id
+  JOIN entity_friendly_ids AS ids ON ids.entity_type = mem.entity_type
+  AND ids.entity_id = mem.entity_id
+WHERE
+  acc.deleted_at IS NULL;
+
+--bun:split
+
+CREATE VIEW indirect_entity_memberships AS
+SELECT
+  usr_acc.id AS user_account_id,
+  usr_acc.uid AS user_account_friendly_id,
+  dmem.rights AS user_rights,
+  org_acc.id AS organization_account_id,
+  org_acc.uid AS organization_account_friendly_id,
+  imem.rights AS entity_rights,
+  imem.entity_type AS entity_type,
+  imem.entity_id AS entity_id,
+  ids.friendly_id AS entity_friendly_id
+FROM
+  accounts AS usr_acc
+  JOIN memberships AS dmem ON dmem.account_id = usr_acc.id
+  JOIN accounts org_acc ON dmem.entity_type = org_acc.account_type
+  AND dmem.entity_id = org_acc.account_id
+  JOIN memberships AS imem ON imem.account_id = org_acc.id
+  JOIN entity_friendly_ids AS ids ON ids.entity_type = imem.entity_type
+  AND ids.entity_id = imem.entity_id
+WHERE
+  usr_acc.deleted_at IS NULL
+  AND usr_acc.account_type = 'user'
+  AND dmem.entity_type = 'organization'
+  AND org_acc.deleted_at IS NULL;

--- a/pkg/identityserver/store/migrations/20220808000000_optimize_membership_views.up.sql
+++ b/pkg/identityserver/store/migrations/20220808000000_optimize_membership_views.up.sql
@@ -1,0 +1,54 @@
+DROP VIEW IF EXISTS direct_entity_memberships CASCADE;
+DROP VIEW IF EXISTS indirect_entity_memberships CASCADE;
+DROP VIEW IF EXISTS entity_friendly_ids CASCADE;
+
+--bun:split
+
+CREATE VIEW direct_entity_memberships AS
+SELECT
+  acc.account_type AS account_type,
+  acc.id AS account_id,
+  acc.uid AS account_friendly_id,
+  mem.rights AS rights,
+  mem.entity_type AS entity_type,
+  mem.entity_id AS entity_id,
+  CASE
+    WHEN mem.entity_type = 'application' THEN (SELECT application_id FROM applications WHERE id = mem.entity_id)
+    WHEN mem.entity_type = 'client' THEN (SELECT client_id FROM clients WHERE id = mem.entity_id)
+    WHEN mem.entity_type = 'gateway' THEN (SELECT gateway_id FROM gateways WHERE id = mem.entity_id)
+    WHEN mem.entity_type = 'organization' THEN (SELECT uid FROM accounts WHERE account_type = 'organization' AND account_id = mem.entity_id)
+  END AS entity_friendly_id
+FROM
+  accounts AS acc
+  JOIN memberships AS mem ON mem.account_id = acc.id
+WHERE
+  acc.deleted_at IS NULL;
+
+--bun:split
+
+CREATE VIEW indirect_entity_memberships AS
+SELECT
+  usr_acc.id AS user_account_id,
+  usr_acc.uid AS user_account_friendly_id,
+  dmem.rights AS user_rights,
+  org_acc.id AS organization_account_id,
+  org_acc.uid AS organization_account_friendly_id,
+  imem.rights AS entity_rights,
+  imem.entity_type AS entity_type,
+  imem.entity_id AS entity_id,
+  CASE
+    WHEN imem.entity_type = 'application' THEN (SELECT application_id FROM applications WHERE id = imem.entity_id)
+    WHEN imem.entity_type = 'client' THEN (SELECT client_id FROM clients WHERE id = imem.entity_id)
+    WHEN imem.entity_type = 'gateway' THEN (SELECT gateway_id FROM gateways WHERE id = imem.entity_id)
+  END AS entity_friendly_id
+FROM
+  accounts AS usr_acc
+  JOIN memberships AS dmem ON dmem.account_id = usr_acc.id
+  JOIN accounts org_acc ON dmem.entity_type = org_acc.account_type
+  AND dmem.entity_id = org_acc.account_id
+  JOIN memberships AS imem ON imem.account_id = org_acc.id
+WHERE
+  usr_acc.deleted_at IS NULL
+  AND usr_acc.account_type = 'user'
+  AND dmem.entity_type = 'organization'
+  AND org_acc.deleted_at IS NULL;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

This pull request addresses some performance issues with the membership views and queries in the experimental `is.bunstore` implementation.

#### Changes
<!-- What are the changes made in this pull request? -->

- Stop using the `entity_friendly_ids` view
- Rewrite the membership views without the `entity_friendly_ids` view
- Small optimization in merging direct and indirect memberships

#### Testing
<!-- How did you verify that this change works? -->

- Existing tests
- `EXPLAIN ANALYZE` the problematic queries and again after the patches.

##### Regressions
<!-- Please indicate features that this change could affect and how that was tested. -->

Don't expect any

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

nil

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
