### PR TITLE
Field styling fixes

### DIFF
--- a/pkg/webui/components/checkbox/checkbox.js
+++ b/pkg/webui/components/checkbox/checkbox.js
@@ -37,6 +37,7 @@ class Checkbox extends React.PureComponent {
     id: PropTypes.string,
     indeterminate: PropTypes.bool,
     label: PropTypes.message,
+    labelAsTitle: PropTypes.bool,
     name: PropTypes.string.isRequired,
     onBlur: PropTypes.func,
     onChange: PropTypes.func,
@@ -50,6 +51,7 @@ class Checkbox extends React.PureComponent {
     children: null,
     className: undefined,
     label: sharedMessages.enabled,
+    labelAsTitle: false,
     disabled: false,
     id: undefined,
     readOnly: false,
@@ -131,6 +133,7 @@ class Checkbox extends React.PureComponent {
       indeterminate,
       id,
       children,
+      labelAsTitle,
       ...rest
     } = this.props
     const { checked } = this.state
@@ -156,6 +159,10 @@ class Checkbox extends React.PureComponent {
       [style.indeterminate]: indeterminate,
     })
 
+    const labelCls = classnames(style.label, {
+      [style.labelAsTitle]: labelAsTitle,
+    })
+
     return (
       <label className={cls}>
         <span className={style.checkbox}>
@@ -173,7 +180,7 @@ class Checkbox extends React.PureComponent {
           />
           <span className={style.checkmark} />
         </span>
-        {label && <Message className={style.label} content={label} />}
+        {label && <Message className={labelCls} content={label} />}
         {children}
       </label>
     )

--- a/pkg/webui/components/checkbox/checkbox.styl
+++ b/pkg/webui/components/checkbox/checkbox.styl
@@ -106,4 +106,8 @@
     content: ''
 
 .label
+  user-select: none
   padding-left: $cs.xs
+
+  &.label-as-title
+    font-weight: $fw.bold

--- a/pkg/webui/components/form/field/field.styl
+++ b/pkg/webui/components/form/field/field.styl
@@ -100,8 +100,8 @@
         margin-right: $ls.xxs
 
 .label
-  display: block
-  align-items: flex-start
+  display: flex
+  align-items: center
   width:  100%
   flex-shrink: 0
   user-select: none
@@ -115,7 +115,6 @@
   display: inline-block
 
   &-icon
-    nudge('up', 1px)
     color: $tc-subtle-gray
     padding: .1rem
     height: 1rem

--- a/pkg/webui/components/tag/group/index.js
+++ b/pkg/webui/components/tag/group/index.js
@@ -41,7 +41,7 @@ class TagGroup extends React.Component {
   static propTypes = {
     className: PropTypes.string,
     tagMaxWidth: PropTypes.number.isRequired,
-    tags: PropTypes.arrayOf(PropTypes.instanceOf(Tag)).isRequired,
+    tags: PropTypes.arrayOf(PropTypes.shape(Tag.PropTypes)).isRequired,
   }
 
   static defaultProps = {


### PR DESCRIPTION
#### Summary
This PR applies two small styling fixes.

<img width="689" alt="image" src="https://user-images.githubusercontent.com/5710611/183683963-4693476a-d8c1-4b34-aa25-70fc67619b56.png">


#### Changes
<!-- What are the changes made in this pull request? -->

- Allow displaying checkbox labels with title styling
- Fix incosistent vertical placement of tooltip icons
- Fix proptype warning related to `<Tags />`-component

#### Testing

Manual.


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
