### PR TITLE
Synchronize gateway time only with GPS timestamps

### DIFF
--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -22,6 +22,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/gogo/protobuf/types"
 	"go.thethings.network/lorawan-stack/v3/pkg/band"
 	"go.thethings.network/lorawan-stack/v3/pkg/config"
 	"go.thethings.network/lorawan-stack/v3/pkg/errorcontext"
@@ -241,19 +242,32 @@ func (c *Connection) HandleUp(up *ttnpb.UplinkMessage, frontendSync *FrontendClo
 	}
 
 	receivedAt := *ttnpb.StdTime(up.ReceivedAt)
+	gpsTime := func(mds []*ttnpb.RxMetadata) *types.Timestamp {
+		for _, md := range mds {
+			if gpsTime := md.GpsTime; gpsTime != nil {
+				return gpsTime
+			}
+		}
+		return nil
+	}(up.RxMetadata)
 
 	var ct scheduling.ConcentratorTime
 	switch {
 	case frontendSync != nil:
-		ct = c.scheduler.SyncWithGatewayConcentrator(frontendSync.Timestamp, frontendSync.ServerTime, frontendSync.GatewayTime, frontendSync.ConcentratorTime)
+		ct = c.scheduler.SyncWithGatewayConcentrator(
+			frontendSync.Timestamp,
+			frontendSync.ServerTime,
+			frontendSync.GatewayTime,
+			frontendSync.ConcentratorTime,
+		)
 		log.FromContext(c.ctx).WithFields(log.Fields(
 			"timestamp", frontendSync.Timestamp,
 			"concentrator_time", frontendSync.ConcentratorTime,
 			"server_time", frontendSync.ServerTime,
 			"gateway_time", frontendSync.GatewayTime,
 		)).Debug("Gateway clocks have been synchronized by the frontend")
-	case up.Settings.Time != nil:
-		gatewayTime := *ttnpb.StdTime(up.Settings.Time)
+	case gpsTime != nil:
+		gatewayTime := *ttnpb.StdTime(gpsTime)
 		ct = c.scheduler.SyncWithGatewayAbsolute(up.Settings.Timestamp, receivedAt, gatewayTime)
 		log.FromContext(c.ctx).WithFields(log.Fields(
 			"timestamp", up.Settings.Timestamp,
@@ -261,7 +275,7 @@ func (c *Connection) HandleUp(up *ttnpb.UplinkMessage, frontendSync *FrontendClo
 			"server_time", receivedAt,
 			"gateway_time", gatewayTime,
 		)).Debug("Synchronized server and gateway absolute time")
-	case up.Settings.Time == nil:
+	case gpsTime == nil:
 		ct = c.scheduler.Sync(up.Settings.Timestamp, receivedAt)
 		log.FromContext(c.ctx).WithFields(log.Fields(
 			"timestamp", up.Settings.Timestamp,

--- a/pkg/gatewayserver/io/mock/frontend.go
+++ b/pkg/gatewayserver/io/mock/frontend.go
@@ -56,7 +56,9 @@ func ConnectFrontend(ctx context.Context, ids *ttnpb.GatewayIdentifiers, server 
 			case up := <-f.Up:
 				gatewayTime := time.Unix(0, 0).Add(time.Since(started))
 				up.ReceivedAt = ttnpb.ProtoTimePtr(time.Now())
-				up.Settings.Time = ttnpb.ProtoTimePtr(gatewayTime)
+				for _, md := range up.RxMetadata {
+					md.GpsTime = ttnpb.ProtoTimePtr(gatewayTime)
+				}
 				conn.HandleUp(up, nil)
 			case status := <-f.Status:
 				conn.HandleStatus(status)

--- a/pkg/networkserver/downlink.go
+++ b/pkg/networkserver/downlink.go
@@ -2096,14 +2096,14 @@ func (ns *NetworkServer) processDownlinkTask(ctx context.Context, consumerID str
 						case !slot.IsApplicationTime && slot.Class == ttnpb.Class_CLASS_C && time.Until(slot.Time) > 0:
 							logger.WithFields(log.Fields(
 								"slot_start", slot.Time,
-							)).Info("Class C downlink scheduling attempt performed too soon, retry attempt")
+							)).Debug("Class C downlink scheduling attempt performed too soon, retry attempt")
 							taskUpdateStrategy = nextDownlinkTask
 							return dev, nil, nil
 
 						case time.Until(slot.Time) > absoluteTimeSchedulingDelay+2*nsScheduleWindow():
 							logger.WithFields(log.Fields(
 								"slot_start", slot.Time,
-							)).Info("Class B/C downlink scheduling attempt performed too soon, retry attempt")
+							)).Debug("Class B/C downlink scheduling attempt performed too soon, retry attempt")
 							taskUpdateStrategy = nextDownlinkTask
 							return dev, nil, nil
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

References https://github.com/Lora-net/LoRaMac-node/issues/1348

This PR fixes some GS scheduling issues which I've encountered while re-testing class B support.

#### Changes
<!-- What are the changes made in this pull request? -->

- Sync gateway time only with timestamps which are guaranteed to come from a GPS source.
  - This ensures that gateways that may provide a `Time` that has undefined accuracy are not considered for class B ping slots.
  - `Time` has undefined accuracy, while `GpsTime` is guaranteed (by the frontends) to have millisecond accuracy.


#### Testing

<!-- How did you verify that this change works? -->

Local testing with real end devices.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

This change causes absolute time class C downlinks to fail in the absence of a GPS sync, or at least of some RTTs being observed between the NS and the gateway. 

Previously scheduling the absolute time downlinks would always work, but the timestamp would have an accuracy equivalent to the accuracy of the forwarder (UDP in some implementations has seconds accuracy, MQTTv2 is always second accuracy, while BasicStation has a fractional timestamps of undefined accuracy).

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
