### PR TITLE
Remove deepcopy.Copy usage for protobufs

### DIFF
--- a/cmd/ttn-lw-cli/commands/lorawan.go
+++ b/cmd/ttn-lw-cli/commands/lorawan.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/mohae/deepcopy"
 	"github.com/spf13/cobra"
 	"go.thethings.network/lorawan-stack/v3/cmd/internal/io"
 	"go.thethings.network/lorawan-stack/v3/pkg/band"
@@ -150,7 +149,7 @@ func decodeJoinAccept(msg *ttnpb.Message, config lorawanConfig) (*lorawanDecoded
 			return &lorawanDecodedFrame{Message: msg}, nil
 		}
 		buf, mic := buf[:n-4], buf[n-4:]
-		decBuf := deepcopy.Copy(pld).(*ttnpb.JoinAcceptPayload)
+		decBuf := ttnpb.Clone(pld)
 		if err := lorawan.UnmarshalJoinAcceptPayload(buf, decBuf); err != nil {
 			logger.WithError(err).Warn("Failed to unmarshal join accept payload")
 			return &lorawanDecodedFrame{Message: msg}, nil

--- a/pkg/applicationserver/applicationserver_test.go
+++ b/pkg/applicationserver/applicationserver_test.go
@@ -29,7 +29,6 @@ import (
 	mqttserver "github.com/TheThingsIndustries/mystique/pkg/server"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 	pbtypes "github.com/gogo/protobuf/types"
-	"github.com/mohae/deepcopy"
 	nats_server "github.com/nats-io/nats-server/v2/server"
 	nats_test_server "github.com/nats-io/nats-server/v2/test"
 	nats_client "github.com/nats-io/nats.go"
@@ -2402,7 +2401,7 @@ func TestSkipPayloadCrypto(t *testing.T) {
 				ns.reset()
 				devsFlush()
 				deviceRegistry.Set(ctx, registeredDevice.Ids, nil, func(_ *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
-					dev := deepcopy.Copy(registeredDevice).(*ttnpb.EndDevice)
+					dev := ttnpb.Clone(registeredDevice)
 					dev.SkipPayloadCryptoOverride = override
 					return dev, []string{
 						"ids",
@@ -2622,7 +2621,7 @@ func TestSkipPayloadCrypto(t *testing.T) {
 				ns.reset()
 				devsFlush()
 				deviceRegistry.Set(ctx, registeredDevice.Ids, nil, func(_ *ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error) {
-					dev := deepcopy.Copy(registeredDevice).(*ttnpb.EndDevice)
+					dev := ttnpb.Clone(registeredDevice)
 					dev.Session = &ttnpb.Session{
 						DevAddr: types.DevAddr{0x42, 0xff, 0xff, 0xff}.Bytes(),
 						Keys: &ttnpb.SessionKeys{

--- a/pkg/applicationserver/grpc_deviceregistry_test.go
+++ b/pkg/applicationserver/grpc_deviceregistry_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/applicationserver"
 	"go.thethings.network/lorawan-stack/v3/pkg/auth/rights"
@@ -192,10 +191,10 @@ func TestDeviceRegistryGet(t *testing.T) {
 				a.So(paths, should.HaveSameElementsDeep, []string{
 					"formatters",
 				})
-				return deepcopy.Copy(&ttnpb.EndDevice{
+				return ttnpb.Clone(&ttnpb.EndDevice{
 					Ids:        registeredDevice.Ids,
 					Formatters: registeredDevice.Formatters,
-				}).(*ttnpb.EndDevice), nil
+				}), nil
 			},
 			DeviceRequest: &ttnpb.GetEndDeviceRequest{
 				EndDeviceIds: registeredDevice.Ids,
@@ -260,7 +259,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 					"skip_payload_crypto",
 					"skip_payload_crypto_override",
 				})
-				return deepcopy.Copy(registeredDevice).(*ttnpb.EndDevice), nil
+				return ttnpb.Clone(registeredDevice), nil
 			},
 			DeviceRequest: &ttnpb.GetEndDeviceRequest{
 				EndDeviceIds: registeredDevice.Ids,
@@ -318,7 +317,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			defer as.Close()
 
 			ctx := as.FillContext(test.Context())
-			req := deepcopy.Copy(tc.DeviceRequest).(*ttnpb.GetEndDeviceRequest)
+			req := ttnpb.Clone(tc.DeviceRequest)
 
 			dev, err := ttnpb.NewAsEndDeviceRegistryClient(as.LoopbackConn()).Get(ctx, req)
 			a.So(req, should.Resemble, tc.DeviceRequest)
@@ -369,7 +368,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 				return nil, errors.New("SetFunc must not be called")
 			},
 			DeviceRequest: &ttnpb.SetEndDeviceRequest{
-				EndDevice: deepcopy.Copy(registeredDevice).(*ttnpb.EndDevice),
+				EndDevice: ttnpb.Clone(registeredDevice),
 				FieldMask: ttnpb.FieldMask("formatters"),
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
@@ -394,7 +393,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 				return nil, errors.New("SetFunc must not be called")
 			},
 			DeviceRequest: &ttnpb.SetEndDeviceRequest{
-				EndDevice: deepcopy.Copy(registeredDevice).(*ttnpb.EndDevice),
+				EndDevice: ttnpb.Clone(registeredDevice),
 				FieldMask: ttnpb.FieldMask("formatters"),
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
@@ -492,7 +491,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 				})
 			},
 			DeviceRequest: &ttnpb.SetEndDeviceRequest{
-				EndDevice: deepcopy.Copy(registeredDevice).(*ttnpb.EndDevice),
+				EndDevice: ttnpb.Clone(registeredDevice),
 				FieldMask: ttnpb.FieldMask("formatters"),
 			},
 			SetFunc: func(ctx context.Context, deviceIds *ttnpb.EndDeviceIdentifiers, gets []string, cb func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
@@ -501,7 +500,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"formatters",
 				})
-				dev, sets, err := cb(deepcopy.Copy(registeredDevice).(*ttnpb.EndDevice))
+				dev, sets, err := cb(ttnpb.Clone(registeredDevice))
 				a.So(sets, should.HaveSameElementsDeep, []string{
 					"formatters",
 				})
@@ -524,7 +523,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			},
 			DeviceRequest: &ttnpb.SetEndDeviceRequest{
 				EndDevice: func() *ttnpb.EndDevice {
-					dev := deepcopy.Copy(registeredDevice).(*ttnpb.EndDevice)
+					dev := ttnpb.Clone(registeredDevice)
 					dev.Formatters.UpFormatterParameter = strings.Repeat("-", maxParameterLength+1)
 					return dev
 				}(),
@@ -552,7 +551,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			},
 			DeviceRequest: &ttnpb.SetEndDeviceRequest{
 				EndDevice: func() *ttnpb.EndDevice {
-					dev := deepcopy.Copy(registeredDevice).(*ttnpb.EndDevice)
+					dev := ttnpb.Clone(registeredDevice)
 					dev.Formatters.DownFormatterParameter = strings.Repeat("-", maxParameterLength+1)
 					return dev
 				}(),
@@ -599,7 +598,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			defer as.Close()
 
 			ctx := as.FillContext(test.Context())
-			req := deepcopy.Copy(tc.DeviceRequest).(*ttnpb.SetEndDeviceRequest)
+			req := ttnpb.Clone(tc.DeviceRequest)
 
 			dev, err := ttnpb.NewAsEndDeviceRegistryClient(as.LoopbackConn()).Set(ctx, req)
 			a.So(setCalls, should.Equal, tc.SetCalls)
@@ -655,7 +654,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 				test.MustTFromContext(ctx).Errorf("UpClearFunc must not be called")
 				return errors.New("UpClearFunc must not be called")
 			},
-			DeviceRequest: deepcopy.Copy(registeredDevice.Ids).(*ttnpb.EndDeviceIdentifiers),
+			DeviceRequest: ttnpb.Clone(registeredDevice.Ids),
 			ErrorAssertion: func(t *testing.T, err error) bool {
 				a := assertions.New(t)
 				return a.So(errors.IsPermissionDenied(err), should.BeTrue)
@@ -681,7 +680,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 				test.MustTFromContext(ctx).Errorf("UpClearFunc must not be called")
 				return errors.New("UpClearFunc must not be called")
 			},
-			DeviceRequest: deepcopy.Copy(registeredDevice.Ids).(*ttnpb.EndDeviceIdentifiers),
+			DeviceRequest: ttnpb.Clone(registeredDevice.Ids),
 			ErrorAssertion: func(t *testing.T, err error) bool {
 				a := assertions.New(t)
 				return a.So(errors.IsPermissionDenied(err), should.BeTrue)
@@ -715,7 +714,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 				a.So(ids, should.Resemble, registeredDevice.Ids)
 				return nil
 			},
-			DeviceRequest: deepcopy.Copy(registeredDevice.Ids).(*ttnpb.EndDeviceIdentifiers),
+			DeviceRequest: ttnpb.Clone(registeredDevice.Ids),
 			SetCalls:      1,
 			UpClearCalls:  1,
 		},
@@ -747,7 +746,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 				a.So(ids, should.Resemble, registeredDevice.Ids)
 				return nil
 			},
-			DeviceRequest: deepcopy.Copy(registeredDevice.Ids).(*ttnpb.EndDeviceIdentifiers),
+			DeviceRequest: ttnpb.Clone(registeredDevice.Ids),
 			SetCalls:      1,
 			UpClearCalls:  1,
 		},
@@ -789,7 +788,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			defer as.Close()
 
 			ctx := as.FillContext(test.Context())
-			req := deepcopy.Copy(tc.DeviceRequest).(*ttnpb.EndDeviceIdentifiers)
+			req := ttnpb.Clone(tc.DeviceRequest)
 
 			_, err := ttnpb.NewAsEndDeviceRegistryClient(as.LoopbackConn()).Delete(ctx, req)
 			a.So(setCalls, should.Equal, tc.SetCalls)

--- a/pkg/auth/rights/rights.go
+++ b/pkg/auth/rights/rights.go
@@ -18,7 +18,6 @@ package rights
 import (
 	"context"
 
-	"github.com/mohae/deepcopy"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 )
 
@@ -189,7 +188,7 @@ func NewContextWithAuthInfoCache(ctx context.Context) context.Context {
 
 func cacheAuthInfoInContext(ctx context.Context, res *ttnpb.AuthInfoResponse) {
 	if authInfo, ok := ctx.Value(authInfoCacheKey).(**ttnpb.AuthInfoResponse); ok {
-		*authInfo = deepcopy.Copy(res).(*ttnpb.AuthInfoResponse)
+		*authInfo = ttnpb.Clone(res)
 	}
 }
 

--- a/pkg/crypto/cryptoutil/cryptoutil_test.go
+++ b/pkg/crypto/cryptoutil/cryptoutil_test.go
@@ -18,7 +18,6 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	. "go.thethings.network/lorawan-stack/v3/pkg/crypto/cryptoutil"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
@@ -439,7 +438,7 @@ func TestUnwrapSelectedSessionKeys(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			a := assertions.New(t)
 
-			sk := deepcopy.Copy(tc.SessionKeys).(*ttnpb.SessionKeys)
+			sk := ttnpb.Clone(tc.SessionKeys)
 			ret, err := UnwrapSelectedSessionKeys(test.Context(), v, sk, tc.Prefix, tc.Paths...)
 			a.So(sk, should.Resemble, tc.SessionKeys)
 			a.So(ret, should.Resemble, tc.ExpectedSessionKeys)

--- a/pkg/crypto/join_messages_test.go
+++ b/pkg/crypto/join_messages_test.go
@@ -23,6 +23,7 @@ import (
 	. "go.thethings.network/lorawan-stack/v3/pkg/crypto"
 	"go.thethings.network/lorawan-stack/v3/pkg/types"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+	"golang.org/x/exp/slices"
 )
 
 func TestJoinAcceptEncryption(t *testing.T) {
@@ -60,7 +61,7 @@ func TestJoinAcceptEncryption(t *testing.T) {
 			a := assertions.New(t)
 
 			key := deepcopy.Copy(tc.Key).(types.AES128Key)
-			dec := deepcopy.Copy(tc.Decrypted).([]byte)
+			dec := slices.Clone(tc.Decrypted)
 			enc, err := EncryptJoinAccept(key, dec)
 			a.So(err, should.BeNil)
 			a.So(dec, should.Resemble, tc.Decrypted)
@@ -68,7 +69,7 @@ func TestJoinAcceptEncryption(t *testing.T) {
 			a.So(key, should.Resemble, tc.Key)
 
 			key = deepcopy.Copy(tc.Key).(types.AES128Key)
-			enc = deepcopy.Copy(tc.Encrypted).([]byte)
+			enc = slices.Clone(tc.Encrypted)
 			dec, err = DecryptJoinAccept(tc.Key, tc.Encrypted)
 			a.So(err, should.BeNil)
 			a.So(dec, should.Resemble, tc.Decrypted)
@@ -109,7 +110,7 @@ func TestComputeJoinRequestMIC(t *testing.T) {
 			a := assertions.New(t)
 
 			key := deepcopy.Copy(tc.Key).(types.AES128Key)
-			pld := deepcopy.Copy(tc.Payload).([]byte)
+			pld := slices.Clone(tc.Payload)
 			mic, err := ComputeJoinRequestMIC(key, pld)
 			a.So(err, should.BeNil)
 			a.So(mic, should.Equal, tc.MIC)
@@ -185,7 +186,7 @@ func TestComputeRejoinRequestMIC(t *testing.T) {
 			a := assertions.New(t)
 
 			key := deepcopy.Copy(tc.Key).(types.AES128Key)
-			pld := deepcopy.Copy(tc.Payload).([]byte)
+			pld := slices.Clone(tc.Payload)
 			mic, err := ComputeRejoinRequestMIC(key, pld)
 			a.So(err, should.BeNil)
 			a.So(mic, should.Equal, tc.MIC)
@@ -228,7 +229,7 @@ func TestComputeLegacyJoinAcceptMIC(t *testing.T) {
 			a := assertions.New(t)
 
 			key := deepcopy.Copy(tc.Key).(types.AES128Key)
-			pld := deepcopy.Copy(tc.Payload).([]byte)
+			pld := slices.Clone(tc.Payload)
 			mic, err := ComputeLegacyJoinAcceptMIC(key, pld)
 			a.So(err, should.BeNil)
 			a.So(mic, should.Equal, tc.MIC)
@@ -281,7 +282,7 @@ func TestComputeJoinAcceptMIC(t *testing.T) {
 			key := deepcopy.Copy(tc.Key).(types.AES128Key)
 			joinEUI := deepcopy.Copy(tc.JoinEUI).(types.EUI64)
 			devNonce := deepcopy.Copy(tc.DevNonce).(types.DevNonce)
-			pld := deepcopy.Copy(tc.Payload).([]byte)
+			pld := slices.Clone(tc.Payload)
 			mic, err := ComputeJoinAcceptMIC(key, tc.Type, joinEUI, devNonce, pld)
 			a.So(err, should.BeNil)
 			a.So(mic, should.Equal, tc.MIC)

--- a/pkg/fetch/basepath_test.go
+++ b/pkg/fetch/basepath_test.go
@@ -17,10 +17,10 @@ package fetch_test
 import (
 	"testing"
 
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/fetch"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
+	"golang.org/x/exp/slices"
 )
 
 type MockInterface struct {
@@ -138,8 +138,8 @@ func TestWithBasePath(t *testing.T) {
 				},
 			}
 
-			basePath := deepcopy.Copy(tc.BasePath).([]string)
-			path := deepcopy.Copy(tc.Path).([]string)
+			basePath := slices.Clone(tc.BasePath)
+			path := slices.Clone(tc.Path)
 			b, err := fetch.WithBasePath(m, basePath...).File(path...)
 			if a.So(tc.AssertError(t, err), should.BeTrue) {
 				a.So(tc.AssertBytes(t, b), should.BeTrue)

--- a/pkg/gatewayserver/grpc_nsgs.go
+++ b/pkg/gatewayserver/grpc_nsgs.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mohae/deepcopy"
 	clusterauth "go.thethings.network/lorawan-stack/v3/pkg/auth/cluster"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/events"
@@ -77,8 +76,8 @@ func (gs *GatewayServer) ScheduleDownlink(ctx context.Context, down *ttnpb.Downl
 		}
 
 		ctx := events.ContextWithCorrelationID(ctx, events.CorrelationIDsFromContext(conn.Context())...)
-		connDown := deepcopy.Copy(down).(*ttnpb.DownlinkMessage) // Let the connection own the DownlinkMessage.
-		connDown.GetRequest().DownlinkPaths = nil                // And do not leak the downlink paths to the gateway.
+		connDown := ttnpb.Clone(down)             // Let the connection own the DownlinkMessage.
+		connDown.GetRequest().DownlinkPaths = nil // And do not leak the downlink paths to the gateway.
 		connDown.CorrelationIds = events.CorrelationIDsFromContext(ctx)
 
 		registerScheduleDownlinkAttempt(ctx, conn.Gateway(), connDown, conn.Frontend().Protocol())

--- a/pkg/gatewayserver/io/downlink_token.go
+++ b/pkg/gatewayserver/io/downlink_token.go
@@ -21,7 +21,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/mohae/deepcopy"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 )
 
@@ -61,7 +60,7 @@ func (t DownlinkTokens) Get(token uint16, time time.Time) (*ttnpb.DownlinkMessag
 	if item.key != token || item.msg == nil || item.time.IsZero() {
 		return nil, 0, false
 	}
-	return deepcopy.Copy(item.msg).(*ttnpb.DownlinkMessage), time.Sub(item.time), true
+	return ttnpb.Clone(item.msg), time.Sub(item.time), true
 }
 
 var parseTokenRegex = regexp.MustCompile(`^gs:down:token:(\d+)$`)

--- a/pkg/gatewayserver/io/grpc/grpc_test.go
+++ b/pkg/gatewayserver/io/grpc/grpc_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/cluster"
 	"go.thethings.network/lorawan-stack/v3/pkg/component"
@@ -367,7 +366,7 @@ func TestTraffic(t *testing.T) {
 				for ups != len(tc.UplinkMessages) || needStatus || needTxAck {
 					select {
 					case up := <-conn.Up():
-						expected := deepcopy.Copy(tc.UplinkMessages[ups]).(*ttnpb.UplinkMessage)
+						expected := ttnpb.Clone(tc.UplinkMessages[ups])
 						expected.ReceivedAt = up.Message.ReceivedAt
 						for i, md := range expected.RxMetadata {
 							md.UplinkToken = up.Message.RxMetadata[i].UplinkToken

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -22,7 +22,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/mohae/deepcopy"
 	"go.thethings.network/lorawan-stack/v3/pkg/band"
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/errorcontext"
@@ -338,7 +337,7 @@ func (c *Connection) HandleStatus(status *ttnpb.GatewayStatus) (err error) {
 	case <-c.ctx.Done():
 		return c.ctx.Err()
 	case c.statusCh <- status:
-		c.lastStatus.Store(deepcopy.Copy(status))
+		c.lastStatus.Store(ttnpb.Clone(status))
 		atomic.StoreInt64(&c.lastStatusTime, time.Now().UnixNano())
 		c.notifyStatsChanged()
 

--- a/pkg/gatewayserver/io/mqtt/mqtt_test.go
+++ b/pkg/gatewayserver/io/mqtt/mqtt_test.go
@@ -23,7 +23,6 @@ import (
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/gogo/protobuf/proto"
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/cluster"
 	"go.thethings.network/lorawan-stack/v3/pkg/component"
@@ -271,7 +270,7 @@ func TestTraffic(t *testing.T) {
 				case up := <-conn.Up():
 					if tc.OK {
 						a.So(time.Since(*ttnpb.StdTime(up.Message.ReceivedAt)), should.BeLessThan, timeout)
-						expected := deepcopy.Copy(tc.Message).(*ttnpb.UplinkMessage)
+						expected := ttnpb.Clone(tc.Message).(*ttnpb.UplinkMessage)
 						expected.ReceivedAt = up.Message.ReceivedAt
 						a.So(up.Message, should.Resemble, expected)
 					} else {

--- a/pkg/gatewayserver/io/ws/lbslns/upstream_test.go
+++ b/pkg/gatewayserver/io/ws/lbslns/upstream_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/band"
 	"go.thethings.network/lorawan-stack/v3/pkg/basicstation"
@@ -250,7 +249,7 @@ func TestJoinRequest(t *testing.T) {
 				if !a.So(&payload, should.Resemble, msg.Payload) {
 					t.Fatalf("Invalid RawPayload: %v", msg.RawPayload)
 				}
-				expected := deepcopy.Copy(tc.ExpectedUplinkMessage).(*ttnpb.UplinkMessage)
+				expected := ttnpb.Clone(tc.ExpectedUplinkMessage)
 				expected.RawPayload = msg.RawPayload
 				expected.ReceivedAt = msg.ReceivedAt
 				if !a.So(msg, should.Resemble, expected) {
@@ -424,7 +423,7 @@ func TestUplinkDataFrame(t *testing.T) {
 			} else if tc.ErrorAssertion != nil {
 				t.Fatalf("Expected error")
 			} else {
-				expected := deepcopy.Copy(tc.ExpectedUplinkMessage).(*ttnpb.UplinkMessage)
+				expected := ttnpb.Clone(tc.ExpectedUplinkMessage)
 				expected.RawPayload = msg.RawPayload
 				expected.ReceivedAt = msg.ReceivedAt
 				if !a.So(msg, should.Resemble, expected) {

--- a/pkg/gatewayserver/io/ws/ws_test.go
+++ b/pkg/gatewayserver/io/ws/ws_test.go
@@ -25,9 +25,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	pbtypes "github.com/gogo/protobuf/types"
 	"github.com/gorilla/websocket"
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/basicstation"
 	"go.thethings.network/lorawan-stack/v3/pkg/cluster"
@@ -820,7 +820,7 @@ func TestTraffic(t *testing.T) {
 		InputBSUpstream         interface{}
 		InputNetworkDownstream  *ttnpb.DownlinkMessage
 		ExpectedBSDownstream    interface{}
-		ExpectedNetworkUpstream interface{}
+		ExpectedNetworkUpstream proto.Message
 	}{
 		{
 			Name: "JoinRequest",
@@ -1142,7 +1142,7 @@ func TestTraffic(t *testing.T) {
 							t.Fatalf("Invalid RawPayload: %v", up.Message.RawPayload)
 						}
 
-						expectedUp := deepcopy.Copy(tc.ExpectedNetworkUpstream).(*ttnpb.UplinkMessage)
+						expectedUp := ttnpb.Clone(tc.ExpectedNetworkUpstream).(*ttnpb.UplinkMessage)
 						expectedUp.ReceivedAt = up.Message.ReceivedAt
 						expectedUp.RawPayload = up.Message.RawPayload
 
@@ -1181,7 +1181,7 @@ func TestTraffic(t *testing.T) {
 							t.Fatalf("Invalid RawPayload: %v", up.Message.RawPayload)
 						}
 
-						expectedUp := deepcopy.Copy(tc.ExpectedNetworkUpstream).(*ttnpb.UplinkMessage)
+						expectedUp := ttnpb.Clone(tc.ExpectedNetworkUpstream).(*ttnpb.UplinkMessage)
 						expectedUp.ReceivedAt = up.Message.ReceivedAt
 						expectedUp.RawPayload = up.Message.RawPayload
 

--- a/pkg/joinserver/grpc_deviceregistry_test.go
+++ b/pkg/joinserver/grpc_deviceregistry_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/auth/rights"
 	"go.thethings.network/lorawan-stack/v3/pkg/component"
@@ -112,7 +111,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 				return nil, errors.New("GetByIDFunc must not be called")
 			},
 			DeviceRequest: &ttnpb.GetEndDeviceRequest{
-				EndDeviceIds: deepcopy.Copy(registeredDevice.Ids).(*ttnpb.EndDeviceIdentifiers),
+				EndDeviceIds: ttnpb.Clone(registeredDevice.Ids),
 				FieldMask:    ttnpb.FieldMask("ids"),
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
@@ -179,7 +178,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 				})
 				a.So(devID, should.Equal, "bar-device")
 				a.So(paths, should.HaveSameElementsDeep, []string{"ids"})
-				return CopyEndDevice(&ttnpb.EndDevice{
+				return ttnpb.Clone(&ttnpb.EndDevice{
 					Ids: registeredDevice.Ids,
 				}), nil
 			},
@@ -221,12 +220,12 @@ func TestDeviceRegistryGet(t *testing.T) {
 				})
 				a.So(devID, should.Equal, registeredDeviceID)
 				a.So(paths, should.HaveSameElementsDeep, []string{"ids"})
-				return CopyEndDevice(&ttnpb.EndDevice{
+				return ttnpb.Clone(&ttnpb.EndDevice{
 					Ids: registeredDevice.Ids,
 				}), nil
 			},
 			DeviceRequest: &ttnpb.GetEndDeviceRequest{
-				EndDeviceIds: deepcopy.Copy(registeredDevice.Ids).(*ttnpb.EndDeviceIdentifiers),
+				EndDeviceIds: ttnpb.Clone(registeredDevice.Ids),
 				FieldMask:    ttnpb.FieldMask("ids"),
 			},
 			DeviceAssertion: func(t *testing.T, dev *ttnpb.EndDevice) bool {
@@ -255,7 +254,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 				return nil, errors.New("GetByIDFunc must not be called")
 			},
 			DeviceRequest: &ttnpb.GetEndDeviceRequest{
-				EndDeviceIds: deepcopy.Copy(registeredDevice.Ids).(*ttnpb.EndDeviceIdentifiers),
+				EndDeviceIds: ttnpb.Clone(registeredDevice.Ids),
 				FieldMask:    ttnpb.FieldMask("ids", "root_keys.app_key.key", "root_keys.nwk_key.key"),
 			},
 			ErrorAssertion: func(t *testing.T, err error) bool {
@@ -295,7 +294,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 					"root_keys.nwk_key.kek_label",
 					"root_keys.nwk_key.key",
 				})
-				ret := CopyEndDevice(registeredDevice)
+				ret := ttnpb.Clone(registeredDevice)
 				ret.RootKeys.AppKey = &ttnpb.KeyEnvelope{
 					EncryptedKey: ret.RootKeys.AppKey.EncryptedKey,
 					KekLabel:     ret.RootKeys.AppKey.KekLabel,
@@ -306,12 +305,12 @@ func TestDeviceRegistryGet(t *testing.T) {
 				return ret, nil
 			},
 			DeviceRequest: &ttnpb.GetEndDeviceRequest{
-				EndDeviceIds: deepcopy.Copy(registeredDevice.Ids).(*ttnpb.EndDeviceIdentifiers),
+				EndDeviceIds: ttnpb.Clone(registeredDevice.Ids),
 				FieldMask:    ttnpb.FieldMask("ids", "root_keys.app_key.key", "root_keys.nwk_key.key"),
 			},
 			DeviceAssertion: func(t *testing.T, dev *ttnpb.EndDevice) bool {
 				a := assertions.New(t)
-				expected := CopyEndDevice(registeredDevice)
+				expected := ttnpb.Clone(registeredDevice)
 				expected.RootKeys = &ttnpb.RootKeys{
 					NwkKey: &ttnpb.KeyEnvelope{
 						Key: registeredNwkKey.Bytes(),
@@ -356,7 +355,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 					"root_keys.nwk_key.kek_label",
 					"root_keys.nwk_key.key",
 				})
-				ret := CopyEndDevice(registeredDevice)
+				ret := ttnpb.Clone(registeredDevice)
 				ret.RootKeys.AppKey = &ttnpb.KeyEnvelope{
 					Key: ret.RootKeys.AppKey.Key,
 				}
@@ -367,12 +366,12 @@ func TestDeviceRegistryGet(t *testing.T) {
 				return ret, nil
 			},
 			DeviceRequest: &ttnpb.GetEndDeviceRequest{
-				EndDeviceIds: deepcopy.Copy(registeredDevice.Ids).(*ttnpb.EndDeviceIdentifiers),
+				EndDeviceIds: ttnpb.Clone(registeredDevice.Ids),
 				FieldMask:    ttnpb.FieldMask("ids", "root_keys.app_key.key", "root_keys.nwk_key.key"),
 			},
 			DeviceAssertion: func(t *testing.T, dev *ttnpb.EndDevice) bool {
 				a := assertions.New(t)
-				expected := CopyEndDevice(registeredDevice)
+				expected := ttnpb.Clone(registeredDevice)
 				expected.RootKeys = &ttnpb.RootKeys{
 					NwkKey: &ttnpb.KeyEnvelope{
 						Key: registeredNwkKey.Bytes(),
@@ -418,7 +417,7 @@ func TestDeviceRegistryGet(t *testing.T) {
 			defer js.Close()
 
 			ctx := js.FillContext(test.Context())
-			req := deepcopy.Copy(tc.DeviceRequest).(*ttnpb.GetEndDeviceRequest)
+			req := ttnpb.Clone(tc.DeviceRequest)
 
 			dev, err := ttnpb.NewJsEndDeviceRegistryClient(js.LoopbackConn()).Get(ctx, req)
 			a.So(getByIDCalls, should.Equal, tc.GetByIDCalls)
@@ -496,7 +495,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 				})
 			},
 			DeviceRequest: &ttnpb.SetEndDeviceRequest{
-				EndDevice: CopyEndDevice(registeredDevice),
+				EndDevice: ttnpb.Clone(registeredDevice),
 			},
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, paths []string, cb func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
 				test.MustTFromContext(ctx).Errorf("SetByIDFunc must not be called")
@@ -513,7 +512,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
 					ApplicationRights: map[string]*ttnpb.Rights{
-						unique.ID(test.Context(), deepcopy.Copy(registeredDevice.Ids.ApplicationIds).(*ttnpb.ApplicationIdentifiers)): ttnpb.RightsFrom(
+						unique.ID(test.Context(), ttnpb.Clone(registeredDevice.Ids.ApplicationIds)): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 						),
 					},
@@ -545,7 +544,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			ContextFunc: func(ctx context.Context) context.Context {
 				return rights.NewContext(ctx, rights.Rights{
 					ApplicationRights: map[string]*ttnpb.Rights{
-						unique.ID(test.Context(), deepcopy.Copy(registeredDevice.Ids.ApplicationIds).(*ttnpb.ApplicationIdentifiers)): ttnpb.RightsFrom(
+						unique.ID(test.Context(), ttnpb.Clone(registeredDevice.Ids.ApplicationIds)): ttnpb.RightsFrom(
 							ttnpb.Right_RIGHT_APPLICATION_DEVICES_WRITE,
 						),
 					},
@@ -653,7 +652,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 				})
 			},
 			DeviceRequest: &ttnpb.SetEndDeviceRequest{
-				EndDevice: CopyEndDevice(&ttnpb.EndDevice{
+				EndDevice: ttnpb.Clone(&ttnpb.EndDevice{
 					Ids:   registeredDevice.Ids,
 					NetId: types.NetID{0x42, 0x00, 0x00}.Bytes(),
 				}),
@@ -668,7 +667,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 				a.So(gets, should.HaveSameElementsDeep, []string{
 					"net_id",
 				})
-				dev, sets, err := cb(CopyEndDevice(&ttnpb.EndDevice{
+				dev, sets, err := cb(ttnpb.Clone(&ttnpb.EndDevice{
 					Ids:   registeredDevice.Ids,
 					NetId: registeredDevice.NetId,
 				}))
@@ -704,7 +703,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 				})
 			},
 			DeviceRequest: &ttnpb.SetEndDeviceRequest{
-				EndDevice: CopyEndDevice(registeredDevice),
+				EndDevice: ttnpb.Clone(registeredDevice),
 				FieldMask: ttnpb.FieldMask("root_keys.app_key.key", "root_keys.nwk_key.key"),
 			},
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, paths []string, cb func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
@@ -732,7 +731,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 				})
 			},
 			DeviceRequest: &ttnpb.SetEndDeviceRequest{
-				EndDevice: CopyEndDevice(&ttnpb.EndDevice{
+				EndDevice: ttnpb.Clone(&ttnpb.EndDevice{
 					Ids: registeredDevice.Ids,
 					RootKeys: &ttnpb.RootKeys{
 						AppKey: &ttnpb.KeyEnvelope{
@@ -755,7 +754,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 					"root_keys.app_key.key",
 					"root_keys.nwk_key.key",
 				})
-				dev, sets, err := cb(CopyEndDevice(registeredDevice))
+				dev, sets, err := cb(ttnpb.Clone(registeredDevice))
 				a.So(sets, should.HaveSameElementsDeep, []string{
 					"root_keys.app_key.encrypted_key",
 					"root_keys.app_key.kek_label",
@@ -825,7 +824,7 @@ func TestDeviceRegistrySet(t *testing.T) {
 			defer js.Close()
 
 			ctx := js.FillContext(test.Context())
-			req := deepcopy.Copy(tc.DeviceRequest).(*ttnpb.SetEndDeviceRequest)
+			req := ttnpb.Clone(tc.DeviceRequest)
 
 			dev, err := ttnpb.NewJsEndDeviceRegistryClient(js.LoopbackConn()).Set(ctx, req)
 			a.So(setByIDCalls, should.Equal, tc.SetByIDCalls)
@@ -903,7 +902,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 					},
 				})
 			},
-			DeviceRequest: deepcopy.Copy(registeredDevice.Ids).(*ttnpb.EndDeviceIdentifiers),
+			DeviceRequest: ttnpb.Clone(registeredDevice.Ids),
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, paths []string, cb func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
 				test.MustTFromContext(ctx).Errorf("SetByIDFunc must not be called")
 				return nil, errors.New("SetByIDFunc must not be called")
@@ -965,7 +964,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 					},
 				})
 			},
-			DeviceRequest: deepcopy.Copy(registeredDevice.Ids).(*ttnpb.EndDeviceIdentifiers),
+			DeviceRequest: ttnpb.Clone(registeredDevice.Ids),
 			SetByIDFunc: func(ctx context.Context, appID *ttnpb.ApplicationIdentifiers, devID string, paths []string, cb func(*ttnpb.EndDevice) (*ttnpb.EndDevice, []string, error)) (*ttnpb.EndDevice, error) {
 				a := assertions.New(test.MustTFromContext(ctx))
 				a.So(appID, should.Resemble, ttnpb.ApplicationIdentifiers{
@@ -973,7 +972,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 				})
 				a.So(devID, should.Equal, registeredDeviceID)
 				a.So(paths, should.BeNil)
-				dev, _, err := cb(CopyEndDevice(registeredDevice))
+				dev, _, err := cb(ttnpb.Clone(registeredDevice))
 				return dev, err
 			},
 			SetByIDCalls:    1,
@@ -1021,7 +1020,7 @@ func TestDeviceRegistryDelete(t *testing.T) {
 			defer js.Close()
 
 			ctx := js.FillContext(test.Context())
-			req := deepcopy.Copy(tc.DeviceRequest).(*ttnpb.EndDeviceIdentifiers)
+			req := ttnpb.Clone(tc.DeviceRequest)
 
 			_, err := ttnpb.NewJsEndDeviceRegistryClient(js.LoopbackConn()).Delete(ctx, req)
 			a.So(setByIDCalls, should.Equal, tc.SetByIDCalls)

--- a/pkg/joinserver/joinserver_test.go
+++ b/pkg/joinserver/joinserver_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	clusterauth "go.thethings.network/lorawan-stack/v3/pkg/auth/cluster"
 	"go.thethings.network/lorawan-stack/v3/pkg/auth/rights"
@@ -2441,7 +2440,7 @@ func TestHandleJoin(t *testing.T) {
 				)).(*joinserver.JoinServer)
 				componenttest.StartComponent(t, c)
 
-				pb := deepcopy.Copy(tc.Device).(*ttnpb.EndDevice)
+				pb := ttnpb.Clone(tc.Device)
 
 				start := time.Now()
 
@@ -2468,7 +2467,7 @@ func TestHandleJoin(t *testing.T) {
 						if !a.So(stored, should.BeNil) {
 							t.Fatal("Registry is not empty")
 						}
-						return CopyEndDevice(pb), []string{
+						return ttnpb.Clone(pb), []string{
 							"application_server_address",
 							"application_server_id",
 							"application_server_kek_label",
@@ -2500,7 +2499,7 @@ func TestHandleJoin(t *testing.T) {
 				pb.UpdatedAt = ret.UpdatedAt
 				a.So(ret, should.HaveEmptyDiff, pb)
 
-				res, err := js.HandleJoin(ctx, deepcopy.Copy(tc.JoinRequest).(*ttnpb.JoinRequest), tc.Authorizer)
+				res, err := js.HandleJoin(ctx, ttnpb.Clone(tc.JoinRequest), tc.Authorizer)
 				if tc.ErrorAssertion != nil {
 					if !a.So(err, should.BeError) || !a.So(tc.ErrorAssertion(err), should.BeTrue) {
 						t.Fatalf("Received an unexpected error: %s", err)
@@ -2512,7 +2511,7 @@ func TestHandleJoin(t *testing.T) {
 				if !a.So(err, should.BeNil) || !a.So(res, should.NotBeNil) {
 					t.FailNow()
 				}
-				expectedResp := deepcopy.Copy(tc.JoinResponse).(*ttnpb.JoinResponse)
+				expectedResp := ttnpb.Clone(tc.JoinResponse)
 				a.So(res.SessionKeys.SessionKeyId, should.NotBeEmpty)
 				expectedResp.SessionKeys.SessionKeyId = res.SessionKeys.SessionKeyId
 				a.So(res, should.Resemble, expectedResp)
@@ -2548,7 +2547,7 @@ func TestHandleJoin(t *testing.T) {
 				pb.Ids.DevAddr = tc.JoinRequest.DevAddr
 				a.So(ret, should.HaveEmptyDiff, pb)
 
-				res, err = js.HandleJoin(ctx, deepcopy.Copy(tc.JoinRequest).(*ttnpb.JoinRequest), tc.Authorizer)
+				res, err = js.HandleJoin(ctx, ttnpb.Clone(tc.JoinRequest), tc.Authorizer)
 				if !tc.Device.ResetsJoinNonces {
 					a.So(err, should.BeError)
 					a.So(res, should.BeNil)

--- a/pkg/joinserver/registry_test.go
+++ b/pkg/joinserver/registry_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	pbtypes "github.com/gogo/protobuf/types"
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	. "go.thethings.network/lorawan-stack/v3/pkg/joinserver"
@@ -32,10 +31,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test"
 	"go.thethings.network/lorawan-stack/v3/pkg/util/test/assertions/should"
 )
-
-func CopyEndDevice(pb *ttnpb.EndDevice) *ttnpb.EndDevice {
-	return deepcopy.Copy(pb).(*ttnpb.EndDevice)
-}
 
 // handleDeviceRegistryTest runs a test suite on reg.
 func handleDeviceRegistryTest(t *testing.T, reg DeviceRegistry) {
@@ -80,7 +75,7 @@ func handleDeviceRegistryTest(t *testing.T, reg DeviceRegistry) {
 			if !a.So(stored, should.BeNil) {
 				t.Fatal("Registry is not empty")
 			}
-			return CopyEndDevice(pb), []string{
+			return ttnpb.Clone(pb), []string{
 				"ids.application_ids",
 				"ids.dev_eui",
 				"ids.device_id",
@@ -106,7 +101,7 @@ func handleDeviceRegistryTest(t *testing.T, reg DeviceRegistry) {
 	}
 	a.So(retCtx.EndDevice, should.HaveEmptyDiff, pb)
 
-	pbOther := CopyEndDevice(pb)
+	pbOther := ttnpb.Clone(pb)
 	pbOther.Ids.DeviceId = "other-device"
 	pbOther.Ids.DevEui = types.EUI64{0x43, 0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}.Bytes()
 
@@ -128,7 +123,7 @@ func handleDeviceRegistryTest(t *testing.T, reg DeviceRegistry) {
 			if !a.So(stored, should.BeNil) {
 				t.Fatal("Registry is not empty")
 			}
-			return CopyEndDevice(pbOther), []string{
+			return ttnpb.Clone(pbOther), []string{
 				"ids.application_ids",
 				"ids.dev_eui",
 				"ids.device_id",
@@ -162,7 +157,7 @@ func handleDeviceRegistryTest(t *testing.T, reg DeviceRegistry) {
 			if !a.So(stored, should.BeNil) {
 				t.Fatal("Registry is not empty")
 			}
-			return CopyEndDevice(pbOther), []string{
+			return ttnpb.Clone(pbOther), []string{
 				"ids.application_ids",
 				"ids.dev_eui",
 				"ids.device_id",
@@ -209,10 +204,6 @@ func handleDeviceRegistryTest(t *testing.T, reg DeviceRegistry) {
 		t.Fatalf("Error received: %v", err)
 	}
 	a.So(retCtx, should.BeNil)
-}
-
-func CopySessionKeys(pb *ttnpb.SessionKeys) *ttnpb.SessionKeys {
-	return deepcopy.Copy(pb).(*ttnpb.SessionKeys)
 }
 
 func TestDeviceRegistries(t *testing.T) {
@@ -307,7 +298,7 @@ func handleKeyRegistryTest(t *testing.T, reg KeyRegistry) {
 			if !a.So(stored, should.BeNil) {
 				t.Fatal("Registry is not empty")
 			}
-			return CopySessionKeys(pb), []string{
+			return ttnpb.Clone(pb), []string{
 				"app_s_key",
 				"f_nwk_s_int_key",
 				"nwk_s_enc_key",
@@ -325,7 +316,7 @@ func handleKeyRegistryTest(t *testing.T, reg KeyRegistry) {
 	a.So(err, should.BeNil)
 	a.So(ret, should.HaveEmptyDiff, pb)
 
-	pbOther := CopySessionKeys(pb)
+	pbOther := ttnpb.Clone(pb)
 	joinEUIOther := types.EUI64{0x43, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
 	devEUIOther := types.EUI64{0x43, 0x42, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
 
@@ -346,7 +337,7 @@ func handleKeyRegistryTest(t *testing.T, reg KeyRegistry) {
 			if !a.So(stored, should.BeNil) {
 				t.Fatal("Registry is not empty")
 			}
-			return CopySessionKeys(pbOther), []string{
+			return ttnpb.Clone(pbOther), []string{
 				"app_s_key",
 				"f_nwk_s_int_key",
 				"nwk_s_enc_key",

--- a/pkg/packetbrokeragent/agent_test.go
+++ b/pkg/packetbrokeragent/agent_test.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	pbtypes "github.com/gogo/protobuf/types"
-	"github.com/mohae/deepcopy"
 	"github.com/smartystreets/assertions"
 	mappingpb "go.packetbroker.org/api/mapping/v2"
 	packetbroker "go.packetbroker.org/api/v3"
@@ -858,7 +857,7 @@ func TestHomeNetwork(t *testing.T) {
 				a.So(nsMsg.CorrelationIds, should.HaveLength, 2)
 				a.So(*ttnpb.StdTime(nsMsg.ReceivedAt), should.HappenBetween, before, time.Now()) // Packet Broker Agent sets local time on receive.
 
-				expected := deepcopy.Copy(tc.UplinkMessage).(*ttnpb.UplinkMessage)
+				expected := ttnpb.Clone(tc.UplinkMessage)
 				expected.CorrelationIds = nsMsg.CorrelationIds
 				expected.ReceivedAt = nsMsg.ReceivedAt
 				for _, md := range expected.RxMetadata {

--- a/pkg/pfconfig/cpf/cpf_test.go
+++ b/pkg/pfconfig/cpf/cpf_test.go
@@ -177,7 +177,7 @@ func TestBuildLorad(t *testing.T) {
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			a := assertions.New(t)
-			gtw := deepcopy.Copy(tc.Gateway).(*ttnpb.Gateway)
+			gtw := ttnpb.Clone(tc.Gateway)
 			conf, err := BuildLorad(gtw, fps)
 			a.So(gtw, should.Resemble, tc.Gateway)
 			if a.So(tc.ErrorAssertion(t, err), should.BeTrue) {
@@ -267,7 +267,7 @@ func TestBuildLorafwd(t *testing.T) {
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			a := assertions.New(t)
-			gtw := deepcopy.Copy(tc.Gateway).(*ttnpb.Gateway)
+			gtw := ttnpb.Clone(tc.Gateway)
 			conf, err := BuildLorafwd(gtw)
 			a.So(gtw, should.Resemble, tc.Gateway)
 			if a.So(tc.ErrorAssertion(t, err), should.BeTrue) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/2798

#### Changes
<!-- What are the changes made in this pull request? -->

- Replace `deepcopy.Copy` with `ttnpb.Clone`, as message cloning in newer protobuf version must be done via `proto.Clone` (and `ttnpb.Clone` is just a type safe wrapper around that)


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

Not expected. We already use `ttnpb.Clone` in most places and it works as expected.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
