### PR TITLE
Add notification receivers validation

### DIFF
--- a/config/messages.json
+++ b/config/messages.json
@@ -5831,6 +5831,15 @@
       "file": "invitation_registry.go"
     }
   },
+  "error:pkg/identityserver:no_receiver_user_ids": {
+    "translations": {
+      "en": "no receiver users ids"
+    },
+    "description": {
+      "package": "pkg/identityserver",
+      "file": "notification_registry.go"
+    }
+  },
   "error:pkg/identityserver:no_validation_needed": {
     "translations": {
       "en": "no validation needed for this contact info"

--- a/pkg/identityserver/client_registry.go
+++ b/pkg/identityserver/client_registry.go
@@ -150,7 +150,10 @@ func (is *IdentityServer) createClient(ctx context.Context, req *ttnpb.CreateCli
 			EntityIds:        req.GetClient().GetIds().GetEntityIdentifiers(),
 			NotificationType: "client_requested",
 			Data:             ttnpb.MustMarshalAny(req),
-			Email:            true,
+			Receivers: []ttnpb.NotificationReceiver{
+				ttnpb.NotificationReceiver_NOTIFICATION_RECEIVER_ADMINISTRATIVE_CONTACT,
+			},
+			Email: true,
 		})
 	}
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

In short while working on the Entity Limit Notification on TTES. I found a behaviour in which if you specify through code that an email notification does not have receivers, the email will be sent to all users. So in short this validation serves as a check in order to avoid having multiple users being spammed if there is an error on the future updates.

Obs: Did not open an issue for this.

#### Changes
<!-- What are the changes made in this pull request? -->

- Validate if the `Receivers` field is `nil` when storing an email.


#### Testing

<!-- How did you verify that this change works? -->

Tested in the same scenario where I found the behaviour, picked this commit put it on my ttes branch and ran the same script that generate the email spam.

##### Regressions

<!-- Please indicate features that this change could affect and how that was tested. -->

I don't  think there is a regression, is an addition of a simple if on the `storeNotification` and this shouldn't be empty unless we specify it so.

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

Ideally this should be an error that should be made to be catched at compile time or on the general CI but I couldn't think of basic way of doing so, the very next things was the current solution where the integration tests would fail due to the email error. 


#### Checklist
<!-- Make sure that this pull request is complete. -->

- [x] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Compatibility: The changes are backwards compatible with existing API, storage, configuration and CLI, according to the compatibility commitments in `README.md` for the chosen target branch.
- [ ] Documentation: Relevant documentation is added or updated.
- [ ] Changelog: Significant features, behavior changes, deprecations and fixes are added to `CHANGELOG.md`.
- [x] Commits: Commit messages follow guidelines in `CONTRIBUTING.md`, there are no fixup commits left.
