### PR TITLE
Prevent accidental navigation when changing PFs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For details about compatibility between different releases, see the **Commitment
 ### Added
 
 - New `SearchAccounts` RPC on the `EntityRegistrySearch` service.
+- Prompt user to confirm navigation when changes have not been saved in the payload formatter form to prevent big change-drafts from getting lost.
 
 ### Changed
 

--- a/pkg/webui/components/form/index.js
+++ b/pkg/webui/components/form/index.js
@@ -245,7 +245,7 @@ const Form = props => {
 }
 
 Form.propTypes = {
-  children: PropTypes.node.isRequired,
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired,
   className: PropTypes.string,
   disabled: PropTypes.bool,
   enableReinitialize: PropTypes.bool,

--- a/pkg/webui/components/prompt/index.js
+++ b/pkg/webui/components/prompt/index.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import React from 'react'
-import { Prompt as RouterPrompt } from 'react-router-dom'
+import { Prompt as RouterPrompt, useHistory } from 'react-router-dom'
 
 import PortalledModal from '@ttn-lw/components/modal/portalled'
 
@@ -26,6 +26,8 @@ import PropTypes from '@ttn-lw/lib/prop-types'
  */
 const Prompt = props => {
   const { modal, children, when, shouldBlockNavigation, onApprove, onCancel } = props
+
+  const history = useHistory()
 
   const [state, setState] = React.useState({
     showModal: false,
@@ -65,11 +67,11 @@ const Prompt = props => {
 
   React.useEffect(() => {
     if (confirmedLocationChange) {
-      onApprove(nextLocation)
+      onApprove(nextLocation, history)
     } else {
-      onCancel(nextLocation)
+      onCancel(nextLocation, history)
     }
-  }, [confirmedLocationChange, nextLocation, onApprove, onCancel])
+  }, [confirmedLocationChange, history, nextLocation, onApprove, onCancel])
 
   return (
     <>
@@ -82,12 +84,21 @@ const Prompt = props => {
 }
 
 Prompt.propTypes = {
-  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
   modal: PropTypes.shape({ ...PortalledModal.Modal.propTypes }).isRequired,
-  onApprove: PropTypes.func.isRequired,
-  onCancel: PropTypes.func.isRequired,
-  shouldBlockNavigation: PropTypes.func.isRequired,
+  onApprove: PropTypes.func,
+  onCancel: PropTypes.func,
+  shouldBlockNavigation: PropTypes.func,
   when: PropTypes.bool.isRequired,
+}
+
+Prompt.defaultProps = {
+  children: undefined,
+  shouldBlockNavigation: () => true,
+  onApprove: (location, history) => {
+    history.push(location)
+  },
+  onCancel: () => null,
 }
 
 export default Prompt

--- a/pkg/webui/console/components/payload-formatters-form/index.js
+++ b/pkg/webui/console/components/payload-formatters-form/index.js
@@ -19,6 +19,7 @@ import { Col, Row } from 'react-grid-system'
 
 import TYPES from '@console/constants/formatter-types'
 
+import Prompt from '@ttn-lw/components/prompt'
 import Select from '@ttn-lw/components/select'
 import Form from '@ttn-lw/components/form'
 import SubmitButton from '@ttn-lw/components/submit-button'
@@ -65,6 +66,9 @@ const m = defineMessages({
   learnMoreAboutCayenne: 'What is CayenneLPP?',
   noRepositoryWarning:
     'The application formatter is set to `Repository` but this device does not have an associated formatter in the LoRaWAN Device repository. Messages for this end device will hence not be formatted.',
+  confirmNavigationTitle: 'Confirm navigation',
+  confirmNavigationMessage:
+    'Are you sure you want to leave this page? Your current changes have not been saved yet.',
 })
 
 const FIELD_NAMES = {
@@ -383,38 +387,50 @@ class PayloadFormattersForm extends React.Component {
               formikRef={this.formRef}
               id="payload-formatter-form"
             >
-              <Form.SubTitle title={m.setupSubTitle} />
-              <Form.Field
-                name={FIELD_NAMES.SELECT}
-                title={m.formatterType}
-                component={Select}
-                options={options}
-                onChange={this.onTypeChange}
-                warning={type === TYPES.DEFAULT ? m.appFormatterWarning : undefined}
-                inputWidth="m"
-                required
-              />
-              {isDefaultType && (
-                <Notification
-                  small
-                  info
-                  content={m.defaultFormatter}
-                  convertBackticks
-                  messageValues={{
-                    Link: msg => (
-                      <Link
-                        secondary
-                        key="manual-link"
-                        to={`/applications/${appId}/payload-formatters/uplink`}
-                      >
-                        {msg}
-                      </Link>
-                    ),
-                    defaultFormatter,
-                  }}
-                />
+              {({ touched }) => (
+                <>
+                  <Form.SubTitle title={m.setupSubTitle} />
+                  <Form.Field
+                    name={FIELD_NAMES.SELECT}
+                    title={m.formatterType}
+                    component={Select}
+                    options={options}
+                    onChange={this.onTypeChange}
+                    warning={type === TYPES.DEFAULT ? m.appFormatterWarning : undefined}
+                    inputWidth="m"
+                    required
+                  />
+                  {isDefaultType && (
+                    <Notification
+                      small
+                      info
+                      content={m.defaultFormatter}
+                      convertBackticks
+                      messageValues={{
+                        Link: msg => (
+                          <Link
+                            secondary
+                            key="manual-link"
+                            to={`/applications/${appId}/payload-formatters/uplink`}
+                          >
+                            {msg}
+                          </Link>
+                        ),
+                        defaultFormatter,
+                      }}
+                    />
+                  )}
+                  {this.formatter}
+                  <Prompt
+                    when={Boolean(touched['javascript-formatter'] || touched['grpc-formatter'])}
+                    modal={{
+                      title: m.confirmNavigationTitle,
+                      message: m.confirmNavigationMessage,
+                      buttonMessage: m.confirmNavigationTitle,
+                    }}
+                  />
+                </>
               )}
-              {this.formatter}
             </Form>
           </Col>
           {this._showTestSection() && (

--- a/pkg/webui/locales/en.json
+++ b/pkg/webui/locales/en.json
@@ -335,6 +335,8 @@
   "console.components.payload-formatters-form.index.learnMoreAboutPayloadFormatters": "Learn more about payload formatters",
   "console.components.payload-formatters-form.index.learnMoreAboutCayenne": "What is CayenneLPP?",
   "console.components.payload-formatters-form.index.noRepositoryWarning": "The application formatter is set to `Repository` but this device does not have an associated formatter in the LoRaWAN Device repository. Messages for this end device will hence not be formatted.",
+  "console.components.payload-formatters-form.index.confirmNavigationTitle": "Confirm navigation",
+  "console.components.payload-formatters-form.index.confirmNavigationMessage": "Are you sure you want to leave this page? Your current changes have not been saved yet.",
   "console.components.payload-formatters-form.test-form.index.validResult": "Payload is valid",
   "console.components.payload-formatters-form.test-form.index.noResult": "No test result generated yet",
   "console.components.payload-formatters-form.test-form.index.testDecoder": "Test decoder",


### PR DESCRIPTION
#### Summary
This quickfix PR will prevent users from accidentally navigating away when changing payload formatters in the Console.

<img width="1433" alt="image" src="https://user-images.githubusercontent.com/5710611/184111900-fee0dba2-96b4-4623-8cfd-acc00ce97937.png">

#### Changes
<!-- What are the changes made in this pull request? -->

- Refactor `<Prompt />`-component a bit
- Add `<Prompt />` to payload formatter form
- Fix missing proptype in form component


#### Testing

Manual testing.

#### Notes for Reviewers
Was notified of this problem by @ysmilda

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [x] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
