### PR TITLE
Support accurate absolute time downlinks in BasicStation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,24 @@ For details about compatibility between different releases, see the **Commitment
 - New `ListBands` RPC on the `Configuration` service.
 - Support for loading end device template from Device Repository when importing devices using a CSV file.
 - Experimental support for normalized payload.
+- Decoded payloads are now visible for downlinks in the Console.
 
 ### Changed
+
+- Absolute time downlinks (such as class B ping slots or class C absolute time downlinks) are now using the native class B downlink API of LoRa Basics Station.
+- Only gateways which are guaranteed to be GPS capable may now be used for absolute time downlinks. This ensures that gateways that have an unknown time source are not used for absolute time scheduling.
+- The static ADR mode may now steer the end device to use custom data rates such as SF7BW250, FSK and LR-FHSS.
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- The Gateway Server scheduler no longer considers the absolute time of a downlink to be the time of arrival.
+- The Network Server now correctly handles the command that may succeed a `LinkADRAns` response.
+- LR-FHSS data rate matching.
+- Console data rate rendering of non-LoRa modulations.
 
 ### Security
 

--- a/pkg/gatewayserver/io/io.go
+++ b/pkg/gatewayserver/io/io.go
@@ -298,10 +298,16 @@ func (c *Connection) HandleUp(up *ttnpb.UplinkMessage, frontendSync *FrontendClo
 			md.DownlinkPathConstraint = ttnpb.DownlinkPathConstraint_DOWNLINK_PATH_CONSTRAINT_NEVER
 			continue
 		}
-		buf, err := UplinkToken(&ttnpb.GatewayAntennaIdentifiers{
-			GatewayIds:   c.gateway.GetIds(),
-			AntennaIndex: md.AntennaIndex,
-		}, md.Timestamp, ct, receivedAt, ttnpb.StdTime(up.Settings.Time))
+		buf, err := UplinkToken(
+			&ttnpb.GatewayAntennaIdentifiers{
+				GatewayIds:   c.gateway.GetIds(),
+				AntennaIndex: md.AntennaIndex,
+			},
+			md.Timestamp,
+			ct,
+			receivedAt,
+			ttnpb.StdTime(gpsTime),
+		)
 		if err != nil {
 			return err
 		}

--- a/pkg/gatewayserver/io/ws/format.go
+++ b/pkg/gatewayserver/io/ws/format.go
@@ -46,7 +46,7 @@ type Formatter interface {
 	// This function optionally returns a byte stream to be sent as response to the upstream message.
 	HandleUp(ctx context.Context, raw []byte, ids *ttnpb.GatewayIdentifiers, conn *io.Connection, receivedAt time.Time) ([]byte, error)
 	// FromDownlink generates a downlink byte stream that can be sent over the WS connection.
-	FromDownlink(ctx context.Context, down *ttnpb.DownlinkMessage, bandID string, concentratorTime scheduling.ConcentratorTime, dlTime time.Time) ([]byte, error)
+	FromDownlink(ctx context.Context, down *ttnpb.DownlinkMessage, bandID string, dlTime time.Time) ([]byte, error)
 	// TransferTime generates a spurious time transfer message for a particular server time.
 	TransferTime(ctx context.Context, serverTime time.Time, gpsTime *time.Time, concentratorTime *scheduling.ConcentratorTime) ([]byte, error)
 }

--- a/pkg/gatewayserver/io/ws/lbslns/downstream.go
+++ b/pkg/gatewayserver/io/ws/lbslns/downstream.go
@@ -22,7 +22,6 @@ import (
 
 	"go.thethings.network/lorawan-stack/v3/pkg/band"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/scheduling"
-	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 )
 
@@ -81,11 +80,6 @@ func (f *lbsLNS) FromDownlink(
 
 	// Estimate the xtime based on the timestamp; xtime = timestamp - (rxdelay). The calculated offset is in microseconds.
 	dnmsg.XTime = xTime - int64(dnmsg.RxDelay*int(time.Second/time.Microsecond))
-
-	log.FromContext(ctx).WithFields(log.Fields(
-		"xtime", dnmsg.XTime,
-		"mux_time", dlTime,
-	)).Info("Prepare downlink message")
 
 	// This field is not used but needs to be defined for the station to parse the json and should be non-zero for the station to return tx confirmations.
 	dnmsg.DevEUI = "00-00-00-00-00-00-00-01"

--- a/pkg/gatewayserver/io/ws/lbslns/downstream.go
+++ b/pkg/gatewayserver/io/ws/lbslns/downstream.go
@@ -59,7 +59,9 @@ func (dnmsg *DownlinkMessage) unmarshalJSON(data []byte) error {
 }
 
 // FromDownlink implements Formatter.
-func (f *lbsLNS) FromDownlink(ctx context.Context, down *ttnpb.DownlinkMessage, bandID string, concentratorTime scheduling.ConcentratorTime, dlTime time.Time) ([]byte, error) {
+func (f *lbsLNS) FromDownlink(
+	ctx context.Context, down *ttnpb.DownlinkMessage, bandID string, dlTime time.Time,
+) ([]byte, error) {
 	var dnmsg DownlinkMessage
 	settings := down.GetScheduled()
 	dnmsg.Pdu = hex.EncodeToString(down.GetRawPayload())
@@ -75,7 +77,7 @@ func (f *lbsLNS) FromDownlink(ctx context.Context, down *ttnpb.DownlinkMessage, 
 	if !found {
 		return nil, errSessionStateNotFound.New()
 	}
-	xTime := ConcentratorTimeToXTime(sessionID, concentratorTime)
+	xTime := ConcentratorTimeToXTime(sessionID, scheduling.ConcentratorTime(settings.ConcentratorTimestamp))
 
 	// Estimate the xtime based on the timestamp; xtime = timestamp - (rxdelay). The calculated offset is in microseconds.
 	dnmsg.XTime = xTime - int64(dnmsg.RxDelay*int(time.Second/time.Microsecond))

--- a/pkg/gatewayserver/io/ws/lbslns/downstream.go
+++ b/pkg/gatewayserver/io/ws/lbslns/downstream.go
@@ -25,19 +25,35 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/ttnpb"
 )
 
+// TimestampDownlinkMessage encapsulates the information used for downlinks
+// which are meant to be sent at fixed concentrator timestamps.
+type TimestampDownlinkMessage struct {
+	RxDelay int   `json:"RxDelay"`
+	Rx1DR   int   `json:"RX1DR"`
+	Rx1Freq int   `json:"RX1Freq"`
+	XTime   int64 `json:"xtime"`
+}
+
+// AbsoluteTimeDownlinkMessage encapsulates the information used for downlinks
+// which are meant to be sent at fixed absolute GPS times.
+type AbsoluteTimeDownlinkMessage struct {
+	DR      int   `json:"DR"`
+	Freq    int   `json:"Freq"`
+	GPSTime int64 `json:"gpstime"`
+}
+
 // DownlinkMessage is the LoRaWAN downlink message sent to the LoRa Basics Station.
 type DownlinkMessage struct {
 	DevEUI      string  `json:"DevEui"`
 	DeviceClass uint    `json:"dC"`
 	Diid        int64   `json:"diid"`
 	Pdu         string  `json:"pdu"`
-	RxDelay     int     `json:"RxDelay"`
-	Rx1DR       int     `json:"RX1DR"`
-	Rx1Freq     int     `json:"RX1Freq"`
 	Priority    int     `json:"priority"`
-	XTime       int64   `json:"xtime"`
 	RCtx        int64   `json:"rctx"`
 	MuxTime     float64 `json:"MuxTime"`
+
+	*TimestampDownlinkMessage    `json:",omitempty"`
+	*AbsoluteTimeDownlinkMessage `json:",omitempty"`
 }
 
 // marshalJSON marshals dnmsg to a JSON byte array.
@@ -61,30 +77,16 @@ func (dnmsg *DownlinkMessage) unmarshalJSON(data []byte) error {
 func (f *lbsLNS) FromDownlink(
 	ctx context.Context, down *ttnpb.DownlinkMessage, bandID string, dlTime time.Time,
 ) ([]byte, error) {
-	var dnmsg DownlinkMessage
 	settings := down.GetScheduled()
-	dnmsg.Pdu = hex.EncodeToString(down.GetRawPayload())
-	dnmsg.RCtx = int64(settings.Downlink.AntennaIndex)
-	dnmsg.Diid = int64(f.tokens.Next(down, dlTime))
-
-	// Chosen fixed values.
-	dnmsg.Priority = 25
-	dnmsg.RxDelay = 1
-
-	// The first 16 bits of XTime gets the session ID from the upstream latestXTime and the other 48 bits are concentrator timestamp accounted for rollover.
-	sessionID, found := getSessionID(ctx)
-	if !found {
-		return nil, errSessionStateNotFound.New()
+	dnmsg := DownlinkMessage{
+		DevEUI:   "00-00-00-00-00-00-00-01", // The DevEUI is required for transmission acknowledgements.
+		Diid:     int64(f.tokens.Next(down, dlTime)),
+		Pdu:      hex.EncodeToString(down.GetRawPayload()),
+		Priority: 25,
+		RCtx:     int64(settings.Downlink.AntennaIndex),
+		MuxTime:  TimeToUnixSeconds(dlTime),
 	}
-	xTime := ConcentratorTimeToXTime(sessionID, scheduling.ConcentratorTime(settings.ConcentratorTimestamp))
 
-	// Estimate the xtime based on the timestamp; xtime = timestamp - (rxdelay). The calculated offset is in microseconds.
-	dnmsg.XTime = xTime - int64(dnmsg.RxDelay*int(time.Second/time.Microsecond))
-
-	// This field is not used but needs to be defined for the station to parse the json and should be non-zero for the station to return tx confirmations.
-	dnmsg.DevEUI = "00-00-00-00-00-00-00-01"
-
-	// Fix the Tx Parameters since we don't use the gateway scheduler.
 	phy, err := band.GetLatest(bandID)
 	if err != nil {
 		return nil, err
@@ -93,14 +95,35 @@ func (f *lbsLNS) FromDownlink(
 	if !ok {
 		return nil, errDataRate.New()
 	}
-	dnmsg.Rx1DR = int(drIdx)
-	dnmsg.Rx1Freq = int(settings.Frequency)
 
-	// Add the MuxTime for RTT measurement
-	dnmsg.MuxTime = TimeToUnixSeconds(dlTime)
+	if transmitAt := ttnpb.StdTime(settings.Time); transmitAt != nil {
+		// Absolute time downlinks are scheduled as class B downlinks.
+		dnmsg.DeviceClass = uint(ttnpb.Class_CLASS_B)
+		dnmsg.AbsoluteTimeDownlinkMessage = &AbsoluteTimeDownlinkMessage{
+			DR:      int(drIdx),
+			Freq:    int(settings.Frequency),
+			GPSTime: TimeToGPSTime(*transmitAt),
+		}
+	} else {
+		// The first 16 bits of XTime gets the session ID from the upstream
+		// latest XTime and the other 48 bits are concentrator timestamp accounted for rollover.
+		sessionID, found := getSessionID(ctx)
+		if !found {
+			return nil, errSessionStateNotFound.New()
+		}
 
-	// The GS controls the scheduling and hence for the gateway, its always Class A.
-	dnmsg.DeviceClass = uint(ttnpb.Class_CLASS_A)
+		xTime := ConcentratorTimeToXTime(sessionID, scheduling.ConcentratorTime(settings.ConcentratorTimestamp))
+		xTime = xTime - int64(time.Second/time.Microsecond) // Subtract a second, since the RX delay is 1.
+
+		// Timestamp based downlinks are scheduled as class A downlinks.
+		dnmsg.DeviceClass = uint(ttnpb.Class_CLASS_A)
+		dnmsg.TimestampDownlinkMessage = &TimestampDownlinkMessage{
+			RxDelay: 1,
+			Rx1DR:   int(drIdx),
+			Rx1Freq: int(settings.Frequency),
+			XTime:   xTime,
+		}
+	}
 
 	return dnmsg.marshalJSON()
 }
@@ -111,23 +134,37 @@ func (dnmsg *DownlinkMessage) ToDownlinkMessage(bandID string) (*ttnpb.DownlinkM
 	if err != nil {
 		return nil, err
 	}
-	bandDR, ok := phy.DataRates[ttnpb.DataRateIndex(dnmsg.Rx1DR)]
-	if !ok {
-		return nil, errDataRate.New()
-	}
-	return &ttnpb.DownlinkMessage{
+	down := &ttnpb.DownlinkMessage{
 		RawPayload: []byte(dnmsg.Pdu),
 		Settings: &ttnpb.DownlinkMessage_Scheduled{
 			Scheduled: &ttnpb.TxSettings{
-				DataRate:  bandDR.Rate,
-				Frequency: uint64(dnmsg.Rx1Freq),
 				Downlink: &ttnpb.TxSettings_Downlink{
 					AntennaIndex: uint32(dnmsg.RCtx),
 				},
-				Timestamp: uint32(dnmsg.XTime),
 			},
 		},
-	}, nil
+	}
+	switch dnmsg.DeviceClass {
+	case uint(ttnpb.Class_CLASS_A):
+		bandDR, ok := phy.DataRates[ttnpb.DataRateIndex(dnmsg.Rx1DR)]
+		if !ok {
+			return nil, errDataRate.New()
+		}
+		down.GetScheduled().DataRate = bandDR.Rate
+		down.GetScheduled().Frequency = uint64(dnmsg.Rx1Freq)
+		down.GetScheduled().Timestamp = TimestampFromXTime(dnmsg.XTime)
+	case uint(ttnpb.Class_CLASS_B):
+		bandDR, ok := phy.DataRates[ttnpb.DataRateIndex(dnmsg.DR)]
+		if !ok {
+			return nil, errDataRate.New()
+		}
+		down.GetScheduled().DataRate = bandDR.Rate
+		down.GetScheduled().Frequency = uint64(dnmsg.Freq)
+		down.GetScheduled().Time = ttnpb.ProtoTimePtr(TimeFromGPSTime(dnmsg.GPSTime))
+	default:
+		panic("unreachable")
+	}
+	return down, nil
 }
 
 const (

--- a/pkg/gatewayserver/io/ws/lbslns/downstream_test.go
+++ b/pkg/gatewayserver/io/ws/lbslns/downstream_test.go
@@ -61,7 +61,7 @@ func TestFromDownlinkMessage(t *testing.T) {
 						Downlink: &ttnpb.TxSettings_Downlink{
 							AntennaIndex: 2,
 						},
-						Timestamp: 1553300787,
+						ConcentratorTimestamp: 1553300787,
 					},
 				},
 				CorrelationIds: []string{"correlation1"},
@@ -101,6 +101,7 @@ func TestFromDownlinkMessage(t *testing.T) {
 						Downlink: &ttnpb.TxSettings_Downlink{
 							AntennaIndex: 2,
 						},
+						ConcentratorTimestamp: 1553300787,
 					},
 				},
 				CorrelationIds: []string{"correlation2"},
@@ -121,7 +122,7 @@ func TestFromDownlinkMessage(t *testing.T) {
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
 			a := assertions.New(t)
-			raw, err := lbsLNS.FromDownlink(ctx, tc.DownlinkMessage, tc.BandID, 1554300787, time.Unix(1554300787, 123456000))
+			raw, err := lbsLNS.FromDownlink(ctx, tc.DownlinkMessage, tc.BandID, time.Unix(1554300787, 123456000))
 			if !a.So(err, should.BeNil) {
 				t.FailNow()
 			}

--- a/pkg/gatewayserver/io/ws/ws.go
+++ b/pkg/gatewayserver/io/ws/ws.go
@@ -32,7 +32,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/errors"
 	"go.thethings.network/lorawan-stack/v3/pkg/frequencyplans"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io"
-	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/scheduling"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	"go.thethings.network/lorawan-stack/v3/pkg/random"
 	"go.thethings.network/lorawan-stack/v3/pkg/ratelimit"
@@ -327,7 +326,7 @@ func (s *srv) handleTraffic(w http.ResponseWriter, r *http.Request) (err error) 
 					return err
 				}
 			case down := <-conn.Down():
-				dnmsg, err := s.formatter.FromDownlink(ctx, down, conn.BandID(), scheduling.ConcentratorTime(down.GetScheduled().ConcentratorTimestamp), time.Now())
+				dnmsg, err := s.formatter.FromDownlink(ctx, down, conn.BandID(), time.Now())
 				if err != nil {
 					logger.WithError(err).Warn("Failed to marshal downlink message")
 					continue

--- a/pkg/gatewayserver/io/ws/ws_test.go
+++ b/pkg/gatewayserver/io/ws/ws_test.go
@@ -40,7 +40,6 @@ import (
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/mock"
 	. "go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/ws"
 	"go.thethings.network/lorawan-stack/v3/pkg/gatewayserver/io/ws/lbslns"
-	"go.thethings.network/lorawan-stack/v3/pkg/gpstime"
 	mockis "go.thethings.network/lorawan-stack/v3/pkg/identityserver/mock"
 	"go.thethings.network/lorawan-stack/v3/pkg/log"
 	pfconfig "go.thethings.network/lorawan-stack/v3/pkg/pfconfig/lbslns"
@@ -976,11 +975,13 @@ func TestTraffic(t *testing.T) {
 				DeviceClass: 0,
 				Pdu:         "596d7868616d74686332356b4a334d3d3d",
 				Diid:        1,
-				RxDelay:     1,
-				Rx1Freq:     868100000,
-				Rx1DR:       5,
 				Priority:    25,
 				MuxTime:     1554300787.123456,
+				TimestampDownlinkMessage: &lbslns.TimestampDownlinkMessage{
+					RxDelay: 1,
+					Rx1Freq: 868100000,
+					Rx1DR:   5,
+				},
 			},
 		},
 		{
@@ -1071,20 +1072,23 @@ func TestTraffic(t *testing.T) {
 						},
 						Rx1Frequency:    868100000,
 						FrequencyPlanId: test.EUFrequencyPlanID,
+						AbsoluteTime:    ttnpb.ProtoTimePtr(time.Unix(0x424242424, 0x42424242)),
 					},
 				},
 				CorrelationIds: []string{"correlation1", "correlation2"},
 			},
 			ExpectedBSDownstream: lbslns.DownlinkMessage{
 				DevEUI:      "00-00-00-00-00-00-00-01",
-				DeviceClass: 0,
+				DeviceClass: 1,
 				Pdu:         "596d7868616d74686332356b4a334d3d3d",
 				Diid:        2,
-				RxDelay:     1,
-				Rx1Freq:     868100000,
-				Rx1DR:       5,
 				Priority:    25,
 				MuxTime:     1554300787.123456,
+				AbsoluteTimeDownlinkMessage: &lbslns.AbsoluteTimeDownlinkMessage{
+					Freq:    868100000,
+					DR:      5,
+					GPSTime: lbslns.TimeToGPSTime(time.Unix(0x424242424, 0x42424242)),
+				},
 			},
 		},
 	} {
@@ -1125,7 +1129,7 @@ func TestTraffic(t *testing.T) {
 					now := time.Unix(time.Now().UTC().Unix(), 0)
 					v.UpInfo.XTime = upXTime
 					v.UpInfo.RxTime = float64(now.Unix())
-					v.UpInfo.GPSTime = int64(gpstime.ToGPS(now) / time.Microsecond)
+					v.UpInfo.GPSTime = lbslns.TimeToGPSTime(now)
 					req, err := json.Marshal(v)
 					if err != nil {
 						panic(err)
@@ -1164,7 +1168,7 @@ func TestTraffic(t *testing.T) {
 					now := time.Unix(time.Now().UTC().Unix(), 0)
 					v.UpInfo.XTime = upXTime
 					v.UpInfo.RxTime = float64(now.Unix())
-					v.UpInfo.GPSTime = int64(gpstime.ToGPS(now) / time.Microsecond)
+					v.UpInfo.GPSTime = lbslns.TimeToGPSTime(now)
 					req, err := json.Marshal(v)
 					if err != nil {
 						panic(err)
@@ -1232,7 +1236,12 @@ func TestTraffic(t *testing.T) {
 
 						now := time.Now().UTC()
 						a.So(msg.TxTime, should.Equal, expected.TxTime)
-						a.So(gpstime.Parse(time.Duration(msg.GPSTime)*time.Microsecond), should.HappenBetween, now.Add(-time.Second), now.Add(time.Second))
+						a.So(
+							lbslns.TimeFromGPSTime(msg.GPSTime),
+							should.HappenBetween,
+							now.Add(-time.Second),
+							now.Add(time.Second),
+						)
 					case <-time.After(timeout):
 						t.Fatalf("Read message timeout")
 					}
@@ -1248,7 +1257,6 @@ func TestTraffic(t *testing.T) {
 					downlinkPath *ttnpb.DownlinkPath
 					down         = tc.InputNetworkDownstream
 					now          = time.Unix(time.Now().UTC().Unix(), 0)
-					dlTime       = now.Add(2 * time.Second)
 					timeStamp    = clock.GetTimestamp()
 					dlClass      = down.GetRequest().Class
 				)
@@ -1272,8 +1280,6 @@ func TestTraffic(t *testing.T) {
 							},
 						},
 					}
-					request := down.GetRequest()
-					request.AbsoluteTime = ttnpb.ProtoTimePtr(dlTime)
 				}
 
 				if _, _, _, err := gsConn.ScheduleDown(downlinkPath, down); err != nil {
@@ -1305,19 +1311,6 @@ func TestTraffic(t *testing.T) {
 						msg.MuxTime = expected.MuxTime
 						if dlClass == ttnpb.Class_CLASS_A {
 							expected.XTime = clock.GetXTimeForTimestamp(timeStamp)
-						} else {
-							expected.XTime = clock.GetXTimeForTime(dlTime)
-							diff := expected.XTime - msg.XTime
-							// The expected difference in XTime is the sum of the following values
-							// 1. Rx1Delay field of the downlink; hardcoded to 1 second.
-							// 2. TOA offset for the payload and the frequency plan used; 51456 microseconds.
-							// Note: If the payload or the frequency plan is changed in the test, adjust the TOA value.
-							expectedDiff := 1*time.Second + 51456*time.Microsecond
-
-							if !a.So(diff, should.BeGreaterThanOrEqualTo, 0) && !a.So(diff, should.BeBetween, (expectedDiff-5*time.Microsecond), (expectedDiff+5*time.Microsecond)) {
-								t.Fatalf("Downlink xtime has larger deviation than expected: %d", diff-int64(expectedDiff))
-							}
-							msg.XTime = expected.XTime
 						}
 						if !a.So(msg, should.Resemble, expected) {
 							t.Fatalf("Incorrect Downlink received: %s", string(res))

--- a/pkg/gatewayserver/scheduling/scheduler_test.go
+++ b/pkg/gatewayserver/scheduling/scheduler_test.go
@@ -142,8 +142,8 @@ func TestScheduleAtWithBandDutyCycle(t *testing.T) {
 			Priority:       ttnpb.TxSchedulePriority_NORMAL,
 			NPercentileRTT: durationPtr(500 * time.Millisecond),
 			ExpectedToa:    2465792 * time.Microsecond,
-			// Too late for transmission with RTT.
-			ExpectedError: scheduling.ErrTooLate,
+			// Exceeding dwell time of 2 seconds.
+			ExpectedError: scheduling.ErrDwellTime,
 		},
 		{
 			PayloadSize: 51,
@@ -183,7 +183,7 @@ func TestScheduleAtWithBandDutyCycle(t *testing.T) {
 			Priority:       ttnpb.TxSchedulePriority_HIGHEST,
 			MedianRTT:      durationPtr(200 * time.Millisecond),
 			ExpectedToa:    51456 * time.Microsecond,
-			ExpectedStarts: 1000000000 - 200000000/2 - 51456000,
+			ExpectedStarts: 1000000000 - 200000000/2,
 		},
 		{
 			SyncWithGatewayAbsolute: true,
@@ -203,7 +203,7 @@ func TestScheduleAtWithBandDutyCycle(t *testing.T) {
 			},
 			Priority:       ttnpb.TxSchedulePriority_HIGHEST,
 			ExpectedToa:    51456 * time.Microsecond,
-			ExpectedStarts: 60000000000 - 51456000,
+			ExpectedStarts: 60000000000,
 		},
 		{
 			PayloadSize: 10,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

OS counter part of https://github.com/TheThingsIndustries/lorawan-stack/pull/3406

#### Changes
<!-- What are the changes made in this pull request? -->

- Remove TOA absolute time downlink adjustment.
  - This never really worked properly - the UDP packet forwarder still used the un-adjusted timestamps, while BasicStation took this into consideration for class B ping slots, which are extremely time sensitive.
- Support absolute time downlinks natively in LoRa BasicsStation
  - Previously, absolute time downlinks were supported by having the GS compute the concentrator timestamp of the gateway. This is prone to drifts when uplinks are not received very often.
  - Now we use the native BasicStation class B scheduling, which uses GPS timestamps, in the same way the UDP packet forwarder does. 
- Ensure uplink tokens do not contain 'fake' gateway timestamps (sourced from `TxSettings.Time`). This would cause 'cross-polenization' of timestamps when an uplink token synchronizes another UDP Gateway Server.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Only CI - no review needed.

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [x] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [x] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
