### PR TITLE
Do not update gateways with unauthenticated connections

### DIFF
--- a/pkg/gatewayserver/gatewayserver.go
+++ b/pkg/gatewayserver/gatewayserver.go
@@ -527,8 +527,13 @@ func (gs *GatewayServer) Connect(
 	gs.startDisconnectOnChangeTask(connEntry)
 	gs.startHandleUpstreamTask(connEntry)
 	gs.startUpdateConnStatsTask(connEntry)
-	gs.startHandleLocationUpdatesTask(connEntry)
-	gs.startHandleVersionUpdatesTask(connEntry)
+	// Unauthenticated connections cannot update the gateway entity.
+	// As such, there is no reason to start these tasks, since they
+	// will perpetually fail.
+	if isAuthenticated {
+		gs.startHandleLocationUpdatesTask(connEntry)
+		gs.startHandleVersionUpdatesTask(connEntry)
+	}
 
 	for name, handler := range gs.upstreamHandlers {
 		connCtx := log.NewContextWithField(conn.Context(), "upstream_handler", name)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/TheThingsNetwork/lorawan-stack/issues/5712

This PR fixes the following warning, which occurs when the UDP gateways try to update their location:
```
{"level":"warn","msg":"Failed to update antennas","error":"error:pkg/rpcmetadata:unauthenticated (the context is not authenticated)","gateway_eui":"7276FF002E0803AB","gateway_ip_address":"x.x.x.x","gateway_uid":"kerlink-ibts-compact-1@tti","namespace":"gatewayserver/io/udp","protocol":"udp","remote_addr":"x.x.x.x:36366","tenant_id":"tti"}
```

#### Changes
<!-- What are the changes made in this pull request? -->

- The tasks which update the antenna location and attributes of a gateway are no longer started if the gateway is unauthenticated.


#### Testing

<!-- How did you verify that this change works? -->

Unit testing.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

N/A. This was already not working since you cannot update an entity without any rights to it.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
